### PR TITLE
fix(workflow): create_pr divergence skips branch-conflict-fix recovery

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -698,6 +698,13 @@ func (a *App) initWorkflowEngine() {
 	if a.agentOrch != nil && a.reviewer != nil {
 		a.agentOrch.SetConflictRecovery(a.reviewer.RecoverStaleBranchConflict)
 	}
+	// Same recovery for a push-time divergence surfaced by push_branch/create_pr
+	// (e.g. a reused worktree rebased out from under an earlier merge-based
+	// push) — otherwise it flips straight to human-required with no attempt
+	// at the autonomous fix other divergence sources already get.
+	if a.reviewer != nil {
+		a.workflowEngine.SetConflictRecovery(a.reviewer.RecoverStaleBranchConflict)
+	}
 	// Workflow completion moves to wireServices so the callback closure binds
 	// to the AgentCompletionHandler constructed there.
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -281,6 +281,7 @@ type Engine struct {
 	agentSteps       map[string]agentEntry  // agentID → {taskID, stepID}
 	dispatchingStep  map[string]int         // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
 	cascadeDepth     map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
+	pendingRecovery  map[string]struct{}    // taskID → branch-conflict recovery deferred until the outer marker releases
 	resumeError      *logging.ErrorThrottle
 	demotionThrottle *logging.ErrorThrottle
 	maxTestAttempts  int           // testing → re-implement loop cap (0 → defaultTestAttempts)
@@ -310,6 +311,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		agentSteps:       make(map[string]agentEntry),
 		dispatchingStep:  make(map[string]int),
 		cascadeDepth:     make(map[string]int),
+		pendingRecovery:  make(map[string]struct{}),
 		resumeError:      logging.NewErrorThrottle(),
 		demotionThrottle: logging.NewErrorThrottle(),
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -287,6 +287,7 @@ type Engine struct {
 	verifyTimeout    time.Duration // verify_checks budget (0 → verifyChecksDefaultTimeout)
 	abTesting        abtest.Config
 	evalGate         *prompteval.Gate // nil = offline eval verdicts do not gate A/B enrollment
+	conflictRecovery func(taskID string) bool
 }
 
 // defaultTestAttempts caps the testing → in-progress re-implementation loop
@@ -404,6 +405,16 @@ func (e *Engine) SetABTestingConfig(cfg abtest.Config) { e.abTesting = cfg }
 // online A/B enrollment for digested variants. Leaving it unset (nil)
 // preserves prior behavior: no offline-eval gating.
 func (e *Engine) SetEvalGate(gate *prompteval.Gate) { e.evalGate = gate }
+
+// SetConflictRecovery wires the autonomous branch-conflict recovery callback
+// (review.Handler.RecoverStaleBranchConflict) used by push_branch/create_pr
+// when a push diverges from remote. Same callback agentorch wires for
+// worktree-prep rebase failures — reused here so a self-inflicted divergence
+// discovered at push time (e.g. a reused worktree rebased out from under an
+// earlier merge-based push) gets the same autonomous fix instead of an
+// unconditional human escalation. Leaving it unset preserves the prior
+// behavior: any divergence flips straight to human-required.
+func (e *Engine) SetConflictRecovery(fn func(taskID string) bool) { e.conflictRecovery = fn }
 
 func (e *Engine) withManualTestConfig(t TaskInfo) TaskInfo {
 	if e.manualTests == nil || t.ID == "" {

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -169,6 +169,7 @@ func (e *Engine) executeNextSteps(taskID string, def *Definition, step *Step, wf
 		err = nil
 	}
 	e.fireComplete(comp)
+	e.drainPendingConflictRecovery(taskID)
 	return err
 }
 

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -43,6 +43,7 @@ func (e *Engine) StartWorkflowFromStepWithVars(taskID, workflowID, startStepID s
 		err = nil
 	}
 	e.fireComplete(comp)
+	e.drainPendingConflictRecovery(taskID)
 	return err
 }
 
@@ -188,7 +189,10 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 	// cleared, or its cascade dispatch re-enters and is dropped. Register the
 	// fire defer *before* the marker-delete defer so LIFO runs it afterwards.
 	var completion *CompletionInfo
-	defer func() { e.fireComplete(completion) }()
+	defer func() {
+		e.fireComplete(completion)
+		e.drainPendingConflictRecovery(taskID)
+	}()
 	defer func() {
 		e.mu.Lock()
 		delete(e.dispatching, taskID)

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -526,6 +526,7 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	delete(e.dispatching, taskID)
 	e.mu.Unlock()
 	e.fireComplete(comp)
+	e.drainPendingConflictRecovery(taskID)
 	e.resumeError.Log(e.logger, "workflow.rate-limit-reschedule.exec", taskID, rErr, "task_id", taskID)
 	if rErr != nil {
 		e.surfaceStartFailure(taskID, t.Status, rErr, t.Workflow, step.ID)
@@ -777,6 +778,7 @@ func (e *Engine) ResumeStalled() {
 		// marker is cleared, so the day a sync step becomes resumable its
 		// completion cascades correctly instead of being silently dropped.
 		e.fireComplete(comp)
+		e.drainPendingConflictRecovery(t.ID)
 		e.resumeError.Log(e.logger, "workflow.resume-stalled.exec", t.ID, rErr, "task_id", t.ID)
 		if rErr != nil {
 			e.surfaceStartFailure(t.ID, fresh.Status, rErr, fresh.Workflow, step.ID)

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -166,6 +166,19 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 	// prompts instructed. Same for a missing local branch ref — both are
 	// unrecoverable by retrying the push.
 	if errors.Is(pushErr, project.ErrDivergedNeedsResolve) {
+		// Try the same autonomous conflict-fix recovery agentorch dispatches
+		// for worktree-prep rebase conflicts before giving up to a human — a
+		// divergence here is often self-inflicted (a reused worktree rebased
+		// onto a newer base after an earlier merge-based push), and
+		// RecoverStaleBranchConflict resolves it the same way regardless of
+		// origin. It cancels this task's active workflow and starts
+		// branch-conflict-fix in its place (capturing resume state to
+		// re-enter this step on success), so the caller must treat the
+		// current workflow execution as already handled — errStepParked
+		// mirrors parkStepForRetry's contract for exactly that case.
+		if e.conflictRecovery != nil && e.conflictRecovery(taskID) {
+			return StepOutput{}, errStepParked, false
+		}
 		out, err = e.humanRequiredPR(taskID, step, "branch diverged from remote — needs manual conflict resolution (never force-pushed): "+pushErr.Error())
 		return out, err, false
 	}

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -176,8 +176,14 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 		// re-enter this step on success), so the caller must treat the
 		// current workflow execution as already handled — errStepParked
 		// mirrors parkStepForRetry's contract for exactly that case.
-		if e.conflictRecovery != nil && e.conflictRecovery(taskID) {
-			return StepOutput{}, errStepParked, false
+		if e.conflictRecovery != nil {
+			e.logger.Info("workflow.pr-tail.branch-conflict.recover",
+				"task_id", taskID, "step", step.ID)
+			if e.tryConflictRecovery(taskID) {
+				return StepOutput{}, errStepParked, false
+			}
+			// Recovery ran inline (no marker held) and declined — fall through
+			// to the human escalation below.
 		}
 		out, err = e.humanRequiredPR(taskID, step, "branch diverged from remote — needs manual conflict resolution (never force-pushed): "+pushErr.Error())
 		return out, err, false
@@ -189,6 +195,66 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 
 	out, err = e.classifyPRGitError(taskID, step, wfExec, t, pushErr, "git push")
 	return out, err, false
+}
+
+// tryConflictRecovery attempts autonomous branch-conflict recovery for a
+// diverged push and reports whether the step must park.
+//
+// The callback (review.Handler.RecoverStaleBranchConflict) cancels this task's
+// active workflow and re-dispatches branch-conflict-fix — a re-entry into
+// StartWorkflow*/DispatchEvent. When push_branch/create_pr runs inside one of
+// those calls (DispatchEvent → startWorkflowLocked, or a resume re-dispatch),
+// the per-task starting/dispatching marker is still held, so invoking recovery
+// now would hit ErrWorkflowAlreadyActive and silently no-op — the reentrancy
+// trap that made this whole path dead on arrival. Detect that case by the held
+// marker and queue the recovery instead; drainPendingConflictRecovery runs it
+// once the outer call releases the marker (returns true → park now). When no
+// marker is held (the AdvanceStep tail, or a direct call), recovery is safe to
+// run inline and its own verdict is returned.
+func (e *Engine) tryConflictRecovery(taskID string) bool {
+	e.mu.Lock()
+	_, starting := e.starting[taskID]
+	_, dispatching := e.dispatching[taskID]
+	if starting || dispatching {
+		if e.pendingRecovery == nil {
+			e.pendingRecovery = make(map[string]struct{})
+		}
+		e.pendingRecovery[taskID] = struct{}{}
+		e.mu.Unlock()
+		return true
+	}
+	e.mu.Unlock()
+	return e.conflictRecovery(taskID)
+}
+
+// drainPendingConflictRecovery runs a branch-conflict recovery that
+// tryConflictRecovery deferred because a per-task marker was held when the
+// diverged push was detected. It MUST be called only after the caller has
+// released its starting/dispatching marker (alongside fireComplete), so the
+// callback's re-dispatch is not rejected as re-entrant. No-op when nothing was
+// queued for the task. When recovery is unavailable or declines, the task is
+// escalated to human-required and its parked workflow terminated — the same
+// terminal outcome the inline divergence path produces.
+func (e *Engine) drainPendingConflictRecovery(taskID string) {
+	e.mu.Lock()
+	_, pending := e.pendingRecovery[taskID]
+	if pending {
+		delete(e.pendingRecovery, taskID)
+	}
+	e.mu.Unlock()
+	if !pending {
+		return
+	}
+	if e.conflictRecovery != nil && e.conflictRecovery(taskID) {
+		return // recovery cancelled this workflow and dispatched branch-conflict-fix
+	}
+	reason := "branch diverged from remote — needs manual conflict resolution (never force-pushed)"
+	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+		e.logger.Error("workflow.pr-tail.conflict-recovery.escalate", "task_id", taskID, "err", err)
+	}
+	if _, err := e.CancelWorkflow(taskID, reason); err != nil {
+		e.logger.Error("workflow.pr-tail.conflict-recovery.cancel", "task_id", taskID, "err", err)
+	}
 }
 
 // classifyPRGitError inspects a push/create failure and either parks the

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -203,6 +203,72 @@ func TestExecPushBranch_DivergedFlipsHumanRequired(t *testing.T) {
 	}
 }
 
+func TestExecPushBranch_DivergedRecoveredParksInsteadOfHumanRequired(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+
+	commitFile(t, wtPath, "one.txt", "one")
+	commitFile(t, wtPath, "two.txt", "two")
+	runGit(t, wtPath, "push", "-u", "origin", "feat/existing-pr")
+
+	runGit(t, wtPath, "reset", "--hard", "HEAD~1")
+	commitFile(t, wtPath, "two-prime.txt", "two-prime")
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+
+	var recoveredTaskID string
+	engine.SetConflictRecovery(func(taskID string) bool {
+		recoveredTaskID = taskID
+		return true
+	})
+
+	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	if out != (StepOutput{}) {
+		t.Fatalf("out = %+v, want zero value", out)
+	}
+	if recoveredTaskID != "t1" {
+		t.Errorf("conflictRecovery called with %q, want t1", recoveredTaskID)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "ready-pr" {
+		t.Errorf("task status = %q, want unchanged ready-pr (recovery owns the transition)", ti.Status)
+	}
+}
+
+func TestExecPushBranch_DivergedRecoveryDeclinesFallsBackToHumanRequired(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+
+	commitFile(t, wtPath, "one.txt", "one")
+	commitFile(t, wtPath, "two.txt", "two")
+	runGit(t, wtPath, "push", "-u", "origin", "feat/existing-pr")
+
+	runGit(t, wtPath, "reset", "--hard", "HEAD~1")
+	commitFile(t, wtPath, "two-prime.txt", "two-prime")
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetConflictRecovery(func(string) bool { return false })
+
+	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
+	if err != nil {
+		t.Fatalf("execPushBranch: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -295,7 +295,14 @@ func TestConflictRecovery_DeferredWhileMarkerHeld(t *testing.T) {
 		t.Fatalf("recovery invoked inline under held marker (calls=%d); want deferred", calls)
 	}
 
-	// Marker still held: a premature drain must also not fire the callback.
+	// Release the marker the way real callers do (alongside fireComplete)
+	// before draining — drainPendingConflictRecovery trusts the caller to
+	// have released it and does not re-check, so draining while still held
+	// would re-enter the very reentrancy trap this test guards against.
+	engine.mu.Lock()
+	delete(engine.dispatching, "t1")
+	engine.mu.Unlock()
+
 	engine.drainPendingConflictRecovery("t1")
 	if calls != 1 {
 		t.Fatalf("recovery calls=%d after drain; want exactly 1", calls)

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -269,6 +269,72 @@ func TestExecPushBranch_DivergedRecoveryDeclinesFallsBackToHumanRequired(t *test
 	}
 }
 
+// TestConflictRecovery_DeferredWhileMarkerHeld locks the reentrancy fix: when a
+// per-task starting/dispatching marker is held (push_branch/create_pr reached
+// via DispatchEvent/startWorkflowLocked or a resume re-dispatch), the recovery
+// callback must NOT run inline — doing so re-enters StartWorkflow*/DispatchEvent
+// against the held marker and is silently rejected. It must be queued and run
+// only once drainPendingConflictRecovery fires after the marker releases.
+func TestConflictRecovery_DeferredWhileMarkerHeld(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+
+	var calls int
+	engine.SetConflictRecovery(func(string) bool { calls++; return true })
+
+	// Simulate running inside DispatchEvent: the dispatching marker is held.
+	engine.mu.Lock()
+	engine.dispatching["t1"] = struct{}{}
+	engine.mu.Unlock()
+
+	if parked := engine.tryConflictRecovery("t1"); !parked {
+		t.Fatal("tryConflictRecovery = false, want true (park while marker held)")
+	}
+	if calls != 0 {
+		t.Fatalf("recovery invoked inline under held marker (calls=%d); want deferred", calls)
+	}
+
+	// Marker still held: a premature drain must also not fire the callback.
+	engine.drainPendingConflictRecovery("t1")
+	if calls != 1 {
+		t.Fatalf("recovery calls=%d after drain; want exactly 1", calls)
+	}
+}
+
+// TestDrainPendingConflictRecovery_DeclineEscalates verifies the deferred path's
+// fallback: when the queued recovery declines, the task lands human-required and
+// its parked workflow is terminated — the same terminal outcome the inline path
+// produces.
+func TestDrainPendingConflictRecovery_DeclineEscalates(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "ready-pr",
+		Workflow: &Execution{
+			WorkflowID:  "simple-task-pr",
+			CurrentStep: "push_branch",
+			State:       ExecRunning,
+		},
+	})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetConflictRecovery(func(string) bool { return false })
+
+	engine.mu.Lock()
+	engine.pendingRecovery["t1"] = struct{}{}
+	engine.mu.Unlock()
+
+	engine.drainPendingConflictRecovery("t1")
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if ti.Workflow == nil || ti.Workflow.State != ExecCompleted {
+		t.Errorf("workflow state = %v, want ExecCompleted (parked workflow terminated)", ti.Workflow)
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
## Motivation

## What happened
Task `94e67c57` reached `simple-task-pr`/`create_pr` with no PR yet created. `pushTaskBranch` got `ErrDivergedNeedsResolve` and immediately called `humanRequiredPR` — no attempt to dispatch the `branch-conflict-fix` recovery workflow that other stages in this same pipeline use successfully (e.g. `fix-review.push-diverged.recovered`, `pr-monitor.branch-conflict.recovered` seen for other tasks in the same host-log window).

Verified the divergence is not a genuine conflict: it's self-inflicted by Sybra.
- At 17:59:32 the `pr-fix` agent (run 3) merged a stale pre-existing remote branch tip into local and pushed merge commit `f45e1d19` (based on old `origin/main` at `e9e45419`).
- At 20:07:00, the next worktree reuse (`run_test` step) called `PrepareForTask` → `reconcileAndRebase`, which unconditionally *rebases* the reused branch onto the current `origin/main` (`internal/worktree/prepare.go:210-222`). By then `origin/main` had advanced to `6843554b`, so the rebase produced a brand-new local commit `d4c817d2` with no shared history-by-SHA with the just-pushed `f45e1d19`.
- That reuse-path `PushSync` divergence is only logged as a WARN (best-effort, per the comment at `prepare.go:214-220`) and the run continues.
- At 20:09:38, `create_pr`'s `pushTaskBranch` hits the very same divergence, but this path is NOT best-effort — it goes straight to `human-required` via `humanRequiredPR`, with no recovery attempt.

So the pipeline itself (rebase-on-reuse immediately after a merge-based push) manufactures an unresolvable-by-fast-forward state, then the `create_pr` step treats it as needing a human instead of retrying via `branch-conflict-fix` (the same recovery flow used elsewhere).

This looks like the same bug class as #1690 (branch-conflict recovery rejected before it starts) and #1633 (branch-conflict fix-step never dispatches during recovery) — but here recovery isn't even attempted for the no-PR `create_pr` case in the current code path (`internal/workflow/engine_steps_pr.go` `pushTaskBranch`/`classifyPRGitError`), unlike the recovery-attempt behavior #1690 describes. Filing as a distinct data point in case the create_pr path regressed separately from those two after the #1702 "make PR creation steps deterministic" refactor — please dedupe against #1690/#1633 if the same fix covers all three.

## Repro
1. Let a `pr-fix`/fix-review agent merge (not rebase) a stale remote branch tip into a task's local worktree branch and push it (creates a merge commit off an older `origin/main`).
2. Before a PR is created, let the task go through another worktree reuse (`testing-task`/`run_test`, or any step calling `PrepareForTask` on the same worktree) after `origin/main` has advanced further — `reconcileAndRebase` rebases the branch again, producing a new local commit with no SHA overlap with the previously pushed merge commit.
3. Reach `simple-task-pr`/`create_pr` — `pushTaskBranch` gets `ErrDivergedNeedsResolve` and flips straight to `human-required` with no recovery dispatch.

Concrete log sequence (task `94e67c57`):
- `17:59:32` `fix-review.pushed` → pushes merge commit `f45e1d19`
- `20:07:00` `worktree.rebased` (base `refs/remotes/origin/main`) then `20:07:02` `worktree.push-sync` WARN diverged (local `d4c817d` vs remote `f45e1d1`) — swallowed, run continues
- `20:09:38` `workflow.pr-tail.human-required` step=`create_pr` reason="branch diverged from remote — needs manual conflict resolution (never force-pushed)"

## Suspected cause
`internal/worktree/prepare.go`'s reused-worktree path always rebases onto the latest `baseRef` on every `PrepareForTask` call (`reconcileAndRebase`, `prepare.go:210-222`) and treats the resulting `PushSync` divergence as best-effort/log-only. That's fine in isolation, but it silently invalidates a merge-based push made by an earlier conflict-resolution agent on the same branch, guaranteeing a later `create_pr`/`push_branch` divergence that has no legitimate fast-forward resolution.

`internal/workflow/engine_steps_pr.go`'s `pushTaskBranch` (~line 168) treats `ErrDivergedNeedsResolve` as terminal (`humanRequiredPR`) instead of dispatching the existing `branch-conflict-fix` workflow (`internal/workflow/builtin/branch-conflict-fix.yaml`, wired via `internal/sybra/review/handler.go` / `internal/sybra/agentorch/agentorch.go`) the way other divergence sources in the pipeline already do.

## Filing failure

GitHub issue filing failed, so Sybra created this local fallback task instead.

Error: exit status 1

## Implementation information

See commit history for fix(workflow): create_pr divergence skips branch-conflict-fix recovery.

_Generated by Sybra harness_