### PR TITLE
fix(agent): failover Claude sessions mid-run on provider health

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -498,6 +498,17 @@ func (a *Agent) PendingPromptCount() int {
 	return len(a.convo.pendingPrompts)
 }
 
+// RestorePendingPrompt pushes text back onto the front of the pending queue.
+// Used by the turn-boundary chokepoint (advanceClaudeTurn) to put a
+// just-reserved prompt back where it came from when the turn cannot proceed
+// (no healthy peer, write failure, cancellation), so it is retried in order
+// rather than lost or reordered behind prompts queued afterward.
+func (a *Agent) RestorePendingPrompt(text string) {
+	a.mu.Lock()
+	a.convo.pendingPrompts = append([]string{text}, a.convo.pendingPrompts...)
+	a.mu.Unlock()
+}
+
 // IncTurnCount increments the turn counter and returns the new value.
 func (a *Agent) IncTurnCount() int {
 	a.mu.Lock()

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -153,9 +153,45 @@ type Agent struct {
 	// observed during the run. Flushed to audit in OnComplete.
 	permissionDenials []PermissionDenial
 
+	// handoff is set by SendMessage/regateBeforeClaudeTurn when a persistent
+	// Claude interactive agent's provider is switched at a turn boundary. The
+	// still-idle Claude process is torn down (closeStdinPipe/signalKill); once
+	// runConversational's goroutine observes the process actually exit, it
+	// consumes this instead of finalizing, and hands the same *Agent off to
+	// runPerTurnConversational on the new provider.
+	handoff *pendingConvoHandoff
+
 	// mu guards mutable fields touched from multiple goroutines. See the
 	// package-level note above the Agent type.
 	mu sync.RWMutex
+}
+
+// pendingConvoHandoff carries the RunConfig and next prompt for a mid-run
+// persistent-Claude -> per-turn provider switch. See Agent.handoff.
+type pendingConvoHandoff struct {
+	cfg    RunConfig
+	prompt string
+}
+
+// SetPendingHandoff records a same-agent provider switch to be picked up by
+// runConversational's finalize path once its (now-doomed) process exits.
+func (a *Agent) SetPendingHandoff(cfg RunConfig, prompt string) {
+	a.mu.Lock()
+	a.handoff = &pendingConvoHandoff{cfg: cfg, prompt: prompt}
+	a.mu.Unlock()
+}
+
+// ConsumePendingHandoff returns and clears any pending handoff recorded by
+// SetPendingHandoff.
+func (a *Agent) ConsumePendingHandoff() (RunConfig, string, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.handoff == nil {
+		return RunConfig{}, "", false
+	}
+	h := a.handoff
+	a.handoff = nil
+	return h.cfg, h.prompt, true
 }
 
 // toRecord snapshots only the fields persisted for restart survival.

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -336,6 +336,28 @@ func (a *Agent) GetSessionID() string {
 	return a.SessionID
 }
 
+// SetProviderAndModel updates the agent's provider and (already-normalized)
+// model. Used when a mid-run per-turn provider re-gate fails the agent's
+// current provider over to a healthy peer; Provider/Model are otherwise fixed
+// for the lifetime of the agent (set once at construction).
+func (a *Agent) SetProviderAndModel(prov, model string) {
+	a.mu.Lock()
+	a.Provider = prov
+	a.Model = model
+	a.mu.Unlock()
+}
+
+// GetProvider returns the agent's current provider name. Safe to call
+// concurrently with a mid-run SetProviderAndModel switch; code within the
+// single-threaded runner loop (which owns all writes) may keep reading
+// a.Provider directly since it's the same goroutine, but any external
+// reader must go through this to avoid racing the switch.
+func (a *Agent) GetProvider() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.Provider
+}
+
 // SetSessionFilePath records the path to the provider session file.
 func (a *Agent) SetSessionFilePath(p string) {
 	a.mu.Lock()

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -263,6 +263,15 @@ func convoResumeState(evs []ConvoEvent) State {
 // rehydrate its chat from the log, and restart the loop in resume-wait mode
 // (waiting for the next prompt). Liveness is not checked — the agent is
 // recreated regardless. Returns nil only on a duplicate.
+//
+// r.Provider is authoritative even when a mid-run regateForTurn switch
+// happened before the restart: regateForTurn persists the switched provider
+// (and clears the old session id) via saveRegistry, so the record already
+// reflects the peer the agent moved to, not the one it started on. The next
+// prompt is dispatched via runPerTurnConversational(..., RunConfig{Dir:...},
+// true), whose regate call reads the live current provider from a.Provider —
+// not from this (mostly empty) RunConfig — so a stale/zero-value cfg.Provider
+// here can never resurrect the pre-switch provider.
 func (m *Manager) reattachPerTurnConvo(r Record, reg survivalRegistry) *Agent {
 	// Per-turn recreate is unconditional (no live process to gate on), so guard
 	// against resurrecting an agent for a task that was deleted while the app

--- a/internal/agent/regate.go
+++ b/internal/agent/regate.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
 	"maps"
 )
 
@@ -27,7 +28,13 @@ import (
 // set to "rate_limit" so the existing isRateLimitedRun /
 // RescheduleRateLimitedAgent reschedule-and-park behavior stays reachable,
 // exactly as it would for an in-flight run that hit the same cap.
-func (m *Manager) regateForTurn(ctx context.Context, a *Agent, cfg RunConfig) (RunConfig, bool, error) {
+//
+// logWriter, if non-nil, receives the convoProviderMarker line for a switch
+// before the registry is persisted (saveRegistry below) — writing the
+// marker first closes the crash window where a restart between a persisted
+// switch and a not-yet-written marker would make rehydratePerTurnConvoFromLog
+// parse the entire pre-switch segment under the new provider's schema.
+func (m *Manager) regateForTurn(ctx context.Context, a *Agent, cfg RunConfig, logWriter io.Writer) (RunConfig, bool, error) {
 	current := a.Provider
 
 	m.mu.RLock()
@@ -106,6 +113,11 @@ func (m *Manager) regateForTurn(ctx context.Context, a *Agent, cfg RunConfig) (R
 
 	cfg.Provider = alt
 	cfg.provider = altProv
+
+	// Marker must land before the registry write below: on a crash between
+	// the two, rehydration must find a marker for every persisted provider
+	// change, never a persisted provider with an unmarked log segment.
+	writeProviderMarkerLine(logWriter, alt)
 
 	if m.survives() {
 		m.saveRegistry(ctx, a)

--- a/internal/agent/regate.go
+++ b/internal/agent/regate.go
@@ -1,0 +1,139 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"maps"
+)
+
+// regateForTurn re-consults provider health/limit gating for a per-turn
+// conversational agent (codex/copilot) immediately before it starts a new
+// turn's process. Dispatch-time gating (prepareRunConfig/gateProvider) only
+// runs once, at Run(); a provider that caps mid-conversation would otherwise
+// strand the agent on a dead provider for the rest of the chat. This is the
+// per-turn analogue, called from runPerTurnConversational before every turn.
+//
+// It differs from gateProvider in two ways required by an already-running
+// agent: it is self-count-aware (the agent's own turn already occupies a
+// slot in its current provider's live bucket, so that bucket must not judge
+// itself "at cap"), and candidate providers are restricted to ones where
+// Provider.UsesPerTurnConvo() is true — persistent Claude is never a valid
+// hot-swap target for this runner.
+//
+// Returns the (possibly updated) RunConfig, whether a provider switch
+// occurred, and a non-nil error only when the current provider is unhealthy
+// and no per-turn-capable peer is usable. On that error path cfg is returned
+// unmodified and the caller must not spawn a turn; the agent's error kind is
+// set to "rate_limit" so the existing isRateLimitedRun /
+// RescheduleRateLimitedAgent reschedule-and-park behavior stays reachable,
+// exactly as it would for an in-flight run that hit the same cap.
+func (m *Manager) regateForTurn(ctx context.Context, a *Agent, cfg RunConfig) (RunConfig, bool, error) {
+	current := a.Provider
+
+	m.mu.RLock()
+	g := m.gate
+	lg := m.limitGate
+	lp := m.limitPolicy
+	maxInFlight := m.maxInFlightPerProvider
+	live := maps.Clone(m.liveByProvider)
+	m.mu.RUnlock()
+
+	// Self-count-aware: this agent's own in-flight turn already occupies one
+	// slot in current's live bucket. Exclude it so a healthy current provider
+	// is never wrongly judged "at cap" by itself.
+	if live[current] > 0 {
+		live[current]--
+	}
+
+	underCap := func(p string) bool {
+		return maxInFlight <= 0 || live[p] < maxInFlight
+	}
+	perTurnCapable := func(p string) bool {
+		prov, err := lookupProvider(p)
+		return err == nil && prov.UsesPerTurnConvo()
+	}
+	limitAvailable := func(p string) bool {
+		if lg == nil {
+			return true
+		}
+		ok, _ := lg.ProviderAvailable(p, lp)
+		return ok
+	}
+	healthy := func(p string) bool {
+		return perTurnCapable(p) && (g == nil || g.IsHealthy(p)) && underCap(p) && limitAvailable(p)
+	}
+
+	if healthy(current) {
+		return cfg, false, nil
+	}
+
+	candidateProviders := []string{"claude", "codex", "copilot"}
+	alt := firstHealthyProvider(current, candidateProviders, healthy)
+	if alt == "" && lg != nil {
+		if chosen, _ := lg.ChooseProvider(current, candidateProviders, healthy, lp); chosen != "" {
+			alt = chosen
+		}
+	}
+	if alt == "" {
+		reason := "no healthy per-turn-capable provider peer available"
+		switch {
+		case g != nil && !g.IsHealthy(current):
+			reason = g.Reason(current)
+		case lg != nil:
+			if ok, r := lg.ProviderAvailable(current, lp); !ok && r != "" {
+				reason = r
+			}
+		}
+		a.SetError("rate_limit", reason)
+		return cfg, false, fmt.Errorf("agent regate: %s capped, no per-turn-capable peer available: %s", current, reason)
+	}
+
+	altProv, err := lookupProvider(alt)
+	if err != nil {
+		return cfg, false, err
+	}
+	newModel := altProv.NormalizeModel(cfg.Model)
+
+	m.logger.Warn("agent.convo.failover", "id", a.ID, "task", cfg.TaskID, "from", current, "to", alt)
+
+	// Native --resume/--session-id is provider-specific: a peer cannot
+	// continue the old provider's session, so start it fresh rather than
+	// attempting a cross-provider resume.
+	a.SetProviderAndModel(alt, newModel)
+	a.SetSessionID("")
+	a.SetSessionFilePath("")
+	m.moveLiveProviderCount(current, alt)
+
+	cfg.Provider = alt
+	cfg.provider = altProv
+
+	if m.survives() {
+		m.saveRegistry(ctx, a)
+	}
+
+	return cfg, true, nil
+}
+
+// moveLiveProviderCount migrates one live-agent count from oldProv to
+// newProv after a mid-run provider switch, preserving the
+// sum(liveByProvider) == liveCount invariant maintained elsewhere by
+// registerRunningAgent/markAgentDone/the reattach paths.
+func (m *Manager) moveLiveProviderCount(oldProv, newProv string) {
+	if oldProv == newProv {
+		return
+	}
+	m.mu.Lock()
+	if oldProv != "" {
+		if v, ok := m.liveByProvider[oldProv]; ok {
+			if v <= 1 {
+				delete(m.liveByProvider, oldProv)
+			} else {
+				m.liveByProvider[oldProv] = v - 1
+			}
+		}
+	}
+	if newProv != "" {
+		m.liveByProvider[newProv]++
+	}
+	m.mu.Unlock()
+}

--- a/internal/agent/regate.go
+++ b/internal/agent/regate.go
@@ -35,7 +35,40 @@ import (
 // switch and a not-yet-written marker would make rehydratePerTurnConvoFromLog
 // parse the entire pre-switch segment under the new provider's schema.
 func (m *Manager) regateForTurn(ctx context.Context, a *Agent, cfg RunConfig, logWriter io.Writer) (RunConfig, bool, error) {
-	current := a.Provider
+	return m.regate(ctx, a, cfg, logWriter, true, false)
+}
+
+// regateBeforeClaudeTurn is the persistent-Claude analogue of regateForTurn,
+// called from SendMessage immediately before writing the next follow-up to an
+// idle Claude session's stdin. Persistent Claude is never itself
+// per-turn-capable (UsesPerTurnConvo() is always false for it), so unlike
+// regateForTurn — where "current" must already be a per-turn provider —
+// "current" here (claude) is judged healthy purely on the health/limit
+// gates; only alternative candidates are restricted to per-turn-capable
+// peers, since the only supported hot-swap target for a persistent Claude
+// session is a per-turn provider (codex/copilot), never another persistent
+// Claude process.
+//
+// Persistence (marker + registry) is deferred: the caller has no open log
+// handle at this point (the running goroutine still owns it) and the process
+// has not been torn down yet, so writing here would let the registry record
+// the switch before the process is actually gone. The caller must persist
+// once the old process has exited and the new per-turn runner is about to
+// take over (see completeConvoHandoff).
+func (m *Manager) regateBeforeClaudeTurn(ctx context.Context, a *Agent, cfg RunConfig) (RunConfig, bool, error) {
+	return m.regate(ctx, a, cfg, nil, false, true)
+}
+
+// regate is the shared decision core of regateForTurn and
+// regateBeforeClaudeTurn. currentMustBePerTurn requires the current provider
+// itself to satisfy UsesPerTurnConvo() to be considered healthy (used by the
+// per-turn runner, where "current" is always codex/copilot); when false, the
+// current provider's health is judged directly regardless of
+// UsesPerTurnConvo() (used for persistent Claude, which never satisfies it).
+// deferPersist skips the marker-write/registry-save side effects, leaving
+// them to the caller once it is safe to record them.
+func (m *Manager) regate(ctx context.Context, a *Agent, cfg RunConfig, logWriter io.Writer, currentMustBePerTurn, deferPersist bool) (RunConfig, bool, error) {
+	current := a.GetProvider()
 
 	m.mu.RLock()
 	g := m.gate
@@ -70,7 +103,11 @@ func (m *Manager) regateForTurn(ctx context.Context, a *Agent, cfg RunConfig, lo
 		return perTurnCapable(p) && (g == nil || g.IsHealthy(p)) && underCap(p) && limitAvailable(p)
 	}
 
-	if healthy(current) {
+	currentHealthy := healthy(current)
+	if !currentMustBePerTurn {
+		currentHealthy = (g == nil || g.IsHealthy(current)) && underCap(current) && limitAvailable(current)
+	}
+	if currentHealthy {
 		return cfg, false, nil
 	}
 
@@ -114,13 +151,15 @@ func (m *Manager) regateForTurn(ctx context.Context, a *Agent, cfg RunConfig, lo
 	cfg.Provider = alt
 	cfg.provider = altProv
 
-	// Marker must land before the registry write below: on a crash between
-	// the two, rehydration must find a marker for every persisted provider
-	// change, never a persisted provider with an unmarked log segment.
-	writeProviderMarkerLine(logWriter, alt)
+	if !deferPersist {
+		// Marker must land before the registry write below: on a crash between
+		// the two, rehydration must find a marker for every persisted provider
+		// change, never a persisted provider with an unmarked log segment.
+		writeProviderMarkerLine(logWriter, alt)
 
-	if m.survives() {
-		m.saveRegistry(ctx, a)
+		if m.survives() {
+			m.saveRegistry(ctx, a)
+		}
 	}
 
 	return cfg, true, nil

--- a/internal/agent/regate_claude_test.go
+++ b/internal/agent/regate_claude_test.go
@@ -1,0 +1,278 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRegateBeforeClaudeTurn_HealthyClaudeNoOp verifies that when Claude
+// itself remains healthy, regateBeforeClaudeTurn never disqualifies it just
+// because UsesPerTurnConvo() is false for a persistent provider — unlike
+// regateForTurn, "current" here is judged on health/limit gates directly.
+func TestRegateBeforeClaudeTurn_HealthyClaudeNoOp(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true}})
+	m.mu.Lock()
+	m.liveByProvider["claude"] = 1
+	m.mu.Unlock()
+
+	a := &Agent{ID: "cn1", Provider: "claude", Model: "sonnet"}
+	a.SetSessionID("sess-keep")
+	cfg := RunConfig{Provider: "claude", TaskID: "tcn1"}
+
+	got, switched, err := m.regateBeforeClaudeTurn(t.Context(), a, cfg)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if switched {
+		t.Fatal("expected no switch: claude is healthy")
+	}
+	if got.Provider != "claude" || a.Provider != "claude" {
+		t.Errorf("provider changed unexpectedly: cfg=%q agent=%q", got.Provider, a.Provider)
+	}
+	if a.GetSessionID() != "sess-keep" {
+		t.Errorf("session id must be untouched on no-op, got %q", a.GetSessionID())
+	}
+}
+
+// TestRegateBeforeClaudeTurn_FailoverToHealthyPeer verifies a capped Claude
+// session switches to a healthy per-turn-capable peer at the turn boundary:
+// provider/model update, session clears, and the live-count bucket moves.
+func TestRegateBeforeClaudeTurn_FailoverToHealthyPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"claude": false, "copilot": true},
+		reasons: map[string]string{"claude": "rate_limited"},
+	})
+	m.mu.Lock()
+	m.liveByProvider["claude"] = 1
+	m.mu.Unlock()
+
+	a := &Agent{ID: "cn2", Provider: "claude", Model: "sonnet"}
+	a.SetSessionID("sess-old")
+	a.SetSessionFilePath("/tmp/old.jsonl")
+	cfg := RunConfig{Provider: "claude", TaskID: "tcn2"}
+
+	got, switched, err := m.regateBeforeClaudeTurn(t.Context(), a, cfg)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !switched {
+		t.Fatal("expected a switch to the healthy copilot peer")
+	}
+	if got.Provider != "copilot" || a.Provider != "copilot" {
+		t.Errorf("expected switch to copilot, cfg=%q agent=%q", got.Provider, a.Provider)
+	}
+	if a.GetSessionID() != "" || a.GetSessionFilePath() != "" {
+		t.Errorf("session state must be cleared on switch, id=%q path=%q", a.GetSessionID(), a.GetSessionFilePath())
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if v, ok := m.liveByProvider["claude"]; ok {
+		t.Errorf("claude bucket should be removed after moving its only count, got %d", v)
+	}
+	if m.liveByProvider["copilot"] != 1 {
+		t.Errorf("copilot bucket should carry the moved count, got %+v", m.liveByProvider)
+	}
+}
+
+// TestRegateBeforeClaudeTurn_NoPeerRejected verifies that when no
+// per-turn-capable peer is healthy, regateBeforeClaudeTurn refuses the turn
+// and records a rate_limit-compatible error kind, without ever switching
+// Claude onto itself or another non-per-turn provider.
+func TestRegateBeforeClaudeTurn_NoPeerRejected(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"claude": false, "codex": false, "copilot": false},
+		reasons: map[string]string{"claude": "rate_limited"},
+	})
+
+	a := &Agent{ID: "cn3", Provider: "claude"}
+	cfg := RunConfig{Provider: "claude", TaskID: "tcn3"}
+
+	got, switched, err := m.regateBeforeClaudeTurn(t.Context(), a, cfg)
+	if err == nil {
+		t.Fatal("expected error: no healthy per-turn peer available")
+	}
+	if switched {
+		t.Fatal("switched must be false on rejection")
+	}
+	if got.Provider != "claude" || a.Provider != "claude" {
+		t.Errorf("provider must be unmodified on rejection, cfg=%q agent=%q", got.Provider, a.Provider)
+	}
+	if a.GetErrorKind() != "rate_limit" {
+		t.Errorf("expected rate_limit error kind, got %q", a.GetErrorKind())
+	}
+}
+
+// fakeClaudeConvoScript is a persistent shell "claude" stand-in: each line
+// read from stdin (one user message) gets one system+result reply, then it
+// waits for the next line — mirroring the real CLI's persistent-session
+// shape closely enough to exercise runConversational end-to-end. It exits
+// cleanly on stdin EOF, matching the closeStdinPipe mechanism used both by
+// the existing one-shot-close path and by the new turn-boundary handoff.
+const fakeClaudeConvoScript = "#!/bin/sh\n" +
+	"while IFS= read -r line; do\n" +
+	"  printf '%s\\n' '{\"type\":\"system\",\"session_id\":\"claude-sess\"}'\n" +
+	"  printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"claude-sess\"}'\n" +
+	"done\n" +
+	"exit 0\n"
+
+// TestSendMessage_HotSwapsPersistentClaudeToPerTurnPeerAtTurnBoundary is the
+// end-to-end regression test for the persistent-Claude half of mid-run
+// provider failover: a Claude interactive session whose provider caps
+// between turns must hot-swap to a healthy per-turn-capable peer (copilot)
+// on the NEXT message, instead of writing that message to the now-capped
+// Claude session's stdin.
+func TestSendMessage_HotSwapsPersistentClaudeToPerTurnPeerAtTurnBoundary(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(fakeClaudeConvoScript), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	writeFakePerTurnBinary(t, dir, "copilot",
+		`{"type":"assistant.message","data":{"content":"hi from copilot"}}`,
+		`{"type":"result","sessionId":"cop-fake"}`,
+	)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "copilot": true}})
+
+	sessionDir := t.TempDir()
+	a := &Agent{ID: "pconv1", TaskID: "ptask1", Provider: "claude", Mode: "interactive", sessionCWD: sessionDir, done: make(chan struct{})}
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.liveByProvider["claude"] = 1
+	m.liveCount = 1
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	a.cancel = cancel
+	go m.runConversational(ctx, a, RunConfig{Prompt: "hi", Provider: "claude"})
+
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+	if a.GetProvider() != "claude" {
+		t.Fatalf("expected first turn to run on claude, got %s", a.GetProvider())
+	}
+
+	// Claude caps between turns; copilot is the only healthy per-turn peer.
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"claude": false, "copilot": true},
+		reasons: map[string]string{"claude": "rate_limited"},
+	})
+
+	if err := m.SendMessage(a.ID, "continue"); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	waitForAgentProvider(t, a, "copilot", 3*time.Second)
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	if a.GetSessionID() != "cop-fake" {
+		t.Errorf("expected copilot's session id captured after handoff, got %q", a.GetSessionID())
+	}
+
+	m.mu.RLock()
+	claudeCount, claudeOK := m.liveByProvider["claude"]
+	copilotCount := m.liveByProvider["copilot"]
+	m.mu.RUnlock()
+	if claudeOK && claudeCount != 0 {
+		t.Errorf("claude live count should be gone after handoff, got %d", claudeCount)
+	}
+	if copilotCount != 1 {
+		t.Errorf("copilot live count should be 1 after handoff, got %d", copilotCount)
+	}
+
+	// The conversation log now spans two schemas (claude stream-json, then
+	// copilot per-turn JSON); rehydration must parse both segments.
+	logPath := a.GetLogPath()
+	rehydrated := &Agent{ID: "pconv1-rehydrate", Provider: "copilot"}
+	rehydratePerTurnConvoFromLog(rehydrated, logPath)
+	var sawClaudeResult, sawCopilotResult bool
+	for _, ev := range rehydrated.ConvoOutput() {
+		if ev.Type == "result" && ev.SessionID == "claude-sess" {
+			sawClaudeResult = true
+		}
+		if ev.Type == "result" && ev.SessionID == "cop-fake" {
+			sawCopilotResult = true
+		}
+	}
+	if !sawClaudeResult {
+		t.Error("expected the pre-handoff claude segment to rehydrate")
+	}
+	if !sawCopilotResult {
+		t.Error("expected the post-handoff copilot segment to rehydrate")
+	}
+
+	if err := m.StopAgent(a.ID); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after StopAgent")
+	}
+}
+
+// TestSendMessage_NoPeerBlocksWithoutWritingToCappedClaude verifies that when
+// Claude caps and no healthy per-turn-capable peer exists, SendMessage
+// refuses the turn (rate_limit error kind) instead of writing the follow-up
+// to the doomed Claude session, and leaves the agent on Claude, still paused.
+func TestSendMessage_NoPeerBlocksWithoutWritingToCappedClaude(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(fakeClaudeConvoScript), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true}})
+
+	sessionDir := t.TempDir()
+	a := &Agent{ID: "pconv2", TaskID: "ptask2", Provider: "claude", Mode: "interactive", sessionCWD: sessionDir, done: make(chan struct{})}
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.liveByProvider["claude"] = 1
+	m.liveCount = 1
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	a.cancel = cancel
+	go m.runConversational(ctx, a, RunConfig{Prompt: "hi", Provider: "claude"})
+
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	// Claude caps; no healthy per-turn peer at all.
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"claude": false, "codex": false, "copilot": false},
+		reasons: map[string]string{"claude": "rate_limited"},
+	})
+
+	err := m.SendMessage(a.ID, "continue")
+	if err == nil {
+		t.Fatal("expected SendMessage to reject the turn when no peer is healthy")
+	}
+	if a.GetErrorKind() != "rate_limit" {
+		t.Errorf("expected rate_limit error kind, got %q", a.GetErrorKind())
+	}
+	if a.GetProvider() != "claude" {
+		t.Errorf("provider must be unchanged when no switch happens, got %q", a.GetProvider())
+	}
+	if a.GetState() != StatePaused {
+		t.Errorf("expected agent to remain paused (no doomed turn spawned), got %s", a.GetState())
+	}
+
+	if err := m.StopAgent(a.ID); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after StopAgent")
+	}
+}

