### PR TITLE
fix(workflow): auto-recover PR creation after outages

### DIFF
--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -16,12 +16,16 @@ var prURLRe = regexp.MustCompile(`github\.com/[^/\s]+/[^/\s]+/pull/(\d+)`)
 var prShortRe = regexp.MustCompile(`\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#(\d+)`)
 
 const (
-	workflowRetryAfterVar        = "workflow.retry_after"
-	prCreateRetryBackoff         = 15 * time.Minute
-	prCreateRetryStatusReason    = "GitHub rate limit during PR creation — retrying later"
-	prCreatePushedNoPRReason     = "commits pushed but no PR created — retrying"
-	prCreateAttemptsVar          = "workflow.pr_create_attempts"
-	maxPRCreatePushedNoPRRetries = 3
+	workflowRetryAfterVar         = "workflow.retry_after"
+	prCreateRetryBackoff          = 15 * time.Minute
+	prCreateRetryStatusReason     = "GitHub rate limit during PR creation — retrying later"
+	prCreateTransientStatusReason = "GitHub connectivity issue during PR creation — retrying later"
+	prCreateAuthRetryReason       = "GitHub authentication issue during PR creation — retrying later"
+	prCreatePushedNoPRReason      = "commits pushed but no PR created — retrying"
+	prCreateAttemptsVar           = "workflow.pr_create_attempts"
+	maxPRCreatePushedNoPRRetries  = 3
+	prCreateAuthAttemptsVar       = "workflow.pr_create_auth_attempts"
+	maxPRCreateAuthRetries        = 3
 )
 
 // execLinkPRAndReview is a non-LLM mechanical step that tries to recover the
@@ -146,49 +150,56 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 
 	reason := "no agent result to evaluate"
 	if last != nil {
-		if isPRCreationStep(last.StepID) && (looksLikeGitHubRateLimit(last.Output) || looksLikeTransientGitHub(last.Output)) {
-			wfExec.CurrentStep = last.StepID
-			wfExec.State = ExecWaiting
-			wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
-			if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-				return StepOutput{}, err
+		if isPRCreationStep(last.StepID) {
+			switch {
+			case looksLikeGitHubRateLimit(last.Output):
+				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateRetryStatusReason)
+			case looksLikeTransientGitHub(last.Output):
+				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateTransientStatusReason)
+			case looksLikeAuthFailure(last.Output):
+				// Bad/expired credentials are not naturally time-bounded like a
+				// rate limit or a network blip, so they only get a bounded
+				// number of retries before escalating to a human.
+				attempts := parseWorkflowInt(wfExec.Variables[prCreateAuthAttemptsVar])
+				if attempts < maxPRCreateAuthRetries {
+					wfExec.SetVar(prCreateAuthAttemptsVar, strconv.Itoa(attempts+1))
+					return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateAuthRetryReason)
+				}
+				reason = fmt.Sprintf("PR creation failing due to invalid or expired GitHub credentials after %d retries", attempts)
 			}
-			if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, prCreateRetryStatusReason); statusErr != nil {
-				return StepOutput{}, statusErr
-			}
-			e.logger.Warn("workflow.evaluate.pr-create-transient-outage", "task_id", taskID, "step", last.StepID)
-			return StepOutput{}, errStepParked
 		}
