### PR TITLE
fix(umbrella): survive planner timeouts

### DIFF
--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -318,9 +318,15 @@ func umbrellaProgressIssueSuffix(ref string) string {
 // cycle, a stuck (human-required) child, or a cancelled child surfaces as
 // human-required (halting only that chain); all-done closes the umbrella. A
 // tracker with no children (every sub-issue was already closed at expansion)
-// is vacuously complete, but only once `settled` so a tracker observed while
-// its children are still being materialized is not closed prematurely.
+// is vacuously complete, but only once `settled` (so a tracker observed while
+// its children are still being materialized is not closed prematurely) and
+// only when expansion isn't currently failing — a tracker carrying
+// umbrella.ExpandFailTagPrefix (see internal/umbrella.recordExpandFailure)
+// never had a chance to materialize its children in the first place, and
+// closing it would silently drop the umbrella issue while sub-issues remain
+// open on GitHub (#1570).
 func trackerRollup(st *umbrellaState, cyclic, settled bool) (status task.Status, reason string, doClose bool) {
+	expandFailing := st.tracker != nil && umbrella.ParseExpandFailCount(st.tracker.Tags) > 0
 	switch {
 	case cyclic:
 		return task.StatusHumanRequired, "umbrella dependency cycle detected", false
@@ -330,6 +336,14 @@ func trackerRollup(st *umbrellaState, cyclic, settled bool) (status task.Status,
 		return task.StatusHumanRequired, "umbrella child was cancelled", false
 	case st.total > 0 && st.doneCount == st.total:
 		return task.StatusDone, "all umbrella children complete", true
+	case st.total == 0 && expandFailing:
+		// Defer entirely to internal/umbrella.recordExpandFailure, which owns
+		// this tracker's status/reason while expansion keeps failing (staying
+		// in-progress below ExpandFailThreshold, human-required at it). A
+		// desired value computed here would fight that state every tick —
+		// e.g. flipping a parked human-required tracker straight back to
+		// in-progress the moment this rollup runs.
+		return st.tracker.Status, st.tracker.StatusReason, false
 	case st.total == 0 && settled:
 		return task.StatusDone, "umbrella has no open sub-issues", true
 	default:

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -334,16 +334,14 @@ func trackerRollup(st *umbrellaState, cyclic, settled bool) (status task.Status,
 		return task.StatusHumanRequired, "umbrella child needs attention", false
 	case st.anyCancelled:
 		return task.StatusHumanRequired, "umbrella child was cancelled", false
+	case expandFailing:
+		// Defer entirely to internal/umbrella.recordExpandFailure, which owns
+		// this tracker's status/reason while expansion keeps failing. Rollup
+		// must not overwrite that state just because the tracker already has
+		// children or all currently-materialized children happen to be done.
+		return st.tracker.Status, st.tracker.StatusReason, false
 	case st.total > 0 && st.doneCount == st.total:
 		return task.StatusDone, "all umbrella children complete", true
-	case st.total == 0 && expandFailing:
-		// Defer entirely to internal/umbrella.recordExpandFailure, which owns
-		// this tracker's status/reason while expansion keeps failing (staying
-		// in-progress below ExpandFailThreshold, human-required at it). A
-		// desired value computed here would fight that state every tick —
-		// e.g. flipping a parked human-required tracker straight back to
-		// in-progress the moment this rollup runs.
-		return st.tracker.Status, st.tracker.StatusReason, false
 	case st.total == 0 && settled:
 		return task.StatusDone, "umbrella has no open sub-issues", true
 	default:

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -230,6 +230,24 @@ func TestTrackerRollup(t *testing.T) {
 			}},
 			false, true, task.StatusHumanRequired, false,
 		},
+		{
+			"existing children expand-failing below threshold stays tracker-owned",
+			umbrellaState{total: 2, doneCount: 1, tracker: &task.Task{
+				Status:       task.StatusInProgress,
+				StatusReason: "umbrella expansion failed (attempt 2): boom",
+				Tags:         []string{"umbrella", umbrella.ExpandFailTag(2)},
+			}},
+			false, true, task.StatusInProgress, false,
+		},
+		{
+			"all materialized children done does not close over fresh expand failure",
+			umbrellaState{total: 2, doneCount: 2, tracker: &task.Task{
+				Status:       task.StatusHumanRequired,
+				StatusReason: "umbrella expansion failed (attempt 3): boom",
+				Tags:         []string{"umbrella", umbrella.ExpandFailTag(3)},
+			}},
+			false, true, task.StatusHumanRequired, false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -212,6 +212,24 @@ func TestTrackerRollup(t *testing.T) {
 		{"in progress", umbrellaState{total: 2, doneCount: 1}, false, true, task.StatusInProgress, false},
 		{"zero children settled completes", umbrellaState{total: 0}, false, true, task.StatusDone, true},
 		{"zero children not settled holds", umbrellaState{total: 0}, false, false, task.StatusInProgress, false},
+		{
+			"zero children expand-failing below threshold never auto-closes",
+			umbrellaState{total: 0, tracker: &task.Task{
+				Status:       task.StatusInProgress,
+				StatusReason: "umbrella expansion failed (attempt 1): boom",
+				Tags:         []string{"umbrella", umbrella.ExpandFailTag(1)},
+			}},
+			false, true, task.StatusInProgress, false,
+		},
+		{
+			"zero children expand-failing at threshold stays parked human-required",
+			umbrellaState{total: 0, tracker: &task.Task{
+				Status:       task.StatusHumanRequired,
+				StatusReason: "umbrella expansion failed (attempt 3): boom",
+				Tags:         []string{"umbrella", umbrella.ExpandFailTag(3)},
+			}},
+			false, true, task.StatusHumanRequired, false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -222,6 +240,39 @@ func TestTrackerRollup(t *testing.T) {
 				t.Fatalf("trackerRollup = (%q, close=%v), want (%q, close=%v)", got, doClose, tt.want, tt.wantClose)
 			}
 		})
+	}
+}
+
+// TestReleaseUnblockedChildren_ExpandFailingTrackerNeverAutoCloses guards
+// #1570: a tracker that exists only because internal/umbrella.Expand failed
+// to materialize any children (planner killed at its timeout, repeatedly)
+// must never be auto-closed as "no open sub-issues" — that previously
+// closed the umbrella's GitHub issue while it still had open sub-issues that
+// simply never got the chance to materialize as local tasks.
+func TestReleaseUnblockedChildren_ExpandFailingTrackerNeverAutoCloses(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	closes := 0
+	app.umbrellaCloseIssue = func(string, int, string) error { closes++; return nil }
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker, err := m.CreateFull("umbrella", "", task.AgentModeHeadless, task.Update{
+		Issue:        task.Ptr(umb),
+		TaskType:     task.Ptr(task.TaskTypeUmbrella),
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("umbrella expansion failed (attempt 3): plan umbrella: run planner: killed"),
+		Tags:         task.Ptr([]string{"umbrella", umbrella.ExpandFailTag(3)}),
+	})
+	if err != nil {
+		t.Fatalf("create failure tracker: %v", err)
+	}
+
+	app.releaseUnblockedChildren()
+
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
+		t.Fatalf("tracker = %q, want to stay human-required (never auto-closed)", got)
+	}
+	if closes != 0 {
+		t.Fatalf("umbrella issue closed %d times, want 0 while expansion keeps failing", closes)
 	}
 }
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -733,16 +733,25 @@ func (s *TaskService) umbrellaExpansionEnabled() bool {
 // expandUmbrellaStub expands a manually-created stub whose URL resolved to a
 // ☂️ umbrella issue into a gated child DAG, then deletes the stub — the
 // expander creates its own umbrella-typed tracker, so keeping the stub would
-// leave a duplicate flat task for the same issue. On expansion failure the stub
-// is enriched into an identifiable (but inert) task so the user is not left
-// empty-handed and can retry with `sybra-cli umbrella <url>`; crucially no flat
-// workflow is started on a known umbrella, which is the bug this path fixes.
+// leave a duplicate flat task for the same issue. On expansion failure, a
+// planner failure (internal/umbrella.recordExpandFailure, see #1570) already
+// created or updated a separate, durable tracker task carrying the failure
+// detail — in that case the stub is marked a duplicate (mirroring the success
+// path) rather than also claiming TaskTypeUmbrella, which would leave two
+// tracker tasks for the same issue. A failure before any tracker existed
+// (bad URL, GitHub fetch failure) has nothing else to defer to, so the stub
+// itself becomes the identifiable (but inert) record instead.
 func (s *TaskService) expandUmbrellaStub(taskID, repo string, issue github.Issue) {
 	res, err := s.umbrellaExpand(issue.URL)
 	if err != nil {
 		s.logger.Error("enrich-issue.umbrella-expand", "task_id", taskID, "issue", issue.URL, "err", err)
-		s.enrichInertUmbrellaStub(taskID, repo, issue,
-			"umbrella expansion failed; retry with `sybra-cli umbrella <url>`")
+		if s.umbrellaTrackerExistsElsewhere(taskID, issue.URL) {
+			s.enrichDuplicateUmbrellaStub(taskID, repo, issue,
+				"umbrella expansion failed; see the umbrella tracker task for details")
+		} else {
+			s.enrichInertUmbrellaStub(taskID, repo, issue,
+				"umbrella expansion failed; retry with `sybra-cli umbrella <url>`")
+		}
 		return
 	}
 	// Expand created the real tracker + children; the stub is now a duplicate.
@@ -758,6 +767,25 @@ func (s *TaskService) expandUmbrellaStub(taskID, repo string, issue github.Issue
 		return
 	}
 	s.logger.Info("enrich-issue.umbrella-expanded", "issue", issue.URL, "created", res.Created, "stub", taskID)
+}
+
+// umbrellaTrackerExistsElsewhere reports whether some other task already
+// carries TaskTypeUmbrella for issueURL. Used to decide, after a failed
+// expandUmbrellaStub, whether that failure already has a durable tracker to
+// point at (see recordExpandFailure) or whether this stub is the only record.
+func (s *TaskService) umbrellaTrackerExistsElsewhere(taskID, issueURL string) bool {
+	all, err := s.tasks.List()
+	if err != nil {
+		return false
+	}
+	key := umbrella.NormalizeIssueRef(issueURL)
+	for i := range all {
+		t := &all[i]
+		if t.ID != taskID && t.TaskType == task.TaskTypeUmbrella && umbrella.NormalizeIssueRef(t.Issue) == key {
+			return true
+		}
+	}
+	return false
 }
 
 // enrichInertUmbrellaStub turns the stub into an identifiable, inert task: real

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -578,6 +578,61 @@ func TestTaskService_CreateTask_UmbrellaExpandFailureKeepsInertStub(t *testing.T
 	}
 }
 
+// TestTaskService_CreateTask_UmbrellaExpandFailureWithExistingTrackerMarksDuplicate
+// guards #1570's follow-on fix: when a planner failure already produced a
+// durable failure tracker (internal/umbrella.recordExpandFailure creates or
+// updates one inside Expand), the manually-created stub must not also claim
+// TaskTypeUmbrella — that would leave two tracker tasks for the same issue,
+// confusing scanExisting/the gate about which one is authoritative.
+func TestTaskService_CreateTask_UmbrellaExpandFailureWithExistingTrackerMarksDuplicate(t *testing.T) {
+	svc, _ := setupTaskService(t)
+	svc.cfg = &config.Config{Umbrella: config.UmbrellaConfig{Enabled: true}}
+	const issueURL = "https://github.com/owner/repo/issues/1151"
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		return github.Issue{
+			Number:     1151,
+			Title:      "☂️ already has a failure tracker",
+			URL:        issueURL,
+			Repository: "owner/repo",
+			Labels:     []string{"umbrella", "backend"},
+		}, nil
+	}
+	// Simulate a prior Expand call's recordExpandFailure having already
+	// materialized the umbrella's durable failure tracker.
+	if _, err := svc.tasks.CreateFull("umbrella tracker", "", task.AgentModeHeadless, task.Update{
+		Issue:        task.Ptr(issueURL),
+		TaskType:     task.Ptr(task.TaskTypeUmbrella),
+		Status:       task.Ptr(task.StatusInProgress),
+		StatusReason: task.Ptr("umbrella expansion failed (attempt 1): planner boom"),
+		Tags:         task.Ptr([]string{"umbrella", umbrella.ExpandFailTag(1)}),
+	}); err != nil {
+		t.Fatalf("seed failure tracker: %v", err)
+	}
+	svc.umbrellaExpand = func(string) (umbrella.Result, error) {
+		return umbrella.Result{}, errors.New("planner boom")
+	}
+
+	created, err := svc.CreateTask(issueURL, "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatalf("duplicate stub should survive a failed expansion: %v", err)
+	}
+	if got.TaskType == task.TaskTypeUmbrella {
+		t.Fatalf("TaskType = %q, want non-umbrella duplicate since a failure tracker already exists for this issue", got.TaskType)
+	}
+	if !slices.Contains(got.Tags, umbrellaDuplicateTag) {
+		t.Fatalf("Tags = %v, want to contain %q", got.Tags, umbrellaDuplicateTag)
+	}
+	if !skipTaskCreatedWorkflow(got) {
+		t.Fatal("simulated watcher re-dispatch on the duplicate stub must be skipped, want no flat workflow")
+	}
+}
+
 func TestTaskService_CreateTask_UmbrellaExpandDeleteFailureKeepsDuplicateNonTracker(t *testing.T) {
 	svc, _ := setupTaskService(t)
 	svc.cfg = &config.Config{Umbrella: config.UmbrellaConfig{Enabled: true}}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -71,6 +71,11 @@ func (s *Store) Comments() *CommentStore {
 	return s.comments
 }
 
+// Dir returns the root tasks directory backing this store.
+func (s *Store) Dir() string {
+	return s.dir
+}
+
 // Plans returns the sidecar store for the human-readable compact plan
 // (Task.Plan).
 func (s *Store) Plans() *PlanStore {

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -25,13 +25,34 @@ import (
 // writing (and without firing a task:updated event).
 var errSkipUpdate = errors.New("skip update")
 
-// PlannerAttemptTimeout bounds a single planner CLI invocation. It is passed
-// to llmjob.Run as Spec.AttemptTimeout so every repair attempt gets this
-// full budget fresh, instead of splitting a single shared deadline across
-// them — a large umbrella's first attempt can legitimately take minutes to
-// read and order every sub-issue, which used to leave nothing for retries
-// (see #1555).
+// PlannerAttemptTimeout is the minimum budget for a single planner CLI
+// invocation. The actual per-attempt budget is plannerAttemptTimeout(subCount):
+// large umbrellas get extra time because one model attempt has to read and
+// order every sub-issue before llmjob can repair malformed JSON.
 const PlannerAttemptTimeout = 4 * time.Minute
+
+const plannerAttemptPerSubIssueTimeout = 10 * time.Second
+
+type plannerAttemptTimeoutContextKey struct{}
+
+func withPlannerAttemptTimeout(ctx context.Context, timeout time.Duration) context.Context {
+	return context.WithValue(ctx, plannerAttemptTimeoutContextKey{}, timeout)
+}
+
+func plannerAttemptTimeoutFromContext(ctx context.Context) time.Duration {
+	timeout, _ := ctx.Value(plannerAttemptTimeoutContextKey{}).(time.Duration)
+	if timeout > 0 {
+		return timeout
+	}
+	return PlannerAttemptTimeout
+}
+
+func plannerAttemptTimeout(subCount int) time.Duration {
+	if subCount < 0 {
+		subCount = 0
+	}
+	return PlannerAttemptTimeout + time.Duration(subCount)*plannerAttemptPerSubIssueTimeout
+}
 
 // plannerJobSpec is the llmjob.Spec FallbackPlannerRunner runs the
 // "umbrella-order" job with. It is shared with plannerTimeout below via
@@ -61,7 +82,7 @@ const plannerGenerateSamples = plannerAttempts * 2
 // legitimately more model time, and a bigger expansion is more expensive to
 // have starved.
 func plannerTimeout(subCount int) time.Duration {
-	return PlannerAttemptTimeout*time.Duration(plannerJobAttempts*plannerGenerateSamples) +
+	return plannerAttemptTimeout(subCount)*time.Duration(plannerJobAttempts*plannerGenerateSamples) +
 		time.Duration(subCount*plannerGenerateSamples)*5*time.Second
 }
 
@@ -69,12 +90,14 @@ func plannerTimeout(subCount int) time.Duration {
 // wedge the caller (notably the issue poll loop).
 const FetchTimeout = 60 * time.Second
 
+var fetchUmbrella = github.FetchUmbrella
+
 // fetchUmbrellaBounded fetches the umbrella under FetchTimeout, releasing the
 // timer as soon as the fetch returns (defer right after WithTimeout).
 func fetchUmbrellaBounded(ctx context.Context, repo string, number int) (umbrella github.Issue, subs []github.Issue, err error) {
 	fctx, cancel := context.WithTimeout(ctx, FetchTimeout)
 	defer cancel()
-	return github.FetchUmbrella(fctx, repo, number)
+	return fetchUmbrella(fctx, repo, number)
 }
 
 // expandConfig holds the optional settings ExpandOption values apply.
@@ -177,6 +200,7 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 
 	pctx, cancel := context.WithTimeout(ctx, plannerTimeout(len(subs)))
 	defer cancel()
+	pctx = withPlannerAttemptTimeout(pctx, plannerAttemptTimeout(len(subs)))
 	plan, err := Generate(pctx, run, umb.URL, umb.Body, planSubs, genOpts...)
 	if err != nil {
 		if recErr := recordExpandFailure(tasks, umb, tracker, err); recErr != nil {
@@ -495,7 +519,9 @@ func FallbackPlannerRunner(model string, gates ...provider.HealthGate) Runner {
 		gate = gates[0]
 	}
 	return func(ctx context.Context, prompt string) (string, error) {
-		plan, _, err := llmjob.Run(ctx, prompt, plannerJobSpec, llmexec.Options{Gate: gate, Models: claudeModelOverride(model)})
+		spec := plannerJobSpec
+		spec.AttemptTimeout = plannerAttemptTimeoutFromContext(ctx)
+		plan, _, err := llmjob.Run(ctx, prompt, spec, llmexec.Options{Gate: gate, Models: claudeModelOverride(model)})
 		if err != nil {
 			return "", err
 		}

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"time"
@@ -137,14 +138,24 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 		byRef[NormalizeIssueRef(subs[i].URL)] = subs[i]
 	}
 
-	existing, trackerExists, trackerID, err := scanExisting(tasks, umb.URL)
+	existing, tracker, err := scanExisting(tasks, umb.URL)
 	if err != nil {
 		return Result{}, fmt.Errorf("scan existing tasks: %w", err)
 	}
 	// Short-circuit a full re-run: nothing to create means no (costly,
 	// stochastic) planner call.
-	if trackerExists && allMaterialized(planSubs, existing) {
+	if tracker.exists && allMaterialized(planSubs, existing) {
 		return Result{UmbrellaURL: umb.URL, Skipped: len(subs)}, nil
+	}
+	// A tracker parked human-required after ExpandFailThreshold consecutive
+	// planner failures stops calling the planner entirely — the incident this
+	// guards against (#1570) burned a killed sonnet call every ~5 minutes
+	// indefinitely because nothing remembered prior failures across calls. A
+	// human must move the tracker off human-required (or clear the tag) to
+	// resume retrying.
+	if tracker.exists && tracker.status == task.StatusHumanRequired &&
+		ParseExpandFailCount(tracker.tags) >= ExpandFailThreshold {
+		return Result{}, fmt.Errorf("umbrella expansion parked human-required after %d consecutive planner failures", ParseExpandFailCount(tracker.tags))
 	}
 
 	var genOpts []GenerateOption
@@ -156,13 +167,21 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 	defer cancel()
 	plan, err := Generate(pctx, run, umb.URL, umb.Body, planSubs, genOpts...)
 	if err != nil {
+		if recErr := recordExpandFailure(tasks, umb, tracker, err); recErr != nil {
+			slog.Error("umbrella.expand.record-failure", "issue", umb.URL, "err", recErr)
+		}
 		return Result{}, fmt.Errorf("plan umbrella: %w", err)
 	}
 
 	specs := ChildSpecs(plan, planSubs, existing)
-	created, err := materialize(tasks, umb, specs, byRef, trackerExists, trackerID, plan.MaxParallel, plan.Fallback)
+	created, err := materialize(tasks, umb, specs, byRef, tracker.exists, tracker.id, plan.MaxParallel, plan.Fallback)
 	if err != nil {
 		return Result{}, err
+	}
+	if tracker.exists && ParseExpandFailCount(tracker.tags) > 0 {
+		if err := clearExpandFailure(tasks, tracker.id); err != nil {
+			slog.Error("umbrella.expand.clear-failure", "issue", umb.URL, "err", err)
+		}
 	}
 	return Result{UmbrellaURL: umb.URL, Created: created, Skipped: len(subs) - created, Degraded: plan.Fallback}, nil
 }
@@ -180,14 +199,24 @@ func allMaterialized(subs []SubIssue, existing map[string]bool) bool {
 	return true
 }
 
+// existingTracker describes the umbrella tracker task scanExisting found for
+// a given umbrella URL, if any. Bundled into one struct (rather than four
+// scanExisting return values) to stay under gocritic's result-count limit.
+type existingTracker struct {
+	exists bool
+	id     string
+	tags   []string
+	status task.Status
+}
+
 // scanExisting returns the set of normalized issue refs that already have a
-// task, whether the umbrella tracker exists, and its task id when it does. A
-// List failure is propagated so the caller aborts rather than treating an
-// unreadable store as empty and creating a duplicate DAG.
-func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool, trackerExists bool, trackerID string, err error) {
+// task, plus the umbrella tracker's own state when it exists. A List failure
+// is propagated so the caller aborts rather than treating an unreadable store
+// as empty and creating a duplicate DAG.
+func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool, tracker existingTracker, err error) {
 	all, err := tasks.List()
 	if err != nil {
-		return nil, false, "", err
+		return nil, existingTracker{}, err
 	}
 	refs = make(map[string]bool, len(all))
 	umbKey := NormalizeIssueRef(umbrellaURL)
@@ -197,11 +226,10 @@ func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool
 			refs[NormalizeIssueRef(t.Issue)] = true
 		}
 		if t.TaskType == task.TaskTypeUmbrella && NormalizeIssueRef(t.Issue) == umbKey {
-			trackerExists = true
-			trackerID = t.ID
+			tracker = existingTracker{exists: true, id: t.ID, tags: t.Tags, status: t.Status}
 		}
 	}
-	return refs, trackerExists, trackerID, nil
+	return refs, tracker, nil
 }
 
 // materialize creates the tracker (when absent) and one gated todo child per
@@ -226,9 +254,19 @@ func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef
 		}); err != nil {
 			return 0, fmt.Errorf("create tracker: %w", err)
 		}
-	} else if degraded {
-		if err := tagTrackerDegraded(tasks, trackerID); err != nil {
+	} else {
+		// A tracker can already exist without a MaxParallelTag: recordExpandFailure
+		// creates a placeholder tracker on a planner failure that never reaches
+		// this function's tag-setting branch above. Backfill it on the first
+		// successful materialize so the cap reflects this plan's judgment instead
+		// of silently defaulting to DefaultMaxParallel forever.
+		if err := ensureMaxParallelTag(tasks, trackerID, maxParallel); err != nil {
 			return 0, err
+		}
+		if degraded {
+			if err := tagTrackerDegraded(tasks, trackerID); err != nil {
+				return 0, err
+			}
 		}
 	}
 
@@ -267,6 +305,90 @@ func tagTrackerDegraded(tasks *task.Manager, trackerID string) error {
 			return nil
 		}
 		return fmt.Errorf("tag tracker degraded: %w", err)
+	}
+	return nil
+}
+
+// ensureMaxParallelTag backfills a MaxParallelTag onto an already-materialized
+// tracker if it doesn't have one yet — the case for a tracker that started
+// life as a recordExpandFailure placeholder. Read-then-write, so a tracker
+// that already carries the tag (the common case) is left untouched.
+func ensureMaxParallelTag(tasks *task.Manager, trackerID string, n int) error {
+	_, err := tasks.UpdateFn(trackerID, func(cur task.Task) (task.Update, error) {
+		if HasMaxParallelTag(cur.Tags) {
+			return task.Update{}, errSkipUpdate
+		}
+		return task.Update{
+			Tags: task.Ptr(append(slices.Clone(cur.Tags), MaxParallelTag(n))),
+		}, nil
+	})
+	if err != nil {
+		if errors.Is(err, errSkipUpdate) {
+			return nil
+		}
+		return fmt.Errorf("backfill tracker max-parallel: %w", err)
+	}
+	return nil
+}
+
+// recordExpandFailure durably records a failed planner run against the
+// umbrella's tracker, so the failure survives restarts and is visible on the
+// board (see #1570: previously a failure was only a log line, and nothing
+// stopped the same doomed planner call from re-running every ~5 minutes
+// indefinitely). When no tracker exists yet (the umbrella has never
+// successfully expanded even once), one is created here purely to hold the
+// failure state — materialize still owns creating the "real" tracker on a
+// later success, which simply overwrites this placeholder's fields.
+func recordExpandFailure(tasks *task.Manager, umb github.Issue, tracker existingTracker, cause error) error {
+	if !tracker.exists {
+		count := 1
+		_, err := tasks.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
+			Issue:        task.Ptr(umb.URL),
+			TaskType:     task.Ptr(task.TaskTypeUmbrella),
+			ProjectID:    task.Ptr(umb.Repository),
+			Status:       task.Ptr(task.StatusInProgress),
+			StatusReason: task.Ptr(fmt.Sprintf("umbrella expansion failed (attempt %d): %s", count, cause)),
+			Tags:         task.Ptr([]string{"umbrella", ExpandFailTag(count)}),
+		})
+		if err != nil {
+			return fmt.Errorf("create failure tracker: %w", err)
+		}
+		return nil
+	}
+
+	count := ParseExpandFailCount(tracker.tags) + 1
+	newTags := slices.DeleteFunc(slices.Clone(tracker.tags), func(t string) bool {
+		return strings.HasPrefix(t, ExpandFailTagPrefix)
+	})
+	newTags = append(newTags, ExpandFailTag(count))
+	upd := task.Update{
+		Tags:         task.Ptr(newTags),
+		StatusReason: task.Ptr(fmt.Sprintf("umbrella expansion failed (attempt %d): %s", count, cause)),
+	}
+	if count >= ExpandFailThreshold {
+		upd.Status = task.Ptr(task.StatusHumanRequired)
+	}
+	if _, err := tasks.Update(tracker.id, upd); err != nil {
+		return fmt.Errorf("tag tracker expand-failed: %w", err)
+	}
+	return nil
+}
+
+// clearExpandFailure strips the failure-count tag from a tracker once
+// expansion succeeds again, so a transient blip doesn't keep counting toward
+// ExpandFailThreshold on the next genuine failure.
+func clearExpandFailure(tasks *task.Manager, trackerID string) error {
+	_, err := tasks.UpdateFn(trackerID, func(cur task.Task) (task.Update, error) {
+		if ParseExpandFailCount(cur.Tags) == 0 {
+			return task.Update{}, errSkipUpdate
+		}
+		newTags := slices.DeleteFunc(slices.Clone(cur.Tags), func(t string) bool {
+			return strings.HasPrefix(t, ExpandFailTagPrefix)
+		})
+		return task.Update{Tags: task.Ptr(newTags)}, nil
+	})
+	if err != nil && !errors.Is(err, errSkipUpdate) {
+		return fmt.Errorf("clear tracker expand-failed: %w", err)
 	}
 	return nil
 }

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -2,14 +2,17 @@ package umbrella
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/llmexec"
 	"github.com/Automaat/sybra/internal/llmjob"
