### PR TITLE
docs(agent): correct stale tmux interactive model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Sybra
 
-Local desktop app to orchestrate a swarm of Claude Code agents. Markdown-based task management, two execution modes (interactive tmux + headless `claude -p`), Wails v3 alpha GUI (darwin-only).
+Local desktop app to orchestrate a swarm of Claude Code agents. Markdown-based task management, two execution modes (interactive conversational session + headless `claude -p`), Wails v3 alpha GUI (darwin-only).
 
 ## Work-Data Confidentiality (HARD RULE)
 
@@ -51,8 +51,6 @@ sybra/
 │   │   ├── model.go         # Agent struct, State enum, StreamEvent
 │   │   ├── manager.go       # Start/stop/list agents
 │   │   └── runner_headless.go # claude -p NDJSON stream parser
-│   ├── tmux/
-│   │   └── manager.go       # tmux session CRUD via os/exec
 │   ├── project/             # GitHub repo mirror + git worktree management
 │   │   ├── model.go         # Project struct
 │   │   ├── store.go         # YAML-backed project store
@@ -195,12 +193,11 @@ claude -p "prompt" --output-format stream-json [--resume <id>] [--allowedTools "
 
 **Fork subagents** (`fork_subagent: true`): sets `CLAUDE_CODE_FORK_SUBAGENT=1` in the subprocess environment (CC v2.1.121+, claude provider only). Allows a single prompt to spawn parallel subagent runs, reducing wall-clock time for multi-part work. Tradeoff: each forked subagent incurs its own token usage — total cost multiplies with parallelism. Enable per-task from the metadata panel or task creation dialog. Not propagated to interactive or codex agents.
 
-**Interactive** (tmux):
-```bash
-tmux new-session -d -s sybra-<id> -x 200 -y 50 "claude"
-```
-- GUI polls `tmux capture-pane -t sybra-<id> -p` for preview
-- User attaches via terminal
+**Interactive** (persistent conversational session — not tmux):
+
+`agent.Manager.Run` spawns a long-lived CLI process that streams stream-json over stdin/stdout: claude via `runConversational` (persistent approval-hook runner), codex/copilot via the per-turn conversational runner (`UsesPerTurnConvo()`). The GUI renders the live stream in a bounded session box; the user drives it by sending turns.
+
+**Same provider gate as headless.** Both modes resolve the provider through `prepareRunConfig` → `gateProvider` → `resolveProviderDecision`, so an unhealthy/rate-limited provider fails over (claude → codex → copilot) and the model is remapped (`NormalizeModel`) exactly like headless. There is no provider-pinned interactive launcher. Failover is decided at *dispatch*; an agent already running when its own provider caps mid-run does not hot-swap (headless recovers by re-dispatch via `RescheduleRateLimitedAgent`).
 
 ### Worktree Agent Context
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Complex tasks go through a planning phase. Simple tasks go straight to execution
 ## Features
 
 - **Task board** — drag-and-drop Kanban with status swimlanes, priority, tags, agent mode
-- **Dual execution modes** — headless (`claude -p` with NDJSON streaming) or interactive (tmux sessions)
+- **Dual execution modes** — headless (`claude -p` with NDJSON streaming) or interactive (persistent conversational sessions)
 - **Worktree isolation** — each agent gets a per-task git worktree from a bare clone; no conflicts between concurrent agents
 - **GitHub integration** — link tasks to repos; agents clone, commit, and open PRs automatically
 - **Eval agents** — post-implementation verification: confirm commits exist, PRs are open, quality gates pass

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -60,6 +60,39 @@ func TestGateProvider_UnhealthyWithFailover(t *testing.T) {
 	}
 }
 
+// TestPrepareRunConfig_InteractiveFailsOverLikeHeadless is a regression guard
+// for the "interactive doesn't fail over" premise: it does. Both modes resolve
+// the provider through the same prepareRunConfig -> gateProvider path, so an
+// unhealthy requested provider fails over to a healthy peer regardless of mode.
+// If a future change re-adds a provider-pinned interactive launcher that skips
+// the gate, the interactive subtest fails.
+func TestPrepareRunConfig_InteractiveFailsOverLikeHeadless(t *testing.T) {
+	for _, mode := range []string{"headless", "interactive"} {
+		t.Run(mode, func(t *testing.T) {
+			m, _ := newTestManager(t)
+			m.SetHealthGate(&fakeGate{
+				healthy:  map[string]bool{"claude": false, "codex": true},
+				failover: map[string]string{"claude": "codex"},
+				reasons:  map[string]string{"claude": "rate_limited"},
+			})
+			cfg, prov, err := m.prepareRunConfig(RunConfig{
+				Provider: "claude",
+				Mode:     mode,
+				Dir:      t.TempDir(),
+			})
+			if err != nil {
+				t.Fatalf("prepareRunConfig(%s): %v", mode, err)
+			}
+			if prov.Name() != "codex" {
+				t.Errorf("mode %s: resolved provider = %q, want codex (failover)", mode, prov.Name())
+			}
+			if cfg.provider == nil || cfg.provider.Name() != "codex" {
+				t.Errorf("mode %s: cfg.provider = %v, want codex", cfg.provider, "codex")
+			}
+		})
+	}
+}
+
 func TestGateProvider_BothUnhealthyReturnsTypedError(t *testing.T) {
 	m, _ := newTestManager(t)
 	m.SetHealthGate(&fakeGate{

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -182,7 +182,7 @@ Headless tasks get a structured prompt:
 
 ```bash
 sybra-cli --json update <id> --status in-progress
-# Then start agent via Sybra GUI or tmux
+# Then start agent via Sybra GUI
 ```
 
 For interactive tasks, just update status — human will attach.


### PR DESCRIPTION
## Motivation

The docs described interactive agents as tmux sessions (`tmux new-session … claude`), an architecture that no longer exists — `internal/tmux` was removed. That stale mental model led to the incorrect belief that interactive agents are pinned to one provider and skip provider failover.

In reality interactive mode is a persistent conversational `os/exec` process (claude via `runConversational`; codex/copilot via the per-turn runner) that routes through the **same** `prepareRunConfig` → `gateProvider` → `resolveProviderDecision` path as headless. So an unhealthy/rate-limited provider fails over (claude → codex → copilot) and the model is remapped identically, regardless of mode.

> Changelog: docs(agent): correct stale tmux interactive-mode description

## Implementation information

Docs corrected:

- `CLAUDE.md` — intro line, removed the deleted `internal/tmux/` tree entry, and rewrote the **Interactive** section to describe the conversational runner and note it shares the headless provider gate/failover (with the one real caveat: failover is decided at dispatch, not mid-run).
- `README.md` — "interactive (tmux sessions)" → "persistent conversational sessions".
- `orchestrator/CLAUDE.md` — dropped the "or tmux" start hint.

Regression test: `TestPrepareRunConfig_InteractiveFailsOverLikeHeadless` (`internal/agent/manager_gate_test.go`) drives the shared `prepareRunConfig` path for both `headless` and `interactive` modes against an unhealthy `claude` + healthy `codex` gate and asserts both resolve to the `codex` failover peer. This closes a coverage gap — the existing gate tests were mode-agnostic and never passed `Mode: "interactive"`, so a future provider-pinned interactive launcher could regress failover silently.

## Supporting documentation

`go test ./internal/agent/...` green; `golangci-lint` clean. No production code changed — docs + test only.
