### PR TITLE
fix(review): push conflict fix to fork remote when present

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -912,10 +912,13 @@ func branchConflictPrompt(t task.Task, base string) string {
 			"# If the merge already completed on its own (clean/fast-forward, no\n"+
 			"# conflicts), it is already committed — do not run git commit again, it\n"+
 			"# will fail with \"nothing to commit\". Still run targeted tests before pushing.\n"+
-			"git push origin HEAD:%s\n"+
+			"PUSH_REMOTE=origin\n"+
+			"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n"+
+			"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
 			"```\n\n"+
 			"Rules:\n"+
 			"- Use `refs/remotes/origin/%s` (not `origin/%s`) to avoid ambiguous refs\n"+
+			"- Push to `fork` (not `origin`) when a `fork` remote exists — the branch was opened from the fork\n"+
 			"- Do not force-push or rewrite existing commits — this is a merge, never a rebase; a plain push is always expected to succeed\n"+
 			"- Resolve conflicts keeping BOTH sides' intent\n"+
 			"- Do not stop just because the conflict count is high — split by file and resolve all conflicts autonomously\n"+

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -80,6 +80,30 @@ func TestConflictPrompt_UsesMergeNotRebase(t *testing.T) {
 	}
 }
 
+func TestBranchConflictPrompt_DetectsForkRemote(t *testing.T) {
+	t.Parallel()
+
+	prompt := branchConflictPrompt(task.Task{Branch: "fix/example"}, "main")
+
+	for _, forbidden := range []string{
+		"git push origin HEAD",
+	} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("branch conflict prompt still hardcodes origin push (%q):\n%s", forbidden, prompt)
+		}
+	}
+	for _, want := range []string{
+		"PUSH_REMOTE=origin",
+		"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi",
+		"git push \"$PUSH_REMOTE\" HEAD:fix/example",
+		"Push to `fork` (not `origin`) when a `fork` remote exists",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("branch conflict prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestStaffCodeReviewRunConfigPinsClaudeProvider(t *testing.T) {
 	cfg := StaffCodeReviewRunConfig(task.Task{ID: "review-task", Title: "Needs review"}, "Run /staff-code-review", t.TempDir(), "default")
 


### PR DESCRIPTION
## Motivation

`branchConflictPrompt` always told the fix-review agent to push its conflict-resolution merge with `git push origin HEAD:%s`. For tasks opened from a fork, the branch lives on `fork`, not `origin` — pushing to `origin` either fails or pushes to the wrong remote, leaving the conflict unresolved from the PR's perspective.

Closes https://github.com/Automaat/sybra/issues/1617

## Implementation information

- `internal/sybra/review/fix.go`: `branchConflictPrompt` now emits a shell snippet that resolves `PUSH_REMOTE` at runtime — `fork` if a `fork` remote is configured, else `origin` — and pushes to `"$PUSH_REMOTE"` instead of hardcoding `origin`. Added an explicit rule line documenting the fork-push behavior.
- `internal/sybra/review/unit_test.go`: added `TestBranchConflictPrompt_DetectsForkRemote`, asserting the prompt no longer hardcodes `git push origin HEAD` and instead contains the remote-detection snippet and the new rule text.

_Generated by Sybra harness_