### PR TITLE
fix(workflow): recover create_pr push divergence

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -698,6 +698,9 @@ func (a *App) initWorkflowEngine() {
 	if a.agentOrch != nil && a.reviewer != nil {
 		a.agentOrch.SetConflictRecovery(a.reviewer.RecoverStaleBranchConflict)
 	}
+	if a.workflowEngine != nil && a.reviewer != nil {
+		a.workflowEngine.SetDivergenceRecovery(a.reviewer.RecoverStaleBranchConflict)
+	}
 	// Workflow completion moves to wireServices so the callback closure binds
 	// to the AgentCompletionHandler constructed there.
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -253,40 +253,41 @@ type agentEntry struct {
 
 // Engine executes workflow definitions against tasks.
 type Engine struct {
-	store            *Store
-	tasks            TaskProvider
-	agents           AgentLauncher
-	prLinker         PRLinker
-	prReviewers      PRReviewRequester
-	prStates         PRStateFetcher
-	prHeads          PRHeadFetcher
-	prCreator        PRCreator
-	prFinder         PRFinder
-	prContentGen     PRContentGenerator
-	worktrees        WorktreeGetter
-	branchSyncer     BranchSyncer
-	checks           CheckConfigGetter
-	manualTests      ManualTestConfigGetter
-	recorder         ArtifactRecorder
-	costBudget       CostBudgetChecker
-	attemptWorktrees AttemptWorktreeManager
-	onComplete       func(CompletionInfo)
-	logger           *slog.Logger
-	ctx              context.Context
-	mu               sync.Mutex
-	inflightMutexes  map[string]*sync.Mutex // taskID → advance serializer (parallel-aware)
-	dispatching      map[string]struct{}    // taskID → dispatch in progress
-	starting         map[string]struct{}    // taskID → StartWorkflowWithVars in progress
-	humanAction      map[string]struct{}    // taskID → HandleHumanAction in progress
-	agentSteps       map[string]agentEntry  // agentID → {taskID, stepID}
-	dispatchingStep  map[string]int         // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
-	cascadeDepth     map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
-	resumeError      *logging.ErrorThrottle
-	demotionThrottle *logging.ErrorThrottle
-	maxTestAttempts  int           // testing → re-implement loop cap (0 → defaultTestAttempts)
-	verifyTimeout    time.Duration // verify_checks budget (0 → verifyChecksDefaultTimeout)
-	abTesting        abtest.Config
-	evalGate         *prompteval.Gate // nil = offline eval verdicts do not gate A/B enrollment
+	store              *Store
+	tasks              TaskProvider
+	agents             AgentLauncher
+	prLinker           PRLinker
+	prReviewers        PRReviewRequester
+	prStates           PRStateFetcher
+	prHeads            PRHeadFetcher
+	prCreator          PRCreator
+	prFinder           PRFinder
+	prContentGen       PRContentGenerator
+	worktrees          WorktreeGetter
+	branchSyncer       BranchSyncer
+	checks             CheckConfigGetter
+	manualTests        ManualTestConfigGetter
+	recorder           ArtifactRecorder
+	costBudget         CostBudgetChecker
+	attemptWorktrees   AttemptWorktreeManager
+	divergenceRecovery func(taskID string) bool
+	onComplete         func(CompletionInfo)
+	logger             *slog.Logger
+	ctx                context.Context
+	mu                 sync.Mutex
+	inflightMutexes    map[string]*sync.Mutex // taskID → advance serializer (parallel-aware)
+	dispatching        map[string]struct{}    // taskID → dispatch in progress
+	starting           map[string]struct{}    // taskID → StartWorkflowWithVars in progress
+	humanAction        map[string]struct{}    // taskID → HandleHumanAction in progress
+	agentSteps         map[string]agentEntry  // agentID → {taskID, stepID}
+	dispatchingStep    map[string]int         // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
+	cascadeDepth       map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
+	resumeError        *logging.ErrorThrottle
+	demotionThrottle   *logging.ErrorThrottle
+	maxTestAttempts    int           // testing → re-implement loop cap (0 → defaultTestAttempts)
+	verifyTimeout      time.Duration // verify_checks budget (0 → verifyChecksDefaultTimeout)
+	abTesting          abtest.Config
+	evalGate           *prompteval.Gate // nil = offline eval verdicts do not gate A/B enrollment
 }
 
 // defaultTestAttempts caps the testing → in-progress re-implementation loop
@@ -358,6 +359,13 @@ func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.worktrees = g }
 // SetBranchSyncer wires a BranchSyncer used by the `sync_branch` step.
 // Leaving it unset makes the step a no-op (skipped outcome).
 func (e *Engine) SetBranchSyncer(s BranchSyncer) { e.branchSyncer = s }
+
+// SetDivergenceRecovery wires the autonomous branch-conflict recovery invoked
+// when create_pr's push hits a self-inflicted divergence (worktree-reuse
+// rebase, not a real content conflict). Returns true when it took over — the
+// step then parks instead of escalating to human-required. Nil keeps the
+// escalate-to-human fallback. Same callback as agentorch/agent_completion use.
+func (e *Engine) SetDivergenceRecovery(fn func(taskID string) bool) { e.divergenceRecovery = fn }
 
 // SetCheckConfigGetter wires the project verify-suite resolver used by the
 // `verify_checks` step. Leaving it unset makes the step a no-op.

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -166,6 +166,10 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 	// prompts instructed. Same for a missing local branch ref — both are
 	// unrecoverable by retrying the push.
 	if errors.Is(pushErr, project.ErrDivergedNeedsResolve) {
+		if e.divergenceRecovery != nil && e.divergenceRecovery(taskID) {
+			e.logger.Info("workflow.pr-tail.diverged-recovery", "task_id", taskID, "step", step.ID)
+			return StepOutput{}, errStepParked, false
+		}
 		out, err = e.humanRequiredPR(taskID, step, "branch diverged from remote — needs manual conflict resolution (never force-pushed): "+pushErr.Error())
 		return out, err, false
 	}

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -203,6 +203,59 @@ func TestExecPushBranch_DivergedFlipsHumanRequired(t *testing.T) {
 	}
 }
 
