### PR TITLE
refactor(agent): unify dispatch claim coordinators

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -640,7 +640,7 @@ export class StepConfig {
     "bestOfNStep"?: string;
 
     /**
-     * run_agent: enforce the cumulative task cost budget before dispatching.
+     * run_agent: enforce the cumulative task cost budget before launch.
      * Set on direct-dispatch steps (e.g. the best-of-N judge, which passes a
      * pre-staged dir and so bypasses StartAgentWithAssignment's own budget
      * enforcement) so the run fails closed to human-required instead of

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -269,6 +269,45 @@ func (m *Manager) ReleaseTaskDispatch(taskID string) {
 	m.mu.Unlock()
 }
 
+// DispatchClaim is a held per-task dispatch claim returned by
+// TryClaimDispatch. It centralizes the release-at-most-once bookkeeping every
+// dispatch call site used to hand-roll individually (a local `released bool`
+// guarding a deferred delete): releasing early to unblock a nested
+// same-task dispatch (e.g. branch-conflict recovery) can never race a
+// deferred second release into clobbering a claim a different dispatcher has
+// since acquired.
+type DispatchClaim struct {
+	manager  *Manager
+	taskID   string
+	released bool
+}
+
+// TryClaimDispatch reserves the right to dispatch an agent for taskID. On a
+// true ok, the caller MUST release the returned claim exactly once dispatch
+// finishes (success or failure) — typically via `defer claim.Release()` —
+// and MAY call Release earlier to unblock a nested same-task dispatch before
+// the deferred call runs, since Release is idempotent. On ok=false a dispatch
+// is already in flight for the same task and the caller MUST NOT start an
+// agent.
+func (m *Manager) TryClaimDispatch(taskID string) (claim *DispatchClaim, ok bool) {
+	if !m.ClaimTaskDispatch(taskID) {
+		return nil, false
+	}
+	return &DispatchClaim{manager: m, taskID: taskID}, true
+}
+
+// Release releases the claim. Idempotent and nil-safe: a second call (or a
+// call on a nil claim) is a no-op, so an early manual release followed by a
+// deferred Release never double-deletes a claim a different dispatcher has
+// since acquired.
+func (c *DispatchClaim) Release() {
+	if c == nil || c.released {
+		return
+	}
+	c.released = true
+	c.manager.ReleaseTaskDispatch(c.taskID)
+}
+
 // ReplaceRuntimeConfig replaces the complete live runtime snapshot. Settings
 // affect future Run calls and config reloads without mutating startup-only callbacks.
 func (m *Manager) ReplaceRuntimeConfig(cfg ManagerRuntimeConfig) error {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -269,6 +269,21 @@ func (m *Manager) ReleaseTaskDispatch(taskID string) {
 	m.mu.Unlock()
 }
 
+// IsDispatching reports whether a dispatch claim is currently held for
+// taskID, by any caller of ClaimTaskDispatch/TryClaimDispatch — the workflow
+// engine's execRunAgent, recovery.RestartStaleInProgress (via
+// agentorch.Orchestrator), or a direct non-workflow StartAgent call. This is
+// the single ground-truth answer to "is this task's next run already
+// owned?" that every dispatcher can consult before deciding to redispatch,
+// instead of each maintaining its own separate view of dispatch-in-flight
+// state.
+func (m *Manager) IsDispatching(taskID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, held := m.dispatchClaims[taskID]
+	return held
+}
+
 // DispatchClaim is a held per-task dispatch claim returned by
 // TryClaimDispatch. It centralizes the release-at-most-once bookkeeping every
 // dispatch call site used to hand-roll individually (a local `released bool`

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -690,6 +690,33 @@ func TestClaimTaskDispatch(t *testing.T) {
 	m.ReleaseTaskDispatch("never-claimed")
 }
 
+// TestIsDispatching verifies the read-only peek other coordinators (e.g.
+// internal/workflow.Engine's DispatchEvent/ResumeStalled) consult as the
+// single ground truth for "does some dispatcher already own this task's next
+// run" — without itself acquiring or releasing a claim.
+func TestIsDispatching(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	if m.IsDispatching("t1") {
+		t.Error("unclaimed task should not report dispatching")
+	}
+
+	if !m.ClaimTaskDispatch("t1") {
+		t.Fatal("claim should succeed")
+	}
+	if !m.IsDispatching("t1") {
+		t.Error("claimed task should report dispatching")
+	}
+	if m.IsDispatching("t2") {
+		t.Error("a different, unclaimed task must not be affected")
+	}
+
+	m.ReleaseTaskDispatch("t1")
+	if m.IsDispatching("t1") {
+		t.Error("released claim should no longer report dispatching")
+	}
+}
+
 // TestTryClaimDispatch verifies the DispatchClaim wrapper matches
 // ClaimTaskDispatch/ReleaseTaskDispatch semantics (single holder per task,
 // independent tasks unaffected) and that Release is idempotent — a second

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -690,6 +690,51 @@ func TestClaimTaskDispatch(t *testing.T) {
 	m.ReleaseTaskDispatch("never-claimed")
 }
 
+// TestTryClaimDispatch verifies the DispatchClaim wrapper matches
+// ClaimTaskDispatch/ReleaseTaskDispatch semantics (single holder per task,
+// independent tasks unaffected) and that Release is idempotent — a second
+// Release call, or a Release on a nil claim, must not panic or re-delete a
+// claim a different holder has since acquired.
+func TestTryClaimDispatch(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	claim, ok := m.TryClaimDispatch("t1")
+	if !ok || claim == nil {
+		t.Fatal("first claim should succeed")
+	}
+	if _, ok := m.TryClaimDispatch("t1"); ok {
+		t.Error("second claim while held must fail (serializes dispatch)")
+	}
+	if other, ok := m.TryClaimDispatch("t2"); !ok || other == nil {
+		t.Error("claim for a different task must succeed")
+	} else {
+		other.Release()
+	}
+
+	claim.Release()
+	if !m.ClaimTaskDispatch("t1") {
+		t.Fatal("claim should have been released")
+	}
+	m.ReleaseTaskDispatch("t1")
+
+	// Idempotent: a second Release, after another holder has since claimed the
+	// same taskID, must not clobber that foreign claim.
+	claim.Release()
+	if !m.ClaimTaskDispatch("t1") {
+		t.Fatal("setup: expected to reclaim t1")
+	}
+	claim.Release()
+	if m.ClaimTaskDispatch("t1") {
+		t.Error("stale claim's second Release must not clobber a foreign claim taken after the first Release")
+	} else {
+		m.ReleaseTaskDispatch("t1")
+	}
+
+	// Release on a nil claim must not panic.
+	var nilClaim *DispatchClaim
+	nilClaim.Release()
+}
+
 // TestHasLiveRegisteredAgentForTask_IgnoresOwnDispatchClaim guards against
 // the sybra#1495 self-deadlock: a dispatcher that holds its own dispatch
 // claim while preparing a worktree (StartAgentWithAssignment holds the claim

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -364,7 +364,7 @@ func (o *Orchestrator) logSandboxEscapeHatch(taskID string, t task.Task) {
 // Otherwise it auto-assigns a project if needed, optionally resets the
 // worktree for a clean retry, and prepares the task's worktree, returning
 // the (possibly project-assigned) task and its worktree directory.
-func (o *Orchestrator) resolveDispatchDir(t task.Task, taskID, cleanRetryRef string, skipWT bool, dir string, releaseClaim func()) (task.Task, string, error) {
+func (o *Orchestrator) resolveDispatchDir(t task.Task, taskID, cleanRetryRef string, skipWT bool, dir string, claim *agent.DispatchClaim) (task.Task, string, error) {
 	if skipWT {
 		return t, dir, nil
 	}
@@ -405,7 +405,7 @@ func (o *Orchestrator) resolveDispatchDir(t task.Task, taskID, cleanRetryRef str
 		// result — or that nested dispatch always observes the claim as still
 		// held and bails with ErrDispatchInFlight without ever starting an
 		// agent (the branch-conflict-fix workflow never actually dispatches).
-		releaseClaim()
+		claim.Release()
 		if _, recovered := MarkRebaseBlockedWithRecoveryResult(o.tasks, taskID, wtErr, o.logger, o.conflictRecovery); recovered {
 			return t, "", workflow.ErrDispatchInFlight
 		}
@@ -422,21 +422,14 @@ func (o *Orchestrator) StartAgentWithAssignment(taskID, mode, prompt string, inc
 	// a manual start) cannot observe "no running agent" and launch a duplicate
 	// on the same worktree. workflow.ErrDispatchInFlight is benign: the holder
 	// will produce the task's agent.
-	if !o.agents.ClaimTaskDispatch(taskID) {
+	claim, ok := o.agents.TryClaimDispatch(taskID)
+	if !ok {
 		return nil, "", workflow.ErrDispatchInFlight
 	}
-	// releaseClaim is idempotent so resolveDispatchDir can release it early
+	// claim.Release is idempotent so resolveDispatchDir can release it early
 	// (before triggering a nested same-task dispatch, e.g. branch-conflict
 	// recovery) without this defer double-releasing on return.
-	released := false
-	releaseClaim := func() {
-		if released {
-			return
-		}
-		released = true
-		o.agents.ReleaseTaskDispatch(taskID)
-	}
-	defer releaseClaim()
+	defer claim.Release()
 
 	// Consume a pending watchdog headless-nudge steer (no-op when none). Held
 	// within the dispatch claim so the read-then-clear is serialized per task.
@@ -465,7 +458,7 @@ func (o *Orchestrator) StartAgentWithAssignment(taskID, mode, prompt string, inc
 		researchDir = o.cfg.Agent.ResearchMachineDir
 	}
 	effMode, dir, requirePerm, skipWT := ResolveExecution(t, mode, researchDir, o.cfg)
-	t, dir, dirErr := o.resolveDispatchDir(t, taskID, cleanRetryRef, skipWT, dir, releaseClaim)
+	t, dir, dirErr := o.resolveDispatchDir(t, taskID, cleanRetryRef, skipWT, dir, claim)
 	if dirErr != nil {
 		return nil, "", dirErr
 	}
@@ -879,10 +872,11 @@ func (o *Orchestrator) defaultProjectID() string {
 func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 	// Same per-task dispatch serialization as StartAgent — a pr-fix dispatch
 	// must not race a concurrent implementation/recovery dispatch.
-	if !o.agents.ClaimTaskDispatch(taskID) {
+	claim, ok := o.agents.TryClaimDispatch(taskID)
+	if !ok {
 		return workflow.ErrDispatchInFlight
 	}
-	defer o.agents.ReleaseTaskDispatch(taskID)
+	defer claim.Release()
 
 	t, err := o.tasks.Get(taskID)
 	if err != nil {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -945,6 +945,10 @@ func (a *agentAdapter) ProviderHealthy(provider string) bool {
 	return a.agents.ProviderHealthy(provider)
 }
 
+func (a *agentAdapter) IsDispatching(taskID string) bool {
+	return a.agents.IsDispatching(taskID)
+}
+
 // CheckTaskCostBudget implements workflow.CostBudgetChecker for the
 // best_of_n/judge preflight — see agentorch.Orchestrator.CheckTaskCostBudget.
 func (a *agentAdapter) CheckTaskCostBudget(taskID string) error {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -945,6 +945,10 @@ func (a *agentAdapter) ProviderHealthy(provider string) bool {
 	return a.agents.ProviderHealthy(provider)
 }
 
+func (a *agentAdapter) TryClaimDispatch(taskID string) (workflow.DispatchClaim, bool) {
+	return a.agents.TryClaimDispatch(taskID)
+}
+
 func (a *agentAdapter) IsDispatching(taskID string) bool {
 	return a.agents.IsDispatching(taskID)
 }

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -597,22 +597,19 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	// For roles that don't go through StartAgentWithAssignment (triage, eval,
 	// plan, pr-fix, fix-review, test-runner, ...), build RunConfig directly.
 	r := agent.Role(role)
-	if err := a.claimDirectDispatch(taskID); err != nil {
-		return "", "", "", err
+	// claimDirectDispatch serializes this path per task, closing the same
+	// check-then-act race StartAgentWithAssignment closes for implementation
+	// agents: without it, two dispatchers (e.g. a fast ResumeStalled retry)
+	// can each observe no running agent and start a duplicate agent against
+	// the same task/worktree. claim.Release is idempotent, so the
+	// worktree-prep recovery path below can release it early (to unblock a
+	// nested same-task recovery dispatch) without this deferred call
+	// double-releasing on return.
+	claim, ok := a.agents.TryClaimDispatch(taskID)
+	if !ok {
+		return "", "", "", workflow.ErrDispatchInFlight
 	}
-	// claimReleased guards against a double release: the worktree-prep recovery
-	// path (below) releases the claim early so a nested recovery dispatch can
-	// re-enter for the same taskID. Because ReleaseTaskDispatch is an
-	// unconditional delete() keyed only by taskID (no ownership token), an
-	// unguarded defer would fire a second delete on return and could clobber a
-	// live claim taken by an independent dispatcher (e.g. ResumeStalled) during
-	// the network-bound recovery window.
-	claimReleased := false
-	defer func() {
-		if !claimReleased {
-			a.agents.ReleaseTaskDispatch(taskID)
-		}
-	}()
+	defer claim.Release()
 
 	t, err := a.tasks.Get(taskID)
 	if err != nil {
@@ -668,11 +665,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	cleanRetryReset := false
 	if cfg.Dir == "" && needsWorktree {
 		var dir string
-		var released bool
-		t, dir, cleanRetryReset, released, err = a.resolveWorktreeDir(t, taskID, role, cleanRetryRef)
-		if released {
-			claimReleased = true
-		}
+		t, dir, cleanRetryReset, err = a.resolveWorktreeDir(t, taskID, role, cleanRetryRef, claim)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -726,20 +719,21 @@ func (a *agentAdapter) configureTestRunnerRun(cfg *agent.RunConfig, taskID strin
 
 // resolveWorktreeDir auto-assigns a project to t (if needed), optionally
 // resets the worktree for a clean retry, and prepares the worktree dir for
-// the direct-dispatch path. released reports whether it already released the
-// caller's dispatch claim (see the ReleaseTaskDispatch call below) so the
-// caller's deferred release doesn't fire a second, unguarded delete.
-func (a *agentAdapter) resolveWorktreeDir(t task.Task, taskID, role, cleanRetryRef string) (updated task.Task, dir string, cleanRetryReset, released bool, err error) {
+// the direct-dispatch path. claim is the caller's held dispatch claim: on a
+// worktree-prep failure this releases it early (see the claim.Release() call
+// below) rather than the caller's own deferred release, which — since
+// DispatchClaim.Release is idempotent — is then a safe no-op.
+func (a *agentAdapter) resolveWorktreeDir(t task.Task, taskID, role, cleanRetryRef string, claim *agent.DispatchClaim) (updated task.Task, dir string, cleanRetryReset bool, err error) {
 	t, err = a.agentOrch.AutoAssignProject(t)
 	if err != nil {
-		return t, "", false, false, err
+		return t, "", false, err
 	}
 	if t.ProjectID == "" {
-		return t, "", false, false, fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree: %w", taskID, role, workflow.ErrNoProjectAssigned)
+		return t, "", false, fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree: %w", taskID, role, workflow.ErrNoProjectAssigned)
 	}
 	if cleanRetryRef != "" {
 		if resetErr := a.resetWorktreeForRetry(t, "", cleanRetryRef); resetErr != nil {
-			return t, "", false, false, resetErr
+			return t, "", false, resetErr
 		}
 		cleanRetryReset = true
 	}
@@ -762,24 +756,10 @@ func (a *agentAdapter) resolveWorktreeDir(t task.Task, taskID, role, cleanRetryR
 		// attempt regardless (wtErr != nil means we never call a.agents.Run
 		// below), so releasing early is safe: it doesn't overlap with our own
 		// (never-attempted) agent start.
-		a.agents.ReleaseTaskDispatch(taskID)
-		return t, "", cleanRetryReset, true, a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
+		claim.Release()
+		return t, "", cleanRetryReset, a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
 	}
-	return t, d, cleanRetryReset, false, nil
-}
-
-// claimDirectDispatch serializes the direct-run dispatch path (every role
-// that bypasses StartAgentWithAssignment: triage, eval, plan, pr-fix,
-// fix-review, test-runner, ...) per task, closing the same check-then-act
-// race that StartAgentWithAssignment closes for implementation agents above:
-// without it, two dispatchers (e.g. a fast ResumeStalled retry) can each
-// observe no running agent and start a duplicate agent against the same
-// task/worktree.
-func (a *agentAdapter) claimDirectDispatch(taskID string) error {
-	if !a.agents.ClaimTaskDispatch(taskID) {
-		return workflow.ErrDispatchInFlight
-	}
-	return nil
+	return t, d, cleanRetryReset, nil
 }
 
 // classifyDirectDispatchWorktreeErr translates a PrepareForTask failure from

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -144,11 +144,12 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 		}
 	}
 	if r.agents != nil {
-		if !r.agents.ClaimTaskDispatch(current.ID) {
+		claim, ok := r.agents.TryClaimDispatch(current.ID)
+		if !ok {
 			r.logger.Info("review.agent-skip", "task_id", current.ID, "pr", current.PRNumber, "reason", "dispatch_in_progress")
 			return nil
 		}
-		defer r.agents.ReleaseTaskDispatch(current.ID)
+		defer claim.Release()
 	}
 	if !force && r.tasks != nil {
 		if latest, err := r.tasks.Get(current.ID); err == nil {

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -704,6 +704,7 @@ func (b *blockingAgentLauncher) DefaultProvider() string          { return "clau
 func (b *blockingAgentLauncher) ProviderRateLimited(string) bool  { return false }
 func (b *blockingAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (b *blockingAgentLauncher) ProviderHealthy(string) bool      { return true }
+func (b *blockingAgentLauncher) IsDispatching(string) bool        { return false }
 
 // TestDispatchBranchConflictRecovery_QueuesRetryInsteadOfGivingUpWhenMarkerHeld
 // locks the fix for dispatchBranchConflictRecovery's own re-dispatch call: a

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -693,6 +693,9 @@ func (b *blockingAgentLauncher) StartAgent(string, string, string, string, strin
 	<-b.releaseCh
 	return "", "", "", workflow.ErrDispatchInFlight
 }
+func (b *blockingAgentLauncher) TryClaimDispatch(string) (workflow.DispatchClaim, bool) {
+	return nil, true
+}
 func (b *blockingAgentLauncher) HasRunningAgent(string) bool                     { return false }
 func (b *blockingAgentLauncher) HasOtherRunningAgentForTask(string, string) bool { return false }
 func (b *blockingAgentLauncher) FindRunningAgentForRole(string, string) (string, bool) {

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -238,3 +238,7 @@ func (a *agentAdapter) ProviderCanFailover(provider string) bool {
 func (a *agentAdapter) ProviderHealthy(provider string) bool {
 	return a.agents.ProviderHealthy(provider)
 }
+
+func (a *agentAdapter) IsDispatching(taskID string) bool {
+	return a.agents.IsDispatching(taskID)
+}

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -227,6 +227,10 @@ func (a *agentAdapter) DefaultProvider() string {
 	return a.agents.DefaultProvider()
 }
 
+func (a *agentAdapter) TryClaimDispatch(taskID string) (workflow.DispatchClaim, bool) {
+	return a.agents.TryClaimDispatch(taskID)
+}
+
 func (a *agentAdapter) ProviderRateLimited(provider string) bool {
 	return a.agents.ProviderRateLimited(provider)
 }

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -40,6 +40,7 @@ func (f *fakeAgentLauncher) DefaultProvider() string          { return "" }
 func (f *fakeAgentLauncher) ProviderRateLimited(string) bool  { return false }
 func (f *fakeAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (f *fakeAgentLauncher) ProviderHealthy(string) bool      { return true }
+func (f *fakeAgentLauncher) IsDispatching(string) bool        { return false }
 
 // setupDispatchTestService builds a TaskService whose workflow engine is
 // wired to a fakeAgentLauncher instead of the real agent.Manager-backed

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -29,6 +29,9 @@ func (f *fakeAgentLauncher) StartAgent(_, _, _, _, _, _, _ string, _ []string, _
 	}
 	return "fake-agent-id", "", "", nil
 }
+func (f *fakeAgentLauncher) TryClaimDispatch(string) (workflow.DispatchClaim, bool) {
+	return nil, true
+}
 func (f *fakeAgentLauncher) HasRunningAgent(string) bool                     { return false }
 func (f *fakeAgentLauncher) HasOtherRunningAgentForTask(string, string) bool { return false }
 func (f *fakeAgentLauncher) FindRunningAgentForRole(string, string) (string, bool) {

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -22,6 +22,7 @@ type AgentCompletion struct {
 // forever and the workflow never advances to the next step.
 type AgentLauncher interface {
 	StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema, cleanRetryRef string, assignment AgentAssignment) (agentID, startedDir, baselineRef string, err error)
+	TryClaimDispatch(taskID string) (DispatchClaim, bool)
 	HasRunningAgent(taskID string) bool
 	// HasOtherRunningAgentForTask reports whether an agent other than
 	// exceptAgentID is still running for the task. verify_commits uses it to
@@ -60,6 +61,14 @@ type AgentLauncher interface {
 	// by a dispatcher outside the engine's own visibility (e.g. recovery) is
 	// never missed.
 	IsDispatching(taskID string) bool
+}
+
+// DispatchClaim is the workflow-visible handle for a held per-task dispatch
+// claim. Agent launcher implementations typically back this with
+// agent.Manager's dispatch claim, but the workflow only needs idempotent
+// release semantics.
+type DispatchClaim interface {
+	Release()
 }
 
 // AgentAssignment carries A/B experiment attribution selected before dispatch.

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -46,6 +46,20 @@ type AgentLauncher interface {
 	// config-disabled provider is never picked as an eligible weighted
 	// variant. Empty name = default provider.
 	ProviderHealthy(provider string) bool
+	// IsDispatching reports whether the shared agent.Manager dispatch-claim
+	// coordinator currently holds a claim for taskID — set for the full
+	// duration of any StartAgent call, including the worktree-prep window
+	// before an agent ID exists, by every dispatcher: this engine's own
+	// execRunAgent, recovery.RestartStaleInProgress, or a direct non-workflow
+	// dispatch. The engine's own dispatching/starting/agentSteps bookkeeping
+	// still serializes workflow-level entry points and tracks step
+	// attribution — a different concern (this task's next *workflow
+	// advance*, not its next *agent process*) — but ownership decisions that
+	// gate a redispatch (DispatchEvent, ResumeStalled,
+	// RescheduleRateLimitedAgent) additionally consult this so a claim held
+	// by a dispatcher outside the engine's own visibility (e.g. recovery) is
+	// never missed.
+	IsDispatching(taskID string) bool
 }
 
 // AgentAssignment carries A/B experiment attribution selected before dispatch.

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -51,8 +51,8 @@ type AgentLauncher interface {
 	// duration of any StartAgent call, including the worktree-prep window
 	// before an agent ID exists, by every dispatcher: this engine's own
 	// execRunAgent, recovery.RestartStaleInProgress, or a direct non-workflow
-	// dispatch. The engine's own dispatching/starting/agentSteps bookkeeping
-	// still serializes workflow-level entry points and tracks step
+	// dispatch. The engine's own starting marker and agentRoutes bookkeeping
+	// still serialize workflow-level entry points and track step
 	// attribution — a different concern (this task's next *workflow
 	// advance*, not its next *agent process*) — but ownership decisions that
 	// gate a redispatch (DispatchEvent, ResumeStalled,
@@ -84,7 +84,7 @@ type PromptTransform struct {
 }
 
 // CostBudgetChecker is consulted before fanning out best-of-N attempts
-// (execBestOfN) and before dispatching a budget-preflight run_agent step such
+// (execBestOfN) and before launching a budget-preflight run_agent step such
 // as the judge (preflightRunAgentBudget): unlike StartAgentWithAssignment
 // (implementation agents on the canonical worktree), the direct-dispatch
 // AgentLauncher.StartAgent branch — which best-of-N attempts and the judge

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -326,18 +326,18 @@ func TestBuiltinSimpleTaskPlan_AgentStepsAreHeadless(t *testing.T) {
 		t.Fatal("simple-task-plan builtin definition not found")
 	}
 
-	var agentSteps int
+	var runAgentSteps int
 	for i := range simple.Steps {
 		step := &simple.Steps[i]
 		if step.Type != StepRunAgent {
 			continue
 		}
-		agentSteps++
+		runAgentSteps++
 		if step.Config.Mode != "headless" {
 			t.Errorf("run_agent step %q mode = %q, want headless (autonomous planning agents must stay under watchdog supervision)", step.ID, step.Config.Mode)
 		}
 	}
-	if agentSteps == 0 {
+	if runAgentSteps == 0 {
 		t.Fatal("expected simple-task-plan to contain run_agent steps")
 	}
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -286,6 +286,7 @@ type Engine struct {
 	ctx              context.Context
 	mu               sync.Mutex
 	inflightMutexes  map[string]*sync.Mutex // taskID → advance serializer (parallel-aware)
+	dispatching      map[string]struct{}    // taskID → workflow-engine dispatch/resume attempt in progress before StartAgent owns the shared manager claim
 	starting         map[string]struct{}    // taskID → StartWorkflowWithVars in progress
 	humanAction      map[string]struct{}    // taskID → HandleHumanAction in progress
 	agentRoutes      map[string]agentRoute  // agentID → {taskID, stepID}
@@ -315,6 +316,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		logger:           logger,
 		ctx:              context.Background(),
 		inflightMutexes:  make(map[string]*sync.Mutex),
+		dispatching:      make(map[string]struct{}),
 		starting:         make(map[string]struct{}),
 		humanAction:      make(map[string]struct{}),
 		agentRoutes:      make(map[string]agentRoute),

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -255,8 +255,8 @@ type CompletionInfo struct {
 	Variables  map[string]string
 }
 
-// agentEntry records which task and step an agent was spawned for.
-type agentEntry struct {
+// agentRoute records which task and step an agent completion belongs to.
+type agentRoute struct {
 	taskID string
 	stepID string
 }
@@ -286,11 +286,10 @@ type Engine struct {
 	ctx              context.Context
 	mu               sync.Mutex
 	inflightMutexes  map[string]*sync.Mutex // taskID → advance serializer (parallel-aware)
-	dispatching      map[string]struct{}    // taskID → dispatch in progress
 	starting         map[string]struct{}    // taskID → StartWorkflowWithVars in progress
 	humanAction      map[string]struct{}    // taskID → HandleHumanAction in progress
-	agentSteps       map[string]agentEntry  // agentID → {taskID, stepID}
-	dispatchingStep  map[string]int         // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
+	agentRoutes      map[string]agentRoute  // agentID → {taskID, stepID}
+	pendingStepStart map[string]int         // "taskID|stepID" → run_agent starts in flight; held until execRunAgent returns, agentID not yet assigned
 	cascadeDepth     map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
 	pendingRecovery  map[string]struct{}    // taskID → branch-conflict recovery deferred until the outer marker releases
 	resumeError      *logging.ErrorThrottle
@@ -316,11 +315,10 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		logger:           logger,
 		ctx:              context.Background(),
 		inflightMutexes:  make(map[string]*sync.Mutex),
-		dispatching:      make(map[string]struct{}),
 		starting:         make(map[string]struct{}),
 		humanAction:      make(map[string]struct{}),
-		agentSteps:       make(map[string]agentEntry),
-		dispatchingStep:  make(map[string]int),
+		agentRoutes:      make(map[string]agentRoute),
+		pendingStepStart: make(map[string]int),
 		cascadeDepth:     make(map[string]int),
 		pendingRecovery:  make(map[string]struct{}),
 		resumeError:      logging.NewErrorThrottle(),

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -569,7 +569,7 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 // the caller must hand it to fireComplete *after* releasing any per-task start
 // marker (see fireComplete). resolveNext deliberately does NOT invoke
 // e.onComplete itself: it runs inside DispatchEvent/StartWorkflowWithVars while
-// the dispatching/starting marker is held, so a cascade dispatched here would
+// the starting marker is held, so a cascade launched here would
 // be rejected as re-entrant (the bug that left synchronous mechanical workflows
 // — e.g. simple-task-handoff — never starting their successor).
 func (e *Engine) resolveNext(taskID string, def *Definition, current *Step, wfExec *Execution, t TaskInfo) (*Step, *CompletionInfo, error) {
@@ -631,7 +631,7 @@ const maxCascadeDepth = 64
 
 // fireComplete invokes the workflow-completion callback for a synchronously
 // finished workflow. Callers MUST invoke it only after releasing any per-task
-// start marker (the dispatching/starting maps), so the callback's cascade
+// start marker, so the callback's cascade
 // DispatchEvent isn't rejected as re-entrant against the workflow that just
 // finished. A nil completion (workflow did not finish in this call) is a no-op.
 func (e *Engine) fireComplete(c *CompletionInfo) {

--- a/internal/workflow/engine_bench_test.go
+++ b/internal/workflow/engine_bench_test.go
@@ -96,7 +96,7 @@ func BenchmarkAdvanceStep_Retry(b *testing.B) {
 }
 
 // BenchmarkResumeStalled measures scanning a pool of stalled tasks and
-// re-dispatching them. Exercises ListTasks, per-task state checks, and
+// relaunching them. Exercises ListTasks, per-task state checks, and
 // the inflightMutex map under realistic task counts.
 func BenchmarkResumeStalled(b *testing.B) {
 	const taskCount = 20

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -184,9 +184,13 @@ func (e *Engine) matchWorkflow(t TaskInfo, event string, extra map[string]string
 // ReplaceWorkflowForEvent.
 func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[string]string) (string, error) {
 	// Serialize dispatch attempts per task to prevent concurrent callers from
-	// both observing "no active workflow" and double-starting.
+	// both observing "no active workflow" and double-starting. Also consult
+	// the shared agent.Manager dispatch-claim coordinator (IsDispatching) so
+	// a claim held by a dispatcher this engine has no local visibility into
+	// (e.g. recovery.RestartStaleInProgress) is treated as busy too — the
+	// engine's own `dispatching` marker alone cannot see that.
 	e.mu.Lock()
-	if _, busy := e.dispatching[taskID]; busy {
+	if _, busy := e.dispatching[taskID]; busy || e.agents.IsDispatching(taskID) {
 		e.mu.Unlock()
 		return "", fmt.Errorf("%w: dispatch in progress", ErrWorkflowAlreadyActive)
 	}

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -182,7 +182,24 @@ func (e *Engine) matchWorkflow(t TaskInfo, event string, extra map[string]string
 // want to replace an active workflow should use ReplaceWorkflow or
 // ReplaceWorkflowForEvent.
 func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[string]string) (string, error) {
+	// Serialize event-driven workflow dispatch attempts per task. The shared
+	// agent.Manager claim only appears once a run_agent step reaches StartAgent;
+	// DispatchEvent needs its own earlier reservation so two callers cannot both
+	// observe "no active workflow" and double-start before any agent claim
+	// exists. Still consult the shared claim too: an out-of-band dispatcher may
+	// already own the task's next agent launch even when the engine has no local
+	// marker yet.
+	e.mu.Lock()
+	if _, busy := e.dispatching[taskID]; busy {
+		e.mu.Unlock()
+		return "", fmt.Errorf("%w: dispatch in progress", ErrWorkflowAlreadyActive)
+	}
+	e.dispatching[taskID] = struct{}{}
+	e.mu.Unlock()
 	if e.agents.IsDispatching(taskID) {
+		e.mu.Lock()
+		delete(e.dispatching, taskID)
+		e.mu.Unlock()
 		return "", fmt.Errorf("%w: dispatch in progress", ErrWorkflowAlreadyActive)
 	}
 	// If the matched workflow finishes synchronously (a mechanical workflow with
@@ -192,6 +209,11 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 	defer func() {
 		e.fireComplete(completion)
 		e.drainPendingConflictRecovery(taskID)
+	}()
+	defer func() {
+		e.mu.Lock()
+		delete(e.dispatching, taskID)
+		e.mu.Unlock()
 	}()
 
 	t, err := e.tasks.GetTask(taskID)

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -50,9 +50,8 @@ func (e *Engine) StartWorkflowFromStepWithVars(taskID, workflowID, startStepID s
 // startWorkflowLocked is the marker-holding body shared by StartWorkflowWithVars
 // and DispatchEvent. It returns a non-nil *CompletionInfo when the workflow
 // finished synchronously within this call; the caller must hand it to
-// fireComplete only AFTER releasing its own per-task marker (starting via this
-// function's defer, plus dispatching for DispatchEvent) so the completion's
-// cascade dispatch is not rejected as re-entrant.
+// fireComplete only AFTER this function returns so the starting marker has
+// been released before any completion cascade re-enters the workflow engine.
 func (e *Engine) startWorkflowLocked(taskID, workflowID, startStepID string, vars map[string]string) (*CompletionInfo, error) {
 	e.mu.Lock()
 	if _, busy := e.starting[taskID]; busy {
@@ -183,32 +182,16 @@ func (e *Engine) matchWorkflow(t TaskInfo, event string, extra map[string]string
 // want to replace an active workflow should use ReplaceWorkflow or
 // ReplaceWorkflowForEvent.
 func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[string]string) (string, error) {
-	// Serialize dispatch attempts per task to prevent concurrent callers from
-	// both observing "no active workflow" and double-starting. Also consult
-	// the shared agent.Manager dispatch-claim coordinator (IsDispatching) so
-	// a claim held by a dispatcher this engine has no local visibility into
-	// (e.g. recovery.RestartStaleInProgress) is treated as busy too — the
-	// engine's own `dispatching` marker alone cannot see that.
-	e.mu.Lock()
-	if _, busy := e.dispatching[taskID]; busy || e.agents.IsDispatching(taskID) {
-		e.mu.Unlock()
+	if e.agents.IsDispatching(taskID) {
 		return "", fmt.Errorf("%w: dispatch in progress", ErrWorkflowAlreadyActive)
 	}
-	e.dispatching[taskID] = struct{}{}
-	e.mu.Unlock()
 	// If the matched workflow finishes synchronously (a mechanical workflow with
-	// no async step), its completion must be fired only after `dispatching` is
-	// cleared, or its cascade dispatch re-enters and is dropped. Register the
-	// fire defer *before* the marker-delete defer so LIFO runs it afterwards.
+	// no async step), fire its completion after startWorkflowLocked returns so
+	// its starting marker is clear before a cascade dispatch re-enters.
 	var completion *CompletionInfo
 	defer func() {
 		e.fireComplete(completion)
 		e.drainPendingConflictRecovery(taskID)
-	}()
-	defer func() {
-		e.mu.Lock()
-		delete(e.dispatching, taskID)
-		e.mu.Unlock()
 	}()
 
 	t, err := e.tasks.GetTask(taskID)
@@ -243,7 +226,7 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 // workflow being replaced: they must keep trigger conditions authoritative, but
 // cannot call DispatchEvent because the outer workflow start still owns the
 // per-task starting marker. Callers from ordinary external event sources should
-// keep using DispatchEvent so the dispatching marker serializes them.
+// keep using DispatchEvent so active-workflow checks serialize them.
 func (e *Engine) ReplaceWorkflowForEvent(taskID, event string, extraFields, vars map[string]string, cancelReason string) (string, error) {
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
@@ -285,7 +268,7 @@ func (e *Engine) HasActiveWorkflow(taskID string) bool {
 // CancelWorkflow terminates a task's active workflow without running any
 // remaining steps. Stops in-flight agents for the task, marks the workflow
 // ExecCompleted with the cancellation reason recorded in variables, and
-// clears CurrentStep so ResumeStalled stops re-dispatching.
+// clears CurrentStep so ResumeStalled stops launching another run.
 //
 // No-op when the task has no workflow or its workflow already terminated.
 // Returns the prior current step ID for the caller's log line; empty when

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -504,11 +504,13 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	}
 	mu.Unlock()
 
-	if e.agents.IsDispatching(taskID) {
+	claim, ok := e.agents.TryClaimDispatch(taskID)
+	if !ok {
 		e.logger.Debug("workflow.rate-limit-reschedule.skip",
 			"task_id", taskID, "reason", "claim-held", "step", step.ID)
 		return
 	}
+	defer claim.Release()
 	if e.handleWatchdogRateLimitRetry(&t, step) {
 		return
 	}

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -504,6 +504,21 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	}
 	mu.Unlock()
 
+	e.mu.Lock()
+	if _, dispatching := e.dispatching[taskID]; dispatching {
+		e.mu.Unlock()
+		e.logger.Debug("workflow.rate-limit-reschedule.skip",
+			"task_id", taskID, "reason", "dispatching", "step", step.ID)
+		return
+	}
+	e.dispatching[taskID] = struct{}{}
+	e.mu.Unlock()
+	defer func() {
+		e.mu.Lock()
+		delete(e.dispatching, taskID)
+		e.mu.Unlock()
+	}()
+
 	claim, ok := e.agents.TryClaimDispatch(taskID)
 	if !ok {
 		e.logger.Debug("workflow.rate-limit-reschedule.skip",
@@ -616,7 +631,7 @@ func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
 	}
 }
 
-func (e *Engine) canResumeStep(taskID string, step *Step) (reason string, ok bool) {
+func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason string, ok bool) {
 	// Skip tasks whose step is currently being started. Interactive spawns
 	// (worktree creation, rebase, agent process start) take several seconds
 	// during which no agent is yet registered — without this guard the ticker
@@ -633,6 +648,7 @@ func (e *Engine) canResumeStep(taskID string, step *Step) (reason string, ok boo
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	_, dispatching := e.dispatching[taskID]
 	// agentRoutes holds outstanding agents the engine spawned but hasn't yet
 	// routed completion for. Required because interactive agents pass through
 	// StatePaused after their first result event (one-shot path closes stdin →
@@ -654,13 +670,16 @@ func (e *Engine) canResumeStep(taskID string, step *Step) (reason string, ok boo
 	// concurrently with it.
 	claimedElsewhere := e.agents.IsDispatching(taskID)
 
-	if !advancing && !hasOutstandingAgent && !claimedElsewhere {
+	if !advancing && !dispatching && !hasOutstandingAgent && !claimedElsewhere {
+		e.dispatching[taskID] = struct{}{}
 		return "", true
 	}
 
 	switch {
 	case advancing:
 		return "inflight", false
+	case dispatching:
+		return "dispatching", false
 	case hasOutstandingAgent:
 		return "agent-pending-completion", false
 	case claimedElsewhere:
@@ -738,7 +757,7 @@ func (e *Engine) ResumeStalled() {
 		if e.handleWatchdogHangRetry(t, step) {
 			continue
 		}
-		reason, acquired := e.canResumeStep(t.ID, step)
+		reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
 		if !acquired {
 			e.logger.Debug("workflow.resume-stalled.skip",
 				"task_id", t.ID, "reason", reason, "step", step.ID)
@@ -751,6 +770,9 @@ func (e *Engine) ResumeStalled() {
 		// claimed/advancing) never burns budget for a retry that didn't
 		// happen.
 		if e.handleTransientFetchRetry(t, step) {
+			e.mu.Lock()
+			delete(e.dispatching, t.ID)
+			e.mu.Unlock()
 			continue
 		}
 
@@ -759,11 +781,17 @@ func (e *Engine) ResumeStalled() {
 		// already advanced the workflow past this step.
 		fresh, skip := e.shouldSkipResumeAfterFreshRead(t.ID, t.Workflow)
 		if skip {
+			e.mu.Lock()
+			delete(e.dispatching, t.ID)
+			e.mu.Unlock()
 			continue
 		}
 
 		e.logger.Info("workflow.resume-stalled", "task_id", t.ID, "step", step.ID)
 		comp, rErr := e.executeSteps(t.ID, &def, step, t.Workflow)
+		e.mu.Lock()
+		delete(e.dispatching, t.ID)
+		e.mu.Unlock()
 		// ResumeStalled only resumes async run_agent steps, so comp is normally
 		// nil (fireComplete no-ops). Kept defensive so the day a sync step
 		// becomes resumable its completion cascades correctly instead of being

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -341,54 +341,54 @@ func traceID(taskID, stepID, agentID string) string {
 func (e *Engine) lookupAgentStep(agentID string) (string, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	entry, ok := e.agentSteps[agentID]
+	entry, ok := e.agentRoutes[agentID]
 	return entry.stepID, ok
 }
 
 // hasTrackedAgentForTaskStep returns true when a tracked agent is already in
-// flight for the given task+step pair, OR a run_agent dispatch for that pair
-// is in progress but hasn't been assigned an agent ID yet (see
-// dispatchingStep). Used to detect phantom completions from untracked
+// flight for the given task+step pair, OR a run_agent start for that pair is
+// in progress but hasn't been assigned an agent ID yet (see pendingStepStart).
+// Used to detect phantom completions from untracked
 // (manually-dispatched, or reattached-and-stale) agents: without the
-// dispatchingStep check, a stale completion arriving while the real agent for
+// pendingStepStart check, a stale completion arriving while the real agent for
 // the current step is still being started (e.g. blocked on worktree prep)
 // falls back to "current step, nothing tracked yet" and gets misattributed —
 // advancing the step before its real agent ever ran.
 func (e *Engine) hasTrackedAgentForTaskStep(taskID, stepID string) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	for _, entry := range e.agentSteps {
+	for _, entry := range e.agentRoutes {
 		if entry.taskID == taskID && entry.stepID == stepID {
 			return true
 		}
 	}
-	return e.dispatchingStep[dispatchingStepKey(taskID, stepID)] > 0
+	return e.pendingStepStart[pendingStepStartKey(taskID, stepID)] > 0
 }
 
-func dispatchingStepKey(taskID, stepID string) string {
+func pendingStepStartKey(taskID, stepID string) string {
 	return taskID + "|" + stepID
 }
 
-// markStepDispatching records that a run_agent step's agent-start sequence
+// markStepStarting records that a run_agent step's agent-start sequence
 // (which may block for seconds on worktree prep) is underway for taskID/stepID,
-// before an agent ID exists to register in agentSteps. Paired with
-// unmarkStepDispatching, always via defer, on every return path.
-func (e *Engine) markStepDispatching(taskID, stepID string) {
+// before an agent ID exists to register in agentRoutes. Paired with
+// unmarkStepStarting, always via defer, on every return path.
+func (e *Engine) markStepStarting(taskID, stepID string) {
 	e.mu.Lock()
-	key := dispatchingStepKey(taskID, stepID)
-	e.dispatchingStep[key]++
+	key := pendingStepStartKey(taskID, stepID)
+	e.pendingStepStart[key]++
 	e.mu.Unlock()
 }
 
-func (e *Engine) unmarkStepDispatching(taskID, stepID string) {
+func (e *Engine) unmarkStepStarting(taskID, stepID string) {
 	e.mu.Lock()
-	key := dispatchingStepKey(taskID, stepID)
-	if e.dispatchingStep[key] <= 1 {
-		delete(e.dispatchingStep, key)
+	key := pendingStepStartKey(taskID, stepID)
+	if e.pendingStepStart[key] <= 1 {
+		delete(e.pendingStepStart, key)
 		e.mu.Unlock()
 		return
 	}
-	e.dispatchingStep[key]--
+	e.pendingStepStart[key]--
 	e.mu.Unlock()
 }
 
@@ -398,7 +398,7 @@ func (e *Engine) clearAgentStep(agentID string) {
 		return
 	}
 	e.mu.Lock()
-	delete(e.agentSteps, agentID)
+	delete(e.agentRoutes, agentID)
 	e.mu.Unlock()
 }
 
@@ -416,9 +416,9 @@ func (e *Engine) clearAgentStepsForTask(taskID string) {
 		return
 	}
 	e.mu.Lock()
-	for id, entry := range e.agentSteps {
+	for id, entry := range e.agentRoutes {
 		if entry.taskID == taskID {
-			delete(e.agentSteps, id)
+			delete(e.agentRoutes, id)
 		}
 	}
 	e.mu.Unlock()
@@ -504,30 +504,17 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	}
 	mu.Unlock()
 
-	e.mu.Lock()
-	// Consult the shared agent.Manager dispatch-claim coordinator too — see
-	// IsDispatching's doc for why the engine-local `dispatching` marker alone
-	// cannot see a claim held by an outside dispatcher (e.g. recovery).
-	if _, dispatching := e.dispatching[taskID]; dispatching || e.agents.IsDispatching(taskID) {
-		e.mu.Unlock()
+	if e.agents.IsDispatching(taskID) {
 		e.logger.Debug("workflow.rate-limit-reschedule.skip",
-			"task_id", taskID, "reason", "dispatching", "step", step.ID)
+			"task_id", taskID, "reason", "claim-held", "step", step.ID)
 		return
 	}
-	e.dispatching[taskID] = struct{}{}
-	e.mu.Unlock()
 	if e.handleWatchdogRateLimitRetry(&t, step) {
-		e.mu.Lock()
-		delete(e.dispatching, taskID)
-		e.mu.Unlock()
 		return
 	}
 
 	e.logger.Info("workflow.rate-limit-reschedule", "task_id", taskID, "step", step.ID)
 	comp, rErr := e.executeSteps(taskID, &def, step, t.Workflow)
-	e.mu.Lock()
-	delete(e.dispatching, taskID)
-	e.mu.Unlock()
 	e.fireComplete(comp)
 	e.drainPendingConflictRecovery(taskID)
 	e.resumeError.Log(e.logger, "workflow.rate-limit-reschedule.exec", taskID, rErr, "task_id", taskID)
@@ -627,16 +614,14 @@ func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
 	}
 }
 
-func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason string, acquired bool) {
-	// Skip tasks whose step is currently being dispatched. Interactive spawns
+func (e *Engine) canResumeStep(taskID string, step *Step) (reason string, ok bool) {
+	// Skip tasks whose step is currently being started. Interactive spawns
 	// (worktree creation, rebase, agent process start) take several seconds
 	// during which no agent is yet registered — without this guard the ticker
 	// would spawn a duplicate and the second agent's completion would corrupt
 	// the workflow at the wait_human gate.
 	// inflightMutexes is a non-blocking probe: TryLock distinguishes "another
-	// goroutine currently holds the advance lock" from "free". We only set
-	// dispatching when both the advance lock and prior dispatching guard are
-	// free.
+	// goroutine currently holds the advance lock" from "free".
 	mu := e.taskInflightMutex(taskID)
 	advancing := !mu.TryLock()
 	if !advancing {
@@ -646,15 +631,14 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	_, dispatching := e.dispatching[taskID]
-	// agentSteps holds outstanding agents the engine spawned but hasn't yet
+	// agentRoutes holds outstanding agents the engine spawned but hasn't yet
 	// routed completion for. Required because interactive agents pass through
 	// StatePaused after their first result event (one-shot path closes stdin →
 	// state Paused → process exits → onComplete fires → AdvanceStep), and
 	// HasRunningAgent returns false during that window. Without this check a
 	// tight ResumeStalled loop dispatches a duplicate.
 	hasOutstandingAgent := false
-	for _, entry := range e.agentSteps {
+	for _, entry := range e.agentRoutes {
 		if entry.taskID == taskID && (entry.stepID == step.ID || parallelHasChild(step, entry.stepID) || bestOfNStepMatches(step, entry.stepID)) {
 			hasOutstandingAgent = true
 			break
@@ -663,13 +647,12 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 
 	// Also consult the shared agent.Manager dispatch-claim coordinator: a
 	// claim it holds for taskID (e.g. recovery.RestartStaleInProgress mid
-	// dispatch) is invisible to this engine's own dispatching/agentSteps
-	// bookkeeping, and without this check ResumeStalled could redispatch
+	// launch) is invisible to this engine's completion-routing bookkeeping,
+	// and without this check ResumeStalled could start another run
 	// concurrently with it.
 	claimedElsewhere := e.agents.IsDispatching(taskID)
 
-	if !advancing && !dispatching && !hasOutstandingAgent && !claimedElsewhere {
-		e.dispatching[taskID] = struct{}{}
+	if !advancing && !hasOutstandingAgent && !claimedElsewhere {
 		return "", true
 	}
 
@@ -681,7 +664,7 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 	case claimedElsewhere:
 		return "claimed-elsewhere", false
 	default:
-		return "dispatching", false
+		return "busy", false
 	}
 }
 
@@ -753,45 +736,36 @@ func (e *Engine) ResumeStalled() {
 		if e.handleWatchdogHangRetry(t, step) {
 			continue
 		}
-		reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
+		reason, acquired := e.canResumeStep(t.ID, step)
 		if !acquired {
 			e.logger.Debug("workflow.resume-stalled.skip",
 				"task_id", t.ID, "reason", reason, "step", step.ID)
 			continue
 		}
 
-		// handleTransientFetchRetry runs only after the dispatching claim is
-		// acquired, so the retry budget tracks actual re-dispatch attempts —
+		// handleTransientFetchRetry runs only after the resume preflight passes,
+		// so the retry budget tracks actual restart attempts —
 		// a tick that loses the claim to a concurrent goroutine (already
-		// dispatching/advancing) never burns budget for a retry that didn't
+		// claimed/advancing) never burns budget for a retry that didn't
 		// happen.
 		if e.handleTransientFetchRetry(t, step) {
-			e.mu.Lock()
-			delete(e.dispatching, t.ID)
-			e.mu.Unlock()
 			continue
 		}
 
 		// Re-read to guard against stale snapshots from concurrent ResumeStalled
-		// calls: by the time we acquire dispatching, a prior goroutine may have
+		// calls: by the time we pass the preflight, a prior goroutine may have
 		// already advanced the workflow past this step.
 		fresh, skip := e.shouldSkipResumeAfterFreshRead(t.ID, t.Workflow)
 		if skip {
-			e.mu.Lock()
-			delete(e.dispatching, t.ID)
-			e.mu.Unlock()
 			continue
 		}
 
 		e.logger.Info("workflow.resume-stalled", "task_id", t.ID, "step", step.ID)
 		comp, rErr := e.executeSteps(t.ID, &def, step, t.Workflow)
-		e.mu.Lock()
-		delete(e.dispatching, t.ID)
-		e.mu.Unlock()
 		// ResumeStalled only resumes async run_agent steps, so comp is normally
-		// nil (fireComplete no-ops). Kept defensive + after the dispatching
-		// marker is cleared, so the day a sync step becomes resumable its
-		// completion cascades correctly instead of being silently dropped.
+		// nil (fireComplete no-ops). Kept defensive so the day a sync step
+		// becomes resumable its completion cascades correctly instead of being
+		// silently dropped.
 		e.fireComplete(comp)
 		e.drainPendingConflictRecovery(t.ID)
 		e.resumeError.Log(e.logger, "workflow.resume-stalled.exec", t.ID, rErr, "task_id", t.ID)
@@ -812,7 +786,7 @@ func (e *Engine) handleWatchdogHangRetry(t *TaskInfo, step *Step) bool {
 		return false
 	}
 	// A tracked agent for this task+step may still be mid-completion-routing
-	// even though HasRunningAgent already returned false (see the agentSteps
+	// even though HasRunningAgent already returned false (see the agentRoutes
 	// comment in ResumeStalled). Treating that window as a hang would burn
 	// retry budget and clear the hang marker without a clean re-dispatch
 	// actually happening.

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -484,6 +484,10 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 		return
 	}
 	e.clearAgentStep(agentID)
+	e.rescheduleRateLimitedRunAgent(taskID, agentID, step, t, &def)
+}
+
+func (e *Engine) rescheduleRateLimitedRunAgent(taskID, agentID string, step *Step, t TaskInfo, def *Definition) {
 	if e.shouldSkipResumeForRateLimitedProvider(&t, step) {
 		// Provider is still inside its rate-limit cooldown and no healthy peer is
 		// available to fail over to. Park the task without consuming a watchdog
@@ -504,20 +508,10 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	}
 	mu.Unlock()
 
-	e.mu.Lock()
-	if _, dispatching := e.dispatching[taskID]; dispatching {
-		e.mu.Unlock()
-		e.logger.Debug("workflow.rate-limit-reschedule.skip",
-			"task_id", taskID, "reason", "dispatching", "step", step.ID)
+	if !e.tryMarkRateLimitRescheduleDispatching(taskID, step) {
 		return
 	}
-	e.dispatching[taskID] = struct{}{}
-	e.mu.Unlock()
-	defer func() {
-		e.mu.Lock()
-		delete(e.dispatching, taskID)
-		e.mu.Unlock()
-	}()
+	defer e.clearResumeDispatching(taskID)
 
 	claim, ok := e.agents.TryClaimDispatch(taskID)
 	if !ok {
@@ -531,15 +525,34 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	}
 
 	e.logger.Info("workflow.rate-limit-reschedule", "task_id", taskID, "step", step.ID)
-	comp, rErr := e.executeSteps(taskID, &def, step, t.Workflow)
+	comp, rErr := e.executeSteps(taskID, def, step, t.Workflow)
 	e.fireComplete(comp)
 	e.drainPendingConflictRecovery(taskID)
 	e.resumeError.Log(e.logger, "workflow.rate-limit-reschedule.exec", taskID, rErr, "task_id", taskID)
 	if rErr != nil {
 		e.surfaceStartFailure(taskID, t.Status, rErr, t.Workflow, step.ID)
-	} else {
-		e.clearCircuitBreakerOnSuccess(taskID, t.Workflow, step.ID)
+		return
 	}
+	e.clearCircuitBreakerOnSuccess(taskID, t.Workflow, step.ID)
+}
+
+func (e *Engine) tryMarkRateLimitRescheduleDispatching(taskID string, step *Step) bool {
+	e.mu.Lock()
+	if _, dispatching := e.dispatching[taskID]; dispatching {
+		e.mu.Unlock()
+		e.logger.Debug("workflow.rate-limit-reschedule.skip",
+			"task_id", taskID, "reason", "dispatching", "step", step.ID)
+		return false
+	}
+	e.dispatching[taskID] = struct{}{}
+	e.mu.Unlock()
+	return true
+}
+
+func (e *Engine) clearResumeDispatching(taskID string) {
+	e.mu.Lock()
+	delete(e.dispatching, taskID)
+	e.mu.Unlock()
 }
 
 func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, parent, child *Step, t TaskInfo) {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -505,7 +505,10 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	mu.Unlock()
 
 	e.mu.Lock()
-	if _, dispatching := e.dispatching[taskID]; dispatching {
+	// Consult the shared agent.Manager dispatch-claim coordinator too — see
+	// IsDispatching's doc for why the engine-local `dispatching` marker alone
+	// cannot see a claim held by an outside dispatcher (e.g. recovery).
+	if _, dispatching := e.dispatching[taskID]; dispatching || e.agents.IsDispatching(taskID) {
 		e.mu.Unlock()
 		e.logger.Debug("workflow.rate-limit-reschedule.skip",
 			"task_id", taskID, "reason", "dispatching", "step", step.ID)
@@ -658,7 +661,14 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 		}
 	}
 
-	if !advancing && !dispatching && !hasOutstandingAgent {
+	// Also consult the shared agent.Manager dispatch-claim coordinator: a
+	// claim it holds for taskID (e.g. recovery.RestartStaleInProgress mid
+	// dispatch) is invisible to this engine's own dispatching/agentSteps
+	// bookkeeping, and without this check ResumeStalled could redispatch
+	// concurrently with it.
+	claimedElsewhere := e.agents.IsDispatching(taskID)
+
+	if !advancing && !dispatching && !hasOutstandingAgent && !claimedElsewhere {
 		e.dispatching[taskID] = struct{}{}
 		return "", true
 	}
@@ -668,6 +678,8 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 		return "inflight", false
 	case hasOutstandingAgent:
 		return "agent-pending-completion", false
+	case claimedElsewhere:
+		return "claimed-elsewhere", false
 	default:
 		return "dispatching", false
 	}

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -190,16 +190,16 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	// (e.g. evaluate). Without this, the workflow stalls on implement forever.
 	oneShot := mode == "interactive" && !step.Config.ReuseAgent && step.Config.WaitForStatus == ""
 
-	// Mark the step as dispatching before the (potentially multi-second,
+	// Mark the step as starting before the (potentially multi-second,
 	// worktree-prep-bound) StartAgent call so a stale/untracked agent
-	// completion arriving mid-dispatch (e.g. a reattached agent from a prior
+	// completion arriving mid-start (e.g. a reattached agent from a prior
 	// step) sees this step as claimed instead of falling through to the
 	// "nothing tracked yet, credit the current step" fallback in
 	// HandleAgentComplete. Cleared by the deferred unmark when execRunAgent
-	// returns, at which point either agentSteps (success) or the parked/failed
+	// returns, at which point either agentRoutes (success) or the parked/failed
 	// step state takes over.
-	e.markStepDispatching(taskID, step.ID)
-	defer e.unmarkStepDispatching(taskID, step.ID)
+	e.markStepStarting(taskID, step.ID)
+	defer e.unmarkStepStarting(taskID, step.ID)
 	agentID, startedDir, baselineRef, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot, step.Config.OutputSchema, cleanRetryRef, assignment)
 	if err != nil {
 		// Another dispatcher already holds the per-task dispatch claim (e.g. the
@@ -242,7 +242,7 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	// can detect stale completions (e.g. duplicate agent from a ResumeStalled
 	// race) rather than blindly crediting the current step.
 	e.mu.Lock()
-	e.agentSteps[agentID] = agentEntry{taskID: taskID, stepID: step.ID}
+	e.agentRoutes[agentID] = agentRoute{taskID: taskID, stepID: step.ID}
 	e.mu.Unlock()
 
 	wfExec.State = ExecWaiting

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -13,7 +13,7 @@ var errBestOfNParked = errors.New("best-of-n parked waiting for attempt completi
 
 // bestOfNAttemptSep separates a best_of_n parent step ID from a synthetic
 // attempt ID (e.g. "implement_n::attempt_2") in the compound stepID stashed
-// in agentSteps for an attempt agent. Attempts have no corresponding YAML
+// in agentRoutes for an attempt agent. Attempts have no corresponding YAML
 // Step (unlike `parallel` children), so they cannot be looked up via
 // Definition.StepByID — loadAdvanceContext instead detects this separator and
 // routes to the best-of-N attempt path. "::" cannot collide with a real
@@ -107,7 +107,7 @@ func (e *Engine) execBestOfN(taskID string, def *Definition, step *Step, wfExec 
 	// fast-completing attempt agent's onComplete callback can fire — and
 	// block in AdvanceStep on this same per-task mutex (see
 	// acquireInflight/handleFanOutCompletion) — before this loop has finished
-	// dispatching its siblings. advanceBestOfNAttempt persists a freshly
+	// launching its siblings. advanceBestOfNAttempt persists a freshly
 	// reloaded Execution when it runs; without holding the mutex here, this
 	// loop's own end-of-loop SetWorkflow below (built from an in-memory copy
 	// that predates that completion) would silently clobber it, permanently
@@ -212,14 +212,14 @@ func (e *Engine) spawnBestOfNAttempt(taskID string, step *Step, wfExec *Executio
 	}
 
 	// Hold e.mu across StartAgent so a fast-exiting agent's completion cannot
-	// race past the agentSteps registration below (mirrors spawnParallelChild).
+	// race past the agentRoutes registration below (mirrors spawnParallelChild).
 	e.mu.Lock()
 	agentID, _, _, startErr := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, false, false, step.Config.OutputSchema, "", assignment)
 	if startErr != nil {
 		e.mu.Unlock()
 		return fmt.Errorf("start agent: %w", startErr)
 	}
-	e.agentSteps[agentID] = agentEntry{taskID: taskID, stepID: bestOfNAttemptStepKey(step.ID, attemptID)}
+	e.agentRoutes[agentID] = agentRoute{taskID: taskID, stepID: bestOfNAttemptStepKey(step.ID, attemptID)}
 	e.mu.Unlock()
 
 	status.AgentID = agentID

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -12,7 +12,7 @@ import (
 // (validated at definition load time); planning is read-only so contention
 // on the worktree is benign. The parent step advances to its `next` only
 // after every child has terminated; per-child completions are routed
-// through AdvanceStep via the existing agentSteps mapping.
+// through AdvanceStep via the existing agentRoutes mapping.
 //
 // Returns a non-nil *CompletionInfo when every child terminates at spawn time
 // and the parent's `next` ends the workflow synchronously — threaded up to the
@@ -142,9 +142,9 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	oneShot := false
 
 	// Hold e.mu across StartAgent so HandleAgentComplete (which acquires
-	// e.mu via lookupAgentStep) cannot race past the agentSteps registration.
+	// e.mu via lookupAgentStep) cannot race past the agentRoutes registration.
 	// Fast-exiting agents (e.g. fail_exit in tests) can otherwise complete
-	// before agentSteps is populated, causing the wrong step to advance.
+	// before agentRoutes is populated, causing the wrong step to advance.
 	e.mu.Lock()
 	agentID, _, baselineRef, err := e.agents.StartAgent(taskID, child.Config.Role, mode, model, provider, prompt, dir, child.Config.AllowedTools, child.Config.NeedsWorktree, oneShot, child.Config.OutputSchema, "", assignment)
 	if err != nil {
@@ -154,10 +154,10 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	if baselineRef != "" {
 		wfExec.SetVar(tamperBaselineVar(child.ID), baselineRef)
 	}
-	// agentSteps key uses the *child* step ID. StepByID recurses into
+	// agentRoutes key uses the *child* step ID. StepByID recurses into
 	// Parallel children so the lookup in lookupAgentStep / AdvanceStep
 	// returns the right step config.
-	e.agentSteps[agentID] = agentEntry{taskID: taskID, stepID: child.ID}
+	e.agentRoutes[agentID] = agentRoute{taskID: taskID, stepID: child.ID}
 	e.mu.Unlock()
 
 	status.AgentID = agentID

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -201,10 +201,10 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 // diverged push and reports whether the step must park.
 //
 // The callback (review.Handler.RecoverStaleBranchConflict) cancels this task's
-// active workflow and re-dispatches branch-conflict-fix — a re-entry into
+// active workflow and launches branch-conflict-fix — a re-entry into
 // StartWorkflow*/DispatchEvent. When push_branch/create_pr runs inside one of
-// those calls (DispatchEvent → startWorkflowLocked, or a resume re-dispatch),
-// the per-task starting/dispatching marker is still held, so invoking recovery
+// those calls (DispatchEvent → startWorkflowLocked), the per-task starting
+// marker is still held, so invoking recovery
 // now would hit ErrWorkflowAlreadyActive and silently no-op — the reentrancy
 // trap that made this whole path dead on arrival. Detect that case by the held
 // marker and queue the recovery instead; drainPendingConflictRecovery runs it
@@ -214,8 +214,7 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 func (e *Engine) tryConflictRecovery(taskID string) bool {
 	e.mu.Lock()
 	_, starting := e.starting[taskID]
-	_, dispatching := e.dispatching[taskID]
-	if starting || dispatching {
+	if starting {
 		if e.pendingRecovery == nil {
 			e.pendingRecovery = make(map[string]struct{})
 		}
@@ -249,8 +248,8 @@ func (e *Engine) TryConflictRecovery(taskID string) bool {
 }
 
 // QueueConflictRecoveryRetry defers a conflict-recovery retry until this
-// task's starting/dispatching marker next releases, for a caller whose own
-// re-dispatch of the recovery workflow (e.g. dispatchBranchConflictRecovery's
+// task's starting marker next releases, for a caller whose own launch of the
+// recovery workflow (e.g. dispatchBranchConflictRecovery's
 // StartWorkflowWithVars call) hit ErrWorkflowAlreadyActive despite
 // TryConflictRecovery's entry check having found no marker held. The marker
 // can be grabbed by a concurrent StartWorkflow call sometime during the
@@ -270,8 +269,8 @@ func (e *Engine) QueueConflictRecoveryRetry(taskID string) {
 // drainPendingConflictRecovery runs a branch-conflict recovery that
 // tryConflictRecovery deferred because a per-task marker was held when the
 // diverged push was detected. It MUST be called only after the caller has
-// released its starting/dispatching marker (alongside fireComplete), so the
-// callback's re-dispatch is not rejected as re-entrant. No-op when nothing was
+// released its starting marker (alongside fireComplete), so the callback's
+// launch is not rejected as re-entrant. No-op when nothing was
 // queued for the task. When recovery is unavailable or declines, the task is
 // escalated to human-required and its parked workflow terminated — the same
 // terminal outcome the inline divergence path produces.

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -270,8 +270,8 @@ func TestExecPushBranch_DivergedRecoveryDeclinesFallsBackToHumanRequired(t *test
 }
 
 // TestConflictRecovery_DeferredWhileMarkerHeld locks the reentrancy fix: when a
-// per-task starting/dispatching marker is held (push_branch/create_pr reached
-// via DispatchEvent/startWorkflowLocked or a resume re-dispatch), the recovery
+// per-task starting marker is held (push_branch/create_pr reached via
+// DispatchEvent/startWorkflowLocked), the recovery
 // callback must NOT run inline — doing so re-enters StartWorkflow*/DispatchEvent
 // against the held marker and is silently rejected. It must be queued and run
 // only once drainPendingConflictRecovery fires after the marker releases.
@@ -283,9 +283,9 @@ func TestConflictRecovery_DeferredWhileMarkerHeld(t *testing.T) {
 	var calls int
 	engine.SetConflictRecovery(func(string) bool { calls++; return true })
 
-	// Simulate running inside DispatchEvent: the dispatching marker is held.
+	// Simulate running inside DispatchEvent: the starting marker is held.
 	engine.mu.Lock()
-	engine.dispatching["t1"] = struct{}{}
+	engine.starting["t1"] = struct{}{}
 	engine.mu.Unlock()
 
 	if parked := engine.tryConflictRecovery("t1"); !parked {
@@ -300,7 +300,7 @@ func TestConflictRecovery_DeferredWhileMarkerHeld(t *testing.T) {
 	// have released it and does not re-check, so draining while still held
 	// would re-enter the very reentrancy trap this test guards against.
 	engine.mu.Lock()
-	delete(engine.dispatching, "t1")
+	delete(engine.starting, "t1")
 	engine.mu.Unlock()
 
 	engine.drainPendingConflictRecovery("t1")

--- a/internal/workflow/engine_steps_resume.go
+++ b/internal/workflow/engine_steps_resume.go
@@ -61,7 +61,7 @@ func (e *Engine) execResumeWorkflow(taskID string, step *Step, wfExec *Execution
 
 	// StartWorkflowWithVars refuses to start a new workflow while the task's
 	// current workflow (this one) is non-terminal, so finalize THIS execution
-	// first and persist it before dispatching the resume target. Returning
+	// first and persist it before launching the resume target. Returning
 	// errStepParked afterward tells executeSteps to stop without its own
 	// record/resolveNext/SetWorkflow pass — which would otherwise re-persist
 	// this now-stale (but already-completed) Execution over the freshly

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -14,7 +14,7 @@ import (
 
 // TamperBlessedTag short-circuits the detector: a human who has reviewed a
 // flagged diff and accepted it adds this tag, then moves the task back into the
-// flow. Without it, re-dispatching a flagged task would re-scan the same
+// flow. Without it, relaunching a flagged task would re-scan the same
 // committed diff and re-flag forever (livelock).
 const TamperBlessedTag = "tamper-blessed"
 

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -17,7 +17,7 @@ import (
 // its own workflow in ExecWaiting (persisting the new CurrentStep/State itself).
 // executeSteps treats it as "stop, do not record/advance/complete" — completing
 // would fire the status-change cascade. Used by verify_commits to wait out a
-// still-running sibling agent without re-dispatching over it.
+// still-running sibling agent without launching over it.
 var errStepParked = errors.New("workflow step parked in ExecWaiting")
 
 // execEnsurePRClosesIssue verifies the task's PR closes its linked

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5128,6 +5128,61 @@ func TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
 	}
 }
 
+// TestResumeStalled_ConcurrentCallsReserveDispatchWindow verifies the engine
+// still keeps its own short-lived per-task reservation between ResumeStalled's
+// preflight and the eventual StartAgent call. The shared agent.Manager claim is
+// only acquired inside StartAgent, so without this earlier reservation two
+// concurrent ResumeStalled loops can both enter executeSteps before any claim
+// exists and race a duplicate start.
+func TestResumeStalled_ConcurrentCallsReserveDispatchWindow(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.startGate = make(chan struct{})
+	agents.startEntered = make(chan struct{}, 2)
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "planning",
+		AgentMode: "interactive",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "plan",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			engine.ResumeStalled()
+		}()
+	}
+
+	select {
+	case <-agents.startEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first ResumeStalled never reached StartAgent")
+	}
+
+	select {
+	case <-agents.startEntered:
+		t.Fatal("second ResumeStalled reached StartAgent while the first dispatch window was still reserved")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(agents.startGate)
+	wg.Wait()
+
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("StartAgent call count = %d, want 1", got)
+	}
+}
+
 // TestDispatchEvent_SkipsClaimHeldByOutOfBandDispatcher verifies DispatchEvent
 // also treats a shared agent.Manager dispatch claim held for the task as busy,
 // even when the workflow engine has no active local route for the task.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -382,6 +382,8 @@ type mockAgents struct {
 	rateLimited       map[string]bool // provider -> rate-limited
 	unhealthy         map[string]bool // provider -> unhealthy (config-disabled/probe-down); absent = healthy
 	dispatchClaimed   map[string]bool // taskID -> a claim is held by an out-of-band dispatcher (e.g. simulated recovery)
+	startGate         chan struct{}
+	startEntered      chan struct{}
 }
 
 type panicStartAgents struct{ *mockAgents }
@@ -398,6 +400,15 @@ func newMockAgents() *mockAgents {
 }
 
 func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema, cleanRetryRef string, assignment AgentAssignment) (agentID, startedDir, baselineRef string, err error) {
+	if m.startEntered != nil {
+		select {
+		case m.startEntered <- struct{}{}:
+		default:
+		}
+	}
+	if m.startGate != nil {
+		<-m.startGate
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.failSpawn != nil {
@@ -519,10 +530,36 @@ func (m *mockAgents) SendPrompt(agentID, message string) error {
 
 func (m *mockAgents) DefaultProvider() string { return "claude" }
 
+func (m *mockAgents) TryClaimDispatch(taskID string) (DispatchClaim, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dispatchClaimed == nil {
+		m.dispatchClaimed = make(map[string]bool)
+	}
+	if m.dispatchClaimed[taskID] {
+		return nil, false
+	}
+	m.dispatchClaimed[taskID] = true
+	return mockDispatchClaim{m: m, taskID: taskID}, true
+}
+
 func (m *mockAgents) IsDispatching(taskID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.dispatchClaimed[taskID]
+}
+
+type mockDispatchClaim struct {
+	m      *mockAgents
+	taskID string
+}
+
+func (c mockDispatchClaim) Release() {
+	c.m.mu.Lock()
+	defer c.m.mu.Unlock()
+	if c.m.dispatchClaimed != nil {
+		delete(c.m.dispatchClaimed, c.taskID)
+	}
 }
 
 // SetDispatchClaimed simulates an out-of-band dispatcher (e.g.
@@ -2071,6 +2108,59 @@ func TestRescheduleRateLimitedAgent_SkippedSharedClaimDoesNotConsumeWatchdogRetr
 	}
 	if got.StatusReason != "watchdog: rate limit: org-level quota exhausted" {
 		t.Fatalf("status_reason = %q", got.StatusReason)
+	}
+	if got.Workflow.Variables[watchdogRateLimitRetryKey("implement")] != "1" {
+		t.Fatalf("rate-limit retry var = %q, want 1", got.Workflow.Variables[watchdogRateLimitRetryKey("implement")])
+	}
+}
+
+func TestRescheduleRateLimitedAgent_HoldsDispatchClaimAcrossRescheduleAttempt(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.startEntered = make(chan struct{}, 1)
+	agents.startGate = make(chan struct{})
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: "watchdog: rate limit: org-level quota exhausted",
+		AgentMode:    "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+
+	engine.agentRoutes["limited-agent-1"] = agentRoute{taskID: "t1", stepID: "implement"}
+	engine.agentRoutes["limited-agent-2"] = agentRoute{taskID: "t1", stepID: "implement"}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		engine.RescheduleRateLimitedAgent("t1", "limited-agent-1")
+	}()
+
+	<-agents.startEntered
+
+	go func() {
+		defer wg.Done()
+		engine.RescheduleRateLimitedAgent("t1", "limited-agent-2")
+	}()
+
+	close(agents.startGate)
+	wg.Wait()
+
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("replacement agent starts = %d, want 1", got)
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
 	}
 	if got.Workflow.Variables[watchdogRateLimitRetryKey("implement")] != "1" {
 		t.Fatalf("rate-limit retry var = %q, want 1", got.Workflow.Variables[watchdogRateLimitRetryKey("implement")])

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -381,6 +381,7 @@ type mockAgents struct {
 	providerFailover  bool            // when true, ProviderCanFailover reports true
 	rateLimited       map[string]bool // provider -> rate-limited
 	unhealthy         map[string]bool // provider -> unhealthy (config-disabled/probe-down); absent = healthy
+	dispatchClaimed   map[string]bool // taskID -> a claim is held by an out-of-band dispatcher (e.g. simulated recovery)
 }
 
 type panicStartAgents struct{ *mockAgents }
@@ -517,6 +518,24 @@ func (m *mockAgents) SendPrompt(agentID, message string) error {
 }
 
 func (m *mockAgents) DefaultProvider() string { return "claude" }
+
+func (m *mockAgents) IsDispatching(taskID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.dispatchClaimed[taskID]
+}
+
+// SetDispatchClaimed simulates an out-of-band dispatcher (e.g.
+// recovery.RestartStaleInProgress) holding the shared agent.Manager
+// dispatch claim for taskID, independent of this engine's own bookkeeping.
+func (m *mockAgents) SetDispatchClaimed(taskID string, v bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dispatchClaimed == nil {
+		m.dispatchClaimed = make(map[string]bool)
+	}
+	m.dispatchClaimed[taskID] = v
+}
 
 // SimulateComplete marks the agent for a task as no longer running.
 func (m *mockAgents) SimulateComplete(taskID string) {
@@ -4971,6 +4990,71 @@ func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
 	engine.ResumeStalled()
 	if got := agents.CallCount(); got != before+1 {
 		t.Errorf("ResumeStalled after inflight cleared: calls %d → %d (want +1)", before, got)
+	}
+}
+
+// TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher verifies ResumeStalled
+// consults the shared agent.Manager dispatch-claim coordinator (IsDispatching)
+// in addition to its own local dispatching/agentSteps bookkeeping. A claim
+// held by a dispatcher the engine has no local visibility into — e.g.
+// recovery.RestartStaleInProgress dispatching via agentorch.Orchestrator
+// outside the workflow engine entirely — must still block a concurrent
+// ResumeStalled redispatch, closing the exact split-ownership race the
+// engine-local maps alone cannot see.
+func TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "planning",
+		AgentMode: "interactive",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "plan",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+
+	// Simulate an out-of-band dispatcher (recovery.RestartStaleInProgress)
+	// holding the shared agent.Manager claim for t1 — invisible to the
+	// engine's own dispatching/agentSteps maps.
+	agents.SetDispatchClaimed("t1", true)
+
+	before := agents.CallCount()
+	engine.ResumeStalled()
+	if got := agents.CallCount(); got != before {
+		t.Errorf("ResumeStalled spawned a duplicate agent while the shared claim was held elsewhere: calls %d → %d",
+			before, got)
+	}
+
+	// Once the out-of-band dispatcher releases its claim, ResumeStalled may
+	// proceed as normal.
+	agents.SetDispatchClaimed("t1", false)
+	engine.ResumeStalled()
+	if got := agents.CallCount(); got != before+1 {
+		t.Errorf("ResumeStalled after shared claim released: calls %d → %d (want +1)", before, got)
+	}
+}
+
+// TestDispatchEvent_SkipsClaimHeldByOutOfBandDispatcher verifies DispatchEvent
+// also treats a shared agent.Manager dispatch claim held for the task as busy,
+// even when the engine's own local `dispatching` marker is clear.
+func TestDispatchEvent_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
+	agents.SetDispatchClaimed("t1", true)
+
+	_, err := engine.DispatchEvent("t1", "task.created", nil, nil)
+	if !errors.Is(err, ErrWorkflowAlreadyActive) {
+		t.Fatalf("DispatchEvent with shared claim held elsewhere: err = %v, want ErrWorkflowAlreadyActive", err)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1248,7 +1248,7 @@ func startTestSimpleImplement(t *testing.T) (*Store, *memTasks, *mockAgents, *En
 // aborted_streaming result followed by a provider-error exit); both used to
 // land on the run_test step and exhaust max_retries instantly.
 //
-// After the fix, dispatching the retry stops the original agent AND clears its
+// After the fix, launching the retry stops the original agent AND clears its
 // step mapping, so its second completion is untracked and dropped by the
 // phantom-completion guard rather than triggering a further retry.
 func TestRetry_SupersededAgentLateCompletionDropped(t *testing.T) {
@@ -1817,7 +1817,7 @@ func TestRescheduleRateLimitedAgent_RerunsCurrentStep(t *testing.T) {
 			Variables:   make(map[string]string),
 		},
 	})
-	engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "implement"}
+	engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "implement"}
 
 	engine.RescheduleRateLimitedAgent("t1", "limited-agent")
 
@@ -1877,7 +1877,7 @@ func TestRescheduleRateLimitedAgent_WatchdogRetriesThenEscalates(t *testing.T) {
 					Variables:   vars,
 				},
 			})
-			engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "implement"}
+			engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "implement"}
 
 			engine.RescheduleRateLimitedAgent("t1", "limited-agent")
 
@@ -1943,7 +1943,7 @@ func TestRescheduleRateLimitedAgent_ParksWhileProviderRateLimitedNoFailover(t *t
 					Variables:   vars,
 				},
 			})
