### PR TITLE
fix(review): adopt orphaned Sybra PRs

### DIFF
--- a/internal/sybra/review/adopt_taskless_test.go
+++ b/internal/sybra/review/adopt_taskless_test.go
@@ -1,0 +1,74 @@
+package review
+
+import (
+	"log/slog"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func newTasklessAdoptHandler(t *testing.T) (*Handler, *task.Manager) {
+	t.Helper()
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	return &Handler{
+		logger:    slog.New(slog.DiscardHandler),
+		tasks:     tasks,
+		prTracker: github.NewIssueTracker(time.Minute),
+	}, tasks
+}
+
+func TestAdoptTasklessPRs_ResurrectsSybraPROnly(t *testing.T) {
+	r, tasks := newTasklessAdoptHandler(t)
+	prs := []github.PullRequest{
+		{Number: 1677, Repository: "owner/repo", HeadRefName: "perf/bound-limits-1a2b3c4d", Title: "perf: bound", URL: "https://x/1677"},
+		{Number: 99, Repository: "owner/repo", HeadRefName: "external/random-branch", Title: "ext", URL: "https://x/99"},
+		{Number: 42, Repository: "owner/repo", HeadRefName: "fix/thing-deadbeef", Title: "draft", URL: "https://x/42", IsDraft: true},
+	}
+
+	r.adoptTasklessPRs(nil, prs)
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("created %d tasks, want 1 (only the non-draft Sybra-branch PR)", len(all))
+	}
+	got := all[0]
+	if got.PRNumber != 1677 || got.Status != task.StatusInReview || got.Branch != "perf/bound-limits-1a2b3c4d" {
+		t.Fatalf("adopted task = {pr:%d status:%q branch:%q}, want {1677 in-review perf/bound-limits-1a2b3c4d}", got.PRNumber, got.Status, got.Branch)
+	}
+	if !slices.Contains(got.Tags, "review") {
+		t.Error("adopted task missing the review tag — would let simple-task-plan claim task.created")
+	}
+}
+
+func TestAdoptTasklessPRs_SkipsAlreadyTracked(t *testing.T) {
+	r, tasks := newTasklessAdoptHandler(t)
+	existing := []task.Task{
+		{ID: "t1", ProjectID: "owner/repo", PRNumber: 1677, Branch: "perf/bound-limits-1a2b3c4d"},
+		{ID: "t2", ProjectID: "owner/repo", Branch: "fix/other-cafe1234"},
+	}
+	prs := []github.PullRequest{
+		{Number: 1677, Repository: "owner/repo", HeadRefName: "perf/bound-limits-1a2b3c4d", Title: "already tracked by pr#", URL: "https://x/1677"},
+		{Number: 500, Repository: "owner/repo", HeadRefName: "fix/other-cafe1234", Title: "already tracked by branch", URL: "https://x/500"},
+	}
+
+	r.adoptTasklessPRs(existing, prs)
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("created %d tasks, want 0 (both PRs already tracked)", len(all))
+	}
+}

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"maps"
 	"os/exec"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -377,6 +378,7 @@ func (r *Handler) pollAndMonitorPRs(ctx context.Context) time.Duration {
 	// normal pr-fix/auto-merge path resumes. Runs before matcher assembly so an
 	// adopted task is monitored in this same poll.
 	r.adoptOrphanPRs(ctx, tasks, monitoredPRs)
+	r.adoptTasklessPRs(tasks, monitoredPRs)
 
 	var (
 		matchers       []github.TaskMatcher
@@ -1354,6 +1356,46 @@ func (r *Handler) adoptOrphanPRs(ctx context.Context, tasks []task.Task, prs []g
 		// No open PR found. Check for a recently merged PR: handles the race
 		// where the PR was opened and merged between poll cycles.
 		r.adoptOrphanMergedPR(ctx, t)
+	}
+}
+
+var sybraTaskBranchRe = regexp.MustCompile(`-[0-9a-f]{8}$`)
+
+func (r *Handler) adoptTasklessPRs(tasks []task.Task, prs []github.PullRequest) {
+	tracked := make(map[string]struct{}, len(tasks)*2)
+	for i := range tasks {
+		if tasks[i].PRNumber != 0 {
+			tracked[fmt.Sprintf("%s#%d", tasks[i].ProjectID, tasks[i].PRNumber)] = struct{}{}
+		}
+		if tasks[i].Branch != "" {
+			tracked[tasks[i].ProjectID+"|"+tasks[i].Branch] = struct{}{}
+		}
+	}
+	for i := range prs {
+		pr := &prs[i]
+		if pr.IsDraft || !sybraTaskBranchRe.MatchString(pr.HeadRefName) {
+			continue
+		}
+		if _, ok := tracked[fmt.Sprintf("%s#%d", pr.Repository, pr.Number)]; ok {
+			continue
+		}
+		if _, ok := tracked[pr.Repository+"|"+pr.HeadRefName]; ok {
+			continue
+		}
+		tags := []string{"review"}
+		t, err := r.tasks.CreateFull(pr.Title, pr.URL+"\n\nAdopted orphaned Sybra PR (its tracking task was lost).", "headless", task.Update{
+			Tags:      &tags,
+			ProjectID: task.Ptr(pr.Repository),
+			PRNumber:  task.Ptr(pr.Number),
+			Branch:    task.Ptr(pr.HeadRefName),
+			Status:    task.Ptr(task.StatusInReview),
+		})
+		if err != nil {
+			r.logger.Error("pr-monitor.taskless-adopt", "pr", pr.Number, "err", err)
+			continue
+		}
+		r.logAudit(audit.EventPROrphanAdopted, t.ID, "", map[string]any{"pr": pr.Number, "repo": pr.Repository, "resurrected": true})
+		r.logger.Info("pr-monitor.taskless-adopted", "task_id", t.ID, "pr", pr.Number, "branch", pr.HeadRefName)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Open PRs were sitting for hours with green CI and never merging. Root cause: their tracking task had been deleted/lost while the PR stayed open, so the PR monitor skipped them entirely (`tm == nil -> continue`) and never even considered `ready_to_merge`. `adoptOrphanPRs` only re-links a PR onto a still-existing task, so a fully-gone task left the PR dangling forever.

> Changelog: fix(review): auto-adopt orphaned Sybra PRs so they merge

## Implementation information

`adoptTasklessPRs` (run right after `adoptOrphanPRs` in the monitor scan) resurrects a tracking task for an open, non-draft PR whose head branch matches Sybra`&#39;`s `<slug>-<taskid8>` naming and that no task references (by PR number or branch). The task carries the `review` tag so `simple-task-plan` does not claim its `task.created`, and starts `in-review` with the PR linked, so the monitor`&#39;`s existing `ready_to_merge` path merges it once clean -- exactly like a normal PR.

Tightly scoped: only branches matching the Sybra task-id convention are adopted, so an unrelated external PR is never resurrected; drafts and already-tracked PRs are skipped.

Tests: resurrects only the non-draft Sybra-branch PR (skips external + draft); skips PRs already tracked by number or branch.
