### PR TITLE
chore(evaluation): promote impl-prompt-checklist, fix verdicts

### DIFF
--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -57,18 +57,25 @@ func (r Role) IsSystem() bool {
 	return r == RoleTriage || r == RoleEval || r == RolePlanCritic || r == RoleHumanReview
 }
 
-// RoleFromName extracts the Role from a prefixed agent name.
-// Returns RoleImplementation for names without a known prefix.
-func RoleFromName(name string) Role {
+// ParseRoleFromName extracts the Role from a prefixed agent name.
+// The bool reports whether the name carried a known role prefix.
+func ParseRoleFromName(name string) (Role, bool) {
 	prefix, _, ok := strings.Cut(name, ":")
 	if !ok {
-		return RoleImplementation
+		return RoleImplementation, false
 	}
 	r := Role(prefix)
 	switch r {
-	case RoleTriage, RolePlan, RolePlanCritic, RoleEval, RolePRFix, RoleReview, RoleFixReview, RoleTestRunner, RoleHumanReview:
-		return r
+	case RoleTriage, RolePlan, RolePlanCritic, RoleEval, RolePRFix, RoleReview, RoleFixReview, RoleTestRunner, RoleImplementation, RoleHumanReview:
+		return r, true
 	default:
-		return RoleImplementation
+		return RoleImplementation, false
 	}
+}
+
+// RoleFromName extracts the Role from a prefixed agent name.
+// Returns RoleImplementation for names without a known prefix.
+func RoleFromName(name string) Role {
+	r, _ := ParseRoleFromName(name)
+	return r
 }

--- a/internal/agent/role_test.go
+++ b/internal/agent/role_test.go
@@ -122,3 +122,28 @@ func TestRoleFromName(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRoleFromName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		want   Role
+		wantOK bool
+	}{
+		{"test-runner:Run Tests", RoleTestRunner, true},
+		{"implementation:Impl", RoleImplementation, true},
+		{"unknown:something", RoleImplementation, false},
+		{"no-colon", RoleImplementation, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseRoleFromName(tt.name)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("ParseRoleFromName(%q) = (%q, %v), want (%q, %v)", tt.name, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -91,24 +91,7 @@ func runDurationSeconds(ag *agent.Agent) float64 {
 }
 
 func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
-	var resultContent string
-	var hasResultEvent bool
-	outputs := ag.Output()
-	for i := range outputs {
-		if outputs[i].Type == "result" {
-			resultContent = outputs[i].Content
-			hasResultEvent = true
-		}
-	}
-	// Codex's terminal turn.completed event carries no text — the final message
-	// arrives as an assistant StreamEvent. When a result event was seen but
-	// carried empty content, fall back to the last assistant turn so that
-	// result-dependent paths (extractTestVerdict, PR-URL scraping) work for
-	// codex too. Guard with hasResultEvent so agents that exit-0 without
-	// emitting any result event (no_result scenario) are NOT back-filled.
-	if hasResultEvent && resultContent == "" {
-		resultContent = lastAssistantText(ag)
-	}
+	resultContent := terminalResultContent(ag)
 
 	// Snapshot mutable fields once under the agent's lock so both the
 	// persistence write and the audit entry see a consistent view.
@@ -159,34 +142,7 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 
 	h.emitPermissionDenialAudits(ag)
 
-	truncated := resultContent
-	if len(truncated) > maxResultLen {
-		truncated = truncated[:maxResultLen] + "\n... (truncated)"
-	}
-	runUpdates := task.RunPatch{
-		State:           task.Ptr(string(state)),
-		CostUSD:         task.Ptr(cost),
-		PremiumRequests: task.Ptr(premiumRequests),
-		Result:          task.Ptr(truncated),
-		LogFile:         task.Ptr(ag.LogPath),
-		SessionID:       task.Ptr(ag.GetSessionID()),
-		Model:           task.Ptr(ag.Model),
-		Provider:        task.Ptr(ag.Provider),
-	}
-	addRunMetadata(&runUpdates, ag)
-	// For human-review agents, parse the verdict from the live (untruncated)
-	// output and persist it in its own field so detector.go can read it even
-	// when the full result text is longer than maxResultLen.
-	if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
-		if v, _, err := verdict.Parse(finalAssistantText(ag)); err == nil {
-			runUpdates.Verdict = task.Ptr(v.Decision)
-		}
-	}
-	// Capture the worktree HEAD while it still exists (cleanup below is async) so
-	// landing can later detect human edits after the agent (merged_with_edits).
-	if sha := h.captureHeadSHA(ag.TaskID); sha != "" {
-		runUpdates.HeadSHA = task.Ptr(sha)
-	}
+	runUpdates := h.buildRunPatch(ag, state, cost, premiumRequests, resultContent)
 	if err := h.tasks.UpdateRun(ag.TaskID, ag.ID, runUpdates); err != nil {
 		h.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
@@ -223,6 +179,28 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 }
 
+func terminalResultContent(ag *agent.Agent) string {
+	var resultContent string
+	var hasResultEvent bool
+	outputs := ag.Output()
+	for i := range outputs {
+		if outputs[i].Type == "result" {
+			resultContent = outputs[i].Content
+			hasResultEvent = true
+		}
+	}
+	// Codex's terminal turn.completed event carries no text — the final message
+	// arrives as an assistant StreamEvent. When a result event was seen but
+	// carried empty content, fall back to the last assistant turn so that
+	// result-dependent paths (extractTestVerdict, PR-URL scraping) work for
+	// codex too. Guard with hasResultEvent so agents that exit-0 without
+	// emitting any result event (no_result scenario) are NOT back-filled.
+	if hasResultEvent && resultContent == "" {
+		return lastAssistantText(ag)
+	}
+	return resultContent
+}
+
 // emitPermissionDenialAudits emits one agent.permission_denied audit event per
 // auto-mode denial recorded during the run. Batched at completion time so the
 // audit log is not spammed mid-run; a killed run may drop its denial events —
@@ -252,6 +230,38 @@ func addRunMetadata(updates *task.RunPatch, ag *agent.Agent) {
 	if ag.ReasoningEffort != "" {
 		updates.ReasoningEffort = task.Ptr(ag.ReasoningEffort)
 	}
+}
+
+func (h *AgentCompletionHandler) buildRunPatch(ag *agent.Agent, state agent.State, cost, premiumRequests float64, resultContent string) task.RunPatch {
+	truncated := resultContent
+	if len(truncated) > maxResultLen {
+		truncated = truncated[:maxResultLen] + "\n... (truncated)"
+	}
+	runUpdates := task.RunPatch{
+		State:           task.Ptr(string(state)),
+		CostUSD:         task.Ptr(cost),
+		PremiumRequests: task.Ptr(premiumRequests),
+		Result:          task.Ptr(truncated),
+		LogFile:         task.Ptr(ag.LogPath),
+		SessionID:       task.Ptr(ag.GetSessionID()),
+		Model:           task.Ptr(ag.Model),
+		Provider:        task.Ptr(ag.Provider),
+	}
+	addRunMetadata(&runUpdates, ag)
+	// For human-review agents, parse the verdict from the live (untruncated)
+	// output and persist it in its own field so detector.go can read it even
+	// when the full result text is longer than maxResultLen.
+	if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
+		if v, _, err := verdict.Parse(finalAssistantText(ag)); err == nil {
+			runUpdates.Verdict = task.Ptr(v.Decision)
+		}
+	}
+	// Capture the worktree HEAD while it still exists (cleanup below is async) so
+	// landing can later detect human edits after the agent (merged_with_edits).
+	if sha := h.captureHeadSHA(ag.TaskID); sha != "" {
+		runUpdates.HeadSHA = task.Ptr(sha)
+	}
+	return runUpdates
 }
 
 // notifyWorkflowEngine advances the workflow engine for a completed agent.

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -141,7 +141,7 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, auditData)
 
-	h.recordRunStats(ag, cost, duration, exitErr)
+	h.recordRunStats(ag, cost, duration, exitErr, resultContent)
 
 	// Loop agents run without a TaskID — let the scheduler record cost
 	// before the early return below kicks in.
@@ -411,9 +411,32 @@ func (h *AgentCompletionHandler) captureHeadSHA(taskID string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// runOutcome derives the stats.RunRecord outcome ("completed"/"failed") for a
+// terminal agent run. Test-runner is special-cased: its exitErr reflects
+// whether the *process* exited clean, not whether it correctly did its job
+// (proving or failing to disprove the implementation). A test-runner that
+// produced a protocol-valid PASS/FAIL verdict succeeded at its job even if a
+// benign post-result glitch (e.g. a trailing stream hiccup) left exitErr
+// non-nil, so it is recorded as "completed" rather than inflating the role's
+// failure_rate with a run that was never actually a failure. Other roles are
+// unaffected: their exitErr already reflects whether they completed the task.
+func runOutcome(role agent.Role, exitErr error, resultContent string) string {
+	if exitErr == nil {
+		return "completed"
+	}
+	if role == agent.RoleTestRunner {
+		if v := workflow.ExtractTestVerdict(resultContent); v == "PASS" || v == "FAIL" {
+			return "completed"
+		}
+	}
+	return "failed"
+}
+
 // recordRunStats persists a stats.RunRecord for the completed agent.
-// No-op when the stats store failed to initialize at startup.
-func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration float64, exitErr error) {
+// No-op when the stats store failed to initialize at startup. resultContent
+// is the agent's final message text, forwarded to runOutcome for test-runner
+// verdict recovery.
+func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration float64, exitErr error, resultContent string) {
 	if h.stats == nil {
 		return
 	}
@@ -423,10 +446,7 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 	cacheRead := ag.GetCacheReadInputTokens()
 	reasoning := ag.GetReasoningTokens()
 	agCost := estimatedRunCost(ag, cost, ag.GetPremiumRequests())
-	outcome := "failed"
-	if exitErr == nil {
-		outcome = "completed"
-	}
+	outcome := runOutcome(agent.RoleFromName(ag.Name), exitErr, resultContent)
 	var projectID string
 	if ag.TaskID != "" {
 		if t, err := h.tasks.Get(ag.TaskID); err == nil {

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -123,12 +123,13 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	// parent task and skip the storage paths below, but their lifecycle
 	// still belongs in the audit trail.
 	duration := runDurationSeconds(ag)
+	role := h.roleForAgentName(ag.Name)
 	auditData := map[string]any{
 		"mode":       ag.Mode,
 		"cost_usd":   cost,
 		"duration_s": duration,
 		"state":      string(state),
-		"role":       agent.RoleFromName(ag.Name),
+		"role":       role,
 		"provider":   ag.Provider,
 		"name":       ag.Name,
 		"log_file":   ag.LogPath,
@@ -141,7 +142,7 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, auditData)
 
-	h.recordRunStats(ag, cost, duration, exitErr, resultContent)
+	h.recordRunStats(ag, role, cost, duration, exitErr, resultContent)
 
 	// Loop agents run without a TaskID — let the scheduler record cost
 	// before the early return below kicks in.
@@ -432,11 +433,20 @@ func runOutcome(role agent.Role, exitErr error, resultContent string) string {
 	return "failed"
 }
 
+func (h *AgentCompletionHandler) roleForAgentName(name string) agent.Role {
+	role, ok := agent.ParseRoleFromName(name)
+	if ok || !strings.Contains(name, ":") {
+		return role
+	}
+	h.logger.Warn("agent.role.unknown-prefix", "name", name)
+	return role
+}
+
 // recordRunStats persists a stats.RunRecord for the completed agent.
 // No-op when the stats store failed to initialize at startup. resultContent
 // is the agent's final message text, forwarded to runOutcome for test-runner
 // verdict recovery.
-func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration float64, exitErr error, resultContent string) {
+func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, role agent.Role, cost, duration float64, exitErr error, resultContent string) {
 	if h.stats == nil {
 		return
 	}
@@ -446,7 +456,7 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 	cacheRead := ag.GetCacheReadInputTokens()
 	reasoning := ag.GetReasoningTokens()
 	agCost := estimatedRunCost(ag, cost, ag.GetPremiumRequests())
-	outcome := runOutcome(agent.RoleFromName(ag.Name), exitErr, resultContent)
+	outcome := runOutcome(role, exitErr, resultContent)
 	var projectID string
 	if ag.TaskID != "" {
 		if t, err := h.tasks.Get(ag.TaskID); err == nil {
@@ -458,7 +468,7 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 		TaskID:                   ag.TaskID,
 		ProjectID:                projectID,
 		Mode:                     ag.Mode,
-		Role:                     string(agent.RoleFromName(ag.Name)),
+		Role:                     string(role),
 		Model:                    ag.Model,
 		Provider:                 ag.Provider,
 		ReasoningEffort:          ag.ReasoningEffort,

--- a/internal/sybra/agent_completion_test.go
+++ b/internal/sybra/agent_completion_test.go
@@ -10,6 +10,56 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 )
 
+func TestRunOutcome(t *testing.T) {
+	t.Parallel()
+	errBoom := errors.New("boom")
+
+	cases := []struct {
+		name          string
+		role          agent.Role
+		exitErr       error
+		resultContent string
+		want          string
+	}{
+		{"clean_exit_any_role", agent.RoleImplementation, nil, "", "completed"},
+		{"non_test_runner_errors_are_failed", agent.RoleImplementation, errBoom, "TEST_VERDICT: PASS", "failed"},
+		{
+			name:          "test_runner_genuine_pass_survives_trailing_process_error",
+			role:          agent.RoleTestRunner,
+			exitErr:       errBoom,
+			resultContent: "ran the app end to end\nTEST_VERDICT: PASS",
+			want:          "completed",
+		},
+		{
+			// A FAIL verdict means the test-runner did its job (proved a real
+			// defect), so it's still "completed" for stats purposes — the
+			// implementation's failure is tracked separately via the task's
+			// TestOutcome/route_test_result, not this agent-run stat.
+			name:          "test_runner_genuine_fail_still_completed_the_protocol",
+			role:          agent.RoleTestRunner,
+			exitErr:       errBoom,
+			resultContent: "found a defect\nTEST_VERDICT: FAIL",
+			want:          "completed",
+		},
+		{
+			name:          "test_runner_no_verdict_is_a_real_failure",
+			role:          agent.RoleTestRunner,
+			exitErr:       errBoom,
+			resultContent: "crashed before concluding anything",
+			want:          "failed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := runOutcome(tc.role, tc.exitErr, tc.resultContent); got != tc.want {
+				t.Errorf("runOutcome(%v, %v, %q) = %q, want %q", tc.role, tc.exitErr, tc.resultContent, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsRateLimitedRun(t *testing.T) {
 	t.Parallel()
 	rateLimited := &agent.Agent{}

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -46,6 +46,9 @@ steps:
         gate. If an existing test is genuinely wrong, fix it correctly and
         explain why in the commit message — do not silently disable it.
         Tampering is detected mechanically and will block the task.
+
+        Before finishing, re-check your change against a short checklist:
+        tests updated, edge cases covered, no leftover debug code.
         {{- if .Task.PlanContract}}
 
         ## Executable Plan Contract

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -80,7 +80,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		// above whenever a thorough test-runner writes a long summary. No-op
 		// (empty) for every non-test step. See route_test_result.
 		if output.Status == "completed" {
-			if v := extractTestVerdict(output.Output); v != "" {
+			if v := ExtractTestVerdict(output.Output); v != "" {
 				wfExec.SetVar("step."+output.StepID+".verdict", v)
 			}
 		}

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1851,6 +1851,15 @@ var fixSuggestionEvidencePrefixes = []string{
 // Non-object-shaped output (claude plain text) falls to the exact-line marker
 // scan. The last matching line wins; missing/ambiguous output yields "" → FAIL,
 // which is the safe direction.
+//
+// ExtractTestVerdict is the exported entry point for callers outside this
+// package (e.g. agent_completion.recordRunStats, which needs the verdict to
+// tell a test-runner that genuinely completed its protocol from one that
+// crashed before producing one).
+func ExtractTestVerdict(output string) string {
+	return extractTestVerdict(output)
+}
+
 func extractTestVerdict(output string) string {
 	// Strip a leading UTF-8 BOM, then trim whitespace before shape detection.
 	s := strings.TrimSpace(strings.TrimPrefix(output, "\xef\xbb\xbf"))

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1843,14 +1843,15 @@ var fixSuggestionEvidencePrefixes = []string{
 //
 // Object-shaped output (leading `{` after trimming BOM/whitespace) is treated
 // as authoritative JSON: the `verdict` field is parsed and the marker scan is
-// skipped entirely. A malformed or unexpected object yields "" → FAIL without
-// falling through to the marker, so a JSON body that incidentally contains a
-// marker-shaped substring cannot misroute. This is the path codex takes when
+// skipped entirely. A malformed or unexpected object yields "", and callers
+// interpret that empty verdict in the fail-safe direction, without falling
+// through to the marker. That prevents a JSON body that incidentally contains
+// a marker-shaped substring from misrouting. This is the path codex takes when
 // --output-schema enforces a structured response.
 //
 // Non-object-shaped output (claude plain text) falls to the exact-line marker
-// scan. The last matching line wins; missing/ambiguous output yields "" → FAIL,
-// which is the safe direction.
+// scan. The last matching line wins; missing/ambiguous output yields "", which
+// callers treat as a non-pass/failing-safe verdict.
 func ExtractTestVerdict(output string) string {
 	// Strip a leading UTF-8 BOM, then trim whitespace before shape detection.
 	s := strings.TrimSpace(strings.TrimPrefix(output, "\xef\xbb\xbf"))

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -466,7 +466,7 @@ func (e *Engine) appendTestFailureReport(taskID string, output StepOutput, wfExe
 			return false, body, nil
 		}
 		report = normalizeStructuredFailuresMarkdown(parsed.FailuresMarkdown, parsed.Outcome)
-	} else if extractTestVerdict(output.Output) == "FAIL" {
+	} else if ExtractTestVerdict(output.Output) == "FAIL" {
 		report = plainTestFailureReport(output.Output)
 	}
 	if report == "" {
@@ -1118,7 +1118,7 @@ func applyTestVerdictCompletion(wfExec *Execution, output *StepOutput, body stri
 	if output.Status != "completed" && output.Status != "failed" {
 		return "", "", ""
 	}
-	v := extractTestVerdict(output.Output)
+	v := ExtractTestVerdict(output.Output)
 	outcome, fingerprint = classifyTestOutcome(output.Status, output.Output, body, wfExec, output.StepID)
 	if outcome != "" {
 		wfExec.SetVar("step."+output.StepID+"."+testVerdictOutcomeKey, outcome)
@@ -1178,7 +1178,7 @@ func appendTestInfrastructureFailure(output string) string {
 }
 
 func classifyTestOutcome(status, output, body string, wfExec *Execution, stepID string) (outcome, fingerprint string) {
-	v := extractTestVerdict(output)
+	v := ExtractTestVerdict(output)
 	if status == "failed" {
 		return testOutcomeInfraFailure, ""
 	}
@@ -1839,7 +1839,7 @@ var fixSuggestionEvidencePrefixes = []string{
 	"temporary test body",
 }
 
-// extractTestVerdict returns "PASS"/"FAIL"/"" from agent output.
+// ExtractTestVerdict returns "PASS"/"FAIL"/"" from agent output.
 //
 // Object-shaped output (leading `{` after trimming BOM/whitespace) is treated
 // as authoritative JSON: the `verdict` field is parsed and the marker scan is
@@ -1851,16 +1851,7 @@ var fixSuggestionEvidencePrefixes = []string{
 // Non-object-shaped output (claude plain text) falls to the exact-line marker
 // scan. The last matching line wins; missing/ambiguous output yields "" → FAIL,
 // which is the safe direction.
-//
-// ExtractTestVerdict is the exported entry point for callers outside this
-// package (e.g. agent_completion.recordRunStats, which needs the verdict to
-// tell a test-runner that genuinely completed its protocol from one that
-// crashed before producing one).
 func ExtractTestVerdict(output string) string {
-	return extractTestVerdict(output)
-}
-
-func extractTestVerdict(output string) string {
 	// Strip a leading UTF-8 BOM, then trim whitespace before shape detection.
 	s := strings.TrimSpace(strings.TrimPrefix(output, "\xef\xbb\xbf"))
 	if strings.HasPrefix(s, "{") {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -70,8 +70,8 @@ func TestExtractTestVerdict(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := extractTestVerdict(tc.output); got != tc.want {
-				t.Errorf("extractTestVerdict(%q) = %q, want %q", tc.output, got, tc.want)
+			if got := ExtractTestVerdict(tc.output); got != tc.want {
+				t.Errorf("ExtractTestVerdict(%q) = %q, want %q", tc.output, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

The impl-prompt-checklist A/B variant cut implementation turns ~21% with no completion regression, so it should become the standing implementation prompt instead of an ongoing experiment. Separately, test-runner's stats outcome was derived solely from the agent process's exit error, unrelated to the verdict it actually produced, inflating the role's failure_rate.

## Implementation information

- Promote the impl-prompt-checklist variant into `simple-task-implement.yaml` as the default implementation prompt.
- Fix test-runner completion accounting: a protocol-valid PASS/FAIL verdict now counts as completed even if a trailing process glitch left `exitErr` set.
- Address follow-up review comments: tighten role handling in `internal/agent/role.go`, adjust workflow test-route step and advance logic, and add corresponding test coverage.

Closes https://github.com/Automaat/sybra/issues/1492

_Generated by Sybra harness_