### PR TITLE
fix(agent): use soft-limit budget as last resort

### DIFF
--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -405,11 +405,12 @@ func TestReportProviderHealthSignal_CleanSuccessMentioningRateLimitDoesNotMarkRa
 	}
 }
 
-// TestGateProvider_SoftThresholdLastResortUsesRemainingBudget is the sybra#1588
-// regression: when the requested provider is only blocked by a soft reserve
-// threshold (budget remains) and no healthy peer exists to fail over to, the
-// run must use the remaining budget rather than gate. Otherwise the reserved
-// headroom is stranded and the task escalates with usable quota left.
+// TestGateProvider_SoftThresholdLastResortUsesRemainingBudget guards the
+// soft-threshold last-resort path: when the requested provider is only blocked
+// by a soft reserve threshold (budget remains) and no healthy peer exists to
+// fail over to, the run must use the remaining budget rather than gate.
+// Otherwise the reserved headroom is stranded and the task escalates with
+// usable quota left.
 func TestGateProvider_SoftThresholdLastResortUsesRemainingBudget(t *testing.T) {
 	for _, reason := range []string{"weekly limit near threshold", "session limit near threshold"} {
 		t.Run(reason, func(t *testing.T) {

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -404,3 +404,59 @@ func TestReportProviderHealthSignal_CleanSuccessMentioningRateLimitDoesNotMarkRa
 		t.Fatalf("unexpected rate-limit report: %+v", fg.reportedRLName)
 	}
 }
+
+// TestGateProvider_SoftThresholdLastResortUsesRemainingBudget is the sybra#1588
+// regression: when the requested provider is only blocked by a soft reserve
+// threshold (budget remains) and no healthy peer exists to fail over to, the
+// run must use the remaining budget rather than gate. Otherwise the reserved
+// headroom is stranded and the task escalates with usable quota left.
+func TestGateProvider_SoftThresholdLastResortUsesRemainingBudget(t *testing.T) {
+	for _, reason := range []string{"weekly limit near threshold", "session limit near threshold"} {
+		t.Run(reason, func(t *testing.T) {
+			m, _ := newTestManager(t)
+			m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true}})
+			if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+				DefaultProvider: "claude",
+				LimitGate: &fakeLimitGate{
+					available: map[string]bool{"claude": false},
+					reasons:   map[string]string{"claude": reason},
+				},
+				LimitPolicy: limits.Policy{},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			got, err := m.gateProvider(RunConfig{Provider: "claude"})
+			if err != nil {
+				t.Fatalf("soft threshold with no peer must not gate: %v", err)
+			}
+			if got != "claude" {
+				t.Errorf("got %q, want claude (use remaining budget as last resort)", got)
+			}
+		})
+	}
+}
+
+// TestGateProvider_HardLimitStillGatesWithNoPeer verifies a hard block (provider
+// actually reports rate limit reached) keeps gating when no peer is available —
+// only soft reserve thresholds fall back to the remaining budget.
+func TestGateProvider_HardLimitStillGatesWithNoPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "claude",
+		LimitGate: &fakeLimitGate{
+			available: map[string]bool{"claude": false},
+			reasons:   map[string]string{"claude": "provider reports rate limit reached"},
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := m.gateProvider(RunConfig{Provider: "claude"})
+	if err == nil {
+		t.Fatal("hard limit with no peer must gate, got nil error")
+	}
+	if !errors.Is(err, provider.ErrProviderUnhealthy) {
+		t.Fatalf("want ErrProviderUnhealthy, got %v", err)
+	}
+}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -443,7 +443,7 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (string, []providerGate
 func (m *Manager) softLimitLastResort(resolved, reason string, gateEvents []providerGateEvent, taskID string) (string, []providerGateEvent, error) {
 	if limits.IsSoftThresholdReason(reason) {
 		gateEvents = append(gateEvents, providerGateEvent{
-			kind: "soft_limit", provider: resolved, reason: reason, logKey: "agent.run.soft_limit_last_resort", logLevel: "info", taskID: taskID,
+			kind: "soft_limit", provider: resolved, reason: reason, logKey: "agent.run.soft_limit_last_resort", taskID: taskID,
 		})
 		return resolved, gateEvents, nil
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/notes"
 	"github.com/Automaat/sybra/internal/provider"
@@ -311,6 +312,8 @@ func (m *Manager) emitProviderGateEvents(gateEvents []providerGateEvent) {
 		switch e.kind {
 		case "gated":
 			metrics.AgentGated(e.provider, e.reason)
+		case "soft_limit":
+			m.logger.Info(e.logKey, "provider", e.provider, "reason", e.reason, "task", e.taskID)
 		case "failover":
 			metrics.AgentFailover(e.from, e.to)
 			fields := []any{"from", e.from, "to", e.to, "task", e.taskID}
@@ -431,17 +434,23 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (string, []providerGate
 			})
 			return alt, gateEvents, nil
 		}
-		gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
-		return "", gateEvents, &provider.UnhealthyError{
-			Provider: resolved,
-			Reason:   reason,
-		}
+		return m.softLimitLastResort(resolved, reason, gateEvents, cfg.TaskID)
 	} else {
-		gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
-		return "", gateEvents, &provider.UnhealthyError{
-			Provider: resolved,
-			Reason:   reason,
-		}
+		return m.softLimitLastResort(resolved, reason, gateEvents, cfg.TaskID)
+	}
+}
+
+func (m *Manager) softLimitLastResort(resolved, reason string, gateEvents []providerGateEvent, taskID string) (string, []providerGateEvent, error) {
+	if limits.IsSoftThresholdReason(reason) {
+		gateEvents = append(gateEvents, providerGateEvent{
+			kind: "soft_limit", provider: resolved, reason: reason, logKey: "agent.run.soft_limit_last_resort", logLevel: "info", taskID: taskID,
+		})
+		return resolved, gateEvents, nil
+	}
+	gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
+	return "", gateEvents, &provider.UnhealthyError{
+		Provider: resolved,
+		Reason:   reason,
 	}
 }
 

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -450,3 +450,22 @@ func TestWalkJSONL_StopsOnCanceledContext(t *testing.T) {
 		t.Fatal("walkJSONL callback ran after context cancellation")
 	}
 }
