### PR TITLE
fix(monitor): auto-retry human-required stalls with known cause

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -143,8 +143,12 @@ const affectedTaskMarkerPrefix = "## Affected task\n- `"
 // already known and tracked. Used to skip re-dispatching an LLM to
 // rediscover the same finding when the origin task later shows up stuck in
 // human-required.
-func openLostAgentInvestigations(tasks []task.Task) map[string]bool {
-	out := make(map[string]bool)
+type openLostAgentInvestigation struct {
+	observedAt time.Time
+}
+
+func openLostAgentInvestigations(tasks []task.Task) map[string]openLostAgentInvestigation {
+	out := make(map[string]openLostAgentInvestigation)
 	for i := range tasks {
 		t := &tasks[i]
 		if task.IsTerminalStatus(t.Status) {
@@ -159,8 +163,19 @@ func openLostAgentInvestigations(tasks []task.Task) map[string]bool {
 		}
 		rest := t.Body[idx+len(affectedTaskMarkerPrefix):]
 		originID, _, ok := strings.Cut(rest, "`")
-		if ok && originID != "" {
-			out[originID] = true
+		if !ok || originID == "" {
+			continue
+		}
+		fpMarker := "- Fingerprint: `" + Fingerprint(KindLostAgent, originID, nil) + "`"
+		if !strings.Contains(t.Body, fpMarker) {
+			continue
+		}
+		observedAt := t.UpdatedAt
+		if observedAt.IsZero() {
+			observedAt = t.CreatedAt
+		}
+		if prev, ok := out[originID]; !ok || prev.observedAt.Before(observedAt) {
+			out[originID] = openLostAgentInvestigation{observedAt: observedAt}
 		}
 	}
 	return out
@@ -200,7 +215,7 @@ func detectUntriaged(t *task.Task, now time.Time) *Anomaly {
 	}
 }
 
-func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration, trackedLostAgent map[string]bool) *Anomaly {
+func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration, trackedLostAgent map[string]openLostAgentInvestigation) *Anomaly {
 	// plan-review is intentionally excluded: a plan awaits the human's approval
 	// indefinitely and must never be auto-escalated to human-required. Only tasks
 	// already in human-required are flagged when they exceed their dwell budget.
@@ -246,7 +261,7 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration, 
 	// instead (remediateHumanRequiredStuck), guarded by monitorAutoRetriedTag
 	// so a second stall on the same task falls through to the normal path
 	// rather than bouncing forever.
-	knownLostAgentCause := trackedLostAgent[t.ID] && !slices.Contains(t.Tags, monitorAutoRetriedTag)
+	knownLostAgentCause := currentLostAgentInvestigation(t, trackedLostAgent) && !slices.Contains(t.Tags, monitorAutoRetriedTag)
 	if knownLostAgentCause {
 		ev["known_lost_agent_investigation"] = true
 	}
@@ -264,6 +279,28 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration, 
 		Evidence:    ev,
 		DetectedAt:  now,
 	}
+}
+
+func currentLostAgentInvestigation(t *task.Task, tracked map[string]openLostAgentInvestigation) bool {
+	inv, ok := tracked[t.ID]
+	if !ok || inv.observedAt.IsZero() {
+		return false
+	}
+	cutoff := t.UpdatedAt
+	if started := latestAgentRunStarted(t.AgentRuns); !started.IsZero() {
+		cutoff = started
+	}
+	return !inv.observedAt.Before(cutoff)
+}
+
+func latestAgentRunStarted(runs []task.AgentRun) time.Time {
+	var latest time.Time
+	for i := range runs {
+		if runs[i].StartedAt.After(latest) {
+			latest = runs[i].StartedAt
+		}
+	}
+	return latest
 }
 
 func detectPRGap(t *task.Task, now time.Time, grace time.Duration) *Anomaly {

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -97,6 +97,7 @@ func detectBoardWide(in DetectInput, counts Counts) []Anomaly {
 func detectPerTask(in DetectInput) []Anomaly {
 	var out []Anomaly
 	stuckBudget := time.Duration(in.Cfg.StuckHumanHours * float64(time.Hour))
+	tracked := openLostAgentInvestigations(in.Tasks)
 	for i := range in.Tasks {
 		t := &in.Tasks[i]
 		if t.TaskType == task.TaskTypeChat {
@@ -108,7 +109,7 @@ func detectPerTask(in DetectInput) []Anomaly {
 		if a := detectUntriaged(t, in.Now); a != nil {
 			out = append(out, *a)
 		}
-		if a := detectStuckHumanBlocked(t, in.Now, stuckBudget); a != nil {
+		if a := detectStuckHumanBlocked(t, in.Now, stuckBudget, tracked); a != nil {
 			out = append(out, *a)
 		}
 		if a := detectPRGap(t, in.Now, time.Duration(in.Cfg.PRGapGraceMinutes)*time.Minute); a != nil {
@@ -116,6 +117,52 @@ func detectPerTask(in DetectInput) []Anomaly {
 		}
 	}
 	out = append(out, detectLostAgents(in)...)
+	return out
+}
+
+// monitorAutoRetriedTag marks a task the monitor has already auto-retried
+// once out of human-required because its stall correlated with a known,
+// already-tracked lost_agent investigation. Present so a second stall on the
+// same task falls back to the normal LLM re-investigation instead of
+// bouncing the task between in-progress and human-required forever.
+const monitorAutoRetriedTag = "monitor:auto-retried"
+
+// lostAgentInvestigationTag is the tag monitorRoutingSink stamps on a local
+// task it files for a KindLostAgent anomaly (see internal/sybra/monitor_sink.go).
+const lostAgentInvestigationTag = "monitor:" + string(KindLostAgent)
+
+// affectedTaskMarkerPrefix precedes the origin task id in a deterministic
+// issue body's "## Affected task" section (see DeterministicIssueBody). Used
+// to recover which task an investigation task was filed for.
+const affectedTaskMarkerPrefix = "## Affected task\n- `"
+
+// openLostAgentInvestigations returns the set of task IDs that already have
+// an open (non-terminal) local investigation task tracking a lost_agent
+// anomaly for them — i.e. monitorRoutingSink already filed (or re-detected
+// into) a task for this exact lost_agent fingerprint, so its root cause is
+// already known and tracked. Used to skip re-dispatching an LLM to
+// rediscover the same finding when the origin task later shows up stuck in
+// human-required.
+func openLostAgentInvestigations(tasks []task.Task) map[string]bool {
+	out := make(map[string]bool)
+	for i := range tasks {
+		t := &tasks[i]
+		if task.IsTerminalStatus(t.Status) {
+			continue
+		}
+		if !slices.Contains(t.Tags, lostAgentInvestigationTag) {
+			continue
+		}
+		idx := strings.Index(t.Body, affectedTaskMarkerPrefix)
+		if idx < 0 {
+			continue
+		}
+		rest := t.Body[idx+len(affectedTaskMarkerPrefix):]
+		originID, _, ok := strings.Cut(rest, "`")
+		if ok && originID != "" {
+			out[originID] = true
+		}
+	}
 	return out
 }
 
@@ -153,7 +200,7 @@ func detectUntriaged(t *task.Task, now time.Time) *Anomaly {
 	}
 }
 
-func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) *Anomaly {
+func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration, trackedLostAgent map[string]bool) *Anomaly {
 	// plan-review is intentionally excluded: a plan awaits the human's approval
 	// indefinitely and must never be auto-escalated to human-required. Only tasks
 	// already in human-required are flagged when they exceed their dwell budget.
@@ -192,10 +239,22 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			ev["human_review_verdict"] = dec
 		}
 	}
-	// Skip the LLM only when human-review already confirmed verdict=human;
+	// A task whose stall already has an open, monitor-filed lost_agent
+	// investigation is a known cause, not an ambiguous one — re-dispatching an
+	// LLM here would just rediscover the same finding the investigation task
+	// already recorded. Skip the LLM once and let the remediator auto-retry
+	// instead (remediateHumanRequiredStuck), guarded by monitorAutoRetriedTag
+	// so a second stall on the same task falls through to the normal path
+	// rather than bouncing forever.
+	knownLostAgentCause := trackedLostAgent[t.ID] && !slices.Contains(t.Tags, monitorAutoRetriedTag)
+	if knownLostAgentCause {
+		ev["known_lost_agent_investigation"] = true
+	}
+	// Skip the LLM when human-review already confirmed verdict=human, or when
+	// the stall correlates with a known, already-tracked lost_agent cause;
 	// otherwise an LLM investigates whether the block is a real human need or a
 	// Sybra misfire.
-	requiresLLM := ev["human_review_verdict"] != "human"
+	requiresLLM := ev["human_review_verdict"] != "human" && !knownLostAgentCause
 	return &Anomaly{
 		Kind:        KindStuckHumanBlocked,
 		TaskID:      t.ID,

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -996,6 +997,62 @@ func TestDetectStuckHumanBlocked_KnownLostAgentCause(t *testing.T) {
 		}
 		if !got.RequiresLLM {
 			t.Error("a task already auto-retried once must fall back to the normal LLM path on a second stall")
+		}
+	})
+
+	t.Run("RequiresLLM=true when the investigation predates the current agent run", func(t *testing.T) {
+		stuck := mkTask("orig", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "new-run", State: "stopped", StartedAt: now.Add(-2 * time.Hour)},
+			}
+		})
+		investigation := lostAgentInvestigationTask("inv", "orig", task.StatusTodo)
+		investigation.UpdatedAt = now.Add(-4 * time.Hour)
+		in := DetectInput{Now: now, Tasks: []task.Task{stuck, investigation}, Cfg: cfg}
+		report := Detect(in)
+
+		var got *Anomaly
+		for i := range report.Anomalies {
+			if report.Anomalies[i].Kind == KindStuckHumanBlocked {
+				got = &report.Anomalies[i]
+			}
+		}
+		if got == nil {
+			t.Fatal("want a stuck_human_blocked anomaly for the stalled task")
+		}
+		if !got.RequiresLLM {
+			t.Error("a stale investigation from an earlier run must not suppress the LLM re-investigation")
+		}
+		if known, _ := got.Evidence["known_lost_agent_investigation"].(bool); known {
+			t.Error("stale investigation must not set known_lost_agent_investigation=true")
+		}
+	})
+
+	t.Run("RequiresLLM=true when the investigation fingerprint does not match the affected task", func(t *testing.T) {
+		stuck := mkTask("orig", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+		})
+		investigation := lostAgentInvestigationTask("inv", "orig", task.StatusTodo)
+		investigation.Body = strings.ReplaceAll(
+			investigation.Body,
+			"- Fingerprint: `"+Fingerprint(KindLostAgent, "orig", nil)+"`",
+			"- Fingerprint: `"+Fingerprint(KindLostAgent, "other", nil)+"`",
+		)
+		in := DetectInput{Now: now, Tasks: []task.Task{stuck, investigation}, Cfg: cfg}
+		report := Detect(in)
+
+		var got *Anomaly
+		for i := range report.Anomalies {
+			if report.Anomalies[i].Kind == KindStuckHumanBlocked {
+				got = &report.Anomalies[i]
+			}
+		}
+		if got == nil {
+			t.Fatal("want a stuck_human_blocked anomaly for the stalled task")
+		}
+		if !got.RequiresLLM {
+			t.Error("a mismatched investigation fingerprint must not suppress the LLM re-investigation")
 		}
 	})
 }

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -911,6 +911,95 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 	})
 }
 
