### PR TITLE
feat(config): split github enabled into sub-toggle

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -168,7 +168,9 @@ real-app/cluster load independently of Agent.MaxConcurrent.
 
 | YAML key | Type | Default | Description |
 |---|---|---|---|
-| `github.enabled` | `bool` | `true` |  |
+| `github.enabled` | `bool` | `true` | Enabled is the top-level kill-switch: false forces every GitHub automation off regardless of the sub-toggles below, so existing configs need no migration. true defers to IssuesEnabled/ReviewsEnabled. |
+| `github.issues_enabled` | `bool` | `true` | IssuesEnabled gates the GitHub Issues fetcher specifically. Defaults to true (see DefaultConfig). Effective state is Enabled && IssuesEnabled — use RunsIssuesFetcher() rather than reading this field directly. |
+| `github.reviews_enabled` | `bool` | `true` | ReviewsEnabled gates PR reviewer poll registration specifically. Defaults to true (see DefaultConfig). Effective state is Enabled && ReviewsEnabled — use RunsReviewer() rather than reading this field directly. |
 | `github.poller_role` | `string` |  | PollerRole splits GitHub search polling (reviews/issues/renovate) across machines sharing one token. "primary" (or empty) runs the search pollers; "secondary" skips them so a sibling instance owns the searches and the shared token isn't billed twice. On-demand per-PR/issue calls still run on every machine — only the periodic searches are gated. |
 | `github.reviews_fast_seconds` | `int` |  | Poll-interval overrides in seconds. Zero falls back to the built-in default. Raised defaults (vs. the original 1m/5m) cut steady-state request volume; lower them only on a high-limit (App-token) instance. |
 | `github.reviews_slow_seconds` | `int` |  |  |

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -315,7 +315,27 @@ export class GitHubAppConfig {
 }
 
 export class GitHubConfig {
+    /**
+     * Enabled is the top-level kill-switch: false forces every GitHub
+     * automation off regardless of the sub-toggles below, so existing configs
+     * need no migration. true defers to IssuesEnabled/ReviewsEnabled.
+     */
     "enabled": boolean;
+
+    /**
+     * IssuesEnabled gates the GitHub Issues fetcher specifically. Defaults to
+     * true (see DefaultConfig). Effective state is Enabled && IssuesEnabled —
+     * use RunsIssuesFetcher() rather than reading this field directly.
+     */
+    "issuesEnabled": boolean;
+
+    /**
+     * ReviewsEnabled gates PR reviewer poll registration specifically.
+     * Defaults to true (see DefaultConfig). Effective state is
+     * Enabled && ReviewsEnabled — use RunsReviewer() rather than reading this
+     * field directly.
+     */
+    "reviewsEnabled": boolean;
 
     /**
      * PollerRole splits GitHub search polling (reviews/issues/renovate) across
@@ -370,6 +390,12 @@ export class GitHubConfig {
         if (!("enabled" in $$source)) {
             this["enabled"] = false;
         }
+        if (!("issuesEnabled" in $$source)) {
+            this["issuesEnabled"] = false;
+        }
+        if (!("reviewsEnabled" in $$source)) {
+            this["reviewsEnabled"] = false;
+        }
         if (!("pollerRole" in $$source)) {
             this["pollerRole"] = "";
         }
@@ -405,10 +431,10 @@ export class GitHubConfig {
      * Creates a new GitHubConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): GitHubConfig {
-        const $$createField7_0 = $$createType0;
+        const $$createField9_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("app" in $$parsedSource) {
-            $$parsedSource["app"] = $$createField7_0($$parsedSource["app"]);
+            $$parsedSource["app"] = $$createField9_0($$parsedSource["app"]);
         }
         return new GitHubConfig($$parsedSource as Partial<GitHubConfig>);
     }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -251,6 +251,18 @@ func (c GitHubConfig) RunsSearchPollers() bool {
 	return !strings.EqualFold(strings.TrimSpace(c.PollerRole), "secondary")
 }
 
+// RunsIssuesFetcher reports the effective state of the GitHub Issues fetcher:
+// the top-level kill-switch AND the issues-specific sub-toggle.
+func (c GitHubConfig) RunsIssuesFetcher() bool {
+	return c.Enabled && c.IssuesEnabled
+}
+
+// RunsReviewer reports the effective state of PR reviewer poll registration:
+// the top-level kill-switch AND the reviews-specific sub-toggle.
+func (c GitHubConfig) RunsReviewer() bool {
+	return c.Enabled && c.ReviewsEnabled
+}
+
 func (c GitHubConfig) reviewsFast() time.Duration {
 	return secsOr(c.ReviewsFastSeconds, DefaultReviewsFastSeconds)
 }
@@ -377,7 +389,9 @@ func DefaultConfig() *Config {
 			Author:  "app/renovate",
 		},
 		GitHub: GitHubConfig{
-			Enabled: true,
+			Enabled:        true,
+			IssuesEnabled:  true,
+			ReviewsEnabled: true,
 		},
 		Monitor: MonitorConfig{
 			Enabled: true,

--- a/internal/config/config_github.go
+++ b/internal/config/config_github.go
@@ -1,7 +1,19 @@
 package config
 
 type GitHubConfig struct {
+	// Enabled is the top-level kill-switch: false forces every GitHub
+	// automation off regardless of the sub-toggles below, so existing configs
+	// need no migration. true defers to IssuesEnabled/ReviewsEnabled.
 	Enabled bool `yaml:"enabled" json:"enabled"`
+	// IssuesEnabled gates the GitHub Issues fetcher specifically. Defaults to
+	// true (see DefaultConfig). Effective state is Enabled && IssuesEnabled —
+	// use RunsIssuesFetcher() rather than reading this field directly.
+	IssuesEnabled bool `yaml:"issues_enabled" json:"issuesEnabled"`
+	// ReviewsEnabled gates PR reviewer poll registration specifically.
+	// Defaults to true (see DefaultConfig). Effective state is
+	// Enabled && ReviewsEnabled — use RunsReviewer() rather than reading this
+	// field directly.
+	ReviewsEnabled bool `yaml:"reviews_enabled" json:"reviewsEnabled"`
 	// PollerRole splits GitHub search polling (reviews/issues/renovate) across
 	// machines sharing one token. "primary" (or empty) runs the search pollers;
 	// "secondary" skips them so a sibling instance owns the searches and the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -632,8 +632,115 @@ func TestDefaultGitHubEnabled(t *testing.T) {
 	if !cfg.GitHub.Enabled {
 		t.Error("default GitHub.Enabled should be true for backward compat")
 	}
+	if !cfg.GitHub.IssuesEnabled {
+		t.Error("default GitHub.IssuesEnabled should be true for backward compat")
+	}
+	if !cfg.GitHub.ReviewsEnabled {
+		t.Error("default GitHub.ReviewsEnabled should be true for backward compat")
+	}
 	if cfg.GitHub.NativeAutoMerge {
 		t.Error("default GitHub.NativeAutoMerge should be false (kill-switch, opt-in)")
+	}
+}
+
+func TestLoadGitHubSubToggleOverrides(t *testing.T) {
+	tests := []struct {
+		name           string
+		yaml           string
+		wantIssues     bool
+		wantReviews    bool
+		wantRunsIssues bool
+		wantRunsRevs   bool
+	}{
+		{
+			name:           "no overrides keep default-true sub-toggles",
+			yaml:           "github:\n  enabled: true\n",
+			wantIssues:     true,
+			wantReviews:    true,
+			wantRunsIssues: true,
+			wantRunsRevs:   true,
+		},
+		{
+			name:           "issues_enabled false overrides only issues",
+			yaml:           "github:\n  enabled: true\n  issues_enabled: false\n",
+			wantIssues:     false,
+			wantReviews:    true,
+			wantRunsIssues: false,
+			wantRunsRevs:   true,
+		},
+		{
+			name:           "reviews_enabled false overrides only reviews",
+			yaml:           "github:\n  enabled: true\n  reviews_enabled: false\n",
+			wantIssues:     true,
+			wantReviews:    false,
+			wantRunsIssues: true,
+			wantRunsRevs:   false,
+		},
+		{
+			name:           "top-level enabled false forces both off regardless of sub-toggles",
+			yaml:           "github:\n  enabled: false\n  issues_enabled: true\n  reviews_enabled: true\n",
+			wantIssues:     true,
+			wantReviews:    true,
+			wantRunsIssues: false,
+			wantRunsRevs:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("SYBRA_HOME", dir)
+
+			if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.GitHub.IssuesEnabled != tt.wantIssues {
+				t.Errorf("IssuesEnabled = %v, want %v", cfg.GitHub.IssuesEnabled, tt.wantIssues)
+			}
+			if cfg.GitHub.ReviewsEnabled != tt.wantReviews {
+				t.Errorf("ReviewsEnabled = %v, want %v", cfg.GitHub.ReviewsEnabled, tt.wantReviews)
+			}
+			if got := cfg.GitHub.RunsIssuesFetcher(); got != tt.wantRunsIssues {
+				t.Errorf("RunsIssuesFetcher() = %v, want %v", got, tt.wantRunsIssues)
+			}
+			if got := cfg.GitHub.RunsReviewer(); got != tt.wantRunsRevs {
+				t.Errorf("RunsReviewer() = %v, want %v", got, tt.wantRunsRevs)
+			}
+		})
+	}
+}
+
+func TestGitHubRunsHelpers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         GitHubConfig
+		wantIssues  bool
+		wantReviews bool
+	}{
+		{"all enabled", GitHubConfig{Enabled: true, IssuesEnabled: true, ReviewsEnabled: true}, true, true},
+		{"top-level disabled forces both off", GitHubConfig{Enabled: false, IssuesEnabled: true, ReviewsEnabled: true}, false, false},
+		{"issues off, reviews on", GitHubConfig{Enabled: true, IssuesEnabled: false, ReviewsEnabled: true}, false, true},
+		{"issues on, reviews off", GitHubConfig{Enabled: true, IssuesEnabled: true, ReviewsEnabled: false}, true, false},
+		{"both sub-toggles off", GitHubConfig{Enabled: true, IssuesEnabled: false, ReviewsEnabled: false}, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.cfg.RunsIssuesFetcher(); got != tt.wantIssues {
+				t.Errorf("RunsIssuesFetcher() = %v, want %v", got, tt.wantIssues)
+			}
+			if got := tt.cfg.RunsReviewer(); got != tt.wantReviews {
+				t.Errorf("RunsReviewer() = %v, want %v", got, tt.wantReviews)
+			}
+		})
 	}
 }
 

--- a/internal/sybra/app_automation_routing_test.go
+++ b/internal/sybra/app_automation_routing_test.go
@@ -6,24 +6,31 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/sybra/review"
 )
 
 // TestInitIssuesFetcher_GitHubDisabled_NoFetcherRegistered verifies the
-// machine-level kill switch: flipping GitHub.Enabled off means the Issues
-// fetcher is never constructed, so startPollHub has nothing to register.
+// machine-level kill switch and the issues-specific sub-toggle: either one
+// being off means the Issues fetcher is never constructed, so startPollHub
+// has nothing to register.
 func TestInitIssuesFetcher_GitHubDisabled_NoFetcherRegistered(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		enabled bool
-		wantNil bool
+		name          string
+		enabled       bool
+		issuesEnabled bool
+		wantNil       bool
 	}{
-		{"github disabled returns nil", false, true},
-		{"github enabled returns fetcher", true, false},
+		{"github disabled returns nil", false, true, true},
+		{"github enabled, issues enabled returns fetcher", true, true, false},
+		{"github enabled, issues_enabled false returns nil", true, false, true},
+		{"github disabled, issues_enabled true still returns nil", false, true, true},
 	}
 
 	for _, tt := range tests {
@@ -31,15 +38,66 @@ func TestInitIssuesFetcher_GitHubDisabled_NoFetcherRegistered(t *testing.T) {
 			t.Parallel()
 
 			a := setupApp(t)
-			a.cfg = &config.Config{GitHub: config.GitHubConfig{Enabled: tt.enabled}}
+			a.cfg = &config.Config{GitHub: config.GitHubConfig{Enabled: tt.enabled, IssuesEnabled: tt.issuesEnabled}}
 
 			got := a.initIssuesFetcher(func(string, any) {})
 
 			if tt.wantNil && got != nil {
-				t.Fatalf("initIssuesFetcher = %v, want nil when GitHub.Enabled=false", got)
+				t.Fatalf("initIssuesFetcher = %v, want nil", got)
 			}
 			if !tt.wantNil && got == nil {
-				t.Fatal("initIssuesFetcher = nil, want non-nil when GitHub.Enabled=true")
+				t.Fatal("initIssuesFetcher = nil, want non-nil")
+			}
+		})
+	}
+}
+
+// fakePollRegistrar is a pollRegistrar test double that records the Name() of
+// every registered Fetcher, so tests can assert on registration decisions
+// without reaching into poll.Hub's private fields.
+type fakePollRegistrar struct {
+	registered []string
+}
+
+func (f *fakePollRegistrar) Register(fetcher poll.Fetcher, _ time.Duration) {
+	f.registered = append(f.registered, fetcher.Name())
+}
+
+// TestPollHubReviewerRegistration_GitHubReviewToggles verifies the fix at the
+// heart of this task: the PR reviewer poll used to register unconditionally
+// whenever a.reviewer was non-nil, regardless of github.enabled. It must now
+// register only when the effective RunsReviewer() state is true.
+func TestPollHubReviewerRegistration_GitHubReviewToggles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		enabled        bool
+		reviewsEnabled bool
+		wantRegistered bool
+	}{
+		{"github enabled, reviews enabled registers reviewer", true, true, true},
+		{"github enabled, reviews_enabled false skips reviewer", true, false, false},
+		{"github disabled skips reviewer even if reviews_enabled true", false, true, false},
+		{"github disabled and reviews_enabled false skips reviewer", false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &App{
+				cfg:      &config.Config{GitHub: config.GitHubConfig{Enabled: tt.enabled, ReviewsEnabled: tt.reviewsEnabled}},
+				logger:   discardLogger(),
+				reviewer: review.New(nil, nil, nil, nil, discardLogger(), nil, nil, nil, nil, nil, nil),
+			}
+
+			reg := &fakePollRegistrar{}
+			registerPollHandlers(a, reg, nil)
+
+			gotRegistered := slices.Contains(reg.registered, "reviews")
+			if gotRegistered != tt.wantRegistered {
+				t.Errorf("reviewer registered = %v, want %v (registered: %v)", gotRegistered, tt.wantRegistered, reg.registered)
 			}
 		})
 	}

--- a/internal/sybra/app_automation_routing_test.go
+++ b/internal/sybra/app_automation_routing_test.go
@@ -103,6 +103,75 @@ func TestPollHubReviewerRegistration_GitHubReviewToggles(t *testing.T) {
 	}
 }
 
+func TestRunsGitHubRateBudgetLoop(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		enabled        bool
+		issuesEnabled  bool
+		reviewsEnabled bool
+		pollerRole     string
+		want           bool
+	}{
+		{
+			name:           "top-level disabled skips budget loop",
+			enabled:        false,
+			issuesEnabled:  true,
+			reviewsEnabled: true,
+			want:           false,
+		},
+		{
+			name:           "both sub-toggles disabled skips budget loop",
+			enabled:        true,
+			issuesEnabled:  false,
+			reviewsEnabled: false,
+			want:           false,
+		},
+		{
+			name:           "issues fetcher enabled runs budget loop",
+			enabled:        true,
+			issuesEnabled:  true,
+			reviewsEnabled: false,
+			want:           true,
+		},
+		{
+			name:           "reviewer enabled runs budget loop",
+			enabled:        true,
+			issuesEnabled:  false,
+			reviewsEnabled: true,
+			want:           true,
+		},
+		{
+			name:           "secondary poller role skips budget loop",
+			enabled:        true,
+			issuesEnabled:  true,
+			reviewsEnabled: true,
+			pollerRole:     "secondary",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				GitHub: config.GitHubConfig{
+					Enabled:        tt.enabled,
+					IssuesEnabled:  tt.issuesEnabled,
+					ReviewsEnabled: tt.reviewsEnabled,
+					PollerRole:     tt.pollerRole,
+				},
+			}
+
+			if got := runsGitHubRateBudgetLoop(cfg); got != tt.want {
+				t.Errorf("runsGitHubRateBudgetLoop() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestAllowsProjectType_RoutingAcrossMachines verifies the config-driven
 // routing closure that IssuesFetcher/RenovateHandler receive. Two configs
 // (pet-only vs work-only) should answer different sets of project types.

--- a/internal/sybra/app_automation_routing_test.go
+++ b/internal/sybra/app_automation_routing_test.go
@@ -107,12 +107,13 @@ func TestRunsGitHubRateBudgetLoop(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		enabled        bool
-		issuesEnabled  bool
-		reviewsEnabled bool
-		pollerRole     string
-		want           bool
+		name            string
+		enabled         bool
+		issuesEnabled   bool
+		reviewsEnabled  bool
+		renovateEnabled bool
+		pollerRole      string
+		want            bool
 	}{
 		{
 			name:           "top-level disabled skips budget loop",
@@ -143,12 +144,37 @@ func TestRunsGitHubRateBudgetLoop(t *testing.T) {
 			want:           true,
 		},
 		{
-			name:           "secondary poller role skips budget loop",
+			name:           "secondary reviewer still runs budget loop",
 			enabled:        true,
-			issuesEnabled:  true,
+			issuesEnabled:  false,
 			reviewsEnabled: true,
 			pollerRole:     "secondary",
+			want:           true,
+		},
+		{
+			name:           "secondary issues-only skips budget loop",
+			enabled:        true,
+			issuesEnabled:  true,
+			reviewsEnabled: false,
+			pollerRole:     "secondary",
 			want:           false,
+		},
+		{
+			name:            "renovate enabled on primary runs budget loop",
+			enabled:         true,
+			issuesEnabled:   false,
+			reviewsEnabled:  false,
+			renovateEnabled: true,
+			want:            true,
+		},
+		{
+			name:            "secondary renovate-only skips budget loop",
+			enabled:         true,
+			issuesEnabled:   false,
+			reviewsEnabled:  false,
+			pollerRole:      "secondary",
+			renovateEnabled: true,
+			want:            false,
 		},
 	}
 
@@ -162,6 +188,9 @@ func TestRunsGitHubRateBudgetLoop(t *testing.T) {
 					IssuesEnabled:  tt.issuesEnabled,
 					ReviewsEnabled: tt.reviewsEnabled,
 					PollerRole:     tt.pollerRole,
+				},
+				Renovate: config.RenovateConfig{
+					Enabled: tt.renovateEnabled,
 				},
 			}
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -119,7 +119,10 @@ func (a *App) workScrubContextForTask(projectID string) *WorkScrubContext {
 // nil otherwise. Kept separate so Startup stays under the funlen limit.
 func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
 	if !a.cfg.GitHub.RunsIssuesFetcher() {
-		a.logger.Info("github.issues.disabled")
+		a.logger.Info("github.issues.disabled",
+			"github_enabled", a.cfg.GitHub.Enabled,
+			"issues_enabled", a.cfg.GitHub.IssuesEnabled,
+		)
 		return nil
 	}
 	f := poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -118,8 +118,8 @@ func (a *App) workScrubContextForTask(projectID string) *WorkScrubContext {
 // initIssuesFetcher constructs the GitHub Issues fetcher if enabled, returning
 // nil otherwise. Kept separate so Startup stays under the funlen limit.
 func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
-	if !a.cfg.GitHub.Enabled {
-		a.logger.Info("github.disabled")
+	if !a.cfg.GitHub.RunsIssuesFetcher() {
+		a.logger.Info("github.issues.disabled")
 		return nil
 	}
 	f := poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)
@@ -161,6 +161,8 @@ func (a *App) logAutomationsSummary() {
 	a.logger.Info("app.automations",
 		"todoist", a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "",
 		"github", a.cfg.GitHub.Enabled,
+		"github_issues", a.cfg.GitHub.RunsIssuesFetcher(),
+		"github_reviews", a.cfg.GitHub.RunsReviewer(),
 		"renovate", a.cfg.Renovate.Enabled,
 		"triage", a.cfg.Triage.Enabled,
 		"human_review", a.humanReview != nil,

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -144,10 +144,16 @@ func (lm *LifecycleManager) startRateBudgetLoop(ctx context.Context) {
 }
 
 func runsGitHubRateBudgetLoop(cfg *config.Config) bool {
-	if cfg == nil || !cfg.GitHub.RunsSearchPollers() {
+	if cfg == nil {
 		return false
 	}
-	return cfg.GitHub.RunsIssuesFetcher() || cfg.GitHub.RunsReviewer()
+	if cfg.GitHub.RunsReviewer() {
+		return true
+	}
+	if !cfg.GitHub.RunsSearchPollers() {
+		return false
+	}
+	return cfg.GitHub.RunsIssuesFetcher() || cfg.Renovate.Enabled
 }
 
 // StartWatchers launches the config-file hot-reload watcher.

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -124,7 +124,7 @@ const rateBudgetRefreshInterval = 60 * time.Second
 // observe directly.
 func (lm *LifecycleManager) startRateBudgetLoop(ctx context.Context) {
 	a := lm.app
-	if !a.cfg.GitHub.Enabled {
+	if !runsGitHubRateBudgetLoop(a.cfg) {
 		return
 	}
 	a.wg.Go(func() {
@@ -141,6 +141,13 @@ func (lm *LifecycleManager) startRateBudgetLoop(ctx context.Context) {
 			}
 		}
 	})
+}
+
+func runsGitHubRateBudgetLoop(cfg *config.Config) bool {
+	if cfg == nil || !cfg.GitHub.RunsSearchPollers() {
+		return false
+	}
+	return cfg.GitHub.RunsIssuesFetcher() || cfg.GitHub.RunsReviewer()
 }
 
 // StartWatchers launches the config-file hot-reload watcher.
@@ -545,7 +552,10 @@ func registerPollHandlers(a *App, reg pollRegistrar, issuesFetcher *poll.IssuesF
 		if a.cfg.GitHub.RunsReviewer() {
 			reg.Register(a.reviewer, 10*time.Second)
 		} else {
-			a.logger.Info("github.reviews.disabled")
+			a.logger.Info("github.reviews.disabled",
+				"github_enabled", a.cfg.GitHub.Enabled,
+				"reviews_enabled", a.cfg.GitHub.ReviewsEnabled,
+			)
 		}
 	}
 	if runSearch {

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -522,10 +522,17 @@ func (lm *LifecycleManager) startPromptLabService(ctx context.Context, _ func(st
 	a.wg.Go(func() { a.promptLab.run(ctx) })
 }
 
-// startPollHub registers all enabled poll handlers and starts the hub.
-func (lm *LifecycleManager) startPollHub(ctx context.Context, issuesFetcher *poll.IssuesFetcher) {
-	a := lm.app
-	hub := poll.NewHub()
+// pollRegistrar is the subset of *poll.Hub used by registerPollHandlers,
+// extracted so tests can substitute a fake and assert on which fetchers were
+// registered without inspecting poll.Hub's private fields.
+type pollRegistrar interface {
+	Register(f poll.Fetcher, initialWait time.Duration)
+}
+
+// registerPollHandlers registers all enabled poll handlers onto reg. Split
+// out of startPollHub so tests can exercise the registration logic (e.g.
+// reviewer gating) directly against a fake pollRegistrar.
+func registerPollHandlers(a *App, reg pollRegistrar, issuesFetcher *poll.IssuesFetcher) {
 	// Periodic GitHub search pollers (reviews/issues/renovate) only run on the
 	// primary instance — a "secondary" machine sharing the same token skips them
 	// so the shared rate budget isn't billed twice. Triage is local (no GitHub
@@ -535,18 +542,29 @@ func (lm *LifecycleManager) startPollHub(ctx context.Context, issuesFetcher *pol
 		a.logger.Info("github.pollers.secondary", "reason", "poller_role=secondary; skipping reviews/issues/renovate searches")
 	}
 	if a.reviewer != nil {
-		hub.Register(a.reviewer, 10*time.Second)
+		if a.cfg.GitHub.RunsReviewer() {
+			reg.Register(a.reviewer, 10*time.Second)
+		} else {
+			a.logger.Info("github.reviews.disabled")
+		}
 	}
 	if runSearch {
 		if issuesFetcher != nil {
-			hub.Register(issuesFetcher, 20*time.Second)
+			reg.Register(issuesFetcher, 20*time.Second)
 		}
 		if renovatePoller := a.renovate.poller(); renovatePoller != nil {
-			hub.Register(renovatePoller, 15*time.Second)
+			reg.Register(renovatePoller, 15*time.Second)
 		}
 	}
 	if triagePoller := a.triage.poller(); triagePoller != nil {
-		hub.Register(triagePoller, 30*time.Second)
+		reg.Register(triagePoller, 30*time.Second)
 	}
+}
+
+// startPollHub registers all enabled poll handlers and starts the hub.
+func (lm *LifecycleManager) startPollHub(ctx context.Context, issuesFetcher *poll.IssuesFetcher) {
+	a := lm.app
+	hub := poll.NewHub()
+	registerPollHandlers(a, hub, issuesFetcher)
 	hub.Start(ctx, &a.wg, a.logger)
 }


### PR DESCRIPTION
## Motivation

`github.enabled` was a single kill-switch for every GitHub automation (Issues fetcher, PR reviewer poll registration). Some machines want to run the issues fetcher without the reviewer poll (or vice versa) without disabling GitHub automation entirely.

## Implementation information

- Added `IssuesEnabled` and `ReviewsEnabled` sub-toggles to `GitHubConfig`, defaulting to `true` so existing configs need no migration.
- Added `RunsIssuesFetcher()` and `RunsReviewer()` helpers that combine the top-level `Enabled` kill-switch with the relevant sub-toggle; call sites use these instead of reading `Enabled` directly.
- Wired the new toggles through `app_init.go` / `lifecycle.go`, regenerated TS bindings, and updated `docs/CONFIG.md`.
- Added config and automation-routing test coverage for the new toggles.

Closes https://github.com/Automaat/sybra/issues/1603

_Generated by Sybra harness_