### PR TITLE
fix(app): single-instance lock on sybra home

### DIFF
--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -1,10 +1,16 @@
 package fsutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// ErrLockUnsupported marks platforms where fsutil cannot provide a
+// cross-process file lock primitive. Callers can degrade to a warning/no-op
+// instead of turning platform support gaps into startup failures.
+var ErrLockUnsupported = errors.New("fsutil: cross-process file locking is not supported on this platform")
 
 // AtomicWrite writes data to path via a temp file + rename to prevent
 // partial reads from concurrent goroutines. The temp file is removed on

--- a/internal/fsutil/lock_other.go
+++ b/internal/fsutil/lock_other.go
@@ -13,7 +13,7 @@ import (
 // packages that import fsutil (e.g. `go vet ./...` on a Windows dev machine)
 // still compile.
 func LockFile(_ string) (func() error, error) {
-	return nil, fmt.Errorf("fsutil: cross-process file locking is not supported on this platform")
+	return nil, fmt.Errorf("%w", ErrLockUnsupported)
 }
 
 // ErrLocked mirrors the unix build's sentinel so callers can compile
@@ -23,5 +23,5 @@ var ErrLocked = errors.New("fsutil: already locked by another process")
 
 // TryLockPath is unimplemented on non-unix platforms; see LockFile.
 func TryLockPath(_ string) (func() error, error) {
-	return nil, fmt.Errorf("fsutil: cross-process file locking is not supported on this platform")
+	return nil, fmt.Errorf("%w", ErrLockUnsupported)
 }

--- a/internal/fsutil/lock_other.go
+++ b/internal/fsutil/lock_other.go
@@ -2,7 +2,10 @@
 
 package fsutil
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // LockFile is unimplemented on non-unix platforms (flock has no direct
 // equivalent without a platform-specific syscall). Sybra's GUI/server/CLI
@@ -10,5 +13,15 @@ import "fmt"
 // packages that import fsutil (e.g. `go vet ./...` on a Windows dev machine)
 // still compile.
 func LockFile(_ string) (func() error, error) {
+	return nil, fmt.Errorf("fsutil: cross-process file locking is not supported on this platform")
+}
+
+// ErrLocked mirrors the unix build's sentinel so callers can compile
+// errors.Is(err, fsutil.ErrLocked) checks on every platform, even though
+// TryLockPath itself is unimplemented here.
+var ErrLocked = errors.New("fsutil: already locked by another process")
+
+// TryLockPath is unimplemented on non-unix platforms; see LockFile.
+func TryLockPath(_ string) (func() error, error) {
 	return nil, fmt.Errorf("fsutil: cross-process file locking is not supported on this platform")
 }

--- a/internal/fsutil/lock_unix.go
+++ b/internal/fsutil/lock_unix.go
@@ -3,8 +3,11 @@
 package fsutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -36,4 +39,70 @@ func LockFile(path string) (func() error, error) {
 		}
 		return unlockErr
 	}, nil
+}
+
+// ErrLocked is returned by TryLockPath when another process already holds
+// the lock. Callers can use errors.Is to distinguish "already running" from
+// other open/flock failures (permissions, missing directory, ...).
+var ErrLocked = errors.New("fsutil: already locked by another process")
+
+// TryLockPath acquires an advisory, cross-process exclusive lock on the
+// exact file at path (unlike LockFile, no ".lock" suffix is appended), failing
+// immediately instead of blocking if another process already holds it. This
+// is the primitive behind Sybra's single-instance-per-home guard: two
+// processes (desktop app, sybra-server, or a test-runner's app-under-test)
+// pointed at the same SYBRA_HOME must never run concurrently, since they
+// would fight over task files, in-memory agent state, and pollers. A second
+// launch should fail fast with a clear "already running" error, not hang
+// waiting for the first to exit.
+//
+// On success, the caller's pid is written into the lock file so a rejected
+// second launch can name the holder. The returned unlock releases the flock,
+// closes the file descriptor, and must be called exactly once.
+func TryLockPath(path string) (func() error, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		holder := readLockHolderPID(f)
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			if holder > 0 {
+				return nil, fmt.Errorf("%w: held by pid %d", ErrLocked, holder)
+			}
+			return nil, ErrLocked
+		}
+		return nil, fmt.Errorf("flock: %w", err)
+	}
+	if err := f.Truncate(0); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, fmt.Errorf("truncate lock file: %w", err)
+	}
+	if _, err := f.WriteAt([]byte(strconv.Itoa(os.Getpid())), 0); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, fmt.Errorf("write lock file: %w", err)
+	}
+	return func() error {
+		unlockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		if closeErr := f.Close(); unlockErr == nil {
+			unlockErr = closeErr
+		}
+		return unlockErr
+	}, nil
+}
+
+// readLockHolderPID best-effort reads the pid a prior TryLockPath winner
+// wrote into f, for a friendlier "held by pid N" error. Returns 0 (omit from
+// the error) if the file is empty, unreadable, or predates this convention.
+func readLockHolderPID(f *os.File) int {
+	buf := make([]byte, 32)
+	n, _ := f.ReadAt(buf, 0)
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil {
+		return 0
+	}
+	return pid
 }