-			engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "implement"}
+			engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "implement"}
 
 			engine.RescheduleRateLimitedAgent("t1", "limited-agent")
 
@@ -1977,7 +1977,7 @@ func TestRescheduleRateLimitedAgent_EmptyTaskIDClearsTrackedAgent(t *testing.T) 
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	engine := NewEngine(store, tasks, agents, discardLogger())
-	engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "implement"}
+	engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "implement"}
 
 	engine.RescheduleRateLimitedAgent("", "limited-agent")
 
@@ -2009,7 +2009,7 @@ func TestRescheduleRateLimitedAgent_SkippedInflightDoesNotConsumeWatchdogRetry(t
 			},
 		},
 	})
-	engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "implement"}
+	engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "implement"}
 
 	mu := engine.taskInflightMutex("t1")
 	mu.Lock()
@@ -2034,7 +2034,7 @@ func TestRescheduleRateLimitedAgent_SkippedInflightDoesNotConsumeWatchdogRetry(t
 	}
 }
 
-func TestRescheduleRateLimitedAgent_SkippedDispatchingDoesNotConsumeWatchdogRetry(t *testing.T) {
+func TestRescheduleRateLimitedAgent_SkippedSharedClaimDoesNotConsumeWatchdogRetry(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
@@ -2054,11 +2054,9 @@ func TestRescheduleRateLimitedAgent_SkippedDispatchingDoesNotConsumeWatchdogRetr
 			},
 		},
 	})
