### PR TITLE
fix(umbrella): fall back to independent planner tasks

### DIFF
--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -74,7 +74,7 @@ func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int, degr
 	}
 	fmt.Printf("Expanded %s: created %d child task(s), %d skipped (done or already present).\n", umbrellaURL, created, skipped)
 	if degraded {
-		fmt.Println("WARNING: planner exhausted its retries — fell back to a linear-chain plan (serial, no parallelism).")
+		fmt.Println("WARNING: planner exhausted its retries — fell back to an independent-parallel plan (no derived ordering, degraded parallelism cap).")
 	}
 	return 0
 }

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -125,7 +125,7 @@ type Result struct {
 	UmbrellaURL string
 	Created     int  // child tasks created this run
 	Skipped     int  // sub-issues already materialized or done
-	Degraded    bool // true when the DAG came from linearChainFallback, not the model
+	Degraded    bool // true when the DAG came from independentFallback, not the model
 }
 
 // Expand fetches a GitHub umbrella issue's native sub-issues, runs the planner
@@ -290,7 +290,7 @@ func findTracker(tasks *task.Manager, umbrellaURL string) (existingTracker, erro
 }
 
 // materialize creates the tracker (when absent) and one gated todo child per
-// spec. When degraded (the plan came from linearChainFallback), the tracker
+// spec. When degraded (the plan came from independentFallback), the tracker
 // carries FallbackTag so a systematically-failing planner is board-visible:
 // on a fresh tracker the tag is included at creation; on re-expansion against
 // an already-materialized tracker it is appended idempotently (add-if-absent)

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -68,7 +68,7 @@ func newTestTaskManager(t *testing.T) *task.Manager {
 	return task.NewManager(store, task.EmitterFunc(func(string, any) {}))
 }
 
