### PR TITLE
fix(agent): reap hung agents and gate reattach

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -114,6 +114,8 @@ type Manager struct {
 	// avoid recreating a zombie codex agent whose chat task was deleted.
 	taskExists func(taskID string) bool
 
+	taskStatus func(taskID string) (string, bool)
+
 	// sandboxHome resolves the per-task sandbox SYBRA_HOME for a task-scoped
 	// run. Required (non-nil) for any Run/StartAgent call with a non-empty
 	// TaskID — see prepareRunConfig. nil is only valid when every caller is a
@@ -168,6 +170,7 @@ type ManagerConfig struct {
 	SurviveRestartDir string
 	SessionSink       func(taskID, agentID, sessionID string) error
 	TaskExists        func(taskID string) bool
+	TaskStatus        func(taskID string) (string, bool)
 	LimitSink         func(limits.Snapshot)
 
 	// SandboxHome resolves the per-task sandbox SYBRA_HOME directory for a
@@ -233,6 +236,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		limitSink:              cfg.LimitSink,
 		sessionSink:            cfg.SessionSink,
 		taskExists:             cfg.TaskExists,
+		taskStatus:             cfg.TaskStatus,
 		maxInFlightPerProvider: cfg.Runtime.MaxInFlightPerProvider,
 		dispatchJitterMs:       cfg.Runtime.DispatchJitterMs,
 		headlessSteerable:      cfg.Runtime.HeadlessSteerable,
@@ -392,6 +396,12 @@ func (m *Manager) taskExistsFn() func(taskID string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.taskExists
+}
+
+func (m *Manager) taskStatusFn() func(taskID string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.taskStatus
 }
 
 // survives reports whether restart survival is active.

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -97,6 +97,11 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 			continue
 		}
 
+		if reason := m.reattachStaleReason(r, time.Now().UTC()); reason != "" {
+			m.reapStaleSurvivor(r, reg, reason)
+			continue
+		}
+
 		a := fromRecord(r)
 		// Rehydrate the buffer and capture the exact byte offset consumed, so
 		// the tailer resumes from there with no gap (a line appended between
@@ -567,4 +572,38 @@ func processStartString(ctx context.Context, pid int) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+const reattachMaxAge = 6 * time.Hour
+
+func (m *Manager) reattachStaleReason(r Record, now time.Time) string {
+	if strings.TrimSpace(r.TaskID) == "" {
+		return "no_task"
+	}
+	if !r.StartedAt.IsZero() && now.Sub(r.StartedAt) > reattachMaxAge {
+		return "deadline"
+	}
+	if statusFn := m.taskStatusFn(); statusFn != nil {
+		if status, ok := statusFn(r.TaskID); ok && staleForLiveAgent(status) {
+			return "task_status_" + status
+		}
+	}
+	return ""
+}
+
+func staleForLiveAgent(status string) bool {
+	switch status {
+	case "todo", "new":
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Manager) reapStaleSurvivor(r Record, reg survivalRegistry, reason string) {
+	m.logger.Warn("agent.reattach.reap", "id", r.ID, "pid", r.PID, "task", r.TaskID, "reason", reason)
+	signalPID(r.PID, stopSIGINTGrace)
+	if err := reg.Delete(r.ID); err != nil {
+		m.logger.Warn("agent.reattach.reap.delete", "id", r.ID, "err", err)
+	}
 }

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -564,6 +564,9 @@ func (m *Manager) reattachStaleReason(r Record, now time.Time) string {
 	if strings.TrimSpace(r.TaskID) == "" {
 		return "no_task"
 	}
+	if existsFn := m.taskExistsFn(); existsFn != nil && !existsFn(r.TaskID) {
+		return "task_gone"
+	}
 	if !r.StartedAt.IsZero() && now.Sub(r.StartedAt) > reattachMaxAge {
 		return "deadline"
 	}

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -235,14 +235,6 @@ func TestReattachReapsStaleSurvivors(t *testing.T) {
 
 func TestReattachAdoptsHealthySurvivor(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
-	prevPoll := reattachPIDPoll
-	reattachPIDPoll = 30 * time.Millisecond
-	prevGrace := stopSIGINTGrace
-	stopSIGINTGrace = 30 * time.Millisecond
-	t.Cleanup(func() {
-		reattachPIDPoll = prevPoll
-		stopSIGINTGrace = prevGrace
-	})
 
 	logDir := t.TempDir()
 	regDir := t.TempDir()

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -148,3 +148,139 @@ func TestReattachAccountingInvariant(t *testing.T) {
 		t.Fatalf("expected empty in-flight map after full drain, got %+v", got)
 	}
 }
+
+func TestReattachReapsStaleSurvivors(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	prevPoll := reattachPIDPoll
+	reattachPIDPoll = 30 * time.Millisecond
+	prevGrace := stopSIGINTGrace
+	stopSIGINTGrace = 30 * time.Millisecond
+	t.Cleanup(func() {
+		reattachPIDPoll = prevPoll
+		stopSIGINTGrace = prevGrace
+	})
+
+	spawnSleeper := func(t *testing.T) *exec.Cmd {
+		t.Helper()
+		cmd := exec.Command("sleep", "30")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start helper process: %v", err)
+		}
+		t.Cleanup(func() { _ = cmd.Process.Kill() })
+		go func() { _ = cmd.Wait() }()
+		return cmd
+	}
+
+	tests := []struct {
+		name   string
+		record func(pid int) Record
+		status map[string]string
+	}{
+		{
+			name: "empty task id",
+			record: func(pid int) Record {
+				return Record{ID: "s1", Mode: "headless", Provider: "claude", PID: pid, StartedAt: time.Now().UTC()}
+			},
+		},
+		{
+			name: "past wall-clock deadline",
+			record: func(pid int) Record {
+				return Record{ID: "s1", TaskID: "task-x", Mode: "headless", Provider: "claude", PID: pid, StartedAt: time.Now().Add(-24 * time.Hour).UTC()}
+			},
+		},
+		{
+			name: "inconsistent task status",
+			record: func(pid int) Record {
+				return Record{ID: "s1", TaskID: "task-x", Mode: "headless", Provider: "claude", PID: pid, StartedAt: time.Now().UTC()}
+			},
+			status: map[string]string{"task-x": "todo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logDir := t.TempDir()
+			regDir := t.TempDir()
+			cfg := ManagerConfig{SurviveRestartDir: regDir, OnComplete: func(*Agent) {}}
+			if tc.status != nil {
+				st := tc.status
+				cfg.TaskStatus = func(id string) (string, bool) { s, ok := st[id]; return s, ok }
+			}
+			m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, cfg)
+
+			cmd := spawnSleeper(t)
+			rec := tc.record(cmd.Process.Pid)
+			rec.ProcStartedAt = processStartString(context.Background(), cmd.Process.Pid)
+			if err := m.reg.Save(rec); err != nil {
+				t.Fatal(err)
+			}
+
+			reattached := m.ReattachAll()
+			if len(reattached) != 0 {
+				t.Fatalf("ReattachAll adopted %d stale agents, want 0", len(reattached))
+			}
+			if m.RunningCount() != 0 {
+				t.Fatalf("liveCount = %d, want 0 (a reaped survivor must not hold a pool slot)", m.RunningCount())
+			}
+			recs, err := m.reg.List()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(recs) != 0 {
+				t.Fatalf("stale survivor record not reaped: %d remain", len(recs))
+			}
+		})
+	}
+}
+
+func TestReattachAdoptsHealthySurvivor(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	prevPoll := reattachPIDPoll
+	reattachPIDPoll = 30 * time.Millisecond
+	prevGrace := stopSIGINTGrace
+	stopSIGINTGrace = 30 * time.Millisecond
+	t.Cleanup(func() {
+		reattachPIDPoll = prevPoll
+		stopSIGINTGrace = prevGrace
+	})
+
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	agentsLogDir := filepath.Join(logDir, "agents")
+	if err := os.MkdirAll(agentsLogDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete:        func(*Agent) {},
+		TaskStatus:        func(string) (string, bool) { return "in-progress", true },
+	})
+
+	logPath := filepath.Join(agentsLogDir, "h1.ndjson")
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	go func() { _ = cmd.Wait() }()
+
+	if err := m.reg.Save(Record{
+		ID: "h1", TaskID: "task-h", Mode: "headless", Provider: "claude",
+		PID: cmd.Process.Pid, LogPath: logPath, StartedAt: time.Now().UTC(),
+		ProcStartedAt: processStartString(context.Background(), cmd.Process.Pid),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reattached := m.ReattachAll()
+	if len(reattached) != 1 {
+		t.Fatalf("ReattachAll adopted %d healthy agents, want 1", len(reattached))
+	}
+	if m.RunningCount() != 1 {
+		t.Fatalf("liveCount = %d, want 1", m.RunningCount())
+	}
+	assertAccountingInvariant(t, m)
+}

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -172,9 +172,10 @@ func TestReattachReapsStaleSurvivors(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		record func(pid int) Record
-		status map[string]string
+		name        string
+		record      func(pid int) Record
+		status      map[string]string
+		taskDeleted bool
 	}{
 		{
 			name: "empty task id",
@@ -195,6 +196,13 @@ func TestReattachReapsStaleSurvivors(t *testing.T) {
 			},
 			status: map[string]string{"task-x": "todo"},
 		},
+		{
+			name: "task deleted while down",
+			record: func(pid int) Record {
+				return Record{ID: "s1", TaskID: "task-x", Mode: "headless", Provider: "claude", PID: pid, StartedAt: time.Now().UTC()}
+			},
+			taskDeleted: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -205,6 +213,9 @@ func TestReattachReapsStaleSurvivors(t *testing.T) {
 			if tc.status != nil {
 				st := tc.status
 				cfg.TaskStatus = func(id string) (string, bool) { s, ok := st[id]; return s, ok }
+			}
+			if tc.taskDeleted {
+				cfg.TaskExists = func(string) bool { return false }
 			}
 			m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, cfg)
 

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -19,7 +19,7 @@ const shutdownWaitDelay = 15 * time.Second
 // it restores terminal modes and persists the session ID for --resume
 // before exiting. 3 seconds is enough for cleanup in the common case;
 // SIGKILL handles any process that ignores SIGINT.
-const stopSIGINTGrace = 3 * time.Second
+var stopSIGINTGrace = 3 * time.Second
 
 // stopWithSIGINT sends SIGINT to cmd's process (CC v2.1.132+ graceful shutdown)
 // and escalates to SIGKILL if the process does not exit within grace. done is

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -358,6 +358,9 @@ func (a *App) taskExistsForAgent(taskID string) bool {
 func (a *App) taskStatusForAgent(taskID string) (string, bool) {
 	t, err := a.tasks.Get(taskID)
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			a.logger.Warn("agent.reattach.task-status", "task_id", taskID, "err", err)
+		}
 		return "", false
 	}
 	return string(t.Status), true

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -257,6 +257,7 @@ func (a *App) agentManagerConfig(approvalAddr string) agent.ManagerConfig {
 			return a.tasks.UpdateRun(taskID, agentID, task.RunPatch{SessionID: task.Ptr(sessionID)})
 		},
 		TaskExists:  a.taskExistsForAgent,
+		TaskStatus:  a.taskStatusForAgent,
 		LimitSink:   a.recordLimitSnapshot,
 		SandboxHome: a.sandboxes.SybraHomeDir,
 		ControlHome: config.HomeDir(),
@@ -350,6 +351,14 @@ func (a *App) taskExistsForAgent(taskID string) bool {
 	}
 	a.logger.Warn("agent.task-exists.error", "task_id", taskID, "err", err)
 	return true
+}
+
+func (a *App) taskStatusForAgent(taskID string) (string, bool) {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return "", false
+	}
+	return string(t.Status), true
 }
 
 func (a *App) startLiveLimitPolling(ctx context.Context, limitStore *limits.Store, policy limits.Policy) {

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -30,6 +30,32 @@ const (
 // otherwise, so this is a hard backstop rather than the primary mechanism.
 const completedHangGrace = 5 * time.Minute
 
+const hardDeadlineMultiplier = 2
+
+const (
+	minHardWallClock = time.Hour
+	minHardIdle      = 30 * time.Minute
+)
+
+func hardWallClockLimit(budget time.Duration) time.Duration {
+	return max(hardDeadlineMultiplier*budget, minHardWallClock)
+}
+
+func hardIdleLimit(stallLim time.Duration) time.Duration {
+	return max(hardDeadlineMultiplier*stallLim, minHardIdle)
+}
+
+func hardDeadlineBreach(ag *agent.Agent, stall, total, stallLim, budget time.Duration) string {
+	switch {
+	case total > hardWallClockLimit(budget):
+		return "wall_clock"
+	case stall > ag.EffectiveHangGrace(hardIdleLimit(stallLim)):
+		return "idle"
+	default:
+		return ""
+	}
+}
+
 // stallLimit returns the max event-gap before triggering inspection.
 func stallLimit(tags []string) time.Duration {
 	switch {
@@ -181,10 +207,6 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 			w.checkCompletedHang(ag, now)
 			continue
 		}
-		logPath := ag.GetLogPath()
-		if logPath == "" {
-			continue
-		}
 
 		stall := now.Sub(ag.GetLastEventAt())
 		total := now.Sub(ag.StartedAt)
@@ -197,6 +219,16 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 		} else {
 			budget = sizeBudget(nil)
 			sl = stallLimit(nil)
+		}
+
+		if reason := hardDeadlineBreach(ag, stall, total, sl, budget); reason != "" {
+			w.hardStop(ag, reason, stall, total)
+			continue
+		}
+
+		logPath := ag.GetLogPath()
+		if logPath == "" {
+			continue
 		}
 
 		trigger := decideTrigger(ag.ToolLoopStreak(), w.loopThreshold, ag.ToolLoopAcknowledged(), stall, sl, total, budget)
@@ -241,6 +273,23 @@ func (w *Watchdog) checkCompletedHang(ag *agent.Agent, now time.Time) {
 	}
 	if err := stop(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.completed_hang.stop_failed", "id", ag.ID, "err", err)
+	}
+}
+
+func (w *Watchdog) hardStop(ag *agent.Agent, reason string, stall, total time.Duration) {
+	w.logger.Warn("agent.watchdog.hard_deadline",
+		"id", ag.ID, "task_id", ag.TaskID, "reason", reason,
+		"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
+	if ag.TaskID != "" {
+		if _, err := w.tasks.Update(ag.TaskID, task.Update{
+			Status:       task.Ptr(task.StatusInProgress),
+			StatusReason: task.Ptr("watchdog hang: " + reason + " deadline exceeded"),
+		}); err != nil {
+			w.logger.Error("agent.watchdog.hard_deadline.task.update", "task_id", ag.TaskID, "err", err)
+		}
+	}
+	if err := w.stopAgent(ag.ID); err != nil {
+		w.logger.Error("agent.watchdog.hard_deadline.stop.failed", "id", ag.ID, "err", err)
 	}
 }
 

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -577,6 +577,89 @@ func TestInspect_LoopAckOnlyWhenLeftRunning(t *testing.T) {
 	}
 }
 
+func TestHardDeadlineBreach(t *testing.T) {
+	const (
+		sl     = 15 * time.Minute
+		budget = 45 * time.Minute
+	)
+	tests := []struct {
+		name         string
+		stall, total time.Duration
+		background   bool
+		want         string
+	}{
+		{"within bounds", 5 * time.Minute, 10 * time.Minute, false, ""},
+		{"idle over ceiling", 40 * time.Minute, 10 * time.Minute, false, "idle"},
+		{"wall clock over ceiling", 5 * time.Minute, 2 * time.Hour, false, "wall_clock"},
+		{"idle within background grace", 40 * time.Minute, 10 * time.Minute, true, ""},
+		{"idle over even with background grace", 60 * time.Minute, 10 * time.Minute, true, "idle"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := &agent.Agent{}
+			if tc.background {
+				ag.SetBackgroundTaskIDs([]string{"bg1"})
+			}
+			got := hardDeadlineBreach(ag, tc.stall, tc.total, sl, budget)
+			if got != tc.want {
+				t.Fatalf("hardDeadlineBreach = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHardStop_MarksRetryableHangAndStops(t *testing.T) {
+	tests := []struct {
+		name       string
+		reason     string
+		wantReason string
+	}{
+		{"idle", "idle", "watchdog hang: idle deadline exceeded"},
+		{"wall_clock", "wall_clock", "watchdog hang: wall_clock deadline exceeded"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+			stopped := ""
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				stopAgent: func(id string) error { stopped = id; return nil },
+			}
+
+			w.hardStop(&agent.Agent{ID: "a1", TaskID: tk.ID}, tc.reason, 40*time.Minute, time.Hour)
+
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != task.StatusInProgress {
+				t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+			}
+			if got.StatusReason != tc.wantReason {
+				t.Fatalf("status_reason = %q, want %q", got.StatusReason, tc.wantReason)
+			}
+			if stopped != "a1" {
+				t.Fatalf("stopAgent called with %q, want a1", stopped)
+			}
+		})
+	}
+}
+
+func TestHardStop_NoTaskStillFreesSlot(t *testing.T) {
+	stopped := ""
+	w := &Watchdog{
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	w.hardStop(&agent.Agent{ID: "a1"}, "wall_clock", 0, 10*time.Hour)
+
+	if stopped != "a1" {
+		t.Fatalf("stopAgent called with %q, want a1", stopped)
+	}
+}
+
 func newTestTasks(t *testing.T) (*task.Manager, task.Task) {
 	t.Helper()
 


### PR DESCRIPTION
## Motivation

Three of six `max_concurrent` slots were held by hung/orphaned agents (one `claude -p` running 10 days with no `task_id`, two hung 4-5h on tasks still in `todo`). An app restart re-adopted all three via survive-restart reattach as healthy. With three dead slots, the fleet starved.

Two root causes:

1. The stall watchdog only ever routed an overrunning agent to the LLM judge. When the judge could not act (unhealthy provider, no task context, repeated inspect failures) the agent ran unbounded — never killed, its slot never freed.
2. Survive-restart reattach re-adopted any surviving PID with no health check, re-adopting agents past their deadline, with no `task_id`, or on a task whose status contradicts a live agent.

> Changelog: fix(agent): reap hung agents and gate reattach on health

## Implementation information

- `internal/watchdog/agent.go`: added a hard wall-clock + idle-output ceiling (`hardDeadlineBreach`, `hardWallClockLimit`/`hardIdleLimit` = 2x the soft inspection trigger, floored at 1h / 30m). On breach, `hardStop` force-stops the process without inspection, marks the run a retryable `watchdog hang` (so the workflow hang-retry budget re-dispatches), and frees the slot. The idle ceiling honors `EffectiveHangGrace` so a live background bash task is not killed mid-write. Reordered `tick` so a task-less / log-less orphan is still evaluated.
- `internal/agent/reattach.go`: `ReattachAll` now gates each surviving headless PID on `reattachStaleReason`; a survivor with no `task_id`, past `reattachMaxAge` (6h), or on a `todo`/`new` task is reaped (`reapStaleSurvivor`: SIGINT/SIGKILL + drop the registry record) instead of re-adopted. Healthy in-flight survivors reattach unchanged; the reap path does not touch `liveCount`, so the slot is freed.
- `internal/agent/manager.go` + `internal/sybra/app_init.go`: added an optional `TaskStatus` callback so reattach can consult a task status without importing the task package.
- `internal/agent/shutdown.go`: `stopSIGINTGrace` const -> var so tests can shorten the reap grace (mirrors the existing `reattachPIDPoll` pattern).

Tests (table-driven, hermetic via `t.Setenv("SYBRA_HOME", t.TempDir())`):
- `TestHardDeadlineBreach`, `TestHardStop_MarksRetryableHangAndStops`, `TestHardStop_NoTaskStillFreesSlot`
- `TestReattachReapsStaleSurvivors` (empty task_id / past deadline / inconsistent status), `TestReattachAdoptsHealthySurvivor`

## Supporting documentation

`go test ./internal/agent/... ./internal/watchdog/...` green; `golangci-lint run ./...` clean.