--- a/internal/agent/regate_test.go
+++ b/internal/agent/regate_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,7 +26,7 @@ func TestRegateForTurn_HealthyCurrentNoOp(t *testing.T) {
 	a.SetSessionID("sess-keep")
 	cfg := RunConfig{Provider: "codex", TaskID: "t1"}
 
-	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestRegateForTurn_FailoverToHealthyPeer(t *testing.T) {
 	a.SetSessionFilePath("/tmp/old-session.jsonl")
 	cfg := RunConfig{Provider: "codex", TaskID: "t2"}
 
-	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -111,7 +112,7 @@ func TestRegateForTurn_NoPerTurnPeerRejected(t *testing.T) {
 	a := &Agent{ID: "a3", Provider: "codex"}
 	cfg := RunConfig{Provider: "codex", TaskID: "t3"}
 
-	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg, nil)
 	if err == nil {
 		t.Fatal("expected error: claude is not a valid per-turn hot-swap target")
 	}
@@ -148,7 +149,7 @@ func TestRegateForTurn_SelfCountAware(t *testing.T) {
 	a := &Agent{ID: "a4", Provider: "codex"}
 	cfg := RunConfig{Provider: "codex"}
 
-	_, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	_, switched, err := m.regateForTurn(t.Context(), a, cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -174,7 +175,7 @@ func TestRegateForTurn_UsesAgentProviderNotStaleCfg(t *testing.T) {
 	a := &Agent{ID: "a5", Provider: "copilot"}
 	cfg := RunConfig{Provider: "codex"}
 
-	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -201,7 +202,7 @@ func TestRegateForTurn_LiveByProviderMultiAgentBucket(t *testing.T) {
 	m.mu.Unlock()
 
 	a := &Agent{ID: "a6", Provider: "codex"}
-	_, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex"})
+	_, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -237,7 +238,7 @@ func TestRegateForTurn_LimitGateCappedFailsOverToPeer(t *testing.T) {
 	}
 
 	a := &Agent{ID: "a7", Provider: "codex"}
-	got, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex"})
+	got, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -264,7 +265,7 @@ func TestRegateForTurn_PersistsSwitchToRegistry(t *testing.T) {
 	a := &Agent{ID: "a8", TaskID: "t8", Provider: "codex", Mode: "interactive"}
 	a.SetSessionID("sess-old")
 
-	if _, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t8"}); err != nil || !switched {
+	if _, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t8"}, nil); err != nil || !switched {
 		t.Fatalf("regateForTurn: switched=%v err=%v", switched, err)
 	}
 
@@ -289,6 +290,35 @@ func TestRegateForTurn_PersistsSwitchToRegistry(t *testing.T) {
 	}
 }
 
+// TestRegateForTurn_WritesMarkerBeforePersistingSwitch verifies the
+// convoProviderMarker line lands in the log before the switch is persisted to
+// the registry, closing the crash window where a restart between the two
+// would leave rehydratePerTurnConvoFromLog with a persisted provider but no
+// marker to bound the pre-switch segment.
+func TestRegateForTurn_WritesMarkerBeforePersistingSwitch(t *testing.T) {
+	regDir := t.TempDir()
+	m := mustNewManager(t, t.Context(), func(string, any) {}, discardLogger(), t.TempDir(), ManagerConfig{SurviveRestartDir: regDir})
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "copilot": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+
+	a := &Agent{ID: "a9", TaskID: "t9", Provider: "codex", Mode: "interactive"}
+	var buf bytes.Buffer
+
+	if _, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t9"}, &buf); err != nil || !switched {
+		t.Fatalf("regateForTurn: switched=%v err=%v", switched, err)
+	}
+
+	provider, ok := parseProviderMarkerLine(bytes.TrimRight(buf.Bytes(), "\n"))
+	if !ok {
+		t.Fatalf("expected a marker line to be written, got %q", buf.String())
+	}
+	if provider != "copilot" {
+		t.Errorf("marker provider = %q, want copilot", provider)
+	}
+}
+
 // TestRegateForTurn_PreservesRequirePermissionsAcrossSwitch verifies a
 // provider switch carries the run's sandbox/approval posture
 // (RequirePermissions) forward unchanged, so a sandboxed chat stays
@@ -302,7 +332,7 @@ func TestRegateForTurn_PreservesRequirePermissionsAcrossSwitch(t *testing.T) {
 	a := &Agent{ID: "perm1", Provider: "copilot"}
 	cfg := RunConfig{Provider: "copilot", RequirePermissions: true}
 
-	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg, nil)
 	if err != nil || !switched {
 		t.Fatalf("switched=%v err=%v", switched, err)
 	}
@@ -396,10 +426,7 @@ func TestRehydratePerTurnConvoFromLog_MixedProviderMarkers(t *testing.T) {
 	lines = append(lines, marshalMarkerLine(t, "copilot"))
 	lines = append(lines, `{"type":"assistant.message","data":{"content":"hello"}}`)
 	lines = append(lines, `{"type":"result","sessionId":"cop-9"}`)
-	content := ""
-	for _, l := range lines {
-		content += l + "\n"
-	}
+	content := strings.Join(lines, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}

--- a/internal/agent/regate_test.go
+++ b/internal/agent/regate_test.go
@@ -1,0 +1,450 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/limits"
+)
+
+// TestRegateForTurn_HealthyCurrentNoOp verifies that when the agent's current
+// provider remains healthy and per-turn-capable, regateForTurn leaves
+// everything untouched: no switch, no provider/model/session mutation, no
+// live-count move.
+func TestRegateForTurn_HealthyCurrentNoOp(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
+	m.mu.Lock()
+	m.liveByProvider["codex"] = 1
+	m.mu.Unlock()
+
+	a := &Agent{ID: "a1", Provider: "codex", Model: "gpt-5.5"}
+	a.SetSessionID("sess-keep")
+	cfg := RunConfig{Provider: "codex", TaskID: "t1"}
+
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if switched {
+		t.Fatal("expected no switch for a healthy current provider")
+	}
+	if got.Provider != "codex" {
+		t.Errorf("cfg.Provider changed: got %q", got.Provider)
+	}
+	if a.Provider != "codex" {
+		t.Errorf("agent provider changed: got %q", a.Provider)
+	}
+	if a.GetSessionID() != "sess-keep" {
+		t.Errorf("session id must be untouched on no-op, got %q", a.GetSessionID())
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.liveByProvider["codex"] != 1 {
+		t.Errorf("liveByProvider must be untouched on no-op, got %+v", m.liveByProvider)
+	}
+}
+
+// TestRegateForTurn_FailoverToHealthyPeer verifies a capped current provider
+// switches to a healthy per-turn-capable peer: provider/model are updated,
+// the session is cleared (native resume can't cross providers), and the
+// live-count bucket moves from the old provider to the new one.
+func TestRegateForTurn_FailoverToHealthyPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "copilot": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+	m.mu.Lock()
+	m.liveByProvider["codex"] = 1
+	m.mu.Unlock()
+
+	a := &Agent{ID: "a2", Provider: "codex", Model: "gpt-5.5"}
+	a.SetSessionID("sess-old")
+	a.SetSessionFilePath("/tmp/old-session.jsonl")
+	cfg := RunConfig{Provider: "codex", TaskID: "t2"}
+
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !switched {
+		t.Fatal("expected a switch to the healthy copilot peer")
+	}
+	if got.Provider != "copilot" {
+		t.Errorf("cfg.Provider = %q, want copilot", got.Provider)
+	}
+	if a.Provider != "copilot" {
+		t.Errorf("agent provider = %q, want copilot", a.Provider)
+	}
+	if a.GetSessionID() != "" {
+		t.Errorf("session id must be cleared on switch, got %q", a.GetSessionID())
+	}
+	if a.GetSessionFilePath() != "" {
+		t.Errorf("session file path must be cleared on switch, got %q", a.GetSessionFilePath())
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if v, ok := m.liveByProvider["codex"]; ok {
+		t.Errorf("codex bucket should be removed after moving its only count, got %d", v)
+	}
+	if m.liveByProvider["copilot"] != 1 {
+		t.Errorf("copilot bucket should carry the moved count, got %+v", m.liveByProvider)
+	}
+}
+
+// TestRegateForTurn_NoPerTurnPeerRejected verifies that when the only healthy
+// alternative is persistent Claude (not per-turn-capable), regateForTurn
+// refuses to spawn a turn and marks a rate-limit-compatible error kind so the
+// existing reschedule/park behavior stays reachable.
+func TestRegateForTurn_NoPerTurnPeerRejected(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "claude": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+
+	a := &Agent{ID: "a3", Provider: "codex"}
+	cfg := RunConfig{Provider: "codex", TaskID: "t3"}
+
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	if err == nil {
+		t.Fatal("expected error: claude is not a valid per-turn hot-swap target")
+	}
+	if switched {
+		t.Fatal("switched must be false on rejection")
+	}
+	if got.Provider != "codex" {
+		t.Errorf("cfg must be unmodified on rejection, got provider %q", got.Provider)
+	}
+	if a.Provider != "codex" {
+		t.Errorf("agent provider must be unmodified on rejection, got %q", a.Provider)
+	}
+	if a.GetErrorKind() != "rate_limit" {
+		t.Errorf("expected rate_limit error kind, got %q", a.GetErrorKind())
+	}
+}
+
+// TestRegateForTurn_SelfCountAware verifies that the agent's own in-flight
+// turn (already counted in its provider's live bucket) does not make its own
+// healthy provider look "at cap" to itself.
+func TestRegateForTurn_SelfCountAware(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider:        "codex",
+		MaxInFlightPerProvider: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	m.liveByProvider["codex"] = 1 // this agent's own slot
+	m.mu.Unlock()
+
+	a := &Agent{ID: "a4", Provider: "codex"}
+	cfg := RunConfig{Provider: "codex"}
+
+	_, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if switched {
+		t.Fatal("agent's own live count must not make its healthy provider look at-cap")
+	}
+}
+
+// TestRegateForTurn_UsesAgentProviderNotStaleCfg verifies the source of truth
+// for "current provider" is a.Provider, not cfg.Provider — cfg carries the
+// stale provider from an earlier dispatch/switch (or, after a reattach, an
+// essentially empty RunConfig), so trusting it could resurrect a provider the
+// agent already switched away from.
+func TestRegateForTurn_UsesAgentProviderNotStaleCfg(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "copilot": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+
+	// Agent already switched to copilot in a prior turn; cfg is stale and
+	// still says codex.
+	a := &Agent{ID: "a5", Provider: "copilot"}
+	cfg := RunConfig{Provider: "codex"}
+
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if switched {
+		t.Fatal("copilot is already healthy; must not switch based on stale cfg.Provider")
+	}
+	if a.Provider != "copilot" {
+		t.Errorf("agent provider must remain copilot, got %q", a.Provider)
+	}
+	_ = got
+}
+
+// TestRegateForTurn_LiveByProviderMultiAgentBucket verifies moving a switched
+// agent's count out of a shared bucket decrements it instead of deleting it
+// when other agents still occupy that provider.
+func TestRegateForTurn_LiveByProviderMultiAgentBucket(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "copilot": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+	m.mu.Lock()
+	m.liveByProvider["codex"] = 2 // this agent plus one other still on codex
+	m.mu.Unlock()
+
+	a := &Agent{ID: "a6", Provider: "codex"}
+	_, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !switched {
+		t.Fatal("expected switch to copilot")
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.liveByProvider["codex"] != 1 {
+		t.Errorf("codex bucket should be decremented (other agent remains), got %+v", m.liveByProvider)
+	}
+	if m.liveByProvider["copilot"] != 1 {
+		t.Errorf("copilot bucket should carry the moved count, got %+v", m.liveByProvider)
+	}
+}
+
+// TestRegateForTurn_LimitGateCappedFailsOverToPeer verifies a soft
+// per-provider quota cap (surfaced via LimitGate, independent of the health
+// gate) also triggers failover to a healthy per-turn peer.
+func TestRegateForTurn_LimitGateCappedFailsOverToPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true, "copilot": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "codex",
+		LimitGate: &fakeLimitGate{
+			available: map[string]bool{"codex": false},
+			reasons:   map[string]string{"codex": "quota_exhausted"},
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Agent{ID: "a7", Provider: "codex"}
+	got, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !switched {
+		t.Fatal("expected failover on quota-capped current provider")
+	}
+	if got.Provider != "copilot" {
+		t.Errorf("got provider %q, want copilot", got.Provider)
+	}
+}
+
+// TestRegateForTurn_PersistsSwitchToRegistry verifies a successful switch is
+// saved to the survival registry immediately, so a restart before the next
+// turn reattaches on the new provider (see reattachPerTurnConvo) instead of
+// resurrecting the pre-switch provider/session.
+func TestRegateForTurn_PersistsSwitchToRegistry(t *testing.T) {
+	regDir := t.TempDir()
+	m := mustNewManager(t, t.Context(), func(string, any) {}, discardLogger(), t.TempDir(), ManagerConfig{SurviveRestartDir: regDir})
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "copilot": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+
+	a := &Agent{ID: "a8", TaskID: "t8", Provider: "codex", Mode: "interactive"}
+	a.SetSessionID("sess-old")
+
+	if _, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t8"}); err != nil || !switched {
+		t.Fatalf("regateForTurn: switched=%v err=%v", switched, err)
+	}
+
+	recs, err := m.reg.List()
+	if err != nil {
+		t.Fatalf("registry List: %v", err)
+	}
+	var rec *Record
+	for i := range recs {
+		if recs[i].ID == "a8" {
+			rec = &recs[i]
+		}
+	}
+	if rec == nil {
+		t.Fatal("expected switch to persist a registry record")
+	}
+	if rec.Provider != "copilot" {
+		t.Errorf("persisted provider = %q, want copilot", rec.Provider)
+	}
+	if rec.SessionID != "" {
+		t.Errorf("persisted session id must be cleared, got %q", rec.SessionID)
+	}
+}
+
+// TestRegateForTurn_PreservesRequirePermissionsAcrossSwitch verifies a
+// provider switch carries the run's sandbox/approval posture
+// (RequirePermissions) forward unchanged, so a sandboxed chat stays
+// sandboxed on its new provider instead of silently becoming permissive.
+func TestRegateForTurn_PreservesRequirePermissionsAcrossSwitch(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"copilot": false, "codex": true},
+		reasons: map[string]string{"copilot": "rate_limited"},
+	})
+	a := &Agent{ID: "perm1", Provider: "copilot"}
+	cfg := RunConfig{Provider: "copilot", RequirePermissions: true}
+
+	got, switched, err := m.regateForTurn(t.Context(), a, cfg)
+	if err != nil || !switched {
+		t.Fatalf("switched=%v err=%v", switched, err)
+	}
+	if !got.RequirePermissions {
+		t.Fatal("RequirePermissions must be preserved across a provider switch")
+	}
+
+	args := buildCodexConvoArgsWithProvider(a, got, "hi", providerByName("codex"))
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--sandbox workspace-write") {
+		t.Fatalf("expected sandboxed codex args after switch (RequirePermissions preserved), got %q", joined)
+	}
+}
+
+// TestReattachPerTurnConvo_UsesSwitchedProviderAndClearedSession verifies
+// that a registry record written after a mid-run regateForTurn switch (new
+// provider, cleared session id) reattaches on the switched provider with no
+// resurrected old-provider session — regateForTurn already persisted the
+// post-switch state via saveRegistry, so ReattachAll only needs to trust it.
+func TestReattachPerTurnConvo_UsesSwitchedProviderAndClearedSession(t *testing.T) {
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "sw1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	history := marshalMarkerLine(t, "codex") + "\n" +
+		`{"type":"thread.started","thread_id":"cx-1"}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}` + "\n" +
+		marshalMarkerLine(t, "copilot") + "\n" +
+		`{"type":"assistant.message","data":{"content":"post-switch"}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(history), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m := mustNewManager(t, t.Context(), func(string, any) {}, discardLogger(), logDir, ManagerConfig{SurviveRestartDir: regDir})
+	// As regateForTurn would have persisted it: switched to copilot, session
+	// cleared, requirePermissions carried over from the pre-switch run.
+	rec := Record{
+		ID: "sw1", TaskID: "t-sw", Mode: "interactive", Provider: "copilot",
+		PID: 0, LogPath: logPath, SessionID: "", RequirePermissions: true,
+		StartedAt: time.Now().UTC(),
+	}
+	if err := m.reg.Save(rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := m.ReattachAll()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 reattached agent, got %d", len(got))
+	}
+	a, err := m.GetAgent("sw1")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if a.Provider != "copilot" {
+		t.Errorf("expected reattach to use switched provider copilot, got %q", a.Provider)
+	}
+	if a.GetSessionID() != "" {
+		t.Errorf("expected no resurrected pre-switch session id, got %q", a.GetSessionID())
+	}
+	if !a.requirePermissions {
+		t.Error("expected requirePermissions preserved across the switch+restart")
+	}
+	// Both segments of the mixed-provider log rehydrate correctly via markers.
+	if len(a.ConvoOutput()) != 3 {
+		t.Errorf("expected 3 rehydrated events across both provider segments, got %d", len(a.ConvoOutput()))
+	}
+
+	if err := m.StopAgent("sw1"); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("reattached agent did not exit after StopAgent")
+	}
+}
+
+// TestRehydratePerTurnConvoFromLog_MixedProviderMarkers verifies that
+// convoProviderMarker lines let rehydration parse each segment of a
+// mixed-provider log (written across a mid-run provider switch) with the
+// correct provider's schema, even though the agent's current provider only
+// matches the LAST segment.
+func TestRehydratePerTurnConvoFromLog_MixedProviderMarkers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mixed.ndjson")
+	var lines []string
+	lines = append(lines, marshalMarkerLine(t, "codex"))
+	lines = append(lines, `{"type":"thread.started","thread_id":"cx-1"}`)
+	lines = append(lines, `{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}`)
+	lines = append(lines, marshalMarkerLine(t, "copilot"))
+	lines = append(lines, `{"type":"assistant.message","data":{"content":"hello"}}`)
+	lines = append(lines, `{"type":"result","sessionId":"cop-9"}`)
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Agent's CURRENT provider is copilot (post-switch); markers must still
+	// let the codex segment parse correctly.
+	a := &Agent{ID: "mix", Provider: "copilot"}
+	rehydratePerTurnConvoFromLog(a, path)
+
+	events := a.ConvoOutput()
+	if len(events) != 4 {
+		t.Fatalf("expected 4 rehydrated events (2 codex + 2 copilot), got %d: %+v", len(events), events)
+	}
+	if a.GetSessionID() != "cop-9" {
+		t.Errorf("expected final session id from copilot segment, got %q", a.GetSessionID())
+	}
+}
+
+// TestRehydratePerTurnConvoFromLog_NoMarkersDropsMismatchedSegment documents
+// the fallback behavior for a log written before provider markers existed:
+// without a marker, every line is parsed with the agent's single current
+// provider, so a segment written under a different (now-switched-away-from)
+// provider whose event types don't overlap is silently dropped. This is the
+// reason writeProviderMarkerLine exists — see the marker-covered test above
+// for the fixed behavior.
+func TestRehydratePerTurnConvoFromLog_NoMarkersDropsMismatchedSegment(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.ndjson")
+	content := `{"type":"thread.started","thread_id":"cx-1"}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}` + "\n" +
+		`{"type":"assistant.message","data":{"content":"hello"}}` + "\n" +
+		`{"type":"result","sessionId":"cop-9"}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	a := &Agent{ID: "legacy", Provider: "copilot"}
+	rehydratePerTurnConvoFromLog(a, path)
+
+	events := a.ConvoOutput()
+	if len(events) != 2 {
+		t.Fatalf("expected only the 2 copilot-parsed events (codex segment dropped without markers), got %d: %+v", len(events), events)
+	}
+}
+
+func marshalMarkerLine(t *testing.T, provider string) string {
+	t.Helper()
+	return `{"__sybra_provider_marker__":"provider_switch","provider":"` + provider + `"}`
+}

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -544,6 +544,12 @@ func parseProviderMarkerLine(line []byte) (string, bool) {
 // provider that never issued it. Only the final segment's id (the one
 // belonging to the agent's current provider) is written to the agent, once,
 // after the full scan.
+//
+// A "claude" segment (a persistent Claude interactive agent that later
+// regated to a per-turn peer via regateBeforeClaudeTurn/beginConvoHandoff)
+// uses an entirely different line schema (Claude's stream-json, not a
+// per-turn provider's ConvoEvent parser), so it is parsed with
+// ParseClaudeLine/claudeEventToConvoEvent instead of parseConvoEvent.
 func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -564,7 +570,17 @@ func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 			sessionID = ""
 			continue
 		}
