### PR TITLE
fix(task): emit task events outside per-task lock

### DIFF
--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -298,9 +298,9 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	mu := m.lockFor(id)
 	mu.Lock()
-	defer mu.Unlock()
 	t, err := m.store.Get(id)
 	if err != nil {
+		mu.Unlock()
 		return Task{}, err
 	}
 	body := strings.TrimRight(t.Body, "\n")
@@ -309,9 +309,13 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	body += content + "\n"
 	t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
+	mu.Unlock()
 	if err != nil {
 		return t, err
 	}
+	// The app emit closure routes task:updated back into OnExternalUpdate,
+	// which re-takes this task's lock — holding it here self-deadlocks (see
+	// AddRunWithStatus).
 	metrics.TaskUpdated()
 	m.emitter.Emit(events.TaskUpdated, t.FilePath)
 	return t, nil
@@ -321,16 +325,22 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 func (m *Manager) Delete(id string) error {
 	mu := m.lockFor(id)
 	mu.Lock()
-	defer mu.Unlock()
 	t, err := m.store.Get(id)
 	if err != nil {
+		mu.Unlock()
 		return err
 	}
 	if err := m.store.Delete(id); err != nil {
+		mu.Unlock()
 		return err
 	}
 	m.locks.Delete(id)
 	m.forgetFiredStatus(id)
+	mu.Unlock()
+	// task:deleted also routes into OnExternalUpdate via the app emit closure;
+	// under the lock that survives only because locks.Delete above hands the
+	// re-entry a fresh mutex. Emit outside the critical section anyway so the
+	// safety does not hinge on that ordering (see AddRunWithStatus).
 	metrics.TaskDeleted()
 	m.emitter.Emit(events.TaskDeleted, t.FilePath)
 	if m.onDeleteHook != nil {

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/events"
 )
@@ -435,4 +436,59 @@ func TestNoopEmitter(t *testing.T) {
 	}
 	// should not panic
 	m.emitter.Emit("x", "y")
+}
+
+// TestEmitReenteringOnExternalUpdateDoesNotDeadlock guards #1569: the app emit
+// closure routes task events synchronously back into OnExternalUpdate, which
+// takes the same per-task lock as the mutation that emitted — so any Manager
+// method that emits while still holding lockFor(id) deadlocks itself. The
+// production incident path was AppendBody (workflow test-failure reports);
+// Delete is covered too since task:deleted takes the same route.
+func TestEmitReenteringOnExternalUpdateDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+	ops := []struct {
+		name string
+		op   func(m *Manager, id string) error
+	}{
+		{"AppendBody", func(m *Manager, id string) error {
+			_, err := m.AppendBody(id, "## Test Failures\nreport")
+			return err
+		}},
+		{"Delete", func(m *Manager, id string) error {
+			return m.Delete(id)
+		}},
+	}
+	for _, tc := range ops {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			var m *Manager
+			m = NewManager(store, EmitterFunc(func(_ string, data any) {
+				if path, ok := data.(string); ok {
+					m.OnExternalUpdate(path)
+				}
+			}))
+			// OnExternalUpdate only takes the per-task lock once a status hook
+			// is wired — mirror the fully-started app, not the startup window.
+			m.SetStatusChangeHook(func(string, string, string) {})
+
+			tk, err := m.Create("Title", "body", "headless")
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			done := make(chan error, 1)
+			go func() { done <- tc.op(m, tk.ID) }()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("%s: %v", tc.name, err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("%s deadlocked emitting under the per-task lock", tc.name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Motivation

Every live test-runner FAIL completion deadlocks the app (#1569). `Engine.AdvanceStep → appendTestFailureReport → Manager.AppendBody` emits `task:updated` while still holding the per-task lock; the app emit closure routes the event synchronously back into `Manager.OnExternalUpdate`, which locks the same non-reentrant mutex on the same goroutine. The completion goroutine hangs forever, the fsnotify watcher loop and the monitor tick pile up behind the stuck mutex, and the agent's `done` channel never closes — so `HasRunningAgentForTask` stays true and every recovery loop silently skips the task until an app restart. Confirmed twice today via pprof goroutine dumps (269 min and 27 min wedges); this is the real mechanism behind the "lost agent completion" incidents (#1559, #1567).

> Changelog: fix(task): emit task events outside per-task lock

## Implementation information

- `AppendBody` and `Delete` now release `lockFor(id)` before firing the emitter, matching the unlock-then-fire pattern `AddRunWithStatus` and `UpdateRun` already document for exactly this hazard. `Delete` currently survives only because `locks.Delete` hands the re-entry a fresh mutex — moved its emit out too so the safety doesn't hinge on that ordering.
- Regression test drives the real wiring (emitter → `OnExternalUpdate`, status hook set) for both methods: it deadlocks on the previous code (timeout hit) and passes with the fix.

## Supporting documentation

- #1569 — full incident analysis with goroutine stacks
- `go test -race ./internal/task/` and `mise run verify` green