-		switch {
-		case last.Status == "failed":
-			reason = truncate(strings.TrimSpace(last.Output), 200)
-			if reason == "" {
-				reason = "agent failed with no output"
-			}
-		case isPRCreationStep(last.StepID):
-			// Agent "succeeded" (didn't self-report failure) but no PR was found
-			// by link_pr_and_review or the late gh pr list check above. The
-			// worktree/branch still exist and re-checking for a race-created PR
-			// is safe, so retry a bounded number of times before giving up.
-			attempts := parseWorkflowInt(wfExec.Variables[prCreateAttemptsVar])
-			if attempts < maxPRCreatePushedNoPRRetries {
-				wfExec.SetVar(prCreateAttemptsVar, strconv.Itoa(attempts+1))
-				wfExec.CurrentStep = last.StepID
-				wfExec.State = ExecWaiting
-				wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
-				if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-					return StepOutput{}, err
+		if reason == "no agent result to evaluate" {
+			switch {
+			case last.Status == "failed":
+				reason = truncate(strings.TrimSpace(last.Output), 200)
+				if reason == "" {
+					reason = "agent failed with no output"
 				}
-				if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, prCreatePushedNoPRReason); statusErr != nil {
-					return StepOutput{}, statusErr
+			case isPRCreationStep(last.StepID):
+				// Agent "succeeded" (didn't self-report failure) but no PR was found
+				// by link_pr_and_review or the late gh pr list check above. The
+				// worktree/branch still exist and re-checking for a race-created PR
+				// is safe, so retry a bounded number of times before giving up.
+				attempts := parseWorkflowInt(wfExec.Variables[prCreateAttemptsVar])
+				if attempts < maxPRCreatePushedNoPRRetries {
+					wfExec.SetVar(prCreateAttemptsVar, strconv.Itoa(attempts+1))
+					wfExec.CurrentStep = last.StepID
+					wfExec.State = ExecWaiting
+					wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
+					if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+						return StepOutput{}, err
+					}
+					if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, prCreatePushedNoPRReason); statusErr != nil {
+						return StepOutput{}, statusErr
+					}
+					e.logger.Warn("workflow.evaluate.pr-create-pushed-no-pr-retry",
+						"task_id", taskID, "step", last.StepID, "attempt", attempts+1, "max", maxPRCreatePushedNoPRRetries)
+					return StepOutput{}, errStepParked
 				}
-				e.logger.Warn("workflow.evaluate.pr-create-pushed-no-pr-retry",
-					"task_id", taskID, "step", last.StepID, "attempt", attempts+1, "max", maxPRCreatePushedNoPRRetries)
-				return StepOutput{}, errStepParked
+				reason = fmt.Sprintf("commits pushed but no PR created after %d retries", attempts)
+			default:
+				reason = "commits pushed but no PR created"
 			}
-			reason = fmt.Sprintf("commits pushed but no PR created after %d retries", attempts)
-		default:
-			reason = "commits pushed but no PR created"
 		}
 	}
 
@@ -197,6 +208,22 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 	}
 	e.logger.Info("workflow.evaluate.human-required", "task_id", taskID, "reason", reason)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+}
