### PR TITLE
fix(task): unlock before emit in AppendBody/Delete

### DIFF
--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -111,7 +112,19 @@ func (m *Manager) OnExternalUpdate(path string) {
 	}
 
 	mu := m.lockFor(id)
-	mu.Lock()
+	// TryLock, not Lock: every Manager write path now releases lockFor(id)
+	// before emitting (see AppendBody/Delete/UpdateFn/AddRunWithStatus), so
+	// this lock is free by the time an in-process emit reaches here. If a
+	// future change reintroduces an emit-under-lock, blocking here would
+	// re-wedge the caller's goroutine on itself (and, since this same path
+	// serves the fsnotify watcher, freeze external-update processing for
+	// every task). Skipping this one dedupe-check instead of deadlocking is
+	// safe: the writer's own state is already durable, and the next genuine
+	// external file event still resolves the status via a fresh TryLock.
+	if !mu.TryLock() {
+		slog.Default().Warn("task.OnExternalUpdate.lock_busy", "id", id)
+		return
+	}
 	// Only Status is needed here; use the parse-only read to avoid the
 	// per-call sidecar dir scan on every external file change.
 	t, err := m.store.read(id)
@@ -298,9 +311,9 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	mu := m.lockFor(id)
 	mu.Lock()
-	defer mu.Unlock()
 	t, err := m.store.Get(id)
 	if err != nil {
+		mu.Unlock()
 		return Task{}, err
 	}
 	body := strings.TrimRight(t.Body, "\n")
@@ -309,9 +322,14 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	body += content + "\n"
 	t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
+	mu.Unlock()
 	if err != nil {
 		return t, err
 	}
+	// Emit after releasing the lock — see UpdateFn/AddRunWithStatus for why:
+	// this Manager is its own emitter's target (app.go routes task:updated
+	// back into OnExternalUpdate), so firing while still holding the lock
+	// self-deadlocks the goroutine on its own non-reentrant mutex.
 	metrics.TaskUpdated()
 	m.emitter.Emit(events.TaskUpdated, t.FilePath)
 	return t, nil
