### PR TITLE
feat(agent): sandbox-allow shared build caches

### DIFF
--- a/internal/agent/agent_sandbox.sb
+++ b/internal/agent/agent_sandbox.sb
@@ -2,7 +2,7 @@
 ;; Sybra agent OS-level process sandbox (darwin, sandbox-exec).
 ;;
 ;; Reads and everything else stay unrestricted: only file-write* operations
-;; are denied by default and re-allowed for the three roots supplied via -D
+;; are denied by default and re-allowed for the four roots supplied via -D
 ;; at spawn time (see procsandbox_darwin.go). This is enforce-mode only —
 ;; report mode validates and logs the same roots without ever passing this
 ;; profile to sandbox-exec, so a bug here cannot regress a default-posture
@@ -13,4 +13,5 @@
 (allow file-write*
   (subpath (param "WORKTREE"))
   (subpath (param "SANDBOX_HOME"))
-  (subpath (param "TMP")))
+  (subpath (param "TMP"))
+  (subpath (param "SHARED_CACHE")))

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -149,6 +149,10 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 		return cfg, nil, err
 	}
 
+	if err := m.injectSharedBuildCache(&cfg); err != nil {
+		return cfg, nil, err
+	}
+
 	if err := m.injectProcessSandbox(&cfg); err != nil {
 		return cfg, nil, err
 	}
@@ -232,6 +236,32 @@ func (m *Manager) injectGolangciCache(cfg *RunConfig) error {
 	return nil
 }
 
+func sharedBuildCacheDir() string {
+	return filepath.Join(config.HomeDir(), "shared-cache")
+}
+
+func (m *Manager) injectSharedBuildCache(cfg *RunConfig) error {
+	if cfg.resolvedSandboxHome == "" {
+		return nil
+	}
+	base := sharedBuildCacheDir()
+	goBuild := filepath.Join(base, "go-build")
+	goMod := filepath.Join(base, "go-mod")
+	npm := filepath.Join(base, "npm")
+	for _, d := range []string{goBuild, goMod, npm} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return fmt.Errorf("agent.Run: create shared build cache %q: %w", d, err)
+		}
+	}
+	cfg.ExtraEnv = stripEnvKeys(cfg.ExtraEnv, "GOCACHE", "GOMODCACHE", "npm_config_cache")
+	cfg.ExtraEnv = append(cfg.ExtraEnv,
+		"GOCACHE="+goBuild,
+		"GOMODCACHE="+goMod,
+		"npm_config_cache="+npm,
+	)
+	return nil
+}
+
 // injectProcessSandbox resolves this run's OS-level process-sandbox posture
 // and allowed write roots (worktree, per-task sandbox home, tmp) into
 // cfg.sandbox, applied later by wrapInvocation at each provider spawn site.
@@ -259,6 +289,7 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		sandboxHome = worktree
 	}
 	tmp := os.TempDir()
+	sharedCache := sharedBuildCacheDir()
 
 	if !sandboxExecAvailable() {
 		if mode == "enforce" {
@@ -279,7 +310,7 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		// representative of what enforce would allow — but never fail the
 		// run closed on a canonicalization error; fall back to logging the
 		// raw (unresolved) roots instead.
-		logWorktree, logSandboxHome, logTmp := worktree, sandboxHome, tmp
+		logWorktree, logSandboxHome, logTmp, logShared := worktree, sandboxHome, tmp, sharedCache
 		if canon, err := canonicalizeRoot(worktree); err == nil {
 			logWorktree = canon
 		} else {
@@ -295,8 +326,13 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		} else {
 			m.logger.Warn("agent.sandbox.report.canonicalize_failed", "task_id", cfg.TaskID, "root", "tmp", "err", err)
 		}
+		if canon, err := canonicalizeRoot(sharedCache); err == nil {
+			logShared = canon
+		} else {
+			m.logger.Warn("agent.sandbox.report.canonicalize_failed", "task_id", cfg.TaskID, "root", "shared_cache", "err", err)
+		}
 		m.logger.Info("agent.sandbox.report", "task_id", cfg.TaskID,
-			"worktree", logWorktree, "sandbox_home", logSandboxHome, "tmp", logTmp)
+			"worktree", logWorktree, "sandbox_home", logSandboxHome, "tmp", logTmp, "shared_cache", logShared)
 		cfg.sandbox = sandboxSpec{mode: "off"}
 		return nil
 	}
