### PR TITLE
fix(verdict): satisfy codex strict output schema

### DIFF
--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -787,8 +787,8 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) st
 	b.WriteString("- `summary`: one-sentence diagnosis\n")
 	b.WriteString("- `issue_title` (sybra_bug only): \"type(scope): short title\", must follow Sybra conventional commit format (e.g. fix(workflow): ...)\n")
 	b.WriteString("- `issue_body` (sybra_bug only): \"## What happened\\n...\\n\\n## Repro\\n...\\n\\n## Suspected cause\\n...\"\n")
-	b.WriteString("- `issue_labels` (sybra_bug only, optional): array of label strings\n\n")
-	b.WriteString("If decision=human, omit issue_* fields.\n")
+	b.WriteString("- `issue_labels` (sybra_bug only): array of label strings\n\n")
+	b.WriteString("If decision=human, set every issue_* field to null (the schema requires the keys to be present).\n")
 	return b.String()
 }
 

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -36,7 +36,14 @@ const (
 
 // Schema is the JSON Schema passed to --json-schema for verdict-producing
 // headless roles (see agent.RunConfig.OutputSchema).
-const Schema = `{"type":"object","properties":{"decision":{"type":"string","enum":["human","sybra_bug"]},"summary":{"type":"string"},"issue_title":{"type":"string"},"issue_body":{"type":"string"},"issue_labels":{"type":"array","items":{"type":"string"}}},"required":["decision","summary"],"additionalProperties":false}`
+//
+// Codex enforces OpenAI strict structured-output rules: with
+// additionalProperties:false, every key in properties must appear in
+// required. Optional fields (issue_* — populated only for sybra_bug) are
+// therefore modeled as nullable and listed as required; the model emits null
+// for them on a human verdict. Go decodes JSON null into the zero value
+// (empty string / nil slice), so normalize() sees them as absent.
+const Schema = `{"type":"object","properties":{"decision":{"type":"string","enum":["human","sybra_bug"]},"summary":{"type":"string"},"issue_title":{"type":["string","null"]},"issue_body":{"type":["string","null"]},"issue_labels":{"type":["array","null"],"items":{"type":"string"}}},"required":["decision","summary","issue_title","issue_body","issue_labels"],"additionalProperties":false}`
 
 var fenceRe = regexp.MustCompile("(?s)```\\s*sybra-verdict\\s*\\n(.*?)\\n```")
 


### PR DESCRIPTION
## Motivation

Auto-review runs on Codex were failing with a hard `invalid_json_schema` 400:

> 'required' is required to be supplied and to be an array including every key in properties. Missing 'issue_title'.

Codex enforces OpenAI strict structured-output rules: when a schema sets `additionalProperties:false`, every key in `properties` must also appear in `required`. The verdict schema (`internal/verdict`) declared `issue_title`/`issue_body`/`issue_labels` in `properties` but only listed `decision` + `summary` in `required`. Claude tolerates this; Codex rejects it, producing the unparseable-verdict issues.

> Changelog: fix(verdict): satisfy codex strict output schema

## Implementation information

- `internal/verdict/verdict.go` — list all five keys in `required` and model the sybra_bug-only `issue_*` fields as nullable (`["string","null"]` / `["array","null"]`). Go decodes JSON `null` into the zero value, so `normalize()` still treats them as absent — no downstream behaviour change.
- `internal/sybra/app_human_review.go` — the human-review prompt now instructs the model to set every `issue_*` field to `null` on a `human` verdict instead of omitting them, matching the strict schema.

`inspectorVerdictSchema` was checked and already lists every property in `required`, so no other schema needed the fix.

## Supporting documentation

- `go build ./...`, `internal/verdict` + `internal/sybra` tests pass.
- The `fake-codex` schema validator accepts the nullable type unions.