### PR TITLE
fix(store): add mutex locking and atomic writes to sidecar stores

### DIFF
--- a/internal/fsutil/keyed_lock.go
+++ b/internal/fsutil/keyed_lock.go
@@ -1,0 +1,89 @@
+package fsutil
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// KeyedLocker serializes read-modify-write critical sections keyed by an
+// arbitrary string (e.g. a task or project ID), both within this process (a
+// ref-counted sync.Mutex per key) and across processes (an flock via
+// LockFile). Sidecar stores that do a Get-then-mutate-then-write should share
+// one KeyedLocker per store and hold it across the full critical section —
+// not just the final write — or a concurrent writer can still interleave
+// between another caller's read and write and silently drop an update.
+//
+// The in-process lock is acquired first (cheap, avoids paying a flock
+// syscall for intra-process contention) and the cross-process flock second;
+// they are released in reverse order. Entries are ref-counted so deleted or
+// one-off keys do not leave lock entries behind for the lifetime of a
+// long-running process.
+type KeyedLocker struct {
+	mu    sync.Mutex
+	locks map[string]*keyRefLock
+}
+
+type keyRefLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// NewKeyedLocker returns a ready-to-use KeyedLocker.
+func NewKeyedLocker() *KeyedLocker {
+	return &KeyedLocker{locks: map[string]*keyRefLock{}}
+}
+
+// Lock acquires the in-process mutex for key, then the cross-process flock
+// on path (typically the record's own file path, or any stable synthetic
+// path if the record has no single backing file), and returns a func that
+// releases both in reverse order. If the flock cannot be acquired, the
+// in-process lock is released before returning the error — a caller must
+// never proceed holding only the in-process half, since that would silently
+// reintroduce the cross-process race this lock exists to close.
+func (l *KeyedLocker) Lock(key, path string) (func(), error) {
+	l.mu.Lock()
+	if l.locks == nil {
+		l.locks = map[string]*keyRefLock{}
+	}
+	lock := l.locks[key]
+	if lock == nil {
+		lock = &keyRefLock{}
+		l.locks[key] = lock
+	}
+	lock.refs++
+	l.mu.Unlock()
+
+	lock.mu.Lock()
+
+	releaseInProcess := func() {
+		lock.mu.Unlock()
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(l.locks, key)
+		}
+	}
+
+	unlockFile, err := LockFile(path)
+	if err != nil {
+		releaseInProcess()
+		return nil, fmt.Errorf("lock %s: %w", key, err)
+	}
+
+	return func() {
+		if err := unlockFile(); err != nil {
+			slog.Default().Warn("fsutil.KeyedLocker.unlock_failed", "key", key, "err", err)
+		}
+		releaseInProcess()
+	}, nil
+}
+
+// Len returns the number of keys currently holding a live lock entry. Exposed
+// for tests that assert ref-counted entries are reclaimed after use.
+func (l *KeyedLocker) Len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.locks)
+}

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -23,9 +23,16 @@ var ErrProjectNotRegistered = errors.New("project not registered locally")
 // Store is the YAML-backed CRUD layer for Project metadata under dir
 // (~/.sybra/projects/), plus the bare-clone root (clonesDir,
 // ~/.sybra/clones/) that Create/CreateMeta clone new projects into.
+//
+// Every mutation is a Get (read) → modify → writeFile sequence, so locker
+// guards the whole critical section per project ID — both in-process (async
+// clone completion racing a UI edit in the same process) and cross-process
+// (GUI server vs. sybra-cli against the same projects dir), the same
+// discipline task.Store's lockTask applies to task files.
 type Store struct {
 	dir       string
 	clonesDir string
+	locker    *fsutil.KeyedLocker
 }
 
 // NewStore creates dir and clonesDir if they do not exist and returns a
@@ -36,7 +43,17 @@ func NewStore(dir, clonesDir string) (*Store, error) {
 			return nil, fmt.Errorf("create dir %s: %w", d, err)
 		}
 	}
-	return &Store{dir: dir, clonesDir: clonesDir}, nil
+	return &Store{dir: dir, clonesDir: clonesDir, locker: fsutil.NewKeyedLocker()}, nil
+}
+
+// lock acquires the per-project write lock for id's Get-modify-writeFile
+// critical section.
+func (s *Store) lock(id string) (func(), error) {
+	unlock, err := s.locker.Lock(id, s.filePath(id))
+	if err != nil {
+		return nil, fmt.Errorf("lock project %s: %w", id, err)
+	}
+	return unlock, nil
 }
 
 // List returns every registered project. A file that fails to parse is
