### PR TITLE
fix(agent): fail over to healthy provider when codex is hard rate-limited

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -501,7 +501,14 @@ func (m *Manager) ProviderCanFailover(name string) bool {
 	if lg == nil {
 		return false
 	}
-	alt, _ := lg.ChooseProvider(resolved, []string{"claude", "codex", "copilot"}, healthy, lp)
+	candidates := []string{"claude", "codex", "copilot"}
+	if alt, _ := lg.ChooseProvider(resolved, candidates, healthy, lp); alt != "" {
+		return true
+	}
+	// Mirror resolveProviderDecision's last-resort path: when no fully
+	// available peer exists, a soft-threshold-limited peer is still a usable
+	// failover target for a hard-blocked provider (e.g. rate limit reached).
+	alt, _ := lg.ChooseSoftLimitedPeer(resolved, candidates, healthy, lp)
 	return alt != ""
 }
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -505,6 +505,10 @@ func (m *Manager) ProviderCanFailover(name string) bool {
 	if alt, _ := lg.ChooseProvider(resolved, candidates, healthy, lp); alt != "" {
 		return true
 	}
+	available, reason := lg.ProviderAvailable(resolved, lp)
+	if available || limits.IsSoftThresholdReason(reason) {
+		return false
+	}
 	// Mirror resolveProviderDecision's last-resort path: when no fully
 	// available peer exists, a soft-threshold-limited peer is still a usable
 	// failover target for a hard-blocked provider (e.g. rate limit reached).

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -132,6 +132,7 @@ type Manager struct {
 type LimitGate interface {
 	ProviderAvailable(provider string, policy limits.Policy) (bool, string)
 	ChooseProvider(requested string, candidates []string, healthy func(string) bool, policy limits.Policy) (string, string)
+	ChooseSoftLimitedPeer(requested string, candidates []string, healthy func(string) bool, policy limits.Policy) (string, string)
 }
 
 // LimitGateOrNil wraps store as a LimitGate, returning a genuine nil

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -168,9 +168,11 @@ func TestGateProvider_IgnoreHealthGateBypasses(t *testing.T) {
 // fakeLimitGate lets a test control ProviderAvailable/ChooseProvider
 // decisions without a real limits.Store.
 type fakeLimitGate struct {
-	available    map[string]bool
-	reasons      map[string]string
-	chooseReason string
+	available      map[string]bool
+	reasons        map[string]string
+	chooseReason   string
+	softPeer       string
+	softPeerReason string
 }
 
 func (f *fakeLimitGate) ProviderAvailable(p string, _ limits.Policy) (available bool, reason string) {
@@ -190,6 +192,18 @@ func (f *fakeLimitGate) ChooseProvider(requested string, candidates []string, he
 		}
 		if healthy(c) {
 			return c, f.chooseReason
+		}
+	}
+	return "", ""
+}
+
+func (f *fakeLimitGate) ChooseSoftLimitedPeer(requested string, candidates []string, healthy func(string) bool, _ limits.Policy) (chosen, reason string) {
+	if f.softPeer == "" || f.softPeer == requested {
+		return "", ""
+	}
+	for _, c := range candidates {
+		if c == f.softPeer && healthy(c) {
+			return f.softPeer, f.softPeerReason
 		}
 	}
 	return "", ""
@@ -527,6 +541,64 @@ func TestGateProvider_HardLimitStillGatesWithNoPeer(t *testing.T) {
 	_, err := m.gateProvider(RunConfig{Provider: "claude"})
 	if err == nil {
 		t.Fatal("hard limit with no peer must gate, got nil error")
+	}
+	if !errors.Is(err, provider.ErrProviderUnhealthy) {
+		t.Fatalf("want ErrProviderUnhealthy, got %v", err)
+	}
+}
+
+// TestGateProvider_HardLimitFailsOverToSoftLimitedPeer is a regression guard
+// for task c61f327a: codex hard rate-limited (ProviderAvailable=false with a
+// hard reason) and ChooseProvider finds no fully-available peer, but claude
+// is only soft-threshold limited (still safely dispatching its own direct
+// runs, per TestGateProvider_SoftThresholdLastResortUsesRemainingBudget).
+// Dispatch must fail over to claude as a last resort instead of failing
+// closed system-wide.
+func TestGateProvider_HardLimitFailsOverToSoftLimitedPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "codex",
+		LimitGate: &fakeLimitGate{
+			available:      map[string]bool{"codex": false},
+			reasons:        map[string]string{"codex": "provider reports rate limit reached"},
+			softPeer:       "claude",
+			softPeerReason: "session limit near threshold",
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.gateProvider(RunConfig{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("hard-limited provider with a soft-limited peer must fail over, got err: %v", err)
+	}
+	if got != "claude" {
+		t.Errorf("got %q, want claude (soft-limited peer used as last-resort failover)", got)
+	}
+}
+
+// TestGateProvider_HardLimitFailoverDisabledSkipsSoftLimitedPeer verifies
+// DisableProviderFailover suppresses the new soft-limited-peer path too, not
+// just the exact-quota ChooseProvider path.
+func TestGateProvider_HardLimitFailoverDisabledSkipsSoftLimitedPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "codex",
+		LimitGate: &fakeLimitGate{
+			available:      map[string]bool{"codex": false},
+			reasons:        map[string]string{"codex": "provider reports rate limit reached"},
+			softPeer:       "claude",
+			softPeerReason: "session limit near threshold",
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := m.gateProvider(RunConfig{Provider: "codex", DisableProviderFailover: true})
+	if err == nil {
+		t.Fatal("DisableProviderFailover must not use the soft-limited peer, got nil error")
 	}
 	if !errors.Is(err, provider.ErrProviderUnhealthy) {
 		t.Fatalf("want ErrProviderUnhealthy, got %v", err)

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -171,6 +171,7 @@ type fakeLimitGate struct {
 	available      map[string]bool
 	reasons        map[string]string
 	chooseReason   string
+	chooseNone     bool // force ChooseProvider to find no fully-available peer
 	softPeer       string
 	softPeerReason string
 }
@@ -186,6 +187,9 @@ func (f *fakeLimitGate) ProviderAvailable(p string, _ limits.Policy) (available 
 }
 
 func (f *fakeLimitGate) ChooseProvider(requested string, candidates []string, healthy func(string) bool, _ limits.Policy) (chosen, reason string) {
+	if f.chooseNone {
+		return "", ""
+	}
 	for _, c := range candidates {
 		if c == requested {
 			continue
@@ -602,5 +606,31 @@ func TestGateProvider_HardLimitFailoverDisabledSkipsSoftLimitedPeer(t *testing.T
 	}
 	if !errors.Is(err, provider.ErrProviderUnhealthy) {
 		t.Fatalf("want ErrProviderUnhealthy, got %v", err)
+	}
+}
+
+// TestProviderCanFailover_ReportsSoftLimitedPeer guards that ProviderCanFailover
+// mirrors resolveProviderDecision's last-resort path: when ChooseProvider finds
+// no fully-available peer but a soft-threshold-limited peer exists, failover is
+// still possible, so recovery must re-dispatch the stranded in-progress task
+// rather than skip it as provider_rate_limited.
+func TestProviderCanFailover_ReportsSoftLimitedPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "codex",
+		LimitGate: &fakeLimitGate{
+			available:      map[string]bool{"codex": false},
+			reasons:        map[string]string{"codex": "provider reports rate limit reached"},
+			chooseNone:     true,
+			softPeer:       "claude",
+			softPeerReason: "session limit near threshold",
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !m.ProviderCanFailover("codex") {
+		t.Fatal("ProviderCanFailover must report true when only a soft-limited peer is available")
 	}
 }

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -582,6 +582,36 @@ func TestGateProvider_HardLimitFailsOverToSoftLimitedPeer(t *testing.T) {
 	}
 }
 
+// TestGateProvider_SoftThresholdDoesNotFailOverToSoftLimitedPeer ensures the
+// new soft-limited-peer last-resort path only applies when the resolved
+// provider is hard-blocked. If resolved is itself merely near threshold, it
+// should keep using its remaining budget instead of bouncing to another
+// soft-limited peer.
+func TestGateProvider_SoftThresholdDoesNotFailOverToSoftLimitedPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "codex",
+		LimitGate: &fakeLimitGate{
+			available:      map[string]bool{"codex": false},
+			reasons:        map[string]string{"codex": "session limit near threshold"},
+			chooseNone:     true,
+			softPeer:       "claude",
+			softPeerReason: "weekly limit near threshold",
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.gateProvider(RunConfig{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("soft-threshold provider with only a soft-limited peer must keep remaining budget, got err: %v", err)
+	}
+	if got != "codex" {
+		t.Errorf("got %q, want codex (soft-threshold last resort must not fail over)", got)
+	}
+}
+
 // TestGateProvider_HardLimitFailoverDisabledSkipsSoftLimitedPeer verifies
 // DisableProviderFailover suppresses the new soft-limited-peer path too, not
 // just the exact-quota ChooseProvider path.
@@ -632,5 +662,26 @@ func TestProviderCanFailover_ReportsSoftLimitedPeer(t *testing.T) {
 	}
 	if !m.ProviderCanFailover("codex") {
 		t.Fatal("ProviderCanFailover must report true when only a soft-limited peer is available")
+	}
+}
+
+func TestProviderCanFailover_SoftThresholdDoesNotReportSoftLimitedPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "codex",
+		LimitGate: &fakeLimitGate{
+			available:      map[string]bool{"codex": false},
+			reasons:        map[string]string{"codex": "session limit near threshold"},
+			chooseNone:     true,
+			softPeer:       "claude",
+			softPeerReason: "weekly limit near threshold",
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if m.ProviderCanFailover("codex") {
+		t.Fatal("ProviderCanFailover must stay false when the resolved provider is only soft-threshold limited")
 	}
 }

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -669,13 +669,17 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (string, []providerGate
 		// whether a peer is only soft-threshold limited (e.g. near its
 		// session cap but still dispatching, the same leniency
 		// softLimitLastResort grants the resolved provider itself) — that
-		// peer is still a safe last-resort failover target when resolved
-		// is hard-blocked (e.g. rate limit actually reached).
-		if alt, altReason := lg.ChooseSoftLimitedPeer(resolved, candidateProviders, healthy, lp); alt != "" {
-			gateEvents = append(gateEvents, providerGateEvent{
-				kind: "failover", from: resolved, to: alt, reason: reason, altReason: altReason, logKey: "agent.run.soft_limit_peer_failover", logLevel: "warn", taskID: cfg.TaskID,
-			})
-			return alt, gateEvents, nil
+		// peer is only a safe last-resort failover target when resolved is
+		// hard-blocked (e.g. rate limit actually reached). If resolved is
+		// itself only soft-threshold limited, keep it so the remaining
+		// budget is not stranded behind another soft-limited peer.
+		if !limits.IsSoftThresholdReason(reason) {
+			if alt, altReason := lg.ChooseSoftLimitedPeer(resolved, candidateProviders, healthy, lp); alt != "" {
+				gateEvents = append(gateEvents, providerGateEvent{
+					kind: "failover", from: resolved, to: alt, reason: reason, altReason: altReason, logKey: "agent.run.soft_limit_peer_failover", logLevel: "warn", taskID: cfg.TaskID,
+				})
+				return alt, gateEvents, nil
+			}
 		}
 		return m.softLimitLastResort(resolved, reason, gateEvents, cfg.TaskID)
 	} else {

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -665,6 +665,18 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (string, []providerGate
 			})
 			return alt, gateEvents, nil
 		}
+		// No fully available peer exists. Before failing closed, check
+		// whether a peer is only soft-threshold limited (e.g. near its
+		// session cap but still dispatching, the same leniency
+		// softLimitLastResort grants the resolved provider itself) — that
+		// peer is still a safe last-resort failover target when resolved
+		// is hard-blocked (e.g. rate limit actually reached).
+		if alt, altReason := lg.ChooseSoftLimitedPeer(resolved, candidateProviders, healthy, lp); alt != "" {
+			gateEvents = append(gateEvents, providerGateEvent{
+				kind: "failover", from: resolved, to: alt, reason: reason, altReason: altReason, logKey: "agent.run.soft_limit_peer_failover", logLevel: "warn", taskID: cfg.TaskID,
+			})
+			return alt, gateEvents, nil
+		}
 		return m.softLimitLastResort(resolved, reason, gateEvents, cfg.TaskID)
 	} else {
 		return m.softLimitLastResort(resolved, reason, gateEvents, cfg.TaskID)

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -257,6 +257,66 @@ func TestChooseProvider_NoDataDoesNotStealRequested(t *testing.T) {
 	}
 }
 
+// TestChooseSoftLimitedPeer_PicksPeerOnlySoftLimited verifies the last-resort
+// failover for task c61f327a: a peer whose only issue is its own soft
+// session/weekly threshold is still eligible when the requested provider is
+// hard rate-limited and every other candidate is either disabled or unhealthy.
+func TestChooseSoftLimitedPeer_PicksPeerOnlySoftLimited(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	if err := s.UpdateSnapshot(Snapshot{
+		Provider:   ProviderClaude,
+		Source:     SourceStream,
+		Confidence: ConfidenceExact,
+		CapturedAt: now,
+		Primary:    &CycleSnapshot{UsedPercent: 90, WindowMinutes: 300, ResetsAt: now.Add(time.Hour)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	alt, reason := s.ChooseSoftLimitedPeer(ProviderCodex, []string{ProviderClaude, ProviderCodex, ProviderCopilot}, func(string) bool {
+		return true
+	}, DefaultPolicy())
+	if alt != ProviderClaude {
+		t.Fatalf("alt = %q, want claude (only soft-limited peer)", alt)
+	}
+	if !IsSoftThresholdReason(reason) {
+		t.Fatalf("reason = %q, want a soft threshold reason", reason)
+	}
+}
+
+// TestChooseSoftLimitedPeer_SkipsHardBlockedPeer verifies a peer that is
+// itself hard blocked (rate limit reached / disabled) is never picked — only
+// soft-threshold peers qualify for this last-resort path.
+func TestChooseSoftLimitedPeer_SkipsHardBlockedPeer(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	if err := s.UpdateSnapshot(Snapshot{
+		Provider:             ProviderClaude,
+		Source:               SourceStream,
+		Confidence:           ConfidenceExact,
+		CapturedAt:           now,
+		RateLimitReachedType: "rate_limit_reached",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	alt, _ := s.ChooseSoftLimitedPeer(ProviderCodex, []string{ProviderClaude, ProviderCodex, ProviderCopilot}, func(string) bool {
+		return true
+	}, DefaultPolicy())
+	if alt != "" {
+		t.Fatalf("alt = %q, want none (claude is hard blocked, not soft-limited)", alt)
+	}
+}
+
 func TestSummary_PrefersSessionFileUsageCountersButKeepsRunSpend(t *testing.T) {
 	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
 	if err != nil {

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -373,6 +373,42 @@ func (s *Store) ChooseProvider(requested string, candidates []string, healthy fu
 	return available[0].Provider, "lower quota pressure"
 }
 
+// ChooseSoftLimitedPeer finds a peer that is only soft-threshold limited
+// (session/weekly near threshold, not a hard rate-limit-reached block or a
+// disabled provider) to use as a last-resort failover target when the
+// requested provider is itself hard-blocked and ChooseProvider found no
+// fully available peer. This mirrors the leniency softLimitLastResort
+// already grants a provider's own soft-threshold state, extended to peers:
+// a peer that still safely dispatches its own direct runs under a soft
+// threshold is an acceptable failover target too, rather than failing the
+// dispatch closed system-wide.
+func (s *Store) ChooseSoftLimitedPeer(requested string, candidates []string, healthy func(string) bool, policy Policy) (provider, reason string) {
+	if !policy.Enabled {
+		return "", ""
+	}
+	summary := s.Summary(policy)
+	byProvider := map[string]*ProviderSummary{}
+	for i := range summary.Providers {
+		p := &summary.Providers[i]
+		byProvider[p.Provider] = p
+	}
+	for _, p := range candidates {
+		if p == requested || !providerEnabled(policy, p) || !healthy(p) {
+			continue
+		}
+		ps := byProvider[p]
+		if ps == nil || !ps.QuotaLimited {
+			// Fully available peers are already handled by ChooseProvider;
+			// reaching here means none existed.
+			continue
+		}
+		if IsSoftThresholdReason(ps.QuotaReason) {
+			return p, ps.QuotaReason
+		}
+	}
+	return "", ""
+}
+
 func (s *Store) flushLocked() error {
 	data, err := json.Marshal(persisted{Snapshots: s.snapshots, Events: s.events})
 	if err != nil {


### PR DESCRIPTION
## Motivation

**Original title:** fix(agent): branch-conflict-fix dispatch fails closed instead of failing over off rate-limited codex

## What happened

Task `ddbbb895` (`fix(agent): snapshot DTO for safe agent state reads, evict dead agents`) was parked `human-required` with the generic reason `branch stale: rebase failed before agent start; resolve conflicts or recreate the task branch`.

Host log sequence (23:03:07–23:03:14 window):

```
workflow.cancelled task_id=ddbbb895 workflow=simple-task-implement step=implement reason="branch conflict recovery"
workflow.start task_id=ddbbb895 workflow=branch-conflict-fix step=set_recovering
workflow.advance task_id=ddbbb895 from=set_recovering to=fix
pr-monitor.branch-conflict.dispatch task_id=ddbbb895 err="start agent: provider codex unhealthy (provider reports rate limit reached)"
workflow.resume-stalled.exec task_id=ddbbb895 err="start agent: worktree required for project task: worktree rebase failed: reconcile fix/fix-agent-snapshot-dto-evict-dead-agents-ddbbb895 with remote: local branch diverged from remote head: local ab5b3bd vs remote origin/fix/fix-agent-snapshot-dto-evict-dead-agents-ddbbb895 a9e3168"
```

The `branch-conflict-fix` workflow's `fix` step (`internal/workflow/builtin/branch-conflict-fix.yaml`, `role: pr-fix`) never actually dispatched an agent — `gateProvider`/`resolveProviderDecision` (`internal/agent/manager_run.go`) resolved the run's provider to codex, found it hard rate-limited, and fell into `softLimitLastResort` -> `newProviderUnhealthy`, returning a hard gate error instead of failing over to claude.

Critically, claude was **not actually unavailable** at this moment. The same log window shows claude successfully running several concurrent headless agents (`agent.start id=a9b86299 taskID=e00f8dfb ... provider=claude`, `agent.start id=65c63998 taskID=3e61e464 ... provider=claude`), only flagged with a soft `agent.run.soft_limit_last_resort reason="session limit near threshold"` — i.e. near its soft ceiling but still dispatching fine. The identical `provider codex unhealthy (provider reports rate limit reached)` dispatch failure hit at least 4 other tasks in the same ~90s window (`e8bb0d98`, `54a3153a`, `3b0ad16d`, `3e61e464`'s own branch-conflict dispatch), all via the pr-fix/branch-conflict-fix path.

The result: the branch-conflict-fix recovery workflow was started and advanced to its `fix` step, but zero reconciliation work happened, and the task's branch stayed genuinely diverged (`local ab5b3bd` vs `origin a9e3168`) — the escalation reason is technically accurate but hides that Sybra had a working provider (claude) it declined to use.

## Repro

1. Get codex into a hard-rate-limited state (`provider reports rate limit reached`) while claude is only near its soft session-limit threshold (still dispatching, `agent.run.soft_limit_last_resort`).
2. Trigger a no-PR branch-conflict recovery (`ReviewHandler.recoverBranchConflictNoPR` → `branch-conflict-fix` workflow → `fix` step, role `pr-fix`) for a task whose default/assigned provider resolves to codex.
3. Observe `pr-monitor.branch-conflict.dispatch err="start agent: provider codex unhealthy (provider reports rate limit reached)"` with no agent run ever recorded on the task, and no failover to the still-usable claude.

## Suspected cause

In `resolveProviderDecision` (`internal/agent/manager_run.go:571`), when the limit gate reports the resolved provider (codex) unavailable and `lg.ChooseProvider(resolved, candidateProviders, healthy, lp)` finds no alt, the request falls through to `softLimitLastResort`, which only grants leniency to the *already-resolved* provider — it never re-checks whether a peer that is merely soft-limited (not hard-limited) would be an acceptable failover target. `healthy(p)` used as the candidate filter treats claude as excluded once it's within its own soft-threshold window, even though claude's own `softLimitLastResort` path proves it can still safely dispatch. So when codex is hard-limited and claude is soft-limited simultaneously, `ChooseProvider` returns no alt and the dispatch fails closed system-wide for pr-fix/branch-conflict-fix roles, instead of using claude as a last-resort failover target the same way claude uses itself as a last resort for its own direct dispatches.

This is a distinct root cause from the open branch-conflict-recovery issues:
- #1690 — recovery workflow rejected before it starts via the workflow engine's `start in progress` guard.
- #1633 — recovery `fix` step never dispatches due to a per-task dispatch-claim collision in `StartAgentWithAssignment`.

Here the workflow *did* start and advance to `fix`, and the claim wasn't held by anything else — the dispatch was rejected purely by provider-failover logic declining to use an available peer.

## Suggested fix

Extend the failover candidate check in `resolveProviderDecision`/`softLimitLastResort` so a peer whose only issue is its own soft-threshold status is still eligible as a failover target when the primary is hard rate-limited, mirroring the leniency already granted when a provider is its own resolved/current pick.

## Filing failure

GitHub issue filing failed, so Sybra created this local fallback task instead.

Error: exit status 1

## Implementation information

See commit history for fix(agent): fail over to healthy provider when codex is hard rate-limited.

_Generated by Sybra harness_