### PR TITLE
fix(umbrella): give planner attempts fresh budgets

### DIFF
--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -103,7 +103,7 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
 				continue
 			}
-			return Result{}, providerError(p, err, stderrOut)
+			return Result{Provider: p}, providerError(p, err, stderrOut)
 		}
 
 		text, cost, parseErr := parseProviderText(p, raw)
@@ -125,7 +125,7 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
 				continue
 			}
-			return Result{}, fmt.Errorf("%s output: %w", p, parseErr)
+			return Result{Provider: p}, fmt.Errorf("%s output: %w", p, parseErr)
 		}
 		return Result{Provider: p, Text: text, CostUSD: cost}, nil
 	}

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -67,7 +67,9 @@ type Result struct {
 func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 	candidates := candidates(opts.Provider)
 	var failures []string
+	var lastProvider string
 	for _, p := range candidates {
+		lastProvider = p
 		if ctx.Err() != nil {
 			return Result{}, ctx.Err()
 		}
@@ -132,7 +134,7 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 	if len(failures) == 0 {
 		return Result{}, errors.New("no providers configured")
 	}
-	return Result{}, fmt.Errorf("all providers failed: %s", strings.Join(failures, "; "))
+	return Result{Provider: lastProvider}, fmt.Errorf("all providers failed: %s", strings.Join(failures, "; "))
 }
 
 func candidates(preferred string) []string {

--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -294,6 +294,31 @@ printf '%s\n' '{"type":"assistant.message","data":{"content":"{\"ok\":true}"}}'
 	}
 }
 
