### PR TITLE
fix(pr-monitor): drop dead tasks from fix retry

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -1042,10 +1043,14 @@ func (r *Handler) dropTerminalWorktreeFailure(taskID string, wtErr error) bool {
 		return false
 	}
 	got, err := r.tasks.Get(taskID)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
 		r.dropWorktreeEntry(taskID)
 		r.logger.Warn("pr-monitor.worktree.task-gone", "task_id", taskID, "err", wtErr)
 		return true
+	}
+	if err != nil {
+		r.logger.Warn("pr-monitor.worktree.task-get", "task_id", taskID, "err", err)
+		return false
 	}
 	if !worktreeFailureTerminal(wtErr) {
 		return false

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -776,6 +776,9 @@ func (r *Handler) RecoverStaleBranchConflict(taskID string) bool {
 // immediately.
 func (r *Handler) recoverBranchConflictNoPR(t task.Task) bool {
 	taskID := t.ID
+	if r.worktreeSkip(taskID) {
+		return false
+	}
 	if r.prTracker.AtCap(taskID, branchConflictRetryKind) {
 		if r.recreateExhaustedNoPRBranch(t) {
 			return true
@@ -1008,6 +1011,9 @@ func (r *Handler) parkOrEscalateBranchConflictDispatchFailure(taskID string, dis
 }
 
 func (r *Handler) parkOrEscalateBranchFixFailure(taskID string, wtErr error) bool {
+	if r.dropTerminalWorktreeFailure(taskID, wtErr) {
+		return false
+	}
 	attempts := r.recordWorktreeFailure(taskID, wtErr)
 	if t, gerr := r.tasks.Get(taskID); gerr == nil && t.Status == task.StatusHumanRequired {
 		return false
@@ -1015,6 +1021,64 @@ func (r *Handler) parkOrEscalateBranchFixFailure(taskID string, wtErr error) boo
 	r.logger.Info("pr-monitor.branch-conflict.parked-retry",
 		"task_id", taskID, "attempts", attempts, "limit", wtFailureLimit)
 	return true
+}
+
+func worktreeFailureTerminal(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, worktree.ErrTaskBranchMissing) {
+		return true
+	}
+	return strings.Contains(err.Error(), "invalid reference")
+}
+
+func (r *Handler) dropTerminalWorktreeFailure(taskID string, wtErr error) bool {
+	if r.tasks == nil {
+		if worktreeFailureTerminal(wtErr) {
+			r.dropWorktreeEntry(taskID)
+			return true
+		}
+		return false
+	}
+	got, err := r.tasks.Get(taskID)
+	if err != nil {
+		r.dropWorktreeEntry(taskID)
+		r.logger.Warn("pr-monitor.worktree.task-gone", "task_id", taskID, "err", wtErr)
+		return true
+	}
+	if !worktreeFailureTerminal(wtErr) {
+		return false
+	}
+	r.clearWorktreeFailure(taskID)
+	if got.Status != task.StatusHumanRequired {
+		reason := fmt.Sprintf("branch deleted: fix worktree cannot be created (%s)", wtErr)
+		if _, uerr := r.tasks.Update(taskID, task.Update{
+			Status:       task.Ptr(task.StatusHumanRequired),
+			StatusReason: task.Ptr(reason),
+		}); uerr != nil {
+			r.logger.Error("pr-monitor.worktree.terminal-escalate", "task_id", taskID, "err", uerr)
+		}
+	}
+	r.logger.Warn("pr-monitor.worktree.branch-deleted", "task_id", taskID, "err", wtErr)
+	return true
+}
+
+func (r *Handler) dropWorktreeEntry(taskID string) {
+	r.failureMu.Lock()
+	defer r.failureMu.Unlock()
+	if r.wtDropped == nil {
+		r.wtDropped = make(map[string]struct{})
+	}
+	r.wtDropped[taskID] = struct{}{}
+	delete(r.wtFailures, taskID)
+}
+
+func (r *Handler) worktreeSkip(taskID string) bool {
+	r.failureMu.Lock()
+	defer r.failureMu.Unlock()
+	_, dropped := r.wtDropped[taskID]
+	return dropped
 }
 
 func (r *Handler) recordDispatchFailure(taskID string) int {
@@ -1134,6 +1198,9 @@ func (r *Handler) prepareWorktree(ctx context.Context, t task.Task, issue github
 	if t.ProjectID == "" {
 		return "", true
 	}
+	if r.worktreeSkip(t.ID) {
+		return "", false
+	}
 	var (
 		d     string
 		wtErr error
@@ -1159,6 +1226,9 @@ func (r *Handler) prepareWorktree(ctx context.Context, t task.Task, issue github
 			recoverFn = r.RecoverStaleBranchConflict
 		}
 		if agentorch.MarkRebaseBlocked(r.tasks, t.ID, wtErr, r.logger, recoverFn) {
+			return "", false
+		}
+		if r.dropTerminalWorktreeFailure(t.ID, wtErr) {
 			return "", false
 		}
 		r.recordWorktreeFailure(t.ID, wtErr)

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -90,6 +90,7 @@ type Handler struct {
 	// run from independent agent-completion goroutines, so even unrelated task
 	// IDs must not write these maps concurrently.
 	failureMu sync.Mutex
+	wtDropped map[string]struct{}
 	// mergePR performs the actual squash-merge; overridable in tests.
 	// nil falls back to github.MergePR.
 	mergePR func(repo string, number int) error

--- a/internal/sybra/review/worktree_drop_test.go
+++ b/internal/sybra/review/worktree_drop_test.go
@@ -1,0 +1,137 @@
+package review
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+func TestDropTerminalWorktreeFailure(t *testing.T) {
+	tests := []struct {
+		name         string
+		wtErr        error
+		deleteTask   bool
+		wantTerminal bool
+		wantHumanReq bool
+		wantSkipNext bool
+	}{
+		{
+			name:         "missing task branch is terminal and escalates",
+			wtErr:        worktree.ErrTaskBranchMissing,
+			wantTerminal: true,
+			wantHumanReq: true,
+		},
+		{
+			name:         "deleted base ref is terminal",
+			wtErr:        errors.New("create fix worktree: git worktree add x refs/remotes/origin/feat/x → exit 128: fatal: invalid reference"),
+			wantTerminal: true,
+			wantHumanReq: true,
+		},
+		{
+			name:         "absent task record is dropped from the monitor set",
+			wtErr:        errors.New("create fix worktree: boom"),
+			deleteTask:   true,
+			wantTerminal: true,
+			wantSkipNext: true,
+		},
+		{
+			name:         "transient failure is not terminal and keeps retrying",
+			wtErr:        errors.New("worktree setup failed: temporary lock"),
+			wantTerminal: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks, _, _ := newRebaseRecoveryDeps(t)
+			r := &Handler{
+				logger:     slog.New(slog.DiscardHandler),
+				tasks:      tasks,
+				wtFailures: make(map[string]int),
+			}
+			tk, err := tasks.Create("terminal wt", "", task.AgentModeHeadless)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); err != nil {
+				t.Fatal(err)
+			}
+			if tt.deleteTask {
+				if err := tasks.Delete(tk.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if got := r.dropTerminalWorktreeFailure(tk.ID, tt.wtErr); got != tt.wantTerminal {
+				t.Fatalf("dropTerminalWorktreeFailure = %v, want %v", got, tt.wantTerminal)
+			}
+
+			if tt.wantHumanReq {
+				got, err := tasks.Get(tk.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.Status != task.StatusHumanRequired {
+					t.Fatalf("status = %q, want human-required", got.Status)
+				}
+				if n := r.wtFailures[tk.ID]; n != 0 {
+					t.Fatalf("wtFailures = %d, want 0 for a terminal failure", n)
+				}
+			}
+
+			if got := r.worktreeSkip(tk.ID); got != tt.wantSkipNext {
+				t.Fatalf("worktreeSkip = %v, want %v", got, tt.wantSkipNext)
+			}
+		})
+	}
+}
+
+func TestTransientWorktreeFailureBoundedByCircuitBreaker(t *testing.T) {
+	tasks, _, _ := newRebaseRecoveryDeps(t)
+	r := &Handler{
+		logger:     slog.New(slog.DiscardHandler),
+		tasks:      tasks,
+		wtFailures: make(map[string]int),
+	}
+	tk, err := tasks.Create("transient wt", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); err != nil {
+		t.Fatal(err)
+	}
+
+	wtErr := errors.New("worktree setup failed: temporary lock")
+	for i := 1; i < wtFailureLimit; i++ {
+		if r.dropTerminalWorktreeFailure(tk.ID, wtErr) {
+			t.Fatalf("attempt %d: transient failure must not be terminal", i)
+		}
+		if got := r.recordWorktreeFailure(tk.ID, wtErr); got != i {
+			t.Fatalf("attempt %d: recordWorktreeFailure = %d, want %d", i, got, i)
+		}
+		got, err := tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == task.StatusHumanRequired {
+			t.Fatalf("attempt %d: escalated before the circuit limit", i)
+		}
+	}
+
+	if r.dropTerminalWorktreeFailure(tk.ID, wtErr) {
+		t.Fatal("circuit-limit attempt: transient failure must not be terminal")
+	}
+	r.recordWorktreeFailure(tk.ID, wtErr)
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required after the circuit trips", got.Status)
+	}
+	if n := r.wtFailures[tk.ID]; n != 0 {
+		t.Fatalf("wtFailures = %d, want 0 after the circuit trips", n)
+	}
+}


### PR DESCRIPTION
## Motivation

The PR monitor's branch-conflict fix path retried `git worktree add`
every tick for tasks whose base branch was deleted or whose task record
is gone. The worktree circuit breaker resets its failure counter when it
escalates, so a task that no longer exists — whose human-required update
silently fails — looped forever with no bound. One hour of logs showed
`pr-monitor.worktree` erroring 1570 times, one dead task retried 351
times with `fatal: invalid reference` on a branch that had been deleted.

> Changelog: fix(pr-monitor): drop dead tasks from fix retry

## Implementation information

Classify a fix-worktree prep failure as terminal when the task record is
absent or the base ref no longer resolves (`invalid reference` /
`ErrTaskBranchMissing`). Terminal failures now:

- escalate a still-present task to `human-required` on the first attempt
  (removing it from `prMonitorEligible`) instead of after five, and
- drop a gone task into a monitor-skip set so no later tick re-attempts
  the worktree add.

Genuinely transient worktree-add failures keep the existing bounded
circuit breaker (five attempts, then escalate). Live tasks with valid
refs are unaffected.

Changes:
- `internal/sybra/review/fix.go`: `worktreeFailureTerminal`,
  `dropTerminalWorktreeFailure`, `dropWorktreeEntry`, `worktreeSkip`;
  terminal checks wired into `prepareWorktree`,
  `parkOrEscalateBranchFixFailure`, and `recoverBranchConflictNoPR`.
- `internal/sybra/review/handler.go`: `wtDropped` monitor-skip set.
- `internal/sybra/review/worktree_drop_test.go`: table-driven coverage.
