### PR TITLE
fix(worktree): run setup/checks from trusted default branch

### DIFF
--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -999,13 +999,16 @@ func TestShutdownWithGrace_WaitsForDoneChannels(t *testing.T) {
 	m.mu.Unlock()
 
 	// Close done after a short delay — models a well-behaved subprocess
-	// noticing SIGTERM and flushing its result before exiting.
+	// noticing SIGTERM and flushing its result before exiting. start is
+	// sampled before launching the goroutine: sampling it after left a
+	// window where a delayed scheduler could run the sleep first, making
+	// elapsed (measured from start) read under 30ms despite a real wait.
+	start := time.Now()
 	go func() {
 		time.Sleep(30 * time.Millisecond)
 		close(done)
 	}()
 
-	start := time.Now()
 	m.ShutdownWithGrace(500 * time.Millisecond)
 	elapsed := time.Since(start)
 	if elapsed > 300*time.Millisecond {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -95,13 +95,17 @@ func LoadRepoConfigAtDefaultBranch(ctx context.Context, barePath string) (*RepoC
 		return nil, fmt.Errorf("resolve default branch: %w", err)
 	}
 	data, found, err := showFileAtRef(ctx, barePath, "refs/remotes/origin/"+branch, ".sybra.yaml")
-	if err != nil {
-		// The remote-tracking ref may be absent (e.g. never fetched) — fall
-		// back to the local head, mirroring TrackedFilesAtDefaultBranch.
+	if errors.Is(err, errRefUnresolved) {
+		// The remote-tracking ref is genuinely absent (e.g. never fetched) — fall
+		// back to the local head, mirroring TrackedFilesAtDefaultBranch. Only a
+		// ref-resolution failure triggers this: a transient error (context
+		// cancellation, disk hiccup) must propagate rather than silently serve
+		// the frozen refs/heads/<branch>, which review/fix worktrees never
+		// advance and so may be stale.
 		data, found, err = showFileAtRef(ctx, barePath, "refs/heads/"+branch, ".sybra.yaml")
-		if err != nil {
-			return nil, fmt.Errorf("read .sybra.yaml at default branch %s: %w", branch, err)
-		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read .sybra.yaml at default branch %s: %w", branch, err)
 	}
 	if !found {
 		return &RepoConfig{}, nil
@@ -113,12 +117,20 @@ func LoadRepoConfigAtDefaultBranch(ctx context.Context, barePath string) (*RepoC
 	return &cfg, nil
 }
 
+// errRefUnresolved marks a showFileAtRef failure where ref itself does not
+// resolve (e.g. a remote-tracking ref that was never fetched). Callers use
+// errors.Is to distinguish this recoverable "try another ref" case from a
+// transient failure (context cancellation, disk error) that must propagate
+// instead of silently falling back to a possibly-stale ref.
+var errRefUnresolved = errors.New("ref does not resolve")
+
 // showFileAtRef returns the bytes of path as tracked at ref in the bare repo
 // via `git show`, without ever materializing a worktree checkout. found is
 // false with a nil error when ref resolves but path is not tracked there —
-// callers treat that the same as a missing file. Any other failure (most
-// commonly ref itself not resolving) is returned as an error so the caller
-// can try a fallback ref.
+// callers treat that the same as a missing file. A ref that does not resolve
+// is returned wrapped in errRefUnresolved so the caller can try a fallback
+// ref; any other failure (e.g. context cancellation) is returned as a plain
+// error so it propagates rather than triggering a fallback.
 func showFileAtRef(ctx context.Context, barePath, ref, path string) (data []byte, found bool, err error) {
 	cmd := exec.CommandContext(ctx, "git", "-c", "safe.bareRepository=all", "show", ref+":"+path)
 	cmd.Dir = barePath
@@ -129,8 +141,14 @@ func showFileAtRef(ctx context.Context, barePath, ref, path string) (data []byte
 	var exitErr *exec.ExitError
 	if errors.As(runErr, &exitErr) {
 		stderr := string(exitErr.Stderr)
-		if strings.Contains(stderr, "does not exist in") || strings.Contains(stderr, "exists on disk, but not in") {
+		switch {
+		case strings.Contains(stderr, "does not exist in") || strings.Contains(stderr, "exists on disk, but not in"):
 			return nil, false, nil
+		case strings.Contains(stderr, "invalid object name") ||
+			strings.Contains(stderr, "unknown revision") ||
+			strings.Contains(stderr, "bad revision") ||
+			strings.Contains(stderr, "ambiguous argument"):
+			return nil, false, fmt.Errorf("git show %s:%s: %w: %w", ref, path, errRefUnresolved, runErr)
 		}
 	}
 	return nil, false, fmt.Errorf("git show %s:%s: %w", ref, path, runErr)

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -79,6 +79,63 @@ func LoadRepoConfig(worktreePath string) (*RepoConfig, error) {
 	return &cfg, nil
 }
 
+// LoadRepoConfigAtDefaultBranch reads .sybra.yaml as tracked at the project's
+// default branch in the bare clone, never from a checked-out worktree.
+// Callers preparing a worktree for an untrusted ref (a PR head, possibly from
+// a fork, or a Renovate branch) must use this instead of LoadRepoConfig: that
+// checked-out ref's own .sybra.yaml is attacker-controlled, and its
+// setup:/checks: commands run via `sh -c` outside the agent permission model
+// (see LoadRepoConfig's callers in internal/worktree for the trusted case,
+// where the checked-out branch is one Sybra created off this same default
+// branch). Returns an empty RepoConfig (not an error) if the file is not
+// tracked at that ref.
+func LoadRepoConfigAtDefaultBranch(ctx context.Context, barePath string) (*RepoConfig, error) {
+	branch, err := DefaultBranch(ctx, barePath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve default branch: %w", err)
+	}
+	data, found, err := showFileAtRef(ctx, barePath, "refs/remotes/origin/"+branch, ".sybra.yaml")
+	if err != nil {
+		// The remote-tracking ref may be absent (e.g. never fetched) — fall
+		// back to the local head, mirroring TrackedFilesAtDefaultBranch.
+		data, found, err = showFileAtRef(ctx, barePath, "refs/heads/"+branch, ".sybra.yaml")
+		if err != nil {
+			return nil, fmt.Errorf("read .sybra.yaml at default branch %s: %w", branch, err)
+		}
+	}
+	if !found {
+		return &RepoConfig{}, nil
+	}
+	var cfg RepoConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse .sybra.yaml: %w", err)
+	}
+	return &cfg, nil
+}
+
+// showFileAtRef returns the bytes of path as tracked at ref in the bare repo
+// via `git show`, without ever materializing a worktree checkout. found is
+// false with a nil error when ref resolves but path is not tracked there —
+// callers treat that the same as a missing file. Any other failure (most
+// commonly ref itself not resolving) is returned as an error so the caller
+// can try a fallback ref.
+func showFileAtRef(ctx context.Context, barePath, ref, path string) (data []byte, found bool, err error) {
+	cmd := exec.CommandContext(ctx, "git", "-c", "safe.bareRepository=all", "show", ref+":"+path)
+	cmd.Dir = barePath
+	out, runErr := cmd.Output()
+	if runErr == nil {
+		return out, true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		stderr := string(exitErr.Stderr)
+		if strings.Contains(stderr, "does not exist in") || strings.Contains(stderr, "exists on disk, but not in") {
+			return nil, false, nil
+		}
+	}
+	return nil, false, fmt.Errorf("git show %s:%s: %w", ref, path, runErr)
+}
+
 // InstallHooks writes pre-commit and pre-push git hooks into the worktree's
 // hooks directory. Existing hooks are overwritten. No-op if checks is nil or
 // both slices are empty.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -931,6 +931,74 @@ func TestLoadRepoConfig_Invalid(t *testing.T) {
 	}
 }
 
+func TestLoadRepoConfigAtDefaultBranch_Missing(t *testing.T) {
+	t.Parallel()
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	cfg, err := LoadRepoConfigAtDefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil || cfg.Setup != nil {
+		t.Errorf("expected empty RepoConfig, got %+v", cfg)
+	}
+}
+
+// TestLoadRepoConfigAtDefaultBranch_IgnoresOtherBranches is the regression
+// for issue #1519: a caller preparing an untrusted-ref worktree (a PR head,
+// possibly from a fork, or a Renovate branch) must only ever see the
+// .sybra.yaml tracked at the project's default branch, never a branch's own
+// (potentially attacker-controlled) version of the file.
+func TestLoadRepoConfigAtDefaultBranch_IgnoresOtherBranches(t *testing.T) {
+	t.Parallel()
+	src := initRepoWithCommit(t)
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	defaultBranch, err := CurrentBranch(context.Background(), src)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(src, ".sybra.yaml"), []byte("setup:\n  - touch trusted-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "trusted config")
+
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	srcGit("checkout", "-b", "attacker-branch")
+	if err := os.WriteFile(filepath.Join(src, ".sybra.yaml"), []byte("setup:\n  - touch evil-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "malicious config")
+	srcGit("checkout", defaultBranch)
+
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+
+	cfg, err := LoadRepoConfigAtDefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("LoadRepoConfigAtDefaultBranch: %v", err)
+	}
+	if len(cfg.Setup) != 1 || cfg.Setup[0] != "touch trusted-marker" {
+		t.Errorf("Setup = %v, want only the default-branch config", cfg.Setup)
+	}
+}
+
 func TestInstallHooks_RepoConfigPriority(t *testing.T) {
 	t.Parallel()
 	_, wtPath := initWorktree(t)

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -923,6 +923,74 @@ func TestLoadRepoConfig_Invalid(t *testing.T) {
 	}
 }
 
+func TestLoadRepoConfigAtDefaultBranch_Missing(t *testing.T) {
+	t.Parallel()
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	cfg, err := LoadRepoConfigAtDefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil || cfg.Setup != nil {
+		t.Errorf("expected empty RepoConfig, got %+v", cfg)
+	}
+}
+
+// TestLoadRepoConfigAtDefaultBranch_IgnoresOtherBranches is the regression
+// for issue #1519: a caller preparing an untrusted-ref worktree (a PR head,
+// possibly from a fork, or a Renovate branch) must only ever see the
+// .sybra.yaml tracked at the project's default branch, never a branch's own
+// (potentially attacker-controlled) version of the file.
+func TestLoadRepoConfigAtDefaultBranch_IgnoresOtherBranches(t *testing.T) {
+	t.Parallel()
+	src := initRepoWithCommit(t)
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	defaultBranch, err := CurrentBranch(context.Background(), src)
+	if err != nil {
+		t.Fatalf("current branch: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(src, ".sybra.yaml"), []byte("setup:\n  - touch trusted-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "trusted config")
+
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	srcGit("checkout", "-b", "attacker-branch")
+	if err := os.WriteFile(filepath.Join(src, ".sybra.yaml"), []byte("setup:\n  - touch evil-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "malicious config")
+	srcGit("checkout", defaultBranch)
+
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+
+	cfg, err := LoadRepoConfigAtDefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("LoadRepoConfigAtDefaultBranch: %v", err)
+	}
+	if len(cfg.Setup) != 1 || cfg.Setup[0] != "touch trusted-marker" {
+		t.Errorf("Setup = %v, want only the default-branch config", cfg.Setup)
+	}
+}
+
 func TestInstallHooks_RepoConfigPriority(t *testing.T) {
 	t.Parallel()
 	_, wtPath := initWorktree(t)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -313,7 +313,9 @@ type worktreeGetterAdapter struct {
 }
 
 // checkConfigGetterAdapter resolves a task's verify-suite commands by merging
-// the repo `.sybra.yaml` checks with the app-level project config.
+// the repo `.sybra.yaml` checks (read from the project's trusted default
+// branch, never the checked-out worktree — see resolveTrustedSetupCommands
+// and issue #1519) with the app-level project config.
 type checkConfigGetterAdapter struct {
 	tasks    *task.Manager
 	projects *project.Store
@@ -371,13 +373,18 @@ func (a *checkConfigGetterAdapter) VerifyCommands(taskID string) []string {
 		return nil
 	}
 	var repoChecks *project.ChecksConfig
-	if repoCfg, rErr := project.LoadRepoConfig(wtPath); rErr == nil && repoCfg != nil {
-		repoChecks = repoCfg.Checks
-	}
 	var appChecks *project.ChecksConfig
 	if t.ProjectID != "" {
 		if p, pErr := a.projects.Get(t.ProjectID); pErr == nil {
 			appChecks = p.Checks
+			// Read checks.verify from the project's trusted default branch,
+			// never the checked-out worktree: the worktree's own .sybra.yaml
+			// may carry a malicious `checks.verify` planted by a compromised
+			// or prompt-injected agent, and these commands run unsandboxed
+			// via `sh -c` (see resolveTrustedSetupCommands, issue #1519).
+			if repoCfg, rErr := project.LoadRepoConfigAtDefaultBranch(context.Background(), p.ClonePath); rErr == nil && repoCfg != nil {
+				repoChecks = repoCfg.Checks
+			}
 		}
 	}
 	merged := project.MergeChecks(repoChecks, appChecks)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -363,7 +363,7 @@ func (a *manualTestConfigGetterAdapter) ManualTestConfig(taskID string) workflow
 	}
 }
 
-func (a *checkConfigGetterAdapter) VerifyCommands(taskID string) []string {
+func (a *checkConfigGetterAdapter) VerifyCommands(ctx context.Context, taskID string) []string {
 	t, err := a.tasks.Get(taskID)
 	if err != nil {
 		return nil
@@ -382,7 +382,9 @@ func (a *checkConfigGetterAdapter) VerifyCommands(taskID string) []string {
 			// may carry a malicious `checks.verify` planted by a compromised
 			// or prompt-injected agent, and these commands run unsandboxed
 			// via `sh -c` (see resolveTrustedSetupCommands, issue #1519).
-			if repoCfg, rErr := project.LoadRepoConfigAtDefaultBranch(context.Background(), p.ClonePath); rErr == nil && repoCfg != nil {
+			// ctx carries the caller's verify-step deadline so a hung
+			// git show/symbolic-ref on the bare repo can't block indefinitely.
+			if repoCfg, rErr := project.LoadRepoConfigAtDefaultBranch(ctx, p.ClonePath); rErr == nil && repoCfg != nil {
 				repoChecks = repoCfg.Checks
 			}
 		}

--- a/internal/sybra/app_workflow_adversarial_test.go
+++ b/internal/sybra/app_workflow_adversarial_test.go
@@ -1,0 +1,119 @@
+package sybra
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+// TestAdversarialVerifyCommandsIgnoreWorktreeRepoConfig is the regression for
+// issue #1519's checks.verify half: verify_checks executes
+// checkConfigGetterAdapter.VerifyCommands' result unsandboxed via `sh -c`
+// (engine_steps_verify_checks.go), so those commands must never be sourced
+// from the checked-out worktree's own .sybra.yaml — a compromised or
+// prompt-injected agent could plant a malicious checks.verify block there and
+// get it executed on the next verify pass. Only the project's trusted
+// default-branch .sybra.yaml (or the app-level project config) may supply
+// verify commands.
+func TestAdversarialVerifyCommandsIgnoreWorktreeRepoConfig(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	for _, args := range [][]string{
+		{"init", "-b", "main", src},
+		{"-C", src, "config", "user.email", "test@test.com"},
+		{"-C", src, "config", "user.name", "Test"},
+		{"-C", src, "config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "init")
+
+	bare := filepath.Join(tmp, "origin.git")
+	if out, err := exec.Command("git", "clone", "--bare", src, bare).CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+		t.Fatalf("git config: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+		t.Fatalf("git fetch: %v: %s", err, out)
+	}
+
+	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Project-level trusted config: not the checked-out worktree, and the
+	// default-branch .sybra.yaml has no checks.verify of its own, so this is
+	// the command MergeChecks must fall back to.
+	projYAML := "id: owner/repo\nname: repo\nowner: owner\nrepo: repo\nurl: " + bare +
+		"\nclone_path: " + bare + "\ntype: pet\nchecks:\n  verify:\n    - echo TRUSTED_DEFAULT_BRANCH\n"
+	if err := os.WriteFile(filepath.Join(tmp, "projects", "owner--repo.yaml"), []byte(projYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	taskStore, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+	tk, err := taskMgr.Create("adversarial verify commands", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := "owner/repo"
+	tk, err = taskMgr.Update(tk.ID, task.Update{ProjectID: &projectID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: filepath.Join(tmp, "worktrees"),
+		Projects:     projects,
+		Tasks:        taskMgr,
+		Logger:       logger,
+	})
+
+	wtPath, err := wm.PrepareForTask(t.Context(), tk, nil)
+	if err != nil {
+		t.Fatalf("PrepareForTask: %v", err)
+	}
+
+	// Attacker-controlled .sybra.yaml planted directly in the task's own
+	// worktree (e.g. by a compromised implementation agent).
+	if err := os.WriteFile(filepath.Join(wtPath, ".sybra.yaml"), []byte("checks:\n  verify:\n    - echo UNTRUSTED_WORKTREE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	getter := &checkConfigGetterAdapter{
+		tasks:    taskMgr,
+		projects: projects,
+		mgr:      wm,
+	}
+
+	got := getter.VerifyCommands(tk.ID)
+	if len(got) != 1 || got[0] != "echo TRUSTED_DEFAULT_BRANCH" {
+		t.Fatalf("VerifyCommands = %#v, want only trusted default-branch command", got)
+	}
+}

--- a/internal/sybra/app_workflow_adversarial_test.go
+++ b/internal/sybra/app_workflow_adversarial_test.go
@@ -112,7 +112,7 @@ func TestAdversarialVerifyCommandsIgnoreWorktreeRepoConfig(t *testing.T) {
 		mgr:      wm,
 	}
 
-	got := getter.VerifyCommands(tk.ID)
+	got := getter.VerifyCommands(t.Context(), tk.ID)
 	if len(got) != 1 || got[0] != "echo TRUSTED_DEFAULT_BRANCH" {
 		t.Fatalf("VerifyCommands = %#v, want only trusted default-branch command", got)
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -138,7 +138,7 @@ type BranchSyncer interface {
 // suite configured — the verify_checks step then becomes a no-op. Engine
 // operates with a nil getter (step skips), so unit tests need not wire one.
 type CheckConfigGetter interface {
-	VerifyCommands(taskID string) []string
+	VerifyCommands(ctx context.Context, taskID string) []string
 }
 
 // ManualTestConfigGetter resolves repo/project-declared black-box testing hints.

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -70,7 +70,15 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 	if e.checks == nil {
 		return stepDone(step, "skipped: no check config getter")
 	}
-	cmds := e.checks.VerifyCommands(taskID)
+
+	timeout := e.verifyTimeout
+	if timeout <= 0 {
+		timeout = verifyChecksDefaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(e.ctx, timeout)
+	defer cancel()
+
+	cmds := e.checks.VerifyCommands(ctx, taskID)
 	if len(cmds) == 0 {
 		return stepDone(step, "skipped: no verify commands configured")
 	}
@@ -81,13 +89,6 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 	if !ok {
 		return stepDone(step, "skipped: no worktree for task")
 	}
-
-	timeout := e.verifyTimeout
-	if timeout <= 0 {
-		timeout = verifyChecksDefaultTimeout
-	}
-	ctx, cancel := context.WithTimeout(e.ctx, timeout)
-	defer cancel()
 
 	maybeMiseTrust(ctx, wtPath)
 	failedCmd, output, runErr := e.runVerifyCommands(ctx, taskID, wtPath, cmds)

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -9,7 +9,7 @@ import (
 
 type fakeCheckGetter struct{ cmds []string }
 
-func (f *fakeCheckGetter) VerifyCommands(string) []string { return f.cmds }
+func (f *fakeCheckGetter) VerifyCommands(context.Context, string) []string { return f.cmds }
 
 func newVerifyChecksStep() *Step { return &Step{ID: "verify_checks", Type: StepVerifyChecks} }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -574,7 +574,12 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	}
 	m.ensureBranch(t, branch)
 	m.logger.Info("branch-fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetupNonGating(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
+	// Read setup from the trusted default branch, never the checked-out worktree:
+	// this branch already carries commits an implementation agent pushed in an
+	// earlier run, so its own .sybra.yaml is not Sybra-authored and a compromised
+	// agent could plant a malicious setup: block that runs via unsandboxed
+	// `sh -c` (same class as issue #1519 — see resolveTrustedSetupCommands).
+	if err := m.runSetupNonGating(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
 		return "", fmt.Errorf("branch-fix setup: %w", err)
 	}
 	// pr-fix-role recovery runs must push straight to origin (the task's own

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -507,7 +507,7 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 		return "", fmt.Errorf("create review worktree: %w", err)
 	}
 	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
+	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
 		return "", fmt.Errorf("review setup: %w", err)
 	}
 	return wtPath, nil
@@ -659,7 +659,7 @@ func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) 
 	}
 	m.ensureBranch(t, branch)
 	m.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetupNonGating(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
+	if err := m.runSetupNonGating(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
 		return "", fmt.Errorf("fix setup: %w", err)
 	}
 	// pr-fix tasks must push to the existing PR's head branch on origin — not

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -220,6 +220,35 @@ func (m *Manager) resolveSetupCommands(wtPath string, proj project.Project) []st
 	return merged
 }
 
+// resolveTrustedSetupCommands loads .sybra.yaml from the project's default
+// branch in the bare clone — never the checked-out worktree — and merges its
+// `setup:` block with the project's app-level SetupCommands. Use this instead
+// of resolveSetupCommands whenever the worktree's checked-out ref is
+// untrusted (PrepareForReview/PrepareForFix check out a PR head, which may be
+// a fork or a Renovate branch): that ref's own .sybra.yaml is
+// attacker-controlled, and its setup commands run via `sh -c` outside the
+// agent permission model (issue #1519).
+func (m *Manager) resolveTrustedSetupCommands(ctx context.Context, proj project.Project) []string {
+	repoCfg, err := project.LoadRepoConfigAtDefaultBranch(ctx, proj.ClonePath)
+	if err != nil {
+		m.logger.Warn("worktree.repo-config-setup-trusted",
+			"project", proj.ID, "err", err)
+		return proj.SetupCommands
+	}
+	var repoSetup []string
+	if repoCfg != nil {
+		repoSetup = repoCfg.Setup
+	}
+	merged := project.MergeSetup(repoSetup, proj.SetupCommands)
+	if len(merged) > 0 {
+		m.logger.Info("worktree.setup-resolved-trusted",
+			"project", proj.ID,
+			"repo_cmds", len(repoSetup), "app_cmds", len(proj.SetupCommands),
+			"total", len(merged))
+	}
+	return merged
+}
+
 func (m *Manager) installChecks(ctx context.Context, wtPath string, proj project.Project) {
 	repoCfg, err := project.LoadRepoConfig(wtPath)
 	if err != nil {

--- a/internal/worktree/setup_trust_test.go
+++ b/internal/worktree/setup_trust_test.go
@@ -1,0 +1,138 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestPrepareForFix_UntrustedRepoSetupNotExecuted is the regression for issue
+// #1519: PrepareForFix checks out a PR's head branch (possibly a fork, or a
+// Renovate branch), which is attacker-controlled content. A .sybra.yaml
+// `setup:` command declared there must never run — only the project's
+// default-branch .sybra.yaml (trusted, since Sybra itself controls what
+// lands there via reviewed PRs) is a valid source of setup commands.
+func TestPrepareForFix_UntrustedRepoSetupNotExecuted(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	// Trusted config on main: this must run.
+	if err := os.WriteFile(filepath.Join(h.src, ".sybra.yaml"), []byte("setup:\n  - touch trusted-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "trusted setup")
+
+	const prNumber = 42
+	const branch = "renovate/bump-dep"
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, ".sybra.yaml"), []byte("setup:\n  - touch evil-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "malicious setup override")
+	srcGit("checkout", "main")
+
+	h.m.prBranch = func(_ string, _ int) (string, error) { return branch, nil }
+
+	tk, err := h.tasks.Create("fix renovate pr", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{"project_id": h.proj.ID})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForFix(context.Background(), tk, prNumber)
+	if err != nil {
+		t.Fatalf("PrepareForFix: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(wtPath, "evil-marker")); err == nil {
+		t.Fatal("malicious setup command from the untrusted PR branch's .sybra.yaml was executed")
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "trusted-marker")); err != nil {
+		t.Errorf("trusted default-branch setup command did not run: %v", err)
+	}
+}
+
+// TestPrepareForReview_UntrustedRepoSetupNotExecuted mirrors
+// TestPrepareForFix_UntrustedRepoSetupNotExecuted for the read-only review
+// worktree, whose checked-out ref is a fork PR's head via
+// refs/pull/<N>/head — never reachable as an origin branch.
+func TestPrepareForReview_UntrustedRepoSetupNotExecuted(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	// Trusted config on main: this must run.
+	if err := os.WriteFile(filepath.Join(h.src, ".sybra.yaml"), []byte("setup:\n  - touch trusted-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "trusted setup")
+
+	const prNumber = 55
+	const forkBranch = "fork/pr-branch"
+	srcGit("checkout", "-b", forkBranch)
+	if err := os.WriteFile(filepath.Join(h.src, ".sybra.yaml"), []byte("setup:\n  - touch evil-marker\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "malicious setup override")
+	shaOut, err := exec.Command("git", "-C", h.src, "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse: %v: %s", err, shaOut)
+	}
+	prSHA := strings.TrimSpace(string(shaOut))
+	// Only reachable via refs/pull/<N>/head, mirroring a fork PR — never
+	// lands under refs/remotes/origin/*.
+	srcGit("update-ref", "refs/pull/55/head", prSHA)
+	srcGit("checkout", "main")
+	srcGit("branch", "-D", forkBranch)
+
+	h.m.prBranch = func(_ string, _ int) (string, error) { return forkBranch, nil }
+
+	tk, err := h.tasks.Create("review fork pr", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"pr_number":  prNumber,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForReview(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForReview: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(wtPath, "evil-marker")); err == nil {
+		t.Fatal("malicious setup command from the untrusted PR head's .sybra.yaml was executed")
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "trusted-marker")); err != nil {
+		t.Errorf("trusted default-branch setup command did not run: %v", err)
+	}
+}


### PR DESCRIPTION
## Motivation

`resolveSetupCommands`/`LoadRepoConfig` read `.sybra.yaml` from the checked-out worktree. For review, fix, and branch-fix worktrees, the checked-out ref is untrusted (a PR head, possibly from a fork, or a branch a prior agent run already pushed to) — its `setup:`/`checks.verify` blocks run via unsandboxed `sh -c`, so a compromised or prompt-injected agent could plant arbitrary commands there and have Sybra execute them.

## Implementation information

- Added `project.LoadRepoConfigAtDefaultBranch`, which reads `.sybra.yaml` via `git show` against the project's default branch in the bare clone (falling back from `refs/remotes/origin/<branch>` to `refs/heads/<branch>` only when the remote-tracking ref itself is unresolved), never materializing or trusting the checked-out worktree.
- Added `Manager.resolveTrustedSetupCommands`, mirroring `resolveSetupCommands` but sourced from the trusted default branch, and switched `PrepareForReview`, `PrepareForBranchFix`, and `PrepareForFix` to use it.
- `checkConfigGetterAdapter.VerifyCommands` now loads repo `checks.verify` via `LoadRepoConfigAtDefaultBranch` against the project's clone path instead of the task's worktree.
- Added coverage in `internal/project/git_test.go` and `internal/worktree/setup_trust_test.go`, plus an adversarial workflow test asserting a malicious worktree `.sybra.yaml` cannot inject verify commands.

Closes https://github.com/Automaat/sybra/issues/1519

_Generated by Sybra harness_