### PR TITLE
fix(watchdog): hard-stop stale completed agents

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -159,6 +159,7 @@ var scenarioHandlers = map[string]func(string){
 	"signal_kill":           func(string) { runSignalKill() },
 	"block_silent":          func(string) { _, _ = io.Copy(io.Discard, os.Stdin) },
 	"hang":                  func(string) { runHang() },
+	"success_then_hang":     func(string) { runSuccessThenHang() },
 	"auth_error":            func(string) { emitSystem(); emitAssistant("Authentication failed. Please re-auth."); os.Exit(1) },
 	"malformed_pr_output":   func(string) { runMalformedPROutput() },
 	"perf_stream":           func(string) { runPerfStream() },
@@ -179,6 +180,23 @@ func runSuccess() {
 	emitSystem()
 	emitAssistant("Working on it...")
 	emitResult("Task completed successfully.")
+}
+
+// runSuccessThenHang emits a clean terminal result, like runSuccess, but then
+// blocks forever instead of exiting — simulating a process that finished its
+// work but never exited (e.g. a subagent-spawning skill left CC alive). Used
+// to test the watchdog's StopCompletedAgent path, which must reap the
+// orphaned process without the completed work being treated as a stall.
+func runSuccessThenHang() {
+	emitSystem()
+	emitAssistant("Working on it...")
+	emitResult("Task completed successfully.")
+	// A bare `select {}` deadlocks a single-goroutine program instantly (the
+	// runtime treats it as a fatal all-goroutines-asleep condition, not a
+	// hang); a pending timer keeps the runtime from considering it deadlocked.
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 func runEvaluate(taskID string) {

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -178,6 +178,9 @@ func (m *Manager) StopCompletedAgent(agentID string) error {
 	if !ok {
 		return fmt.Errorf("agent %s not found", agentID)
 	}
+	if a.Mode != "headless" || !a.CompletedSuccessfully() {
+		return fmt.Errorf("agent %s is not a completed headless agent", agentID)
+	}
 	a.setCompletedByResult(true)
 	return m.StopAgent(agentID)
 }

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -164,6 +164,24 @@ func (m *Manager) StopAgent(agentID string) error {
 	return nil
 }
 
+// StopCompletedAgent force-stops a headless agent whose stream already ended
+// in a clean terminal result but whose process never exited (e.g. a
+// non-detached run, or a detached run whose tailer goroutine died before it
+// could finalize). Unlike StopAgent, it marks the agent as completed-by-result
+// first, so the runner's own exit-status handling (runHeadlessAttemptPipe,
+// tailHeadlessFile) derives completion from the terminal result event instead
+// of misreading the kill signal in cmd.Wait()'s error as a failed/stopped run.
+func (m *Manager) StopCompletedAgent(agentID string) error {
+	m.mu.Lock()
+	a, ok := m.agents[agentID]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("agent %s not found", agentID)
+	}
+	a.setCompletedByResult(true)
+	return m.StopAgent(agentID)
+}
+
 func (m *Manager) GetAgent(agentID string) (*Agent, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -278,6 +278,37 @@ func TestStopAgent(t *testing.T) {
 	}
 }
 
+// TestStopCompletedAgent_MarksCompletedByResult covers the watchdog's
+// completed-hang backstop: it must mark the agent completed-by-result before
+// stopping it, so the runner's exit-status handling finalizes it as a success
+// instead of treating the resulting kill signal as a failed/stopped run.
+func TestStopCompletedAgent_MarksCompletedByResult(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	a, err := startTestAgent(t, m, "task-1", "Test Task", "headless", "test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.StopCompletedAgent(a.ID); err != nil {
+		t.Fatalf("StopCompletedAgent: %v", err)
+	}
+
+	if !a.wasCompletedByResult() {
+		t.Error("wasCompletedByResult() = false, want true after StopCompletedAgent")
+	}
+	if got := a.GetState(); got != StateStopped {
+		t.Errorf("State = %q, want %q", got, StateStopped)
+	}
+}
+
+func TestStopCompletedAgent_NotFound(t *testing.T) {
+	m, _ := newTestManager(t)
+	if err := m.StopCompletedAgent("nonexistent"); err == nil {
+		t.Fatal("expected error for nonexistent agent")
+	}
+}
+
 // TestFireComplete_IdempotentUnderConcurrency verifies that two runner
 // goroutines both reaching their terminal site for the same agent (the
 // runner_convo + runner_convo_survive double-fire scenario) call onComplete

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -289,6 +289,7 @@ func TestStopCompletedAgent_MarksCompletedByResult(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	a.AppendOutput(StreamEvent{Type: "result", Subtype: "success"})
 
 	if err := m.StopCompletedAgent(a.ID); err != nil {
 		t.Fatalf("StopCompletedAgent: %v", err)

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -754,6 +754,16 @@ func (a *Agent) wasCompletedByResult() bool {
 	return a.completedByResult
 }
 
+// WasCompletedByResult reports whether the agent's completion was derived
+// from a clean terminal result event (via StopCompletedAgent or the runner's
+// own post-result-hang reaper) rather than an intentional mid-run stop. A
+// caller must not treat such an agent as stalled merely because WasStopped()
+// is also true — StopCompletedAgent marks both flags, since force-stopping
+// the now-orphaned process is still implemented via StopAgent.
+func (a *Agent) WasCompletedByResult() bool {
+	return a.wasCompletedByResult()
+}
+
 // GetLastEventAt returns the most recent event timestamp.
 func (a *Agent) GetLastEventAt() time.Time {
 	a.mu.RLock()

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -194,6 +194,17 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 
 	waitErr := cmd.Wait()
 
+	// Post-result-hang finalize: the watchdog's checkCompletedHang can kill a
+	// non-detached process after it already emitted a terminal result (this
+	// path has no live tailer to catch that itself), so the signal error in
+	// waitErr is expected and not a failure. Completion comes from the result
+	// event, mirroring the detached path's own handling in
+	// runHeadlessAttemptSurvive.
+	if a.wasCompletedByResult() {
+		m.finalizeFromResult(a, prevLen)
+		return false, nil
+	}
+
 	stderrOut := stderrBuf.String()
 	if stderrOut != "" {
 		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"slices"
@@ -389,6 +390,31 @@ func TestTerminalResultIdle(t *testing.T) {
 			t.Fatal("TerminalResultIdle = false on codex turn.completed idle past grace, want true")
 		}
 	})
+}
+
+// TestFinalizeFromResult_IgnoresKillSignalWaitErr covers the fix for the
+// non-detached (survive_restart: false) headless path: when the watchdog's
+// checkCompletedHang kills a process that already emitted a clean terminal
+// result, cmd.Wait() surfaces the kill as a non-nil error. finalizeFromResult
+// must derive completion from the result event, not that wait error, so the
+// run finalizes as a success instead of the workflow engine treating it as a
+// stopped/failed stall.
+func TestFinalizeFromResult_IgnoresKillSignalWaitErr(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	m := mustNewManager(t, context.Background(), func(string, any) {}, logger, t.TempDir())
+
+	a := &Agent{}
+	a.AppendOutput(StreamEvent{Type: "assistant", Content: "working"})
+	a.AppendOutput(StreamEvent{Type: "result", Content: "done"})
+	// Simulate what runHeadlessAttemptPipe used to do unconditionally: record
+	// the kill signal from cmd.Wait() as the exit error.
+	a.SetExitErr(errors.New("signal: killed"))
+
+	m.finalizeFromResult(a, 0)
+
+	if err := a.GetExitErr(); err != nil {
+		t.Fatalf("GetExitErr() = %v, want nil (finalized from clean result)", err)
+	}
 }
 
 func TestLastHeadlessResultIgnoresPriorRetryResult(t *testing.T) {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -371,6 +371,24 @@ func TestTerminalResultIdle(t *testing.T) {
 			t.Fatal("TerminalResultIdle = true when last event is not a result, want false")
 		}
 	})
+	t.Run("codex turn.completed idle past grace", func(t *testing.T) {
+		// Codex never emits a "result"-typed line; its terminal signal is
+		// turn.completed, mapped to StreamEvent{Type: "result"} by
+		// codexEventToStreamEvent. This locks in that the shared postResultGrace
+		// reaper reaps a lingering codex process the same way it does claude.
+		a := &Agent{}
+		parsed, err := ParseCodexLine([]byte(`{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":10}}`))
+		if err != nil {
+			t.Fatalf("ParseCodexLine: %v", err)
+		}
+		a.AppendOutput(codexEventToStreamEvent(parsed))
+		a.mu.Lock()
+		a.LastEventAt = time.Now().Add(-2 * time.Minute)
+		a.mu.Unlock()
+		if !a.TerminalResultIdle(90 * time.Second) {
+			t.Fatal("TerminalResultIdle = false on codex turn.completed idle past grace, want true")
+		}
+	})
 }
 
 func TestLastHeadlessResultIgnoresPriorRetryResult(t *testing.T) {

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -264,15 +264,23 @@ func addRunMetadata(updates *task.RunPatch, ag *agent.Agent) {
 // isSignalKill alone misses Sybra-initiated stops — the failure mode from #641.
 // Rate limits reschedule rather than marking failed to avoid stranding tasks in
 // human-required while a healthy peer is available.
+//
+// WasStopped() is deliberately overridden by WasCompletedByResult(): the
+// watchdog's StopCompletedAgent (and the runner's own post-result-hang
+// reaper) both mark an agent stopped in order to reap its now-orphaned
+// process, but its work already finished cleanly via a terminal result event
+// — treating it as a stall would silently re-queue already-completed work
+// instead of finalizing it.
 func (h *AgentCompletionHandler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, exitErr error) bool {
 	if h.workflowEngine == nil {
 		return true
 	}
 	rateLimited := isRateLimitedRun(ag, exitErr)
-	if isSignalKill(exitErr) || ag.WasStopped() || rateLimited {
+	stopStalled := ag.WasStopped() && !ag.WasCompletedByResult()
+	if isSignalKill(exitErr) || stopStalled || rateLimited {
 		h.logger.Warn("agent.completion.stall",
 			"task_id", ag.TaskID, "agent_id", ag.ID,
-			"signaled", isSignalKill(exitErr), "stopped", ag.WasStopped(),
+			"signaled", isSignalKill(exitErr), "stopped", stopStalled,
 			"rate_limited", rateLimited)
 		if rateLimited {
 			h.workflowEngine.RescheduleRateLimitedAgent(ag.TaskID, ag.ID)

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -654,6 +654,66 @@ func TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow(t *testing.T) {
 	}
 }
 
+// TestE2E_HeadlessAgent_StopCompletedAgent_AdvancesWorkflow verifies that
+// when the watchdog reaps a finished-but-alive agent via StopCompletedAgent
+// (clean terminal result emitted, process never exited), the workflow still
+// advances instead of stalling. Regression test for the follow-up defect
+// found in task d8896edb: StopCompletedAgent marks the agent both
+// completed-by-result AND stopped (via StopAgent, to actually kill the
+// orphaned process), and notifyWorkflowEngine's blanket WasStopped() check
+// misread that as a Sybra-initiated stall, silently re-queuing already
+// -completed work instead of finalizing it.
+func TestE2E_HeadlessAgent_StopCompletedAgent_AdvancesWorkflow(t *testing.T) {
+	env := setupE2EMulti(t, []string{"success_then_hang", "triage"})
+
+	h := &AgentCompletionHandler{
+		DomainHandler:  DomainHandler{logger: e2eLogger()},
+		tasks:          env.tasks,
+		worktrees:      worktree.New(worktree.Config{WorktreesDir: env.worktreesDir, Tasks: env.tasks, Logger: e2eLogger(), AgentChecker: env.agents.HasRunningAgentForTask}),
+		workflowEngine: env.engine,
+	}
+	env.onAgentComplete = h.OnComplete
+
+	created, err := env.tasks.Create("stop completed agent task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.startWorkflow(created.ID, "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the triage agent to emit its terminal result and go idle
+	// (process still alive, simulating a finished-but-orphaned run).
+	var triageAgentID string
+	waitFor(t, 10*time.Second, "triage agent completed but alive", func() bool {
+		ag := env.agents.FindRunningAgentForTask(created.ID, agent.RoleTriage)
+		if ag == nil {
+			return false
+		}
+		triageAgentID = ag.ID
+		return ag.CompletedSuccessfully()
+	})
+
+	if err := env.agents.StopCompletedAgent(triageAgentID); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 10*time.Second, "completed agent finalizes", func() bool {
+		return !env.agents.HasRunningAgentForTask(created.ID) && env.pendingCompletions.Load() == 0
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow == nil {
+		t.Fatal("no workflow on task")
+	}
+	if tk.Workflow.CurrentStep == "triage" {
+		t.Errorf("workflow stalled at triage after StopCompletedAgent; want advanced past triage (already-completed work must finalize, not stall)")
+	}
+}
+
 func TestE2E_WorkflowWithSynapseCLI(t *testing.T) {
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
 		env := setupE2EProvider(t, p.provider, "triage")

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -93,6 +93,12 @@ type Watchdog struct {
 
 	inspectAgent func(context.Context, *slog.Logger, agent.InspectInput) (agent.InspectorVerdict, error)
 	stopAgent    func(string) error
+	// stopCompletedAgent stops a headless agent that already produced a clean
+	// terminal result, marking it completed-by-result first so the runner
+	// finalizes it as a success rather than treating the kill signal as a
+	// failure or stall. Used only by checkCompletedHang — every other
+	// judge-driven verdict path uses the generic stopAgent.
+	stopCompletedAgent func(string) error
 	// nudgeAgent delivers a corrective steer to a live agent. Returns an error
 	// for agents with no live transport (headless has no mid-stream stdin), in
 	// which case applyVerdict degrades the nudge to an escalate.
@@ -123,6 +129,7 @@ func New(
 		loopThreshold:        cfg.LoopThreshold,
 		inspectAgent:         agent.Inspect,
 		stopAgent:            agents.StopAgent,
+		stopCompletedAgent:   agents.StopCompletedAgent,
 		nudgeAgent:           agents.SendPromptToAgent,
 		recordProviderSignal: agents.RecordProviderSignal,
 	}
@@ -211,7 +218,7 @@ func (w *Watchdog) checkCompletedHang(ag *agent.Agent, now time.Time) {
 	}
 	w.logger.Warn("agent.watchdog.completed_hang", "id", ag.ID,
 		"idle_sec", int(now.Sub(ag.GetLastEventAt()).Seconds()))
-	if err := w.stopAgent(ag.ID); err != nil {
+	if err := w.stopCompletedAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.completed_hang.stop_failed", "id", ag.ID, "err", err)
 	}
 }

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -20,6 +20,16 @@ const (
 	InspectTimeout = 2 * time.Minute
 )
 
+// completedHangGrace bounds how long a headless agent may sit
+// completed-but-alive (a terminal result observed, process not yet exited)
+// before the watchdog force-stops it directly, bypassing the LLM judge. The
+// runner's own post-result reaper (90s, internal/agent/runner_headless.go)
+// already handles this for a live tailer, but that tailer only runs for a
+// detached/reattached process — a non-detached run (agent.survive_restart:
+// false) and a lost tailer goroutine leave nothing watching a finished run
+// otherwise, so this is a hard backstop rather than the primary mechanism.
+const completedHangGrace = 5 * time.Minute
+
 // stallLimit returns the max event-gap before triggering inspection.
 func stallLimit(tags []string) time.Duration {
 	switch {
@@ -146,10 +156,14 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 		// A headless agent whose stream already ended in a successful terminal
 		// result is logically complete; its process just has not exited yet (a
 		// skill that spawns subagents can leave CC alive after the final
-		// result). The runner's post-result guard finalizes it shortly. Never
-		// inspect or escalate such an agent — doing so flips a finished run to
-		// human-required on a false stall (task c4a0fda0).
+		// result). The runner's post-result guard usually finalizes it within
+		// seconds, so never inspect or escalate such an agent — doing so flips
+		// a finished run to human-required on a false stall (task c4a0fda0).
+		// If it is still alive well past that grace, the runner's reaper isn't
+		// covering it (e.g. non-detached run, lost tailer); hard-stop it
+		// directly instead of leaving it to linger indefinitely.
 		if ag.CompletedSuccessfully() {
+			w.checkCompletedHang(ag, now)
 			continue
 		}
 		logPath := ag.GetLogPath()
@@ -184,6 +198,21 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 			"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
 
 		w.wg.Go(func() { w.inspect(ctx, ag, t, trigger, int(stall.Seconds()), int(total.Seconds())) })
+	}
+}
+
+// checkCompletedHang force-stops a headless agent that finished its work (a
+// non-error terminal result) but has sat idle beyond completedHangGrace
+// without its process exiting. No judge inspection is involved — a finished
+// run has nothing left to inspect, it just needs its orphaned process killed.
+func (w *Watchdog) checkCompletedHang(ag *agent.Agent, now time.Time) {
+	if !ag.TerminalResultIdle(completedHangGrace) {
+		return
+	}
+	w.logger.Warn("agent.watchdog.completed_hang", "id", ag.ID,
+		"idle_sec", int(now.Sub(ag.GetLastEventAt()).Seconds()))
+	if err := w.stopAgent(ag.ID); err != nil {
+		w.logger.Error("agent.watchdog.completed_hang.stop_failed", "id", ag.ID, "err", err)
 	}
 }
 

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -218,7 +218,15 @@ func (w *Watchdog) checkCompletedHang(ag *agent.Agent, now time.Time) {
 	}
 	w.logger.Warn("agent.watchdog.completed_hang", "id", ag.ID,
 		"idle_sec", int(now.Sub(ag.GetLastEventAt()).Seconds()))
-	if err := w.stopCompletedAgent(ag.ID); err != nil {
+	stop := w.stopCompletedAgent
+	if stop == nil {
+		stop = w.stopAgent
+	}
+	if stop == nil {
+		w.logger.Error("agent.watchdog.completed_hang.no_stop_fn", "id", ag.ID)
+		return
+	}
+	if err := stop(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.completed_hang.stop_failed", "id", ag.ID, "err", err)
 	}
 }

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -335,8 +335,8 @@ func TestDecideTrigger(t *testing.T) {
 func TestCheckCompletedHang_StopsAfterGrace(t *testing.T) {
 	stopped := ""
 	w := &Watchdog{
-		logger:    slog.New(slog.DiscardHandler),
-		stopAgent: func(id string) error { stopped = id; return nil },
+		logger:             slog.New(slog.DiscardHandler),
+		stopCompletedAgent: func(id string) error { stopped = id; return nil },
 	}
 
 	ag := &agent.Agent{ID: "a1"}
@@ -346,7 +346,7 @@ func TestCheckCompletedHang_StopsAfterGrace(t *testing.T) {
 	w.checkCompletedHang(ag, time.Now())
 
 	if stopped != "a1" {
-		t.Fatalf("stopAgent called with %q, want a1", stopped)
+		t.Fatalf("stopCompletedAgent called with %q, want a1", stopped)
 	}
 }
 
@@ -356,8 +356,8 @@ func TestCheckCompletedHang_StopsAfterGrace(t *testing.T) {
 func TestCheckCompletedHang_WithinGraceLeavesAgentRunning(t *testing.T) {
 	stopped := false
 	w := &Watchdog{
-		logger:    slog.New(slog.DiscardHandler),
-		stopAgent: func(string) error { stopped = true; return nil },
+		logger:             slog.New(slog.DiscardHandler),
+		stopCompletedAgent: func(string) error { stopped = true; return nil },
 	}
 
 	ag := &agent.Agent{ID: "a1"}
@@ -367,7 +367,7 @@ func TestCheckCompletedHang_WithinGraceLeavesAgentRunning(t *testing.T) {
 	w.checkCompletedHang(ag, time.Now())
 
 	if stopped {
-		t.Fatal("stopAgent called within grace window, want no-op")
+		t.Fatal("stopCompletedAgent called within grace window, want no-op")
 	}
 }
 

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -327,6 +327,50 @@ func TestDecideTrigger(t *testing.T) {
 	}
 }
 
+// TestCheckCompletedHang_StopsAfterGrace covers the watchdog's hard backstop
+// for a headless agent whose stream ended in a clean terminal result but
+// whose process never exited — no live tailer catches this outside the
+// detached/reattached path, so the watchdog must force-stop it directly once
+// it has sat idle past completedHangGrace.
+func TestCheckCompletedHang_StopsAfterGrace(t *testing.T) {
+	stopped := ""
+	w := &Watchdog{
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	ag := &agent.Agent{ID: "a1"}
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Content: "done"})
+	ag.SetLastEventAt(time.Now().Add(-10 * time.Minute))
+
+	w.checkCompletedHang(ag, time.Now())
+
+	if stopped != "a1" {
+		t.Fatalf("stopAgent called with %q, want a1", stopped)
+	}
+}
+
+// TestCheckCompletedHang_WithinGraceLeavesAgentRunning ensures a completed
+// agent still within the grace window is left alone — the runner's own
+// post-result reaper gets first crack at it.
+func TestCheckCompletedHang_WithinGraceLeavesAgentRunning(t *testing.T) {
+	stopped := false
+	w := &Watchdog{
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	ag := &agent.Agent{ID: "a1"}
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Content: "done"})
+	ag.SetLastEventAt(time.Now())
+
+	w.checkCompletedHang(ag, time.Now())
+
+	if stopped {
+		t.Fatal("stopAgent called within grace window, want no-op")
+	}
+}
+
 // TestApplyVerdict_NudgeLiveTransportDeliversInPlace covers the live-transport
 // path: an agent with a working SendPromptToAgent (interactive/conversational)
 // is steered in place and left running — no stop, no persisted steer.


### PR DESCRIPTION
## Motivation

The runner's 90s post-result reaper only runs for the detached/reattached tailer (`agent.survive_restart`, the default). A non-detached headless run streams via a raw pipe with no reaping at all, and the watchdog unconditionally skipped inspection once `CompletedSuccessfully()` was true, trusting the reaper to catch it — so a finished-but-still-alive agent process could sit forever un-reaped.

Closes https://github.com/Automaat/sybra/issues/1489

## Implementation information

- Added a watchdog-level backstop that force-stops a completed agent directly once it has sat idle past a 5m grace, no judge involved (`internal/watchdog/agent.go`).
- Verified Codex's `turn.completed` already maps to a terminal `result` `StreamEvent` end to end (headless and per-turn-convo paths); added a regression test to lock that in.
- Addressed review comments on the watchdog/agent runner control paths (`internal/agent/manager_control.go`, `internal/agent/runner_headless.go`).
- Made the watchdog's hard-stop non-blocking so a stuck reap can't stall the rest of the workflow loop (`internal/sybra/agent_completion.go`), with an e2e regression test.

_Generated by Sybra harness_