### PR TITLE
fix(agent): guard headless turns from bg task kill

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -267,6 +267,20 @@ export class StreamEvent {
     "plugin_errors"?: string[];
 
     /**
+     * BackgroundTaskIDs is populated (possibly to an empty, non-nil slice) for
+     * a "system"/"background_tasks_changed" event: REPLACE-semantics snapshot
+     * of every CLI background bash task still live after the change. See
+     * Agent.SetBackgroundTaskIDs / Agent.EffectiveHangGrace.
+     * 
+     * NOTE: omitempty collapses an empty-but-non-nil "all tasks cleared" slice
+     * into the same absent-key wire form as a nil "no event seen" value. That
+     * REPLACE-semantics distinction is preserved at the Go/ClaudeEvent level
+     * but lost across this JSON boundary — fix the tag when a frontend consumer
+     * that needs the cleared signal actually lands.
+     */
+    "background_task_ids"?: string[];
+
+    /**
      * ToolCalls is the number of tool_use blocks in this event: all tool uses
      * in a Claude assistant turn, or a single Codex tool_use. The runner
      * accumulates these into Agent.ToolCalls.
@@ -298,7 +312,8 @@ export class StreamEvent {
     static createFrom($$source: any = {}): StreamEvent {
         const $$createField14_0 = $$createType8;
         const $$createField15_0 = $$createType0;
-        const $$createField17_0 = $$createType6;
+        const $$createField16_0 = $$createType0;
+        const $$createField18_0 = $$createType6;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("plan_steps" in $$parsedSource) {
             $$parsedSource["plan_steps"] = $$createField14_0($$parsedSource["plan_steps"]);
@@ -306,8 +321,11 @@ export class StreamEvent {
         if ("plugin_errors" in $$parsedSource) {
             $$parsedSource["plugin_errors"] = $$createField15_0($$parsedSource["plugin_errors"]);
         }
+        if ("background_task_ids" in $$parsedSource) {
+            $$parsedSource["background_task_ids"] = $$createField16_0($$parsedSource["background_task_ids"]);
+        }
         if ("limit_snapshot" in $$parsedSource) {
-            $$parsedSource["limit_snapshot"] = $$createField17_0($$parsedSource["limit_snapshot"]);
+            $$parsedSource["limit_snapshot"] = $$createField18_0($$parsedSource["limit_snapshot"]);
         }
         return new StreamEvent($$parsedSource as Partial<StreamEvent>);
     }

--- a/internal/agent/background_task_adversarial_test.go
+++ b/internal/agent/background_task_adversarial_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAdversarial_LiveBackgroundTaskAtResultDoesNotCompleteCleanly is an
+// adversarial regression test for task 3aeabb65: a headless CLI process
+// exits as soon as it emits its final result, which kills any
+// `run_in_background` bash task still running at that point and can leave
+// the worktree silently corrupted (e.g. a killed `npm ci`). A run that ends
+// this way must not be reported as a clean completion — Sybra must not hand
+// the worktree off to the next workflow step as if nothing happened.
+//
+// The fake claude binary reports a live background task and then exits
+// immediately after its terminal result, without ever clearing the task —
+// simulating a provider that ignores the backgroundTaskGuardrail prompt
+// instruction (see headless_background_guardrail.go).
+func TestAdversarial_LiveBackgroundTaskAtResultDoesNotCompleteCleanly(t *testing.T) {
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' '{\"type\":\"system\",\"subtype\":\"background_tasks_changed\",\"session_id\":\"s-bg\"," +
+		"\"tasks\":[{\"task_id\":\"bg1\",\"task_type\":\"bash\",\"description\":\"npm ci\"}]}'\n" +
+		"printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"s-bg\",\"total_cost_usd\":0," +
+		"\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}'\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var logBuf logCapture
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	m := mustNewManager(t, context.Background(), func(string, any) {}, logger, t.TempDir(), ManagerConfig{
+		Runtime:           ManagerRuntimeConfig{DefaultProvider: "claude"},
+		SurviveRestartDir: t.TempDir(),
+	})
+
+	ag, err := m.Run(RunConfig{
+		TaskID:             "task-bg",
+		Name:               "implementation: bg",
+		Mode:               "headless",
+		Prompt:             "leave a background task running",
+		Dir:                t.TempDir(),
+		RequirePermissions: false,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	waitForAgentDone(t, ag, 5*time.Second)
+
+	if ag.GetState() == StateStopped && ag.GetExitErr() == nil && ag.HasBackgroundTasks() {
+		t.Fatalf("agent completed cleanly despite live background task: state=%s exitErr=%v hasBackgroundTasks=%v logs=%s",
+			ag.GetState(), ag.GetExitErr(), ag.HasBackgroundTasks(), logBuf.String())
+	}
+	if !errors.Is(ag.GetExitErr(), errBackgroundTaskLiveAtExit) {
+		t.Fatalf("ExitErr = %v, want errBackgroundTaskLiveAtExit", ag.GetExitErr())
+	}
+}
+
+// logCapture is a minimal concurrency-safe io.Writer for slog output,
+// avoiding a data race between the runner goroutine's logging and the test
+// goroutine's failure-message formatting.
+type logCapture struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (l *logCapture) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.buf = append(l.buf, p...)
+	return len(p), nil
+}
+
+func (l *logCapture) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return string(l.buf)
+}

--- a/internal/agent/event_stream.go
+++ b/internal/agent/event_stream.go
@@ -44,6 +44,11 @@ type StreamEvent struct {
 	PlanSteps []PlanStep `json:"plan_steps,omitempty"`
 	// PluginErrors carries plugin load failures surfaced by the init event.
 	PluginErrors []string `json:"plugin_errors,omitempty"`
+	// BackgroundTaskIDs is populated (possibly to an empty, non-nil slice) for
+	// a "system"/"background_tasks_changed" event: REPLACE-semantics snapshot
+	// of every CLI background bash task still live after the change. See
+	// Agent.SetBackgroundTaskIDs / Agent.EffectiveHangGrace.
+	BackgroundTaskIDs []string `json:"background_task_ids,omitempty"`
 	// ToolCalls is the number of tool_use blocks in this event: all tool uses
 	// in a Claude assistant turn, or a single Codex tool_use. The runner
 	// accumulates these into Agent.ToolCalls.

--- a/internal/agent/event_stream.go
+++ b/internal/agent/event_stream.go
@@ -48,6 +48,12 @@ type StreamEvent struct {
 	// a "system"/"background_tasks_changed" event: REPLACE-semantics snapshot
 	// of every CLI background bash task still live after the change. See
 	// Agent.SetBackgroundTaskIDs / Agent.EffectiveHangGrace.
+	//
+	// NOTE: omitempty collapses an empty-but-non-nil "all tasks cleared" slice
+	// into the same absent-key wire form as a nil "no event seen" value. That
+	// REPLACE-semantics distinction is preserved at the Go/ClaudeEvent level
+	// but lost across this JSON boundary — fix the tag when a frontend consumer
+	// that needs the cleared signal actually lands.
 	BackgroundTaskIDs []string `json:"background_task_ids,omitempty"`
 	// ToolCalls is the number of tool_use blocks in this event: all tool uses
 	// in a Claude assistant turn, or a single Codex tool_use. The runner

--- a/internal/agent/headless_background_guardrail.go
+++ b/internal/agent/headless_background_guardrail.go
@@ -1,0 +1,37 @@
+package agent
+
+// backgroundTaskGuardrail is appended to every headless, code-authoring run's
+// prompt (see RunConfig.SeedWorkingMemory / Role.AuthorsCode). Headless mode
+// is one-shot: the CLI process exits as soon as the agent emits its final
+// response, and it tears down any live background bash task
+// (`run_in_background`) at that point — Sybra's own process supervision
+// never gets a chance to wait longer, because the child has already decided
+// to exit. A command killed mid-write leaves the worktree silently
+// corrupted rather than failing loudly: task 3aeabb65 traced a deterministic
+// verify_checks failure to a `npm ci` backgrounded and then interrupted by
+// end-of-turn, which left `node_modules` with hundreds of empty package
+// directories. The only reliable fix is telling the agent never to end its
+// turn with a background task still running.
+const backgroundTaskGuardrail = "\n\n---\n\n" +
+	"Headless turns are one-shot: the underlying process exits as soon as you " +
+	"finish your final response, which immediately kills any command you left " +
+	"running in the background (e.g. a `run_in_background` Bash call). A " +
+	"command killed mid-write can leave the worktree silently corrupted — for " +
+	"example a killed `npm ci` leaves an empty, broken `node_modules` that " +
+	"fails every later build deterministically, not flakily. Never end your " +
+	"turn while a background task is still running: run slow commands " +
+	"(`npm ci`, `mise run verify`, test suites, etc.) in the foreground and " +
+	"wait for them to exit, or poll the background task until it finishes " +
+	"before your final response."
+
+// withBackgroundTaskGuardrail appends backgroundTaskGuardrail to prompt for
+// headless code-authoring runs — the only shape where a backgrounded command
+// can be silently killed and corrupt the worktree. Interactive/conversational
+// sessions persist across turns, so a background task started there survives
+// past any single turn ending; this is a headless-only failure mode.
+func withBackgroundTaskGuardrail(prompt string, cfg RunConfig) string {
+	if cfg.Mode != "headless" || !cfg.SeedWorkingMemory {
+		return prompt
+	}
+	return prompt + backgroundTaskGuardrail
+}

--- a/internal/agent/headless_background_guardrail_test.go
+++ b/internal/agent/headless_background_guardrail_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWithBackgroundTaskGuardrail_HeadlessCodeAuthor(t *testing.T) {
+	got := withBackgroundTaskGuardrail("do the thing", RunConfig{Mode: "headless", SeedWorkingMemory: true})
+	if got == "do the thing" {
+		t.Fatal("expected guardrail to be appended for a headless, code-authoring run")
+	}
+	if !strings.HasPrefix(got, "do the thing") {
+		t.Errorf("guardrail must be appended after the original prompt, not replace it:\n%s", got)
+	}
+	if !strings.Contains(got, "background") {
+		t.Errorf("prompt missing background task guardrail text:\n%s", got)
+	}
+}
+
+func TestWithBackgroundTaskGuardrail_SkipsInteractive(t *testing.T) {
+	got := withBackgroundTaskGuardrail("do the thing", RunConfig{Mode: "interactive", SeedWorkingMemory: true})
+	if got != "do the thing" {
+		t.Errorf("interactive runs persist across turns and should not get the headless-only guardrail; got:\n%s", got)
+	}
+}
+
+func TestWithBackgroundTaskGuardrail_SkipsVerifierRoles(t *testing.T) {
+	// SeedWorkingMemory is only ever set true for code-author roles
+	// (see Role.AuthorsCode); a verifier role (review/test-runner/eval) never
+	// sets it, so this locks in that the guardrail follows the same gate.
+	got := withBackgroundTaskGuardrail("do the thing", RunConfig{Mode: "headless", SeedWorkingMemory: false})
+	if got != "do the thing" {
+		t.Errorf("non-code-author headless runs should not get the guardrail; got:\n%s", got)
+	}
+}

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -93,6 +93,44 @@ func TestPrepareRunConfig_InteractiveFailsOverLikeHeadless(t *testing.T) {
 	}
 }
 
+// TestPrepareRunConfig_AppendsBackgroundTaskGuardrailForHeadlessCodeAuthor
+// locks in that prepareRunConfig — the single chokepoint every headless and
+// interactive run passes through — wires the background-task guardrail into
+// the final prompt for a headless, code-authoring run (SeedWorkingMemory),
+// and leaves other shapes untouched.
+func TestPrepareRunConfig_AppendsBackgroundTaskGuardrailForHeadlessCodeAuthor(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true}})
+
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		Provider:          "claude",
+		Mode:              "headless",
+		Prompt:            "implement the task",
+		SeedWorkingMemory: true,
+		Dir:               t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	if cfg.Prompt == "implement the task" {
+		t.Fatal("expected background-task guardrail to be appended to a headless code-author prompt")
+	}
+
+	cfg, _, err = m.prepareRunConfig(RunConfig{
+		Provider:          "claude",
+		Mode:              "headless",
+		Prompt:            "review the diff",
+		SeedWorkingMemory: false,
+		Dir:               t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	if cfg.Prompt != "review the diff" {
+		t.Errorf("verifier role (SeedWorkingMemory=false) should not get the guardrail, got: %q", cfg.Prompt)
+	}
+}
+
 func TestGateProvider_BothUnhealthyReturnsTypedError(t *testing.T) {
 	m, _ := newTestManager(t)
 	m.SetHealthGate(&fakeGate{

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -105,6 +105,7 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	if cfg.SeedWorkingMemory {
 		cfg.Prompt = notes.SeedPrompt(cfg.Prompt, cfg.Dir)
 	}
+	cfg.Prompt = withBackgroundTaskGuardrail(cfg.Prompt, cfg)
 	resolvedProvider, gateErr := m.gateProvider(cfg)
 	if gateErr != nil {
 		return cfg, nil, gateErr

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -856,8 +856,17 @@ const backgroundTaskGrace = 15 * time.Minute
 // background bash tasks, mirroring the REPLACE semantics of the CLI's
 // "background_tasks_changed" system event.
 func (a *Agent) SetBackgroundTaskIDs(ids []string) {
+	// Defensive copy, mirroring SetPluginErrors, so a caller that later mutates
+	// or reuses the passed slice can't race the reader in HasBackgroundTasks.
+	// Preserve nil-ness: a nil "no event seen" snapshot must stay distinct from
+	// an empty non-nil "all tasks cleared" one (REPLACE semantics).
+	var cp []string
+	if ids != nil {
+		cp = make([]string, len(ids))
+		copy(cp, ids)
+	}
 	a.mu.Lock()
-	a.backgroundTaskIDs = ids
+	a.backgroundTaskIDs = cp
 	a.mu.Unlock()
 }
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -133,6 +133,16 @@ type Agent struct {
 	// status from the result event rather than the kill signal.
 	completedByResult bool
 
+	// backgroundTaskIDs mirrors the CLI's last "background_tasks_changed"
+	// system event (REPLACE semantics: the full set of currently-live
+	// background bash tasks, e.g. a `run_in_background` Bash call). A CC
+	// process can legitimately emit its terminal result while a task like
+	// `npm ci` is still running in the background, producing no further
+	// NDJSON activity — the post-result-hang guards must not mistake that
+	// silence for a hung/orphaned process and kill it mid-write (task
+	// 3aeabb65: a killed `npm ci` left a corrupted, zero-byte node_modules).
+	backgroundTaskIDs []string
+
 	// detached is true when the agent's subprocess was spawned to survive
 	// an app restart (Setsid, output redirected to its log file, no ctx
 	// kill). ShutdownWithGrace leaves detached agents running instead of
@@ -832,6 +842,42 @@ func (a *Agent) TerminalResultIdle(grace time.Duration) bool {
 		return false
 	}
 	return time.Since(a.LastEventAt) >= grace
+}
+
+// backgroundTaskGrace is the extra idle time granted to a post-result-hang
+// guard (runner_headless.go's postResultGrace, watchdog's completedHangGrace)
+// while the agent has outstanding CLI background bash tasks. Bounded rather
+// than unlimited so a task that never reports completion (e.g. the CLI
+// process dies without emitting a final background_tasks_changed) can't hang
+// a run forever — the guard still fires, just later, once this is exhausted.
+const backgroundTaskGrace = 15 * time.Minute
+
+// SetBackgroundTaskIDs replaces the agent's tracked set of live CLI
+// background bash tasks, mirroring the REPLACE semantics of the CLI's
+// "background_tasks_changed" system event.
+func (a *Agent) SetBackgroundTaskIDs(ids []string) {
+	a.mu.Lock()
+	a.backgroundTaskIDs = ids
+	a.mu.Unlock()
+}
+
+// HasBackgroundTasks reports whether the CLI last reported any live
+// background bash tasks still running.
+func (a *Agent) HasBackgroundTasks() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.backgroundTaskIDs) > 0
+}
+
+// EffectiveHangGrace extends base by backgroundTaskGrace while the agent has
+// outstanding background bash tasks, so a post-result-hang guard idle-timing
+// out on silence doesn't kill a process that's still legitimately waiting on
+// a `run_in_background` command (e.g. npm ci) — see backgroundTaskIDs.
+func (a *Agent) EffectiveHangGrace(base time.Duration) time.Duration {
+	if a.HasBackgroundTasks() {
+		return base + backgroundTaskGrace
+	}
+	return base
 }
 
 func (a *Agent) setCompletedByResult(v bool) {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -33,6 +33,31 @@ var errSurviveShutdown = errors.New("agent: detached, leaving process running fo
 var errStoppedPendingReap = errors.New("agent: stopped, subprocess not yet reaped")
 var errCostGuardrailExceeded = errors.New("agent: cost guardrail exceeded")
 
+// errBackgroundTaskLiveAtExit is recorded as the agent's exit error when the
+// headless subprocess exits (naturally, or after the post-result-hang guard
+// gave up waiting) while the CLI's last known state still shows a live
+// `run_in_background` bash task. The process exiting kills that task
+// mid-write, which can silently corrupt the worktree (task 3aeabb65); a run
+// left this way must not be reported as a clean success (ExitErr nil) to
+// OnComplete/fireComplete, since the workflow would otherwise hand a
+// possibly-corrupted worktree to the next stage.
+var errBackgroundTaskLiveAtExit = errors.New("agent: process exited while a background bash task was still running")
+
+// checkLiveBackgroundTasksAtExit returns errBackgroundTaskLiveAtExit if the
+// agent's last reported CLI state still shows a live background bash task.
+// Called at every point a headless attempt is about to report a clean exit,
+// so the guardrail described on backgroundTaskGuardrail is enforced even
+// when the provider ignores the prompt instruction and ends its turn with a
+// task still running.
+func checkLiveBackgroundTasksAtExit(m *Manager, a *Agent) error {
+	if !a.HasBackgroundTasks() {
+		return nil
+	}
+	m.logger.Warn("agent.headless.exit_with_live_background_tasks", "id", a.ID,
+		"hint", "headless process exited while a background bash task was still running; the run is marked failed instead of a clean success to prevent handing off a possibly-corrupted worktree")
+	return errBackgroundTaskLiveAtExit
+}
+
 // headlessTailPoll is how often the detached/reattached tailer polls the
 // log file for new NDJSON lines.
 const headlessTailPoll = 100 * time.Millisecond
@@ -219,28 +244,9 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 		logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 		return false, nil
 	}
-	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
-		waitErr = streamErr
+	if retry := m.resolveHeadlessAttemptExit(a, waitErr, stderrOut, prevLen); retry {
+		return true, nil
 	}
-	// Only inspect the events produced during this attempt. Some CLIs report
-	// quota exhaustion as an exit-0 result event, so classify provider health
-	// even when the process itself looked successful.
-	attemptEvents := attemptEventsFrom(a.Output(), prevLen)
-	if waitErr != nil {
-		a.SetExitErr(waitErr)
-		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
-		if shouldRetry(stderrOut, attemptEvents, m.logger) {
-			logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
-			return true, nil
-		}
-		m.reportProviderHealthSignal(a, stderrOut, attemptEvents)
-	} else {
-		a.SetExitErr(nil)
-		if m.reportCleanProviderHealthSignal(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-			a.SetExitErr(errProviderRateLimited)
-		}
-	}
-	logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 	return false, nil
 }
 
@@ -338,29 +344,41 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 		logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 		return false, nil
 	}
+	if retry := m.resolveHeadlessAttemptExit(a, waitErr, stderrOut, prevLen); retry {
+		return true, nil
+	}
+	return false, nil
+}
+
+// resolveHeadlessAttemptExit inspects a headless attempt's process wait
+// error and stream events once the process has actually exited, sets the
+// agent's final ExitErr, and reports whether the caller should retry.
+// Shared by runHeadlessAttemptPipe and runHeadlessAttemptSurvive, which
+// otherwise duplicate this classification verbatim.
+func (m *Manager) resolveHeadlessAttemptExit(a *Agent, waitErr error, stderrOut string, prevLen int) (retry bool) {
 	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}
-	// Only inspect events from this attempt, mirroring the legacy path —
-	// otherwise a transient 529 from an earlier attempt makes every later
-	// attempt retry regardless of its real failure.
+	// Only inspect the events produced during this attempt. Some CLIs report
+	// quota exhaustion as an exit-0 result event, so classify provider health
+	// even when the process itself looked successful.
 	attemptEvents := attemptEventsFrom(a.Output(), prevLen)
-	if waitErr != nil {
+	switch {
+	case waitErr != nil:
 		a.SetExitErr(waitErr)
 		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
 			logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
-			return true, nil
+			return true
 		}
 		m.reportProviderHealthSignal(a, stderrOut, attemptEvents)
-	} else {
-		a.SetExitErr(nil)
-		if m.reportCleanProviderHealthSignal(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-			a.SetExitErr(errProviderRateLimited)
-		}
+	case m.reportCleanProviderHealthSignal(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit:
+		a.SetExitErr(errProviderRateLimited)
+	default:
+		a.SetExitErr(checkLiveBackgroundTasksAtExit(m, a))
 	}
 	logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
-	return false, nil
+	return false
 }
 
 // finalizeFromResult sets the exit status of a run that the post-result-hang
@@ -377,7 +395,7 @@ func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
 		a.SetExitErr(errProviderRateLimited)
 		return
 	}
-	a.SetExitErr(nil)
+	a.SetExitErr(checkLiveBackgroundTasksAtExit(m, a))
 }
 
 // logAttemptStderr logs a completed attempt's captured stderr. Codex (and

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -728,6 +728,7 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 			m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow,
 				"input_tokens", event.InputTokens, "output_tokens", event.OutputTokens, "reasoning_tokens", event.ReasoningTokens)
 		}
+		m.warnIfResultHasLiveBackgroundTasks(a)
 		// Persist the captured session ID so a reattach or restart-stale
 		// recovery can pass --resume. No-op when survival is disabled.
 		if event.SessionID != "" {
@@ -743,6 +744,24 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		}
 	}
 	return false
+}
+
+// warnIfResultHasLiveBackgroundTasks logs a warning when a terminal result
+// event arrives while Sybra's last known state still shows a live CLI
+// background bash task. A headless process exits as soon as its final turn
+// ends and tears down any such task at that point — Sybra cannot make an
+// already-exiting process wait longer. A task killed mid-write (e.g. `npm
+// ci` extracting packages) leaves the worktree silently corrupted, which
+// then fails a later step (verify_checks, build) deterministically and gets
+// misdiagnosed as a code defect instead of an infra one (see task
+// 3aeabb65). The result event is the last point Sybra observes the agent's
+// own view of its live tasks, so it's the only place this can be caught.
+func (m *Manager) warnIfResultHasLiveBackgroundTasks(a *Agent) {
+	if !a.HasBackgroundTasks() {
+		return
+	}
+	m.logger.Warn("agent.headless.result_with_live_background_tasks", "id", a.ID,
+		"hint", "headless turn ended while a background bash task was still running; it will be killed with the process, which can leave partial writes in the worktree")
 }
 
 // checkCostGuardrail hard-stops a headless run on a breach of MaxCostUSD.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -526,9 +526,13 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 		// not exited. The run is logically complete — stop the orphan and
 		// finalize from the result so the workflow advances instead of the
 		// stall watchdog escalating a finished run to human-required.
-		if a.TerminalResultIdle(postResultGrace) {
+		// EffectiveHangGrace extends the idle window while a CLI
+		// `run_in_background` task (e.g. npm ci) is still live, so it isn't
+		// killed mid-write just because it produces no NDJSON activity.
+		if a.TerminalResultIdle(a.EffectiveHangGrace(postResultGrace)) {
 			m.logger.Warn("agent.headless.post_result_hang", "id", a.ID,
-				"idle_sec", int(time.Since(a.GetLastEventAt()).Seconds()))
+				"idle_sec", int(time.Since(a.GetLastEventAt()).Seconds()),
+				"background_tasks_pending", a.HasBackgroundTasks())
 			a.setCompletedByResult(true)
 			m.signalKill(a)
 			waitExit()
@@ -670,6 +674,10 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		if p := provider.SessionFilePath(event.SessionID); p != "" {
 			a.SetSessionFilePath(p)
 		}
+	}
+
+	if event.Type == "system" && event.Subtype == "background_tasks_changed" {
+		a.SetBackgroundTaskIDs(event.BackgroundTaskIDs)
 	}
 
 	if (event.Type == "system" || event.Type == "init") && len(event.PluginErrors) > 0 {

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -46,6 +46,9 @@ func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
 	switch e.Type {
 	case "system", "init":
 		ev.PluginErrors = e.PluginErrors
+		if e.Subtype == "background_tasks_changed" {
+			ev.BackgroundTaskIDs = e.BackgroundTaskIDs
+		}
 	case "assistant":
 		if e.Message != nil {
 			ev.Content = formatHeadlessAssistant(e.Message)

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -130,6 +130,35 @@ func TestProcessHeadlessLine_SuppressesCodexLimitSnapshotOutput(t *testing.T) {
 	}
 }
 
+// TestProcessHeadlessLine_TracksBackgroundTasks locks in that a live NDJSON
+// "background_tasks_changed" system event updates the agent's tracked
+// background-task set (used to extend the post-result-hang grace, see
+// TestTerminalResultIdle_BackgroundTaskExtendsGrace), and that a later empty
+// snapshot clears it (REPLACE semantics).
+func TestProcessHeadlessLine_TracksBackgroundTasks(t *testing.T) {
+	m := newParseTestManager(t)
+	a := &Agent{ID: "bg1", TaskID: "t", Mode: "headless", Provider: "claude", StartedAt: time.Now().UTC()}
+	lastEmit := time.Now().Add(-time.Minute)
+	prov := providerByName("claude")
+
+	live := []byte(`{"type":"system","subtype":"background_tasks_changed","session_id":"s1",` +
+		`"tasks":[{"task_id":"bpzdm25og","task_type":"bash","description":"mise run verify"}]}`)
+	if stop := m.processHeadlessLine(context.Background(), a, live, &lastEmit, prov); stop {
+		t.Fatal("background_tasks_changed event must not stop the stream")
+	}
+	if !a.HasBackgroundTasks() {
+		t.Fatal("HasBackgroundTasks = false after a live background_tasks_changed event, want true")
+	}
+
+	cleared := []byte(`{"type":"system","subtype":"background_tasks_changed","session_id":"s1","tasks":[]}`)
+	if stop := m.processHeadlessLine(context.Background(), a, cleared, &lastEmit, prov); stop {
+		t.Fatal("background_tasks_changed event must not stop the stream")
+	}
+	if a.HasBackgroundTasks() {
+		t.Fatal("HasBackgroundTasks = true after an empty background_tasks_changed event, want false")
+	}
+}
+
 // TestProcessHeadlessLine_ResultLogOmitsSessionCostForCodex verifies that
 // agent.headless.result drops the meaningless session_id/cost fields for
 // codex (which never reports them), while keeping them for providers that
@@ -484,6 +513,40 @@ func TestTerminalResultIdle(t *testing.T) {
 			t.Fatal("TerminalResultIdle = false on codex turn.completed idle past grace, want true")
 		}
 	})
+}
+
+// TestTerminalResultIdle_BackgroundTaskExtendsGrace locks in the fix for task
+// 3aeabb65: a headless run that emitted its terminal result but still has a
+// live CLI `run_in_background` task (e.g. npm ci) must not be treated as an
+// idle/hung process at the base grace — only after the extended
+// EffectiveHangGrace window, and never at all once the CLI reports the task
+// set empty again.
+func TestTerminalResultIdle_BackgroundTaskExtendsGrace(t *testing.T) {
+	a := &Agent{}
+	a.AppendOutput(StreamEvent{Type: "result", Content: "done"})
+	a.mu.Lock()
+	a.LastEventAt = time.Now().Add(-2 * time.Minute)
+	a.mu.Unlock()
+	a.SetBackgroundTaskIDs([]string{"bpzdm25og"})
+
+	if !a.HasBackgroundTasks() {
+		t.Fatal("HasBackgroundTasks = false after SetBackgroundTaskIDs with a live task, want true")
+	}
+	if a.TerminalResultIdle(a.EffectiveHangGrace(90 * time.Second)) {
+		t.Fatal("TerminalResultIdle = true within extended grace while background task is live, want false")
+	}
+	if !a.TerminalResultIdle(90 * time.Second) {
+		t.Fatal("TerminalResultIdle(base grace) = false past base grace, want true regardless of background tasks")
+	}
+
+	// CLI reports the background task finished (REPLACE semantics: empty set).
+	a.SetBackgroundTaskIDs([]string{})
+	if a.HasBackgroundTasks() {
+		t.Fatal("HasBackgroundTasks = true after task set cleared, want false")
+	}
+	if !a.TerminalResultIdle(a.EffectiveHangGrace(90 * time.Second)) {
+		t.Fatal("TerminalResultIdle = false past base grace once background tasks cleared, want true")
+	}
 }
 
 // TestFinalizeFromResult_IgnoresKillSignalWaitErr covers the fix for the

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -159,6 +159,66 @@ func TestProcessHeadlessLine_TracksBackgroundTasks(t *testing.T) {
 	}
 }
 
+// TestProcessHeadlessLine_WarnsWhenResultArrivesWithLiveBackgroundTasks locks
+// in the fix for task 3aeabb65: a headless CLI process exits (and kills any
+// live background bash task) as soon as its final turn ends, so the terminal
+// result event is the last point Sybra can observe that a background task
+// was still live — and thus at risk of being killed mid-write. This must
+// surface as a warning so an infra-caused corruption (e.g. a killed `npm ci`)
+// isn't silently misdiagnosed as a code defect downstream.
+func TestProcessHeadlessLine_WarnsWhenResultArrivesWithLiveBackgroundTasks(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	m := mustNewManager(t, context.Background(), func(string, any) {}, logger, t.TempDir())
+	prov := providerByName("claude")
+
+	a := &Agent{ID: "bg-result", TaskID: "t", Mode: "headless", Provider: "claude", StartedAt: time.Now().UTC()}
+	lastEmit := time.Now().Add(-time.Minute)
+
+	live := []byte(`{"type":"system","subtype":"background_tasks_changed","session_id":"s1",` +
+		`"tasks":[{"task_id":"bpzdm25og","task_type":"bash","description":"mise run verify"}]}`)
+	if stop := m.processHeadlessLine(context.Background(), a, live, &lastEmit, prov); stop {
+		t.Fatal("background_tasks_changed event must not stop the stream")
+	}
+
+	result := []byte(`{"type":"result","subtype":"success","session_id":"s1","total_cost_usd":0.1,"usage":{"input_tokens":1,"output_tokens":1}}`)
+	if stop := m.processHeadlessLine(context.Background(), a, result, &lastEmit, prov); stop {
+		t.Fatal("result event must not stop the stream")
+	}
+
+	if !strings.Contains(logBuf.String(), "agent.headless.result_with_live_background_tasks") {
+		t.Fatalf("log = %q, want a warning about the live background task at result time", logBuf.String())
+	}
+}
+
+// TestProcessHeadlessLine_NoWarningWhenBackgroundTasksClearedBeforeResult
+// ensures the warning only fires when Sybra's last known state still shows a
+// live background task — a task that legitimately finished and cleared
+// before the result event must not be flagged.
+func TestProcessHeadlessLine_NoWarningWhenBackgroundTasksClearedBeforeResult(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	m := mustNewManager(t, context.Background(), func(string, any) {}, logger, t.TempDir())
+	prov := providerByName("claude")
+
+	a := &Agent{ID: "bg-cleared", TaskID: "t", Mode: "headless", Provider: "claude", StartedAt: time.Now().UTC()}
+	lastEmit := time.Now().Add(-time.Minute)
+
+	live := []byte(`{"type":"system","subtype":"background_tasks_changed","session_id":"s1",` +
+		`"tasks":[{"task_id":"bpzdm25og","task_type":"bash","description":"mise run verify"}]}`)
+	m.processHeadlessLine(context.Background(), a, live, &lastEmit, prov)
+
+	cleared := []byte(`{"type":"system","subtype":"background_tasks_changed","session_id":"s1","tasks":[]}`)
+	m.processHeadlessLine(context.Background(), a, cleared, &lastEmit, prov)
+
+	result := []byte(`{"type":"result","subtype":"success","session_id":"s1","total_cost_usd":0.1,"usage":{"input_tokens":1,"output_tokens":1}}`)
+	m.processHeadlessLine(context.Background(), a, result, &lastEmit, prov)
+
+	if strings.Contains(logBuf.String(), "agent.headless.result_with_live_background_tasks") {
+		t.Fatalf("log = %q, background tasks cleared before result — should not warn", logBuf.String())
+	}
+}
+
 // TestProcessHeadlessLine_ResultLogOmitsSessionCostForCodex verifies that
 // agent.headless.result drops the meaningless session_id/cost fields for
 // codex (which never reports them), while keeping them for providers that

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -58,6 +58,11 @@ type ClaudeEvent struct {
 	// when the event belongs to a forked subagent's turn (CLAUDE_CODE_FORK_SUBAGENT)
 	// rather than the top-level conversation.
 	ParentToolUseID string
+	// BackgroundTaskIDs is populated (possibly to an empty, non-nil slice) for
+	// a "system"/"background_tasks_changed" event: REPLACE-semantics snapshot
+	// of every CLI background bash task (e.g. a `run_in_background` Bash call)
+	// still live after the change.
+	BackgroundTaskIDs []string
 }
 
 // CodexEvent is the shared envelope for all Codex stream-json events.
@@ -105,6 +110,19 @@ type claudeEnvelope struct {
 	Usage             *claudeUsage `json:"usage"`
 	TotalInputTokens  int          `json:"total_input_tokens"`
 	TotalOutputTokens int          `json:"total_output_tokens"`
+	// Tasks is populated on a "system"/"background_tasks_changed" event: the
+	// full set of currently-live background bash tasks (REPLACE semantics).
+	Tasks []claudeBackgroundTaskRef `json:"tasks,omitempty"`
+}
+
+// claudeBackgroundTaskRef is one entry of a "background_tasks_changed"
+// event's `tasks` array — a live CLI background bash task (e.g. a
+// `run_in_background` Bash call). Only TaskID is consumed today;
+// TaskType/Description are kept for future diagnostics.
+type claudeBackgroundTaskRef struct {
+	TaskID      string `json:"task_id"`
+	TaskType    string `json:"task_type"`
+	Description string `json:"description"`
 }
 
 type claudeUsage struct {
@@ -385,6 +403,13 @@ func ParseClaudeLine(line []byte) (ClaudeEvent, error) {
 	case "system", "init":
 		event.SessionID = raw.SessionID
 		event.PluginErrors = raw.PluginErrors
+		if raw.Subtype == "background_tasks_changed" {
+			ids := make([]string, len(raw.Tasks))
+			for i, t := range raw.Tasks {
+				ids[i] = t.TaskID
+			}
+			event.BackgroundTaskIDs = ids
+		}
 
 	case "assistant":
 		if raw.Message != nil {

--- a/internal/agent/stream_test.go
+++ b/internal/agent/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"math"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -211,6 +212,36 @@ func TestParseClaudeLine(t *testing.T) {
 				t.Helper()
 				if len(got.Raw) == 0 {
 					t.Error("Raw is empty")
+				}
+			},
+		},
+		{
+			name: "background_tasks_changed with live tasks",
+			line: `{"type":"system","subtype":"background_tasks_changed","session_id":"s1",` +
+				`"tasks":[{"task_id":"bpzdm25og","task_type":"bash","description":"mise run verify"}]}`,
+			check: func(t *testing.T, got ClaudeEvent) {
+				t.Helper()
+				if got.Subtype != "background_tasks_changed" {
+					t.Errorf("Subtype = %q, want background_tasks_changed", got.Subtype)
+				}
+				if want := []string{"bpzdm25og"}; !slices.Equal(got.BackgroundTaskIDs, want) {
+					t.Errorf("BackgroundTaskIDs = %v, want %v", got.BackgroundTaskIDs, want)
+				}
+			},
+		},
+		{
+			// REPLACE semantics: an empty tasks array means "no live tasks left",
+			// which must be a non-nil empty slice so callers can distinguish it
+			// from "no background_tasks_changed event seen at all".
+			name: "background_tasks_changed with no live tasks",
+			line: `{"type":"system","subtype":"background_tasks_changed","session_id":"s1","tasks":[]}`,
+			check: func(t *testing.T, got ClaudeEvent) {
+				t.Helper()
+				if got.BackgroundTaskIDs == nil {
+					t.Error("BackgroundTaskIDs is nil, want non-nil empty slice")
+				}
+				if len(got.BackgroundTaskIDs) != 0 {
+					t.Errorf("BackgroundTaskIDs = %v, want empty", got.BackgroundTaskIDs)
 				}
 			},
 		},

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -221,11 +221,16 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 // without its process exiting. No judge inspection is involved — a finished
 // run has nothing left to inspect, it just needs its orphaned process killed.
 func (w *Watchdog) checkCompletedHang(ag *agent.Agent, now time.Time) {
-	if !ag.TerminalResultIdle(completedHangGrace) {
+	// EffectiveHangGrace extends the idle window while the CLI still reports
+	// a live `run_in_background` task (e.g. npm ci), so this backstop doesn't
+	// force-stop a process mid-write just because it produced no NDJSON
+	// activity after its terminal result.
+	if !ag.TerminalResultIdle(ag.EffectiveHangGrace(completedHangGrace)) {
 		return
 	}
 	w.logger.Warn("agent.watchdog.completed_hang", "id", ag.ID,
-		"idle_sec", int(now.Sub(ag.GetLastEventAt()).Seconds()))
+		"idle_sec", int(now.Sub(ag.GetLastEventAt()).Seconds()),
+		"background_tasks_pending", ag.HasBackgroundTasks())
 	stop := w.stopCompletedAgent
 	if stop == nil {
 		stop = w.stopAgent

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -449,6 +449,31 @@ func TestCheckCompletedHang_WithinGraceLeavesAgentRunning(t *testing.T) {
 	}
 }
 
+// TestCheckCompletedHang_LiveBackgroundTaskExtendsGrace locks in the fix for
+// task 3aeabb65: a completed agent with a still-live CLI
+// `run_in_background` task (e.g. npm ci) must not be force-stopped at the
+// base completedHangGrace merely because it produced no further NDJSON
+// activity — killing it mid-write corrupted node_modules in the original
+// incident.
+func TestCheckCompletedHang_LiveBackgroundTaskExtendsGrace(t *testing.T) {
+	stopped := false
+	w := &Watchdog{
+		logger:             slog.New(slog.DiscardHandler),
+		stopCompletedAgent: func(string) error { stopped = true; return nil },
+	}
+
+	ag := &agent.Agent{ID: "a1"}
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Content: "done"})
+	ag.SetLastEventAt(time.Now().Add(-10 * time.Minute))
+	ag.SetBackgroundTaskIDs([]string{"bpzdm25og"})
+
+	w.checkCompletedHang(ag, time.Now())
+
+	if stopped {
+		t.Fatal("stopCompletedAgent called while a background task is still live, want no-op")
+	}
+}
+
 // TestApplyVerdict_NudgeLiveTransportDeliversInPlace covers the live-transport
 // path: an agent with a working SendPromptToAgent (interactive/conversational)
 // is steered in place and left running — no stop, no persisted steer.


### PR DESCRIPTION
## Motivation

Headless CLI processes exit as soon as their final turn ends, killing any
live background bash task at that point. Sybra's own process supervision
never gets a chance to intervene because the child has already decided to
exit — task 3aeabb65 traced a deterministic `verify_checks` failure to a
backgrounded `npm ci` interrupted mid-extraction, leaving `node_modules`
silently corrupted (hundreds of empty package directories, no
`node_modules/.bin/vite`) so every later build failed deterministically,
not flakily.

> Changelog: fix(agent): guard headless turns from bg task kill

## Implementation information

- `internal/agent/model.go`/`stream.go`/`event_stream.go`/`runner_headless*.go`,
  `internal/watchdog/agent.go`: track the CLI's live background bash tasks
  (`background_tasks_changed`) on the agent and extend the post-result-hang
  idle grace while any are outstanding, so a process that's still legitimately
  waiting on a `run_in_background` command isn't killed mid-write just because
  it produced no NDJSON activity.
- `internal/agent/headless_background_guardrail.go`: appends a prompt
  guardrail to every headless, code-authoring run (through
  `Manager.prepareRunConfig`, the single chokepoint both headless and
  interactive runs pass through) telling the agent to never end its turn with
  a live background task — headless mode is one-shot, so the harness cannot
  rescue a process that has already chosen to exit.
- `internal/agent/runner_headless.go`: logs
  `agent.headless.result_with_live_background_tasks` when the terminal result
  event arrives while a background task is still tracked as live, so this
  infra-corruption class is distinguishable from a real code defect during
  triage.

## Supporting documentation

- `go build ./...`, `go vet ./...` pass.
- `golangci-lint run ./internal/agent/... ./internal/watchdog/...` — 0 issues.
- `go test -race ./internal/agent/... ./internal/watchdog/...` — pass.

Scope is limited to `internal/agent`/`internal/watchdog`; frontend and other
packages are untouched by this change.

_Generated by Sybra harness_