-		ev, perr := parseConvoEvent(segmentProvider, line)
+		var ev ConvoEvent
+		var perr error
+		if segmentProvider == "claude" {
+			var parsed ClaudeEvent
+			parsed, perr = ParseClaudeLine(line)
+			if perr == nil {
+				ev = claudeEventToConvoEvent(parsed)
+			}
+		} else {
+			ev, perr = parseConvoEvent(segmentProvider, line)
+		}
 		if perr != nil {
 			continue
 		}

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -196,17 +196,18 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 	prompt := cfg.Prompt
 	for {
 		if !resumeWait {
-			updatedCfg, switched, regateErr := m.regateForTurn(ctx, a, cfg)
+			updatedCfg, _, regateErr := m.regateForTurn(ctx, a, cfg, logWriter)
 			if regateErr != nil {
-				m.logger.Warn("agent.convo.regate.blocked", "id", a.ID, "provider", a.Provider, "err", regateErr)
+				m.logger.Warn("agent.convo.regate.blocked", "id", a.ID, "task", a.TaskID, "provider", a.Provider, "err", regateErr)
 				a.SetExitErr(errProviderRateLimited)
+				select {
+				case a.promptChannel() <- prompt:
+				default:
+				}
 				if shutdownSurvive() {
 					survived = true
 				}
 				return
-			}
-			if switched {
-				writeProviderMarkerLine(logWriter, updatedCfg.Provider)
 			}
 			cfg = updatedCfg
 
@@ -479,6 +480,11 @@ func parseConvoEvent(provider string, line []byte) (ConvoEvent, error) {
 	return prov.ParseConvoLine(line)
 }
 
+// convoProviderMarkerVersion identifies the marker line schema. Bump it if a
+// field is ever added/changed so old markers (version 0, absent) can still be
+// told apart from new ones during rehydration.
+const convoProviderMarkerVersion = 1
+
 // convoProviderMarker is a durable, out-of-band log line that records which
 // provider's schema parses the lines following it. A mid-run provider switch
 // (regateForTurn) writes one at the switch boundary, and a fresh log gets one
@@ -489,6 +495,7 @@ func parseConvoEvent(provider string, line []byte) (ConvoEvent, error) {
 // genuine codex/copilot JSON line.
 type convoProviderMarker struct {
 	Marker   string `json:"__sybra_provider_marker__"`
+	Version  int    `json:"version"`
 	Provider string `json:"provider"`
 }
 
@@ -499,7 +506,7 @@ func writeProviderMarkerLine(w io.Writer, provider string) {
 	if w == nil {
 		return
 	}
-	data, err := json.Marshal(convoProviderMarker{Marker: "provider_switch", Provider: provider})
+	data, err := json.Marshal(convoProviderMarker{Marker: "provider_switch", Version: convoProviderMarkerVersion, Provider: provider})
 	if err != nil {
 		return
 	}
@@ -508,7 +515,8 @@ func writeProviderMarkerLine(w io.Writer, provider string) {
 }
 
 // parseProviderMarkerLine reports whether line is a convoProviderMarker and,
-// if so, the provider it names.
+// if so, the provider it names. Version is not yet enforced (only version 1
+// exists), but is parsed so a future schema change can branch on it.
 func parseProviderMarkerLine(line []byte) (string, bool) {
 	var mark convoProviderMarker
 	if err := json.Unmarshal(line, &mark); err != nil {

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -150,42 +150,11 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 		m.markAgentDone(a)
 	}()
 
-	// On recreate (resume), append to the existing log so the rehydrated
-	// chat history is preserved across restarts; a fresh run opens a new
-	// file. Without this, each restart would open a new empty log and the
-	// next restart would rehydrate zero history.
-	existingLog := a.GetLogPath()
-	var outFile *os.File
-	var fileErr error
-	if existingLog != "" {
-		outFile, fileErr = os.OpenFile(existingLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	} else {
-		outFile, fileErr = logging.NewAgentOutputFile(m.logDir, a.ID)
-	}
-	if fileErr != nil {
-		m.logger.Error("agent.output.file", "id", a.ID, "err", fileErr)
-	}
+	outFile, logWriter := m.openPerTurnConvoLog(a)
 	if outFile != nil {
-		a.SetLogPath(outFile.Name())
 		defer func() { _ = outFile.Close() }()
 	}
-
-	var logWriter io.Writer
-	if outFile != nil {
-		logWriter = outFile
-	}
-	if existingLog == "" {
-		// First line of a fresh log records the starting provider, so a
-		// restart's rehydration can tell which parser covers the segment
-		// before any mid-run provider switch (see writeProviderMarkerLine).
-		writeProviderMarkerLine(logWriter, a.Provider)
-	}
-
-	// Record the agent so a restart can recreate it (the log path is now set).
-	if m.survives() {
-		a.setDetached(true)
-		m.saveRegistry(ctx, a)
-	}
+	m.persistPerTurnConvoSurvival(ctx, a)
 
 	// shutdownSurvive reports whether a ctx cancel should leave the agent
 	// running for recreate (survival on, app shutdown, not an intentional stop).
@@ -227,35 +196,70 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 		}
 		resumeWait = false
 
-		// Drain any prompts still queued on the Agent before blocking on the
-		// prompt channel. This carries a persistent-Claude session's queued
-		// follow-ups across a mid-run handoff (completeConvoHandoff hands off
-		// only the prompt that triggered the switch; any prompts queued
-		// before it are still sitting in this same *Agent's pending queue)
-		// so they replay here in original order instead of being stranded.
-		if next, ok := a.PopPendingPrompt(); ok {
-			a.SetState(StateRunning)
-			m.emit(events.AgentState(a.ID), a)
-			prompt = next
-			continue
-		}
-
-		ch := a.promptChannel()
-
-		select {
-		case <-ctx.Done():
+		nextPrompt, ok := m.waitPerTurnPrompt(ctx, a)
+		if !ok {
 			if shutdownSurvive() {
 				survived = true
 			}
 			return
-		case next, ok := <-ch:
-			if !ok {
-				return
-			}
-			a.SetState(StateRunning)
-			m.emit(events.AgentState(a.ID), a)
-			prompt = next
 		}
+		prompt = nextPrompt
+	}
+}
+
+// openPerTurnConvoLog reuses an existing recreated-agent log when present and
+// otherwise allocates a fresh one, seeding the first segment with the current
+// provider marker for mixed-provider rehydration.
+func (m *Manager) openPerTurnConvoLog(a *Agent) (*os.File, io.Writer) {
+	existingLog := a.GetLogPath()
+	var (
+		outFile *os.File
+		err     error
+	)
+	if existingLog != "" {
+		outFile, err = os.OpenFile(existingLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	} else {
+		outFile, err = logging.NewAgentOutputFile(m.logDir, a.ID)
+	}
+	if err != nil {
+		m.logger.Error("agent.output.file", "id", a.ID, "err", err)
+		return nil, nil
+	}
+
+	a.SetLogPath(outFile.Name())
+	if existingLog == "" {
+		writeProviderMarkerLine(outFile, a.Provider)
+	}
+	return outFile, outFile
+}
+
+func (m *Manager) persistPerTurnConvoSurvival(ctx context.Context, a *Agent) {
+	if !m.survives() {
+		return
+	}
+	a.setDetached(true)
+	m.saveRegistry(ctx, a)
+}
+
+// waitPerTurnPrompt drains already-queued prompts before blocking on the live
+// prompt channel so same-agent handoffs preserve message order.
+func (m *Manager) waitPerTurnPrompt(ctx context.Context, a *Agent) (string, bool) {
+	if next, ok := a.PopPendingPrompt(); ok {
+		a.SetState(StateRunning)
+		m.emit(events.AgentState(a.ID), a)
+		return next, true
+	}
+
+	select {
+	case <-ctx.Done():
+		return "", false
+	case next, ok := <-a.promptChannel():
+		if !ok {
+			return "", false
+		}
+		a.SetState(StateRunning)
+		m.emit(events.AgentState(a.ID), a)
+		return next, true
 	}
 }
 

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -153,10 +154,11 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 	// chat history is preserved across restarts; a fresh run opens a new
 	// file. Without this, each restart would open a new empty log and the
 	// next restart would rehydrate zero history.
+	existingLog := a.GetLogPath()
 	var outFile *os.File
 	var fileErr error
-	if existing := a.GetLogPath(); existing != "" {
-		outFile, fileErr = os.OpenFile(existing, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if existingLog != "" {
+		outFile, fileErr = os.OpenFile(existingLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	} else {
 		outFile, fileErr = logging.NewAgentOutputFile(m.logDir, a.ID)
 	}
@@ -171,6 +173,12 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 	var logWriter io.Writer
 	if outFile != nil {
 		logWriter = outFile
+	}
+	if existingLog == "" {
+		// First line of a fresh log records the starting provider, so a
+		// restart's rehydration can tell which parser covers the segment
+		// before any mid-run provider switch (see writeProviderMarkerLine).
+		writeProviderMarkerLine(logWriter, a.Provider)
 	}
 
 	// Record the agent so a restart can recreate it (the log path is now set).
@@ -188,6 +196,20 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 	prompt := cfg.Prompt
 	for {
 		if !resumeWait {
+			updatedCfg, switched, regateErr := m.regateForTurn(ctx, a, cfg)
+			if regateErr != nil {
+				m.logger.Warn("agent.convo.regate.blocked", "id", a.ID, "provider", a.Provider, "err", regateErr)
+				a.SetExitErr(errProviderRateLimited)
+				if shutdownSurvive() {
+					survived = true
+				}
+				return
+			}
+			if switched {
+				writeProviderMarkerLine(logWriter, updatedCfg.Provider)
+			}
+			cfg = updatedCfg
+
 			if !m.runConvoTurn(ctx, a, cfg, prompt, logWriter) {
 				if shutdownSurvive() {
 					survived = true
@@ -457,10 +479,63 @@ func parseConvoEvent(provider string, line []byte) (ConvoEvent, error) {
 	return prov.ParseConvoLine(line)
 }
 
+// convoProviderMarker is a durable, out-of-band log line that records which
+// provider's schema parses the lines following it. A mid-run provider switch
+// (regateForTurn) writes one at the switch boundary, and a fresh log gets one
+// up front recording its starting provider, so rehydratePerTurnConvoFromLog
+// can parse each segment of a mixed-provider log with the right parser
+// instead of guessing from the agent's current (possibly since-switched)
+// provider. The field name is namespaced so it can never collide with a
+// genuine codex/copilot JSON line.
+type convoProviderMarker struct {
+	Marker   string `json:"__sybra_provider_marker__"`
+	Provider string `json:"provider"`
+}
+
+// writeProviderMarkerLine writes a convoProviderMarker line directly to the
+// log (bypassing ConvoEvent emission — it is a rehydration aid, not
+// conversation content). No-op if w is nil.
+func writeProviderMarkerLine(w io.Writer, provider string) {
+	if w == nil {
+		return
+	}
+	data, err := json.Marshal(convoProviderMarker{Marker: "provider_switch", Provider: provider})
+	if err != nil {
+		return
+	}
+	_, _ = w.Write(data)
+	_, _ = w.Write([]byte("\n"))
+}
+
+// parseProviderMarkerLine reports whether line is a convoProviderMarker and,
+// if so, the provider it names.
+func parseProviderMarkerLine(line []byte) (string, bool) {
+	var mark convoProviderMarker
+	if err := json.Unmarshal(line, &mark); err != nil {
+		return "", false
+	}
+	if mark.Marker != "provider_switch" || mark.Provider == "" {
+		return "", false
+	}
+	return mark.Provider, true
+}
+
 // rehydratePerTurnConvoFromLog replays a per-turn (codex/copilot)
 // conversational agent's log into its convo buffer (and session id) without
 // emitting events, so a recreated agent shows its prior chat history after a
-// restart.
+// restart. The log may cover more than one provider if a mid-run switch
+// occurred; convoProviderMarker lines mark each segment boundary so each
+// segment is parsed with its own provider's schema. a.Provider (the agent's
+// current provider) is only a fallback, used for any content preceding the
+// first marker in an older log written before this mechanism existed.
+//
+// Session ids are provider-scoped (a Codex thread id means nothing to
+// Copilot and vice versa), so the id tracked across the scan resets at every
+// marker: a segment must never inherit a session id from the provider that
+// preceded it, or the next turn could pass a foreign --session-id to a
+// provider that never issued it. Only the final segment's id (the one
+// belonging to the agent's current provider) is written to the agent, once,
+// after the full scan.
 func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -469,12 +544,19 @@ func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 	defer func() { _ = f.Close() }()
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+	segmentProvider := a.Provider
+	var sessionID string
 	for sc.Scan() {
 		line := sc.Bytes()
 		if len(line) == 0 {
 			continue
 		}
-		ev, perr := parseConvoEvent(a.Provider, line)
+		if p, ok := parseProviderMarkerLine(line); ok {
+			segmentProvider = p
+			sessionID = ""
+			continue
+		}
+		ev, perr := parseConvoEvent(segmentProvider, line)
 		if perr != nil {
 			continue
 		}
@@ -483,7 +565,7 @@ func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 		}
 		a.AppendConvo(ev)
 		if ev.SessionID != "" {
-			a.SetSessionID(ev.SessionID)
+			sessionID = ev.SessionID
 		}
 		if ev.Type == "result" {
 			a.AddResultStats(ev.SessionID, ev.CostUSD, ev.InputTokens, ev.OutputTokens, ev.ReasoningTokens)
@@ -493,6 +575,7 @@ func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 			}
 		}
 	}
+	a.SetSessionID(sessionID)
 }
 
 // sendConvoPrompt delivers a follow-up prompt to a per-turn (codex/copilot)

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -227,6 +227,19 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 		}
 		resumeWait = false
 
+		// Drain any prompts still queued on the Agent before blocking on the
+		// prompt channel. This carries a persistent-Claude session's queued
+		// follow-ups across a mid-run handoff (completeConvoHandoff hands off
+		// only the prompt that triggered the switch; any prompts queued
+		// before it are still sitting in this same *Agent's pending queue)
+		// so they replay here in original order instead of being stranded.
+		if next, ok := a.PopPendingPrompt(); ok {
+			a.SetState(StateRunning)
+			m.emit(events.AgentState(a.ID), a)
+			prompt = next
+			continue
+		}
+
 		ch := a.promptChannel()
 
 		select {

--- a/internal/agent/runner_codex_convo_failover_test.go
+++ b/internal/agent/runner_codex_convo_failover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -14,10 +15,12 @@ import (
 // real provider.
 func writeFakePerTurnBinary(t *testing.T, dir, name string, lines ...string) {
 	t.Helper()
-	script := "#!/bin/sh\n"
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
 	for _, l := range lines {
-		script += "printf '%s\\n' " + shQuote(l) + "\n"
+		b.WriteString("printf '%s\\n' " + shQuote(l) + "\n")
 	}
+	script := b.String()
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake %s: %v", name, err)
@@ -27,15 +30,15 @@ func writeFakePerTurnBinary(t *testing.T, dir, name string, lines ...string) {
 // shQuote wraps s in single quotes for embedding in a generated shell script,
 // escaping any literal single quotes it contains.
 func shQuote(s string) string {
-	escaped := ""
+	var b strings.Builder
 	for _, r := range s {
 		if r == '\'' {
-			escaped += `'\''`
+			b.WriteString(`'\''`)
 		} else {
-			escaped += string(r)
+			b.WriteRune(r)
 		}
 	}
-	return "'" + escaped + "'"
+	return "'" + b.String() + "'"
 }
 
 func waitForAgentState(t *testing.T, a *Agent, want State, timeout time.Duration) {
@@ -192,5 +195,16 @@ func TestRunPerTurnConversational_NoPeerParksInstead(t *testing.T) {
 	}
 	if a.GetProvider() != "codex" {
 		t.Errorf("provider must be unchanged when no switch happens, got %q", a.GetProvider())
+	}
+
+	// The "continue" follow-up dequeued from the prompt channel for this turn
+	// must not vanish on a blocked regate — it is requeued so it isn't lost.
+	select {
+	case got := <-a.promptChannel():
+		if got != "continue" {
+			t.Errorf("requeued prompt = %q, want %q", got, "continue")
+		}
+	default:
+		t.Fatal("expected the in-flight prompt to be requeued on a blocked regate")
 	}
 }

--- a/internal/agent/runner_codex_convo_failover_test.go
+++ b/internal/agent/runner_codex_convo_failover_test.go
@@ -1,0 +1,196 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeFakePerTurnBinary drops an executable shell script named `name` on
+// PATH that ignores its arguments and prints the given NDJSON lines, one per
+// line, to stdout. Used to simulate codex/copilot per-turn CLIs without a
+// real provider.
+func writeFakePerTurnBinary(t *testing.T, dir, name string, lines ...string) {
+	t.Helper()
+	script := "#!/bin/sh\n"
+	for _, l := range lines {
+		script += "printf '%s\\n' " + shQuote(l) + "\n"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+}
+
+// shQuote wraps s in single quotes for embedding in a generated shell script,
+// escaping any literal single quotes it contains.
+func shQuote(s string) string {
+	escaped := ""
+	for _, r := range s {
+		if r == '\'' {
+			escaped += `'\''`
+		} else {
+			escaped += string(r)
+		}
+	}
+	return "'" + escaped + "'"
+}
+
+func waitForAgentState(t *testing.T, a *Agent, want State, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if a.GetState() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("agent did not reach state %s within %s (last state %s)", want, timeout, a.GetState())
+}
+
+func waitForAgentProvider(t *testing.T, a *Agent, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if a.GetProvider() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("agent provider never became %q within %s (last %q)", want, timeout, a.GetProvider())
+}
+
+// TestRunPerTurnConversational_FailsOverMidConversation is an end-to-end
+// regression test for the core feature: a per-turn conversational agent
+// (codex) whose provider caps mid-conversation must hot-swap to a healthy
+// per-turn-capable peer (copilot) on its NEXT turn, without the caller
+// spawning a doomed codex process and without losing the conversation.
+func TestRunPerTurnConversational_FailsOverMidConversation(t *testing.T) {
+	dir := t.TempDir()
+	writeFakePerTurnBinary(t, dir, "codex",
+		`{"type":"thread.started","thread_id":"cx-fake"}`,
+		`{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}`,
+	)
+	writeFakePerTurnBinary(t, dir, "copilot",
+		`{"type":"assistant.message","data":{"content":"hi from copilot"}}`,
+		`{"type":"result","sessionId":"cop-fake"}`,
+	)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true, "copilot": true}})
+
+	sessionDir := t.TempDir()
+	a := &Agent{ID: "conv1", TaskID: "task1", Provider: "codex", Mode: "interactive", sessionCWD: sessionDir, done: make(chan struct{})}
+	a.setPromptChannel(make(chan string, 1))
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.liveByProvider["codex"] = 1
+	m.liveCount = 1
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	a.cancel = cancel
+	go m.runPerTurnConversational(ctx, a, RunConfig{Prompt: "hi", Provider: "codex", RequirePermissions: true}, false)
+
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+	if a.GetProvider() != "codex" {
+		t.Fatalf("expected first turn to run on codex, got %s", a.GetProvider())
+	}
+
+	// codex caps mid-conversation; copilot is the only healthy per-turn peer.
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "copilot": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+
+	if err := m.sendConvoPrompt(a.ID, "continue"); err != nil {
+		t.Fatalf("sendConvoPrompt: %v", err)
+	}
+
+	waitForAgentProvider(t, a, "copilot", 3*time.Second)
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	if a.GetSessionID() != "cop-fake" {
+		t.Errorf("expected copilot's session id captured after switch, got %q", a.GetSessionID())
+	}
+
+	m.mu.RLock()
+	codexCount, codexOK := m.liveByProvider["codex"]
+	copilotCount := m.liveByProvider["copilot"]
+	m.mu.RUnlock()
+	if codexOK && codexCount != 0 {
+		t.Errorf("codex live count should be gone after switch, got %d", codexCount)
+	}
+	if copilotCount != 1 {
+		t.Errorf("copilot live count should be 1 after switch, got %d", copilotCount)
+	}
+
+	if err := m.StopAgent(a.ID); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after StopAgent")
+	}
+}
+
+// TestRunPerTurnConversational_NoPeerParksInstead verifies that when a
+// per-turn agent's provider caps and no healthy per-turn peer exists, the
+// runner does not spawn a doomed turn: it exits with a rate_limit error kind
+// (compatible with the existing reschedule/park behavior) instead of
+// reporting false success or silently hanging.
+func TestRunPerTurnConversational_NoPeerParksInstead(t *testing.T) {
+	dir := t.TempDir()
+	writeFakePerTurnBinary(t, dir, "codex",
+		`{"type":"thread.started","thread_id":"cx-fake"}`,
+		`{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}`,
+	)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
+
+	sessionDir := t.TempDir()
+	a := &Agent{ID: "conv2", TaskID: "task2", Provider: "codex", Mode: "interactive", sessionCWD: sessionDir, done: make(chan struct{})}
+	a.setPromptChannel(make(chan string, 1))
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.liveByProvider["codex"] = 1
+	m.liveCount = 1
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go m.runPerTurnConversational(ctx, a, RunConfig{Prompt: "hi", Provider: "codex"}, false)
+
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	// codex caps with no healthy per-turn peer at all (copilot unhealthy too,
+	// claude is never a valid per-turn hot-swap target).
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"codex": false, "copilot": false, "claude": true},
+		reasons: map[string]string{"codex": "rate_limited"},
+	})
+
+	if err := m.sendConvoPrompt(a.ID, "continue"); err != nil {
+		t.Fatalf("sendConvoPrompt: %v", err)
+	}
+
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not finalize after a blocked re-gate")
+	}
+
+	if a.GetErrorKind() != "rate_limit" {
+		t.Errorf("expected rate_limit error kind on no-peer block, got %q", a.GetErrorKind())
+	}
+	if a.GetProvider() != "codex" {
+		t.Errorf("provider must be unchanged when no switch happens, got %q", a.GetProvider())
+	}
+}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -218,7 +218,60 @@ func (m *Manager) runConversational(ctx context.Context, a *Agent, cfg RunConfig
 		return
 	}
 
+	// A pending handoff (SendMessage/regateBeforeClaudeTurn regated this
+	// agent's next turn onto a healthy per-turn peer and tore down the idle
+	// Claude process to force this exit) takes over instead of finalizing:
+	// the same *Agent hands off to the per-turn runner on the new provider.
+	if handoffCfg, prompt, ok := a.ConsumePendingHandoff(); ok {
+		m.completeConvoHandoff(ctx, a, &outFile, handoffCfg, prompt)
+		return
+	}
+
 	m.finalizeRun(ctx, a, "agent.convo.done")
+}
+
+// beginConvoHandoff records a regated provider switch on a persistent Claude
+// interactive agent and tears down its (idle) process so runConversational's
+// goroutine exits and completeConvoHandoff can take over. Called from
+// SendMessage when regateBeforeClaudeTurn finds Claude capped and a healthy
+// per-turn-capable peer available.
+func (m *Manager) beginConvoHandoff(a *Agent, cfg RunConfig, prompt string) {
+	cfg.Prompt = prompt
+	a.SetPendingHandoff(cfg, prompt)
+	a.SetState(StateRunning)
+	m.emit(events.AgentState(a.ID), a)
+	if a.isDetached() {
+		// A detached agent's stdin is a never-EOF O_RDWR FIFO (see
+		// startConvoProcessSurvive) — closing our end does not signal the
+		// child, so it must be killed by PID like StopAgent does.
+		m.signalKill(a)
+	} else {
+		a.convo.closeStdinPipe()
+	}
+	m.logger.Info("agent.convo.handoff", "id", a.ID, "task", cfg.TaskID, "to", cfg.Provider)
+}
+
+// completeConvoHandoff finishes a mid-run persistent-Claude -> per-turn
+// provider switch once the killed Claude process has actually exited: it
+// writes the provider-marker boundary into the still-open log (closing the
+// crash window before the switch lands on disk — see regate's deferPersist),
+// persists the switched registry record, then hands the log and a fresh
+// prompt channel to the per-turn runner. Returns without finalizing/marking
+// the agent done: the new goroutine owns the agent's completion from here.
+func (m *Manager) completeConvoHandoff(ctx context.Context, a *Agent, outFile **os.File, cfg RunConfig, prompt string) {
+	a.SetExitErr(nil)
+	if *outFile != nil {
+		writeProviderMarkerLine(*outFile, a.Provider)
+		_ = (*outFile).Close()
+		*outFile = nil
+	}
+	if m.survives() {
+		m.saveRegistry(ctx, a)
+	}
+	cfg.Prompt = prompt
+	a.setPromptChannel(make(chan string, 1))
+	m.logger.Info("agent.convo.handoff.start", "id", a.ID, "provider", a.Provider)
+	go m.runPerTurnConversational(ctx, a, cfg, false)
 }
 
 func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
@@ -257,7 +310,8 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 	}
 
 	// Open log file on first successful start; subsequent retries append.
-	if *outFile == nil {
+	freshLog := *outFile == nil
+	if freshLog {
 		f, fileErr := logging.NewAgentOutputFile(m.logDir, a.ID)
 		if fileErr != nil {
 			m.logger.Error("agent.output.file", "id", a.ID, "err", fileErr)
@@ -271,6 +325,13 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 	var logWriter io.Writer
 	if *outFile != nil {
 		logWriter = *outFile
+	}
+	if freshLog {
+		// Records the starting provider up front so a mid-run
+		// regateBeforeClaudeTurn switch away from Claude can be told apart
+		// from this initial segment on rehydration (see
+		// rehydratePerTurnConvoFromLog).
+		writeProviderMarkerLine(logWriter, a.Provider)
 	}
 
 	prevLen := len(a.ConvoOutput())
@@ -453,12 +514,30 @@ func (m *Manager) SendMessage(agentID, text string) error {
 		a.EnqueuePrompt(text)
 		m.logger.Info("agent.convo.message_queued", "id", a.ID, "queue_len", a.PendingPromptCount())
 	} else {
-		if err := m.writeUserMessage(a, text); err != nil {
-			return err
+		// Turn boundary: re-consult provider health before writing to the
+		// idle Claude session's stdin, so a provider that capped since the
+		// last turn does not strand this chat for the rest of its life.
+		regateCfg := RunConfig{
+			TaskID:             a.TaskID,
+			Dir:                a.sessionCWD,
+			Provider:           a.Provider,
+			Model:              a.Model,
+			RequirePermissions: a.requirePermissions,
 		}
-		a.SetState(StateRunning)
-		m.emit(events.AgentState(a.ID), a)
-		m.logger.Info("agent.convo.message_sent", "id", a.ID)
+		updatedCfg, switched, regateErr := m.regateBeforeClaudeTurn(context.Background(), a, regateCfg)
+		if regateErr != nil {
+			return fmt.Errorf("agent %s: %w", agentID, regateErr)
+		}
+		if switched {
+			m.beginConvoHandoff(a, updatedCfg, text)
+		} else {
+			if err := m.writeUserMessage(a, text); err != nil {
+				return err
+			}
+			a.SetState(StateRunning)
+			m.emit(events.AgentState(a.ID), a)
+			m.logger.Info("agent.convo.message_sent", "id", a.ID)
+		}
 	}
 
 	// Add user message to convo buffer regardless — the user should see

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -445,19 +445,20 @@ func (m *Manager) processConvoLine(ctx context.Context, a *Agent, line []byte, s
 		m.logger.Info("agent.convo.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
 		// Drain any prompts queued mid-turn before flipping to paused. Each
 		// queued prompt fires the next turn back-to-back so the user's
-		// chat-window queue executes in order without manual re-trigger.
+		// chat-window queue executes in order without manual re-trigger. This
+		// turn boundary must re-gate exactly like SendMessage's idle path —
+		// otherwise a provider that capped while the turn was running would
+		// still receive the queued follow-up on its stranded stdin.
 		if next, ok := a.PopPendingPrompt(); ok {
-			if err := m.writeUserMessage(a, next); err != nil {
+			if err := m.advanceClaudeTurn(ctx, a, next); err != nil {
 				m.logger.Error("agent.convo.flush-queue", "id", a.ID, "err", err)
-				a.SetState(StatePaused)
 			} else {
-				a.SetState(StateRunning)
 				m.logger.Info("agent.convo.queue-flushed", "id", a.ID, "remaining", a.PendingPromptCount())
 			}
 		} else {
 			a.SetState(StatePaused)
+			m.emit(events.AgentState(a.ID), a)
 		}
-		m.emit(events.AgentState(a.ID), a)
 		// One-shot runs close stdin so the claude process sees EOF and exits.
 		if oneShot {
 			m.logger.Info("agent.convo.one-shot-close", "id", a.ID)
@@ -493,6 +494,63 @@ func (m *Manager) writeUserMessage(a *Agent, text string) error {
 	return a.convo.writeStdin(data)
 }
 
+// claudeRegateConfig builds the RunConfig used to re-gate a persistent
+// Claude agent at a turn boundary (SendMessage's idle path and
+// advanceClaudeTurn's queued-flush path share this so both judge/switch
+// provider health from identical agent state).
+func claudeRegateConfig(a *Agent) RunConfig {
+	return RunConfig{
+		TaskID:             a.TaskID,
+		Dir:                a.sessionCWD,
+		Provider:           a.Provider,
+		Model:              a.Model,
+		RequirePermissions: a.requirePermissions,
+	}
+}
+
+// advanceClaudeTurn is the single persistent-Claude turn-boundary
+// chokepoint: given the next prompt to send — either SendMessage's idle
+// turn boundary or a queued follow-up flushed after a "result" event — it
+// re-gates provider health before writing to Claude's stdin, so a provider
+// that capped since the last turn does not strand this session. On any
+// outcome that cannot proceed (no healthy peer, write failure, cancellation,
+// stopped agent), prompt is restored to the front of the pending queue so a
+// later attempt retries it in order instead of losing or reordering it.
+func (m *Manager) advanceClaudeTurn(ctx context.Context, a *Agent, prompt string) error {
+	if a.WasStopped() || ctx.Err() != nil {
+		a.RestorePendingPrompt(prompt)
+		return fmt.Errorf("agent %s: not advancing turn, stopped or canceled", a.ID)
+	}
+
+	cfg := claudeRegateConfig(a)
+	updatedCfg, switched, regateErr := m.regateBeforeClaudeTurn(ctx, a, cfg)
+	if regateErr != nil {
+		// No healthy peer: regate already set a.SetError("rate_limit", ...).
+		// Restore the prompt so it is retried (not lost) once a peer or
+		// Claude itself recovers, and park the session instead of stranding
+		// it mid-write.
+		a.RestorePendingPrompt(prompt)
+		a.SetState(StatePaused)
+		m.emit(events.AgentState(a.ID), a)
+		m.logger.Warn("agent.convo.regate.blocked", "id", a.ID, "task", a.TaskID, "err", regateErr)
+		return regateErr
+	}
+	if switched {
+		m.beginConvoHandoff(a, updatedCfg, prompt)
+		return nil
+	}
+	if err := m.writeUserMessage(a, prompt); err != nil {
+		a.RestorePendingPrompt(prompt)
+		a.SetState(StatePaused)
+		m.emit(events.AgentState(a.ID), a)
+		m.logger.Error("agent.convo.write", "id", a.ID, "err", err)
+		return err
+	}
+	a.SetState(StateRunning)
+	m.emit(events.AgentState(a.ID), a)
+	return nil
+}
+
 // SendMessage sends a follow-up user message to a conversational agent.
 // When the agent is mid-turn (StateRunning), the message is appended to a
 // pending queue and flushed on the next "result" event, so users can pile
@@ -517,27 +575,10 @@ func (m *Manager) SendMessage(agentID, text string) error {
 		// Turn boundary: re-consult provider health before writing to the
 		// idle Claude session's stdin, so a provider that capped since the
 		// last turn does not strand this chat for the rest of its life.
-		regateCfg := RunConfig{
-			TaskID:             a.TaskID,
-			Dir:                a.sessionCWD,
-			Provider:           a.Provider,
-			Model:              a.Model,
-			RequirePermissions: a.requirePermissions,
+		if err := m.advanceClaudeTurn(m.ctx, a, text); err != nil {
+			return fmt.Errorf("agent %s: %w", agentID, err)
 		}
-		updatedCfg, switched, regateErr := m.regateBeforeClaudeTurn(context.Background(), a, regateCfg)
-		if regateErr != nil {
-			return fmt.Errorf("agent %s: %w", agentID, regateErr)
-		}
-		if switched {
-			m.beginConvoHandoff(a, updatedCfg, text)
-		} else {
-			if err := m.writeUserMessage(a, text); err != nil {
-				return err
-			}
-			a.SetState(StateRunning)
-			m.emit(events.AgentState(a.ID), a)
-			m.logger.Info("agent.convo.message_sent", "id", a.ID)
-		}
+		m.logger.Info("agent.convo.message_sent", "id", a.ID)
 	}
 
 	// Add user message to convo buffer regardless — the user should see

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -223,7 +223,8 @@ func (m *Manager) runConversational(ctx context.Context, a *Agent, cfg RunConfig
 	// Claude process to force this exit) takes over instead of finalizing:
 	// the same *Agent hands off to the per-turn runner on the new provider.
 	if handoffCfg, prompt, ok := a.ConsumePendingHandoff(); ok {
-		m.completeConvoHandoff(ctx, a, &outFile, handoffCfg, prompt)
+		m.completeConvoHandoff(ctx, a, outFile, handoffCfg, prompt)
+		outFile = nil
 		return
 	}
 
@@ -251,6 +252,36 @@ func (m *Manager) beginConvoHandoff(a *Agent, cfg RunConfig, prompt string) {
 	m.logger.Info("agent.convo.handoff", "id", a.ID, "task", cfg.TaskID, "to", cfg.Provider)
 }
 
+// reopenConvoHandoffLog reacquires the log writer used to bound a same-agent
+// Claude -> per-turn handoff. If the existing detached log cannot be reopened
+// for append, fall back to a fresh log file so the persisted provider switch
+// still has a marker-bounded segment instead of leaving restart rehydration
+// with a switched registry record and no boundary marker.
+func (m *Manager) reopenConvoHandoffLog(a *Agent, outFile *os.File) (*os.File, error) {
+	if outFile != nil {
+		return outFile, nil
+	}
+
+	var reopenErr error
+	if logPath := a.GetLogPath(); logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err == nil {
+			return f, nil
+		}
+		reopenErr = err
+	}
+
+	fresh, err := logging.NewAgentOutputFile(m.logDir, a.ID)
+	if err != nil {
+		if reopenErr != nil {
+			return nil, fmt.Errorf("reopen handoff log: %w; fresh handoff log: %w", reopenErr, err)
+		}
+		return nil, fmt.Errorf("fresh handoff log: %w", err)
+	}
+	a.SetLogPath(fresh.Name())
+	return fresh, nil
+}
+
 // completeConvoHandoff finishes a mid-run persistent-Claude -> per-turn
 // provider switch once the killed Claude process has actually exited: it
 // writes the provider-marker boundary into the still-open log (closing the
@@ -258,12 +289,11 @@ func (m *Manager) beginConvoHandoff(a *Agent, cfg RunConfig, prompt string) {
 // persists the switched registry record, then hands the log and a fresh
 // prompt channel to the per-turn runner. Returns without finalizing/marking
 // the agent done: the new goroutine owns the agent's completion from here.
-func (m *Manager) completeConvoHandoff(ctx context.Context, a *Agent, outFile **os.File, cfg RunConfig, prompt string) {
+func (m *Manager) completeConvoHandoff(ctx context.Context, a *Agent, outFile *os.File, cfg RunConfig, prompt string) {
 	a.SetExitErr(nil)
-	if *outFile != nil {
-		writeProviderMarkerLine(*outFile, a.Provider)
-		_ = (*outFile).Close()
-		*outFile = nil
+	if outFile != nil {
+		writeProviderMarkerLine(outFile, a.Provider)
+		_ = outFile.Close()
 	}
 	if m.survives() {
 		m.saveRegistry(ctx, a)
@@ -394,6 +424,9 @@ func (m *Manager) streamConvoOutput(ctx context.Context, a *Agent, stdout io.Rea
 // state machine. Shared by the pipe-backed streamer and the survival file
 // tailer; it never writes the log file (caller or child owns that).
 func (m *Manager) processConvoLine(ctx context.Context, a *Agent, line []byte, st *convoEmitState, oneShot bool) {
+	if _, ok := parseProviderMarkerLine(line); ok {
+		return
+	}
 	parsed, parseErr := ParseClaudeLine(line)
 	if parseErr != nil {
 		m.logger.Warn("agent.convo.parse", "id", a.ID, "err", parseErr, "line", string(line))

--- a/internal/agent/runner_convo_queue_test.go
+++ b/internal/agent/runner_convo_queue_test.go
@@ -1,0 +1,237 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeClaudeConvoScriptSlow mirrors fakeClaudeConvoScript but sleeps briefly
+// after reading each line before replying, giving a test a window to enqueue
+// a follow-up message (via SendMessage's queued branch) while the turn is
+// still StateRunning.
+const fakeClaudeConvoScriptSlow = "#!/bin/sh\n" +
+	"while IFS= read -r line; do\n" +
+	"  sleep 0.3\n" +
+	"  printf '%s\\n' '{\"type\":\"system\",\"session_id\":\"claude-sess\"}'\n" +
+	"  printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"claude-sess\"}'\n" +
+	"done\n" +
+	"exit 0\n"
+
+// startSlowPersistentClaude spins up a persistent-Claude conversational agent
+// backed by fakeClaudeConvoScriptSlow and waits for the initial turn to
+// settle at StatePaused, ready for a follow-up.
+func startSlowPersistentClaude(t *testing.T, id string) (*Manager, *Agent) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(fakeClaudeConvoScriptSlow), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	writeFakePerTurnBinary(t, dir, "copilot",
+		`{"type":"assistant.message","data":{"content":"hi from copilot"}}`,
+		`{"type":"result","sessionId":"cop-fake"}`,
+	)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "copilot": true}})
+
+	sessionDir := t.TempDir()
+	a := &Agent{ID: id, TaskID: "t-" + id, Provider: "claude", Mode: "interactive", sessionCWD: sessionDir, done: make(chan struct{})}
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.liveByProvider["claude"] = 1
+	m.liveCount = 1
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	a.cancel = cancel
+	go m.runConversational(ctx, a, RunConfig{Prompt: "hi", Provider: "claude"})
+
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+	return m, a
+}
+
+// TestQueuedFlush_RegatesAndHotSwapsAtTurnBoundary is the permanent
+// regression test for the bug reported by adversarial testing: a follow-up
+// queued while a persistent-Claude turn is running must be re-gated (not
+// written directly to the now-capped Claude stdin) when it is flushed after
+// the turn's result.
+func TestQueuedFlush_RegatesAndHotSwapsAtTurnBoundary(t *testing.T) {
+	m, a := startSlowPersistentClaude(t, "q1")
+
+	if err := m.SendMessage(a.ID, "turn2"); err != nil {
+		t.Fatalf("SendMessage turn2: %v", err)
+	}
+	waitForAgentState(t, a, StateRunning, 2*time.Second)
+
+	// Enqueue a follow-up while turn2 is still running (sleeping in the fake
+	// script), then flip Claude unhealthy before its result arrives.
+	if err := m.SendMessage(a.ID, "turn3"); err != nil {
+		t.Fatalf("SendMessage turn3 (queued): %v", err)
+	}
+	if a.PendingPromptCount() != 1 {
+		t.Fatalf("expected turn3 queued, PendingPromptCount=%d", a.PendingPromptCount())
+	}
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"claude": false, "copilot": true},
+		reasons: map[string]string{"claude": "rate_limited"},
+	})
+
+	waitForAgentProvider(t, a, "copilot", 3*time.Second)
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	if a.GetSessionID() != "cop-fake" {
+		t.Errorf("expected copilot session id after queued-flush handoff, got %q", a.GetSessionID())
+	}
+	if a.PendingPromptCount() != 0 {
+		t.Errorf("queued prompt should have been consumed by the handoff, remaining=%d", a.PendingPromptCount())
+	}
+
+	if err := m.StopAgent(a.ID); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after StopAgent")
+	}
+}
+
+// TestQueuedFlush_NoPeerRestoresPromptToFront verifies that when the queued
+// flush finds no healthy peer, the prompt is restored to the front of the
+// queue (not lost) and the agent parks with a rate_limit error instead of
+// writing to the capped Claude stdin.
+func TestQueuedFlush_NoPeerRestoresPromptToFront(t *testing.T) {
+	m, a := startSlowPersistentClaude(t, "q2")
+
+	if err := m.SendMessage(a.ID, "turn2"); err != nil {
+		t.Fatalf("SendMessage turn2: %v", err)
+	}
+	waitForAgentState(t, a, StateRunning, 2*time.Second)
+
+	if err := m.SendMessage(a.ID, "turn3"); err != nil {
+		t.Fatalf("SendMessage turn3 (queued): %v", err)
+	}
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"claude": false, "codex": false, "copilot": false},
+		reasons: map[string]string{"claude": "rate_limited"},
+	})
+
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	if a.GetProvider() != "claude" {
+		t.Errorf("provider must stay claude when no peer is healthy, got %q", a.GetProvider())
+	}
+	if a.GetErrorKind() != "rate_limit" {
+		t.Errorf("expected rate_limit error kind, got %q", a.GetErrorKind())
+	}
+	if got, ok := a.PopPendingPrompt(); !ok || got != "turn3" {
+		t.Errorf("expected turn3 restored to front of queue, got %q ok=%v", got, ok)
+	}
+
+	if err := m.StopAgent(a.ID); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after StopAgent")
+	}
+}
+
+// TestQueuedFlush_CarriesRemainingQueueInOrderAcrossHandoff verifies that
+// when a queued flush hot-swaps to a per-turn peer, any further prompts still
+// sitting in the same Agent's pending queue survive the handoff and replay
+// on the peer in original order, without waiting on a new SendPromptToAgent
+// call.
+func TestQueuedFlush_CarriesRemainingQueueInOrderAcrossHandoff(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(fakeClaudeConvoScriptSlow), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	writeFakePerTurnBinary(t, dir, "copilot",
+		`{"type":"assistant.message","data":{"content":"hi from copilot"}}`,
+		`{"type":"result","sessionId":"cop-fake"}`,
+	)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "copilot": true}})
+
+	sessionDir := t.TempDir()
+	a := &Agent{ID: "q3", TaskID: "t-q3", Provider: "claude", Mode: "interactive", sessionCWD: sessionDir, done: make(chan struct{})}
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.liveByProvider["claude"] = 1
+	m.liveCount = 1
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	a.cancel = cancel
+	go m.runConversational(ctx, a, RunConfig{Prompt: "hi", Provider: "claude"})
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	if err := m.SendMessage(a.ID, "turn2"); err != nil {
+		t.Fatalf("SendMessage turn2: %v", err)
+	}
+	waitForAgentState(t, a, StateRunning, 2*time.Second)
+
+	// Enqueue two follow-ups while turn2 runs: the flush should pop and
+	// regate "turn3" (triggering the handoff), while "turn4" stays queued on
+	// the same *Agent and must replay on copilot afterward, in order.
+	if err := m.SendMessage(a.ID, "turn3"); err != nil {
+		t.Fatalf("SendMessage turn3: %v", err)
+	}
+	if err := m.SendMessage(a.ID, "turn4"); err != nil {
+		t.Fatalf("SendMessage turn4: %v", err)
+	}
+	if a.PendingPromptCount() != 2 {
+		t.Fatalf("expected 2 prompts queued, got %d", a.PendingPromptCount())
+	}
+
+	m.SetHealthGate(&fakeGate{
+		healthy: map[string]bool{"claude": false, "copilot": true},
+		reasons: map[string]string{"claude": "rate_limited"},
+	})
+
+	waitForAgentProvider(t, a, "copilot", 3*time.Second)
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	// turn4 should have replayed automatically (queue drains before the
+	// per-turn loop blocks on its prompt channel), leaving the queue empty.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && a.PendingPromptCount() != 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if a.PendingPromptCount() != 0 {
+		t.Fatalf("expected carried queue to fully drain, remaining=%d", a.PendingPromptCount())
+	}
+
+	var userTexts []string
+	for _, ev := range a.ConvoOutput() {
+		if ev.Type == "user_input" {
+			userTexts = append(userTexts, ev.Text)
+		}
+	}
+	want := []string{"turn2", "turn3", "turn4"}
+	if len(userTexts) != len(want) {
+		t.Fatalf("expected user_input events %v, got %v", want, userTexts)
+	}
+	for i, w := range want {
+		if userTexts[i] != w {
+			t.Errorf("user_input[%d] = %q, want %q (order matters)", i, userTexts[i], w)
+		}
+	}
+
+	if err := m.StopAgent(a.ID); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after StopAgent")
+	}
+}

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -423,6 +423,22 @@ func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64
 		return
 	}
 
+	// A pending handoff can only exist here if this *Agent is the same
+	// in-memory object that had SendMessage/advanceClaudeTurn regate it onto
+	// a peer just before its (now-doomed) Claude process was torn down — the
+	// handoff field is never persisted, so a genuine restart's fromRecord
+	// Agent always has none and falls through to ordinary finalization below.
+	if handoffCfg, prompt, ok := a.ConsumePendingHandoff(); ok {
+		var outFile *os.File
+		if f, ferr := os.OpenFile(a.GetLogPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); ferr == nil {
+			outFile = f
+		} else {
+			m.logger.Warn("agent.reattach.handoff.log", "id", a.ID, "err", ferr)
+		}
+		m.completeConvoHandoff(ctx, a, &outFile, handoffCfg, prompt)
+		return
+	}
+
 	// No cmd.Wait runs for a reattached agent, so GetExitErr is nil. Infer
 	// the outcome from the terminal result: none -> crash (errReattachedGone);
 	// an error result -> a real failure; a success result -> leave nil.

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -70,6 +70,12 @@ func (m *Manager) startConvoProcessSurvive(ctx context.Context, a *Agent, cfg Ru
 		}
 		a.SetLogPath(f.Name())
 		*outFile = f
+		// Records the starting provider up front so a mid-run
+		// regateBeforeClaudeTurn switch away from Claude can be told apart
+		// from this initial segment on rehydration (see
+		// rehydratePerTurnConvoFromLog). Written directly (the child hasn't
+		// started yet, so nothing else has written to the file).
+		writeProviderMarkerLine(f, a.Provider)
 	}
 	cmd.Stdout = *outFile
 
@@ -204,6 +210,7 @@ func (m *Manager) runConvoAttemptSurviveOneShot(ctx context.Context, a *Agent, c
 		}
 		a.SetLogPath(f.Name())
 		*outFile = f
+		writeProviderMarkerLine(f, a.Provider)
 	}
 	cmd.Stdout = *outFile
 

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -429,13 +429,14 @@ func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64
 	// handoff field is never persisted, so a genuine restart's fromRecord
 	// Agent always has none and falls through to ordinary finalization below.
 	if handoffCfg, prompt, ok := a.ConsumePendingHandoff(); ok {
-		var outFile *os.File
-		if f, ferr := os.OpenFile(a.GetLogPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); ferr == nil {
-			outFile = f
-		} else {
-			m.logger.Warn("agent.reattach.handoff.log", "id", a.ID, "err", ferr)
+		prevLogPath := a.GetLogPath()
+		outFile, err := m.reopenConvoHandoffLog(a, nil)
+		if err != nil {
+			m.logger.Warn("agent.reattach.handoff.log", "id", a.ID, "err", err)
+		} else if prevLogPath != "" && outFile.Name() != prevLogPath {
+			m.logger.Warn("agent.reattach.handoff.log-fallback", "id", a.ID, "from", prevLogPath, "to", outFile.Name())
 		}
-		m.completeConvoHandoff(ctx, a, &outFile, handoffCfg, prompt)
+		m.completeConvoHandoff(ctx, a, outFile, handoffCfg, prompt)
 		return
 	}
 

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -510,3 +510,103 @@ func TestReattachInteractive_ReattachesLiveAgent(t *testing.T) {
 		t.Fatalf("expected registry empty after completion, got %d", len(list))
 	}
 }
