### PR TITLE
fix(server): authenticate HTTP control plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,8 @@ jobs:
           cat > "$SYBRA_HOME/config.yaml" <<EOF
           agent:
             provider: ${{ matrix.provider }}
+          server:
+            auth_token: e2e-test-token
           monitor:
             stuck_human_hours: 99999
           EOF
@@ -318,6 +320,8 @@ jobs:
 
       - name: Build web frontend
         run: cd frontend && npm run build:web
+        env:
+          VITE_API_TOKEN: e2e-test-token
 
       - name: Build sybra-server
         run: go build -o bin/sybra-server ./cmd/sybra-server

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -30,9 +30,15 @@ jobs:
           mkdir -p "$SYBRA_HOME/tasks" "$SYBRA_HOME/workflows"
           cp frontend/e2e/fixtures/*.md "$SYBRA_HOME/tasks/"
           cp frontend/e2e/fixtures/wf-editor-e2e.yaml "$SYBRA_HOME/workflows/"
+          cat > "$SYBRA_HOME/config.yaml" <<EOF
+          server:
+            auth_token: e2e-test-token
+          EOF
 
       - name: Build web frontend
         run: cd frontend && npm run build:web
+        env:
+          VITE_API_TOKEN: e2e-test-token
 
       - name: Build sybra-server
         run: go build -o bin/sybra-server ./cmd/sybra-server

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ frontend/coverage/
 /sybra-perf
 /fake-claude
 /synapse-server
-sybra-server
 core.*
 /fake-codex
 

--- a/cmd/gen-config-docs/main.go
+++ b/cmd/gen-config-docs/main.go
@@ -193,6 +193,7 @@ func structFields(st *ast.StructType) []fieldInfo {
 // static types alone.
 var redactedYAMLPaths = map[string]bool{
 	"todoist.api_token": true,
+	"server.auth_token": true,
 }
 
 // homeDir is config.HomeDir() at generation time — substituted back out of

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1944,6 +1944,9 @@ func redactedConfig(cfg *config.Config) config.Config {
 	if out.Todoist.APIToken != "" {
 		out.Todoist.APIToken = "[redacted]"
 	}
+	if out.Server.AuthToken != "" {
+		out.Server.AuthToken = "[redacted]"
+	}
 	return out
 }
 

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -262,7 +262,7 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 		if origin := r.Header.Get("Origin"); origin != "" {
 			if _, ok := allowed[origin]; ok {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
-				w.Header().Set("Vary", "Origin")
+				w.Header().Add("Vary", "Origin")
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 			}

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -105,11 +105,12 @@ func run() (int, error) {
 
 	mux := buildMux(logger, broker, app)
 
-	// authMiddleware gates everything except GET /health behind the
-	// shared-secret bearer token; corsMiddleware only echoes CORS headers
-	// back for origins on the configured allowlist (no wildcard). Order
-	// matters: CORS must sit outside auth so preflight OPTIONS requests
-	// (which never carry Authorization) are answered before reaching it.
+	// authMiddleware gates the HTTP control plane behind the shared-secret
+	// bearer token while leaving SPA/static delivery public; corsMiddleware
+	// only echoes CORS headers back for origins on the configured allowlist
+	// (no wildcard). Order matters: CORS must sit outside auth so preflight
+	// OPTIONS requests (which never carry Authorization) are answered before
+	// reaching it.
 	handler := cspMiddleware(corsMiddleware(cfg.Server.AllowedOrigins, authMiddleware(cfg.Server.AuthToken, logger, mux)))
 
 	port := os.Getenv("SYBRA_PORT")
@@ -274,16 +275,18 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	})
 }
 
-// authMiddleware gates every request behind a shared-secret bearer token,
-// except GET /health (container-orchestration liveness probes have no way
-// to carry a header). Browser EventSource cannot set request headers, so the
+// authMiddleware gates only the HTTP control plane behind a shared-secret
+// bearer token: `/api/*`, `/events`, `/api/events/*`, `/metrics`, and
+// `/debug/pprof/*`. Browser EventSource cannot set request headers, so the
 // SSE endpoints additionally accept the token as a `?token=` query param.
-// A blank token fails every request closed rather than treating it as "auth
+// Static SPA assets stay public so normal browser navigations can load the
+// app shell before JS starts issuing authenticated API calls. A blank token
+// fails every protected request closed rather than treating it as "auth
 // disabled" — config.Load always generates one, so an empty value here means
 // misconfiguration, not intent.
 func authMiddleware(token string, logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/health" {
+		if !requestRequiresAuth(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -297,6 +300,23 @@ func authMiddleware(token string, logger *slog.Logger, next http.Handler) http.H
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func requestRequiresAuth(r *http.Request) bool {
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/health":
+		return false
+	case r.URL.Path == "/events":
+		return true
+	case r.URL.Path == "/metrics":
+		return true
+	case strings.HasPrefix(r.URL.Path, "/api/"):
+		return true
+	case strings.HasPrefix(r.URL.Path, "/debug/pprof/"):
+		return true
+	default:
+		return false
+	}
 }
 
 func requestAuthorized(r *http.Request, token string) bool {

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -104,8 +105,12 @@ func run() (int, error) {
 
 	mux := buildMux(logger, broker, app)
 
-	// CORS for dev (permissive; tighten for production).
-	handler := cspMiddleware(corsMiddleware(mux))
+	// authMiddleware gates everything except GET /health behind the
+	// shared-secret bearer token; corsMiddleware only echoes CORS headers
+	// back for origins on the configured allowlist (no wildcard). Order
+	// matters: CORS must sit outside auth so preflight OPTIONS requests
+	// (which never carry Authorization) are answered before reaching it.
+	handler := cspMiddleware(corsMiddleware(cfg.Server.AllowedOrigins, authMiddleware(cfg.Server.AuthToken, logger, mux)))
 
 	port := os.Getenv("SYBRA_PORT")
 	if port == "" {
@@ -243,17 +248,78 @@ func cspMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func corsMiddleware(next http.Handler) http.Handler {
+// corsMiddleware echoes CORS headers back only for an Origin present in
+// allowedOrigins (exact match) — no wildcard. Requests without a matching
+// Origin still reach next (non-browser callers don't need CORS headers at
+// all), they just won't be readable cross-origin from an unlisted site.
+func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		allowed[o] = struct{}{}
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if origin := r.Header.Get("Origin"); origin != "" {
+			if _, ok := allowed[origin]; ok {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Vary", "Origin")
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			}
+		}
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// authMiddleware gates every request behind a shared-secret bearer token,
+// except GET /health (container-orchestration liveness probes have no way
+// to carry a header). Browser EventSource cannot set request headers, so the
+// SSE endpoints additionally accept the token as a `?token=` query param.
+// A blank token fails every request closed rather than treating it as "auth
+// disabled" — config.Load always generates one, so an empty value here means
+// misconfiguration, not intent.
+func authMiddleware(token string, logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !requestAuthorized(r, token) {
+			logger.Warn("server.auth.denied", "path", r.URL.Path, "remote", r.RemoteAddr)
+			w.Header().Set("WWW-Authenticate", `Bearer realm="sybra"`)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"error":"unauthorized","code":"unauthorized"}`)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func requestAuthorized(r *http.Request, token string) bool {
+	if token == "" {
+		return false
+	}
+	if bearer, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer "); ok && tokensEqual(bearer, token) {
+		return true
+	}
+	if isSSEPath(r.URL.Path) {
+		if qt := r.URL.Query().Get("token"); qt != "" && tokensEqual(qt, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSSEPath(p string) bool {
+	return p == "/events" || strings.HasPrefix(p, "/api/events/")
+}
+
+func tokensEqual(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
 type slogWriter struct{ logger *slog.Logger }

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestAuthMiddlewareRejectsMissingToken(t *testing.T) {
+	h := authMiddleware("secret", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareAcceptsMatchingBearerToken(t *testing.T) {
+	h := authMiddleware("secret", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareRejectsWrongBearerToken(t *testing.T) {
+	h := authMiddleware("secret", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareAllowsHealthWithoutToken(t *testing.T) {
+	h := authMiddleware("secret", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareBlankTokenFailsClosed(t *testing.T) {
+	h := authMiddleware("", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Authorization", "Bearer ")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (blank server token must never authorize)", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareSSEAcceptsQueryToken(t *testing.T) {
+	h := authMiddleware("secret", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodGet, "/events?token=secret", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (SSE path should accept query token)", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareNonSSEPathRejectsQueryToken(t *testing.T) {
+	h := authMiddleware("secret", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks?token=secret", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (query token must only be honored on SSE paths)", rr.Code)
+	}
+}
+
+func TestCorsMiddlewareEchoesAllowedOrigin(t *testing.T) {
+	h := corsMiddleware([]string{"https://allowed.example"}, okHandler())
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
+	req.Header.Set("Origin", "https://allowed.example")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://allowed.example" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want the allowed origin", got)
+	}
+}
+
+func TestCorsMiddlewareOmitsHeadersForUnlistedOrigin(t *testing.T) {
+	h := corsMiddleware([]string{"https://allowed.example"}, okHandler())
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
+	req.Header.Set("Origin", "https://evil.example")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty for an unlisted origin", got)
+	}
+}
+
+func TestCorsMiddlewareNeverSetsWildcard(t *testing.T) {
+	h := corsMiddleware(nil, okHandler())
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
+	req.Header.Set("Origin", "https://anything.example")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got == "*" {
+		t.Error("Access-Control-Allow-Origin must never be a wildcard")
+	}
+}
+
+func TestCorsMiddlewareHandlesPreflight(t *testing.T) {
+	h := corsMiddleware([]string{"https://allowed.example"}, okHandler())
+	req := httptest.NewRequest(http.MethodOptions, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Origin", "https://allowed.example")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 for OPTIONS preflight", rr.Code)
+	}
+}

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/sse"
@@ -185,6 +187,35 @@ func TestServerHandlerServesSPAWithoutToken(t *testing.T) {
 	}
 	if body := rr.Body.String(); body != "ok" {
 		t.Fatalf("body = %q, want %q", body, "ok")
+	}
+}
+
+func TestSSEHandlerNeverSetsWildcardCORS(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Server.AuthToken = "secret"
+	cfg.Server.AllowedOrigins = []string{"https://allowed.example"}
+
+	app := sybra.NewApp(testLogger(), nil, cfg)
+	handler := cspMiddleware(corsMiddleware(cfg.Server.AllowedOrigins, authMiddleware(cfg.Server.AuthToken, testLogger(), buildMux(testLogger(), sse.New(), app))))
+
+	for _, path := range []string{"/events?token=secret", "/api/events/task:updated?token=secret"} {
+		ctx, cancel := context.WithCancel(context.Background())
+		req := httptest.NewRequest(http.MethodGet, path, http.NoBody).WithContext(ctx)
+		req.Header.Set("Origin", "https://evil.example")
+		rr := httptest.NewRecorder()
+
+		done := make(chan struct{})
+		go func() {
+			handler.ServeHTTP(rr, req)
+			close(done)
+		}()
+		<-time.After(20 * time.Millisecond)
+		cancel()
+		<-done
+
+		if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("%s: Access-Control-Allow-Origin = %q, want empty for an unlisted origin", path, got)
+		}
 	}
 }
 

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/sse"
+	"github.com/Automaat/sybra/internal/sybra"
 )
 
 func testLogger() *slog.Logger {
@@ -55,6 +62,17 @@ func TestAuthMiddlewareRejectsWrongBearerToken(t *testing.T) {
 func TestAuthMiddlewareAllowsHealthWithoutToken(t *testing.T) {
 	h := authMiddleware("secret", testLogger(), okHandler())
 	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareAllowsStaticRouteWithoutToken(t *testing.T) {
+	h := authMiddleware("secret", testLogger(), okHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
@@ -142,5 +160,53 @@ func TestCorsMiddlewareHandlesPreflight(t *testing.T) {
 
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204 for OPTIONS preflight", rr.Code)
+	}
+}
+
+func TestServerHandlerServesSPAWithoutToken(t *testing.T) {
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SYBRA_STATIC_DIR", staticDir)
+
+	cfg := config.DefaultConfig()
+	cfg.Server.AuthToken = "secret"
+
+	app := sybra.NewApp(testLogger(), nil, cfg)
+	handler := cspMiddleware(corsMiddleware(nil, authMiddleware(cfg.Server.AuthToken, testLogger(), buildMux(testLogger(), sse.New(), app))))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if body := rr.Body.String(); body != "ok" {
+		t.Fatalf("body = %q, want %q", body, "ok")
+	}
+}
+
+func TestSPAHandlerFallsBackToIndexForUnknownRoute(t *testing.T) {
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub, err := fs.Sub(os.DirFS(staticDir), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := spaHandler{fs: http.FileServer(http.FS(sub)), staticDir: staticDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/tasks/123", http.NoBody)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if body := rr.Body.String(); body != "index" {
+		t.Fatalf("body = %q, want %q", body, "index")
 	}
 }

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -129,6 +129,22 @@ func TestCorsMiddlewareEchoesAllowedOrigin(t *testing.T) {
 	}
 }
 
+func TestCorsMiddlewarePreservesExistingVaryHeaders(t *testing.T) {
+	h := corsMiddleware([]string{"https://allowed.example"}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Vary", "Accept-Encoding")
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
+	req.Header.Set("Origin", "https://allowed.example")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	got := rr.Result().Header.Values("Vary")
+	if len(got) != 2 || got[0] != "Origin" || got[1] != "Accept-Encoding" {
+		t.Fatalf("Vary headers = %q, want [Origin Accept-Encoding]", got)
+	}
+}
+
 func TestCorsMiddlewareOmitsHeadersForUnlistedOrigin(t *testing.T) {
 	h := corsMiddleware([]string{"https://allowed.example"}, okHandler())
 	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,6 +41,7 @@ machine.
 | `ab_testing` | `abtest.Config` |  |  |
 | `providers` | `ProvidersConfig` | _(see below)_ |  |
 | `metrics` | `MetricsConfig` | _(see below)_ |  |
+| `server` | `ServerConfig` | _(see below)_ |  |
 | `auto_update` | `AutoUpdateConfig` | _(see below)_ |  |
 | `browser` | `BrowserConfig` | _(see below)_ |  |
 | `project_types` | `[]string` |  |  |
@@ -448,6 +449,21 @@ Prometheus-format output for external scrapers.
 | YAML key | Type | Default | Description |
 |---|---|---|---|
 | `metrics.enabled` | `bool` |  |  |
+
+## ServerConfig (`server`)
+
+ServerConfig controls sybra-server's HTTP control-plane authentication and
+CORS policy. AuthToken gates every request except GET /health behind a
+shared-secret bearer token: callers must send
+`Authorization: Bearer <token>`, or, for the SSE endpoints only (browser
+EventSource cannot set request headers), a `?token=<token>` query param.
+AuthToken is auto-generated and persisted to config.yaml on first run if
+left empty — see applyServerDefaults.
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `server.auth_token` | `string` | `[redacted]` |  |
+| `server.allowed_origins` | `[]string` |  |  |
 
 ## AutoUpdateConfig (`auto_update`)
 

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -68,8 +68,12 @@ evaluation:
   enabled: true
   interval_hours: 24
   window_days: 30
+server:
+  auth_token: smoke-test-token
 YAML
 ```
+
+A pinned `server.auth_token` keeps the harness's `curl` calls reproducible — without it, sybra-server auto-generates a random token on first start (see `internal/config.applyServerDefaults`) and the value would only be discoverable by re-reading `$TMP/home/config.yaml` after the fact.
 
 Create fake CLIs:
 
@@ -120,13 +124,15 @@ The server exposes allowlisted bound methods as:
 POST /api/{Service}/{Method}
 ```
 
-Request bodies are JSON arrays of positional arguments.
+Request bodies are JSON arrays of positional arguments. Every path except `GET /health` requires
+`Authorization: Bearer <server.auth_token>` (see `cmd/sybra-server`'s `authMiddleware`) — the harness's
+config above pins this to `smoke-test-token`.
 
 Examples:
 
 ```bash
 api() {
-  curl -fsS -H 'Content-Type: application/json' \
+  curl -fsS -H 'Content-Type: application/json' -H 'Authorization: Bearer smoke-test-token' \
     -X POST "http://127.0.0.1:$PORT/api/$1/$2" \
     --data "$3"
 }

--- a/frontend/src/lib/api-http.test.ts
+++ b/frontend/src/lib/api-http.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+
+  url: string
+  addEventListener = vi.fn()
+  removeEventListener = vi.fn()
+  close = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+}
+
+describe('api-http live updates auth', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    MockEventSource.instances = []
+    vi.restoreAllMocks()
+    vi.stubGlobal('EventSource', MockEventSource)
+    vi.resetModules()
+  })
+
+  it('prompts for a token before opening the first SSE connection', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('secret')
+    const { EventsOn } = await import('./api-http.ts')
+
+    const off = EventsOn('task:updated', vi.fn())
+
+    expect(window.prompt).toHaveBeenCalledTimes(1)
+    expect(MockEventSource.instances).toHaveLength(1)
+    expect(MockEventSource.instances[0]?.url).toBe('/events?token=secret')
+    expect(localStorage.getItem('sybra.apiToken')).toBe('secret')
+
+    off()
+  })
+
+  it('fails closed when the token prompt is canceled', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('')
+    const { EventsOn } = await import('./api-http.ts')
+
+    expect(() => EventsOn('task:updated', vi.fn())).toThrow(
+      'sybra server auth token required for live updates',
+    )
+    expect(MockEventSource.instances).toHaveLength(0)
+  })
+})

--- a/frontend/src/lib/api-http.test.ts
+++ b/frontend/src/lib/api-http.test.ts
@@ -25,7 +25,7 @@ describe('api-http live updates auth', () => {
 
   it('prompts for a token before opening the first SSE connection', async () => {
     vi.spyOn(window, 'prompt').mockReturnValue('secret')
-    const { EventsOn } = await import('./api-http.ts')
+    const { EventsOn } = await import('./api-http')
 
     const off = EventsOn('task:updated', vi.fn())
 
@@ -39,7 +39,7 @@ describe('api-http live updates auth', () => {
 
   it('fails closed when the token prompt is canceled', async () => {
     vi.spyOn(window, 'prompt').mockReturnValue('')
-    const { EventsOn } = await import('./api-http.ts')
+    const { EventsOn } = await import('./api-http')
 
     expect(() => EventsOn('task:updated', vi.fn())).toThrow(
       'sybra server auth token required for live updates',

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -216,6 +216,9 @@ let _subCount = 0
 
 function getSharedES(): EventSource {
   if (!_sharedES) {
+    if (!getApiToken() && !promptForApiToken()) {
+      throw new Error('sybra server auth token required for live updates')
+    }
     _sharedES = new EventSource(eventsURL())
   }
   return _sharedES

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -17,12 +17,47 @@ import type { Digest, Status as LearningDigestStatus } from '../../bindings/gith
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? '/api'
 
+// sybra-server gates every request (except GET /health) behind a shared
+// bearer token (see cmd/sybra-server authMiddleware). A build-time default
+// can be baked in via VITE_API_TOKEN; otherwise the token is entered once at
+// runtime and cached in localStorage so it survives reloads.
+const TOKEN_STORAGE_KEY = 'sybra.apiToken'
+
+export function getApiToken(): string {
+  if (typeof localStorage === 'undefined') return (import.meta.env.VITE_API_TOKEN as string | undefined) ?? ''
+  return localStorage.getItem(TOKEN_STORAGE_KEY) || (import.meta.env.VITE_API_TOKEN as string | undefined) || ''
+}
+
+export function setApiToken(token: string): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(TOKEN_STORAGE_KEY, token)
+}
+
+// promptForApiToken asks the operator for the sybra-server auth token once
+// per session (retrieved via `cat ~/.sybra/config.yaml` on the server host,
+// key `server.auth_token`). Returns '' if the user cancels.
+function promptForApiToken(): string {
+  if (typeof window === 'undefined') return ''
+  const entered = window.prompt('Sybra server auth token required (see server.auth_token in config.yaml):')
+  if (!entered) return ''
+  setApiToken(entered)
+  return entered
+}
+
 async function call<T>(service: string, method: string, ...args: unknown[]): Promise<T> {
-  const res = await fetch(`${API_BASE}/${service}/${method}`, {
+  const doFetch = () => fetch(`${API_BASE}/${service}/${method}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(getApiToken() ? { Authorization: `Bearer ${getApiToken()}` } : {}),
+    },
     body: args.length > 0 ? JSON.stringify(args) : undefined,
   })
+
+  let res = await doFetch()
+  if (res.status === 401 && promptForApiToken()) {
+    res = await doFetch()
+  }
   if (!res.ok) {
     const rawText = await res.text()
     // web-mode only: desktop Wails IPC errors never reach this path
@@ -165,18 +200,23 @@ export function StartWorkflow(arg1: string, arg2: string): Promise<void> { retur
 
 // Shared EventSource for the multiplexed /events SSE stream.
 // All EventsOn subscriptions funnel through a single connection.
-const EVENTS_URL = (() => {
+// EventSource cannot set an Authorization header, so the token travels as a
+// query param instead — the server's authMiddleware accepts either form, but
+// only for SSE paths (see isSSEPath in cmd/sybra-server).
+function eventsURL(): string {
   // Strip /api suffix to get server root, then append /events.
   const base = (import.meta.env.VITE_API_BASE as string | undefined) ?? '/api'
-  return base.replace(/\/api$/, '') + '/events'
-})()
+  const url = base.replace(/\/api$/, '') + '/events'
+  const token = getApiToken()
+  return token ? `${url}?token=${encodeURIComponent(token)}` : url
+}
 
 let _sharedES: EventSource | null = null
 let _subCount = 0
 
 function getSharedES(): EventSource {
   if (!_sharedES) {
-    _sharedES = new EventSource(EVENTS_URL)
+    _sharedES = new EventSource(eventsURL())
   }
   return _sharedES
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_MODE?: string
   readonly VITE_API_BASE?: string
+  readonly VITE_API_TOKEN?: string
 }
 
 interface Window {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	ABTesting      abtest.Config        `yaml:"ab_testing" json:"abTesting"`
 	Providers      ProvidersConfig      `yaml:"providers" json:"providers"`
 	Metrics        MetricsConfig        `yaml:"metrics" json:"metrics"`
+	Server         ServerConfig         `yaml:"server" json:"server"`
 	AutoUpdate     AutoUpdateConfig     `yaml:"auto_update" json:"autoUpdate"`
 	Browser        BrowserConfig        `yaml:"browser" json:"browser"`
 	ProjectTypes   []string             `yaml:"project_types" json:"projectTypes"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -544,19 +546,68 @@ func load(opts loadOptions) (*Config, error) {
 	applyOrchestratorDefaults(cfg)
 	applyAutoUpdateDefaults(cfg)
 	applyReviewHoldDefaults(cfg)
+	serverTokenGenerated := applyServerDefaults(cfg)
 
-	// Persist a builtin A/B experiment reconcile immediately so the refreshed
-	// weights survive a restart instead of only living in this in-memory cfg
-	// until something else happens to call Save(). Only for a config file that
-	// already existed — a brand-new install seeds def.Experiments directly and
-	// writeDefaultConfig already wrote the (comment-only) file above.
+	persistLoadReconciles(cfg, opts, existingFile, abTestingReconciled, serverTokenGenerated)
+
+	return cfg, nil
+}
+
+// persistLoadReconciles writes back in-memory-only changes made during load()
+// that must survive a restart: the ab_testing builtin reconcile (existing
+// files only) and a freshly generated server auth token (even for a
+// brand-new install — sybra-server reads Server.AuthToken once at startup,
+// so an unsaved token would silently rotate on every restart and lock
+// operators out).
+func persistLoadReconciles(cfg *Config, opts loadOptions, existingFile, abTestingReconciled, serverTokenGenerated bool) {
 	if opts.persistABTestingReconcile && existingFile && abTestingReconciled {
 		if saveErr := cfg.Save(); saveErr != nil {
 			slog.Warn("config: failed to persist ab_testing builtin reconcile", "err", saveErr)
 		}
 	}
+	if opts.persistABTestingReconcile && serverTokenGenerated {
+		if saveErr := cfg.Save(); saveErr != nil {
+			slog.Warn("config: failed to persist generated server auth token", "err", saveErr)
+		}
+	}
+}
 
-	return cfg, nil
+// applyServerDefaults resolves sybra-server's auth token and CORS allowlist:
+// env vars win when set, otherwise a missing token is auto-generated so the
+// HTTP control plane always fails closed instead of silently running
+// unauthenticated. Returns true when a new token was generated (the caller
+// must persist it — see load()).
+func applyServerDefaults(cfg *Config) bool {
+	if v := os.Getenv("SYBRA_AUTH_TOKEN"); v != "" {
+		cfg.Server.AuthToken = v
+	}
+	if v := os.Getenv("SYBRA_ALLOWED_ORIGINS"); v != "" {
+		origins := strings.Split(v, ",")
+		for i := range origins {
+			origins[i] = strings.TrimSpace(origins[i])
+		}
+		cfg.Server.AllowedOrigins = origins
+	}
+	if cfg.Server.AuthToken != "" {
+		return false
+	}
+	token, err := generateAuthToken()
+	if err != nil {
+		slog.Warn("config: failed to generate server auth token", "err", err)
+		return false
+	}
+	cfg.Server.AuthToken = token
+	return true
+}
+
+// generateAuthToken returns a random 256-bit hex-encoded shared secret for
+// sybra-server's bearer-token auth.
+func generateAuthToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // Review-hold modes control how far the hold extends to the fix-review agent's

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -439,7 +439,7 @@ func (c *Config) ExperiencesDir() string {
 }
 
 func Load() (*Config, error) {
-	return load(loadOptions{persistABTestingReconcile: true})
+	return load(loadOptions{persistLoadReconciles: true})
 }
 
 // LoadNoPersist reads config.yaml and applies in-memory defaults/reconciles
@@ -450,7 +450,7 @@ func LoadNoPersist() (*Config, error) {
 }
 
 type loadOptions struct {
-	persistABTestingReconcile bool
+	persistLoadReconciles bool
 }
 
 func load(opts loadOptions) (*Config, error) {
@@ -542,11 +542,11 @@ func load(opts loadOptions) (*Config, error) {
 	applyHarnessEvolveDefaults(cfg)
 	applyPromptLabDefaults(cfg)
 	applyExperienceDefaults(cfg)
-	abTestingReconciled := applyABTestingDefaults(cfg, opts.persistABTestingReconcile)
+	abTestingReconciled := applyABTestingDefaults(cfg, opts.persistLoadReconciles)
 	applyOrchestratorDefaults(cfg)
 	applyAutoUpdateDefaults(cfg)
 	applyReviewHoldDefaults(cfg)
-	serverTokenGenerated := applyServerDefaults(cfg)
+	serverTokenGenerated := applyServerDefaults(cfg, opts.persistLoadReconciles)
 
 	persistLoadReconciles(cfg, opts, existingFile, abTestingReconciled, serverTokenGenerated)
 
@@ -560,12 +560,12 @@ func load(opts loadOptions) (*Config, error) {
 // so an unsaved token would silently rotate on every restart and lock
 // operators out).
 func persistLoadReconciles(cfg *Config, opts loadOptions, existingFile, abTestingReconciled, serverTokenGenerated bool) {
-	if opts.persistABTestingReconcile && existingFile && abTestingReconciled {
+	if opts.persistLoadReconciles && existingFile && abTestingReconciled {
 		if saveErr := cfg.Save(); saveErr != nil {
 			slog.Warn("config: failed to persist ab_testing builtin reconcile", "err", saveErr)
 		}
 	}
-	if opts.persistABTestingReconcile && serverTokenGenerated {
+	if opts.persistLoadReconciles && serverTokenGenerated {
 		if saveErr := cfg.Save(); saveErr != nil {
 			slog.Warn("config: failed to persist generated server auth token", "err", saveErr)
 		}
@@ -576,8 +576,9 @@ func persistLoadReconciles(cfg *Config, opts loadOptions, existingFile, abTestin
 // env vars win when set, otherwise a missing token is auto-generated so the
 // HTTP control plane always fails closed instead of silently running
 // unauthenticated. Returns true when a new token was generated (the caller
-// must persist it — see load()).
-func applyServerDefaults(cfg *Config) bool {
+// must persist it — see load()). Read-only config loads pass allowGenerate=false
+// so they never invent an in-memory-only secret that diverges from disk.
+func applyServerDefaults(cfg *Config, allowGenerate bool) bool {
 	if v := os.Getenv("SYBRA_AUTH_TOKEN"); v != "" {
 		cfg.Server.AuthToken = v
 	}
@@ -589,6 +590,9 @@ func applyServerDefaults(cfg *Config) bool {
 		cfg.Server.AllowedOrigins = origins
 	}
 	if cfg.Server.AuthToken != "" {
+		return false
+	}
+	if !allowGenerate {
 		return false
 	}
 	token, err := generateAuthToken()

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -1,0 +1,13 @@
+package config
+
+// ServerConfig controls sybra-server's HTTP control-plane authentication and
+// CORS policy. AuthToken gates every request except GET /health behind a
+// shared-secret bearer token: callers must send
+// `Authorization: Bearer <token>`, or, for the SSE endpoints only (browser
+// EventSource cannot set request headers), a `?token=<token>` query param.
+// AuthToken is auto-generated and persisted to config.yaml on first run if
+// left empty — see applyServerDefaults.
+type ServerConfig struct {
+	AuthToken      string   `yaml:"auth_token" json:"authToken"`
+	AllowedOrigins []string `yaml:"allowed_origins" json:"allowedOrigins"`
+}

--- a/internal/config/config_server_test.go
+++ b/internal/config/config_server_test.go
@@ -96,3 +96,33 @@ func TestLoadServerAllowedOriginsEnvOverride(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadNoPersistDoesNotGenerateServerAuthToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	yaml := []byte("server:\n  allowed_origins: [https://a.example]\n")
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadNoPersist()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.AuthToken != "" {
+		t.Fatalf("AuthToken = %q, want empty for read-only loads", cfg.Server.AuthToken)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "allowed_origins") {
+		t.Fatalf("config.yaml changed unexpectedly: %s", data)
+	}
+	if strings.Contains(string(data), "auth_token") {
+		t.Fatalf("LoadNoPersist should not persist auth_token, got %s", data)
+	}
+}

--- a/internal/config/config_server_test.go
+++ b/internal/config/config_server_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadGeneratesAndPersistsServerAuthToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.AuthToken == "" {
+		t.Fatal("Server.AuthToken should be auto-generated when unset")
+	}
+	if len(cfg.Server.AuthToken) != 64 {
+		t.Errorf("AuthToken length = %d, want 64 (32 random bytes, hex-encoded)", len(cfg.Server.AuthToken))
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), cfg.Server.AuthToken) {
+		t.Error("generated token was not persisted to config.yaml")
+	}
+
+	// A second Load() must reuse the persisted token rather than rotating it.
+	cfg2, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg2.Server.AuthToken != cfg.Server.AuthToken {
+		t.Error("AuthToken rotated across restarts — should be persisted and stable")
+	}
+}
+
+func TestLoadPreservesExplicitServerAuthToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	yaml := []byte("server:\n  auth_token: my-explicit-token\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.AuthToken != "my-explicit-token" {
+		t.Errorf("AuthToken = %q, want unchanged explicit value", cfg.Server.AuthToken)
+	}
+}
+
+func TestLoadServerAuthTokenEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	t.Setenv("SYBRA_AUTH_TOKEN", "env-token")
+
+	yaml := []byte("server:\n  auth_token: file-token\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.AuthToken != "env-token" {
+		t.Errorf("AuthToken = %q, want env override to win", cfg.Server.AuthToken)
+	}
+}
+
+func TestLoadServerAllowedOriginsEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	t.Setenv("SYBRA_ALLOWED_ORIGINS", "https://a.example, https://b.example")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"https://a.example", "https://b.example"}
+	if len(cfg.Server.AllowedOrigins) != len(want) {
+		t.Fatalf("AllowedOrigins = %v, want %v", cfg.Server.AllowedOrigins, want)
+	}
+	for i, o := range want {
+		if cfg.Server.AllowedOrigins[i] != o {
+			t.Errorf("AllowedOrigins[%d] = %q, want %q", i, cfg.Server.AllowedOrigins[i], o)
+		}
+	}
+}

--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -151,7 +151,6 @@ func (b *Broker) ServeAll(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
@@ -197,7 +196,6 @@ func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 


### PR DESCRIPTION
## Motivation

The sybra-server HTTP control plane (API, SSE, pprof/metrics) had no authentication and used a wildcard CORS policy. Any principal reaching the port had full unauthenticated admin access, including workflow shell steps that run via `bash -c` on the host, and any origin could read the SSE stream cross-origin.

## Implementation information

- Add shared-secret bearer-token auth in front of the server API, SSE, and pprof/metrics endpoints.
- `Server.AuthToken` is auto-generated and persisted to `config.yaml` on first run so the control plane fails closed by default.
- Replace wildcard CORS with an allowlisted-origin policy.
- Since `EventSource` can't set request headers, SSE paths additionally accept the token as a `?token=` query param.
- Thread the token through `fetch`/`EventSource` calls in the web frontend (desktop uses in-process Wails IPC and is unaffected).
- Fix `Broker.ServeAll`/`ServeHTTP` overwriting the CORS middleware's allowlisted `Access-Control-Allow-Origin` with an unconditional `*`.
- Drop a stray unanchored `sybra-server` gitignore rule that was shadowing new files under `cmd/sybra-server/` from `git status`/`git add`.

Closes https://github.com/Automaat/sybra/issues/1515

_Generated by Sybra harness_