### PR TITLE
feat(renovate): merge PRs pending stability

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -439,6 +439,7 @@ export class RenovatePR {
      */
     "restCiFetched": boolean;
     "checkRuns": CheckRunInfo[];
+    "waitingForStability": boolean;
 
     /** Creates a new RenovatePR instance. */
     constructor($$source: Partial<RenovatePR> = {}) {
@@ -525,6 +526,9 @@ export class RenovatePR {
         }
         if (!("checkRuns" in $$source)) {
             this["checkRuns"] = [];
+        }
+        if (!("waitingForStability" in $$source)) {
+            this["waitingForStability"] = false;
         }
 
         Object.assign(this, $$source);

--- a/frontend/src/components/RenovatePRCard.svelte
+++ b/frontend/src/components/RenovatePRCard.svelte
@@ -21,7 +21,7 @@
   const isEligible = $derived(
     !pr.isDraft &&
     pr.mergeable === 'MERGEABLE' &&
-    (pr.ciStatus === 'SUCCESS' || pr.ciStatus === '') &&
+    (pr.ciStatus === 'SUCCESS' || pr.ciStatus === '' || pr.waitingForStability) &&
     (pr.reviewDecision === 'APPROVED' || pr.reviewDecision === '')
   )
 
@@ -89,6 +89,9 @@
       <h3 class="text-sm font-semibold leading-tight">{pr.title}</h3>
     </div>
     <div class="flex shrink-0 items-center gap-1.5">
+      {#if pr.waitingForStability}
+        <span class="rounded bg-warning-500/15 px-1.5 py-0.5 text-xs font-medium text-warning-700 dark:text-warning-400" title="Waiting for Renovate stability days (minimum release age); otherwise green and mergeable">Stability days</span>
+      {/if}
       {#if pr.reviewDecision === 'APPROVED'}
         <span class="rounded bg-success-500/15 px-1.5 py-0.5 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
       {/if}

--- a/frontend/src/stores/renovate.svelte.ts
+++ b/frontend/src/stores/renovate.svelte.ts
@@ -17,7 +17,7 @@ class RenovateStore {
       (pr) =>
         !pr.isDraft &&
         pr.mergeable === 'MERGEABLE' &&
-        (pr.ciStatus === 'SUCCESS' || pr.ciStatus === ''),
+        (pr.ciStatus === 'SUCCESS' || pr.ciStatus === '' || pr.waitingForStability),
     )
   }
 

--- a/internal/github/check_filter.go
+++ b/internal/github/check_filter.go
@@ -70,6 +70,36 @@ func hasAnyPrefix(name string, prefixes []string) bool {
 	return false
 }
 
+var stabilityCheckPrefixes = []string{
+	"renovate/stability-days",
+	"renovate/minimum-release-age",
+}
+
+func isStabilityCheck(name string) bool {
+	return hasAnyPrefix(name, stabilityCheckPrefixes)
+}
+
+func renovateWaitingForStability(contexts []gqlCheckContext) bool {
+	var sawStabilityPending, sawOtherBlocker bool
+	for i := range contexts {
+		name := contexts[i].effectiveName()
+		if isStabilityCheck(name) {
+			if effectiveCheckState(contexts[i]) == "PENDING" {
+				sawStabilityPending = true
+			}
+			continue
+		}
+		if isNonGatingCheck(name) {
+			continue
+		}
+		switch effectiveCheckState(contexts[i]) {
+		case "FAILURE", "PENDING":
+			sawOtherBlocker = true
+		}
+	}
+	return sawStabilityPending && !sawOtherBlocker
+}
+
 // effectiveCheckState normalizes a single context to one of
 // SUCCESS/FAILURE/PENDING. Returns "" when the context is malformed
 // (no usable typename and no state fields).

--- a/internal/github/check_filter_test.go
+++ b/internal/github/check_filter_test.go
@@ -387,3 +387,59 @@ func TestConvertPRs_emptyContextsFallsBackToRollupState(t *testing.T) {
 		t.Fatalf("CIStatus = %q, want FAILURE (fallback)", prs[0].CIStatus)
 	}
 }
+
+func TestIsStabilityCheck(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"renovate/stability-days", true},
+		{"Renovate/Stability-Days", true},
+		{"renovate/minimum-release-age", true},
+		{"renovate/artifacts", false},
+		{"build", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isStabilityCheck(tt.name); got != tt.want {
+				t.Errorf("isStabilityCheck(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenovateWaitingForStability(t *testing.T) {
+	t.Parallel()
+	stabilityPending := gqlCheckContext{Typename: "StatusContext", Name: "renovate/stability-days", State: "PENDING"}
+	buildOK := gqlCheckContext{Typename: "CheckRun", Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"}
+	buildPending := gqlCheckContext{Typename: "CheckRun", Name: "build", Status: "IN_PROGRESS"}
+	buildFail := gqlCheckContext{Typename: "CheckRun", Name: "build", Status: "COMPLETED", Conclusion: "FAILURE"}
+	codecovPending := gqlCheckContext{Typename: "StatusContext", Name: "codecov/patch", State: "PENDING"}
+	stabilitySuccess := gqlCheckContext{Typename: "StatusContext", Name: "renovate/stability-days", State: "SUCCESS"}
+
+	tests := []struct {
+		name     string
+		contexts []gqlCheckContext
+		want     bool
+	}{
+		{"stability sole blocker", []gqlCheckContext{stabilityPending, buildOK}, true},
+		{"stability only", []gqlCheckContext{stabilityPending}, true},
+		{"stability plus other pending", []gqlCheckContext{stabilityPending, buildPending}, false},
+		{"stability plus failure", []gqlCheckContext{stabilityPending, buildFail}, false},
+		{"non-gating pending ignored", []gqlCheckContext{stabilityPending, codecovPending, buildOK}, true},
+		{"stability already passed", []gqlCheckContext{stabilitySuccess, buildOK}, false},
+		{"no stability check", []gqlCheckContext{buildOK}, false},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := renovateWaitingForStability(tt.contexts); got != tt.want {
+				t.Errorf("renovateWaitingForStability() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -85,7 +85,8 @@ type CheckRunInfo struct {
 // RenovatePR extends PullRequest with individual check run details.
 type RenovatePR struct {
 	PullRequest
-	CheckRuns []CheckRunInfo `json:"checkRuns"`
+	CheckRuns           []CheckRunInfo `json:"checkRuns"`
+	WaitingForStability bool           `json:"waitingForStability"`
 }
 
 // Issue represents a GitHub issue for display.

--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -173,8 +173,10 @@ func convertRenovatePRs(nodes []gqlPR, viewer string) []RenovatePR {
 		pr := convertCommonPR(n, viewer)
 
 		var checks []CheckRunInfo
+		var waitingForStability bool
 		if len(n.Commits.Nodes) > 0 {
 			if rollup := n.Commits.Nodes[0].Commit.StatusCheckRollup; rollup != nil {
+				waitingForStability = renovateWaitingForStability(rollup.Contexts.Nodes)
 				for _, ctx := range rollup.Contexts.Nodes {
 					if ctx.Name == "" {
 						continue
@@ -188,7 +190,7 @@ func convertRenovatePRs(nodes []gqlPR, viewer string) []RenovatePR {
 			}
 		}
 
-		prs = append(prs, RenovatePR{PullRequest: pr, CheckRuns: checks})
+		prs = append(prs, RenovatePR{PullRequest: pr, CheckRuns: checks, WaitingForStability: waitingForStability})
 	}
 	return prs
 }


### PR DESCRIPTION
## Motivation

Some Renovate PRs are fully green except for a pending stability-days check (Renovate's minimumReleaseAge / stabilityDays gate) — the dependency is fine, it is just younger than the configured minimum release age. Today these show a generic amber "CI: pending" dot in the Renovate tab, the Merge button is hidden, and there is no way to merge them from Sybra.

> Changelog: feat(renovate): merge PRs pending stability

## Implementation information

Backend (internal/github):

- renovateWaitingForStability detects when a pending stability check is the only blocker: stability pending, no gating failure, no other gating check pending. Non-gating reporters (codecov, copilot) are ignored, matching the existing CIStatus rollup. Stability contexts match by prefix (renovate/stability-days, renovate/minimum-release-age).
- New RenovatePR.WaitingForStability bool field, computed in convertRenovatePRs. The stability check stays in the rollup so CIStatus still honestly reads PENDING.
- Wails bindings regenerated (models.ts).

Frontend:

- RenovatePRCard shows a "Stability days" badge and includes waitingForStability in merge eligibility, so the Merge button appears.
- renovateStore.eligible honors the same flag.

Tests: TestIsStabilityCheck, TestRenovateWaitingForStability.

## Supporting documentation

mise run verify passes. The one e2e failure (TestE2E_ConcurrentWorkflows) is a pre-existing flake that passes in isolation and is unrelated to this change, which only touches internal/github and the frontend.