--- a/internal/fsutil/lock_unix.go
+++ b/internal/fsutil/lock_unix.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -60,6 +61,9 @@ var ErrLocked = errors.New("fsutil: already locked by another process")
 // second launch can name the holder. The returned unlock releases the flock,
 // closes the file descriptor, and must be called exactly once.
 func TryLockPath(path string) (func() error, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("open lock file: %w", err)

--- a/internal/fsutil/lock_unix_test.go
+++ b/internal/fsutil/lock_unix_test.go
@@ -74,3 +74,22 @@ func TestTryLockPath_ReleaseAllowsReacquire(t *testing.T) {
 		t.Fatalf("unlock2: %v", err)
 	}
 }
+
+func TestTryLockPath_CreatesParentDir(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "fresh", "nested", "sybra.lock")
+
+	unlock, err := TryLockPath(path)
+	if err != nil {
+		t.Fatalf("TryLockPath: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := unlock(); err != nil {
+			t.Errorf("unlock: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Fatalf("stat parent dir: %v", err)
+	}
+}

--- a/internal/fsutil/lock_unix_test.go
+++ b/internal/fsutil/lock_unix_test.go
@@ -1,0 +1,76 @@
+//go:build unix
+
+package fsutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestTryLockPath_SecondCallerFails(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "sybra.lock")
+
+	unlock, err := TryLockPath(path)
+	if err != nil {
+		t.Fatalf("first TryLockPath: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := unlock(); err != nil {
+			t.Errorf("unlock: %v", err)
+		}
+	})
+
+	if _, err := TryLockPath(path); !errors.Is(err, ErrLocked) {
+		t.Fatalf("second TryLockPath: want ErrLocked, got %v", err)
+	}
+}
+
+func TestTryLockPath_NamesHolderPID(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "sybra.lock")
+
+	unlock, err := TryLockPath(path)
+	if err != nil {
+		t.Fatalf("first TryLockPath: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := unlock(); err != nil {
+			t.Errorf("unlock: %v", err)
+		}
+	})
+
+	_, err = TryLockPath(path)
+	if err == nil {
+		t.Fatal("expected an error from the second caller")
+	}
+	want := "held by pid " + strconv.Itoa(os.Getpid())
+	if got := err.Error(); !strings.Contains(got, want) {
+		t.Fatalf("error %q does not name the holder pid (want substring %q)", got, want)
+	}
+}
+
+func TestTryLockPath_ReleaseAllowsReacquire(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "sybra.lock")
+
+	unlock, err := TryLockPath(path)
+	if err != nil {
+		t.Fatalf("first TryLockPath: %v", err)
+	}
+	if err := unlock(); err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+
+	unlock2, err := TryLockPath(path)
+	if err != nil {
+		t.Fatalf("re-acquire after unlock: %v", err)
+	}
+	if err := unlock2(); err != nil {
+		t.Fatalf("unlock2: %v", err)
+	}
+}

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -1,6 +1,9 @@
 package project
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // ProjectType classifies a Project for per-machine automation routing (see
 // Config.AllowsProjectType and the "Per-Machine Automations" section of
