### PR TITLE
fix(agent): stop auto-approving MCP and WebFetch tools

### DIFF
--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -325,11 +325,18 @@ func betterSessionMatch(candidate, incumbent *Agent) bool {
 	return candidate.ID > incumbent.ID
 }
 
+// isSafeTool reports whether a tool is safe to auto-approve without a
+// human prompt. MCP tools are never auto-approved here: their capabilities
+// are arbitrary and server-defined, so a blanket "mcp__*" allow would let an
+// injected agent reach dangerous or egress-capable tools unattended.
+// WebFetch is excluded too — it's an egress-sensitive tool (attacker-supplied
+// URL is a ready exfiltration channel for ingested content). WebSearch stays
+// safe: it can only issue search queries, not fetch arbitrary attacker-chosen
+// destinations.
 func isSafeTool(name string) bool {
-	safe := []string{"Read", "Glob", "Grep", "LSP", "WebSearch", "WebFetch"}
-	lower := strings.ToLower(name)
+	safe := []string{"Read", "Glob", "Grep", "LSP", "WebSearch"}
 	for _, s := range safe {
-		if strings.EqualFold(s, name) || strings.HasPrefix(lower, "mcp__") {
+		if strings.EqualFold(s, name) {
 			return true
 		}
 	}

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -101,7 +101,11 @@ func TestApprovalServer_SafeToolAutoApprove(t *testing.T) {
 	}
 }
 
-func TestApprovalServer_SafeToolMCP(t *testing.T) {
+// TestApprovalServer_MCPNotAutoApproved verifies MCP tools are never
+// blanket-auto-approved: with no manager/agent set up, an mcp__ tool falls
+// through to the unknown-session deny path rather than short-circuiting to
+// allow like the old isSafeTool blanket "mcp__*" match did.
+func TestApprovalServer_MCPNotAutoApproved(t *testing.T) {
 	t.Parallel()
 	srv := newTestApprovalServer(t)
 
@@ -111,8 +115,26 @@ func TestApprovalServer_SafeToolMCP(t *testing.T) {
 		"tool_use_id": "tuid-mcp",
 		"tool_input":  map[string]any{},
 	})
-	if resp.HookSpecificOutput.PermissionDecision != "allow" {
-		t.Errorf("expected allow for mcp__ tool, got %q", resp.HookSpecificOutput.PermissionDecision)
+	if resp.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("expected deny for mcp__ tool (no blanket auto-approve), got %q", resp.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// TestApprovalServer_WebFetchNotAutoApproved verifies WebFetch requires
+// approval like any other egress-sensitive tool, since it is a ready
+// exfiltration channel for content ingested from untrusted sources.
+func TestApprovalServer_WebFetchNotAutoApproved(t *testing.T) {
+	t.Parallel()
+	srv := newTestApprovalServer(t)
+
+	resp := postHook(t, srv.Addr(), map[string]any{
+		"session_id":  "any-session",
+		"tool_name":   "WebFetch",
+		"tool_use_id": "tuid-webfetch",
+		"tool_input":  map[string]any{},
+	})
+	if resp.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("expected deny for WebFetch (no blanket auto-approve), got %q", resp.HookSpecificOutput.PermissionDecision)
 	}
 }
 
@@ -508,9 +530,9 @@ func TestIsSafeTool(t *testing.T) {
 		{"Grep", true},
 		{"LSP", true},
 		{"WebSearch", true},
-		{"WebFetch", true},
-		{"mcp__anything", true},
-		{"mcp__fs__read", true},
+		{"WebFetch", false},
+		{"mcp__anything", false},
+		{"mcp__fs__read", false},
 		{"Bash", false},
 		{"Edit", false},
 		{"Write", false},


### PR DESCRIPTION
## Motivation

The approval-hook auto-approve allowlist blanket-matched any tool prefixed
`mcp__`, and also included `WebFetch`. MCP tool capabilities are arbitrary
and server-defined, so auto-approving all of them let an injected agent
reach dangerous or egress-capable tools unattended. `WebFetch` is similarly
egress-sensitive — an attacker-supplied URL is a ready exfiltration channel
for ingested content.

## Implementation information

- `internal/agent/approval_server.go`: drop the `mcp__` prefix match and
  remove `WebFetch` from `isSafeTool`'s safe list. `WebSearch` stays
  auto-approved since it can only issue search queries, not fetch arbitrary
  attacker-chosen destinations.
- `internal/agent/approval_server_test.go`: extend coverage for the
  narrowed safe-tool list.

Closes https://github.com/Automaat/sybra/issues/1522

_Generated by Sybra harness_