### PR TITLE
fix(frontend): resync GUI plan-approval off workflow state

### DIFF
--- a/frontend/src/App.svelte.test.ts
+++ b/frontend/src/App.svelte.test.ts
@@ -23,6 +23,7 @@ vi.mock('./stores/tasks.svelte.js', () => ({
     error: '',
     list: [],
     byStatus: () => [],
+    tasksNeedingPlanApproval: () => [],
   },
 }))
 

--- a/frontend/src/components/shell/BottomTabBar.svelte
+++ b/frontend/src/components/shell/BottomTabBar.svelte
@@ -19,7 +19,7 @@
   )
 
   const reviewCount = $derived(
-    taskStore.byStatus('plan-review').length
+    taskStore.tasksNeedingPlanApproval().length
   )
 
   function tab(key: TabKey, action: () => void) {

--- a/frontend/src/components/shell/BottomTabBar.svelte.test.ts
+++ b/frontend/src/components/shell/BottomTabBar.svelte.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../lib/navigation.svelte.js', () => ({
   navStore: { reset: (...a: unknown[]) => mockReset(...a), get activeTab() { return 'board' } },
 }))
 vi.mock('../../stores/tasks.svelte.js', () => ({
-  taskStore: { byStatus: () => [] },
+  taskStore: { tasksNeedingPlanApproval: () => [] },
 }))
 vi.mock('../../stores/agents.svelte.js', () => ({
   agentStore: { get list() { return [] } },

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -19,7 +19,7 @@
   )
 
   const reviewCount = $derived(
-    taskStore.byStatus('plan-review').length
+    taskStore.tasksNeedingPlanApproval().length
   )
 
   interface NavItem {

--- a/frontend/src/components/shell/SideRail.svelte.test.ts
+++ b/frontend/src/components/shell/SideRail.svelte.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../lib/navigation.svelte.js', () => ({
 
 vi.mock('../../stores/tasks.svelte.js', () => ({
   taskStore: {
-    byStatus: vi.fn(() => []),
+    tasksNeedingPlanApproval: vi.fn(() => []),
   },
 }))
 

--- a/frontend/src/components/task-detail/AgentLauncher.svelte
+++ b/frontend/src/components/task-detail/AgentLauncher.svelte
@@ -2,6 +2,7 @@
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../../stores/agents.svelte.js'
   import { connectionStore } from '../../stores/connection.svelte.js'
+  import { needsPlanApproval } from '../../lib/statuses.js'
 
   interface Props {
     task: Task
@@ -45,10 +46,12 @@
   <p class="text-xs text-error-500">{error}</p>
 {/if}
 
-{#if task.status !== 'plan-review'}
-  <!-- A plan-review task's job is to approve/reject the plan (Plan tab), not
-       launch a new ad-hoc run, so the generic "new run" form is collapsed for
-       it. A live running agent still shows via LiveAgentPanel above the tabs. -->
+{#if !needsPlanApproval(task)}
+  <!-- A task awaiting plan approval's job is to approve/reject the plan (Plan
+       tab), not launch a new ad-hoc run, so the generic "new run" form is
+       collapsed for it. Keys off the workflow step (via needsPlanApproval) so a
+       manual status desync can't leak the form back in (issue #1642). A live
+       running agent still shows via LiveAgentPanel above the tabs. -->
   <div class="flex flex-col gap-3">
     <div class="flex flex-col gap-0.5">
       <span class="text-sm font-medium text-surface-500">New agent run</span>

--- a/frontend/src/components/task-detail/AgentLauncher.svelte.test.ts
+++ b/frontend/src/components/task-detail/AgentLauncher.svelte.test.ts
@@ -88,4 +88,30 @@ describe('AgentLauncher', () => {
     })
     expect(screen.queryByText('Start agent')).toBeNull()
   })
+
+  it('collapses the form when workflow awaits plan approval despite a desynced status', () => {
+    render(AgentLauncher, {
+      props: {
+        task: {
+          ...baseTask,
+          status: 'planning',
+          workflow: { currentStep: 'review_plan', state: 'waiting' },
+        } as never,
+      },
+    })
+    expect(screen.queryByText('Start agent')).toBeNull()
+  })
+
+  it('shows the form when the workflow has advanced past plan review despite a stale plan-review status', () => {
+    render(AgentLauncher, {
+      props: {
+        task: {
+          ...baseTask,
+          status: 'plan-review',
+          workflow: { currentStep: 'implement', state: 'running' },
+        } as never,
+      },
+    })
+    expect(screen.getByText('Start agent')).toBeDefined()
+  })
 })

--- a/frontend/src/components/task-detail/PlanReviewPanel.svelte
+++ b/frontend/src/components/task-detail/PlanReviewPanel.svelte
@@ -2,6 +2,7 @@
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { renderMarkdown } from '../../lib/markdown.js'
+  import { needsPlanApproval } from '../../lib/statuses.js'
   import PlanDecisionReview from './PlanDecisionReview.svelte'
 
   interface Props {
@@ -46,7 +47,7 @@
   }
 </script>
 
-{#if task.status === 'plan-review'}
+{#if needsPlanApproval(task)}
   <div class="flex flex-col gap-3 rounded-lg border border-tertiary-300 bg-tertiary-50 p-4 dark:border-tertiary-700 dark:bg-tertiary-900/30">
     <div class="flex items-center justify-between">
       <span class="text-sm font-semibold text-tertiary-700 dark:text-tertiary-300">Plan Review</span>

--- a/frontend/src/components/task-detail/PlanReviewPanel.svelte.test.ts
+++ b/frontend/src/components/task-detail/PlanReviewPanel.svelte.test.ts
@@ -66,4 +66,31 @@ describe('PlanReviewPanel', () => {
     render(PlanReviewPanel, { props: { task: baseTask as never, onreviewplan } })
     expect(screen.getByText('Review Plan →')).toBeDefined()
   })
+
+  it('renders when workflow is waiting on review_plan even if status desynced to planning', () => {
+    render(PlanReviewPanel, {
+      props: {
+        task: {
+          ...baseTask,
+          status: 'planning',
+          workflow: { currentStep: 'review_plan', state: 'waiting' },
+        } as never,
+      },
+    })
+    expect(screen.getByText('Approve Plan')).toBeDefined()
+    expect(screen.getByText('Reject Plan')).toBeDefined()
+  })
+
+  it('does not render when workflow has moved past review_plan even if status is stale plan-review', () => {
+    const { container } = render(PlanReviewPanel, {
+      props: {
+        task: {
+          ...baseTask,
+          status: 'plan-review',
+          workflow: { currentStep: 'implement', state: 'running' },
+        } as never,
+      },
+    })
+    expect(container.querySelector('button')).toBeNull()
+  })
 })

--- a/frontend/src/lib/statuses.test.ts
+++ b/frontend/src/lib/statuses.test.ts
@@ -151,4 +151,22 @@ describe('needsPlanApproval — keyed off workflow, not stale status (issue #164
       }),
     ).toBe(false)
   })
