### PR TITLE
fix(agent): human-review bypasses agent cap

### DIFF
--- a/internal/agent/manager_run_test.go
+++ b/internal/agent/manager_run_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -291,5 +292,30 @@ func TestNewProviderUnhealthy_RateLimitedFlag(t *testing.T) {
 		if ue.Provider != "codex" || ue.Reason != c.reason {
 			t.Errorf("newProviderUnhealthy dropped fields: %+v", ue)
 		}
+	}
+}
+
+func TestRegisterRunningAgent_IgnoreConcurrencyLimitBypassesCap(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.maxConcurrent = 2
+
+	for i := range m.maxConcurrent {
+		a := &Agent{ID: fmt.Sprintf("live%d", i), Provider: "claude", done: make(chan struct{})}
+		if err := m.registerRunningAgent(a, RunConfig{}, func() {}); err != nil {
+			t.Fatalf("registerRunningAgent(live%d): %v", i, err)
+		}
+	}
+
+	normal := &Agent{ID: "normal", Provider: "claude", done: make(chan struct{})}
+	if err := m.registerRunningAgent(normal, RunConfig{}, func() {}); !errors.Is(err, ErrMaxConcurrentReached) {
+		t.Fatalf("normal spawn at cap: err = %v, want ErrMaxConcurrentReached", err)
+	}
+
+	control := &Agent{ID: "control-plane", Provider: "claude", done: make(chan struct{})}
+	if err := m.registerRunningAgent(control, RunConfig{IgnoreConcurrencyLimit: true}, func() {}); err != nil {
+		t.Fatalf("IgnoreConcurrencyLimit spawn at cap must succeed, got err = %v", err)
+	}
+	if _, err := m.GetAgent(control.ID); err != nil {
+		t.Fatalf("control-plane agent should be registered: %v", err)
 	}
 }

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -185,16 +185,17 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 
 	prompt := h.buildPrompt(t, wctx)
 	ag, err := h.agents.Run(agent.RunConfig{
-		TaskID:             taskID,
-		Name:               agent.RoleHumanReview.AgentName(t.Title),
-		Mode:               "headless",
-		Provider:           "claude",
-		Model:              h.cfg.HumanReviewModel(),
-		Prompt:             prompt,
-		Dir:                h.cfg.HumanReview.SybraRepoDir,
-		RequirePermissions: false,
-		OneShot:            true,
-		OutputSchema:       verdict.Schema,
+		TaskID:                 taskID,
+		Name:                   agent.RoleHumanReview.AgentName(t.Title),
+		Mode:                   "headless",
+		Provider:               "claude",
+		Model:                  h.cfg.HumanReviewModel(),
+		Prompt:                 prompt,
+		Dir:                    h.cfg.HumanReview.SybraRepoDir,
+		RequirePermissions:     false,
+		OneShot:                true,
+		OutputSchema:           verdict.Schema,
+		IgnoreConcurrencyLimit: true,
 	})
 	if err != nil {
 		h.mu.Lock()


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): human-review spawns bypass the concurrency cap

Escalation / human-review spawns went through the same `agent.max_concurrent`
gate as normal fleet dispatch, so when the pool was full they errored with
"max concurrent agents reached" instead of bypassing the cap. Under load this
broke recovery exactly when it was needed: a task that needed to escalate
couldn't get a slot, the spawn errored, and the task stranded at
`human-required` with no live workflow gate.

Observed: `human-review.spawn err=max concurrent agents reached (6)` for
recovery-driven tasks.

## Implementation information

`humanReviewHandler.maybeSpawn` now sets `IgnoreConcurrencyLimit: true` on its
`RunConfig`, matching the pattern already used by the monitor and loop-agent
dispatchers (`internal/monitor/dispatcher.go`, `internal/loopagent/scheduler.go`,
`internal/sybra/svc_orchestrator.go`). Human-review is a short, bounded
control-plane operation, not a long fleet run — it must not compete for the
fleet cap. Normal implementation/review/pr-fix dispatch is unchanged.

Test `TestRegisterRunningAgent_IgnoreConcurrencyLimitBypassesCap`: with the
pool at cap, a normal spawn is rejected with `ErrMaxConcurrentReached` while an
`IgnoreConcurrencyLimit` spawn succeeds and registers.
