### PR TITLE
fix(workflow): escalate recurring test failures as spec conflicts

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1755,10 +1756,74 @@ func hasReportLinePrefix(report string, prefixes ...string) bool {
 	return false
 }
 
+// fingerprintQuotedRe captures quoted error/value strings a test-runner cites
+// verbatim (command output, error messages, expected/actual literals).
+var fingerprintQuotedRe = regexp.MustCompile("\"[^\"\n]{1,200}\"|'[^'\n]{1,200}'|`[^`\n]{1,200}`")
+
+// fingerprintNumberRe captures counts, HTTP statuses, and other numeric
+// tokens that distinguish otherwise-similar failure prose (e.g. "reappears
+// after 2 occurrences" vs "after 3 occurrences").
+var fingerprintNumberRe = regexp.MustCompile(`-?\d+(?:\.\d+)?%?`)
+
+// fingerprintEnumTokenRe captures enum-like identifiers (SCREAMING_SNAKE,
+// snake_case, dotted paths) that carry semantic meaning independent of
+// surrounding wording — statuses, outcome names, field names.
+var fingerprintEnumTokenRe = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[_.][A-Za-z0-9]+)+\b`)
+
+// fingerprintMinTokens is the minimum count of discriminating tokens
+// (quoted strings, file:line citations, numbers, enum-like identifiers)
+// required before the token-based fingerprint is trusted. Below this, the
+// report is too sparse to distinguish reliably, and testFailureFingerprint
+// falls back to the original whole-prose hash.
+const fingerprintMinTokens = 2
+
+// testFailureFingerprint derives a stable identifier for a test-runner
+// failure report, used to detect when the SAME failure class recurs across
+// reimplementation attempts. Reports describing genuinely different defects
+// must hash differently; reports describing the same defect with minor LLM
+// wording drift (synonyms, reordered sentences, rephrased summaries) must
+// hash the same.
+//
+// The report is reduced to its semantically load-bearing tokens — quoted
+// error/value strings, file:line citations, numeric counts/statuses, and
+// enum-like identifiers — sorted for order-independence and hashed. Prose
+// glue words carry no signal for this purpose and are dropped. When a
+// report is too sparse to yield enough discriminating tokens (short or
+// unusually terse reports), this falls back to the original lowercased,
+// whitespace-normalized full-prose hash so a fingerprint is still produced.
+//
+// NOTE: this is NOT the same hash as the original exact-prose fingerprint.
+// Fingerprints persisted by older runs (AgentRunInfo.TestFailureFingerprint)
+// are not migrated or recomputed — they simply will not match a fingerprint
+// computed by this hardened function until a new test-runner attempt
+// records one. This only delays recurrence detection for tasks whose
+// testing cycle straddles the deploy of this change; it never produces
+// a false recurrence match.
 func testFailureFingerprint(report string) string {
-	normalized := strings.Join(strings.Fields(strings.ToLower(report)), " ")
-	sum := sha256.Sum256([]byte(normalized))
+	basis := fingerprintNormalizedBasis(report)
+	sum := sha256.Sum256([]byte(basis))
 	return hex.EncodeToString(sum[:8])
+}
+
+func fingerprintNormalizedBasis(report string) string {
+	var tokens []string
+	tokens = append(tokens, fingerprintQuotedRe.FindAllString(report, -1)...)
+	tokens = append(tokens, fileLineCitationRe.FindAllString(report, -1)...)
+	tokens = append(tokens, fingerprintNumberRe.FindAllString(report, -1)...)
+	tokens = append(tokens, fingerprintEnumTokenRe.FindAllString(report, -1)...)
+
+	normalized := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok != "" {
+			normalized = append(normalized, tok)
+		}
+	}
+	if len(normalized) < fingerprintMinTokens {
+		return strings.Join(strings.Fields(strings.ToLower(report)), " ")
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, "|")
 }
 
 // containsFixSuggestionsInCurrentTestReport scans the agent result and the task
@@ -2086,15 +2151,42 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 
 	if duplicate {
-		reason := "same grounded test failure reproduced twice — needs targeted local reproduction/fix from latest ## Test Failures"
+		recurring := recurringProductBugFingerprints(t)
+		if len(recurring) == 0 {
+			// Defensive: countValidProductTestAttempts already confirmed the
+			// current fingerprint recurred with an intervening code-author
+			// run, so this should always be non-empty. Fall back to the
+			// just-finished attempt's own fingerprint so the section still
+			// carries evidence rather than an empty class list.
+			if cf := wfExec.Variables["step."+testVerdictSourceStep+"."+testFailureFingerprintKey]; cf != "" {
+				recurring = []string{cf}
+			}
+		}
+		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+			return StepOutput{}, err
+		}
+		reason := "suspected acceptance-criteria conflict after recurring product-bug test failures — human spec decision needed; see ## Test Failures"
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
 		}
-		e.logger.Warn("workflow.test.duplicate-failure", "task_id", taskID)
+		e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "duplicate failure"}, nil
 	}
 
 	if attempts >= limit {
+		if recurring := recurringProductBugFingerprints(t); len(recurring) > 0 {
+			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+				return StepOutput{}, err
+			}
+			reason := fmt.Sprintf(
+				"suspected acceptance-criteria conflict: %d recurring product-bug failure class(es) after %d test attempts (cap %d) — human spec decision needed; see ## Test Failures",
+				len(recurring), attempts, limit)
+			if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+				return StepOutput{}, err
+			}
+			e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "escalated"}, nil
+		}
 		reason := fmt.Sprintf("manual testing found %d grounded product defects: feature still does not match the task — needs targeted local reproduction/fix from latest ## Test Failures", attempts)
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
@@ -2116,6 +2208,117 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 	e.logger.Info("workflow.test.reimplement", "task_id", taskID, "attempts", attempts, "cap", limit)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "reimplement"}, nil
+}
+
+// recurringProductBugFingerprints returns the distinct product-bug failure
+// fingerprints (sorted) that recurred at least twice within the current
+// testing cycle, with an intervening code-author run between two of their
+// occurrences — the same "the implementer fixed something and the SAME
+// failure class came back" signal countValidProductTestAttempts uses for its
+// immediate-duplicate check, but surfaced here as a set. This lets cap-time
+// escalation reframe as a spec-decision on ANY recurring class among the
+// attempts that exhausted the cap, not only the just-finished attempt's
+// fingerprint.
+func recurringProductBugFingerprints(t TaskInfo) []string {
+	var fingerprints []string
+	var indices []int
+	for i := range t.AgentRuns {
+		run := t.AgentRuns[i]
+		if t.TestingCycleStartedAt != nil && run.StartedAt.Before(*t.TestingCycleStartedAt) {
+			continue
+		}
+		if run.Role != testRunnerRole || run.ProtocolViolation != "" ||
+			run.TestOutcome != testOutcomeProductBug || run.TestFailureFingerprint == "" {
+			continue
+		}
+		fingerprints = append(fingerprints, run.TestFailureFingerprint)
+		indices = append(indices, i)
+	}
+	seen := make(map[string]bool)
+	var recurring []string
+	for a := range fingerprints {
+		if seen[fingerprints[a]] {
+			continue
+		}
+		for b := a + 1; b < len(fingerprints); b++ {
+			if fingerprints[b] != fingerprints[a] {
+				continue
+			}
+			if hasInterveningCodeAuthorRun(t.AgentRuns, indices[a], indices[b]) {
+				seen[fingerprints[a]] = true
+				recurring = append(recurring, fingerprints[a])
+				break
+			}
+		}
+	}
+	sort.Strings(recurring)
+	return recurring
+}
+
+// specDecisionHeading marks the section appended to a task body when
+// escalating on recurring product-bug failure classes. A distinct heading
+// (not "## Test Failures") keeps it out of testFailSectionOf's scan.
+const specDecisionHeading = "## Spec Decision Needed"
+
+// specDecisionMarker returns a stable HTML-comment marker keyed by the sorted
+// set of recurring fingerprints driving an escalation. appendSpecDecisionSection
+// uses it to skip re-appending an identical section on a rerun (idempotency),
+// while a genuinely new recurring set still gets its own section appended.
+func specDecisionMarker(fingerprints []string) string {
+	sorted := append([]string(nil), fingerprints...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, "|")))
+	return "<!-- sybra:spec-decision:" + hex.EncodeToString(sum[:6]) + " -->"
+}
+
+// buildSpecDecisionSection renders the task-body evidence for a spec-decision
+// escalation. It deliberately avoids asserting a proven contradiction —
+// the same recurrence shape can also be produced by two independent
+// sequential bugs — and points at the latest "## Test Failures" section
+// for repros rather than claiming an exact section-to-fingerprint mapping,
+// since AgentRunInfo does not persist historical report text or offsets.
+func buildSpecDecisionSection(fingerprints []string, attempts, limit int) string {
+	sorted := append([]string(nil), fingerprints...)
+	sort.Strings(sorted)
+	var b strings.Builder
+	b.WriteString(specDecisionHeading + "\n\n")
+	b.WriteString(specDecisionMarker(sorted) + "\n\n")
+	fmt.Fprintf(&b,
+		"Manual testing reproduced %d recurring product-bug failure class(es) across an intervening "+
+			"reimplementation attempt (%d test attempt(s), cap %d). This is evidence of a suspected "+
+			"acceptance-criteria conflict — not a confirmed one, since two independent sequential bugs "+
+			"can produce the same recurrence shape. A human spec decision is needed.\n\n",
+		len(sorted), attempts, limit)
+	fmt.Fprintf(&b,
+		"Recurring fingerprint(s): %s. Repros for these failure classes are identifiable in the latest "+
+			"%q section of this task body.\n",
+		strings.Join(sorted, ", "), testFailuresHeading)
+	return b.String()
+}
+
+// appendSpecDecisionSection appends the spec-decision evidence section to the
+// task body, unless a section with an identical marker (same recurring
+// fingerprint set) is already present — reruns then skip instead of
+// duplicating. A new/different recurring set still gets appended, since
+// AppendTaskBody has no in-place replace and the older section remains valid
+// historical evidence.
+func (e *Engine) appendSpecDecisionSection(taskID, body string, fingerprints []string, attempts, limit int) error {
+	if strings.Contains(body, specDecisionMarker(fingerprints)) {
+		return nil
+	}
+	if err := e.tasks.AppendTaskBody(taskID, buildSpecDecisionSection(fingerprints, attempts, limit)); err != nil {
+		return fmt.Errorf("append spec-decision section: %w", err)
+	}
+	return nil
+}
+
+// logSpecDecisionEscalation emits a bounded structured event for a
+// spec-decision escalation: task id, attempt/cap counters, and the distinct
+// recurring-class count and fingerprints. Raw test reports are never logged.
+func (e *Engine) logSpecDecisionEscalation(taskID string, attempts, limit int, fingerprints []string) {
+	e.logger.Warn("workflow.test.spec-decision",
+		"task_id", taskID, "attempts", attempts, "cap", limit,
+		"recurring_classes", len(fingerprints), "fingerprints", fingerprints)
 }
 
 func (e *Engine) countValidProductTestAttempts(t TaskInfo, wfExec *Execution) (int, bool) {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1777,11 +1777,12 @@ var fingerprintPathTokenRe = regexp.MustCompile(`/(?:[A-Za-z0-9][A-Za-z0-9._~-]*
 
 var fingerprintFilePathTokenRe = regexp.MustCompile(`(?i)\.(?:go|ts|tsx|js|jsx|svelte)$`)
 
-// fingerprintMinTokens is the minimum count of discriminating tokens
-// (quoted strings, file:line citations, numbers, enum-like identifiers)
-// required before the token-based fingerprint is trusted. Below this, the
-// report is too sparse to distinguish reliably, and testFailureFingerprint
-// falls back to the original whole-prose hash.
+// fingerprintMinTokens is the minimum count of unique discriminating tokens
+// required before the token-based fingerprint is trusted, alongside at least
+// one strong token (quoted strings, endpoint paths, or non-filepath enum-like
+// identifiers). Below this, the report is too sparse or too boilerplate-heavy
+// to distinguish reliably, and testFailureFingerprint falls back to the
+// original whole-prose hash.
 const fingerprintMinTokens = 2
 
 // testFailureFingerprint derives a stable identifier for a test-runner
@@ -1827,10 +1828,15 @@ func fingerprintNormalizedBasis(report string) string {
 	tokens = append(tokens, enums...)
 	strongTokens += len(quoted) + len(paths)
 
+	seen := make(map[string]struct{}, len(tokens))
 	normalized := make([]string, 0, len(tokens))
 	for _, tok := range tokens {
 		tok = strings.ToLower(strings.TrimSpace(tok))
 		if tok != "" {
+			if _, ok := seen[tok]; ok {
+				continue
+			}
+			seen[tok] = struct{}{}
 			normalized = append(normalized, tok)
 		}
 	}
@@ -2247,8 +2253,11 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 // attempts that exhausted the cap, not only the just-finished attempt's
 // fingerprint.
 func recurringProductBugFingerprints(t TaskInfo) []string {
-	var fingerprints []string
-	var indices []int
+	type fingerprintOccurrence struct {
+		fingerprint string
+		runIndex    int
+	}
+	var occurrences []fingerprintOccurrence
 	for i := range t.AgentRuns {
 		run := t.AgentRuns[i]
 		if t.TestingCycleStartedAt != nil && run.StartedAt.Before(*t.TestingCycleStartedAt) {
@@ -2258,22 +2267,24 @@ func recurringProductBugFingerprints(t TaskInfo) []string {
 			run.TestOutcome != testOutcomeProductBug || run.TestFailureFingerprint == "" {
 			continue
 		}
-		fingerprints = append(fingerprints, run.TestFailureFingerprint)
-		indices = append(indices, i)
+		occurrences = append(occurrences, fingerprintOccurrence{
+			fingerprint: run.TestFailureFingerprint,
+			runIndex:    i,
+		})
 	}
 	seen := make(map[string]bool)
 	var recurring []string
-	for a := range fingerprints {
-		if seen[fingerprints[a]] {
+	for a := range occurrences {
+		if seen[occurrences[a].fingerprint] {
 			continue
 		}
-		for b := a + 1; b < len(fingerprints); b++ {
-			if fingerprints[b] != fingerprints[a] {
+		for b := a + 1; b < len(occurrences); b++ {
+			if occurrences[b].fingerprint != occurrences[a].fingerprint {
 				continue
 			}
-			if hasInterveningCodeAuthorRun(t.AgentRuns, indices[a], indices[b]) {
-				seen[fingerprints[a]] = true
-				recurring = append(recurring, fingerprints[a])
+			if hasInterveningCodeAuthorRun(t.AgentRuns, occurrences[a].runIndex, occurrences[b].runIndex) {
+				seen[occurrences[a].fingerprint] = true
+				recurring = append(recurring, occurrences[a].fingerprint)
 				break
 			}
 		}

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1770,6 +1770,13 @@ var fingerprintNumberRe = regexp.MustCompile(`-?\d+(?:\.\d+)?%?`)
 // surrounding wording — statuses, outcome names, field names.
 var fingerprintEnumTokenRe = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[_.][A-Za-z0-9]+)+\b`)
 
+// fingerprintPathTokenRe captures endpoint/route-shaped literals such as
+// "/login" or "/api/export". These are often the stable part of a test report
+// when prose drifts between runner attempts.
+var fingerprintPathTokenRe = regexp.MustCompile(`/(?:[A-Za-z0-9][A-Za-z0-9._~-]*)(?:/[A-Za-z0-9][A-Za-z0-9._~-]*)*`)
+
+var fingerprintFilePathTokenRe = regexp.MustCompile(`(?i)\.(?:go|ts|tsx|js|jsx|svelte)$`)
+
 // fingerprintMinTokens is the minimum count of discriminating tokens
 // (quoted strings, file:line citations, numbers, enum-like identifiers)
 // required before the token-based fingerprint is trusted. Below this, the
@@ -1785,12 +1792,13 @@ const fingerprintMinTokens = 2
 // hash the same.
 //
 // The report is reduced to its semantically load-bearing tokens — quoted
-// error/value strings, file:line citations, numeric counts/statuses, and
-// enum-like identifiers — sorted for order-independence and hashed. Prose
-// glue words carry no signal for this purpose and are dropped. When a
-// report is too sparse to yield enough discriminating tokens (short or
-// unusually terse reports), this falls back to the original lowercased,
-// whitespace-normalized full-prose hash so a fingerprint is still produced.
+// error/value strings, endpoint paths, file:line citations, numeric
+// counts/statuses, and enum-like identifiers — sorted for order-independence
+// and hashed. Prose glue words carry no signal for this purpose and are
+// dropped. When a report is too sparse or contains only boilerplate-shaped
+// tokens (for example, a shared file:line and HTTP 500/200 pair), this falls
+// back to the original lowercased, whitespace-normalized full-prose hash so
+// unrelated bugs do not collapse into the same recurrence class.
 //
 // NOTE: this is NOT the same hash as the original exact-prose fingerprint.
 // Fingerprints persisted by older runs (AgentRunInfo.TestFailureFingerprint)
@@ -1807,10 +1815,17 @@ func testFailureFingerprint(report string) string {
 
 func fingerprintNormalizedBasis(report string) string {
 	var tokens []string
-	tokens = append(tokens, fingerprintQuotedRe.FindAllString(report, -1)...)
+	strongTokens := 0
+	quoted := fingerprintQuotedRe.FindAllString(report, -1)
+	paths := fingerprintPathTokenRe.FindAllString(report, -1)
+	enums := fingerprintEnumTokenRe.FindAllString(report, -1)
+
+	tokens = append(tokens, quoted...)
+	tokens = append(tokens, paths...)
 	tokens = append(tokens, fileLineCitationRe.FindAllString(report, -1)...)
 	tokens = append(tokens, fingerprintNumberRe.FindAllString(report, -1)...)
-	tokens = append(tokens, fingerprintEnumTokenRe.FindAllString(report, -1)...)
+	tokens = append(tokens, enums...)
+	strongTokens += len(quoted) + len(paths)
 
 	normalized := make([]string, 0, len(tokens))
 	for _, tok := range tokens {
@@ -1819,7 +1834,13 @@ func fingerprintNormalizedBasis(report string) string {
 			normalized = append(normalized, tok)
 		}
 	}
-	if len(normalized) < fingerprintMinTokens {
+	for _, tok := range enums {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok != "" && !fingerprintFilePathTokenRe.MatchString(tok) {
+			strongTokens++
+		}
+	}
+	if len(normalized) < fingerprintMinTokens || strongTokens == 0 {
 		return strings.Join(strings.Fields(strings.ToLower(report)), " ")
 	}
 	sort.Strings(normalized)
@@ -2162,12 +2183,12 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 				recurring = []string{cf}
 			}
 		}
-		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
-			return StepOutput{}, err
-		}
 		reason := "suspected acceptance-criteria conflict after recurring product-bug test failures — human spec decision needed; see ## Test Failures"
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
+		}
+		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+			e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
 		}
 		e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "duplicate failure"}, nil
@@ -2175,14 +2196,14 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 
 	if attempts >= limit {
 		if recurring := recurringProductBugFingerprints(t); len(recurring) > 0 {
-			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
-				return StepOutput{}, err
-			}
 			reason := fmt.Sprintf(
 				"suspected acceptance-criteria conflict: %d recurring product-bug failure class(es) after %d test attempts (cap %d) — human spec decision needed; see ## Test Failures",
 				len(recurring), attempts, limit)
 			if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 				return StepOutput{}, err
+			}
+			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+				e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
 			}
 			e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
 			return StepOutput{StepID: step.ID, Status: "completed", Output: "escalated"}, nil

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1643,10 +1644,74 @@ func hasReportLinePrefix(report string, prefixes ...string) bool {
 	return false
 }
 
+// fingerprintQuotedRe captures quoted error/value strings a test-runner cites
+// verbatim (command output, error messages, expected/actual literals).
+var fingerprintQuotedRe = regexp.MustCompile("\"[^\"\n]{1,200}\"|'[^'\n]{1,200}'|`[^`\n]{1,200}`")
+
+// fingerprintNumberRe captures counts, HTTP statuses, and other numeric
+// tokens that distinguish otherwise-similar failure prose (e.g. "reappears
+// after 2 occurrences" vs "after 3 occurrences").
+var fingerprintNumberRe = regexp.MustCompile(`-?\d+(?:\.\d+)?%?`)
+
+// fingerprintEnumTokenRe captures enum-like identifiers (SCREAMING_SNAKE,
+// snake_case, dotted paths) that carry semantic meaning independent of
+// surrounding wording — statuses, outcome names, field names.
+var fingerprintEnumTokenRe = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[_.][A-Za-z0-9]+)+\b`)
+
+// fingerprintMinTokens is the minimum count of discriminating tokens
+// (quoted strings, file:line citations, numbers, enum-like identifiers)
+// required before the token-based fingerprint is trusted. Below this, the
+// report is too sparse to distinguish reliably, and testFailureFingerprint
+// falls back to the original whole-prose hash.
+const fingerprintMinTokens = 2
+
+// testFailureFingerprint derives a stable identifier for a test-runner
+// failure report, used to detect when the SAME failure class recurs across
+// reimplementation attempts. Reports describing genuinely different defects
+// must hash differently; reports describing the same defect with minor LLM
+// wording drift (synonyms, reordered sentences, rephrased summaries) must
+// hash the same.
+//
+// The report is reduced to its semantically load-bearing tokens — quoted
+// error/value strings, file:line citations, numeric counts/statuses, and
+// enum-like identifiers — sorted for order-independence and hashed. Prose
+// glue words carry no signal for this purpose and are dropped. When a
+// report is too sparse to yield enough discriminating tokens (short or
+// unusually terse reports), this falls back to the original lowercased,
+// whitespace-normalized full-prose hash so a fingerprint is still produced.
+//
+// NOTE: this is NOT the same hash as the original exact-prose fingerprint.
+// Fingerprints persisted by older runs (AgentRunInfo.TestFailureFingerprint)
+// are not migrated or recomputed — they simply will not match a fingerprint
+// computed by this hardened function until a new test-runner attempt
+// records one. This only delays recurrence detection for tasks whose
+// testing cycle straddles the deploy of this change; it never produces
+// a false recurrence match.
 func testFailureFingerprint(report string) string {
-	normalized := strings.Join(strings.Fields(strings.ToLower(report)), " ")
-	sum := sha256.Sum256([]byte(normalized))
+	basis := fingerprintNormalizedBasis(report)
+	sum := sha256.Sum256([]byte(basis))
 	return hex.EncodeToString(sum[:8])
+}
+
+func fingerprintNormalizedBasis(report string) string {
+	var tokens []string
+	tokens = append(tokens, fingerprintQuotedRe.FindAllString(report, -1)...)
+	tokens = append(tokens, fileLineCitationRe.FindAllString(report, -1)...)
+	tokens = append(tokens, fingerprintNumberRe.FindAllString(report, -1)...)
+	tokens = append(tokens, fingerprintEnumTokenRe.FindAllString(report, -1)...)
+
+	normalized := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok != "" {
+			normalized = append(normalized, tok)
+		}
+	}
+	if len(normalized) < fingerprintMinTokens {
+		return strings.Join(strings.Fields(strings.ToLower(report)), " ")
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, "|")
 }
 
 // containsFixSuggestionsInCurrentTestReport scans the agent result and the task
@@ -1974,15 +2039,42 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 
 	if duplicate {
-		reason := "same grounded test failure reproduced twice — needs targeted local reproduction/fix from latest ## Test Failures"
+		recurring := recurringProductBugFingerprints(t)
+		if len(recurring) == 0 {
+			// Defensive: countValidProductTestAttempts already confirmed the
+			// current fingerprint recurred with an intervening code-author
+			// run, so this should always be non-empty. Fall back to the
+			// just-finished attempt's own fingerprint so the section still
+			// carries evidence rather than an empty class list.
+			if cf := wfExec.Variables["step."+testVerdictSourceStep+"."+testFailureFingerprintKey]; cf != "" {
+				recurring = []string{cf}
+			}
+		}
+		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+			return StepOutput{}, err
+		}
+		reason := "suspected acceptance-criteria conflict after recurring product-bug test failures — human spec decision needed; see ## Test Failures"
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
 		}
-		e.logger.Warn("workflow.test.duplicate-failure", "task_id", taskID)
+		e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "duplicate failure"}, nil
 	}
 
 	if attempts >= limit {
+		if recurring := recurringProductBugFingerprints(t); len(recurring) > 0 {
+			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+				return StepOutput{}, err
+			}
+			reason := fmt.Sprintf(
+				"suspected acceptance-criteria conflict: %d recurring product-bug failure class(es) after %d test attempts (cap %d) — human spec decision needed; see ## Test Failures",
+				len(recurring), attempts, limit)
+			if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+				return StepOutput{}, err
+			}
+			e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "escalated"}, nil
+		}
 		reason := fmt.Sprintf("manual testing found %d grounded product defects: feature still does not match the task — needs targeted local reproduction/fix from latest ## Test Failures", attempts)
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
@@ -2004,6 +2096,117 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 	e.logger.Info("workflow.test.reimplement", "task_id", taskID, "attempts", attempts, "cap", limit)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "reimplement"}, nil
+}
+
+// recurringProductBugFingerprints returns the distinct product-bug failure
+// fingerprints (sorted) that recurred at least twice within the current
+// testing cycle, with an intervening code-author run between two of their
+// occurrences — the same "the implementer fixed something and the SAME
+// failure class came back" signal countValidProductTestAttempts uses for its
+// immediate-duplicate check, but surfaced here as a set. This lets cap-time
+// escalation reframe as a spec-decision on ANY recurring class among the
+// attempts that exhausted the cap, not only the just-finished attempt's
+// fingerprint.
+func recurringProductBugFingerprints(t TaskInfo) []string {
+	var fingerprints []string
+	var indices []int
+	for i := range t.AgentRuns {
+		run := t.AgentRuns[i]
+		if t.TestingCycleStartedAt != nil && run.StartedAt.Before(*t.TestingCycleStartedAt) {
+			continue
+		}
+		if run.Role != testRunnerRole || run.ProtocolViolation != "" ||
+			run.TestOutcome != testOutcomeProductBug || run.TestFailureFingerprint == "" {
+			continue
+		}
+		fingerprints = append(fingerprints, run.TestFailureFingerprint)
+		indices = append(indices, i)
+	}
+	seen := make(map[string]bool)
+	var recurring []string
+	for a := range fingerprints {
+		if seen[fingerprints[a]] {
+			continue
+		}
+		for b := a + 1; b < len(fingerprints); b++ {
+			if fingerprints[b] != fingerprints[a] {
+				continue
+			}
+			if hasInterveningCodeAuthorRun(t.AgentRuns, indices[a], indices[b]) {
+				seen[fingerprints[a]] = true
+				recurring = append(recurring, fingerprints[a])
+				break
+			}
+		}
+	}
+	sort.Strings(recurring)
+	return recurring
+}
+
+// specDecisionHeading marks the section appended to a task body when
+// escalating on recurring product-bug failure classes. A distinct heading
+// (not "## Test Failures") keeps it out of testFailSectionOf's scan.
+const specDecisionHeading = "## Spec Decision Needed"
+
+// specDecisionMarker returns a stable HTML-comment marker keyed by the sorted
+// set of recurring fingerprints driving an escalation. appendSpecDecisionSection
+// uses it to skip re-appending an identical section on a rerun (idempotency),
+// while a genuinely new recurring set still gets its own section appended.
+func specDecisionMarker(fingerprints []string) string {
+	sorted := append([]string(nil), fingerprints...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, "|")))
+	return "<!-- sybra:spec-decision:" + hex.EncodeToString(sum[:6]) + " -->"
+}
+
+// buildSpecDecisionSection renders the task-body evidence for a spec-decision
+// escalation. It deliberately avoids asserting a proven contradiction —
+// the same recurrence shape can also be produced by two independent
+// sequential bugs — and points at the latest "## Test Failures" section
+// for repros rather than claiming an exact section-to-fingerprint mapping,
+// since AgentRunInfo does not persist historical report text or offsets.
+func buildSpecDecisionSection(fingerprints []string, attempts, limit int) string {
+	sorted := append([]string(nil), fingerprints...)
+	sort.Strings(sorted)
+	var b strings.Builder
+	b.WriteString(specDecisionHeading + "\n\n")
+	b.WriteString(specDecisionMarker(sorted) + "\n\n")
+	fmt.Fprintf(&b,
+		"Manual testing reproduced %d recurring product-bug failure class(es) across an intervening "+
+			"reimplementation attempt (%d test attempt(s), cap %d). This is evidence of a suspected "+
+			"acceptance-criteria conflict — not a confirmed one, since two independent sequential bugs "+
+			"can produce the same recurrence shape. A human spec decision is needed.\n\n",
+		len(sorted), attempts, limit)
+	fmt.Fprintf(&b,
+		"Recurring fingerprint(s): %s. Repros for these failure classes are identifiable in the latest "+
+			"%q section of this task body.\n",
+		strings.Join(sorted, ", "), testFailuresHeading)
+	return b.String()
+}
+
+// appendSpecDecisionSection appends the spec-decision evidence section to the
+// task body, unless a section with an identical marker (same recurring
+// fingerprint set) is already present — reruns then skip instead of
+// duplicating. A new/different recurring set still gets appended, since
+// AppendTaskBody has no in-place replace and the older section remains valid
+// historical evidence.
+func (e *Engine) appendSpecDecisionSection(taskID, body string, fingerprints []string, attempts, limit int) error {
+	if strings.Contains(body, specDecisionMarker(fingerprints)) {
+		return nil
+	}
+	if err := e.tasks.AppendTaskBody(taskID, buildSpecDecisionSection(fingerprints, attempts, limit)); err != nil {
+		return fmt.Errorf("append spec-decision section: %w", err)
+	}
+	return nil
+}
+
+// logSpecDecisionEscalation emits a bounded structured event for a
+// spec-decision escalation: task id, attempt/cap counters, and the distinct
+// recurring-class count and fingerprints. Raw test reports are never logged.
+func (e *Engine) logSpecDecisionEscalation(taskID string, attempts, limit int, fingerprints []string) {
+	e.logger.Warn("workflow.test.spec-decision",
+		"task_id", taskID, "attempts", attempts, "cap", limit,
+		"recurring_classes", len(fingerprints), "fingerprints", fingerprints)
 }
 
 func (e *Engine) countValidProductTestAttempts(t TaskInfo, wfExec *Execution) (int, bool) {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -2190,22 +2190,28 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
 			e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
 		}
-		e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
+		e.logSpecDecisionEscalation(taskID, attempts, limit, recurring, false)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "duplicate failure"}, nil
 	}
 
 	if attempts >= limit {
-		if recurring := recurringProductBugFingerprints(t); len(recurring) > 0 {
+		if nonConvergingProductBugLoop(t) {
+			// Evidence only — the reframe below fires on non-convergence
+			// (ping-ponging product-bug attempts with an intervening
+			// code-author run) even when concrete repro evidence differs
+			// across attempts and no exact fingerprint recurred, so
+			// `recurring` may legitimately be empty here.
+			recurring := recurringProductBugFingerprints(t)
 			reason := fmt.Sprintf(
-				"suspected acceptance-criteria conflict: %d recurring product-bug failure class(es) after %d test attempts (cap %d) — human spec decision needed; see ## Test Failures",
-				len(recurring), attempts, limit)
+				"suspected acceptance-criteria conflict: the implement/test loop failed to converge over %d product-bug attempt(s) (cap %d) — could be a contradictory spec or a hard defect the fixes keep missing; human spec decision needed; see ## Test Failures",
+				attempts, limit)
 			if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 				return StepOutput{}, err
 			}
 			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
 				e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
 			}
-			e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
+			e.logSpecDecisionEscalation(taskID, attempts, limit, recurring, true)
 			return StepOutput{StepID: step.ID, Status: "completed", Output: "escalated"}, nil
 		}
 		reason := fmt.Sprintf("manual testing found %d grounded product defects: feature still does not match the task — needs targeted local reproduction/fix from latest ## Test Failures", attempts)
@@ -2276,6 +2282,36 @@ func recurringProductBugFingerprints(t TaskInfo) []string {
 	return recurring
 }
 
+// nonConvergingProductBugLoop reports whether the implement/test loop has
+// ping-ponged between valid product-bug test-runner attempts within the
+// current testing cycle, regardless of whether their fingerprints match.
+// Unlike recurringProductBugFingerprints (which requires the SAME failure
+// class to reappear byte-for-byte), this only requires two valid product-bug
+// attempts separated by a code-author run — the realistic shape when a live
+// tester re-probes the same conceptual defect but picks different concrete
+// repro evidence (fixture values, ids, quoted literals) each time, which
+// would otherwise fingerprint differently and hide the recurrence.
+func nonConvergingProductBugLoop(t TaskInfo) bool {
+	var indices []int
+	for i := range t.AgentRuns {
+		run := t.AgentRuns[i]
+		if t.TestingCycleStartedAt != nil && run.StartedAt.Before(*t.TestingCycleStartedAt) {
+			continue
+		}
+		if run.Role != testRunnerRole || run.ProtocolViolation != "" ||
+			run.TestOutcome != testOutcomeProductBug || run.TestFailureFingerprint == "" {
+			continue
+		}
+		indices = append(indices, i)
+	}
+	for i := 1; i < len(indices); i++ {
+		if hasInterveningCodeAuthorRun(t.AgentRuns, indices[i-1], indices[i]) {
+			return true
+		}
+	}
+	return false
+}
+
 // specDecisionHeading marks the section appended to a task body when
 // escalating on recurring product-bug failure classes. A distinct heading
 // (not "## Test Failures") keeps it out of testFailSectionOf's scan.
@@ -2304,6 +2340,18 @@ func buildSpecDecisionSection(fingerprints []string, attempts, limit int) string
 	var b strings.Builder
 	b.WriteString(specDecisionHeading + "\n\n")
 	b.WriteString(specDecisionMarker(sorted) + "\n\n")
+	if len(sorted) == 0 {
+		fmt.Fprintf(&b,
+			"The implement/test loop failed to converge over %d product-bug test attempt(s) (cap %d), but "+
+				"the concrete repro evidence differed across attempts — a fresh test-runner agent can pick a "+
+				"different repro (fixture values, ids, quoted literals) to demonstrate the same conceptual "+
+				"defect each time, so no exact fingerprint recurred. This is evidence of a suspected "+
+				"acceptance-criteria conflict — not a confirmed one, since a hard defect the fixes keep "+
+				"missing can look the same. A human spec decision is needed; inspect the latest %q section "+
+				"of this task body for the most recent repro.\n",
+			attempts, limit, testFailuresHeading)
+		return b.String()
+	}
 	fmt.Fprintf(&b,
 		"Manual testing reproduced %d recurring product-bug failure class(es) across an intervening "+
 			"reimplementation attempt (%d test attempt(s), cap %d). This is evidence of a suspected "+
@@ -2334,12 +2382,16 @@ func (e *Engine) appendSpecDecisionSection(taskID, body string, fingerprints []s
 }
 
 // logSpecDecisionEscalation emits a bounded structured event for a
-// spec-decision escalation: task id, attempt/cap counters, and the distinct
-// recurring-class count and fingerprints. Raw test reports are never logged.
-func (e *Engine) logSpecDecisionEscalation(taskID string, attempts, limit int, fingerprints []string) {
+// spec-decision escalation: task id, attempt/cap counters, the distinct
+// recurring-class count and fingerprints, and whether the escalation fired
+// via the cap-time non-convergence path (nonConvergingProductBugLoop) rather
+// than the pre-cap exact-fingerprint duplicate shortcut. Raw test reports are
+// never logged.
+func (e *Engine) logSpecDecisionEscalation(taskID string, attempts, limit int, fingerprints []string, nonConvergingCap bool) {
 	e.logger.Warn("workflow.test.spec-decision",
 		"task_id", taskID, "attempts", attempts, "cap", limit,
-		"recurring_classes", len(fingerprints), "fingerprints", fingerprints)
+		"recurring_classes", len(fingerprints), "fingerprints", fingerprints,
+		"non_converging_cap", nonConvergingCap)
 }
 
 func (e *Engine) countValidProductTestAttempts(t TaskInfo, wfExec *Execution) (int, bool) {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1658,6 +1658,13 @@ var fingerprintNumberRe = regexp.MustCompile(`-?\d+(?:\.\d+)?%?`)
 // surrounding wording — statuses, outcome names, field names.
 var fingerprintEnumTokenRe = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[_.][A-Za-z0-9]+)+\b`)
 
+// fingerprintPathTokenRe captures endpoint/route-shaped literals such as
+// "/login" or "/api/export". These are often the stable part of a test report
+// when prose drifts between runner attempts.
+var fingerprintPathTokenRe = regexp.MustCompile(`/(?:[A-Za-z0-9][A-Za-z0-9._~-]*)(?:/[A-Za-z0-9][A-Za-z0-9._~-]*)*`)
+
+var fingerprintFilePathTokenRe = regexp.MustCompile(`(?i)\.(?:go|ts|tsx|js|jsx|svelte)$`)
+
 // fingerprintMinTokens is the minimum count of discriminating tokens
 // (quoted strings, file:line citations, numbers, enum-like identifiers)
 // required before the token-based fingerprint is trusted. Below this, the
@@ -1673,12 +1680,13 @@ const fingerprintMinTokens = 2
 // hash the same.
 //
 // The report is reduced to its semantically load-bearing tokens — quoted
-// error/value strings, file:line citations, numeric counts/statuses, and
-// enum-like identifiers — sorted for order-independence and hashed. Prose
-// glue words carry no signal for this purpose and are dropped. When a
-// report is too sparse to yield enough discriminating tokens (short or
-// unusually terse reports), this falls back to the original lowercased,
-// whitespace-normalized full-prose hash so a fingerprint is still produced.
+// error/value strings, endpoint paths, file:line citations, numeric
+// counts/statuses, and enum-like identifiers — sorted for order-independence
+// and hashed. Prose glue words carry no signal for this purpose and are
+// dropped. When a report is too sparse or contains only boilerplate-shaped
+// tokens (for example, a shared file:line and HTTP 500/200 pair), this falls
+// back to the original lowercased, whitespace-normalized full-prose hash so
+// unrelated bugs do not collapse into the same recurrence class.
 //
 // NOTE: this is NOT the same hash as the original exact-prose fingerprint.
 // Fingerprints persisted by older runs (AgentRunInfo.TestFailureFingerprint)
@@ -1695,10 +1703,17 @@ func testFailureFingerprint(report string) string {
 
 func fingerprintNormalizedBasis(report string) string {
 	var tokens []string
-	tokens = append(tokens, fingerprintQuotedRe.FindAllString(report, -1)...)
+	strongTokens := 0
+	quoted := fingerprintQuotedRe.FindAllString(report, -1)
+	paths := fingerprintPathTokenRe.FindAllString(report, -1)
+	enums := fingerprintEnumTokenRe.FindAllString(report, -1)
+
+	tokens = append(tokens, quoted...)
+	tokens = append(tokens, paths...)
 	tokens = append(tokens, fileLineCitationRe.FindAllString(report, -1)...)
 	tokens = append(tokens, fingerprintNumberRe.FindAllString(report, -1)...)
-	tokens = append(tokens, fingerprintEnumTokenRe.FindAllString(report, -1)...)
+	tokens = append(tokens, enums...)
+	strongTokens += len(quoted) + len(paths)
 
 	normalized := make([]string, 0, len(tokens))
 	for _, tok := range tokens {
@@ -1707,7 +1722,13 @@ func fingerprintNormalizedBasis(report string) string {
 			normalized = append(normalized, tok)
 		}
 	}
-	if len(normalized) < fingerprintMinTokens {
+	for _, tok := range enums {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok != "" && !fingerprintFilePathTokenRe.MatchString(tok) {
+			strongTokens++
+		}
+	}
+	if len(normalized) < fingerprintMinTokens || strongTokens == 0 {
 		return strings.Join(strings.Fields(strings.ToLower(report)), " ")
 	}
 	sort.Strings(normalized)
@@ -2050,12 +2071,12 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 				recurring = []string{cf}
 			}
 		}
-		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
-			return StepOutput{}, err
-		}
 		reason := "suspected acceptance-criteria conflict after recurring product-bug test failures — human spec decision needed; see ## Test Failures"
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
+		}
+		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+			e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
 		}
 		e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "duplicate failure"}, nil
@@ -2063,14 +2084,14 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 
 	if attempts >= limit {
 		if recurring := recurringProductBugFingerprints(t); len(recurring) > 0 {
-			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
-				return StepOutput{}, err
-			}
 			reason := fmt.Sprintf(
 				"suspected acceptance-criteria conflict: %d recurring product-bug failure class(es) after %d test attempts (cap %d) — human spec decision needed; see ## Test Failures",
 				len(recurring), attempts, limit)
 			if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 				return StepOutput{}, err
+			}
+			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+				e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
 			}
 			e.logSpecDecisionEscalation(taskID, attempts, limit, recurring)
 			return StepOutput{StepID: step.ID, Status: "completed", Output: "escalated"}, nil

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1369,6 +1369,30 @@ func TestTestFailureFingerprint_DistinguishesDifferentEvidence(t *testing.T) {
 	}
 }
 
+func TestTestFailureFingerprint_DistinguishesSharedBoilerplateFileCitation(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /foo\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /bar\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports that share only boilerplate file/status evidence:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_DistinguishesSharedStatusPairWithoutStrongTokens(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nThe login form rejects valid credentials.\nActual: 500\nExpected: 200"
+	b := "## Test Failures\n\nThe dashboard export crashes during download.\nActual: 500\nExpected: 200"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports that share only status numbers:\na=%q\nb=%q", a, b)
+	}
+}
+
 // TestTestFailureFingerprint_FallsBackOnSparseReport guards the fallback path:
 // a report too short to yield enough discriminating tokens must still hash
 // deterministically and distinguish from an unrelated sparse report, rather
@@ -2490,6 +2514,50 @@ func TestRouteTestResult_DuplicateFailureEscalatesWithoutAnotherRetry(t *testing
 	}
 	if !strings.Contains(ti.Body, fp) {
 		t.Errorf("body = %q, want the recurring fingerprint referenced", ti.Body)
+	}
+}
+
+func TestRouteTestResult_DuplicateFailureEscalatesWhenSpecDecisionAppendFails(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	tasks.appendErr = errors.New("append unavailable")
+	now := time.Now().UTC()
+	fp := "same-repro"
+	tasks.Put(TaskInfo{
+		ID:     "t-dup-append-fails",
+		Status: "testing",
+		AgentRuns: []AgentRunInfo{
+			{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+			{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+			{AgentID: "second", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		},
+	})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+		},
+	}
+
+	out, err := e.execRouteTestResult("t-dup-append-fails", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup-append-fails"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "duplicate failure" {
+		t.Errorf("output = %q, want duplicate failure", out.Output)
+	}
+	ti := mustGetTaskInfo(t, tasks, "t-dup-append-fails")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-dup-append-fails"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want no spec-decision section when append fails", ti.Body)
 	}
 }
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -2658,6 +2658,330 @@ func TestRouteTestResult_FailAtCapWithRecurringClassReframesAsSpecDecision(t *te
 	}
 }
 
+// TestNonConvergingProductBugLoop exercises nonConvergingProductBugLoop
+// directly against the filtering rules it must share with
+// recurringProductBugFingerprints, but without requiring fingerprint
+// equality between the paired attempts.
+func TestNonConvergingProductBugLoop(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name string
+		t    TaskInfo
+		want bool
+	}{
+		{
+			name: "distinct fingerprints separated by implementation run",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				productBugRun(now.Add(2*time.Minute), "B"),
+			}},
+			want: true,
+		},
+		{
+			name: "no author gap between adjacent product-bug attempts",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				productBugRun(now.Add(time.Minute), "B"),
+			}},
+			want: false,
+		},
+		{
+			name: "protocol-violation run ignored",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				{AgentID: "bad", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), ProtocolViolation: testProtocolFixSuggestions, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: "B"},
+			}},
+			want: false,
+		},
+		{
+			name: "infra-failure outcome ignored",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				{AgentID: "infra", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeInfraFailure},
+			}},
+			want: false,
+		},
+		{
+			name: "missing-evidence outcome ignored",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				{AgentID: "missing", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeMissingEvidence},
+			}},
+			want: false,
+		},
+		{
+			name: "prior-cycle runs before TestingCycleStartedAt ignored",
+			t: func() TaskInfo {
+				cycleStart := now.Add(10 * time.Minute)
+				return TaskInfo{
+					TestingCycleStartedAt: &cycleStart,
+					AgentRuns: []AgentRunInfo{
+						productBugRun(now, "A"),
+						{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+						productBugRun(cycleStart.Add(time.Minute), "B"),
+					},
+				}
+			}(),
+			want: false,
+		},
+		{
+			name: "non-author run between product-bug attempts does not count as a gap",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "reviewer", Role: "review", StartedAt: now.Add(time.Minute)},
+				productBugRun(now.Add(2*time.Minute), "B"),
+			}},
+			want: false,
+		},
+		{
+			name: "noise runs between filtered pairs still resolve via original indices",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "infra-noise", Role: testRunnerRole, StartedAt: now.Add(time.Minute), TestOutcome: testOutcomeInfraFailure},
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(2 * time.Minute)},
+				productBugRun(now.Add(3*time.Minute), "B"),
+			}},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := nonConvergingProductBugLoop(tc.t); got != tc.want {
+				t.Errorf("nonConvergingProductBugLoop() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRouteTestResult_FailAtCapWithDistinctFailuresAfterImplementationReframesAsSpecDecision
+// is the regression test for the recurring-fingerprint narrowing gap: a
+// live adversarial test-runner naturally exercises different concrete repro
+// evidence (different fixture ids/literals) each attempt while describing
+// the SAME conceptual failure mode, so an exact-fingerprint recurrence check
+// never fires even though the loop is genuinely ping-ponging. The cap must
+// still reframe as a suspected acceptance-criteria conflict.
+func TestRouteTestResult_FailAtCapWithDistinctFailuresAfterImplementationReframesAsSpecDecision(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "fp-2"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "fp-3"),
+	}
+	out, err := runRouteTestResult(e, tasks, "t-cap-distinct", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-cap-distinct")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	reason := tasks.Reason("t-cap-distinct")
+	if !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if !strings.Contains(reason, "contradictory spec") || !strings.Contains(reason, "hard defect") {
+		t.Errorf("reason = %q, want it to name both a contradictory spec and a hard defect", reason)
+	}
+	for _, forbidden := range []string{"proven contradiction", "found contradiction", "requirements are contradictory"} {
+		if strings.Contains(strings.ToLower(reason), forbidden) {
+			t.Errorf("reason = %q, must not assert a proven contradiction", reason)
+		}
+	}
+	if strings.Contains(reason, "recurring class") || strings.Contains(reason, "recurring product-bug failure class(es)") {
+		t.Errorf("reason = %q, must not report a count of recurring classes", reason)
+	}
+	if strings.Count(ti.Body, specDecisionHeading) != 1 {
+		t.Errorf("body = %q, want exactly one spec-decision section", ti.Body)
+	}
+}
+
+// TestRouteTestResult_FailAtCapWithoutInterveningCodeAuthorUsesGenericReason
+// verifies the generic cap-time floor is preserved when the product-bug
+// attempts that exhausted the cap were never separated by a code-author run
+// (e.g. the test-runner retried without a fix in between) — this is not a
+// non-converging implement/test loop, so no spec-decision section belongs
+// on the body.
+func TestRouteTestResult_FailAtCapWithoutInterveningCodeAuthorUsesGenericReason(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		productBugRun(now.Add(time.Minute), "fp-2"),
+		productBugRun(now.Add(2*time.Minute), "fp-3"),
+	}
+	out, err := runRouteTestResult(e, tasks, "t-cap-no-author-gap", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-cap-no-author-gap")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	reason := tasks.Reason("t-cap-no-author-gap")
+	if strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, must not use spec-decision reframing without an author gap", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, must not gain a spec-decision section without an author gap", ti.Body)
+	}
+}
+
+// TestRouteTestResult_FailAtCapSpecDecisionEscalatesWhenAppendFails verifies
+// that a body-append failure during the non-convergence cap reframe still
+// leaves the task in human-required with the softened suspected-spec reason,
+// and does not propagate the append error out of the route step.
+func TestRouteTestResult_FailAtCapSpecDecisionEscalatesWhenAppendFails(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	tasks.appendErr = errors.New("append unavailable")
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "fp-2"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "fp-3"),
+	}
+	out, err := runRouteTestResult(e, tasks, "t-cap-append-fails", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti := mustGetTaskInfo(t, tasks, "t-cap-append-fails")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-cap-append-fails"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing despite append failure", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want no spec-decision section when append fails", ti.Body)
+	}
+}
+
+// TestRouteTestResult_EmptyRecurringSpecDecisionSectionIsIdempotent verifies
+// the empty-recurring-evidence spec-decision section (no exact fingerprint
+// recurred, only non-convergence) uses a stable marker, renders no blank
+// "Recurring fingerprint(s):" list, and does not duplicate on a second call
+// with the same empty evidence set.
+func TestRouteTestResult_EmptyRecurringSpecDecisionSectionIsIdempotent(t *testing.T) {
+	t.Parallel()
+	section1 := buildSpecDecisionSection(nil, 3, 3)
+	section2 := buildSpecDecisionSection([]string{}, 3, 3)
+	if section1 != section2 {
+		t.Errorf("empty-recurring sections differ:\n%q\n%q", section1, section2)
+	}
+	if !strings.Contains(section1, specDecisionMarker(nil)) {
+		t.Errorf("section = %q, want the stable empty-set marker", section1)
+	}
+	if strings.Contains(section1, "Recurring fingerprint(s): .") || strings.Contains(section1, "Recurring fingerprint(s): \n") {
+		t.Errorf("section = %q, must not render a blank fingerprint list", section1)
+	}
+	if !strings.Contains(section1, testFailuresHeading) {
+		t.Errorf("section = %q, want a pointer to the latest %q section", section1, testFailuresHeading)
+	}
+
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "fp-2"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "fp-3"),
+	}
+	tasks.Put(TaskInfo{ID: "t-cap-empty-idem", Status: "testing", AgentRuns: runs})
+	route := func() {
+		wf := &Execution{
+			WorkflowID: "testing-task",
+			StartedAt:  now,
+			Variables: map[string]string{
+				"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+				"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+				"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: "fp-3",
+			},
+		}
+		if _, err := e.execRouteTestResult("t-cap-empty-idem", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-cap-empty-idem")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	route()
+	ti := mustGetTaskInfo(t, tasks, "t-cap-empty-idem")
+	first := ti.Body
+	if strings.Count(first, specDecisionHeading) != 1 {
+		t.Fatalf("body = %q, want exactly one spec-decision section", first)
+	}
+	route()
+	ti = mustGetTaskInfo(t, tasks, "t-cap-empty-idem")
+	if ti.Body != first {
+		t.Errorf("body changed on idempotent rerun:\nfirst: %q\nsecond: %q", first, ti.Body)
+	}
+	if strings.Count(ti.Body, specDecisionHeading) != 1 {
+		t.Errorf("body = %q, want exactly one spec-decision section after rerun", ti.Body)
+	}
+}
+
+// TestRouteTestResult_ReDispatchDoesNotUsePriorCycleForSpecDecision verifies
+// prior-cycle product-bug runs and their author gaps do not bleed into a new
+// testing cycle's non-convergence check — only runs at/after
+// TestingCycleStartedAt may drive a spec-decision reframe.
+func TestRouteTestResult_ReDispatchDoesNotUsePriorCycleForSpecDecision(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+
+	priorCycleEnd := time.Now().UTC().Add(-time.Hour)
+	newCycleStart := time.Now().UTC()
+
+	// Prior cycle already ping-ponged (author gap between distinct
+	// fingerprints) and hit human-required — that history must not count
+	// toward the new cycle's non-convergence check. Single new run in the
+	// current cycle — no new author gap yet.
+	runs := []AgentRunInfo{
+		productBugRun(priorCycleEnd.Add(-2*time.Minute), "old-1"),
+		{AgentID: "impl-old", Role: "implementation", StartedAt: priorCycleEnd.Add(-time.Minute)},
+		productBugRun(priorCycleEnd, "old-2"),
+		productBugRun(newCycleStart.Add(time.Minute), "new-1"),
+	}
+
+	out, err := runRouteTestResult(e, tasks, "t-redispatch-spec", "FAIL", newCycleStart, runs, &newCycleStart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "reimplement" {
+		t.Errorf("output = %q, want reimplement (prior-cycle runs must not drive a spec-decision reframe)", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-redispatch-spec")
+	if ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", ti.Status)
+	}
+	if reason := tasks.Reason("t-redispatch-spec"); strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, must not reframe as spec-decision from prior-cycle evidence", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, must not gain a spec-decision section from prior-cycle evidence", ti.Body)
+	}
+}
+
 func TestRouteTestResult_DuplicateFailureWithoutInterveningFixDoesNotEscalate(t *testing.T) {
 	t.Parallel()
 	e, tasks := makeTestEngine(t)

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1300,6 +1300,30 @@ func TestTestFailureFingerprint_DistinguishesDifferentEvidence(t *testing.T) {
 	}
 }
 
+func TestTestFailureFingerprint_DistinguishesSharedBoilerplateFileCitation(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /foo\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /bar\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports that share only boilerplate file/status evidence:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_DistinguishesSharedStatusPairWithoutStrongTokens(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nThe login form rejects valid credentials.\nActual: 500\nExpected: 200"
+	b := "## Test Failures\n\nThe dashboard export crashes during download.\nActual: 500\nExpected: 200"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports that share only status numbers:\na=%q\nb=%q", a, b)
+	}
+}
+
 // TestTestFailureFingerprint_FallsBackOnSparseReport guards the fallback path:
 // a report too short to yield enough discriminating tokens must still hash
 // deterministically and distinguish from an unrelated sparse report, rather
@@ -2239,6 +2263,50 @@ func TestRouteTestResult_DuplicateFailureEscalatesWithoutAnotherRetry(t *testing
 	}
 	if !strings.Contains(ti.Body, fp) {
 		t.Errorf("body = %q, want the recurring fingerprint referenced", ti.Body)
+	}
+}
+
+func TestRouteTestResult_DuplicateFailureEscalatesWhenSpecDecisionAppendFails(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	tasks.appendErr = errors.New("append unavailable")
+	now := time.Now().UTC()
+	fp := "same-repro"
+	tasks.Put(TaskInfo{
+		ID:     "t-dup-append-fails",
+		Status: "testing",
+		AgentRuns: []AgentRunInfo{
+			{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+			{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+			{AgentID: "second", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		},
+	})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+		},
+	}
+
+	out, err := e.execRouteTestResult("t-dup-append-fails", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup-append-fails"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "duplicate failure" {
+		t.Errorf("output = %q, want duplicate failure", out.Output)
+	}
+	ti := mustGetTaskInfo(t, tasks, "t-dup-append-fails")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-dup-append-fails"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want no spec-decision section when append fails", ti.Body)
 	}
 }
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1342,6 +1342,60 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 	}
 }
 