+
+  it('falls back to status when only currentStep is populated (state missing)', () => {
+    expect(
+      needsPlanApproval({
+        status: 'plan-review',
+        workflow: { currentStep: 'review_plan' },
+      }),
+    ).toBe(true)
+  })
+
+  it('falls back to status when only state is populated (currentStep missing)', () => {
+    expect(
+      needsPlanApproval({
+        status: 'plan-review',
+        workflow: { state: 'waiting' },
+      }),
+    ).toBe(true)
+  })
 })

--- a/frontend/src/lib/statuses.test.ts
+++ b/frontend/src/lib/statuses.test.ts
@@ -7,6 +7,7 @@ import {
   awaitsHuman,
   awaitsHumanLabel,
   coreStatus,
+  needsPlanApproval,
   statusLabel,
   statusOptionsFor,
   BOARD_COLUMNS,
@@ -112,5 +113,42 @@ describe('awaitsHumanLabel — canonical, never a divergent name', () => {
       if (AWAITS_HUMAN.has(meta.value)) continue
       expect(awaitsHumanLabel(meta.value)).toBe('')
     }
+  })
+})
+
+describe('needsPlanApproval — keyed off workflow, not stale status (issue #1642)', () => {
+  it('is true when status is plan-review and no workflow is attached', () => {
+    expect(needsPlanApproval({ status: 'plan-review' })).toBe(true)
+  })
+
+  it('is false when status is anything else and no workflow is attached', () => {
+    expect(needsPlanApproval({ status: 'planning' })).toBe(false)
+  })
+
+  it('is true when the workflow is waiting on review_plan, even if status desynced away from plan-review', () => {
+    expect(
+      needsPlanApproval({
+        status: 'planning',
+        workflow: { currentStep: 'review_plan', state: 'waiting' },
+      }),
+    ).toBe(true)
+  })
+
+  it('is false when the workflow has moved past review_plan, even if status is stale plan-review', () => {
+    expect(
+      needsPlanApproval({
+        status: 'plan-review',
+        workflow: { currentStep: 'implement', state: 'running' },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false when review_plan is reached but not yet waiting (still running)', () => {
+    expect(
+      needsPlanApproval({
+        status: 'plan-review',
+        workflow: { currentStep: 'review_plan', state: 'running' },
+      }),
+    ).toBe(false)
   })
 })

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -125,6 +125,28 @@ export function awaitsHuman(status: string): boolean {
 }
 
 /**
+ * True when a task has a plan sitting at the review_plan workflow step,
+ * waiting on a human approve/reject decision.
+ *
+ * Checks the workflow engine's own currentStep/state first, falling back to
+ * the top-level status only when no workflow is attached. This is what keeps
+ * the plan-approval affordance visible even if a manual `sybra-cli update
+ * --status` desyncs the task's outer status from its active workflow (see
+ * issue #1642) — the workflow, not the possibly-stale status string, is the
+ * source of truth for whether a human decision is actually pending.
+ */
+export function needsPlanApproval(task: {
+  status?: string
+  workflow?: { currentStep?: string; state?: string } | null
+}): boolean {
+  const wf = task.workflow
+  if (wf?.currentStep || wf?.state) {
+    return wf.currentStep === 'review_plan' && wf.state === 'waiting'
+  }
+  return task.status === 'plan-review'
+}
+
+/**
  * Canonical, human-facing label for a status — the label every status surface
  * (board pill, list cell, move popover) should resolve through so one state
  * reads the same wherever it appears. Unknown values pass through verbatim so

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -134,13 +134,19 @@ export function awaitsHuman(status: string): boolean {
  * --status` desyncs the task's outer status from its active workflow (see
  * issue #1642) — the workflow, not the possibly-stale status string, is the
  * source of truth for whether a human decision is actually pending.
+ *
+ * Requires *both* currentStep and state to be non-empty before trusting the
+ * workflow — a workflow with only one populated (e.g. an older serialized
+ * execution, or ExecState's zero value) is not a reliable signal either way,
+ * so falls back to status rather than risk a false negative that hides the
+ * approval UI.
  */
 export function needsPlanApproval(task: {
   status?: string
   workflow?: { currentStep?: string; state?: string } | null
 }): boolean {
   const wf = task.workflow
-  if (wf?.currentStep || wf?.state) {
+  if (wf?.currentStep && wf?.state) {
     return wf.currentStep === 'review_plan' && wf.state === 'waiting'
   }
   return task.status === 'plan-review'

--- a/frontend/src/pages/Reviews.svelte
+++ b/frontend/src/pages/Reviews.svelte
@@ -18,7 +18,7 @@
   let errorMsg = $state('')
   let hasLiveAgent = $state(false)
 
-  const allReviewTasks = $derived(taskStore.byStatus('plan-review'))
+  const allReviewTasks = $derived(taskStore.tasksNeedingPlanApproval())
 
   const selectedTask = $derived(
     selectedId ? taskStore.items.get(selectedId) ?? null : null,

--- a/frontend/src/pages/Reviews.svelte.test.ts
+++ b/frontend/src/pages/Reviews.svelte.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 
-const mockByStatus = vi.fn()
+const mockTasksNeedingPlanApproval = vi.fn()
 const mockApprovePlan = vi.fn()
 const mockRejectPlan = vi.fn()
 const mockSendPlanMessage = vi.fn()
@@ -14,7 +14,7 @@ const taskItemsMap = new Map<string, any>()
 vi.mock('../stores/tasks.svelte.js', () => ({
   taskStore: {
     get items() { return taskItemsMap },
-    byStatus: (...args: unknown[]) => mockByStatus(...args),
+    tasksNeedingPlanApproval: (...args: unknown[]) => mockTasksNeedingPlanApproval(...args),
     approvePlan: (...args: unknown[]) => mockApprovePlan(...args),
     rejectPlan: (...args: unknown[]) => mockRejectPlan(...args),
     sendPlanMessage: (...args: unknown[]) => mockSendPlanMessage(...args),
@@ -57,14 +57,14 @@ function makeTask(overrides: Record<string, unknown> = {}) {
 
 describe('Reviews', () => {
   beforeEach(() => {
-    mockByStatus.mockReset()
+    mockTasksNeedingPlanApproval.mockReset()
     mockApprovePlan.mockReset()
     mockRejectPlan.mockReset()
     mockSendPlanMessage.mockReset()
     mockHasLivePlanAgent.mockResolvedValue(false)
     mockCommentLoad.mockResolvedValue(undefined)
     mockUnresolvedCount.mockReturnValue(0)
-    mockByStatus.mockReturnValue([])
+    mockTasksNeedingPlanApproval.mockReturnValue([])
     taskItemsMap.clear()
   })
 
@@ -85,10 +85,7 @@ describe('Reviews', () => {
 
   it('renders review task titles in sidebar', () => {
     const task = makeTask({ id: 't1', title: 'Feature planning task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     render(Reviews)
     expect(screen.getByText('Feature planning task')).toBeDefined()
@@ -96,20 +93,14 @@ describe('Reviews', () => {
 
   it('shows count badge when review tasks exist', () => {
     const task = makeTask({ id: 't1' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     render(Reviews)
     expect(screen.getByText('1')).toBeDefined()
   })
 
   it('shows Plan badge for plan-review tasks', () => {
     const task = makeTask({ id: 't1', status: 'plan-review' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     render(Reviews)
     expect(screen.getByText('Plan')).toBeDefined()
   })
@@ -122,10 +113,7 @@ describe('Reviews', () => {
 
   it('shows task title in panel after selecting a task', async () => {
     const task = makeTask({ id: 't1', title: 'Auth refactor plan' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     render(Reviews)
     await fireEvent.click(screen.getByText('Auth refactor plan'))
@@ -136,10 +124,7 @@ describe('Reviews', () => {
 
   it('shows Approve and Reject buttons after selecting a task', async () => {
     const task = makeTask({ id: 't1', title: 'Plan task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     render(Reviews)
     await fireEvent.click(screen.getByText('Plan task'))
@@ -151,10 +136,7 @@ describe('Reviews', () => {
 
   it('calls approvePlan and clears selection on Approve', async () => {
     const task = makeTask({ id: 't1', title: 'Approve me' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockApprovePlan.mockResolvedValue({ ...task, status: 'todo' })
     render(Reviews)
@@ -170,10 +152,7 @@ describe('Reviews', () => {
 
   it('calls rejectPlan on Reject', async () => {
     const task = makeTask({ id: 't1', title: 'Reject me' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockRejectPlan.mockResolvedValue({ ...task, status: 'planning' })
     render(Reviews)
@@ -189,10 +168,7 @@ describe('Reviews', () => {
 
   it('shows error message when approve fails', async () => {
     const task = makeTask({ id: 't1', title: 'Failing task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockApprovePlan.mockRejectedValue(new Error('server error'))
     render(Reviews)
@@ -208,10 +184,7 @@ describe('Reviews', () => {
 
   it('shows task tags in sidebar', () => {
     const task = makeTask({ id: 't1', title: 'Tagged task', tags: ['backend', 'api'] })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     render(Reviews)
     expect(screen.getByText('backend')).toBeDefined()
     expect(screen.getByText('api')).toBeDefined()
@@ -219,10 +192,7 @@ describe('Reviews', () => {
 
   it('shows unresolved comment count badge', () => {
     const task = makeTask({ id: 't1', title: 'Commented task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     mockUnresolvedCount.mockReturnValue(3)
     render(Reviews)
     expect(screen.getByText('3')).toBeDefined()
@@ -230,20 +200,14 @@ describe('Reviews', () => {
 
   it('shows projectId in sidebar when set', () => {
     const task = makeTask({ id: 't1', title: 'Scoped task', projectId: 'owner/repo' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     render(Reviews)
     expect(screen.getByText('owner/repo')).toBeDefined()
   })
 
   it('shows View Task button when onviewtask is passed', async () => {
     const task = makeTask({ id: 't1', title: 'Linkable task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     const onviewtask = vi.fn()
     render(Reviews, { props: { onviewtask } })
@@ -257,10 +221,7 @@ describe('Reviews', () => {
 
   it('renders Send Message button (disabled until feedback and live agent)', async () => {
     const task = makeTask({ id: 't1', title: 'Send target' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockHasLivePlanAgent.mockResolvedValue(false)
     render(Reviews)
@@ -272,10 +233,7 @@ describe('Reviews', () => {
 
   it('calls sendPlanMessage when Send Message clicked with live agent and feedback', async () => {
     const task = makeTask({ id: 't1', title: 'Live agent task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockHasLivePlanAgent.mockResolvedValue(true)
     mockSendPlanMessage.mockResolvedValue(undefined)
@@ -293,10 +251,7 @@ describe('Reviews', () => {
   it('ignores stale live-agent availability results after switching tasks', async () => {
     const first = makeTask({ id: 't1', title: 'First task' })
     const second = makeTask({ id: 't2', title: 'Second task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [first, second]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([first, second])
     taskItemsMap.set('t1', first)
     taskItemsMap.set('t2', second)
 
@@ -335,10 +290,7 @@ describe('Reviews', () => {
       title: 'Critiqued task',
       planCritique: 'Plan needs more detail on auth',
     })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     render(Reviews)
     await fireEvent.click(screen.getByText('Critiqued task'))
@@ -349,10 +301,7 @@ describe('Reviews', () => {
 
   it('shows error message when reject fails', async () => {
     const task = makeTask({ id: 't1', title: 'Reject fails' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockRejectPlan.mockRejectedValue(new Error('reject error'))
     render(Reviews)
@@ -366,10 +315,7 @@ describe('Reviews', () => {
 
   it('shows unresolved comments banner in detail panel when count > 0', async () => {
     const task = makeTask({ id: 't1', title: 'Commented' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockUnresolvedCount.mockReturnValue(2)
     render(Reviews)
@@ -381,10 +327,7 @@ describe('Reviews', () => {
 
   it('uses singular comment label when only one unresolved', async () => {
     const task = makeTask({ id: 't1', title: 'One comment' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockUnresolvedCount.mockReturnValue(1)
     render(Reviews)
@@ -396,10 +339,7 @@ describe('Reviews', () => {
 
   it('approve "a" keypress triggers plan approval', async () => {
     const task = makeTask({ id: 't1', title: 'Keyboard task' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockApprovePlan.mockResolvedValue(undefined)
     render(Reviews)
@@ -413,10 +353,7 @@ describe('Reviews', () => {
 
   it('reject "r" keypress triggers plan rejection', async () => {
     const task = makeTask({ id: 't1', title: 'Reject keyboard' })
-    mockByStatus.mockImplementation((status: string) => {
-      if (status === 'plan-review') return [task]
-      return []
-    })
+    mockTasksNeedingPlanApproval.mockReturnValue([task])
     taskItemsMap.set('t1', task)
     mockRejectPlan.mockResolvedValue(undefined)
     render(Reviews)

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -14,6 +14,7 @@
   import LiveAgentPanel from '../components/task-detail/LiveAgentPanel.svelte'
   import AgentLauncher from '../components/task-detail/AgentLauncher.svelte'
   import AgentHistoryList from '../components/task-detail/AgentHistoryList.svelte'
+  import { needsPlanApproval } from '../lib/statuses.js'
 
   interface Props {
     taskId: string
@@ -37,7 +38,8 @@
   )
   // A plan-review task always needs a Plan tab to host the approve/reject
   // decision, even when its plan lives in the body rather than a sidecar.
-  const showPlanTab = $derived(hasPlan || t?.status === 'plan-review')
+  const pendingApproval = $derived(!!t && needsPlanApproval(t))
+  const showPlanTab = $derived(hasPlan || pendingApproval)
   const hasReview = $derived(
     !!(t && (t.codeReview || (t.agentRuns ?? []).some((r) => REVIEW_ROLES.has(r.role)))),
   )
@@ -45,7 +47,7 @@
 
   const tabs = $derived([
     { value: 'overview', label: 'Overview' },
-    ...(showPlanTab ? [{ value: 'plan', label: t?.status === 'plan-review' ? 'Plan ●' : 'Plan' }] : []),
+    ...(showPlanTab ? [{ value: 'plan', label: pendingApproval ? 'Plan ●' : 'Plan' }] : []),
     ...(hasReview ? [{ value: 'review', label: 'Review' }] : []),
     { value: 'runs', label: runsCount > 0 ? `Runs · ${runsCount}` : 'Runs' },
   ])
@@ -155,7 +157,7 @@
       <TaskHeaderBar task={t} {ondelete} />
       <TaskStatusBanner task={t} />
       <HumanRequiredPanel task={t} />
-      {#if t.status === 'plan-review' && activeTab !== 'plan'}
+      {#if pendingApproval && activeTab !== 'plan'}
         <!-- Default is Overview, so nudge the pending approve/reject to the fore. -->
         <button
           type="button"
@@ -189,7 +191,7 @@
 
           {#if showPlanTab}
             <section class={panelClass('plan', 'flex flex-col gap-4')}>
-              {#if t.status === 'plan-review'}
+              {#if pendingApproval}
                 <PlanReviewPanel task={t} {onreviewplan} />
               {:else}
                 <TaskPlanPanel task={t} />

--- a/frontend/src/stores/tasks.svelte.test.ts
+++ b/frontend/src/stores/tasks.svelte.test.ts
@@ -313,4 +313,36 @@ describe('TaskStore', () => {
       expect(taskStore.byStatus('all')).toHaveLength(2)
     })
   })
+
+  describe('tasksNeedingPlanApproval', () => {
+    it('includes a task whose workflow is waiting on review_plan even if status desynced away from plan-review', () => {
+      taskStore.tasks.set(
+        't1',
+        makeTask({
+          id: 't1',
+          status: 'planning',
+          workflow: { currentStep: 'review_plan', state: 'waiting' },
+        }),
+      )
+      taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'todo' }))
+
+      const result = taskStore.tasksNeedingPlanApproval()
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('t1')
+    })
+
+    it('excludes a task with a stale plan-review status once its workflow has moved on', () => {
+      taskStore.tasks.set(
+        't1',
+        makeTask({
+          id: 't1',
+          status: 'plan-review',
+          workflow: { currentStep: 'implement', state: 'running' },
+        }),
+      )
+
+      expect(taskStore.tasksNeedingPlanApproval()).toHaveLength(0)
+    })
+  })
 })

--- a/frontend/src/stores/tasks.svelte.ts
+++ b/frontend/src/stores/tasks.svelte.ts
@@ -13,6 +13,7 @@ import {
 } from '$lib/api'
 import { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
 import { EntityStore } from './entity-store.svelte.js'
+import { needsPlanApproval } from '../lib/statuses.js'
 
 class TaskStore extends EntityStore<Task> {
   // Per-id operation counter guarding the async patchOne against its own
@@ -59,6 +60,14 @@ class TaskStore extends EntityStore<Task> {
   byStatus(status: string): Task[] {
     if (status === 'all') return this.list
     return this.list.filter((t) => t.status === status)
+  }
+
+  // Tasks genuinely waiting on a plan approve/reject decision — keyed off the
+  // workflow engine's own currentStep/state rather than solely the top-level
+  // status, so a manual status update that desyncs from an active workflow
+  // (issue #1642) can't hide a pending decision from the review surfaces.
+  tasksNeedingPlanApproval(): Task[] {
+    return this.list.filter(needsPlanApproval)
   }
 
   async get(id: string): Promise<Task> {


### PR DESCRIPTION
## Motivation

A manual `sybra-cli update --status` can desync a task's top-level `status`
string from the state of its active workflow. When that happens, the GUI's
plan-approval affordance (approve/reject buttons, review surfaces) was keyed
solely off `status === 'plan-review'`, so a task genuinely waiting on a human
decision could silently lose its approval UI if the status field drifted.

## Implementation information

- Added `needsPlanApproval(task)` in `frontend/src/lib/statuses.ts`: checks
  the workflow engine's own `currentStep`/`state` first (`review_plan` +
  `waiting`), falling back to the top-level `status` only when no workflow is
  attached.
- Added `tasksNeedingPlanApproval()` to the task store
  (`frontend/src/stores/tasks.svelte.ts`), filtering via the new helper so
  review surfaces don't hide pending decisions after a manual status desync.
- Updated `AgentLauncher.svelte`, `PlanReviewPanel.svelte`, `Reviews.svelte`,
  and `TaskDetail.svelte` to key off workflow state instead of the raw
  status string.
- Added/updated tests covering the new helper and the affected components.

Closes https://github.com/Automaat/sybra/issues/1642

_Generated by Sybra harness_