### PR TITLE
fix(workflow): persist replan and retry counters

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -180,6 +180,16 @@ export class Execution {
      */
     "parallelInflight"?: { [_ in string]?: ParallelChildren | null };
 
+    /**
+     * StepCounts tracks, per step ID, how many times RecordStep has recorded
+     * that step — independent of StepHistory, which RecordStep trims to
+     * maxStepHistory. Replan/retry budgets (CountStep) read from this map so
+     * history eviction can never silently reset a cap. ClearStepRecords resets
+     * a step's count deliberately, for the re-arm case (a fresh attempt cycle
+     * that should not inherit a prior cycle's budget).
+     */
+    "stepCounts"?: { [_ in string]?: number };
+
     /** Creates a new Execution instance. */
     constructor($$source: Partial<Execution> = {}) {
         if (!("workflowId" in $$source)) {
@@ -214,6 +224,7 @@ export class Execution {
         const $$createField3_0 = $$createType4;
         const $$createField4_0 = $$createType5;
         const $$createField8_0 = $$createType8;
+        const $$createField9_0 = $$createType9;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("stepHistory" in $$parsedSource) {
             $$parsedSource["stepHistory"] = $$createField3_0($$parsedSource["stepHistory"]);
@@ -223,6 +234,9 @@ export class Execution {
         }
         if ("parallelInflight" in $$parsedSource) {
             $$parsedSource["parallelInflight"] = $$createField8_0($$parsedSource["parallelInflight"]);
+        }
+        if ("stepCounts" in $$parsedSource) {
+            $$parsedSource["stepCounts"] = $$createField9_0($$parsedSource["stepCounts"]);
         }
         return new Execution($$parsedSource as Partial<Execution>);
     }
@@ -300,7 +314,7 @@ export class ParallelChildren {
      * Creates a new ParallelChildren instance from a string or object.
      */
     static createFrom($$source: any = {}): ParallelChildren {
-        const $$createField2_0 = $$createType11;
+        const $$createField2_0 = $$createType12;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("children" in $$parsedSource) {
             $$parsedSource["children"] = $$createField2_0($$parsedSource["children"]);
@@ -384,10 +398,10 @@ export class Step {
      * Creates a new Step instance from a string or object.
      */
     static createFrom($$source: any = {}): Step {
-        const $$createField3_0 = $$createType12;
-        const $$createField4_0 = $$createType14;
+        const $$createField3_0 = $$createType13;
+        const $$createField4_0 = $$createType15;
         const $$createField5_0 = $$createType2;
-        const $$createField6_0 = $$createType16;
+        const $$createField6_0 = $$createType17;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("config" in $$parsedSource) {
             $$parsedSource["config"] = $$createField3_0($$parsedSource["config"]);
@@ -567,11 +581,11 @@ export class StepConfig {
      * Creates a new StepConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): StepConfig {
-        const $$createField5_0 = $$createType17;
-        const $$createField7_0 = $$createType17;
-        const $$createField10_0 = $$createType19;
-        const $$createField18_0 = $$createType21;
-        const $$createField19_0 = $$createType22;
+        const $$createField5_0 = $$createType18;
+        const $$createField7_0 = $$createType18;
+        const $$createField10_0 = $$createType20;
+        const $$createField18_0 = $$createType22;
+        const $$createField19_0 = $$createType23;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField5_0($$parsedSource["allowedTools"]);
@@ -758,7 +772,7 @@ export class Transition {
      * Creates a new Transition instance from a string or object.
      */
     static createFrom($$source: any = {}): Transition {
-        const $$createField0_0 = $$createType19;
+        const $$createField0_0 = $$createType20;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("when" in $$parsedSource) {
             $$parsedSource["when"] = $$createField0_0($$parsedSource["when"]);
@@ -808,8 +822,8 @@ export class Trigger {
      * Creates a new Trigger instance from a string or object.
      */
     static createFrom($$source: any = {}): Trigger {
-        const $$createField2_0 = $$createType23;
-        const $$createField3_0 = $$createType16;
+        const $$createField2_0 = $$createType24;
+        const $$createField3_0 = $$createType17;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("conditions" in $$parsedSource) {
             $$parsedSource["conditions"] = $$createField2_0($$parsedSource["conditions"]);
@@ -831,18 +845,19 @@ const $$createType5 = $Create.Map($Create.Any, $Create.Any);
 const $$createType6 = ParallelChildren.createFrom;
 const $$createType7 = $Create.Nullable($$createType6);
 const $$createType8 = $Create.Map($Create.Any, $$createType7);
-const $$createType9 = ChildStatus.createFrom;
-const $$createType10 = $Create.Nullable($$createType9);
-const $$createType11 = $Create.Map($Create.Any, $$createType10);
-const $$createType12 = StepConfig.createFrom;
-const $$createType13 = Transition.createFrom;
-const $$createType14 = $Create.Array($$createType13);
-const $$createType15 = Position.createFrom;
-const $$createType16 = $Create.Nullable($$createType15);
-const $$createType17 = $Create.Array($Create.Any);
-const $$createType18 = Condition.createFrom;
-const $$createType19 = $Create.Nullable($$createType18);
-const $$createType20 = ImportSidecar.createFrom;
-const $$createType21 = $Create.Nullable($$createType20);
-const $$createType22 = $Create.Array($$createType20);
-const $$createType23 = $Create.Array($$createType18);
+const $$createType9 = $Create.Map($Create.Any, $Create.Any);
+const $$createType10 = ChildStatus.createFrom;
+const $$createType11 = $Create.Nullable($$createType10);
+const $$createType12 = $Create.Map($Create.Any, $$createType11);
+const $$createType13 = StepConfig.createFrom;
+const $$createType14 = Transition.createFrom;
+const $$createType15 = $Create.Array($$createType14);
+const $$createType16 = Position.createFrom;
+const $$createType17 = $Create.Nullable($$createType16);
+const $$createType18 = $Create.Array($Create.Any);
+const $$createType19 = Condition.createFrom;
+const $$createType20 = $Create.Nullable($$createType19);
+const $$createType21 = ImportSidecar.createFrom;
+const $$createType22 = $Create.Nullable($$createType21);
+const $$createType23 = $Create.Array($$createType21);
+const $$createType24 = $Create.Array($$createType19);

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1486,6 +1486,10 @@ func cloneWorkflow(wf workflow.Execution) workflow.Execution {
 		clone.Variables = make(map[string]string, len(wf.Variables))
 		maps.Copy(clone.Variables, wf.Variables)
 	}
+	if wf.StepCounts != nil {
+		clone.StepCounts = make(map[string]int, len(wf.StepCounts))
+		maps.Copy(clone.StepCounts, wf.StepCounts)
+	}
 	if wf.CompletedAt != nil {
 		ts := *wf.CompletedAt
 		clone.CompletedAt = &ts

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1752,6 +1752,31 @@ func TestCloneWorkflowDoesNotAliasParallelInflight(t *testing.T) {
 	}
 }
 
+// TestCloneWorkflowDoesNotAliasStepCounts guards against cloneWorkflow
+// sharing the StepCounts map (persistent replan/retry counters, see
+// workflow.Execution.StepCounts) between the cache entry and the
+// caller-visible clone — the same aliasing class as ParallelInflight above.
+func TestCloneWorkflowDoesNotAliasStepCounts(t *testing.T) {
+	t.Parallel()
+	orig := workflow.Execution{
+		WorkflowID:  "wf",
+		CurrentStep: "start_replan",
+		State:       workflow.ExecRunning,
+		StepCounts:  map[string]int{"start_replan": 2},
+	}
+
+	clone := cloneWorkflow(orig)
+
+	clone.StepCounts["start_replan"] = 99
+	clone.StepCounts["other"] = 1
+	if orig.StepCounts["start_replan"] != 2 {
+		t.Errorf("clone mutation leaked to original: start_replan=%d", orig.StepCounts["start_replan"])
+	}
+	if _, ok := orig.StepCounts["other"]; ok {
+		t.Error("clone added key 'other' that leaked to original StepCounts map")
+	}
+}
+
 // TestStoreListMutateClonedParallelInflightDoesNotAffectCache exercises the
 // real path: List() returns clones whose ParallelInflight is independent
 // of the Store's cache. Mutating a returned clone must not change what a

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -36,6 +36,13 @@ type Execution struct {
 	// Persisted so a process restart can resume the parent step rather than
 	// stranding half-completed forks.
 	ParallelInflight map[string]*ParallelChildren `yaml:"parallel_inflight,omitempty" json:"parallelInflight,omitempty"`
+	// StepCounts tracks, per step ID, how many times RecordStep has recorded
+	// that step — independent of StepHistory, which RecordStep trims to
+	// maxStepHistory. Replan/retry budgets (CountStep) read from this map so
+	// history eviction can never silently reset a cap. ClearStepRecords resets
+	// a step's count deliberately, for the re-arm case (a fresh attempt cycle
+	// that should not inherit a prior cycle's budget).
+	StepCounts map[string]int `yaml:"step_counts,omitempty" json:"stepCounts,omitempty"`
 }
 
 // ParallelChildren is the in-flight bookkeeping for one `parallel` parent.
@@ -67,6 +74,9 @@ func (e *Execution) Clone() *Execution {
 	}
 	if e.Variables != nil {
 		cloned.Variables = maps.Clone(e.Variables)
+	}
+	if e.StepCounts != nil {
+		cloned.StepCounts = maps.Clone(e.StepCounts)
 	}
 	if e.ParallelInflight != nil {
 		cloned.ParallelInflight = make(map[string]*ParallelChildren, len(e.ParallelInflight))
@@ -134,12 +144,30 @@ func (e *Execution) SetVar(key, value string) {
 	e.Variables[key] = value
 }
 
-// RecordStep appends a step record and trims history to maxStepHistory.
+// RecordStep appends a step record, trims history to maxStepHistory, and
+// increments the step's persistent count (see StepCounts) so trimming never
+// affects CountStep. On the first call for an Execution whose StepCounts is
+// still nil (a task loaded from disk before this field existed, or a
+// hand-built fixture), the map is seeded by counting whatever StepHistory
+// already holds — a one-time migration of the still-live (unevicted) window
+// — before the new record is added.
 func (e *Execution) RecordStep(r StepRecord) {
+	if e.StepCounts == nil {
+		e.StepCounts = stepCountsFromHistory(e.StepHistory)
+	}
 	e.StepHistory = append(e.StepHistory, r)
 	if len(e.StepHistory) > maxStepHistory {
 		e.StepHistory = e.StepHistory[len(e.StepHistory)-maxStepHistory:]
 	}
+	e.StepCounts[r.StepID]++
+}
+
+func stepCountsFromHistory(history []StepRecord) map[string]int {
+	counts := make(map[string]int, len(history))
+	for i := range history {
+		counts[history[i].StepID]++
+	}
+	return counts
 }
 
 // LastRecord returns the most recent step record, or nil.
@@ -150,8 +178,17 @@ func (e *Execution) LastRecord() *StepRecord {
 	return &e.StepHistory[len(e.StepHistory)-1]
 }
 
-// CountStep returns the number of records for a given step ID.
+// CountStep returns the number of times a given step ID has been recorded.
+// Prefers the persistent StepCounts map (unaffected by StepHistory trimming);
+// falls back to scanning StepHistory when StepCounts has never been
+// initialized (RecordStep seeds it lazily — see there) or holds no entry for
+// this step, e.g. right after ClearStepRecords.
 func (e *Execution) CountStep(stepID string) int {
+	if e.StepCounts != nil {
+		if n, ok := e.StepCounts[stepID]; ok {
+			return n
+		}
+	}
 	n := 0
 	for i := range e.StepHistory {
 		if e.StepHistory[i].StepID == stepID {
@@ -161,21 +198,22 @@ func (e *Execution) CountStep(stepID string) int {
 	return n
 }
 
-// ClearStepRecords removes all history records for a given step ID, resetting
-// CountStep(stepID) to 0. Used when a step is deliberately re-armed for a
-// fresh attempt cycle (e.g. route-level auto-retry) so its own in-step
-// max_retries budget is not seen as already exhausted by prior cycles.
+// ClearStepRecords removes all history records for a given step ID and resets
+// its persistent count (see StepCounts), resetting CountStep(stepID) to 0.
+// Used when a step is deliberately re-armed for a fresh attempt cycle (e.g.
+// route-level auto-retry) so its own in-step max_retries budget is not seen
+// as already exhausted by prior cycles.
 func (e *Execution) ClearStepRecords(stepID string) {
-	if len(e.StepHistory) == 0 {
-		return
-	}
-	kept := e.StepHistory[:0]
-	for i := range e.StepHistory {
-		if e.StepHistory[i].StepID != stepID {
-			kept = append(kept, e.StepHistory[i])
+	if len(e.StepHistory) > 0 {
+		kept := e.StepHistory[:0]
+		for i := range e.StepHistory {
+			if e.StepHistory[i].StepID != stepID {
+				kept = append(kept, e.StepHistory[i])
+			}
 		}
+		e.StepHistory = kept
 	}
-	e.StepHistory = kept
+	delete(e.StepCounts, stepID)
 }
 
 // RecordForStep returns the latest record for a given step ID, or nil.

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -109,6 +109,27 @@ func TestCountStep_SurvivesHistoryTrim(t *testing.T) {
 	}
 }
 
+func TestRecordStep_SeedsStepCountsFromExistingHistory(t *testing.T) {
+	// Simulate a task loaded from disk before StepCounts existed: history is
+	// already populated (and trimmed to the cap) while StepCounts is nil. The
+	// first RecordStep must lazily seed StepCounts from the surviving history
+	// window before appending, so CountStep reflects the pre-existing entries
+	// plus the new one.
+	e := &Execution{}
+	for range maxStepHistory {
+		e.StepHistory = append(e.StepHistory, StepRecord{StepID: "start_replan", Status: "completed"})
+	}
+	if e.StepCounts != nil {
+		t.Fatalf("precondition: expected nil StepCounts, got %v", e.StepCounts)
+	}
+
+	e.RecordStep(StepRecord{StepID: "start_replan", Status: "completed"})
+
+	if got := e.CountStep("start_replan"); got != maxStepHistory+1 {
+		t.Errorf("expected seeded count %d, got %d", maxStepHistory+1, got)
+	}
+}
+
 func TestLastRecord_ReturnsNilForEmptyHistory(t *testing.T) {
 	e := &Execution{}
 

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -90,6 +90,25 @@ func TestRecordStep_TrimsAtMaxHistory(t *testing.T) {
 	}
 }
 
+func TestCountStep_SurvivesHistoryTrim(t *testing.T) {
+	e := &Execution{}
+
+	total := maxStepHistory + 10
+	for range total {
+		e.RecordStep(StepRecord{StepID: "start_replan", Status: "completed"})
+	}
+
+	if len(e.StepHistory) != maxStepHistory {
+		t.Fatalf("expected history trimmed to %d, got %d", maxStepHistory, len(e.StepHistory))
+	}
+	// CountStep must reflect every recorded step, not just the entries left
+	// in StepHistory after trimming — otherwise churn silently resets a
+	// replan/retry cap once early records are evicted.
+	if got := e.CountStep("start_replan"); got != total {
+		t.Errorf("expected CountStep to survive trim and report %d, got %d", total, got)
+	}
+}
+
 func TestLastRecord_ReturnsNilForEmptyHistory(t *testing.T) {
 	e := &Execution{}
 


### PR DESCRIPTION
## Motivation

Workflow replan and retry counters need to survive task reloads and branch history reconciliation so automated runs keep accurate execution state across restarts.

Closes https://github.com/Automaat/sybra/issues/1517

## Implementation information

- Persists workflow replan and retry counter state with task store updates.
- Restores persisted counters when workflow execution state is loaded.
- Adds regression coverage for counter persistence and retry/replan behavior.

_Generated by Sybra harness_