### PR TITLE
feat(review): recreate branch when recovery spent

### DIFF
--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -12,6 +12,7 @@ const (
 	// matching and exists only to keep its retry budget separate from PR-backed
 	// conflicts.
 	PRIssueBranchConflictNoPR PRIssueKind = "branch_conflict_no_pr"
+	PRIssueBranchRecreate     PRIssueKind = "branch_recreate"
 	PRIssueCIFailure          PRIssueKind = "ci_failure"
 	PRIssueComments           PRIssueKind = "comments"
 	PRIssueReadyToMerge       PRIssueKind = "ready_to_merge"

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -741,6 +741,18 @@ func DeleteBranch(ctx context.Context, barePath, branch string) error {
 	})
 }
 
+// BackupBranchRef points refs/sybra-backup/<branch> at the branch's current
+// tip so a subsequent DeleteBranch does not lose the commits — they stay
+// recoverable via the backup ref. Used before recreating a task's branch from
+// a fresh base when merge-based conflict recovery is exhausted.
+func BackupBranchRef(ctx context.Context, barePath, branch string) error {
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(ctx, barePath, "update-ref", "refs/sybra-backup/"+branch, "refs/heads/"+branch)
+		})
+	})
+}
+
 // ResolveBareRef resolves a git ref (e.g. "refs/heads/<branch>") to its SHA in
 // the bare repo. Returns ("", false) if the ref does not exist. Exported
 // wrapper around resolveRef for best-of-N promotion's divergence check.

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -832,8 +832,6 @@ func (r *Handler) recreateExhaustedNoPRBranch(t task.Task) bool {
 		r.logger.Warn("pr-monitor.branch-recreate.failed", "task_id", taskID, "err", err)
 		return false
 	}