@@ -316,6 +352,12 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)
 		return fmt.Errorf("agent.Run: sandbox tmp root: %w", err)
 	}
+	_ = os.MkdirAll(sharedCache, 0o755)
+	canonSharedCache, err := canonicalizeRoot(sharedCache)
+	if err != nil {
+		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)
+		return fmt.Errorf("agent.Run: sandbox shared-cache root: %w", err)
+	}
 	profilePath, err := materializeSandboxProfile()
 	if err != nil {
 		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)
@@ -327,10 +369,12 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		worktree:    canonWorktree,
 		sandboxHome: canonSandboxHome,
 		tmp:         canonTmp,
+		sharedCache: canonSharedCache,
 		profilePath: profilePath,
 	}
 	m.logger.Info("agent.sandbox.enforce", "task_id", cfg.TaskID,
-		"worktree", canonWorktree, "sandbox_home", canonSandboxHome, "tmp", canonTmp, "profile", profilePath)
+		"worktree", canonWorktree, "sandbox_home", canonSandboxHome, "tmp", canonTmp,
+		"shared_cache", canonSharedCache, "profile", profilePath)
 	return nil
 }
 

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -352,7 +352,10 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)
 		return fmt.Errorf("agent.Run: sandbox tmp root: %w", err)
 	}
-	_ = os.MkdirAll(sharedCache, 0o755)
+	if err := os.MkdirAll(sharedCache, 0o755); err != nil {
+		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)
+		return fmt.Errorf("agent.Run: create sandbox shared-cache root: %w", err)
+	}
 	canonSharedCache, err := canonicalizeRoot(sharedCache)
 	if err != nil {
 		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)

--- a/internal/agent/procsandbox_darwin.go
+++ b/internal/agent/procsandbox_darwin.go
@@ -97,12 +97,13 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 	if cfg == nil || cfg.sandbox.mode != "enforce" {
 		return name, args
 	}
-	wrapped := make([]string, 0, len(args)+9)
+	wrapped := make([]string, 0, len(args)+11)
 	wrapped = append(wrapped,
 		"-f", cfg.sandbox.profilePath,
 		"-D", "WORKTREE="+cfg.sandbox.worktree,
 		"-D", "SANDBOX_HOME="+cfg.sandbox.sandboxHome,
 		"-D", "TMP="+cfg.sandbox.tmp,
+		"-D", "SHARED_CACHE="+cfg.sandbox.sharedCache,
 		name,
 	)
 	wrapped = append(wrapped, args...)

--- a/internal/agent/runner_core.go
+++ b/internal/agent/runner_core.go
@@ -53,6 +53,7 @@ type sandboxSpec struct {
 	worktree    string
 	sandboxHome string
 	tmp         string
+	sharedCache string
 	profilePath string
 }
 

--- a/internal/agent/sandbox_breakout_test.go
+++ b/internal/agent/sandbox_breakout_test.go
@@ -50,11 +50,16 @@ func newEnforceSandboxCfg(t *testing.T, worktree, sandboxHome, tmp string) *RunC
 	if err != nil {
 		t.Fatalf("canonicalizeRoot(tmp): %v", err)
 	}
+	shared, err := canonicalizeRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalizeRoot(sharedCache): %v", err)
+	}
 	return &RunConfig{sandbox: sandboxSpec{
 		mode:        "enforce",
 		worktree:    wt,
 		sandboxHome: home,
 		tmp:         tp,
+		sharedCache: shared,
 		profilePath: profile,
 	}}
 }

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -27,10 +27,14 @@ func TestPrepareRunConfig_SandboxHome_Injected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareRunConfig: %v", err)
 	}
