### PR TITLE
fix(recovery): guard restart-stale on dispatch

### DIFF
--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -39,6 +39,9 @@ func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
 		if r.Agents.HasRunningAgentForTask(t.ID) {
 			continue
 		}
+		if r.Agents.IsDispatching(t.ID) {
+			continue
+		}
 		// Don't re-dispatch to the same provider while it is rate-limited; do
 		// continue when failover can route this run to a healthy peer. (A
 		// rate-limited run is stalled in-progress by the completion handler, not


### PR DESCRIPTION
## Motivation

Part of the recovery-storm that produced false-completed tasks (done, no merged PR). `RestartStaleInProgress` gated only on `HasRunningAgentForTask` — not on an in-flight *dispatch*. During a provider rate-limit stall there is no running agent, so restart-stale fired while `ResumeStalled` or a branch-conflict recovery was mid-dispatch on the same task, producing overlapping recovery workflows that cancelled each other and churned worktrees (orphaning PRs).

> Changelog: fix(recovery): restart-stale defers to in-flight dispatch

## Implementation

Add `if r.Agents.IsDispatching(t.ID) { continue }` alongside the existing `HasRunningAgentForTask` guard, matching what `ResumeStalled` already checks. `recovery.Agents` is `*agent.Manager`, which already exposes `IsDispatching`, so no interface change. Strictly a tightening — closes Race 2 of the storm; the remaining races (CancelWorkflow ownership) are tracked separately.