### PR TITLE
fix(agent): stop codex noise from masking healthy runs

### DIFF
--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -276,9 +276,7 @@ func (m *Manager) runConvoTurn(ctx context.Context, a *Agent, cfg RunConfig, pro
 			a.SetExitErr(errProviderRateLimited)
 		}
 	}
-	if stderrOut != "" {
-		m.logger.Error("agent.convo.stderr", "id", a.ID, "provider", a.Provider, "stderr", stderrOut)
-	}
+	logAttemptStderr(m.logger, "agent.convo.stderr", a.ID, stderrOut, a.GetExitErr(), "provider", a.Provider)
 	return gotResult && a.GetExitErr() == nil
 }
 

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -278,21 +278,23 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 
 	waitErr := cmd.Wait()
 	stderrOut := stderrBuf.String()
-	if stderrOut != "" {
-		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
-	}
 	attemptEvents := attemptEventsFrom(a.ConvoOutput(), prevLen)
 	if waitErr != nil {
-		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
+		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 
 		if shouldRetryConvo(stderrOut, attemptEvents, m.logger) {
+			logAttemptStderr(m.logger, "agent.convo.stderr", a.ID, stderrOut, a.GetExitErr())
 			return true, nil
 		}
 		m.reportProviderHealthSignalConvo(a, stderrOut, attemptEvents)
-	} else if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-		a.SetExitErr(errProviderRateLimited)
+	} else {
+		a.SetExitErr(nil)
+		if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
+			a.SetExitErr(errProviderRateLimited)
+		}
 	}
+	logAttemptStderr(m.logger, "agent.convo.stderr", a.ID, stderrOut, a.GetExitErr())
 	return false, nil
 }
 

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -157,20 +157,22 @@ func (m *Manager) runConvoAttemptSurvive(ctx context.Context, a *Agent, cfg RunC
 	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
 		stderrOut = string(b)
 	}
-	if stderrOut != "" {
-		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
-	}
 	attemptEvents := attemptEventsFrom(a.ConvoOutput(), prevLen)
 	if waitErr != nil {
-		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
+		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		if shouldRetryConvo(stderrOut, attemptEvents, m.logger) {
+			logAttemptStderr(m.logger, "agent.convo.stderr", a.ID, stderrOut, a.GetExitErr())
 			return true, nil
 		}
 		m.reportProviderHealthSignalConvo(a, stderrOut, attemptEvents)
-	} else if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-		a.SetExitErr(errProviderRateLimited)
+	} else {
+		a.SetExitErr(nil)
+		if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
+			a.SetExitErr(errProviderRateLimited)
+		}
 	}
+	logAttemptStderr(m.logger, "agent.convo.stderr", a.ID, stderrOut, a.GetExitErr())
 	return false, nil
 }
 
@@ -252,20 +254,22 @@ func (m *Manager) runConvoAttemptSurviveOneShot(ctx context.Context, a *Agent, c
 	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
 		stderrOut = string(b)
 	}
-	if stderrOut != "" {
-		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
-	}
 	attemptEvents := attemptEventsFrom(a.ConvoOutput(), prevLen)
 	if waitErr != nil {
-		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
+		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		if shouldRetryConvo(stderrOut, attemptEvents, m.logger) {
+			logAttemptStderr(m.logger, "agent.convo.stderr", a.ID, stderrOut, a.GetExitErr())
 			return true, nil
 		}
 		m.reportProviderHealthSignalConvo(a, stderrOut, attemptEvents)
-	} else if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-		a.SetExitErr(errProviderRateLimited)
+	} else {
+		a.SetExitErr(nil)
+		if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
+			a.SetExitErr(errProviderRateLimited)
+		}
 	}
+	logAttemptStderr(m.logger, "agent.convo.stderr", a.ID, stderrOut, a.GetExitErr())
 	return false, nil
 }
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -690,11 +690,17 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		}
 		// Codex NDJSON never reports session_id/cost on the result event, so
 		// those alone read as an empty/crashed run (this misled diagnosis of
