### PR TITLE
fix(human-review): reject placeholder verdict filings

### DIFF
--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -87,8 +88,9 @@ func (s *GHIssueSink) SubmitIssue(ctx context.Context, title, body string, extra
 		return false, "", err
 	}
 	if num > 0 {
-		if _, runErr := s.exec.run(ctx, append(s.repoArgs(), "issue", "comment", strconv.Itoa(num), "--body", attribution.Append(body))...); runErr != nil {
-			return false, foundURL, classifyGHError(runErr)
+		out, runErr := s.exec.run(ctx, append(s.repoArgs(), "issue", "comment", strconv.Itoa(num), "--body", attribution.Append(body))...)
+		if runErr != nil {
+			return false, foundURL, classifyGHError("gh issue comment", out, runErr)
 		}
 		return false, foundURL, nil
 	}
@@ -108,7 +110,7 @@ func (s *GHIssueSink) SubmitIssue(ctx context.Context, title, body string, extra
 		"--label", lb.String(),
 	)...)
 	if err != nil {
-		return false, "", classifyGHError(err)
+		return false, "", classifyGHError("gh issue create", out, err)
 	}
 	return true, parseIssueCreateURL(out), nil
 }
@@ -151,7 +153,7 @@ func (s *GHIssueSink) findOpenIssue(ctx context.Context, title string) (number i
 		"--limit", "5",
 	)...)
 	if err != nil {
-		return 0, "", classifyGHError(err)
+		return 0, "", classifyGHError("gh issue list", out, err)
 	}
 	num, url := parseFirstMatchingIssue(out, title)
 	return num, url, nil
@@ -220,13 +222,32 @@ func parseFirstMatchingIssue(raw []byte, want string) (number int, url string) {
 	}
 }
 
-func classifyGHError(err error) error {
+func classifyGHError(op string, out []byte, err error) error {
 	if err == nil {
 		return nil
 	}
-	msg := err.Error()
+	msg := err.Error() + "\n" + string(out)
 	if strings.Contains(msg, "API rate limit exceeded") || strings.Contains(msg, "secondary rate limit") {
 		return ErrGHRateLimit
 	}
-	return err
+	if detail := sanitizeGHOutput(out); detail != "" {
+		return fmt.Errorf("%s: %s: %w", op, detail, err)
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}
+
+func sanitizeGHOutput(out []byte) string {
+	s := strings.TrimSpace(string(out))
+	if !strings.Contains(s, "<!DOCTYPE html") && !strings.Contains(s, "<html") {
+		return s
+	}
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] != '\n' {
+			continue
+		}
+		if line := strings.TrimSpace(s[i+1:]); strings.HasPrefix(line, "gh:") {
+			return line
+		}
+	}
+	return "GitHub returned an HTML error page"
 }

