### PR TITLE
feat(abtest): fix-review on opus-grade models

### DIFF
--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -19,13 +19,13 @@ type Config struct {
 // returned by DefaultConfig. Bump this whenever the built-in experiments'
 // roles, variants, or weights change in a way that persisted configs should
 // pick up automatically.
-const CurrentBuiltinVersion = 2
+const CurrentBuiltinVersion = 3
 
 // BuiltinExperimentIDs lists the experiment IDs owned by Sybra's shipped
 // defaults. A persisted config's experiment is only replaced during a builtin
 // reconcile if its ID appears here — every other experiment ID is treated as
 // user-authored and preserved verbatim.
-var BuiltinExperimentIDs = []string{"code-author-cheap", "code-author-maintenance-cheap", "review-expensive"}
+var BuiltinExperimentIDs = []string{"code-author-cheap", "code-author-maintenance-cheap", "fix-review-expensive", "review-expensive"}
 
 // Experiment selects among variants for matching workflow roles.
 type Experiment struct {
@@ -128,10 +128,21 @@ func DefaultConfig() Config {
 				Enabled:        &expEnabled,
 				AssignmentUnit: "stage",
 				Bracket:        "cheap",
-				Roles:          []string{"fix-review", "pr-fix", "test-runner"},
+				Roles:          []string{"pr-fix", "test-runner"},
 				Variants: []Variant{
 					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
 					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 3},
+				},
+			},
+			{
+				ID:             "fix-review-expensive",
+				Enabled:        &expEnabled,
+				AssignmentUnit: "stage",
+				Bracket:        "expensive",
+				Roles:          []string{"fix-review"},
+				Variants: []Variant{
+					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
+					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
 				},
 			},
 			{

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -93,7 +93,6 @@ func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
 	}{
 		{"implementation", "code-author-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
 		{"test-runner", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
-		{"fix-review", "fix-review-expensive", []string{"claude-opus", "codex-gpt-5.5"}},
 		{"pr-fix", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
 	}
 	for _, tt := range cases {
@@ -127,6 +126,24 @@ func TestDefaultConfigScopesCopilotToImplementation(t *testing.T) {
 					t.Fatalf("code-author-maintenance-cheap must not include a copilot variant, got %+v", v)
 				}
 			}
+		}
+	}
+}
+
+func TestDefaultConfigUsesExpensiveBracketForFixReview(t *testing.T) {
+	cfg := DefaultConfig()
+	for i := range 100 {
+		a, ok, err := Select(cfg, fmt.Sprintf("task-%d", i), "fix-review", "step")
+		if err != nil || !ok {
+			t.Fatalf("Select ok=%v err=%v", ok, err)
+		}
+		if a.ExperimentID != "fix-review-expensive" {
+			t.Fatalf("ExperimentID = %q, want fix-review-expensive", a.ExperimentID)
+		}
+		switch a.VariantID {
+		case "claude-opus", "codex-gpt-5.5":
+		default:
+			t.Fatalf("VariantID = %q, want claude-opus or codex-gpt-5.5", a.VariantID)
 		}
 	}
 }

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -93,7 +93,7 @@ func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
 	}{
 		{"implementation", "code-author-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
 		{"test-runner", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
-		{"fix-review", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
+		{"fix-review", "fix-review-expensive", []string{"claude-opus", "codex-gpt-5.5"}},
 		{"pr-fix", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
 	}
 	for _, tt := range cases {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -901,6 +901,9 @@ func TestLoadReconcilesStaleBuiltinABExperiments(t *testing.T) {
 	if _, ok := byID["code-author-maintenance-cheap"]; !ok {
 		t.Fatal("code-author-maintenance-cheap not adopted by reconcile")
 	}
+	if _, ok := byID["fix-review-expensive"]; !ok {
+		t.Fatal("fix-review-expensive not adopted by reconcile")
+	}
 	authorCheap, ok := byID["code-author-cheap"]
 	if !ok {
 		t.Fatal("code-author-cheap missing after reconcile")
@@ -1082,7 +1085,7 @@ func TestLoadReconcileKeepsVersionedBackupsPerPriorBuiltinVersion(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	rewritten := strings.Replace(string(data), "builtin_version: 2", "builtin_version: 1", 1)
+	rewritten := strings.Replace(string(data), "builtin_version: 3", "builtin_version: 1", 1)
 	if rewritten == string(data) {
 		t.Fatal("failed to downgrade builtin_version in persisted config")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/abtest"
@@ -1085,7 +1085,7 @@ func TestLoadReconcileKeepsVersionedBackupsPerPriorBuiltinVersion(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	rewritten := strings.Replace(string(data), "builtin_version: 3", "builtin_version: 1", 1)
+	rewritten := regexp.MustCompile(`builtin_version: \d+`).ReplaceAllString(string(data), "builtin_version: 1")
 	if rewritten == string(data) {
 		t.Fatal("failed to downgrade builtin_version in persisted config")
 	}

--- a/internal/sybra/svc_config_rawconfig_test.go
+++ b/internal/sybra/svc_config_rawconfig_test.go
@@ -163,7 +163,7 @@ func TestSaveRawConfig_PreservesFormattingWhenBuiltinVersionMissing(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	edited := "# keep this comment\n" + strings.Replace(raw, "builtin_version: 2\n", "", 1)
+	edited := "# keep this comment\n" + strings.Replace(raw, "builtin_version: 3\n", "", 1)
 	edited = strings.Replace(edited, "max_files: 5", "max_files: 7", 1)
 
 	if err := svc.SaveRawConfig(edited); err != nil {

--- a/internal/sybra/svc_config_rawconfig_test.go
+++ b/internal/sybra/svc_config_rawconfig_test.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"bytes"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -163,7 +164,7 @@ func TestSaveRawConfig_PreservesFormattingWhenBuiltinVersionMissing(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	edited := "# keep this comment\n" + strings.Replace(raw, "builtin_version: 3\n", "", 1)
+	edited := "# keep this comment\n" + regexp.MustCompile(`builtin_version: \d+\n`).ReplaceAllString(raw, "")
 	edited = strings.Replace(edited, "max_files: 5", "max_files: 7", 1)
 
 	if err := svc.SaveRawConfig(edited); err != nil {


### PR DESCRIPTION
## Motivation

Sonnet-class models underperform on multi-comment review fixes. Promoting `fix-review` to opus-grade improves fix quality.

> Changelog: feat(abtest): fix-review on opus-grade models

## Implementation information

- Splits `fix-review` out of `code-author-maintenance-cheap` (cheap bracket, sonnet/gpt-5.4) into a new `fix-review-expensive` experiment
- New experiment: `claude:opus` + `codex:gpt-5.5`, 1:1 weight, expensive bracket
- `pr-fix` and `test-runner` remain on cheap bracket
- Bumps `CurrentBuiltinVersion` → 3; adds `fix-review-expensive` to `BuiltinExperimentIDs` so existing installs auto-reconcile on next startup