### PR TITLE
fix(agent): don't fail completed cost-guarded runs

### DIFF
--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -990,10 +990,22 @@ func (m *Manager) warnIfResultHasLiveBackgroundTasks(a *Agent) {
 // breach must terminate the subprocess immediately instead of leaving a
 // headless process alive while waiting for a response. Returns false so the
 // caller stops the stream and kills/cancels the subprocess.
+//
+// This is only ever called from handleHeadlessResult on a "result" event, so
+// the breach always coincides with a turn that already finished cleanly on
+// its own — there is no more work the subprocess could still do, only an
+// idle process left to reap. Mark completedByResult so the attempt-exit path
+// (wasCompletedByResult check in runHeadlessAttemptPipe/Survive) derives the
+// outcome from that terminal result event instead of stamping
+// errCostGuardrailExceeded — otherwise a legitimately completed turn (and
+// any sidecar it already wrote) gets discarded as a hard failure purely
+// because the kill happened to land after the cost ceiling (see task
+// 6ee7ee8d).
 func (m *Manager) checkCostGuardrail(a *Agent, costNow, maxCost float64) bool {
 	m.logger.Warn("agent.guardrail.cost", "id", a.ID, "cost", costNow, "limit", maxCost)
 	a.MarkStopped()
 	a.SetEscalationReason("cost")
+	a.setCompletedByResult(true)
 	m.emit(events.AgentEscalation(a.ID), EscalationEvent{
 		Reason:  "cost",
 		CostUSD: costNow,

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1277,6 +1277,63 @@ func TestGuardrails_CostKillRaceSetsExitErr(t *testing.T) {
 	}
 }
 
+// TestGuardrails_CostHardStop_CompletedTurnIsNotAFailure verifies the fix for
+// task 6ee7ee8d: a cost-guardrail breach detected on the terminal "result"
+// event (the only place checkCostGuardrail ever fires) means the agent's own
+// turn already finished cleanly — there is nothing left for the subprocess to
+// do but exit. Unlike TestGuardrails_CostKillRaceSetsExitErr (where the
+// process is stuck and the reap races the drain timeout), here the fake
+// process exits immediately after its result line, so the attempt-exit path
+// must derive completion from that result event and leave ExitErr nil rather
+// than stamping errCostGuardrailExceeded — otherwise a legitimately completed
+// review (and any sidecar it already wrote) gets discarded as a hard failure
+// purely because the kill happened to land after the cost ceiling.
+func TestGuardrails_CostHardStop_CompletedTurnIsNotAFailure(t *testing.T) {
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' '{\"type\":\"result\",\"result\":\"done\",\"session_id\":\"sess-clean\",\"total_cost_usd\":11.0,\"total_input_tokens\":1,\"total_output_tokens\":1}'\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{
+		Runtime:           ManagerRuntimeConfig{DefaultProvider: "claude"},
+		SurviveRestartDir: t.TempDir(),
+	})
+	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0})
+
+	ag, err := m.Run(RunConfig{
+		TaskID:             "task-clean-cost-stop",
+		Name:               "implementation: clean cost stop",
+		Mode:               "headless",
+		Prompt:             "trigger guardrail on an already-completed turn",
+		Dir:                t.TempDir(),
+		RequirePermissions: false,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd := ag.GetCmd(); cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	waitForAgentDone(t, ag, 3*time.Second)
+
+	if !ag.WasStopped() {
+		t.Fatal("expected WasStopped=true after guardrail kill")
+	}
+	if !ag.WasCompletedByResult() {
+		t.Fatal("WasCompletedByResult() = false; cost guardrail always fires on the terminal result event so completion must be derived from it")
+	}
+	if got := ag.GetExitErr(); got != nil {
+		t.Fatalf("ExitErr = %v, want nil — the turn completed cleanly before the cost ceiling stopped the now-idle subprocess", got)
+	}
+}
+
 // TestRespondEscalation_DoubleSendRejected verifies the escalation channel
 // is buffered size 1 and a second RespondEscalation call before the agent
 // drains the first returns a clear error instead of blocking the caller.


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): don't fail completed cost-guarded runs

The cost guardrail (`checkCostGuardrail`) only ever fires from
`handleHeadlessResult` on a terminal "result" event — the agent's turn has
already finished cleanly by the time the breach is detected. It still hard-
stopped the now-idle subprocess but never marked `completedByResult`, so the
attempt-exit path fell through to `SetExitErr(errCostGuardrailExceeded)`
instead of deriving the outcome from the already-received result event.
`notifyWorkflowEngine` then saw a non-nil exit error and reported the run as
failed, burning a retry and discarding a review (and any sidecar it already
wrote) that had actually completed successfully. For an expensive review
role that routinely lands at/above the cost ceiling, this makes retry
exhaustion deterministic and the task falls to human-required with a
"missing" sidecar that was, per the agent's own final output, already
written.

## Implementation information

`checkCostGuardrail` now also marks the agent `completedByResult` alongside
`MarkStopped`/`SetEscalationReason("cost")`. This routes the process-exit
handling (`runHeadlessAttemptPipe`/`Survive`) through the existing
`wasCompletedByResult()` → `finalizeFromResult` branch — the same path
already used by the post-result-hang reaper — instead of stamping
`errCostGuardrailExceeded`. The subprocess is still stopped immediately;
only the "this was a failure" classification changes for a breach that
coincides with an already-terminal result.

Added `TestGuardrails_CostHardStop_CompletedTurnIsNotAFailure` documenting
the fix. Verified `TestGuardrails_CostKillRaceSetsExitErr` (the reap-race
case where the process hangs past `drainTimeout`) is unaffected — that path
sets `ExitErr` via the `procDone` select/default branch before the
`wasCompletedByResult()` check, so a genuinely stuck process still fails.
Also verified the e2e `TestE2E_HeadlessAgent_CostHardStopRetriesBoundedPath`
(`-tags e2e`) still passes.

## Supporting documentation

`mise run verify` passes (Go build/tests/e2e, lint, frontend checks,
bindings drift).