### PR TITLE
fix(workflow): self-heal broken worktree toolchain

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -396,6 +396,26 @@ func (a *checkConfigGetterAdapter) VerifyCommands(ctx context.Context, taskID st
 	return merged.Verify
 }
 
+func (a *checkConfigGetterAdapter) SetupCommands(ctx context.Context, taskID string) []string {
+	t, err := a.tasks.Get(taskID)
+	if err != nil || t.ProjectID == "" {
+		return nil
+	}
+	wtPath := a.mgr.PathFor(t)
+	if _, statErr := os.Stat(wtPath); statErr != nil {
+		return nil
+	}
+	p, pErr := a.projects.Get(t.ProjectID)
+	if pErr != nil {
+		return nil
+	}
+	var repoSetup []string
+	if repoCfg, rErr := project.LoadRepoConfigAtDefaultBranch(ctx, p.ClonePath); rErr == nil && repoCfg != nil {
+		repoSetup = repoCfg.Setup
+	}
+	return project.MergeSetup(repoSetup, p.SetupCommands)
+}
+
 func (a *worktreeGetterAdapter) GetWorktreePath(taskID string) (string, bool) {
 	t, err := a.tasks.Get(taskID)
 	if err != nil {

--- a/internal/sybra/app_workflow_adversarial_test.go
+++ b/internal/sybra/app_workflow_adversarial_test.go
@@ -102,7 +102,7 @@ func TestAdversarialVerifyCommandsIgnoreWorktreeRepoConfig(t *testing.T) {
 
 	// Attacker-controlled .sybra.yaml planted directly in the task's own
 	// worktree (e.g. by a compromised implementation agent).
-	if err := os.WriteFile(filepath.Join(wtPath, ".sybra.yaml"), []byte("checks:\n  verify:\n    - echo UNTRUSTED_WORKTREE\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(wtPath, ".sybra.yaml"), []byte("checks:\n  verify:\n    - echo UNTRUSTED_WORKTREE\nsetup:\n  - echo UNTRUSTED_SETUP\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,5 +115,12 @@ func TestAdversarialVerifyCommandsIgnoreWorktreeRepoConfig(t *testing.T) {
 	got := getter.VerifyCommands(t.Context(), tk.ID)
 	if len(got) != 1 || got[0] != "echo TRUSTED_DEFAULT_BRANCH" {
 		t.Fatalf("VerifyCommands = %#v, want only trusted default-branch command", got)
+	}
+
+	gotSetup := getter.SetupCommands(t.Context(), tk.ID)
+	for _, c := range gotSetup {
+		if c == "echo UNTRUSTED_SETUP" {
+			t.Fatalf("SetupCommands leaked the untrusted worktree setup: %#v", gotSetup)
+		}
 	}
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -139,6 +139,7 @@ type BranchSyncer interface {
 // operates with a nil getter (step skips), so unit tests need not wire one.
 type CheckConfigGetter interface {
 	VerifyCommands(ctx context.Context, taskID string) []string
+	SetupCommands(ctx context.Context, taskID string) []string
 }
 
 // ManualTestConfigGetter resolves repo/project-declared black-box testing hints.

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sync"
 	"time"
@@ -39,6 +40,9 @@ const verifyBlessedTag = "verify-blessed"
 const verifyChecksFlakeRetries = 1
 
 const verifyChecksTimeoutRetries = 1
+
+var verifyMissingToolchainRe = regexp.MustCompile(
+	`(?i)command not found|executable file not found|not found in \$?PATH`)
 
 // verifyChecksReport is the structured result, stored as a generic artifact.
 type verifyChecksReport struct {
@@ -90,6 +94,12 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 	}
 
 	failedCmd, output, runErr := e.runVerifySuiteWithRetry(taskID, wtPath, cmds, timeout, step.ID)
+
+	if failedCmd != "" && verifyMissingToolchainRe.MatchString(output) {
+		if healed, fc, out, rErr := e.healToolchainAndRetry(taskID, wtPath, cmds, timeout, step.ID); healed {
+			failedCmd, output, runErr = fc, out, rErr
+		}
+	}
 
 	report := verifyChecksReport{
 		Commands: cmds, FailedCmd: failedCmd, OutputTail: tailString(output, verifyChecksOutputTail),
@@ -146,6 +156,28 @@ func (e *Engine) runVerifySuiteWithRetry(taskID, wtPath string, cmds []string, t
 		}
 	}
 	return failedCmd, output, runErr
+}
+
+func (e *Engine) healToolchainAndRetry(taskID, wtPath string, cmds []string, timeout time.Duration, stepID string) (attempted bool, failedCmd, output string, runErr error) {
+	setup := e.checks.SetupCommands(e.ctx, taskID)
+	if len(setup) == 0 {
+		return false, "", "", nil
+	}
+	e.logger.Warn("workflow.verify-checks.toolchain-heal",
+		"task_id", taskID, "step", stepID, "setup_commands", len(setup))
+	ctx, cancel := context.WithTimeout(e.ctx, timeout)
+	maybeMiseTrust(ctx, wtPath)
+	sFailed, sOut, sErr := e.runVerifyCommands(ctx, taskID, wtPath, setup)
+	cancel()
+	if sFailed != "" || sErr != nil {
+		e.logger.Warn("workflow.verify-checks.toolchain-heal.setup-failed",
+			"task_id", taskID, "cmd", trimDiffLine(sFailed), "err", sErr, "tail", tailString(sOut, 400))
+		return false, "", "", nil
+	}
+	failedCmd, output, runErr = e.runVerifySuiteWithRetry(taskID, wtPath, cmds, timeout, stepID)
+	e.logger.Info("workflow.verify-checks.toolchain-heal.reran",
+		"task_id", taskID, "step", stepID, "still_failing", failedCmd != "" || runErr != nil)
+	return true, failedCmd, output, runErr
 }
 
 func (e *Engine) flagVerifyChecks(taskID string, step *Step, reason, detail string) (StepOutput, error) {

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -42,7 +42,7 @@ const verifyChecksFlakeRetries = 1
 const verifyChecksTimeoutRetries = 1
 
 var verifyMissingToolchainRe = regexp.MustCompile(
-	`(?i)command not found|executable file not found|not found in \$?PATH`)
+	`(?i)command not found|executable file not found|not found in \$?PATH|[\w./-]+: not found`)
 
 // verifyChecksReport is the structured result, stored as a generic artifact.
 type verifyChecksReport struct {
@@ -159,15 +159,16 @@ func (e *Engine) runVerifySuiteWithRetry(taskID, wtPath string, cmds []string, t
 }
 
 func (e *Engine) healToolchainAndRetry(taskID, wtPath string, cmds []string, timeout time.Duration, stepID string) (attempted bool, failedCmd, output string, runErr error) {
-	setup := e.checks.SetupCommands(e.ctx, taskID)
+	setupCtx, cancel := context.WithTimeout(e.ctx, timeout)
+	setup := e.checks.SetupCommands(setupCtx, taskID)
 	if len(setup) == 0 {
+		cancel()
 		return false, "", "", nil
 	}
 	e.logger.Warn("workflow.verify-checks.toolchain-heal",
 		"task_id", taskID, "step", stepID, "setup_commands", len(setup))
-	ctx, cancel := context.WithTimeout(e.ctx, timeout)
-	maybeMiseTrust(ctx, wtPath)
-	sFailed, sOut, sErr := e.runVerifyCommands(ctx, taskID, wtPath, setup)
+	maybeMiseTrust(setupCtx, wtPath)
+	sFailed, sOut, sErr := e.runVerifyCommands(setupCtx, taskID, wtPath, setup)
 	cancel()
 	if sFailed != "" || sErr != nil {
 		e.logger.Warn("workflow.verify-checks.toolchain-heal.setup-failed",

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -7,9 +7,11 @@ import (
 	"time"
 )
 
-type fakeCheckGetter struct{ cmds []string }
+type fakeCheckGetter struct{ cmds, setup []string }
 
 func (f *fakeCheckGetter) VerifyCommands(context.Context, string) []string { return f.cmds }
+
+func (f *fakeCheckGetter) SetupCommands(context.Context, string) []string { return f.setup }
 
 func newVerifyChecksStep() *Step { return &Step{ID: "verify_checks", Type: StepVerifyChecks} }
 
@@ -145,6 +147,68 @@ func TestExecVerifyChecks_TimeoutRetryAbsorbsLoadSpike(t *testing.T) {
 	}
 	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
 		t.Errorf("status = %q, want unchanged (retry passed, no human-required)", ti.Status)
+	}
+}
+
+func newVerifyChecksEngineWithSetup(t *testing.T, wt string, cmds, setup []string) (*Engine, *memTasks) {
+	t.Helper()
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
+	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: cmds, setup: setup})
+	return engine, engine.tasks.(*memTasks)
+}
+
+func TestExecVerifyChecks_ToolchainHealRepairs(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	cmds := []string{`test -f .healed || { echo "vite: command not found" >&2; exit 1; }`}
+	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"touch .healed"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Fatalf("Output = %q, want clean (setup re-run repaired the toolchain)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged (heal succeeded)", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_ToolchainHealSetupFailsEscalates(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	cmds := []string{`echo "vite: command not found" >&2; exit 1`}
+	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"false"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged (setup could not repair)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_RealFailureSkipsToolchainHeal(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	cmds := []string{`test -f .healed || { echo "assertion failed: got 4 want 5" >&2; exit 1; }`}
+	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"touch .healed"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged (non-toolchain failure must not trigger setup heal)", out.Output)
 	}
 }
 

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -177,6 +177,22 @@ func TestExecVerifyChecks_ToolchainHealRepairs(t *testing.T) {
 	}
 }
 
+func TestExecVerifyChecks_ToolchainHealMatchesDashNotFound(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	cmds := []string{`test -f .healed || { echo "sh: 1: vite: not found" >&2; exit 1; }`}
+	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"touch .healed"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Fatalf("Output = %q, want clean (dash '<cmd>: not found' must trigger heal)", out.Output)
+	}
+}
+
 func TestExecVerifyChecks_ToolchainHealSetupFailsEscalates(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})


### PR DESCRIPTION
## Motivation

After the four escalation-cascade fixes landed, a fifth false-positive class
surfaced in production: three tasks stuck in human-required with `implementation
does not pass the project verify suite`, all failing identically on `vite:
command not found`.

Their code was fine. The worktrees had a corrupted `node_modules` — 154
packages installed but an **empty `.bin/` directory**, so the `vite` executable
symlink was missing. That is the signature of an interrupted `npm ci` (packages
install first, `.bin` symlinks are linked last). Fittingly, one of the three
tasks was literally *"kill setup process group on timeout."*

The failure is doubly sticky: verify escalates it to human-required as if the
code were broken, and it survives a re-dispatch, because worktree setup only
runs on **creation**, not reuse — so the broken `node_modules` is never
repaired. (I repaired the three by hand with `npm ci` and they cleared, which
confirmed the diagnosis.)

> Changelog: fix(workflow): re-run setup to repair a broken verify toolchain

## Implementation information

`verify_checks` now self-heals a missing-toolchain failure before escalating:

- On a verify failure whose output matches a missing-toolchain signature
  (`command not found`, `executable file not found`, `not found in PATH`), it
  re-runs the project's setup commands once — the same `npm ci` / `mise install`
  that run on worktree creation, which recreates the `.bin` symlinks — then
  re-runs the verify suite. If it now passes, clean; if it still fails, escalate
  with the real result.
- New `CheckConfigGetter.SetupCommands`, resolved from the **trusted default
  branch** (repo `.sybra.yaml` `setup:` merged with the project's app-level
  `SetupCommands`), never the worktree's own config — same trust boundary as
  `VerifyCommands`, since these commands run unsandboxed via `sh -c`. The
  existing adversarial test is extended to assert an attacker-planted worktree
  `setup:` is ignored.
- The heal is bounded (one setup + one verify re-run per step execution) and
  strictly gated: a genuine, non-toolchain failure never triggers setup, and a
  heal whose setup itself fails still escalates.

Tests: repair-succeeds → clean; setup-can't-repair → escalates; non-toolchain
failure → setup never runs. Build, the workflow/sybra suites, the e2e smoke,
and golangci-lint are all green.

## Supporting documentation

Diagnosed live: `node_modules` present with an empty `.bin`, `git clean -fd`
(no `-x`) in SanitizeWorktree preserves `node_modules` across reuse so it is
never rebuilt, and a manual `npm ci` restored `.bin` and unblocked the tasks.
