### PR TITLE
fix(workflow): gate critique addr, cap replan

### DIFF
--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -440,6 +440,27 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - goto: route_critique_verdict
+
+  # The critic's own output format (see the plan-critic skill) is
+  # `# Plan Review: <APPROVE|REFINE|REJECT>`. An APPROVE verdict means the
+  # plan is executable as-is — routing straight to human review skips a
+  # second full opus address_critique run that would otherwise revise a
+  # plan the critic already signed off on.
+  - id: route_critique_verdict
+    name: Route on Critique Verdict
+    type: condition
+    config:
+      check:
+        field: task.plan_critique
+        operator: contains
+        value: 'Plan Review: APPROVE'
+    next:
+      - when:
+          field: task.plan_critique
+          operator: contains
+          value: 'Plan Review: APPROVE'
+        goto: review_plan
       - goto: reset_for_address
 
   - id: reset_for_address
@@ -587,7 +608,41 @@ steps:
           field: vars.human_action
           operator: equals
           value: reject
+        goto: check_replan_cap
+
+  # The human-reject loop (review_plan reject -> start_replan -> plan) is
+  # gated only by a human clicking reject each time; the engine's per-advance
+  # cycle detector can't span wait_human suspensions. task.replan_count is
+  # start_replan's own step-history count as of this reject, so 0/1/2 means
+  # start_replan has run at most twice before — allow one more full opus
+  # replan cycle (cap: 3 total). Past that, stop burning opus runs on a plan
+  # a human keeps rejecting and hand it to a human directly.
+  - id: check_replan_cap
+    name: Check Replan Cap
+    type: condition
+    config:
+      check:
+        field: task.replan_count
+        operator: in
+        value: '0,1,2'
+    next:
+      - when:
+          field: task.replan_count
+          operator: in
+          value: '0,1,2'
         goto: start_replan
+      - goto: replan_cap_exceeded
+
+  - id: replan_cap_exceeded
+    name: Replan Cap Exceeded
+    type: set_status
+    config:
+      status: human-required
+      status_reason: >-
+        Plan rejected by human 3 times in a row — stopping the automated
+        replan loop before a 4th opus run. Needs a human to re-plan directly.
+    next:
+      - goto: ""
 
   # Reset status before re-entering `plan` so the plan-review status-change
   # hook fires again when the agent delivers a revised plan. Without this

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -115,6 +115,131 @@ func TestBuiltinSimpleTask_MissingCritiqueSkipsToHumanReview(t *testing.T) {
 	}
 }
 
