### PR TITLE
fix(workflow): release dispatch claim before conflict recovery

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -514,6 +514,19 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		// scope for this pass.
 		d, wtErr := a.agentOrch.Worktrees().PrepareForTask(context.Background(), t, nil)
 		if wtErr != nil {
+			// Release our dispatch claim before classifying/recovering: a
+			// rebase-blocked wtErr routes through RecoverFromWorktreePrepFailure
+			// -> RecoverStaleBranchConflict, which synchronously starts the
+			// branch-conflict-fix workflow and dispatches ITS OWN "fix" agent for
+			// this same taskID. dispatchClaims is a non-reentrant per-task map
+			// (agent.Manager.ClaimTaskDispatch), so if we still held the claim
+			// here, that nested dispatch would collide with it and park on
+			// ErrDispatchInFlight without ever starting the conflict-resolution
+			// agent -- see task df8a91f4. We're bailing out of this dispatch
+			// attempt regardless (wtErr != nil means we never call a.agents.Run
+			// below), so releasing early is safe: it doesn't overlap with our own
+			// (never-attempted) agent start.
+			a.agents.ReleaseTaskDispatch(taskID)
 			return "", "", "", a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
 		}
 		cfg.Dir = d

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -444,7 +444,19 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	if err := a.claimDirectDispatch(taskID); err != nil {
 		return "", "", "", err
 	}