@@ -84,6 +101,12 @@ func (s *Store) Create(rawURL string, ptype ProjectType) (Project, error) {
 	}
 
 	id := owner + "/" + repo
+	unlock, err := s.lock(id)
+	if err != nil {
+		return Project{}, err
+	}
+	defer unlock()
+
 	if _, err := s.Get(id); err == nil {
 		return Project{}, fmt.Errorf("project %s already exists", id)
 	}
@@ -130,6 +153,12 @@ func (s *Store) CreateMeta(rawURL string, ptype ProjectType) (Project, error) {
 		return Project{}, fmt.Errorf("invalid project type: %s (must be pet or work)", ptype)
 	}
 	id := owner + "/" + repo
+	unlock, err := s.lock(id)
+	if err != nil {
+		return Project{}, err
+	}
+	defer unlock()
+
 	if _, err := s.Get(id); err == nil {
 		return Project{}, fmt.Errorf("project %s already exists", id)
 	}
@@ -155,6 +184,12 @@ func (s *Store) CreateMeta(rawURL string, ptype ProjectType) (Project, error) {
 
 // MarkReady transitions a project from cloning to ready after a successful clone.
 func (s *Store) MarkReady(id string) error {
+	unlock, err := s.lock(id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	p, err := s.Get(id)
 	if err != nil {
 		return err
@@ -166,6 +201,12 @@ func (s *Store) MarkReady(id string) error {
 
 // MarkError transitions a project to the error state when cloning fails.
 func (s *Store) MarkError(id string) error {
+	unlock, err := s.lock(id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	p, err := s.Get(id)
 	if err != nil {
 		return err
@@ -182,6 +223,12 @@ func (s *Store) Update(id string, ptype ProjectType) (Project, error) {
 	if ptype != ProjectTypePet && ptype != ProjectTypeWork {
 		return Project{}, fmt.Errorf("invalid project type: %s (must be pet or work)", ptype)
 	}
+	unlock, err := s.lock(id)
+	if err != nil {
+		return Project{}, err
+	}
+	defer unlock()
+
 	p, err := s.Get(id)
 	if err != nil {
 		return p, err
@@ -193,6 +240,12 @@ func (s *Store) Update(id string, ptype ProjectType) (Project, error) {
 
 // SetSandboxConfig replaces the sandbox configuration for a project.
 func (s *Store) SetSandboxConfig(id string, cfg *SandboxConfig) (Project, error) {
+	unlock, err := s.lock(id)
+	if err != nil {
+		return Project{}, err
+	}
+	defer unlock()
+
 	p, err := s.Get(id)
 	if err != nil {
 		return p, err
@@ -204,6 +257,12 @@ func (s *Store) SetSandboxConfig(id string, cfg *SandboxConfig) (Project, error)
 
 // SetSetupCommands replaces the setup commands for a project.
 func (s *Store) SetSetupCommands(id string, cmds []string) (Project, error) {
+	unlock, err := s.lock(id)
+	if err != nil {
+		return Project{}, err
+	}
+	defer unlock()
+
 	p, err := s.Get(id)
 	if err != nil {
 		return p, err
@@ -219,6 +278,12 @@ func (s *Store) SetWorktreeBaseRef(id, ref string) (Project, error) {
 	if ref != WorktreeBaseRefFresh && ref != WorktreeBaseRefHead {
 		return Project{}, fmt.Errorf("invalid worktree_base_ref %q (must be %q or %q)", ref, WorktreeBaseRefFresh, WorktreeBaseRefHead)
 	}
+	unlock, err := s.lock(id)
+	if err != nil {
+		return Project{}, err
+	}
+	defer unlock()
+
 	p, err := s.Get(id)
 	if err != nil {
 		return p, err
@@ -232,6 +297,12 @@ func (s *Store) SetWorktreeBaseRef(id, ref string) (Project, error) {
 // metadata file. It does not touch any per-task worktrees already checked
 // out from that clone.
 func (s *Store) Delete(id string) error {
+	unlock, err := s.lock(id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	p, err := s.Get(id)
 	if err != nil {
 		return err

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -291,6 +292,54 @@ func TestStoreSetSetupCommands(t *testing.T) {
 	}
 	if len(persisted.SetupCommands) != 2 {
 		t.Errorf("persisted SetupCommands = %v, want %v", persisted.SetupCommands, cmds)
+	}
+}
+
+// TestStoreConcurrentUpdatesDontDropWrites exercises the exact race the
+// mutex closes: MarkReady simulating an async clone completion racing
+// SetSetupCommands from a UI edit, both doing Get→mutate→writeFile against
+// the same project. Without per-id locking one goroutine's write can
+// silently overwrite the other's read-stale copy, dropping a field.
+func TestStoreConcurrentUpdatesDontDropWrites(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := Project{ID: "owner/repo", Owner: "owner", Repo: "repo", Type: ProjectTypePet, Status: ProjectStatusCloning}
+	if err := store.writeFile(p); err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+	for range n {
+		go func() {
+			defer wg.Done()
+			if err := store.MarkReady("owner/repo"); err != nil {
+				t.Error(err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := store.SetSetupCommands("owner/repo", []string{"npm install"}); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := store.Get("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != ProjectStatusReady {
+		t.Errorf("Status = %q, want %q (a racing SetSetupCommands write dropped MarkReady's update)", got.Status, ProjectStatusReady)
+	}
+	if len(got.SetupCommands) != 1 {
+		t.Errorf("SetupCommands = %v, want 1 entry (a racing MarkReady write dropped SetSetupCommands's update)", got.SetupCommands)
 	}
 }
 

--- a/internal/task/comment.go
+++ b/internal/task/comment.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/google/uuid"
 )
 
@@ -19,13 +20,18 @@ type ReviewComment struct {
 	CreatedAt time.Time `json:"createdAt"`
 }
 
-// CommentStore persists review comments as a JSON sidecar next to the task file.
+// CommentStore persists review comments as a JSON sidecar next to the task
+// file. Every mutation is a List (read) → modify → write sequence, so a
+// per-task lock guards the whole critical section — otherwise a concurrent
+// reader can catch the sidecar mid-truncation (JSON parse error) and two
+// racing writers can silently drop one another's update.
 type CommentStore struct {
-	dir string
+	dir    string
+	locker *fsutil.KeyedLocker
 }
 
 func NewCommentStore(dir string) *CommentStore {
-	return &CommentStore{dir: dir}
+	return &CommentStore{dir: dir, locker: fsutil.NewKeyedLocker()}
 }
 
 func (s *CommentStore) sidecarPath(taskID string) string {
@@ -48,6 +54,12 @@ func (s *CommentStore) List(taskID string) ([]ReviewComment, error) {
 }
 
 func (s *CommentStore) Add(taskID string, line int, body string) (ReviewComment, error) {
+	unlock, err := s.lock(taskID)
+	if err != nil {
+		return ReviewComment{}, err
+	}
+	defer unlock()
+
 	comments, err := s.List(taskID)
 	if err != nil {
 		return ReviewComment{}, err
@@ -67,6 +79,12 @@ func (s *CommentStore) Add(taskID string, line int, body string) (ReviewComment,
 }
 
 func (s *CommentStore) Resolve(taskID, commentID string) error {
+	unlock, err := s.lock(taskID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	comments, err := s.List(taskID)
 	if err != nil {
 		return err
@@ -86,6 +104,12 @@ func (s *CommentStore) Resolve(taskID, commentID string) error {
 }
 
 func (s *CommentStore) Delete(taskID, commentID string) error {
+	unlock, err := s.lock(taskID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	comments, err := s.List(taskID)
 	if err != nil {
 		return err
@@ -104,6 +128,12 @@ func (s *CommentStore) Delete(taskID, commentID string) error {
 
 // ResolveAll marks every unresolved comment for a task as resolved.
 func (s *CommentStore) ResolveAll(taskID string) error {
+	unlock, err := s.lock(taskID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	comments, err := s.List(taskID)
 	if err != nil {
 		return err
@@ -114,12 +144,22 @@ func (s *CommentStore) ResolveAll(taskID string) error {
 	return s.write(taskID, comments)
 }
 
+// lock acquires the per-task write lock for the full List-modify-write
+// critical section of taskID's comment sidecar.
+func (s *CommentStore) lock(taskID string) (func(), error) {
+	unlock, err := s.locker.Lock(taskID, s.sidecarPath(taskID))
+	if err != nil {
+		return nil, fmt.Errorf("lock comments %s: %w", taskID, err)
+	}
+	return unlock, nil
+}
+
 func (s *CommentStore) write(taskID string, comments []ReviewComment) error {
 	data, err := json.MarshalIndent(comments, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal comments: %w", err)
 	}
-	if err := os.WriteFile(s.sidecarPath(taskID), data, 0o644); err != nil {
+	if err := fsutil.AtomicWrite(s.sidecarPath(taskID), data); err != nil {
 		return fmt.Errorf("write comments: %w", err)
 	}
 	return nil

--- a/internal/task/comment_test.go
+++ b/internal/task/comment_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -46,6 +47,37 @@ func TestCommentStore_AddAndList(t *testing.T) {
 	}
 	if comments[0].ID != c.ID {
 		t.Errorf("ID mismatch: got %q, want %q", comments[0].ID, c.ID)
+	}
+}
+
+// TestCommentStore_ConcurrentAddsDontDropWrites exercises the List→append→
+// write race directly: without a per-task lock around the whole critical
+// section, two goroutines can both List the same (empty) baseline and each
+// write back a single-comment slice, so the loser's Add is silently
+// discarded. With the lock, every Add lands.
+func TestCommentStore_ConcurrentAddsDontDropWrites(t *testing.T) {
+	t.Parallel()
+	s := NewCommentStore(t.TempDir())
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			if _, err := s.Add("task-race", i, "comment"); err != nil {
+				t.Error(err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	comments, err := s.List("task-race")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(comments) != n {
+		t.Errorf("got %d comments, want %d (a racing Add dropped an update)", len(comments), n)
 	}
 }
 

--- a/internal/task/plan_draft.go
+++ b/internal/task/plan_draft.go
@@ -43,10 +43,32 @@ type PlanDraftStore struct {
 	have    map[string]struct{}
 	indexed bool
 	gen     uint64
+
+	// locker serializes per-task write paths (Write/Delete/DeleteAll)
+	// against each other, both in-process and cross-process, so a re-plan's
+	// DeleteAll never interleaves with another provider's still-in-flight
+	// Write for the same task.
+	locker *fsutil.KeyedLocker
 }
 
 func NewPlanDraftStore(dir string) *PlanDraftStore {
-	return &PlanDraftStore{dir: dir}
+	return &PlanDraftStore{dir: dir, locker: fsutil.NewKeyedLocker()}
+}
+
+// lockPath returns the synthetic path used as the cross-process flock target
+// for taskID's plan drafts. Drafts are stored one file per name, so there is
+// no single backing file to lock on — this path need not exist; LockFile
+// only ever opens/creates its ".lock" sibling.
+func (s *PlanDraftStore) lockPath(taskID string) string {
+	return filepath.Join(s.dir, taskID+".plan-drafts")
+}
+
+func (s *PlanDraftStore) lock(taskID string) (func(), error) {
+	unlock, err := s.locker.Lock(taskID, s.lockPath(taskID))
+	if err != nil {
+		return nil, fmt.Errorf("lock plan drafts %s: %w", taskID, err)
+	}
+	return unlock, nil
 }
 
 // invalidateIndex drops the cached have-set. Called after every local
@@ -117,6 +139,11 @@ func (s *PlanDraftStore) Write(taskID, name, content string) error {
 	if content == "" {
 		return s.Delete(taskID, name)
 	}
+	unlock, err := s.lock(taskID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if err := fsutil.AtomicWrite(s.sidecarPath(taskID, name), []byte(content)); err != nil {
 		return fmt.Errorf("write plan draft %q: %w", name, err)
 	}
@@ -129,6 +156,11 @@ func (s *PlanDraftStore) Delete(taskID, name string) error {
 	if err := s.validate(name); err != nil {
 		return err
 	}
+	unlock, err := s.lock(taskID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if err := os.Remove(s.sidecarPath(taskID, name)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete plan draft %q: %w", name, err)
 	}
@@ -200,6 +232,12 @@ func (s *PlanDraftStore) adoptIndex(startGen uint64, fresh map[string]struct{}) 
 // DeleteAll removes every draft for the task. Used by callers that need
 // to reset the dual-planning state (e.g. before a re-plan iteration).
 func (s *PlanDraftStore) DeleteAll(taskID string) error {
+	unlock, err := s.lock(taskID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	prefix := taskID + PlanDraftSidecarPrefix
 	entries, err := os.ReadDir(s.dir)
 	if os.IsNotExist(err) {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -34,16 +34,10 @@ type Store struct {
 	planDecisions *PlanningSidecarStore
 	planBrief     *PlanningSidecarStore
 	codeReviews   *CodeReviewStore
-	writeLocksMu  sync.Mutex
-	writeLocks    map[string]*taskWriteLock
+	locker        *fsutil.KeyedLocker
 	cacheMu       sync.RWMutex
 	listCache     []Task
 	listValid     bool
-}
-
-type taskWriteLock struct {
-	mu   sync.Mutex
-	refs int
 }
 
 // NewStore creates dir if it does not exist and returns a Store rooted
@@ -64,7 +58,7 @@ func NewStore(dir string) (*Store, error) {
 		planDecisions: NewPlanningSidecarStore(dir, ".plan-decisions.md", "plan decisions"),
 		planBrief:     NewPlanningSidecarStore(dir, ".plan-brief.md", "plan brief"),
 		codeReviews:   NewCodeReviewStore(dir),
-		writeLocks:    map[string]*taskWriteLock{},
+		locker:        fsutil.NewKeyedLocker(),
 	}, nil
 }
 
@@ -149,47 +143,15 @@ func (s *Store) CodeReviews() *CodeReviewStore {
 // race this lock exists to close — so the in-process lock is released and an
 // error is returned instead.
 func (s *Store) lockTask(id string) (func(), error) {
-	s.writeLocksMu.Lock()
-	if s.writeLocks == nil {
-		s.writeLocks = map[string]*taskWriteLock{}
-	}
-	lock := s.writeLocks[id]
-	if lock == nil {
-		lock = &taskWriteLock{}
-		s.writeLocks[id] = lock
-	}
-	lock.refs++
-	s.writeLocksMu.Unlock()
-
-	lock.mu.Lock()
-
-	releaseInProcess := func() {
-		lock.mu.Unlock()
-		s.writeLocksMu.Lock()
-		defer s.writeLocksMu.Unlock()
-		lock.refs--
-		if lock.refs == 0 {
-			delete(s.writeLocks, id)
-		}
-	}
-
 	path, err := s.safePath(id)
 	if err != nil {
-		releaseInProcess()
 		return nil, err
 	}
-	unlockFile, err := fsutil.LockFile(path)
+	unlock, err := s.locker.Lock(id, path)
 	if err != nil {
-		releaseInProcess()
 		return nil, fmt.Errorf("lock task %s: %w", id, err)
 	}
-
-	return func() {
-		if err := unlockFile(); err != nil {
-			slog.Default().Warn("task.lockTask.unlock_failed", "id", id, "err", err)
-		}
-		releaseInProcess()
-	}, nil
+	return unlock, nil
 }
 
 // sidecarFileSuffixes lists every fixed-name (non-plan-draft) sidecar

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -256,21 +256,15 @@ func TestStoreWriteLocksAreReclaimed(t *testing.T) {
 		t.Fatalf("update: %v", err)
 	}
 
-	store.writeLocksMu.Lock()
-	lockCount := len(store.writeLocks)
-	store.writeLocksMu.Unlock()
-	if lockCount != 0 {
-		t.Fatalf("writeLocks length after update = %d, want 0", lockCount)
+	if lockCount := store.locker.Len(); lockCount != 0 {
+		t.Fatalf("locker entries after update = %d, want 0", lockCount)
 	}
 
 	if err := store.Delete(created.ID); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	store.writeLocksMu.Lock()
-	lockCount = len(store.writeLocks)
-	store.writeLocksMu.Unlock()
-	if lockCount != 0 {
-		t.Fatalf("writeLocks length after delete = %d, want 0", lockCount)
+	if lockCount := store.locker.Len(); lockCount != 0 {
+		t.Fatalf("locker entries after delete = %d, want 0", lockCount)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Two sidecar stores lacked write discipline and were prone to data loss under concurrent access. The YAML project store had no mutex — operations like `MarkReady`, `Update`, `SetSetupCommands`, and `SetWorktreeBaseRef` performed unlocked Get→mutate→write sequences, so concurrent clone completion racing a UI edit could silently drop writes. CommentStore used non-atomic `os.WriteFile` with unlocked read-modify-writes, causing JSON parse errors and lost updates.

## Implementation information

Introduced a unified write-path helper using `lockTask` and `fsutil.AtomicWrite` that synchronizes all sidecar reads and writes. Applied to the task store, CommentStore, plan drafts, and project store. This ensures atomic file operations and prevents concurrent modifications from dropping or corrupting updates.

Closes https://github.com/Automaat/sybra/issues/1534

_Generated by Sybra harness_