### PR TITLE
fix(review): cancel task on closed-unmerged PR

### DIFF
--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -723,8 +723,12 @@ func (r *Handler) advanceClosedTaskPRsWithFetch(ctx context.Context, monitoredPR
 		// Flip to done immediately with the base outcome — the status transition
 		// must never wait on GitHub enrichment.
 		base := classifyLandingOutcome(c.State)
+		landedStatus := task.StatusDone
+		if c.State == "CLOSED" {
+			landedStatus = task.StatusCancelled
+		}
 		if _, err := r.tasks.Update(c.TaskID, task.Update{
-			Status:  task.Ptr(task.StatusDone),
+			Status:  task.Ptr(landedStatus),
 			Outcome: task.Ptr(base),
 		}); err != nil {
 			r.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -2025,6 +2025,51 @@ func TestAdvanceClosedTaskPRs_CancelsStaleWorkflow(t *testing.T) {
 	}
 }
 
+func TestAdvanceClosedTaskPRs_ClosedUnmergedCancelsNotDone(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	created, err := tasks.Create("Task whose PR was closed unmerged", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(1444),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.DiscardHandler)
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	r := &Handler{
+		logger: logger, emit: func(string, any) {},
+		tasks:     tasks,
+		agents:    agentMgr,
+		prTracker: github.NewIssueTracker(time.Minute),
+	}
+	closedMatchers := []github.TaskMatcher{{ID: created.ID, PRNumber: 1444, ProjectID: "o/r"}}
+	fetchFn := func(string, int) (github.PRState, error) {
+		return github.PRState{State: "CLOSED"}, nil
+	}
+
+	r.advanceClosedTaskPRsWithFetch(context.Background(), []github.PullRequest{}, closedMatchers, fetchFn)
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusCancelled {
+		t.Errorf("status = %q, want cancelled (a PR closed without merging did not ship its work)", got.Status)
+	}
+	if got.Outcome != "closed" {
+		t.Errorf("outcome = %q, want closed", got.Outcome)
+	}
+}
+
 func TestPollSecondaryReconcilesKnownTaskPRsWithoutSearch(t *testing.T) {
 	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
 	if err != nil {


### PR DESCRIPTION
## Motivation

Root cause of tasks showing `done` with no merged PR (and inflated done counts). `advanceClosedTaskPRsWithFetch` flipped a task to `done` whenever its PR reached a terminal state — **including a PR closed *without* merging**. A closed-unmerged PR (abandoned, superseded, orphan-closed, force-push casualty) never shipped its work, so marking the task `done` misreports unshipped work as complete. This session's orphan/force-push churn produced exactly this.

> Changelog: fix(review): a PR closed without merging cancels the task, not done

## Implementation

A merged PR still lands the task `done`; a PR whose terminal state is `CLOSED` now lands it `cancelled` with `outcome=closed`. One-line status branch in `advanceClosedTaskPRsWithFetch`. Tests: MERGED→done (unchanged), CLOSED→cancelled (new). Full review suite green.

## Related
Complements #1730 (durable completion counts) — this stops non-shipped work from being counted as done.