### PR TITLE
fix(recovery): reconcile in-review lost pr_number

### DIFF
--- a/internal/github/pr_find.go
+++ b/internal/github/pr_find.go
@@ -36,3 +36,47 @@ func FindPRForBranch(ctx context.Context, repo, head string) (number int, found 
 	}
 	return prs[0].Number, true, nil
 }
+
+// FindPRForBranchAnyState resolves the PR for a branch across every state so a
+// task that lost its pr_number can be reconciled. A MERGED PR wins (the task
+// has landed and must advance to done); otherwise a single OPEN PR is returned
+// to backfill the number. state is "MERGED" or "OPEN". found is false (nil err)
+// when no unambiguous PR matches — several open PRs, or only closed-unmerged
+// ones, leave the caller to make no change.
+func FindPRForBranchAnyState(ctx context.Context, repo, head string) (number int, state string, found bool, err error) {
+	out, runErr := findPRRunner(ctx, "pr", "list",
+		"--repo", repo, "--head", head, "--state", "all",
+		"--json", "number,state", "--limit", "20")
+	if runErr != nil {
+		return 0, "", false, fmt.Errorf("gh pr list --head %s --state all: %s: %w", head, sanitizeGHOutput(out), runErr)
+	}
+	var prs []struct {
+		Number int    `json:"number"`
+		State  string `json:"state"`
+	}
+	if jsonErr := json.Unmarshal(out, &prs); jsonErr != nil {
+		return 0, "", false, fmt.Errorf("parse pr list: %w", jsonErr)
+	}
+	var mergedNum, openNum, openCount int
+	for _, pr := range prs {
+		if pr.Number <= 0 {
+			continue
+		}
+		switch pr.State {
+		case "MERGED":
+			if mergedNum == 0 {
+				mergedNum = pr.Number
+			}
+		case "OPEN":
+			openCount++
+			openNum = pr.Number
+		}
+	}
+	if mergedNum > 0 {
+		return mergedNum, "MERGED", true, nil
+	}
+	if openCount == 1 {
+		return openNum, "OPEN", true, nil
+	}
+	return 0, "", false, nil
+}

--- a/internal/github/pr_find_test.go
+++ b/internal/github/pr_find_test.go
@@ -57,3 +57,51 @@ func TestFindPRForBranch_RunError(t *testing.T) {
 		t.Fatal("expected error propagated to caller")
 	}
 }
+
+func TestFindPRForBranchAnyState(t *testing.T) {
+	cases := []struct {
+		name       string
+		payload    string
+		wantNumber int
+		wantState  string
+		wantFound  bool
+	}{
+		{"merged wins over closed", `[{"number":10,"state":"CLOSED"},{"number":11,"state":"MERGED"}]`, 11, "MERGED", true},
+		{"single open backfills", `[{"number":42,"state":"OPEN"}]`, 42, "OPEN", true},
+		{"only closed leaves none", `[{"number":9,"state":"CLOSED"}]`, 0, "", false},
+		{"ambiguous open leaves none", `[{"number":1,"state":"OPEN"},{"number":2,"state":"OPEN"}]`, 0, "", false},
+		{"empty leaves none", `[]`, 0, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := findPRRunner
+			t.Cleanup(func() { findPRRunner = orig })
+			var gotArgs []string
+			findPRRunner = func(_ context.Context, args ...string) ([]byte, error) {
+				gotArgs = args
+				return []byte(tc.payload), nil
+			}
+			number, state, found, err := FindPRForBranchAnyState(context.Background(), "acme/widgets", "b")
+			if err != nil {
+				t.Fatalf("FindPRForBranchAnyState: %v", err)
+			}
+			if number != tc.wantNumber || state != tc.wantState || found != tc.wantFound {
+				t.Fatalf("got (%d, %q, %v), want (%d, %q, %v)", number, state, found, tc.wantNumber, tc.wantState, tc.wantFound)
+			}
+			if joined := strings.Join(gotArgs, " "); !strings.Contains(joined, "--state all") {
+				t.Errorf("args %q missing --state all", joined)
+			}
+		})
+	}
+}
+
+func TestFindPRForBranchAnyState_RunError(t *testing.T) {
+	orig := findPRRunner
+	t.Cleanup(func() { findPRRunner = orig })
+	findPRRunner = func(context.Context, ...string) ([]byte, error) {
+		return []byte("gh: boom"), errors.New("exit status 1")
+	}
+	if _, _, _, err := FindPRForBranchAnyState(context.Background(), "acme/widgets", "b"); err == nil {
+		t.Fatal("expected error propagated to caller")
+	}
+}

