### PR TITLE
fix(workflow): gate fix_review on review verdict

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -128,7 +128,7 @@ export class Condition {
     "field": string;
 
     /**
-     * "equals", "not_equals", "contains", "not_contains", "exists", "in", "not_in"
+     * "equals", "not_equals", "contains", "not_contains", "starts_with", "exists", "in", "not_in"
      */
     "operator": string;
     "value": string;

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -97,11 +97,17 @@ steps:
           2. Run /pr-review against that patch and the worktree source
           3. Save the full review to .sybra-review-{{.Task.ID}}.md
 
-        The FIRST line of .sybra-review-{{.Task.ID}}.md MUST be a verdict
-        marker: `Review Verdict: CLEAN` if there are zero actionable
-        (critical/high/medium severity) findings, or
-        `Review Verdict: NEEDS_FIXES` otherwise. This line gates whether a
-        fix-review agent runs next — get it right.
+        The FIRST line of .sybra-review-{{.Task.ID}}.md MUST be exactly one
+        verdict marker:
+          - `Review Verdict: CLEAN` when /pr-review found no bug-risk,
+            correctness, reliability, security, data-loss, test-breaking,
+            or otherwise actionable implementation issue that should be fixed
+            before PR creation. Style-only comments, simplification ideas,
+            unused-code observations that do not affect behavior, and optional
+            consistency suggestions stay CLEAN.
+          - `Review Verdict: NEEDS_FIXES` when any /pr-review finding should
+            trigger code changes before PR creation.
+        This line gates whether a fix-review agent runs next — get it right.
 
         Do NOT submit anything to GitHub. Sybra will ingest
         .sybra-review-{{.Task.ID}}.md as the code_review sidecar
@@ -138,11 +144,15 @@ steps:
           2. Run /staff-code-review against that patch and the worktree source
           3. Save the full review to .sybra-review-{{.Task.ID}}.md
 
-        The FIRST line of .sybra-review-{{.Task.ID}}.md MUST be a verdict
-        marker: `Review Verdict: CLEAN` if there are zero actionable
-        (critical/high/medium severity) findings, or
-        `Review Verdict: NEEDS_FIXES` otherwise. This line gates whether a
-        fix-review agent runs next — get it right.
+        The FIRST line of .sybra-review-{{.Task.ID}}.md MUST be exactly one
+        verdict marker, mapped from /staff-code-review's native verdict:
+          - `Review Verdict: CLEAN` for APPROVE, and for
+            APPROVE_WITH_COMMENTS only when every comment is low-severity,
+            style-only, optional, or non-actionable before PR creation.
+          - `Review Verdict: NEEDS_FIXES` for REQUEST_CHANGES, or for
+            APPROVE_WITH_COMMENTS when any critical/high/medium severity
+            finding should trigger code changes before PR creation.
+        This line gates whether a fix-review agent runs next — get it right.
 
         Do NOT submit anything to GitHub. Sybra will ingest
         .sybra-review-{{.Task.ID}}.md as the code_review sidecar
@@ -184,12 +194,12 @@ steps:
     config:
       check:
         field: task.code_review
-        operator: contains
+        operator: starts_with
         value: 'Review Verdict: CLEAN'
     next:
       - when:
           field: task.code_review
-          operator: contains
+          operator: starts_with
           value: 'Review Verdict: CLEAN'
         goto: done_review
       - goto: fix_review

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -97,6 +97,12 @@ steps:
           2. Run /pr-review against that patch and the worktree source
           3. Save the full review to .sybra-review-{{.Task.ID}}.md
 
+        The FIRST line of .sybra-review-{{.Task.ID}}.md MUST be a verdict
+        marker: `Review Verdict: CLEAN` if there are zero actionable
+        (critical/high/medium severity) findings, or
+        `Review Verdict: NEEDS_FIXES` otherwise. This line gates whether a
+        fix-review agent runs next — get it right.
+
         Do NOT submit anything to GitHub. Sybra will ingest
         .sybra-review-{{.Task.ID}}.md as the code_review sidecar
         after you exit — you do not need to call sybra-cli yourself.
@@ -132,6 +138,12 @@ steps:
           2. Run /staff-code-review against that patch and the worktree source
           3. Save the full review to .sybra-review-{{.Task.ID}}.md
 
+        The FIRST line of .sybra-review-{{.Task.ID}}.md MUST be a verdict
+        marker: `Review Verdict: CLEAN` if there are zero actionable
+        (critical/high/medium severity) findings, or
+        `Review Verdict: NEEDS_FIXES` otherwise. This line gates whether a
+        fix-review agent runs next — get it right.
+
         Do NOT submit anything to GitHub. Sybra will ingest
         .sybra-review-{{.Task.ID}}.md as the code_review sidecar
         after you exit — you do not need to call sybra-cli yourself.
@@ -159,6 +171,27 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - goto: route_review_verdict
+
+  # Mirrors route_critique_verdict in simple-task-plan: a clean review (zero
+  # actionable findings) skips the fix_review agent entirely — the exact
+  # analog of #1490, which gated address_critique on the plan-critique
+  # verdict but left review ungated (#1524). Saves ~1 wasted agent run per
+  # clean-review task, which is nearly every landing.
+  - id: route_review_verdict
+    name: Route on Review Verdict
+    type: condition
+    config:
+      check:
+        field: task.code_review
+        operator: contains
+        value: 'Review Verdict: CLEAN'
+    next:
+      - when:
+          field: task.code_review
+          operator: contains
+          value: 'Review Verdict: CLEAN'
+        goto: done_review
       - goto: fix_review
 
   - id: fix_review

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -551,6 +551,51 @@ func TestBuiltinSimpleTaskReview_MaybeReviewTrivialRouting(t *testing.T) {
 	}
 }
 