+
+// parkStepForRetry rewinds wfExec back to stepID and persists a bounded
+// retry-after window, then parks the current evaluate step via errStepParked.
+func (e *Engine) parkStepForRetry(taskID string, wfExec *Execution, t TaskInfo, stepID, statusReason string) (StepOutput, error) {
+	wfExec.CurrentStep = stepID
+	wfExec.State = ExecWaiting
+	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		return StepOutput{}, err
+	}
+	if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, statusReason); statusErr != nil {
+		return StepOutput{}, statusErr
+	}
+	e.logger.Warn("workflow.evaluate.pr-create-transient-outage", "task_id", taskID, "step", stepID, "reason", statusReason)
+	return StepOutput{}, errStepParked
 }
 
 func isPRCreationStep(stepID string) bool {
@@ -215,29 +242,44 @@ func looksLikeGitHubRateLimit(output string) bool {
 		strings.Contains(lower, "secondary rate limit")
 }
 
-// looksLikeTransientGitHub matches connectivity/auth failures that keep a PR
+// looksLikeTransientGitHub matches network-level failures that keep a PR
 // creation agent from reaching GitHub at all — DNS/connection errors, TLS
-// failures, timeouts, bad/expired credentials, and 502/503 responses. These
-// are distinct from looksLikeGitHubRateLimit (which requires the substring
-// "rate limit") and are just as safe to retry once connectivity or auth is
-// restored.
+// failures, timeouts, and 502/503 responses. These are naturally time-bounded
+// (retrying once connectivity is restored is safe) and are distinct from
+// looksLikeGitHubRateLimit (requires "rate limit") and looksLikeAuthFailure
+// (credential problems, which are not naturally time-bounded).
 func looksLikeTransientGitHub(output string) bool {
 	lower := strings.ToLower(output)
 	patterns := []string{
 		"connection refused",
 		"could not resolve host",
 		"no such host",
-		"dns",
+		"temporary failure in name resolution",
 		"i/o timeout",
 		"timed out",
-		"bad credentials",
-		"authentication failed",
-		"gh auth",
-		"401 unauthorized",
 		"502 bad gateway",
 		"503 service unavailable",
 		"tls handshake",
 		"tls:",
+	}
+	for _, p := range patterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeAuthFailure matches bad/expired GitHub credentials. Unlike rate
+// limits or network blips, a broken token does not self-heal, so callers must
+// bound how many times they retry before escalating to a human.
+func looksLikeAuthFailure(output string) bool {
+	lower := strings.ToLower(output)
+	patterns := []string{
+		"bad credentials",
+		"authentication failed",
+		"gh auth",
+		"401 unauthorized",
 	}
 	for _, p := range patterns {
 		if strings.Contains(lower, p) {

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -153,9 +153,9 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 		if isPRCreationStep(last.StepID) {
 			switch {
 			case looksLikeGitHubRateLimit(last.Output):
-				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateRetryStatusReason)
+				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateRetryStatusReason, "workflow.evaluate.pr-create-rate-limit")
 			case looksLikeTransientGitHub(last.Output):
-				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateTransientStatusReason)
+				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateTransientStatusReason, "workflow.evaluate.pr-create-transient-outage")
 			case looksLikeAuthFailure(last.Output):
 				// Bad/expired credentials are not naturally time-bounded like a
 				// rate limit or a network blip, so they only get a bounded
@@ -163,7 +163,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 				attempts := parseWorkflowInt(wfExec.Variables[prCreateAuthAttemptsVar])
 				if attempts < maxPRCreateAuthRetries {
 					wfExec.SetVar(prCreateAuthAttemptsVar, strconv.Itoa(attempts+1))
-					return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateAuthRetryReason)
+					return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateAuthRetryReason, "workflow.evaluate.pr-create-auth-retry", "attempt", attempts+1, "max", maxPRCreateAuthRetries)
 				}
 				reason = fmt.Sprintf("PR creation failing due to invalid or expired GitHub credentials after %d retries", attempts)
 			}
@@ -183,18 +183,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 				attempts := parseWorkflowInt(wfExec.Variables[prCreateAttemptsVar])
 				if attempts < maxPRCreatePushedNoPRRetries {
 					wfExec.SetVar(prCreateAttemptsVar, strconv.Itoa(attempts+1))
-					wfExec.CurrentStep = last.StepID
-					wfExec.State = ExecWaiting
-					wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
-					if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-						return StepOutput{}, err
-					}
-					if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, prCreatePushedNoPRReason); statusErr != nil {
-						return StepOutput{}, statusErr
-					}
-					e.logger.Warn("workflow.evaluate.pr-create-pushed-no-pr-retry",
-						"task_id", taskID, "step", last.StepID, "attempt", attempts+1, "max", maxPRCreatePushedNoPRRetries)
-					return StepOutput{}, errStepParked
+					return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreatePushedNoPRReason, "workflow.evaluate.pr-create-pushed-no-pr-retry", "attempt", attempts+1, "max", maxPRCreatePushedNoPRRetries)
 				}
 				reason = fmt.Sprintf("commits pushed but no PR created after %d retries", attempts)
 			default:
@@ -212,7 +201,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 
 // parkStepForRetry rewinds wfExec back to stepID and persists a bounded
 // retry-after window, then parks the current evaluate step via errStepParked.