+// TestBuiltinSimpleTask_RouteCritiqueVerdictSkipsAddressOnApprove locks the
+// behavior that an APPROVE plan-critique verdict routes straight to
+// review_plan, skipping the second full opus address_critique run — that
+// run only makes sense when the critic asked for changes.
+func TestBuiltinSimpleTask_RouteCritiqueVerdictSkipsAddressOnApprove(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-plan" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-plan builtin definition not found")
+	}
+	step := simple.StepByID("route_critique_verdict")
+	if step == nil {
+		t.Fatal("route_critique_verdict step not found in simple-task-plan")
+	}
+
+	cases := []struct {
+		name         string
+		planCritique string
+		want         string
+	}{
+		{
+			name:         "approve_skips_address_critique",
+			planCritique: "# Plan Review: APPROVE\n\n## Verdict\n\nExecutable as-is.\n",
+			want:         "review_plan",
+		},
+		{
+			name:         "refine_routes_to_address_critique",
+			planCritique: "# Plan Review: REFINE\n\n## Verdict\n\nNeeds targeted edits.\n",
+			want:         "reset_for_address",
+		},
+		{
+			name:         "reject_routes_to_address_critique",
+			planCritique: "# Plan Review: REJECT\n\n## Verdict\n\nUngrounded.\n",
+			want:         "reset_for_address",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, map[string]string{
+				"task.plan_critique": tc.planCritique,
+			})
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuiltinSimpleTask_ReplanCapEscalatesAfterThreeRejects locks the replan
+// iteration cap: task.replan_count is start_replan's own step-history count
+// as of the current reject, so 0/1/2 still have budget for another full
+// opus replan cycle, and 3+ hands the task to a human instead of burning a
+// 4th opus run on a plan the human keeps rejecting.
+func TestBuiltinSimpleTask_ReplanCapEscalatesAfterThreeRejects(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-plan" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-plan builtin definition not found")
+	}
+	step := simple.StepByID("check_replan_cap")
+	if step == nil {
+		t.Fatal("check_replan_cap step not found in simple-task-plan")
+	}
+
+	cases := []struct {
+		name        string
+		replanCount string
+		want        string
+	}{
+		{name: "first_reject_under_cap", replanCount: "0", want: "start_replan"},
+		{name: "second_reject_under_cap", replanCount: "1", want: "start_replan"},
+		{name: "third_reject_under_cap", replanCount: "2", want: "start_replan"},
+		{name: "fourth_reject_hits_cap", replanCount: "3", want: "replan_cap_exceeded"},
+		{name: "well_past_cap", replanCount: "9", want: "replan_cap_exceeded"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, map[string]string{
+				"task.replan_count": tc.replanCount,
+			})
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	exceeded := simple.StepByID("replan_cap_exceeded")
+	if exceeded == nil {
+		t.Fatal("replan_cap_exceeded step not found in simple-task-plan")
+	}
+	if exceeded.Config.Status != "human-required" {
+		t.Errorf("replan_cap_exceeded status = %q, want human-required", exceeded.Config.Status)
+	}
+}
+
 func TestBuiltinSimpleTask_AddressCritiqueRevalidatesPlanArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -28,6 +28,8 @@ var KnownTriggerFields = map[string]bool{
 	"task.branch":                  true,
 	"task.pr_number":               true,
 	"task.reviewed":                true,
+	"task.plan_critique":           true,
+	"task.replan_count":            true,
 	// Supplied as extras by DispatchEvent("pr.event", ...) callers in
 	// app_reviews.go and svc_integrations.go.
 	"pr.issue_kind": true,

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -603,9 +603,18 @@ func taskFields(t TaskInfo) map[string]string {
 		"task.handoff_source_provider": t.HandoffSourceProvider,
 		"task.branch":                  t.Branch,
 		"task.reviewed":                strconv.FormatBool(t.Reviewed),
+		"task.plan_critique":           t.PlanCritique,
 	}
 	if t.PRNumber > 0 {
 		fields["task.pr_number"] = strconv.Itoa(t.PRNumber)
+	}
+	// start_replan's own step-history count: how many times a human-rejected
+	// plan has already been sent back through the full plan→critique→address
+	// cycle. Populated from t.Workflow (the just-recorded execution state) so
+	// simple-task-plan.yaml's replan cap gate sees the count as of the current
+	// reject, before this cycle's start_replan runs.
+	if t.Workflow != nil {
+		fields["task.replan_count"] = strconv.Itoa(t.Workflow.CountStep("start_replan"))
 	}
 	return fields
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -22,6 +22,42 @@ import (
 	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
+// TestTaskFields_PlanCritiqueAndReplanCount locks the two fields the
+// simple-task-plan replan/critique gates depend on: task.plan_critique
+// mirrors TaskInfo.PlanCritique verbatim (route_critique_verdict substring-
+// matches its verdict heading), and task.replan_count is start_replan's own
+// step-history count as of the current call — the number of full opus
+// replan cycles already spent, not counting the one about to start.
+func TestTaskFields_PlanCritiqueAndReplanCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plan_critique mirrors TaskInfo verbatim", func(t *testing.T) {
+		ti := TaskInfo{ID: "t1", PlanCritique: "# Plan Review: APPROVE\n"}
+		fields := taskFields(ti)
+		if got := fields["task.plan_critique"]; got != ti.PlanCritique {
+			t.Errorf("task.plan_critique = %q, want %q", got, ti.PlanCritique)
+		}
+	})
+
+	t.Run("replan_count absent without a workflow", func(t *testing.T) {
+		fields := taskFields(TaskInfo{ID: "t1"})
+		if _, ok := fields["task.replan_count"]; ok {
+			t.Errorf("task.replan_count = %q, want absent when Workflow is nil", fields["task.replan_count"])
+		}
+	})
+
+	t.Run("replan_count reflects start_replan history", func(t *testing.T) {
+		wf := &Execution{}
+		wf.RecordStep(StepRecord{StepID: "start_replan", Status: "completed"})
+		wf.RecordStep(StepRecord{StepID: "start_replan", Status: "completed"})
+		ti := TaskInfo{ID: "t1", Workflow: wf}
+		fields := taskFields(ti)
+		if got := fields["task.replan_count"]; got != "2" {
+			t.Errorf("task.replan_count = %q, want %q", got, "2")
+		}
+	})
+}
+
 // --- Test helpers ---
 
 func init() {


### PR DESCRIPTION
## Motivation

The plan workflow always re-ran a full opus address_critique pass even when the plan-critic already returned APPROVE, wasting a model run. It also had no ceiling on the human-reject replan loop, letting a task cycle through opus planning indefinitely instead of escalating to a human.

## Implementation information

- Skip the address_critique step when plan-critic already approved the plan.
- Cap the human-reject replan loop at 3 iterations before routing the task to human-required.
- Add workflow condition/engine support and builtin plan test coverage for both changes.

Closes https://github.com/Automaat/sybra/issues/1490

_Generated by Sybra harness_