### PR TITLE
fix(e2e): refuse to run against real sybra home

### DIFF
--- a/frontend/e2e/history.spec.ts
+++ b/frontend/e2e/history.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test'
 import { mkdir, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
+
+import { isolatedSybraHome } from './lib/sybra-home'
 
 // Verifies the fix for the empty-history bug: interactive agent runs persist
 // their NDJSON log in raw Anthropic-envelope format. Before the fix,
@@ -14,7 +15,7 @@ import { homedir } from 'node:os'
 // the matching log) then asserts the visible content inside the history
 // section — not just bubble count.
 
-const SYBRA_HOME = process.env.SYBRA_HOME ?? join(homedir(), '.sybra')
+const SYBRA_HOME = isolatedSybraHome()
 const TASKS_DIR = join(SYBRA_HOME, 'tasks')
 const AGENTS_LOG_DIR = join(SYBRA_HOME, 'logs', 'agents')
 

--- a/frontend/e2e/lib/sybra-home.ts
+++ b/frontend/e2e/lib/sybra-home.ts
@@ -1,0 +1,28 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+/**
+ * Resolve the Sybra home the e2e suite may touch. The suite seeds fixtures
+ * and deletes every non-fixture task file in its target home between tests,
+ * so a fallback to the real `~/.sybra` destroys the operator's board — which
+ * is exactly what happened on 2026-07-06 when an agent ran the suite without
+ * `SYBRA_HOME` (#1576). Fail closed: an explicit, disposable home is
+ * required, and the real default home is rejected even when set explicitly.
+ */
+export function isolatedSybraHome(): string {
+  const env = process.env.SYBRA_HOME?.trim()
+  if (!env) {
+    throw new Error(
+      'SYBRA_HOME is not set — refusing to run the e2e suite against a default home. ' +
+        'It deletes task files in its target dir; point SYBRA_HOME at a disposable dir ' +
+        '(CI uses /tmp/sybra-e2e).',
+    )
+  }
+  if (resolve(env) === resolve(join(homedir(), '.sybra'))) {
+    throw new Error(
+      `SYBRA_HOME=${env} is the real operator home — refusing to run the e2e suite ` +
+        'against it. Use a disposable dir (CI uses /tmp/sybra-e2e).',
+    )
+  }
+  return env
+}

--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -14,9 +14,10 @@ import { mockReviewComments } from './lib/review-mocks.js'
 import { copyFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 
-const SYBRA_HOME = process.env.SYBRA_HOME ?? join(homedir(), '.sybra')
+import { isolatedSybraHome } from './lib/sybra-home'
+
+const SYBRA_HOME = isolatedSybraHome()
 const TASKS_DIR = join(SYBRA_HOME, 'tasks')
 const WORKFLOWS_DIR = join(SYBRA_HOME, 'workflows')
 

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -1,19 +1,30 @@
 import { test, expect, type Page } from '@playwright/test'
 import { readdir, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 
-const SYBRA_HOME = process.env.SYBRA_HOME ?? join(homedir(), '.sybra')
+import { isolatedSybraHome } from './lib/sybra-home'
+
+const SYBRA_HOME = isolatedSybraHome()
 const TASKS_DIR = join(SYBRA_HOME, 'tasks')
 
 const FIXTURE_FILES = new Set(['auth0001.md', 'test0001.md', 'db0001.md', 'plan0001.md'])
 
+// A fixtures-only home accumulates at most a handful of test-created files
+// between cleanups; hundreds of strays means a real board (#1576) — refuse
+// rather than delete.
+const MAX_CLEANUP_STRAYS = 25
+
 async function cleanupCreatedTasks() {
   const files = await readdir(TASKS_DIR)
-  for (const f of files) {
-    if (!FIXTURE_FILES.has(f) && f.endsWith('.md')) {
-      await unlink(join(TASKS_DIR, f))
-    }
+  const strays = files.filter((f) => !FIXTURE_FILES.has(f) && f.endsWith('.md'))
+  if (strays.length > MAX_CLEANUP_STRAYS) {
+    throw new Error(
+      `cleanupCreatedTasks: ${strays.length} non-fixture task files in ${TASKS_DIR} — ` +
+        'not a disposable e2e home, refusing to delete',
+    )
+  }
+  for (const f of strays) {
+    await unlink(join(TASKS_DIR, f))
   }
 }
 

--- a/frontend/e2e/workflow-editor.spec.ts
+++ b/frontend/e2e/workflow-editor.spec.ts
@@ -2,9 +2,10 @@ import { test, expect, type Page } from '@playwright/test'
 import { copyFile, unlink, readFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 
-const SYBRA_HOME = process.env.SYBRA_HOME ?? join(homedir(), '.sybra')
+import { isolatedSybraHome } from './lib/sybra-home'
+
+const SYBRA_HOME = isolatedSybraHome()
 const WORKFLOWS_DIR = join(SYBRA_HOME, 'workflows')
 const FIXTURE_ID = 'wf-editor-e2e'
 const FIXTURE_DEST = join(WORKFLOWS_DIR, `${FIXTURE_ID}.yaml`)

--- a/frontend/e2e/workflow.spec.ts
+++ b/frontend/e2e/workflow.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect, type Page } from '@playwright/test'
 import { readdir, unlink, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 
-const SYBRA_HOME = process.env.SYBRA_HOME ?? join(homedir(), '.sybra')
+import { isolatedSybraHome } from './lib/sybra-home'
+
+const SYBRA_HOME = isolatedSybraHome()
 const TASKS_DIR = join(SYBRA_HOME, 'tasks')
 
 const FIXTURE_FILES = new Set([


### PR DESCRIPTION
## Motivation

On 2026-07-06 a Sybra agent ran the frontend Playwright suite from its worktree without SYBRA_HOME set; every spec defaults to the real ~/.sybra, and the suite deletes every non-fixture task file in its target home between tests — the entire production board (391 tasks) was wiped. Full forensics in #1576.

> Changelog: fix(e2e): refuse to run against real sybra home

## Implementation information

- New `frontend/e2e/lib/sybra-home.ts`: `isolatedSybraHome()` fails closed — `SYBRA_HOME` must be set explicitly and must not resolve to the real `~/.sybra`. All five specs (tasks, history, workflow, workflow-editor, screenshots) resolve their home through it; the `homedir()` fallbacks are gone.
- `cleanupCreatedTasks` refuses to delete when the dir holds more than 25 non-fixture task files — a disposable e2e home never accumulates hundreds; a real board does.
- CI is unaffected: the e2e job always sets `SYBRA_HOME=/tmp/sybra-e2e`.

## Supporting documentation

- #1576 (incident + fix item 1 and 2), umbrella #1582
- Verified: guard errors with SYBRA_HOME unset and when pointed at the real home; `npx playwright test --list` enumerates all 46 tests with an isolated home; `mise run verify` green.