-		// the 2026-07-05 stalled-workflow incident, #1559). Log the token
-		// counts codex does report so a healthy codex completion is
-		// distinguishable from a real crash at a glance.
-		m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow,
-			"input_tokens", event.InputTokens, "output_tokens", event.OutputTokens, "reasoning_tokens", event.ReasoningTokens)
+		// the 2026-07-05 stalled-workflow incident, #1559). Omit the
+		// meaningless fields for codex and log only the token counts it does
+		// report, so a healthy codex completion is distinguishable from a
+		// real crash at a glance.
+		if provider.Name() == "codex" {
+			m.logger.Info("agent.headless.result", "id", a.ID,
+				"input_tokens", event.InputTokens, "output_tokens", event.OutputTokens, "reasoning_tokens", event.ReasoningTokens)
+		} else {
+			m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow,
+				"input_tokens", event.InputTokens, "output_tokens", event.OutputTokens, "reasoning_tokens", event.ReasoningTokens)
+		}
 		// Persist the captured session ID so a reattach or restart-stale
 		// recovery can pass --resume. No-op when survival is disabled.
 		if event.SessionID != "" {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -694,7 +694,7 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		// meaningless fields for codex and log only the token counts it does
 		// report, so a healthy codex completion is distinguishable from a
 		// real crash at a glance.
-		if provider.Name() == "codex" {
+		if a.Provider == "codex" {
 			m.logger.Info("agent.headless.result", "id", a.ID,
 				"input_tokens", event.InputTokens, "output_tokens", event.OutputTokens, "reasoning_tokens", event.ReasoningTokens)
 		} else {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"slices"
@@ -206,12 +207,10 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 	}
 
 	stderrOut := stderrBuf.String()
-	if stderrOut != "" {
-		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)
-	}
 	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}
+	logHeadlessStderr(m.logger, a.ID, stderrOut, waitErr)
 	if waitErr != nil {
 		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
@@ -322,12 +321,10 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
 		stderrOut = string(b)
 	}
-	if stderrOut != "" {
-		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)
-	}
 	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}
+	logHeadlessStderr(m.logger, a.ID, stderrOut, waitErr)
 	if waitErr != nil {
 		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
@@ -364,6 +361,25 @@ func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
 		return
 	}
 	a.SetExitErr(nil)
+}
+
+// logHeadlessStderr logs a completed attempt's captured stderr. Codex (and
+// other CLIs) routinely write informational lines to stderr on healthy runs
+// (e.g. "Reading additional input from stdin..."), so logging unconditionally
+// at ERROR made every run look like a crash and actively misled diagnosis of
+// task 133a5d46 / issue #1560. Only a genuine failure (non-zero exit or a
+// provider-reported result error, both folded into waitErr by the caller)
+// warrants ERROR; a clean exit logs the same content at DEBUG for anyone
+// still chasing provider noise.
+func logHeadlessStderr(logger *slog.Logger, id, stderrOut string, waitErr error) {
+	if stderrOut == "" {
+		return
+	}
+	if waitErr != nil {
+		logger.Error("agent.headless.stderr", "id", id, "stderr", stderrOut)
+		return
+	}
+	logger.Debug("agent.headless.stderr", "id", id, "stderr", stderrOut)
 }
 
 func resultStreamError(streamEvents []StreamEvent) error {
@@ -671,7 +687,13 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		if event.PremiumRequests > 0 {
 			a.AddPremiumRequests(event.PremiumRequests)
 		}
-		m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
+		// Codex NDJSON never reports session_id/cost on the result event, so
+		// those alone read as an empty/crashed run (this misled diagnosis of
+		// the 2026-07-05 stalled-workflow incident, #1559). Log the token
+		// counts codex does report so a healthy codex completion is
+		// distinguishable from a real crash at a glance.
+		m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow,
+			"input_tokens", event.InputTokens, "output_tokens", event.OutputTokens, "reasoning_tokens", event.ReasoningTokens)
 		// Persist the captured session ID so a reattach or restart-stale
 		// recovery can pass --resume. No-op when survival is disabled.
 		if event.SessionID != "" {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -210,26 +210,25 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}
