### PR TITLE
fix(project,workflow): refresh PushSync remote ref and harden test-failure recurrence routing

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -765,9 +765,16 @@ func worktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
 //   - local SHA == remote tracking SHA: no-op
 //   - remote tracking SHA is an ancestor of local (fast-forward): regular push
 //   - histories diverged: never force-pushes. Returns ErrDivergedNeedsResolve
-//     (wrapping ErrRemoteAdvanced when the live remote head has moved past the
-//     stale tracking ref) so the caller can spawn agent work to reconcile the
+//     (wrapping ErrRemoteAdvanced when the live remote head could not be
+//     freshly verified) so the caller can spawn agent work to reconcile the
 //     branches instead of rewriting already-published history.
+//
+// Refreshes refs/remotes/<remote>/<branch> from the live remote before
+// comparing, the same way ReconcileWithRemote does — a separate recovery
+// worktree (e.g. branch-conflict-fix) can push this branch directly without
+// ever touching this worktree's cached tracking ref, so comparing against
+// that stale cache can see a divergence the live remote no longer has,
+// re-triggering recovery in a loop even though it already succeeded.
 //
 // Returns ErrBranchMissing if the local branch ref does not exist.
 func PushSync(ctx context.Context, worktreePath, branch string) error {
@@ -785,6 +792,19 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 		return err
 	}
 
+	// Refresh the tracking ref first; a first-push branch has no remote head
+	// yet, so "couldn't find remote ref" is expected and not fatal. Any other
+	// failure (network/auth/remote misconfig) means the live remote state
+	// can't be verified before a push decision — fail closed rather than
+	// fall back to comparing against a possibly-stale cached ref.
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+	fetchErr := withNetworkRetry(ctx, func() error {
+		return executil.Run(ctx, worktreePath, "git", "fetch", remote, refspec)
+	})
+	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
+		return fmt.Errorf("%w: %w: could not verify live remote head before push: %w", ErrDivergedNeedsResolve, ErrRemoteAdvanced, fetchErr)
+	}
+
 	remoteSHA, remoteErr := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch)
 	if remoteErr != nil {
 		// Remote tracking ref unknown — first push, set upstream.
@@ -800,17 +820,10 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 		return executil.Run(ctx, worktreePath, "git", "push", "-u", remote, branch)
 	}
 
-	// Divergence path: never force-push. Check the live remote head purely to
-	// give a precise error — either outcome means the branch needs
-	// agent-driven resolution (rebase/merge onto the remote), never a rewrite.
-	liveSHA, err := remoteBranchHead(ctx, worktreePath, remote, branch)
-	if err != nil {
-		return fmt.Errorf("%w: %w: could not verify live remote head before push: %w", ErrDivergedNeedsResolve, ErrRemoteAdvanced, err)
-	}
-	if liveSHA != "" && liveSHA != remoteSHA {
-		return fmt.Errorf("%w: %w: tracking %s but remote %s/%s is at %s", ErrDivergedNeedsResolve, ErrRemoteAdvanced, remoteSHA[:min(7, len(remoteSHA))], remote, branch, liveSHA[:min(7, len(liveSHA))])
-	}
-
+	// Divergence path: never force-push. remoteSHA reflects the freshly
+	// fetched live remote head, so this is a genuine content divergence, not
+	// a stale-cache artifact — the branch needs agent-driven resolution
+	// (rebase/merge onto the remote), never a rewrite.
 	return fmt.Errorf("%w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
 }
 

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -40,9 +40,10 @@ var ErrBranchDiverged = errors.New("local branch diverged from remote head")
 var ErrDirtyWorktree = errors.New("worktree has uncommitted changes")
 
 // ErrRemoteAdvanced is returned by PushSync when the live remote branch head no
-// longer matches the remote-tracking ref the push decision was based on — the
-// tracking ref is stale, so PushSync cannot even be sure what "diverged" means
-// right now. Always wrapped together with ErrDivergedNeedsResolve.
+// longer matches the remote-tracking ref the push decision was based on, or
+// when the live remote head cannot be verified before deciding whether to push.
+// It is wrapped together with ErrDivergedNeedsResolve only when the verified
+// live remote state also requires agent-driven branch reconciliation.
 var ErrRemoteAdvanced = errors.New("remote branch advanced past tracking ref")
 
 // ErrDivergedNeedsResolve is returned by PushSync when the local branch and
@@ -684,6 +685,24 @@ func remoteBranchHead(ctx context.Context, worktreePath, remote, branch string) 
 	return strings.Fields(out)[0], nil
 }
 
+func remoteTrackingRef(ctx context.Context, worktreePath, remote, branch string) (string, bool) {
+	sha, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch)
+	return sha, err == nil
+}
+
+func refreshTrackingRef(ctx context.Context, worktreePath, remote, branch string) error {
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+	fetchErr := withNetworkRetry(ctx, func() error {
+		return withLockRetry(func() error {
+			return executil.Run(ctx, worktreePath, "git", "fetch", remote, refspec)
+		})
+	})
+	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
+		return fmt.Errorf("fetch %s %s: %w", remote, refspec, fetchErr)
+	}
+	return nil
+}
+
 // ReconcileWithRemote fast-forwards the worktree's checked-out branch to the
 // remote branch head before a rebase, so remote-only commits (e.g. a review fix
 // pushed from another clone or machine) are carried forward instead of dropped
@@ -709,12 +728,8 @@ func ReconcileWithRemote(ctx context.Context, worktreePath, branch string) error
 	// other failure (network/auth/remote misconfig) must propagate, since
 	// continuing on stale history is exactly the data-loss scenario this
 	// function exists to prevent.
-	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
-	fetchErr := withNetworkRetry(ctx, func() error {
-		return executil.Run(ctx, worktreePath, "git", "fetch", remote, refspec)
-	})
-	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
-		return fmt.Errorf("fetch %s %s: %w", remote, refspec, fetchErr)
+	if err := refreshTrackingRef(ctx, worktreePath, remote, branch); err != nil {
+		return err
 	}
 
 	// An absent branch (first push) means there is nothing to reconcile; any
@@ -765,9 +780,9 @@ func worktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
 //   - local SHA == remote tracking SHA: no-op
 //   - remote tracking SHA is an ancestor of local (fast-forward): regular push
 //   - histories diverged: never force-pushes. Returns ErrDivergedNeedsResolve
-//     (wrapping ErrRemoteAdvanced when the live remote head could not be
-//     freshly verified) so the caller can spawn agent work to reconcile the
-//     branches instead of rewriting already-published history.
+//     so the caller can spawn agent work to reconcile the branches instead of
+//     rewriting already-published history. If the live remote advanced since
+//     the cached tracking ref, ErrRemoteAdvanced is wrapped too.
 //
 // Refreshes refs/remotes/<remote>/<branch> from the live remote before
 // comparing, the same way ReconcileWithRemote does — a separate recovery
@@ -792,24 +807,23 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 		return err
 	}
 
+	beforeRefreshSHA, beforeRefreshOK := remoteTrackingRef(ctx, worktreePath, remote, branch)
+
 	// Refresh the tracking ref first; a first-push branch has no remote head
 	// yet, so "couldn't find remote ref" is expected and not fatal. Any other
 	// failure (network/auth/remote misconfig) means the live remote state
 	// can't be verified before a push decision — fail closed rather than
 	// fall back to comparing against a possibly-stale cached ref.
-	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
-	fetchErr := withNetworkRetry(ctx, func() error {
-		return executil.Run(ctx, worktreePath, "git", "fetch", remote, refspec)
-	})
-	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
-		return fmt.Errorf("%w: %w: could not verify live remote head before push: %w", ErrDivergedNeedsResolve, ErrRemoteAdvanced, fetchErr)
+	if err := refreshTrackingRef(ctx, worktreePath, remote, branch); err != nil {
+		return fmt.Errorf("%w: could not verify live remote head before push: %w", ErrRemoteAdvanced, err)
 	}
 