+// lostAgentInvestigationTask builds a local investigation task the way
+// monitorRoutingSink.Submit would file it for a KindLostAgent anomaly on
+// originID, using the same fingerprint/body shape DeterministicIssueBody
+// produces (see internal/monitor/prompts.go).
+func lostAgentInvestigationTask(id, originID string, status task.Status) task.Task {
+	fp := Fingerprint(KindLostAgent, originID, nil)
+	body := "## Detection\n- Kind: `lost_agent`\n- Fingerprint: `" + fp + "`\n\n" +
+		"## Affected task\n- `" + originID + "`\n\n"
+	return mkTask(id, status, func(t *task.Task) {
+		t.Tags = []string{lostAgentInvestigationTag}
+		t.Body = body
+	})
+}
+
+func TestDetectStuckHumanBlocked_KnownLostAgentCause(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+
+	t.Run("RequiresLLM=false and evidence set when an open lost_agent investigation tracks this task", func(t *testing.T) {
+		stuck := mkTask("orig", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+		})
+		investigation := lostAgentInvestigationTask("inv", "orig", task.StatusTodo)
+		in := DetectInput{Now: now, Tasks: []task.Task{stuck, investigation}, Cfg: cfg}
+		report := Detect(in)
+
+		var got *Anomaly
+		for i := range report.Anomalies {
+			if report.Anomalies[i].Kind == KindStuckHumanBlocked {
+				got = &report.Anomalies[i]
+			}
+		}
+		if got == nil {
+			t.Fatal("want a stuck_human_blocked anomaly for the stalled task")
+		}
+		if got.RequiresLLM {
+			t.Error("RequiresLLM must be false when an open lost_agent investigation already tracks this task")
+		}
+		if known, _ := got.Evidence["known_lost_agent_investigation"].(bool); !known {
+			t.Error("evidence missing known_lost_agent_investigation=true")
+		}
+	})
+
+	t.Run("RequiresLLM=true when the investigation task is terminal", func(t *testing.T) {
+		stuck := mkTask("orig", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+		})
+		investigation := lostAgentInvestigationTask("inv", "orig", task.StatusDone)
+		in := DetectInput{Now: now, Tasks: []task.Task{stuck, investigation}, Cfg: cfg}
+		report := Detect(in)
+
+		var got *Anomaly
+		for i := range report.Anomalies {
+			if report.Anomalies[i].Kind == KindStuckHumanBlocked {
+				got = &report.Anomalies[i]
+			}
+		}
+		if got == nil {
+			t.Fatal("want a stuck_human_blocked anomaly for the stalled task")
+		}
+		if !got.RequiresLLM {
+			t.Error("a closed/done investigation task must not suppress the LLM re-investigation")
+		}
+	})
+
+	t.Run("RequiresLLM=true once the task already carries the auto-retried tag", func(t *testing.T) {
+		stuck := mkTask("orig", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.Tags = []string{"medium", monitorAutoRetriedTag}
+		})
+		investigation := lostAgentInvestigationTask("inv", "orig", task.StatusTodo)
+		in := DetectInput{Now: now, Tasks: []task.Task{stuck, investigation}, Cfg: cfg}
+		report := Detect(in)
+
+		var got *Anomaly
+		for i := range report.Anomalies {
+			if report.Anomalies[i].Kind == KindStuckHumanBlocked {
+				got = &report.Anomalies[i]
+			}
+		}
+		if got == nil {
+			t.Fatal("want a stuck_human_blocked anomaly for the stalled task")
+		}
+		if !got.RequiresLLM {
+			t.Error("a task already auto-retried once must fall back to the normal LLM path on a second stall")
+		}
+	})
+}
+
 func TestCounts(t *testing.T) {
 	tasks := []task.Task{
 		mkTask("a", task.StatusTodo),

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -85,9 +85,17 @@ func (r *remediator) tagUntriaged(a Anomaly) (string, error) {
 // already human-required and has exceeded its dwell budget. Updating the task
 // file stamps a new UpdatedAt, resetting the dwell timer and suppressing
 // repeated meta-task creation for the same block.
+//
+// When the anomaly's stall correlates with a known, already-tracked
+// lost_agent investigation (detectStuckHumanBlocked's
+// known_lost_agent_investigation evidence), this instead auto-retries the
+// task once — see retryKnownLostAgentStuck.
 func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 	if a.TaskID == "" {
 		return "", fmt.Errorf("stuck_human_blocked without task id")
+	}
+	if known, _ := a.Evidence["known_lost_agent_investigation"].(bool); known {
+		return r.retryKnownLostAgentStuck(a)
 	}
 	// Empty update: preserve existing StatusReason; Marshal stamps new UpdatedAt.
 	upd := task.Update{}
@@ -95,6 +103,30 @@ func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 		return "", fmt.Errorf("tag human-required task %s stalled: %w", a.TaskID, err)
 	}
 	return string(a.Kind) + ":" + a.TaskID, nil
+}
+
+// retryKnownLostAgentStuck moves a task out of human-required back to
+// in-progress when its stall already has an open, monitor-filed lost_agent
+// investigation tracking the root cause — no point leaving it parked for a
+// human when recovery can retry it and the finding is already recorded
+// elsewhere. Stamps monitorAutoRetriedTag so a second stall on the same task
+// (the auto-retry did not help) falls back to the normal human-review path
+// instead of bouncing between in-progress and human-required forever.
+func (r *remediator) retryKnownLostAgentStuck(a Anomaly) (string, error) {
+	t, err := r.tasks.Get(a.TaskID)
+	if err != nil {
+		return "", fmt.Errorf("retry known lost_agent stuck task %s: %w", a.TaskID, err)
+	}
+	tags := append(slices.Clone(t.Tags), monitorAutoRetriedTag)
+	upd := task.Update{
+		Status:       task.Ptr(task.StatusInProgress),
+		StatusReason: task.Ptr("monitor: stall matches an already-tracked lost_agent investigation; auto-retrying"),
+		Tags:         &tags,
+	}
+	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
+		return "", fmt.Errorf("retry known lost_agent stuck task %s: %w", a.TaskID, err)
+	}
+	return string(a.Kind) + ":retry:" + a.TaskID, nil
 }
 
 // isHumanRequiredStuck reports whether a is a stuck_human_blocked anomaly for

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // taskAPI is the slice of task.Manager the remediator + service needs. Keeps
@@ -95,8 +96,19 @@ func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 		return "", fmt.Errorf("stuck_human_blocked without task id")
 	}
 	if known, _ := a.Evidence["known_lost_agent_investigation"].(bool); known {
-		return r.retryKnownLostAgentStuck(a)
+		t, err := r.tasks.Get(a.TaskID)
+		if err != nil {
+			return "", fmt.Errorf("inspect known lost_agent stuck task %s: %w", a.TaskID, err)
+		}
+		if humanReviewVerdict(a) == "human" || workflow.IsTamperFlaggedReason(t.StatusReason) {
+			return r.refreshHumanRequiredStuck(a)
+		}
+		return r.retryKnownLostAgentStuck(a, t)
 	}