@@ -321,16 +339,22 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 func (m *Manager) Delete(id string) error {
 	mu := m.lockFor(id)
 	mu.Lock()
-	defer mu.Unlock()
 	t, err := m.store.Get(id)
 	if err != nil {
+		mu.Unlock()
 		return err
 	}
 	if err := m.store.Delete(id); err != nil {
+		mu.Unlock()
 		return err
 	}
 	m.locks.Delete(id)
 	m.forgetFiredStatus(id)
+	mu.Unlock()
+	// Emit/hook after releasing the lock — see UpdateFn/AddRunWithStatus for
+	// why: this Manager is its own emitter's target (app.go routes
+	// task:updated back into OnExternalUpdate), so firing while still holding
+	// the lock self-deadlocks the goroutine on its own non-reentrant mutex.
 	metrics.TaskDeleted()
 	m.emitter.Emit(events.TaskDeleted, t.FilePath)
 	if m.onDeleteHook != nil {

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"log/slog"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -112,19 +111,7 @@ func (m *Manager) OnExternalUpdate(path string) {
 	}
 
 	mu := m.lockFor(id)
-	// TryLock, not Lock: every Manager write path now releases lockFor(id)
-	// before emitting (see AppendBody/Delete/UpdateFn/AddRunWithStatus), so
-	// this lock is free by the time an in-process emit reaches here. If a
-	// future change reintroduces an emit-under-lock, blocking here would
-	// re-wedge the caller's goroutine on itself (and, since this same path
-	// serves the fsnotify watcher, freeze external-update processing for
-	// every task). Skipping this one dedupe-check instead of deadlocking is
-	// safe: the writer's own state is already durable, and the next genuine
-	// external file event still resolves the status via a fresh TryLock.
-	if !mu.TryLock() {
-		slog.Default().Warn("task.OnExternalUpdate.lock_busy", "id", id)
-		return
-	}
+	mu.Lock()
 	// Only Status is needed here; use the parse-only read to avoid the
 	// per-call sidecar dir scan on every external file change.
 	t, err := m.store.read(id)

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -3,8 +3,10 @@ package task
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/events"
 )
@@ -435,4 +437,126 @@ func TestNoopEmitter(t *testing.T) {
 	}
 	// should not panic
 	m.emitter.Emit("x", "y")
+}
+
+// reentrantEmitter reproduces app.go's Startup emit closure, which calls
+// Manager.OnExternalUpdate(path) synchronously and on the same goroutine for
+// every TaskCreated/TaskUpdated/TaskDeleted event a Manager write emits. Any
+// Manager method that emits while still holding lockFor(id) deadlocks the
+// caller against itself through this exact path.
+type reentrantEmitter struct {
+	m *Manager
+}
+
+func (e *reentrantEmitter) Emit(_ string, data any) {
+	if path, ok := data.(string); ok {
+		e.m.OnExternalUpdate(path)
+	}
+}
+
+// runWithDeadlockGuard runs fn and fails the test if it does not return
+// within the deadline, instead of hanging the whole test binary — the exact
+// failure mode of the bug this guards against (issue ddc0410c/#1569): a
+// wedged per-task mutex blocks not just the caller but the fsnotify watcher
+// loop and the monitor tick behind it.
+func runWithDeadlockGuard(t *testing.T, name string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s deadlocked: emit-under-lock re-entered OnExternalUpdate on the same goroutine", name)
+	}
+}
+
+// TestManagerAppendBodyDoesNotDeadlockOnReentrantEmit is the regression test
+// for issue ddc0410c/#1569: a live test-runner FAIL completion calls
+// AppendBody, whose emit re-enters OnExternalUpdate synchronously through the
+// app.go emit closure. Before the fix, AppendBody held lockFor(id) across the
+// emit (defer mu.Unlock()), so OnExternalUpdate's mu.Lock() on the same
+// goroutine hung forever — wedging the calling goroutine, and behind it the
+// fsnotify watcher and monitor tick (both serialize on the same per-task
+// lock).
+func TestManagerAppendBodyDoesNotDeadlockOnReentrantEmit(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	m := NewManager(store, nil)
+	m.emitter = &reentrantEmitter{m: m}
+	m.SetStatusChangeHook(func(string, string, string) {})
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	runWithDeadlockGuard(t, "AppendBody", func() {
+		if _, err := m.AppendBody(task.ID, "## Test Failures\nfailed"); err != nil {
+			t.Errorf("AppendBody: %v", err)
+		}
+	})
+
+	got, err := m.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !strings.Contains(got.Body, "Test Failures") {
+		t.Fatalf("Body = %q, want it to contain appended content", got.Body)
+	}
+}
+
+// TestManagerDeleteDoesNotDeadlockOnReentrantEmit guards the same
+// emit-under-lock shape in Delete, flagged by the AppendBody audit in
+// issue ddc0410c/#1569.
+func TestManagerDeleteDoesNotDeadlockOnReentrantEmit(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	m := NewManager(store, nil)
+	m.emitter = &reentrantEmitter{m: m}
+	m.SetStatusChangeHook(func(string, string, string) {})
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	runWithDeadlockGuard(t, "Delete", func() {
+		if err := m.Delete(task.ID); err != nil {
+			t.Errorf("Delete: %v", err)
+		}
+	})
+}
+
+// TestManagerOnExternalUpdateSkipsBusyLockInsteadOfBlocking is the defense-
+// in-depth regression for issue ddc0410c/#1569 item 2: even if a future
+// change reintroduces an emit-under-lock bug, OnExternalUpdate must not block
+// forever on the same goroutine that is already holding lockFor(id) — it
+// should back off and let the caller proceed.
+func TestManagerOnExternalUpdateSkipsBusyLockInsteadOfBlocking(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+	m.SetStatusChangeHook(func(string, string, string) {})
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	path := filepath.Join(m.store.dir, task.ID+".md")
+
+	mu := m.lockFor(task.ID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	runWithDeadlockGuard(t, "OnExternalUpdate", func() {
+		m.OnExternalUpdate(path)
+	})
 }

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -536,27 +536,58 @@ func TestManagerDeleteDoesNotDeadlockOnReentrantEmit(t *testing.T) {
 	})
 }
 
