### PR TITLE
feat(task): trash-based soft delete with retention

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -2056,6 +2056,35 @@ func cmdTrashRestore(s *task.Manager, args []string, jsonOut bool) int {
 	return 0
 }
 
+type trashPruneReportJSON struct {
+	Scanned int               `json:"scanned"`
+	Removed int               `json:"removed"`
+	Entries []task.TrashEntry `json:"entries"`
+	Errors  []string          `json:"errors"`
+}
+
+func newTrashPruneReportJSON(rep task.TrashPruneReport) trashPruneReportJSON {
+	out := trashPruneReportJSON{
+		Scanned: rep.Scanned,
+		Removed: rep.Removed,
+		Entries: rep.Entries,
+	}
+	if len(rep.Errors) > 0 {
+		out.Errors = make([]string, 0, len(rep.Errors))
+		for _, err := range rep.Errors {
+			out.Errors = append(out.Errors, err.Error())
+		}
+	}
+	return out
+}
+
+func trashDeleteMessage(id string, removed bool) string {
+	if removed {
+		return fmt.Sprintf("Purged trashed task %s\n", id)
+	}
+	return fmt.Sprintf("Trashed task %s was already purged\n", id)
+}
+
 // cmdTrashDelete permanently purges id's newest trashed generation right
 // away, bypassing the retention window — for a compliance request or a
 // leaked credential that needs the content gone now, not after
@@ -2071,7 +2100,7 @@ func cmdTrashDelete(s *task.Manager, args []string, jsonOut bool) int {
 	if jsonOut {
 		return printJSON(map[string]any{"status": "ok", "id": args[0], "removed": removed})
 	}
-	fmt.Printf("Purged trashed task %s\n", args[0])
+	fmt.Print(trashDeleteMessage(args[0], removed))
 	return 0
 }
 
@@ -2083,7 +2112,7 @@ func cmdTrashEmpty(s *task.Manager, jsonOut bool) int {
 		return fatal(jsonOut, "%v", err)
 	}
 	if jsonOut {
-		return printJSON(rep)
+		return printJSON(newTrashPruneReportJSON(rep))
 	}
 	fmt.Printf("Purged %d/%d trashed generations\n", rep.Removed, rep.Scanned)
 	return 0

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -197,6 +197,8 @@ func dispatch(cmd string, rest []string, cfg *config.Config, store *task.Manager
 		return cmdArtifact(rest, jsonOut)
 	case "config":
 		return cmdConfig(cfg, rest, jsonOut)
+	case "trash":
+		return cmdTrash(store, rest, jsonOut)
 	default:
 		return fatal(jsonOut, "unknown command: %s", cmd)
 	}
@@ -1868,6 +1870,13 @@ Commands:
            was opened outside of Sybra; the PR monitor will then auto-merge or
            advance the task to done once the PR lands.
   delete   <id>
+           Soft-deletes: moves the task file and its sidecars into the trash
+           dir instead of unlinking them. See trash list / trash restore.
+
+  trash list
+  trash restore <id>
+           Restore the newest trashed generation for id back into the tasks
+           dir. Refuses if a live task with that id already exists.
 
   project list
   project get <id>
@@ -1982,6 +1991,58 @@ func cmdArtifactReindex(store *artifact.Store, args []string, jsonOut bool) int 
 		return printJSON(map[string]string{"status": "ok", "task_id": taskID})
 	}
 	fmt.Printf("reindexed %s\n", taskID)
+	return 0
+}
+
+// cmdTrash handles `sybra-cli trash list|restore <id>` — recovery for tasks
+// soft-deleted by Store.Delete (see internal/task.Store's ListTrash/
+// RestoreFromTrash).
+func cmdTrash(s *task.Manager, args []string, jsonOut bool) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "usage: trash <list|restore>")
+	}
+	switch sub, rest := args[0], args[1:]; sub {
+	case "list":
+		return cmdTrashList(s, jsonOut)
+	case "restore":
+		return cmdTrashRestore(s, rest, jsonOut)
+	default:
+		return fatal(jsonOut, "unknown trash command: %s", sub)
+	}
+}
+
+func cmdTrashList(s *task.Manager, jsonOut bool) int {
+	entries, err := s.ListTrash()
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if jsonOut {
+		if entries == nil {
+			entries = []task.TrashEntry{}
+		}
+		return printJSON(entries)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tDELETED\tGENERATION\tTITLE")
+	for i := range entries {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", entries[i].ID, entries[i].DeletedDate, entries[i].Generation, entries[i].Title)
+	}
+	_ = w.Flush()
+	return 0
+}
+
+func cmdTrashRestore(s *task.Manager, args []string, jsonOut bool) int {
+	if len(args) < 1 {
+		return fatal(jsonOut, "usage: trash restore <id>")
+	}
+	t, err := s.RestoreFromTrash(args[0])
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if jsonOut {
+		return printJSON(t)
+	}
+	fmt.Printf("Restored task %s\n", t.ID)
 	return 0
 }
 

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1877,6 +1877,11 @@ Commands:
   trash restore <id>
            Restore the newest trashed generation for id back into the tasks
            dir. Refuses if a live task with that id already exists.
+  trash delete <id>
+           Permanently purge id's newest trashed generation right away,
+           bypassing the retention window.
+  trash empty
+           Permanently purge every trashed generation, regardless of age.
 
   project list
   project get <id>
@@ -1994,18 +1999,23 @@ func cmdArtifactReindex(store *artifact.Store, args []string, jsonOut bool) int 
 	return 0
 }
 