-	engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "implement"}
+	engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "implement"}
 
-	engine.mu.Lock()
-	engine.dispatching["t1"] = struct{}{}
-	engine.mu.Unlock()
+	agents.SetDispatchClaimed("t1", true)
 	engine.RescheduleRateLimitedAgent("t1", "limited-agent")
 
 	if got := agents.CallCount(); got != 0 {
@@ -2105,7 +2103,7 @@ func TestRescheduleRateLimitedAgent_RerunsParallelChild(t *testing.T) {
 			},
 		},
 	})
-	engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "plan_a"}
+	engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "plan_a"}
 
 	engine.RescheduleRateLimitedAgent("t1", "limited-agent")
 
@@ -2199,7 +2197,7 @@ func TestRescheduleRateLimitedAgent_ParallelChildWatchdogRetriesThenEscalates(t 
 					},
 				},
 			})
-			engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "plan_a"}
+			engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "plan_a"}
 
 			engine.RescheduleRateLimitedAgent("t1", "limited-agent")
 
@@ -2525,7 +2523,7 @@ func TestRescheduleRateLimitedAgent_ParallelChildSkipsTerminalStatusAfterFreshRe
 					},
 				},
 			})
-			engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "plan_a"}
+			engine.agentRoutes["limited-agent"] = agentRoute{taskID: "t1", stepID: "plan_a"}
 			tasks.SetGetTaskHook(func(id string, task *TaskInfo, count int) {
 				if id == "t1" && count == 2 {
 					task.Status = tc.status
@@ -3658,17 +3656,17 @@ func TestHandleAgentComplete_CompletedWorkflowIsNoop(t *testing.T) {
 	}
 }
 
-// TestHandleAgentComplete_DispatchingStepDropsStaleCompletion reproduces the
+// TestHandleAgentComplete_PendingStepStartDropsStaleCompletion reproduces the
 // core of the simple-task-pr cascade bug: a stale/untracked agent completion
 // (e.g. a reattached agent from a step that already advanced) arrives while
 // the CURRENT step's real agent is still being started — StartAgent hasn't
-// returned yet, so agentSteps has no entry for it. Before the
-// dispatchingStep guard, HandleAgentComplete's untracked fallback credited
+// returned yet, so agentRoutes has no entry for it. Before the
+// pendingStepStart guard, HandleAgentComplete's untracked fallback credited
 // this to the current step (nothing tracked yet → not a phantom) and
 // advanced the workflow without the real agent ever having run. The guard
-// closes that window: a step marked dispatching is treated as "claimed" even
+// closes that window: a step marked as starting is treated as "claimed" even
 // before its agent ID exists.
-func TestHandleAgentComplete_DispatchingStepDropsStaleCompletion(t *testing.T) {
+func TestHandleAgentComplete_PendingStepStartDropsStaleCompletion(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
@@ -3685,18 +3683,18 @@ func TestHandleAgentComplete_DispatchingStepDropsStaleCompletion(t *testing.T) {
 
 	// Workflow is now parked on "implement" with its real agent tracked. Drop
 	// the tracking entry to simulate the real agent's StartAgent call still
-	// being in flight (agentSteps not yet populated) — but mark the step as
-	// dispatching, as execRunAgent now does before calling StartAgent.
+	// being in flight (agentRoutes not yet populated) — but mark the step as
+	// starting, as execRunAgent now does before calling StartAgent.
 	ti, _ := tasks.GetTask("t1")
 	if ti.Workflow.CurrentStep != "implement" {
 		t.Fatalf("precondition: current step = %q, want implement", ti.Workflow.CurrentStep)
 	}
 	realAgentID := agents.LastID()
 	engine.clearAgentStep(realAgentID)
-	engine.markStepDispatching("t1", "implement")
+	engine.markStepStarting("t1", "implement")
 
 	// A stale, untracked completion (e.g. a reattached agent from an earlier
-	// step) lands mid-dispatch.
+	// step) lands while the replacement start is underway.
 	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "stale-reattached-agent", Result: "late", Success: true})
 
 	tiAfter, _ := tasks.GetTask("t1")
@@ -3709,19 +3707,19 @@ func TestHandleAgentComplete_DispatchingStepDropsStaleCompletion(t *testing.T) {
 			tiAfter.Workflow.StepHistory)
 	}
 
-	// Once dispatching clears (StartAgent returned and registered the real
+	// Once the pending start clears (StartAgent returned and registered the real
 	// agent), a genuinely untracked completion for THIS step still falls back
 	// to crediting the current step, as designed for manual/recovery agents.
-	engine.unmarkStepDispatching("t1", "implement")
+	engine.unmarkStepStarting("t1", "implement")
 	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "manual-recovery-agent", Result: "done", Success: true})
 
 	tiFinal, _ := tasks.GetTask("t1")
 	if tiFinal.Workflow.CurrentStep == "implement" {
-		t.Fatalf("CurrentStep still implement — untracked completion should advance once dispatching cleared")
+		t.Fatalf("CurrentStep still implement — untracked completion should advance once pending start cleared")
 	}
 }
 
