### PR TITLE
fix(worktree): guarantee DCO sign-off on commits

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -881,11 +881,12 @@ func cmdInstallSkills(cfg *config.Config, jsonOut bool) int {
 		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	}
 	(&skillsync.Syncer{Logger: logger}).Run(skillsync.Options{
-		RepoDir:      repoDir,
-		SkillsFS:     skills.FS,
-		PrimaryDst:   cfg.SkillsDir,
-		SybraHomeDir: config.HomeDir(),
-		UserHomeDir:  home,
+		RepoDir:              repoDir,
+		SkillsFS:             skills.FS,
+		PrimaryDst:           cfg.SkillsDir,
+		SybraHomeDir:         config.HomeDir(),
+		UserHomeDir:          home,
+		DowngradeCommitFlags: !project.GPGSigningAvailable(context.Background()),
 	})
 
 	dsts := []string{

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -239,6 +239,11 @@ func InstallSignoffHook(ctx context.Context, worktreePath string) error {
 	if err := os.WriteFile(path, []byte(signoffHook), 0o755); err != nil {
 		return fmt.Errorf("write prepare-commit-msg hook: %w", err)
 	}
+	pin := exec.CommandContext(ctx, "git", "config", "core.hooksPath", hooksDir)
+	pin.Dir = worktreePath
+	if err := pin.Run(); err != nil {
+		return fmt.Errorf("pin core.hooksPath: %w", err)
+	}
 	return nil
 }
 

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -200,6 +200,48 @@ func InstallHooks(ctx context.Context, worktreePath string, checks *ChecksConfig
 	return write("pre-push", checks.PrePush)
 }
 
+const signoffHook = `#!/bin/sh
+# Auto-installed by Sybra. Guarantees a DCO Signed-off-by trailer on every
+# commit so PRs never fail the DCO check when an agent forgets 'git commit -s'.
+msg_file="$1"
+sob=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+[ -z "$sob" ] && exit 0
+git interpret-trailers --if-exists addIfDifferent --trailer "$sob" --in-place "$msg_file"
+`
+
+// InstallSignoffHook writes a prepare-commit-msg hook that guarantees a DCO
+// Signed-off-by trailer on every commit made in the worktree. Agents commit
+// via a plain git commit and don't reliably pass -s, so relying on the prompt
+// instruction leaves unsigned commits that fail the kumahq/kuma DCO check.
+// prepare-commit-msg is the only hook that fires on every commit — including
+// merges and --no-verify, which bypass only pre-commit and commit-msg — so it
+// is the single place sign-off can be enforced no matter how the commit is
+// produced. Unlike InstallHooks it is unconditional and manages its own hooks
+// dir, so it also covers projects with no pre-commit/pre-push checks. The hook
+// lives in the git-common-dir and so covers every worktree of the clone; the
+// write is idempotent.
+func InstallSignoffHook(ctx context.Context, worktreePath string) error {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
+	cmd.Dir = worktreePath
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("resolve git dir: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreePath, gitDir)
+	}
+	hooksDir := filepath.Join(gitDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return fmt.Errorf("create hooks dir: %w", err)
+	}
+	path := filepath.Join(hooksDir, "prepare-commit-msg")
+	if err := os.WriteFile(path, []byte(signoffHook), 0o755); err != nil {
+		return fmt.Errorf("write prepare-commit-msg hook: %w", err)
+	}
+	return nil
+}
+
 // ParseGitHubURL extracts owner and repo from a GitHub URL in SSH form
 // (git@github.com:owner/repo[.git]) or HTTPS form
 // (https://github.com/owner/repo[.git]). Returns an error for any other
@@ -251,6 +293,9 @@ func splitOwnerRepo(path string) (owner, repo string, err error) {
 func CloneBare(ctx context.Context, repoURL, destPath string) error {
 	if err := executil.Run(ctx, "", "git", "clone", "--bare", repoURL, destPath); err != nil {
 		return err
+	}
+	if err := InstallSignoffHook(ctx, destPath); err != nil {
+		return fmt.Errorf("install signoff hook: %w", err)
 	}
 	// `git clone --bare` leaves remote.origin.fetch empty, so later `git fetch
 	// origin` becomes a no-op against refs/remotes/origin/*. Configure the

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -2602,3 +2602,105 @@ func TestTryCleanMerge(t *testing.T) {
 		}
 	})
 }
