### PR TITLE
test(review): add AgentLauncher drift stubs

### DIFF
--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -950,6 +950,10 @@ func (f *failingAgentLauncher) DefaultProvider() string          { return "claud
 func (f *failingAgentLauncher) ProviderRateLimited(string) bool  { return false }
 func (f *failingAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (f *failingAgentLauncher) ProviderHealthy(string) bool      { return false }
+func (f *failingAgentLauncher) IsDispatching(string) bool        { return false }
+func (f *failingAgentLauncher) TryClaimDispatch(string) (workflow.DispatchClaim, bool) {
+	return nil, true
+}
 
 // newDispatchFailureHandler builds a Handler wired to a real workflow.Engine
 // whose "branch-conflict-fix" definition has a genuine run_agent first step


### PR DESCRIPTION
## Motivation

The `internal/sybra/review` **test package does not compile on main** — `go test -race ./...` fails before running any test. `failingAgentLauncher` is missing `TryClaimDispatch` and `IsDispatching`, which were added to `workflow.AgentLauncher`. `blockingAgentLauncher` got them; this helper didn't.

Classic semantic merge race: the PR adding the interface methods and the PR keeping `failingAgentLauncher` were each green in isolation, so per-PR CI never saw the combined breakage.

> Changelog: test(review): fix review test package compile drift

## Implementation

Add the two stub methods to `failingAgentLauncher`, mirroring `blockingAgentLauncher`. Restores compilation; full `go test ./internal/sybra/review/` passes.