+// TestBuiltinSimpleTaskReview_RouteReviewVerdictSkipsFixReviewOnClean locks
+// the #1524 fix: a clean review (zero actionable findings) routes straight
+// to done_review, skipping the fix_review agent entirely — the review-side
+// analog of route_critique_verdict's plan-critique gate (#1490).
+func TestBuiltinSimpleTaskReview_RouteReviewVerdictSkipsFixReviewOnClean(t *testing.T) {
+	t.Parallel()
+
+	review := mustBuiltinDefinition(t, "simple-task-review")
+	step := review.StepByID("route_review_verdict")
+	if step == nil {
+		t.Fatal("route_review_verdict step not found in simple-task-review")
+	}
+
+	cases := []struct {
+		name       string
+		codeReview string
+		want       string
+	}{
+		{
+			name:       "clean_skips_fix_review",
+			codeReview: "Review Verdict: CLEAN\n\nNo actionable findings.\n",
+			want:       "done_review",
+		},
+		{
+			name:       "needs_fixes_routes_to_fix_review",
+			codeReview: "Review Verdict: NEEDS_FIXES\n\nfoo.go:12: nil deref risk.\n",
+			want:       "fix_review",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, map[string]string{
+				"task.code_review": tc.codeReview,
+			})
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuiltinDefinitions(t *testing.T) {
 	t.Parallel()
 	defs, err := BuiltinDefinitions()

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -579,6 +579,13 @@ func TestBuiltinSimpleTaskReview_RouteReviewVerdictSkipsFixReviewOnClean(t *test
 			codeReview: "Review Verdict: NEEDS_FIXES\n\nfoo.go:12: nil deref risk.\n",
 			want:       "fix_review",
 		},
+		{
+			name: "needs_fixes_echoing_clean_marker_routes_to_fix_review",
+			codeReview: "Review Verdict: NEEDS_FIXES\n\n" +
+				"This is not a Review Verdict: CLEAN pass; see the finding below.\n\n" +
+				"foo.go:12: nil deref risk.\n",
+			want: "fix_review",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -134,6 +134,7 @@ func checkEnumOperator(field, operator string) bool {
 //   - exists / equals / not_equals: single-value checks
 //   - contains / not_contains: for task.tags, exact tag membership in the
 //     comma-joined tag list; for other fields, substring check.
+//   - starts_with: prefix check after trimming surrounding whitespace.
 //   - in / not_in: membership check — condition value is a comma-separated
 //     list of allowed values, field must match one of them. Use this when
 //     the field is a single scalar (e.g. pr.issue_kind) and the trigger
@@ -152,6 +153,8 @@ func EvalCondition(c Condition, fields map[string]string) bool {
 		return containsFieldValue(c.Field, val, c.Value)
 	case "not_contains":
 		return !containsFieldValue(c.Field, val, c.Value)
+	case "starts_with":
+		return strings.HasPrefix(strings.TrimSpace(val), c.Value)
 	case "in":
 		return inList(val, c.Value)
 	case "not_in":

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -29,6 +29,7 @@ var KnownTriggerFields = map[string]bool{
 	"task.pr_number":               true,
 	"task.reviewed":                true,
 	"task.plan_critique":           true,
+	"task.code_review":             true,
 	"task.replan_count":            true,
 	// Supplied as extras by DispatchEvent("pr.event", ...) callers in
 	// app_reviews.go and svc_integrations.go.

--- a/internal/workflow/condition_test.go
+++ b/internal/workflow/condition_test.go
@@ -7,6 +7,7 @@ func TestEvalCondition(t *testing.T) {
 		"task.status": "in-progress",
 		"task.tags":   "backend,auth",
 		"task.title":  "implement auth middleware",
+		"task.review": " \nReview Verdict: CLEAN\n\nNo findings.",
 		"empty":       "",
 	}
 
@@ -49,6 +50,16 @@ func TestEvalCondition(t *testing.T) {
 			name: "contains keeps substring behavior for text fields",
 			cond: Condition{Field: "task.title", Operator: "contains", Value: "auth"},
 			want: true,
+		},
+		{
+			name: "starts_with matches trimmed prefix",
+			cond: Condition{Field: "task.review", Operator: "starts_with", Value: "Review Verdict: CLEAN"},
+			want: true,
+		},
+		{
+			name: "starts_with rejects later substring",
+			cond: Condition{Field: "task.title", Operator: "starts_with", Value: "auth"},
+			want: false,
 		},
 		{
 			name: "not_contains passes when tag absent",
@@ -229,6 +240,8 @@ func TestEvalConditions_AllMustMatch(t *testing.T) {
 //   - not_equals "x"  → true  ("" != "x")
 //   - contains ""     → true  (every string contains empty substring)
 //   - contains "x"    → false
+//   - starts_with ""  → true  (every string starts with empty string)
+//   - starts_with "x" → false
 //   - exists          → false (presence-check)
 //   - in "a,b"        → false (zero value not in list)
 //   - in ",a,b"       → true  (empty string IS in the csv-list containing "")
@@ -251,6 +264,8 @@ func TestEvalCondition_UndefinedField(t *testing.T) {
 		{"contains", "x", false},
 		{"not_contains", "x", true},
 		{"not_contains", "", false},
+		{"starts_with", "", true},
+		{"starts_with", "x", false},
 		{"exists", "", false},
 		{"exists", "x", false},
 		{"in", "a,b,c", false},

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -675,6 +675,7 @@ func taskFields(t TaskInfo) map[string]string {
 		"task.branch":                  t.Branch,
 		"task.reviewed":                strconv.FormatBool(t.Reviewed),
 		"task.plan_critique":           t.PlanCritique,
+		"task.code_review":             t.CodeReview,
 	}
 	if t.PRNumber > 0 {
 		fields["task.pr_number"] = strconv.Itoa(t.PRNumber)

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -67,7 +67,7 @@ type Trigger struct {
 // Condition is a field-operator-value check.
 type Condition struct {
 	Field    string `yaml:"field" json:"field"`       // "task.tags", "task.status", "task.agent_mode"
-	Operator string `yaml:"operator" json:"operator"` // "equals", "not_equals", "contains", "not_contains", "exists", "in", "not_in"
+	Operator string `yaml:"operator" json:"operator"` // "equals", "not_equals", "contains", "not_contains", "starts_with", "exists", "in", "not_in"
 	Value    string `yaml:"value" json:"value"`
 }
 


### PR DESCRIPTION
## Motivation

`fix_review` runs unconditionally after every review step, including on clean reviews with no actionable findings. This wastes resources by triggering a fix-review agent on nearly every landing task (~1 Sonnet run per clean review). #1490 already addressed the same issue for plan critique; review verdict gating was left incomplete.

## Implementation information

Added verdict gate to `fix_review` in `internal/workflow/builtin/simple-task-review.yaml`, mirroring the #1490 pattern. The `route_review_verdict` gate ensures the fix_review step only runs when the review yields actionable findings.

Closes https://github.com/Automaat/sybra/issues/1524

_Generated by Sybra harness_