+	base := sharedBuildCacheDir()
 	want := []string{
 		"SYBRA_HOME=" + sandboxDir,
 		"SYBRA_CONTROL_HOME=/real/home",
 		"GOLANGCI_LINT_CACHE=" + filepath.Join(sandboxDir, "golangci-lint-cache"),
+		"GOCACHE=" + filepath.Join(base, "go-build"),
+		"GOMODCACHE=" + filepath.Join(base, "go-mod"),
+		"npm_config_cache=" + filepath.Join(base, "npm"),
 	}
 	if len(cfg.ExtraEnv) != len(want) || cfg.ExtraEnv[0] != want[0] || cfg.ExtraEnv[1] != want[1] || cfg.ExtraEnv[2] != want[2] {
 		t.Fatalf("ExtraEnv = %v, want %v", cfg.ExtraEnv, want)
@@ -161,11 +165,15 @@ func TestPrepareRunConfig_SandboxHome_StripsDuplicateCallerEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareRunConfig: %v", err)
 	}
+	base := sharedBuildCacheDir()
 	want := []string{
 		"OTHER=keep-me",
 		"SYBRA_HOME=" + sandboxDir,
 		"SYBRA_CONTROL_HOME=/real/home",
 		"GOLANGCI_LINT_CACHE=" + filepath.Join(sandboxDir, "golangci-lint-cache"),
+		"GOCACHE=" + filepath.Join(base, "go-build"),
+		"GOMODCACHE=" + filepath.Join(base, "go-mod"),
+		"npm_config_cache=" + filepath.Join(base, "npm"),
 	}
 	if len(cfg.ExtraEnv) != len(want) {
 		t.Fatalf("ExtraEnv = %v, want %v", cfg.ExtraEnv, want)
@@ -194,9 +202,13 @@ func TestPrepareRunConfig_SandboxHome_EmptyControlHomeOmitsVar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareRunConfig: %v", err)
 	}
