### PR TITLE
fix(task): release lock before emit in AppendBody

### DIFF
--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -298,9 +298,9 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	mu := m.lockFor(id)
 	mu.Lock()
-	defer mu.Unlock()
 	t, err := m.store.Get(id)
 	if err != nil {
+		mu.Unlock()
 		return Task{}, err
 	}
 	body := strings.TrimRight(t.Body, "\n")
@@ -309,9 +309,14 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	body += content + "\n"
 	t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
+	mu.Unlock()
 	if err != nil {
 		return t, err
 	}
+	// Emit after releasing the lock — see AddRunWithStatus for why: this
+	// Manager is its own emitter's target (app.go routes task:updated back
+	// into OnExternalUpdate), so firing while still holding the lock
+	// self-deadlocks the goroutine on its own non-reentrant mutex.
 	metrics.TaskUpdated()
 	m.emitter.Emit(events.TaskUpdated, t.FilePath)
 	return t, nil

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -296,20 +296,26 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	if content == "" {
 		return m.Get(id)
 	}
-	mu := m.lockFor(id)
-	mu.Lock()
-	t, err := m.store.Get(id)
-	if err != nil {
-		mu.Unlock()
-		return Task{}, err
-	}
-	body := strings.TrimRight(t.Body, "\n")
-	if body != "" {
-		body += "\n\n"
-	}
-	body += content + "\n"
-	t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
-	mu.Unlock()
+	var (
+		t   Task
+		err error
+	)
+	func() {
+		mu := m.lockFor(id)
+		mu.Lock()
+		defer mu.Unlock()
+
+		t, err = m.store.Get(id)
+		if err != nil {
+			return
+		}
+		body := strings.TrimRight(t.Body, "\n")
+		if body != "" {
+			body += "\n\n"
+		}
+		body += content + "\n"
+		t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
+	}()
 	if err != nil {
 		return t, err
 	}

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/events"
 )
@@ -260,6 +261,52 @@ func TestManagerOnExternalUpdateInvalidatesJSONSidecar(t *testing.T) {
 	}
 	if tasks[0].PlanContract != contract {
 		t.Fatalf("PlanContract = %q, want %q", tasks[0].PlanContract, contract)
+	}
+}
+
+// TestManagerAppendBodyDoesNotDeadlockOnSelfRoutedEmit reproduces the
+// production wiring in app.go's emit closure, which routes every
+// task:updated event straight back into Manager.OnExternalUpdate on the
+// same goroutine (so cross-process file writes and in-process updates share
+// one status-change path). AppendBody used to fire that emit while still
+// holding lockFor(id) via a deferred unlock, so the re-entrant
+// OnExternalUpdate call blocked forever on the same non-reentrant mutex —
+// the goroutine that wedged issue #1567 (a FAIL test-runner verdict calls
+// AppendBody via appendTestFailureReport).
+func TestManagerAppendBodyDoesNotDeadlockOnSelfRoutedEmit(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	created, err := m.Create("Task", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// OnExternalUpdate only takes lockFor(id) when a status-change hook is
+	// registered — without one it returns before locking and the reentrant
+	// path this test targets would never be exercised.
+	m.SetStatusChangeHook(func(string, string, string) {})
+	m.emitter = EmitterFunc(func(event string, data any) {
+		if event != events.TaskUpdated {
+			return
+		}
+		if path, ok := data.(string); ok {
+			m.OnExternalUpdate(path)
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, appendErr := m.AppendBody(created.ID, "note")
+		done <- appendErr
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AppendBody: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AppendBody deadlocked on self-routed emit")
 	}
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -211,11 +211,15 @@ func (e *Engine) HandleStatusChange(taskID, newStatus string) {
 // HandleAgentComplete is called when an agent finishes. It maps the agent
 // back to the workflow step and advances.
 //
-// Silently skips (Debug log) when the task's workflow is already terminal or
-// has no current step. Agents that were started outside the workflow engine
-// (e.g. manual pr-fix retries, recovery spawns) land here on completion; the
-// guard avoids the "step not found" error loop that followed workflow
-// completion in older versions.
+// Every non-advancing exit below logs at INFO with task_id, agent_id, and a
+// reason — a completion that bails here produces no other signal (no error,
+// no workflow.advance), so a Debug-only log made the drop invisible at the
+// default log level and let a genuine regression (e.g. #1567) masquerade as
+// routine "agent started outside the workflow engine" noise. Agents started
+// outside the workflow engine (e.g. manual pr-fix retries, recovery spawns)
+// legitimately land here on completion; the guards below avoid the "step not
+// found" error loop that followed workflow completion in older versions —
+// but that legitimacy still needs to be visible when diagnosing a stall.
 func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
@@ -223,7 +227,7 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		return
 	}
 	if t.Workflow == nil {
-		e.logger.Debug("workflow.agent-complete.no-workflow", "task_id", taskID)
+		e.logger.Info("workflow.agent-complete.bail", "task_id", taskID, "agent_id", c.AgentID, "reason", "no-workflow")
 		return
 	}
 	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
@@ -235,14 +239,14 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 				e.importSidecarIfConfigured(taskID, spawnedStep, t)
 			}
 		}
-		e.logger.Debug("workflow.agent-complete.terminal",
-			"task_id", taskID, "agent_id", c.AgentID, "state", string(t.Workflow.State))
+		e.logger.Info("workflow.agent-complete.bail",
+			"task_id", taskID, "agent_id", c.AgentID, "reason", "terminal", "state", string(t.Workflow.State))
 		e.clearAgentStep(c.AgentID)
 		return
 	}
 	if t.Workflow.CurrentStep == "" {
-		e.logger.Debug("workflow.agent-complete.no-current-step",
-			"task_id", taskID, "agent_id", c.AgentID, "state", string(t.Workflow.State))
+		e.logger.Info("workflow.agent-complete.bail",
+			"task_id", taskID, "agent_id", c.AgentID, "reason", "no-current-step", "state", string(t.Workflow.State))
 		e.clearAgentStep(c.AgentID)
 		return
 	}
@@ -257,8 +261,8 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	if !tracked {
 		spawnedStep = t.Workflow.CurrentStep
 		if e.hasTrackedAgentForTaskStep(taskID, spawnedStep) {
-			e.logger.Debug("workflow.agent-complete.untracked-ignored",
-				"task_id", taskID, "agent_id", c.AgentID, "current_step", spawnedStep)
+			e.logger.Info("workflow.agent-complete.bail",
+				"task_id", taskID, "agent_id", c.AgentID, "reason", "untracked-ignored", "current_step", spawnedStep)
 			e.clearAgentStep(c.AgentID)
 			return
 		}


### PR DESCRIPTION
## Motivation

`AppendBody` fired its `task:updated` emit while still holding `lockFor(id)` via a deferred unlock. Production wiring routes that event straight back into `Manager.OnExternalUpdate` on the same goroutine, so the re-entrant call blocked forever on the same non-reentrant mutex — the deadlock behind a wedged test-runner FAIL-verdict path. Workflow completion bail-outs were also only logged at Debug, making a genuine regression indistinguishable from routine "agent started outside the workflow engine" noise.

## Implementation information

- `internal/task/manager.go`: scope `AppendBody`'s locked section to a closure so the lock releases before `Emit` runs.
- `internal/task/manager_test.go`: add a regression test reproducing the self-routed emit wiring and asserting no deadlock.
- `internal/workflow/engine_events.go`: promote `HandleAgentComplete`'s non-advancing bail-out logs from Debug to Info with task_id/agent_id/reason, so a stalled workflow is diagnosable at default log level.

_Generated by Sybra harness_