### PR TITLE
Rerun setup when reusing task worktrees

### DIFF
--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -826,6 +826,43 @@ func TestPrepareForTask_RunsBootstrap(t *testing.T) {
 	}
 }
 
+func TestPrepareForTask_RerunsBootstrapOnExistingWorktreeReuse(t *testing.T) {
+	counterPath := filepath.Join(t.TempDir(), "setup-count")
+	h := prepareHarness(t, []string{fmt.Sprintf("printf x >> %s", strconv.Quote(counterPath))}, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("reuse bootstrap task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+	secondPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("reused PrepareForTask: %v", err)
+	}
+	if secondPath != firstPath {
+		t.Fatalf("reused PrepareForTask path = %q, want %q", secondPath, firstPath)
+	}
+
+	count, err := os.ReadFile(counterPath)
+	if err != nil {
+		t.Fatalf("read setup counter: %v", err)
+	}
+	if got, want := string(count), "xx"; got != want {
+		t.Fatalf("setup command ran %d times, want 2 (counter %q)", len(got), got)
+	}
+}
+
 // TestPrepareForTask_MergesRepoAndAppSetup confirms that .sybra.yaml's
 // `setup:` block runs first (canonical repo bootstrap) and then any
 // machine-local SetupCommands are appended. Both must execute and the

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -220,6 +220,9 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 			// again since that earlier fetch.
 			callPhase(onPhase, "Syncing upstream…")
 			m.logPushSync(t.ID, wtBranch, project.PushSync(ctx, wtPath, wtBranch))
+			if err := m.runPrepareSetup(ctx, t.ID, wtPath, proj, "reused worktree", onPhase); err != nil {
+				return "", err
+			}
 			return m.finalizeWorktree(ctx, t, wtPath, wtBranch, proj)
 		}
 		// Worktree was wiped — fall through to create paths below.
@@ -242,9 +245,8 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 		callPhase(onPhase, "Syncing upstream…")
 		m.logPushSync(t.ID, wtBranch, project.PushSync(ctx, wtPath, wtBranch))
 		m.logger.Info("worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
-		callPhase(onPhase, "Running setup…")
-		if err := m.runSetup(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
-			return "", fmt.Errorf("setup on reused branch: %w", err)
+		if err := m.runPrepareSetup(ctx, t.ID, wtPath, proj, "reused branch", onPhase); err != nil {
+			return "", err
 		}
 		return m.finalizeWorktree(ctx, t, wtPath, wtBranch, proj)
 	}
@@ -254,9 +256,8 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 	m.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)
-	callPhase(onPhase, "Running setup…")
-	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
-		return "", fmt.Errorf("setup on new worktree: %w", err)
+	if err := m.runPrepareSetup(ctx, t.ID, wtPath, proj, "new worktree", onPhase); err != nil {
+		return "", err
 	}
 	m.installChecks(ctx, wtPath, proj)
 
@@ -268,6 +269,14 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 	m.ensureBranch(t, wtBranch)
 	m.seedWorktree(ctx, t, wtPath, wtBranch)
 	return wtPath, nil
+}
+
+func (m *Manager) runPrepareSetup(ctx context.Context, taskID, wtPath string, proj project.Project, label string, onPhase func(string)) error {
+	callPhase(onPhase, "Running setup…")
+	if err := m.runSetup(ctx, taskID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
+		return fmt.Errorf("setup on %s: %w", label, err)
+	}
+	return nil
 }
 
 // reconcileAndRebase prepares a reused worktree branch for another agent run.


### PR DESCRIPTION
## Summary
- rerun project setup commands when PrepareForTask reuses an existing Sybra-managed worktree directory
- share setup phase handling across fresh, branch-reuse, and directory-reuse prepare paths
- add a regression test that prepares the same task twice and asserts setup runs twice

## Tests
- go test ./internal/worktree
- go test ./...
- pre-push hook: Go package tests + frontend svelte-check