+	return r.refreshHumanRequiredStuck(a)
+}
+
+func (r *remediator) refreshHumanRequiredStuck(a Anomaly) (string, error) {
 	// Empty update: preserve existing StatusReason; Marshal stamps new UpdatedAt.
 	upd := task.Update{}
 	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
@@ -112,11 +124,7 @@ func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 // elsewhere. Stamps monitorAutoRetriedTag so a second stall on the same task
 // (the auto-retry did not help) falls back to the normal human-review path
 // instead of bouncing between in-progress and human-required forever.
-func (r *remediator) retryKnownLostAgentStuck(a Anomaly) (string, error) {
-	t, err := r.tasks.Get(a.TaskID)
-	if err != nil {
-		return "", fmt.Errorf("retry known lost_agent stuck task %s: %w", a.TaskID, err)
-	}
+func (r *remediator) retryKnownLostAgentStuck(a Anomaly, t task.Task) (string, error) {
 	tags := append(slices.Clone(t.Tags), monitorAutoRetriedTag)
 	upd := task.Update{
 		Status:       task.Ptr(task.StatusInProgress),
@@ -127,6 +135,11 @@ func (r *remediator) retryKnownLostAgentStuck(a Anomaly) (string, error) {
 		return "", fmt.Errorf("retry known lost_agent stuck task %s: %w", a.TaskID, err)
 	}
 	return string(a.Kind) + ":retry:" + a.TaskID, nil
+}
+
+func humanReviewVerdict(a Anomaly) string {
+	verdict, _ := a.Evidence["human_review_verdict"].(string)
+	return verdict
 }
 
 // isHumanRequiredStuck reports whether a is a stuck_human_blocked anomaly for

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 func TestRemediator_LostAgent_MarksRunningRunStopped(t *testing.T) {
@@ -187,6 +188,79 @@ func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_AutoRetries(t *testing
 	// Original tags must be preserved, not clobbered.
 	if !slices.Contains(*u.u.Tags, "medium") {
 		t.Errorf("tags = %v, want to still contain %q", *u.u.Tags, "medium")
+	}
+}
+
+func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_HumanVerdictDoesNotRetry(t *testing.T) {
+	t.Parallel()
+	existing := mkTask("hr3", task.StatusHumanRequired, func(t *task.Task) {
+		t.StatusReason = "waiting for human-provided context"
+		t.Tags = []string{"medium"}
+	})
+	ft := &fakeTasks{tasks: []task.Task{existing}}
+	rem := newRemediator(ft)
+	a := Anomaly{
+		Kind:   KindStuckHumanBlocked,
+		TaskID: "hr3",
+		Evidence: map[string]any{
+			"status":                         "human-required",
+			"known_lost_agent_investigation": true,
+			"human_review_verdict":           "human",
+		},
+	}
+
+	label, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if label == "" {
+		t.Fatal("expected non-empty label")
+	}
+	if len(ft.updates) != 1 {
+		t.Fatalf("want 1 update, got %d", len(ft.updates))
+	}
+	u := ft.updates[0]
+	if u.u.Status != nil {
+		t.Fatalf("status must not change for human-confirmed block, got %v", u.u.Status)
+	}
+	if u.u.Tags != nil {
+		t.Fatalf("tags must not change for human-confirmed block, got %v", *u.u.Tags)
+	}
+}
+
+func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_TamperFlagDoesNotRetry(t *testing.T) {
+	t.Parallel()
+	existing := mkTask("hr4", task.StatusHumanRequired, func(t *task.Task) {
+		t.StatusReason = workflow.TamperFlaggedReasonPrefix + " removed coverage in internal/foo_test.go"
+		t.Tags = []string{"medium"}
+	})
+	ft := &fakeTasks{tasks: []task.Task{existing}}
+	rem := newRemediator(ft)
+	a := Anomaly{
+		Kind:   KindStuckHumanBlocked,
+		TaskID: "hr4",
+		Evidence: map[string]any{
+			"status":                         "human-required",
+			"known_lost_agent_investigation": true,
+		},
+	}
+
+	label, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if label == "" {
+		t.Fatal("expected non-empty label")
+	}
+	if len(ft.updates) != 1 {
+		t.Fatalf("want 1 update, got %d", len(ft.updates))
+	}
+	u := ft.updates[0]
+	if u.u.Status != nil {
+		t.Fatalf("status must not change for tamper-flagged block, got %v", u.u.Status)
+	}
+	if u.u.Tags != nil {
+		t.Fatalf("tags must not change for tamper-flagged block, got %v", *u.u.Tags)
 	}
 }
 

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
@@ -132,6 +133,60 @@ func TestRemediator_StuckHumanBlocked_HumanRequired_PreservesStatusReason(t *tes
 	}
 	if u.u.StatusReason != nil {
 		t.Errorf("status_reason must not change, got %q", *u.u.StatusReason)
+	}
+}
+
+func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_AutoRetries(t *testing.T) {
+	t.Parallel()
+	existing := mkTask("hr2", task.StatusHumanRequired, func(t *task.Task) {
+		t.StatusReason = "watchdog: stop"
+		t.Tags = []string{"medium"}
+	})
+	ft := &fakeTasks{tasks: []task.Task{existing}}
+	rem := newRemediator(ft)
+	a := Anomaly{
+		Kind:   KindStuckHumanBlocked,
+		TaskID: "hr2",
+		Evidence: map[string]any{
+			"status":                         "human-required",
+			"known_lost_agent_investigation": true,
+		},
+	}
+	label, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if label == "" {
+		t.Fatal("expected non-empty label")
+	}
+	if len(ft.updates) != 1 {
+		t.Fatalf("want 1 update, got %d", len(ft.updates))
+	}
+	u := ft.updates[0]
+	if u.id != "hr2" {
+		t.Errorf("updated wrong task: %q", u.id)
+	}
+	if u.u.Status == nil || *u.u.Status != task.StatusInProgress {
+		t.Fatalf("status = %v, want in-progress", u.u.Status)
+	}
+	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
+		t.Error("status_reason should explain the auto-retry")
+	}
+	if u.u.Tags == nil {
+		t.Fatal("expected tags to be updated with the auto-retried marker")
+	}
+	found := false
+	for _, tag := range *u.u.Tags {
+		if tag == monitorAutoRetriedTag {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("tags = %v, want to contain %q", *u.u.Tags, monitorAutoRetriedTag)
+	}
+	// Original tags must be preserved, not clobbered.
+	if !slices.Contains(*u.u.Tags, "medium") {
+		t.Errorf("tags = %v, want to still contain %q", *u.u.Tags, "medium")
 	}
 }
 

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -58,6 +58,7 @@ Complex: new → planning → plan-review → [human approves] → todo → in-p
 | in-progress | in-review | Agent completed, output needs review |
 | in-review | done | Output verified correct |
 | in-progress | todo | Agent failed, needs retry |
+| human-required | in-progress | Monitor auto-retries once when the stall matches a current open `lost_agent` investigation and is not human-confirmed or tamper-flagged |
 | any | human-required | Cannot proceed without human input |
 
 ## Work Project Rules


### PR DESCRIPTION
## Motivation

The monitor's `stuck_human_blocked` detector dispatched an LLM investigation every time a task exceeded its human-required dwell budget, even when the exact stall already had an open, monitor-filed `lost_agent` investigation tracking the root cause. This wasted LLM investigations rediscovering an already-known finding and left the task parked in `human-required` indefinitely instead of retrying it.

## Implementation information

- `internal/monitor/detector.go`: added `openLostAgentInvestigations` to correlate a stalled task with an open, monitor-filed `lost_agent` investigation task (matched by fingerprint and origin task id parsed from the investigation body). `detectStuckHumanBlocked` now skips the LLM investigation when the stall correlates with such a known cause and the task hasn't already been auto-retried (`monitor:auto-retried` tag guards against bouncing forever).
- `internal/monitor/remediator.go`: `remediateHumanRequiredStuck` now branches — a known lost_agent cause routes to `retryKnownLostAgentStuck`, which moves the task back to `in-progress` and stamps `monitor:auto-retried`, unless human review already confirmed `verdict=human` or the task is tamper-flagged, in which case it falls back to the existing dwell-timer refresh (`refreshHumanRequiredStuck`).
- `orchestrator/CLAUDE.md`: documented the new `human-required` → `in-progress` auto-retry transition in the status transition table.
- Added unit test coverage in `internal/monitor/detector_test.go` and `internal/monitor/remediator_test.go`.

_Generated by Sybra harness_