### PR TITLE
fix(server): app-token git auth + container gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ codex/copilot) routes through one constructor, `newProviderCmd`
 (`runner_core.go`) — the sole caller of a provider `exec.CommandContext`. A
 `rg exec.CommandContext internal/agent` drift check must only ever match
 `newProviderCmd` itself plus four documented non-provider probe sites
-(`reattach.go` ps, `discovery.go` pgrep/lsof, `skill_invoke.go` codex plugin
+(`reattach_other.go` ps, `discovery.go` pgrep/lsof, `skill_invoke.go` codex plugin
 list); a new spawn site cannot obtain an unsandboxed process by construction.
 
 `newProviderCmd` wraps the invocation via `wrapInvocation`

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ARG SYBRA_GID=1000
 
 # --- Layer A: apt system packages + gh repo ---
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git curl gpg \
+    && apt-get install -y --no-install-recommends ca-certificates git openssh-client curl gpg \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
          | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -124,6 +124,8 @@ type Manager struct {
 	// real operator store even though SYBRA_HOME points at the task's sandbox.
 	controlHome string
 
+	ghAppToken func() string
+
 	// deadAgentRetention bounds how long a completed agent stays in agents
 	// after markAgentDone before being evicted. <= 0 evicts synchronously
 	// (used by tests that need deterministic immediate eviction).
@@ -468,6 +470,12 @@ func (m *Manager) signalKill(a *Agent) {
 func (m *Manager) SetHealthGate(g provider.HealthGate) {
 	m.mu.Lock()
 	m.gate = g
+	m.mu.Unlock()
+}
+
+func (m *Manager) SetGHAppToken(fn func() string) {
+	m.mu.Lock()
+	m.ghAppToken = fn
 	m.mu.Unlock()
 }
 

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -153,6 +153,8 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 		return cfg, nil, err
 	}
 
+	m.injectGitHubToken(&cfg)
+
 	if err := m.injectProcessSandbox(&cfg); err != nil {
 		return cfg, nil, err
 	}
@@ -221,6 +223,21 @@ func (m *Manager) injectSandboxHome(cfg *RunConfig) error {
 	}
 	cfg.resolvedSandboxHome = dir
 	return nil
+}
+
+func (m *Manager) injectGitHubToken(cfg *RunConfig) {
+	m.mu.RLock()
+	tokenFn := m.ghAppToken
+	m.mu.RUnlock()
+	if tokenFn == nil {
+		return
+	}
+	token := tokenFn()
+	if token == "" {
+		return
+	}
+	cfg.ExtraEnv = stripEnvKeys(cfg.ExtraEnv, "GH_TOKEN", "GITHUB_TOKEN")
+	cfg.ExtraEnv = append(cfg.ExtraEnv, "GH_TOKEN="+token, "GITHUB_TOKEN="+token)
 }
 
 func (m *Manager) injectGolangciCache(cfg *RunConfig) error {

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -5,10 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
-	"os/exec"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/events"
@@ -553,18 +550,4 @@ func reattachAlive(r Record) bool {
 		}
 	}
 	return true
-}
-
-// processStartString returns the OS-reported start time of a process as an
-// opaque string, used only for equality comparison to detect PID reuse.
-// Best-effort: an empty result disables the guard for that record.
-func processStartString(ctx context.Context, pid int) string {
-	if pid <= 0 {
-		return ""
-	}
-	out, err := exec.CommandContext(ctx, "ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
 }

--- a/internal/agent/reattach_linux.go
+++ b/internal/agent/reattach_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package agent
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const procStatStarttimeIndexAfterComm = 19
+
+func processStartString(_ context.Context, pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return ""
+	}
+	stat := string(data)
+	afterComm := strings.LastIndexByte(stat, ')')
+	if afterComm < 0 || afterComm+2 >= len(stat) {
+		return ""
+	}
+	fields := strings.Fields(stat[afterComm+2:])
+	if len(fields) <= procStatStarttimeIndexAfterComm {
+		return ""
+	}
+	return fields[procStatStarttimeIndexAfterComm]
+}