-// cmdTrash handles `sybra-cli trash list|restore <id>` — recovery for tasks
-// soft-deleted by Store.Delete (see internal/task.Store's ListTrash/
-// RestoreFromTrash).
+// cmdTrash handles `sybra-cli trash list|restore <id>|delete <id>|empty` —
+// recovery and permanent-purge for tasks soft-deleted by Store.Delete (see
+// internal/task.Store's ListTrash/RestoreFromTrash/DeleteTrashedGeneration/
+// PruneAllTrash).
 func cmdTrash(s *task.Manager, args []string, jsonOut bool) int {
 	if len(args) == 0 {
-		return fatal(jsonOut, "usage: trash <list|restore>")
+		return fatal(jsonOut, "usage: trash <list|restore|delete|empty>")
 	}
 	switch sub, rest := args[0], args[1:]; sub {
 	case "list":
 		return cmdTrashList(s, jsonOut)
 	case "restore":
 		return cmdTrashRestore(s, rest, jsonOut)
+	case "delete":
+		return cmdTrashDelete(s, rest, jsonOut)
+	case "empty":
+		return cmdTrashEmpty(s, jsonOut)
 	default:
 		return fatal(jsonOut, "unknown trash command: %s", sub)
 	}
@@ -2043,6 +2053,39 @@ func cmdTrashRestore(s *task.Manager, args []string, jsonOut bool) int {
 		return printJSON(t)
 	}
 	fmt.Printf("Restored task %s\n", t.ID)
+	return 0
+}
+
+// cmdTrashDelete permanently purges id's newest trashed generation right
+// away, bypassing the retention window — for a compliance request or a
+// leaked credential that needs the content gone now, not after
+// RetentionDays.
+func cmdTrashDelete(s *task.Manager, args []string, jsonOut bool) int {
+	if len(args) < 1 {
+		return fatal(jsonOut, "usage: trash delete <id>")
+	}
+	removed, err := s.DeleteTrashedGeneration(args[0])
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if jsonOut {
+		return printJSON(map[string]any{"status": "ok", "id": args[0], "removed": removed})
+	}
+	fmt.Printf("Purged trashed task %s\n", args[0])
+	return 0
+}
+
+// cmdTrashEmpty permanently purges every trashed generation, regardless of
+// age.
+func cmdTrashEmpty(s *task.Manager, jsonOut bool) int {
+	rep, err := s.PruneAllTrash()
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if jsonOut {
+		return printJSON(rep)
+	}
+	fmt.Printf("Purged %d/%d trashed generations\n", rep.Removed, rep.Scanned)
 	return 0
 }
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -250,6 +250,126 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestTrashListAndRestore(t *testing.T) {
+	setupStore(t)
+
+	code, out := runCLI(t, "--json", "create", "--title", "trash me")
+	if code != 0 {
+		t.Fatalf("create exit %d", code)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+
+	code, _ = runCLI(t, "--json", "delete", created.ID)
+	if code != 0 {
+		t.Fatalf("delete exit %d", code)
+	}
+
+	code, out = runCLI(t, "--json", "trash", "list")
+	if code != 0 {
+		t.Fatalf("trash list exit %d: %s", code, out)
+	}
+	var entries []task.TrashEntry
+	mustUnmarshal(t, out, &entries)
+	if len(entries) != 1 || entries[0].ID != created.ID {
+		t.Fatalf("trash list = %+v, want the trashed task", entries)
+	}
+
+	code, tableOut := runCLI(t, "trash", "list")
+	if code != 0 {
+		t.Fatalf("trash list (table) exit %d", code)
+	}
+	if !strings.Contains(tableOut, created.ID) || !strings.Contains(tableOut, created.Title) {
+		t.Errorf("table output = %q, want it to contain id and title", tableOut)
+	}
+
+	code, out = runCLI(t, "--json", "trash", "restore", created.ID)
+	if code != 0 {
+		t.Fatalf("trash restore exit %d: %s", code, out)
+	}
+	var restored task.Task
+	mustUnmarshal(t, out, &restored)
+	if restored.ID != created.ID {
+		t.Fatalf("restored.ID = %q, want %q", restored.ID, created.ID)
+	}
+
+	code, out = runCLI(t, "--json", "list")
+	if code != 0 {
+		t.Fatalf("list exit %d", code)
+	}
+	var tasks []task.Task
+	mustUnmarshal(t, out, &tasks)
+	if len(tasks) != 1 || tasks[0].ID != created.ID {
+		t.Fatalf("expected restored task back in list, got %+v", tasks)
+	}
+}
+
+func TestTrashRestoreRefusesLiveCollision(t *testing.T) {
+	home := setupStore(t)
+
+	code, out := runCLI(t, "--json", "create", "--title", "collide")
+	if code != 0 {
+		t.Fatalf("create exit %d", code)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+
+	code, _ = runCLI(t, "--json", "delete", created.ID)
+	if code != 0 {
+		t.Fatalf("delete exit %d", code)
+	}
+
+	// Simulate a live task reappearing at the same id (e.g. an external
+	// tool wrote the file directly) so restore must refuse to overwrite it.
+	tasksDir := filepath.Join(home, "tasks")
+	livePath := filepath.Join(tasksDir, created.ID+".md")
+	if err := os.WriteFile(livePath, []byte("---\nid: "+created.ID+"\n---\nlive again"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _ = runCLI(t, "--json", "trash", "restore", created.ID)
+	if code == 0 {
+		t.Error("expected non-zero exit when restore would overwrite a live task")
+	}
+}
+
+func TestTrashListEmpty(t *testing.T) {
+	setupStore(t)
+	code, out := runCLI(t, "--json", "trash", "list")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	var entries []task.TrashEntry
+	mustUnmarshal(t, out, &entries)
+	if len(entries) != 0 {
+		t.Errorf("expected 0 trash entries, got %d", len(entries))
+	}
+}
+
+func TestTrashRestoreNotFound(t *testing.T) {
+	setupStore(t)
+	code, _ := runCLI(t, "--json", "trash", "restore", "nonexistent")
+	if code == 0 {
+		t.Error("expected non-zero exit for restoring nonexistent trash entry")
+	}
+}
+
+func TestTrashRestoreNoID(t *testing.T) {
+	setupStore(t)
+	code, _ := runCLI(t, "--json", "trash", "restore")
+	if code == 0 {
+		t.Error("expected non-zero exit for trash restore without ID")
+	}
+}
+
+func TestTrashUnknownSubcommand(t *testing.T) {
+	setupStore(t)
+	code, _ := runCLI(t, "--json", "trash", "bogus")
+	if code == 0 {
+		t.Error("expected non-zero exit for unknown trash subcommand")
+	}
+}
+
 func TestConfigDoctorJSONReturnsNonZeroForErrors(t *testing.T) {
 	setupStore(t)
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -370,6 +370,53 @@ func TestTrashUnknownSubcommand(t *testing.T) {
 	}
 }
 
+func TestTrashDeleteMessage(t *testing.T) {
+	if got := trashDeleteMessage("task-1", true); got != "Purged trashed task task-1\n" {
+		t.Fatalf("removed=true message = %q", got)
+	}
+	if got := trashDeleteMessage("task-1", false); got != "Trashed task task-1 was already purged\n" {
+		t.Fatalf("removed=false message = %q", got)
+	}
+}
+
+func TestTrashEmptyJSONUsesStableDTO(t *testing.T) {
+	setupStore(t)
+
+	code, out := runCLI(t, "--json", "create", "--title", "trash me")
+	if code != 0 {
+		t.Fatalf("create exit %d", code)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+
+	code, _ = runCLI(t, "--json", "delete", created.ID)
+	if code != 0 {
+		t.Fatalf("delete exit %d", code)
+	}
+
+	code, out = runCLI(t, "--json", "trash", "empty")
+	if code != 0 {
+		t.Fatalf("trash empty exit %d: %s", code, out)
+	}
+
+	var rep struct {
+		Scanned int               `json:"scanned"`
+		Removed int               `json:"removed"`
+		Entries []task.TrashEntry `json:"entries"`
+		Errors  []string          `json:"errors"`
+	}
+	mustUnmarshal(t, out, &rep)
+	if rep.Scanned != 1 || rep.Removed != 1 {
+		t.Fatalf("trash empty report = %+v, want scanned=1 removed=1", rep)
+	}
+	if len(rep.Entries) != 1 || rep.Entries[0].ID != created.ID {
+		t.Fatalf("trash empty entries = %+v, want one entry for %s", rep.Entries, created.ID)
+	}
+	if len(rep.Errors) != 0 {
+		t.Fatalf("trash empty errors = %+v, want empty", rep.Errors)
+	}
+}
+
 func TestConfigDoctorJSONReturnsNonZeroForErrors(t *testing.T) {
 	setupStore(t)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,7 @@ machine.
 |---|---|---|---|
 | `logging` | `LoggingConfig` | _(see below)_ |  |
 | `audit` | `AuditConfig` | _(see below)_ |  |
+| `trash` | `TrashConfig` | _(see below)_ |  |
 | `agent` | `AgentDefaults` | _(see below)_ |  |
 | `testing` | `TestingConfig` | _(see below)_ |  |
 | `notification` | `NotificationConfig` | _(see below)_ |  |
@@ -68,6 +69,15 @@ machine.
 |---|---|---|---|
 | `audit.enabled` | `bool` | `true` |  |
 | `audit.retention_days` | `int` | `30` |  |
+
+## TrashConfig (`trash`)
+
+TrashConfig controls the retention of soft-deleted tasks under
+~/.sybra/trash (see internal/task.Store.Delete).
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `trash.retention_days` | `int` |  | RetentionDays bounds how long a trashed task generation survives before the startup sweep permanently removes it. 0 falls back to DefaultTrashRetentionDays (14); a negative value disables pruning. |
 
 ## AgentDefaults (`agent`)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import "github.com/Automaat/sybra/internal/abtest"
 type Config struct {
 	Logging        LoggingConfig        `yaml:"logging" json:"logging"`
 	Audit          AuditConfig          `yaml:"audit" json:"audit"`
+	Trash          TrashConfig          `yaml:"trash" json:"trash"`
 	Agent          AgentDefaults        `yaml:"agent" json:"agent"`
 	Testing        TestingConfig        `yaml:"testing" json:"testing"`
 	Notification   NotificationConfig   `yaml:"notification" json:"notification"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -78,6 +78,22 @@ func (c *Config) DefaultLogRetentionDays() int {
 	return c.Agent.LogRetentionDays
 }
 
+// DefaultTrashRetentionDays returns the configured retention window for
+// soft-deleted tasks under ~/.sybra/trash, or 14 days if unset. A negative
+// value disables age-based pruning entirely.
+func (c *Config) DefaultTrashRetentionDays() int {
+	if c == nil {
+		return 14
+	}
+	if c.Trash.RetentionDays < 0 {
+		return c.Trash.RetentionDays
+	}
+	if c.Trash.RetentionDays == 0 {
+		return 14
+	}
+	return c.Trash.RetentionDays
+}
+
 // DefaultRequirePermissions returns the configured default, or true if unset.
 func (c *Config) DefaultRequirePermissions() bool {
 	if c != nil && c.Agent.RequirePermissions != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -804,6 +804,27 @@ func TestDefaultLogRetentionDays(t *testing.T) {
 	}
 }
 
+func TestDefaultTrashRetentionDays(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{"nil config → 14", nil, 14},
+		{"unset → 14", &Config{}, 14},
+		{"explicit 7 → 7", &Config{Trash: TrashConfig{RetentionDays: 7}}, 7},
+		{"negative disables (sentinel preserved)", &Config{Trash: TrashConfig{RetentionDays: -1}}, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.DefaultTrashRetentionDays(); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRetryWatchdog(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/config/config_trash.go
+++ b/internal/config/config_trash.go
@@ -1,0 +1,10 @@
+package config
+
+// TrashConfig controls the retention of soft-deleted tasks under
+// ~/.sybra/trash (see internal/task.Store.Delete).
+type TrashConfig struct {
+	// RetentionDays bounds how long a trashed task generation survives
+	// before the startup sweep permanently removes it. 0 falls back to
+	// DefaultTrashRetentionDays (14); a negative value disables pruning.
+	RetentionDays int `yaml:"retention_days" json:"retentionDays"`
+}

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -104,12 +104,19 @@ func (r *Recovery) PruneTrash() {
 	r.pruneTrash()
 }
 
+func (r *Recovery) effectiveTrashRetentionDays() int {
+	if r.TrashRetentionDays == 0 {
+		return 14
+	}
+	return r.TrashRetentionDays
+}
+
 // pruneTrash permanently removes trash generations older than
 // TrashRetentionDays, run right after gcOrphanChats (whose Delete calls just
 // trashed any orphaned chat tasks) and before Worktrees.CleanupOrphaned.
 // Logs the resulting count and every generation removed.
 func (r *Recovery) pruneTrash() {
-	rep, err := r.Tasks.PruneTrash(r.TrashRetentionDays)
+	rep, err := r.Tasks.PruneTrash(r.effectiveTrashRetentionDays())
 	if err != nil {
 		r.Logger.Warn("recovery.trash.prune_failed", "err", err)
 		return

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -96,6 +96,14 @@ func (r *Recovery) pruneAgentLogs() {
 	logging.LogPruneReport(r.Logger, rep)
 }
 
+// PruneTrash is the periodic entry point for a background ticker (see
+// LifecycleManager.startTrashPruneLoop) that keeps the trash dir bounded
+// between restarts on long-lived server deployments — RunStartupCleanup's
+// call only covers the boot-time pass.
+func (r *Recovery) PruneTrash() {
+	r.pruneTrash()
+}
+
 // pruneTrash permanently removes trash generations older than
 // TrashRetentionDays, run right after gcOrphanChats (whose Delete calls just
 // trashed any orphaned chat tasks) and before Worktrees.CleanupOrphaned.

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -55,6 +55,12 @@ type Recovery struct {
 
 	LogDir       string
 	LogRetention time.Duration // 0 disables age-based pruning
+
+	// TrashRetentionDays bounds how long a soft-deleted task (see
+	// task.Store.Delete) survives under the trash dir before
+	// pruneTrash permanently removes it. A negative value disables
+	// pruning.
+	TrashRetentionDays int
 }
 
 // RunStartupCleanup sequences boot-time maintenance in the order that lets
@@ -76,6 +82,7 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 	}
 	r.Worktrees.RepairAll(ctx)
 	r.gcOrphanChats(ctx)
+	r.pruneTrash()
 	r.Worktrees.CleanupOrphaned(ctx)
 	r.cleanStaleRuns()
 	r.pruneAgentLogs()
@@ -87,4 +94,23 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 func (r *Recovery) pruneAgentLogs() {
 	rep := logging.PruneAgentLogs(r.LogDir, r.LogRetention, time.Now())
 	logging.LogPruneReport(r.Logger, rep)
+}
+
+// pruneTrash permanently removes trash generations older than
+// TrashRetentionDays, run right after gcOrphanChats (whose Delete calls just
+// trashed any orphaned chat tasks) and before Worktrees.CleanupOrphaned.
+// Logs the resulting count and every generation removed.
+func (r *Recovery) pruneTrash() {
+	rep, err := r.Tasks.PruneTrash(r.TrashRetentionDays)
+	if err != nil {
+		r.Logger.Warn("recovery.trash.prune_failed", "err", err)
+		return
+	}
+	for _, entry := range rep.Entries {
+		r.Logger.Info("recovery.trash.pruned", "id", entry.ID, "generation", entry.Generation, "deleted_date", entry.DeletedDate, "title", entry.Title)
+	}
+	for _, err := range rep.Errors {
+		r.Logger.Warn("recovery.trash.prune_error", "err", err)
+	}
+	r.Logger.Info("recovery.trash.prune", "scanned", rep.Scanned, "removed", rep.Removed, "errors", len(rep.Errors))
 }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -198,6 +198,65 @@ func TestRunStartupCleanup_PruneTrashRemovesExpiredGenerations(t *testing.T) {
 	}
 }
 
+func TestRunStartupCleanup_PruneTrashZeroUsesDefaultRetention(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("Expired", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := tasks.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ListTrash() = %d entries, want 1", len(entries))
+	}
+	backdated := filepath.Join(store.TrashDir(), time.Now().UTC().AddDate(0, 0, -30).Format(time.DateOnly))
+	if err := os.Rename(filepath.Join(store.TrashDir(), entries[0].DeletedDate), backdated); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	var wg sync.WaitGroup
+	r := &recovery.Recovery{
+		Tasks:              tasks,
+		Agents:             agents,
+		Worktrees:          wm,
+		Logger:             logger,
+		Throttle:           logging.NewErrorThrottle(),
+		WG:                 &wg,
+		LogDir:             t.TempDir(),
+		TrashRetentionDays: 0,
+	}
+	r.RunStartupCleanup(context.Background())
+	wg.Wait()
+
+	remaining, err := tasks.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining = %+v, want the default 14-day retention to prune the expired generation", remaining)
+	}
+}
+
 // TestRestartStaleSkipsRecentRun verifies the dev-reload debounce: an
 // in-progress task whose latest agent run started seconds ago is left
 // alone (no respawn) so a hot-reloaded App doesn't race a still-living

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -76,6 +78,124 @@ func TestRunStartupCleanupEmpty(t *testing.T) {
 	}
 	r.RunStartupCleanup(context.Background())
 	wg.Wait()
+}
+
+// TestRunStartupCleanup_GcOrphanChatIsTrashedNotLost verifies the
+// gcOrphanChats → pruneTrash ordering: an orphaned chat task gc'd during
+// startup goes through Tasks.Delete (now a soft delete, see
+// internal/task.Store.Delete), so a wrongly-collected chat is still
+// recoverable via trash restore rather than gone for good. pruneTrash runs
+// immediately after gcOrphanChats in the same pass, but with retention
+// unset (0 → default 14 days) a same-day trash entry must survive it.
+func TestRunStartupCleanup_GcOrphanChatIsTrashedNotLost(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	chat, err := tasks.CreateChat("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	var wg sync.WaitGroup
+	r := &recovery.Recovery{
+		Tasks:     tasks,
+		Agents:    agents,
+		Worktrees: wm,
+		Logger:    logger,
+		Throttle:  logging.NewErrorThrottle(),
+		WG:        &wg,
+		LogDir:    t.TempDir(),
+	}
+	r.RunStartupCleanup(context.Background())
+	wg.Wait()
+
+	if _, err := tasks.Get(chat.ID); err == nil {
+		t.Fatal("orphaned chat task should no longer be live after startup cleanup")
+	}
+
+	entries, err := tasks.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].ID != chat.ID {
+		t.Fatalf("ListTrash() = %+v, want the gc'd chat task preserved in trash", entries)
+	}
+}
+
+// TestRunStartupCleanup_PruneTrashRemovesExpiredGenerations verifies
+// pruneTrash actually runs during RunStartupCleanup and respects
+// TrashRetentionDays: an old, already-expired trash generation is gone
+// after the pass.
+func TestRunStartupCleanup_PruneTrashRemovesExpiredGenerations(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("Expired", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := tasks.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ListTrash() = %d entries, want 1", len(entries))
+	}
+	backdated := filepath.Join(store.TrashDir(), time.Now().UTC().AddDate(0, 0, -30).Format(time.DateOnly))
+	if err := os.Rename(filepath.Join(store.TrashDir(), entries[0].DeletedDate), backdated); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	var wg sync.WaitGroup
+	r := &recovery.Recovery{
+		Tasks:              tasks,
+		Agents:             agents,
+		Worktrees:          wm,
+		Logger:             logger,
+		Throttle:           logging.NewErrorThrottle(),
+		WG:                 &wg,
+		LogDir:             t.TempDir(),
+		TrashRetentionDays: 14,
+	}
+	r.RunStartupCleanup(context.Background())
+	wg.Wait()
+
+	remaining, err := tasks.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining = %+v, want the expired generation pruned", remaining)
+	}
 }
 
 // TestRestartStaleSkipsRecentRun verifies the dev-reload debounce: an

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -781,17 +781,18 @@ func (a *App) newRecovery() *recovery.Recovery {
 		retention = time.Duration(days) * 24 * time.Hour
 	}
 	return &recovery.Recovery{
-		Tasks:          a.tasks,
-		Agents:         a.agents,
-		Worktrees:      a.worktrees,
-		WorkflowEngine: a.workflowEngine,
-		Orchestrator:   a.agentOrch,
-		Projects:       a.projects,
-		Logger:         a.logger,
-		Throttle:       a.restartStaleErr,
-		WG:             &a.wg,
-		LogDir:         a.logDir,
-		LogRetention:   retention,
+		Tasks:              a.tasks,
+		Agents:             a.agents,
+		Worktrees:          a.worktrees,
+		WorkflowEngine:     a.workflowEngine,
+		Orchestrator:       a.agentOrch,
+		Projects:           a.projects,
+		Logger:             a.logger,
+		Throttle:           a.restartStaleErr,
+		WG:                 &a.wg,
+		LogDir:             a.logDir,
+		LogRetention:       retention,
+		TrashRetentionDays: a.cfg.DefaultTrashRetentionDays(),
 	}
 }
 

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -59,6 +59,7 @@ func (lm *LifecycleManager) StartManagers(ctx context.Context, emit func(string,
 	lm.startPromptLabService(ctx, emit)
 	lm.startAutoUpdate(ctx)
 	lm.startAgentLogPruneLoop(ctx)
+	lm.startTrashPruneLoop(ctx)
 	lm.registerMetricsObservers()
 }
 
@@ -206,6 +207,26 @@ func (lm *LifecycleManager) startAgentLogPruneLoop(ctx context.Context) {
 				return
 			case <-ticker.C:
 				lm.prune()
+			}
+		}
+	})
+}
+
+// startTrashPruneLoop sweeps expired soft-deleted task generations once a
+// day. The startup call inside Recovery.RunStartupCleanup handles the first
+// pass; this goroutine bounds trash growth between restarts on long-lived
+// server deployments, mirroring startAgentLogPruneLoop.
+func (lm *LifecycleManager) startTrashPruneLoop(ctx context.Context) {
+	a := lm.app
+	a.wg.Go(func() {
+		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				a.recovery.PruneTrash()
 			}
 		}
 	})

--- a/internal/task/comment.go
+++ b/internal/task/comment.go
@@ -114,15 +114,6 @@ func (s *CommentStore) ResolveAll(taskID string) error {
 	return s.write(taskID, comments)
 }
 
-// DeleteAll removes the sidecar file for a task (called on task deletion).
-func (s *CommentStore) DeleteAll(taskID string) error {
-	path := s.sidecarPath(taskID)
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("delete comments: %w", err)
-	}
-	return nil
-}
-
 func (s *CommentStore) write(taskID string, comments []ReviewComment) error {
 	data, err := json.MarshalIndent(comments, "", "  ")
 	if err != nil {

--- a/internal/task/comment_test.go
+++ b/internal/task/comment_test.go
@@ -138,35 +138,3 @@ func TestCommentStore_Delete_NotFound(t *testing.T) {
 		t.Fatal("expected error for non-existent comment")
 	}
 }
-
-func TestCommentStore_DeleteAll(t *testing.T) {
-	t.Parallel()
-	s := NewCommentStore(t.TempDir())
-
-	if _, err := s.Add("task-1", 1, "a"); err != nil {
-		t.Fatalf("Add a: %v", err)
-	}
-	if _, err := s.Add("task-1", 2, "b"); err != nil {
-		t.Fatalf("Add b: %v", err)
-	}
-
-	if err := s.DeleteAll("task-1"); err != nil {
-		t.Fatalf("DeleteAll: %v", err)
-	}
-
-	comments, err := s.List("task-1")
-	if err != nil {
-		t.Fatalf("List after DeleteAll: %v", err)
-	}
-	if len(comments) != 0 {
-		t.Errorf("expected empty, got %d comments", len(comments))
-	}
-}
-
-func TestCommentStore_DeleteAll_NoFile(t *testing.T) {
-	t.Parallel()
-	s := NewCommentStore(t.TempDir())
-	if err := s.DeleteAll("task-1"); err != nil {
-		t.Fatalf("DeleteAll with no file: %v", err)
-	}
-}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -350,6 +350,34 @@ func (m *Manager) Delete(id string) error {
 	return nil
 }
 
+// RestoreFromTrash restores id's newest trash generation and emits
+// task:created — restored tasks re-enter the system the same way a fresh
+// Create does, so watchers (file watcher, workflow engine) treat it as a
+// new task rather than an update to one that "already existed".
+func (m *Manager) RestoreFromTrash(id string) (Task, error) {
+	mu := m.lockFor(id)
+	mu.Lock()
+	t, err := m.store.RestoreFromTrash(id)
+	mu.Unlock()
+	if err != nil {
+		return Task{}, err
+	}
+	m.recordFiredStatus(t.ID, string(t.Status))
+	m.emitter.Emit(events.TaskCreated, t.FilePath)
+	return t, nil
+}
+
+// ListTrash returns every trashed task generation, newest first.
+func (m *Manager) ListTrash() ([]TrashEntry, error) {
+	return m.store.ListTrash()
+}
+
+// PruneTrash permanently removes trash generations older than
+// retentionDays. A negative retentionDays disables pruning.
+func (m *Manager) PruneTrash(retentionDays int) (TrashPruneReport, error) {
+	return m.store.PruneTrash(retentionDays)
+}
+
 // AddRun appends an agent run to the task and emits task:updated.
 func (m *Manager) AddRun(taskID string, run AgentRun) error {
 	return m.AddRunWithStatus(taskID, run, nil)

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -378,6 +378,18 @@ func (m *Manager) PruneTrash(retentionDays int) (TrashPruneReport, error) {
 	return m.store.PruneTrash(retentionDays)
 }
 
+// DeleteTrashedGeneration permanently removes id's newest trashed
+// generation immediately, bypassing the retention window.
+func (m *Manager) DeleteTrashedGeneration(id string) (bool, error) {
+	return m.store.DeleteTrashedGeneration(id)
+}
+
+// PruneAllTrash permanently removes every trashed generation regardless of
+// age.
+func (m *Manager) PruneAllTrash() (TrashPruneReport, error) {
+	return m.store.PruneAllTrash()
+}
+
 // AddRun appends an agent run to the task and emits task:updated.
 func (m *Manager) AddRun(taskID string, run AgentRun) error {
 	return m.AddRunWithStatus(taskID, run, nil)

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -192,20 +192,36 @@ func (s *Store) lockTask(id string) (func(), error) {
 	}, nil
 }
 
+// sidecarFileSuffixes lists every fixed-name (non-plan-draft) sidecar
+// suffix a task can own. Single source of truth for both IsSidecarFile and
+// Store.taskFiles, so a new fixed-name sidecar kind only needs to be added
+// here. Plan drafts use caller-chosen names (see IsPlanDraftFile) and so
+// can't be enumerated as fixed suffixes.
+var sidecarFileSuffixes = []string{
+	".comments.json",
+	".plan.md",
+	".plan-contract.json",
+	".plan-critique.md",
+	".plan-research.md",
+	".plan-decisions.md",
+	".plan-brief.md",
+	".review.md",
+}
+
 // IsSidecarFile reports whether a filename (basename) belongs to a sidecar
 // store rather than a primary task file. Centralized so adding a new
-// sidecar kind only requires updating this list.
+// sidecar kind only requires updating sidecarFileSuffixes (or, for
+// caller-named sidecars like plan drafts, IsPlanDraftFile).
 func IsSidecarFile(base string) bool {
 	if IsPlanDraftFile(base) {
 		return true
 	}
-	return strings.HasSuffix(base, ".plan.md") ||
-		strings.HasSuffix(base, ".plan-contract.json") ||
-		strings.HasSuffix(base, ".plan-critique.md") ||
-		strings.HasSuffix(base, ".plan-research.md") ||
-		strings.HasSuffix(base, ".plan-decisions.md") ||
-		strings.HasSuffix(base, ".plan-brief.md") ||
-		strings.HasSuffix(base, ".review.md")
+	for _, suffix := range sidecarFileSuffixes {
+		if strings.HasSuffix(base, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // List returns every task under the store's directory, in directory-read
@@ -620,34 +636,34 @@ func (s *Store) CreateChat(projectID string) (Task, error) {
 	return t, nil
 }
 
-// taskFiles returns the basenames of every file this store owns for id: the
-// primary task file (id.md) plus any sidecar (comments, plans, contracts,
-// critiques, research, decisions, brief, code reviews, plan drafts). All of
-// these are named "<id>.<suffix>", so a literal "id+.\" prefix match — after
-// validating id through safePath — is exact: it cannot match another task's
-// files because that would require the other id to equal this one up to and
-// including the separating dot. The per-task flock sidecar ("<id>.md.lock")
-// is deliberately excluded — it is lock plumbing, not task data, and must
-// stay in place so a concurrent lockTask call on the same id keeps working.
+// taskFiles returns the basenames of every sidecar file this store owns for
+// id (comments, plans, contracts, critiques, research, decisions, brief,
+// code reviews, plan drafts) — the primary "<id>.md" is not included, since
+// Delete/RestoreFromTrash handle it separately. Checks each fixed-name
+// suffix in sidecarFileSuffixes directly (bounded, ~8 stat calls) rather
+// than scanning the whole tasks directory, so cost scales with the sidecar
+// kinds that exist, not with the number of live tasks in the store. Plan
+// drafts go through planDrafts.List, which has its own negative-cache index
+// and so is also O(1) for the common case of a task with no drafts.
 func (s *Store) taskFiles(id string) ([]string, error) {
 	if _, err := s.safePath(id); err != nil {
 		return nil, err
 	}
-	entries, err := os.ReadDir(s.dir)
-	if err != nil {
-		return nil, fmt.Errorf("read tasks dir: %w", err)
-	}
-	prefix := id + "."
 	var out []string
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
+	for _, suffix := range sidecarFileSuffixes {
+		base := id + suffix
+		if _, err := os.Stat(filepath.Join(s.dir, base)); err == nil {
+			out = append(out, base)
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("stat %s: %w", base, err)
 		}
-		base := e.Name()
-		if !strings.HasPrefix(base, prefix) || strings.HasSuffix(base, ".lock") {
-			continue
-		}
-		out = append(out, base)
+	}
+	drafts, err := s.planDrafts.List(id)
+	if err != nil {
+		return nil, fmt.Errorf("list plan drafts: %w", err)
+	}
+	for name := range drafts {
+		out = append(out, id+PlanDraftSidecarPrefix+name+".md")
 	}
 	return out, nil
 }
@@ -686,9 +702,13 @@ func (s *Store) newTrashGeneration(id string) (string, error) {
 // the primary "<id>.md" file so that a crash or rename failure partway
 // through leaves the primary file as the source of truth for whether the
 // task still "exists": either it's still in place (delete didn't complete)
-// or it's gone (delete completed, modulo any sidecars this call already
-// moved). There is deliberately no copy/delete fallback if a rename fails
-// (e.g. trash on a different filesystem) — the error is returned as-is.
+// or it's gone (delete completed). If any rename fails partway through,
+// every file already moved into genDir is rolled back to s.dir and genDir
+// is removed, so a partial failure never leaves an orphaned generation
+// (unlistable/unrestorable/unprunable — trashGenerationID requires the
+// primary file to identify a generation) or a live task missing sidecars.
+// There is deliberately no copy/delete fallback if a rename itself fails
+// (e.g. trash on a different filesystem) — that error is returned as-is.
 func (s *Store) Delete(id string) error {
 	unlock, err := s.lockTask(id)
 	if err != nil {
@@ -709,15 +729,22 @@ func (s *Store) Delete(id string) error {
 		return fmt.Errorf("create trash generation: %w", err)
 	}
 	primary := id + ".md"
-	for _, base := range files {
-		if base == primary {
-			continue
+	moved := make([]string, 0, len(files))
+	rollback := func() {
+		for _, base := range moved {
+			_ = os.Rename(filepath.Join(genDir, base), filepath.Join(s.dir, base))
 		}
+		_ = os.Remove(genDir)
+	}
+	for _, base := range files {
 		if err := os.Rename(filepath.Join(s.dir, base), filepath.Join(genDir, base)); err != nil {
+			rollback()
 			return fmt.Errorf("move %s to trash: %w", base, err)
 		}
+		moved = append(moved, base)
 	}
 	if err := os.Rename(t.FilePath, filepath.Join(genDir, primary)); err != nil {
+		rollback()
 		return fmt.Errorf("move task file to trash: %w", err)
 	}
 	s.planDrafts.invalidateIndex()
@@ -874,8 +901,13 @@ func removeEmptyTrashDirs(genDir string) {
 
 // RestoreFromTrash moves id's newest trash generation back into the tasks
 // dir under the same per-task lock Delete uses, restoring sidecars before
-// the primary "<id>.md" file (mirror of Delete's ordering). Refuses if a
-// live task with id already exists rather than silently overwriting it.
+// the primary "<id>.md" file (mirror of Delete's ordering). If any rename
+// fails partway through, every file already restored to s.dir is rolled
+// back into genDir so a partial failure never leaves orphaned "<id>.*"
+// sidecars in the live tasks dir with no primary file — such litter would
+// be invisible to List, ListTrash, and PruneTrash, and unreachable by a
+// future Delete(id), which requires the primary file to exist. Refuses if
+// a live task with id already exists rather than silently overwriting it.
 func (s *Store) RestoreFromTrash(id string) (Task, error) {
 	unlock, err := s.lockTask(id)
 	if err != nil {
@@ -906,16 +938,25 @@ func (s *Store) RestoreFromTrash(id string) (Task, error) {
 		return Task{}, fmt.Errorf("read trash generation: %w", err)
 	}
 	primary := id + ".md"
+	restored := make([]string, 0, len(entries))
+	rollback := func() {
+		for _, base := range restored {
+			_ = os.Rename(filepath.Join(s.dir, base), filepath.Join(genDir, base))
+		}
+	}
 	for _, e := range entries {
 		base := e.Name()
 		if base == primary {
 			continue
 		}
 		if err := os.Rename(filepath.Join(genDir, base), filepath.Join(s.dir, base)); err != nil {
+			rollback()
 			return Task{}, fmt.Errorf("restore %s: %w", base, err)
 		}
+		restored = append(restored, base)
 	}
 	if err := os.Rename(filepath.Join(genDir, primary), livePath); err != nil {
+		rollback()
 		return Task{}, fmt.Errorf("restore task file: %w", err)
 	}
 	removeEmptyTrashDirs(genDir)
@@ -958,6 +999,22 @@ func (s *Store) pruneGeneration(id, genDir string) (removed bool, err error) {
 	return true, nil
 }
 
+// DeleteTrashedGeneration permanently removes id's newest trashed
+// generation right away, bypassing the retention window. This is the
+// escape hatch PruneTrash can't provide: a compliance request or a leaked
+// credential needs trashed content gone immediately, not after
+// RetentionDays or the next prune sweep.
+func (s *Store) DeleteTrashedGeneration(id string) (bool, error) {
+	genDir, err := s.newestGeneration(id)
+	if err != nil {
+		return false, err
+	}
+	if genDir == "" {
+		return false, fmt.Errorf("no trashed task found for id %s: %w", id, os.ErrNotExist)
+	}
+	return s.pruneGeneration(id, genDir)
+}
+
 // PruneTrash permanently removes trash generations deleted more than
 // retentionDays ago. A negative retentionDays disables pruning entirely
 // (no-op). Each generation is removed under its own id's per-task lock, so
@@ -965,12 +1022,26 @@ func (s *Store) pruneGeneration(id, genDir string) (removed bool, err error) {
 // naive "remove the whole date directory" sweep, which could not take a
 // single lock covering every id it touches.
 func (s *Store) PruneTrash(retentionDays int) (TrashPruneReport, error) {
-	var rep TrashPruneReport
 	if retentionDays < 0 {
-		return rep, nil
+		return TrashPruneReport{}, nil
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays).Format(time.DateOnly)
+	return s.pruneTrashBefore(cutoff)
+}
 
+// PruneAllTrash permanently removes every trash generation regardless of
+// age — the "empty the trash now" counterpart to PruneTrash's
+// retention-gated sweep, for a `trash empty` CLI command.
+func (s *Store) PruneAllTrash() (TrashPruneReport, error) {
+	// No real deletion date sorts >= this, so every date dir qualifies.
+	return s.pruneTrashBefore("9999-99-99")
+}
+
+// pruneTrashBefore is the shared body of PruneTrash and PruneAllTrash: it
+// removes every trash generation dated strictly before cutoff (a
+// time.DateOnly string).
+func (s *Store) pruneTrashBefore(cutoff string) (TrashPruneReport, error) {
+	var rep TrashPruneReport
 	dateEntries, err := os.ReadDir(s.trashDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -24,6 +24,7 @@ import (
 // lockTask for the cross-process locking story.
 type Store struct {
 	dir           string
+	trashDir      string
 	comments      *CommentStore
 	plans         *PlanStore
 	planContracts *PlanningSidecarStore
@@ -53,6 +54,7 @@ func NewStore(dir string) (*Store, error) {
 	}
 	return &Store{
 		dir:           dir,
+		trashDir:      filepath.Join(filepath.Dir(dir), "trash"),
 		comments:      NewCommentStore(dir),
 		plans:         NewPlanStore(dir),
 		planContracts: NewPlanningSidecarStore(dir, ".plan-contract.json", "plan contract"),
@@ -74,6 +76,13 @@ func (s *Store) Comments() *CommentStore {
 // Dir returns the root tasks directory backing this store.
 func (s *Store) Dir() string {
 	return s.dir
+}
+
+// TrashDir returns the directory soft-deleted tasks are moved into by
+// Delete, sibling to the tasks dir (e.g. ~/.sybra/trash for
+// ~/.sybra/tasks). Exposed for CLI diagnostics and tests.
+func (s *Store) TrashDir() string {
+	return s.trashDir
 }
 
 // Plans returns the sidecar store for the human-readable compact plan
@@ -611,10 +620,75 @@ func (s *Store) CreateChat(projectID string) (Task, error) {
 	return t, nil
 }
 
-// Delete removes task id's file along with every sidecar it may own
+// taskFiles returns the basenames of every file this store owns for id: the
+// primary task file (id.md) plus any sidecar (comments, plans, contracts,
+// critiques, research, decisions, brief, code reviews, plan drafts). All of
+// these are named "<id>.<suffix>", so a literal "id+.\" prefix match — after
+// validating id through safePath — is exact: it cannot match another task's
+// files because that would require the other id to equal this one up to and
+// including the separating dot. The per-task flock sidecar ("<id>.md.lock")
+// is deliberately excluded — it is lock plumbing, not task data, and must
+// stay in place so a concurrent lockTask call on the same id keeps working.
+func (s *Store) taskFiles(id string) ([]string, error) {
+	if _, err := s.safePath(id); err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("read tasks dir: %w", err)
+	}
+	prefix := id + "."
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		base := e.Name()
+		if !strings.HasPrefix(base, prefix) || strings.HasSuffix(base, ".lock") {
+			continue
+		}
+		out = append(out, base)
+	}
+	return out, nil
+}
+
+// newTrashGeneration creates and returns a fresh, empty directory under
+// trashDir/<yyyy-mm-dd>/ to hold one Delete's worth of files for id. The
+// first delete of id on a given date uses the bare id as the generation
+// name; same-day redeletes (delete → restore → delete again) get a
+// "<id>--<HHMMSS>-<nn>" suffix so they don't collide with — or silently
+// overwrite — the earlier generation.
+func (s *Store) newTrashGeneration(id string) (string, error) {
+	dateDir := filepath.Join(s.trashDir, time.Now().UTC().Format(time.DateOnly))
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		return "", fmt.Errorf("create trash date dir: %w", err)
+	}
+	base := filepath.Join(dateDir, id)
+	if err := os.Mkdir(base, 0o755); err == nil {
+		return base, nil
+	} else if !os.IsExist(err) {
+		return "", err
+	}
+	for n := 1; ; n++ {
+		candidate := filepath.Join(dateDir, fmt.Sprintf("%s--%s-%02d", id, time.Now().UTC().Format("150405"), n))
+		if err := os.Mkdir(candidate, 0o755); err == nil {
+			return candidate, nil
+		} else if !os.IsExist(err) {
+			return "", err
+		}
+	}
+}
+
+// Delete moves task id's file, along with every sidecar it may own
 // (comments, plans, contracts, critiques, research, decisions, brief, code
-// reviews). Sidecar deletion errors are ignored — a missing sidecar is not
-// a failure — but a missing task file is.
+// reviews, plan drafts), into a dated generation directory under the trash
+// dir instead of unlinking them — see TrashDir. Sidecars are moved before
+// the primary "<id>.md" file so that a crash or rename failure partway
+// through leaves the primary file as the source of truth for whether the
+// task still "exists": either it's still in place (delete didn't complete)
+// or it's gone (delete completed, modulo any sidecars this call already
+// moved). There is deliberately no copy/delete fallback if a rename fails
+// (e.g. trash on a different filesystem) — the error is returned as-is.
 func (s *Store) Delete(id string) error {
 	unlock, err := s.lockTask(id)
 	if err != nil {
@@ -626,19 +700,322 @@ func (s *Store) Delete(id string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.Remove(t.FilePath); err != nil {
-		return fmt.Errorf("delete task file: %w", err)
+	files, err := s.taskFiles(id)
+	if err != nil {
+		return err
 	}
-	_ = s.comments.DeleteAll(id)
-	_ = s.plans.Delete(id)
-	_ = s.planContracts.Delete(id)
-	_ = s.planCritiques.Delete(id)
-	_ = s.planResearch.Delete(id)
-	_ = s.planDecisions.Delete(id)
-	_ = s.planBrief.Delete(id)
-	_ = s.codeReviews.Delete(id)
+	genDir, err := s.newTrashGeneration(id)
+	if err != nil {
+		return fmt.Errorf("create trash generation: %w", err)
+	}
+	primary := id + ".md"
+	for _, base := range files {
+		if base == primary {
+			continue
+		}
+		if err := os.Rename(filepath.Join(s.dir, base), filepath.Join(genDir, base)); err != nil {
+			return fmt.Errorf("move %s to trash: %w", base, err)
+		}
+	}
+	if err := os.Rename(t.FilePath, filepath.Join(genDir, primary)); err != nil {
+		return fmt.Errorf("move task file to trash: %w", err)
+	}
+	s.planDrafts.invalidateIndex()
 	s.deleteCachedTask(id)
 	return nil
+}
+
+// TrashEntry describes one soft-deleted task generation for ListTrash and
+// PruneTrash callers (CLI table/JSON output, prune logging).
+type TrashEntry struct {
+	ID          string    `json:"id"`
+	Generation  string    `json:"generation"`
+	DeletedDate string    `json:"deleted_date"`
+	DeletedAt   time.Time `json:"deleted_at"`
+	Title       string    `json:"title"`
+}
+
+// trashGenerationID returns the task id owned by a trash generation
+// directory, identified by the one file inside it that ends in ".md" but is
+// not itself a sidecar (IsSidecarFile) — i.e. the primary "<id>.md". This
+// avoids relying on the generation directory's name (which is a convenience
+// naming scheme, not a contract) to recover id, so list/restore/prune never
+// prefix-match an arbitrary id. ok is false for an empty, already-restored,
+// or corrupt generation.
+func trashGenerationID(genDir string) (id string, ok bool) {
+	entries, err := os.ReadDir(genDir)
+	if err != nil {
+		return "", false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		base := e.Name()
+		if strings.HasSuffix(base, ".md") && !IsSidecarFile(base) {
+			return strings.TrimSuffix(base, ".md"), true
+		}
+	}
+	return "", false
+}
+
+// walkTrashGenerations calls fn for every generation directory under
+// trashDir/<yyyy-mm-dd>/, passing the deletion date, the generation
+// directory's basename, and its full path. fn's error stops the walk for
+// that generation only (recorded via the returned slice) — one unreadable
+// generation must not abort ListTrash/PruneTrash for the rest.
+func (s *Store) walkTrashGenerations(fn func(date, generation, path string) error) []error {
+	var errs []error
+	dateEntries, err := os.ReadDir(s.trashDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("read trash dir: %w", err))
+		}
+		return errs
+	}
+	for _, de := range dateEntries {
+		if !de.IsDir() {
+			continue
+		}
+		date := de.Name()
+		dateDir := filepath.Join(s.trashDir, date)
+		genEntries, err := os.ReadDir(dateDir)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("read trash date dir %s: %w", date, err))
+			continue
+		}
+		for _, ge := range genEntries {
+			if !ge.IsDir() {
+				continue
+			}
+			if err := fn(date, ge.Name(), filepath.Join(dateDir, ge.Name())); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+// trashEntryFor builds a TrashEntry for a generation directory, reading its
+// title from the trashed primary file (best-effort — a parse failure leaves
+// Title empty rather than failing the whole entry).
+func trashEntryFor(date, generation, path, id string) TrashEntry {
+	entry := TrashEntry{ID: id, Generation: generation, DeletedDate: date}
+	if info, err := os.Stat(path); err == nil {
+		entry.DeletedAt = info.ModTime()
+	}
+	if t, err := Parse(filepath.Join(path, id+".md")); err == nil {
+		entry.Title = t.Title
+	}
+	return entry
+}
+
+// ListTrash returns one entry per trashed generation across all dates,
+// newest first. Multiple generations for the same id (repeated
+// delete/restore cycles) each get their own entry so callers can
+// distinguish them.
+func (s *Store) ListTrash() ([]TrashEntry, error) {
+	var out []TrashEntry
+	errs := s.walkTrashGenerations(func(date, generation, path string) error {
+		id, ok := trashGenerationID(path)
+		if !ok {
+			return nil
+		}
+		out = append(out, trashEntryFor(date, generation, path, id))
+		return nil
+	})
+	if len(errs) > 0 {
+		return out, errors.Join(errs...)
+	}
+	slices.SortFunc(out, func(a, b TrashEntry) int {
+		return b.DeletedAt.Compare(a.DeletedAt)
+	})
+	return out, nil
+}
+
+// newestGeneration returns the path to the most recently deleted trash
+// generation owned by id, or "" if none exist.
+func (s *Store) newestGeneration(id string) (string, error) {
+	var newest string
+	var newestAt time.Time
+	errs := s.walkTrashGenerations(func(date, generation, path string) error {
+		gid, ok := trashGenerationID(path)
+		if !ok || gid != id {
+			return nil
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			return fmt.Errorf("stat trash generation %s: %w", path, statErr)
+		}
+		if newest == "" || info.ModTime().After(newestAt) {
+			newest = path
+			newestAt = info.ModTime()
+		}
+		return nil
+	})
+	if len(errs) > 0 {
+		return "", errors.Join(errs...)
+	}
+	return newest, nil
+}
+
+// removeEmptyTrashDirs removes genDir (expected empty after a restore) and,
+// if that leaves its parent date directory empty too, removes that as well.
+func removeEmptyTrashDirs(genDir string) {
+	if err := os.Remove(genDir); err != nil {
+		return
+	}
+	dateDir := filepath.Dir(genDir)
+	entries, err := os.ReadDir(dateDir)
+	if err == nil && len(entries) == 0 {
+		_ = os.Remove(dateDir)
+	}
+}
+
+// RestoreFromTrash moves id's newest trash generation back into the tasks
+// dir under the same per-task lock Delete uses, restoring sidecars before
+// the primary "<id>.md" file (mirror of Delete's ordering). Refuses if a
+// live task with id already exists rather than silently overwriting it.
+func (s *Store) RestoreFromTrash(id string) (Task, error) {
+	unlock, err := s.lockTask(id)
+	if err != nil {
+		return Task{}, err
+	}
+	defer unlock()
+
+	livePath, err := s.safePath(id)
+	if err != nil {
+		return Task{}, err
+	}
+	if _, err := os.Stat(livePath); err == nil {
+		return Task{}, fmt.Errorf("task %s already exists, refusing to overwrite with trashed copy", id)
+	} else if !os.IsNotExist(err) {
+		return Task{}, fmt.Errorf("stat live task: %w", err)
+	}
+
+	genDir, err := s.newestGeneration(id)
+	if err != nil {
+		return Task{}, err
+	}
+	if genDir == "" {
+		return Task{}, fmt.Errorf("no trashed task found for id %s: %w", id, os.ErrNotExist)
+	}
+
+	entries, err := os.ReadDir(genDir)
+	if err != nil {
+		return Task{}, fmt.Errorf("read trash generation: %w", err)
+	}
+	primary := id + ".md"
+	for _, e := range entries {
+		base := e.Name()
+		if base == primary {
+			continue
+		}
+		if err := os.Rename(filepath.Join(genDir, base), filepath.Join(s.dir, base)); err != nil {
+			return Task{}, fmt.Errorf("restore %s: %w", base, err)
+		}
+	}
+	if err := os.Rename(filepath.Join(genDir, primary), livePath); err != nil {
+		return Task{}, fmt.Errorf("restore task file: %w", err)
+	}
+	removeEmptyTrashDirs(genDir)
+
+	s.planDrafts.invalidateIndex()
+	t, err := s.Get(id)
+	if err != nil {
+		return Task{}, err
+	}
+	s.storeTaskCache(t)
+	return t, nil
+}
+
+// TrashPruneReport summarizes one PruneTrash run.
+type TrashPruneReport struct {
+	Scanned int
+	Removed int
+	Entries []TrashEntry
+	Errors  []error
+}
+
+// pruneGeneration removes genDir under id's per-task lock, rechecking that
+// it still exists once the lock is held — a concurrent RestoreFromTrash may
+// have already moved it out from under the unlocked scan in PruneTrash.
+// removed is false (with a nil error) when the recheck lost the race, so
+// callers can distinguish "actually deleted" from "already gone" instead of
+// double-counting a generation a concurrent restore already consumed.
+func (s *Store) pruneGeneration(id, genDir string) (removed bool, err error) {
+	unlock, err := s.lockTask(id)
+	if err != nil {
+		return false, err
+	}
+	defer unlock()
+	if _, err := os.Stat(genDir); os.IsNotExist(err) {
+		return false, nil
+	}
+	if err := os.RemoveAll(genDir); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// PruneTrash permanently removes trash generations deleted more than
+// retentionDays ago. A negative retentionDays disables pruning entirely
+// (no-op). Each generation is removed under its own id's per-task lock, so
+// pruning can never race a concurrent restore of the same id — unlike a
+// naive "remove the whole date directory" sweep, which could not take a
+// single lock covering every id it touches.
+func (s *Store) PruneTrash(retentionDays int) (TrashPruneReport, error) {
+	var rep TrashPruneReport
+	if retentionDays < 0 {
+		return rep, nil
+	}
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays).Format(time.DateOnly)
+
+	dateEntries, err := os.ReadDir(s.trashDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return rep, nil
+		}
+		return rep, fmt.Errorf("read trash dir: %w", err)
+	}
+	for _, de := range dateEntries {
+		if !de.IsDir() || de.Name() >= cutoff {
+			continue
+		}
+		date := de.Name()
+		dateDir := filepath.Join(s.trashDir, date)
+		genEntries, err := os.ReadDir(dateDir)
+		if err != nil {
+			rep.Errors = append(rep.Errors, fmt.Errorf("read trash date dir %s: %w", date, err))
+			continue
+		}
+		for _, ge := range genEntries {
+			if !ge.IsDir() {
+				continue
+			}
+			rep.Scanned++
+			genDir := filepath.Join(dateDir, ge.Name())
+			id, ok := trashGenerationID(genDir)
+			if !ok {
+				continue
+			}
+			entry := trashEntryFor(date, ge.Name(), genDir, id)
+			removed, err := s.pruneGeneration(id, genDir)
+			if err != nil {
+				rep.Errors = append(rep.Errors, fmt.Errorf("prune %s/%s: %w", date, ge.Name(), err))
+				continue
+			}
+			if !removed {
+				continue
+			}
+			rep.Removed++
+			rep.Entries = append(rep.Entries, entry)
+		}
+		if remaining, err := os.ReadDir(dateDir); err == nil && len(remaining) == 0 {
+			_ = os.Remove(dateDir)
+		}
+	}
+	return rep, nil
 }
 
 func (s *Store) writeSidecars(id string, u Update, t *Task) error {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -768,11 +768,12 @@ type TrashEntry struct {
 // avoids relying on the generation directory's name (which is a convenience
 // naming scheme, not a contract) to recover id, so list/restore/prune never
 // prefix-match an arbitrary id. ok is false for an empty, already-restored,
-// or corrupt generation.
-func trashGenerationID(genDir string) (id string, ok bool) {
+// or corrupt generation. Read errors are returned so callers can surface
+// unreadable generations instead of silently skipping them.
+func trashGenerationID(genDir string) (id string, ok bool, err error) {
 	entries, err := os.ReadDir(genDir)
 	if err != nil {
-		return "", false
+		return "", false, err
 	}
 	for _, e := range entries {
 		if e.IsDir() {
@@ -780,10 +781,10 @@ func trashGenerationID(genDir string) (id string, ok bool) {
 		}
 		base := e.Name()
 		if strings.HasSuffix(base, ".md") && !IsSidecarFile(base) {
-			return strings.TrimSuffix(base, ".md"), true
+			return strings.TrimSuffix(base, ".md"), true, nil
 		}
 	}
-	return "", false
+	return "", false, nil
 }
 
 // walkTrashGenerations calls fn for every generation directory under
@@ -844,7 +845,10 @@ func trashEntryFor(date, generation, path, id string) TrashEntry {
 func (s *Store) ListTrash() ([]TrashEntry, error) {
 	var out []TrashEntry
 	errs := s.walkTrashGenerations(func(date, generation, path string) error {
-		id, ok := trashGenerationID(path)
+		id, ok, err := trashGenerationID(path)
+		if err != nil {
+			return fmt.Errorf("read trash generation %s/%s: %w", date, generation, err)
+		}
 		if !ok {
 			return nil
 		}
@@ -866,7 +870,10 @@ func (s *Store) newestGeneration(id string) (string, error) {
 	var newest string
 	var newestAt time.Time
 	errs := s.walkTrashGenerations(func(date, generation, path string) error {
-		gid, ok := trashGenerationID(path)
+		gid, ok, err := trashGenerationID(path)
+		if err != nil {
+			return fmt.Errorf("read trash generation %s/%s: %w", date, generation, err)
+		}
 		if !ok || gid != id {
 			return nil
 		}
@@ -1066,7 +1073,11 @@ func (s *Store) pruneTrashBefore(cutoff string) (TrashPruneReport, error) {
 			}
 			rep.Scanned++
 			genDir := filepath.Join(dateDir, ge.Name())
-			id, ok := trashGenerationID(genDir)
+			id, ok, err := trashGenerationID(genDir)
+			if err != nil {
+				rep.Errors = append(rep.Errors, fmt.Errorf("read trash generation %s/%s: %w", date, ge.Name(), err))
+				continue
+			}
 			if !ok {
 				continue
 			}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2123,5 +2124,489 @@ func runCrossProcessUpdateWorker(t *testing.T, dir string) {
 		}
 	default:
 		t.Fatal("worker: unknown SYBRA_TASK_CROSS_PROCESS_MODE")
+	}
+}
+
+// --- Trash (soft-delete) tests ---
+
+func TestStoreDeleteMovesFileAndSidecarsToTrash(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Trash me", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.plans.Write(created.ID, "the plan"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.planDrafts.Write(created.ID, "claude", "draft content"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.comments.Add(created.ID, 1, "a comment"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// Primary file and every sidecar are gone from the live tasks dir.
+	if _, err := os.Stat(created.FilePath); !os.IsNotExist(err) {
+		t.Error("task file should be removed from tasks dir after delete")
+	}
+	liveEntries, err := os.ReadDir(store.Dir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range liveEntries {
+		if strings.HasPrefix(e.Name(), created.ID+".") && !strings.HasSuffix(e.Name(), ".lock") {
+			t.Errorf("unexpected leftover file in tasks dir: %s", e.Name())
+		}
+	}
+
+	// The lock sidecar stays behind — it's lock plumbing, not task data.
+	if _, err := os.Stat(filepath.Join(store.Dir(), created.ID+".md.lock")); err != nil {
+		t.Errorf("lock file should remain in tasks dir: %v", err)
+	}
+
+	entries, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ListTrash() = %d entries, want 1", len(entries))
+	}
+	if entries[0].ID != created.ID {
+		t.Errorf("entry ID = %q, want %q", entries[0].ID, created.ID)
+	}
+	if entries[0].Title != created.Title {
+		t.Errorf("entry Title = %q, want %q", entries[0].Title, created.Title)
+	}
+
+	genDir := filepath.Join(store.TrashDir(), entries[0].DeletedDate, entries[0].Generation)
+	genEntries, err := os.ReadDir(genDir)
+	if err != nil {
+		t.Fatalf("read generation dir: %v", err)
+	}
+	names := map[string]bool{}
+	for _, e := range genEntries {
+		names[e.Name()] = true
+	}
+	for _, want := range []string{
+		created.ID + ".md",
+		created.ID + ".plan.md",
+		created.ID + ".comments.json",
+		created.ID + ".plan-draft-claude.md",
+	} {
+		if !names[want] {
+			t.Errorf("trash generation missing %s (have %v)", want, names)
+		}
+	}
+	if names[created.ID+".md.lock"] {
+		t.Error("trash generation should not contain the .lock file")
+	}
+}
+
+func TestStoreRestoreFromTrash(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Restore me", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.plans.Write(created.ID, "the plan"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Get(created.ID); err == nil {
+		t.Fatal("task should not be gettable while trashed")
+	}
+
+	restored, err := store.RestoreFromTrash(created.ID)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if restored.ID != created.ID || restored.Title != created.Title {
+		t.Errorf("restored task = %+v, want id/title matching %+v", restored, created)
+	}
+	if restored.Plan != "the plan" {
+		t.Errorf("restored.Plan = %q, want %q", restored.Plan, "the plan")
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("get after restore: %v", err)
+	}
+	if got.Title != created.Title {
+		t.Errorf("got.Title = %q, want %q", got.Title, created.Title)
+	}
+
+	// Trash generation should be cleaned up after a successful restore.
+	remaining, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("ListTrash() after restore = %d entries, want 0", len(remaining))
+	}
+}
+
+func TestStoreRestoreFromTrash_RefusesLiveCollision(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Collide", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// A new live task happens to reuse the same id (e.g. an external tool
+	// recreated the file directly).
+	if err := os.WriteFile(filepath.Join(store.Dir(), created.ID+".md"), []byte("---\nid: "+created.ID+"\n---\nnew task"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.RestoreFromTrash(created.ID); err == nil {
+		t.Fatal("expected restore to refuse overwriting a live task")
+	}
+}
+
+func TestStoreRestoreFromTrash_NotFound(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.RestoreFromTrash("nonexistent"); err == nil {
+		t.Fatal("expected error for id with no trashed generation")
+	}
+}
+
+func TestStoreTrash_DuplicateGenerationsAndNewestRestore(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Delete twice", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	primaryContent, err := os.ReadFile(created.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A restore always cleans up the generation directory it consumes, so
+	// two same-day generations for one id can't coexist through the public
+	// Delete/RestoreFromTrash API alone (the freed bare-id slot gets reused
+	// on the next delete). Drive the internal generation-naming helper
+	// directly to produce the two-generations-for-one-id state that
+	// ListTrash/RestoreFromTrash must handle — e.g. a crash between
+	// restoring a task's files and removing the now-empty generation dir,
+	// or a second delete racing in from another process.
+	genA, err := store.newTrashGeneration(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(genA, created.ID+".md"), primaryContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(genA, older, older); err != nil {
+		t.Fatal(err)
+	}
+
+	genB, err := store.newTrashGeneration(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if genA == genB {
+		t.Fatalf("newTrashGeneration returned the same dir twice: %s", genA)
+	}
+	if err := os.WriteFile(filepath.Join(genB, created.ID+".md"), primaryContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(created.FilePath); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("ListTrash() = %d entries, want 2 distinct generations for %s", len(entries), created.ID)
+	}
+
+	restored, err := store.RestoreFromTrash(created.ID)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if restored.ID != created.ID {
+		t.Fatalf("restored.ID = %q, want %q", restored.ID, created.ID)
+	}
+
+	// The newer generation (genB) was consumed by restore; the older one
+	// (genA) remains trashed.
+	remaining, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("remaining = %+v, want exactly one leftover generation", remaining)
+	}
+	if remaining[0].Generation != filepath.Base(genA) {
+		t.Fatalf("remaining generation = %q, want the older generation %q to survive", remaining[0].Generation, filepath.Base(genA))
+	}
+}
+
+func TestStorePruneTrash(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldTask, err := store.Create("Old", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(oldTask.ID); err != nil {
+		t.Fatal(err)
+	}
+	recentTask, err := store.Create("Recent", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(recentTask.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both tasks were deleted today, so they share one date directory.
+	// Backdate only the "old" task's own generation dir by moving it into a
+	// separate, expired date directory — moving the whole shared date
+	// directory would backdate (and later prune) the recent task too.
+	oldEntries, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var oldGenDir string
+	for _, e := range oldEntries {
+		if e.ID == oldTask.ID {
+			oldGenDir = filepath.Join(store.TrashDir(), e.DeletedDate, e.Generation)
+		}
+	}
+	if oldGenDir == "" {
+		t.Fatal("could not find old task's trash generation")
+	}
+	backdated := filepath.Join(store.TrashDir(), time.Now().UTC().AddDate(0, 0, -30).Format(time.DateOnly))
+	if err := os.MkdirAll(backdated, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(oldGenDir, filepath.Join(backdated, filepath.Base(oldGenDir))); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := store.PruneTrash(14)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if rep.Removed != 1 {
+		t.Fatalf("rep.Removed = %d, want 1", rep.Removed)
+	}
+	if len(rep.Entries) != 1 || rep.Entries[0].ID != oldTask.ID {
+		t.Fatalf("rep.Entries = %+v, want one entry for %s", rep.Entries, oldTask.ID)
+	}
+
+	remaining, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 1 || remaining[0].ID != recentTask.ID {
+		t.Fatalf("remaining = %+v, want only the recent task", remaining)
+	}
+
+	// The now-empty backdated date directory should have been removed.
+	if _, err := os.Stat(backdated); !os.IsNotExist(err) {
+		t.Error("expired, now-empty date directory should be removed")
+	}
+}
+
+func TestStorePruneTrash_NegativeDisables(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Never pruned", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdated := filepath.Join(store.TrashDir(), time.Now().UTC().AddDate(0, 0, -3650).Format(time.DateOnly))
+	if err := os.Rename(filepath.Join(store.TrashDir(), entries[0].DeletedDate), backdated); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := store.PruneTrash(-1)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if rep.Scanned != 0 || rep.Removed != 0 {
+		t.Fatalf("negative retention should no-op, got %+v", rep)
+	}
+
+	remaining, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("remaining = %d, want 1 (nothing pruned)", len(remaining))
+	}
+}
+
+func TestStoreTrash_PruneVsRestoreRace(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Race", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate so PruneTrash(1) treats this generation as expired.
+	entries, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdated := filepath.Join(store.TrashDir(), time.Now().UTC().AddDate(0, 0, -30).Format(time.DateOnly))
+	if err := os.Rename(filepath.Join(store.TrashDir(), entries[0].DeletedDate), backdated); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	var restoreErr error
+	var pruneRep TrashPruneReport
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, restoreErr = store.RestoreFromTrash(created.ID)
+	}()
+	go func() {
+		defer wg.Done()
+		pruneRep, _ = store.PruneTrash(1)
+	}()
+	wg.Wait()
+
+	// Per-task locking (shared between Delete/RestoreFromTrash/pruneGeneration)
+	// guarantees exactly one side wins: either the task is restored and prune
+	// removed nothing, or prune won and the task stays gone.
+	if restoreErr == nil {
+		if pruneRep.Removed != 0 {
+			t.Fatalf("prune must not remove a generation restore just consumed, got %+v", pruneRep)
+		}
+		if _, err := store.Get(created.ID); err != nil {
+			t.Fatalf("restored task should be live: %v", err)
+		}
+	} else {
+		if pruneRep.Removed != 1 {
+			t.Fatalf("expected prune to have removed the generation when restore lost the race, got %+v", pruneRep)
+		}
+		if _, err := store.Get(created.ID); err == nil {
+			t.Fatal("task should not be live when restore lost the race")
+		}
+	}
+}
+
+func TestStoreDelete_RenameFailureLeavesTaskIntact(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Undeletable", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-create a regular file where the trash dir needs to be a
+	// directory, so MkdirAll(dateDir) fails before any rename is attempted.
+	if err := os.WriteFile(store.TrashDir(), []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Delete(created.ID); err == nil {
+		t.Fatal("expected delete to fail when the trash dir cannot be created")
+	}
+
+	if _, err := os.Stat(created.FilePath); err != nil {
+		t.Errorf("task file should remain in place after a failed delete: %v", err)
+	}
+	if _, err := store.Get(created.ID); err != nil {
+		t.Errorf("task should still be gettable after a failed delete: %v", err)
+	}
+}
+
+func TestStoreGcOrphanChatInteraction_TrashesInsteadOfUnlinking(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chat, err := store.CreateChat("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// gcOrphanChats (internal/recovery) deletes orphaned chat tasks through
+	// Manager.Delete → Store.Delete; assert that path now trashes the chat
+	// task rather than unlinking it outright, so a wrongly-GC'd chat is
+	// still recoverable.
+	if err := store.Delete(chat.ID); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := store.ListTrash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].ID != chat.ID {
+		t.Fatalf("ListTrash() = %+v, want the trashed chat task", entries)
 	}
 }

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -2472,6 +2472,9 @@ func TestStorePruneTrash_NegativeDisables(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(entries) != 1 {
+		t.Fatalf("ListTrash() = %d entries, want 1", len(entries))
+	}
 	backdated := filepath.Join(store.TrashDir(), time.Now().UTC().AddDate(0, 0, -3650).Format(time.DateOnly))
 	if err := os.Rename(filepath.Join(store.TrashDir(), entries[0].DeletedDate), backdated); err != nil {
 		t.Fatal(err)
@@ -2513,6 +2516,9 @@ func TestStoreTrash_PruneVsRestoreRace(t *testing.T) {
 	entries, err := store.ListTrash()
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ListTrash() = %d entries, want 1", len(entries))
 	}
 	backdated := filepath.Join(store.TrashDir(), time.Now().UTC().AddDate(0, 0, -30).Format(time.DateOnly))
 	if err := os.Rename(filepath.Join(store.TrashDir(), entries[0].DeletedDate), backdated); err != nil {
@@ -2608,5 +2614,13 @@ func TestStoreGcOrphanChatInteraction_TrashesInsteadOfUnlinking(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].ID != chat.ID {
 		t.Fatalf("ListTrash() = %+v, want the trashed chat task", entries)
+	}
+}
+
+func TestTrashGenerationID_ReadError(t *testing.T) {
+	t.Parallel()
+	genDir := filepath.Join(t.TempDir(), "missing")
+	if _, _, err := trashGenerationID(genDir); err == nil {
+		t.Fatal("expected read error for missing generation dir")
 	}
 }


### PR DESCRIPTION
## Motivation

Deleting a task today removes its markdown file permanently with no
recovery path. A single accidental `sybra-cli delete` or a buggy
automation wipes work with no undo. This adds a trash-based soft
delete: deleted tasks move to a recoverable trash location instead of
being unlinked immediately, with a configurable retention window
before permanent purge.

## Implementation information

- `internal/task/store.go` / `manager.go`: soft-delete moves task files
  into a trash directory instead of removing them; adds restore and
  purge-expired operations.
- `internal/config/config_trash.go` + `config_defaults.go`: new trash
  retention config with sane defaults.
- `cmd/sybra-cli/main.go`: CLI support for the trash workflow.
- `internal/recovery/recovery.go`: startup recovery pass to purge
  expired trash entries.
- `internal/sybra/lifecycle.go`, `app_init.go`: wire trash purge into
  app lifecycle.
- Follow-up commit addresses review feedback on the initial
  implementation.

Closes https://github.com/Automaat/sybra/issues/1579

_Generated by Sybra harness_