+func TestRunJSONAllProvidersFailedNamesLastProvider(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "claude"), `#!/bin/sh
+echo "rate limit exceeded" >&2
+exit 1
+`)
+	writeExe(t, filepath.Join(dir, "codex"), `#!/bin/sh
+echo "rate limit exceeded" >&2
+exit 1
+`)
+	writeExe(t, filepath.Join(dir, "copilot"), `#!/bin/sh
+echo "rate limit exceeded" >&2
+exit 1
+`)
+	t.Setenv("PATH", dir)
+
+	res, err := RunJSON(context.Background(), "classify", Options{})
+	if err == nil {
+		t.Fatal("RunJSON: want error when every provider fails")
+	}
+	if res.Provider != "copilot" {
+		t.Fatalf("provider = %q, want copilot (last candidate tried)", res.Provider)
+	}
+}
+
 func writeExe(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -41,6 +41,18 @@ type Spec[T any] struct {
 	AttemptTimeout time.Duration
 }
 
+// Attempts returns the total number of runJSON invocations Run will make for
+// this Spec (the initial attempt plus repairs), so callers that need to size
+// an outer deadline around Run don't have to hand-maintain their own copy of
+// 1+maxRepairs.
+func (s Spec[T]) Attempts() int {
+	maxRepairs := s.MaxRepairs
+	if maxRepairs == 0 {
+		maxRepairs = defaultMaxRepairs
+	}
+	return 1 + maxRepairs
+}
+
 type Meta struct {
 	Provider string
 	Tier     Tier
@@ -66,7 +78,7 @@ func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options
 	if maxRepairs == 0 {
 		maxRepairs = defaultMaxRepairs
 	}
-	attempts := 1 + maxRepairs
+	attempts := s.Attempts()
 	attemptPrompt := prompt
 	var lastErr error
 	var lastProvider string

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -28,6 +28,17 @@ type Spec[T any] struct {
 	Validate      func(*T) error
 	MaxRepairs    int
 	AvoidProvider string
+	// AttemptTimeout, when set, bounds a single runJSON invocation instead of
+	// letting the caller's ctx govern the whole call directly. Each attempt
+	// (including repairs) gets its own context.WithTimeout derived fresh from
+	// ctx, so one slow/hung attempt cannot consume the budget a later retry
+	// needs. It also opts the job into retrying after a hard runJSON error
+	// (not just a malformed/invalid response) — with a shared, un-bounded
+	// per-attempt budget that retry would just re-hit the same expired
+	// deadline, so it stays gated on AttemptTimeout being set. Zero leaves
+	// legacy behavior unchanged: the whole call shares ctx, and a runJSON
+	// error is fatal (no retry).
+	AttemptTimeout time.Duration
 }
 
 type Meta struct {
@@ -59,11 +70,16 @@ func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options
 	attemptPrompt := prompt
 	var lastErr error
 	var lastProvider string
+	madeAttempts := 0
 	for attempt := range attempts {
-		res, err := runJSON(ctx, attemptPrompt, o)
+		madeAttempts = attempt + 1
+		res, err := runAttempt(ctx, s.AttemptTimeout, attemptPrompt, o)
 		if err != nil {
 			lastErr = err
 			lastProvider = res.Provider
+			if s.AttemptTimeout > 0 && attempt < attempts-1 && ctx.Err() == nil {
+				continue
+			}
 			break
 		}
 		lastProvider = res.Provider
@@ -92,7 +108,20 @@ func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options
 	}
 	logJob(o.Logger, s.Name, lastProvider, s.Tier, maxRepairs, false)
 	return zero, Meta{Provider: lastProvider, Tier: s.Tier, Repairs: maxRepairs},
-		fmt.Errorf("%s job failed with provider %q after %d attempts: %w", s.Name, lastProvider, attempts, lastErr)
+		fmt.Errorf("%s job failed with provider %q after %d attempts: %w", s.Name, lastProvider, madeAttempts, lastErr)
+}
+
+// runAttempt runs one runJSON invocation, optionally bounding it with its own
+// fresh timeout derived from ctx rather than letting a shared ambient
+// deadline decide how much of the budget is left by the time this attempt
+// starts.
+func runAttempt(ctx context.Context, timeout time.Duration, prompt string, o llmexec.Options) (llmexec.Result, error) {
+	if timeout <= 0 {
+		return runJSON(ctx, prompt, o)
+	}
+	actx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return runJSON(actx, prompt, o)
 }
 
 func mergeModels(defaults, explicit map[string]string) map[string]string {

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -120,7 +120,7 @@ func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options
 	}
 	logJob(o.Logger, s.Name, lastProvider, s.Tier, maxRepairs, false)
 	return zero, Meta{Provider: lastProvider, Tier: s.Tier, Repairs: maxRepairs},
-		fmt.Errorf("%s job failed with provider %q after %d attempts: %w", s.Name, lastProvider, madeAttempts, lastErr)
+		fmt.Errorf("%s job failed with provider %q model %q after %d attempts: %w", s.Name, lastProvider, o.Models[lastProvider], madeAttempts, lastErr)
 }
 
 // runAttempt runs one runJSON invocation, optionally bounding it with its own

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/llmexec"
 )
@@ -93,6 +94,71 @@ func TestRun(t *testing.T) {
 				t.Fatalf("repair prompt missing invalid-output context: %q", prompts[len(prompts)-1])
 			}
 		})
