### PR TITLE
fix(workflow): park throttled tasks, not escalate

### DIFF
--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -12,6 +12,12 @@ import (
 // ErrProviderUnhealthy sentinel — use errors.Is to detect gate-block errors.
 var ErrProviderUnhealthy = errors.New("provider unhealthy")
 
+// RateLimitReason is the Status.Reason value set when a provider is throttled
+// (ReportRateLimit). Exposed so callers can tell a transient capacity throttle
+// (self-heals when the cooldown window expires) apart from an auth failure
+// (needs a human login) without string-matching a literal.
+const RateLimitReason = "rate_limited"
+
 // UnhealthyError carries the structured reason a provider was refused.
 type UnhealthyError struct {
 	Provider string

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -293,7 +293,7 @@ func (c *Checker) clearExpiredRateLimitsLocked(now time.Time) []Status {
 	for _, s := range c.statuses {
 		if !s.RateLimitedUntil.IsZero() && now.After(s.RateLimitedUntil) {
 			s.RateLimitedUntil = time.Time{}
-			if s.Reason == "rate_limited" {
+			if s.Reason == RateLimitReason {
 				s.Healthy = true
 				s.Reason = "ok"
 				s.Detail = "rate_limit_window_expired"
@@ -341,7 +341,7 @@ func (c *Checker) setStatusLocked(name string, next Status, fromProbe bool) (Sta
 		// should be cleared by clearExpiredRateLimits or a newer passive signal.
 		if next.Healthy && !prev.RateLimitedUntil.IsZero() && c.now().Before(prev.RateLimitedUntil) {
 			next.Healthy = false
-			next.Reason = "rate_limited"
+			next.Reason = RateLimitReason
 			next.RateLimitedUntil = prev.RateLimitedUntil
 		}
 		flip = statusChanged(prev, &next)
@@ -520,13 +520,13 @@ func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, rea
 		c.mu.RUnlock()
 	}
 	if reason == "" {
-		reason = "rate_limited"
+		reason = RateLimitReason
 	}
 	until := c.now().Add(cooldown)
 	c.setStatus(provider, Status{
 		Provider:         provider,
 		Healthy:          false,
-		Reason:           "rate_limited",
+		Reason:           RateLimitReason,
 		Detail:           reason,
 		LastCheck:        c.now(),
 		RateLimitedUntil: until,

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -475,6 +475,13 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 		return
 	}
 	e.clearAgentStep(agentID)
+	if e.shouldSkipResumeForRateLimitedProvider(&t, step) {
+		// Provider is still inside its rate-limit cooldown and no healthy peer is
+		// available to fail over to. Park the task without consuming a watchdog
+		// retry budget or feeding the circuit breaker — ResumeStalled re-drives
+		// it once clearExpiredRateLimits reopens a provider.
+		return
+	}
 	if e.agents.HasOtherRunningAgentForTask(taskID, agentID) {
 		e.logger.Debug("workflow.rate-limit-reschedule.skip",
 			"task_id", taskID, "reason", "other-agent-running", "step", step.ID)
@@ -540,6 +547,13 @@ func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, pare
 		return
 	}
 	e.clearAgentStep(agentID)
+
+	if e.shouldSkipResumeForRateLimitedProvider(&fresh, child) {
+		// See RescheduleRateLimitedAgent: park rather than burn a retry budget or
+		// trip the breaker while this child's provider is rate-limited with no
+		// failover peer. The parent stays inflight; ResumeStalled retries later.
+		return
+	}
 
 	if e.handleWatchdogRateLimitRetry(&fresh, child) {
 		return
@@ -965,7 +979,12 @@ func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error, wf
 	if permanent {
 		target = "human-required"
 	}
-	if wf != nil && stepID != "" {
+	// A provider being rate-limited right now is a transient capacity condition,
+	// not a genuine start failure: counting it toward the breaker would trip a
+	// task to human-required for something that self-heals when the cooldown
+	// window expires. Only genuine failures (bad worktree, missing project,
+	// crashes) — and auth failures that need a human login — feed the breaker.
+	if wf != nil && stepID != "" && !isTransientCapacityError(err) {
 		attempts, trip := recordCircuitBreakerFailure(wf, stepID, time.Now())
 		if trip {
 			// The status skip in resumeSkipReasonForStatus alone is not a

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1868,6 +1868,74 @@ func TestRescheduleRateLimitedAgent_WatchdogRetriesThenEscalates(t *testing.T) {
 	}
 }
 
+// TestRescheduleRateLimitedAgent_ParksWhileProviderRateLimitedNoFailover is the
+// regression guard for sybra#1585: a reschedule that fires while the step's
+// provider is still inside its rate-limit cooldown (and no healthy peer exists
+// to fail over to) must PARK the task — not consume a watchdog retry budget and
+// not escalate to human-required. Even with the retry budget already exhausted,
+// the task waits for the cooldown to expire instead of bothering a human.
+func TestRescheduleRateLimitedAgent_ParksWhileProviderRateLimitedNoFailover(t *testing.T) {
+	tests := []struct {
+		name    string
+		retries string
+	}{
+		{name: "fresh budget parks", retries: ""},
+		{name: "exhausted budget still parks", retries: strconv.Itoa(maxWatchdogRateLimitRetries)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestStore(t)
+			tasks := newMemTasks()
+			agents := newMockAgents()
+			// Provider throttled, no peer to fail over to → must park and wait.
+			agents.SetProviderRateLimited(true)
+			engine := NewEngine(store, tasks, agents, discardLogger())
+
+			vars := map[string]string{}
+			if tc.retries != "" {
+				vars[watchdogRateLimitRetryKey("implement")] = tc.retries
+			}
+			tasks.Put(TaskInfo{
+				ID:           "t1",
+				Status:       "in-progress",
+				StatusReason: "watchdog: rate limit: org-level quota exhausted",
+				AgentMode:    "headless",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					Variables:   vars,
+				},
+			})
+			engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "implement"}
+
+			engine.RescheduleRateLimitedAgent("t1", "limited-agent")
+
+			if got := agents.CallCount(); got != 0 {
+				t.Fatalf("expected no replacement agent starts while parked, got %d", got)
+			}
+			got, err := tasks.GetTask("t1")
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != "in-progress" {
+				t.Fatalf("status = %q, want in-progress (parked, not escalated)", got.Status)
+			}
+			// Budget untouched: the parked attempt never counted.
+			if got := got.Workflow.Variables[watchdogRateLimitRetryKey("implement")]; got != tc.retries {
+				t.Fatalf("rate-limit retry var = %q, want unchanged %q", got, tc.retries)
+			}
+			// Breaker untouched: a transient throttle is not a dispatch failure.
+			if _, tripped := got.Workflow.Variables[circuitBreakerFailureKey("implement")]; tripped {
+				t.Fatalf("circuit breaker recorded a failure for a transient rate limit: %v", got.Workflow.Variables)
+			}
+			if _, tracked := engine.lookupAgentStep("limited-agent"); tracked {
+				t.Fatal("rate-limited agent step mapping was not cleared")
+			}
+		})
+	}
+}
+
 func TestRescheduleRateLimitedAgent_EmptyTaskIDClearsTrackedAgent(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -76,6 +76,20 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 	return truncateReason(reason), permanent
 }
 
+// isTransientCapacityError reports whether err is a provider-capacity throttle
+// (rate limit) that self-heals once the provider's cooldown window expires.
+// Such errors must not be counted toward the circuit breaker or escalated to
+// human-required — the task should park and retry when a provider frees up.
+// Auth failures (logged out) are deliberately NOT capacity errors: they need a
+// human login, so an UnhealthyError without a rate-limit reason returns false.
+func isTransientCapacityError(err error) bool {
+	var ue *provider.UnhealthyError
+	if errors.As(err, &ue) {
+		return ue.Reason == provider.RateLimitReason || !ue.Until.IsZero()
+	}
+	return false
+}
+
 func transientAgentStartError(err error) bool {
 	return errors.Is(err, ErrDispatchInFlight) ||
 		errors.Is(err, ErrTestRunnerBusy) ||

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -80,8 +80,10 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 // (rate limit) that self-heals once the provider's cooldown window expires.
 // Such errors must not be counted toward the circuit breaker or escalated to
 // human-required — the task should park and retry when a provider frees up.
-// Auth failures (logged out) are deliberately NOT capacity errors: they need a
-// human login, so an UnhealthyError without a rate-limit reason returns false.
+// Both the rate-limit reason and a cooldown deadline (Until) are accepted
+// because resolveProviderDecision tags the reason but leaves Until zero, while
+// other gate paths may carry only the deadline. A logged-out auth failure has
+// neither, so it stays escalatable — a human must log in.
 func isTransientCapacityError(err error) bool {
 	var ue *provider.UnhealthyError
 	if errors.As(err, &ue) {

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -271,6 +271,34 @@ func TestSurfaceStartFailure_CircuitBreakerTripsAfterRepeatedFailures(t *testing
 	}
 }
 
+// TestSurfaceStartFailure_TransientRateLimitDoesNotTripBreaker guards sybra#1585:
+// an all-providers-throttled gate error (provider.UnhealthyError, rate_limited)
+// is a transient capacity condition that self-heals when the cooldown expires,
+// so it must never feed the circuit breaker or escalate the task, no matter how
+// many times it repeats within the window. Auth failures keep tripping it.
+func TestSurfaceStartFailure_TransientRateLimitDoesNotTripBreaker(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	rateLimited := &provider.UnhealthyError{Provider: "claude", Reason: provider.RateLimitReason}
+	wf := &Execution{CurrentStep: "implement", State: ExecRunning, Variables: map[string]string{}}
+
+	for i := range maxCircuitBreakerFailures + 2 {
+		engine.surfaceStartFailure("t1", "in-progress", rateLimited, wf, "implement")
+		if wf.State == ExecFailed {
+			t.Fatalf("transient rate limit tripped the breaker on attempt %d", i+1)
+		}
+	}
+	if _, recorded := wf.Variables[circuitBreakerFailureKey("implement")]; recorded {
+		t.Fatalf("transient rate limit recorded a breaker failure: %v", wf.Variables)
+	}
+	got, _ := tasks.GetTask("t1")
+	if got.Status == "human-required" {
+		t.Fatal("transient rate limit escalated to human-required")
+	}
+}
+
 func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})


### PR DESCRIPTION
## Motivation

Tasks were landing in `human-required` because of provider capacity (rate limits / all providers throttled), when the correct behavior is to park and retry once a cooldown window clears. Sybra should exhaust the full combined budget of all available providers — and wait out transient throttles — before ever bothering a human. Closes #1585.

> Changelog: fix(workflow): park throttled tasks instead of escalating to human-required

Rate-limited runs already have a park-and-retry path (`RescheduleRateLimitedAgent`, per-provider `RateLimitedUntil` cooldowns, `clearExpiredRateLimits`, failover claude→codex→copilot). Two bounded escalations fired before that path could succeed.

## Implementation information

**Defect 1 — retry budgets counted per re-dispatch, not per cooldown window.** When every provider was exhausted, immediate re-drives came back rate-limited instantly and burned all attempts in seconds, long before the 15min–1h cooldown that actually fixes it. `RescheduleRateLimitedAgent` (and the parallel-child variant) now call the existing `shouldSkipResumeForRateLimitedProvider` guard before consuming a watchdog retry budget: if the step's provider is still throttled with no failover peer, the task parks and `ResumeStalled` re-drives it once the cooldown expires. The watchdog budget is now only spent on genuine repeated exhaustion (provider dispatchable, agent runs, hits a fresh limit again), preserving that safety valve.

**Defect 2 — `ErrProviderUnhealthy` fed the circuit breaker despite being classified transient.** `surfaceStartFailure` called `recordCircuitBreakerFailure` unconditionally, ignoring the `permanent=false` flag, so "all providers throttled right now" tripped the breaker → `ExecFailed` + `human-required`, same as a genuinely broken task. A new `isTransientCapacityError` helper excludes rate-limit `UnhealthyError`s from the breaker; genuine start failures (bad worktree, missing project, crashes) and auth failures still trip it.

Auth failures (logged out) keep taking the immediate `human-required` path — they need a human login.

Added a `provider.RateLimitReason` constant so the workflow layer distinguishes a throttle from an auth failure without matching a string literal.

## Supporting documentation

New regression tests:

- `TestRescheduleRateLimitedAgent_ParksWhileProviderRateLimitedNoFailover` — a reschedule while the provider is throttled with no failover parks the task, consumes no retry budget, records no breaker failure, and does not escalate — even with the budget already exhausted.
- `TestSurfaceStartFailure_TransientRateLimitDoesNotTripBreaker` — a repeated rate-limit gate error never trips the breaker or escalates, no matter how many times it fires in the window.

Existing escalation and breaker tests (genuine `ErrRebaseFailed` failures, auth failures, non-throttled providers) are unaffected. `go test -race` green across `internal/{provider,workflow,sybra,recovery}`; `golangci-lint` clean.