-func TestExpandPlannerDeadlineFallsBackToLinearChain(t *testing.T) {
+func TestExpandPlannerDeadlineFallsBackToIndependentParallel(t *testing.T) {
 	restore := githubFetchUmbrellaForTest(t, github.Issue{
 		Title:      "umbrella",
 		URL:        "https://github.com/o/r/issues/100",
@@ -115,11 +115,14 @@ func TestExpandPlannerDeadlineFallsBackToLinearChain(t *testing.T) {
 	if got := ParseExpandFailCount(tracker.Tags); got != 0 {
 		t.Fatalf("expand fail count = %d, want 0 for degraded fallback success", got)
 	}
-	if got := children["o/r#2"].DependsOn; len(got) != 1 || got[0] != "https://github.com/o/r/issues/1" {
-		t.Fatalf("child #2 deps = %v, want issue #1", got)
+	if got := children["o/r#1"].DependsOn; len(got) != 0 {
+		t.Fatalf("child #1 deps = %v, want none (independent-parallel fallback)", got)
 	}
-	if got := children["o/r#3"].DependsOn; len(got) != 1 || got[0] != "https://github.com/o/r/issues/2" {
-		t.Fatalf("child #3 deps = %v, want issue #2", got)
+	if got := children["o/r#2"].DependsOn; len(got) != 0 {
+		t.Fatalf("child #2 deps = %v, want none (independent-parallel fallback)", got)
+	}
+	if got := children["o/r#3"].DependsOn; len(got) != 0 {
+		t.Fatalf("child #3 deps = %v, want none (independent-parallel fallback)", got)
 	}
 }
 

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -112,6 +112,9 @@ func TestExpandPlannerDeadlineFallsBackToIndependentParallel(t *testing.T) {
 	if !slices.Contains(tracker.Tags, FallbackTag) {
 		t.Fatalf("tracker tags = %v, want %q", tracker.Tags, FallbackTag)
 	}
+	if got := ParseMaxParallel(tracker.Tags); got != 3 {
+		t.Fatalf("tracker max parallel = %d, want 3 after degraded fallback", got)
+	}
 	if got := ParseExpandFailCount(tracker.Tags); got != 0 {
 		t.Fatalf("expand fail count = %d, want 0 for degraded fallback success", got)
 	}

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -22,7 +22,7 @@ const plannerAttempts = 3
 
 // errPlannerExhausted marks attemptPlan's exhaustion return (plannerAttempts
 // samples, none parsed/resolved/validated) so Generate can distinguish it from
-// a fatal runner error via errors.Is and fall back to a linear chain instead
+// a fatal runner error via errors.Is and fall back to an independent-parallel plan instead
 // of aborting the whole expansion.
 var errPlannerExhausted = errors.New("planner exhausted retries")
 
@@ -58,7 +58,7 @@ type PlannedChild struct {
 type Plan struct {
 	Children    []PlannedChild `json:"children"`
 	MaxParallel int            `json:"maxParallel"`
-	// Fallback marks a plan built by linearChainFallback instead of the model,
+	// Fallback marks a plan built by independentFallback instead of the model,
 	// so callers can surface degradation loudly. Never persisted on the wire.
 	Fallback bool `json:"-"`
 }
@@ -102,7 +102,7 @@ const criticSuffix = "You produced a fully-parallel plan — re-examine `touches
 // falls back to the original plan rather than failing the whole expansion.
 // If the first attempt exhausts plannerAttempts without ever producing a
 // valid plan, or the planner deadline expires, Generate falls back to a
-// fully-serial linear chain (linearChainFallback) instead of aborting the
+// independent-parallel plan (independentFallback) instead of aborting the
 // expansion; a fatal runner error (couldn't launch the model) is not
 // exhaustion and still aborts.
 func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue, opts ...GenerateOption) (Plan, error) {
@@ -119,7 +119,7 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 	plan, err := attemptPlan(ctx, run, idx, prompt, subs, cfg)
 	if err != nil {
 		if plannerExhausted(err) {
-			return linearChainFallback(subs)
+			return independentFallback(subs)
 		}
 		return Plan{}, err
 	}
@@ -173,19 +173,21 @@ func attemptPlan(ctx context.Context, run Runner, idx refIndex, prompt string, s
 	return Plan{}, fmt.Errorf("planner produced no valid plan in %d attempts: %w: %w", plannerAttempts, errPlannerExhausted, lastErr)
 }
 
-// linearChainFallback builds a fully-serial fallback plan for when the
-// planner exhausts its retries without producing a valid DAG: sub-issues are
-// ordered by numeric issue number (ties and non-numeric refs keep fetch
-// order, via a stable sort), and each open child depends on the previous open
-// child. A closed sub-issue carries no edges — ChildSpecs already drops any
-// dependency on a closed sub-issue as satisfied — so a closed sub-issue in
-// the middle of the chain cannot split the remaining open children into
-// parallel islands; the open child that follows it still chains to the last
-// open child before it. MaxParallel is pinned to 1 and Fallback is set so
-// callers can surface the degradation. The constructed plan still runs
-// through validate as a real guard: a validation failure is returned rather
-// than silently committing a malformed chain.
-func linearChainFallback(subs []SubIssue) (Plan, error) {
+// independentFallback builds an independent-parallel fallback plan for when
+// the planner exhausts its retries without producing a valid DAG: since the
+// planner produced no ordering information at all, assuming total order is
+// the most expensive possible wrong guess (it multiplies wall-clock by N),
+// while assuming no order is cheap and self-healing — every child runs in
+// its own worktree and opens its own PR, so real conflicts surface at
+// merge/review (handled by pr-fix), not at run time. Sub-issues are ordered
+// by numeric issue number (ties and non-numeric refs keep fetch order, via a
+// stable sort) purely for deterministic child ordering; no DependsOn edges
+// are emitted between children. MaxParallel is set to a modest degraded cap
+// and Fallback is set so callers can surface the degradation. The
+// constructed plan still runs through validate as a real guard: a validation
+// failure is returned rather than silently committing a malformed plan.
+func independentFallback(subs []SubIssue) (Plan, error) {
+	const fallbackMaxParallel = 3
 	type numberedSub struct {
 		sub    SubIssue
 		num    int
@@ -220,21 +222,13 @@ func linearChainFallback(subs []SubIssue) (Plan, error) {
 		keyed[idx] = numbered[i]
 	}
 
-	p := Plan{MaxParallel: 1, Fallback: true}
-	prevOpen := ""
+	p := Plan{MaxParallel: fallbackMaxParallel, Fallback: true}
 	for _, ks := range keyed {
 		canon := NormalizeIssueRef(ks.sub.Ref)
-		child := PlannedChild{Ref: canon}
-		if !ks.sub.Closed {
-			if prevOpen != "" {
-				child.DependsOn = []string{prevOpen}
-			}
-			prevOpen = canon
-		}
-		p.Children = append(p.Children, child)
+		p.Children = append(p.Children, PlannedChild{Ref: canon})
 	}
 	if err := p.validate(subs); err != nil {
-		return Plan{}, fmt.Errorf("linear-chain fallback failed validation: %w", err)
+		return Plan{}, fmt.Errorf("independent fallback failed validation: %w", err)
 	}
 	return p, nil
 }

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -101,7 +101,7 @@ const criticSuffix = "You produced a fully-parallel plan — re-examine `touches
 // a critic nudge; any failure of that re-ask (parse, validate, or run error)
 // falls back to the original plan rather than failing the whole expansion.
 // If the first attempt exhausts plannerAttempts without ever producing a
-// valid plan, or the planner deadline expires, Generate falls back to a
+// valid plan, or the planner deadline expires, Generate falls back to an
 // independent-parallel plan (independentFallback) instead of aborting the
 // expansion; a fatal runner error (couldn't launch the model) is not
 // exhaustion and still aborts.

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -574,7 +575,7 @@ func TestGenerate(t *testing.T) {
 		}
 	})
 
-	t.Run("exhausted retries fall back to a linear chain instead of erroring", func(t *testing.T) {
+	t.Run("exhausted retries fall back to an independent-parallel plan instead of erroring", func(t *testing.T) {
 		t.Parallel()
 		run := func(_ context.Context, _ string) (string, error) { return "not json", nil }
 		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2", "o/r#3"))
@@ -584,8 +585,8 @@ func TestGenerate(t *testing.T) {
 		if !plan.Fallback {
 			t.Fatalf("Fallback = false, want true")
 		}
-		if plan.MaxParallel != 1 {
-			t.Fatalf("MaxParallel = %d, want 1", plan.MaxParallel)
+		if plan.MaxParallel != 3 {
+			t.Fatalf("MaxParallel = %d, want 3", plan.MaxParallel)
 		}
 		if len(plan.Children) != 3 {
 			t.Fatalf("Children = %d, want 3", len(plan.Children))
@@ -602,11 +603,11 @@ func TestGenerate(t *testing.T) {
 		if got := depsOf("o/r#1"); len(got) != 0 {
 			t.Errorf("o/r#1 deps = %v, want none", got)
 		}
-		if got := depsOf("o/r#2"); len(got) != 1 || got[0] != "o/r#1" {
-			t.Errorf("o/r#2 deps = %v, want [o/r#1]", got)
+		if got := depsOf("o/r#2"); len(got) != 0 {
+			t.Errorf("o/r#2 deps = %v, want none", got)
 		}
-		if got := depsOf("o/r#3"); len(got) != 1 || got[0] != "o/r#2" {
-			t.Errorf("o/r#3 deps = %v, want [o/r#2]", got)
+		if got := depsOf("o/r#3"); len(got) != 0 {
+			t.Errorf("o/r#3 deps = %v, want none", got)
 		}
 	})
 
@@ -621,8 +622,8 @@ func TestGenerate(t *testing.T) {
 	t.Run("cycle rejected", func(t *testing.T) {
 		t.Parallel()
 		// A persistently cyclic plan is never accepted as valid; attemptPlan
-		// exhausts its retries and Generate falls back to a linear chain
-		// rather than committing the cyclic plan or hard-erroring.
+		// exhausts its retries and Generate falls back to an independent-parallel
+		// plan rather than committing the cyclic plan or hard-erroring.
 		cyclic := `{"children":[{"issue":"o/r#1","dependsOn":["o/r#2"]},{"issue":"o/r#2","dependsOn":["o/r#1"]}],"maxParallel":2}`
 		run := func(_ context.Context, _ string) (string, error) { return cyclic, nil }
 		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2"))
@@ -734,7 +735,7 @@ func TestGenerate(t *testing.T) {
 			t.Fatalf("expected fallback to original flat plan: %+v", plan)
 		}
 		if plan.Fallback {
-			t.Fatalf("re-ask failure must return the original valid plan, not linearChainFallback: %+v", plan)
+			t.Fatalf("re-ask failure must return the original valid plan, not independentFallback: %+v", plan)
 		}
 	})
 
@@ -754,7 +755,7 @@ func TestGenerate(t *testing.T) {
 			t.Fatalf("expected fallback to original flat plan: %+v", plan)
 		}
 		if plan.Fallback {
-			t.Fatalf("re-ask failure must return the original valid plan, not linearChainFallback: %+v", plan)
+			t.Fatalf("re-ask failure must return the original valid plan, not independentFallback: %+v", plan)
 		}
 	})
 
@@ -825,7 +826,7 @@ func TestGenerateGroundedEdge(t *testing.T) {
 	})
 }
 
-func TestLinearChainFallback(t *testing.T) {
+func TestIndependentFallback(t *testing.T) {
 	t.Parallel()
 
 	depsOf := func(t *testing.T, p Plan, ref string) []string {
@@ -839,24 +840,51 @@ func TestLinearChainFallback(t *testing.T) {
 		return nil
 	}
 
-	t.Run("orders by issue number regardless of fetch order", func(t *testing.T) {
+	t.Run("emits no DependsOn edges between children", func(t *testing.T) {
 		t.Parallel()
-		p, err := linearChainFallback(subs("o/r#3", "o/r#1", "o/r#2"))
+		s := subs("o/r#3", "o/r#1", "o/r#2")
+		p, err := independentFallback(s)
 		if err != nil {
-			t.Fatalf("linearChainFallback: %v", err)
+			t.Fatalf("independentFallback: %v", err)
 		}
-		if len(depsOf(t, p, "o/r#1")) != 0 {
-			t.Errorf("o/r#1 should be first, deps = %v", depsOf(t, p, "o/r#1"))
-		}
-		if got := depsOf(t, p, "o/r#2"); len(got) != 1 || got[0] != "o/r#1" {
-			t.Errorf("o/r#2 deps = %v, want [o/r#1]", got)
-		}
-		if got := depsOf(t, p, "o/r#3"); len(got) != 1 || got[0] != "o/r#2" {
-			t.Errorf("o/r#3 deps = %v, want [o/r#2]", got)
+		for _, c := range p.Children {
+			if len(c.DependsOn) != 0 {
+				t.Errorf("%s deps = %v, want none", c.Ref, c.DependsOn)
+			}
 		}
 	})
 
-	t.Run("closed sub mid-chain keeps remaining open children serially chained", func(t *testing.T) {
+	t.Run("orders children by issue number regardless of fetch order", func(t *testing.T) {
+		t.Parallel()
+		p, err := independentFallback(subs("o/r#3", "o/r#1", "o/r#2"))
+		if err != nil {
+			t.Fatalf("independentFallback: %v", err)
+		}
+		var refs []string
+		for _, c := range p.Children {
+			refs = append(refs, c.Ref)
+		}
+		want := []string{"o/r#1", "o/r#2", "o/r#3"}
+		if !slices.Equal(refs, want) {
+			t.Errorf("child order = %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("sets MaxParallel to the degraded cap and marks Fallback", func(t *testing.T) {
+		t.Parallel()
+		p, err := independentFallback(subs("o/r#1", "o/r#2"))
+		if err != nil {
+			t.Fatalf("independentFallback: %v", err)
+		}
+		if p.MaxParallel != 3 {
+			t.Errorf("MaxParallel = %d, want 3", p.MaxParallel)
+		}
+		if !p.Fallback {
+			t.Error("Fallback = false, want true")
+		}
+	})
+
+	t.Run("closed sub carries no edges either", func(t *testing.T) {
 		t.Parallel()
 		s := []SubIssue{
 			{Ref: "o/r#1"},
@@ -864,29 +892,24 @@ func TestLinearChainFallback(t *testing.T) {
 			{Ref: "o/r#3"},
 			{Ref: "o/r#4"},
 		}
-		p, err := linearChainFallback(s)
+		p, err := independentFallback(s)
 		if err != nil {
-			t.Fatalf("linearChainFallback: %v", err)
+			t.Fatalf("independentFallback: %v", err)
 		}
 		if got := depsOf(t, p, "o/r#2"); len(got) != 0 {
 			t.Errorf("closed o/r#2 should carry no edges, got %v", got)
 		}
-		// #3 must chain to the last OPEN sibling (#1), skipping the closed #2 —
-		// not split into a parallel island by the gap.
-		if got := depsOf(t, p, "o/r#3"); len(got) != 1 || got[0] != "o/r#1" {
-			t.Errorf("o/r#3 deps = %v, want [o/r#1] (skips closed o/r#2)", got)
-		}
-		if got := depsOf(t, p, "o/r#4"); len(got) != 1 || got[0] != "o/r#3" {
-			t.Errorf("o/r#4 deps = %v, want [o/r#3]", got)
+		if got := depsOf(t, p, "o/r#3"); len(got) != 0 {
+			t.Errorf("o/r#3 deps = %v, want none", got)
 		}
 	})
 
 	t.Run("covers every sub-issue exactly once", func(t *testing.T) {
 		t.Parallel()
 		s := subs("o/r#1", "o/r#2", "o/r#3")
-		p, err := linearChainFallback(s)
+		p, err := independentFallback(s)
 		if err != nil {
-			t.Fatalf("linearChainFallback: %v", err)
+			t.Fatalf("independentFallback: %v", err)
 		}
 		if err := p.validate(s); err != nil {
 			t.Errorf("validate: %v", err)
@@ -901,30 +924,34 @@ func TestLinearChainFallback(t *testing.T) {
 		// o/r#1 and x/y#1 share the numeric tail "1" but are different
 		// sub-issues (different repos); the tie must not reorder them.
 		s := []SubIssue{{Ref: "o/r#1"}, {Ref: "x/y#1"}, {Ref: "o/r#2"}}
-		p, err := linearChainFallback(s)
+		p, err := independentFallback(s)
 		if err != nil {
-			t.Fatalf("linearChainFallback: %v", err)
+			t.Fatalf("independentFallback: %v", err)
 		}
-		if got := depsOf(t, p, "x/y#1"); len(got) != 1 || got[0] != "o/r#1" {
-			t.Errorf("x/y#1 deps = %v, want [o/r#1] (tie keeps fetch order)", got)
+		var refs []string
+		for _, c := range p.Children {
+			refs = append(refs, c.Ref)
 		}
-		if got := depsOf(t, p, "o/r#2"); len(got) != 1 || got[0] != "x/y#1" {
-			t.Errorf("o/r#2 deps = %v, want [x/y#1]", got)
+		want := []string{"o/r#1", "x/y#1", "o/r#2"}
+		if !slices.Equal(refs, want) {
+			t.Errorf("child order = %v, want %v (tie keeps fetch order)", refs, want)
 		}
 	})
 
 	t.Run("non-numeric refs keep fetch order", func(t *testing.T) {
 		t.Parallel()
 		s := []SubIssue{{Ref: "o/r#foo"}, {Ref: "o/r#bar"}, {Ref: "o/r#baz"}}
-		p, err := linearChainFallback(s)
+		p, err := independentFallback(s)
 		if err != nil {
-			t.Fatalf("linearChainFallback: %v", err)
+			t.Fatalf("independentFallback: %v", err)
 		}
-		if got := depsOf(t, p, "o/r#bar"); len(got) != 1 || got[0] != "o/r#foo" {
-			t.Errorf("o/r#bar deps = %v, want [o/r#foo] (fetch order preserved)", got)
+		var refs []string
+		for _, c := range p.Children {
+			refs = append(refs, c.Ref)
 		}
-		if got := depsOf(t, p, "o/r#baz"); len(got) != 1 || got[0] != "o/r#bar" {
-			t.Errorf("o/r#baz deps = %v, want [o/r#bar]", got)
+		want := []string{"o/r#foo", "o/r#bar", "o/r#baz"}
+		if !slices.Equal(refs, want) {
+			t.Errorf("child order = %v, want %v (fetch order preserved)", refs, want)
 		}
 	})
 
@@ -933,98 +960,19 @@ func TestLinearChainFallback(t *testing.T) {
 		// A leading non-numeric ref must not block later numeric refs from
 		// being reordered into numeric order around it.
 		s := []SubIssue{{Ref: "o/r#foo"}, {Ref: "o/r#3"}, {Ref: "o/r#1"}, {Ref: "o/r#2"}}
-		p, err := linearChainFallback(s)
+		p, err := independentFallback(s)
 		if err != nil {
-			t.Fatalf("linearChainFallback: %v", err)
+			t.Fatalf("independentFallback: %v", err)
 		}
-		if got := depsOf(t, p, "o/r#1"); len(got) != 1 || got[0] != "o/r#foo" {
-			t.Errorf("o/r#1 deps = %v, want [o/r#foo] (non-numeric keeps its fetch slot)", got)
+		var refs []string
+		for _, c := range p.Children {
+			refs = append(refs, c.Ref)
 		}
-		if got := depsOf(t, p, "o/r#2"); len(got) != 1 || got[0] != "o/r#1" {
-			t.Errorf("o/r#2 deps = %v, want [o/r#1]", got)
-		}
-		if got := depsOf(t, p, "o/r#3"); len(got) != 1 || got[0] != "o/r#2" {
-			t.Errorf("o/r#3 deps = %v, want [o/r#2]", got)
+		want := []string{"o/r#foo", "o/r#1", "o/r#2", "o/r#3"}
+		if !slices.Equal(refs, want) {
+			t.Errorf("child order = %v, want %v", refs, want)
 		}
 	})
-
-	t.Run("semantic agreement: same serial reachability as a metadata-free plan", func(t *testing.T) {
-		t.Parallel()
-		// A closed sub-issue sits mid-chain so the fallback's sparse edges
-		// (chain to the last OPEN sibling) differ textually from a
-		// metadata-free plan run through deriveEdges (which serializes
-		// against every earlier canonical sibling, closed or not). Both must
-		// still materialize to the same reachability/topological order over
-		// the open children once ChildSpecs drops edges into closed subs.
-		s := []SubIssue{
-			{Ref: "o/r#1"},
-			{Ref: "o/r#2", Closed: true},
-			{Ref: "o/r#3"},
-			{Ref: "o/r#4"},
-		}
-		fallback, err := linearChainFallback(s)
-		if err != nil {
-			t.Fatalf("linearChainFallback: %v", err)
-		}
-
-		dense := Plan{Children: []PlannedChild{
-			{Ref: "o/r#1"}, {Ref: "o/r#2"}, {Ref: "o/r#3"}, {Ref: "o/r#4"},
-		}}
-		dense.deriveEdges(s)
-		if err := dense.validate(s); err != nil {
-			t.Fatalf("dense plan validate: %v", err)
-		}
-
-		existing := map[string]bool{}
-		fallbackDeps := depsMap(ChildSpecs(fallback, s, existing))
-		denseDeps := depsMap(ChildSpecs(dense, s, existing))
-
-		open := []string{"o/r#1", "o/r#3", "o/r#4"} // canonical order, closed o/r#2 excluded
-		for i, later := range open {
-			for _, earlier := range open[:i] {
-				if !reachableFrom(fallbackDeps, later, earlier) {
-					t.Errorf("fallback: %s should transitively depend on %s", later, earlier)
-				}
-				if !reachableFrom(denseDeps, later, earlier) {
-					t.Errorf("dense: %s should transitively depend on %s", later, earlier)
-				}
-			}
-		}
-		// No back-edges: nothing earlier depends on something later, in either plan.
-		for i, earlier := range open {
-			for _, later := range open[i+1:] {
-				if reachableFrom(fallbackDeps, earlier, later) {
-					t.Errorf("fallback: %s must not depend on later sibling %s", earlier, later)
-				}
-				if reachableFrom(denseDeps, earlier, later) {
-					t.Errorf("dense: %s must not depend on later sibling %s", earlier, later)
-				}
-			}
-		}
-	})
-}
-
-// depsMap flattens ChildSpecs into ref -> DependsOn for reachability checks.
-func depsMap(specs []ChildSpec) map[string][]string {
-	out := make(map[string][]string, len(specs))
-	for _, s := range specs {
-		out[s.Issue] = s.DependsOn
-	}
-	return out
-}
-
-// reachableFrom walks deps transitively from `from`, reporting whether
-// `target` is reachable.
-func reachableFrom(deps map[string][]string, from, target string) bool {
-	if from == target {
-		return true
-	}
-	for _, d := range deps[from] {
-		if reachableFrom(deps, d, target) {
-			return true
-		}
-	}
-	return false
 }
 
 func TestFlatPlanSuspicious(t *testing.T) {

--- a/internal/umbrella/tags.go
+++ b/internal/umbrella/tags.go
@@ -11,7 +11,7 @@ import (
 const MaxParallelTagPrefix = "umbrella-max-parallel:"
 
 // FallbackTag marks an umbrella tracker whose DAG was built by
-// linearChainFallback (the planner exhausted its retries) instead of the
+// independentFallback (the planner exhausted its retries) instead of the
 // model, so a systematically-failing planner is board-visible rather than
 // silently masked.
 const FallbackTag = "umbrella-planner-fallback"


### PR DESCRIPTION
## Motivation

When the umbrella planner exhausts its retries or deadline, the previous fallback serialized every child into a linear chain. That made degraded expansions correct but unnecessarily slow, multiplying wall-clock time by the number of sub-issues even when the planner had produced no trustworthy ordering information.

Closes https://github.com/Automaat/sybra/issues/1651

## Implementation information

- Replace the exhausted-planner fallback with an independent-parallel plan that emits no child dependency edges and caps degraded parallelism at 3.
- Keep deterministic fallback child ordering by issue number while preserving fetch order for ties and non-numeric refs.
- Update degraded tracker/CLI wording and tests to cover the new fallback behavior.

_Generated by Sybra harness_