### PR TITLE
fix(frontend): scope pending approvals per agent

### DIFF
--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -28,9 +28,7 @@
 
   const isRunning = $derived(agentState === 'running')
   const isPaused = $derived(agentState === 'paused')
-  const approvals = $derived(
-    [...convoStore.pendingApprovals.values()],
-  )
+  const approvals = $derived(convoStore.approvalsFor(agentId))
   const hasApproval = $derived(approvals.length > 0)
   const isWaitingForApproval = $derived(isPaused && hasApproval)
   const isWaitingForInput = $derived(isPaused && !hasApproval)
@@ -102,7 +100,7 @@
   }
 
   async function handleApproval(toolUseId: string, approved: boolean) {
-    await convoStore.respondApproval(toolUseId, approved)
+    await convoStore.respondApproval(agentId, toolUseId, approved)
   }
 </script>
 

--- a/frontend/src/components/ChatView.svelte.test.ts
+++ b/frontend/src/components/ChatView.svelte.test.ts
@@ -8,12 +8,13 @@ const mockRespondApproval = vi.fn()
 const mockSubscribe = vi.fn((..._args: unknown[]) => () => {})
 
 const conversations = new SvelteMap<string, unknown[]>()
-const pendingApprovals = new SvelteMap<string, unknown>()
+const pendingApprovals = new SvelteMap<string, SvelteMap<string, unknown>>()
 
 vi.mock('../stores/convo.svelte.js', () => ({
   convoStore: {
     conversations,
     pendingApprovals,
+    approvalsFor: (agentId: string) => [...(pendingApprovals.get(agentId)?.values() ?? [])],
     getOutput: (...args: unknown[]) => mockGetOutput(...args),
     sendMessage: (...args: unknown[]) => mockSendMessage(...args),
     respondApproval: (...args: unknown[]) => mockRespondApproval(...args),
@@ -58,17 +59,33 @@ describe('ChatView', () => {
   // a follow-up while a tool-use is awaiting consent would race the queue
   // ahead of the approval handshake.
   it('disables input when a tool approval is pending', async () => {
-    pendingApprovals.set('tool-1', {
+    pendingApprovals.set('a1', new SvelteMap([['tool-1', {
       toolUseId: 'tool-1',
       toolName: 'Bash',
       input: {},
-    })
+    }]]))
 
     render(ChatView, { props: { agentId: 'a1', agentState: 'paused' } })
 
     const textarea = await screen.findByRole('textbox')
     expect((textarea as HTMLTextAreaElement).disabled).toBe(true)
     expect((textarea as HTMLTextAreaElement).placeholder).toBe('Waiting for approval...')
+  })
+
+  // Regression: a second agent's pending approval must not leak into this
+  // agent's ChatView — approvals are scoped per agentId.
+  it('does not show another agent\'s pending approval', async () => {
+    pendingApprovals.set('a2', new SvelteMap([['tool-2', {
+      toolUseId: 'tool-2',
+      toolName: 'Write',
+      input: {},
+    }]]))
+
+    render(ChatView, { props: { agentId: 'a1', agentState: 'paused' } })
+
+    const textarea = await screen.findByRole('textbox')
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(false)
+    expect((textarea as HTMLTextAreaElement).placeholder).toBe('Type a message...')
   })
 
   it('forwards typed messages to convoStore.sendMessage', async () => {

--- a/frontend/src/components/agent-view/BlockedLayout.svelte
+++ b/frontend/src/components/agent-view/BlockedLayout.svelte
@@ -44,10 +44,10 @@
   let historyOpen = $state(false)
   let timelineOpen = $state(true)
 
-  const approvals = $derived([...convoStore.pendingApprovals.values()])
+  const approvals = $derived(convoStore.approvalsFor(a.id))
 
   async function handleApproval(toolUseId: string, approved: boolean) {
-    await convoStore.respondApproval(toolUseId, approved)
+    await convoStore.respondApproval(a.id, toolUseId, approved)
   }
 </script>
 

--- a/frontend/src/stores/convo.svelte.test.ts
+++ b/frontend/src/stores/convo.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SvelteMap } from 'svelte/reactivity'
 import { ConvoEvent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
 import { agentConvo, agentApproval } from '../lib/events.js'
 
@@ -94,30 +95,49 @@ describe('ConvoStore', () => {
 
   describe('respondApproval', () => {
     it('calls RespondApproval and removes from pendingApprovals', async () => {
-      convoStore.pendingApprovals.set('tool-1', {
+      convoStore.pendingApprovals.set('a1', new SvelteMap([['tool-1', {
         toolUseId: 'tool-1',
         toolName: 'Bash',
         input: {},
-      })
+      }]]))
       mockRespondApproval.mockResolvedValue(undefined)
 
-      await convoStore.respondApproval('tool-1', true)
+      await convoStore.respondApproval('a1', 'tool-1', true)
 
       expect(mockRespondApproval).toHaveBeenCalledWith('tool-1', true)
-      expect(convoStore.pendingApprovals.has('tool-1')).toBe(false)
+      expect(convoStore.pendingApprovals.get('a1')?.has('tool-1')).toBe(false)
     })
 
     it('calls RespondApproval with false for denial', async () => {
-      convoStore.pendingApprovals.set('tool-2', {
+      convoStore.pendingApprovals.set('a1', new SvelteMap([['tool-2', {
         toolUseId: 'tool-2',
         toolName: 'Write',
         input: {},
-      })
+      }]]))
       mockRespondApproval.mockResolvedValue(undefined)
 
-      await convoStore.respondApproval('tool-2', false)
+      await convoStore.respondApproval('a1', 'tool-2', false)
 
       expect(mockRespondApproval).toHaveBeenCalledWith('tool-2', false)
+    })
+  })
+
+  describe('approvalsFor', () => {
+    it('scopes approvals to the given agentId', () => {
+      convoStore.pendingApprovals.set('a1', new SvelteMap([['tool-1', {
+        toolUseId: 'tool-1',
+        toolName: 'Bash',
+        input: {},
+      }]]))
+      convoStore.pendingApprovals.set('a2', new SvelteMap([['tool-2', {
+        toolUseId: 'tool-2',
+        toolName: 'Write',
+        input: {},
+      }]]))
+
+      expect(convoStore.approvalsFor('a1').map((r) => r.toolUseId)).toEqual(['tool-1'])
+      expect(convoStore.approvalsFor('a2').map((r) => r.toolUseId)).toEqual(['tool-2'])
+      expect(convoStore.approvalsFor('a3')).toEqual([])
     })
   })
 
@@ -147,14 +167,30 @@ describe('ConvoStore', () => {
       unsub()
     })
 
-    it('stores pending approval from approval stream', () => {
+    it('stores pending approval from approval stream, scoped to the agent', () => {
       const unsub = convoStore.subscribe('a1')
       const req = { toolUseId: 'tu-1', toolName: 'Bash', input: { cmd: 'ls' } }
 
       eventCallbacks[agentApproval('a1')](req)
 
-      expect(convoStore.pendingApprovals.get('tu-1')).toEqual(req)
+      expect(convoStore.pendingApprovals.get('a1')?.get('tu-1')).toEqual(req)
+      expect(convoStore.approvalsFor('a1')).toEqual([req])
       unsub()
+    })
+
+    it('keeps approvals from different agents isolated', () => {
+      const unsub1 = convoStore.subscribe('a1')
+      const unsub2 = convoStore.subscribe('a2')
+      const req1 = { toolUseId: 'tu-1', toolName: 'Bash', input: {} }
+      const req2 = { toolUseId: 'tu-2', toolName: 'Write', input: {} }
+
+      eventCallbacks[agentApproval('a1')](req1)
+      eventCallbacks[agentApproval('a2')](req2)
+
+      expect(convoStore.approvalsFor('a1')).toEqual([req1])
+      expect(convoStore.approvalsFor('a2')).toEqual([req2])
+      unsub1()
+      unsub2()
     })
 
     it('unsubscribes both listeners', () => {

--- a/frontend/src/stores/convo.svelte.ts
+++ b/frontend/src/stores/convo.svelte.ts
@@ -16,7 +16,10 @@ export interface ApprovalRequest {
 
 class ConvoStore {
   conversations = new SvelteMap<string, ConvoEvent[]>()
-  pendingApprovals = new SvelteMap<string, ApprovalRequest>()
+  // Keyed by agentId, then toolUseId — so a toolUseId is only ever looked up
+  // within its own agent's chat, and one agent's approvals never bleed into
+  // another agent's ChatView/BlockedLayout.
+  pendingApprovals = new SvelteMap<string, SvelteMap<string, ApprovalRequest>>()
 
   async getOutput(agentId: string): Promise<ConvoEvent[]> {
     const events = (await GetConvoOutput(agentId)) ?? []
@@ -33,9 +36,13 @@ class ConvoStore {
     await SendMessage(agentId, text)
   }
 
-  async respondApproval(toolUseId: string, approved: boolean): Promise<void> {
+  approvalsFor(agentId: string): ApprovalRequest[] {
+    return [...(this.pendingApprovals.get(agentId)?.values() ?? [])]
+  }
+
+  async respondApproval(agentId: string, toolUseId: string, approved: boolean): Promise<void> {
     await RespondApproval(toolUseId, approved)
-    this.pendingApprovals.delete(toolUseId)
+    this.pendingApprovals.get(agentId)?.delete(toolUseId)
   }
 
   subscribe(agentId: string): () => void {
@@ -49,7 +56,12 @@ class ConvoStore {
     const unsubApproval = EventsOn(
       agentApproval(agentId),
       (req: ApprovalRequest) => {
-        this.pendingApprovals.set(req.toolUseId, req)
+        let forAgent = this.pendingApprovals.get(agentId)
+        if (!forAgent) {
+          forAgent = new SvelteMap<string, ApprovalRequest>()
+          this.pendingApprovals.set(agentId, forAgent)
+        }
+        forAgent.set(req.toolUseId, req)
       },
     )
 


### PR DESCRIPTION
## Motivation
Task detail and agent chat views can display stale pending approval state when switching between agents or when updates arrive for a different agent. That makes the UI feel non-reactive and can surface actions in the wrong context.

Closes https://github.com/Automaat/sybra/issues/1543

## Implementation information
- Key pending approval state by agent id in the conversation store.
- Thread agent-specific pending approval state through ChatView and BlockedLayout.
- Add frontend coverage for scoped approval updates and view behavior.

_Generated by Sybra harness_