### PR TITLE
fix(frontend): count only landed umbrella children

### DIFF
--- a/frontend/src/lib/umbrella-progress.test.ts
+++ b/frontend/src/lib/umbrella-progress.test.ts
@@ -29,21 +29,22 @@ describe('umbrella progress', () => {
     expect(normalizeIssueRef('Automaat/sybra#1213')).toBe('automaat/sybra#1213')
   })
 
-  it('counts done and total materialized children per umbrella', () => {
+  it('counts only genuinely-landed done children, not false completions', () => {
     const byUmbrella = buildUmbrellaProgress([
-      task({ id: 'c1', status: Status.StatusDone, umbrellaIssue: 'https://github.com/Automaat/sybra/issues/1213' }),
+      task({ id: 'c1', status: Status.StatusDone, outcome: 'merged', umbrellaIssue: 'https://github.com/Automaat/sybra/issues/1213' }),
       task({ id: 'c2', status: Status.StatusInProgress, umbrellaIssue: 'Automaat/sybra#1213' }),
-      task({ id: 'c3', status: Status.StatusDone, umbrellaIssue: 'Automaat/sybra#999' }),
-      task({ id: 'standalone', status: Status.StatusDone }),
+      task({ id: 'c4', status: Status.StatusDone, outcome: '', umbrellaIssue: 'Automaat/sybra#1213' }),
+      task({ id: 'c3', status: Status.StatusDone, outcome: 'merged_with_edits', umbrellaIssue: 'Automaat/sybra#999' }),
+      task({ id: 'standalone', status: Status.StatusDone, outcome: 'merged' }),
     ])
 
-    expect(byUmbrella.get('automaat/sybra#1213')).toEqual({ done: 1, total: 2 })
+    expect(byUmbrella.get('automaat/sybra#1213')).toEqual({ done: 1, total: 3 })
     expect(byUmbrella.get('automaat/sybra#999')).toEqual({ done: 1, total: 1 })
   })
 
   it('resolves tracker progress from its issue ref', () => {
     const byUmbrella = buildUmbrellaProgress([
-      task({ id: 'c1', status: Status.StatusDone, umbrellaIssue: 'Automaat/sybra#1213' }),
+      task({ id: 'c1', status: Status.StatusDone, outcome: 'merged', umbrellaIssue: 'Automaat/sybra#1213' }),
       task({ id: 'c2', status: Status.StatusTodo, umbrellaIssue: 'Automaat/sybra#1213' }),
     ])
 

--- a/frontend/src/lib/umbrella-progress.ts
+++ b/frontend/src/lib/umbrella-progress.ts
@@ -5,6 +5,12 @@ export interface UmbrellaProgress {
   total: number
 }
 
+const LANDED_OUTCOMES = new Set(['merged', 'merged_with_edits'])
+
+export function isGenuinelyDone(task: Task): boolean {
+  return task.status === 'done' && LANDED_OUTCOMES.has(task.outcome ?? '')
+}
+
 export function buildUmbrellaProgress(tasks: Task[]): Map<string, UmbrellaProgress> {
   const byUmbrella = new Map<string, UmbrellaProgress>()
   for (const task of tasks) {
@@ -12,7 +18,7 @@ export function buildUmbrellaProgress(tasks: Task[]): Map<string, UmbrellaProgre
     if (!key) continue
     const progress = byUmbrella.get(key) ?? { done: 0, total: 0 }
     progress.total += 1
-    if (task.status === 'done') progress.done += 1
+    if (isGenuinelyDone(task)) progress.done += 1
     byUmbrella.set(key, progress)
   }
   return byUmbrella

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -110,6 +110,7 @@ describe('TaskList', () => {
         },
         {
           ...mockTask('c1', 'Done child', 'done'),
+          outcome: 'merged',
           umbrellaIssue: 'Automaat/sybra#1213',
         },
         {


### PR DESCRIPTION
## Motivation

The umbrella progress shows **36/38 done** while GitHub shows **23/38** subissues closed. `buildUmbrellaProgress` counts every child with `status === 'done'`, including **false completions** — tasks flipped to done with `outcome === ''` and no merged PR (the closed-PR-not-done class). That over-counts shipped work.

> Changelog: fix(frontend): umbrella progress counts only landed children

## Implementation

Count a child as done only when its outcome actually landed (`merged` / `merged_with_edits`), via a new `isGenuinelyDone` helper. Test updated + a false-done case added. Full backend issue-state reconciliation (closed subissue as source of truth) tracked in #1756.