### PR TITLE
fix(triage): stop classifier overriding project_id

### DIFF
--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -27,29 +27,25 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 
 	// t.ProjectID is sticky: once set (e.g. by the GitHub issue fetcher at
 	// task creation), the classifier's free-text guess must never override
-	// it with a lower-confidence, content-similarity match. Only fill it in
-	// when currently empty, and prefer the task's own Issue URL — the
-	// authoritative source-of-truth link — over the classifier's guess and
-	// generic title/body scanning.
+	// it with a lower-confidence, content-similarity match. But a sticky ID
+	// is only authoritative while it still resolves to a registered project —
+	// a renamed/deleted project leaves a stale ID that would otherwise lock
+	// the task to an empty project type, silently skipping the work-typed
+	// forced-interactive/forced-planning routing. So keep it only when it
+	// resolves; otherwise re-resolve, preferring the task's own Issue URL —
+	// the authoritative source-of-truth link — over the classifier's guess
+	// and generic title/body scanning.
 	projectID := strings.TrimSpace(t.ProjectID)
-	if projectID == "" {
+	projectType, resolved := projectTypeFor(projectID, projects)
+	if !resolved {
 		projectID = MatchProjectFromIssue(t.Issue, projects)
-	}
-	if projectID == "" {
-		projectID = strings.TrimSpace(v.ProjectID)
-	}
-	if projectID == "" {
-		projectID = MatchProject(t.Title, t.Body, projects)
-	}
-
-	projectType := ""
-	if projectID != "" {
-		for i := range projects {
-			if projects[i].ID == projectID {
-				projectType = string(projects[i].Type)
-				break
-			}
+		if projectID == "" {
+			projectID = strings.TrimSpace(v.ProjectID)
 		}
+		if projectID == "" {
+			projectID = MatchProject(t.Title, t.Body, projects)
+		}
+		projectType, _ = projectTypeFor(projectID, projects)
 	}
 
 	newTitle := strings.TrimSpace(v.Title)
@@ -107,6 +103,20 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 		return task.Task{}, fmt.Errorf("update task: %w", err)
 	}
 	return updated, nil
+}
+
+// projectTypeFor returns the registered project type for id and whether id
+// resolves to a registered project. An empty id never resolves.
+func projectTypeFor(id string, projects []project.Project) (string, bool) {
+	if id == "" {
+		return "", false
+	}
+	for i := range projects {
+		if projects[i].ID == id {
+			return string(projects[i].Type), true
+		}
+	}
+	return "", false
 }
 
 // prependOriginalTitle adds a line preserving the original verbose title

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -37,10 +37,17 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	// and generic title/body scanning.
 	projectID := strings.TrimSpace(t.ProjectID)
 	projectType, resolved := projectTypeFor(projectID, projects)