+
+func TestIsSoftThresholdReason(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   bool
+	}{
+		{quotaReasonWeeklyThreshold, true},
+		{quotaReasonSessionThreshold, true},
+		{quotaReasonRateLimitReached, false},
+		{quotaReasonProviderDisabled, false},
+		{"", false},
+		{"something else", false},
+	}
+	for _, c := range cases {
+		if got := IsSoftThresholdReason(c.reason); got != c.want {
+			t.Errorf("IsSoftThresholdReason(%q) = %v, want %v", c.reason, got, c.want)
+		}
+	}
+}

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -281,7 +281,7 @@ func (s *Store) Summary(policy Policy) Summary {
 // still affects scoring but not hard blocking.
 func (s *Store) ProviderAvailable(provider string, policy Policy) (available bool, reason string) {
 	if !providerEnabled(policy, provider) {
-		return false, "provider disabled"
+		return false, quotaReasonProviderDisabled
 	}
 	if !policy.Enabled {
 		return true, ""
@@ -425,18 +425,35 @@ func addEventToProviderSummary(e *UsageEvent, ps *ProviderSummary, session, addC
 	ps.WeeklyReasoningTokens += e.ReasoningTokens
 }
 
+const (
+	quotaReasonRateLimitReached = "provider reports rate limit reached"
+	quotaReasonSessionThreshold = "session limit near threshold"
+	quotaReasonWeeklyThreshold  = "weekly limit near threshold"
+	quotaReasonProviderDisabled = "provider disabled"
+)
+
+// IsSoftThresholdReason reports whether a ProviderAvailable "unavailable" reason
+// is a soft reserve threshold (session/weekly near threshold) rather than a hard
+// block. A soft threshold should only redirect a run to a healthier peer; it
+// must never strand a task on a provider that still has budget when no peer is
+// available. Hard blocks (rate limit actually reached, provider disabled) return
+// false so they keep gating.
+func IsSoftThresholdReason(reason string) bool {
+	return reason == quotaReasonSessionThreshold || reason == quotaReasonWeeklyThreshold
+}
+
 func quotaLimited(ps ProviderSummary, snap Snapshot, policy Policy) (limited bool, reason string) {
 	if ps.Confidence != ConfidenceExact {
 		return false, ""
 	}
 	if strings.TrimSpace(snap.RateLimitReachedType) != "" {
-		return true, "provider reports rate limit reached"
+		return true, quotaReasonRateLimitReached
 	}
 	if ps.SessionUsedPercent > 0 && ps.SessionUsedPercent >= policy.SessionThresholdPercent {
-		return true, "session limit near threshold"
+		return true, quotaReasonSessionThreshold
 	}
 	if ps.WeeklyUsedPercent > 0 && ps.WeeklyUsedPercent >= policy.WeeklyThresholdPercent {
-		return true, "weekly limit near threshold"
+		return true, quotaReasonWeeklyThreshold
 	}
 	return false, ""
 }


### PR DESCRIPTION
## Motivation

Tasks were gating to `human-required` on "weekly limit near threshold" **with usable budget still left** (e.g. 5% remaining). The limit gate (`internal/limits`) marks a provider unavailable once exact usage crosses a soft reserve threshold — default **90% weekly / 85% session**. That reserve exists to trigger *early failover to a healthier peer*, but when there is no peer to fail over to (the other providers are also limited/disabled), the gate stranded the remaining 5–10% of budget and escalated the task instead of spending it.

This is the "use the whole limit of available providers" gap: we already failover at dispatch (#1587), and we now park instead of escalating on a true cap (#1586), but the soft reserve threshold was still hard-blocking the last-resort provider.

> Changelog: fix(agent): spend soft-limited provider budget as last resort instead of escalating

## Implementation information

`resolveProviderDecision` (`internal/agent/manager_run.go`) already tries `ChooseProvider` for a healthier peer when the requested provider is quota-limited. The change is what happens when **no peer is found**: instead of always returning a gated `UnhealthyError`, it now routes through `softLimitLastResort`:

- **Soft reserve threshold** (`session/weekly limit near threshold`, budget remains) → use the requested provider's remaining budget; emit `agent.run.soft_limit_last_resort` (info) for observability.
- **Hard block** (`provider reports rate limit reached`, `provider disabled`) → keep gating with the typed `UnhealthyError`, unchanged.

`internal/limits` gains `IsSoftThresholdReason(reason)` and names the four quota-reason strings as constants so the soft/hard distinction isn't a fragile literal match. Both the failover-enabled and failover-disabled (A/B experiment) branches share the same last-resort helper; an experiment stays pinned to its provider and simply spends the remaining budget rather than switching.

The default 90/85 thresholds are unchanged — they still drive proactive failover and ranking. This only stops them from *stranding* budget when they're the last option. (The thresholds also remain config-tunable via `providers.limits.weekly_threshold_percent` / `session_threshold_percent` for anyone who wants a different reserve.)

## Supporting documentation

Tests:

- `internal/agent`: `TestGateProvider_SoftThresholdLastResortUsesRemainingBudget` (weekly + session, no peer → resolves to the requested provider) and `TestGateProvider_HardLimitStillGatesWithNoPeer` (rate-limit-reached still gates).
- `internal/limits`: `TestIsSoftThresholdReason` truth table.

`go test -race ./internal/agent/... ./internal/limits/...` green; `golangci-lint` clean. Related: #1586 (park on hard cap), #1587 (interactive failover docs/test), #1588 (mid-run hot-swap — separate).