+func TestExecPushBranch_DivergedRecoveryParks(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+	commitFile(t, wtPath, "one.txt", "one")
+	commitFile(t, wtPath, "two.txt", "two")
+	runGit(t, wtPath, "push", "-u", "origin", "feat/existing-pr")
+	runGit(t, wtPath, "reset", "--hard", "HEAD~1")
+	commitFile(t, wtPath, "two-prime.txt", "two-prime")
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	recovered := false
+	engine.SetDivergenceRecovery(func(string) bool { recovered = true; return true })
+
+	_, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked (recovery took over)", err)
+	}
+	if !recovered {
+		t.Fatal("divergence recovery was not invoked")
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status == "human-required" {
+		t.Errorf("task escalated to human-required despite recovery taking over")
+	}
+}
+
+func TestExecPushBranch_DivergedRecoveryDeclinesEscalates(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+	commitFile(t, wtPath, "one.txt", "one")
+	commitFile(t, wtPath, "two.txt", "two")
+	runGit(t, wtPath, "push", "-u", "origin", "feat/existing-pr")
+	runGit(t, wtPath, "reset", "--hard", "HEAD~1")
+	commitFile(t, wtPath, "two-prime.txt", "two-prime")
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetDivergenceRecovery(func(string) bool { return false })
+
+	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	if err != nil {
+		t.Fatalf("execPushBranch: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, want completed", out.Status)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required (recovery declined)", ti.Status)
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
## Motivation

The human-review automation surfaced a seventh escalation path (the same class
as #1700, on a different code path):

> create_pr's `pushTaskBranch` flips straight to human-required on a
> self-inflicted worktree-reuse rebase divergence (not a real content
> conflict), without ever invoking the branch-conflict-fix recovery workflow
> that handles this exact case elsewhere.

`#1700` fixed the *pre-agent-start* rebase recovery. But `create_pr`'s push
lives in the workflow engine and, on `project.ErrDivergedNeedsResolve`,
escalated directly to human-required — while the pre-agent-start path
(`agentorch.MarkRebaseBlocked`) and the fix-review push backstop
(`agent_completion.recoverDivergedFixReviewPush`) both route the identical
error through `RecoverStaleBranchConflict`, which merges the branch cleanly and
re-pushes as a hook-interceptable agent tool call (Sybra's process never
force-pushes).

> Changelog: fix(workflow): route create_pr push divergence through recovery

## Implementation information

- New engine callback `SetDivergenceRecovery`, wired in `app_init.go` to the
  same `reviewer.RecoverStaleBranchConflict` the other two paths use.
- In `pushTaskBranch`, an `ErrDivergedNeedsResolve` now invokes the recovery
  first. When it takes over (cancels this workflow and dispatches the
  branch-conflict-fix run), the step returns `errStepParked` — `executeSteps`
  stops without advancing or re-persisting the now-replaced workflow. A nil
  callback or a declined recovery keeps the existing human-required fallback,
  so the push is never silently stranded.

Re-entrancy is safe: `RecoverStaleBranchConflict` → `CancelWorkflow` takes no
engine lock, and `StartWorkflowWithVars` uses the separate `starting` marker
(not the per-task advance mutex) and parks the branch-conflict-fix workflow at
its async run_agent step — so invoking it from inside a step neither deadlocks
against the advance mutex nor drives steps recursively past that park.

Tests: recovery-takes-over → parks (`errStepParked`, no human-required);
recovery-declines → escalates as before; the existing nil-callback diverged
test is unchanged. Build, workflow/sybra suites, the e2e smoke, and
golangci-lint are green.

## Supporting documentation

Diagnosed by Sybra's own human-review automation on a stuck task, which
correctly identified that `create_pr` bypassed the recovery used elsewhere.