-	logHeadlessStderr(m.logger, a.ID, stderrOut, waitErr)
-	if waitErr != nil {
-		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
-		a.SetExitErr(waitErr)
-	} else {
-		a.SetExitErr(nil)
-	}
-
 	// Only inspect the events produced during this attempt. Some CLIs report
 	// quota exhaustion as an exit-0 result event, so classify provider health
 	// even when the process itself looked successful.
 	attemptEvents := attemptEventsFrom(a.Output(), prevLen)
 	if waitErr != nil {
+		a.SetExitErr(waitErr)
+		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
+			logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 			return true, nil
 		}
 		m.reportProviderHealthSignal(a, stderrOut, attemptEvents)
-	} else if m.reportCleanProviderHealthSignal(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-		a.SetExitErr(errProviderRateLimited)
+	} else {
+		a.SetExitErr(nil)
+		if m.reportCleanProviderHealthSignal(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
+			a.SetExitErr(errProviderRateLimited)
+		}
 	}
+	logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 	return false, nil
 }
 
@@ -324,25 +323,25 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}
-	logHeadlessStderr(m.logger, a.ID, stderrOut, waitErr)
-	if waitErr != nil {
-		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
-		a.SetExitErr(waitErr)
-	} else {
-		a.SetExitErr(nil)
-	}
 	// Only inspect events from this attempt, mirroring the legacy path —
 	// otherwise a transient 529 from an earlier attempt makes every later
 	// attempt retry regardless of its real failure.
 	attemptEvents := attemptEventsFrom(a.Output(), prevLen)
 	if waitErr != nil {
+		a.SetExitErr(waitErr)
+		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
+			logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 			return true, nil
 		}
 		m.reportProviderHealthSignal(a, stderrOut, attemptEvents)
-	} else if m.reportCleanProviderHealthSignal(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-		a.SetExitErr(errProviderRateLimited)
+	} else {
+		a.SetExitErr(nil)
+		if m.reportCleanProviderHealthSignal(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
+			a.SetExitErr(errProviderRateLimited)
+		}
 	}
+	logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 	return false, nil
 }
 
@@ -363,23 +362,25 @@ func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
 	a.SetExitErr(nil)
 }
 
-// logHeadlessStderr logs a completed attempt's captured stderr. Codex (and
+// logAttemptStderr logs a completed attempt's captured stderr. Codex (and
 // other CLIs) routinely write informational lines to stderr on healthy runs
 // (e.g. "Reading additional input from stdin..."), so logging unconditionally
 // at ERROR made every run look like a crash and actively misled diagnosis of