-func (e *Engine) parkStepForRetry(taskID string, wfExec *Execution, t TaskInfo, stepID, statusReason string) (StepOutput, error) {
+func (e *Engine) parkStepForRetry(taskID string, wfExec *Execution, t TaskInfo, stepID, statusReason, logEvent string, logAttrs ...any) (StepOutput, error) {
 	wfExec.CurrentStep = stepID
 	wfExec.State = ExecWaiting
 	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
@@ -222,7 +211,8 @@ func (e *Engine) parkStepForRetry(taskID string, wfExec *Execution, t TaskInfo, 
 	if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, statusReason); statusErr != nil {
 		return StepOutput{}, statusErr
 	}
-	e.logger.Warn("workflow.evaluate.pr-create-transient-outage", "task_id", taskID, "step", stepID, "reason", statusReason)
+	attrs := append([]any{"task_id", taskID, "step", stepID, "reason", statusReason}, logAttrs...)
+	e.logger.Warn(logEvent, attrs...)
 	return StepOutput{}, errStepParked
 }
 
@@ -277,14 +267,14 @@ func looksLikeGatewayStatus(lower string) bool {
 		if idx < 0 {
 			continue
 		}
-		// Guard against matching an unrelated 3-digit number embedded in a
-		// larger numeral (e.g. a PR number like "15029") by requiring the
-		// code to be flanked by non-digit boundaries.
-		if idx > 0 && isDigit(lower[idx-1]) {
+		// Guard against matching a status embedded in a larger token
+		// (e.g. "15029" or "abc502def") by requiring non-alphanumeric
+		// boundaries around the code.
+		if idx > 0 && !isStatusBoundary(lower[idx-1]) {
 			continue
 		}
 		end := idx + len(code)
-		if end < len(lower) && isDigit(lower[end]) {
+		if end < len(lower) && !isStatusBoundary(lower[end]) {
 			continue
 		}
 		return true
@@ -294,6 +284,14 @@ func looksLikeGatewayStatus(lower string) bool {
 
 func isDigit(b byte) bool {
 	return b >= '0' && b <= '9'
+}
+
+func isLowerAlpha(b byte) bool {
+	return b >= 'a' && b <= 'z'
+}
+
+func isStatusBoundary(b byte) bool {
+	return !isDigit(b) && !isLowerAlpha(b)
 }
 
 // looksLikeAuthFailure matches bad/expired GitHub credentials. Unlike rate

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -16,9 +16,12 @@ var prURLRe = regexp.MustCompile(`github\.com/[^/\s]+/[^/\s]+/pull/(\d+)`)
 var prShortRe = regexp.MustCompile(`\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#(\d+)`)
 
 const (
-	workflowRetryAfterVar     = "workflow.retry_after"
-	prCreateRetryBackoff      = 15 * time.Minute
-	prCreateRetryStatusReason = "GitHub rate limit during PR creation — retrying later"
+	workflowRetryAfterVar        = "workflow.retry_after"
+	prCreateRetryBackoff         = 15 * time.Minute
+	prCreateRetryStatusReason    = "GitHub rate limit during PR creation — retrying later"
+	prCreatePushedNoPRReason     = "commits pushed but no PR created — retrying"
+	prCreateAttemptsVar          = "workflow.pr_create_attempts"
+	maxPRCreatePushedNoPRRetries = 3
 )
 
 // execLinkPRAndReview is a non-LLM mechanical step that tries to recover the
@@ -143,7 +146,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 
 	reason := "no agent result to evaluate"
 	if last != nil {
-		if isPRCreationStep(last.StepID) && looksLikeGitHubRateLimit(last.Output) {
+		if isPRCreationStep(last.StepID) && (looksLikeGitHubRateLimit(last.Output) || looksLikeTransientGitHub(last.Output)) {
 			wfExec.CurrentStep = last.StepID
 			wfExec.State = ExecWaiting
 			wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
@@ -153,15 +156,38 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 			if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, prCreateRetryStatusReason); statusErr != nil {
 				return StepOutput{}, statusErr
 			}
-			e.logger.Warn("workflow.evaluate.pr-create-rate-limited", "task_id", taskID, "step", last.StepID)
+			e.logger.Warn("workflow.evaluate.pr-create-transient-outage", "task_id", taskID, "step", last.StepID)
 			return StepOutput{}, errStepParked
 		}
-		if last.Status == "failed" {
+		switch {
+		case last.Status == "failed":
 			reason = truncate(strings.TrimSpace(last.Output), 200)
 			if reason == "" {
 				reason = "agent failed with no output"
 			}
-		} else {
+		case isPRCreationStep(last.StepID):
+			// Agent "succeeded" (didn't self-report failure) but no PR was found
+			// by link_pr_and_review or the late gh pr list check above. The
+			// worktree/branch still exist and re-checking for a race-created PR
+			// is safe, so retry a bounded number of times before giving up.
+			attempts := parseWorkflowInt(wfExec.Variables[prCreateAttemptsVar])
+			if attempts < maxPRCreatePushedNoPRRetries {
+				wfExec.SetVar(prCreateAttemptsVar, strconv.Itoa(attempts+1))
+				wfExec.CurrentStep = last.StepID
+				wfExec.State = ExecWaiting
+				wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
+				if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+					return StepOutput{}, err
+				}
+				if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, prCreatePushedNoPRReason); statusErr != nil {
+					return StepOutput{}, statusErr
+				}
+				e.logger.Warn("workflow.evaluate.pr-create-pushed-no-pr-retry",
+					"task_id", taskID, "step", last.StepID, "attempt", attempts+1, "max", maxPRCreatePushedNoPRRetries)
+				return StepOutput{}, errStepParked
+			}
+			reason = fmt.Sprintf("commits pushed but no PR created after %d retries", attempts)
+		default:
 			reason = "commits pushed but no PR created"
 		}
 	}
@@ -187,4 +213,36 @@ func looksLikeGitHubRateLimit(output string) bool {
 		strings.Contains(lower, "gh ") ||
 		strings.Contains(lower, "api rate limit") ||
 		strings.Contains(lower, "secondary rate limit")
+}
+
+// looksLikeTransientGitHub matches connectivity/auth failures that keep a PR
+// creation agent from reaching GitHub at all — DNS/connection errors, TLS
+// failures, timeouts, bad/expired credentials, and 502/503 responses. These
+// are distinct from looksLikeGitHubRateLimit (which requires the substring
+// "rate limit") and are just as safe to retry once connectivity or auth is
+// restored.
+func looksLikeTransientGitHub(output string) bool {
+	lower := strings.ToLower(output)
+	patterns := []string{
+		"connection refused",
+		"could not resolve host",
+		"no such host",
+		"dns",
+		"i/o timeout",
+		"timed out",
+		"bad credentials",
+		"authentication failed",
+		"gh auth",
+		"401 unauthorized",
+		"502 bad gateway",
+		"503 service unavailable",
+		"tls handshake",
+		"tls:",
+	}
+	for _, p := range patterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -257,8 +257,6 @@ func looksLikeTransientGitHub(output string) bool {
 		"temporary failure in name resolution",
 		"i/o timeout",
 		"timed out",
-		"502 bad gateway",
-		"503 service unavailable",
 		"tls handshake",
 		"tls:",
 	}
@@ -267,7 +265,35 @@ func looksLikeTransientGitHub(output string) bool {
 			return true
 		}
 	}
+	return looksLikeGatewayStatus(lower)
+}
+
+// looksLikeGatewayStatus matches HTTP 502/503 responses regardless of how the
+// status is phrased ("HTTP 502", "502 bad gateway", "503 Service Unavailable",
+// ...) — GitHub/gh can surface either the bare code or a reason phrase.
+func looksLikeGatewayStatus(lower string) bool {
+	for _, code := range []string{"502", "503"} {
+		idx := strings.Index(lower, code)
+		if idx < 0 {
+			continue
+		}
+		// Guard against matching an unrelated 3-digit number embedded in a
+		// larger numeral (e.g. a PR number like "15029") by requiring the
+		// code to be flanked by non-digit boundaries.
+		if idx > 0 && isDigit(lower[idx-1]) {
+			continue
+		}
+		end := idx + len(code)
+		if end < len(lower) && isDigit(lower[end]) {
+			continue
+		}
+		return true
+	}
 	return false
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }
 
 // looksLikeAuthFailure matches bad/expired GitHub credentials. Unlike rate

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5558,6 +5558,34 @@ func newEvaluateStep() *Step {
 	return &Step{ID: "evaluate", Type: StepEvaluate}
 }
 
+func TestLooksLikeTransientGitHub(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"connection refused", "dial tcp: connection refused", true},
+		{"dns failure", "could not resolve host: api.github.com", true},
+		{"i/o timeout", "context deadline exceeded (i/o timeout)", true},
+		{"bad credentials", "gh: Bad credentials (HTTP 401)", true},
+		{"auth failed", "authentication failed for repository", true},
+		{"gh auth hint", "run gh auth login to authenticate", true},
+		{"502", "502 Bad Gateway", true},
+		{"503", "503 Service Unavailable", true},
+		{"tls handshake", "remote error: tls: handshake failure", true},
+		{"unrelated failure", "PR title does not follow conventional commit format", false},
+		{"empty", "", false},
+		{"rate limit alone handled elsewhere", "API rate limit exceeded", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksLikeTransientGitHub(tt.output); got != tt.want {
+				t.Errorf("looksLikeTransientGitHub(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
 func newEngineForEval(t *testing.T, tasks *memTasks) *Engine {
 	t.Helper()
 	store := newTestStore(t)
@@ -5674,6 +5702,102 @@ func TestExecEvaluate_PRCreateRateLimitParksForRetry(t *testing.T) {
 	}
 	if got := tasks.Reason("t1"); got != prCreateRetryStatusReason {
 		t.Errorf("reason = %q, want %q", got, prCreateRetryStatusReason)
+	}
+}
+
+func TestExecEvaluate_PRCreateTransientOutageParksForRetry(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{
+		WorkflowID:  "simple-task-pr",
+		CurrentStep: "evaluate",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+		StepHistory: []StepRecord{
+			{
+				StepID:  "create_pr",
+				Status:  "completed",
+				AgentID: "a1",
+				Output:  "Network/auth is broken: connection refused to api.github.com. Please check connectivity.",
+			},
+		},
+	}
+
+	_, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	if wfExec.CurrentStep != "create_pr" {
+		t.Errorf("CurrentStep = %q, want create_pr", wfExec.CurrentStep)
+	}
+	if wfExec.State != ExecWaiting {
+		t.Errorf("State = %q, want ExecWaiting", wfExec.State)
+	}
+	if _, ok := workflowRetryAfter(wfExec); !ok {
+		t.Errorf("%s not set to a valid retry timestamp", workflowRetryAfterVar)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "ready-pr" {
+		t.Errorf("task status = %q, want ready-pr", ti.Status)
+	}
+	if got := tasks.Reason("t1"); got != prCreateRetryStatusReason {
+		t.Errorf("reason = %q, want %q", got, prCreateRetryStatusReason)
+	}
+}
+
+func TestExecEvaluate_PRCreatePushedNoPRRetriesThenEscalates(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
+	engine := newEngineForEval(t, tasks)
+	newWfExec := func(attempts string) *Execution {
+		vars := map[string]string{}
+		if attempts != "" {
+			vars[prCreateAttemptsVar] = attempts
+		}
+		return &Execution{
+			WorkflowID:  "simple-task-pr",
+			CurrentStep: "evaluate",
+			State:       ExecRunning,
+			Variables:   vars,
+			StepHistory: []StepRecord{
+				{
+					StepID:  "create_pr",
+					Status:  "completed",
+					AgentID: "a1",
+					Output:  "I was unable to create the PR due to an unexpected issue.",
+				},
+			},
+		}
+	}
+
+	// First three attempts (0, 1, 2) park for retry and increment the counter.
+	for i := range maxPRCreatePushedNoPRRetries {
+		wfExec := newWfExec(strconv.Itoa(i))
+		_, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr"})
+		if !errors.Is(err, errStepParked) {
+			t.Fatalf("attempt %d: err = %v, want errStepParked", i, err)
+		}
+		if wfExec.Variables[prCreateAttemptsVar] != strconv.Itoa(i+1) {
+			t.Errorf("attempt %d: %s = %q, want %q", i, prCreateAttemptsVar, wfExec.Variables[prCreateAttemptsVar], strconv.Itoa(i+1))
+		}
+		if got := tasks.Reason("t1"); got != prCreatePushedNoPRReason {
+			t.Errorf("attempt %d: reason = %q, want %q", i, got, prCreatePushedNoPRReason)
+		}
+	}
+
+	// After exhausting the budget, it escalates to human-required.
+	wfExec := newWfExec(strconv.Itoa(maxPRCreatePushedNoPRRetries))
+	if _, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr"}); err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	wantReason := fmt.Sprintf("commits pushed but no PR created after %d retries", maxPRCreatePushedNoPRRetries)
+	if got := tasks.Reason("t1"); got != wantReason {
+		t.Errorf("reason = %q, want %q", got, wantReason)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5566,21 +5566,44 @@ func TestLooksLikeTransientGitHub(t *testing.T) {
 	}{
 		{"connection refused", "dial tcp: connection refused", true},
 		{"dns failure", "could not resolve host: api.github.com", true},
+		{"name resolution failure", "temporary failure in name resolution", true},
 		{"i/o timeout", "context deadline exceeded (i/o timeout)", true},
-		{"bad credentials", "gh: Bad credentials (HTTP 401)", true},
-		{"auth failed", "authentication failed for repository", true},
-		{"gh auth hint", "run gh auth login to authenticate", true},
 		{"502", "502 Bad Gateway", true},
 		{"503", "503 Service Unavailable", true},
 		{"tls handshake", "remote error: tls: handshake failure", true},
 		{"unrelated failure", "PR title does not follow conventional commit format", false},
 		{"empty", "", false},
 		{"rate limit alone handled elsewhere", "API rate limit exceeded", false},
+		{"auth failure handled elsewhere", "gh: Bad credentials (HTTP 401)", false},
+		{"bare dns mention is not a network error", "cannot title DNS cache fix", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := looksLikeTransientGitHub(tt.output); got != tt.want {
 				t.Errorf("looksLikeTransientGitHub(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeAuthFailure(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"bad credentials", "gh: Bad credentials (HTTP 401)", true},
+		{"auth failed", "authentication failed for repository", true},
+		{"gh auth hint", "run gh auth login to authenticate", true},
+		{"401", "401 Unauthorized", true},
+		{"unrelated failure", "PR title does not follow conventional commit format", false},
+		{"empty", "", false},
+		{"network failure handled elsewhere", "dial tcp: connection refused", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksLikeAuthFailure(tt.output); got != tt.want {
+				t.Errorf("looksLikeAuthFailure(%q) = %v, want %v", tt.output, got, tt.want)
 			}
 		})
 	}
@@ -5741,8 +5764,64 @@ func TestExecEvaluate_PRCreateTransientOutageParksForRetry(t *testing.T) {
 	if ti.Status != "ready-pr" {
 		t.Errorf("task status = %q, want ready-pr", ti.Status)
 	}
-	if got := tasks.Reason("t1"); got != prCreateRetryStatusReason {
-		t.Errorf("reason = %q, want %q", got, prCreateRetryStatusReason)
+	if got := tasks.Reason("t1"); got != prCreateTransientStatusReason {
+		t.Errorf("reason = %q, want %q", got, prCreateTransientStatusReason)
+	}
+}
+
+func TestExecEvaluate_PRCreateAuthFailureRetriesThenEscalates(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
+	engine := newEngineForEval(t, tasks)
+	newWfExec := func(attempts string) *Execution {
+		vars := map[string]string{}
+		if attempts != "" {
+			vars[prCreateAuthAttemptsVar] = attempts
+		}
+		return &Execution{
+			WorkflowID:  "simple-task-pr",
+			CurrentStep: "evaluate",
+			State:       ExecRunning,
+			Variables:   vars,
+			StepHistory: []StepRecord{
+				{
+					StepID:  "create_pr",
+					Status:  "completed",
+					AgentID: "a1",
+					Output:  "gh: Bad credentials (HTTP 401)",
+				},
+			},
+		}
+	}
+
+	// First three attempts (0, 1, 2) park for retry and increment the counter.
+	for i := range maxPRCreateAuthRetries {
+		wfExec := newWfExec(strconv.Itoa(i))
+		_, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr"})
+		if !errors.Is(err, errStepParked) {
+			t.Fatalf("attempt %d: err = %v, want errStepParked", i, err)
+		}
+		if wfExec.Variables[prCreateAuthAttemptsVar] != strconv.Itoa(i+1) {
+			t.Errorf("attempt %d: %s = %q, want %q", i, prCreateAuthAttemptsVar, wfExec.Variables[prCreateAuthAttemptsVar], strconv.Itoa(i+1))
+		}
+		if got := tasks.Reason("t1"); got != prCreateAuthRetryReason {
+			t.Errorf("attempt %d: reason = %q, want %q", i, got, prCreateAuthRetryReason)
+		}
+	}
+
+	// After exhausting the budget, it escalates to human-required instead of
+	// retrying a broken credential forever.
+	wfExec := newWfExec(strconv.Itoa(maxPRCreateAuthRetries))
+	if _, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr"}); err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	wantReason := fmt.Sprintf("PR creation failing due to invalid or expired GitHub credentials after %d retries", maxPRCreateAuthRetries)
+	if got := tasks.Reason("t1"); got != wantReason {
+		t.Errorf("reason = %q, want %q", got, wantReason)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5579,6 +5579,8 @@ func TestLooksLikeTransientGitHub(t *testing.T) {
 		{"auth failure handled elsewhere", "gh: Bad credentials (HTTP 401)", false},
 		{"bare dns mention is not a network error", "cannot title DNS cache fix", false},
 		{"5-digit numeral containing 502 is not a gateway status", "task 150290 failed validation", false},
+		{"letters around 502 are not a gateway status", "abc502def", false},
+		{"status glued to HTTP token is not a gateway status", "gh failed: http502", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5570,12 +5570,15 @@ func TestLooksLikeTransientGitHub(t *testing.T) {
 		{"i/o timeout", "context deadline exceeded (i/o timeout)", true},
 		{"502", "502 Bad Gateway", true},
 		{"503", "503 Service Unavailable", true},
+		{"bare HTTP 502", "gh failed: HTTP 502", true},
+		{"bare HTTP 503", "gh failed: HTTP 503", true},
 		{"tls handshake", "remote error: tls: handshake failure", true},
 		{"unrelated failure", "PR title does not follow conventional commit format", false},
 		{"empty", "", false},
 		{"rate limit alone handled elsewhere", "API rate limit exceeded", false},
 		{"auth failure handled elsewhere", "gh: Bad credentials (HTTP 401)", false},
 		{"bare dns mention is not a network error", "cannot title DNS cache fix", false},
+		{"5-digit numeral containing 502 is not a gateway status", "task 150290 failed validation", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Motivation

PR-creation steps that fail because of transient GitHub outages, auth issues, or a race where commits landed but no PR was found were escalating straight to human-required instead of retrying, even though most of these conditions are self-healing.

## Implementation information

- Add `looksLikeTransientGitHub` to detect DNS/connection/TLS/timeout errors and bare or worded 502/503 gateway responses, distinct from the existing rate-limit and auth-failure matchers.
- Add `looksLikeAuthFailure` for bad/expired credentials, with a bounded retry counter (`workflow.pr_create_auth_attempts`, max 3) since a broken token won't self-heal.
- Add a bounded retry path (`workflow.pr_create_attempts`, max 3) for the "commits pushed but no PR created" case, covering a race between the PR-creation agent and the late `gh pr list` check.
- Extract the common park/reschedule logic into `parkStepForRetry`.
- Guard the 502/503 match against false positives on embedded numerals (e.g. PR number `15029`).

## Supporting documentation

Closes https://github.com/Automaat/sybra/issues/1506

_Generated by Sybra harness_