### PR TITLE
perf(limits): bound limits.json event retention

### DIFF
--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -14,6 +14,15 @@ import (
 
 const exactSnapshotMaxAge = 30 * time.Minute
 
+// eventMaxAge bounds how long a UsageEvent survives in limits.json.
+// Summary never looks back further than the weekly window (7d, see
+// fallbackWindows) and BackfillLocalSessionFiles defaults to a 14d cutoff
+// (ProviderLimitsConfig.BackfillDays) — 21d leaves a safety margin over both
+// so a slow reload or clock skew can't prune data a consumer still needs.
+// Without this, limits.json grows unbounded (56MB / ~189k events observed in
+// production) since every RecordUsage/Import call only ever appends.
+const eventMaxAge = 21 * 24 * time.Hour
+
 type persisted struct {
 	Snapshots map[string]Snapshot `json:"snapshots"`
 	Events    []UsageEvent        `json:"events"`
@@ -148,9 +157,13 @@ func (s *Store) reloadLocked() error {
 	}
 	s.events = nil
 	s.seen = map[string]struct{}{}
+	cutoff := s.now().UTC().Add(-eventMaxAge)
 	for i := range p.Events {
 		e := p.Events[i]
 		if e.ID == "" {
+			continue
+		}
+		if e.Timestamp.Before(cutoff) {
 			continue
 		}
 		if _, ok := s.seen[e.ID]; ok {

--- a/internal/limits/store_test.go
+++ b/internal/limits/store_test.go
@@ -1,0 +1,91 @@
+package limits
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeLimitsFile(t *testing.T, path string, p persisted) {
+	t.Helper()
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStore_ReloadPrunesExpiredEvents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "limits.json")
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+
+	writeLimitsFile(t, path, persisted{
+		Events: []UsageEvent{
+			{ID: "old", Provider: ProviderClaude, Timestamp: now.Add(-eventMaxAge - time.Hour)},
+			{ID: "fresh", Provider: ProviderClaude, Timestamp: now.Add(-time.Hour)},
+			{ID: "boundary", Provider: ProviderClaude, Timestamp: now.Add(-eventMaxAge + time.Hour)},
+		},
+	})
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.now = func() time.Time { return now }
+	if err := s.reloadLocked(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(s.events) != 2 {
+		t.Fatalf("expected 2 surviving events, got %d: %+v", len(s.events), s.events)
+	}
+	ids := map[string]bool{}
+	for _, e := range s.events {
+		ids[e.ID] = true
+	}
+	if ids["old"] {
+		t.Fatal("expired event was not pruned")
+	}
+	if !ids["fresh"] || !ids["boundary"] {
+		t.Fatalf("unexpected surviving events: %+v", s.events)
+	}
+}
+
+func TestStore_RecordUsageFlushesPrunedEvents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "limits.json")
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+
+	writeLimitsFile(t, path, persisted{
+		Events: []UsageEvent{
+			{ID: "old", Provider: ProviderClaude, Timestamp: now.Add(-eventMaxAge - time.Hour)},
+		},
+	})
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.now = func() time.Time { return now }
+
+	if err := s.RecordUsage(UsageEvent{ID: "new", Provider: ProviderClaude, Timestamp: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p persisted
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Events) != 1 || p.Events[0].ID != "new" {
+		t.Fatalf("expected only the fresh event on disk, got %+v", p.Events)
+	}
+}


### PR DESCRIPTION
## Motivation

`~/.sybra/limits.json` grows unbounded — every `RecordUsage`/`Import` call
only ever appends `UsageEvent`s, and the file is rewritten whole under a
lockfile on every write. In production this reached 56MB / ~189k events,
slowing every read/write. Agent log rotation (`~/.sybra/logs/agents/`, 14d
default retention) already exists via `logging.PruneAgentLogs`, run at
startup and on a daily loop (`internal/sybra/lifecycle.go`) — no gap there.

> Changelog: perf(limits): bound limits.json event retention

## Implementation information

- `internal/limits/store.go`: added `eventMaxAge` (21d) and prune expired
  events in `reloadLocked`, which every read-modify-write path
  (`UpdateSnapshot`/`RecordUsage`/`Import`) already calls under the
  cross-process lock before mutating and flushing.
- 21d leaves margin over both consumers: `Summary` never looks back further
  than the 7d weekly window (`fallbackWindows`), and
  `BackfillLocalSessionFiles` defaults to a 14d cutoff
  (`ProviderLimitsConfig.BackfillDays`).
- Self-healing: the next write after this ships prunes and rewrites the
  file, no separate migration/cleanup pass needed.
- Added `internal/limits/store_test.go` covering pruning on reload and that
  a flush persists only the surviving events.

## Supporting documentation

Issue: https://github.com/Automaat/sybra/issues/1530