-// task 133a5d46 / issue #1560. Only a genuine failure (non-zero exit or a
-// provider-reported result error, both folded into waitErr by the caller)
-// warrants ERROR; a clean exit logs the same content at DEBUG for anyone
-// still chasing provider noise.
-func logHeadlessStderr(logger *slog.Logger, id, stderrOut string, waitErr error) {
+// task 133a5d46 / issue #1560. Only a genuine failure warrants ERROR; a clean
+// exit logs the same content at DEBUG for anyone still chasing provider noise.
+func logAttemptStderr(logger *slog.Logger, eventName, id, stderrOut string, finalErr error, attrs ...any) {
 	if stderrOut == "" {
 		return
 	}
-	if waitErr != nil {
-		logger.Error("agent.headless.stderr", "id", id, "stderr", stderrOut)
+	kv := make([]any, 0, len(attrs)+4)
+	kv = append(kv, "id", id)
+	kv = append(kv, attrs...)
+	kv = append(kv, "stderr", stderrOut)
+	if finalErr != nil {
+		logger.Error(eventName, kv...)
 		return
 	}
-	logger.Debug("agent.headless.stderr", "id", id, "stderr", stderrOut)
+	logger.Debug(eventName, kv...)
 }
 
 func resultStreamError(streamEvents []StreamEvent) error {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -230,11 +230,11 @@ func TestShouldRetry_FatalError_NoRetry(t *testing.T) {
 	}
 }
 
-func TestLogHeadlessStderr_CleanExit_LogsDebugNotError(t *testing.T) {
+func TestLogAttemptStderr_CleanExit_LogsDebugNotError(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	logHeadlessStderr(logger, "agent-1", "Reading additional input from stdin...", nil)
+	logAttemptStderr(logger, "agent.headless.stderr", "agent-1", "Reading additional input from stdin...", nil)
 
 	out := buf.String()
 	if strings.Contains(out, "level=ERROR") {
@@ -245,23 +245,35 @@ func TestLogHeadlessStderr_CleanExit_LogsDebugNotError(t *testing.T) {
 	}
 }
 
-func TestLogHeadlessStderr_NonZeroExit_LogsError(t *testing.T) {
+func TestLogAttemptStderr_FinalProviderFailure_LogsError(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	logHeadlessStderr(logger, "agent-1", "panic: runtime error", errors.New("exit status 1"))
+	logAttemptStderr(logger, "agent.headless.stderr", "agent-1", "You've hit your weekly limit", errProviderRateLimited)
 
 	out := buf.String()
-	if !strings.Contains(out, "level=ERROR") || !strings.Contains(out, "panic: runtime error") {
-		t.Fatalf("expected ERROR log with stderr content on non-zero exit, got: %s", out)
+	if !strings.Contains(out, "level=ERROR") || !strings.Contains(out, "You've hit your weekly limit") {
+		t.Fatalf("expected ERROR log with stderr content on final provider failure, got: %s", out)
 	}
 }
 
-func TestLogHeadlessStderr_EmptyStderr_NoLog(t *testing.T) {
+func TestLogAttemptStderr_ConvoPreservesExtraFields(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	logHeadlessStderr(logger, "agent-1", "", nil)
+	logAttemptStderr(logger, "agent.convo.stderr", "agent-1", "Reading additional input from stdin...", nil, "provider", "codex")
+
+	out := buf.String()
+	if !strings.Contains(out, "level=DEBUG") || !strings.Contains(out, "provider=codex") {
+		t.Fatalf("expected DEBUG convo log with provider field, got: %s", out)
+	}
+}
+
+func TestLogAttemptStderr_EmptyStderr_NoLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	logAttemptStderr(logger, "agent.headless.stderr", "agent-1", "", nil)
 
 	if buf.Len() != 0 {
 		t.Fatalf("expected no log for empty stderr, got: %s", buf.String())

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -128,6 +128,48 @@ func TestProcessHeadlessLine_SuppressesCodexLimitSnapshotOutput(t *testing.T) {
 	}
 }
 
+// TestProcessHeadlessLine_ResultLogOmitsSessionCostForCodex verifies that
+// agent.headless.result drops the meaningless session_id/cost fields for
+// codex (which never reports them), while keeping them for providers that
+// do (e.g. claude) — see #1560.
+func TestProcessHeadlessLine_ResultLogOmitsSessionCostForCodex(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	m := mustNewManager(t, context.Background(), func(string, any) {}, logger, t.TempDir())
+
+	a := &Agent{ID: "codex1", TaskID: "t", Mode: "headless", Provider: "codex", StartedAt: time.Now().UTC()}
+	lastEmit := time.Now().Add(-time.Minute)
+	line := []byte(`{"type":"turn.completed","usage":{"input_tokens":123,"output_tokens":45}}`)
+	if stop := m.processHeadlessLine(context.Background(), a, line, &lastEmit, providerByName("codex")); stop {
+		t.Fatal("result event must not stop the stream")
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "agent.headless.result") {
+		t.Fatalf("log = %q, want agent.headless.result entry", logged)
+	}
+	if strings.Contains(logged, "session_id=") || strings.Contains(logged, "cost=") {
+		t.Fatalf("log = %q, want no session_id/cost fields for codex", logged)
+	}
+	if !strings.Contains(logged, "input_tokens=123") || !strings.Contains(logged, "output_tokens=45") {
+		t.Fatalf("log = %q, want input_tokens/output_tokens present", logged)
+	}
+
+	logBuf.Reset()
+	b := &Agent{ID: "claude1", TaskID: "t", Mode: "headless", Provider: "claude", StartedAt: time.Now().UTC()}
+	claudeLine := []byte(`{"type":"result","subtype":"success","session_id":"sess-1","total_cost_usd":0.25,"usage":{"input_tokens":10,"output_tokens":5}}`)
+	if stop := m.processHeadlessLine(context.Background(), b, claudeLine, &lastEmit, providerByName("claude")); stop {
+		t.Fatal("result event must not stop the stream")
+	}
+	claudeLogged := logBuf.String()
+	if !strings.Contains(claudeLogged, `session_id=sess-1`) {
+		t.Fatalf("log = %q, want session_id present for claude", claudeLogged)
+	}
+	if !strings.Contains(claudeLogged, "cost=0.25") {
+		t.Fatalf("log = %q, want cost present for claude", claudeLogged)
+	}
+}
+
 func TestParseCodexStreamEvent_Error_SubstringFallback(t *testing.T) {
 	line := []byte(`{"type":"error","message":"Service overloaded (529)"}`)
 

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -230,6 +230,44 @@ func TestShouldRetry_FatalError_NoRetry(t *testing.T) {
 	}
 }
 
+func TestLogHeadlessStderr_CleanExit_LogsDebugNotError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	logHeadlessStderr(logger, "agent-1", "Reading additional input from stdin...", nil)
+
+	out := buf.String()
+	if strings.Contains(out, "level=ERROR") {
+		t.Fatalf("expected no ERROR log on clean exit, got: %s", out)
+	}
+	if !strings.Contains(out, "level=DEBUG") || !strings.Contains(out, "Reading additional input from stdin...") {
+		t.Fatalf("expected DEBUG log with stderr content, got: %s", out)
+	}
+}
+
+func TestLogHeadlessStderr_NonZeroExit_LogsError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	logHeadlessStderr(logger, "agent-1", "panic: runtime error", errors.New("exit status 1"))
+
+	out := buf.String()
+	if !strings.Contains(out, "level=ERROR") || !strings.Contains(out, "panic: runtime error") {
+		t.Fatalf("expected ERROR log with stderr content on non-zero exit, got: %s", out)
+	}
+}
+
+func TestLogHeadlessStderr_EmptyStderr_NoLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	logHeadlessStderr(logger, "agent-1", "", nil)
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no log for empty stderr, got: %s", buf.String())
+	}
+}
+
 // TestClassifyProviderError_CodexConnectivityRoutesToRateLimit pins the
 // acceptance path: a codex backend connectivity error must classify as
 // SignalRateLimit and map to ErrorKind "rate_limit" (not "" / a fatal kind),


### PR DESCRIPTION
## Motivation

Codex headless runs were misdiagnosed as crashes: informational stderr lines
were logged unconditionally at ERROR, and the result event always reported
empty session_id/zero cost since Codex never populates those fields. Both
made healthy completions indistinguishable from failures during incident
triage.

## Implementation information

- Downgrade codex stderr to DEBUG on a clean exit, ERROR only on failed exit
- Enrich `agent.headless.result` with token counts so a healthy codex
  completion isn't mistaken for an empty one
- Drop the meaningless codex `session_id`/`total_cost_usd` fields from the
  result log instead of logging them as empty/zero
- Address review feedback on the above runner changes

_Generated by Sybra harness_