-	r.prTracker.MarkHandled(taskID, branchRecreateKind, "")
-	r.prTracker.Clear(taskID, branchConflictRetryKind)
 	if r.WorkflowEngine.HasActiveWorkflow(taskID) {
 		if _, cancelErr := r.WorkflowEngine.CancelWorkflow(taskID, "branch recreated from fresh base"); cancelErr != nil {
 			r.logger.Error("pr-monitor.branch-recreate.cancel", "task_id", taskID, "err", cancelErr)
@@ -848,6 +846,8 @@ func (r *Handler) recreateExhaustedNoPRBranch(t task.Task) bool {
 		r.logger.Error("pr-monitor.branch-recreate.status", "task_id", taskID, "err", err)
 		return false
 	}
+	r.prTracker.MarkHandled(taskID, branchRecreateKind, "")
+	r.prTracker.Clear(taskID, branchConflictRetryKind)
 	r.logAudit(audit.EventBranchConflictAutoResolved, taskID, "", map[string]any{"recreated": true})
 	r.logger.Info("pr-monitor.branch-recreate.done", "task_id", taskID)
 	return true

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -26,6 +26,7 @@ import (
 // internal/workflow/builtin/branch-conflict-fix.yaml.
 const branchConflictFixWorkflowID = "branch-conflict-fix"
 const branchConflictRetryKind = github.PRIssueBranchConflictNoPR
+const branchRecreateKind = github.PRIssueBranchRecreate
 
 const wtFailureLimit = 5
 
@@ -750,6 +751,9 @@ func (r *Handler) RecoverStaleBranchConflict(taskID string) bool {
 func (r *Handler) recoverBranchConflictNoPR(t task.Task) bool {
 	taskID := t.ID
 	if r.prTracker.AtCap(taskID, branchConflictRetryKind) {
+		if r.recreateExhaustedNoPRBranch(t) {
+			return true
+		}
 		r.markConflictRecoveryExhausted(taskID, branchConflictRetryKind)
 		return false
 	}
@@ -814,6 +818,39 @@ func (r *Handler) recoverBranchConflictNoPR(t task.Task) bool {
 		r.logger.Warn("pr-monitor.branch-conflict.head-sha", "task_id", taskID, "err", shaErr)
 	}
 	return r.dispatchBranchConflictRecovery(taskID, dir, base, t, headSHA, resume)
+}
+
+func (r *Handler) recreateExhaustedNoPRBranch(t task.Task) bool {
+	taskID := t.ID
+	if r.worktrees == nil || r.WorkflowEngine == nil {
+		return false
+	}
+	if r.prTracker.AtCap(taskID, branchRecreateKind) {
+		return false
+	}
+	if err := r.worktrees.RecreateFromBase(context.Background(), t); err != nil {
+		r.logger.Warn("pr-monitor.branch-recreate.failed", "task_id", taskID, "err", err)
+		return false
+	}
+	r.prTracker.MarkHandled(taskID, branchRecreateKind, "")
+	r.prTracker.Clear(taskID, branchConflictRetryKind)
+	if r.WorkflowEngine.HasActiveWorkflow(taskID) {
+		if _, cancelErr := r.WorkflowEngine.CancelWorkflow(taskID, "branch recreated from fresh base"); cancelErr != nil {
+			r.logger.Error("pr-monitor.branch-recreate.cancel", "task_id", taskID, "err", cancelErr)
+			return false
+		}
+	}
+	reason := "branch recreated from a fresh base after conflict recovery was exhausted; re-implementing (diverged commits saved under refs/sybra-backup)"
+	if _, err := r.tasks.Update(taskID, task.Update{
+		Status:       task.Ptr(task.StatusInProgress),
+		StatusReason: task.Ptr(reason),
+	}); err != nil {
+		r.logger.Error("pr-monitor.branch-recreate.status", "task_id", taskID, "err", err)
+		return false
+	}
+	r.logAudit(audit.EventBranchConflictAutoResolved, taskID, "", map[string]any{"recreated": true})
+	r.logger.Info("pr-monitor.branch-recreate.done", "task_id", taskID)
+	return true
 }
 
 func (r *Handler) captureBranchConflictResumeState(t task.Task) branchConflictResumeState {

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -471,7 +471,7 @@ func (r *Handler) handleKnownPRConflictsViaREST(ctx context.Context, tasks []tas
 		matched := github.MatchTaskPRs(monitoredPRs, matchers)
 		for i := range matched {
 			switch matched[i].Kind {
-			case github.PRIssueConflict, github.PRIssueBranchConflictNoPR, github.PRIssueCIFailure, github.PRIssueReadyToMerge:
+			case github.PRIssueConflict, github.PRIssueBranchConflictNoPR, github.PRIssueBranchRecreate, github.PRIssueCIFailure, github.PRIssueReadyToMerge:
 				handled = append(handled, matched[i])
 			case github.PRIssueComments:
 				// REST exposes no thread-resolution data; comments stay

--- a/internal/sybra/review/outbound.go
+++ b/internal/sybra/review/outbound.go
@@ -257,7 +257,7 @@ func hasFixableIssue(issues []github.PRIssue) bool {
 		switch issues[i].Kind {
 		case github.PRIssueConflict, github.PRIssueCIFailure, github.PRIssueComments:
 			return true
-		case github.PRIssueBranchConflictNoPR, github.PRIssueReadyToMerge:
+		case github.PRIssueBranchConflictNoPR, github.PRIssueBranchRecreate, github.PRIssueReadyToMerge:
 			// branch_conflict_no_pr is tracker-only (never emitted by
 			// MatchTaskPRs); ready_to_merge is not a blocker.
 		}

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -487,6 +487,7 @@ func TestRecoverBranchConflictNoPR_AtCapEscalates(t *testing.T) {
 	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
 	for range github.MaxRetries {
 		r.prTracker.MarkHandled(tk.ID, github.PRIssueBranchConflictNoPR, "somesha")
+		r.prTracker.MarkHandled(tk.ID, branchRecreateKind, "")
 	}
 
 	if r.RecoverStaleBranchConflict(tk.ID) {
@@ -630,6 +631,48 @@ func TestRecoverBranchConflictNoPR_WorktreeFailuresTripCircuitBreaker(t *testing
 	}
 	if n := r.wtFailures[tk.ID]; n != 0 {
 		t.Fatalf("wtFailures[%s] = %d after circuit trip, want 0", tk.ID, n)
+	}
+}
+
+func TestRecoverBranchConflictNoPR_RecreatesWhenExhausted(t *testing.T) {
+	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
+	for range github.MaxRetries {
+		r.prTracker.MarkHandled(tk.ID, branchConflictRetryKind, "")
+	}
+	if !r.prTracker.AtCap(tk.ID, branchConflictRetryKind) {
+		t.Fatal("precondition: conflict-recovery budget should be at cap")
+	}
+
+	if !r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("want true: exhausted conflict recovery should recreate the branch, not escalate")
+	}
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (recreated, re-implementing)", got.Status)
+	}
+	if n := r.prTracker.Retries(tk.ID, branchConflictRetryKind); n != 0 {
+		t.Errorf("conflict-recovery budget = %d, want 0 (reset for the fresh branch)", n)
+	}
+	if n := r.prTracker.Retries(tk.ID, branchRecreateKind); n != 1 {
+		t.Errorf("recreate counter = %d, want 1", n)
+	}
+}
+
+func TestRecoverBranchConflictNoPR_RecreateBudgetExhaustedEscalates(t *testing.T) {
+	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
+	for range github.MaxRetries {
+		r.prTracker.MarkHandled(tk.ID, branchConflictRetryKind, "")
+		r.prTracker.MarkHandled(tk.ID, branchRecreateKind, "")
+	}
+
+	if r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("want false: both conflict-recovery and recreate budgets exhausted must escalate")
+	}
+	if got, _ := r.tasks.Get(tk.ID); got.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want human-required", got.Status)
 	}
 }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -592,6 +592,39 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	return wtPath, nil
 }
 
+// RecreateFromBase discards a task's diverged branch and its worktree so the
+// next PrepareForTask rebuilds it fresh off the project's base ref. The branch
+// tip is first backed up to refs/sybra-backup/<branch> (best-effort) so the
+// discarded commits stay recoverable. Used as the last-resort recovery when
+// merge-based branch-conflict recovery is exhausted on a no-PR task: the branch
+// genuinely cannot be reconciled, so re-implementing from a clean base is the
+// only autonomous path left.
+func (m *Manager) RecreateFromBase(ctx context.Context, t task.Task) error {
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return fmt.Errorf("get project: %w", err)
+	}
+	branch := branchNameForTask(t)
+	wtPath := m.PathFor(t)
+	if project.BranchExists(ctx, proj.ClonePath, branch) {
+		if berr := project.BackupBranchRef(ctx, proj.ClonePath, branch); berr != nil {
+			m.logger.Warn("worktree.recreate.backup", "task_id", t.ID, "branch", branch, "err", berr)
+		}
+	}
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		if rerr := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); rerr != nil {
+			return fmt.Errorf("remove worktree: %w", rerr)
+		}
+	}
+	if project.BranchExists(ctx, proj.ClonePath, branch) {
+		if derr := project.DeleteBranch(ctx, proj.ClonePath, branch); derr != nil {
+			return fmt.Errorf("delete branch: %w", derr)
+		}
+	}
+	m.logger.Info("worktree.recreated-from-base", "task_id", t.ID, "branch", branch)
+	return nil
+}
+
 // PrepareForFix creates a worktree checking out the PR's head branch
 // so the agent can rebase and push. Setup command failures do not abort
 // worktree creation (see runSetupNonGating) — the fixer this worktree is for

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -611,10 +611,8 @@ func (m *Manager) RecreateFromBase(ctx context.Context, t task.Task) error {
 			m.logger.Warn("worktree.recreate.backup", "task_id", t.ID, "branch", branch, "err", berr)
 		}
 	}
-	if _, statErr := os.Stat(wtPath); statErr == nil {
-		if rerr := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); rerr != nil {
-			return fmt.Errorf("remove worktree: %w", rerr)
-		}
+	if rerr := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); rerr != nil {
+		return fmt.Errorf("remove worktree: %w", rerr)
 	}
 	if project.BranchExists(ctx, proj.ClonePath, branch) {
 		if derr := project.DeleteBranch(ctx, proj.ClonePath, branch); derr != nil {


### PR DESCRIPTION
## Motivation

The last recurring branch-conflict escalation: when merge-based branch-conflict recovery is exhausted on a no-PR task, the branch genuinely cannot be reconciled (Sybra never force-pushes), so the task was stranded in human-required. This automates the "recreate the task branch" that every such reason names.

> Changelog: feat(review): recreate an unmergeable branch from a fresh base

## Implementation information

When recoverBranchConflictNoPR hits its retry cap, before escalating it now attempts a bounded recreate (separate PRIssueBranchRecreate budget):

- Back up the diverged branch tip to refs/sybra-backup/<branch> so the discarded commits stay recoverable.
- Remove the worktree + delete the branch so the next PrepareForTask rebuilds it clean off origin.
- Reset the conflict-recovery budget, cancel the active workflow, flip the task to in-progress to re-dispatch a fresh implement run.
- Only after the recreate budget is also spent does it escalate to human-required.

Destructive-in-name only: the commits are preserved under a backup ref, and the branch was unmergeable anyway. Re-entrancy mirrors the proven RecoverStaleBranchConflict pattern (CancelWorkflow takes no engine lock; the caller parks on the true return).

Tests: exhausted recovery recreates + resets budgets + flips to in-progress; both budgets exhausted escalates.