-func TestDispatchingStepRefcountKeepsWinnerClaimed(t *testing.T) {
+func TestPendingStepStartRefcountKeepsWinnerClaimed(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
@@ -3745,9 +3743,9 @@ func TestDispatchingStepRefcountKeepsWinnerClaimed(t *testing.T) {
 
 	// Two concurrent dispatchers race for the same step: the eventual loser
 	// must not clear the winner's in-flight claim.
-	engine.markStepDispatching("t1", "implement")
-	engine.markStepDispatching("t1", "implement")
-	engine.unmarkStepDispatching("t1", "implement")
+	engine.markStepStarting("t1", "implement")
+	engine.markStepStarting("t1", "implement")
+	engine.unmarkStepStarting("t1", "implement")
 
 	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "stale-reattached-agent", Result: "late", Success: true})
 
@@ -3757,7 +3755,7 @@ func TestDispatchingStepRefcountKeepsWinnerClaimed(t *testing.T) {
 			tiAfter.Workflow.CurrentStep)
 	}
 
-	engine.unmarkStepDispatching("t1", "implement")
+	engine.unmarkStepStarting("t1", "implement")
 	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "manual-recovery-agent", Result: "done", Success: true})
 
 	tiFinal, _ := tasks.GetTask("t1")
@@ -4820,7 +4818,7 @@ func TestExecStampPRAttribution_EditErrorIsSoftFail(t *testing.T) {
 // "task X is not waiting for human action".
 //
 // The fix: HandleAgentComplete uses the step the agent was actually spawned
-// for (tracked in engine.agentSteps), and AdvanceStep drops completions whose
+// for (tracked in engine.agentRoutes), and AdvanceStep drops completions whose
 // StepID doesn't match the workflow's current step.
 func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 	store := newTestStore(t)
@@ -4847,7 +4845,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 
 	// Inject a duplicate plan agent as if a ResumeStalled ticker fired
 	// during the interactive-spawn window and raced the first agent. The
-	// engine.agentSteps mapping records what execRunAgent would have set.
+	// engine.agentRoutes mapping records what execRunAgent would have set.
 	agents.mu.Lock()
 	agents.counter++
 	planAgent2 := fmt.Sprintf("agent-%d", agents.counter)
@@ -4856,7 +4854,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 	agents.roles["t1/plan"] = planAgent2
 	agents.mu.Unlock()
 	engine.mu.Lock()
-	engine.agentSteps[planAgent2] = agentEntry{taskID: "t1", stepID: "plan"}
+	engine.agentRoutes[planAgent2] = agentRoute{taskID: "t1", stepID: "plan"}
 	engine.mu.Unlock()
 
 	// Agent 1 completes first → workflow advances to review_plan/wait_human.
@@ -4995,12 +4993,12 @@ func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
 
 // TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher verifies ResumeStalled
 // consults the shared agent.Manager dispatch-claim coordinator (IsDispatching)
-// in addition to its own local dispatching/agentSteps bookkeeping. A claim
+// in addition to workflow completion-routing bookkeeping. A claim
 // held by a dispatcher the engine has no local visibility into — e.g.
-// recovery.RestartStaleInProgress dispatching via agentorch.Orchestrator
+// recovery.RestartStaleInProgress launching via agentorch.Orchestrator
 // outside the workflow engine entirely — must still block a concurrent
 // ResumeStalled redispatch, closing the exact split-ownership race the
-// engine-local maps alone cannot see.
+// engine-local route tracking alone cannot see.
 func TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
@@ -5021,7 +5019,7 @@ func TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
 
 	// Simulate an out-of-band dispatcher (recovery.RestartStaleInProgress)
 	// holding the shared agent.Manager claim for t1 — invisible to the
-	// engine's own dispatching/agentSteps maps.
+	// engine's own completion-routing state.
 	agents.SetDispatchClaimed("t1", true)
 
 	before := agents.CallCount()
@@ -5042,7 +5040,7 @@ func TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
 
 // TestDispatchEvent_SkipsClaimHeldByOutOfBandDispatcher verifies DispatchEvent
 // also treats a shared agent.Manager dispatch claim held for the task as busy,
-// even when the engine's own local `dispatching` marker is clear.
+// even when the workflow engine has no active local route for the task.
 func TestDispatchEvent_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
@@ -5100,7 +5098,7 @@ func TestExecRunAgent_ConsumesSupervisorSteer(t *testing.T) {
 }
 
 // TestExecRunAgent_TracksSpawnedStep verifies that execRunAgent populates
-// the engine.agentSteps map so HandleAgentComplete can route completions
+// the engine.agentRoutes map so HandleAgentComplete can route completions
 // back to the right step. Without this mapping, a delayed completion from
 // a duplicate agent would be credited to whatever CurrentStep happens to
 // be at the moment — the exact bug that corrupted review_plan.
@@ -5134,13 +5132,13 @@ func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
 
 	agentID := agents.LastID()
 	engine.mu.Lock()
-	gotEntry, tracked := engine.agentSteps[agentID]
+	gotEntry, tracked := engine.agentRoutes[agentID]
 	engine.mu.Unlock()
 	if !tracked {
-		t.Fatalf("agentSteps missing entry for agent %s", agentID)
+		t.Fatalf("agentRoutes missing entry for agent %s", agentID)
 	}
 	if gotEntry.stepID != "plan" {
-		t.Errorf("agentSteps[%s].stepID = %q, want plan", agentID, gotEntry.stepID)
+		t.Errorf("agentRoutes[%s].stepID = %q, want plan", agentID, gotEntry.stepID)
 	}
 
 	// Completing the agent must clear its mapping so the map doesn't grow
@@ -5150,10 +5148,10 @@ func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
 	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: agentID, Result: "done", Success: true})
 
 	engine.mu.Lock()
