### PR TITLE
fix(agent): gate headless runs through approval hook

### DIFF
--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -290,6 +290,9 @@ const (
 // stdout parser has recorded the session ID. Returns "" if still unresolved
 // after the bounded wait or if the request is canceled.
 func (s *ApprovalServer) findAgentBySessionWithRetry(ctx context.Context, sessionID string) string {
+	if strings.TrimSpace(sessionID) == "" {
+		return ""
+	}
 	for attempt := 0; ; attempt++ {
 		if id := s.findAgentBySession(sessionID); id != "" {
 			return id
@@ -314,7 +317,12 @@ func betterSessionMatch(candidate, incumbent *Agent) bool {
 	if candStopped != incStopped {
 		return !candStopped
 	}
-	return candidate.StartedAt.After(incumbent.StartedAt)
+	candStarted := candidate.GetStartedAt()
+	incStarted := incumbent.GetStartedAt()
+	if !candStarted.Equal(incStarted) {
+		return candStarted.After(incStarted)
+	}
+	return candidate.ID > incumbent.ID
 }
 
 func isSafeTool(name string) bool {

--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -134,8 +134,12 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Find the agent by session_id; deny if unknown.
-	agentID := s.findAgentBySession(input.SessionID)
+	// Find the agent by session_id; deny if unknown. The stdout parser sets
+	// SessionID from the init event on a separate goroutine, with no ordering
+	// guarantee against the CLI's first tool call reaching this hook. Retry
+	// briefly on a miss before denying so that race doesn't fail the first
+	// tool call of an otherwise healthy run.
+	agentID := s.findAgentBySessionWithRetry(r.Context(), input.SessionID)
 	if agentID == "" {
 		s.logger.Warn("approval-server.no-agent", "session_id", input.SessionID)
 		s.respondDeny(w, "Unknown session")
@@ -247,16 +251,70 @@ func (s *ApprovalServer) RespondApproval(toolUseID string, approved bool) error 
 // regardless of Mode: a headless run only reaches here when it was started
 // with RequirePermissions (see buildClaudeHookSettings), and must resolve to
 // its agent the same way an interactive session does.
+//
+// The registry is never pruned, so a rate-limited retry that resumes a prior
+// session ID (RescheduleRateLimitedAgent) leaves the stopped original agent
+// registered with the same SessionID as the new live one. First-match over a
+// map is nondeterministic and could resolve to the dead original, hanging the
+// live retry. Resolve deterministically instead: prefer a non-stopped agent,
+// and among ties prefer the most-recently-started, so a live retry always
+// wins over the stale entry it reused a session ID from.
 func (s *ApprovalServer) findAgentBySession(sessionID string) string {
 	if s.agents == nil {
 		return ""
 	}
+	var best *Agent
 	for _, a := range s.agents.ListAgents() {
-		if a.GetSessionID() == sessionID {
-			return a.ID
+		if a.GetSessionID() != sessionID {
+			continue
+		}
+		if best == nil || betterSessionMatch(a, best) {
+			best = a
 		}
 	}
-	return ""
+	if best == nil {
+		return ""
+	}
+	return best.ID
+}
+
+// sessionLookupRetries and sessionLookupBackoff bound the wait for the stdout
+// parser to record SessionID before a first tool call is denied as unknown.
+const (
+	sessionLookupRetries = 20
+	sessionLookupBackoff = 50 * time.Millisecond
+)
+
+// findAgentBySessionWithRetry resolves a session to an agent, retrying briefly
+// to absorb the race where the CLI issues its first tool call before the
+// stdout parser has recorded the session ID. Returns "" if still unresolved
+// after the bounded wait or if the request is canceled.
+func (s *ApprovalServer) findAgentBySessionWithRetry(ctx context.Context, sessionID string) string {
+	for attempt := 0; ; attempt++ {
+		if id := s.findAgentBySession(sessionID); id != "" {
+			return id
+		}
+		if attempt >= sessionLookupRetries {
+			return ""
+		}
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-time.After(sessionLookupBackoff):
+		}
+	}
+}
+
+// betterSessionMatch reports whether candidate should win over incumbent when
+// both share a session ID: a live (non-stopped) agent beats a stopped one, and
+// among agents of the same liveness the most-recently-started wins.
+func betterSessionMatch(candidate, incumbent *Agent) bool {
+	candStopped := candidate.GetState() == StateStopped
+	incStopped := incumbent.GetState() == StateStopped
+	if candStopped != incStopped {
+		return !candStopped
+	}
+	return candidate.StartedAt.After(incumbent.StartedAt)
 }
 
 func isSafeTool(name string) bool {

--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -242,12 +242,17 @@ func (s *ApprovalServer) RespondApproval(toolUseID string, approved bool) error 
 	}
 }
 
+// findAgentBySession resolves the agent a PreToolUse hook request came from.
+// Session IDs are provider-issued and unique per run, so this matches
+// regardless of Mode: a headless run only reaches here when it was started
+// with RequirePermissions (see buildClaudeHookSettings), and must resolve to
+// its agent the same way an interactive session does.
 func (s *ApprovalServer) findAgentBySession(sessionID string) string {
 	if s.agents == nil {
 		return ""
 	}
 	for _, a := range s.agents.ListAgents() {
-		if a.GetSessionID() == sessionID && a.Mode == "interactive" {
+		if a.GetSessionID() == sessionID {
 			return a.ID
 		}
 	}

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -132,6 +132,32 @@ func TestApprovalServer_UnknownSession(t *testing.T) {
 	}
 }
 
+// TestFindAgentBySession_MatchesHeadlessAgent verifies the approval hook
+// resolves a headless-mode agent by session ID, not just interactive ones.
+// Headless runs only reach this hook when RequirePermissions is set (see
+// buildClaudeHookSettings), so restricting the match to Mode=="interactive"
+// left every headless approval request unresolved and fail-closed to deny —
+// forcing operators to disable permission requirements entirely.
+func TestFindAgentBySession_MatchesHeadlessAgent(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := newTestManager(t)
+	fakeAgent := &Agent{
+		ID:        "fake-headless-1",
+		Mode:      "headless",
+		SessionID: "session-headless",
+		State:     StateRunning,
+	}
+	mgr.mu.Lock()
+	mgr.agents["fake-headless-1"] = fakeAgent
+	mgr.mu.Unlock()
+
+	srv := &ApprovalServer{agents: mgr}
+	if got := srv.findAgentBySession("session-headless"); got != "fake-headless-1" {
+		t.Errorf("findAgentBySession(headless) = %q, want %q", got, "fake-headless-1")
+	}
+}
+
 func TestApprovalServer_CanceledContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -223,6 +223,49 @@ func TestFindAgentBySession_MostRecentAmongSameLiveness(t *testing.T) {
 		t.Errorf("findAgentBySession = %q, want %q (most recent)", got, "newer")
 	}
 }
+
+func TestFindAgentBySession_DeterministicTieBreakOnAgentID(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := newTestManager(t)
+	started := time.Now()
+	low := &Agent{
+		ID:        "agent-a",
+		Mode:      "headless",
+		SessionID: "same-session",
+		State:     StateRunning,
+		StartedAt: started,
+	}
+	high := &Agent{
+		ID:        "agent-b",
+		Mode:      "headless",
+		SessionID: "same-session",
+		State:     StateRunning,
+		StartedAt: started,
+	}
+	mgr.mu.Lock()
+	mgr.agents[low.ID] = low
+	mgr.agents[high.ID] = high
+	mgr.mu.Unlock()
+
+	srv := &ApprovalServer{agents: mgr}
+	if got := srv.findAgentBySession("same-session"); got != "agent-b" {
+		t.Errorf("findAgentBySession = %q, want %q (deterministic agent ID tie-break)", got, "agent-b")
+	}
+}
+
+func TestFindAgentBySessionWithRetry_EmptySessionReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	srv := &ApprovalServer{}
+	start := time.Now()
+	if got := srv.findAgentBySessionWithRetry(context.Background(), " \t "); got != "" {
+		t.Fatalf("findAgentBySessionWithRetry(empty) = %q, want empty", got)
+	}
+	if elapsed := time.Since(start); elapsed >= sessionLookupBackoff {
+		t.Fatalf("findAgentBySessionWithRetry(empty) took %v, want < %v", elapsed, sessionLookupBackoff)
+	}
+}
 func TestApprovalServer_CanceledContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -158,6 +158,72 @@ func TestFindAgentBySession_MatchesHeadlessAgent(t *testing.T) {
 	}
 }
 
+// TestFindAgentBySession_PrefersLiveRetryOverStaleOriginal covers the
+// registry-never-pruned hazard: a rate-limited retry resumes the prior session
+// ID, so the stopped original and the live retry share a SessionID. The lookup
+// must resolve to the live retry, not the dead original nobody is watching.
+func TestFindAgentBySession_PrefersLiveRetryOverStaleOriginal(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := newTestManager(t)
+	base := time.Now()
+	original := &Agent{
+		ID:        "orig",
+		Mode:      "headless",
+		SessionID: "shared-session",
+		State:     StateStopped,
+		StartedAt: base,
+	}
+	retry := &Agent{
+		ID:        "retry",
+		Mode:      "headless",
+		SessionID: "shared-session",
+		State:     StateRunning,
+		StartedAt: base.Add(time.Minute),
+	}
+	mgr.mu.Lock()
+	mgr.agents["orig"] = original
+	mgr.agents["retry"] = retry
+	mgr.mu.Unlock()
+
+	srv := &ApprovalServer{agents: mgr}
+	if got := srv.findAgentBySession("shared-session"); got != "retry" {
+		t.Errorf("findAgentBySession = %q, want %q (live retry)", got, "retry")
+	}
+}
+
+// TestFindAgentBySession_MostRecentAmongSameLiveness verifies the tie-breaker
+// when two matching agents share liveness: the most-recently-started wins.
+func TestFindAgentBySession_MostRecentAmongSameLiveness(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := newTestManager(t)
+	base := time.Now()
+	older := &Agent{
+		ID:        "older",
+		Mode:      "headless",
+		SessionID: "same-session",
+		State:     StateRunning,
+		StartedAt: base,
+	}
+	newer := &Agent{
+		ID:        "newer",
+		Mode:      "headless",
+		SessionID: "same-session",
+		State:     StateRunning,
+		StartedAt: base.Add(time.Second),
+	}
+	mgr.mu.Lock()
+	mgr.agents["older"] = older
+	mgr.agents["newer"] = newer
+	mgr.mu.Unlock()
+
+	srv := &ApprovalServer{agents: mgr}
+	if got := srv.findAgentBySession("same-session"); got != "newer" {
+		t.Errorf("findAgentBySession = %q, want %q (most recent)", got, "newer")
+	}
+}
+
 func TestApprovalServer_CanceledContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -116,6 +116,19 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort)
 	cfg.approvalAddr = m.approvalAddr
 
+	// require_permissions:true relies on the approval hook to gate each tool
+	// call. If the approval server never started (approvalAddr empty) the hook
+	// is silently omitted and the run falls back to CLI defaults — neither the
+	// gating the operator asked for nor an explicit bypass. Surface it loudly
+	// rather than degrading quietly. Skipped when an explicit tool allowlist or
+	// the auto permission-mode classifier already governs the run.
+	if cfg.RequirePermissions && cfg.approvalAddr == "" &&
+		len(cfg.AllowedTools) == 0 && cfg.HeadlessPermissionMode != "auto" {
+		m.logger.Warn("agent.approval.unavailable",
+			"task_id", cfg.TaskID,
+			"detail", "require_permissions is set but no approval server is running; tool calls are ungated")
+	}
+
 	if err := m.injectSandboxHome(&cfg); err != nil {
 		return cfg, nil, err
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -116,13 +116,21 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	cfg.provider = prov
 	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort)
 	cfg.approvalAddr = m.approvalAddr
-	// require_permissions:true relies on the approval hook to gate each tool
-	// call. If the approval server never started (approvalAddr empty) the hook
-	// is silently omitted and the run falls back to CLI defaults — neither the
-	// gating the operator asked for nor an explicit bypass. Fail closed rather
-	// than degrading quietly. Skipped when an explicit tool allowlist or the
-	// auto permission-mode classifier already governs the run.
-	if cfg.RequirePermissions && cfg.approvalAddr == "" &&
+	// Headless Claude runs with require_permissions:true rely on Sybra's
+	// approval hook to gate each tool call. If the approval server never
+	// started (approvalAddr empty) the hook is silently omitted and the run
+	// falls back to CLI defaults — neither the gating the operator asked for
+	// nor an explicit bypass. Fail closed rather than degrading quietly.
+	//
+	// Scope this to the exact vulnerable shape:
+	// - claude provider
+	// - headless mode
+	// - no explicit AllowedTools allowlist
+	// - not using Claude's own auto classifier
+	//
+	// Other providers do not depend on this hook for headless execution.
+	if prov.Name() == "claude" && cfg.Mode == "headless" &&
+		cfg.RequirePermissions && cfg.approvalAddr == "" &&
 		len(cfg.AllowedTools) == 0 && cfg.HeadlessPermissionMode != "auto" {
 		return cfg, nil, fmt.Errorf("require_permissions requires a running approval server for ungated headless claude runs")
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -114,6 +114,7 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	}
 	cfg.provider = prov
 	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort)
+	cfg.approvalAddr = m.approvalAddr
 
 	if err := m.injectSandboxHome(&cfg); err != nil {
 		return cfg, nil, err

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -119,14 +119,12 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	// require_permissions:true relies on the approval hook to gate each tool
 	// call. If the approval server never started (approvalAddr empty) the hook
 	// is silently omitted and the run falls back to CLI defaults — neither the
-	// gating the operator asked for nor an explicit bypass. Surface it loudly
-	// rather than degrading quietly. Skipped when an explicit tool allowlist or
-	// the auto permission-mode classifier already governs the run.
+	// gating the operator asked for nor an explicit bypass. Fail closed rather
+	// than degrading quietly. Skipped when an explicit tool allowlist or the
+	// auto permission-mode classifier already governs the run.
 	if cfg.RequirePermissions && cfg.approvalAddr == "" &&
 		len(cfg.AllowedTools) == 0 && cfg.HeadlessPermissionMode != "auto" {
-		m.logger.Warn("agent.approval.unavailable",
-			"task_id", cfg.TaskID,
-			"detail", "require_permissions is set but no approval server is running; tool calls are ungated")
+		return cfg, nil, fmt.Errorf("require_permissions requires a running approval server for ungated headless claude runs")
 	}
 
 	if err := m.injectSandboxHome(&cfg); err != nil {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1002,6 +1002,14 @@ type RunConfig struct {
 	// computed once by injectProcessSandbox and consumed by wrapInvocation
 	// at each provider spawn site. Never set by callers.
 	sandbox sandboxSpec
+	// approvalAddr is the manager's HTTP approval-server address
+	// ("127.0.0.1:port"), set by prepareRunConfig for every run. Consumed by
+	// claudeProvider.BuildHeadlessInvocation to wire the PreToolUse approval
+	// hook when RequirePermissions is true — without it, a headless run under
+	// require_permissions:true has no path to grant a tool call and
+	// operators are forced to require_permissions:false, which collapses to
+	// --dangerously-skip-permissions. Never set by callers.
+	approvalAddr string
 }
 
 // ConvoOutput returns a snapshot of the conversation event buffer.

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -380,6 +380,13 @@ func (a *Agent) GetSessionID() string {
 	return a.SessionID
 }
 
+// GetStartedAt returns the agent's recorded start time.
+func (a *Agent) GetStartedAt() time.Time {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.StartedAt
+}
+
 // SetProviderAndModel updates the agent's provider and (already-normalized)
 // model. Used when a mid-run per-turn provider re-gate fails the agent's
 // current provider over to a healthy peer; Provider/Model are otherwise fixed

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1012,6 +1012,17 @@ type RunConfig struct {
 	approvalAddr string
 }
 
+// needsApprovalHook reports whether a run should wire the PreToolUse approval
+// hook. True when permissions are required or an interactive permission-mode is
+// set. Both the headless (provider_claude.go) and conversational
+// (runner_convo.go) call sites gate on this so a future change can't silently
+// desync them: headless runs never set PermissionMode (they use
+// HeadlessPermissionMode for the auto classifier), so for them it collapses to
+// RequirePermissions alone.
+func (cfg RunConfig) needsApprovalHook() bool {
+	return cfg.RequirePermissions || cfg.PermissionMode != ""
+}
+
 // ConvoOutput returns a snapshot of the conversation event buffer.
 func (a *Agent) ConvoOutput() []ConvoEvent {
 	a.mu.RLock()

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -45,7 +45,13 @@ func (claudeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headless
 	if cfg.OutputSchema != "" {
 		args = append(args, "--json-schema", cfg.OutputSchema)
 	}
-	if hookSettings := buildClaudeHookSettings("", false); hookSettings != "" {
+	// Wire the same PreToolUse approval hook the conversational runner uses
+	// whenever this run requires permission gating. Without this, a headless
+	// agent under require_permissions:true has no path to approve a tool
+	// call (the CLI has no TTY to prompt), forcing operators to
+	// require_permissions:false — which collapses to
+	// --dangerously-skip-permissions (see claudePermissionArgs).
+	if hookSettings := buildClaudeHookSettings(cfg.approvalAddr, cfg.RequirePermissions); hookSettings != "" {
 		args = append(args, "--settings", hookSettings)
 	}
 	args = append(args, effortArgs(a.ReasoningEffort)...)

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -51,7 +51,7 @@ func (claudeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headless
 	// call (the CLI has no TTY to prompt), forcing operators to
 	// require_permissions:false — which collapses to
 	// --dangerously-skip-permissions (see claudePermissionArgs).
-	if hookSettings := buildClaudeHookSettings(cfg.approvalAddr, cfg.RequirePermissions); hookSettings != "" {
+	if hookSettings := buildClaudeHookSettings(cfg.approvalAddr, cfg.needsApprovalHook()); hookSettings != "" {
 		args = append(args, "--settings", hookSettings)
 	}
 	args = append(args, effortArgs(a.ReasoningEffort)...)

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -107,8 +107,7 @@ func (m *Manager) convoCommonArgs(a *Agent, cfg RunConfig) []string {
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
-	needsApproval := cfg.RequirePermissions || cfg.PermissionMode != ""
-	if hookSettings := buildClaudeHookSettings(m.approvalAddr, needsApproval); hookSettings != "" {
+	if hookSettings := buildClaudeHookSettings(m.approvalAddr, cfg.needsApprovalHook()); hookSettings != "" {
 		args = append(args, "--settings", hookSettings)
 	}
 	return args

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1985,6 +1985,33 @@ func TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWithoutRequirePerms(t *
 	}
 }
 
+// TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWhenAddrEmpty pins the
+// silent-degradation path: RequirePermissions is set but the approval server
+// never started (approvalAddr empty), so no HTTP approval hook can be wired.
+// The run must still not fall back to --dangerously-skip-permissions — that
+// would turn a requested-but-unavailable gate into an implicit full bypass.
+// prepareRunConfig logs agent.approval.unavailable for exactly this case.
+func TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWhenAddrEmpty(t *testing.T) {
+	a := &Agent{ID: "a", Provider: "claude", TaskID: "task-abc123"}
+	_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+		Prompt:             "do stuff",
+		RequirePermissions: true,
+		approvalAddr:       "",
+	})
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+	for i, arg := range args {
+		if arg == "--dangerously-skip-permissions" {
+			t.Fatalf("RequirePermissions=true must not bypass permissions even without an approval server: %v", args)
+		}
+		if arg == "--settings" && i+1 < len(args) &&
+			strings.Contains(args[i+1], "pre-tool-use") {
+			t.Fatalf("no approval hook can be wired without an approval-server address: %v", args)
+		}
+	}
+}
+
 // TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs verifies that Claude and
 // Copilot invocations never receive codex hook args regardless of TaskID.
 func TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs(t *testing.T) {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -2070,6 +2070,25 @@ func TestPrepareRunConfig_AllowsRequirePermissionsWithoutApprovalServerWhenAllow
 	}
 }
 
+func TestPrepareRunConfig_AllowsRequirePermissionsWithoutApprovalServerForHeadlessCodex(t *testing.T) {
+	t.Parallel()
+
+	m := newParseTestManager(t)
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		Provider:           "codex",
+		Mode:               "headless",
+		Prompt:             "do stuff",
+		Dir:                t.TempDir(),
+		RequirePermissions: true,
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	if cfg.Provider != "codex" {
+		t.Fatalf("Provider = %q, want codex", cfg.Provider)
+	}
+}
+
 // TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs verifies that Claude and
 // Copilot invocations never receive codex hook args regardless of TaskID.
 func TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs(t *testing.T) {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1985,12 +1985,11 @@ func TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWithoutRequirePerms(t *
 	}
 }
 
-// TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWhenAddrEmpty pins the
-// silent-degradation path: RequirePermissions is set but the approval server
-// never started (approvalAddr empty), so no HTTP approval hook can be wired.
-// The run must still not fall back to --dangerously-skip-permissions — that
-// would turn a requested-but-unavailable gate into an implicit full bypass.
-// prepareRunConfig logs agent.approval.unavailable for exactly this case.
+// TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWhenAddrEmpty verifies the
+// lower-level command builder stays fail-closed when no approval hook can be
+// wired. Manager.prepareRunConfig rejects this posture before launch, but the
+// invocation builder itself must still avoid turning a missing gate into an
+// implicit full bypass.
 func TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWhenAddrEmpty(t *testing.T) {
 	a := &Agent{ID: "a", Provider: "claude", TaskID: "task-abc123"}
 	_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
@@ -2009,6 +2008,65 @@ func TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWhenAddrEmpty(t *testin
 			strings.Contains(args[i+1], "pre-tool-use") {
 			t.Fatalf("no approval hook can be wired without an approval-server address: %v", args)
 		}
+	}
+}
+
+func TestPrepareRunConfig_RejectsRequirePermissionsWithoutApprovalServer(t *testing.T) {
+	t.Parallel()
+
+	m := newParseTestManager(t)
+	_, _, err := m.prepareRunConfig(RunConfig{
+		Provider:           "claude",
+		Mode:               "headless",
+		Prompt:             "do stuff",
+		Dir:                t.TempDir(),
+		RequirePermissions: true,
+	})
+	if err == nil {
+		t.Fatal("prepareRunConfig succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "require_permissions requires a running approval server") {
+		t.Fatalf("prepareRunConfig error = %v, want approval-server requirement", err)
+	}
+}
+
+func TestPrepareRunConfig_AllowsRequirePermissionsWithoutApprovalServerWhenAutoMode(t *testing.T) {
+	t.Parallel()
+
+	m := newParseTestManager(t)
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		Provider:               "claude",
+		Mode:                   "headless",
+		Prompt:                 "do stuff",
+		Dir:                    t.TempDir(),
+		RequirePermissions:     true,
+		HeadlessPermissionMode: "auto",
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	if cfg.HeadlessPermissionMode != "auto" {
+		t.Fatalf("HeadlessPermissionMode = %q, want auto", cfg.HeadlessPermissionMode)
+	}
+}
+
+func TestPrepareRunConfig_AllowsRequirePermissionsWithoutApprovalServerWhenAllowedToolsPresent(t *testing.T) {
+	t.Parallel()
+
+	m := newParseTestManager(t)
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		Provider:           "claude",
+		Mode:               "headless",
+		Prompt:             "do stuff",
+		Dir:                t.TempDir(),
+		RequirePermissions: true,
+		AllowedTools:       []string{"Read"},
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	if len(cfg.AllowedTools) != 1 || cfg.AllowedTools[0] != "Read" {
+		t.Fatalf("AllowedTools = %v, want [Read]", cfg.AllowedTools)
 	}
 }
 

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1935,6 +1935,56 @@ func TestBuildHeadlessInvocation_ClaudeKlaudiushHookPresent(t *testing.T) {
 	t.Fatalf("Claude headless args missing klaudiush --settings hook: %v", args)
 }
 
+// TestBuildHeadlessInvocation_ClaudeApprovalHookWiredWhenRequired verifies
+// that a headless claude run with RequirePermissions=true wires the same
+// PreToolUse HTTP approval hook the conversational runner uses, pointed at
+// the manager's approval-server address. Without this, require_permissions
+// has no path to grant a headless tool call and operators are forced to
+// require_permissions:false, which collapses to --dangerously-skip-permissions.
+func TestBuildHeadlessInvocation_ClaudeApprovalHookWiredWhenRequired(t *testing.T) {
+	a := &Agent{ID: "a", Provider: "claude", TaskID: "task-abc123"}
+	_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+		Prompt:             "do stuff",
+		RequirePermissions: true,
+		approvalAddr:       "127.0.0.1:54321",
+	})
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+	for i, arg := range args {
+		if arg == "--dangerously-skip-permissions" {
+			t.Fatalf("RequirePermissions=true must not bypass permissions: %v", args)
+		}
+		if arg == "--settings" && i+1 < len(args) &&
+			strings.Contains(args[i+1], "http://127.0.0.1:54321/hooks/pre-tool-use") {
+			return
+		}
+	}
+	t.Fatalf("Claude headless args missing approval-server --settings hook: %v", args)
+}
+
+// TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWithoutRequirePerms
+// verifies the approval hook is only wired when the run actually needs
+// permission gating — an unattended bypass/auto run must not block on a
+// hook nobody is watching.
+func TestBuildHeadlessInvocation_ClaudeApprovalHookAbsentWithoutRequirePerms(t *testing.T) {
+	a := &Agent{ID: "a", Provider: "claude", TaskID: "task-abc123"}
+	_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+		Prompt:             "do stuff",
+		RequirePermissions: false,
+		approvalAddr:       "127.0.0.1:54321",
+	})
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+	for i, arg := range args {
+		if arg == "--settings" && i+1 < len(args) &&
+			strings.Contains(args[i+1], "pre-tool-use") {
+			t.Fatalf("approval hook must not be wired without RequirePermissions: %v", args)
+		}
+	}
+}
+
 // TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs verifies that Claude and
 // Copilot invocations never receive codex hook args regardless of TaskID.
 func TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs(t *testing.T) {

--- a/internal/sybra/agent_manager_test_helpers_test.go
+++ b/internal/sybra/agent_manager_test_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 )
@@ -18,9 +19,31 @@ func newTestAgentManager(tb testing.TB, ctx context.Context, emit agent.EmitFunc
 		dir := tb.TempDir()
 		cfg.SandboxHome = func(string) (string, error) { return dir, nil }
 	}
+	var approvalServer *agent.ApprovalServer
+	if cfg.ApprovalAddr == "" {
+		srv, err := agent.NewApprovalServer(ctx, emit, logger, 0)
+		if err != nil {
+			tb.Fatalf("NewApprovalServer: %v", err)
+		}
+		approvalServer = srv
+		cfg.ApprovalAddr = srv.Addr()
+	}
 	m, err := agent.NewManager(ctx, emit, logger, logDir, cfg)
 	if err != nil {
+		if approvalServer != nil {
+			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			_ = approvalServer.Shutdown(shutdownCtx)
+			cancel()
+		}
 		tb.Fatalf("NewManager: %v", err)
+	}
+	if approvalServer != nil {
+		approvalServer.SetManager(m)
+		tb.Cleanup(func() {
+			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			_ = approvalServer.Shutdown(shutdownCtx)
+			cancel()
+		})
 	}
 	return m
 }

--- a/internal/sybra/review/agent_manager_test_helpers_test.go
+++ b/internal/sybra/review/agent_manager_test_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/project"
@@ -17,9 +18,31 @@ func newTestAgentManager(tb testing.TB, ctx context.Context, emit agent.EmitFunc
 	if len(cfgs) > 0 {
 		cfg = cfgs[0]
 	}
+	var approvalServer *agent.ApprovalServer
+	if cfg.ApprovalAddr == "" {
+		srv, err := agent.NewApprovalServer(ctx, emit, logger, 0)
+		if err != nil {
+			tb.Fatalf("NewApprovalServer: %v", err)
+		}
+		approvalServer = srv
+		cfg.ApprovalAddr = srv.Addr()
+	}
 	m, err := agent.NewManager(ctx, emit, logger, logDir, cfg)
 	if err != nil {
+		if approvalServer != nil {
+			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			_ = approvalServer.Shutdown(shutdownCtx)
+			cancel()
+		}
 		tb.Fatalf("NewManager: %v", err)
+	}
+	if approvalServer != nil {
+		approvalServer.SetManager(m)
+		tb.Cleanup(func() {
+			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			_ = approvalServer.Shutdown(shutdownCtx)
+			cancel()
+		})
 	}
 	return m
 }


### PR DESCRIPTION
## Motivation

Headless Claude runs need to honor Sybra's approval hook when permissions are required, instead of silently falling back to permissive behavior. This keeps stop/headless task execution aligned with the configured permission posture.

Closes https://github.com/Automaat/sybra/issues/1520

## Implementation information

- Add approval server wiring to headless run configuration and Claude provider invocation.
- Preserve existing conversational approval behavior while enabling headless approval-hook gating.
- Add regression coverage for approval server behavior and headless runner permission arguments.

_Generated by Sybra harness_