### PR TITLE
fix(recovery): escalate zero-run stale interactive tasks

### DIFF
--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -640,6 +640,76 @@ func TestRestartStaleInteractiveNoRunRedispatchesWhenProjectAssigned(t *testing.
 	}
 }
 
+// TestRestartStaleInteractiveModeMismatchRedispatches covers the Copilot
+// review finding on this PR: a task whose AgentMode was flipped to
+// interactive (e.g. by selfmonitor's flipAgentMode) after its last recorded
+// run was headless must not be silently swallowed by
+// recoverStaleInteractive's mode no-op — it should fall through to the
+// normal restart path instead of getting stuck in-progress forever.
+func TestRestartStaleInteractiveModeMismatchRedispatches(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("mode-mismatch stale", "", "interactive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	if _, err := tasks.Update(created.ID, task.Update{Status: &inProg, ProjectID: &projID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ag-headless-stale",
+		Mode:      "headless",
+		State:     string(agent.StateStopped),
+		StartedAt: time.Now().Add(-30 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Projects:     stubProjects{},
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress(context.Background())
+	wg.Wait()
+
+	if stub.startCalls != 1 {
+		t.Fatalf("dispatch count = %d, want 1", stub.startCalls)
+	}
+	if stub.lastMode != "interactive" {
+		t.Fatalf("mode = %q, want interactive", stub.lastMode)
+	}
+	if stub.lastOneShot {
+		t.Fatal("mode-mismatch stale restart must not force oneShot")
+	}
+}
+
 func TestRestartStaleInteractiveNoRunWithoutProjectEscalates(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -584,6 +584,120 @@ func TestRestartStaleInteractiveOneShotRestartsAsOneShot(t *testing.T) {
 	}
 }
 
+func TestRestartStaleInteractiveNoRunRedispatchesWhenProjectAssigned(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("zero-run stale", "", "interactive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	if _, err := tasks.Update(created.ID, task.Update{Status: &inProg, ProjectID: &projID}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Projects:     stubProjects{},
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress(context.Background())
+	wg.Wait()
+
+	if stub.startCalls != 1 {
+		t.Fatalf("dispatch count = %d, want 1", stub.startCalls)
+	}
+	if stub.lastMode != "interactive" {
+		t.Fatalf("mode = %q, want interactive", stub.lastMode)
+	}
+	if stub.lastOneShot {
+		t.Fatal("zero-run stale restart must not force oneShot")
+	}
+}
+
+func TestRestartStaleInteractiveNoRunWithoutProjectEscalates(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("zero-run stale missing project", "", "interactive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	if _, err := tasks.Update(created.ID, task.Update{Status: &inProg}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress(context.Background())
+	wg.Wait()
+
+	if stub.startCalls != 0 {
+		t.Fatalf("dispatch count = %d, want 0", stub.startCalls)
+	}
+	updated, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %s, want %s", updated.Status, task.StatusHumanRequired)
+	}
+	if !strings.Contains(updated.StatusReason, "no project could be assigned") {
+		t.Fatalf("status reason = %q, want no-project assignment guidance", updated.StatusReason)
+	}
+}
+
 // TestRestartStalePRFixRebaseFailedFlipsToHumanRequired covers the actual
 // path that had the infinite-retry bug this PR fixes: run_role=="pr-fix"
 // skips markRebaseBlocked (unlike the other three agent-start call sites) and

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -102,20 +102,10 @@ func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
 		// onAgentComplete.
 		oneShot := false
 		if t.AgentMode != "headless" {
-			lr := lastAgentRun(&t)
-			switch {
-			case lr == nil:
-				// No recorded run: recoverStaleInteractive would no-op on
-				// lr == nil, silently skipping this task forever. Fall
-				// through to the normal dispatch path below so a stale
-				// interactive task with zero runs actually gets restarted.
-				r.Logger.Info("restart-stale.no-run-fallthrough", "task_id", t.ID)
-			case !lr.OneShot:
-				r.recoverStaleInteractive(&t)
+			var handled bool
+			oneShot, handled = r.resolveInteractiveStaleRestart(&t)
+			if handled {
 				continue
-			default:
-				oneShot = true
-				r.Logger.Info("restart-stale.interactive-oneshot", "task_id", t.ID)
 			}
 		}
 		if t.ProjectID == "" {
@@ -257,6 +247,40 @@ func (r *Recovery) surfaceStartFailure(taskID string, currentStatus task.Status,
 		StatusReason: task.Ptr(reason),
 	}); uErr != nil {
 		r.Logger.Error("restart-stale.surface", "task_id", taskID, "err", uErr)
+	}
+}
+
+// resolveInteractiveStaleRestart decides how a stale interactive task's
+// last agent run should be handled: recovered in place via
+// recoverStaleInteractive (handled=true, caller should skip re-dispatch), or
+// fallen through to the normal restart/escalation path below with the
+// resolved oneShot flag.
+func (r *Recovery) resolveInteractiveStaleRestart(t *task.Task) (oneShot, handled bool) {
+	lr := lastAgentRun(t)
+	switch {
+	case lr == nil:
+		// No recorded run: recoverStaleInteractive would no-op on
+		// lr == nil, silently skipping this task forever. Fall
+		// through to the normal dispatch path below so a stale
+		// interactive task with zero runs actually gets restarted.
+		r.Logger.Info("restart-stale.no-run-fallthrough", "task_id", t.ID)
+		return false, false
+	case lr.Mode != "interactive":
+		// Last run's mode doesn't match the task's current
+		// interactive AgentMode (e.g. flipped by selfmonitor's
+		// flipAgentMode after a headless run). recoverStaleInteractive
+		// would no-op on the mode mismatch, silently leaving the task
+		// stuck in-progress forever. Fall through to the normal
+		// restart path instead.
+		r.Logger.Info("restart-stale.mode-mismatch-fallthrough",
+			"task_id", t.ID, "last_run_mode", lr.Mode)
+		return false, false
+	case !lr.OneShot:
+		r.recoverStaleInteractive(t)
+		return false, true
+	default:
+		r.Logger.Info("restart-stale.interactive-oneshot", "task_id", t.ID)
+		return true, false
 	}
 }
 

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -2,6 +2,7 @@ package recovery
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -102,15 +103,20 @@ func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
 		oneShot := false
 		if t.AgentMode != "headless" {
 			lr := lastAgentRun(&t)
-			if lr == nil || !lr.OneShot {
+			if lr == nil {
+				r.Logger.Info("recover-stale.no-run-fallthrough", "task_id", t.ID)
+			} else if !lr.OneShot {
 				r.recoverStaleInteractive(&t)
 				continue
+			} else {
+				oneShot = true
+				r.Logger.Info("restart-stale.interactive-oneshot", "task_id", t.ID)
 			}
-			oneShot = true
-			r.Logger.Info("restart-stale.interactive-oneshot", "task_id", t.ID)
 		}
 		if t.ProjectID == "" {
+			err := fmt.Errorf("task %s has no project_id: refusing to restart stale agent without isolated worktree: %w", t.ID, workflow.ErrNoProjectAssigned)
 			r.Logger.Warn("restart-stale.skip", "task_id", t.ID, "reason", "no project_id")
+			r.surfaceStartFailure(t.ID, t.Status, err)
 			continue
 		}
 		r.Logger.Info("restart.stale-in-progress", "task_id", t.ID, "run_role", t.RunRole)

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -103,12 +103,17 @@ func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
 		oneShot := false
 		if t.AgentMode != "headless" {
 			lr := lastAgentRun(&t)
-			if lr == nil {
-				r.Logger.Info("recover-stale.no-run-fallthrough", "task_id", t.ID)
-			} else if !lr.OneShot {
+			switch {
+			case lr == nil:
+				// No recorded run: recoverStaleInteractive would no-op on
+				// lr == nil, silently skipping this task forever. Fall
+				// through to the normal dispatch path below so a stale
+				// interactive task with zero runs actually gets restarted.
+				r.Logger.Info("restart-stale.no-run-fallthrough", "task_id", t.ID)
+			case !lr.OneShot:
 				r.recoverStaleInteractive(&t)
 				continue
-			} else {
+			default:
 				oneShot = true
 				r.Logger.Info("restart-stale.interactive-oneshot", "task_id", t.ID)
 			}
@@ -116,7 +121,13 @@ func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
 		if t.ProjectID == "" {
 			err := fmt.Errorf("task %s has no project_id: refusing to restart stale agent without isolated worktree: %w", t.ID, workflow.ErrNoProjectAssigned)
 			r.Logger.Warn("restart-stale.skip", "task_id", t.ID, "reason", "no project_id")
-			r.surfaceStartFailure(t.ID, t.Status, err)
+			// Surface off the scan loop, matching the other two
+			// surfaceStartFailure call sites in this function, so a
+			// file-backed Tasks.Update never blocks the fleet-wide sweep.
+			taskID, currentStatus := t.ID, t.Status
+			r.WG.Go(func() {
+				r.surfaceStartFailure(taskID, currentStatus, err)
+			})
 			continue
 		}
 		r.Logger.Info("restart.stale-in-progress", "task_id", t.ID, "run_role", t.RunRole)


### PR DESCRIPTION
## Motivation

Interactive tasks stuck `in-progress` with zero agent runs and no `project_id` were silently skipped by `RestartStaleInProgress` forever — no restart, no escalation. The lost agent stayed lost with no path to human attention.

> Changelog: fix(recovery): escalate zero-run stale interactive tasks

## Implementation information

- `RestartStaleInProgress` (`internal/recovery/stale.go`) previously fell through to the missing-`project_id` branch silently on a zero-run interactive task; it now calls `surfaceStartFailure` with `workflow.ErrNoProjectAssigned`, which flips the task to `human-required` with a status reason via `workflow.ClassifyAgentStartError`.
- Added coverage for both branches: zero-run stale task with a `project_id` redispatches normally (not forced one-shot), and without one it escalates to `human-required`.

## Supporting documentation

N/A

_Generated by Sybra harness_