--- a/internal/recovery/reconcile.go
+++ b/internal/recovery/reconcile.go
@@ -1,0 +1,85 @@
+package recovery
+
+import (
+	"context"
+	"slices"
+
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+// ReconcileLostPRNumber self-heals in-review tasks whose pr_number is 0: with
+// no linked PR the landing detector can never match a merged PR, so the task
+// orphans at in-review while every recovery pass re-derives that status from
+// its stale workflow. A merged PR (resolved by branch, then linked issue)
+// advances the task to done and clears the workflow so the status sticks; an
+// open PR backfills pr_number; no match is left untouched. A nil PRs resolver
+// makes this a no-op so it never blocks a machine without GitHub configured.
+func (r *Recovery) ReconcileLostPRNumber(ctx context.Context) {
+	if r.PRs == nil {
+		return
+	}
+	tasks, err := r.Tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if !reconcileLostPREligible(t) {
+			continue
+		}
+		if r.Agents.HasRunningAgentForTask(t.ID) || r.Agents.IsDispatching(t.ID) {
+			continue
+		}
+		ref, resolveErr := r.PRs.ResolvePRForTask(ctx, t.ProjectID, t.Branch, t.Issue)
+		if resolveErr != nil {
+			r.Throttle.Log(r.Logger, "reconcile-lost-pr.resolve", "reconcile:"+t.ID, resolveErr, "task_id", t.ID)
+			continue
+		}
+		if ref.Number <= 0 {
+			continue
+		}
+		switch ref.State {
+		case "MERGED":
+			r.reconcileLandedTask(t, ref.Number)
+		case "OPEN":
+			r.reconcileBackfillPR(t, ref.Number)
+		}
+	}
+}
+
+func (r *Recovery) reconcileLandedTask(t *task.Task, prNumber int) {
+	var clearWorkflow *workflow.Execution
+	if _, err := r.Tasks.Update(t.ID, task.Update{
+		PRNumber:     task.Ptr(prNumber),
+		Status:       task.Ptr(task.StatusDone),
+		Outcome:      task.Ptr("merged"),
+		StatusReason: task.Ptr(""),
+		Workflow:     &clearWorkflow,
+	}); err != nil {
+		r.Logger.Error("reconcile-lost-pr.landed", "task_id", t.ID, "pr", prNumber, "err", err)
+		return
+	}
+	r.Logger.Info("reconcile-lost-pr.landed", "task_id", t.ID, "pr", prNumber)
+}
+
+func (r *Recovery) reconcileBackfillPR(t *task.Task, prNumber int) {
+	if _, err := r.Tasks.Update(t.ID, task.Update{PRNumber: task.Ptr(prNumber)}); err != nil {
+		r.Logger.Error("reconcile-lost-pr.backfill", "task_id", t.ID, "pr", prNumber, "err", err)
+		return
+	}
+	r.Logger.Info("reconcile-lost-pr.backfilled", "task_id", t.ID, "pr", prNumber)
+}
+
+func reconcileLostPREligible(t *task.Task) bool {
+	if t.Status != task.StatusInReview {
+		return false
+	}
+	if t.PRNumber != 0 || t.Branch == "" || t.ProjectID == "" {
+		return false
+	}
+	if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
+		return false
+	}
+	return !slices.Contains(t.Tags, "review")
+}