-	remoteSHA, remoteErr := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch)
-	if remoteErr != nil {
+	remoteSHA, remoteOK := remoteTrackingRef(ctx, worktreePath, remote, branch)
+	if !remoteOK {
 		// Remote tracking ref unknown — first push, set upstream.
 		return executil.Run(ctx, worktreePath, "git", "push", "-u", remote, branch)
 	}
+	remoteAdvanced := beforeRefreshOK && beforeRefreshSHA != remoteSHA
 
 	if localSHA == remoteSHA {
 		return nil
@@ -824,6 +838,9 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 	// fetched live remote head, so this is a genuine content divergence, not
 	// a stale-cache artifact — the branch needs agent-driven resolution
 	// (rebase/merge onto the remote), never a rewrite.
+	if remoteAdvanced {
+		return fmt.Errorf("%w: %w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, ErrRemoteAdvanced, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
+	}
 	return fmt.Errorf("%w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
 }
 

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1953,6 +1953,9 @@ func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 	if !errors.Is(err, ErrDivergedNeedsResolve) {
 		t.Fatalf("PushSync = %v, want ErrDivergedNeedsResolve", err)
 	}
+	if !errors.Is(err, ErrRemoteAdvanced) {
+		t.Fatalf("PushSync = %v, want ErrRemoteAdvanced", err)
+	}
 	// The remote fix must survive untouched.
 	if got := remoteRefSHA(t, remoteBare, branch); got != advancedSHA {
 		t.Fatalf("remote SHA = %q, want untouched fix %q", got, advancedSHA)
@@ -2031,8 +2034,8 @@ func TestPushSync_FailsClosedWhenRemoteHeadUnverifiable(t *testing.T) {
 	}
 	makeCommit(t, wtPath, "two-prime")
 
-	// Break the remote so the live-head verification (ls-remote) errors
-	// instead of returning a SHA.
+	// Break the remote so the live-head verification fetch errors instead of
+	// updating the tracking ref.
 	if out, err := exec.Command("git", "-C", wtPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "no-such-remote.git")).CombinedOutput(); err != nil {
 		t.Fatalf("remote set-url: %v: %s", err, out)
 	}
@@ -2041,8 +2044,8 @@ func TestPushSync_FailsClosedWhenRemoteHeadUnverifiable(t *testing.T) {
 	if !errors.Is(err, ErrRemoteAdvanced) {
 		t.Fatalf("PushSync = %v, want ErrRemoteAdvanced (fail closed)", err)
 	}
-	if !errors.Is(err, ErrDivergedNeedsResolve) {
-		t.Fatalf("PushSync = %v, want ErrDivergedNeedsResolve (fail closed)", err)
+	if errors.Is(err, ErrDivergedNeedsResolve) {
+		t.Fatalf("PushSync = %v, must not return ErrDivergedNeedsResolve for remote verification failure", err)
 	}
 	if got := remoteRefSHA(t, remoteBare, branch); got != beforeSHA {
 		t.Fatalf("remote SHA = %q, want untouched %q", got, beforeSHA)

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1925,9 +1925,10 @@ func TestMergeOnto_ConflictReturnsErrorAndCleansUp(t *testing.T) {
 }
 
 // TestPushSync_RefusesForceWhenRemoteAdvanced is the defense-in-depth net: when
-// the live remote head no longer matches the stale tracking ref the push
-// decision was based on, PushSync must refuse to push at all rather than
-// clobber the newer commits with a force push.
+// another clone has pushed to the branch since this worktree last synced,
+// PushSync must refresh its view of the remote (rather than compare against
+// its own stale tracking ref) and refuse to push at all instead of clobbering
+// the newer commits with a force push.
 func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 	t.Parallel()
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
@@ -1944,19 +1945,69 @@ func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 	makeCommit(t, wtPath, "two-prime")
 
 	// Meanwhile the remote branch advances from another clone. wtPath never
-	// fetches, so its tracking ref stays behind the live remote head.
+	// explicitly fetches, so its cached tracking ref stays behind the live
+	// remote head until PushSync's own fetch refreshes it.
 	advancedSHA := pushRemoteCommit(t, remoteBare, branch, "concurrent-fix")
 
 	err := PushSync(context.Background(), wtPath, branch)
-	if !errors.Is(err, ErrRemoteAdvanced) {
-		t.Fatalf("PushSync = %v, want ErrRemoteAdvanced", err)
-	}
 	if !errors.Is(err, ErrDivergedNeedsResolve) {
 		t.Fatalf("PushSync = %v, want ErrDivergedNeedsResolve", err)
 	}
 	// The remote fix must survive untouched.
 	if got := remoteRefSHA(t, remoteBare, branch); got != advancedSHA {
 		t.Fatalf("remote SHA = %q, want untouched fix %q", got, advancedSHA)
+	}
+}
+
+// TestPushSync_RefreshesStaleCacheBeforeComparing is the regression for the
+// create_pr/branch-conflict-fix tight loop (issue #1628): a stale cached
+// refs/remotes/<remote>/<branch> can point at a commit that is not an
+// ancestor of the true (live) remote head — e.g. left over from a prior
+// divergence — even though the local branch and the live remote head are
+// actually identical right now (a separate recovery path already converged
+// them). Comparing against the stale cache alone would misreport this as an
+// unresolved divergence forever, since the "true" state never gets a chance
+// to update the cache; PushSync must fetch fresh before deciding.
+func TestPushSync_RefreshesStaleCacheBeforeComparing(t *testing.T) {
+	t.Parallel()
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	sha1 := makeCommit(t, wtPath, "one")
+	if err := PushSync(context.Background(), wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Legitimately advance and push — this becomes the true, converged state
+	// both locally and on the remote.
+	shaX := makeCommit(t, wtPath, "two-a")
+	if err := PushSync(context.Background(), wtPath, branch); err != nil {
+		t.Fatalf("PushSync advance: %v", err)
+	}
+
+	// Build a sibling commit off sha1 purely to obtain a real, valid SHA that
+	// is not an ancestor of shaX — simulating a stale/incorrect cached ref.
+	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", sha1).CombinedOutput(); err != nil {
+		t.Fatalf("reset to sha1: %v: %s", err, out)
+	}
+	shaY := makeCommit(t, wtPath, "two-b")
+	if out, err := exec.Command("git", "-C", wtPath, "merge-base", "--is-ancestor", shaY, shaX).CombinedOutput(); err == nil {
+		t.Fatalf("shaY unexpectedly an ancestor of shaX: %s", out)
+	}
+
+	// Restore local to the true converged state (shaX) but leave the cached
+	// tracking ref corrupted at the unrelated sibling (shaY) — this is the
+	// "stale cache" the fix must not trust blindly.
+	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", shaX).CombinedOutput(); err != nil {
+		t.Fatalf("reset to shaX: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "update-ref", "refs/remotes/origin/"+branch, shaY).CombinedOutput(); err != nil {
+		t.Fatalf("corrupt cached tracking ref: %v: %s", err, out)
+	}
+
+	if err := PushSync(context.Background(), wtPath, branch); err != nil {
+		t.Fatalf("PushSync = %v, want nil (converged after fresh fetch)", err)
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != shaX {
+		t.Fatalf("remote SHA = %q, want unchanged converged state %q", got, shaX)
 	}
 }
 

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -444,7 +444,19 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	if err := a.claimDirectDispatch(taskID); err != nil {
 		return "", "", "", err
 	}
-	defer a.agents.ReleaseTaskDispatch(taskID)
+	// claimReleased guards against a double release: the worktree-prep recovery
+	// path (below) releases the claim early so a nested recovery dispatch can
+	// re-enter for the same taskID. Because ReleaseTaskDispatch is an
+	// unconditional delete() keyed only by taskID (no ownership token), an
+	// unguarded defer would fire a second delete on return and could clobber a
+	// live claim taken by an independent dispatcher (e.g. ResumeStalled) during
+	// the network-bound recovery window.
+	claimReleased := false
+	defer func() {
+		if !claimReleased {
+			a.agents.ReleaseTaskDispatch(taskID)
+		}
+	}()
 
 	t, err := a.tasks.Get(taskID)
 	if err != nil {
@@ -494,29 +506,16 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 
 	cleanRetryReset := false
 	if cfg.Dir == "" && needsWorktree {
-		t, err = a.agentOrch.AutoAssignProject(t)
+		var dir string
+		var released bool
+		t, dir, cleanRetryReset, released, err = a.resolveWorktreeDir(t, taskID, role, cleanRetryRef)
+		if released {
+			claimReleased = true
+		}
 		if err != nil {
 			return "", "", "", err
 		}
-		if t.ProjectID == "" {
-			return "", "", "", fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree: %w", taskID, role, workflow.ErrNoProjectAssigned)
-		}
-		if cleanRetryRef != "" {
-			if resetErr := a.resetWorktreeForRetry(t, "", cleanRetryRef); resetErr != nil {
-				return "", "", "", resetErr
-			}
-			cleanRetryReset = true
-		}
-		// context.Background(): StartAgent implements workflow.AgentDispatcher,
-		// a fixed interface signature with no ctx parameter (invoked from many
-		// workflow step-execution call sites); see the Engine.SetContext /
-		// e.ctx pattern for why threading ctx across that interface is out of
-		// scope for this pass.
-		d, wtErr := a.agentOrch.Worktrees().PrepareForTask(context.Background(), t, nil)
-		if wtErr != nil {
-			return "", "", "", a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
-		}
-		cfg.Dir = d
+		cfg.Dir = dir
 	}
 	if cfg.Dir != "" && cleanRetryRef != "" && !cleanRetryReset {
 		if resetErr := a.resetWorktreeForRetry(t, cfg.Dir, cleanRetryRef); resetErr != nil {
@@ -550,6 +549,50 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	a.recordSystemAgentStart(taskID, role, mode, cfg, ag)
 
 	return ag.ID, cfg.Dir, baselineRef, nil
+}
+
+// resolveWorktreeDir auto-assigns a project to t (if needed), optionally
+// resets the worktree for a clean retry, and prepares the worktree dir for
+// the direct-dispatch path. released reports whether it already released the
+// caller's dispatch claim (see the ReleaseTaskDispatch call below) so the
+// caller's deferred release doesn't fire a second, unguarded delete.
+func (a *agentAdapter) resolveWorktreeDir(t task.Task, taskID, role, cleanRetryRef string) (updated task.Task, dir string, cleanRetryReset, released bool, err error) {
+	t, err = a.agentOrch.AutoAssignProject(t)
+	if err != nil {
+		return t, "", false, false, err
+	}
+	if t.ProjectID == "" {
+		return t, "", false, false, fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree: %w", taskID, role, workflow.ErrNoProjectAssigned)
+	}
+	if cleanRetryRef != "" {
+		if resetErr := a.resetWorktreeForRetry(t, "", cleanRetryRef); resetErr != nil {
+			return t, "", false, false, resetErr
+		}
+		cleanRetryReset = true
+	}
+	// context.Background(): StartAgent implements workflow.AgentDispatcher,
+	// a fixed interface signature with no ctx parameter (invoked from many
+	// workflow step-execution call sites); see the Engine.SetContext /
+	// e.ctx pattern for why threading ctx across that interface is out of
+	// scope for this pass.
+	d, wtErr := a.agentOrch.Worktrees().PrepareForTask(context.Background(), t, nil)
+	if wtErr != nil {
+		// Release our dispatch claim before classifying/recovering: a
+		// rebase-blocked wtErr routes through RecoverFromWorktreePrepFailure
+		// -> RecoverStaleBranchConflict, which synchronously starts the
+		// branch-conflict-fix workflow and dispatches ITS OWN "fix" agent for
+		// this same taskID. dispatchClaims is a non-reentrant per-task map
+		// (agent.Manager.ClaimTaskDispatch), so if we still held the claim
+		// here, that nested dispatch would collide with it and park on
+		// ErrDispatchInFlight without ever starting the conflict-resolution
+		// agent. We're bailing out of this dispatch
+		// attempt regardless (wtErr != nil means we never call a.agents.Run
+		// below), so releasing early is safe: it doesn't overlap with our own
+		// (never-attempted) agent start.
+		a.agents.ReleaseTaskDispatch(taskID)
+		return t, "", cleanRetryReset, true, a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
+	}
+	return t, d, cleanRetryReset, false, nil
 }
 
 // claimDirectDispatch serializes the direct-run dispatch path (every role

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -245,6 +246,214 @@ func TestAgentAdapterStartAgentSystemRoleHonorsDispatchClaim(t *testing.T) {
 	}
 	if agentID != "" {
 		t.Fatalf("StartAgent() agentID = %q, want empty on dispatch-in-flight", agentID)
+	}
+}
+
+// conflictRecoveryHarness bundles the real-git fixture used to drive a
+// direct-dispatch StartAgent into a rebase-blocked worktree-prep error and its
+// synchronous conflict-recovery callback.
+type conflictRecoveryHarness struct {
+	aa        *agentAdapter
+	agents    *agent.Manager
+	agentOrch *agentorch.Orchestrator
+	taskID    string
+}
+
+// setupConflictRecoveryHarness builds a git repo + bare remote + worktree whose
+// next PrepareForTask hits ErrRebaseFailed, wiring an agentAdapter over it. The
+// caller installs its own SetConflictRecovery callback before invoking
+// StartAgent.
+func setupConflictRecoveryHarness(t *testing.T) conflictRecoveryHarness {
+	t.Helper()
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	for _, args := range [][]string{
+		{"init", "-b", "main", src},
+		{"-C", src, "config", "user.email", "test@test.com"},
+		{"-C", src, "config", "user.name", "Test"},
+		{"-C", src, "config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", src, "add", "."},
+		{"-C", src, "commit", "-m", "init"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	bare := filepath.Join(tmp, "origin.git")
+	if out, err := exec.Command("git", "clone", "--bare", src, bare).CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+		t.Fatalf("git config: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+		t.Fatalf("git fetch: %v: %s", err, out)
+	}
+
+	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projYAML := "id: owner/repo\nname: repo\nowner: owner\nrepo: repo\nurl: " + bare +
+		"\nclone_path: " + bare + "\ntype: pet\n"
+	if err := os.WriteFile(filepath.Join(tmp, "projects", "owner--repo.yaml"), []byte(projYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	taskStore, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+	tk, err := taskMgr.Create("conflict recovery claim release", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := "owner/repo"
+	tk, err = taskMgr.Update(tk.ID, task.Update{ProjectID: &projectID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, filepath.Join(tmp, "logs"))
+	wm := worktree.New(worktree.Config{
+		WorktreesDir:     filepath.Join(tmp, "worktrees"),
+		Projects:         projects,
+		Tasks:            taskMgr,
+		Logger:           logger,
+		AgentChecker:     agents.HasRunningAgentForTask,
+		LiveAgentChecker: agents.HasLiveRegisteredAgentForTask,
+	})
+
+	// Prepare the worktree once so the task has a real branch, then make an
+	// unrelated edit on the branch and a conflicting edit upstream so the
+	// next PrepareForTask hits ErrRebaseFailed.
+	wtPath, err := wm.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "config", "user.email", "test@test.com"},
+		{"-C", wtPath, "config", "user.name", "Test"},
+		{"-C", wtPath, "config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("branch edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "add", "."},
+		{"-C", wtPath, "commit", "-m", "branch edit"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("upstream edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", src, "add", "."},
+		{"-C", src, "commit", "-m", "upstream edit"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	agentOrch := agentorch.New(taskMgr, projects, agents, nil, logger, wm, nil)
+	aa := &agentAdapter{agents: agents, agentOrch: agentOrch, tasks: taskMgr, projects: projects}
+	return conflictRecoveryHarness{aa: aa, agents: agents, agentOrch: agentOrch, taskID: tk.ID}
+}
+
+// TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery guards
+// against a nested-claim deadlock: a direct-dispatch
+// StartAgent call (e.g. the create_pr step) that hits a rebase-blocked
+// worktree-prep error synchronously invokes the conflict-recovery callback
+// (RecoverStaleBranchConflict -> recoverBranchConflictNoPR), which itself
+// dispatches a nested "fix" agent for the SAME task ID through the SAME
+// non-reentrant dispatchClaims map. If the outer StartAgent still held its
+// claim while the recovery callback ran, the nested dispatch would always
+// see ErrDispatchInFlight and the conflict-resolution agent would never
+// start. This asserts the claim is released before the callback fires.
+func TestAgentAdapterStartAgentReleasesDispatchClaimBeforeConflictRecovery(t *testing.T) {
+	h := setupConflictRecoveryHarness(t)
+
+	var claimAcquiredDuringRecovery, recoveryCalled bool
+	h.agentOrch.SetConflictRecovery(func(id string) bool {
+		recoveryCalled = true
+		if id != h.taskID {
+			t.Errorf("conflict recovery got task id %q, want %q", id, h.taskID)
+		}
+		// This is what the nested branch-conflict-fix workflow's own "fix"
+		// step dispatch effectively does: claim the SAME per-task dispatch
+		// slot the outer StartAgent call above was holding. If StartAgent
+		// hadn't released it first, this would fail exactly like the fix
+		// step did in the original repro of this deadlock.
+		claimAcquiredDuringRecovery = h.agents.ClaimTaskDispatch(id)
+		if claimAcquiredDuringRecovery {
+			h.agents.ReleaseTaskDispatch(id)
+		}
+		return false
+	})
+
+	_, _, _, err := h.aa.StartAgent(h.taskID, string(agent.RolePRFix), "headless", "sonnet", "claude", "prompt", "", nil, true, false, "", "", workflow.AgentAssignment{})
+	t.Logf("StartAgent err=%v recoveryCalled=%v claimAcquired=%v", err, recoveryCalled, claimAcquiredDuringRecovery)
+	if !errors.Is(err, workflow.ErrDispatchInFlight) {
+		t.Fatalf("StartAgent() err = %v, want ErrDispatchInFlight", err)
+	}
+	if !claimAcquiredDuringRecovery {
+		t.Fatal("conflict-recovery callback could not claim task dispatch — StartAgent still held it, reproducing the nested-claim deadlock")
+	}
+}
+
+// TestAgentAdapterStartAgentDoesNotClobberForeignClaimAfterRecovery guards
+// against the double-release hazard: StartAgent releases its dispatch claim
+// early before the recovery callback so a nested recovery dispatch can
+// re-enter, but the outer deferred release must NOT fire a second, unguarded
+// delete when StartAgent returns. If it does, an independent dispatcher (e.g.
+// ResumeStalled) that claimed the same taskID during the network-bound
+// recovery window loses its claim — reintroducing the duplicate-agent race
+// the claim map exists to prevent. Because ReleaseTaskDispatch is keyed only
+// by taskID with no ownership token, a foreign claim taken during recovery
+// must survive StartAgent's return.
+func TestAgentAdapterStartAgentDoesNotClobberForeignClaimAfterRecovery(t *testing.T) {
+	h := setupConflictRecoveryHarness(t)
+
+	// Model an independent dispatcher (ResumeStalled) that grabs the freed slot
+	// during the recovery window and keeps holding it — it does NOT release
+	// inline. StartAgent's return must leave this foreign claim intact.
+	var foreignClaimAcquired bool
+	h.agentOrch.SetConflictRecovery(func(id string) bool {
+		foreignClaimAcquired = h.agents.ClaimTaskDispatch(id)
+		return false
+	})
+
+	_, _, _, err := h.aa.StartAgent(h.taskID, string(agent.RolePRFix), "headless", "sonnet", "claude", "prompt", "", nil, true, false, "", "", workflow.AgentAssignment{})
+	if !errors.Is(err, workflow.ErrDispatchInFlight) {
+		t.Fatalf("StartAgent() err = %v, want ErrDispatchInFlight", err)
+	}
+	if !foreignClaimAcquired {
+		t.Fatal("foreign dispatcher could not claim during recovery — StartAgent still held it")
+	}
+	// The foreign claim must still be held: a re-claim attempt must fail. If
+	// StartAgent's stale defer clobbered it, ClaimTaskDispatch would succeed.
+	if h.agents.ClaimTaskDispatch(h.taskID) {
+		t.Fatal("foreign dispatch claim was clobbered by StartAgent's stale deferred release — double-release hazard")
 	}
 }
 

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1755,10 +1756,101 @@ func hasReportLinePrefix(report string, prefixes ...string) bool {
 	return false
 }
 
+// fingerprintQuotedRe captures quoted error/value strings a test-runner cites
+// verbatim (command output, error messages, expected/actual literals).
+var fingerprintQuotedRe = regexp.MustCompile("\"[^\"\n]{1,200}\"|'[^'\n]{1,200}'|`[^`\n]{1,200}`")
+
+// fingerprintNumberRe captures counts, HTTP statuses, and other numeric
+// tokens that distinguish otherwise-similar failure prose (e.g. "reappears
+// after 2 occurrences" vs "after 3 occurrences").
+var fingerprintNumberRe = regexp.MustCompile(`-?\d+(?:\.\d+)?%?`)
+
+// fingerprintEnumTokenRe captures enum-like identifiers (SCREAMING_SNAKE,
+// snake_case, dotted paths) that carry semantic meaning independent of
+// surrounding wording — statuses, outcome names, field names.
+var fingerprintEnumTokenRe = regexp.MustCompile(`\b[A-Za-z][A-Za-z0-9]*(?:[_.][A-Za-z0-9]+)+\b`)
+
+// fingerprintPathTokenRe captures endpoint/route-shaped literals such as
+// "/login" or "/api/export". These are often the stable part of a test report
+// when prose drifts between runner attempts.
+var fingerprintPathTokenRe = regexp.MustCompile(`/(?:[A-Za-z0-9][A-Za-z0-9._~-]*)(?:/[A-Za-z0-9][A-Za-z0-9._~-]*)*`)
+
+var fingerprintFilePathTokenRe = regexp.MustCompile(`(?i)\.(?:go|ts|tsx|js|jsx|svelte)$`)
+
+// fingerprintMinTokens is the minimum count of unique discriminating tokens
+// required before the token-based fingerprint is trusted, alongside at least
+// one strong token (quoted strings, endpoint paths, or non-filepath enum-like
+// identifiers). Below this, the report is too sparse or too boilerplate-heavy
+// to distinguish reliably, and testFailureFingerprint falls back to the
+// original whole-prose hash.
+const fingerprintMinTokens = 2
+
+// testFailureFingerprint derives a stable identifier for a test-runner
+// failure report, used to detect when the SAME failure class recurs across
+// reimplementation attempts. Reports describing genuinely different defects
+// must hash differently; reports describing the same defect with minor LLM
+// wording drift (synonyms, reordered sentences, rephrased summaries) must
+// hash the same.
+//
+// The report is reduced to its semantically load-bearing tokens — quoted
+// error/value strings, endpoint paths, file:line citations, numeric
+// counts/statuses, and enum-like identifiers — sorted for order-independence
+// and hashed. Prose glue words carry no signal for this purpose and are
+// dropped. When a report is too sparse or contains only boilerplate-shaped
+// tokens (for example, a shared file:line and HTTP 500/200 pair), this falls
+// back to the original lowercased, whitespace-normalized full-prose hash so
+// unrelated bugs do not collapse into the same recurrence class.
+//
+// NOTE: this is NOT the same hash as the original exact-prose fingerprint.
+// Fingerprints persisted by older runs (AgentRunInfo.TestFailureFingerprint)
+// are not migrated or recomputed — they simply will not match a fingerprint
+// computed by this hardened function until a new test-runner attempt
+// records one. This only delays recurrence detection for tasks whose
+// testing cycle straddles the deploy of this change; it never produces
+// a false recurrence match.
 func testFailureFingerprint(report string) string {
-	normalized := strings.Join(strings.Fields(strings.ToLower(report)), " ")
-	sum := sha256.Sum256([]byte(normalized))
+	basis := fingerprintNormalizedBasis(report)
+	sum := sha256.Sum256([]byte(basis))
 	return hex.EncodeToString(sum[:8])
+}
+
+func fingerprintNormalizedBasis(report string) string {
+	var tokens []string
+	strongTokens := 0
+	quoted := fingerprintQuotedRe.FindAllString(report, -1)
+	paths := fingerprintPathTokenRe.FindAllString(report, -1)
+	enums := fingerprintEnumTokenRe.FindAllString(report, -1)
+
+	tokens = append(tokens, quoted...)
+	tokens = append(tokens, paths...)
+	tokens = append(tokens, fileLineCitationRe.FindAllString(report, -1)...)
+	tokens = append(tokens, fingerprintNumberRe.FindAllString(report, -1)...)
+	tokens = append(tokens, enums...)
+	strongTokens += len(quoted) + len(paths)
+
+	seen := make(map[string]struct{}, len(tokens))
+	normalized := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok != "" {
+			if _, ok := seen[tok]; ok {
+				continue
+			}
+			seen[tok] = struct{}{}
+			normalized = append(normalized, tok)
+		}
+	}
+	for _, tok := range enums {
+		tok = strings.ToLower(strings.TrimSpace(tok))
+		if tok != "" && !fingerprintFilePathTokenRe.MatchString(tok) {
+			strongTokens++
+		}
+	}
+	if len(normalized) < fingerprintMinTokens || strongTokens == 0 {
+		return strings.Join(strings.Fields(strings.ToLower(report)), " ")
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, "|")
 }
 
 // containsFixSuggestionsInCurrentTestReport scans the agent result and the task
@@ -2086,15 +2178,48 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 
 	if duplicate {
-		reason := "same grounded test failure reproduced twice — needs targeted local reproduction/fix from latest ## Test Failures"
+		recurring := recurringProductBugFingerprints(t)
+		if len(recurring) == 0 {
+			// Defensive: countValidProductTestAttempts already confirmed the
+			// current fingerprint recurred with an intervening code-author
+			// run, so this should always be non-empty. Fall back to the
+			// just-finished attempt's own fingerprint so the section still
+			// carries evidence rather than an empty class list.
+			if cf := wfExec.Variables["step."+testVerdictSourceStep+"."+testFailureFingerprintKey]; cf != "" {
+				recurring = []string{cf}
+			}
+		}
+		reason := "suspected acceptance-criteria conflict after recurring product-bug test failures — human spec decision needed; see ## Test Failures"
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
 		}
-		e.logger.Warn("workflow.test.duplicate-failure", "task_id", taskID)
+		if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+			e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
+		}
+		e.logSpecDecisionEscalation(taskID, attempts, limit, recurring, false)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "duplicate failure"}, nil
 	}
 
 	if attempts >= limit {
+		if nonConvergingProductBugLoop(t) {
+			// Evidence only — the reframe below fires on non-convergence
+			// (ping-ponging product-bug attempts with an intervening
+			// code-author run) even when concrete repro evidence differs
+			// across attempts and no exact fingerprint recurred, so
+			// `recurring` may legitimately be empty here.
+			recurring := recurringProductBugFingerprints(t)
+			reason := fmt.Sprintf(
+				"suspected acceptance-criteria conflict: the implement/test loop failed to converge over %d product-bug attempt(s) (cap %d) — could be a contradictory spec or a hard defect the fixes keep missing; human spec decision needed; see ## Test Failures",
+				attempts, limit)
+			if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+				return StepOutput{}, err
+			}
+			if err := e.appendSpecDecisionSection(taskID, t.Body, recurring, attempts, limit); err != nil {
+				e.logger.Warn("workflow.test.spec-decision.append-failed", "task_id", taskID, "err", err)
+			}
+			e.logSpecDecisionEscalation(taskID, attempts, limit, recurring, true)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "escalated"}, nil
+		}
 		reason := fmt.Sprintf("manual testing found %d grounded product defects: feature still does not match the task — needs targeted local reproduction/fix from latest ## Test Failures", attempts)
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
@@ -2116,6 +2241,168 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 	e.logger.Info("workflow.test.reimplement", "task_id", taskID, "attempts", attempts, "cap", limit)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "reimplement"}, nil
+}
+
+// recurringProductBugFingerprints returns the distinct product-bug failure
+// fingerprints (sorted) that recurred at least twice within the current
+// testing cycle, with an intervening code-author run between two of their
+// occurrences — the same "the implementer fixed something and the SAME
+// failure class came back" signal countValidProductTestAttempts uses for its
+// immediate-duplicate check, but surfaced here as a set. This lets cap-time
+// escalation reframe as a spec-decision on ANY recurring class among the
+// attempts that exhausted the cap, not only the just-finished attempt's
+// fingerprint.
+func recurringProductBugFingerprints(t TaskInfo) []string {
+	type fingerprintOccurrence struct {
+		fingerprint string
+		runIndex    int
+	}
+	var occurrences []fingerprintOccurrence
+	for i := range t.AgentRuns {
+		run := t.AgentRuns[i]
+		if t.TestingCycleStartedAt != nil && run.StartedAt.Before(*t.TestingCycleStartedAt) {
+			continue
+		}
+		if run.Role != testRunnerRole || run.ProtocolViolation != "" ||
+			run.TestOutcome != testOutcomeProductBug || run.TestFailureFingerprint == "" {
+			continue
+		}
+		occurrences = append(occurrences, fingerprintOccurrence{
+			fingerprint: run.TestFailureFingerprint,
+			runIndex:    i,
+		})
+	}
+	seen := make(map[string]bool)
+	var recurring []string
+	for a := range occurrences {
+		if seen[occurrences[a].fingerprint] {
+			continue
+		}
+		for b := a + 1; b < len(occurrences); b++ {
+			if occurrences[b].fingerprint != occurrences[a].fingerprint {
+				continue
+			}
+			if hasInterveningCodeAuthorRun(t.AgentRuns, occurrences[a].runIndex, occurrences[b].runIndex) {
+				seen[occurrences[a].fingerprint] = true
+				recurring = append(recurring, occurrences[a].fingerprint)
+				break
+			}
+		}
+	}
+	sort.Strings(recurring)
+	return recurring
+}
+
+// nonConvergingProductBugLoop reports whether the implement/test loop has
+// ping-ponged between valid product-bug test-runner attempts within the
+// current testing cycle, regardless of whether their fingerprints match.
+// Unlike recurringProductBugFingerprints (which requires the SAME failure
+// class to reappear byte-for-byte), this only requires two valid product-bug
+// attempts separated by a code-author run — the realistic shape when a live
+// tester re-probes the same conceptual defect but picks different concrete
+// repro evidence (fixture values, ids, quoted literals) each time, which
+// would otherwise fingerprint differently and hide the recurrence.
+func nonConvergingProductBugLoop(t TaskInfo) bool {
+	var indices []int
+	for i := range t.AgentRuns {
+		run := t.AgentRuns[i]
+		if t.TestingCycleStartedAt != nil && run.StartedAt.Before(*t.TestingCycleStartedAt) {
+			continue
+		}
+		if run.Role != testRunnerRole || run.ProtocolViolation != "" ||
+			run.TestOutcome != testOutcomeProductBug || run.TestFailureFingerprint == "" {
+			continue
+		}
+		indices = append(indices, i)
+	}
+	for i := 1; i < len(indices); i++ {
+		if hasInterveningCodeAuthorRun(t.AgentRuns, indices[i-1], indices[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// specDecisionHeading marks the section appended to a task body when
+// escalating on recurring product-bug failure classes. A distinct heading
+// (not "## Test Failures") keeps it out of testFailSectionOf's scan.
+const specDecisionHeading = "## Spec Decision Needed"
+
+// specDecisionMarker returns a stable HTML-comment marker keyed by the sorted
+// set of recurring fingerprints driving an escalation. appendSpecDecisionSection
+// uses it to skip re-appending an identical section on a rerun (idempotency),
+// while a genuinely new recurring set still gets its own section appended.
+func specDecisionMarker(fingerprints []string) string {
+	sorted := append([]string(nil), fingerprints...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, "|")))
+	return "<!-- sybra:spec-decision:" + hex.EncodeToString(sum[:6]) + " -->"
+}
+
+// buildSpecDecisionSection renders the task-body evidence for a spec-decision
+// escalation. It deliberately avoids asserting a proven contradiction —
+// the same recurrence shape can also be produced by two independent
+// sequential bugs — and points at the latest "## Test Failures" section
+// for repros rather than claiming an exact section-to-fingerprint mapping,
+// since AgentRunInfo does not persist historical report text or offsets.
+func buildSpecDecisionSection(fingerprints []string, attempts, limit int) string {
+	sorted := append([]string(nil), fingerprints...)
+	sort.Strings(sorted)
+	var b strings.Builder
+	b.WriteString(specDecisionHeading + "\n\n")
+	b.WriteString(specDecisionMarker(sorted) + "\n\n")
+	if len(sorted) == 0 {
+		fmt.Fprintf(&b,
+			"The implement/test loop failed to converge over %d product-bug test attempt(s) (cap %d), but "+
+				"the concrete repro evidence differed across attempts — a fresh test-runner agent can pick a "+
+				"different repro (fixture values, ids, quoted literals) to demonstrate the same conceptual "+
+				"defect each time, so no exact fingerprint recurred. This is evidence of a suspected "+
+				"acceptance-criteria conflict — not a confirmed one, since a hard defect the fixes keep "+
+				"missing can look the same. A human spec decision is needed; inspect the latest %q section "+
+				"of this task body for the most recent repro.\n",
+			attempts, limit, testFailuresHeading)
+		return b.String()
+	}
+	fmt.Fprintf(&b,
+		"Manual testing reproduced %d recurring product-bug failure class(es) across an intervening "+
+			"reimplementation attempt (%d test attempt(s), cap %d). This is evidence of a suspected "+
+			"acceptance-criteria conflict — not a confirmed one, since two independent sequential bugs "+
+			"can produce the same recurrence shape. A human spec decision is needed.\n\n",
+		len(sorted), attempts, limit)
+	fmt.Fprintf(&b,
+		"Recurring fingerprint(s): %s. Repros for these failure classes are identifiable in the latest "+
+			"%q section of this task body.\n",
+		strings.Join(sorted, ", "), testFailuresHeading)
+	return b.String()
+}
+
+// appendSpecDecisionSection appends the spec-decision evidence section to the
+// task body, unless a section with an identical marker (same recurring
+// fingerprint set) is already present — reruns then skip instead of
+// duplicating. A new/different recurring set still gets appended, since
+// AppendTaskBody has no in-place replace and the older section remains valid
+// historical evidence.
+func (e *Engine) appendSpecDecisionSection(taskID, body string, fingerprints []string, attempts, limit int) error {
+	if strings.Contains(body, specDecisionMarker(fingerprints)) {
+		return nil
+	}
+	if err := e.tasks.AppendTaskBody(taskID, buildSpecDecisionSection(fingerprints, attempts, limit)); err != nil {
+		return fmt.Errorf("append spec-decision section: %w", err)
+	}
+	return nil
+}
+
+// logSpecDecisionEscalation emits a bounded structured event for a
+// spec-decision escalation: task id, attempt/cap counters, the distinct
+// recurring-class count and fingerprints, and whether the escalation fired
+// via the cap-time non-convergence path (nonConvergingProductBugLoop) rather
+// than the pre-cap exact-fingerprint duplicate shortcut. Raw test reports are
+// never logged.
+func (e *Engine) logSpecDecisionEscalation(taskID string, attempts, limit int, fingerprints []string, nonConvergingCap bool) {
+	e.logger.Warn("workflow.test.spec-decision",
+		"task_id", taskID, "attempts", attempts, "cap", limit,
+		"recurring_classes", len(fingerprints), "fingerprints", fingerprints,
+		"non_converging_cap", nonConvergingCap)
 }
 
 func (e *Engine) countValidProductTestAttempts(t TaskInfo, wfExec *Execution) (int, bool) {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1342,6 +1342,97 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 	}
 }
 
+func TestTestFailureFingerprint_ToleratesWordingDriftOnSameEvidence(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nI reran the same probe and observed the identical failure again — " +
+		"hitting curl /status still returns HTTP 500 instead of the required HTTP 200. " +
+		"Code evidence: internal/server.go:42"
+
+	if testFailureFingerprint(a) != testFailureFingerprint(b) {
+		t.Fatalf("fingerprints differ for reworded reports describing the same defect:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_DistinguishesDifferentEvidence(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /health\nActual: HTTP 404\nExpected: HTTP 200\n" +
+		"Code evidence: internal/health.go:17"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports describing different defects:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_DistinguishesSharedBoilerplateFileCitation(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /foo\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /bar\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports that share only boilerplate file/status evidence:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_IgnoresRepeatedEvidenceTokens(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42"
+	b := "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200\n" +
+		"Code evidence: internal/server.go:42\nObserved again: curl /status still returns HTTP 500. internal/server.go:42"
+
+	if testFailureFingerprint(a) != testFailureFingerprint(b) {
+		t.Fatalf("fingerprints differ when the same evidence is repeated:\na=%q\nb=%q", a, b)
+	}
+}
+
+func TestTestFailureFingerprint_DistinguishesSharedStatusPairWithoutStrongTokens(t *testing.T) {
+	t.Parallel()
+
+	a := "## Test Failures\n\nThe login form rejects valid credentials.\nActual: 500\nExpected: 200"
+	b := "## Test Failures\n\nThe dashboard export crashes during download.\nActual: 500\nExpected: 200"
+
+	if testFailureFingerprint(a) == testFailureFingerprint(b) {
+		t.Fatalf("fingerprints matched for reports that share only status numbers:\na=%q\nb=%q", a, b)
+	}
+}
+
+// TestTestFailureFingerprint_FallsBackOnSparseReport guards the fallback path:
+// a report too short to yield enough discriminating tokens must still hash
+// deterministically and distinguish from an unrelated sparse report, rather
+// than collapsing to an empty-token hash shared by every terse report.
+func TestTestFailureFingerprint_FallsBackOnSparseReport(t *testing.T) {
+	t.Parallel()
+
+	a := "the button does nothing when clicked"
+	b := "the page never loads at all"
+
+	fa := testFailureFingerprint(a)
+	fb := testFailureFingerprint(b)
+	if fa == "" || fb == "" {
+		t.Fatalf("fingerprints must be non-empty even for sparse reports: a=%q b=%q", fa, fb)
+	}
+	if fa == fb {
+		t.Fatalf("fingerprints matched for different sparse reports:\na=%q\nb=%q", a, b)
+	}
+	// The sparse fallback hashes full lowercased, whitespace-normalized prose,
+	// so it is NOT guaranteed to tolerate synonym drift the way the
+	// token-based path does — but it must still be stable across repeated
+	// calls on byte-identical input.
+	if again := testFailureFingerprint(a); again != fa {
+		t.Fatalf("fingerprint is not deterministic for identical input: %q vs %q", fa, again)
+	}
+}
+
 func TestHasRawReadinessProbeEvidenceRejectsHypotheticalText(t *testing.T) {
 	t.Parallel()
 
@@ -2422,8 +2513,485 @@ func TestRouteTestResult_DuplicateFailureEscalatesWithoutAnotherRetry(t *testing
 	if ti.Status != "human-required" {
 		t.Errorf("status = %q, want human-required", ti.Status)
 	}
-	if reason := tasks.Reason("t-dup"); !strings.Contains(reason, "same grounded test failure") {
-		t.Errorf("reason = %q, want duplicate failure", reason)
+	if reason := tasks.Reason("t-dup"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	for _, forbidden := range []string{"proven contradiction", "found contradiction", "requirements are contradictory"} {
+		if reason := tasks.Reason("t-dup"); strings.Contains(strings.ToLower(reason), forbidden) {
+			t.Errorf("reason = %q, must not assert a proven contradiction", reason)
+		}
+	}
+	ti, _ = tasks.GetTask("t-dup")
+	if !strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want a spec-decision section appended", ti.Body)
+	}
+	if !strings.Contains(ti.Body, fp) {
+		t.Errorf("body = %q, want the recurring fingerprint referenced", ti.Body)
+	}
+}
+
+func TestRouteTestResult_DuplicateFailureEscalatesWhenSpecDecisionAppendFails(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	tasks.appendErr = errors.New("append unavailable")
+	now := time.Now().UTC()
+	fp := "same-repro"
+	tasks.Put(TaskInfo{
+		ID:     "t-dup-append-fails",
+		Status: "testing",
+		AgentRuns: []AgentRunInfo{
+			{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+			{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+			{AgentID: "second", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		},
+	})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+		},
+	}
+
+	out, err := e.execRouteTestResult("t-dup-append-fails", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup-append-fails"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "duplicate failure" {
+		t.Errorf("output = %q, want duplicate failure", out.Output)
+	}
+	ti := mustGetTaskInfo(t, tasks, "t-dup-append-fails")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-dup-append-fails"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want no spec-decision section when append fails", ti.Body)
+	}
+}
+
+// TestRouteTestResult_DuplicateFailureSpecDecisionIsIdempotent guards against a
+// second call re-appending the spec-decision section when the recurring
+// fingerprint set hasn't changed — the marker must make the append a no-op.
+func TestRouteTestResult_DuplicateFailureSpecDecisionIsIdempotent(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	fp := "same-repro"
+	runs := []AgentRunInfo{
+		{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		{AgentID: "second", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+	}
+	tasks.Put(TaskInfo{ID: "t-dup-idem", Status: "testing", AgentRuns: runs})
+	route := func() {
+		wf := &Execution{
+			WorkflowID: "testing-task",
+			StartedAt:  now,
+			Variables: map[string]string{
+				"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+				"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+				"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+			},
+		}
+		if _, err := e.execRouteTestResult("t-dup-idem", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup-idem")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	route()
+	ti := mustGetTaskInfo(t, tasks, "t-dup-idem")
+	first := ti.Body
+	if strings.Count(first, specDecisionHeading) != 1 {
+		t.Fatalf("body = %q, want exactly one spec-decision section", first)
+	}
+	route()
+	ti = mustGetTaskInfo(t, tasks, "t-dup-idem")
+	if ti.Body != first {
+		t.Errorf("body changed on idempotent rerun:\nfirst: %q\nsecond: %q", first, ti.Body)
+	}
+	if strings.Count(ti.Body, specDecisionHeading) != 1 {
+		t.Errorf("body = %q, want exactly one spec-decision section after rerun", ti.Body)
+	}
+}
+
+// TestRouteTestResult_FailAtCapWithRecurringClassReframesAsSpecDecision
+// verifies the cap-escalation path also reframes as a spec-decision when the
+// attempts that exhausted the cap include a recurring failure class, per the
+// acceptance criteria ("a single recurring class at cap" still gets the
+// spec-decision framing, not the generic distinct-defects cap message).
+func TestRouteTestResult_FailAtCapWithRecurringClassReframesAsSpecDecision(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	// A recurs at i0/i2 (intervening author at i1) — that pair would have
+	// escalated as an immediate "duplicate" if route_test_result had been
+	// called right after i2 in a real run. This fixture instead reaches cap
+	// without that earlier call (e.g. the recurrence only becomes visible in
+	// hindsight), so the cap branch itself must recognize the recurring
+	// class rather than treating three distinct-looking attempts generically.
+	// The current (last) attempt's own fingerprint ("current") is distinct
+	// from A, so the immediate-duplicate check does not fire here either.
+	runs := []AgentRunInfo{
+		productBugRun(now, "A"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "A"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "current"),
+	}
+	tasks.Put(TaskInfo{ID: "t-cap-recur", Status: "testing", AgentRuns: runs})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: "current",
+		},
+	}
+	out, err := e.execRouteTestResult("t-cap-recur", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-cap-recur"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-cap-recur")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-cap-recur"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if !strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want a spec-decision section appended", ti.Body)
+	}
+}
+
+// TestNonConvergingProductBugLoop exercises nonConvergingProductBugLoop
+// directly against the filtering rules it must share with
+// recurringProductBugFingerprints, but without requiring fingerprint
+// equality between the paired attempts.
+func TestNonConvergingProductBugLoop(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name string
+		t    TaskInfo
+		want bool
+	}{
+		{
+			name: "distinct fingerprints separated by implementation run",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				productBugRun(now.Add(2*time.Minute), "B"),
+			}},
+			want: true,
+		},
+		{
+			name: "no author gap between adjacent product-bug attempts",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				productBugRun(now.Add(time.Minute), "B"),
+			}},
+			want: false,
+		},
+		{
+			name: "protocol-violation run ignored",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				{AgentID: "bad", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), ProtocolViolation: testProtocolFixSuggestions, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: "B"},
+			}},
+			want: false,
+		},
+		{
+			name: "infra-failure outcome ignored",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				{AgentID: "infra", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeInfraFailure},
+			}},
+			want: false,
+		},
+		{
+			name: "missing-evidence outcome ignored",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+				{AgentID: "missing", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeMissingEvidence},
+			}},
+			want: false,
+		},
+		{
+			name: "prior-cycle runs before TestingCycleStartedAt ignored",
+			t: func() TaskInfo {
+				cycleStart := now.Add(10 * time.Minute)
+				return TaskInfo{
+					TestingCycleStartedAt: &cycleStart,
+					AgentRuns: []AgentRunInfo{
+						productBugRun(now, "A"),
+						{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+						productBugRun(cycleStart.Add(time.Minute), "B"),
+					},
+				}
+			}(),
+			want: false,
+		},
+		{
+			name: "non-author run between product-bug attempts does not count as a gap",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "reviewer", Role: "review", StartedAt: now.Add(time.Minute)},
+				productBugRun(now.Add(2*time.Minute), "B"),
+			}},
+			want: false,
+		},
+		{
+			name: "noise runs between filtered pairs still resolve via original indices",
+			t: TaskInfo{AgentRuns: []AgentRunInfo{
+				productBugRun(now, "A"),
+				{AgentID: "infra-noise", Role: testRunnerRole, StartedAt: now.Add(time.Minute), TestOutcome: testOutcomeInfraFailure},
+				{AgentID: "impl", Role: "implementation", StartedAt: now.Add(2 * time.Minute)},
+				productBugRun(now.Add(3*time.Minute), "B"),
+			}},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := nonConvergingProductBugLoop(tc.t); got != tc.want {
+				t.Errorf("nonConvergingProductBugLoop() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRouteTestResult_FailAtCapWithDistinctFailuresAfterImplementationReframesAsSpecDecision
+// is the regression test for the recurring-fingerprint narrowing gap: a
+// live adversarial test-runner naturally exercises different concrete repro
+// evidence (different fixture ids/literals) each attempt while describing
+// the SAME conceptual failure mode, so an exact-fingerprint recurrence check
+// never fires even though the loop is genuinely ping-ponging. The cap must
+// still reframe as a suspected acceptance-criteria conflict.
+func TestRouteTestResult_FailAtCapWithDistinctFailuresAfterImplementationReframesAsSpecDecision(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "fp-2"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "fp-3"),
+	}
+	out, err := runRouteTestResult(e, tasks, "t-cap-distinct", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-cap-distinct")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	reason := tasks.Reason("t-cap-distinct")
+	if !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing", reason)
+	}
+	if !strings.Contains(reason, "contradictory spec") || !strings.Contains(reason, "hard defect") {
+		t.Errorf("reason = %q, want it to name both a contradictory spec and a hard defect", reason)
+	}
+	for _, forbidden := range []string{"proven contradiction", "found contradiction", "requirements are contradictory"} {
+		if strings.Contains(strings.ToLower(reason), forbidden) {
+			t.Errorf("reason = %q, must not assert a proven contradiction", reason)
+		}
+	}
+	if strings.Contains(reason, "recurring class") || strings.Contains(reason, "recurring product-bug failure class(es)") {
+		t.Errorf("reason = %q, must not report a count of recurring classes", reason)
+	}
+	if strings.Count(ti.Body, specDecisionHeading) != 1 {
+		t.Errorf("body = %q, want exactly one spec-decision section", ti.Body)
+	}
+}
+
+// TestRouteTestResult_FailAtCapWithoutInterveningCodeAuthorUsesGenericReason
+// verifies the generic cap-time floor is preserved when the product-bug
+// attempts that exhausted the cap were never separated by a code-author run
+// (e.g. the test-runner retried without a fix in between) — this is not a
+// non-converging implement/test loop, so no spec-decision section belongs
+// on the body.
+func TestRouteTestResult_FailAtCapWithoutInterveningCodeAuthorUsesGenericReason(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		productBugRun(now.Add(time.Minute), "fp-2"),
+		productBugRun(now.Add(2*time.Minute), "fp-3"),
+	}
+	out, err := runRouteTestResult(e, tasks, "t-cap-no-author-gap", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-cap-no-author-gap")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	reason := tasks.Reason("t-cap-no-author-gap")
+	if strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, must not use spec-decision reframing without an author gap", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, must not gain a spec-decision section without an author gap", ti.Body)
+	}
+}
+
+// TestRouteTestResult_FailAtCapSpecDecisionEscalatesWhenAppendFails verifies
+// that a body-append failure during the non-convergence cap reframe still
+// leaves the task in human-required with the softened suspected-spec reason,
+// and does not propagate the append error out of the route step.
+func TestRouteTestResult_FailAtCapSpecDecisionEscalatesWhenAppendFails(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	tasks.appendErr = errors.New("append unavailable")
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "fp-2"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "fp-3"),
+	}
+	out, err := runRouteTestResult(e, tasks, "t-cap-append-fails", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti := mustGetTaskInfo(t, tasks, "t-cap-append-fails")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-cap-append-fails"); !strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, want spec-decision reframing despite append failure", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, want no spec-decision section when append fails", ti.Body)
+	}
+}
+
+// TestRouteTestResult_EmptyRecurringSpecDecisionSectionIsIdempotent verifies
+// the empty-recurring-evidence spec-decision section (no exact fingerprint
+// recurred, only non-convergence) uses a stable marker, renders no blank
+// "Recurring fingerprint(s):" list, and does not duplicate on a second call
+// with the same empty evidence set.
+func TestRouteTestResult_EmptyRecurringSpecDecisionSectionIsIdempotent(t *testing.T) {
+	t.Parallel()
+	section1 := buildSpecDecisionSection(nil, 3, 3)
+	section2 := buildSpecDecisionSection([]string{}, 3, 3)
+	if section1 != section2 {
+		t.Errorf("empty-recurring sections differ:\n%q\n%q", section1, section2)
+	}
+	if !strings.Contains(section1, specDecisionMarker(nil)) {
+		t.Errorf("section = %q, want the stable empty-set marker", section1)
+	}
+	if strings.Contains(section1, "Recurring fingerprint(s): .") || strings.Contains(section1, "Recurring fingerprint(s): \n") {
+		t.Errorf("section = %q, must not render a blank fingerprint list", section1)
+	}
+	if !strings.Contains(section1, testFailuresHeading) {
+		t.Errorf("section = %q, want a pointer to the latest %q section", section1, testFailuresHeading)
+	}
+
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		productBugRun(now, "fp-1"),
+		{AgentID: "impl-1", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		productBugRun(now.Add(2*time.Minute), "fp-2"),
+		{AgentID: "impl-2", Role: "implementation", StartedAt: now.Add(3 * time.Minute)},
+		productBugRun(now.Add(4*time.Minute), "fp-3"),
+	}
+	tasks.Put(TaskInfo{ID: "t-cap-empty-idem", Status: "testing", AgentRuns: runs})
+	route := func() {
+		wf := &Execution{
+			WorkflowID: "testing-task",
+			StartedAt:  now,
+			Variables: map[string]string{
+				"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+				"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+				"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: "fp-3",
+			},
+		}
+		if _, err := e.execRouteTestResult("t-cap-empty-idem", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-cap-empty-idem")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	route()
+	ti := mustGetTaskInfo(t, tasks, "t-cap-empty-idem")
+	first := ti.Body
+	if strings.Count(first, specDecisionHeading) != 1 {
+		t.Fatalf("body = %q, want exactly one spec-decision section", first)
+	}
+	route()
+	ti = mustGetTaskInfo(t, tasks, "t-cap-empty-idem")
+	if ti.Body != first {
+		t.Errorf("body changed on idempotent rerun:\nfirst: %q\nsecond: %q", first, ti.Body)
+	}
+	if strings.Count(ti.Body, specDecisionHeading) != 1 {
+		t.Errorf("body = %q, want exactly one spec-decision section after rerun", ti.Body)
+	}
+}
+
+// TestRouteTestResult_ReDispatchDoesNotUsePriorCycleForSpecDecision verifies
+// prior-cycle product-bug runs and their author gaps do not bleed into a new
+// testing cycle's non-convergence check — only runs at/after
+// TestingCycleStartedAt may drive a spec-decision reframe.
+func TestRouteTestResult_ReDispatchDoesNotUsePriorCycleForSpecDecision(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+
+	priorCycleEnd := time.Now().UTC().Add(-time.Hour)
+	newCycleStart := time.Now().UTC()
+
+	// Prior cycle already ping-ponged (author gap between distinct
+	// fingerprints) and hit human-required — that history must not count
+	// toward the new cycle's non-convergence check. Single new run in the
+	// current cycle — no new author gap yet.
+	runs := []AgentRunInfo{
+		productBugRun(priorCycleEnd.Add(-2*time.Minute), "old-1"),
+		{AgentID: "impl-old", Role: "implementation", StartedAt: priorCycleEnd.Add(-time.Minute)},
+		productBugRun(priorCycleEnd, "old-2"),
+		productBugRun(newCycleStart.Add(time.Minute), "new-1"),
+	}
+
+	out, err := runRouteTestResult(e, tasks, "t-redispatch-spec", "FAIL", newCycleStart, runs, &newCycleStart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "reimplement" {
+		t.Errorf("output = %q, want reimplement (prior-cycle runs must not drive a spec-decision reframe)", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-redispatch-spec")
+	if ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", ti.Status)
+	}
+	if reason := tasks.Reason("t-redispatch-spec"); strings.Contains(reason, "suspected acceptance-criteria conflict") {
+		t.Errorf("reason = %q, must not reframe as spec-decision from prior-cycle evidence", reason)
+	}
+	if strings.Contains(ti.Body, specDecisionHeading) {
+		t.Errorf("body = %q, must not gain a spec-decision section from prior-cycle evidence", ti.Body)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -103,12 +103,13 @@ func newTestStoreWith(t *testing.T, files ...string) *Store {
 // --- In-memory TaskProvider ---
 
 type memTasks struct {
-	mu      sync.Mutex
-	tasks   map[string]*TaskInfo
-	reasons map[string]string
-	steers  map[string]string
-	gets    map[string]int
-	onGet   func(id string, t *TaskInfo, count int)
+	mu        sync.Mutex
+	tasks     map[string]*TaskInfo
+	reasons   map[string]string
+	steers    map[string]string
+	gets      map[string]int
+	onGet     func(id string, t *TaskInfo, count int)
+	appendErr error
 }
 
 func newMemTasks() *memTasks {
@@ -266,6 +267,9 @@ func (m *memTasks) AppendTaskBody(id, content string) error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.appendErr != nil {
+		return m.appendErr
+	}
 	t, ok := m.tasks[id]
 	if !ok {
 		return fmt.Errorf("task %s not found", id)


### PR DESCRIPTION
## Motivation

`PushSync` compared local HEAD against a locally cached
`refs/remotes/<remote>/<branch>` ref that only a prior fetch/push in the
same worktree ever refreshed. A separate recovery worktree pushing this
branch directly left that cache stale, so the next `PushSync` call could
report a divergence the live remote no longer had, re-triggering conflict
recovery in a tight loop even though it had already succeeded.

While validating that path, this branch also picks up workflow-side fixes for
repeated test-route escalations: the recurrence fingerprint now keys off the
stable, semantically discriminating tokens in test-runner output instead of the
entire prose blob, and the spec-decision escalation payload records the
concrete fingerprints/attempt context reviewers need to distinguish a real
recurrence from two independent failures that happen to look similar.

Closes https://github.com/Automaat/sybra/issues/1628

## Implementation information

`PushSync` now fetches the specific branch fresh before comparing local
HEAD to the remote tracking ref, the same way `ReconcileWithRemote`
already does. A "couldn't find remote ref" fetch failure is treated as
the expected first-push case; any other fetch failure now fails closed with
`ErrRemoteAdvanced` instead of falling back to a possibly-stale cached ref.
When the fresh fetch succeeds and shows a real divergence, `PushSync` still
returns `ErrDivergedNeedsResolve`, additionally wrapping `ErrRemoteAdvanced`
when the live remote advanced beyond the previously cached tracking ref.

On the workflow side, recurrence detection now hashes the load-bearing tokens
from test reports so wording drift between retries does not hide the same
underlying bug, while still falling back to full-prose hashing for sparse
reports that do not carry enough discriminating signal.

_Generated by Sybra harness_
