### PR TITLE
fix(project): sign off Sybra recovery commits

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -343,7 +343,7 @@ func AutoCommitUncommitted(ctx context.Context, wtPath, message string) bool {
 	commit := exec.CommandContext(ctx, "git",
 		"-c", "user.name=Sybra",
 		"-c", "user.email=sybra@localhost",
-		"commit", "--no-verify", "--no-gpg-sign", "-m", message)
+		"commit", "--no-verify", "--no-gpg-sign", "--signoff", "-m", message)
 	commit.Dir = wtPath
 	return commit.Run() == nil
 }
@@ -963,7 +963,7 @@ func MergeOnto(ctx context.Context, worktreePath, ref string) error {
 		"-c", "user.name=Sybra",
 		"-c", "user.email=sybra@localhost",
 		"-c", "commit.gpgsign=false",
-		"merge", "--no-edit", "--no-verify", ref); err != nil {
+		"merge", "--no-edit", "--no-verify", "--signoff", ref); err != nil {
 		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rebaseAbortTimeout)
 		_ = executil.Run(abortCtx, worktreePath, "git", "merge", "--abort")
 		cancel()
@@ -1028,7 +1028,7 @@ func TryCleanMerge(ctx context.Context, wtPath, baseRef string) (CleanMergeResul
 		"-c", "user.name=Sybra",
 		"-c", "user.email=sybra@localhost",
 		"-c", "commit.gpgsign=false",
-		"merge", "--no-edit", "--no-verify", baseRef)
+		"merge", "--no-edit", "--no-verify", "--signoff", baseRef)
 	if mergeErr != nil {
 		conflict := false
 		var exitErr *exec.ExitError

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -339,6 +339,14 @@ func TestAutoCommitUncommitted(t *testing.T) {
 		t.Errorf("commit message = %q, want %q", got, "wip: recovered work")
 	}
 
+	bodyOut, err := exec.Command("git", "-C", dir, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if !strings.Contains(string(bodyOut), "Signed-off-by: Sybra <sybra@localhost>") {
+		t.Errorf("commit body missing DCO trailer, got %q", bodyOut)
+	}
+
 	// Idempotent: nothing left to commit on the now-clean tree.
 	if got := AutoCommitUncommitted(context.Background(), dir, "wip: should not commit"); got {
 		t.Fatal("expected no commit on an already-clean tree")

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -344,7 +344,7 @@ func TestAutoCommitUncommitted(t *testing.T) {
 		t.Fatalf("git log: %v", err)
 	}
 	if !strings.Contains(string(bodyOut), "Signed-off-by: Sybra <sybra@localhost>") {
-		t.Errorf("commit body missing DCO trailer, got %q", bodyOut)
+		t.Errorf("commit body missing DCO trailer, got %q", string(bodyOut))
 	}
 
 	// Idempotent: nothing left to commit on the now-clean tree.


### PR DESCRIPTION
## Motivation

> Changelog: fix(project): sign off Sybra recovery commits

Task PRs were intermittently failing the DCO check even when the
agent's own commits were correctly signed off. Root cause: Sybra's
own safety-net recovery commits — `AutoCommitUncommitted` (sweeps up
uncommitted agent work before worktree reset) and the conflict-recovery
merges in `MergeOnto`/`TryCleanMerge` — were created with no
`Signed-off-by` trailer, so any PR that went through worktree
sanitization or conflict recovery picked up at least one unsigned
commit.

No history rewriting (rebase/amend/force-push) is involved anywhere in
this path — `EnforceForkOnlyPush`/`PushSync` already forbid it — so the
fix is simply to never create the unsigned commit in the first place.

## Implementation information

Added `--signoff` to the three `git commit`/`git merge` invocations in
`internal/project/git.go`:

- `AutoCommitUncommitted`
- `MergeOnto`
- `TryCleanMerge`

`--no-gpg-sign`/`commit.gpgsign=false` is kept — the fallback `Sybra
<sybra@localhost>` identity has no GPG signing key configured, so when
GPG isn't available these commits fall back to DCO signoff only (`-s`),
never a bare unsigned/unattributed commit.

Extended `TestAutoCommitUncommitted` to assert the resulting commit
body contains the `Signed-off-by:` trailer.

## Supporting documentation

N/A