### PR TITLE
fix(review): retry branch-conflict prep flakes

### DIFF
--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -605,7 +605,7 @@ func MarkRebaseBlocked(tasks *task.Manager, taskID string, err error, logger *sl
 	}
 	if recoverConflict != nil {
 		if recoverConflict(taskID) {
-			logger.Info("worktree.rebase-block.recovered-as-conflict", "task_id", taskID)
+			logger.Info("worktree.rebase-block.handled", "task_id", taskID)
 			return true
 		}
 	}

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -870,6 +870,8 @@ func (r *Handler) parkOrEscalateBranchFixFailure(taskID string, wtErr error) boo
 	if t, gerr := r.tasks.Get(taskID); gerr == nil && t.Status == task.StatusHumanRequired {
 		return false
 	}
+	r.logger.Info("pr-monitor.branch-conflict.parked-retry",
+		"task_id", taskID, "attempts", r.wtFailures[taskID], "limit", wtFailureLimit)
 	return true
 }
 

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -786,8 +786,7 @@ func (r *Handler) recoverBranchConflictNoPR(t task.Task) bool {
 	dir, err := r.worktrees.PrepareForBranchFix(ctx, t)
 	if err != nil {
 		r.logger.Warn("pr-monitor.branch-conflict.prepare", "task_id", taskID, "err", err)
-		r.recordWorktreeFailure(taskID, err)
-		return false
+		return r.parkOrEscalateBranchFixFailure(taskID, err)
 	}
 	if !r.allowPreparedWorktree(taskID, dir) {
 		return false
@@ -863,6 +862,14 @@ func (r *Handler) dispatchBranchConflictRecovery(taskID, dir, base string, t tas
 	r.prTracker.MarkHandled(taskID, branchConflictRetryKind, headSHA)
 	r.logAudit(audit.EventBranchConflictAutoResolved, taskID, "", map[string]any{})
 	r.logger.Info("pr-monitor.branch-conflict.recovered", "task_id", taskID)
+	return true
+}
+
+func (r *Handler) parkOrEscalateBranchFixFailure(taskID string, wtErr error) bool {
+	r.recordWorktreeFailure(taskID, wtErr)
+	if t, gerr := r.tasks.Get(taskID); gerr == nil && t.Status == task.StatusHumanRequired {
+		return false
+	}
 	return true
 }
 

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -522,8 +522,16 @@ func TestRecoverBranchConflictNoPR_MissingBranchEscalates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if r.RecoverStaleBranchConflict(tk.ID) {
-		t.Fatal("RecoverStaleBranchConflict returned true for a missing branch")
+	var escalated bool
+	for range wtFailureLimit {
+		r.RecoverStaleBranchConflict(tk.ID)
+		if got, _ := r.tasks.Get(tk.ID); got.Status == task.StatusHumanRequired {
+			escalated = true
+			break
+		}
+	}
+	if !escalated {
+		t.Fatal("an unpreparable branch must escalate to human-required after the retry circuit trips")
 	}
 }
 
@@ -582,13 +590,13 @@ func TestRecoverBranchConflictNoPR_DispatchFailureRestoresPriorWorkflow(t *testi
 
 func TestRecoverBranchConflictNoPR_WorktreeFailuresTripCircuitBreaker(t *testing.T) {
 	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
-	if _, err := r.tasks.Update(tk.ID, task.Update{Branch: task.Ptr("branch/does-not-exist")}); err != nil {
+	if _, err := r.tasks.Update(tk.ID, task.Update{Branch: task.Ptr("main")}); err != nil {
 		t.Fatal(err)
 	}
 
 	for i := range wtFailureLimit - 1 {
-		if r.RecoverStaleBranchConflict(tk.ID) {
-			t.Fatalf("call %d: want false on worktree failure", i+1)
+		if !r.RecoverStaleBranchConflict(tk.ID) {
+			t.Fatalf("call %d: want true (parked for retry) on transient worktree failure", i+1)
 		}
 		got, err := r.tasks.Get(tk.ID)
 		if err != nil {

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -522,16 +522,27 @@ func TestRecoverBranchConflictNoPR_MissingBranchEscalates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var escalated bool
-	for range wtFailureLimit {
-		r.RecoverStaleBranchConflict(tk.ID)
-		if got, _ := r.tasks.Get(tk.ID); got.Status == task.StatusHumanRequired {
-			escalated = true
-			break
+	for i := range wtFailureLimit - 1 {
+		if !r.RecoverStaleBranchConflict(tk.ID) {
+			t.Fatalf("call %d: want true (parked for retry) before the circuit trips", i+1)
+		}
+		got, err := r.tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == task.StatusHumanRequired {
+			t.Fatalf("call %d: escalated before the circuit limit", i+1)
 		}
 	}
-	if !escalated {
-		t.Fatal("an unpreparable branch must escalate to human-required after the retry circuit trips")
+	if r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("circuit-limit call: want false")
+	}
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required after the circuit trips", got.Status)
 	}
 }
 


### PR DESCRIPTION
## Motivation

The last recurring false-positive escalation refilling the human-required
column is the branch-stale / rebase bucket. Every time the fleet ran hot, a
batch of tasks landed in human-required with `branch stale: rebase failed
before agent start; resolve conflicts or recreate the task branch` — yet
re-dispatching the very same tasks under lower load cleared the rebase and let
them proceed. That is the signature of a transient failure being treated as
terminal.

Root cause: the no-PR branch-conflict recovery (`recoverBranchConflictNoPR`)
declined (returned `false`) on the **first** `PrepareForBranchFix` failure, and
`agentorch.MarkRebaseBlocked`'s caller-side fallback then wrote a generic
`human-required` reason. That defeated the `wtFailureLimit` (5) retry circuit
that `recordWorktreeFailure` already implements — the circuit could never count
past 1 because the task was escalated before it got a second attempt. Under
load these prep failures are transient (a fetch flake, git worktree
contention), so a single one stranded otherwise-healthy work.

> Changelog: fix(review): retry transient branch-conflict prep failures

## Implementation information

`recoverBranchConflictNoPR` now routes a `PrepareForBranchFix` failure through
`parkOrEscalateBranchFixFailure`:

- Below the circuit limit, it records the failure and returns `true` (handled)
  — `MarkRebaseBlockedWithRecoveryResult` maps that to `ErrDispatchInFlight`,
  so the `run_agent` step parks in `ExecWaiting` and `ResumeStalled` retries,
  paced by the resume interval.
- At the limit, `recordWorktreeFailure` escalates to `human-required` with its
  specific "worktree creation failed N times" reason, and the helper returns
  `false` so that specific reason is preserved (not overwritten by the generic
  one).

A genuinely unpreparable branch still escalates — just after the bounded
retries instead of on the first attempt. This deliberately drops the previous
special-case for a permanently-missing branch: in practice the common failure
is transient, and routing everything through the one bounded circuit is simpler
and self-heals the load-induced case. The retry ceiling (`wtFailureLimit`) is
unchanged, so nothing can loop unbounded.

Tests: the circuit-breaker test now drives a deterministic transient prep
failure (task pointed at an already-checked-out branch so `git worktree add`
fails every call) and asserts park-below-limit / escalate-at-limit; the
unpreparable-branch test asserts escalation after the circuit trips. Build, the
review/agentorch/sybra suites, and golangci-lint are green.

## Supporting documentation

Confirmed empirically in this incident: the same rebase-blocked tasks that sat
in human-required cleared and progressed to test/review the moment they were
re-dispatched under lower load — i.e. the recovery works, it was just escalating
one attempt too early.