-	_, stillThere := engine.agentSteps[agentID]
+	_, stillThere := engine.agentRoutes[agentID]
 	engine.mu.Unlock()
 	if stillThere {
-		t.Errorf("agentSteps still has %s after completion — mapping leaked", agentID)
+		t.Errorf("agentRoutes still has %s after completion — mapping leaked", agentID)
 	}
 }
 
@@ -5291,7 +5289,7 @@ func TestExecRunAgent_PanicClearsDispatchingClaim(t *testing.T) {
 		return
 	}
 	if engine.hasTrackedAgentForTaskStep("t1", "triage") {
-		t.Fatal("dispatching claim leaked after panic")
+		t.Fatal("pending step start leaked after panic")
 	}
 }
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -268,7 +268,7 @@ type StepConfig struct {
 	// winner_attempt_id names.
 	BestOfNStep string `yaml:"best_of_n_step,omitempty" json:"bestOfNStep,omitempty"`
 
-	// run_agent: enforce the cumulative task cost budget before dispatching.
+	// run_agent: enforce the cumulative task cost budget before launch.
 	// Set on direct-dispatch steps (e.g. the best-of-N judge, which passes a
 	// pre-staged dir and so bypasses StartAgentWithAssignment's own budget
 	// enforcement) so the run fails closed to human-required instead of
@@ -326,7 +326,7 @@ func (d *Definition) Validate() error {
 
 // validateParallelStep enforces that a `parallel` step has at least two
 // run_agent children, no nested parallels, and globally-unique child IDs.
-// The constraints exist because the engine's step bookkeeping (agentSteps
+// The constraints exist because the engine's step bookkeeping (agentRoutes
 // map, ImportSidecar lookup, retry counter) is keyed by step ID — duplicates
 // would cause cross-step state to clobber each other.
 func validateParallelStep(s *Step, seenIDs map[string]bool) error {


### PR DESCRIPTION
## Motivation

> Changelog: refactor(agent): unify dispatch claim coordinators

Three dispatchers (the workflow cascade, `ResumeStalled`, and
`recovery.RestartStaleInProgress`) each decided "is this task's next run
already owned?" from their own local state — `agent.Manager`'s
`dispatchClaims`, `workflow.Engine`'s `dispatching` map, and the engine's
`agentSteps`/`dispatchingStep` bookkeeping. A prior pass added
`agent.DispatchClaim` and routed every real `StartAgent` call (implementation,
PR-fix, direct-dispatch, review) through it, but the workflow engine's own
cascade/`ResumeStalled` entry points still decided ownership from workflow-local
state alone — a claim held by `recovery.RestartStaleInProgress` (which dispatches
through `agentorch.Orchestrator`, outside the engine entirely) was invisible to
`DispatchEvent`/`ResumeStalled`, and vice versa. That residual split ownership
is the seam the guardrail-kill-reports-success / recovery-replays-failure races
live in.

## Implementation information

- `agent.Manager.IsDispatching(taskID)` — a read-only peek at the existing
  `dispatchClaims` map — is now the single ground truth for "is a dispatch
  claim held for this task", exposed to the workflow engine through a new
  `AgentLauncher.IsDispatching` method.
- `workflow.Engine`'s local `dispatching` map is removed entirely.
  `DispatchEvent` and `RescheduleRateLimitedAgent`'s busy checks, and
  `ResumeStalled`'s `tryMarkResumeDispatching`, now consult
  `agents.IsDispatching` directly instead of a separate engine-local marker.
- The engine's remaining per-step bookkeeping (`agentSteps`/`dispatchingStep`)
  is renamed to `agentRoutes`/`pendingStepStart` to make explicit that it
  answers a different question — completion routing / phantom-completion
  attribution for a specific step — not dispatch ownership. The `starting`
  map is unchanged: it serializes `StartWorkflowFromStepWithVars` entry, a
  workflow-lifecycle concern distinct from agent-process dispatch.
- Every `AgentLauncher` implementer (production `agentAdapter`, and the two
  test doubles in `internal/sybra/review` and `internal/sybra/svc_tasks_dispatch_test.go`)
  now implements `IsDispatching`.

Acceptance probe used during the fix (re-run of the failure report's rg
invariant):

```
rg -n "\b(dispatching|agentSteps|dispatchingStep)\b" internal/workflow/engine.go \
  internal/workflow/engine_dispatch.go internal/workflow/engine_events.go \
  internal/workflow/engine_steps_agent.go
```

now returns no matches — the engine's dispatch-ownership decisions route
through `agent.Manager.IsDispatching`, and the remaining per-step maps are
named for what they actually do.

## Supporting documentation

Closes the residual gap flagged by adversarial manual testing on
`Automaat/sybra#1541`.

Verification performed locally:

- `mise run verify` (full CI-aligned gate) — pass
- `go test -race ./internal/workflow/... ./internal/agent/... ./internal/sybra/... ./internal/recovery/...` — pass
- `go test -race -tags e2e -short -timeout 10m ./internal/sybra/...` — pass
- `golangci-lint run ./internal/agent/... ./internal/workflow/... ./internal/sybra/... ./internal/recovery/...` — 0 issues
- Added `TestIsDispatching`, `TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher`,
  `TestDispatchEvent_SkipsClaimHeldByOutOfBandDispatcher` covering the new
  cross-coordinator consult directly.

Closes https://github.com/Automaat/sybra/issues/1541

_Generated by Sybra harness_