### PR TITLE
fix(agent): correct inflated duration and cost

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -545,8 +545,14 @@ func (m *Manager) RespondEscalation(agentID string, continueRun bool) error {
 
 // recordCompletion records duration + result into the metrics pipeline.
 // Call through fireComplete — do not call directly from runner terminal sites.
+//
+// Duration is measured against the last observed stream activity, not against
+// this call's own wall-clock time: fireComplete can run long after the
+// process actually finished (reattach/stop recovering a run the app missed
+// while it was down), and time.Since(a.StartedAt) would then count that idle
+// gap as run time.
 func (m *Manager) recordCompletion(ctx context.Context, a *Agent, ok bool) {
-	dur := time.Since(a.StartedAt)
+	dur := max(a.GetLastEventAt().Sub(a.StartedAt), 0)
 	result := "ok"
 	if !ok {
 		result = "error"

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -770,6 +770,16 @@ func (a *Agent) TouchLastEvent() {
 	a.mu.Unlock()
 }
 
+// SetLastEventAt overrides the last-activity timestamp directly. Used by
+// dead-process reattach recovery, where every replayed event is stamped at
+// replay time (not history), so AppendOutput/AppendConvo would otherwise
+// collapse LastEventAt to the wall-clock moment finalization happens to run.
+func (a *Agent) SetLastEventAt(t time.Time) {
+	a.mu.Lock()
+	a.LastEventAt = t
+	a.mu.Unlock()
+}
+
 // Output returns a snapshot of the stream events produced so far. The
 // returned slice is safe to inspect concurrently with the agent's runner
 // goroutine appending more events.

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -105,6 +105,14 @@ type Agent struct {
 	// runner_convo and runner_convo_survive both firing when the process exits
 	// while a reattach tail is still live) only advance the workflow once.
 	completedOnce sync.Once
+	// costSessionID and costBaseUSD back AddResultStats' per-session cost
+	// bookkeeping. Providers report CostUSD as a cumulative total for the
+	// current session (not a per-turn delta), so a repeated session id must
+	// replace the running total rather than add to it; costBaseUSD banks the
+	// last cumulative snapshot of any prior session once a new session id
+	// appears (e.g. across a --resume segment boundary).
+	costSessionID string
+	costBaseUSD   float64
 
 	// escalationCh receives the human's decision when a guardrail is hit.
 	// true = continue, false = kill.
@@ -342,14 +350,25 @@ func (a *Agent) GetSessionFilePath() string {
 	return a.sessionFilePath
 }
 
-// AddResultStats merges a result-event's stats into the running totals
-// and returns the new cumulative CostUSD.
+// AddResultStats merges a result-event's stats into the running totals and
+// returns the new cumulative CostUSD. Token counts are genuine per-turn
+// deltas and accumulate normally. Cost is not: providers report CostUSD as
+// the cumulative total for the whole session (including every prior turn,
+// and — across a --resume segment boundary — every prior segment too), so
+// summing it turn over turn multiplies the true spend several times over.
+// A same-session event therefore replaces the running total instead of
+// adding to it; only a change in session id banks the previous session's
+// final snapshot and starts counting the new one from there.
 func (a *Agent) AddResultStats(sessionID string, cost float64, in, out, reasoning int) float64 {
 	a.mu.Lock()
 	if sessionID != "" {
 		a.SessionID = sessionID
 	}
-	a.CostUSD += cost
+	if sessionID != "" && sessionID != a.costSessionID {
+		a.costBaseUSD = a.CostUSD
+		a.costSessionID = sessionID
+	}
+	a.CostUSD = a.costBaseUSD + cost
 	a.InputTokens += in
 	a.OutputTokens += out
 	a.ReasoningTokens += reasoning

--- a/internal/agent/model_usage_test.go
+++ b/internal/agent/model_usage_test.go
@@ -11,8 +11,12 @@ func TestAgentCumulativeUsageUpdates(t *testing.T) {
 	a.AddCacheStats(5, 7)
 	a.AddPremiumRequests(0.5)
 	a.AddOutputTokens(4)
-	if got := a.AddResultStats("", 2.75, 30, 40, 6); got != 4 {
-		t.Fatalf("second cumulative cost = %v, want 4", got)
+	// Second event carries no session id — it continues session-a, whose
+	// reported cost (like every provider's total_cost_usd) is already a
+	// cumulative total for that session, so it replaces rather than adds to
+	// the first snapshot.
+	if got := a.AddResultStats("", 2.75, 30, 40, 6); got != 2.75 {
+		t.Fatalf("second cumulative cost = %v, want 2.75", got)
 	}
 	a.AddCacheStats(11, 13)
 	a.AddPremiumRequests(1.25)
@@ -21,8 +25,8 @@ func TestAgentCumulativeUsageUpdates(t *testing.T) {
 	if a.SessionID != "session-a" {
 		t.Fatalf("SessionID = %q, want session-a", a.SessionID)
 	}
-	if a.CostUSD != 4 {
-		t.Fatalf("CostUSD = %v, want 4", a.CostUSD)
+	if a.CostUSD != 2.75 {
+		t.Fatalf("CostUSD = %v, want 2.75", a.CostUSD)
 	}
 	if a.InputTokens != 40 {
 		t.Fatalf("InputTokens = %d, want 40", a.InputTokens)
@@ -41,5 +45,35 @@ func TestAgentCumulativeUsageUpdates(t *testing.T) {
 	}
 	if a.PremiumRequests != 1.75 {
 		t.Fatalf("PremiumRequests = %v, want 1.75", a.PremiumRequests)
+	}
+}
+
+// TestAgentCostUSD_SameSessionReplacesNotAdds is the regression guard for
+// the multi-segment cost inflation bug: a --resume'd provider process keeps
+// reporting the same session id, and its cost is a cumulative total for that
+// whole session (not a per-turn delta) — so successive results within one
+// session must replace the running cost, never sum on top of it.
+func TestAgentCostUSD_SameSessionReplacesNotAdds(t *testing.T) {
+	a := &Agent{}
+
+	a.AddResultStats("sess-1", 5.0, 0, 0, 0)
+	if got := a.AddResultStats("sess-1", 6.0, 0, 0, 0); got != 6.0 {
+		t.Fatalf("cost after second same-session result = %v, want 6.0 (replace, not 11.0)", got)
+	}
+	if a.CostUSD != 6.0 {
+		t.Fatalf("CostUSD = %v, want 6.0", a.CostUSD)
+	}
+}
+
+// TestAgentCostUSD_NewSessionBanksPriorTotal verifies that a genuinely new
+// session (e.g. a later resume segment that gets its own session id) adds on
+// top of the prior session's final cumulative snapshot instead of replacing
+// it outright — each session's own total is real spend that must be kept.
+func TestAgentCostUSD_NewSessionBanksPriorTotal(t *testing.T) {
+	a := &Agent{}
+
+	a.AddResultStats("sess-1", 0.10, 0, 0, 0)
+	if got := a.AddResultStats("sess-2", 0.20, 0, 0, 0); got < 0.29 || got > 0.31 {
+		t.Fatalf("cost after new-session result = %v, want ~0.30", got)
 	}
 }

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -140,6 +140,9 @@ func (m *Manager) finalizeIfCompleted(r Record) bool {
 	}
 	a := fromRecord(r)
 	rehydrateFromLog(a, r.LogPath)
+	if mt, ok := logActivityTime(r.LogPath); ok {
+		a.SetLastEventAt(mt)
+	}
 	found, isError := a.lastHeadlessResult()
 	if !found {
 		return false
@@ -277,6 +280,9 @@ func (m *Manager) reattachPerTurnConvo(r Record, reg survivalRegistry) *Agent {
 		rehydratePerTurnConvoFromLog(a, r.LogPath)
 	}
 	if r.OneShot {
+		if mt, ok := logActivityTime(r.LogPath); ok {
+			a.SetLastEventAt(mt)
+		}
 		m.finalizePerTurnOneShot(r, a, reg)
 		return nil
 	}
@@ -462,6 +468,25 @@ func rehydrateFromLog(a *Agent, path string) int64 {
 		}
 	}
 	return offset
+}
+
+// logActivityTime returns the log file's mtime: the last time the (now-dead)
+// process actually wrote to it, and the only faithful proxy for "when did
+// this run actually finish" available on the dead-process recovery path.
+// Every event replayed by rehydrateFromLog/rehydratePerTurnConvoFromLog is
+// re-stamped at replay time, so without this a run finalized long after an
+// app-downtime gap would report the full idle time as its duration. Returns
+// false if the file cannot be statted (missing path, deleted log, etc.), in
+// which case the caller falls back to the pre-fix behavior.
+func logActivityTime(path string) (time.Time, bool) {
+	if path == "" {
+		return time.Time{}, false
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return fi.ModTime(), true
 }
 
 // reattachAlive reports whether the recorded process is still the agent we

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -528,10 +528,12 @@ func TestStreamHeadlessOutput_PartialLineAtEOF(t *testing.T) {
 }
 
 // TestStreamHeadlessOutput_MultipleResultEvents pins the current semantics
-// when a provider emits more than one "result" event in a single stream.
-// Both events are recorded in the output buffer; per-run cost accumulates;
-// session_id takes the last non-empty value. Callers downstream that pick
-// the "final" result via backward scan thus see the last one.
+// when a provider emits more than one "result" event in a single stream,
+// each under a distinct session id. Both events are recorded in the output
+// buffer; the second session's final cumulative cost is banked on top of the
+// first session's (genuinely separate spend, so it adds); session_id takes
+// the last non-empty value. Callers downstream that pick the "final" result
+// via backward scan thus see the last one.
 func TestStreamHeadlessOutput_MultipleResultEvents(t *testing.T) {
 	input := `{"type":"result","result":"first","session_id":"s1","total_cost_usd":0.10,"total_input_tokens":10,"total_output_tokens":5}` + "\n" +
 		`{"type":"result","result":"second","session_id":"s2","total_cost_usd":0.20,"total_input_tokens":20,"total_output_tokens":10}` + "\n"
@@ -545,7 +547,7 @@ func TestStreamHeadlessOutput_MultipleResultEvents(t *testing.T) {
 		t.Fatalf("got %d result events, want 2 (both must be recorded). events=%+v", len(out), out)
 	}
 	if got := a.GetCostUSD(); got < 0.29 || got > 0.31 {
-		t.Errorf("GetCostUSD = %f, want ~0.30 (accumulated across both results)", got)
+		t.Errorf("GetCostUSD = %f, want ~0.30 (session s1's final cost banked, plus session s2's final cost)", got)
 	}
 	if got := a.GetSessionID(); got != "s2" {
 		t.Errorf("GetSessionID = %q, want %q (last non-empty wins)", got, "s2")
@@ -830,9 +832,11 @@ func TestGuardrails_SubagentAssistantTurnsExcluded(t *testing.T) {
 // escalationCh reply ("continue") to unblock the stream without a live
 // responder.
 func TestGuardrails_SetMidRunVisibleToStream(t *testing.T) {
-	// Result #1 below the eventual limit, result #2 pushes cumulative above.
+	// Same session both times — cost is a cumulative-per-session snapshot,
+	// so result #2's 12.0 is the real running total (not summed with #1's
+	// 5.0), and it's what must push the tightened limit.
 	input := `{"type":"result","result":"r1","session_id":"s1","total_cost_usd":5.0,"total_input_tokens":1,"total_output_tokens":1}` + "\n" +
-		`{"type":"result","result":"r2","session_id":"s1","total_cost_usd":6.0,"total_input_tokens":1,"total_output_tokens":1}` + "\n"
+		`{"type":"result","result":"r2","session_id":"s1","total_cost_usd":12.0,"total_input_tokens":1,"total_output_tokens":1}` + "\n"
 
 	var (
 		escalations int
@@ -863,7 +867,7 @@ func TestGuardrails_SetMidRunVisibleToStream(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	// Cumulative cost after both results = 11.0, > new limit 10.0.
+	// Cumulative cost after result #2 = 12.0, > new limit 10.0.
 	if escalations != 1 {
 		t.Errorf("got %d escalation events, want 1 (limit tightened mid-run should fire on result #2)", escalations)
 	}

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -586,6 +586,54 @@ func TestReattachAll_RecoversCompletedDuringDowntime(t *testing.T) {
 	}
 }
 
+// TestReattachAll_RecoversCompletedDuringDowntime_UsesLogMtimeForDuration
+// guards the dead-process recovery path against the duration bug the fix
+// targets: replaying the log stamps every event at replay time, so without
+// the fix LastEventAt collapses to the reattach wall-clock moment and a run
+// finalized after an app-downtime gap reports the full idle time as its
+// duration. The log file's mtime is the last real signal of when the
+// process actually finished, so it must win instead.
+func TestReattachAll_RecoversCompletedDuringDowntime_UsesLogMtimeForDuration(t *testing.T) {
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "comp2.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := `{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n" +
+		`{"type":"result","result":"done","session_id":"sess-9","total_cost_usd":0.2}` + "\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	// Simulate the process having actually finished writing well before this
+	// reattach runs (the app-downtime gap).
+	finishedAt := time.Now().Add(-2 * time.Hour).UTC()
+	if err := os.Chtimes(logPath, finishedAt, finishedAt); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	var completed atomic.Value
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: t.TempDir(),
+		OnComplete:        func(ag *Agent) { completed.Store(ag) },
+	})
+
+	startedAt := finishedAt.Add(-time.Minute)
+	if err := m.reg.Save(Record{ID: "comp2", TaskID: "t", Mode: "headless", Provider: "claude", PID: 0, LogPath: logPath, StartedAt: startedAt}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if got := m.ReattachAll(); len(got) != 0 {
+		t.Fatalf("expected dead record not reattached as live, got %d", len(got))
+	}
+	ag, _ := completed.Load().(*Agent)
+	if ag == nil {
+		t.Fatal("expected onComplete to fire for comp2")
+	}
+	if got := ag.GetLastEventAt(); got.Sub(finishedAt).Abs() > time.Second {
+		t.Fatalf("LastEventAt = %s, want ~%s (log mtime, not reattach wall-clock)", got, finishedAt)
+	}
+}
+
 // TestProcessHeadlessLine_CapturesSessionOnInit is the real regression
 // guard for Phase 2: the session id must be captured (and persisted to the
 // registry) on the init/system event, not only on the terminal result —

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -81,6 +81,15 @@ type AgentCompletionHandler struct {
 
 // OnComplete is called by the manager's construction-time completion callback.
 // once per terminal agent state transition.
+// runDurationSeconds measures against the last observed stream activity,
+// not finalize time: a process that emits its terminal result but lingers
+// before the agent record is finalized (reattach, stop, app restart) would
+// otherwise have that idle gap counted as run time — real runs have shown
+// multi-hour "durations" for work that took minutes.
+func runDurationSeconds(ag *agent.Agent) float64 {
+	return max(ag.GetLastEventAt().Sub(ag.StartedAt).Seconds(), 0)
+}
+
 func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	var resultContent string
 	var hasResultEvent bool
@@ -113,7 +122,7 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	// Audit logging always fires — orchestrator brain agents have no
 	// parent task and skip the storage paths below, but their lifecycle
 	// still belongs in the audit trail.
-	duration := time.Since(ag.StartedAt).Seconds()
+	duration := runDurationSeconds(ag)
 	auditData := map[string]any{
 		"mode":       ag.Mode,
 		"cost_usd":   cost,


### PR DESCRIPTION
## Motivation

Agent duration and cost stats were inflated in two independent ways:

- Duration was computed as `time.Since(StartedAt)` at finalize time, so a process that lingers after emitting its terminal result (reattach, stop, app restart, or a dead-process recovery after app downtime) had that idle gap counted as run time — real runs have shown multi-hour "durations" for work that took minutes.
- Cost was double-counted because `AddResultStats` summed each result event's `CostUSD`, but providers report it as a cumulative total for the whole session, not a per-turn delta — repeated results within one session (including across `--resume` segments) multiplied the true spend.

## Implementation information

- Both duration sites (task-level stats and the agent-completion metric) now use `LastEventAt`, the timestamp of the last observed stream activity, instead of finalize-time wall clock.
- For the dead-process reattach path, every replayed event is re-stamped at replay time, so `LastEventAt` is additionally corrected using the log file's mtime (the last real signal of when the process actually finished).
- `AddResultStats` now tracks the current session id: a same-session result replaces the running cost instead of adding to it; only a genuinely new session id banks the prior session's final total before counting the new one.
- Added regression tests for same-session cost replacement, new-session cost banking, and log-mtime-based duration recovery on the dead-process reattach path.

Closes https://github.com/Automaat/sybra/issues/1488

_Generated by Sybra harness_