-	defer a.agents.ReleaseTaskDispatch(taskID)
+	// claimReleased guards against a double release: the worktree-prep recovery
+	// path (below) releases the claim early so a nested recovery dispatch can
+	// re-enter for the same taskID. Because ReleaseTaskDispatch is an
+	// unconditional delete() keyed only by taskID (no ownership token), an
+	// unguarded defer would fire a second delete on return and could clobber a
+	// live claim taken by an independent dispatcher (e.g. ResumeStalled) during
+	// the network-bound recovery window.
+	claimReleased := false
+	defer func() {
+		if !claimReleased {
+			a.agents.ReleaseTaskDispatch(taskID)
+		}
+	}()
 
 	t, err := a.tasks.Get(taskID)
 	if err != nil {
@@ -525,8 +537,11 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 			// agent -- see task df8a91f4. We're bailing out of this dispatch
 			// attempt regardless (wtErr != nil means we never call a.agents.Run
 			// below), so releasing early is safe: it doesn't overlap with our own
-			// (never-attempted) agent start.
+			// (never-attempted) agent start. Set claimReleased so the outer defer
+			// doesn't fire a second, unguarded delete that could clobber a claim
+			// another dispatcher took during the recovery window.
 			a.agents.ReleaseTaskDispatch(taskID)
+			claimReleased = true
 			return "", "", "", a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
 		}
 		cfg.Dir = d

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -506,45 +506,16 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 
 	cleanRetryReset := false
 	if cfg.Dir == "" && needsWorktree {
-		t, err = a.agentOrch.AutoAssignProject(t)
+		var dir string
+		var released bool
+		t, dir, cleanRetryReset, released, err = a.resolveWorktreeDir(t, taskID, role, cleanRetryRef)
+		if released {
+			claimReleased = true
+		}
 		if err != nil {
 			return "", "", "", err
 		}
-		if t.ProjectID == "" {
-			return "", "", "", fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree: %w", taskID, role, workflow.ErrNoProjectAssigned)
-		}
-		if cleanRetryRef != "" {
-			if resetErr := a.resetWorktreeForRetry(t, "", cleanRetryRef); resetErr != nil {
-				return "", "", "", resetErr
-			}
-			cleanRetryReset = true
-		}
-		// context.Background(): StartAgent implements workflow.AgentDispatcher,
-		// a fixed interface signature with no ctx parameter (invoked from many
-		// workflow step-execution call sites); see the Engine.SetContext /
-		// e.ctx pattern for why threading ctx across that interface is out of
-		// scope for this pass.
-		d, wtErr := a.agentOrch.Worktrees().PrepareForTask(context.Background(), t, nil)
-		if wtErr != nil {
-			// Release our dispatch claim before classifying/recovering: a
-			// rebase-blocked wtErr routes through RecoverFromWorktreePrepFailure
-			// -> RecoverStaleBranchConflict, which synchronously starts the
-			// branch-conflict-fix workflow and dispatches ITS OWN "fix" agent for
-			// this same taskID. dispatchClaims is a non-reentrant per-task map
-			// (agent.Manager.ClaimTaskDispatch), so if we still held the claim
-			// here, that nested dispatch would collide with it and park on
-			// ErrDispatchInFlight without ever starting the conflict-resolution
-			// agent -- see task df8a91f4. We're bailing out of this dispatch
-			// attempt regardless (wtErr != nil means we never call a.agents.Run
-			// below), so releasing early is safe: it doesn't overlap with our own
-			// (never-attempted) agent start. Set claimReleased so the outer defer
-			// doesn't fire a second, unguarded delete that could clobber a claim
-			// another dispatcher took during the recovery window.
-			a.agents.ReleaseTaskDispatch(taskID)
-			claimReleased = true
-			return "", "", "", a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
-		}
-		cfg.Dir = d
+		cfg.Dir = dir
 	}
 	if cfg.Dir != "" && cleanRetryRef != "" && !cleanRetryReset {
 		if resetErr := a.resetWorktreeForRetry(t, cfg.Dir, cleanRetryRef); resetErr != nil {
@@ -578,6 +549,50 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	a.recordSystemAgentStart(taskID, role, mode, cfg, ag)
 
 	return ag.ID, cfg.Dir, baselineRef, nil
+}
+
+// resolveWorktreeDir auto-assigns a project to t (if needed), optionally
+// resets the worktree for a clean retry, and prepares the worktree dir for
+// the direct-dispatch path. released reports whether it already released the
+// caller's dispatch claim (see the ReleaseTaskDispatch call below) so the
+// caller's deferred release doesn't fire a second, unguarded delete.
+func (a *agentAdapter) resolveWorktreeDir(t task.Task, taskID, role, cleanRetryRef string) (updated task.Task, dir string, cleanRetryReset, released bool, err error) {
+	t, err = a.agentOrch.AutoAssignProject(t)
+	if err != nil {
+		return t, "", false, false, err
+	}
+	if t.ProjectID == "" {
+		return t, "", false, false, fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree: %w", taskID, role, workflow.ErrNoProjectAssigned)
+	}
+	if cleanRetryRef != "" {
+		if resetErr := a.resetWorktreeForRetry(t, "", cleanRetryRef); resetErr != nil {
+			return t, "", false, false, resetErr
+		}
+		cleanRetryReset = true
+	}
+	// context.Background(): StartAgent implements workflow.AgentDispatcher,
+	// a fixed interface signature with no ctx parameter (invoked from many
+	// workflow step-execution call sites); see the Engine.SetContext /
+	// e.ctx pattern for why threading ctx across that interface is out of
+	// scope for this pass.
+	d, wtErr := a.agentOrch.Worktrees().PrepareForTask(context.Background(), t, nil)
+	if wtErr != nil {
+		// Release our dispatch claim before classifying/recovering: a
+		// rebase-blocked wtErr routes through RecoverFromWorktreePrepFailure
+		// -> RecoverStaleBranchConflict, which synchronously starts the
+		// branch-conflict-fix workflow and dispatches ITS OWN "fix" agent for
+		// this same taskID. dispatchClaims is a non-reentrant per-task map
+		// (agent.Manager.ClaimTaskDispatch), so if we still held the claim
+		// here, that nested dispatch would collide with it and park on
+		// ErrDispatchInFlight without ever starting the conflict-resolution
+		// agent. We're bailing out of this dispatch
+		// attempt regardless (wtErr != nil means we never call a.agents.Run
+		// below), so releasing early is safe: it doesn't overlap with our own
+		// (never-attempted) agent start.
+		a.agents.ReleaseTaskDispatch(taskID)
+		return t, "", cleanRetryReset, true, a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
+	}
+	return t, d, cleanRetryReset, false, nil
 }
 
 // claimDirectDispatch serializes the direct-run dispatch path (every role

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -381,7 +381,7 @@ func setupConflictRecoveryHarness(t *testing.T) conflictRecoveryHarness {
 }
 
 // TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery guards
-// against the nested-claim deadlock in task df8a91f4: a direct-dispatch
+// against a nested-claim deadlock: a direct-dispatch
 // StartAgent call (e.g. the create_pr step) that hits a rebase-blocked
 // worktree-prep error synchronously invokes the conflict-recovery callback
 // (RecoverStaleBranchConflict -> recoverBranchConflictNoPR), which itself
@@ -403,7 +403,7 @@ func TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery(t *te
 		// step dispatch effectively does: claim the SAME per-task dispatch
 		// slot the outer StartAgent call above was holding. If StartAgent
 		// hadn't released it first, this would fail exactly like the fix
-		// step did in task df8a91f4's repro.
+		// step did in the original repro of this deadlock.
 		claimAcquiredDuringRecovery = h.agents.ClaimTaskDispatch(id)
 		if claimAcquiredDuringRecovery {
 			h.agents.ReleaseTaskDispatch(id)

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -249,17 +249,22 @@ func TestAgentAdapterStartAgentSystemRoleHonorsDispatchClaim(t *testing.T) {
 	}
 }
 
-// TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery guards
-// against the nested-claim deadlock in task df8a91f4: a direct-dispatch
-// StartAgent call (e.g. the create_pr step) that hits a rebase-blocked
-// worktree-prep error synchronously invokes the conflict-recovery callback
-// (RecoverStaleBranchConflict -> recoverBranchConflictNoPR), which itself
-// dispatches a nested "fix" agent for the SAME task ID through the SAME
-// non-reentrant dispatchClaims map. If the outer StartAgent still held its
-// claim while the recovery callback ran, the nested dispatch would always
-// see ErrDispatchInFlight and the conflict-resolution agent would never
-// start. This asserts the claim is released before the callback fires.
-func TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery(t *testing.T) {
+// conflictRecoveryHarness bundles the real-git fixture used to drive a
+// direct-dispatch StartAgent into a rebase-blocked worktree-prep error and its
+// synchronous conflict-recovery callback.
+type conflictRecoveryHarness struct {
+	aa        *agentAdapter
+	agents    *agent.Manager
+	agentOrch *agentorch.Orchestrator
+	taskID    string
+}
+
+// setupConflictRecoveryHarness builds a git repo + bare remote + worktree whose
+// next PrepareForTask hits ErrRebaseFailed, wiring an agentAdapter over it. The
+// caller installs its own SetConflictRecovery callback before invoking
+// StartAgent.
+func setupConflictRecoveryHarness(t *testing.T) conflictRecoveryHarness {
+	t.Helper()
 	tmp := t.TempDir()
 	src := filepath.Join(tmp, "src")
 	for _, args := range [][]string{
@@ -371,33 +376,84 @@ func TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery(t *te
 	}
 
 	agentOrch := agentorch.New(taskMgr, projects, agents, nil, logger, wm, nil)
+	aa := &agentAdapter{agents: agents, agentOrch: agentOrch, tasks: taskMgr, projects: projects}
+	return conflictRecoveryHarness{aa: aa, agents: agents, agentOrch: agentOrch, taskID: tk.ID}
+}
+
+// TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery guards
+// against the nested-claim deadlock in task df8a91f4: a direct-dispatch
+// StartAgent call (e.g. the create_pr step) that hits a rebase-blocked
+// worktree-prep error synchronously invokes the conflict-recovery callback
+// (RecoverStaleBranchConflict -> recoverBranchConflictNoPR), which itself
+// dispatches a nested "fix" agent for the SAME task ID through the SAME
+// non-reentrant dispatchClaims map. If the outer StartAgent still held its
+// claim while the recovery callback ran, the nested dispatch would always
+// see ErrDispatchInFlight and the conflict-resolution agent would never
+// start. This asserts the claim is released before the callback fires.
+func TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery(t *testing.T) {
+	h := setupConflictRecoveryHarness(t)
 
 	var claimAcquiredDuringRecovery, recoveryCalled bool
-	agentOrch.SetConflictRecovery(func(id string) bool {
+	h.agentOrch.SetConflictRecovery(func(id string) bool {
 		recoveryCalled = true
-		if id != tk.ID {
-			t.Errorf("conflict recovery got task id %q, want %q", id, tk.ID)
+		if id != h.taskID {
+			t.Errorf("conflict recovery got task id %q, want %q", id, h.taskID)
 		}
 		// This is what the nested branch-conflict-fix workflow's own "fix"
 		// step dispatch effectively does: claim the SAME per-task dispatch
 		// slot the outer StartAgent call above was holding. If StartAgent
 		// hadn't released it first, this would fail exactly like the fix
 		// step did in task df8a91f4's repro.
-		claimAcquiredDuringRecovery = agents.ClaimTaskDispatch(id)
+		claimAcquiredDuringRecovery = h.agents.ClaimTaskDispatch(id)
 		if claimAcquiredDuringRecovery {
-			agents.ReleaseTaskDispatch(id)
+			h.agents.ReleaseTaskDispatch(id)
 		}
 		return false
 	})
 
-	aa := &agentAdapter{agents: agents, agentOrch: agentOrch, tasks: taskMgr, projects: projects}
-	_, _, _, err = aa.StartAgent(tk.ID, string(agent.RolePRFix), "headless", "sonnet", "claude", "prompt", "", nil, true, false, "", "", workflow.AgentAssignment{})
+	_, _, _, err := h.aa.StartAgent(h.taskID, string(agent.RolePRFix), "headless", "sonnet", "claude", "prompt", "", nil, true, false, "", "", workflow.AgentAssignment{})
 	t.Logf("StartAgent err=%v recoveryCalled=%v claimAcquired=%v", err, recoveryCalled, claimAcquiredDuringRecovery)
 	if !errors.Is(err, workflow.ErrDispatchInFlight) {
 		t.Fatalf("StartAgent() err = %v, want ErrDispatchInFlight", err)
 	}
 	if !claimAcquiredDuringRecovery {
 		t.Fatal("conflict-recovery callback could not claim task dispatch — StartAgent still held it, reproducing the nested-claim deadlock")
+	}
+}
+
+// TestAgentAdapterStartAgentDoesNotClobberForeignClaimAfterRecovery guards
+// against the double-release hazard: StartAgent releases its dispatch claim
+// early before the recovery callback so a nested recovery dispatch can
+// re-enter, but the outer deferred release must NOT fire a second, unguarded
+// delete when StartAgent returns. If it does, an independent dispatcher (e.g.
+// ResumeStalled) that claimed the same taskID during the network-bound
+// recovery window loses its claim — reintroducing the duplicate-agent race
+// the claim map exists to prevent. Because ReleaseTaskDispatch is keyed only
+// by taskID with no ownership token, a foreign claim taken during recovery
+// must survive StartAgent's return.
+func TestAgentAdapterStartAgentDoesNotClobberForeignClaimAfterRecovery(t *testing.T) {
+	h := setupConflictRecoveryHarness(t)
+
+	// Model an independent dispatcher (ResumeStalled) that grabs the freed slot
+	// during the recovery window and keeps holding it — it does NOT release
+	// inline. StartAgent's return must leave this foreign claim intact.
+	var foreignClaimAcquired bool
+	h.agentOrch.SetConflictRecovery(func(id string) bool {
+		foreignClaimAcquired = h.agents.ClaimTaskDispatch(id)
+		return false
+	})
+
+	_, _, _, err := h.aa.StartAgent(h.taskID, string(agent.RolePRFix), "headless", "sonnet", "claude", "prompt", "", nil, true, false, "", "", workflow.AgentAssignment{})
+	if !errors.Is(err, workflow.ErrDispatchInFlight) {
+		t.Fatalf("StartAgent() err = %v, want ErrDispatchInFlight", err)
+	}
+	if !foreignClaimAcquired {
+		t.Fatal("foreign dispatcher could not claim during recovery — StartAgent still held it")
+	}
+	// The foreign claim must still be held: a re-claim attempt must fail. If
+	// StartAgent's stale defer clobbered it, ClaimTaskDispatch would succeed.
+	if h.agents.ClaimTaskDispatch(h.taskID) {
+		t.Fatal("foreign dispatch claim was clobbered by StartAgent's stale deferred release — double-release hazard")
 	}
 }
 

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -245,6 +246,158 @@ func TestAgentAdapterStartAgentSystemRoleHonorsDispatchClaim(t *testing.T) {
 	}
 	if agentID != "" {
 		t.Fatalf("StartAgent() agentID = %q, want empty on dispatch-in-flight", agentID)
+	}
+}
+
+// TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery guards
+// against the nested-claim deadlock in task df8a91f4: a direct-dispatch
+// StartAgent call (e.g. the create_pr step) that hits a rebase-blocked
+// worktree-prep error synchronously invokes the conflict-recovery callback
+// (RecoverStaleBranchConflict -> recoverBranchConflictNoPR), which itself
+// dispatches a nested "fix" agent for the SAME task ID through the SAME
+// non-reentrant dispatchClaims map. If the outer StartAgent still held its
+// claim while the recovery callback ran, the nested dispatch would always
+// see ErrDispatchInFlight and the conflict-resolution agent would never
+// start. This asserts the claim is released before the callback fires.
+func TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	for _, args := range [][]string{
+		{"init", "-b", "main", src},
+		{"-C", src, "config", "user.email", "test@test.com"},
+		{"-C", src, "config", "user.name", "Test"},
+		{"-C", src, "config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", src, "add", "."},
+		{"-C", src, "commit", "-m", "init"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	bare := filepath.Join(tmp, "origin.git")
+	if out, err := exec.Command("git", "clone", "--bare", src, bare).CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+		t.Fatalf("git config: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+		t.Fatalf("git fetch: %v: %s", err, out)
+	}
+
+	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projYAML := "id: owner/repo\nname: repo\nowner: owner\nrepo: repo\nurl: " + bare +
+		"\nclone_path: " + bare + "\ntype: pet\n"
+	if err := os.WriteFile(filepath.Join(tmp, "projects", "owner--repo.yaml"), []byte(projYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	taskStore, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+	tk, err := taskMgr.Create("conflict recovery claim release", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := "owner/repo"
+	tk, err = taskMgr.Update(tk.ID, task.Update{ProjectID: &projectID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, filepath.Join(tmp, "logs"))
+	wm := worktree.New(worktree.Config{
+		WorktreesDir:     filepath.Join(tmp, "worktrees"),
+		Projects:         projects,
+		Tasks:            taskMgr,
+		Logger:           logger,
+		AgentChecker:     agents.HasRunningAgentForTask,
+		LiveAgentChecker: agents.HasLiveRegisteredAgentForTask,
+	})
+
+	// Prepare the worktree once so the task has a real branch, then make an
+	// unrelated edit on the branch and a conflicting edit upstream so the
+	// next PrepareForTask hits ErrRebaseFailed.
+	wtPath, err := wm.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "config", "user.email", "test@test.com"},
+		{"-C", wtPath, "config", "user.name", "Test"},
+		{"-C", wtPath, "config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("branch edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "add", "."},
+		{"-C", wtPath, "commit", "-m", "branch edit"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("upstream edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", src, "add", "."},
+		{"-C", src, "commit", "-m", "upstream edit"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	agentOrch := agentorch.New(taskMgr, projects, agents, nil, logger, wm, nil)
+
+	var claimAcquiredDuringRecovery, recoveryCalled bool
+	agentOrch.SetConflictRecovery(func(id string) bool {
+		recoveryCalled = true
+		if id != tk.ID {
+			t.Errorf("conflict recovery got task id %q, want %q", id, tk.ID)
+		}
+		// This is what the nested branch-conflict-fix workflow's own "fix"
+		// step dispatch effectively does: claim the SAME per-task dispatch
+		// slot the outer StartAgent call above was holding. If StartAgent
+		// hadn't released it first, this would fail exactly like the fix
+		// step did in task df8a91f4's repro.
+		claimAcquiredDuringRecovery = agents.ClaimTaskDispatch(id)
+		if claimAcquiredDuringRecovery {
+			agents.ReleaseTaskDispatch(id)
+		}
+		return false
+	})
+
+	aa := &agentAdapter{agents: agents, agentOrch: agentOrch, tasks: taskMgr, projects: projects}
+	_, _, _, err = aa.StartAgent(tk.ID, string(agent.RolePRFix), "headless", "sonnet", "claude", "prompt", "", nil, true, false, "", "", workflow.AgentAssignment{})
+	t.Logf("StartAgent err=%v recoveryCalled=%v claimAcquired=%v", err, recoveryCalled, claimAcquiredDuringRecovery)
+	if !errors.Is(err, workflow.ErrDispatchInFlight) {
+		t.Fatalf("StartAgent() err = %v, want ErrDispatchInFlight", err)
+	}
+	if !claimAcquiredDuringRecovery {
+		t.Fatal("conflict-recovery callback could not claim task dispatch — StartAgent still held it, reproducing the nested-claim deadlock")
 	}
 }
 


### PR DESCRIPTION
## Motivation

`StartAgent` held a per-task dispatch claim (`dispatchClaims`, keyed only by
task ID, no ownership token) for its full duration via an unconditional
`defer ReleaseTaskDispatch`. A rebase-blocked worktree-prep error routes
through `RecoverFromWorktreePrepFailure` -> `RecoverStaleBranchConflict`,
which synchronously starts the branch-conflict-fix workflow and dispatches
its own "fix" agent for the same task ID. Since the claim map is
non-reentrant, that nested dispatch collided with the still-held outer claim
and parked on `ErrDispatchInFlight` without ever starting the
conflict-resolution agent.

## Implementation information

- Release the dispatch claim before invoking the worktree-prep failure
  classifier/recovery path, since a `wtErr != nil` return never reaches
  `a.agents.Run` and therefore never needed the claim held that far.
- Guard the original `defer` with a `claimReleased` flag so the deferred
  release only fires once — an unconditional double release could otherwise
  clobber a claim taken by a separate, unrelated dispatcher (e.g.
  `ResumeStalled`) during the recovery window.
- Add coverage in `app_workflow_test.go` for the claim-release-before-recovery
  path.

_Generated by Sybra harness_