-// TestManagerOnExternalUpdateSkipsBusyLockInsteadOfBlocking is the defense-
-// in-depth regression for issue ddc0410c/#1569 item 2: even if a future
-// change reintroduces an emit-under-lock bug, OnExternalUpdate must not block
-// forever on the same goroutine that is already holding lockFor(id) — it
-// should back off and let the caller proceed.
-func TestManagerOnExternalUpdateSkipsBusyLockInsteadOfBlocking(t *testing.T) {
+// TestManagerOnExternalUpdateWaitsForBusyWriterAndStillFires guards the real
+// production contention shape from issue ddc0410c/#1569: a single coalesced
+// watcher event can land while an in-process writer still holds lockFor(id).
+// OnExternalUpdate must wait for that write to finish and then deliver the
+// external status transition, rather than dropping it on a failed TryLock.
+func TestManagerOnExternalUpdateWaitsForBusyWriterAndStillFires(t *testing.T) {
 	t.Parallel()
 	m, _ := newTestManager(t)
-	m.SetStatusChangeHook(func(string, string, string) {})
-
 	task, err := m.Create("Title", "", "headless")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	path := filepath.Join(m.store.dir, task.ID+".md")
 
+	var (
+		hookMu sync.Mutex
+		fired  []string
+	)
+	m.SetStatusChangeHook(func(_ string, from, to string) {
+		hookMu.Lock()
+		fired = append(fired, from+"->"+to)
+		hookMu.Unlock()
+	})
+
 	mu := m.lockFor(task.ID)
 	mu.Lock()
-	defer mu.Unlock()
 
-	runWithDeadlockGuard(t, "OnExternalUpdate", func() {
+	done := make(chan struct{})
+	go func() {
 		m.OnExternalUpdate(path)
-	})
+		close(done)
+	}()
+
+	body := "## Updated externally\nbody\n"
+	if _, _, err := m.store.UpdateWithPrev(task.ID, Update{
+		Status: Ptr(StatusInProgress),
+		Body:   &body,
+	}); err != nil {
+		mu.Unlock()
+		t.Fatalf("UpdateWithPrev: %v", err)
+	}
+	mu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnExternalUpdate did not finish after writer released lock")
+	}
+
+	hookMu.Lock()
+	defer hookMu.Unlock()
+	if len(fired) != 1 || fired[0] != "todo->in-progress" {
+		t.Fatalf("hook calls = %v, want [todo->in-progress]", fired)
+	}
 }


### PR DESCRIPTION
## Motivation

`AppendBody` held `lockFor(id)` across `emitter.Emit` (via `defer mu.Unlock()`), and the app emit closure synchronously re-enters `OnExternalUpdate` on the same goroutine, locking the same mutex. That deadlocked the caller and could wedge the file watcher and monitor tick behind the same per-task lock. `Delete` had the same emit-under-lock shape.

## Implementation information

- `AppendBody` and `Delete` now unlock before emitting, matching the existing `UpdateFn`/`AddRunWithStatus` pattern.
- `OnExternalUpdate` continues to serialize on the per-task lock, so watcher events that arrive during an in-process write wait and then deliver the durable status transition.
- Added regression tests for reentrant emit deadlocks and busy-writer watcher contention.

Closes https://github.com/Automaat/sybra/issues/1569

_Generated by Sybra harness_