+	// A non-empty t.ProjectID that fails to resolve is stale (renamed/deleted
+	// project) and must be explicitly cleared below if re-resolution also
+	// comes up empty — otherwise the task stays stuck on an unresolvable id.
+	stale := projectID != "" && !resolved
 	if !resolved {
 		projectID = MatchProjectFromIssue(t.Issue, projects)
 		if projectID == "" {
-			projectID = strings.TrimSpace(v.ProjectID)
+			guess := strings.TrimSpace(v.ProjectID)
+			if _, ok := projectTypeFor(guess, projects); ok {
+				projectID = guess
+			}
 		}
 		if projectID == "" {
 			projectID = MatchProject(t.Title, t.Body, projects)
@@ -81,7 +88,7 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	mode := RouteMode(v.Mode, v.Type, projectType)
 	updates["agent_mode"] = mode
 
-	if projectID != "" {
+	if projectID != "" || stale {
 		updates["project_id"] = projectID
 	}
 

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -25,9 +25,18 @@ var preservedTags = append(append([]string{}, escapeHatchTags...), umbrella.Gate
 func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project) (task.Task, error) {
 	updates := make(map[string]any, 8)
 
-	projectID := strings.TrimSpace(v.ProjectID)
+	// t.ProjectID is sticky: once set (e.g. by the GitHub issue fetcher at
+	// task creation), the classifier's free-text guess must never override
+	// it with a lower-confidence, content-similarity match. Only fill it in
+	// when currently empty, and prefer the task's own Issue URL — the
+	// authoritative source-of-truth link — over the classifier's guess and
+	// generic title/body scanning.
+	projectID := strings.TrimSpace(t.ProjectID)
 	if projectID == "" {
-		projectID = strings.TrimSpace(t.ProjectID)
+		projectID = MatchProjectFromIssue(t.Issue, projects)
+	}
+	if projectID == "" {
+		projectID = strings.TrimSpace(v.ProjectID)
 	}
 	if projectID == "" {
 		projectID = MatchProject(t.Title, t.Body, projects)

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -261,6 +261,70 @@ func TestApplyUsesExistingProjectWhenTaskHasNoRepoURL(t *testing.T) {
 	}
 }
 
+func TestApplyExistingProjectIDNotOverriddenByClassifierGuess(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("debug workflow completion race", "shares vocabulary with another project", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err = mgr.Update(created.ID, task.Update{ProjectID: task.Ptr("correct-org/correct-repo")})
+	if err != nil {
+		t.Fatalf("Update project: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "correct-org/correct-repo", Owner: "correct-org", Repo: "correct-repo"},
+		{ID: "wrong-org/wrong-repo", Owner: "wrong-org", Repo: "wrong-repo"},
+	}
+	// Simulate the classifier misfiring: it guesses an unrelated registered
+	// project from vocabulary overlap in the title/body.
+	v := Verdict{
+		Title:     "fix(workflow): handle completion race",
+		Size:      "small",
+		Type:      "bug",
+		Mode:      "headless",
+		Tags:      []string{"backend", "small", "bug"},
+		ProjectID: "wrong-org/wrong-repo",
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.ProjectID != "correct-org/correct-repo" {
+		t.Errorf("project_id: got %q, want correct-org/correct-repo (existing project_id must be sticky)", updated.ProjectID)
+	}
+}
+
+func TestApplyIssueURLOutranksClassifierGuess(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("debug workflow completion race", "shares vocabulary with another project", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err = mgr.Update(created.ID, task.Update{Issue: task.Ptr("https://github.com/correct-org/correct-repo/issues/9")})
+	if err != nil {
+		t.Fatalf("Update issue: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "correct-org/correct-repo", Owner: "correct-org", Repo: "correct-repo"},
+		{ID: "wrong-org/wrong-repo", Owner: "wrong-org", Repo: "wrong-repo"},
+	}
+	v := Verdict{
+		Title:     "fix(workflow): handle completion race",
+		Size:      "small",
+		Type:      "bug",
+		Mode:      "headless",
+		Tags:      []string{"backend", "small", "bug"},
+		ProjectID: "wrong-org/wrong-repo",
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.ProjectID != "correct-org/correct-repo" {
+		t.Errorf("project_id: got %q, want correct-org/correct-repo (issue URL must outrank classifier guess)", updated.ProjectID)
+	}
+}
+
 func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
 	mgr := newTestManager(t)
 	// Create a work-project task that would normally go to planning.

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -366,6 +366,64 @@ func TestApplyStaleProjectIDReResolvesFromIssueURL(t *testing.T) {
 	}
 }
 
+func TestApplyRejectsUnregisteredClassifierGuess(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("investigate flaky retry loop", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo"},
+	}
+	// Classifier hallucinates/typos a project id that isn't registered.
+	v := Verdict{
+		Title:     "fix(retry): stop flaky retry loop",
+		Size:      "small",
+		Type:      "bug",
+		Mode:      "headless",
+		Tags:      []string{"backend", "small", "bug"},
+		ProjectID: "unregistered-org/unregistered-repo",
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.ProjectID != "" {
+		t.Errorf("project_id: got %q, want empty (unregistered classifier guess must not be persisted)", updated.ProjectID)
+	}
+}
+
+func TestApplyClearsStaleProjectIDWhenReResolutionFails(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("refactor ingestion", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// project_id from a project that has since been renamed/deleted, with no
+	// Issue URL and no classifier/title-body match available to re-resolve it.
+	created, err = mgr.Update(created.ID, task.Update{ProjectID: task.Ptr("old-org/renamed-repo")})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "refactor(ingestion): split pipeline stages",
+		Size:  "small",
+		Type:  "refactor",
+		Mode:  "headless",
+		Tags:  []string{"backend", "small", "refactor"},
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.ProjectID != "" {
+		t.Errorf("project_id: got %q, want empty (stale id must be cleared, not left dangling)", updated.ProjectID)
+	}
+}
+
 func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
 	mgr := newTestManager(t)
 	// Create a work-project task that would normally go to planning.

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -325,6 +325,47 @@ func TestApplyIssueURLOutranksClassifierGuess(t *testing.T) {
 	}
 }
 
+func TestApplyStaleProjectIDReResolvesFromIssueURL(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("refactor ingestion", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// A project_id set under a prior name that is no longer registered (renamed
+	// or deleted). It must not lock the task to an empty project type.
+	created, err = mgr.Update(created.ID, task.Update{
+		ProjectID: task.Ptr("old-org/renamed-repo"),
+		Issue:     task.Ptr("https://github.com/example-org/example-repo/issues/1"),
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "refactor(ingestion): split pipeline stages",
+		Size:  "small",
+		Type:  "refactor",
+		Mode:  "headless",
+		Tags:  []string{"backend", "small", "refactor"},
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.ProjectID != "example-org/example-repo" {
+		t.Errorf("project_id: got %q, want example-org/example-repo (stale ID must re-resolve)", updated.ProjectID)
+	}
+	// Re-resolution must recover the work project type so its forced routing applies.
+	if updated.AgentMode != task.AgentModeInteractive {
+		t.Errorf("mode: got %q, want interactive (work-typed routing must apply after re-resolve)", updated.AgentMode)
+	}
+	if updated.Status != task.StatusPlanning {
+		t.Errorf("status: got %s, want planning", updated.Status)
+	}
+}
+
 func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
 	mgr := newTestManager(t)
 	// Create a work-project task that would normally go to planning.

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -103,7 +103,7 @@ Rules:
 - size: small|medium|large
 - type: bug|feature|refactor|review|chore|docs
 - mode: headless (automated, no human-in-the-loop needed) or interactive (needs human judgment during execution)
-- project_id: if the task title or body contains a github.com URL matching one of the registered projects below, set this to that project's "owner/repo". Otherwise empty string.
+- project_id: if the task title or body contains a github.com URL matching one of the registered projects below, set this to that project's "owner/repo". Otherwise empty string. If the "System metadata" section below already shows an existing_project_id or issue_url resolving to a registered project, leave project_id empty — the system already knows the answer and will not use your guess to override it. Only ever set this from a clear github.com URL, never from topical/vocabulary similarity to a project's name.
 
 Decision guide for mode:
 - PR review, simple fix, test writing, refactor → headless
@@ -151,8 +151,10 @@ Output schema (single JSON object):
 	}
 
 	// Expose system metadata so the classifier can recognise pr-fix tasks and
-	// emit "noplan" without depending solely on title/body heuristics.
-	if t.RunRole != "" || t.PRNumber > 0 {
+	// emit "noplan" without depending solely on title/body heuristics, and so
+	// it has an anchor for project_id instead of guessing from vocabulary
+	// overlap with a registered project's domain.
+	if t.RunRole != "" || t.PRNumber > 0 || t.ProjectID != "" || t.Issue != "" {
 		b.WriteString("System metadata (do not include in output):\n")
 		if t.RunRole != "" {
 			b.WriteString("- run_role: " + t.RunRole + "\n")
@@ -160,8 +162,22 @@ Output schema (single JSON object):
 		if t.PRNumber > 0 {
 			fmt.Fprintf(&b, "- pr_number: %d\n", t.PRNumber)
 		}
-		b.WriteString("IMPORTANT: when run_role=pr-fix or pr_number>0 this is a system task " +
-			"fixing an existing PR. Always emit \"noplan\" in tags.\n\n")
+		if t.ProjectID != "" {
+			b.WriteString("- existing_project_id: " + t.ProjectID + "\n")
+		}
+		if t.Issue != "" {
+			b.WriteString("- issue_url: " + t.Issue + "\n")
+		}
+		if t.RunRole != "" || t.PRNumber > 0 {
+			b.WriteString("IMPORTANT: when run_role=pr-fix or pr_number>0 this is a system task " +
+				"fixing an existing PR. Always emit \"noplan\" in tags.\n")
+		}
+		if t.ProjectID != "" || t.Issue != "" {
+			b.WriteString("IMPORTANT: existing_project_id and/or issue_url above are already " +
+				"authoritative for this task's project. Leave project_id empty in your output — " +
+				"the system resolves it from these fields, not your guess.\n")
+		}
+		b.WriteString("\n")
 	}
 
 	b.WriteString("Task to classify:\n")

--- a/internal/triage/projectmatch.go
+++ b/internal/triage/projectmatch.go
@@ -15,7 +15,19 @@ var githubURLRe = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9][A-Za-z0-
 // and returns the matching registered project's ID ("owner/repo"). Returns ""
 // if no URL is present or no matching project is registered.
 func MatchProject(title, body string, projects []project.Project) string {
-	text := title + "\n" + body
+	return matchProjectInText(title+"\n"+body, projects)
+}
+
+// MatchProjectFromIssue looks at the task's Issue field — the authoritative
+// source-of-truth link when the task originated from a GitHub issue — and
+// returns the matching registered project's ID. Callers should prefer this
+// over MatchProject/the classifier's free-text guess when Issue is set: it
+// is a system-populated link, not a content-similarity guess.
+func MatchProjectFromIssue(issue string, projects []project.Project) string {
+	return matchProjectInText(issue, projects)
+}
+
+func matchProjectInText(text string, projects []project.Project) string {
 	matches := githubURLRe.FindAllStringSubmatch(text, -1)
 	for _, m := range matches {
 		owner, repo := m[1], strings.TrimSuffix(m[2], ".git")

--- a/internal/triage/projectmatch_test.go
+++ b/internal/triage/projectmatch_test.go
@@ -30,3 +30,25 @@ func TestMatchProject(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchProjectFromIssue(t *testing.T) {
+	projects := []project.Project{
+		{ID: "Automaat/sybra", Owner: "Automaat", Repo: "sybra"},
+		{ID: "foo/bar", Owner: "foo", Repo: "bar"},
+	}
+	tests := []struct {
+		name, issue, want string
+	}{
+		{"no issue", "", ""},
+		{"issue url", "https://github.com/Automaat/sybra/issues/42", "Automaat/sybra"},
+		{"unregistered repo", "https://github.com/unknown/repo/issues/1", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchProjectFromIssue(tc.issue, projects)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

The triage classifier could clobber a task's already-authoritative `project_id` with a lower-confidence, content-similarity guess derived from title/body vocabulary overlap. A task's `t.ProjectID` (e.g. set by the GitHub issue fetcher at creation) should be sticky and win over the classifier's free-text match — but only while it still resolves to a registered project, so a renamed/deleted project doesn't permanently lock a task to an empty project type and silently skip work-typed forced-interactive/forced-planning routing.

## Implementation information

- `internal/triage/apply.go`: `Apply` now keeps the task's existing `ProjectID` only if it resolves to a registered project (`projectTypeFor` helper). If it doesn't resolve, re-resolution order is: the task's `Issue` URL (authoritative source-of-truth link) → the classifier's guess (`v.ProjectID`) → generic title/body scan (`MatchProject`).
- `internal/triage/projectmatch.go`: extracted `matchProjectInText` and added `MatchProjectFromIssue`, which matches a registered project against the task's `Issue` field specifically.
- `internal/triage/classifier.go`: the classifier prompt now surfaces `existing_project_id` and `issue_url` as system metadata when present, and instructs the model to leave `project_id` empty in that case instead of guessing from topical similarity.
- Added coverage in `apply_test.go` and `projectmatch_test.go` for the sticky-but-only-if-resolved behavior and the new issue-URL matcher.

Closes https://github.com/Automaat/sybra/issues/1640

_Generated by Sybra harness_