### PR TITLE
fix(agent): park provider rate-limit off breaker

### DIFF
--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -592,10 +592,7 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (string, []providerGate
 		if cfg.DisableProviderFailover {
 			reason := g.Reason(resolved)
 			gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
-			return "", gateEvents, &provider.UnhealthyError{
-				Provider: resolved,
-				Reason:   reason,
-			}
+			return "", gateEvents, newProviderUnhealthy(resolved, reason)
 		}
 		alt := g.Failover(resolved)
 		if alt != "" && !underCap(alt) {
@@ -620,10 +617,7 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (string, []providerGate
 		} else {
 			reason := g.Reason(resolved)
 			gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
-			return "", gateEvents, &provider.UnhealthyError{
-				Provider: resolved,
-				Reason:   reason,
-			}
+			return "", gateEvents, newProviderUnhealthy(resolved, reason)
 		}
 	}
 	if lg == nil {
@@ -677,9 +671,14 @@ func (m *Manager) softLimitLastResort(resolved, reason string, gateEvents []prov
 		return resolved, gateEvents, nil
 	}
 	gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
-	return "", gateEvents, &provider.UnhealthyError{
-		Provider: resolved,
-		Reason:   reason,
+	return "", gateEvents, newProviderUnhealthy(resolved, reason)
+}
+
+func newProviderUnhealthy(prov, reason string) *provider.UnhealthyError {
+	return &provider.UnhealthyError{
+		Provider:    prov,
+		Reason:      reason,
+		RateLimited: reason == provider.RateLimitReason || limits.IsRateLimitReachedReason(reason),
 	}
 }
 

--- a/internal/agent/manager_run_test.go
+++ b/internal/agent/manager_run_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/provider"
 )
 
 // TestRegisterMarkAgentDone_ProviderAccountingInvariant locks in that
@@ -171,5 +173,27 @@ func TestRun_JitterSkippedForInteractiveMode(t *testing.T) {
 	t.Cleanup(func() { _ = m.StopAgent(a.ID) })
 	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
 		t.Fatalf("interactive Run must skip jitter, took %s", elapsed)
+	}
+}
+
+func TestNewProviderUnhealthy_RateLimitedFlag(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   bool
+	}{
+		{provider.RateLimitReason, true},
+		{"provider reports rate limit reached", true},
+		{"provider disabled", false},
+		{"logged out", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		ue := newProviderUnhealthy("codex", c.reason)
+		if ue.RateLimited != c.want {
+			t.Errorf("newProviderUnhealthy(%q).RateLimited = %v, want %v", c.reason, ue.RateLimited, c.want)
+		}
+		if ue.Provider != "codex" || ue.Reason != c.reason {
+			t.Errorf("newProviderUnhealthy dropped fields: %+v", ue)
+		}
 	}
 }

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -469,3 +469,22 @@ func TestIsSoftThresholdReason(t *testing.T) {
 		}
 	}
 }
+
+func TestIsRateLimitReachedReason(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   bool
+	}{
+		{quotaReasonRateLimitReached, true},
+		{quotaReasonProviderDisabled, false},
+		{quotaReasonWeeklyThreshold, false},
+		{quotaReasonSessionThreshold, false},
+		{"rate_limited", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsRateLimitReachedReason(c.reason); got != c.want {
+			t.Errorf("IsRateLimitReachedReason(%q) = %v, want %v", c.reason, got, c.want)
+		}
+	}
+}

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -442,6 +442,15 @@ func IsSoftThresholdReason(reason string) bool {
 	return reason == quotaReasonSessionThreshold || reason == quotaReasonWeeklyThreshold
 }
 
