### PR TITLE
fix(promptlab): stabilize proposal dedup identity

### DIFF
--- a/internal/promptlab/model.go
+++ b/internal/promptlab/model.go
@@ -103,12 +103,8 @@ type RunResult struct {
 	Dropped      int           `json:"dropped,omitempty"`
 }
 
-// proposalID is content-addressed on the subject, evidence window (sample
-// count + effect size), and variant intent — stable across runs over
-// unchanged evidence, with no wall-clock input, so re-running the loop before
-// new data lands never re-proposes the same idea under a new ID.
 func proposalID(s WeakSubject, intent string) string {
-	raw := fmt.Sprintf("%s|%s|%d|%.3f|%s", s.Role, s.WorkflowStep, s.Samples, s.EffectSize, intent)
+	raw := fmt.Sprintf("%s|%s|%s", s.Role, s.WorkflowStep, intent)
 	sum := sha256.Sum256([]byte(raw))
 	return "pl-" + hex.EncodeToString(sum[:])[:12]
 }

--- a/internal/promptlab/model_test.go
+++ b/internal/promptlab/model_test.go
@@ -16,10 +16,17 @@ func TestProposalIDStable(t *testing.T) {
 	if id1 == proposalID(s, "restructure-context") {
 		t.Fatalf("proposalID collided across distinct intents")
 	}
+	drifted := s
+	drifted.Samples = 13
+	drifted.EffectSize = 0.301
+	if id1 != proposalID(drifted, "tighten-instructions") {
+		t.Fatalf("proposalID must stay stable as evidence magnitude drifts")
+	}
+
 	other := s
-	other.Samples = 13
+	other.WorkflowStep = "review"
 	if id1 == proposalID(other, "tighten-instructions") {
-		t.Fatalf("proposalID collided across distinct sample counts")
+		t.Fatalf("proposalID collided across distinct workflow steps")
 	}
 }
 


### PR DESCRIPTION
## Motivation

Prompt Lab was constantly filing new tasks and overwhelming the board.

The ticker files a local task per proposal each run, deduping on a `Proposal ID` embedded in the task body. That ID was content-addressed on `Samples` and `EffectSize`:

```go
raw := fmt.Sprintf("%s|%s|%d|%.3f|%s", s.Role, s.WorkflowStep, s.Samples, s.EffectSize, intent)
```

Both are evidence magnitudes recomputed from fleet run records every tick. Since the fleet is always producing runs, sample count increments and effect size drifts on essentially every tick, so a fresh ID was minted each tick for the *same underlying weak subject*. `findExistingPromptLabProposal` never matched, and a new task was filed every tick (up to `max_proposals_per_run`). The old code comment claimed "stable across unchanged evidence" — but evidence is never unchanged.

> Changelog: fix(promptlab): stabilize proposal dedup identity

## Implementation information

- `proposalID` now content-addresses on the proposal's **stable identity only**: role, workflow step, and intent. Evidence magnitude is excluded, so there is one open proposal per `(role, step, intent)` until it is resolved.
- Updated `TestProposalIDStable`, which had *encoded* the bug (asserted the ID must change when `Samples` changed). It now asserts stability across magnitude drift and distinctness across workflow steps.

## Supporting documentation

Two follow-ups, not addressed here:
1. Already-filed duplicate `prompt-lab-proposal` tasks are not auto-cleaned; they need a one-off bulk close.
2. `findExistingPromptLabProposal` skips terminal tasks, so a completed proposal for a still-weak role is re-filed on the next tick — much slower than the tick-frequency flood, and arguably intended. Left as-is.