+	}
+}
+
+// TestRunAttemptTimeoutGivesEachAttemptFreshBudget covers the umbrella
+// planner regression (#1555): a single shared deadline let attempt 1 consume
+// the whole budget on a hung provider call, so attempts 2/3 died instantly on
+// an already-expired context. With AttemptTimeout set, each attempt gets its
+// own context.WithTimeout derived fresh from ctx, so a provider that sleeps
+// past its own per-attempt deadline still leaves later attempts a full
+// budget to actually run in.
+func TestRunAttemptTimeoutGivesEachAttemptFreshBudget(t *testing.T) {
+	const attemptTimeout = 20 * time.Millisecond
+	calls := 0
+	restore := stubRunner(func(ctx context.Context, _ string, _ llmexec.Options) (llmexec.Result, error) {
+		calls++
+		if calls == 1 {
+			<-ctx.Done()
+			return llmexec.Result{Provider: "claude"}, ctx.Err()
+		}
+		return llmexec.Result{Provider: "claude", Text: `{"ok":true}`}, nil
+	})
+	defer restore()
+
+	_, meta, err := Run(context.Background(), "prompt", Spec[testOut]{
+		Name:           "umbrella-order",
+		Tier:           Cheap,
+		AttemptTimeout: attemptTimeout,
+	}, llmexec.Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2 (attempt 2 must run after attempt 1's deadline expires)", calls)
+	}
+	if meta.Provider != "claude" {
+		t.Fatalf("meta.Provider = %q, want %q", meta.Provider, "claude")
+	}
+}
+
+// TestRunAttemptTimeoutFinalErrorNamesProvider covers the other half of
+// #1555: when every attempt fails, the wrapped error must still name the
+// provider that failed rather than reporting an empty provider (previously
+// lost because RunJSON's error-path Results were zero-valued).
+func TestRunAttemptTimeoutFinalErrorNamesProvider(t *testing.T) {
+	restore := stubRunner(func(_ context.Context, _ string, _ llmexec.Options) (llmexec.Result, error) {
+		return llmexec.Result{Provider: "claude"}, errors.New("signal: killed")
+	})
+	defer restore()
+
+	_, meta, err := Run(context.Background(), "prompt", Spec[testOut]{
+		Name:           "umbrella-order",
+		Tier:           Cheap,
+		AttemptTimeout: 20 * time.Millisecond,
+	}, llmexec.Options{})
+	if err == nil {
+		t.Fatal("Run: want error")
+	}
+	if !strings.Contains(err.Error(), `provider "claude"`) {
+		t.Fatalf("err = %v, want it to name provider %q", err, "claude")
+	}
+	if !strings.Contains(err.Error(), "after 3 attempts") {
+		t.Fatalf("err = %v, want it to report all 3 attempts made", err)
+	}
+	if meta.Provider != "claude" {
+		t.Fatalf("meta.Provider = %q, want %q", meta.Provider, "claude")
 	}
 }
 

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -135,8 +135,11 @@ func TestRunAttemptTimeoutGivesEachAttemptFreshBudget(t *testing.T) {
 
 // TestRunAttemptTimeoutFinalErrorNamesProvider covers the other half of
 // #1555: when every attempt fails, the wrapped error must still name the
-// provider that failed rather than reporting an empty provider (previously
-// lost because RunJSON's error-path Results were zero-valued).
+// provider and model that failed rather than reporting an empty provider
+// (previously lost because RunJSON's error-path Results were zero-valued).
+// Tier: Standard matches the umbrella planner's actual Spec (llmjob.Standard
+// maps claude to sonnet), so this doubles as a regression test for the
+// missing-model-name defect found during manual testing.
 func TestRunAttemptTimeoutFinalErrorNamesProvider(t *testing.T) {
 	restore := stubRunner(func(_ context.Context, _ string, _ llmexec.Options) (llmexec.Result, error) {
 		return llmexec.Result{Provider: "claude"}, errors.New("signal: killed")
@@ -145,7 +148,7 @@ func TestRunAttemptTimeoutFinalErrorNamesProvider(t *testing.T) {
 
 	_, meta, err := Run(context.Background(), "prompt", Spec[testOut]{
 		Name:           "umbrella-order",
-		Tier:           Cheap,
+		Tier:           Standard,
 		AttemptTimeout: 20 * time.Millisecond,
 	}, llmexec.Options{})
 	if err == nil {
@@ -153,6 +156,9 @@ func TestRunAttemptTimeoutFinalErrorNamesProvider(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `provider "claude"`) {
 		t.Fatalf("err = %v, want it to name provider %q", err, "claude")
+	}
+	if !strings.Contains(err.Error(), `model "sonnet"`) {
+		t.Fatalf("err = %v, want it to name model %q", err, "sonnet")
 	}
 	if !strings.Contains(err.Error(), "after 3 attempts") {
 		t.Fatalf("err = %v, want it to report all 3 attempts made", err)

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -43,14 +43,22 @@ var plannerJobSpec = llmjob.Spec[Plan]{
 // — used only to size plannerTimeout below.
 var plannerJobAttempts = plannerJobSpec.Attempts()
 
+// plannerGenerateSamples is the maximum number of planner samples Generate can
+// request: plannerAttempts for the initial attemptPlan plus another
+// plannerAttempts for the critic re-ask path when the first valid plan looks
+// suspiciously flat.
+const plannerGenerateSamples = plannerAttempts * 2
+
 // plannerTimeout bounds the whole Generate call — every attemptPlan retry
 // plus the zero-edge-floor critic re-ask — so a hung process cannot wedge an
-// expansion indefinitely. It comfortably covers plannerJobAttempts each
-// getting a full PlannerAttemptTimeout, plus headroom that scales with
-// subCount: a bigger umbrella means a longer prompt and legitimately more
-// model time, and a bigger expansion is more expensive to have starved.
+// expansion indefinitely. It comfortably covers plannerGenerateSamples each
+// getting plannerJobAttempts full PlannerAttemptTimeout slices, plus headroom
+// that scales with subCount: a bigger umbrella means a longer prompt and
+// legitimately more model time, and a bigger expansion is more expensive to
+// have starved.
 func plannerTimeout(subCount int) time.Duration {
-	return PlannerAttemptTimeout*time.Duration(plannerJobAttempts) + time.Duration(subCount)*5*time.Second
+	return PlannerAttemptTimeout*time.Duration(plannerJobAttempts*plannerGenerateSamples) +
+		time.Duration(subCount*plannerGenerateSamples)*5*time.Second
 }
 
 // FetchTimeout bounds the GitHub sub-issue fetch so a stalled gh call cannot

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -29,10 +29,19 @@ var errSkipUpdate = errors.New("skip update")
 // (see #1555).
 const PlannerAttemptTimeout = 4 * time.Minute
 
-// plannerJobAttempts mirrors llmjob's default 1+maxRepairs attempts for the
-// "umbrella-order" job (Tier Standard, no MaxRepairs override) — used only to
-// size plannerTimeout below.
-const plannerJobAttempts = 3
+// plannerJobSpec is the llmjob.Spec FallbackPlannerRunner runs the
+// "umbrella-order" job with. It is shared with plannerTimeout below via
+// Attempts() so the two can never drift out of sync the way a
+// hand-maintained attempt-count constant could.
+var plannerJobSpec = llmjob.Spec[Plan]{
+	Name:           "umbrella-order",
+	Tier:           llmjob.Standard,
+	AttemptTimeout: PlannerAttemptTimeout,
+}
+
+// plannerJobAttempts mirrors llmjob's 1+maxRepairs attempts for plannerJobSpec
+// — used only to size plannerTimeout below.
+var plannerJobAttempts = plannerJobSpec.Attempts()
 
 // plannerTimeout bounds the whole Generate call — every attemptPlan retry
 // plus the zero-edge-floor critic re-ask — so a hung process cannot wedge an
@@ -41,7 +50,7 @@ const plannerJobAttempts = 3
 // subCount: a bigger umbrella means a longer prompt and legitimately more
 // model time, and a bigger expansion is more expensive to have starved.
 func plannerTimeout(subCount int) time.Duration {
-	return PlannerAttemptTimeout*plannerJobAttempts + time.Duration(subCount)*5*time.Second
+	return PlannerAttemptTimeout*time.Duration(plannerJobAttempts) + time.Duration(subCount)*5*time.Second
 }
 
 // FetchTimeout bounds the GitHub sub-issue fetch so a stalled gh call cannot
@@ -305,11 +314,7 @@ func FallbackPlannerRunner(model string, gates ...provider.HealthGate) Runner {
 		gate = gates[0]
 	}
 	return func(ctx context.Context, prompt string) (string, error) {
-		plan, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[Plan]{
-			Name:           "umbrella-order",
-			Tier:           llmjob.Standard,
-			AttemptTimeout: PlannerAttemptTimeout,
-		}, llmexec.Options{Gate: gate, Models: claudeModelOverride(model)})
+		plan, _, err := llmjob.Run(ctx, prompt, plannerJobSpec, llmexec.Options{Gate: gate, Models: claudeModelOverride(model)})
 		if err != nil {
 			return "", err
 		}

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -21,10 +21,28 @@ import (
 // writing (and without firing a task:updated event).
 var errSkipUpdate = errors.New("skip update")
 
-// PlannerTimeout bounds the whole Generate call — every attemptPlan retry
+// PlannerAttemptTimeout bounds a single planner CLI invocation. It is passed
+// to llmjob.Run as Spec.AttemptTimeout so every repair attempt gets this
+// full budget fresh, instead of splitting a single shared deadline across
+// them — a large umbrella's first attempt can legitimately take minutes to
+// read and order every sub-issue, which used to leave nothing for retries
+// (see #1555).
+const PlannerAttemptTimeout = 4 * time.Minute
+
+// plannerJobAttempts mirrors llmjob's default 1+maxRepairs attempts for the
+// "umbrella-order" job (Tier Standard, no MaxRepairs override) — used only to
+// size plannerTimeout below.
+const plannerJobAttempts = 3
+
+// plannerTimeout bounds the whole Generate call — every attemptPlan retry
 // plus the zero-edge-floor critic re-ask — so a hung process cannot wedge an
-// expansion indefinitely.
-const PlannerTimeout = 5 * time.Minute
+// expansion indefinitely. It comfortably covers plannerJobAttempts each
+// getting a full PlannerAttemptTimeout, plus headroom that scales with
+// subCount: a bigger umbrella means a longer prompt and legitimately more
+// model time, and a bigger expansion is more expensive to have starved.
+func plannerTimeout(subCount int) time.Duration {
+	return PlannerAttemptTimeout*plannerJobAttempts + time.Duration(subCount)*5*time.Second
+}
 
 // FetchTimeout bounds the GitHub sub-issue fetch so a stalled gh call cannot
 // wedge the caller (notably the issue poll loop).
@@ -70,8 +88,8 @@ type Result struct {
 // plus one `blocked`+gated child per open sub-issue. It is idempotent: only
 // sub-issues without an existing task are created, and a fully-materialized
 // re-run skips the planner entirely. The planner run is bounded by
-// PlannerTimeout. Shared by the `sybra-cli umbrella` command and the GitHub
-// issue fetcher's auto-detect path.
+// plannerTimeout, scaled to the sub-issue count. Shared by the `sybra-cli
+// umbrella` command and the GitHub issue fetcher's auto-detect path.
 func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL string, opts ...ExpandOption) (Result, error) {
 	var cfg expandConfig
 	for _, opt := range opts {
@@ -117,7 +135,7 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 		genOpts = append(genOpts, WithGrounder(cfg.lister, cfg.minSubs))
 	}
 
-	pctx, cancel := context.WithTimeout(ctx, PlannerTimeout)
+	pctx, cancel := context.WithTimeout(ctx, plannerTimeout(len(subs)))
 	defer cancel()
 	plan, err := Generate(pctx, run, umb.URL, umb.Body, planSubs, genOpts...)
 	if err != nil {
@@ -288,8 +306,9 @@ func FallbackPlannerRunner(model string, gates ...provider.HealthGate) Runner {
 	}
 	return func(ctx context.Context, prompt string) (string, error) {
 		plan, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[Plan]{
-			Name: "umbrella-order",
-			Tier: llmjob.Standard,
+			Name:           "umbrella-order",
+			Tier:           llmjob.Standard,
+			AttemptTimeout: PlannerAttemptTimeout,
 		}, llmexec.Options{Gate: gate, Models: claudeModelOverride(model)})
 		if err != nil {
 			return "", err

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -11,14 +11,16 @@ import (
 )
 
 // TestPlannerTimeout_ScalesWithSubCountAndCoversEveryAttempt guards #1555: the
-// overall Generate deadline must comfortably fit plannerJobAttempts each
-// getting a full PlannerAttemptTimeout, and grow with subCount rather than
-// staying a single fixed ceiling shared across every retry.
+// overall Generate deadline must comfortably fit the full worst-case Generate
+// path (initial attemptPlan plus critic re-ask, each with plannerAttempts
+// planner samples, each sample with plannerJobAttempts full llmjob slices),
+// and grow with subCount rather than staying a single fixed ceiling shared
+// across every retry.
 func TestPlannerTimeout_ScalesWithSubCountAndCoversEveryAttempt(t *testing.T) {
 	t.Parallel()
-	minBudget := PlannerAttemptTimeout * time.Duration(plannerJobAttempts)
+	minBudget := PlannerAttemptTimeout * time.Duration(plannerJobAttempts*plannerGenerateSamples)
 	if got := plannerTimeout(0); got < minBudget {
-		t.Fatalf("plannerTimeout(0) = %v, want at least %v (room for %d full attempts)", got, minBudget, plannerJobAttempts)
+		t.Fatalf("plannerTimeout(0) = %v, want at least %v (room for %d planner samples x %d llmjob attempts)", got, minBudget, plannerGenerateSamples, plannerJobAttempts)
 	}
 	small := plannerTimeout(1)
 	large := plannerTimeout(38)

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
@@ -15,7 +16,7 @@ import (
 // staying a single fixed ceiling shared across every retry.
 func TestPlannerTimeout_ScalesWithSubCountAndCoversEveryAttempt(t *testing.T) {
 	t.Parallel()
-	minBudget := PlannerAttemptTimeout * plannerJobAttempts
+	minBudget := PlannerAttemptTimeout * time.Duration(plannerJobAttempts)
 	if got := plannerTimeout(0); got < minBudget {
 		t.Fatalf("plannerTimeout(0) = %v, want at least %v (room for %d full attempts)", got, minBudget, plannerJobAttempts)
 	}

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -9,6 +9,23 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+// TestPlannerTimeout_ScalesWithSubCountAndCoversEveryAttempt guards #1555: the
+// overall Generate deadline must comfortably fit plannerJobAttempts each
+// getting a full PlannerAttemptTimeout, and grow with subCount rather than
+// staying a single fixed ceiling shared across every retry.
+func TestPlannerTimeout_ScalesWithSubCountAndCoversEveryAttempt(t *testing.T) {
+	t.Parallel()
+	minBudget := PlannerAttemptTimeout * plannerJobAttempts
+	if got := plannerTimeout(0); got < minBudget {
+		t.Fatalf("plannerTimeout(0) = %v, want at least %v (room for %d full attempts)", got, minBudget, plannerJobAttempts)
+	}
+	small := plannerTimeout(1)
+	large := plannerTimeout(38)
+	if large <= small {
+		t.Fatalf("plannerTimeout(38) = %v, want greater than plannerTimeout(1) = %v", large, small)
+	}
+}
+
 func newTestTaskManager(t *testing.T) *task.Manager {
 	t.Helper()
 	store, err := task.NewStore(t.TempDir())


### PR DESCRIPTION
## Motivation

The umbrella planner's whole-call timeout (`PlannerTimeout`, 5 min) was shared across every retry attempt inside `llmjob.Run`. A large umbrella whose first planner attempt legitimately takes several minutes to read and order every sub-issue could exhaust the whole budget on that single attempt, leaving nothing for repair retries and killing the expansion outright.

## Implementation information

- `llmjob.Spec` gains an `AttemptTimeout` field: when set, each `runJSON` invocation (including repairs) gets its own fresh `context.WithTimeout` derived from the caller's `ctx`, instead of splitting one shared deadline across attempts. It also opts a hard `runJSON` error into a retry (previously fatal), gated on `AttemptTimeout` being set so legacy zero-value behavior is unchanged.
- `Spec.Attempts()` centralizes `1 + maxRepairs` so callers sizing an outer deadline don't hand-maintain a duplicate attempt count.
- `umbrella.Expand` replaces the fixed `PlannerTimeout` constant with `plannerTimeout(subCount)`, covering `plannerJobAttempts` full `PlannerAttemptTimeout` (4 min) windows plus headroom scaling with sub-issue count.
- `llmexec.RunJSON` now returns the last-tried provider in `Result.Provider` on failure paths (previously zero-valued), and the final `llmjob.Run` failure error now names the model along with the provider for a clearer failure diagnostic.

Closes https://github.com/Automaat/sybra/issues/1555

_Generated by Sybra harness_