### PR TITLE
fix(workflow): recover stale task branches before human-required

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -261,6 +261,10 @@ type agentEntry struct {
 	stepID string
 }
 
+type pendingRecovery struct {
+	onDecline func()
+}
+
 // Engine executes workflow definitions against tasks.
 type Engine struct {
 	store            *Store
@@ -285,14 +289,14 @@ type Engine struct {
 	logger           *slog.Logger
 	ctx              context.Context
 	mu               sync.Mutex
-	inflightMutexes  map[string]*sync.Mutex // taskID → advance serializer (parallel-aware)
-	dispatching      map[string]struct{}    // taskID → dispatch in progress
-	starting         map[string]struct{}    // taskID → StartWorkflowWithVars in progress
-	humanAction      map[string]struct{}    // taskID → HandleHumanAction in progress
-	agentSteps       map[string]agentEntry  // agentID → {taskID, stepID}
-	dispatchingStep  map[string]int         // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
-	cascadeDepth     map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
-	pendingRecovery  map[string]struct{}    // taskID → branch-conflict recovery deferred until the outer marker releases
+	inflightMutexes  map[string]*sync.Mutex     // taskID → advance serializer (parallel-aware)
+	dispatching      map[string]struct{}        // taskID → dispatch in progress
+	starting         map[string]struct{}        // taskID → StartWorkflowWithVars in progress
+	humanAction      map[string]struct{}        // taskID → HandleHumanAction in progress
+	agentSteps       map[string]agentEntry      // agentID → {taskID, stepID}
+	dispatchingStep  map[string]int             // "taskID|stepID" → run_agent dispatches in flight; held until execRunAgent returns, agentID not yet assigned
+	cascadeDepth     map[string]int             // taskID → synchronous cascade hop depth (recursion guard)
+	pendingRecovery  map[string]pendingRecovery // taskID → branch-conflict recovery deferred until the outer marker releases
 	resumeError      *logging.ErrorThrottle
 	demotionThrottle *logging.ErrorThrottle
 	maxTestAttempts  int           // testing → re-implement loop cap (0 → defaultTestAttempts)
@@ -322,7 +326,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		agentSteps:       make(map[string]agentEntry),
 		dispatchingStep:  make(map[string]int),
 		cascadeDepth:     make(map[string]int),
-		pendingRecovery:  make(map[string]struct{}),
+		pendingRecovery:  make(map[string]pendingRecovery),
 		resumeError:      logging.NewErrorThrottle(),
 		demotionThrottle: logging.NewErrorThrottle(),
 	}

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -3,11 +3,14 @@ package workflow
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 const (
@@ -978,6 +981,21 @@ func workflowRetryAfter(wf *Execution) (time.Time, bool) {
 // tracked. Either may be zero-valued (nil wf, empty stepID) for callers that
 // don't have them handy — the breaker simply stays inactive for that call.
 func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error, wf *Execution, stepID string) {
+	// A pre-agent-start rebase failure is the same "task branch conflicts
+	// with base" condition push_branch/create_pr hit further down the
+	// pipeline (see pushTaskBranch's project.ErrDivergedNeedsResolve branch) —
+	// try the same autonomous branch-conflict-fix recovery before parking the
+	// task on a human. currentStatus != "human-required" mirrors the sticky
+	// guard below: don't re-trigger recovery for a task a concurrent handler
+	// already parked.
+	if currentStatus != "human-required" && e.conflictRecovery != nil && errors.Is(err, worktreeerr.ErrRebaseFailed) {
+		e.logger.Info("workflow.start-failure.branch-conflict.recover", "task_id", taskID, "step", stepID)
+		if e.tryConflictRecovery(taskID) {
+			return
+		}
+		// Recovery declined (e.g. no linked PR, retry budget exhausted) — fall
+		// through to the normal classification/escalation below.
+	}
 	reason, permanent := ClassifyAgentStartError(err)
 	if reason == "" {
 		return

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -990,12 +990,18 @@ func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error, wf
 	// already parked.
 	if currentStatus != "human-required" && e.conflictRecovery != nil && errors.Is(err, worktreeerr.ErrRebaseFailed) {
 		e.logger.Info("workflow.start-failure.branch-conflict.recover", "task_id", taskID, "step", stepID)
-		if e.tryConflictRecovery(taskID) {
+		if e.tryConflictRecoveryWithFallback(taskID, func() {
+			e.surfaceStartFailureClassified(taskID, currentStatus, err, wf, stepID)
+		}) {
 			return
 		}
 		// Recovery declined (e.g. no linked PR, retry budget exhausted) — fall
 		// through to the normal classification/escalation below.
 	}
+	e.surfaceStartFailureClassified(taskID, currentStatus, err, wf, stepID)
+}
+
+func (e *Engine) surfaceStartFailureClassified(taskID, currentStatus string, err error, wf *Execution, stepID string) {
 	reason, permanent := ClassifyAgentStartError(err)
 	if reason == "" {
 		return

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -212,14 +212,20 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 // marker is held (the AdvanceStep tail, or a direct call), recovery is safe to
 // run inline and its own verdict is returned.
 func (e *Engine) tryConflictRecovery(taskID string) bool {
+	return e.tryConflictRecoveryWithFallback(taskID, func() {
+		e.escalatePendingConflictRecovery(taskID)
+	})
+}
+
+func (e *Engine) tryConflictRecoveryWithFallback(taskID string, onDecline func()) bool {
 	e.mu.Lock()
 	_, starting := e.starting[taskID]
 	_, dispatching := e.dispatching[taskID]
 	if starting || dispatching {
 		if e.pendingRecovery == nil {
-			e.pendingRecovery = make(map[string]struct{})
+			e.pendingRecovery = make(map[string]pendingRecovery)
 		}
-		e.pendingRecovery[taskID] = struct{}{}
+		e.pendingRecovery[taskID] = pendingRecovery{onDecline: onDecline}
 		e.mu.Unlock()
 		return true
 	}
@@ -261,9 +267,11 @@ func (e *Engine) TryConflictRecovery(taskID string) bool {
 func (e *Engine) QueueConflictRecoveryRetry(taskID string) {
 	e.mu.Lock()
 	if e.pendingRecovery == nil {
-		e.pendingRecovery = make(map[string]struct{})
+		e.pendingRecovery = make(map[string]pendingRecovery)
 	}
-	e.pendingRecovery[taskID] = struct{}{}
+	e.pendingRecovery[taskID] = pendingRecovery{onDecline: func() {
+		e.escalatePendingConflictRecovery(taskID)
+	}}
 	e.mu.Unlock()
 }
 
@@ -277,17 +285,25 @@ func (e *Engine) QueueConflictRecoveryRetry(taskID string) {
 // terminal outcome the inline divergence path produces.
 func (e *Engine) drainPendingConflictRecovery(taskID string) {
 	e.mu.Lock()
-	_, pending := e.pendingRecovery[taskID]
-	if pending {
+	pending, ok := e.pendingRecovery[taskID]
+	if ok {
 		delete(e.pendingRecovery, taskID)
 	}
 	e.mu.Unlock()
-	if !pending {
+	if !ok {
 		return
 	}
 	if e.conflictRecovery != nil && e.conflictRecovery(taskID) {
 		return // recovery cancelled this workflow and dispatched branch-conflict-fix
 	}
+	if pending.onDecline != nil {
+		pending.onDecline()
+		return
+	}
+	e.escalatePendingConflictRecovery(taskID)
+}
+
+func (e *Engine) escalatePendingConflictRecovery(taskID string) {
 	reason := "branch diverged from remote — needs manual conflict resolution (never force-pushed)"
 	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 		e.logger.Error("workflow.pr-tail.conflict-recovery.escalate", "task_id", taskID, "err", err)

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -328,7 +328,7 @@ func TestDrainPendingConflictRecovery_DeclineEscalates(t *testing.T) {
 	engine.SetConflictRecovery(func(string) bool { return false })
 
 	engine.mu.Lock()
-	engine.pendingRecovery["t1"] = struct{}{}
+	engine.pendingRecovery["t1"] = pendingRecovery{}
 	engine.mu.Unlock()
 
 	engine.drainPendingConflictRecovery("t1")

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -349,6 +349,55 @@ func TestSurfaceStartFailure_RebaseFailedRecoveryDeferredWhileMarkerHeld(t *test
 	}
 }
 
+// TestSurfaceStartFailure_RebaseFailedDeferredDeclineKeepsOriginalReason locks
+// the queued-start-failure regression from PR #1749: when recovery is deferred
+// under a held marker and later declines, the fallback must preserve the
+// original rebase-failed classification instead of using the generic PR-tail
+// divergence escalation.
+func TestSurfaceStartFailure_RebaseFailedDeferredDeclineKeepsOriginalReason(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "in-progress",
+		Workflow: &Execution{
+			WorkflowID:  "simple-task-implement",
+			CurrentStep: "run_agent",
+			State:       ExecRunning,
+			Variables:   map[string]string{},
+		},
+	})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine.SetConflictRecovery(func(string) bool { return false })
+
+	engine.mu.Lock()
+	engine.dispatching["t1"] = struct{}{}
+	engine.mu.Unlock()
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	taskInfo, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("GetTask(t1): %v", err)
+	}
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, taskInfo.Workflow, "run_agent")
+
+	engine.mu.Lock()
+	delete(engine.dispatching, "t1")
+	engine.mu.Unlock()
+	engine.drainPendingConflictRecovery("t1")
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "branch stale") {
+		t.Fatalf("reason %q missing rebase-failed classification", reason)
+	}
+	if strings.Contains(reason, "branch diverged from remote") {
+		t.Fatalf("reason %q used PR-tail divergence fallback", reason)
+	}
+}
+
 func TestSurfaceStartFailure_NilErrIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -255,6 +255,100 @@ func TestSurfaceStartFailure_RebaseFailedFlipsToHumanRequired(t *testing.T) {
 	}
 }
 
+// TestSurfaceStartFailure_RebaseFailedRecoversInsteadOfHumanRequired guards
+// the fix for sybra task d3be219e: a rebase failure detected before an agent
+// even starts (e.g. simple-task-implement's pre-dispatch worktree prep) must
+// try the same autonomous branch-conflict-fix recovery that push_branch/
+// create_pr already use for the equivalent project.ErrDivergedNeedsResolve
+// condition, instead of unconditionally parking the task human-required.
+func TestSurfaceStartFailure_RebaseFailedRecoversInsteadOfHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	var recoveredTaskID string
+	engine.SetConflictRecovery(func(taskID string) bool {
+		recoveredTaskID = taskID
+		return true
+	})
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
+
+	if recoveredTaskID != "t1" {
+		t.Errorf("conflictRecovery called with %q, want t1", recoveredTaskID)
+	}
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged in-progress (recovery owns the transition)", got.Status)
+	}
+	if reason := tasks.Reason("t1"); reason != "" {
+		t.Errorf("reason = %q, want empty (recovery owns the transition)", reason)
+	}
+}
+
+// TestSurfaceStartFailure_RebaseFailedRecoveryDeclinesFallsBackToHumanRequired
+// verifies the fallback: when branch-conflict-fix recovery declines (e.g. no
+// linked PR to fix, or its retry budget is spent), the task still lands
+// human-required with the original rebase-blocked reason — recovery is a
+// first attempt, not a silent swallow of a genuinely unrecoverable divergence.
+func TestSurfaceStartFailure_RebaseFailedRecoveryDeclinesFallsBackToHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine.SetConflictRecovery(func(string) bool { return false })
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", got.Status)
+	}
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "branch stale") {
+		t.Errorf("reason %q missing rebase-failed classification", reason)
+	}
+}
+
+// TestSurfaceStartFailure_RebaseFailedRecoveryDeferredWhileMarkerHeld guards
+// the same reentrancy trap execPushBranch's tryConflictRecovery already
+// solves (TestConflictRecovery_DeferredWhileMarkerHeld): if
+// surfaceStartFailure ever runs while a starting/dispatching marker is still
+// held for the task, recovery must be queued (not invoked inline) and the
+// task left untouched, so a later drainPendingConflictRecovery can run it
+// without re-entering StartWorkflow*/DispatchEvent against the held marker.
+func TestSurfaceStartFailure_RebaseFailedRecoveryDeferredWhileMarkerHeld(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	var calls int
+	engine.SetConflictRecovery(func(string) bool { calls++; return true })
+
+	engine.mu.Lock()
+	engine.dispatching["t1"] = struct{}{}
+	engine.mu.Unlock()
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
+
+	if calls != 0 {
+		t.Fatalf("recovery invoked inline under held marker (calls=%d); want deferred", calls)
+	}
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged in-progress while recovery is queued", got.Status)
+	}
+
+	engine.mu.Lock()
+	delete(engine.dispatching, "t1")
+	engine.mu.Unlock()
+	engine.drainPendingConflictRecovery("t1")
+	if calls != 1 {
+		t.Fatalf("recovery calls=%d after drain; want exactly 1", calls)
+	}
+}
+
 func TestSurfaceStartFailure_NilErrIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})


### PR DESCRIPTION
## Motivation
A task branch that had already diverged from its remote was being marked `human-required` when the pre-agent rebase failed. That is the wrong fallback for a recoverable branch-sync problem, since Sybra already has a branch-conflict recovery path that can repair this class of failure without operator intervention.

## Implementation information
- Updated the workflow so pre-agent stale-branch and rebase failures are routed through the existing branch-conflict recovery path before falling back to `human-required`.
- Kept the recovery behavior aligned with the successful `pr-fix`/branch-conflict flow used elsewhere, so equivalent divergence is handled consistently regardless of when it is detected.
- Added regression coverage for a diverged task branch that fails during pre-start sync, asserting Sybra dispatches recovery instead of stopping the task for human review.

_Generated by Sybra harness_