--- a/internal/recovery/reconcile_test.go
+++ b/internal/recovery/reconcile_test.go
@@ -1,0 +1,210 @@
+package recovery_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/logging"
+	"github.com/Automaat/sybra/internal/recovery"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+type fakePRResolver struct {
+	ref   recovery.PRRef
+	err   error
+	calls int
+}
+
+func (f *fakePRResolver) ResolvePRForTask(context.Context, string, string, string) (recovery.PRRef, error) {
+	f.calls++
+	return f.ref, f.err
+}
+
+func newInReviewOrphan(t *testing.T, tasks *task.Manager, mutate func(*task.Update)) string {
+	t.Helper()
+	created, err := tasks.Create("lost pr number", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := task.StatusInReview
+	branch := "feat/thing-abcd1234"
+	proj := "owner/repo"
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-pr",
+		State:       workflow.ExecCompleted,
+		CompletedAt: task.Ptr(time.Now().UTC()),
+	}
+	u := task.Update{Status: &status, Branch: &branch, ProjectID: &proj, Workflow: &wf}
+	if mutate != nil {
+		mutate(&u)
+	}
+	if _, err := tasks.Update(created.ID, u); err != nil {
+		t.Fatal(err)
+	}
+	return created.ID
+}
+
+func newReconcileRecovery(t *testing.T, tasks *task.Manager, resolver recovery.PRResolver) (*recovery.Recovery, *sync.WaitGroup) {
+	t.Helper()
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+	var wg sync.WaitGroup
+	r := &recovery.Recovery{
+		Tasks:     tasks,
+		Agents:    agents,
+		Worktrees: wm,
+		PRs:       resolver,
+		Logger:    logger,
+		Throttle:  logging.NewErrorThrottle(),
+		WG:        &wg,
+	}
+	return r, &wg
+}
+
+func TestReconcileLostPRNumber(t *testing.T) {
+	cases := []struct {
+		name            string
+		ref             recovery.PRRef
+		resolveErr      error
+		wantStatus      task.Status
+		wantPR          int
+		wantWorkflowNil bool
+	}{
+		{
+			name:            "merged PR advances to done and clears workflow",
+			ref:             recovery.PRRef{Number: 1775, State: "MERGED"},
+			wantStatus:      task.StatusDone,
+			wantPR:          1775,
+			wantWorkflowNil: true,
+		},
+		{
+			name:       "open PR backfills pr_number and stays in-review",
+			ref:        recovery.PRRef{Number: 42, State: "OPEN"},
+			wantStatus: task.StatusInReview,
+			wantPR:     42,
+		},
+		{
+			name:       "no matching PR leaves the task unchanged",
+			ref:        recovery.PRRef{},
+			wantStatus: task.StatusInReview,
+			wantPR:     0,
+		},
+		{
+			name:       "resolver error leaves the task unchanged",
+			resolveErr: errors.New("gh unavailable"),
+			wantStatus: task.StatusInReview,
+			wantPR:     0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := task.NewStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			tasks := task.NewManager(store, nil)
+			id := newInReviewOrphan(t, tasks, nil)
+
+			resolver := &fakePRResolver{ref: tc.ref, err: tc.resolveErr}
+			r, wg := newReconcileRecovery(t, tasks, resolver)
+			r.ReconcileLostPRNumber(context.Background())
+			wg.Wait()
+
+			if resolver.calls != 1 {
+				t.Fatalf("resolver calls = %d, want 1", resolver.calls)
+			}
+			got, err := tasks.Get(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("status = %s, want %s", got.Status, tc.wantStatus)
+			}
+			if got.PRNumber != tc.wantPR {
+				t.Errorf("pr_number = %d, want %d", got.PRNumber, tc.wantPR)
+			}
+			if tc.wantWorkflowNil && got.Workflow != nil {
+				t.Errorf("workflow = %+v, want nil (cleared)", got.Workflow)
+			}
+			if !tc.wantWorkflowNil && got.Workflow == nil {
+				t.Errorf("workflow was cleared but should have been preserved")
+			}
+			if tc.wantStatus == task.StatusDone && got.Outcome != "merged" {
+				t.Errorf("outcome = %q, want merged", got.Outcome)
+			}
+		})
+	}
+}
+
+func TestReconcileLostPRNumberSkipsIneligible(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*task.Update)
+	}{
+		{
+			name:   "pr_number already linked",
+			mutate: func(u *task.Update) { u.PRNumber = task.Ptr(99) },
+		},
+		{
+			name:   "review-tagged task",
+			mutate: func(u *task.Update) { u.Tags = task.Ptr([]string{"review"}) },
+		},
+		{
+			name:   "no branch to resolve from",
+			mutate: func(u *task.Update) { u.Branch = task.Ptr("") },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := task.NewStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			tasks := task.NewManager(store, nil)
+			newInReviewOrphan(t, tasks, tc.mutate)
+
+			resolver := &fakePRResolver{ref: recovery.PRRef{Number: 1, State: "MERGED"}}
+			r, wg := newReconcileRecovery(t, tasks, resolver)
+			r.ReconcileLostPRNumber(context.Background())
+			wg.Wait()
+
+			if resolver.calls != 0 {
+				t.Fatalf("resolver called %d times for ineligible task, want 0", resolver.calls)
+			}
+		})
+	}
+}
+
+func TestReconcileLostPRNumberNilResolver(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	id := newInReviewOrphan(t, tasks, nil)
+
+	r, wg := newReconcileRecovery(t, tasks, nil)
+	r.ReconcileLostPRNumber(context.Background())
+	wg.Wait()
+
+	got, err := tasks.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInReview {
+		t.Errorf("status = %s, want in-review (nil resolver must no-op)", got.Status)
+	}
+}

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -39,6 +39,20 @@ type WorkflowRestarter interface {
 	HandleAgentComplete(taskID string, completion workflow.AgentCompletion)
 }
 
