### PR TITLE
fix: retry generic watchdog budget stalls

### DIFF
--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -120,6 +120,14 @@ repeated tool calls returning empty results, very short assistant messages
 (a handful of tokens), high cache_read_input_tokens with no forward
 progress, or explicit rate-limit/quota/overage text in the log.
 
+Repeated short polling calls (e.g. TaskOutput, ScheduleWakeup) waiting on a
+backgrounded long-running command such as a test suite or verify/build gate
+are NOT a stall by themselves — check whether the polling is waiting on a
+command that legitimately takes many minutes (verify gates, e2e suites,
+builds) before concluding the agent is stuck. Only treat it as a stall if
+the backgrounded command has already finished or errored and the agent
+keeps polling anyway, or if there is no backgrounded command at all.
+
 Output ONLY a single JSON object on the final line, nothing else:
 {"stuck": bool, "reason": "short explanation", "recommendation": "stop"|"continue"|"escalate"|"nudge", "nudge": "corrective steer (only when recommendation is nudge)", "reason_kind": "rate_limit"|"generic_stall"|"reward_hacking"|""}
 

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -296,10 +296,11 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, trigger string, verdict agent.I
 		}
 		// Set the task state before stopping so the completion callback sees the
 		// intended recovery path. A stall stop is a retryable hang; the workflow
-		// engine consumes the marker from ResumeStalled. A loop stop whose judge
-		// reason is "generic_stall" (a benign command-repetition flake, not
-		// reward-hacking) gets the same retryable treatment — see #1456. Budget
-		// stops and reward-hacking loops remain immediate human-required
+		// engine consumes the marker from ResumeStalled. A loop or budget stop
+		// whose judge reason is "generic_stall" (a benign command-repetition or
+		// long-running-verify-poll flake, not reward-hacking) gets the same
+		// retryable treatment — see #1456. Reward-hacking loops (and any other
+		// reason_kind on a budget trigger) remain immediate human-required
 		// escalations.
 		if ag.TaskID != "" {
 			reason := "watchdog stop"
@@ -307,7 +308,7 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, trigger string, verdict agent.I
 				reason = "watchdog: " + verdict.Reason
 			}
 			status := task.StatusHumanRequired
-			if trigger == "stall" || (trigger == "loop" && verdict.ReasonKind == "generic_stall") {
+			if trigger == "stall" || ((trigger == "loop" || trigger == "budget") && verdict.ReasonKind == "generic_stall") {
 				status = task.StatusInProgress
 				reason = "watchdog hang"
 				if verdict.Reason != "" {

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -295,13 +295,14 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, trigger string, verdict agent.I
 			return
 		}
 		// Set the task state before stopping so the completion callback sees the
-		// intended recovery path. A stall stop is a retryable hang; the workflow
-		// engine consumes the marker from ResumeStalled. A loop or budget stop
-		// whose judge reason is "generic_stall" (a benign command-repetition or
-		// long-running-verify-poll flake, not reward-hacking) gets the same
-		// retryable treatment — see #1456. Reward-hacking loops (and any other
-		// reason_kind on a budget trigger) remain immediate human-required
-		// escalations.
+		// intended recovery path. rate_limit is already handled above regardless
+		// of trigger. Of what remains: a stall stop is a retryable hang; the
+		// workflow engine consumes the marker from ResumeStalled. A loop or
+		// budget stop whose judge reason is "generic_stall" (a benign
+		// command-repetition or long-running-verify-poll flake, not
+		// reward-hacking) gets the same retryable treatment — see #1456.
+		// Reward-hacking loops (and any other non-rate_limit reason_kind on a
+		// budget trigger) remain immediate human-required escalations.
 		if ag.TaskID != "" {
 			reason := "watchdog stop"
 			if verdict.Reason != "" {

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -201,6 +201,84 @@ func TestApplyVerdict_LoopStopWithRewardHackingEscalates(t *testing.T) {
 	}
 }
 
+// TestApplyVerdict_BudgetStopWithGenericStallMarksRetryableHang covers the
+// gap left by #1456: a "stop" verdict on the "budget" trigger whose
+// ReasonKind is "generic_stall" (e.g. an agent legitimately polling
+// TaskOutput/ScheduleWakeup for a long-running backgrounded verify/test gate)
+// must route through the same retryable watchdog-hang path as a "stall" stop
+// or a "loop"+generic_stall stop, not straight to human-required.
+func TestApplyVerdict_BudgetStopWithGenericStallMarksRetryableHang(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "polling for backgrounded verify command to complete",
+		Recommendation: "stop",
+		ReasonKind:     "generic_stall",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	}
+	if got.StatusReason != "watchdog hang: polling for backgrounded verify command to complete" {
+		t.Fatalf("status_reason = %q, want retryable watchdog hang marker", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on generic_stall budget stop verdict")
+	}
+}
+
+// TestApplyVerdict_BudgetStopWithoutGenericStallEscalates ensures a "budget"
+// trigger stop whose ReasonKind is anything other than "generic_stall"
+// (including empty, for older judges) still escalates straight to
+// human-required — only the explicit generic_stall reason gets the retry.
+func TestApplyVerdict_BudgetStopWithoutGenericStallEscalates(t *testing.T) {
+	for _, kind := range []string{"", "reward_hacking"} {
+		t.Run(kind, func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+
+			stopped := false
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				stopAgent: func(string) error { stopped = true; return nil },
+			}
+
+			w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
+				Stuck:          true,
+				Reason:         "burned through budget with no forward progress",
+				Recommendation: "stop",
+				ReasonKind:     kind,
+			})
+
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != task.StatusHumanRequired {
+				t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+			}
+			if got.StatusReason != "watchdog: burned through budget with no forward progress" {
+				t.Fatalf("status_reason = %q, want watchdog reason", got.StatusReason)
+			}
+			if !stopped {
+				t.Fatal("stopAgent not called on budget stop verdict")
+			}
+		})
+	}
+}
+
 // TestApplyVerdict_RateLimitStopReschedulesInsteadOfEscalating covers #1428:
 // a "stop" verdict with ReasonKind "rate_limit" must route through the
 // provider-health signal path and leave the task in-progress, regardless of


### PR DESCRIPTION
## Motivation

Budget-triggered watchdog stop verdicts with `generic_stall` should behave like retryable hangs when the agent is plausibly polling a long-running verification command. Sending those cases directly to human-required interrupts work that can recover through the existing stalled-agent resume path.

## Implementation information

- Treat `budget` + `generic_stall` stop verdicts as retryable watchdog hangs, matching the existing `stall` and `loop` generic-stall behavior.
- Keep non-generic budget stops, including reward-hacking or older empty reason kinds, on the human-required escalation path.
- Add watchdog tests for both retryable and escalation budget-stop cases.
- Update the inspector prompt to distinguish legitimate long-running command polling from actual stalls.

_Generated by Sybra harness_