--- a/internal/agent/reattach_other.go
+++ b/internal/agent/reattach_other.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package agent
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func processStartString(ctx context.Context, pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, "ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/agent/regate_test.go
+++ b/internal/agent/regate_test.go
@@ -325,6 +325,7 @@ func TestRegateForTurn_WritesMarkerBeforePersistingSwitch(t *testing.T) {
 // (RequirePermissions) forward unchanged, so a sandboxed chat stays
 // sandboxed on its new provider instead of silently becoming permissive.
 func TestRegateForTurn_PreservesRequirePermissionsAcrossSwitch(t *testing.T) {
+	t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", "")
 	m, _ := newTestManager(t)
 	m.SetHealthGate(&fakeGate{
 		healthy: map[string]bool{"copilot": false, "codex": true},

--- a/internal/github/appauth.go
+++ b/internal/github/appauth.go
@@ -104,6 +104,10 @@ func RefreshAppToken(ctx context.Context) error {
 // cachedAppToken returns the current installation token, or "" when App auth is
 // disabled or no token has been minted yet. Non-blocking — never performs I/O —
 // so the request gate is never stalled on a token mint.
+func CurrentAppToken() string {
+	return cachedAppToken()
+}
+
 func cachedAppToken() string {
 	src := currentAppSource()
 	if src == nil {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -758,6 +758,43 @@ func EnforceForkOnlyPush(ctx context.Context, worktreePath string) error {
 	return executil.Run(ctx, worktreePath, "git", "remote", "set-url", "--push", "origin", forkOnlyDisabledPushURL)
 }
 
+// ConfigureGitHubAuth removes any credentials embedded in the origin remote
+// URL and points github.com at the gh credential helper, so pushes and fetches
+// authenticate via whatever token gh sees (the injected GitHub App
+// installation token) instead of a stale PAT baked into the URL. Idempotent
+// and safe to re-run on every worktree prepare; writes land in the shared bare
+// clone config, so existing tokenized clones self-heal.
+func ConfigureGitHubAuth(ctx context.Context, worktreePath string) error {
+	if err := stripRemoteURLCredentials(ctx, worktreePath, "origin"); err != nil {
+		return err
+	}
+	return executil.Run(ctx, worktreePath, "git", "config",
+		"credential.https://github.com.helper", "!gh auth git-credential")
+}
+
+func stripRemoteURLCredentials(ctx context.Context, worktreePath, remote string) error {
+	raw, _ := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote."+remote+".url")
+	cleaned, changed := stripHTTPSUserinfo(strings.TrimSpace(raw))
+	if !changed {
+		return nil
+	}
+	return executil.Run(ctx, worktreePath, "git", "remote", "set-url", remote, cleaned)
+}
+
+func stripHTTPSUserinfo(rawURL string) (string, bool) {
+	const scheme = "https://"
+	rest, ok := strings.CutPrefix(rawURL, scheme)
+	if !ok {
+		return rawURL, false
+	}
+	at := strings.IndexByte(rest, '@')
+	slash := strings.IndexByte(rest, '/')
+	if at < 0 || (slash >= 0 && at > slash) {
+		return rawURL, false
+	}
+	return scheme + rest[at+1:], true
+}
+
 // PushUpstream pushes branch to the fork remote if present, else origin,
 // with -u to set remote tracking.
 func PushUpstream(ctx context.Context, worktreePath, branch string) error {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -773,7 +773,10 @@ func ConfigureGitHubAuth(ctx context.Context, worktreePath string) error {
 }
 
 func stripRemoteURLCredentials(ctx context.Context, worktreePath, remote string) error {
-	raw, _ := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote."+remote+".url")
+	raw, err := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote."+remote+".url")
+	if err != nil {
+		return fmt.Errorf("read %s remote url: %w", remote, err)
+	}
 	cleaned, changed := stripHTTPSUserinfo(strings.TrimSpace(raw))
 	if !changed {
 		return nil

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -2740,3 +2740,26 @@ func TestCloneBare_InstallsSignoffHook(t *testing.T) {
 		t.Errorf("CloneBare worktree commit missing DCO trailer, got:\n%s", out)
 	}
 }
+
+func TestStripHTTPSUserinfo(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		changed bool
+	}{
+		{"token userinfo", "https://ghp_abc123@github.com/o/r.git", "https://github.com/o/r.git", true},
+		{"user colon token", "https://user:ghp_x@github.com/o/r.git", "https://github.com/o/r.git", true},
+		{"clean https", "https://github.com/o/r.git", "https://github.com/o/r.git", false},
+		{"ssh untouched", "git@github.com:o/r.git", "git@github.com:o/r.git", false},
+		{"at in path only", "https://github.com/o/r@v2.git", "https://github.com/o/r@v2.git", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := stripHTTPSUserinfo(tc.in)
+			if got != tc.want || changed != tc.changed {
+				t.Errorf("stripHTTPSUserinfo(%q) = (%q,%v), want (%q,%v)", tc.in, got, changed, tc.want, tc.changed)
+			}
+		})
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/experience"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/learning"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/loopagent"
@@ -292,6 +293,7 @@ func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) erro
 		a.logger.Error("agent.manager.init", "err", err)
 		return fmt.Errorf("agent manager: %w", err)
 	}
+	a.agents.SetGHAppToken(github.CurrentAppToken)
 	if agentCfg.SurviveRestartDir != "" {
 		a.logger.Info("agent.survive-restart.enabled", "dir", agentCfg.SurviveRestartDir)
 	}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -103,6 +104,9 @@ func (lm *LifecycleManager) startAppAuthLoop(ctx context.Context) {
 		for {
 			if err := github.RefreshAppToken(ctx); err != nil {
 				a.logger.Warn("github.app.token.refresh", "err", err)
+			} else if tok := github.CurrentAppToken(); tok != "" {
+				_ = os.Setenv("GH_TOKEN", tok)
+				_ = os.Setenv("GITHUB_TOKEN", tok)
 			}
 			select {
 			case <-ctx.Done():

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -634,12 +634,29 @@ func TestRunSetup_TimeoutKillsProcessGroup(t *testing.T) {
 
 	deadline = time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if syscallKillErr := syscall.Kill(pid, 0); syscallKillErr != nil {
-			return // grandchild is gone — process group was killed
+		if processGoneOrZombie(pid) {
+			return
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("grandchild pid %d still alive after setup timeout", pid)
+}
+
+func processGoneOrZombie(pid int) bool {
+	if syscall.Kill(pid, 0) != nil {
+		return true
+	}
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return false
+	}
+	stat := string(data)
+	afterComm := strings.LastIndexByte(stat, ')')
+	if afterComm < 0 || afterComm+2 >= len(stat) {
+		return false
+	}
+	fields := strings.Fields(stat[afterComm+2:])
+	return len(fields) > 0 && fields[0] == "Z"
 }
 
 // TestRunSetup_NoLogsDir — when no LogsDir is configured the hook still

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -298,4 +298,7 @@ func (m *Manager) installChecks(ctx context.Context, wtPath string, proj project
 	if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
 		m.logger.Warn("worktree.fork-only-push", "path", wtPath, "err", err)
 	}
+	if err := project.ConfigureGitHubAuth(ctx, wtPath); err != nil {
+		m.logger.Warn("worktree.github-auth", "path", wtPath, "err", err)
+	}
 }


### PR DESCRIPTION
## Motivation

Agent pushes on the synapse server were failing and parking tasks in
`human-required` (e.g. 62a30470). Two independent root causes:

1. **Dead PAT.** Agent `git`/`gh` authenticated via a static classic PAT
   (`GH_TOKEN` in the container env, and one baked into the bare-clone
   `origin` URL). When that PAT expired it 401'd every push, while sybra's
   own GitHub App-based pollers kept working — masking the cause.
2. **Unpassable pre-push gate.** Even with valid auth, the pre-push hook
   (`go test ./...` from `.sybra.yaml`) could not pass in the `node:24-slim`
   container: 4 environment-specific failures, one a real Linux gap.

> Changelog: fix(server): authenticate agent git/gh via GitHub App token

## Implementation information

**GitHub App auth for agent git/gh (retires the PAT):**
- Inject the App installation token as `GH_TOKEN`/`GITHUB_TOKEN` into every
  agent subprocess (`Manager.injectGitHubToken` + `SetGHAppToken`, wired from
  `app_init` to `github.CurrentAppToken`).
- Keep the sybra process env's token fresh from the App on each refresh
  (`lifecycle` loop), so in-process git/gh use it too.
- `project.ConfigureGitHubAuth`: strip credentials embedded in the `origin`
  URL and point `github.com` at the `gh` credential helper; called on every
  worktree prepare, so existing tokenized clones self-heal.

**Container test gate:**
- Add `openssh-client` to the image (transport-error test needs `ssh`).
- Read process start time from `/proc/<pid>/stat` on Linux
  (`reattach_linux.go`) so the PID-reuse reattach guard works without `ps`
  (absent in the image) — real defect, guard was silently off on the server.
- Pin `SYBRA_DISABLE_CODEX_SANDBOX` in the regate test (ambient value leaked).
- Treat a killed-but-unreaped zombie as dead in the process-group test.

## Supporting documentation

Verified: `go build` (darwin + linux), `golangci-lint` clean, affected
package suites green on darwin, and the 3 Go gate fixes confirmed passing
**inside the server container**. Closes #1660.