### PR TITLE
feat(agent): bias routing toward codex/copilot

### DIFF
--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -7,7 +7,25 @@ type Config struct {
 	Enabled              *bool        `yaml:"enabled" json:"enabled"`
 	MinSamplesPerVariant int          `yaml:"min_samples_per_variant" json:"minSamplesPerVariant"`
 	Experiments          []Experiment `yaml:"experiments" json:"experiments"`
+	// BuiltinVersion stamps which generation of DefaultConfig's built-in
+	// experiments a persisted config has adopted. config.applyABTestingDefaults
+	// bumps a lagging config's built-in experiments (see BuiltinExperimentIDs)
+	// up to CurrentBuiltinVersion, leaving any other (user-authored) experiment
+	// untouched.
+	BuiltinVersion int `yaml:"builtin_version,omitempty" json:"builtinVersion,omitempty"`
 }
+
+// CurrentBuiltinVersion is the version stamp for the built-in experiment set
+// returned by DefaultConfig. Bump this whenever the built-in experiments'
+// roles, variants, or weights change in a way that persisted configs should
+// pick up automatically.
+const CurrentBuiltinVersion = 2
+
+// BuiltinExperimentIDs lists the experiment IDs owned by Sybra's shipped
+// defaults. A persisted config's experiment is only replaced during a builtin
+// reconcile if its ID appears here — every other experiment ID is treated as
+// user-authored and preserved verbatim.
+var BuiltinExperimentIDs = []string{"code-author-cheap", "code-author-maintenance-cheap", "review-expensive"}
 
 // Experiment selects among variants for matching workflow roles.
 type Experiment struct {
@@ -64,27 +82,65 @@ type Assignment struct {
 }
 
 // DefaultConfig returns the default A/B suite split by price bracket: code
-// author roles use cheap variants, while planning and review use premium ones.
+// author roles use cheap variants, while planning and review use premium
+// ones.
+//
+// The cheap bracket is split into two role-scoped experiments rather than one
+// shared bracket. The live evaluation scorecard (30d, 2026-07-05) grounds the
+// weights:
+//   - implementation: claude:sonnet:medium is the highest-quality/highest-cost
+//     option (failureRate 0.059, mergeRate 0.933, ~$2.58/run over 236 runs);
+//     codex:gpt-5.5 is comparable-to-better at a fraction of the cost
+//     (failureRate 0.038-0.13, mergeRate 1.0, ~$0.31/run); copilot:gpt-5.5
+//     lands respectably too (failureRate 0.021, mergeRate 0.833, ~$0.07/run).
+//     Weighted 1:2:1 (claude:codex:copilot) — codex takes the plurality,
+//     copilot gets a capped (not blanket) exposure, claude keeps a non-zero
+//     exploration/fallback floor.
+//   - fix-review/pr-fix/test-runner ("maintenance"): codex clearly wins on
+//     pr-fix (failureRate 0.036 vs claude's 0.084) and test-runner (0.037 vs
+//     claude's 0.268), and is only modestly behind claude on fix-review
+//     (0.095 vs 0.014). Copilot's maintenance-role sample is too thin to
+//     enable here (see decision log) — weighted 1:3 (claude:codex), no
+//     copilot, until more data justifies widening it.
 func DefaultConfig() Config {
 	enabled := true
 	expEnabled := true
 	return Config{
 		Enabled:              &enabled,
 		MinSamplesPerVariant: 20,
+		BuiltinVersion:       CurrentBuiltinVersion,
 		Experiments: []Experiment{
 			{
 				ID:             "code-author-cheap",
 				Enabled:        &expEnabled,
 				AssignmentUnit: "stage",
 				Bracket:        "cheap",
-				Roles:          []string{"implementation", "test-runner", "fix-review", "pr-fix"},
+				Roles:          []string{"implementation"},
 				Variants: []Variant{
-					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 2},
+					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
 					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 2},
 					{ID: "copilot-sonnet", Provider: "copilot", Model: "claude-sonnet-4.6", Tier: "cheap", Weight: 1},
 				},
 			},
 			{
+				ID:             "code-author-maintenance-cheap",
+				Enabled:        &expEnabled,
+				AssignmentUnit: "stage",
+				Bracket:        "cheap",
+				Roles:          []string{"fix-review", "pr-fix", "test-runner"},
+				Variants: []Variant{
+					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
+					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 3},
+				},
+			},
+			{
+				// Inert for review routing: simple-task-review.yaml pins both
+				// review steps to an explicit provider (claude for staff,
+				// cross for simple) instead of "ab"/"", so selectABVariant
+				// never runs for the review role. Kept as a built-in (rather
+				// than deleted) so a future workflow that opts a review step
+				// back into "ab" picks up a sane premium-tier default; the
+				// "plan" role is likewise routed by provider: cross today.
 				ID:             "review-expensive",
 				Enabled:        &expEnabled,
 				AssignmentUnit: "stage",

--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -12,7 +12,7 @@ type Config struct {
 	// bumps a lagging config's built-in experiments (see BuiltinExperimentIDs)
 	// up to CurrentBuiltinVersion, leaving any other (user-authored) experiment
 	// untouched.
-	BuiltinVersion int `yaml:"builtin_version,omitempty" json:"builtinVersion,omitempty"`
+	BuiltinVersion *int `yaml:"builtin_version,omitempty" json:"builtinVersion,omitempty"`
 }
 
 // CurrentBuiltinVersion is the version stamp for the built-in experiment set
@@ -105,10 +105,11 @@ type Assignment struct {
 func DefaultConfig() Config {
 	enabled := true
 	expEnabled := true
+	builtinVersion := CurrentBuiltinVersion
 	return Config{
 		Enabled:              &enabled,
 		MinSamplesPerVariant: 20,
-		BuiltinVersion:       CurrentBuiltinVersion,
+		BuiltinVersion:       &builtinVersion,
 		Experiments: []Experiment{
 			{
 				ID:             "code-author-cheap",
@@ -169,6 +170,13 @@ func (c Config) Validate() error {
 // EnabledValue reports whether A/B assignment should run.
 func (c Config) EnabledValue() bool {
 	return c.Enabled == nil || *c.Enabled
+}
+
+func (c Config) BuiltinVersionValue() int {
+	if c.BuiltinVersion == nil {
+		return 0
+	}
+	return *c.BuiltinVersion
 }
 
 func (e Experiment) EnabledValue() bool {

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -3,6 +3,7 @@ package abtest
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -85,23 +86,48 @@ func TestSelectSkipsNonMatchingRole(t *testing.T) {
 
 func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
 	cfg := DefaultConfig()
-	for _, role := range []string{"implementation", "test-runner", "fix-review", "pr-fix"} {
-		t.Run(role, func(t *testing.T) {
+	cases := []struct {
+		role         string
+		experimentID string
+		variantIDs   []string
+	}{
+		{"implementation", "code-author-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
+		{"test-runner", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
+		{"fix-review", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
+		{"pr-fix", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.role, func(t *testing.T) {
 			for i := range 100 {
-				a, ok, err := Select(cfg, fmt.Sprintf("task-%d", i), role, "step")
+				a, ok, err := Select(cfg, fmt.Sprintf("task-%d", i), tt.role, "step")
 				if err != nil || !ok {
 					t.Fatalf("Select ok=%v err=%v", ok, err)
 				}
-				if a.ExperimentID != "code-author-cheap" {
-					t.Fatalf("ExperimentID = %q, want code-author-cheap", a.ExperimentID)
+				if a.ExperimentID != tt.experimentID {
+					t.Fatalf("ExperimentID = %q, want %s", a.ExperimentID, tt.experimentID)
 				}
-				switch a.VariantID {
-				case "claude-sonnet", "codex-gpt-5.4", "copilot-sonnet":
-				default:
-					t.Fatalf("VariantID = %q, want cheap variant", a.VariantID)
+				if !slices.Contains(tt.variantIDs, a.VariantID) {
+					t.Fatalf("VariantID = %q, want one of %v", a.VariantID, tt.variantIDs)
 				}
 			}
 		})
+	}
+}
+
+// TestDefaultConfigScopesCopilotToImplementation locks the "capped, not
+// blanket" copilot requirement: the maintenance-role experiment
+// (fix-review/pr-fix/test-runner) must never surface a copilot variant, only
+// the implementation-scoped experiment may.
+func TestDefaultConfigScopesCopilotToImplementation(t *testing.T) {
+	cfg := DefaultConfig()
+	for _, exp := range cfg.Experiments {
+		if exp.ID == "code-author-maintenance-cheap" {
+			for _, v := range exp.Variants {
+				if v.Provider == "copilot" {
+					t.Fatalf("code-author-maintenance-cheap must not include a copilot variant, got %+v", v)
+				}
+			}
+		}
 	}
 }
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -437,24 +437,33 @@ func (c *Config) ExperiencesDir() string {
 }
 
 func Load() (*Config, error) {
+	return load(loadOptions{persistABTestingReconcile: true})
+}
+
+// LoadNoPersist reads config.yaml and applies in-memory defaults/reconciles
+// without writing any migration back to disk. Reload paths use this to keep
+// their read-only contract and to preserve raw-editor formatting/comments.
+func LoadNoPersist() (*Config, error) {
+	return load(loadOptions{})
+}
+
+type loadOptions struct {
+	persistABTestingReconcile bool
+}
+
+func load(opts loadOptions) (*Config, error) {
 	cfg := DefaultConfig()
 
 	path := configPath()
 	data, err := os.ReadFile(path)
 	existingFile := err == nil
 	if existingFile {
+		// Keep the rest of DefaultConfig pre-seeded, but let builtin_version
+		// reflect the document exactly: nil means "key absent" on older files.
+		cfg.ABTesting.BuiltinVersion = nil
 		if err := yaml.Unmarshal(data, cfg); err != nil {
 			return nil, err
 		}
-		// cfg started pre-seeded with DefaultConfig()'s CurrentBuiltinVersion,
-		// so a persisted document that predates builtin_version (and thus
-		// omits the key entirely) leaves that pre-seeded value in place after
-		// Unmarshal instead of reverting to the document's true (absent →
-		// zero) value. Re-read just this field from the raw document so
-		// applyABTestingDefaults sees what was actually persisted, not what
-		// DefaultConfig() happened to seed — otherwise a stale config looks
-		// already up to date and never reconciles.
-		cfg.ABTesting.BuiltinVersion = persistedBuiltinVersion(data)
 	} else if os.IsNotExist(err) {
 		if writeErr := writeDefaultConfig(path); writeErr != nil {
 			return nil, writeErr
@@ -531,7 +540,7 @@ func Load() (*Config, error) {
 	applyHarnessEvolveDefaults(cfg)
 	applyPromptLabDefaults(cfg)
 	applyExperienceDefaults(cfg)
-	abTestingReconciled := applyABTestingDefaults(cfg)
+	abTestingReconciled := applyABTestingDefaults(cfg, opts.persistABTestingReconcile)
 	applyOrchestratorDefaults(cfg)
 	applyAutoUpdateDefaults(cfg)
 	applyReviewHoldDefaults(cfg)
@@ -541,7 +550,7 @@ func Load() (*Config, error) {
 	// until something else happens to call Save(). Only for a config file that
 	// already existed — a brand-new install seeds def.Experiments directly and
 	// writeDefaultConfig already wrote the (comment-only) file above.
-	if existingFile && abTestingReconciled {
+	if opts.persistABTestingReconcile && existingFile && abTestingReconciled {
 		if saveErr := cfg.Save(); saveErr != nil {
 			slog.Warn("config: failed to persist ab_testing builtin reconcile", "err", saveErr)
 		}
@@ -631,27 +640,11 @@ func applyAutoUpdateDefaults(cfg *Config) {
 	}
 }
 
-// persistedBuiltinVersion reads only ab_testing.builtin_version from the raw
-// config bytes, independent of the DefaultConfig()-seeded Config that data
-// gets unmarshaled into elsewhere. Returns 0 (never reconciled) for a
-// document that omits the key, is malformed, or predates its existence.
-func persistedBuiltinVersion(data []byte) int {
-	var raw struct {
-		ABTesting struct {
-			BuiltinVersion int `yaml:"builtin_version"`
-		} `yaml:"ab_testing"`
-	}
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return 0
-	}
-	return raw.ABTesting.BuiltinVersion
-}
-
 // applyABTestingDefaults fills zero-value A/B testing config and reconciles
 // built-in experiments against the current code defaults. Returns true when
 // a builtin experiment reconcile actually rewrote cfg.ABTesting.Experiments,
 // so the caller knows whether the change needs persisting.
-func applyABTestingDefaults(cfg *Config) bool {
+func applyABTestingDefaults(cfg *Config, persist bool) bool {
 	if cfg == nil {
 		return false
 	}
@@ -667,7 +660,7 @@ func applyABTestingDefaults(cfg *Config) bool {
 		cfg.ABTesting.BuiltinVersion = def.BuiltinVersion
 		return false
 	}
-	return reconcileBuiltinExperiments(cfg, def)
+	return reconcileBuiltinExperiments(cfg, def, persist)
 }
 
 // reconcileBuiltinExperiments refreshes a persisted config's built-in A/B
@@ -676,13 +669,16 @@ func applyABTestingDefaults(cfg *Config) bool {
 // are left untouched. A one-generation backup of the prior experiment list is
 // written before the built-ins are replaced, so a same-ID hand-tuned built-in
 // is recoverable even though reconcile treats the ID as Sybra-owned.
-func reconcileBuiltinExperiments(cfg *Config, def abtest.Config) bool {
-	if cfg.ABTesting.BuiltinVersion >= def.BuiltinVersion {
+func reconcileBuiltinExperiments(cfg *Config, def abtest.Config, persist bool) bool {
+	priorVersion := cfg.ABTesting.BuiltinVersionValue()
+	if priorVersion >= def.BuiltinVersionValue() {
 		return false
 	}
-	if err := backupABTestingExperiments(cfg.ABTesting.Experiments, cfg.ABTesting.BuiltinVersion); err != nil {
-		slog.Warn("config: ab_testing builtin reconcile backup failed; skipping refresh", "err", err)
-		return false
+	if persist {
+		if err := backupABTestingExperiments(cfg.ABTesting.Experiments, priorVersion); err != nil {
+			slog.Warn("config: ab_testing builtin reconcile backup failed; skipping refresh", "err", err)
+			return false
+		}
 	}
 	builtin := make(map[string]bool, len(abtest.BuiltinExperimentIDs))
 	for _, id := range abtest.BuiltinExperimentIDs {
@@ -697,15 +693,16 @@ func reconcileBuiltinExperiments(cfg *Config, def abtest.Config) bool {
 	kept = append(kept, def.Experiments...)
 	cfg.ABTesting.Experiments = kept
 	cfg.ABTesting.BuiltinVersion = def.BuiltinVersion
-	slog.Info("config: ab_testing builtin experiments reconciled", "builtin_version", def.BuiltinVersion)
+	slog.Info("config: ab_testing builtin experiments reconciled", "builtin_version", def.BuiltinVersionValue())
 	return true
 }
 
-// abTestingBackupPath is the one-generation backup written before a builtin
-// experiment reconcile overwrites persisted experiments. Only the most recent
-// pre-reconcile snapshot is kept — each reconcile overwrites the prior backup.
-func abTestingBackupPath() string {
-	return filepath.Join(HomeDir(), "config.ab_testing.backup.yaml")
+// abTestingBackupPath returns the version-stamped backup path written before a
+// builtin reconcile overwrites persisted experiments. Each prior builtin
+// version keeps its own snapshot so successive builtin-version bumps do not
+// destroy the true pre-migration original.
+func abTestingBackupPath(priorVersion int) string {
+	return filepath.Join(HomeDir(), fmt.Sprintf("config.ab_testing.backup.v%d.yaml", priorVersion))
 }
 
 type abTestingBackup struct {
@@ -718,7 +715,7 @@ func backupABTestingExperiments(experiments []abtest.Experiment, priorVersion in
 	if err != nil {
 		return err
 	}
-	path := abTestingBackupPath()
+	path := abTestingBackupPath(priorVersion)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -441,10 +441,20 @@ func Load() (*Config, error) {
 
 	path := configPath()
 	data, err := os.ReadFile(path)
-	if err == nil {
+	existingFile := err == nil
+	if existingFile {
 		if err := yaml.Unmarshal(data, cfg); err != nil {
 			return nil, err
 		}
+		// cfg started pre-seeded with DefaultConfig()'s CurrentBuiltinVersion,
+		// so a persisted document that predates builtin_version (and thus
+		// omits the key entirely) leaves that pre-seeded value in place after
+		// Unmarshal instead of reverting to the document's true (absent →
+		// zero) value. Re-read just this field from the raw document so
+		// applyABTestingDefaults sees what was actually persisted, not what
+		// DefaultConfig() happened to seed — otherwise a stale config looks
+		// already up to date and never reconciles.
+		cfg.ABTesting.BuiltinVersion = persistedBuiltinVersion(data)
 	} else if os.IsNotExist(err) {
 		if writeErr := writeDefaultConfig(path); writeErr != nil {
 			return nil, writeErr
@@ -521,10 +531,21 @@ func Load() (*Config, error) {
 	applyHarnessEvolveDefaults(cfg)
 	applyPromptLabDefaults(cfg)
 	applyExperienceDefaults(cfg)
-	applyABTestingDefaults(cfg)
+	abTestingReconciled := applyABTestingDefaults(cfg)
 	applyOrchestratorDefaults(cfg)
 	applyAutoUpdateDefaults(cfg)
 	applyReviewHoldDefaults(cfg)
+
+	// Persist a builtin A/B experiment reconcile immediately so the refreshed
+	// weights survive a restart instead of only living in this in-memory cfg
+	// until something else happens to call Save(). Only for a config file that
+	// already existed — a brand-new install seeds def.Experiments directly and
+	// writeDefaultConfig already wrote the (comment-only) file above.
+	if existingFile && abTestingReconciled {
+		if saveErr := cfg.Save(); saveErr != nil {
+			slog.Warn("config: failed to persist ab_testing builtin reconcile", "err", saveErr)
+		}
+	}
 
 	return cfg, nil
 }
@@ -610,9 +631,29 @@ func applyAutoUpdateDefaults(cfg *Config) {
 	}
 }
 
-func applyABTestingDefaults(cfg *Config) {
+// persistedBuiltinVersion reads only ab_testing.builtin_version from the raw
+// config bytes, independent of the DefaultConfig()-seeded Config that data
+// gets unmarshaled into elsewhere. Returns 0 (never reconciled) for a
+// document that omits the key, is malformed, or predates its existence.
+func persistedBuiltinVersion(data []byte) int {
+	var raw struct {
+		ABTesting struct {
+			BuiltinVersion int `yaml:"builtin_version"`
+		} `yaml:"ab_testing"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return 0
+	}
+	return raw.ABTesting.BuiltinVersion
+}
+
+// applyABTestingDefaults fills zero-value A/B testing config and reconciles
+// built-in experiments against the current code defaults. Returns true when
+// a builtin experiment reconcile actually rewrote cfg.ABTesting.Experiments,
+// so the caller knows whether the change needs persisting.
+func applyABTestingDefaults(cfg *Config) bool {
 	if cfg == nil {
-		return
+		return false
 	}
 	def := abtest.DefaultConfig()
 	if cfg.ABTesting.Enabled == nil {
@@ -623,7 +664,65 @@ func applyABTestingDefaults(cfg *Config) {
 	}
 	if len(cfg.ABTesting.Experiments) == 0 {
 		cfg.ABTesting.Experiments = def.Experiments
+		cfg.ABTesting.BuiltinVersion = def.BuiltinVersion
+		return false
 	}
+	return reconcileBuiltinExperiments(cfg, def)
+}
+
+// reconcileBuiltinExperiments refreshes a persisted config's built-in A/B
+// experiments (see abtest.BuiltinExperimentIDs) when they lag the code's
+// current defaults. Experiments outside that ID set — i.e. user-authored —
+// are left untouched. A one-generation backup of the prior experiment list is
+// written before the built-ins are replaced, so a same-ID hand-tuned built-in
+// is recoverable even though reconcile treats the ID as Sybra-owned.
+func reconcileBuiltinExperiments(cfg *Config, def abtest.Config) bool {
+	if cfg.ABTesting.BuiltinVersion >= def.BuiltinVersion {
+		return false
+	}
+	if err := backupABTestingExperiments(cfg.ABTesting.Experiments, cfg.ABTesting.BuiltinVersion); err != nil {
+		slog.Warn("config: ab_testing builtin reconcile backup failed; skipping refresh", "err", err)
+		return false
+	}
+	builtin := make(map[string]bool, len(abtest.BuiltinExperimentIDs))
+	for _, id := range abtest.BuiltinExperimentIDs {
+		builtin[id] = true
+	}
+	kept := make([]abtest.Experiment, 0, len(cfg.ABTesting.Experiments)+len(def.Experiments))
+	for i := range cfg.ABTesting.Experiments {
+		if exp := cfg.ABTesting.Experiments[i]; !builtin[exp.ID] {
+			kept = append(kept, exp)
+		}
+	}
+	kept = append(kept, def.Experiments...)
+	cfg.ABTesting.Experiments = kept
+	cfg.ABTesting.BuiltinVersion = def.BuiltinVersion
+	slog.Info("config: ab_testing builtin experiments reconciled", "builtin_version", def.BuiltinVersion)
+	return true
+}
+
+// abTestingBackupPath is the one-generation backup written before a builtin
+// experiment reconcile overwrites persisted experiments. Only the most recent
+// pre-reconcile snapshot is kept — each reconcile overwrites the prior backup.
+func abTestingBackupPath() string {
+	return filepath.Join(HomeDir(), "config.ab_testing.backup.yaml")
+}
+
+type abTestingBackup struct {
+	PriorBuiltinVersion int                 `yaml:"prior_builtin_version"`
+	Experiments         []abtest.Experiment `yaml:"experiments"`
+}
+
+func backupABTestingExperiments(experiments []abtest.Experiment, priorVersion int) error {
+	data, err := yaml.Marshal(abTestingBackup{PriorBuiltinVersion: priorVersion, Experiments: experiments})
+	if err != nil {
+		return err
+	}
+	path := abTestingBackupPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
 }
 
 // applyWatchdogDefaults fills the Watchdog model default. Enabled and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/abtest"
@@ -887,8 +889,8 @@ func TestLoadReconcilesStaleBuiltinABExperiments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.ABTesting.BuiltinVersion != abtest.CurrentBuiltinVersion {
-		t.Fatalf("BuiltinVersion = %d, want %d", cfg.ABTesting.BuiltinVersion, abtest.CurrentBuiltinVersion)
+	if got := cfg.ABTesting.BuiltinVersionValue(); got != abtest.CurrentBuiltinVersion {
+		t.Fatalf("BuiltinVersion = %d, want %d", got, abtest.CurrentBuiltinVersion)
 	}
 
 	byID := make(map[string]abtest.Experiment, len(cfg.ABTesting.Experiments))
@@ -929,7 +931,7 @@ func TestLoadReconcilePersistsBackupBeforeOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	backupPath := filepath.Join(dir, "config.ab_testing.backup.yaml")
+	backupPath := filepath.Join(dir, "config.ab_testing.backup.v0.yaml")
 	data, err := os.ReadFile(backupPath)
 	if err != nil {
 		t.Fatalf("backup file not written: %v", err)
@@ -984,8 +986,8 @@ func TestLoadReconcilePersistsToDisk(t *testing.T) {
 	if err := yamlv3.Unmarshal(data, &onDisk); err != nil {
 		t.Fatal(err)
 	}
-	if onDisk.ABTesting.BuiltinVersion != abtest.CurrentBuiltinVersion {
-		t.Fatalf("persisted BuiltinVersion = %d, want %d", onDisk.ABTesting.BuiltinVersion, abtest.CurrentBuiltinVersion)
+	if got := onDisk.ABTesting.BuiltinVersionValue(); got != abtest.CurrentBuiltinVersion {
+		t.Fatalf("persisted BuiltinVersion = %d, want %d", got, abtest.CurrentBuiltinVersion)
 	}
 	foundCustom := false
 	for _, exp := range onDisk.ABTesting.Experiments {
@@ -1009,8 +1011,11 @@ func TestLoadDoesNotReconcileUpToDateBuiltins(t *testing.T) {
 		ABTesting: abtest.Config{
 			Enabled:              &enabled,
 			MinSamplesPerVariant: 20,
-			BuiltinVersion:       abtest.CurrentBuiltinVersion,
-			Experiments:          abtest.DefaultConfig().Experiments,
+			BuiltinVersion: func() *int {
+				v := abtest.CurrentBuiltinVersion
+				return &v
+			}(),
+			Experiments: abtest.DefaultConfig().Experiments,
 		},
 	}
 	data, err := yamlv3.Marshal(cfg)
@@ -1025,7 +1030,81 @@ func TestLoadDoesNotReconcileUpToDateBuiltins(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, "config.ab_testing.backup.yaml")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(dir, "config.ab_testing.backup.v0.yaml")); !os.IsNotExist(err) {
 		t.Fatalf("backup file should not be written when already at current builtin version, stat err = %v", err)
+	}
+}
+
+func TestLoadNoPersistLeavesStaleConfigUntouched(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	writeOldShapeConfig(t, dir)
+
+	before, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadNoPersist()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.ABTesting.BuiltinVersionValue(); got != abtest.CurrentBuiltinVersion {
+		t.Fatalf("BuiltinVersion = %d, want %d", got, abtest.CurrentBuiltinVersion)
+	}
+
+	after, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("LoadNoPersist rewrote config.yaml")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.ab_testing.backup.v0.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("LoadNoPersist should not write backup, stat err = %v", err)
+	}
+}
+
+func TestLoadReconcileKeepsVersionedBackupsPerPriorBuiltinVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	writeOldShapeConfig(t, dir)
+
+	if _, err := Load(); err != nil {
+		t.Fatal(err)
+	}
+	firstBackup, err := os.ReadFile(filepath.Join(dir, "config.ab_testing.backup.v0.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewritten := strings.Replace(string(data), "builtin_version: 2", "builtin_version: 1", 1)
+	if rewritten == string(data) {
+		t.Fatal("failed to downgrade builtin_version in persisted config")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(rewritten), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(); err != nil {
+		t.Fatal(err)
+	}
+	secondBackup, err := os.ReadFile(filepath.Join(dir, "config.ab_testing.backup.v1.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stillFirstBackup, err := os.ReadFile(filepath.Join(dir, "config.ab_testing.backup.v0.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(stillFirstBackup, firstBackup) {
+		t.Fatal("v0 backup was overwritten by a later reconcile")
+	}
+	if len(secondBackup) == 0 {
+		t.Fatal("v1 backup should not be empty")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/abtest"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -817,5 +820,212 @@ func TestRetryWatchdog(t *testing.T) {
 				t.Errorf("got %d, want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+// oldShapeABTestingExperiments returns the pre-reconcile shape: the original
+// single shared "code-author-cheap" bracket (hand-tuned claude weight 99, a
+// value neither the old nor new DefaultConfig would ever produce, so a
+// recovered backup is unambiguously distinguishable), no builtin_version
+// stamp, plus a user-authored experiment that must survive reconcile intact.
+func oldShapeABTestingExperiments() []abtest.Experiment {
+	enabled := true
+	return []abtest.Experiment{
+		{
+			ID:             "code-author-cheap",
+			Enabled:        &enabled,
+			AssignmentUnit: "stage",
+			Bracket:        "cheap",
+			Roles:          []string{"implementation", "test-runner", "fix-review", "pr-fix"},
+			Variants: []abtest.Variant{
+				{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 99},
+				{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 2},
+			},
+		},
+		{
+			ID:             "my-custom-experiment",
+			Enabled:        &enabled,
+			AssignmentUnit: "stage",
+			Roles:          []string{"implementation"},
+			Variants: []abtest.Variant{
+				{ID: "custom-v1", Provider: "claude", Model: "sonnet", Weight: 1},
+			},
+		},
+	}
+}
+
+func writeOldShapeConfig(t *testing.T, dir string) {
+	t.Helper()
+	enabled := true
+	cfg := &Config{
+		ABTesting: abtest.Config{
+			Enabled:              &enabled,
+			MinSamplesPerVariant: 20,
+			Experiments:          oldShapeABTestingExperiments(),
+			// BuiltinVersion deliberately left at zero: simulates a config
+			// persisted before builtin_version existed.
+		},
+	}
+	data, err := yamlv3.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLoadReconcilesStaleBuiltinABExperiments proves an existing persisted
+// config (predating the code-author-cheap/-maintenance-cheap split) adopts
+// the new built-in experiments on Load, not only fresh installs.
+func TestLoadReconcilesStaleBuiltinABExperiments(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	writeOldShapeConfig(t, dir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ABTesting.BuiltinVersion != abtest.CurrentBuiltinVersion {
+		t.Fatalf("BuiltinVersion = %d, want %d", cfg.ABTesting.BuiltinVersion, abtest.CurrentBuiltinVersion)
+	}
+
+	byID := make(map[string]abtest.Experiment, len(cfg.ABTesting.Experiments))
+	for _, exp := range cfg.ABTesting.Experiments {
+		byID[exp.ID] = exp
+	}
+
+	if _, ok := byID["code-author-maintenance-cheap"]; !ok {
+		t.Fatal("code-author-maintenance-cheap not adopted by reconcile")
+	}
+	authorCheap, ok := byID["code-author-cheap"]
+	if !ok {
+		t.Fatal("code-author-cheap missing after reconcile")
+	}
+	for _, v := range authorCheap.Variants {
+		if v.ID == "claude-sonnet" && v.Weight == 99 {
+			t.Fatal("code-author-cheap still carries the stale hand-tuned weight; reconcile did not replace it")
+		}
+	}
+	if len(authorCheap.Roles) != 1 || authorCheap.Roles[0] != "implementation" {
+		t.Fatalf("code-author-cheap roles = %v, want [implementation] (role split did not land)", authorCheap.Roles)
+	}
+
+	if _, ok := byID["my-custom-experiment"]; !ok {
+		t.Fatal("user-authored experiment my-custom-experiment was dropped by reconcile")
+	}
+}
+
+// TestLoadReconcilePersistsBackupBeforeOverwrite proves a one-generation
+// backup of the prior experiment list is written to disk before the stale
+// same-ID built-in is overwritten, so a hand-tuned built-in is recoverable.
+func TestLoadReconcilePersistsBackupBeforeOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	writeOldShapeConfig(t, dir)
+
+	if _, err := Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	backupPath := filepath.Join(dir, "config.ab_testing.backup.yaml")
+	data, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("backup file not written: %v", err)
+	}
+	var backup struct {
+		PriorBuiltinVersion int                 `yaml:"prior_builtin_version"`
+		Experiments         []abtest.Experiment `yaml:"experiments"`
+	}
+	if err := yamlv3.Unmarshal(data, &backup); err != nil {
+		t.Fatalf("backup file unreadable: %v", err)
+	}
+	if backup.PriorBuiltinVersion != 0 {
+		t.Fatalf("PriorBuiltinVersion = %d, want 0", backup.PriorBuiltinVersion)
+	}
+	var recovered *abtest.Experiment
+	for i := range backup.Experiments {
+		if backup.Experiments[i].ID == "code-author-cheap" {
+			recovered = &backup.Experiments[i]
+		}
+	}
+	if recovered == nil {
+		t.Fatal("backup does not contain the prior code-author-cheap experiment")
+	}
+	found := false
+	for _, v := range recovered.Variants {
+		if v.ID == "claude-sonnet" && v.Weight == 99 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("backup lost the hand-tuned claude-sonnet weight — same-ID built-in is not recoverable")
+	}
+}
+
+// TestLoadReconcilePersistsToDisk proves the reconciled config is written
+// back to config.yaml immediately, so the refresh survives a process
+// restart rather than living only in the in-memory Load() result.
+func TestLoadReconcilePersistsToDisk(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	writeOldShapeConfig(t, dir)
+
+	if _, err := Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var onDisk Config
+	if err := yamlv3.Unmarshal(data, &onDisk); err != nil {
+		t.Fatal(err)
+	}
+	if onDisk.ABTesting.BuiltinVersion != abtest.CurrentBuiltinVersion {
+		t.Fatalf("persisted BuiltinVersion = %d, want %d", onDisk.ABTesting.BuiltinVersion, abtest.CurrentBuiltinVersion)
+	}
+	foundCustom := false
+	for _, exp := range onDisk.ABTesting.Experiments {
+		if exp.ID == "my-custom-experiment" {
+			foundCustom = true
+		}
+	}
+	if !foundCustom {
+		t.Fatal("persisted config.yaml lost the user-authored experiment")
+	}
+}
+
+// TestLoadDoesNotReconcileUpToDateBuiltins proves a config already stamped at
+// the current builtin version is left alone — no repeat backup/rewrite work
+// on every Load (e.g. every hot reload).
+func TestLoadDoesNotReconcileUpToDateBuiltins(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	enabled := true
+	cfg := &Config{
+		ABTesting: abtest.Config{
+			Enabled:              &enabled,
+			MinSamplesPerVariant: 20,
+			BuiltinVersion:       abtest.CurrentBuiltinVersion,
+			Experiments:          abtest.DefaultConfig().Experiments,
+		},
+	}
+	data, err := yamlv3.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "config.ab_testing.backup.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("backup file should not be written when already at current builtin version, stat err = %v", err)
 	}
 }

--- a/internal/sybra/svc_config_rawconfig_test.go
+++ b/internal/sybra/svc_config_rawconfig_test.go
@@ -155,6 +155,37 @@ func TestSaveRawConfig_ValidRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSaveRawConfig_PreservesFormattingWhenBuiltinVersionMissing(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	raw, err := svc.GetRawConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edited := "# keep this comment\n" + strings.Replace(raw, "builtin_version: 2\n", "", 1)
+	edited = strings.Replace(edited, "max_files: 5", "max_files: 7", 1)
+
+	if err := svc.SaveRawConfig(edited); err != nil {
+		t.Fatalf("SaveRawConfig: %v", err)
+	}
+
+	saved, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	savedText := string(saved)
+	if !strings.Contains(savedText, "# keep this comment") {
+		t.Fatal("raw save lost the preserved comment")
+	}
+	if strings.Contains(savedText, "builtin_version:") {
+		t.Fatal("hot reload rewrote the raw config with builtin_version")
+	}
+	if !strings.Contains(savedText, "max_files: 7") {
+		t.Fatal("raw save did not persist the edit")
+	}
+}
+
 func TestSaveRawConfig_RejectsInvalidYAML(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)
 	writeConfigYAML(t, cfgPath, svc.cfg)

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -12,7 +12,7 @@ import (
 // of hot-reloadable keys that changed. On any error the in-memory config is
 // left unchanged. Never writes to disk.
 func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
-	next, err := config.Load()
+	next, err := config.LoadNoPersist()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -117,7 +117,10 @@ steps:
     config:
       role: review
       mode: headless
-      provider: cross
+      # High-risk/staff review is pinned to claude, not routed by "cross" or
+      # the A/B suite — codex review fails ~2x more often than claude review
+      # (scorecard: 17% vs 9%) on the diffs that reach staff-level scrutiny.
+      provider: claude
       needs_worktree: true
       max_retries: 2
       prompt: >-

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -199,33 +199,34 @@ type agentEntry struct {
 
 // Engine executes workflow definitions against tasks.
 type Engine struct {
-	store           *Store
-	tasks           TaskProvider
-	agents          AgentLauncher
-	prLinker        PRLinker
-	prReviewers     PRReviewRequester
-	prStates        PRStateFetcher
-	worktrees       WorktreeGetter
-	branchSyncer    BranchSyncer
-	checks          CheckConfigGetter
-	manualTests     ManualTestConfigGetter
-	recorder        ArtifactRecorder
-	onComplete      func(CompletionInfo)
-	logger          *slog.Logger
-	ctx             context.Context
-	mu              sync.Mutex
-	inflightMutexes map[string]*sync.Mutex // taskID → advance serializer (parallel-aware)
-	dispatching     map[string]struct{}    // taskID → dispatch in progress
-	starting        map[string]struct{}    // taskID → StartWorkflowWithVars in progress
-	humanAction     map[string]struct{}    // taskID → HandleHumanAction in progress
-	agentSteps      map[string]agentEntry  // agentID → {taskID, stepID}
-	dispatchingStep map[string]int         // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
-	cascadeDepth    map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
-	resumeError     *logging.ErrorThrottle
-	maxTestAttempts int           // testing → re-implement loop cap (0 → defaultTestAttempts)
-	verifyTimeout   time.Duration // verify_checks budget (0 → verifyChecksDefaultTimeout)
-	abTesting       abtest.Config
-	evalGate        *prompteval.Gate // nil = offline eval verdicts do not gate A/B enrollment
+	store            *Store
+	tasks            TaskProvider
+	agents           AgentLauncher
+	prLinker         PRLinker
+	prReviewers      PRReviewRequester
+	prStates         PRStateFetcher
+	worktrees        WorktreeGetter
+	branchSyncer     BranchSyncer
+	checks           CheckConfigGetter
+	manualTests      ManualTestConfigGetter
+	recorder         ArtifactRecorder
+	onComplete       func(CompletionInfo)
+	logger           *slog.Logger
+	ctx              context.Context
+	mu               sync.Mutex
+	inflightMutexes  map[string]*sync.Mutex // taskID → advance serializer (parallel-aware)
+	dispatching      map[string]struct{}    // taskID → dispatch in progress
+	starting         map[string]struct{}    // taskID → StartWorkflowWithVars in progress
+	humanAction      map[string]struct{}    // taskID → HandleHumanAction in progress
+	agentSteps       map[string]agentEntry  // agentID → {taskID, stepID}
+	dispatchingStep  map[string]int         // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
+	cascadeDepth     map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
+	resumeError      *logging.ErrorThrottle
+	demotionThrottle *logging.ErrorThrottle
+	maxTestAttempts  int           // testing → re-implement loop cap (0 → defaultTestAttempts)
+	verifyTimeout    time.Duration // verify_checks budget (0 → verifyChecksDefaultTimeout)
+	abTesting        abtest.Config
+	evalGate         *prompteval.Gate // nil = offline eval verdicts do not gate A/B enrollment
 }
 
 // defaultTestAttempts caps the testing → in-progress re-implementation loop
@@ -236,19 +237,20 @@ const defaultTestAttempts = 3
 // NewEngine creates a workflow engine.
 func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {
 	return &Engine{
-		store:           store,
-		tasks:           tasks,
-		agents:          agents,
-		logger:          logger,
-		ctx:             context.Background(),
-		inflightMutexes: make(map[string]*sync.Mutex),
-		dispatching:     make(map[string]struct{}),
-		starting:        make(map[string]struct{}),
-		humanAction:     make(map[string]struct{}),
-		agentSteps:      make(map[string]agentEntry),
-		dispatchingStep: make(map[string]int),
-		cascadeDepth:    make(map[string]int),
-		resumeError:     logging.NewErrorThrottle(),
+		store:            store,
+		tasks:            tasks,
+		agents:           agents,
+		logger:           logger,
+		ctx:              context.Background(),
+		inflightMutexes:  make(map[string]*sync.Mutex),
+		dispatching:      make(map[string]struct{}),
+		starting:         make(map[string]struct{}),
+		humanAction:      make(map[string]struct{}),
+		agentSteps:       make(map[string]agentEntry),
+		dispatchingStep:  make(map[string]int),
+		cascadeDepth:     make(map[string]int),
+		resumeError:      logging.NewErrorThrottle(),
+		demotionThrottle: logging.NewErrorThrottle(),
 	}
 }
 

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -245,8 +245,13 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 }
 
 func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, bool, error) {
+	eligibility := e.providerEligibilitySnapshot(ctx)
 	providerAllowed := func(provider string) bool {
-		return providerAvailable(provider) && e.agents.ProviderHealthy(provider) && !e.agents.ProviderRateLimited(provider)
+		status, ok := eligibility[provider]
+		if !ok {
+			status = e.providerEligibility(provider)
+		}
+		return status.allowed
 	}
 	var evalPassed abtest.EvalPassed
 	if e.evalGate != nil {
@@ -264,7 +269,7 @@ func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, 
 	if err != nil || !ok {
 		return AgentAssignment{}, ok, err
 	}
-	e.reportProviderDemotion(ctx, a, evalPassed)
+	e.reportProviderDemotion(ctx, a, eligibility, evalPassed)
 	return AgentAssignment{
 		ExperimentID:    a.ExperimentID,
 		Kind:            a.Kind,
@@ -279,40 +284,67 @@ func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, 
 	}, true, nil
 }
 
+type providerEligibilityStatus struct {
+	allowed bool
+	reason  string
+}
+
+func (e *Engine) providerEligibility(provider string) providerEligibilityStatus {
+	switch {
+	case !providerAvailable(provider):
+		return providerEligibilityStatus{reason: "cli_not_found"}
+	case !e.agents.ProviderHealthy(provider):
+		return providerEligibilityStatus{reason: "unhealthy"}
+	case e.agents.ProviderRateLimited(provider):
+		return providerEligibilityStatus{reason: "rate_limited"}
+	default:
+		return providerEligibilityStatus{allowed: true}
+	}
+}
+
+func (e *Engine) providerEligibilitySnapshot(_ abtest.SelectionContext) map[string]providerEligibilityStatus {
+	statuses := map[string]providerEligibilityStatus{}
+	for i := range e.abTesting.Experiments {
+		exp := e.abTesting.Experiments[i]
+		if !exp.EnabledValue() {
+			continue
+		}
+		for j := range exp.Variants {
+			provider := exp.Variants[j].Provider
+			if _, ok := statuses[provider]; ok {
+				continue
+			}
+			statuses[provider] = e.providerEligibility(provider)
+		}
+	}
+	return statuses
+}
+
 // reportProviderDemotion detects when provider eligibility filtering (CLI
-// missing, unhealthy, rate-limited) changed the A/B outcome for this
-// task/step: it re-runs selection with no provider filter to find the
-// provider that would have won on hash alone, and compares it to the actual
-// (filtered) assignment. A mismatch means the intended provider got demoted —
-// logged once per (task, step, wanted provider) at Error, then throttled to
-// Debug for identical repeats (e.g. a provider stuck rate-limited for an
-// extended window) so sustained outages don't flood the log.
-func (e *Engine) reportProviderDemotion(ctx abtest.SelectionContext, actual abtest.Assignment, evalPassed abtest.EvalPassed) {
+// missing, unhealthy, rate-limited) changed the A/B outcome for this routing
+// context. It re-runs selection with no provider filter to find the provider
+// that would have won on hash alone, compares it to the actual (filtered)
+// assignment, then logs the captured selection-time reason. Throttling is
+// fleet-wide per routing context + demotion tuple so a sustained outage does
+// not emit one ERROR per task.
+func (e *Engine) reportProviderDemotion(ctx abtest.SelectionContext, actual abtest.Assignment, eligibility map[string]providerEligibilityStatus, evalPassed abtest.EvalPassed) {
 	wanted, ok, err := abtest.SelectEligibleForContext(e.abTesting, ctx, nil, evalPassed)
 	if err != nil || !ok || wanted.Provider == actual.Provider {
 		return
 	}
-	reason := e.demotionReason(wanted.Provider)
-	key := ctx.TaskID + "|" + ctx.StepID + "|" + wanted.Provider
+	status, ok := eligibility[wanted.Provider]
+	if !ok {
+		status = e.providerEligibility(wanted.Provider)
+	}
+	reason := status.reason
+	if reason == "" {
+		reason = "unknown"
+	}
+	key := strings.Join([]string{ctx.WorkflowID, ctx.Role, ctx.StepID, wanted.Provider, actual.Provider, reason}, "|")
 	msg := fmt.Sprintf("wanted=%s got=%s reason=%s", wanted.Provider, actual.Provider, reason)
 	e.demotionThrottle.Log(e.logger, "workflow.ab.provider_demoted", key, errors.New(msg),
 		"task_id", ctx.TaskID, "workflow_id", ctx.WorkflowID, "role", ctx.Role, "step_id", ctx.StepID,
 		"wanted_provider", wanted.Provider, "selected_provider", actual.Provider, "reason", reason)
-}
-
-// demotionReason categorizes why the wanted provider was filtered out of
-// eligibility, mirroring the providerAllowed predicate's checks in order.
-func (e *Engine) demotionReason(provider string) string {
-	switch {
-	case !providerAvailable(provider):
-		return "cli_not_found"
-	case !e.agents.ProviderHealthy(provider):
-		return "unhealthy"
-	case e.agents.ProviderRateLimited(provider):
-		return "rate_limited"
-	default:
-		return "unknown"
-	}
 }
 
 func (e *Engine) renderAssignedPrompt(taskID string, step *Step, ctx TemplateContext, assignment AgentAssignment, steerLog string) (string, error) {

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -264,6 +264,7 @@ func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, 
 	if err != nil || !ok {
 		return AgentAssignment{}, ok, err
 	}
+	e.reportProviderDemotion(ctx, a, evalPassed)
 	return AgentAssignment{
 		ExperimentID:    a.ExperimentID,
 		Kind:            a.Kind,
@@ -276,6 +277,42 @@ func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, 
 		PromptTransform: workflowPromptTransform(a.PromptTransform),
 		SkillAliases:    cloneWorkflowSkillAliases(a.SkillAliases),
 	}, true, nil
+}
+
+// reportProviderDemotion detects when provider eligibility filtering (CLI
+// missing, unhealthy, rate-limited) changed the A/B outcome for this
+// task/step: it re-runs selection with no provider filter to find the
+// provider that would have won on hash alone, and compares it to the actual
+// (filtered) assignment. A mismatch means the intended provider got demoted —
+// logged once per (task, step, wanted provider) at Error, then throttled to
+// Debug for identical repeats (e.g. a provider stuck rate-limited for an
+// extended window) so sustained outages don't flood the log.
+func (e *Engine) reportProviderDemotion(ctx abtest.SelectionContext, actual abtest.Assignment, evalPassed abtest.EvalPassed) {
+	wanted, ok, err := abtest.SelectEligibleForContext(e.abTesting, ctx, nil, evalPassed)
+	if err != nil || !ok || wanted.Provider == actual.Provider {
+		return
+	}
+	reason := e.demotionReason(wanted.Provider)
+	key := ctx.TaskID + "|" + ctx.StepID + "|" + wanted.Provider
+	msg := fmt.Sprintf("wanted=%s got=%s reason=%s", wanted.Provider, actual.Provider, reason)
+	e.demotionThrottle.Log(e.logger, "workflow.ab.provider_demoted", key, errors.New(msg),
+		"task_id", ctx.TaskID, "workflow_id", ctx.WorkflowID, "role", ctx.Role, "step_id", ctx.StepID,
+		"wanted_provider", wanted.Provider, "selected_provider", actual.Provider, "reason", reason)
+}
+
+// demotionReason categorizes why the wanted provider was filtered out of
+// eligibility, mirroring the providerAllowed predicate's checks in order.
+func (e *Engine) demotionReason(provider string) string {
+	switch {
+	case !providerAvailable(provider):
+		return "cli_not_found"
+	case !e.agents.ProviderHealthy(provider):
+		return "unhealthy"
+	case e.agents.ProviderRateLimited(provider):
+		return "rate_limited"
+	default:
+		return "unknown"
+	}
 }
 
 func (e *Engine) renderAssignedPrompt(taskID string, step *Step, ctx TemplateContext, assignment AgentAssignment, steerLog string) (string, error) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3306,8 +3306,8 @@ func recordAttr(r slog.Record, key string) string {
 // TestExecRunAgent_ProviderDemotionEmitsThrottledSignal proves selection-time
 // provider filtering (here: rate limiting) that changes the A/B outcome
 // surfaces a first-class demotion signal — wanted/selected/reason — logged at
-// Warn on first occurrence and throttled to Debug on identical repeats, so a
-// sustained rate limit does not flood the log with duplicate Warns.
+// Error on first occurrence and throttled to Debug on identical repeats, so a
+// sustained rate limit does not flood the log with duplicate errors.
 func TestExecRunAgent_ProviderDemotionEmitsThrottledSignal(t *testing.T) {
 	prev := providerAvailable
 	providerAvailable = func(string) bool { return true }
@@ -3340,14 +3340,14 @@ func TestExecRunAgent_ProviderDemotionEmitsThrottledSignal(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	step := &Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "test prompt"}}
 
-	runOnce := func() {
+	runOnce := func(taskID string) {
 		wfExec := &Execution{WorkflowID: "test-simple", State: ExecRunning, Variables: make(map[string]string)}
-		ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
-		if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		ctx := TemplateContext{Task: TaskInfo{ID: taskID}, Step: *step, Vars: wfExec.Variables}
+		if err := engine.execRunAgent(taskID, step, wfExec, ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
-	runOnce()
+	runOnce("t1")
 	call := agents.LastCall()
 	if call.Provider != "claude" {
 		t.Fatalf("provider = %q, want claude (codex is rate-limited)", call.Provider)
@@ -3379,11 +3379,12 @@ func TestExecRunAgent_ProviderDemotionEmitsThrottledSignal(t *testing.T) {
 		t.Fatalf("task_id = %q, want t1", got)
 	}
 
-	// A second identical demotion (codex still rate-limited) must be
-	// throttled to Debug, not repeated at Warn — otherwise a sustained outage
-	// floods the log with one Warn per dispatch.
+	// A second identical demotion for a different task must still be
+	// throttled to Debug — otherwise a sustained outage floods the log with
+	// one Error per dispatch across the fleet.
 	records = nil
-	runOnce()
+	tasks.Put(TaskInfo{ID: "t2", Status: "todo", AgentMode: "headless"})
+	runOnce("t2")
 	var second []slog.Record
 	for _, r := range records {
 		if r.Message == "workflow.ab.provider_demoted" {
@@ -3395,6 +3396,9 @@ func TestExecRunAgent_ProviderDemotionEmitsThrottledSignal(t *testing.T) {
 	}
 	if second[0].Level != slog.LevelDebug {
 		t.Fatalf("repeat demotion level = %v, want Debug (throttled)", second[0].Level)
+	}
+	if got := recordAttr(second[0], "task_id"); got != "t2" {
+		t.Fatalf("task_id = %q, want t2 on throttled cross-task repeat", got)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3277,6 +3277,127 @@ func TestExecRunAgent_ABTestingSkipsConfigDisabledProvider(t *testing.T) {
 	}
 }
 
+// demotionRecordHandler captures slog records for assertions, mirroring
+// internal/sybra's recordHandler test helper.
+type demotionRecordHandler struct {
+	records *[]slog.Record
+}
+
+func (h *demotionRecordHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *demotionRecordHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h *demotionRecordHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *demotionRecordHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func recordAttr(r slog.Record, key string) string {
+	var out string
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			out = a.Value.String()
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+// TestExecRunAgent_ProviderDemotionEmitsThrottledSignal proves selection-time
+// provider filtering (here: rate limiting) that changes the A/B outcome
+// surfaces a first-class demotion signal — wanted/selected/reason — logged at
+// Warn on first occurrence and throttled to Debug on identical repeats, so a
+// sustained rate limit does not flood the log with duplicate Warns.
+func TestExecRunAgent_ProviderDemotionEmitsThrottledSignal(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	var records []slog.Record
+	logger := slog.New(&demotionRecordHandler{records: &records})
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.SetProviderRateLimitedFor("codex", true)
+	engine := NewEngine(store, tasks, agents, logger)
+	enabled := true
+	// codex carries almost all the weight so the unfiltered ("wanted")
+	// selection is codex with overwhelming probability for any task ID,
+	// making the test deterministic without hand-computing the hash.
+	engine.SetABTestingConfig(abtest.Config{
+		Enabled: &enabled,
+		Experiments: []abtest.Experiment{{
+			ID:             "exp",
+			AssignmentUnit: "stage",
+			Roles:          []string{"implementation"},
+			Variants: []abtest.Variant{
+				{ID: "codex-variant", Provider: "codex", Model: "gpt-5.5", Weight: 100},
+				{ID: "claude-variant", Provider: "claude", Model: "opus", Weight: 1},
+			},
+		}},
+	})
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	step := &Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "test prompt"}}
+
+	runOnce := func() {
+		wfExec := &Execution{WorkflowID: "test-simple", State: ExecRunning, Variables: make(map[string]string)}
+		ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
+		if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runOnce()
+	call := agents.LastCall()
+	if call.Provider != "claude" {
+		t.Fatalf("provider = %q, want claude (codex is rate-limited)", call.Provider)
+	}
+
+	var demotions []slog.Record
+	for _, r := range records {
+		if r.Message == "workflow.ab.provider_demoted" {
+			demotions = append(demotions, r)
+		}
+	}
+	if len(demotions) != 1 {
+		t.Fatalf("got %d demotion records after first run, want 1: %+v", len(demotions), demotions)
+	}
+	first := demotions[0]
+	if first.Level != slog.LevelError {
+		t.Fatalf("first demotion level = %v, want Error", first.Level)
+	}
+	if got := recordAttr(first, "wanted_provider"); got != "codex" {
+		t.Fatalf("wanted_provider = %q, want codex", got)
+	}
+	if got := recordAttr(first, "selected_provider"); got != "claude" {
+		t.Fatalf("selected_provider = %q, want claude", got)
+	}
+	if got := recordAttr(first, "reason"); got != "rate_limited" {
+		t.Fatalf("reason = %q, want rate_limited", got)
+	}
+	if got := recordAttr(first, "task_id"); got != "t1" {
+		t.Fatalf("task_id = %q, want t1", got)
+	}
+
+	// A second identical demotion (codex still rate-limited) must be
+	// throttled to Debug, not repeated at Warn — otherwise a sustained outage
+	// floods the log with one Warn per dispatch.
+	records = nil
+	runOnce()
+	var second []slog.Record
+	for _, r := range records {
+		if r.Message == "workflow.ab.provider_demoted" {
+			second = append(second, r)
+		}
+	}
+	if len(second) != 1 {
+		t.Fatalf("got %d demotion records after second run, want 1: %+v", len(second), second)
+	}
+	if second[0].Level != slog.LevelDebug {
+		t.Fatalf("repeat demotion level = %v, want Debug (throttled)", second[0].Level)
+	}
+}
+
 func TestHandleAgentComplete_CompletedWorkflowIsNoop(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3285,7 +3285,7 @@ type demotionRecordHandler struct {
 
 func (h *demotionRecordHandler) Enabled(context.Context, slog.Level) bool { return true }
 func (h *demotionRecordHandler) Handle(_ context.Context, r slog.Record) error {
-	*h.records = append(*h.records, r)
+	*h.records = append(*h.records, r.Clone())
 	return nil
 }
 func (h *demotionRecordHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }

--- a/internal/workflow/handoff_test.go
+++ b/internal/workflow/handoff_test.go
@@ -120,14 +120,21 @@ func TestBuiltinHandoffReview_SkipsToReview(t *testing.T) {
 	if !hasCondition(review.Trigger.Conditions, "task.status", "equals", "ready-review") {
 		t.Errorf("simple-task-review must trigger on status=ready-review; got %+v", review.Trigger.Conditions)
 	}
-	for _, stepID := range []string{"code_review_simple", "code_review_staff"} {
-		step := review.StepByID(stepID)
-		if step == nil {
-			t.Fatalf("simple-task-review %s step not found", stepID)
-		}
-		if step.Config.Provider != "cross" {
-			t.Errorf("simple-task-review %s provider = %q, want cross", stepID, step.Config.Provider)
-		}
+	// code_review_simple stays a cross-check lane; code_review_staff is pinned
+	// to claude for high-risk review (see simple-task-review.yaml).
+	simple := review.StepByID("code_review_simple")
+	if simple == nil {
+		t.Fatal("simple-task-review code_review_simple step not found")
+	}
+	if simple.Config.Provider != "cross" {
+		t.Errorf("simple-task-review code_review_simple provider = %q, want cross", simple.Config.Provider)
+	}
+	staff := review.StepByID("code_review_staff")
+	if staff == nil {
+		t.Fatal("simple-task-review code_review_staff step not found")
+	}
+	if staff.Config.Provider != "claude" {
+		t.Errorf("simple-task-review code_review_staff provider = %q, want claude", staff.Config.Provider)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Live 30-day scorecard data shows codex outperforming for most code-author roles, and copilot is only ready for a subset of them — the shared A/B bracket couldn't express that split. Staff-level code review also needed pinning to claude, since codex fails roughly twice as often there on high-risk diffs.

## Implementation information

- Split the code-author A/B bracket: implementation gets codex-heavy routing with capped copilot exposure; fix-review/pr-fix/test-runner get codex-heavy routing without copilot yet.
- Pin staff-level code review to claude.
- Add a versioned reconcile so persisted configs adopt refreshed built-in experiments (not just fresh installs), backing up the prior experiment list before overwriting any same-ID built-in, leaving user-authored experiments untouched.
- Add a selection-time provider-demotion signal, throttled to avoid log storms, so a rate-limited/unhealthy/missing provider silently remapped to a fallback becomes visible instead of hiding cost-savings evaporation.
- Follow-up commit addresses review feedback on the above.

Closes https://github.com/Automaat/sybra/issues/1491

_Generated by Sybra harness_