+	base := sharedBuildCacheDir()
 	want := []string{
 		"SYBRA_HOME=" + sandboxDir,
 		"GOLANGCI_LINT_CACHE=" + filepath.Join(sandboxDir, "golangci-lint-cache"),
+		"GOCACHE=" + filepath.Join(base, "go-build"),
+		"GOMODCACHE=" + filepath.Join(base, "go-mod"),
+		"npm_config_cache=" + filepath.Join(base, "npm"),
 	}
 	if len(cfg.ExtraEnv) != len(want) || cfg.ExtraEnv[0] != want[0] || cfg.ExtraEnv[1] != want[1] {
 		t.Fatalf("ExtraEnv = %v, want %v", cfg.ExtraEnv, want)
@@ -236,6 +248,48 @@ func TestPrepareRunConfig_GolangciCache_PerWorktreeAndStripsCaller(t *testing.T)
 	}
 	if info, statErr := os.Stat(wantCache); statErr != nil || !info.IsDir() {
 		t.Fatalf("cache dir %q not created: %v", wantCache, statErr)
+	}
+}
+
+func TestPrepareRunConfig_SharedBuildCache_StripsCallerAndShares(t *testing.T) {
+	sandboxDir := t.TempDir()
+	m, _ := newTestManager(t, ManagerConfig{
+		SandboxHome: func(string) (string, error) { return sandboxDir, nil },
+	})
+
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		TaskID:   "task-1",
+		Mode:     "headless",
+		Dir:      t.TempDir(),
+		ExtraEnv: []string{"GOCACHE=/attacker/cache", "GOMODCACHE=/attacker/mod"},
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+
+	base := sharedBuildCacheDir()
+	for key, want := range map[string]string{
+		"GOCACHE=":          filepath.Join(base, "go-build"),
+		"GOMODCACHE=":       filepath.Join(base, "go-mod"),
+		"npm_config_cache=": filepath.Join(base, "npm"),
+	} {
+		var got string
+		hits := 0
+		for _, kv := range cfg.ExtraEnv {
+			if v, ok := strings.CutPrefix(kv, key); ok {
+				got = v
+				hits++
+			}
+		}
+		if hits != 1 {
+			t.Fatalf("want exactly one %s entry, got %d in %v", key, hits, cfg.ExtraEnv)
+		}
+		if got != want {
+			t.Fatalf("%s%q, want shared %q", key, got, want)
+		}
+		if info, statErr := os.Stat(want); statErr != nil || !info.IsDir() {
+			t.Fatalf("shared cache dir %q not created: %v", want, statErr)
+		}
 	}
 }
 

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -13,6 +13,7 @@ import (
 // wins over anything already in cfg.ExtraEnv, plus SYBRA_CONTROL_HOME when a
 // control home is configured.
 func TestPrepareRunConfig_SandboxHome_Injected(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
 	sandboxDir := t.TempDir()
 	m, _ := newTestManager(t, ManagerConfig{
 		SandboxHome: func(taskID string) (string, error) { return sandboxDir, nil },
@@ -146,6 +147,7 @@ func TestPrepareRunConfig_SandboxHome_NonDirectoryFailsClosed(t *testing.T) {
 // alongside the trusted values — it must be removed, not merely shadowed, so
 // duplicate-key resolution order in the target process can't leak it through.
 func TestPrepareRunConfig_SandboxHome_StripsDuplicateCallerEnv(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
 	sandboxDir := t.TempDir()
 	m, _ := newTestManager(t, ManagerConfig{
 		SandboxHome: func(string) (string, error) { return sandboxDir, nil },
@@ -189,6 +191,7 @@ func TestPrepareRunConfig_SandboxHome_StripsDuplicateCallerEnv(t *testing.T) {
 // unconfigured ControlHome is simply omitted rather than injected as an empty
 // SYBRA_CONTROL_HOME=.
 func TestPrepareRunConfig_SandboxHome_EmptyControlHomeOmitsVar(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
 	sandboxDir := t.TempDir()
 	m, _ := newTestManager(t, ManagerConfig{
 		SandboxHome: func(string) (string, error) { return sandboxDir, nil },
@@ -252,6 +255,7 @@ func TestPrepareRunConfig_GolangciCache_PerWorktreeAndStripsCaller(t *testing.T)
 }
 
 func TestPrepareRunConfig_SharedBuildCache_StripsCallerAndShares(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
 	sandboxDir := t.TempDir()
 	m, _ := newTestManager(t, ManagerConfig{
 		SandboxHome: func(string) (string, error) { return sandboxDir, nil },


### PR DESCRIPTION
## Motivation

Under `enforce` sandbox mode the agent's build caches would break. The agent's `HOME` is unchanged (only `SYBRA_HOME` is injected), so `GOCACHE`/`GOMODCACHE`/npm default to per-$HOME locations that are **outside** the seatbelt write-allowlist (`WORKTREE`/`SANDBOX_HOME`/`TMP`) — so a sandboxed `go build` would be denied and fall back to cold per-task caches. This future-proofs enforce mode so the shared caches keep working.

> Changelog: feat(agent): shared build caches survive enforce sandbox mode

## Implementation

- `injectSharedBuildCache` points `GOCACHE`/`GOMODCACHE`/`npm_config_cache` at one shared dir under the real home (`config.HomeDir()/shared-cache`), gated to task-scoped runs.
- These caches are **content-addressed and lock their own concurrent access**, so sharing is safe. `GOLANGCI_LINT_CACHE` deliberately stays **per-task** (`injectGolangciCache`) — its lock serializes concurrent runs and its results bleed across worktrees.
- Sandbox: adds a fourth write root `SHARED_CACHE` — a `-D` param in `wrapInvocation` + a `(subpath (param "SHARED_CACHE"))` allow in `agent_sandbox.sb`. `injectProcessSandbox` pre-creates the dir so enforce never fails closed on a missing root.

## Tests
New `TestPrepareRunConfig_SharedBuildCache_StripsCallerAndShares` (caller GOCACHE overridden, shared paths, dirs created); existing sandbox-home + breakout (real `sandbox-exec`) tests updated for the 4th root. Full `internal/agent` suite + golangci-lint clean.