+// PRResolver resolves the GitHub PR a task lost track of when its pr_number was
+// cleared, so recovery can reconcile it. Implemented by the App over the repo's
+// github abstraction; kept a narrow interface so recovery stays a leaf package.
+type PRResolver interface {
+	ResolvePRForTask(ctx context.Context, repo, branch, issue string) (PRRef, error)
+}
+
+// PRRef is the PR a PRResolver matched to a task. State is "OPEN" or "MERGED";
+// a zero Number with an empty State means no unambiguous PR was found.
+type PRRef struct {
+	Number int
+	State  string
+}
+
 // Recovery owns the dependencies needed by the boot-time cleanup pass and
 // the periodic restart-stale sweep. Construct once during App.Startup,
 // reuse from the orchestrator loop.
@@ -49,6 +63,7 @@ type Recovery struct {
 	WorkflowEngine WorkflowRestarter // optional; nil-safe
 	Orchestrator   Orchestrator
 	Projects       ProjectGetter
+	PRs            PRResolver
 	Logger         *slog.Logger
 	Throttle       *logging.ErrorThrottle
 	WG             *sync.WaitGroup

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -819,6 +819,7 @@ func (a *App) newRecovery() *recovery.Recovery {
 		WorkflowEngine:     a.workflowEngine,
 		Orchestrator:       a.agentOrch,
 		Projects:           a.projects,
+		PRs:                newRecoveryPRResolver(),
 		Logger:             a.logger,
 		Throttle:           a.restartStaleErr,
 		WG:                 &a.wg,

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -54,6 +54,7 @@ func (a *App) maintenancePass(ctx context.Context) {
 	// Recover in-progress tasks whose agent died — runs continuously, not just at
 	// startup, to catch agents that finished without advancing the workflow.
 	a.recovery.RestartStaleInProgress(ctx)
+	a.recovery.ReconcileLostPRNumber(ctx)
 	// Re-attempt enrichment for URL stubs orphaned by a failed/interrupted
 	// initial fetch — otherwise they keep the enrich-pending marker (and their
 	// raw-URL title) forever and never dispatch a workflow. The eventual

--- a/internal/sybra/recovery_pr_resolver.go
+++ b/internal/sybra/recovery_pr_resolver.go
@@ -30,7 +30,7 @@ func (rp recoveryPRResolver) ResolvePRForTask(ctx context.Context, repo, branch,
 		}
 	}
 	if issue != "" {
-		if _, number := github.ParseIssueURL(issue); number > 0 {
+		if parsedRepo, number := github.ParseIssueURL(issue); number > 0 && parsedRepo == repo {
 			prs, err := rp.issueLinked(repo, number)
 			if err != nil {
 				return recovery.PRRef{}, err

--- a/internal/sybra/recovery_pr_resolver.go
+++ b/internal/sybra/recovery_pr_resolver.go
@@ -1,0 +1,44 @@
+package sybra
+
+import (
+	"context"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/recovery"
+)
+
+type recoveryPRResolver struct {
+	findByBranch func(ctx context.Context, repo, head string) (int, string, bool, error)
+	issueLinked  func(repo string, issueNumber int) ([]github.PullRequest, error)
+}
+
+func newRecoveryPRResolver() recoveryPRResolver {
+	return recoveryPRResolver{
+		findByBranch: github.FindPRForBranchAnyState,
+		issueLinked:  github.FetchIssueLinkedPRs,
+	}
+}
+
+func (rp recoveryPRResolver) ResolvePRForTask(ctx context.Context, repo, branch, issue string) (recovery.PRRef, error) {
+	if branch != "" {
+		num, state, found, err := rp.findByBranch(ctx, repo, branch)
+		if err != nil {
+			return recovery.PRRef{}, err
+		}
+		if found {
+			return recovery.PRRef{Number: num, State: state}, nil
+		}
+	}
+	if issue != "" {
+		if _, number := github.ParseIssueURL(issue); number > 0 {
+			prs, err := rp.issueLinked(repo, number)
+			if err != nil {
+				return recovery.PRRef{}, err
+			}
+			if len(prs) == 1 && prs[0].Number > 0 {
+				return recovery.PRRef{Number: prs[0].Number, State: "OPEN"}, nil
+			}
+		}
+	}
+	return recovery.PRRef{}, nil
+}


### PR DESCRIPTION
## Motivation

An in-review task whose `pr_number` is `0`/unset can never be matched to its
merged PR by the landing detector, so on merge it is never advanced to `done`.
It orphans at `in-review` with a `completed` workflow, and because that stale
workflow re-derives `in-review` on every recovery pass, a manual `--status done`
reverts immediately and an app restart does not fix it. Observed 2026-07-10:
~13 tasks stuck at `in-review`, all with `pr_number = 0`, several whose PRs had
already merged.

> Changelog: fix(recovery): reconcile in-review tasks that lost their pr_number

## Implementation information

- New `Recovery.ReconcileLostPRNumber`, run on the maintenance cadence next to
  `RestartStaleInProgress`, so it self-heals with no operator action.
- Eligibility is narrow: `in-review`, `pr_number == 0`, has a branch + project,
  not chat/umbrella, not `review`-tagged, and no running/dispatching agent — so
  a legitimately mid-flight task is never disturbed.
- PR resolution goes through the repo's github abstraction (not a raw `gh`
  shell): a new `github.FindPRForBranchAnyState` lists `--state all` and prefers
  a MERGED PR, else a single OPEN one; the App resolver falls back to the linked
  issue (`FetchIssueLinkedPRs`) when the branch yields nothing.
- MERGED -> task advances to `done` (outcome `merged`) and the orphaned workflow
  is cleared so the status sticks. OPEN -> `pr_number` is backfilled so normal
  merge-detection resumes. No match / lookup error -> the task is left untouched.
- Recovery stays a leaf package: it depends only on a narrow `PRResolver`
  interface, implemented by the App.

Tests: table-driven `TestReconcileLostPRNumber` (merged -> done + workflow
cleared; open -> backfilled, still in-review; none/error -> unchanged), plus
ineligibility and nil-resolver no-op cases, and `TestFindPRForBranchAnyState`
for the branch-lookup preference logic. The GitHub lookup is faked; no real
GitHub or `~/.sybra` access.