+
+// TestReattachConvo_SameProcessHandoffSkipsOrdinaryFinalization verifies
+// that when the *Agent object being reattached still carries an in-memory
+// pending handoff (SendMessage/advanceClaudeTurn regated it onto a peer
+// right before its now-doomed Claude process was torn down), reattachConvo
+// hands off to the peer via completeConvoHandoff instead of finalizing the
+// agent as stopped. This only happens for the same in-memory Agent — a
+// genuine restart's fromRecord Agent never carries a handoff (see
+// TestReattachInteractive_ReattachesLiveAgent for that path).
+func TestReattachConvo_SameProcessHandoffSkipsOrdinaryFinalization(t *testing.T) {
+	dir := t.TempDir()
+	writeFakePerTurnBinary(t, dir, "copilot",
+		`{"type":"assistant.message","data":{"content":"hi from copilot"}}`,
+		`{"type":"result","sessionId":"cop-fake"}`,
+	)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "hoff1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	history := `{"__sybra_provider_marker__":"provider_switch","version":1,"provider":"claude"}` + "\n" +
+		`{"type":"system","session_id":"claude-sess"}` + "\n" +
+		`{"type":"result","subtype":"success","session_id":"claude-sess"}` + "\n"
+	if err := os.WriteFile(logPath, []byte(history), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var completed atomic.Bool
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete:        func(*Agent) { completed.Store(true) },
+	})
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"copilot": true}})
+
+	// A short-lived helper process stands in for the doomed Claude process:
+	// it exits almost immediately, which is what should make reattachConvo's
+	// tail loop return exited=true.
+	cmd := exec.Command("sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	procStart := processStartString(context.Background(), cmd.Process.Pid)
+	go func() { _ = cmd.Wait() }()
+
+	a := &Agent{ID: "hoff1", TaskID: "t-hoff1", Provider: "claude", Mode: "interactive", done: make(chan struct{})}
+	a.SetLogPath(logPath)
+	// Mirrors real usage: regateBeforeClaudeTurn (called from advanceClaudeTurn
+	// before beginConvoHandoff/SetPendingHandoff) already flips a.Provider to
+	// the peer before the handoff is recorded.
+	a.SetProviderAndModel("copilot", "")
+	a.SetPendingHandoff(RunConfig{TaskID: "t-hoff1", Provider: "copilot"}, "continue-on-peer")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.cancel = cancel
+	t.Cleanup(cancel)
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.liveCount = 1
+	m.liveByProvider["claude"] = 1
+	m.mu.Unlock()
+
+	m.reattachConvo(ctx, a, 0, procStart, false)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && a.GetSessionID() != "cop-fake" {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if a.GetSessionID() != "cop-fake" {
+		t.Fatalf("expected copilot session id after handoff, got %q", a.GetSessionID())
+	}
+	waitForAgentState(t, a, StatePaused, 3*time.Second)
+
+	var sawHandoffPrompt bool
+	for _, ev := range a.ConvoOutput() {
+		if ev.Type == "result" && ev.SessionID == "cop-fake" {
+			sawHandoffPrompt = true
+		}
+	}
+	if !sawHandoffPrompt {
+		t.Error("expected the handed-off prompt to run on copilot")
+	}
+	// completeConvoHandoff hands the agent to a fresh runPerTurnConversational
+	// goroutine rather than finalizing it, so OnComplete must not have fired
+	// yet — the ordinary reattachConvo finalization path was skipped.
+	if completed.Load() {
+		t.Error("expected ordinary finalization to be skipped by the handoff, but OnComplete already fired")
+	}
+
+	if err := m.StopAgent(a.ID); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after StopAgent")
+	}
+}

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -81,6 +81,42 @@ func TestRehydrateCodexConvoFromLog(t *testing.T) {
 	}
 }
 