@@ -117,6 +120,15 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 	if !ok {
 		return Result{}, fmt.Errorf("not a GitHub issue URL: %s", issueURL)
 	}
+	unlock, err := lockExpandIssue(tasks, issueURL)
+	if err != nil {
+		return Result{}, err
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			slog.Warn("umbrella.expand.unlock_failed", "issue", issueURL, "err", err)
+		}
+	}()
 	umb, subs, err := fetchUmbrellaBounded(ctx, repo, number)
 	if err != nil {
 		return Result{}, fmt.Errorf("fetch umbrella: %w", err)
@@ -178,12 +190,22 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 	if err != nil {
 		return Result{}, err
 	}
-	if tracker.exists && ParseExpandFailCount(tracker.tags) > 0 {
+	if tracker.exists {
 		if err := clearExpandFailure(tasks, tracker.id); err != nil {
 			slog.Error("umbrella.expand.clear-failure", "issue", umb.URL, "err", err)
 		}
 	}
 	return Result{UmbrellaURL: umb.URL, Created: created, Skipped: len(subs) - created, Degraded: plan.Fallback}, nil
+}
+
+func lockExpandIssue(tasks *task.Manager, issueURL string) (func() error, error) {
+	sum := sha256.Sum256([]byte(NormalizeIssueRef(issueURL)))
+	lockPath := filepath.Join(tasks.Store().Dir(), fmt.Sprintf(".umbrella-expand-%x", sum[:8]))
+	unlock, err := fsutil.LockFile(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("lock umbrella expand %s: %w", issueURL, err)
+	}
+	return unlock, nil
 }
 
 // allMaterialized reports whether every open sub-issue already has a task.
@@ -230,6 +252,11 @@ func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool
 		}
 	}
 	return refs, tracker, nil