+
+func TestInstallSignoffHook(t *testing.T) {
+	t.Parallel()
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "sybra/test", branch); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	gitWt := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", wtPath}, args...)
+		if out, gerr := exec.Command("git", full...).CombinedOutput(); gerr != nil {
+			t.Fatalf("git %v: %v: %s", args, gerr, out)
+		}
+	}
+	gitWt("config", "user.email", "agent@example.com")
+	gitWt("config", "user.name", "Agent")
+
+	if err := InstallSignoffHook(context.Background(), wtPath); err != nil {
+		t.Fatalf("InstallSignoffHook: %v", err)
+	}
+
+	body := func() string {
+		t.Helper()
+		out, gerr := exec.Command("git", "-C", wtPath, "log", "-1", "--format=%B").Output()
+		if gerr != nil {
+			t.Fatalf("git log: %v", gerr)
+		}
+		return string(out)
+	}
+
+	wantSOB := "Signed-off-by: Agent <agent@example.com>"
+
+	if err := os.WriteFile(filepath.Join(wtPath, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitWt("add", ".")
+	gitWt("commit", "-m", "feat: add a")
+	if got := body(); !strings.Contains(got, wantSOB) {
+		t.Errorf("plain commit missing DCO trailer, got:\n%s", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitWt("add", ".")
+	gitWt("commit", "-s", "-m", "feat: add b")
+	if got := body(); strings.Count(got, wantSOB) != 1 {
+		t.Errorf("commit -s should not duplicate the trailer, got %d in:\n%s",
+			strings.Count(got, wantSOB), got)
+	}
+}
+
+func TestCloneBare_InstallsSignoffHook(t *testing.T) {
+	t.Parallel()
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "sybra/test", branch); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	gitWt := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", wtPath}, args...)
+		if out, gerr := exec.Command("git", full...).CombinedOutput(); gerr != nil {
+			t.Fatalf("git %v: %v: %s", args, gerr, out)
+		}
+	}
+	gitWt("config", "user.email", "agent@example.com")
+	gitWt("config", "user.name", "Agent")
+
+	if err := os.WriteFile(filepath.Join(wtPath, "c.txt"), []byte("c\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitWt("add", ".")
+	gitWt("commit", "-m", "feat: add c")
+
+	out, err := exec.Command("git", "-C", wtPath, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if want := "Signed-off-by: Agent <agent@example.com>"; !strings.Contains(string(out), want) {
+		t.Errorf("CloneBare worktree commit missing DCO trailer, got:\n%s", out)
+	}
+}

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -2664,6 +2664,42 @@ func TestInstallSignoffHook(t *testing.T) {
 	}
 }
 
+func TestInstallSignoffHook_OverridesHooksPath(t *testing.T) {
+	t.Parallel()
+
+	dir := initRepoWithCommit(t)
+	gitDir := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", dir}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	stray := filepath.Join(t.TempDir(), "stray-hooks")
+	if err := os.MkdirAll(stray, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitDir("config", "core.hooksPath", stray)
+
+	if err := InstallSignoffHook(context.Background(), dir); err != nil {
+		t.Fatalf("InstallSignoffHook: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "x.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitDir("add", ".")
+	gitDir("commit", "-m", "feat: x")
+
+	out, err := exec.Command("git", "-C", dir, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if !strings.Contains(string(out), "Signed-off-by: Test <test@test.com>") {
+		t.Errorf("hook did not run despite a stray core.hooksPath override, got:\n%s", out)
+	}
+}
+
 func TestCloneBare_InstallsSignoffHook(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/signing.go
+++ b/internal/project/signing.go
@@ -13,7 +13,7 @@ import (
 // emit only -s there. DCO sign-off (-s) is guaranteed independently by the
 // prepare-commit-msg hook (see InstallSignoffHook).
 func GPGSigningAvailable(ctx context.Context) bool {
-	out, err := exec.CommandContext(ctx, "git", "config", "--get", "user.signingkey").Output()
+	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--get", "user.signingkey").Output()
 	if err != nil {
 		return false
 	}

--- a/internal/project/signing.go
+++ b/internal/project/signing.go
@@ -1,0 +1,32 @@
+package project
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// GPGSigningAvailable reports whether this machine can GPG-sign commits, i.e.
+// whether git resolves a non-empty user.signingkey. Used to decide whether an
+// agent commit instruction should carry -S: on a keyless host (e.g. the Linux
+// server) `git commit -S` fails with "gpg failed to sign the data", so callers
+// emit only -s there. DCO sign-off (-s) is guaranteed independently by the
+// prepare-commit-msg hook (see InstallSignoffHook).
+func GPGSigningAvailable(ctx context.Context) bool {
+	out, err := exec.CommandContext(ctx, "git", "config", "--get", "user.signingkey").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
+}
+
+// CommitSignFlags returns the git commit flags an agent should use on this
+// machine: "-s -S" when a signing key is available, otherwise "-s". The
+// prepare-commit-msg hook still enforces -s regardless; this only governs the
+// optional, key-dependent GPG flag.
+func CommitSignFlags(ctx context.Context) string {
+	if GPGSigningAvailable(ctx) {
+		return "-s -S"
+	}
+	return "-s"
+}

--- a/internal/skillsync/commitflags.go
+++ b/internal/skillsync/commitflags.go
@@ -1,0 +1,16 @@
+package skillsync
+
+import "strings"
+
+var commitFlagDowngrader = strings.NewReplacer(
+	"-s -S", "-s",
+	"-sS", "-s",
+	"-S -s", "-s",
+)
+
+func (s *Syncer) transform(data []byte) []byte {
+	if !s.downgrade {
+		return data
+	}
+	return []byte(commitFlagDowngrader.Replace(string(data)))
+}

--- a/internal/skillsync/copy.go
+++ b/internal/skillsync/copy.go
@@ -9,7 +9,7 @@ import (
 
 // copyDirTree recursively copies src into dst. Uses os.Root to confine
 // reads to the source subtree, preventing symlink TOCTOU escape.
-func copyDirTree(src, dst string) error {
+func copyDirTree(src, dst string, transform func([]byte) []byte) error {
 	srcRoot, err := os.OpenRoot(src)
 	if err != nil {
 		return err
@@ -44,6 +44,9 @@ func copyDirTree(src, dst string) error {
 		}
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return err
+		}
+		if transform != nil {
+			data = transform(data)
 		}
 		return os.WriteFile(target, data, 0o644)
 	})
@@ -89,7 +92,7 @@ func (s *Syncer) copySkillDir(src, dst, cleanSrc, cleanDst, name, logPrefix stri
 		s.warn(logPrefix+".clean.fail", "name", name, "err", err)
 		return false
 	}
-	if err := copyDirTree(srcSkillDir, dstSkillDir); err != nil {
+	if err := copyDirTree(srcSkillDir, dstSkillDir, s.transform); err != nil {
 		s.error(logPrefix+".copy.tree", "name", name, "err", err)
 		return false
 	}

--- a/internal/skillsync/syncer.go
+++ b/internal/skillsync/syncer.go
@@ -44,12 +44,15 @@ type Options struct {
 	// and ~/.codex/skills as additional destinations. Empty disables
 	// user-home destinations.
 	UserHomeDir string
+
+	DowngradeCommitFlags bool
 }
 
 // Syncer copies skill files into one or more destination directories.
 // Zero-value Logger is safe (logs are dropped).
 type Syncer struct {
-	Logger *slog.Logger
+	Logger    *slog.Logger
+	downgrade bool
 }
 
 // Run executes the full skill-sync flow described in Options: choose
@@ -57,6 +60,10 @@ type Syncer struct {
 // user-home directories, and (in disk mode) copy orchestrator CLAUDE.md
 // alongside.
 func (s *Syncer) Run(opts Options) {
+	s.downgrade = opts.DowngradeCommitFlags
+	if s.downgrade {
+		s.info("skills.sync.commit_flags_downgraded", "reason", "no gpg signing key")
+	}
 	repoDir := opts.RepoDir
 	if repoDir == "" {
 		cwd, err := os.Getwd()
@@ -144,7 +151,7 @@ func (s *Syncer) SyncFile(src, dst string) {
 		s.error("sync.mkdir", "dst", dst, "err", err)
 		return
 	}
-	if err := os.WriteFile(dst, data, fs.FileMode(0o644)); err != nil {
+	if err := os.WriteFile(dst, s.transform(data), fs.FileMode(0o644)); err != nil {
 		s.error("sync.write", "dst", dst, "err", err)
 		return
 	}
@@ -217,7 +224,7 @@ func (s *Syncer) syncDir(src, dst string, prune bool) map[string]struct{} {
 			s.error("sync.skill.mkdir.skill", "dir", skillDir, "err", err)
 			continue
 		}
-		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+		if err := os.WriteFile(dstPath, s.transform(data), 0o644); err != nil {
 			s.error("sync.skill.write", "dst", dstPath, "err", err)
 			continue
 		}
@@ -278,7 +285,7 @@ func (s *Syncer) syncFS(fsys fs.FS, srcDir, dst string, prune bool) map[string]s
 			s.error("sync.skill.mkdir.skill", "dir", skillDir, "err", err)
 			continue
 		}
-		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+		if err := os.WriteFile(dstPath, s.transform(data), 0o644); err != nil {
 			s.error("sync.skill.write", "dst", dstPath, "err", err)
 			continue
 		}

--- a/internal/skillsync/syncer_test.go
+++ b/internal/skillsync/syncer_test.go
@@ -482,6 +482,87 @@ func TestRunWithRepoDirAndOrchestrator(t *testing.T) {
 	}
 }
 
+func TestRunDowngradesCommitFlags(t *testing.T) {
+	repoDir := t.TempDir()
+	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
+	dirSkillSrc := filepath.Join(skillsSrc, "dirskill")
+	if err := os.MkdirAll(dirSkillSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	flatSkill := []byte("---\nname: flat\ndescription: test\n---\n\nCommit with `git commit -s -S -m msg`.")
+	if err := os.WriteFile(filepath.Join(skillsSrc, "flat.md"), flatSkill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dirSkill := []byte("---\nname: dirskill\ndescription: test\n---\n\nRun `git commit -sS -m msg`.")
+	if err := os.WriteFile(filepath.Join(dirSkillSrc, "SKILL.md"), dirSkill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orchDir := filepath.Join(repoDir, "orchestrator")
+	if err := os.MkdirAll(orchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	claude := []byte("# orchestrator\n\n```bash\ngit commit -s -S -m \"type(scope): desc\"\n```")
+	if err := os.WriteFile(filepath.Join(orchDir, "CLAUDE.md"), claude, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	primaryDst := filepath.Join(t.TempDir(), "app-skills")
+	sybraHome := t.TempDir()
+	newSyncer().Run(skillsync.Options{
+		RepoDir:              repoDir,
+		PrimaryDst:           primaryDst,
+		SybraHomeDir:         sybraHome,
+		DowngradeCommitFlags: true,
+	})
+
+	read := func(p string) string {
+		t.Helper()
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		return string(b)
+	}
+	for _, p := range []string{
+		filepath.Join(sybraHome, "CLAUDE.md"),
+		filepath.Join(primaryDst, "flat", "SKILL.md"),
+		filepath.Join(primaryDst, "dirskill", "SKILL.md"),
+	} {
+		got := read(p)
+		if strings.Contains(got, "-S") {
+			t.Errorf("%s still contains -S after downgrade:\n%s", p, got)
+		}
+		if !strings.Contains(got, "git commit -s") {
+			t.Errorf("%s lost the -s sign-off flag:\n%s", p, got)
+		}
+	}
+}
+
+func TestRunKeepsCommitFlagsWhenSigningAvailable(t *testing.T) {
+	repoDir := t.TempDir()
+	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
+	if err := os.MkdirAll(skillsSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	flatSkill := []byte("---\nname: flat\ndescription: test\n---\n\nCommit with `git commit -s -S -m msg`.")
+	if err := os.WriteFile(filepath.Join(skillsSrc, "flat.md"), flatSkill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	primaryDst := filepath.Join(t.TempDir(), "app-skills")
+	newSyncer().Run(skillsync.Options{
+		RepoDir:              repoDir,
+		PrimaryDst:           primaryDst,
+		DowngradeCommitFlags: false,
+	})
+	b, err := os.ReadFile(filepath.Join(primaryDst, "flat", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "git commit -s -S") {
+		t.Errorf("expected -s -S preserved, got:\n%s", b)
+	}
+}
+
 func TestHasYAMLFrontmatter(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -846,10 +846,11 @@ func (a *App) syncSkillsBundle() {
 		userHome = ""
 	}
 	(&skillsync.Syncer{Logger: a.logger}).Run(skillsync.Options{
-		RepoDir:      a.repoDir,
-		SkillsFS:     a.skillsFS,
-		PrimaryDst:   a.skillsDir,
-		SybraHomeDir: config.HomeDir(),
-		UserHomeDir:  userHome,
+		RepoDir:              a.repoDir,
+		SkillsFS:             a.skillsFS,
+		PrimaryDst:           a.skillsDir,
+		SybraHomeDir:         config.HomeDir(),
+		UserHomeDir:          userHome,
+		DowngradeCommitFlags: !project.GPGSigningAvailable(context.Background()),
 	})
 }

--- a/internal/sybra/review/coalesce_test.go
+++ b/internal/sybra/review/coalesce_test.go
@@ -43,7 +43,7 @@ func TestCoalescedFixPrompt(t *testing.T) {
 	t.Parallel()
 	pr := github.PullRequest{Number: 7, Repository: "o/r", HeadRefName: "feat", URL: "https://github.com/o/r/pull/7"}
 
-	single := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, "")
+	single := coalescedFixPrompt(context.Background(), []github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, "")
 	if strings.Contains(single, "multiple open issues") {
 		t.Errorf("single-issue prompt must not carry the coalesced header:\n%s", single)
 	}
@@ -51,7 +51,7 @@ func TestCoalescedFixPrompt(t *testing.T) {
 		t.Errorf("single comments prompt missing its body:\n%s", single)
 	}
 
-	multi := coalescedFixPrompt([]github.PRIssue{
+	multi := coalescedFixPrompt(context.Background(), []github.PRIssue{
 		{Kind: github.PRIssueCIFailure, PR: pr},
 		{Kind: github.PRIssueComments, PR: pr},
 	}, "")
@@ -144,18 +144,18 @@ func TestCoalescedFixPrompt_ReviewHold(t *testing.T) {
 	pr := github.PullRequest{Number: 7, Repository: "o/r", HeadRefName: "feat", URL: "https://github.com/o/r/pull/7"}
 	const suffix = "\n\n---\nREVIEW HOLD sentinel"
 
-	withComments := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, suffix)
+	withComments := coalescedFixPrompt(context.Background(), []github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, suffix)
 	if !strings.HasSuffix(withComments, suffix) {
 		t.Errorf("comments prompt must end with the hold suffix:\n%s", withComments)
 	}
 
-	noComments := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueCIFailure, PR: pr}}, suffix)
+	noComments := coalescedFixPrompt(context.Background(), []github.PRIssue{{Kind: github.PRIssueCIFailure, PR: pr}}, suffix)
 	if strings.Contains(noComments, "REVIEW HOLD") {
 		t.Errorf("a non-comments fix posts no replies, so it must not carry the hold suffix:\n%s", noComments)
 	}
 
 	// Disabled hold (empty suffix) leaves a comments prompt byte-for-byte as-is.
-	plain := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, "")
+	plain := coalescedFixPrompt(context.Background(), []github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, "")
 	if strings.Contains(plain, "REVIEW HOLD") {
 		t.Errorf("empty suffix must not alter the prompt:\n%s", plain)
 	}

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -314,14 +314,14 @@ func ciFailurePrompt(pr github.PullRequest) string {
 // prIssueBody returns the pr-fix agent prompt for one fixable issue kind. ok is
 // false for kinds with no agent prompt (ready_to_merge), which never reach the
 // dispatch path.
-func prIssueBody(issue github.PRIssue) (string, bool) {
+func prIssueBody(ctx context.Context, issue github.PRIssue) (string, bool) {
 	switch issue.Kind {
 	case github.PRIssueConflict:
 		return conflictPrompt(issue.PR), true
 	case github.PRIssueCIFailure:
 		return ciFailurePrompt(issue.PR), true
 	case github.PRIssueComments:
-		return commentsPrompt(issue.PR), true
+		return commentsPrompt(ctx, issue.PR), true
 	default:
 		return "", false
 	}
@@ -388,17 +388,17 @@ func (r *Handler) logPRIssueDetected(taskID string, issue github.PRIssue) {
 // review-hold setting is on AND the set includes a review-comments issue — the
 // only kind that posts thread replies. It overrides the "reply live and push"
 // instructions above, so it must land after them.
-func coalescedFixPrompt(issues []github.PRIssue, holdSuffix string) string {
+func coalescedFixPrompt(ctx context.Context, issues []github.PRIssue, holdSuffix string) string {
 	var prompt string
 	if len(issues) == 1 {
-		prompt, _ = prIssueBody(issues[0])
+		prompt, _ = prIssueBody(ctx, issues[0])
 	} else {
 		var b strings.Builder
 		b.WriteString("This PR has multiple open issues from the same push. Address " +
 			"ALL of them in one pass, then push once at the end (the per-section push " +
 			"commands are equivalent — run it a single time).\n\n")
 		for i := range issues {
-			body, ok := prIssueBody(issues[i])
+			body, ok := prIssueBody(ctx, issues[i])
 			if !ok {
 				continue
 			}
@@ -476,7 +476,7 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 	// e.ctx field (Engine.SetContext), not an explicit parameter threaded here.
 	// contextcheck no longer flags this call site (verified with a clean
 	// build+lint cache), so no suppression directive is needed here.
-	return r.dispatchPRIssueWithOptions(t, primary, handle, coalescedFixPrompt(handle, reviewHoldFixSuffix(r.cfg)), dir, opts)
+	return r.dispatchPRIssueWithOptions(t, primary, handle, coalescedFixPrompt(ctx, handle, reviewHoldFixSuffix(r.cfg)), dir, opts)
 }
 
 // autoResolveConflict attempts the deterministic clean-merge fast-path for a
@@ -1173,7 +1173,7 @@ func (r *Handler) prepareWorktree(ctx context.Context, t task.Task, issue github
 // commentsPrompt instructs the fix agent to address unresolved review comments
 // on the user's own PR via the /fix-review skill (which replies on every
 // thread), then push and re-request review.
-func commentsPrompt(pr github.PullRequest) string {
+func commentsPrompt(ctx context.Context, pr github.PullRequest) string {
 	return fmt.Sprintf(
 		"Run /fix-review %s --auto\n\n"+
 			"This is your own PR (#%d) — reviewers left comments or unresolved "+
@@ -1186,7 +1186,7 @@ func commentsPrompt(pr github.PullRequest) string {
 			"task.\n\n"+
 			"IMPORTANT: when committing, use conventional commit format "+
 			"`fix(review): address PR review comments` (type(scope) required by "+
-			"repo hooks). Sign the commit with `git commit -s -S`.\n\n"+
+			"repo hooks). Sign the commit with `git commit %s`.\n\n"+
 			"Push to the same remote the PR was opened from — never to `origin` "+
 			"when a `fork` remote exists:\n"+
 			"```sh\n"+
@@ -1194,7 +1194,7 @@ func commentsPrompt(pr github.PullRequest) string {
 			"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n"+
 			"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
 			"```",
-		pr.URL, pr.Number, pr.HeadRefName,
+		pr.URL, pr.Number, project.CommitSignFlags(ctx), pr.HeadRefName,
 	)
 }
 

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -107,8 +108,8 @@ func (r *Handler) StartFixReviewAgent(t task.Task) error {
 		"Run /fix-review https://github.com/%s/pull/%d --auto\n\n"+
 			"IMPORTANT: when committing, use conventional commit format "+
 			"`fix(review): address PR review comments` (type(scope) required by repo hooks). "+
-			"Sign the commit with `git commit -s -S`. Push the branch when done.",
-		t.ProjectID, t.PRNumber,
+			"Sign the commit with `git commit %s`. Push the branch when done.",
+		t.ProjectID, t.PRNumber, project.CommitSignFlags(context.Background()),
 	) + reviewHoldFixSuffix(r.cfg)
 
 	ag, err := r.agents.Run(agent.RunConfig{

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -506,6 +506,9 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 	if err := project.CreateWorktreeDetached(ctx, proj.ClonePath, wtPath, ref); err != nil {
 		return "", fmt.Errorf("create review worktree: %w", err)
 	}
+	if err := project.InstallSignoffHook(ctx, wtPath); err != nil {
+		m.logger.Warn("review.worktree.signoff-hook", "task_id", t.ID, "err", err)
+	}
 	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
 	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
 		return "", fmt.Errorf("review setup: %w", err)
@@ -573,6 +576,9 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 		m.logger.Warn("branch-fix.worktree.sanitize", "task_id", t.ID, "err", err)
 	}
 	m.ensureBranch(t, branch)
+	if err := project.InstallSignoffHook(ctx, wtPath); err != nil {
+		m.logger.Warn("branch-fix.worktree.signoff-hook", "task_id", t.ID, "err", err)
+	}
 	m.logger.Info("branch-fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
 	// Read setup from the trusted default branch, never the checked-out worktree:
 	// this branch already carries commits an implementation agent pushed in an
@@ -694,6 +700,9 @@ func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) 
 		m.logger.Warn("fix.worktree.sanitize", "task_id", t.ID, "err", err)
 	}
 	m.ensureBranch(t, branch)
+	if err := project.InstallSignoffHook(ctx, wtPath); err != nil {
+		m.logger.Warn("fix.worktree.signoff-hook", "task_id", t.ID, "err", err)
+	}
 	m.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
 	if err := m.runSetupNonGating(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
 		return "", fmt.Errorf("fix setup: %w", err)

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -292,6 +292,9 @@ func (m *Manager) installChecks(ctx context.Context, wtPath string, proj project
 	if err := project.InstallHooks(ctx, wtPath, checks); err != nil {
 		m.logger.Warn("worktree.hooks", "path", wtPath, "err", err)
 	}
+	if err := project.InstallSignoffHook(ctx, wtPath); err != nil {
+		m.logger.Warn("worktree.signoff-hook", "path", wtPath, "err", err)
+	}
 	if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
 		m.logger.Warn("worktree.fork-only-push", "path", wtPath, "err", err)
 	}


### PR DESCRIPTION
## Motivation

Agent-authored commits used a plain `git commit` and did not reliably carry a
`Signed-off-by` trailer, so PRs on repos with the DCO check (e.g. kumahq/kuma)
failed and had to be signed off by hand. Only Sybra's own git ops
(`AutoCommitUncommitted`, `MergeOnto`, `TryCleanMerge`) passed `--signoff`; the
agent's own commits relied on an advisory prompt instruction the LLM did not
always follow, and klaudiush's flag enforcement is a Bash-command parser that
leaks across command forms, providers, and machines (the server has no such
config).

> Changelog: fix(worktree): guarantee DCO sign-off on commits

## Implementation information

**DCO sign-off (`-s`) — guaranteed, GPG-free.** A `prepare-commit-msg` hook
(`project.InstallSignoffHook`) appends `Signed-off-by:` via
`git interpret-trailers`. It is the only hook that fires on every commit
(including merges and `--no-verify`), needs no key, and is idempotent (no
duplicate when `-s` was already used). Installed into each clone's shared hooks
dir at `CloneBare`, `installChecks`, and the review/fix prepare paths, so no
code path can produce an unsigned commit.

**GPG (`-S`) — per machine.** DCO does not require GPG, and keyless hosts (the
Linux server) fail `git commit -S`. `project.GPGSigningAvailable` /
`CommitSignFlags` emit `-s -S` where a signing key exists and `-s` where not:
- runtime PR-fix prompts (`review/fix.go`, `review/inbound.go`) build the flags per machine;
- `skillsync` downgrades `-s -S`→`-s` in synced docs/skills when no key is present (sources stay `-s -S` for keyed hosts).

Tests cover the hook end-to-end (clone → worktree → plain `git commit` → signed;
`-s` no-duplicate) and the skillsync downgrade across CLAUDE.md and flat/dir
skills.

## Supporting documentation

`go build`, `go vet`, `golangci-lint` (0 issues), and the affected test suites
(`project`, `worktree`, `skillsync`, `review`) all pass.