+func TestTestFailureFingerprint_ToleratesWordingDriftOnSameEvidence(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nI reran the same probe and observed the identical failure again — " +
+		"hitting curl /status still returns HTTP 500 instead of the required HTTP 200. " +
+		"Code evidence: internal/server.go:42"
+
+	if testFailureFingerprint(a) != testFailureFingerprint(b) {
+		t.Fatalf("fingerprints differ for reworded reports describing the same defect:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_DistinguishesDifferentEvidence(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /health\nActual: HTTP 404\nExpected: HTTP 200\n" +
+		"Code evidence: internal/health.go:17"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports describing different defects:\na=%q\nb=%q", a, b)
+	}
+}
+
+// TestTestFailureFingerprint_FallsBackOnSparseReport guards the fallback path:
+// a report too short to yield enough discriminating tokens must still hash
+// deterministically and distinguish from an unrelated sparse report, rather
+// than collapsing to an empty-token hash shared by every terse report.
+func TestTestFailureFingerprint_FallsBackOnSparseReport(t *testing.T) {
+	t.Parallel()
+
+	a := "the button does nothing when clicked"
+	b := "the page never loads at all"
+
+	fa := testFailureFingerprint(a)
+	fb := testFailureFingerprint(b)
+	if fa == "" || fb == "" {
+		t.Fatalf("fingerprints must be non-empty even for sparse reports: a=%q b=%q", fa, fb)
+	}
+	if fa == fb {
+		t.Fatalf("fingerprints matched for different sparse reports:\na=%q\nb=%q", a, b)
+	}
+	// The sparse fallback hashes full lowercased, whitespace-normalized prose,
+	// so it is NOT guaranteed to tolerate synonym drift the way the
+	// token-based path does — but it must still be stable across repeated
+	// calls on byte-identical input.
+	if again := testFailureFingerprint(a); again != fa {
+		t.Fatalf("fingerprint is not deterministic for identical input: %q vs %q", fa, again)
+	}
+}
+
 func TestHasRawReadinessProbeEvidenceRejectsHypotheticalText(t *testing.T) {
 	t.Parallel()
 
@@ -2422,8 +2476,117 @@ func TestRouteTestResult_DuplicateFailureEscalatesWithoutAnotherRetry(t *testing
 	if ti.Status != "human-required" {
 		t.Errorf("status = %q, want human-required", ti.Status)
 	}
-	if reason := tasks.Reason("t-dup"); !strings.Contains(reason, "same grounded test failure") {
-		t.Errorf("reason = %q, want duplicate failure", reason)
+	if reason := tasks.Reason("t-dup"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	for _, forbidden := range []string{"proven contradiction", "found contradiction", "requirements are contradictory"} {
+		if reason := tasks.Reason("t-dup"); strings.Contains(strings.ToLower(reason), forbidden) {
+			t.Errorf("reason = %q, must not assert a proven contradiction", reason)
+		}
+	}
+	ti, _ = tasks.GetTask("t-dup")
+	if !strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want a spec-decision section appended", ti.Body)
+	}
+	if !strings.Contains(ti.Body, fp) {
+		t.Errorf("body = %q, want the recurring fingerprint referenced", ti.Body)
+	}
+}
+
+// TestRouteTestResult_DuplicateFailureSpecDecisionIsIdempotent guards against a
+// second call re-appending the spec-decision section when the recurring
+// fingerprint set hasn't changed — the marker must make the append a no-op.
+func TestRouteTestResult_DuplicateFailureSpecDecisionIsIdempotent(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	fp := "same-repro"
+	runs := []AgentRunInfo{
+		{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		{AgentID: "second", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+	}
+	tasks.Put(TaskInfo{ID: "t-dup-idem", Status: "testing", AgentRuns: runs})
+	route := func() {
+		wf := &Execution{
+			WorkflowID: "testing-task",
+			StartedAt:  now,
+			Variables: map[string]string{
+				"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+				"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+				"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+			},
+		}
+		if _, err := e.execRouteTestResult("t-dup-idem", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup-idem")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	route()
+	ti := mustGetTaskInfo(t, tasks, "t-dup-idem")
+	first := ti.Body
+	if strings.Count(first, specDecisionHeading) != 1 {
+		t.Fatalf("body = %q, want exactly one spec-decision section", first)
+	}
+	route()
+	ti = mustGetTaskInfo(t, tasks, "t-dup-idem")
+	if ti.Body != first {
+		t.Errorf("body changed on idempotent rerun:\nfirst: %q\nsecond: %q", first, ti.Body)
+	}
+	if strings.Count(ti.Body, specDecisionHeading) != 1 {
+		t.Errorf("body = %q, want exactly one spec-decision section after rerun", ti.Body)
+	}
+}
+
+// TestRouteTestResult_FailAtCapWithRecurringClassReframesAsSpecDecision
+// verifies the cap-escalation path also reframes as a spec-decision when the
+// attempts that exhausted the cap include a recurring failure class, per the
+// acceptance criteria ("a single recurring class at cap" still gets the
+// spec-decision framing, not the generic distinct-defects cap message).
+func TestRouteTestResult_FailAtCapWithRecurringClassReframesAsSpecDecision(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	// A recurs at i0/i2 (intervening author at i1) — that pair would have
+	// escalated as an immediate "duplicate" if route_test_result had been
+	// called right after i2 in a real run. This fixture instead reaches cap
+	// without that earlier call (e.g. the recurrence only becomes visible in
+	// hindsight), so the cap branch itself must recognize the recurring
+	// class rather than treating three distinct-looking attempts generically.
+	// The current (last) attempt's own fingerprint ("current") is distinct
+	// from A, so the immediate-duplicate check does not fire here either.
+	runs := []AgentRunInfo{
+		productBugRun(now, "A"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "A"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "current"),
+	}
+	tasks.Put(TaskInfo{ID: "t-cap-recur", Status: "testing", AgentRuns: runs})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: "current",
+		},
+	}
+	out, err := e.execRouteTestResult("t-cap-recur", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-cap-recur"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-cap-recur")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-cap-recur"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if !strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want a spec-decision section appended", ti.Body)
 	}
 }
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1382,6 +1382,19 @@ func TestTestFailureFingerprint_DistinguishesSharedBoilerplateFileCitation(t *te
 	}
 }
 
+func TestTestFailureFingerprint_IgnoresRepeatedEvidenceTokens(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42\nObserved again: curl /status still returns HTTP 500. internal/server.go:42"
+
+	if testFailureFingerprint(a) != testFailureFingerprint(b) {
+		t.Fatalf("fingerprints differ when the same evidence is repeated:\na=%q\nb=%q", a, b)
+	}
+}
+
 func TestTestFailureFingerprint_DistinguishesSharedStatusPairWithoutStrongTokens(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1273,6 +1273,60 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 	}
 }
 
+func TestTestFailureFingerprint_ToleratesWordingDriftOnSameEvidence(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nI reran the same probe and observed the identical failure again — " +
+		"hitting curl /status still returns HTTP 500 instead of the required HTTP 200. " +
+		"Code evidence: internal/server.go:42"
+
+	if testFailureFingerprint(a) != testFailureFingerprint(b) {
+		t.Fatalf("fingerprints differ for reworded reports describing the same defect:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_DistinguishesDifferentEvidence(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /health\nActual: HTTP 404\nExpected: HTTP 200\n" +
+		"Code evidence: internal/health.go:17"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports describing different defects:\na=%q\nb=%q", a, b)
+	}
+}
+
+// TestTestFailureFingerprint_FallsBackOnSparseReport guards the fallback path:
+// a report too short to yield enough discriminating tokens must still hash
+// deterministically and distinguish from an unrelated sparse report, rather
+// than collapsing to an empty-token hash shared by every terse report.
+func TestTestFailureFingerprint_FallsBackOnSparseReport(t *testing.T) {
+	t.Parallel()
+
+	a := "the button does nothing when clicked"
+	b := "the page never loads at all"
+
+	fa := testFailureFingerprint(a)
+	fb := testFailureFingerprint(b)
+	if fa == "" || fb == "" {
+		t.Fatalf("fingerprints must be non-empty even for sparse reports: a=%q b=%q", fa, fb)
+	}
+	if fa == fb {
+		t.Fatalf("fingerprints matched for different sparse reports:\na=%q\nb=%q", a, b)
+	}
+	// The sparse fallback hashes full lowercased, whitespace-normalized prose,
+	// so it is NOT guaranteed to tolerate synonym drift the way the
+	// token-based path does — but it must still be stable across repeated
+	// calls on byte-identical input.
+	if again := testFailureFingerprint(a); again != fa {
+		t.Fatalf("fingerprint is not deterministic for identical input: %q vs %q", fa, again)
+	}
+}
+
 func TestHasRawReadinessProbeEvidenceRejectsHypotheticalText(t *testing.T) {
 	t.Parallel()
 
@@ -2171,8 +2225,117 @@ func TestRouteTestResult_DuplicateFailureEscalatesWithoutAnotherRetry(t *testing
 	if ti.Status != "human-required" {
 		t.Errorf("status = %q, want human-required", ti.Status)
 	}
-	if reason := tasks.Reason("t-dup"); !strings.Contains(reason, "same grounded test failure") {
-		t.Errorf("reason = %q, want duplicate failure", reason)
+	if reason := tasks.Reason("t-dup"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	for _, forbidden := range []string{"proven contradiction", "found contradiction", "requirements are contradictory"} {
+		if reason := tasks.Reason("t-dup"); strings.Contains(strings.ToLower(reason), forbidden) {
+			t.Errorf("reason = %q, must not assert a proven contradiction", reason)
+		}
+	}
+	ti, _ = tasks.GetTask("t-dup")
+	if !strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want a spec-decision section appended", ti.Body)
+	}
+	if !strings.Contains(ti.Body, fp) {
+		t.Errorf("body = %q, want the recurring fingerprint referenced", ti.Body)
+	}
+}
+
+// TestRouteTestResult_DuplicateFailureSpecDecisionIsIdempotent guards against a
+// second call re-appending the spec-decision section when the recurring
+// fingerprint set hasn't changed — the marker must make the append a no-op.
+func TestRouteTestResult_DuplicateFailureSpecDecisionIsIdempotent(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	fp := "same-repro"
+	runs := []AgentRunInfo{
+		{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		{AgentID: "second", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+	}
+	tasks.Put(TaskInfo{ID: "t-dup-idem", Status: "testing", AgentRuns: runs})
+	route := func() {
+		wf := &Execution{
+			WorkflowID: "testing-task",
+			StartedAt:  now,
+			Variables: map[string]string{
+				"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+				"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+				"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+			},
+		}
+		if _, err := e.execRouteTestResult("t-dup-idem", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup-idem")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	route()
+	ti := mustGetTaskInfo(t, tasks, "t-dup-idem")
+	first := ti.Body
+	if strings.Count(first, specDecisionHeading) != 1 {
+		t.Fatalf("body = %q, want exactly one spec-decision section", first)
+	}
+	route()
+	ti = mustGetTaskInfo(t, tasks, "t-dup-idem")
+	if ti.Body != first {
+		t.Errorf("body changed on idempotent rerun:\nfirst: %q\nsecond: %q", first, ti.Body)
+	}
+	if strings.Count(ti.Body, specDecisionHeading) != 1 {
+		t.Errorf("body = %q, want exactly one spec-decision section after rerun", ti.Body)
+	}
+}
+
+// TestRouteTestResult_FailAtCapWithRecurringClassReframesAsSpecDecision
+// verifies the cap-escalation path also reframes as a spec-decision when the
+// attempts that exhausted the cap include a recurring failure class, per the
+// acceptance criteria ("a single recurring class at cap" still gets the
+// spec-decision framing, not the generic distinct-defects cap message).
+func TestRouteTestResult_FailAtCapWithRecurringClassReframesAsSpecDecision(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	// A recurs at i0/i2 (intervening author at i1) — that pair would have
+	// escalated as an immediate "duplicate" if route_test_result had been
+	// called right after i2 in a real run. This fixture instead reaches cap
+	// without that earlier call (e.g. the recurrence only becomes visible in
+	// hindsight), so the cap branch itself must recognize the recurring
+	// class rather than treating three distinct-looking attempts generically.
+	// The current (last) attempt's own fingerprint ("current") is distinct
+	// from A, so the immediate-duplicate check does not fire here either.
+	runs := []AgentRunInfo{
+		productBugRun(now, "A"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "A"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "current"),
+	}
+	tasks.Put(TaskInfo{ID: "t-cap-recur", Status: "testing", AgentRuns: runs})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: "current",
+		},
+	}
+	out, err := e.execRouteTestResult("t-cap-recur", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-cap-recur"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-cap-recur")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-cap-recur"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if !strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want a spec-decision section appended", ti.Body)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -103,12 +103,13 @@ func newTestStoreWith(t *testing.T, files ...string) *Store {
 // --- In-memory TaskProvider ---
 
 type memTasks struct {
-	mu      sync.Mutex
-	tasks   map[string]*TaskInfo
-	reasons map[string]string
-	steers  map[string]string
-	gets    map[string]int
-	onGet   func(id string, t *TaskInfo, count int)
+	mu        sync.Mutex
+	tasks     map[string]*TaskInfo
+	reasons   map[string]string
+	steers    map[string]string
+	gets      map[string]int
+	onGet     func(id string, t *TaskInfo, count int)
+	appendErr error
 }
 
 func newMemTasks() *memTasks {
@@ -266,6 +267,9 @@ func (m *memTasks) AppendTaskBody(id, content string) error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.appendErr != nil {
+		return m.appendErr
+	}
 	t, ok := m.tasks[id]
 	if !ok {
 		return fmt.Errorf("task %s not found", id)


### PR DESCRIPTION
## Motivation

When manual testing keeps hitting product-bug failures across reimplementation attempts, the loop escalated to human-required with a generic "grounded defect" reason — even when the recurring shape looks like a contradictory acceptance criterion rather than a fix the implementer keeps missing. The exact-prose fingerprint used to detect recurrence was also brittle: a test-runner citing different concrete evidence (fixture ids, quoted literals) for the same conceptual defect would fingerprint differently and never trip recurrence detection.

## Implementation information

- Hardened `testFailureFingerprint` to derive a token-based basis (quoted strings, file:line citations, numeric tokens, enum-like identifiers, endpoint paths) instead of hashing the full lowercased prose, falling back to the old whole-prose hash when too few discriminating tokens are present.
- Added `recurringProductBugFingerprints` and `nonConvergingProductBugLoop` to detect ping-ponging product-bug attempts (with an intervening code-author run) both by exact fingerprint recurrence and by non-convergence when fingerprints differ but attempts don't converge.
- On duplicate-failure or cap-exhaustion escalation, append a `## Spec Decision Needed` section to the task body (idempotent per recurring fingerprint set) and reframe the human-required reason to flag a suspected acceptance-criteria conflict, while being explicit this isn't a confirmed contradiction.
- Added `logSpecDecisionEscalation` for structured, bounded logging of the escalation (no raw report text).

_Generated by Sybra harness_