### PR TITLE
feat(workflow): dispatch review work before new

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -647,6 +648,21 @@ func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
 	}
 }
 
+func dispatchPriorityRank(status string) int {
+	switch status {
+	case "in-review", "ready-pr":
+		return 0
+	case "ready-review", "testing":
+		return 1
+	case "in-progress":
+		return 2
+	case "planning", "plan-review":
+		return 3
+	default:
+		return 4
+	}
+}
+
 func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason string, ok bool) {
 	// Skip tasks whose step is currently being started. Interactive spawns
 	// (worktree creation, rebase, agent process start) take several seconds
@@ -725,6 +741,10 @@ func (e *Engine) ResumeStalled() {
 		e.logger.Error("workflow.resume-stalled.list", "err", err)
 		return
 	}
+
+	slices.SortStableFunc(tasks, func(a, b TaskInfo) int {
+		return cmp.Compare(dispatchPriorityRank(a.Status), dispatchPriorityRank(b.Status))
+	})
 
 	for i := range tasks {
 		t := &tasks[i]

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1778,6 +1779,65 @@ func TestNoWorkflowField(t *testing.T) {
 
 	// Should not panic or error fatally.
 	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "agent-1", Result: "result", Success: true})
+}
+
+func TestDispatchPriorityRank(t *testing.T) {
+	cases := []struct {
+		status string
+		want   int
+	}{
+		{"in-review", 0},
+		{"ready-pr", 0},
+		{"ready-review", 1},
+		{"testing", 1},
+		{"in-progress", 2},
+		{"planning", 3},
+		{"plan-review", 3},
+		{"todo", 4},
+		{"new", 4},
+		{"blocked", 4},
+		{"", 4},
+	}
+	for _, tc := range cases {
+		if got := dispatchPriorityRank(tc.status); got != tc.want {
+			t.Errorf("dispatchPriorityRank(%q) = %d, want %d", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestResumeStalled_PrioritizesReviewOverNewWork(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	parked := func(id, status string) TaskInfo {
+		return TaskInfo{
+			ID:        id,
+			Status:    status,
+			AgentMode: "headless",
+			Workflow: &Execution{
+				WorkflowID:  "test-simple",
+				CurrentStep: "implement",
+				State:       ExecWaiting,
+				Variables:   make(map[string]string),
+			},
+		}
+	}
+	tasks.Put(parked("t-new", "todo"))
+	tasks.Put(parked("t-mid", "in-progress"))
+	tasks.Put(parked("t-review", "in-review"))
+
+	engine.ResumeStalled()
+
+	var order []string
+	for _, c := range agents.calls {
+		order = append(order, c.TaskID)
+	}
+	want := []string{"t-review", "t-mid", "t-new"}
+	if !slices.Equal(order, want) {
+		t.Fatalf("dispatch order = %v, want %v", order, want)
+	}
 }
 
 func TestResumeStalled_RunAgent(t *testing.T) {


### PR DESCRIPTION
## Motivation

> Changelog: feat(workflow): dispatch review work before new implementation

When the agent pool is saturated (`max_concurrent` reached), a task's
`run_agent` step parks in `ExecWaiting` and the periodic `ResumeStalled`
pass retries parked steps. Whichever parked task `ResumeStalled` reaches
first claims the freed slot — but it iterated `ListTasks()` in
unspecified (map) order. Under contention this let a brand-new
implementation task jump ahead of an in-review PR waiting on a pr-fix or
review agent, so open PRs starved behind fresh work instead of landing.

## Implementation information

`ResumeStalled` now sorts resumable tasks by a status-derived
`dispatchPriorityRank` before the loop (stable sort):

- rank 0: `in-review`, `ready-pr` (land / pr-fix / merge)
- rank 1: `ready-review`, `testing` (review + test)
- rank 2: `in-progress` (implementation already in flight)
- rank 3: `planning`, `plan-review`
- rank 4: everything else, incl. `todo` / `new` (brand-new)

Post-implementation work therefore claims freed slots before new
implementation. The stable sort preserves prior order within a rank, so
intra-rank behavior is unchanged. Status literals mirror `internal/task`,
matching this package's decoupled `TaskInfo.Status` convention.

Only the contention path is affected: with free slots, first-agent
starts still flow through `DispatchEvent` immediately; when the pool is
full those starts also park and compete through the same sorted
`ResumeStalled` retry, so the priority holds exactly when it matters.

## Supporting documentation

- `TestDispatchPriorityRank` — table-driven rank coverage
- `TestResumeStalled_PrioritizesReviewOverNewWork` — asserts dispatch
  order (in-review → in-progress → todo) regardless of list order
