### PR TITLE
test(recovery): cover restart-stale dispatch guard

### DIFF
--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -385,6 +385,70 @@ func TestRestartStaleSkipsRateLimitedProvider(t *testing.T) {
 	}
 }
 
+func TestRestartStaleSkipsWhileDispatchInFlight(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("dispatching", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	if _, err := tasks.Update(created.ID, task.Update{Status: &inProg, ProjectID: &projID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ag-1",
+		Mode:      "headless",
+		Provider:  "claude",
+		State:     string(agent.StateStopped),
+		StartedAt: time.Now().Add(-30 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	claim, ok := agents.TryClaimDispatch(created.ID)
+	if !ok {
+		t.Fatal("expected to acquire dispatch claim")
+	}
+	defer claim.Release()
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress(context.Background())
+	wg.Wait()
+
+	if stub.startCalls != 0 {
+		t.Errorf("orchestrator was called %d times; want 0 (dispatch in flight)", stub.startCalls)
+	}
+}
+
 // TestRestartStaleSteerBypassesRecentRunDebounce verifies the recovery half of
 // a watchdog headless nudge: a pending SupervisorSteer makes a just-stopped task
 // re-dispatch immediately instead of waiting out the recent-run debounce. The


### PR DESCRIPTION
## Motivation

Follow-up to the restart-stale dispatch guard (merged in #1757). Copilot noted the new `IsDispatching` guard was behaviorally important but untested. This adds the coverage.

> Changelog: test(recovery): cover restart-stale dispatch-in-flight guard

## Implementation

`TestRestartStaleSkipsWhileDispatchInFlight`: builds a stale in-progress headless task (old run, past the debounce), holds a real dispatch claim via `TryClaimDispatch` so `IsDispatching` is true, then asserts `RestartStaleInProgress` does not dispatch (`startCalls == 0`) — proving it defers to a concurrent ResumeStalled/branch-conflict recovery instead of racing it. Mirrors the existing `TestRestartStaleSkipsRateLimitedProvider` setup.