### PR TITLE
fix(workflow): reduce false human-required parks

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -19,6 +19,14 @@ type EmitFunc func(event string, data any)
 // ErrSurvivalRegistry marks failures initializing restart-survival persistence.
 var ErrSurvivalRegistry = errors.New("agent survival registry")
 
+// ErrMaxConcurrentReached is returned by registerRunningAgent when the live
+// agent count is already at MaxConcurrent. It is a transient, self-healing
+// capacity condition (a slot frees when any running agent completes), so
+// callers must park-and-retry rather than escalate — the workflow layer maps
+// it to workflow.ErrAgentPoolBusy. Kept a sentinel (not a bare fmt.Errorf) so
+// that mapping is errors.Is-based, not string-matched.
+var ErrMaxConcurrentReached = errors.New("max concurrent agents reached")
+
 // Guardrails defines per-agent execution limits.
 type Guardrails struct {
 	MaxCostUSD float64

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -370,7 +370,7 @@ func (m *Manager) registerRunningAgent(a *Agent, cfg RunConfig, cancel context.C
 	if !cfg.IgnoreConcurrencyLimit && m.maxConcurrent > 0 && m.liveCount >= m.maxConcurrent {
 		m.mu.Unlock()
 		cancel()
-		return fmt.Errorf("max concurrent agents reached (%d)", m.maxConcurrent)
+		return fmt.Errorf("%w (%d)", ErrMaxConcurrentReached, m.maxConcurrent)
 	}
 	m.agents[a.ID] = a
 	if a.done != nil {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -433,6 +433,13 @@ type agentAdapter struct {
 	experience *experience.Store
 }
 
+func translatePoolBusy(err error) error {
+	if errors.Is(err, agent.ErrMaxConcurrentReached) {
+		return fmt.Errorf("%w: %w", workflow.ErrAgentPoolBusy, err)
+	}
+	return err
+}
+
 func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema, cleanRetryRef string, assignment workflow.AgentAssignment) (agentID, startedDir, baselineRef string, err error) {
 	// For implementation agents without a pre-staged dir, use the full
 	// orchestrator (handles worktree, project assignment). A workflow that
@@ -442,7 +449,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	if (role == "" || role == string(agent.RoleImplementation)) && dir == "" {
 		ag, baselineRef, err := a.agentOrch.StartAgentWithAssignment(taskID, mode, prompt, false, oneShot, cleanRetryRef, assignment)
 		if err != nil {
-			return "", "", "", err
+			return "", "", "", translatePoolBusy(err)
 		}
 		return ag.ID, "", baselineRef, nil
 	}
@@ -552,7 +559,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 
 	ag, err := a.agents.Run(cfg)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", translatePoolBusy(err)
 	}
 
 	a.recordSystemAgentStart(taskID, role, mode, cfg, ag)

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -220,6 +220,12 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 			e.logger.Info("workflow.run-agent.test-runner-busy", "task_id", taskID, "step", step.ID)
 			return e.tasks.SetWorkflow(taskID, wfExec)
 		}
+
+		if errors.Is(err, ErrAgentPoolBusy) {
+			wfExec.State = ExecWaiting
+			e.logger.Info("workflow.run-agent.agent-pool-busy", "task_id", taskID, "step", step.ID)
+			return e.tasks.SetWorkflow(taskID, wfExec)
+		}
 		return fmt.Errorf("start agent: %w", err)
 	}
 	if startedDir != "" && (step.Config.NeedsWorktree || dir != "") {

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -159,6 +159,10 @@ var (
 			`\b(it|describe|test|context)\.skip\s*\(|\bx(it|describe|test)\s*\(|` + // jest/mocha/vitest
 			`\b(test|it)\.todo\s*\(|@(Ignore|Disabled)\b`) // todo / JUnit
 	// tamperAddedExitRe matches an added forced success exit.
+	tamperCapabilityGuardRe = regexp.MustCompile(
+		`\b(os\.Symlink|os\.Link|os\.Readlink|filepath\.EvalSymlinks|` +
+			`exec\.LookPath|LookPath|user\.Current|user\.Lookup|` +
+			`net\.Listen|net\.Dial)\b|testing\.Short\s*\(\s*\)`)
 	tamperAddedExitRe = regexp.MustCompile(
 		`\bos\.Exit\s*\(\s*0\s*\)|\bsys\.exit\s*\(\s*0\s*\)|\bprocess\.exit\s*\(\s*0\s*\)|(^|[^.\w])exit\s*\(\s*0\s*\)`)
 	// tamperBuildIgnoreRe matches an added Go build-ignore tag (excludes the
@@ -327,7 +331,10 @@ type tamperScan struct {
 	delDecl     int
 	addRun      int
 	delRun      int
+	guardWindow int
 }
+
+const tamperGuardWindowLines = 3
 
 func (s *tamperScan) add(rule, detail string) {
 	if s.seen[rule] {
@@ -349,7 +356,14 @@ func (s *tamperScan) feedAdded(content string) {
 	if looksLikeComment(content) {
 		return
 	}
-	if tamperAddedSkipRe.MatchString(content) && !isEstablishedSkipIdiom(content, s.baseContent) {
+	isGuard := tamperCapabilityGuardRe.MatchString(content)
+	guarded := isGuard || s.guardWindow > 0
+	if isGuard {
+		s.guardWindow = tamperGuardWindowLines
+	} else if s.guardWindow > 0 {
+		s.guardWindow--
+	}
+	if tamperAddedSkipRe.MatchString(content) && !guarded && !isEstablishedSkipIdiom(content, s.baseContent) {
 		s.add("added-skip", trimDiffLine(content))
 	}
 	if tamperAddedExitRe.MatchString(content) {

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -73,6 +73,31 @@ func TestScanTamperPatch(t *testing.T) {
 			wantRules:   []string{"added-skip"},
 		},
 		{
+			name:      "capability_guarded_skip_same_line_not_flagged",
+			patch:     "@@ @@\n func TestSymlink(t *testing.T) {\n+\tif err := os.Symlink(a, b); err != nil { t.Skipf(\"symlink unsupported: %v\", err) }\n",
+			wantRules: nil,
+		},
+		{
+			name:      "capability_guarded_skip_next_line_not_flagged",
+			patch:     "@@ @@\n func TestSymlink(t *testing.T) {\n+\tif err := os.Symlink(a, b); err != nil {\n+\t\tt.Skipf(\"symlink unsupported: %v\", err)\n+\t}\n",
+			wantRules: nil,
+		},
+		{
+			name:      "testing_short_guarded_skip_not_flagged",
+			patch:     "@@ @@\n func TestSlow(t *testing.T) {\n+\tif testing.Short() {\n+\t\tt.Skip(\"skipping slow test in -short\")\n+\t}\n",
+			wantRules: nil,
+		},
+		{
+			name:      "lookpath_guarded_skip_not_flagged",
+			patch:     "@@ @@\n func TestDocker(t *testing.T) {\n+\tif _, err := exec.LookPath(\"docker\"); err != nil {\n+\t\tt.Skip(\"docker not installed\")\n+\t}\n",
+			wantRules: nil,
+		},
+		{
+			name:      "unconditional_skip_after_guard_window_still_flags",
+			patch:     "@@ @@\n func TestX(t *testing.T) {\n+\tif _, err := exec.LookPath(\"docker\"); err != nil {\n+\t\treturn\n+\t}\n+\tsetup()\n+\tvalidate()\n+\tt.Skip(\"flaky\")\n",
+			wantRules: []string{"added-skip"},
+		},
+		{
 			name:  "two_new_identical_skips_same_commit_still_flags",
 			patch: "@@ @@\n func TestFoo(t *testing.T) {\n+\tt.Skip(\"flaky\")\n func TestBar(t *testing.T) {\n+\tt.Skip(\"flaky\")\n",
 			baseContent: "func TestFoo(t *testing.T) {\n}\n\n" +

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -38,6 +38,8 @@ const verifyBlessedTag = "verify-blessed"
 // still blocks; the cost is one extra suite run only on the failing command.
 const verifyChecksFlakeRetries = 1
 
+const verifyChecksTimeoutRetries = 1
+
 // verifyChecksReport is the structured result, stored as a generic artifact.
 type verifyChecksReport struct {
 	Commands   []string `json:"commands"`
@@ -75,10 +77,7 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 	if timeout <= 0 {
 		timeout = verifyChecksDefaultTimeout
 	}
-	ctx, cancel := context.WithTimeout(e.ctx, timeout)
-	defer cancel()
-
-	cmds := e.checks.VerifyCommands(ctx, taskID)
+	cmds := e.checks.VerifyCommands(e.ctx, taskID)
 	if len(cmds) == 0 {
 		return stepDone(step, "skipped: no verify commands configured")
 	}
@@ -90,8 +89,7 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 		return stepDone(step, "skipped: no worktree for task")
 	}
 
-	maybeMiseTrust(ctx, wtPath)
-	failedCmd, output, runErr := e.runVerifyCommands(ctx, taskID, wtPath, cmds)
+	failedCmd, output, runErr := e.runVerifySuiteWithRetry(taskID, wtPath, cmds, timeout, step.ID)
 
 	report := verifyChecksReport{
 		Commands: cmds, FailedCmd: failedCmd, OutputTail: tailString(output, verifyChecksOutputTail),
@@ -109,8 +107,10 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 	// otherwise an agent could hang a test past the budget to dodge the gate.
 	if runErr != nil {
 		if errors.Is(runErr, context.DeadlineExceeded) {
-			reason := "verify suite exceeded the time budget (" + timeout.String() +
-				") — fix slow or hanging tests, or add the `verify-blessed` tag to override"
+			reason := fmt.Sprintf(
+				"verify suite exceeded the time budget (%s) on all %d attempts"+
+					" — fix slow or hanging tests, or add the `verify-blessed` tag to override",
+				timeout, verifyChecksTimeoutRetries+1)
 			return e.flagVerifyChecks(taskID, step, reason, "timeout")
 		}
 		e.logger.Warn("workflow.verify-checks.canceled", "task_id", taskID, "err", runErr)
@@ -131,6 +131,23 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 // returns an error so the workflow stalls instead of advancing past the gate —
 // the YAML transition keys off task.status, so a silently-failed write would
 // otherwise route a failing implementation straight to review.
+func (e *Engine) runVerifySuiteWithRetry(taskID, wtPath string, cmds []string, timeout time.Duration, stepID string) (failedCmd, output string, runErr error) {
+	for attempt := 0; attempt <= verifyChecksTimeoutRetries; attempt++ {
+		ctx, cancel := context.WithTimeout(e.ctx, timeout)
+		maybeMiseTrust(ctx, wtPath)
+		failedCmd, output, runErr = e.runVerifyCommands(ctx, taskID, wtPath, cmds)
+		cancel()
+		if !errors.Is(runErr, context.DeadlineExceeded) || e.ctx.Err() != nil {
+			return failedCmd, output, runErr
+		}
+		if attempt < verifyChecksTimeoutRetries {
+			e.logger.Warn("workflow.verify-checks.timeout-retry",
+				"task_id", taskID, "step", stepID, "attempt", attempt+1, "budget", timeout.String())
+		}
+	}
+	return failedCmd, output, runErr
+}
+
 func (e *Engine) flagVerifyChecks(taskID string, step *Step, reason, detail string) (StepOutput, error) {
 	if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
 		return StepOutput{}, fmt.Errorf("verify-checks: set human-required: %w", statusErr)

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -128,6 +128,26 @@ func TestExecVerifyChecks_TimeoutFailsClosed(t *testing.T) {
 	}
 }
 
+func TestExecVerifyChecks_TimeoutRetryAbsorbsLoadSpike(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	slowOnce := "test -f .timeout-marker || { touch .timeout-marker; sleep 30; }"
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{slowOnce})
+	engine.SetVerifyTimeout(200 * time.Millisecond)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Fatalf("Output = %q, want clean (one-off timeout absorbed by suite retry)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged (retry passed, no human-required)", ti.Status)
+	}
+}
+
 func TestExecVerifyChecks_FlakeRetryPasses(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -30,6 +30,15 @@ var ErrDispatchInFlight = errors.New("agent dispatch already in flight for task"
 // so it must never flip the task to human-required or write a status_reason.
 var ErrTestRunnerBusy = errors.New("test-runner concurrency cap reached")
 
+// ErrAgentPoolBusy is returned by the agent-start path when the global agent
+// pool (agent.MaxConcurrent) is already saturated. The sybra adapter maps
+// agent.ErrMaxConcurrentReached onto this sentinel. Like ErrTestRunnerBusy it
+// is benign and transient — a slot frees when any running agent completes — so
+// the run_agent step parks in ExecWaiting and ResumeStalled retries it. It must
+// never feed the circuit breaker or flip the task to human-required: a
+// transient "too many agents running" is not a dispatch fault.
+var ErrAgentPoolBusy = errors.New("agent pool concurrency cap reached")
+
 // ErrNoProjectAssigned is returned by an agent-start path when a task needs
 // an isolated worktree but has no project_id, and auto-assignment could not
 // resolve one (no agent.default_project_id configured, and more than one
@@ -69,6 +78,8 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 		return "", false
 	case errors.Is(err, ErrTestRunnerBusy):
 		// Transient: the testing slot frees and ResumeStalled retries. No reason.
+		return "", false
+	case errors.Is(err, ErrAgentPoolBusy):
 		return "", false
 	case errors.Is(err, worktreeerr.ErrAgentRunning):
 		// Transient: PrepareForTask refused to rebase a worktree a tracked
@@ -120,6 +131,7 @@ func isTransientCapacityError(err error) bool {
 func transientAgentStartError(err error) bool {
 	return errors.Is(err, ErrDispatchInFlight) ||
 		errors.Is(err, ErrTestRunnerBusy) ||
+		errors.Is(err, ErrAgentPoolBusy) ||
 		errors.Is(err, worktreeerr.ErrTransientFetch) ||
 		errors.Is(err, worktreeerr.ErrAgentRunning) ||
 		errors.Is(err, provider.ErrProviderUnhealthy)

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -68,6 +68,10 @@ func TestClassifyAgentStartError(t *testing.T) {
 			wantPermanent: true,
 			wantContains:  "task cumulative cost exceeds agent.max_task_cost_usd",
 		},
+		{
+			name: "agent pool busy yields empty and transient",
+			err:  fmt.Errorf("start agent: %w", ErrAgentPoolBusy),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -106,6 +110,20 @@ func TestClassifyAgentStartError_DispatchInFlightSuppressed(t *testing.T) {
 	wrapped := fmt.Errorf("start agent: %w", ErrDispatchInFlight)
 	if r, p := ClassifyAgentStartError(wrapped); r != "" || p {
 		t.Errorf("wrapped: got reason=%q permanent=%v, want empty/false", r, p)
+	}
+}
+
+func TestClassifyAgentStartError_AgentPoolBusySuppressed(t *testing.T) {
+	wrapped := fmt.Errorf("start agent: %w", ErrAgentPoolBusy)
+	reason, permanent := ClassifyAgentStartError(wrapped)
+	if reason != "" {
+		t.Errorf("reason = %q, want empty", reason)
+	}
+	if permanent {
+		t.Error("agent-pool-busy must not be permanent")
+	}
+	if !transientAgentStartError(wrapped) {
+		t.Error("transientAgentStartError() = false, want true")
 	}
 }
 


### PR DESCRIPTION
## Motivation

The `human-required` column had accumulated ~21 tasks. Analysis showed the
large majority were **not genuine human needs** — they were Sybra escalating
on transient, self-healing, or load-induced conditions and then treating
`human-required` as terminal (only two narrow PR-monitor paths ever auto-clear
it). Most were manufactured inside a single ~2h window when the fleet
oversaturated one machine (agent pool at its cap while many verify suites and
dispatches ran concurrently).

> Changelog: fix(workflow): reduce false human-required escalations

This PR fixes the three highest-impact, safe-by-construction buckets. Three
further buckets are deliberately deferred (see below) because they either
change a well-tested recovery contract or loosen an outward-facing human gate
and need an explicit posture decision.

## Implementation information

**1. Park on a saturated agent pool instead of escalating** (biggest false
positive). A hit on the global `agent.MaxConcurrent` cap surfaced as a bare
error that fell through to the circuit breaker, tripping tasks to
`human-required` after 3 dispatch failures in 15m. Capacity saturation is
transient — a slot frees when any running agent completes. New
`agent.ErrMaxConcurrentReached` sentinel, mapped in the dispatch adapter to a
new transient `workflow.ErrAgentPoolBusy`, parks the `run_agent` step in
`ExecWaiting` for `ResumeStalled` to retry — mirroring `ErrTestRunnerBusy`.
The global cap now has the same benign-transient treatment the per-machine
test-runner cap already had.

**2. Retry the verify suite once on timeout** (largest bucket). The verify
budget is one wall-clock window over the whole serial suite (build + `test
-race` + e2e + lint). A machine starved by many concurrent agents blows it
with no hanging test, escalating unrelated work. The suite is now re-run once
under a fresh budget on a clean `DeadlineExceeded`; a genuinely hung test
exhausts every attempt and still blocks. Engine-shutdown cancellation still
fails open.

**3. Exempt capability-guarded skips from the tamper gate.** An added
`t.Skip` guarded by a real capability probe (`os.Symlink`, `exec.LookPath`,
`testing.Short`, …) is a legitimate environment skip, but the detector flagged
any novel added skip as high-severity and parked the task for a human bless.
A short added-line guard window now exempts a skip that sits inside such a
probe. Static platform/env equality checks (`GOOS ==`, `Getenv() ==`) are
deliberately **not** exempted — an always-true one could wrap a failing test
to dodge the gate — so those still flag. This tightens precision; it does not
weaken the reward-hacking defense.

Each fix ships with unit tests; the existing tamper/verify/dispatch suites and
the e2e smoke pass.

### Deferred (follow-ups)

- **Stale-rebase auto-recreate.** The `wtFailureLimit` retry circuit in the
  no-PR branch-conflict recovery is defeated by `MarkRebaseBlocked` escalating
  on the first decline. The correct fix is a three-state recovery contract
  (recovered / retry-pending / escalate) plus updates to the tests that encode
  the current two-state behavior — too risky for the conflict-recovery hot path
  inside a multi-fix PR. Fixes 1 and 2 also reduce the concurrent-agent load
  that triggers these rebase races in the first place.
- **Auto-submit drafted reviews** and **auto-approve trivially-small PRs.**
  Both loosen an intentional human gate on outward-facing GitHub actions and
  affect work-typed review tasks, where the work-data confidentiality rule
  applies. These need an explicit opt-in config default (and a work-typed
  carve-out) rather than being flipped on unilaterally.

## Supporting documentation

Root-cause taxonomy of the 21 stuck tasks and the master list of every
`human-required` escalation site were produced during analysis and are
available on request.
