### PR TITLE
feat(agent): per-worktree golangci-lint cache

### DIFF
--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"math/rand/v2"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -119,6 +120,10 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 		return cfg, nil, err
 	}
 
+	if err := m.injectGolangciCache(&cfg); err != nil {
+		return cfg, nil, err
+	}
+
 	if err := m.injectProcessSandbox(&cfg); err != nil {
 		return cfg, nil, err
 	}
@@ -184,6 +189,19 @@ func (m *Manager) injectSandboxHome(cfg *RunConfig) error {
 		cfg.ExtraEnv = append(cfg.ExtraEnv, "SYBRA_CONTROL_HOME="+controlHome)
 	}
 	cfg.resolvedSandboxHome = dir
+	return nil
+}
+
+func (m *Manager) injectGolangciCache(cfg *RunConfig) error {
+	if cfg.resolvedSandboxHome == "" {
+		return nil
+	}
+	dir := filepath.Join(cfg.resolvedSandboxHome, "golangci-lint-cache")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("agent.Run: create golangci-lint cache for task %q: %w", cfg.TaskID, err)
+	}
+	cfg.ExtraEnv = stripEnvKeys(cfg.ExtraEnv, "GOLANGCI_LINT_CACHE")
+	cfg.ExtraEnv = append(cfg.ExtraEnv, "GOLANGCI_LINT_CACHE="+dir)
 	return nil
 }
 

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -26,8 +27,12 @@ func TestPrepareRunConfig_SandboxHome_Injected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareRunConfig: %v", err)
 	}
-	want := []string{"SYBRA_HOME=" + sandboxDir, "SYBRA_CONTROL_HOME=/real/home"}
-	if len(cfg.ExtraEnv) != len(want) || cfg.ExtraEnv[0] != want[0] || cfg.ExtraEnv[1] != want[1] {
+	want := []string{
+		"SYBRA_HOME=" + sandboxDir,
+		"SYBRA_CONTROL_HOME=/real/home",
+		"GOLANGCI_LINT_CACHE=" + filepath.Join(sandboxDir, "golangci-lint-cache"),
+	}
+	if len(cfg.ExtraEnv) != len(want) || cfg.ExtraEnv[0] != want[0] || cfg.ExtraEnv[1] != want[1] || cfg.ExtraEnv[2] != want[2] {
 		t.Fatalf("ExtraEnv = %v, want %v", cfg.ExtraEnv, want)
 	}
 }
@@ -156,7 +161,12 @@ func TestPrepareRunConfig_SandboxHome_StripsDuplicateCallerEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareRunConfig: %v", err)
 	}
-	want := []string{"OTHER=keep-me", "SYBRA_HOME=" + sandboxDir, "SYBRA_CONTROL_HOME=/real/home"}
+	want := []string{
+		"OTHER=keep-me",
+		"SYBRA_HOME=" + sandboxDir,
+		"SYBRA_CONTROL_HOME=/real/home",
+		"GOLANGCI_LINT_CACHE=" + filepath.Join(sandboxDir, "golangci-lint-cache"),
+	}
 	if len(cfg.ExtraEnv) != len(want) {
 		t.Fatalf("ExtraEnv = %v, want %v", cfg.ExtraEnv, want)
 	}
@@ -184,7 +194,66 @@ func TestPrepareRunConfig_SandboxHome_EmptyControlHomeOmitsVar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareRunConfig: %v", err)
 	}