+// IsRateLimitReachedReason reports whether a ProviderAvailable "unavailable"
+// reason is a hard rate-limit-reached block. Unlike provider-disabled (a config
+// kill-switch that stays until a human re-enables it), a reached rate limit is
+// transient and self-heals when the quota window rolls over, so callers mark it
+// on the gate error to keep it off the dispatch circuit breaker.
+func IsRateLimitReachedReason(reason string) bool {
+	return reason == quotaReasonRateLimitReached
+}
+
 func quotaLimited(ps ProviderSummary, snap Snapshot, policy Policy) (limited bool, reason string) {
 	if ps.Confidence != ConfidenceExact {
 		return false, ""

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -19,10 +19,20 @@ var ErrProviderUnhealthy = errors.New("provider unhealthy")
 const RateLimitReason = "rate_limited"
 
 // UnhealthyError carries the structured reason a provider was refused.
+//
+// RateLimited marks a transient, self-healing capacity throttle (a health-gate
+// rate limit or a limits-store quota-reached block) as opposed to a permanent
+// refusal (auth failure needing a human login, provider disabled in config).
+// Downstream classification (workflow.isTransientCapacityError) keys off it so a
+// rate limit parks-and-retries instead of feeding the dispatch circuit breaker.
+// A rate limit is not always tagged with Until (the limits store knows the
+// condition but not always the exact reset time), so the flag is the reliable
+// signal where a zero Until would otherwise read as "not a rate limit".
 type UnhealthyError struct {
-	Provider string
-	Reason   string
-	Until    time.Time
+	Provider    string
+	Reason      string
+	Until       time.Time
+	RateLimited bool
 }
 
 func (e *UnhealthyError) Error() string {

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -123,7 +123,7 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 func isTransientCapacityError(err error) bool {
 	var ue *provider.UnhealthyError
 	if errors.As(err, &ue) {
-		return ue.Reason == provider.RateLimitReason || !ue.Until.IsZero()
+		return ue.RateLimited || ue.Reason == provider.RateLimitReason || !ue.Until.IsZero()
 	}
 	return false
 }

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -122,10 +122,12 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 // neither, so it stays escalatable — a human must log in.
 func isTransientCapacityError(err error) bool {
 	var ue *provider.UnhealthyError
-	if errors.As(err, &ue) {
-		return ue.RateLimited || ue.Reason == provider.RateLimitReason || !ue.Until.IsZero()
+	if !errors.As(err, &ue) {
+		return false
 	}
-	return false
+	rateLimited := ue.RateLimited || ue.Reason == provider.RateLimitReason
+	hasCooldownDeadline := !ue.Until.IsZero()
+	return rateLimited || hasCooldownDeadline
 }
 
 func transientAgentStartError(err error) bool {

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -329,6 +329,32 @@ func TestSurfaceStartFailure_TransientRateLimitDoesNotTripBreaker(t *testing.T) 
 	}
 }
 
+func TestSurfaceStartFailure_QuotaRateLimitDoesNotTripBreaker(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	quotaLimited := &provider.UnhealthyError{
+		Provider:    "codex",
+		Reason:      "provider reports rate limit reached",
+		RateLimited: true,
+	}
+	if !isTransientCapacityError(quotaLimited) {
+		t.Fatal("quota rate-limit (RateLimited flag, no RateLimitReason/Until) not classified transient")
+	}
+	wf := &Execution{CurrentStep: "code_review_staff", State: ExecRunning, Variables: map[string]string{}}
+
+	for i := range maxCircuitBreakerFailures + 2 {
+		engine.surfaceStartFailure("t1", "in-progress", quotaLimited, wf, "code_review_staff")
+		if wf.State == ExecFailed {
+			t.Fatalf("quota rate limit tripped the breaker on attempt %d", i+1)
+		}
+	}
+	if got, _ := tasks.GetTask("t1"); got.Status == "human-required" {
+		t.Fatal("quota rate limit escalated to human-required")
+	}
+}
+
 func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})


### PR DESCRIPTION
## Motivation

After the agent-pool park fix (#1688) landed and the stuck board was
re-dispatched, a new circuit-breaker cascade appeared: ~9 tasks bounced to
human-required with `circuit breaker: agent start blocked: provider codex
unhealthy (provider reports rate limit reached) (tripped after 3 dispatch
failures ...)`.

This is the **same bug class** as #1688 — a transient, self-healing capacity
condition being counted as a genuine dispatch fault — on the provider path
instead of the agent-pool path.

Root cause: the limits-store quota block builds a `provider.UnhealthyError`
with `Reason = "provider reports rate limit reached"` and **no** `Until`
deadline (`internal/agent/manager_run.go`). `isTransientCapacityError` only
accepted `Reason == provider.RateLimitReason` ("rate_limited") or a non-zero
`Until`, so this quota-path rate limit matched neither, fed the breaker, and
escalated. The heavy load from re-dispatching the previously-stuck tasks is
what pushed codex to its quota and surfaced it.

> Changelog: fix(agent): recognize provider quota rate-limits as transient

## Implementation information

Typed signal rather than cross-package string matching:

- `provider.UnhealthyError` gains a `RateLimited bool` — a self-healing
  capacity throttle, as opposed to a permanent refusal (auth failure needing a
  human login, provider disabled in config).
- `internal/agent`: all three gate `UnhealthyError` constructions now route
  through one `newProviderUnhealthy(prov, reason)` that sets `RateLimited` for
  both the health `rate_limited` reason and the limits `quota-reached` reason,
  but **not** for auth failures or provider-disabled (those stay escalatable).
- `internal/limits`: new exported `IsRateLimitReachedReason`, mirroring the
  existing `IsSoftThresholdReason`.
- `internal/workflow`: `isTransientCapacityError` now also honors the flag, so
  a quota rate-limit parks the `run_agent` step and `ResumeStalled` retries it
  when the provider frees up, instead of tripping the breaker.

Tests: the quota-path `UnhealthyError` is classified transient and does not
trip the breaker across repeated failures; the limits recognizer table; and the
`newProviderUnhealthy` flag mapping (rate-limit reasons → true, auth/disabled →
false). Build, the four affected package suites, and golangci-lint are green.

Out of scope (noted, not fixed here): the diagnostic human-review agent spawn
also hits the raw agent-pool cap and logs `human_review.skipped`, but it
degrades gracefully (skipped, never escalates), so it is not part of this
regression.

## Supporting documentation

Observed in production immediately after the #1688 board re-dispatch; the
tripped status reason and the `manager_run.go` gate constructors are the
evidence trail.