--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -238,7 +238,8 @@ func classifyGHError(op string, out []byte, err error) error {
 
 func sanitizeGHOutput(out []byte) string {
 	s := strings.TrimSpace(string(out))
-	if !strings.Contains(s, "<!DOCTYPE html") && !strings.Contains(s, "<html") {
+	lower := strings.ToLower(s)
+	if !strings.Contains(lower, "<!doctype html") && !strings.Contains(lower, "<html") {
 		return s
 	}
 	for i := len(s) - 1; i >= 0; i-- {

--- a/internal/monitor/issuesink_test.go
+++ b/internal/monitor/issuesink_test.go
@@ -261,6 +261,36 @@ func TestGHIssueSink_FingerprintTitleExactMatch(t *testing.T) {
 	}
 }
 
+func TestSanitizeGHOutput_CaseInsensitiveHTML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "uppercase doctype collapses to status line",
+			in:   "<!DOCTYPE HTML>\n<html><body>Unicorn</body></html>\ngh: HTTP 504",
+			want: "gh: HTTP 504",
+		},
+		{
+			name: "mixed-case html with no trailing gh line",
+			in:   "<!DoCtYpE hTmL><HtMl><body>Unicorn</body></HtMl>",
+			want: "GitHub returned an HTML error page",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sanitizeGHOutput([]byte(tt.in)); got != tt.want {
+				t.Errorf("sanitizeGHOutput = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // containsPair returns true if args contains key followed immediately by val.
 func containsPair(args []string, key, val string) bool {
 	for i := range len(args) - 1 {

--- a/internal/monitor/issuesink_test.go
+++ b/internal/monitor/issuesink_test.go
@@ -14,13 +14,15 @@ import (
 // by subcommand ("label", "issue list", "issue comment", "issue create").
 // Tests mutate the response table per scenario.
 type fakeExecer struct {
-	mu         sync.Mutex
-	calls      [][]string
-	listResp   []byte
-	listErr    error
-	createErr  error
-	commentErr error
-	labelErr   error
+	mu          sync.Mutex
+	calls       [][]string
+	listResp    []byte
+	listErr     error
+	createResp  []byte
+	createErr   error
+	commentResp []byte
+	commentErr  error
+	labelErr    error
 }
 
 func (f *fakeExecer) run(_ context.Context, args ...string) ([]byte, error) {
@@ -41,9 +43,9 @@ func (f *fakeExecer) run(_ context.Context, args ...string) ([]byte, error) {
 		case "list":
 			return f.listResp, f.listErr
 		case "comment":
-			return nil, f.commentErr
+			return f.commentResp, f.commentErr
 		case "create":
-			return nil, f.createErr
+			return f.createResp, f.createErr
 		}
 	}
 	return nil, nil
@@ -166,8 +168,9 @@ func TestGHIssueSink_LabelsEnsuredOnce(t *testing.T) {
 
 func TestGHIssueSink_ClassifiesRateLimit(t *testing.T) {
 	fe := &fakeExecer{
-		listResp:  []byte(`[]`),
-		createErr: errors.New("HTTP 403: API rate limit exceeded for 1.2.3.4"),
+		listResp:   []byte(`[]`),
+		createErr:  errors.New("exit status 1"),
+		createResp: []byte("gh: API rate limit exceeded for 1.2.3.4"),
 	}
 	s := newTestSink(fe)
 
@@ -175,6 +178,44 @@ func TestGHIssueSink_ClassifiesRateLimit(t *testing.T) {
 	_, err := s.Submit(context.Background(), a, "body")
 	if !errors.Is(err, ErrGHRateLimit) {
 		t.Fatalf("want ErrGHRateLimit, got %v", err)
+	}
+}
+
+func TestGHIssueSink_CreateErrorIncludesOutput(t *testing.T) {
+	fe := &fakeExecer{
+		listResp:   []byte(`[]`),
+		createResp: []byte("GraphQL: Resource not accessible by integration"),
+		createErr:  errors.New("exit status 1"),
+	}
+	s := newTestSink(fe)
+
+	a := Anomaly{Kind: KindOverDispatchLimit, Fingerprint: "over_dispatch_limit"}
+	_, err := s.Submit(context.Background(), a, "body")
+	if err == nil {
+		t.Fatal("expected create error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "gh issue create") || !strings.Contains(msg, "Resource not accessible") {
+		t.Fatalf("error did not include operation and gh output: %v", err)
+	}
+}
+
+func TestGHIssueSink_CommentErrorIncludesOutput(t *testing.T) {
+	fe := &fakeExecer{
+		listResp:    []byte(`[{"number":87,"title":"[monitor] failure_spike"}]`),
+		commentResp: []byte("GraphQL: Could not resolve to an Issue with the number of 87"),
+		commentErr:  errors.New("exit status 1"),
+	}
+	s := newTestSink(fe)
+
+	a := Anomaly{Kind: KindFailureSpike, Fingerprint: "failure_spike"}
+	_, err := s.Submit(context.Background(), a, "body")
+	if err == nil {
+		t.Fatal("expected comment error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "gh issue comment") || !strings.Contains(msg, "Could not resolve") {
+		t.Fatalf("error did not include operation and gh output: %v", err)
 	}
 }
 

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -633,11 +633,22 @@ func (h *humanReviewHandler) findExistingLocalBugTask(title string) (task.Task, 
 		return task.Task{}, false
 	}
 	for i := range all {
-		if all[i].Title == title && slices.Contains(all[i].Tags, "sybra-bug") {
+		if all[i].Title == title &&
+			slices.Contains(all[i].Tags, "sybra-bug") &&
+			hasAnyTag(all[i].Tags, "local", "scrubbed", "issue-filing-failed") {
 			return all[i], true
 		}
 	}
 	return task.Task{}, false
+}
+
+func hasAnyTag(tags []string, needles ...string) bool {
+	for _, needle := range needles {
+		if slices.Contains(tags, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // linkExistingLocalBug re-blocks taskID against an already-filed local

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -370,6 +370,10 @@ func (h *humanReviewHandler) fileLocalConfigured(taskID, agentID string, v verdi
 		}
 		return
 	}
+	if existing, ok := h.findExistingLocalBugTask(v.IssueTitle); ok {
+		h.linkExistingLocalBug(taskID, agentID, existing, v)
+		return
+	}
 	body := strings.TrimSpace(v.IssueBody) + "\n\n## Filing route\n\nGitHub issue filing disabled by `human_review.sybra_bug_action: local_task`; Sybra created this local task instead."
 	tags := append([]string{"sybra-bug", "local"}, v.IssueLabels...)
 	init := task.Update{Tags: &tags}
@@ -462,6 +466,11 @@ func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdict
 	title, titleRed := scrub.Scrub(v.IssueTitle, wctx.Blocklist)
 	body, bodyRed := scrub.Scrub(v.IssueBody, wctx.Blocklist)
 	summary, _ := scrub.Scrub(v.Summary, wctx.Blocklist)
+
+	if existing, ok := h.findExistingLocalBugTask(title); ok {
+		h.linkExistingLocalBug(taskID, agentID, existing, verdictDecision{Summary: summary})
+		return
+	}
 
 	tags := append([]string{"sybra-bug", "scrubbed"}, v.IssueLabels...)
 	init := task.Update{Tags: &tags}
@@ -560,6 +569,10 @@ func (h *humanReviewHandler) fileLocalIssueFallback(taskID, agentID string, v ve
 	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
 		return false
 	}
+	if existing, ok := h.findExistingLocalBugTask(v.IssueTitle); ok {
+		h.linkExistingLocalBug(taskID, agentID, existing, v)
+		return true
+	}
 	body := strings.TrimSpace(v.IssueBody) + "\n\n## Filing failure\n\nGitHub issue filing failed, so Sybra created this local fallback task instead.\n\nError: " + submitErr.Error()
 	tags := append([]string{"sybra-bug", "issue-filing-failed"}, v.IssueLabels...)
 	init := task.Update{Tags: &tags}
@@ -599,6 +612,58 @@ func (h *humanReviewHandler) fileLocalIssueFallback(taskID, agentID string, v ve
 	}
 	h.markVerdictRendered(taskID, agentID)
 	return true
+}
+
+// findExistingLocalBugTask returns an already-filed local sybra-bug task with
+// an exact title match, if one exists. This is the local-fallback-path
+// counterpart to GHIssueSink.findOpenIssue's title-based dedup on the public
+// path: without it, a task that cycles human-required -> blocked -> todo ->
+// human-required for the same root cause spawns a brand-new local fallback
+// task on every fallback filing instead of pointing back at the one already
+// filed (see task 2379fece's repro: task 3e61e464 accumulated multiple
+// bug/fallback links for one underlying failure).
+func (h *humanReviewHandler) findExistingLocalBugTask(title string) (task.Task, bool) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return task.Task{}, false
+	}
+	all, err := h.tasks.List()
+	if err != nil {
+		h.logger.Warn("human-review.local.dedup-list", "err", err)
+		return task.Task{}, false
+	}
+	for i := range all {
+		if all[i].Title == title && slices.Contains(all[i].Tags, "sybra-bug") {
+			return all[i], true
+		}
+	}
+	return task.Task{}, false
+}
+
+// linkExistingLocalBug re-blocks taskID against an already-filed local
+// sybra-bug task instead of creating a duplicate.
+func (h *humanReviewHandler) linkExistingLocalBug(taskID, agentID string, existing task.Task, v verdictDecision) {
+	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
+		"created": false, "url": "", "title": existing.Title, "local_task_id": existing.ID, "deduped": true,
+	})
+	origin, err := h.tasks.Get(taskID)
+	if err != nil {
+		h.logger.Error("human-review.local.dedup-origin-get", "task_id", taskID, "err", err)
+		return
+	}
+	summary := strings.TrimSpace(v.Summary)
+	noteBody := fmt.Sprintf("**Linked local sybra task (already filed):** %s\n\n%s", existing.ID, summary)
+	newBody := appendSection(origin.Body, "Auto-review verdict: blocked by Sybra bug (already filed)", noteBody)
+	upd := task.Update{
+		Body:         &newBody,
+		Status:       task.Ptr(task.StatusBlocked),
+		StatusReason: task.Ptr(fmt.Sprintf("auto-review: %s (local task %s, already filed)", summary, existing.ID)),
+	}
+	if _, err := h.tasks.Update(taskID, upd); err != nil {
+		h.logger.Error("human-review.local.dedup-origin-update", "task_id", taskID, "err", err)
+		return
+	}
+	h.markVerdictRendered(taskID, agentID)
 }
 
 // appendNote appends a section to the task body. Returns true if the update

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -746,6 +746,64 @@ func TestOnComplete_SinkError_DedupesExistingLocalFallback(t *testing.T) {
 	}
 }
 
+func TestOnComplete_SinkError_DoesNotDedupAgainstUnrelatedSybraBug(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+	sink.err = errors.New("rate limited")
+
+	if _, err := tasks.CreateFull("fix(workflow): stale branch race", "existing unrelated bug", task.AgentModeHeadless, task.Update{
+		Tags: task.Ptr([]string{"sybra-bug"}),
+	}); err != nil {
+		t.Fatalf("seed unrelated sybra-bug task: %v", err)
+	}
+
+	tk, err := tasks.Create("Whatever", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type: "assistant",
+		Content: "```sybra-verdict\n" +
+			`{"decision":"sybra_bug","summary":"branch stale before agent start","issue_title":"fix(workflow): stale branch race","issue_body":"z"}` +
+			"\n```",
+	})
+	h.onComplete(ag)
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	localFallbackCount := 0
+	for _, got := range all {
+		if got.ID == tk.ID {
+			continue
+		}
+		if slices.Contains(got.Tags, "issue-filing-failed") {
+			localFallbackCount++
+		}
+	}
+	if localFallbackCount != 1 {
+		t.Fatalf("want exactly 1 new local fallback task, got %d", localFallbackCount)
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if !strings.Contains(got.Body, "blocked by Sybra bug (local fallback)") {
+		t.Errorf("expected fresh local fallback note, got:\n%s", got.Body)
+	}
+	if strings.Contains(got.Body, "already filed") {
+		t.Errorf("must not dedupe against unrelated sybra-bug task; got:\n%s", got.Body)
+	}
+}
+
 func TestOnComplete_WorkProject_LocalTaskScrubbed(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -685,6 +685,67 @@ func TestOnComplete_SinkError_CreatesLocalFallback(t *testing.T) {
 	}
 }
 
+// TestOnComplete_SinkError_DedupesExistingLocalFallback pins that a second
+// human-review run diagnosing the same root cause (same issue_title) does not
+// spawn a second local fallback task — it links back to the one already
+// filed. Mirrors task 2379fece's repro, where task 3e61e464 accumulated a GH
+// issue link and a separate local fallback task for one underlying failure.
+func TestOnComplete_SinkError_DedupesExistingLocalFallback(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+	sink.err = errors.New("rate limited")
+
+	tk, err := tasks.Create("Whatever", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	verdictContent := "```sybra-verdict\n" +
+		`{"decision":"sybra_bug","summary":"branch stale before agent start","issue_title":"fix(workflow): stale branch race","issue_body":"z"}` +
+		"\n```"
+
+	runOnce := func() {
+		if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+			t.Fatalf("flip: %v", err)
+		}
+		ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+		ag.AppendOutput(agent.StreamEvent{Type: "assistant", Content: verdictContent})
+		h.onComplete(ag)
+	}
+
+	runOnce()
+	runOnce()
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	var localBugTasks []task.Task
+	for _, lt := range all {
+		if lt.ID == tk.ID {
+			continue
+		}
+		localBugTasks = append(localBugTasks, lt)
+	}
+	if len(localBugTasks) != 1 {
+		t.Fatalf("want exactly 1 local fallback task after two runs, got %d: %+v", len(localBugTasks), localBugTasks)
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if got.Status != task.StatusBlocked {
+		t.Errorf("status: got %q want blocked", got.Status)
+	}
+	if !strings.Contains(got.Body, "Auto-review verdict: blocked by Sybra bug (already filed)") {
+		t.Errorf("expected dedup note on second run; got:\n%s", got.Body)
+	}
+	if strings.Count(got.Body, "Linked local Sybra bug") > 1 {
+		t.Errorf("expected only one fresh-filing note, got body:\n%s", got.Body)
+	}
+}
+
 func TestOnComplete_WorkProject_LocalTaskScrubbed(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)
@@ -810,6 +871,46 @@ func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {
 	}
 	if sink.calls != 0 {
 		t.Errorf("sink should not be called on malformed verdict; calls=%d", sink.calls)
+	}
+}
+
+// TestOnComplete_PlaceholderVerdict_RejectedNotFiled pins task 2379fece's
+// repro: a run that returns a placeholder/echoed-schema payload
+// (summary="test", issue_title="test title", issue_body="test body") must
+// not file a GitHub issue or block the task — verdict.Parse rejects it, so
+// onComplete treats it like any other unparseable verdict.
+func TestOnComplete_PlaceholderVerdict_RejectedNotFiled(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Some task", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type:    "assistant",
+		Content: `{"decision":"sybra_bug","summary":"test","issue_title":"test title","issue_body":"test body"}`,
+	})
+	h.onComplete(ag)
+
+	if sink.calls != 0 {
+		t.Errorf("sink should not be called for placeholder verdict; calls=%d", sink.calls)
+	}
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status: got %q want human-required (placeholder verdict must not block)", got.Status)
+	}
+	if !strings.Contains(got.Body, "unparseable verdict") {
+		t.Errorf("expected unparseable-verdict note; got:\n%s", got.Body)
 	}
 }
 

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -107,7 +107,34 @@ func normalize(v Decision, src Source) (Decision, Source, error) {
 	if v.Summary == "" {
 		return Decision{}, "", errors.New("verdict: empty summary")
 	}
+	if isPlaceholder(v.Summary) {
+		return Decision{}, "", fmt.Errorf("verdict: placeholder summary %q", v.Summary)
+	}
+	if v.Decision == "sybra_bug" && (isPlaceholder(v.IssueTitle) || isPlaceholder(v.IssueBody)) {
+		return Decision{}, "", fmt.Errorf("verdict: placeholder issue payload (title=%q body=%q)", v.IssueTitle, v.IssueBody)
+	}
 	return v, src, nil
+}
+
+// placeholderValues are exact (case-insensitive, trimmed) strings a model
+// sometimes emits when it echoes the schema/example instead of producing a
+// real diagnosis (observed: decision=sybra_bug with summary="test",
+// issue_title="test title", issue_body="test body", which got filed as a
+// real GitHub issue and a duplicate local fallback task). Checked as an
+// exact match rather than a substring so a genuine diagnosis that merely
+// mentions "test" (e.g. "the test suite is flaky") is never rejected.
+var placeholderValues = map[string]bool{
+	"test":        true,
+	"test title":  true,
+	"test body":   true,
+	"placeholder": true,
+	"todo":        true,
+	"tbd":         true,
+	"n/a":         true,
+}
+
+func isPlaceholder(s string) bool {
+	return placeholderValues[strings.ToLower(strings.TrimSpace(s))]
 }
 
 // normalizeLabels trims each label and drops any that are blank, so

--- a/internal/verdict/verdict_test.go
+++ b/internal/verdict/verdict_test.go
@@ -110,6 +110,32 @@ func TestParse(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "placeholder summary fails closed",
+			input:   `{"decision":"sybra_bug","summary":"test","issue_title":"test title","issue_body":"test body"}`,
+			wantErr: true,
+		},
+		{
+			name:    "placeholder summary case-insensitive fails closed",
+			input:   `{"decision":"human","summary":"  Test  "}`,
+			wantErr: true,
+		},
+		{
+			name: "placeholder issue title fails closed even with real summary",
+			input: `{"decision":"sybra_bug","summary":"verify_commits flipped despite push",` +
+				`"issue_title":"test title","issue_body":"real body"}`,
+			wantErr: true,
+		},
+		{
+			name: "summary merely mentioning test is not a placeholder",
+			input: `{"decision":"sybra_bug","summary":"the test suite is flaky",` +
+				`"issue_title":"fix(ci): flaky test","issue_body":"real body"}`,
+			want: Decision{
+				Decision: "sybra_bug", Summary: "the test suite is flaky",
+				IssueTitle: "fix(ci): flaky test", IssueBody: "real body",
+			},
+			wantSource: SourceJSON,
+		},
+		{
 			name:    "envelope-shaped input fails closed",
 			input:   `{"structured_output":{"decision":"human","summary":"nested, should not be found"}}`,
 			wantErr: true,


### PR DESCRIPTION
## Summary
- reject exact placeholder-shaped human-review verdict payloads in the shared verdict parser
- dedupe local human-review sybra-bug fallback tasks by existing sybra-bug title
- include sanitized gh issue command output in issue-filing errors so fallback tasks retain useful failure detail

## Tests
- go test ./internal/verdict ./internal/monitor ./internal/sybra -run 'TestParse|TestGHIssueSink_|TestOnComplete_PlaceholderVerdict_RejectedNotFiled|TestOnComplete_SinkError_DedupesExistingLocalFallback|TestOnComplete_SinkError_CreatesLocalFallback'

_Generated by Sybra harness_