+func TestProcessConvoLine_IgnoresProviderMarker(t *testing.T) {
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "marker", Provider: "claude"}
+	st := &convoEmitState{}
+
+	m.processConvoLine(context.Background(), a, []byte(`{"__sybra_provider_marker__":"provider_switch","version":1,"provider":"copilot"}`), st, false)
+
+	if got := len(a.ConvoOutput()); got != 0 {
+		t.Fatalf("expected provider marker to be ignored, got %d convo events", got)
+	}
+}
+
+func TestReopenConvoHandoffLog_FallsBackToFreshFile(t *testing.T) {
+	logDir := t.TempDir()
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	a := &Agent{ID: "handoff-fallback"}
+	badPath := filepath.Join(t.TempDir(), "stale-log")
+	if err := os.MkdirAll(badPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	a.SetLogPath(badPath)
+
+	f, err := m.reopenConvoHandoffLog(a, nil)
+	if err != nil {
+		t.Fatalf("reopenConvoHandoffLog: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if f.Name() == badPath {
+		t.Fatalf("expected fallback fresh log, kept broken path %q", badPath)
+	}
+	if a.GetLogPath() != f.Name() {
+		t.Fatalf("expected agent log path updated to fallback file, got %q want %q", a.GetLogPath(), f.Name())
+	}
+}
+
 // TestReattachCodexConvo_RecreatesIdleAgent verifies a codex interactive
 // record is recreated as an idle, sendable agent on restart (no live process
 // required — codex has none between turns).


### PR DESCRIPTION
## Motivation

Persistent Claude interactive sessions never re-consulted provider
health between turns, unlike the per-turn codex/copilot runner — a
Claude session that hit a cap or outage stayed pinned to itself for
the rest of its life instead of failing over to a healthy peer.

## Implementation information

- `SendMessage` now regates provider health before writing to an idle
  persistent Claude session, and hands the same agent off to the
  per-turn runner on a healthy peer when the current one is unhealthy.
- Tears down the old process cleanly and preserves mixed-provider log
  rehydration across the handoff.
- Closes a crash window in the regate path and requeues instead of
  escalating when blocked.
- Adds coverage for regate decisions, codex/copilot convo failover,
  and convo queue/survive behavior.

Closes https://github.com/Automaat/sybra/issues/1588

_Generated by Sybra harness_