### PR TITLE
fix(frontend): restore live updates on v3

### DIFF
--- a/frontend/src/stores/issues.svelte.ts
+++ b/frontend/src/stores/issues.svelte.ts
@@ -45,5 +45,11 @@ class IssueStore {
 
 export const issueStore = new IssueStore()
 if (typeof window !== 'undefined') {
-  issueStore.listen()
+  // Guard against a synchronous throw (e.g. web-mode token prompt cancelled)
+  // poisoning the lazy import chunk this module lives in.
+  try {
+    issueStore.listen()
+  } catch (e) {
+    console.warn('issueStore.listen() failed to attach:', e)
+  }
 }

--- a/frontend/src/stores/issues.svelte.ts
+++ b/frontend/src/stores/issues.svelte.ts
@@ -44,6 +44,6 @@ class IssueStore {
 }
 
 export const issueStore = new IssueStore()
-if (typeof window !== 'undefined' && window.runtime) {
+if (typeof window !== 'undefined') {
   issueStore.listen()
 }

--- a/frontend/src/stores/renovate.svelte.ts
+++ b/frontend/src/stores/renovate.svelte.ts
@@ -57,6 +57,6 @@ class RenovateStore {
 }
 
 export const renovateStore = new RenovateStore()
-if (typeof window !== 'undefined' && window.runtime) {
+if (typeof window !== 'undefined') {
   renovateStore.listen()
 }

--- a/frontend/src/stores/renovate.svelte.ts
+++ b/frontend/src/stores/renovate.svelte.ts
@@ -58,5 +58,11 @@ class RenovateStore {
 
 export const renovateStore = new RenovateStore()
 if (typeof window !== 'undefined') {
-  renovateStore.listen()
+  // Guard against a synchronous throw (e.g. web-mode token prompt cancelled)
+  // poisoning the lazy import chunk this module lives in.
+  try {
+    renovateStore.listen()
+  } catch (e) {
+    console.warn('renovateStore.listen() failed to attach:', e)
+  }
 }

--- a/frontend/src/stores/reviews.svelte.ts
+++ b/frontend/src/stores/reviews.svelte.ts
@@ -83,5 +83,11 @@ class ReviewStore {
 
 export const reviewStore = new ReviewStore()
 if (typeof window !== 'undefined') {
-  reviewStore.listen()
+  // Guard against a synchronous throw (e.g. web-mode token prompt cancelled)
+  // poisoning the import chunk this module lives in.
+  try {
+    reviewStore.listen()
+  } catch (e) {
+    console.warn('reviewStore.listen() failed to attach:', e)
+  }
 }

--- a/frontend/src/stores/reviews.svelte.ts
+++ b/frontend/src/stores/reviews.svelte.ts
@@ -83,8 +83,5 @@ class ReviewStore {
 
 export const reviewStore = new ReviewStore()
 if (typeof window !== 'undefined') {
-  // Desktop mode needs window.runtime (Wails IPC); web mode uses SSE directly.
-  if (import.meta.env.VITE_MODE === 'web' || window.runtime) {
-    reviewStore.listen()
-  }
+  reviewStore.listen()
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,7 +5,3 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE?: string
   readonly VITE_API_TOKEN?: string
 }
-
-interface Window {
-  runtime?: unknown
-}


### PR DESCRIPTION
## Motivation

Issues, Renovate, and Review store listeners stopped attaching in some
runtime configurations after a prior refactor tightened the guard around
`window.runtime`. A synchronous throw during listener setup (e.g. a
cancelled web-mode token prompt) could also poison the lazy import chunk
the store lives in, silently killing live updates for the rest of the
session.

## Implementation information

- Wrap each store's `.listen()` call in try/catch so a synchronous throw
  during setup logs a warning instead of poisoning the module's import
  chunk.
- Simplify the desktop/web runtime guard to attach listeners whenever
  `window` exists, relying on the try/catch to handle the case where the
  expected transport isn't available yet.
- Drop the now-unused `Window.runtime` type augmentation from
  `vite-env.d.ts`.

Closes https://github.com/Automaat/sybra/issues/1542

_Generated by Sybra harness_