### PR TITLE
fix(review): merge PR base ref, not hardcoded main

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1215,13 +1215,18 @@ func conflictPrompt(pr github.PullRequest) string {
 }
 
 func buildConflictPrompt(pr github.PullRequest, filesCtx string) string {
+	base := pr.BaseRefName
+	if base == "" {
+		base = "main"
+	}
+	baseRef := "refs/remotes/origin/" + base
 	return fmt.Sprintf(
 		"Fix merge conflicts on branch `%s` (PR #%d). "+
 			"Use the task body, PR diff, changed-file list, and current code as context, then merge.\n\n"+
 			"Steps:\n"+
 			"```bash\n"+
 			"git fetch origin\n"+
-			"git merge refs/remotes/origin/main\n"+
+			"git merge %s\n"+
 			"# If the merge stopped for conflicts: resolve every conflict preserving\n"+
 			"# the PR intent and upstream changes, run targeted tests for touched code,\n"+
 			"# then git add and git commit to complete the merge.\n"+
@@ -1233,7 +1238,7 @@ func buildConflictPrompt(pr github.PullRequest, filesCtx string) string {
 			"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
 			"```\n\n"+
 			"Rules:\n"+
-			"- Use `refs/remotes/origin/main` (not `origin/main`) to avoid ambiguous refs\n"+
+			"- Use `%s` (the PR's base branch, a full ref not a bare name) to avoid ambiguous refs\n"+
 			"- Push to `fork` (not `origin`) when a `fork` remote exists — the PR was opened from the fork\n"+
 			"- Do not force-push or rewrite existing commits — the merge commit and any conflict-resolution commits must be purely additive, and a plain push is expected to succeed\n"+
 			"- Resolve conflicts keeping BOTH sides' intent\n"+
@@ -1241,6 +1246,6 @@ func buildConflictPrompt(pr github.PullRequest, filesCtx string) string {
 			"- Stop only for a concrete blocker: binary conflict, missing secret/credential, deleted context you cannot reconstruct, or a semantic decision that the task/PR context does not answer\n"+
 			"- No investigation, no extra commits, no unrelated changes"+
 			"%s",
-		pr.HeadRefName, pr.Number, pr.HeadRefName, filesCtx,
+		pr.HeadRefName, pr.Number, baseRef, pr.HeadRefName, baseRef, filesCtx,
 	)
 }

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -950,6 +950,10 @@ func (f *failingAgentLauncher) DefaultProvider() string          { return "claud
 func (f *failingAgentLauncher) ProviderRateLimited(string) bool  { return false }
 func (f *failingAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (f *failingAgentLauncher) ProviderHealthy(string) bool      { return false }
+func (f *failingAgentLauncher) IsDispatching(string) bool        { return false }
+func (f *failingAgentLauncher) TryClaimDispatch(string) (workflow.DispatchClaim, bool) {
+	return nil, true
+}
 
 // newDispatchFailureHandler builds a Handler wired to a real workflow.Engine
 // whose "branch-conflict-fix" definition has a genuine run_agent first step

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -80,6 +80,23 @@ func TestConflictPrompt_UsesMergeNotRebase(t *testing.T) {
 	}
 }
 
+func TestConflictPrompt_UsesPRBaseRef(t *testing.T) {
+	t.Parallel()
+
+	prompt := buildConflictPrompt(github.PullRequest{
+		Number:      1178,
+		HeadRefName: "fix/example",
+		BaseRefName: "master",
+	}, "")
+
+	if !strings.Contains(prompt, "git merge refs/remotes/origin/master") {
+		t.Fatalf("conflict prompt did not merge the PR base ref (master):\n%s", prompt)
+	}
+	if strings.Contains(prompt, "origin/main") {
+		t.Fatalf("conflict prompt still references origin/main for a master-based PR:\n%s", prompt)
+	}
+}
+
 func TestBranchConflictPrompt_DetectsForkRemote(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

The pr-fix conflict-resolution agent was told to `git merge refs/remotes/origin/main` **regardless of the PR's actual base branch**. For a PR based on `master` (e.g. kuma), a release branch, or a fork, that merges the wrong ref — the agent reports *'no conflicts, already up to date'*, the pr-fix workflow **completes as a false success**, and the real conflict never clears. The monitor then stops re-dispatching a PR that is still `DIRTY` on GitHub, so it sits stuck with no agent working it.

Observed live: a `master`-based fork PR whose pr-fix 'succeeded' at 02:31 by merging `origin/main` (a no-op) while GitHub still reported `CONFLICTING`.

> Changelog: fix(review): pr-fix merges the PR's real base branch

## Implementation

`buildConflictPrompt` now interpolates `pr.BaseRefName` (falling back to `main`) into both the `git merge` command and the ambiguity rule — matching the deterministic merge path (`fix.go`) and the no-PR `branchConflictPrompt`, which already parameterize the base. New test `TestConflictPrompt_UsesPRBaseRef` asserts a `master`-based PR merges `origin/master` and never `origin/main`.

## Note
Stacked on #(the AgentLauncher drift-stubs PR) — the review test package doesn't compile on main without it; this PR's diff will show only the prompt change once that merges.