### PR TITLE
fix(github): preserve PR issue retry memory

### DIFF
--- a/internal/github/debounce.go
+++ b/internal/github/debounce.go
@@ -145,27 +145,23 @@ func (t *IssueTracker) AtCap(taskID string, kind PRIssueKind) bool {
 	return t.retries[issueKey(taskID, kind)] >= maxRetries
 }
 
-// Cleanup removes entries older than 2x cooldown. Entries that have hit the
-// retry cap are kept so the escalation path in the caller survives long gaps
-// between flaky CI runs — without this, Cleanup would reset the counter and
-// the cap would never fire.
+// Cleanup drops the time-based cooldown record for entries older than 2x
+// cooldown, letting a subsequent poll dispatch immediately once a genuinely
+// new commit or feedback signature shows up — but it never touches
+// retries/lastSHA/sigs. Those three are the durable per-commit memory: an
+// unchanged head SHA must keep skipping dispatch (and an at-cap signature
+// must keep escalating) no matter how long the PR sits idle between polls.
+// A prior version wiped retries/lastSHA/sigs here once retries were below
+// the cap, which meant a long-lived PR whose head never changed would forget
+// it had already been handled and re-dispatch a fresh pr-fix agent forever
+// (#1528 — 42 runs against one static head SHA over 10 days).
 func (t *IssueTracker) Cleanup() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	cutoff := t.now().Add(-2 * t.cooldown)
 	for k, v := range t.handled {
-		if !v.Before(cutoff) {
-			continue
-		}
-		if t.retries[k] >= maxRetries {
-			// At cap: keep retries/lastSHA so the caller can escalate;
-			// only drop the time-based handled entry (no more cooldown).
+		if v.Before(cutoff) {
 			delete(t.handled, k)
-			continue
 		}
-		delete(t.handled, k)
-		delete(t.retries, k)
-		delete(t.lastSHA, k)
-		delete(t.sigs, k)
 	}
 }

--- a/internal/github/debounce_test.go
+++ b/internal/github/debounce_test.go
@@ -165,17 +165,25 @@ func TestIssueTracker(t *testing.T) {
 		}
 	})
 
-	t.Run("cleanup removes old entries", func(t *testing.T) {
+	t.Run("cleanup drops cooldown but never forgets the last SHA", func(t *testing.T) {
+		// Regression for #1528: a long-lived PR whose head never changes must
+		// keep skipping dispatch even once the time-based cooldown record ages
+		// out of Cleanup — otherwise the tracker "forgets" it already handled
+		// this exact commit and re-dispatches a fresh pr-fix agent forever.
 		tracker.MarkHandled("t3", PRIssueConflict, "sha-old")
 		now = now.Add(61 * time.Minute) // past 2x cooldown
 		tracker.Cleanup()
 
-		// t3 should be cleaned up — new SHA allowed
-		if !tracker.ShouldHandle("t3", PRIssueConflict, "sha-old") {
-			t.Fatal("expected ShouldHandle=true after cleanup")
+		// Same SHA still blocks — Cleanup must not erase the SHA memory.
+		if tracker.ShouldHandle("t3", PRIssueConflict, "sha-old") {
+			t.Fatal("expected ShouldHandle=false: same SHA still blocks after cleanup")
 		}
-		if tracker.Retries("t3", PRIssueConflict) != 0 {
-			t.Fatal("expected retries cleaned up")
+		if tracker.Retries("t3", PRIssueConflict) != 1 {
+			t.Fatalf("expected retries preserved at 1 after cleanup, got %d", tracker.Retries("t3", PRIssueConflict))
+		}
+		// A genuinely new commit is still handled promptly.
+		if !tracker.ShouldHandle("t3", PRIssueConflict, "sha-new") {
+			t.Fatal("expected ShouldHandle=true: new SHA allowed after cleanup")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- keep PR issue retry counters, last head SHA, and feedback signatures across debounce cleanup
- only expire the time-based cooldown record so unchanged PR heads do not re-dispatch pr-fix after idle gaps
- update debounce regression coverage for long-lived unchanged PRs

## Tests
- go test ./internal/github ./internal/sybra/review ./internal/recovery ./internal/workflow