+}
+
+func findTracker(tasks *task.Manager, umbrellaURL string) (existingTracker, error) {
+	_, tracker, err := scanExisting(tasks, umbrellaURL)
+	return tracker, err
 }
 
 // materialize creates the tracker (when absent) and one gated todo child per
@@ -341,13 +368,20 @@ func ensureMaxParallelTag(tasks *task.Manager, trackerID string, n int) error {
 // later success, which simply overwrites this placeholder's fields.
 func recordExpandFailure(tasks *task.Manager, umb github.Issue, tracker existingTracker, cause error) error {
 	if !tracker.exists {
+		var err error
+		tracker, err = findTracker(tasks, umb.URL)
+		if err != nil {
+			return fmt.Errorf("refresh tracker before failure record: %w", err)
+		}
+	}
+	if !tracker.exists {
 		count := 1
 		_, err := tasks.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
 			Issue:        task.Ptr(umb.URL),
 			TaskType:     task.Ptr(task.TaskTypeUmbrella),
 			ProjectID:    task.Ptr(umb.Repository),
 			Status:       task.Ptr(task.StatusInProgress),
-			StatusReason: task.Ptr(fmt.Sprintf("umbrella expansion failed (attempt %d): %s", count, cause)),
+			StatusReason: task.Ptr(formatExpandFailureReason(count, cause)),
 			Tags:         task.Ptr([]string{"umbrella", ExpandFailTag(count)}),
 		})
 		if err != nil {
@@ -356,19 +390,22 @@ func recordExpandFailure(tasks *task.Manager, umb github.Issue, tracker existing
 		return nil
 	}
 
-	count := ParseExpandFailCount(tracker.tags) + 1
-	newTags := slices.DeleteFunc(slices.Clone(tracker.tags), func(t string) bool {
-		return strings.HasPrefix(t, ExpandFailTagPrefix)
+	_, err := tasks.UpdateFn(tracker.id, func(cur task.Task) (task.Update, error) {
+		count := ParseExpandFailCount(cur.Tags) + 1
+		newTags := slices.DeleteFunc(slices.Clone(cur.Tags), func(t string) bool {
+			return strings.HasPrefix(t, ExpandFailTagPrefix)
+		})
+		newTags = append(newTags, ExpandFailTag(count))
+		upd := task.Update{
+			Tags:         task.Ptr(newTags),
+			StatusReason: task.Ptr(formatExpandFailureReason(count, cause)),
+		}
+		if count >= ExpandFailThreshold {
+			upd.Status = task.Ptr(task.StatusHumanRequired)
+		}
+		return upd, nil
 	})
-	newTags = append(newTags, ExpandFailTag(count))
-	upd := task.Update{
-		Tags:         task.Ptr(newTags),
-		StatusReason: task.Ptr(fmt.Sprintf("umbrella expansion failed (attempt %d): %s", count, cause)),
-	}
-	if count >= ExpandFailThreshold {
-		upd.Status = task.Ptr(task.StatusHumanRequired)
-	}
-	if _, err := tasks.Update(tracker.id, upd); err != nil {
+	if err != nil {
 		return fmt.Errorf("tag tracker expand-failed: %w", err)
 	}
 	return nil
@@ -385,12 +422,26 @@ func clearExpandFailure(tasks *task.Manager, trackerID string) error {
 		newTags := slices.DeleteFunc(slices.Clone(cur.Tags), func(t string) bool {
 			return strings.HasPrefix(t, ExpandFailTagPrefix)
 		})
-		return task.Update{Tags: task.Ptr(newTags)}, nil
+		upd := task.Update{Tags: task.Ptr(newTags)}
+		if strings.HasPrefix(cur.StatusReason, "umbrella expansion failed (attempt ") {
+			upd.StatusReason = task.Ptr("")
+		}
+		return upd, nil
 	})
 	if err != nil && !errors.Is(err, errSkipUpdate) {
 		return fmt.Errorf("clear tracker expand-failed: %w", err)
 	}
 	return nil
+}
+
+func formatExpandFailureReason(count int, cause error) string {
+	reason := fmt.Sprintf("umbrella expansion failed (attempt %d): %v", count, cause)
+	const maxLen = 200
+	if len(reason) <= maxLen {
+		return reason
+	}
+	const tail = "..."
+	return reason[:maxLen-len(tail)] + tail
 }
 
 // childProjectID returns the repo a child should be worked in: the sub-issue's

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -184,6 +184,68 @@ func TestRecordExpandFailure_EscalatesAtThreshold(t *testing.T) {
 	}
 }
 
+func TestRecordExpandFailure_RefreshesMissingTrackerSnapshot(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	umb := github.Issue{Title: "umbrella", URL: "https://github.com/o/r/issues/100", Repository: "o/r"}
+	tracker, err := tasks.CreateFull(umb.Title, "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb.URL),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella", ExpandFailTag(1)}),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+
+	if err := recordExpandFailure(tasks, umb, existingTracker{}, errors.New("killed")); err != nil {
+		t.Fatalf("recordExpandFailure: %v", err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("len(tasks) = %d, want 1 existing tracker updated in place", len(all))
+	}
+	got, err := tasks.Get(tracker.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ParseExpandFailCount(got.Tags) != 2 {
+		t.Fatalf("fail count = %d, want 2 after updating the existing tracker", ParseExpandFailCount(got.Tags))
+	}
+}
+
+func TestRecordExpandFailure_UsesLiveTagCount(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	umb := github.Issue{Title: "umbrella", URL: "https://github.com/o/r/issues/100", Repository: "o/r"}
+	tracker, err := tasks.CreateFull(umb.Title, "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb.URL),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella", ExpandFailTag(2)}),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+
+	stale := existingTracker{exists: true, id: tracker.ID, tags: []string{"umbrella", ExpandFailTag(1)}}
+	if err := recordExpandFailure(tasks, umb, stale, errors.New("killed")); err != nil {
+		t.Fatalf("recordExpandFailure: %v", err)
+	}
+
+	got, err := tasks.Get(tracker.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ParseExpandFailCount(got.Tags) != 3 {
+		t.Fatalf("fail count = %d, want 3 from the live tracker state, not stale input", ParseExpandFailCount(got.Tags))
+	}
+}
+
 // TestClearExpandFailure_StripsTagOnSuccess guards the recovery path: once
 // expansion succeeds again, the failure count must reset so a later, distinct
 // failure streak starts counting from zero rather than resuming near the
@@ -192,10 +254,11 @@ func TestClearExpandFailure_StripsTagOnSuccess(t *testing.T) {
 	t.Parallel()
 	tasks := newTestTaskManager(t)
 	tracker, err := tasks.CreateFull("umbrella", "", task.AgentModeHeadless, task.Update{
-		Issue:    task.Ptr("https://github.com/o/r/issues/100"),
-		TaskType: task.Ptr(task.TaskTypeUmbrella),
-		Status:   task.Ptr(task.StatusInProgress),
-		Tags:     task.Ptr([]string{"umbrella", ExpandFailTag(2)}),
+		Issue:        task.Ptr("https://github.com/o/r/issues/100"),
+		TaskType:     task.Ptr(task.TaskTypeUmbrella),
+		Status:       task.Ptr(task.StatusInProgress),
+		StatusReason: task.Ptr("umbrella expansion failed (attempt 2): planner killed"),
+		Tags:         task.Ptr([]string{"umbrella", ExpandFailTag(2)}),
 	})
 	if err != nil {
 		t.Fatalf("create tracker: %v", err)
@@ -211,6 +274,9 @@ func TestClearExpandFailure_StripsTagOnSuccess(t *testing.T) {
 	}
 	if ParseExpandFailCount(got.Tags) != 0 {
 		t.Fatalf("fail count = %d, want 0 after clear", ParseExpandFailCount(got.Tags))
+	}
+	if got.StatusReason != "" {
+		t.Fatalf("StatusReason = %q, want cleared with the failure tag", got.StatusReason)
 	}
 
 	// Idempotent: clearing an already-clean tracker is a no-op, not an error.

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -3,6 +3,7 @@ package umbrella
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ import (
 // across every retry.
 func TestPlannerTimeout_ScalesWithSubCountAndCoversEveryAttempt(t *testing.T) {
 	t.Parallel()
-	minBudget := PlannerAttemptTimeout * time.Duration(plannerJobAttempts*plannerGenerateSamples)
+	minBudget := plannerAttemptTimeout(0) * time.Duration(plannerJobAttempts*plannerGenerateSamples)
 	if got := plannerTimeout(0); got < minBudget {
 		t.Fatalf("plannerTimeout(0) = %v, want at least %v (room for %d planner samples x %d llmjob attempts)", got, minBudget, plannerGenerateSamples, plannerJobAttempts)
 	}
@@ -31,6 +32,21 @@ func TestPlannerTimeout_ScalesWithSubCountAndCoversEveryAttempt(t *testing.T) {
 	}
 }
 
+func TestPlannerAttemptTimeout_ScalesWithSubCount(t *testing.T) {
+	t.Parallel()
+	if got := plannerAttemptTimeout(0); got != PlannerAttemptTimeout {
+		t.Fatalf("plannerAttemptTimeout(0) = %v, want base %v", got, PlannerAttemptTimeout)
+	}
+	small := plannerAttemptTimeout(1)
+	large := plannerAttemptTimeout(38)
+	if large <= small {
+		t.Fatalf("plannerAttemptTimeout(38) = %v, want greater than plannerAttemptTimeout(1) = %v", large, small)
+	}
+	if large <= PlannerAttemptTimeout {
+		t.Fatalf("plannerAttemptTimeout(38) = %v, want greater than fixed floor %v", large, PlannerAttemptTimeout)
+	}
+}
+
 func newTestTaskManager(t *testing.T) *task.Manager {
 	t.Helper()
 	store, err := task.NewStore(t.TempDir())
@@ -38,6 +54,56 @@ func newTestTaskManager(t *testing.T) *task.Manager {
 		t.Fatalf("task.NewStore: %v", err)
 	}
 	return task.NewManager(store, task.EmitterFunc(func(string, any) {}))
+}
+
+func TestExpandThreadsScaledAttemptTimeoutToPlanner(t *testing.T) {
+	restore := githubFetchUmbrellaForTest(t, github.Issue{
+		Title:      "umbrella",
+		URL:        "https://github.com/o/r/issues/100",
+		Repository: "o/r",
+	}, makeTestIssues(38))
+	defer restore()
+
+	tasks := newTestTaskManager(t)
+	var got time.Duration
+	run := func(ctx context.Context, _ string) (string, error) {
+		got = plannerAttemptTimeoutFromContext(ctx)
+		return "", errors.New("stop after observing context")
+	}
+
+	_, err := Expand(context.Background(), tasks, run, "https://github.com/o/r/issues/100")
+	if err == nil {
+		t.Fatal("Expand succeeded unexpectedly with an intentionally failing runner")
+	}
+	want := plannerAttemptTimeout(38)
+	if got != want {
+		t.Fatalf("planner attempt timeout from context = %v, want %v", got, want)
+	}
+}
+
+func githubFetchUmbrellaForTest(t *testing.T, umb github.Issue, subs []github.Issue) func() {
+	t.Helper()
+	old := fetchUmbrella
+	fetchUmbrella = func(_ context.Context, _ string, _ int) (github.Issue, []github.Issue, error) {
+		return umb, subs, nil
+	}
+	return func() {
+		fetchUmbrella = old
+	}
+}
+
+func makeTestIssues(n int) []github.Issue {
+	out := make([]github.Issue, n)
+	for i := range out {
+		num := i + 1
+		out[i] = github.Issue{
+			Title:      "child",
+			URL:        fmt.Sprintf("https://github.com/o/r/issues/%d", num),
+			Repository: "o/r",
+			State:      "OPEN",
+		}
+	}
+	return out
 }
 
 func TestMaterialize_DegradedFreshTrackerCarriesFallbackTag(t *testing.T) {

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -81,6 +81,60 @@ func TestExpandThreadsScaledAttemptTimeoutToPlanner(t *testing.T) {
 	}
 }
 
+func TestExpandPlannerDeadlineFallsBackToLinearChain(t *testing.T) {
+	restore := githubFetchUmbrellaForTest(t, github.Issue{
+		Title:      "umbrella",
+		URL:        "https://github.com/o/r/issues/100",
+		Repository: "o/r",
+	}, makeTestIssues(3))
+	defer restore()
+
+	tasks := newTestTaskManager(t)
+	run := func(context.Context, string) (string, error) {
+		return "", context.DeadlineExceeded
+	}
+
+	res, err := Expand(context.Background(), tasks, run, "https://github.com/o/r/issues/100")
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if !res.Degraded {
+		t.Fatalf("Degraded = false, want true after planner deadline fallback")
+	}
+	if res.Created != 3 {
+		t.Fatalf("Created = %d, want 3", res.Created)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var tracker *task.Task
+	children := map[string]task.Task{}
+	for i := range all {
+		if all[i].TaskType == task.TaskTypeUmbrella {
+			tracker = &all[i]
+			continue
+		}
+		children[NormalizeIssueRef(all[i].Issue)] = all[i]
+	}
+	if tracker == nil {
+		t.Fatal("no umbrella tracker created")
+	}
+	if !slices.Contains(tracker.Tags, FallbackTag) {
+		t.Fatalf("tracker tags = %v, want %q", tracker.Tags, FallbackTag)
+	}
+	if got := ParseExpandFailCount(tracker.Tags); got != 0 {
+		t.Fatalf("expand fail count = %d, want 0 for degraded fallback success", got)
+	}
+	if got := children["o/r#2"].DependsOn; len(got) != 1 || got[0] != "https://github.com/o/r/issues/1" {
+		t.Fatalf("child #2 deps = %v, want issue #1", got)
+	}
+	if got := children["o/r#3"].DependsOn; len(got) != 1 || got[0] != "https://github.com/o/r/issues/2" {
+		t.Fatalf("child #3 deps = %v, want issue #2", got)
+	}
+}
+
 func githubFetchUmbrellaForTest(t *testing.T, umb github.Issue, subs []github.Issue) func() {
 	t.Helper()
 	old := fetchUmbrella

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -2,7 +2,9 @@ package umbrella
 
 import (
 	"context"
+	"errors"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,6 +115,147 @@ func TestMaterialize_DegradedExistingTrackerGetsFallbackTagIdempotently(t *testi
 	}
 }
 
+// TestRecordExpandFailure_NoTrackerCreatesVisibleFailureTracker guards #1570's
+// board-visibility gap: previously a failed expansion with no prior tracker
+// left zero trace on the board besides a log line. The first failure must
+// materialize a real, inspectable task.
+func TestRecordExpandFailure_NoTrackerCreatesVisibleFailureTracker(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	umb := github.Issue{Title: "umbrella", URL: "https://github.com/o/r/issues/100", Repository: "o/r", Body: "body"}
+
+	if err := recordExpandFailure(tasks, umb, existingTracker{}, errors.New("planner killed")); err != nil {
+		t.Fatalf("recordExpandFailure: %v", err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("len(tasks) = %d, want 1", len(all))
+	}
+	tracker := all[0]
+	if tracker.TaskType != task.TaskTypeUmbrella || tracker.Issue != umb.URL {
+		t.Fatalf("tracker = %+v, want TaskType=umbrella Issue=%q", tracker, umb.URL)
+	}
+	if ParseExpandFailCount(tracker.Tags) != 1 {
+		t.Fatalf("fail count = %d, want 1: %v", ParseExpandFailCount(tracker.Tags), tracker.Tags)
+	}
+	if !strings.Contains(tracker.StatusReason, "planner killed") {
+		t.Fatalf("StatusReason = %q, want to mention the failure cause", tracker.StatusReason)
+	}
+	if tracker.Status == task.StatusHumanRequired {
+		t.Fatalf("status = human-required after a single failure, want to stay non-terminal below threshold")
+	}
+}
+
+// TestRecordExpandFailure_EscalatesAtThreshold guards the "stop retrying"
+// half of #1570: after ExpandFailThreshold consecutive failures against an
+// existing tracker, the tracker must park human-required rather than keep
+// silently retrying forever.
+func TestRecordExpandFailure_EscalatesAtThreshold(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	umb := github.Issue{Title: "umbrella", URL: "https://github.com/o/r/issues/100", Repository: "o/r"}
+	tracker, err := tasks.CreateFull(umb.Title, "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb.URL),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella", ExpandFailTag(ExpandFailThreshold - 1)}),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+
+	if err := recordExpandFailure(tasks, umb, existingTracker{exists: true, id: tracker.ID, tags: tracker.Tags}, errors.New("killed")); err != nil {
+		t.Fatalf("recordExpandFailure: %v", err)
+	}
+
+	got, err := tasks.Get(tracker.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required at ExpandFailThreshold=%d", got.Status, ExpandFailThreshold)
+	}
+	if ParseExpandFailCount(got.Tags) != ExpandFailThreshold {
+		t.Fatalf("fail count = %d, want %d", ParseExpandFailCount(got.Tags), ExpandFailThreshold)
+	}
+}
+
+// TestClearExpandFailure_StripsTagOnSuccess guards the recovery path: once
+// expansion succeeds again, the failure count must reset so a later, distinct
+// failure streak starts counting from zero rather than resuming near the
+// threshold.
+func TestClearExpandFailure_StripsTagOnSuccess(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	tracker, err := tasks.CreateFull("umbrella", "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr("https://github.com/o/r/issues/100"),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella", ExpandFailTag(2)}),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+
+	if err := clearExpandFailure(tasks, tracker.ID); err != nil {
+		t.Fatalf("clearExpandFailure: %v", err)
+	}
+
+	got, err := tasks.Get(tracker.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ParseExpandFailCount(got.Tags) != 0 {
+		t.Fatalf("fail count = %d, want 0 after clear", ParseExpandFailCount(got.Tags))
+	}
+
+	// Idempotent: clearing an already-clean tracker is a no-op, not an error.
+	if err := clearExpandFailure(tasks, tracker.ID); err != nil {
+		t.Fatalf("clearExpandFailure (idempotent): %v", err)
+	}
+}
+
+// TestMaterialize_BackfillsMaxParallelOnPlaceholderTracker guards the tracker
+// created by recordExpandFailure (which has no MaxParallelTag, since it never
+// ran through materialize's fresh-tracker branch): the first successful
+// materialize against it must backfill the tag rather than leaving the
+// tracker's parallelism cap silently pinned to DefaultMaxParallel forever.
+func TestMaterialize_BackfillsMaxParallelOnPlaceholderTracker(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	umb := github.Issue{Title: "umbrella", URL: "https://github.com/o/r/issues/100", Repository: "o/r"}
+
+	placeholder, err := tasks.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb.URL),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella", ExpandFailTag(1)}),
+	})
+	if err != nil {
+		t.Fatalf("create placeholder tracker: %v", err)
+	}
+	if HasMaxParallelTag(placeholder.Tags) {
+		t.Fatal("placeholder tracker unexpectedly already has a MaxParallelTag")
+	}
+
+	specs := []ChildSpec{{Title: "c1", Issue: "o/r#1"}}
+	if _, err := materialize(tasks, umb, specs, map[string]github.Issue{}, true, placeholder.ID, 7, false); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+
+	got, err := tasks.Get(placeholder.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !HasMaxParallelTag(got.Tags) || ParseMaxParallel(got.Tags) != 7 {
+		t.Fatalf("tracker tags = %v, want a MaxParallelTag backfilled to 7", got.Tags)
+	}
+}
+
 func TestScanExisting_ReturnsTrackerID(t *testing.T) {
 	t.Parallel()
 	tasks := newTestTaskManager(t)
@@ -127,15 +270,15 @@ func TestScanExisting_ReturnsTrackerID(t *testing.T) {
 		t.Fatalf("create tracker: %v", err)
 	}
 
-	_, trackerExists, trackerID, err := scanExisting(tasks, umb)
+	_, got, err := scanExisting(tasks, umb)
 	if err != nil {
 		t.Fatalf("scanExisting: %v", err)
 	}
-	if !trackerExists {
+	if !got.exists {
 		t.Fatal("trackerExists = false, want true")
 	}
-	if trackerID != tracker.ID {
-		t.Fatalf("trackerID = %q, want %q", trackerID, tracker.ID)
+	if got.id != tracker.ID {
+		t.Fatalf("trackerID = %q, want %q", got.id, tracker.ID)
 	}
 }
 

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -101,9 +101,10 @@ const criticSuffix = "You produced a fully-parallel plan — re-examine `touches
 // a critic nudge; any failure of that re-ask (parse, validate, or run error)
 // falls back to the original plan rather than failing the whole expansion.
 // If the first attempt exhausts plannerAttempts without ever producing a
-// valid plan, Generate falls back to a fully-serial linear chain
-// (linearChainFallback) instead of aborting the expansion; a fatal runner
-// error (couldn't launch the model) is not exhaustion and still aborts.
+// valid plan, or the planner deadline expires, Generate falls back to a
+// fully-serial linear chain (linearChainFallback) instead of aborting the
+// expansion; a fatal runner error (couldn't launch the model) is not
+// exhaustion and still aborts.
 func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue, opts ...GenerateOption) (Plan, error) {
 	if len(subs) == 0 {
 		return Plan{}, fmt.Errorf("umbrella %s has no sub-issues to expand", umbrellaRef)
@@ -117,7 +118,7 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 
 	plan, err := attemptPlan(ctx, run, idx, prompt, subs, cfg)
 	if err != nil {
-		if errors.Is(err, errPlannerExhausted) {
+		if plannerExhausted(err) {
 			return linearChainFallback(subs)
 		}
 		return Plan{}, err
@@ -129,6 +130,10 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 		}
 	}
 	return plan, nil
+}
+
+func plannerExhausted(err error) bool {
+	return errors.Is(err, errPlannerExhausted) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // attemptPlan runs up to plannerAttempts model invocations with the given

--- a/internal/umbrella/tags.go
+++ b/internal/umbrella/tags.go
@@ -21,6 +21,36 @@ func MaxParallelTag(n int) string {
 	return MaxParallelTagPrefix + strconv.Itoa(n)
 }
 
+// ExpandFailTagPrefix carries a tracker's consecutive expansion-failure count,
+// e.g. "umbrella-expand-fail:2". Persisted on the task so the count survives
+// restarts and is shared by every caller of Expand (issue fetcher, manual
+// stub enrichment, `sybra-cli umbrella`) instead of living in one process's
+// memory.
+const ExpandFailTagPrefix = "umbrella-expand-fail:"
+
+// ExpandFailThreshold is how many consecutive Expand failures against an
+// already-materialized tracker are tolerated before Expand stops calling the
+// planner and parks the tracker human-required — see #1570.
+const ExpandFailThreshold = 3
+
+// ExpandFailTag renders the tracker tag encoding n consecutive failures.
+func ExpandFailTag(n int) string {
+	return ExpandFailTagPrefix + strconv.Itoa(n)
+}
+
+// ParseExpandFailCount reads the consecutive expansion-failure count from a
+// tracker's tags, defaulting to 0 when absent or malformed.
+func ParseExpandFailCount(tags []string) int {
+	for _, t := range tags {
+		if rest, ok := strings.CutPrefix(t, ExpandFailTagPrefix); ok {
+			if n, err := strconv.Atoi(strings.TrimSpace(rest)); err == nil && n >= 0 {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
 // ParseMaxParallel reads the max-parallel value from a tracker's tags, falling
 // back to DefaultMaxParallel when the tag is absent or malformed.
 func ParseMaxParallel(tags []string) int {
@@ -32,6 +62,18 @@ func ParseMaxParallel(tags []string) int {
 		}
 	}
 	return DefaultMaxParallel
+}
+
+// HasMaxParallelTag reports whether tags already carry a MaxParallelTag,
+// distinguishing "never set" from "set to DefaultMaxParallel" — ParseMaxParallel
+// alone cannot tell those apart since both resolve to the same int.
+func HasMaxParallelTag(tags []string) bool {
+	for _, t := range tags {
+		if strings.HasPrefix(t, MaxParallelTagPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // controlTags are Sybra-load-bearing tags a child task must not inherit from a


### PR DESCRIPTION
## Summary

- scale the umbrella planner per-attempt timeout with sub-issue count instead of keeping every llmjob attempt at the fixed 4-minute floor
- treat planner deadline exhaustion like planner-output exhaustion and materialize the existing serial fallback DAG
- add regression coverage that Expand returns a degraded fallback with canonical serial dependencies instead of recording a planner failure

Fixes #1570.

## Tests

- go test ./internal/umbrella
- go test ./internal/poll ./internal/sybra
- go test ./internal/llmjob ./internal/llmexec ./internal/provider
- go test ./...

_Generated by Sybra harness_