### PR TITLE
fix(git): never force-push; recover via agent

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -40,10 +40,18 @@ var ErrBranchDiverged = errors.New("local branch diverged from remote head")
 var ErrDirtyWorktree = errors.New("worktree has uncommitted changes")
 
 // ErrRemoteAdvanced is returned by PushSync when the live remote branch head no
-// longer matches the remote-tracking ref the push decision was based on. The
-// tracking ref is stale, so a --force-with-lease would clobber commits pushed
-// after the last fetch.
+// longer matches the remote-tracking ref the push decision was based on — the
+// tracking ref is stale, so PushSync cannot even be sure what "diverged" means
+// right now. Always wrapped together with ErrDivergedNeedsResolve.
 var ErrRemoteAdvanced = errors.New("remote branch advanced past tracking ref")
+
+// ErrDivergedNeedsResolve is returned by PushSync when the local branch and
+// its remote tracking branch have diverged (neither is a fast-forward of the
+// other). PushSync never force-pushes to resolve this — a force push rewrites
+// already-published history, which Sybra must never do out-of-band. Callers
+// must instead spawn agent work to reconcile the branches (rebase/merge onto
+// the remote) so a later push can fast-forward.
+var ErrDivergedNeedsResolve = errors.New("branch diverged from remote; needs agent-driven resolution, not a force push")
 
 func runBare(ctx context.Context, barePath string, args ...string) error {
 	return executil.Run(ctx, barePath, "git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
@@ -756,11 +764,11 @@ func worktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
 //   - first push (remote tracking ref absent): regular push with -u
 //   - local SHA == remote tracking SHA: no-op
 //   - remote tracking SHA is an ancestor of local (fast-forward): regular push
-//   - histories diverged: --force-with-lease, but only after confirming the live
-//     remote head still matches the tracking ref (else ErrRemoteAdvanced)
+//   - histories diverged: never force-pushes. Returns ErrDivergedNeedsResolve
+//     (wrapping ErrRemoteAdvanced when the live remote head has moved past the
+//     stale tracking ref) so the caller can spawn agent work to reconcile the
+//     branches instead of rewriting already-published history.
 //
-// Compared to an unconditional force push, this avoids gratuitous rewrites of
-// the remote when a rebase was a no-op or the agent produced no new commits.
 // Returns ErrBranchMissing if the local branch ref does not exist.
 func PushSync(ctx context.Context, worktreePath, branch string) error {
 	if err := executil.Run(ctx, worktreePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
@@ -792,21 +800,18 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 		return executil.Run(ctx, worktreePath, "git", "push", "-u", remote, branch)
 	}
 
-	// Divergence path: about to force-push. Verify the live remote head still
-	// matches the tracking ref this decision was based on. If it advanced since
-	// the last fetch, --force-with-lease would pass against the stale tracking
-	// ref and clobber the newer commits — refuse instead. Fail closed if the
-	// live head can't even be verified, rather than proceeding with a force
-	// push against an unconfirmed remote state.
+	// Divergence path: never force-push. Check the live remote head purely to
+	// give a precise error — either outcome means the branch needs
+	// agent-driven resolution (rebase/merge onto the remote), never a rewrite.
 	liveSHA, err := remoteBranchHead(ctx, worktreePath, remote, branch)
 	if err != nil {
-		return fmt.Errorf("%w: could not verify live remote head before force push: %w", ErrRemoteAdvanced, err)
+		return fmt.Errorf("%w: %w: could not verify live remote head before push: %w", ErrDivergedNeedsResolve, ErrRemoteAdvanced, err)
 	}
 	if liveSHA != "" && liveSHA != remoteSHA {
-		return fmt.Errorf("%w: tracking %s but remote %s/%s is at %s", ErrRemoteAdvanced, remoteSHA[:min(7, len(remoteSHA))], remote, branch, liveSHA[:min(7, len(liveSHA))])
+		return fmt.Errorf("%w: %w: tracking %s but remote %s/%s is at %s", ErrDivergedNeedsResolve, ErrRemoteAdvanced, remoteSHA[:min(7, len(remoteSHA))], remote, branch, liveSHA[:min(7, len(liveSHA))])
 	}
 
-	return executil.Run(ctx, worktreePath, "git", "push", "--force-with-lease", "-u", remote, branch)
+	return fmt.Errorf("%w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
 }
 
 // RemoveWorktree deletes worktreePath and its `git worktree` registration

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1650,7 +1650,11 @@ func TestPushSync_FastForwardWithoutForce(t *testing.T) {
 	}
 }
 
-func TestPushSync_DivergenceForcePushes(t *testing.T) {
+// TestPushSync_DivergenceReturnsErrorNoForce guards the core "never
+// force-push" property: on a genuinely diverged branch, PushSync must refuse
+// to push (returning ErrDivergedNeedsResolve) rather than force-with-lease
+// over remote-only commits.
+func TestPushSync_DivergenceReturnsErrorNoForce(t *testing.T) {
 	t.Parallel()
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
@@ -1658,25 +1662,28 @@ func TestPushSync_DivergenceForcePushes(t *testing.T) {
 	if err := PushSync(context.Background(), wtPath, branch); err != nil {
 		t.Fatalf("PushSync seed: %v", err)
 	}
+	beforeSHA := remoteRefSHA(t, remoteBare, branch)
 
 	// Rewrite history locally so HEAD diverges from the remote tracking ref.
 	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", "HEAD~1").CombinedOutput(); err != nil {
 		t.Fatalf("reset: %v: %s", err, out)
 	}
-	divergedSHA := makeCommit(t, wtPath, "two-prime")
+	makeCommit(t, wtPath, "two-prime")
 
-	// Prove a regular push would now be rejected — only force-with-lease should succeed.
+	// Prove a regular push would now be rejected — confirms this is a genuine
+	// divergence, not a fast-forward PushSync mis-detected as one.
 	rejectCmd := exec.Command("git", "push", "origin", branch)
 	rejectCmd.Dir = wtPath
 	if out, err := rejectCmd.CombinedOutput(); err == nil {
 		t.Fatalf("expected regular push to be rejected on divergence; succeeded: %s", out)
 	}
 
-	if err := PushSync(context.Background(), wtPath, branch); err != nil {
-		t.Fatalf("PushSync divergence: %v", err)
+	err := PushSync(context.Background(), wtPath, branch)
+	if !errors.Is(err, ErrDivergedNeedsResolve) {
+		t.Fatalf("PushSync divergence = %v, want ErrDivergedNeedsResolve", err)
 	}
-	if got := remoteRefSHA(t, remoteBare, branch); got != divergedSHA {
-		t.Fatalf("remote SHA after force-with-lease = %q, want %q", got, divergedSHA)
+	if got := remoteRefSHA(t, remoteBare, branch); got != beforeSHA {
+		t.Fatalf("remote SHA = %q, want untouched %q (PushSync must never force-push)", got, beforeSHA)
 	}
 }
 
@@ -1919,8 +1926,8 @@ func TestMergeOnto_ConflictReturnsErrorAndCleansUp(t *testing.T) {
 
 // TestPushSync_RefusesForceWhenRemoteAdvanced is the defense-in-depth net: when
 // the live remote head no longer matches the stale tracking ref the push
-// decision was based on, PushSync must refuse the --force-with-lease rather than
-// clobber the newer commits (which the lease would wrongly permit).
+// decision was based on, PushSync must refuse to push at all rather than
+// clobber the newer commits with a force push.
 func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 	t.Parallel()
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
@@ -1944,6 +1951,9 @@ func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 	if !errors.Is(err, ErrRemoteAdvanced) {
 		t.Fatalf("PushSync = %v, want ErrRemoteAdvanced", err)
 	}
+	if !errors.Is(err, ErrDivergedNeedsResolve) {
+		t.Fatalf("PushSync = %v, want ErrDivergedNeedsResolve", err)
+	}
 	// The remote fix must survive untouched.
 	if got := remoteRefSHA(t, remoteBare, branch); got != advancedSHA {
 		t.Fatalf("remote SHA = %q, want untouched fix %q", got, advancedSHA)
@@ -1951,8 +1961,8 @@ func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 }
 
 // TestPushSync_FailsClosedWhenRemoteHeadUnverifiable guards the fail-closed
-// fix: if the live remote head can't be verified before a force push, PushSync
-// must refuse rather than proceed with --force-with-lease against unconfirmed
+// fix: if the live remote head can't be verified before a push, PushSync
+// must refuse rather than proceed with a force push against unconfirmed
 // remote state.
 func TestPushSync_FailsClosedWhenRemoteHeadUnverifiable(t *testing.T) {
 	t.Parallel()
@@ -1979,6 +1989,9 @@ func TestPushSync_FailsClosedWhenRemoteHeadUnverifiable(t *testing.T) {
 	err := PushSync(context.Background(), wtPath, branch)
 	if !errors.Is(err, ErrRemoteAdvanced) {
 		t.Fatalf("PushSync = %v, want ErrRemoteAdvanced (fail closed)", err)
+	}
+	if !errors.Is(err, ErrDivergedNeedsResolve) {
+		t.Fatalf("PushSync = %v, want ErrDivergedNeedsResolve (fail closed)", err)
 	}
 	if got := remoteRefSHA(t, remoteBare, branch); got != beforeSHA {
 		t.Fatalf("remote SHA = %q, want untouched %q", got, beforeSHA)

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -52,6 +52,9 @@ func (a *App) newAgentCompletionHandler(emit func(string, any)) *AgentCompletion
 		humanReview:    a.humanReview,
 		prTracker:      a.prTracker,
 		cfg:            a.cfg,
+		// a.reviewer.RecoverStaleBranchConflict is nil-receiver-safe (see its
+		// own guard), same pattern as agentOrch.SetConflictRecovery.
+		conflictRecovery: a.reviewer.RecoverStaleBranchConflict,
 	}
 }
 
@@ -77,6 +80,14 @@ type AgentCompletionHandler struct {
 	humanReview    *humanReviewHandler
 	prTracker      *github.IssueTracker
 	cfg            *config.Config
+
+	// conflictRecovery dispatches the autonomous conflict-fix agent for a
+	// task (review.Handler.RecoverStaleBranchConflict) — reused here so a
+	// fix-review push that hits project.ErrDivergedNeedsResolve resolves via
+	// an agent-driven merge+push (a real tool call, interceptable by hooks)
+	// rather than Sybra's own process force-pushing. May be nil (degraded
+	// init / tests): callers must treat that like "no recovery available".
+	conflictRecovery func(taskID string) bool
 }
 
 // OnComplete is called by the manager's construction-time completion callback.
@@ -398,10 +409,37 @@ func (h *AgentCompletionHandler) pushFixReviewBranch(ag *agent.Agent) {
 			h.logger.Info("fix-review.push-skipped", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch, "reason", "local branch ref missing")
 			return
 		}
+		if errors.Is(err, project.ErrDivergedNeedsResolve) {
+			h.recoverDivergedFixReviewPush(ag, branch, err)
+			return
+		}
 		h.logger.Warn("fix-review.push", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch, "err", err)
 		return
 	}
 	h.logger.Info("fix-review.pushed", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch)
+}
+
+// recoverDivergedFixReviewPush handles a fix-review push backstop that hit
+// project.ErrDivergedNeedsResolve: Sybra's own process must never force-push
+// (see project.PushSync's doc), so the fix sitting in the worktree is handed
+// to the autonomous conflict-fix agent instead — it merges the branch cleanly
+// and pushes as its own tool call, which unlike this Go process's shell-out
+// is interceptable by hooks. Escalates to human-required when no recovery
+// callback is wired or it declines (e.g. retry budget spent), so the fix is
+// never silently stranded on local disk.
+func (h *AgentCompletionHandler) recoverDivergedFixReviewPush(ag *agent.Agent, branch string, pushErr error) {
+	if h.conflictRecovery != nil && h.conflictRecovery(ag.TaskID) {
+		h.logger.Info("fix-review.push-diverged.recovered", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch)
+		return
+	}
+	h.logger.Warn("fix-review.push-diverged", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch, "err", pushErr)
+	reason := "fix-review: branch diverged from remote and needs manual rebase/merge before the fix can be pushed"
+	if _, err := h.tasks.Update(ag.TaskID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(reason),
+	}); err != nil {
+		h.logger.Error("fix-review.push-diverged.human-required", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
+	}
 }
 
 // captureHeadSHA returns the worktree HEAD commit for the task, or "" when the

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -245,7 +245,7 @@ func TestOnAgentComplete_EmptyTaskID_NoCrash(t *testing.T) {
 	}
 }
 
-func setupFixReviewPushTest(t *testing.T) (*AgentCompletionHandler, *task.Manager, string) {
+func setupFixReviewPushTest(t *testing.T) (h *AgentCompletionHandler, taskMgr *task.Manager, barePath, src string) {
 	t.Helper()
 	home, err := os.MkdirTemp("", "sybra-fix-review-*")
 	if err != nil {
@@ -258,15 +258,15 @@ func setupFixReviewPushTest(t *testing.T) (*AgentCompletionHandler, *task.Manage
 	if err != nil {
 		t.Fatal(err)
 	}
-	taskMgr := task.NewManager(taskStore, nil)
+	taskMgr = task.NewManager(taskStore, nil)
 
 	projStore, err := project.NewStore(filepath.Join(home, "projects"), filepath.Join(home, "clones"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	src := initFixReviewSourceRepo(t)
-	barePath := filepath.Join(home, "clones", "testowner", "testrepo.git")
+	src = initFixReviewSourceRepo(t)
+	barePath = filepath.Join(home, "clones", "testowner", "testrepo.git")
 	if err := os.MkdirAll(filepath.Dir(barePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -300,12 +300,12 @@ updated_at: 2025-01-01T00:00:00Z
 		},
 	})
 
-	h := &AgentCompletionHandler{
+	h = &AgentCompletionHandler{
 		DomainHandler: DomainHandler{logger: logger},
 		tasks:         taskMgr,
 		worktrees:     wm,
 	}
-	return h, taskMgr, barePath
+	return h, taskMgr, barePath, src
 }
 
 func initFixReviewSourceRepo(t *testing.T) string {
@@ -339,7 +339,7 @@ func initFixReviewSourceRepo(t *testing.T) string {
 }
 
 func TestOnAgentComplete_FixReviewPushesBranch(t *testing.T) {
-	h, taskMgr, barePath := setupFixReviewPushTest(t)
+	h, taskMgr, barePath, _ := setupFixReviewPushTest(t)
 	branch, err := project.DefaultBranch(context.Background(), barePath)
 	if err != nil {
 		t.Fatalf("default branch: %v", err)
@@ -421,7 +421,7 @@ func TestOnAgentComplete_FixReviewPushesBranch(t *testing.T) {
 // path (which never touches status). The push decision is owned by the agent per
 // the configured mode, so Sybra runs no force-push here.
 func TestOnAgentComplete_FixReviewHoldParksForHuman(t *testing.T) {
-	h, taskMgr, _ := setupFixReviewPushTest(t)
+	h, taskMgr, _, _ := setupFixReviewPushTest(t)
 	h.cfg = &config.Config{ReviewHold: config.ReviewHoldConfig{
 		Enabled: true, Mode: config.ReviewHoldModeHold,
 	}}
@@ -469,6 +469,150 @@ func TestOnAgentComplete_FixReviewHoldParksForHuman(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+
+	h.OnComplete(&agent.Agent{
+		ID:        "agent-1",
+		TaskID:    tk.ID,
+		Mode:      "headless",
+		Name:      agent.RoleFixReview.AgentName(tk.Title),
+		StartedAt: time.Now(),
+	})
+
+	got, err := taskMgr.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+}
+
+// setupDivergedFixReviewPush prepares a fix-review worktree whose branch has
+// genuinely diverged from its remote tracking ref (neither is an ancestor of
+// the other) — the exact condition project.PushSync now refuses to force
+// through. Mirrors internal/project's own PushSync divergence tests: seed a
+// push, then rewrite local history so it no longer contains the tracking
+// ref's tip.
+func setupDivergedFixReviewPush(t *testing.T) (h *AgentCompletionHandler, taskMgr *task.Manager, tk task.Task) {
+	t.Helper()
+	h, taskMgr, barePath, src := setupFixReviewPushTest(t)
+	branch, err := project.DefaultBranch(context.Background(), barePath)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	// src has its default branch checked out; without this, any push to it
+	// (the seed push below and the fix-review push under test) is rejected
+	// with "refusing to update checked out branch" regardless of divergence.
+	if out, err := exec.Command("git", "-C", src, "config", "receive.denyCurrentBranch", "updateInstead").CombinedOutput(); err != nil {
+		t.Fatalf("config denyCurrentBranch: %v: %s", err, out)
+	}
+
+	tk, err = taskMgr.Create("fix pr", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk, err = taskMgr.Update(tk.ID, task.Update{
+		ProjectID: task.Ptr("testowner/testrepo"),
+		PRNumber:  task.Ptr(42),
+		Status:    task.Ptr(task.StatusInReview),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.worktrees.PrepareForFix(context.Background(), tk, 42)
+	if err != nil {
+		t.Fatalf("PrepareForFix: %v", err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "config", "user.email", "test@test.com"},
+		{"-C", wtPath, "config", "user.name", "Test"},
+		{"-C", wtPath, "config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	gitCommit := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"-C", wtPath, "add", "."},
+			{"-C", wtPath, "commit", "-m", "fix(review): " + content},
+		} {
+			if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v: %s", args, err, out)
+			}
+		}
+	}
+	gitCommit("one")
+	if err := project.PushSync(context.Background(), wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Rewrite history locally so HEAD diverges from the remote tracking ref
+	// PushSync compares against — same technique as
+	// TestPushSync_DivergenceReturnsErrorNoForce in internal/project.
+	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", "HEAD~1").CombinedOutput(); err != nil {
+		t.Fatalf("reset: %v: %s", err, out)
+	}
+	gitCommit("two-prime")
+
+	if err := taskMgr.AddRun(tk.ID, task.AgentRun{
+		AgentID:   "agent-1",
+		Role:      string(agent.RoleFixReview),
+		Mode:      "headless",
+		State:     string(agent.StateRunning),
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return h, taskMgr, tk
+}
+
+// TestOnAgentComplete_FixReviewPushDivergedRecoversViaAgent proves the core
+// "never force-push" fix for the fix-review backstop: when the push hits a
+// genuine divergence, Sybra must not force through it and must not strand the
+// fix — it hands off to the wired conflict-recovery callback (the same
+// autonomous agent-driven merge+push used elsewhere) instead.
+func TestOnAgentComplete_FixReviewPushDivergedRecoversViaAgent(t *testing.T) {
+	h, taskMgr, tk := setupDivergedFixReviewPush(t)
+	var recoveredTaskID string
+	h.conflictRecovery = func(taskID string) bool {
+		recoveredTaskID = taskID
+		return true
+	}
+
+	h.OnComplete(&agent.Agent{
+		ID:        "agent-1",
+		TaskID:    tk.ID,
+		Mode:      "headless",
+		Name:      agent.RoleFixReview.AgentName(tk.Title),
+		StartedAt: time.Now(),
+	})
+
+	if recoveredTaskID != tk.ID {
+		t.Fatalf("conflictRecovery called with task %q, want %q", recoveredTaskID, tk.ID)
+	}
+	got, err := taskMgr.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == task.StatusHumanRequired {
+		t.Fatalf("status = %q, want unchanged (recovery handled it, not human-required)", got.Status)
+	}
+}
+
+// TestOnAgentComplete_FixReviewPushDivergedEscalatesToHuman guards the other
+// half: when there is no recovery path (nil callback) or it declines, the
+// diverged fix must not be silently dropped — the task escalates to
+// human-required rather than leaving the fix stranded with no signal.
+func TestOnAgentComplete_FixReviewPushDivergedEscalatesToHuman(t *testing.T) {
+	h, taskMgr, tk := setupDivergedFixReviewPush(t)
+	h.conflictRecovery = func(string) bool { return false }
 
 	h.OnComplete(&agent.Agent{
 		ID:        "agent-1",

--- a/internal/workflow/builtin/simple-task-pr.yaml
+++ b/internal/workflow/builtin/simple-task-pr.yaml
@@ -55,8 +55,15 @@ steps:
              FORK_URL="$(git config --get remote.fork.url 2>/dev/null || true)"
              if [ -n "$FORK_URL" ] && echo "$FORK_URL" | grep -qF "$PR_HEAD"; then PUSH_REMOTE="fork"; fi
           2. Push: git push "$PUSH_REMOTE" HEAD:"$BRANCH"
-             If rejected due to divergence, force-push:
-             git push --force-with-lease "$PUSH_REMOTE" HEAD:"$BRANCH"
+             Never force-push. If rejected due to divergence, resolve it
+             properly instead:
+             git fetch "$PUSH_REMOTE" "$BRANCH"
+             git rebase "$PUSH_REMOTE/$BRANCH"
+             If the rebase reports conflicts, run `git rebase --abort` and stop
+             — report the task as blocked on manual conflict resolution. Do
+             not force-push under any circumstances.
+             Otherwise, after a clean rebase, push again:
+             git push "$PUSH_REMOTE" HEAD:"$BRANCH"
           3. Verify the remote PR head matches local HEAD:
              LOCAL_SHA="$(git rev-parse HEAD)"
              PR_SHA="$(gh pr view {{.Task.PRNumber}} --json headRefOid --jq .headRefOid)"
@@ -94,9 +101,15 @@ steps:
              If a PR number is returned, skip creation — the PR already exists.
           3. If no PR exists, push the branch and create one:
              git push -u "$PUSH_REMOTE" HEAD:"$BRANCH"
-             If push is rejected because the remote has diverged (e.g. after a
-             rebase), force-push without asking for confirmation:
-             git push --force-with-lease -u "$PUSH_REMOTE" HEAD:"$BRANCH"
+             Never force-push. If the push is rejected because the remote has
+             diverged, resolve it properly instead:
+             git fetch "$PUSH_REMOTE" "$BRANCH"
+             git rebase "$PUSH_REMOTE/$BRANCH"
+             If the rebase reports conflicts, run `git rebase --abort` and stop
+             — report the task as blocked on manual conflict resolution. Do
+             not force-push under any circumstances.
+             Otherwise, after a clean rebase, push again:
+             git push -u "$PUSH_REMOTE" HEAD:"$BRANCH"
              gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}} \
                --head "$HEAD_ARG" \
                --title "<conventional-commit title>" \

--- a/internal/workflow/builtin/simple-task-pr.yaml
+++ b/internal/workflow/builtin/simple-task-pr.yaml
@@ -60,8 +60,8 @@ steps:
              git fetch "$PUSH_REMOTE" "$BRANCH"
              git rebase "$PUSH_REMOTE/$BRANCH"
              If the rebase reports conflicts, run `git rebase --abort` and stop
-             — report the task as blocked on manual conflict resolution. Do
-             not force-push under any circumstances.
+             — report the task as human-required for manual conflict
+             resolution. Do not force-push under any circumstances.
              Otherwise, after a clean rebase, push again:
              git push "$PUSH_REMOTE" HEAD:"$BRANCH"
           3. Verify the remote PR head matches local HEAD:
@@ -106,8 +106,8 @@ steps:
              git fetch "$PUSH_REMOTE" "$BRANCH"
              git rebase "$PUSH_REMOTE/$BRANCH"
              If the rebase reports conflicts, run `git rebase --abort` and stop
-             — report the task as blocked on manual conflict resolution. Do
-             not force-push under any circumstances.
+             — report the task as human-required for manual conflict
+             resolution. Do not force-push under any circumstances.
              Otherwise, after a clean rebase, push again:
              git push -u "$PUSH_REMOTE" HEAD:"$BRANCH"
              gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}} \

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -614,6 +614,37 @@ func TestBuiltinPRFix_RoutesAgentHumanRequiredBeforePRRelink(t *testing.T) {
 	}
 }
 
+// TestBuiltinDefinitions_NeverInstructForcePush is the repo-wide acceptance
+// probe for the "never force-push" invariant: no builtin workflow prompt may
+// instruct an agent to force-push, under any spelling. Sybra's own process
+// (project.PushSync) already refuses to force-push and instead returns
+// ErrDivergedNeedsResolve for agent-driven recovery — this test guards the
+// other force-push surface, the prompts Sybra authors for agents, so a new
+// builtin workflow can't reintroduce a force-push instruction unnoticed.
+func TestBuiltinDefinitions_NeverInstructForcePush(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	// Match actual command flags, not advisory prose like "Never force-push".
+	forbidden := []string{"--force-with-lease", "--force"}
+	for _, def := range defs {
+		for _, step := range def.Steps {
+			prompt := step.Config.Prompt
+			if prompt == "" {
+				continue
+			}
+			for _, term := range forbidden {
+				if strings.Contains(prompt, term) {
+					t.Fatalf("builtin %q step %q prompt instructs force-push (contains %q):\n%s", def.ID, step.ID, term, prompt)
+				}
+			}
+		}
+	}
+}
+
 func TestBuiltinSimpleTaskReview_CreatePRUsesForkRemote(t *testing.T) {
 	t.Parallel()
 	defs, err := BuiltinDefinitions()

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -628,17 +628,24 @@ func TestBuiltinDefinitions_NeverInstructForcePush(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuiltinDefinitions: %v", err)
 	}
-	// Match actual command flags, not advisory prose like "Never force-push".
-	forbidden := []string{"--force-with-lease", "--force"}
+	// Match actual git-push instructions, not advisory prose like
+	// "Never force-push" or unrelated commands that may legitimately use
+	// a --force flag.
+	forbidden := []string{"--force-with-lease", "--force", " -f", "\t-f", "`-f`"}
 	for _, def := range defs {
 		for _, step := range def.Steps {
 			prompt := step.Config.Prompt
 			if prompt == "" {
 				continue
 			}
-			for _, term := range forbidden {
-				if strings.Contains(prompt, term) {
-					t.Fatalf("builtin %q step %q prompt instructs force-push (contains %q):\n%s", def.ID, step.ID, term, prompt)
+			for line := range strings.Lines(prompt) {
+				if !strings.Contains(line, "git push") {
+					continue
+				}
+				for _, term := range forbidden {
+					if strings.Contains(line, term) {
+						t.Fatalf("builtin %q step %q prompt instructs force-push (contains %q):\n%s", def.ID, step.ID, term, prompt)
+					}
 				}
 			}
 		}

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -213,7 +213,10 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 			m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
 			// Sync remote after rebase. PushSync picks the minimum mode —
 			// no-op when local matches remote, regular push for
-			// fast-forward, --force-with-lease only on divergence.
+			// fast-forward. On divergence it returns ErrDivergedNeedsResolve
+			// instead of force-pushing; callers here only log it (see
+			// logPushSync) since the follow-up rebase/reconcile already
+			// resolved genuine divergence before this call.
 			callPhase(onPhase, "Syncing upstream…")
 			m.logPushSync(t.ID, wtBranch, project.PushSync(ctx, wtPath, wtBranch))
 			return m.finalizeWorktree(ctx, t, wtPath, wtBranch, proj)

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -215,8 +215,9 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 			// no-op when local matches remote, regular push for
 			// fast-forward. On divergence it returns ErrDivergedNeedsResolve
 			// instead of force-pushing; callers here only log it (see
-			// logPushSync) since the follow-up rebase/reconcile already
-			// resolved genuine divergence before this call.
+			// logPushSync) because this is best-effort cleanup after the
+			// main reconcile/rebase path and the remote may have advanced
+			// again since that earlier fetch.
 			callPhase(onPhase, "Syncing upstream…")
 			m.logPushSync(t.ID, wtBranch, project.PushSync(ctx, wtPath, wtBranch))
 			return m.finalizeWorktree(ctx, t, wtPath, wtBranch, proj)


### PR DESCRIPTION
## Motivation

PushSync's divergence path force-pushed directly from Sybra's own process, bypassing the PreToolUse hooks that would otherwise gate a force push. A rebase/merge no-op or a bad agent run could silently rewrite already-published history on the remote branch.

## Implementation information

- `PushSync` no longer force-pushes on divergence; it returns `ErrDivergedNeedsResolve` (wrapping `ErrRemoteAdvanced` when the live remote head has moved past the stale tracking ref) instead.
- The fix-review push backstop — the only caller that could silently strand work on divergence — now hands off to the conflict-recovery agent (a real, hook-governed tool call) and escalates to `human-required` if the agent declines.
- Updated `internal/project/git_test.go` and `internal/sybra/app_test.go` to assert the new refuse-and-recover behavior instead of the old force-with-lease behavior.

Closes https://github.com/Automaat/sybra/issues/1590

_Generated by Sybra harness_