@@ -191,6 +194,16 @@ type Project struct {
 	WorktreeBaseRef string    `yaml:"worktree_base_ref,omitempty" json:"worktreeBaseRef,omitempty"`
 	CreatedAt       time.Time `yaml:"created_at" json:"createdAt"`
 	UpdatedAt       time.Time `yaml:"updated_at" json:"updatedAt"`
+}
+
+// IsSybraProject reports whether p is the Sybra repo itself (owner
+// "Automaat", repo "sybra", case-insensitive). Used to gate spawn-time
+// SYBRA_HOME isolation for test-runner/eval agents that launch a Sybra
+// build under test — see agentorch.Orchestrator.TestIsolationEnv. Testing
+// any other project never needs this: only Sybra testing Sybra risks a
+// second instance fighting the production one over ~/.sybra.
+func (p Project) IsSybraProject() bool {
+	return strings.EqualFold(p.Owner, "Automaat") && strings.EqualFold(p.Repo, "sybra")
 }
 
 // Worktree describes one `git worktree` checkout of a Project's bare clone,

--- a/internal/project/model_test.go
+++ b/internal/project/model_test.go
@@ -1,0 +1,28 @@
+package project
+
+import "testing"
+
+func TestProject_IsSybraProject(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		owner string
+		repo  string
+		want  bool
+	}{
+		{"exact match", "Automaat", "sybra", true},
+		{"case-insensitive", "automaat", "SYBRA", true},
+		{"different repo", "Automaat", "sybra-testbed", false},
+		{"different owner", "someone-else", "sybra", false},
+		{"empty", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := Project{Owner: tt.owner, Repo: tt.repo}
+			if got := p.IsSybraProject(); got != tt.want {
+				t.Errorf("IsSybraProject() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 
 	"github.com/Automaat/sybra/internal/project"
@@ -121,4 +122,19 @@ func (m *Manager) Stop(taskID string) {
 		m.stopDocker(inst)
 	}
 	m.logger.Info("sandbox.stopped", "task_id", taskID)
+}
+
+// SybraHomeDir returns (creating on first call) an isolated, empty directory
+// under dataDir a test-runner/eval agent should point SYBRA_HOME at when the
+// task under test is Sybra itself. Unlike Start, this needs no Docker/k8s
+// machinery — plain isolation of the app-under-test's data dir is all
+// Sybra's own startup needs, since it creates tasks/, logs/, etc. itself
+// against a fresh home (see docs/manual-testing.md). Kept on Manager anyway
+// so per-task sandbox state lives under one dataDir regardless of kind.
+func (m *Manager) SybraHomeDir(taskID string) (string, error) {
+	dir := filepath.Join(m.dataDir, taskID, "sybra-home")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir sybra home: %w", err)
+	}
+	return dir, nil
 }

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -325,6 +325,40 @@ func TestManager_StartNilConfig(t *testing.T) {
 	}
 }
 
+func TestManager_SybraHomeDir(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+
+	dir, err := m.SybraHomeDir("task-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info, statErr := os.Stat(dir); statErr != nil || !info.IsDir() {
+		t.Fatalf("SybraHomeDir did not create a directory at %q: %v", dir, statErr)
+	}
+	if !strings.HasSuffix(dir, filepath.Join("task-1", "sybra-home")) {
+		t.Fatalf("unexpected dir layout: %q", dir)
+	}
+
+	dir2, err := m.SybraHomeDir("task-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir == dir2 {
+		t.Fatal("different tasks must not share a SYBRA_HOME")
+	}
+
+	// Idempotent — calling again for the same task returns the same path and
+	// does not fail even though the directory already exists.
+	dirAgain, err := m.SybraHomeDir("task-1")
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	if dirAgain != dir {
+		t.Fatalf("expected stable path, got %q then %q", dir, dirAgain)
+	}
+}
+
 // TestRunCmd_ContextCancellationKillsProcess proves runCmd's exec.Command is
 // built with the caller's context (exec.CommandContext): cancelling ctx must
 // kill an in-flight subprocess instead of leaving it to run to completion.

--- a/internal/skills/data/sybra-test.md
+++ b/internal/skills/data/sybra-test.md
@@ -76,6 +76,8 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
    - Namespace anything global by the task id.
    - **Tear down** every process/container/cluster you start before exiting (trap/defer). Leaks starve the next agent.
 
+   **If the project under test is Sybra itself**, never point a second Sybra process at the real `~/.sybra` — two instances sharing one home fight over task files, in-memory agent state, and pollers (one incident: a second instance reattached to the production instance's live agents and corrupted their bookkeeping). Sybra now enforces this with an exclusive `flock` on `<home>/sybra.lock`, so a stray second instance fails fast instead of running — but don't rely on that as your only safeguard. If `SYBRA_HOME` is already set in your environment, an isolated home was pre-provisioned for this run — use it (e.g. `SYBRA_HOME=$SYBRA_HOME go run ./cmd/sybra-server`, `SYBRA_HOME=$SYBRA_HOME go run ./cmd/sybra-cli ...`). If it is not set, follow `docs/manual-testing.md`: point `SYBRA_HOME` at a fresh temp directory and use the fake-provider harness before starting anything.
+
 5. **Attack across all angles** (aim for thorough, not one path):
    - **Happy path** — the primary flow from the task, end to end.
    - **Edge cases** — empty/missing input, max/min/boundary values, unicode, very large input, concurrent/repeated calls, re-entrancy.

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -294,6 +294,32 @@ func (o *Orchestrator) SandboxEnv(taskID, dir string, t task.Task) []string {
 	return inst.EnvVars()
 }
 
+// TestIsolationEnv returns SYBRA_HOME=<isolated-dir> when task t's project is
+// Sybra itself, so a test-runner/eval agent that launches a Sybra build under
+// test never touches the production ~/.sybra. Without this, an app-under-test
+// process spawned by an adversarial test agent shares the real instance's
+// task files, in-memory agent state, and pollers — a second instance can
+// reattach to live production agents, advance other tasks' workflows, and
+// corrupt completion bookkeeping (the incident this guards against). Returns
+// nil for every other project, and for roles other than test-runner/eval,
+// which legitimately operate on the real worktree/repo and must not be
+// redirected.
+func (o *Orchestrator) TestIsolationEnv(taskID string, t task.Task) []string {
+	if o.sandboxes == nil || t.ProjectID == "" {
+		return nil
+	}
+	proj, err := o.projects.Get(t.ProjectID)
+	if err != nil || !proj.IsSybraProject() {
+		return nil
+	}
+	dir, err := o.sandboxes.SybraHomeDir(taskID)
+	if err != nil {
+		o.logger.Warn("sandbox.sybra_home.failed", "task_id", taskID, "err", err)
+		return nil
+	}
+	return []string{"SYBRA_HOME=" + dir}
+}
+
 // PrependSupervisorSteer consumes a pending watchdog headless-nudge steer for
 // taskID: it clears the one-shot SupervisorSteer field and returns prompt with
 // the correction prepended. Returns prompt unchanged when none is pending.

--- a/internal/sybra/agentorch/agentorch_test.go
+++ b/internal/sybra/agentorch/agentorch_test.go
@@ -1,11 +1,16 @@
 package agentorch
 
 import (
+	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -260,4 +265,76 @@ func TestBuildTaskStartPrompt(t *testing.T) {
 	if !strings.Contains(got, "# Task: My task") {
 		t.Fatalf("BuildTaskStartPrompt(include=true, empty prompt) = %q, want task context", got)
 	}
+}
+
+func newProjectStoreWithProject(t *testing.T, id, owner, repo string) *project.Store {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := project.NewStore(dir, t.TempDir())
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+	yamlBody := "id: " + id + "\nname: " + repo + "\nowner: " + owner + "\nrepo: " + repo +
+		"\nurl: https://github.com/" + owner + "/" + repo + "\nclone_path: /tmp/" + repo + ".git\ntype: pet\n"
+	fileName := strings.ReplaceAll(id, "/", "--") + ".yaml"
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(yamlBody), 0o644); err != nil {
+		t.Fatalf("write project fixture: %v", err)
+	}
+	return store
+}
+
+// TestOrchestrator_TestIsolationEnv pins the SYBRA_HOME injection this task
+// adds (sybra#1558): a test-runner/eval agent testing Sybra against itself
+// must get an isolated SYBRA_HOME, or a second instance can fight the
+// production one over ~/.sybra (reattaching to live agents, advancing other
+// tasks' workflows). Every other project must be unaffected.
+func TestOrchestrator_TestIsolationEnv(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sybra project gets an isolated SYBRA_HOME", func(t *testing.T) {
+		t.Parallel()
+		projects := newProjectStoreWithProject(t, "Automaat/sybra", "Automaat", "sybra")
+		o := New(nil, projects, nil, nil, slog.New(slog.DiscardHandler), nil, nil)
+		o.SetSandboxes(sandbox.NewManager(t.TempDir(), slog.New(slog.DiscardHandler)))
+
+		env := o.TestIsolationEnv("task-1", task.Task{ProjectID: "Automaat/sybra"})
+		if len(env) != 1 || !strings.HasPrefix(env[0], "SYBRA_HOME=") {
+			t.Fatalf("TestIsolationEnv = %v, want a single SYBRA_HOME entry", env)
+		}
+		dir := strings.TrimPrefix(env[0], "SYBRA_HOME=")
+		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+			t.Fatalf("SYBRA_HOME dir %q was not created: %v", dir, err)
+		}
+	})
+
+	t.Run("non-sybra project is untouched", func(t *testing.T) {
+		t.Parallel()
+		projects := newProjectStoreWithProject(t, "owner/repo", "owner", "repo")
+		o := New(nil, projects, nil, nil, slog.New(slog.DiscardHandler), nil, nil)
+		o.SetSandboxes(sandbox.NewManager(t.TempDir(), slog.New(slog.DiscardHandler)))
+
+		if env := o.TestIsolationEnv("task-1", task.Task{ProjectID: "owner/repo"}); env != nil {
+			t.Fatalf("TestIsolationEnv = %v, want nil for a non-sybra project", env)
+		}
+	})
+
+	t.Run("no project id is a no-op", func(t *testing.T) {
+		t.Parallel()
+		o := New(nil, nil, nil, nil, slog.New(slog.DiscardHandler), nil, nil)
+		o.SetSandboxes(sandbox.NewManager(t.TempDir(), slog.New(slog.DiscardHandler)))
+
+		if env := o.TestIsolationEnv("task-1", task.Task{}); env != nil {
+			t.Fatalf("TestIsolationEnv = %v, want nil without a project id", env)
+		}
+	})
+
+	t.Run("no sandboxes manager wired is a no-op", func(t *testing.T) {
+		t.Parallel()
+		projects := newProjectStoreWithProject(t, "Automaat/sybra", "Automaat", "sybra")
+		o := New(nil, projects, nil, nil, slog.New(slog.DiscardHandler), nil, nil)
+
+		if env := o.TestIsolationEnv("task-1", task.Task{ProjectID: "Automaat/sybra"}); env != nil {
+			t.Fatalf("TestIsolationEnv = %v, want nil before sandboxes are wired", env)
+		}
+	})
 }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -10,6 +10,7 @@ package sybra
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -26,6 +27,7 @@ import (
 	"github.com/Automaat/sybra/internal/evaluation"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/experience"
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/learning"
 	"github.com/Automaat/sybra/internal/limits"
@@ -77,6 +79,7 @@ type App struct {
 	providerHealth    *provider.Checker
 	worktrees         *worktree.Manager
 	sandboxes         *sandbox.Manager
+	homeUnlock        func() error
 	monitorSvc        *monitor.Service
 	selfMonitorSvc    *selfmonitor.Service
 	evaluationSvc     *evaluation.Service
@@ -203,6 +206,28 @@ func NewApp(logger *slog.Logger, logLevel *slog.LevelVar, cfg *config.Config, op
 	return a
 }
 
+// acquireHomeLock takes an exclusive, non-blocking flock on
+// <SYBRA_HOME>/sybra.lock, held for the process lifetime, so a second Sybra
+// instance (desktop, sybra-server, or an app-under-test spawned by a
+// test-runner agent) pointed at the same home fails fast instead of racing
+// the first over task files, in-memory agent state, and pollers — the
+// dual-instance incident this guards against saw a second instance reattach
+// to the production instance's live agents and corrupt its completion
+// bookkeeping. The unlock is released in Shutdown; if Shutdown is never
+// called (process killed, os.Exit on a Startup error), the OS releases the
+// flock when the process's file descriptors close.
+func (a *App) acquireHomeLock() error {
+	unlock, err := fsutil.TryLockPath(filepath.Join(config.HomeDir(), "sybra.lock"))
+	if err != nil {
+		if errors.Is(err, fsutil.ErrLocked) {
+			return fmt.Errorf("another Sybra instance is already running against %s (%w) — stop it first, or point this run at a different SYBRA_HOME", config.HomeDir(), err)
+		}
+		return fmt.Errorf("acquire home lock: %w", err)
+	}
+	a.homeUnlock = unlock
+	return nil
+}
+
 // Startup initializes all subsystems. Returns an error if a critical subsystem
 // fails; callers (Wails OnStartup, HTTP server main) handle the error.
 // contextcheck note: several call chains below (emit's task.created dispatch,
@@ -219,6 +244,10 @@ func NewApp(logger *slog.Logger, logLevel *slog.LevelVar, cfg *config.Config, op
 // pass through is out of scope for this pass — nolint annotations below
 // point back to this comment.
 func (a *App) Startup(ctx context.Context) error {
+	if err := a.acquireHomeLock(); err != nil {
+		return err
+	}
+
 	ctx, a.cancel = context.WithCancel(ctx)
 	a.ctx = ctx
 	a.logger.Info("app.starting")
@@ -436,6 +465,12 @@ func (a *App) Shutdown(_ context.Context) {
 	}
 	if a.audit != nil {
 		_ = a.audit.Close()
+	}
+	if a.homeUnlock != nil {
+		if err := a.homeUnlock(); err != nil {
+			a.logger.Warn("app.home_unlock.failed", "err", err)
+		}
+		a.homeUnlock = nil
 	}
 	a.logger.Info("app.stopped")
 }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -222,6 +222,10 @@ func (a *App) acquireHomeLock() error {
 		if errors.Is(err, fsutil.ErrLocked) {
 			return fmt.Errorf("another Sybra instance is already running against %s (%w) — stop it first, or point this run at a different SYBRA_HOME", config.HomeDir(), err)
 		}
+		if errors.Is(err, fsutil.ErrLockUnsupported) {
+			a.logger.Warn("app.home_lock.unsupported", "home", config.HomeDir(), "err", err)
+			return nil
+		}
 		return fmt.Errorf("acquire home lock: %w", err)
 	}
 	a.homeUnlock = unlock

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -232,6 +232,38 @@ func (a *App) acquireHomeLock() error {
 	return nil
 }
 
+func (a *App) startLifecycle(ctx context.Context, emit func(string, any)) {
+	a.initLoopScheduler(ctx, emit)
+	a.initFileWatcher(ctx, emit)
+
+	issuesFetcher := a.initAutomations(emit)
+	a.wireServices(emit)
+
+	// syncSkillsBundle's deep diagnostic logging uses context.Background()
+	// intentionally (see skillsync.Syncer.log) — not a cancellation bug.
+	a.syncSkillsBundle() //nolint:contextcheck // plain diagnostic logging inside skillsync, see its log() comment
+	a.recovery = a.newRecovery()
+	a.recovery.RunStartupCleanup(ctx)
+	a.RegisterSpotlightHotkey() //nolint:contextcheck // agent.Manager dispatch chain uses its own m.ctx field, see Startup's contextcheck note
+
+	lm := newLifecycleManager(a)
+	lm.StartManagers(ctx, emit)
+	lm.StartPollers(ctx, emit, issuesFetcher)
+	lm.StartWatchers(ctx)
+}
+
+func (a *App) cleanupFailedStartup() {
+	if a.cancel != nil {
+		a.cancel()
+	}
+	if a.homeUnlock != nil {
+		if err := a.homeUnlock(); err != nil {
+			a.logger.Warn("app.home_unlock.failed", "err", err)
+		}
+		a.homeUnlock = nil
+	}
+}
+
 // Startup initializes all subsystems. Returns an error if a critical subsystem
 // fails; callers (Wails OnStartup, HTTP server main) handle the error.
 // contextcheck note: several call chains below (emit's task.created dispatch,
@@ -256,15 +288,7 @@ func (a *App) Startup(ctx context.Context) error {
 		if started {
 			return
 		}
-		if a.cancel != nil {
-			a.cancel()
-		}
-		if a.homeUnlock != nil {
-			if err := a.homeUnlock(); err != nil {
-				a.logger.Warn("app.home_unlock.failed", "err", err)
-			}
-			a.homeUnlock = nil
-		}
+		a.cleanupFailedStartup()
 	}()
 
 	ctx, a.cancel = context.WithCancel(ctx)
@@ -362,23 +386,7 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.initAgentConfig()
 
-	a.initLoopScheduler(ctx, emit)
-	a.initFileWatcher(ctx, emit)
-
-	issuesFetcher := a.initAutomations(emit)
-	a.wireServices(emit)
-
-	// syncSkillsBundle's deep diagnostic logging uses context.Background()
-	// intentionally (see skillsync.Syncer.log) — not a cancellation bug.
-	a.syncSkillsBundle() //nolint:contextcheck // plain diagnostic logging inside skillsync, see its log() comment
-	a.recovery = a.newRecovery()
-	a.recovery.RunStartupCleanup(ctx)
-	a.RegisterSpotlightHotkey() //nolint:contextcheck // agent.Manager dispatch chain uses its own m.ctx field, see Startup's contextcheck note
-
-	lm := newLifecycleManager(a)
-	lm.StartManagers(ctx, emit)
-	lm.StartPollers(ctx, emit, issuesFetcher)
-	lm.StartWatchers(ctx)
+	a.startLifecycle(ctx, emit)
 
 	a.logAutomationsSummary()
 	a.logger.Info("app.started")

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -247,6 +247,21 @@ func (a *App) Startup(ctx context.Context) error {
 	if err := a.acquireHomeLock(); err != nil {
 		return err
 	}
+	started := false
+	defer func() {
+		if started {
+			return
+		}
+		if a.cancel != nil {
+			a.cancel()
+		}
+		if a.homeUnlock != nil {
+			if err := a.homeUnlock(); err != nil {
+				a.logger.Warn("app.home_unlock.failed", "err", err)
+			}
+			a.homeUnlock = nil
+		}
+	}()
 
 	ctx, a.cancel = context.WithCancel(ctx)
 	a.ctx = ctx
@@ -363,6 +378,7 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.logAutomationsSummary()
 	a.logger.Info("app.started")
+	started = true
 	return nil
 }
 

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"context"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -101,6 +102,36 @@ func TestAppStartup_SecondInstanceOnSameHomeFailsFast(t *testing.T) {
 		t.Fatalf("Startup after releasing the lock: %v", err)
 	}
 	shutdown(third)
+}
+
+func TestAppStartup_ReleasesHomeLockOnStartupFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
+
+	cfg := startupTestConfig(home)
+	if err := os.WriteFile(cfg.TasksDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("seed tasks path as file: %v", err)
+	}
+
+	logger := slog.New(slog.DiscardHandler)
+
+	first := NewApp(logger, &slog.LevelVar{}, cfg)
+	if err := first.Startup(context.Background()); err == nil {
+		t.Fatal("Startup succeeded with tasks dir blocked by a regular file, want failure")
+	}
+	if err := os.Remove(cfg.TasksDir); err != nil {
+		t.Fatalf("remove blocking tasks file: %v", err)
+	}
+
+	second := NewApp(logger, &slog.LevelVar{}, startupTestConfig(home))
+	if err := second.Startup(context.Background()); err != nil {
+		t.Fatalf("Startup after failed startup should reacquire released lock: %v", err)
+	}
+	if second.agentSvc != nil && second.agentSvc.approval != nil {
+		_ = second.agentSvc.approval.Shutdown(context.Background())
+	}
+	second.Shutdown(context.Background())
 }
 
 func TestAppShutdownBeforeStartupDoesNotPanic(t *testing.T) {

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 func TestAppStartupWiresSubsystemsAndServices(t *testing.T) {
@@ -93,6 +95,9 @@ func TestAppStartup_SecondInstanceOnSameHomeFailsFast(t *testing.T) {
 	err := second.Startup(context.Background())
 	if err == nil {
 		t.Fatal("second Startup against the same home succeeded, want a fail-fast lock error")
+	}
+	if !errors.Is(err, fsutil.ErrLocked) {
+		t.Fatalf("second Startup error = %v, want fsutil.ErrLocked", err)
 	}
 	shutdown(second) // must not touch the first instance's tasks/agents
 

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -69,6 +69,40 @@ func (r *startupEventRecorder) snapshot() []string {
 	return append([]string(nil), r.events...)
 }
 
+func TestAppStartup_SecondInstanceOnSameHomeFailsFast(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
+
+	logger := slog.New(slog.DiscardHandler)
+
+	shutdown := func(app *App) {
+		if app.agentSvc != nil && app.agentSvc.approval != nil {
+			_ = app.agentSvc.approval.Shutdown(context.Background())
+		}
+		app.Shutdown(context.Background())
+	}
+
+	first := NewApp(logger, &slog.LevelVar{}, startupTestConfig(home))
+	if err := first.Startup(context.Background()); err != nil {
+		t.Fatalf("first Startup: %v", err)
+	}
+
+	second := NewApp(logger, &slog.LevelVar{}, startupTestConfig(home))
+	err := second.Startup(context.Background())
+	if err == nil {
+		t.Fatal("second Startup against the same home succeeded, want a fail-fast lock error")
+	}
+	shutdown(second) // must not touch the first instance's tasks/agents
+
+	shutdown(first)
+	third := NewApp(logger, &slog.LevelVar{}, startupTestConfig(home))
+	if err := third.Startup(context.Background()); err != nil {
+		t.Fatalf("Startup after releasing the lock: %v", err)
+	}
+	shutdown(third)
+}
+
 func TestAppShutdownBeforeStartupDoesNotPanic(t *testing.T) {
 	app := NewApp(slog.New(slog.DiscardHandler), &slog.LevelVar{}, startupTestConfig(t.TempDir()))
 

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -532,6 +532,14 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		} else if inst := a.sandboxes.Get(taskID); inst != nil {
 			cfg.ExtraEnv = inst.EnvVars()
 		}
+		// Verifier roles that launch a Sybra build under test (test-runner,
+		// eval) must never share the production ~/.sybra — see
+		// Orchestrator.TestIsolationEnv. Additive: a SANDBOX_URL/KUBECONFIG
+		// pair from the branch above (a Docker/k8s sandbox for a non-Sybra
+		// app-under-test) and SYBRA_HOME are not mutually exclusive.
+		if r == agent.RoleTestRunner || r == agent.RoleEval {
+			cfg.ExtraEnv = append(cfg.ExtraEnv, a.agentOrch.TestIsolationEnv(taskID, t)...)
+		}
 	}
 
 	ag, err := a.agents.Run(cfg)

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -92,6 +92,14 @@ steps:
         sandbox is already running for this task — use it. Bind only ephemeral
         ports and tear down anything you start.
 
+        If the project under test is Sybra itself, never point a second Sybra
+        process at the real ~/.sybra — two instances sharing one home fight
+        over task files, agent state, and pollers. If SYBRA_HOME is already
+        set in your environment, use it (e.g.
+        SYBRA_HOME=$SYBRA_HOME go run ./cmd/sybra-server). Otherwise follow
+        docs/manual-testing.md: point SYBRA_HOME at a fresh temp directory
+        with the fake-provider harness before starting anything.
+
         Manual testing is mandatory by default. Before PASS, run at least one
         product-level probe that a user/operator would recognize: start the
         web/server surface and hit it with curl/browser/devtools; run the real


### PR DESCRIPTION
## Motivation

A `/sybra-test` test-runner agent launched an app-under-test from its worktree without an isolated `SYBRA_HOME`. For ~14 seconds a second Sybra instance ran against the production `~/.sybra`: it reattached to live production agents, advanced another task's workflow, then shut down and orphaned that agent, corrupting completion bookkeeping. Two instances sharing one home fight over task files, in-memory agent state, and pollers — this is the same failure class as the known desktop + `sybra-server` dual-process conflict.

> Changelog: fix(app): single-instance lock on sybra home

## Implementation information

Layered fix:

1. **Instance lock** — `fsutil.TryLockPath` (new non-blocking `flock` primitive) locks `<SYBRA_HOME>/sybra.lock` for the process lifetime via `App.Startup`/`Shutdown`, covering both the desktop binary and `sybra-server`. A second instance on the same home fails fast with a clear "already running (held by pid N)" error. `sybra-cli` is unaffected — it never calls `Startup`.
2. **Spawn-time isolation** — for `test-runner`/`eval` roles whose task project is Sybra itself, `SYBRA_HOME` is now injected into the agent subprocess env (`agentorch.Orchestrator.TestIsolationEnv`), pointing at an isolated dir under `~/.sybra/sandboxes/<task>/sybra-home`, so even an agent that forgets to isolate itself is protected.
3. **Prompt/skill layer** — `sybra-test` skill and the `testing-task` workflow prompt now call out the isolated `SYBRA_HOME` convention when the project under test is Sybra itself.

## Supporting documentation

- Regression test `TestAppStartup_SecondInstanceOnSameHomeFailsFast`: second `Startup` against a locked home fails without touching tasks/agents; a fresh instance succeeds after `Shutdown`.
- `TestOrchestrator_TestIsolationEnv`: `SYBRA_HOME` is only injected for the Sybra project, additive to any Docker/k8s sandbox env, no-op otherwise.
- `mise run verify` passes clean (build, `go test -race` incl. e2e, golangci-lint, frontend checks, bindings sync, hadolint).

_Generated by Sybra harness_