-	if len(cfg.ExtraEnv) != 1 || cfg.ExtraEnv[0] != "SYBRA_HOME="+sandboxDir {
-		t.Fatalf("ExtraEnv = %v, want only SYBRA_HOME", cfg.ExtraEnv)
+	want := []string{
+		"SYBRA_HOME=" + sandboxDir,
+		"GOLANGCI_LINT_CACHE=" + filepath.Join(sandboxDir, "golangci-lint-cache"),
+	}
+	if len(cfg.ExtraEnv) != len(want) || cfg.ExtraEnv[0] != want[0] || cfg.ExtraEnv[1] != want[1] {
+		t.Fatalf("ExtraEnv = %v, want %v", cfg.ExtraEnv, want)
+	}
+}
+
+func TestPrepareRunConfig_GolangciCache_PerWorktreeAndStripsCaller(t *testing.T) {
+	sandboxDir := t.TempDir()
+	m, _ := newTestManager(t, ManagerConfig{
+		SandboxHome: func(string) (string, error) { return sandboxDir, nil },
+	})
+
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		TaskID:   "task-1",
+		Mode:     "headless",
+		Dir:      t.TempDir(),
+		ExtraEnv: []string{"GOLANGCI_LINT_CACHE=/attacker/shared-cache"},
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+
+	wantCache := filepath.Join(sandboxDir, "golangci-lint-cache")
+	var got string
+	hits := 0
+	for _, kv := range cfg.ExtraEnv {
+		if v, ok := strings.CutPrefix(kv, "GOLANGCI_LINT_CACHE="); ok {
+			got = v
+			hits++
+		}
+	}
+	if hits != 1 {
+		t.Fatalf("want exactly one GOLANGCI_LINT_CACHE entry, got %d in %v", hits, cfg.ExtraEnv)
+	}
+	if got != wantCache {
+		t.Fatalf("GOLANGCI_LINT_CACHE = %q, want per-worktree %q", got, wantCache)
+	}
+	if info, statErr := os.Stat(wantCache); statErr != nil || !info.IsDir() {
+		t.Fatalf("cache dir %q not created: %v", wantCache, statErr)
+	}
+}
+
+func TestPrepareRunConfig_GolangciCache_SystemRunSkips(t *testing.T) {
+	m, _ := newTestManager(t, ManagerConfig{
+		SandboxHome: func(string) (string, error) {
+			t.Fatal("resolver must not be called for a system run")
+			return "", nil
+		},
+	})
+
+	cfg, _, err := m.prepareRunConfig(RunConfig{Mode: "headless", Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	for _, kv := range cfg.ExtraEnv {
+		if strings.HasPrefix(kv, "GOLANGCI_LINT_CACHE=") {
+			t.Fatalf("system run must not inject GOLANGCI_LINT_CACHE, got %v", cfg.ExtraEnv)
+		}
 	}
 }


### PR DESCRIPTION
## Motivation

Every agent worktree runs golangci-lint (its pre-commit hook, `mise run verify`) against the **one default cache** under the operator's home (`~/Library/Caches/golangci-lint`). With a fleet of concurrent agents this causes two problems:

1. **Cache corruption / cross-worktree bleed** — concurrent runs writing the shared cache produce wrong results, including a commit hook in one worktree reporting lint findings in *another task's* worktree files (observed live: a `synapse` commit hook surfaced `contextcheck` errors from `~/.sybra/worktrees/…/internal/sandbox/`).
2. **Lock contention** — golangci-lint serializes on a single machine-global lock (`$TMPDIR/golangci-lint.lock`) and errors `parallel golangci-lint is running` when it's held, so fleet commits flake.

> Changelog: feat(agent): per-worktree golangci-lint cache

## Implementation information

Inject a per-worktree `GOLANGCI_LINT_CACHE` into every task-scoped agent subprocess, mirroring `injectSandboxHome`:

- New `Manager.injectGolangciCache`, called from `prepareRunConfig` right after `injectSandboxHome`. Points `GOLANGCI_LINT_CACHE` at `<sandboxHome>/golangci-lint-cache` (per task), stripping any caller-supplied value first so it always wins.
- Lives **under the per-task sandbox home** — already a seatbelt write root (so enforce-mode writes are allowed) and **outside the git worktree**, so `SanitizeWorktree`'s `git add -A` can never commit the cache onto a PR.
- No-ops for system/probe runs (empty `TaskID`, no sandbox home resolved).

Each worktree now lints against an isolated cache → no corruption, no cross-worktree bleed.

### Scope note

This fixes the **cache** (the correctness bug). The global-lock `parallel golangci-lint is running` error is a separate axis (the lock lives at `$TMPDIR/golangci-lint.lock`, only relocatable via a blanket `TMPDIR` change that risks macOS's 104-char unix-socket limit) — best handled by `--allow-serial-runners` in the hook/`verify` command, not tackled here.

## Supporting documentation

New tests in `internal/agent/sandbox_home_test.go`: `TestPrepareRunConfig_GolangciCache_PerWorktreeAndStripsCaller` (per-worktree path, caller value stripped, dir created) and `_SystemRunSkips`; three existing sandbox-home assertions updated for the appended env var. `go build` + `go test ./internal/agent/ -run 'SandboxHome|GolangciCache'` pass locally.