### PR TITLE
fix(sybra): open window before boot recovery

### DIFF
--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -253,13 +253,16 @@ func (a *App) startLifecycle(ctx context.Context, emit func(string, any)) {
 		a.snapshotter.EnsureRepo(ctx)
 	}
 	a.recovery = a.newRecovery()
-	a.recovery.RunStartupCleanup(ctx)
 	a.RegisterSpotlightHotkey() //nolint:contextcheck // agent.Manager dispatch chain uses its own m.ctx field, see Startup's contextcheck note
 
 	lm := newLifecycleManager(a)
-	lm.StartManagers(ctx, emit)
-	lm.StartPollers(ctx, emit, issuesFetcher)
 	lm.StartWatchers(ctx)
+
+	a.wg.Go(func() {
+		a.recovery.RunStartupCleanup(ctx)
+		lm.StartManagers(ctx, emit)
+		lm.StartPollers(ctx, emit, issuesFetcher)
+	})
 }
 
 func (a *App) cleanupFailedStartup() {


### PR DESCRIPTION
## Motivation

Starting the desktop app (`mise dev:auto`) on a busy board left **no window** — the backend booted and orchestrated tasks fine, but the Cocoa window never appeared.

Root cause (confirmed via a live goroutine dump of the wedged process): `App.Startup` runs `recovery.RunStartupCleanup` **synchronously before** `main`'s `v3app.Run()`. The reattach step finalizes agents that completed while Sybra was down by firing their completion callbacks inline (`reattach.go` `finalizeIfCompleted` → `fireComplete`), which advance the workflow and **start the next agent, whose worktree setup (`mise install` / `npm ci` / `npm run build:desktop`, ~60-70s each) blocks the main goroutine**. With several recovered-complete agents, that serialized minutes of subprocess work ahead of window creation, so `v3app.Run()` was never reached.

The main goroutine was sitting in `wait4` under:
```
main.run → App.Startup → startLifecycle → recovery.RunStartupCleanup
  → agent.Manager.ReattachAllContext → finalizeIfCompleted → fireComplete
  → workflow.HandleAgentComplete → AdvanceStep → StartAgent
  → worktree.PrepareForTask → runSetup → exec.Cmd.Run → wait4  ⛔
```

> Changelog: fix(sybra): open desktop window before boot recovery

## Implementation information

Move `RunStartupCleanup` and the dispatch-capable loops (`StartManagers`, `StartPollers`/`orchestratorLoop`) onto a `wg`-tracked goroutine so `Startup` returns promptly and the window opens immediately, populating via events as recovery drains behind it.

- `StartWatchers` stays **synchronous** so config hot-reload (`configWatcher`) is wired before `Startup` returns (also what the startup wiring test asserts).
- `RegisterSpotlightHotkey` stays synchronous (main-thread hotkey registration), moved just above the goroutine.
- **Reattach-before-dispatch ordering is preserved**: `RunStartupCleanup` still completes before the orchestrator loop starts, since both run sequentially on the one goroutine.
- Shutdown is unaffected — `Shutdown`'s `a.cancel()` + `a.wg.Wait()` drains the new goroutine.

## Supporting documentation

`go build` + `go test ./internal/sybra/ -run 'Startup|Lifecycle|Recovery|Reattach'` pass locally.