### PR TITLE
fix(workflow): raise reimplement cap to 10

### DIFF
--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -215,8 +215,13 @@ func (c *Config) InAppBrowserEnabled() bool {
 const DefaultTestingMaxConcurrent = 3
 
 // DefaultTestingMaxAttempts bounds the testing → in-progress re-implementation
-// loop when TestingConfig.MaxAttempts is unset.
-const DefaultTestingMaxAttempts = 3
+// loop when TestingConfig.MaxAttempts is unset. This is a cost backstop, not
+// the primary stall detector — workflow.countValidProductTestAttempts
+// escalates immediately on a genuine stall (same grounded failure fingerprint
+// twice with an intervening code-author run), so a sequence that keeps
+// finding distinct grounded defects should not be starved by a low count
+// here.
+const DefaultTestingMaxAttempts = 10
 
 // TestingMaxConcurrent returns the configured cap or DefaultTestingMaxConcurrent.
 func (c *Config) TestingMaxConcurrent() int {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1284,3 +1284,21 @@ func TestLoadReconcileKeepsVersionedBackupsPerPriorBuiltinVersion(t *testing.T) 
 		t.Fatal("v1 backup should not be empty")
 	}
 }
+
+func TestTestingMaxAttemptsDefault(t *testing.T) {
+	t.Parallel()
+	var cfg *Config
+	if got := cfg.TestingMaxAttempts(); got != DefaultTestingMaxAttempts {
+		t.Errorf("nil config TestingMaxAttempts() = %d, want %d", got, DefaultTestingMaxAttempts)
+	}
+
+	cfg = &Config{}
+	if got := cfg.TestingMaxAttempts(); got != DefaultTestingMaxAttempts {
+		t.Errorf("zero-value TestingMaxAttempts() = %d, want %d", got, DefaultTestingMaxAttempts)
+	}
+
+	cfg.Testing.MaxAttempts = 5
+	if got := cfg.TestingMaxAttempts(); got != 5 {
+		t.Errorf("configured TestingMaxAttempts() = %d, want 5", got)
+	}
+}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2056,12 +2056,14 @@ func TestE2E_TestingTaskWorkflow_FailLoopsBackToImplement(t *testing.T) {
 }
 
 // TestE2E_TestingTaskWorkflow_FailEscalatesAtCap verifies that once the task has
-// failed testing TestingMaxAttempts times (engine default 3 — here pre-seeded
-// with 2 prior test-runner runs plus this one), it escalates to human-required
+// failed testing TestingMaxAttempts times (pinned to 3 here via
+// SetTestingMaxAttempts, independent of the engine default — pre-seeded with
+// 2 prior test-runner runs plus this one), it escalates to human-required
 // instead of looping back to implement.
 func TestE2E_TestingTaskWorkflow_FailEscalatesAtCap(t *testing.T) {
 	env := setupE2EMulti(t, []string{"test_fail"})
 	installTestingTaskWorkflow(t, env)
+	env.engine.SetTestingMaxAttempts(3)
 
 	created, err := env.tasks.Create("manual test cap", "", "headless")
 	if err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/abtest"
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/prompteval"
@@ -236,8 +237,8 @@ type Engine struct {
 
 // defaultTestAttempts caps the testing → in-progress re-implementation loop
 // when SetTestingMaxAttempts was never called. Mirrors
-// config.DefaultTestingMaxAttempts (kept as a literal to avoid a config import).
-const defaultTestAttempts = 3
+// config.DefaultTestingMaxAttempts directly.
+const defaultTestAttempts = config.DefaultTestingMaxAttempts
 
 // NewEngine creates a workflow engine.
 func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {


### PR DESCRIPTION
## Motivation

The testing→reimplement escalation cap (`defaultTestAttempts`) was a
hardcoded literal duplicated in two places — `workflow.defaultTestAttempts`
and `config.DefaultTestingMaxAttempts`, both `3` — with no link between them,
so they could silently drift apart.

Separately, at 3 the cap fired on tasks whose *every* reimplement attempt
found a genuinely new, distinct grounded defect — real forward progress, not
a stall — killing the loop before it could converge. Observed today on a
real task: 3 reimplement cycles, 3 different real bugs found and reported,
escalated to human-required anyway purely on attempt count.

The actual stall detector already exists and is more precise:
`countValidProductTestAttempts`'s duplicate-fingerprint check escalates
immediately when the *same* grounded failure reproduces twice with an
intervening code-author run — a genuine stall, independent of this count.
The attempt-count cap is only meant to be a cost backstop on top of that.

## Implementation information

- `workflow.defaultTestAttempts` now references `config.DefaultTestingMaxAttempts`
  directly instead of duplicating it as a separate literal — single source
  of truth, can't diverge again. (No import cycle: `internal/config` and
  `internal/workflow` don't depend on each other; verified with a full build.)
- Raised the default from 3 to 10, since the duplicate-fingerprint check
  remains the primary/fast stall detector and this is now purely a cost
  ceiling.
- Added `TestTestingMaxAttemptsDefault` pinning the default and the
  configured-override path.

## Supporting documentation

n/a