### PR TITLE
test(flakes): deflake load-sensitive timing tests

### DIFF
--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -372,10 +372,7 @@ func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 	if found, isError := a.lastHeadlessResult(); !found || isError {
 		t.Fatal("expected terminal result in buffer")
 	}
-	// Registry record is removed on completion.
-	if list, _ := m.reg.List(); len(list) != 0 {
-		t.Fatalf("expected registry empty after completion, got %d", len(list))
-	}
+	waitForRegistryEmpty(t, m, 5*time.Second)
 }
 
 func TestManagerRunPersistsAndReattachesLiveHeadlessAgent(t *testing.T) {
@@ -729,6 +726,25 @@ func waitForRegistryRecord(t *testing.T, m *Manager, agentID string) Record {
 		select {
 		case <-deadline:
 			t.Fatalf("timed out waiting for registry record for %s; records=%+v", agentID, recs)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+func waitForRegistryEmpty(t *testing.T, m *Manager, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		list, err := m.reg.List()
+		if err != nil {
+			t.Fatalf("registry list: %v", err)
+		}
+		if len(list) == 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected registry empty after completion, got %d", len(list))
 		case <-time.After(20 * time.Millisecond):
 		}
 	}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -408,16 +410,54 @@ func e2eTimeoutScale() int64 {
 	return e2eTimeoutScaleCached.value
 }
 
+const e2eTimeoutScaleCeiling = 12
+
 func e2eTimeoutScaleResolve() int64 {
 	if v := strings.TrimSpace(os.Getenv("SYBRA_E2E_TIMEOUT_SCALE")); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
 			return n
 		}
 	}
+	base := int64(1)
 	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
-		return 4
+		base = 4
 	}
-	return 1
+	scaled := base * hostOversubscriptionFactor()
+	if scaled < base {
+		return base
+	}
+	if scaled > e2eTimeoutScaleCeiling {
+		return e2eTimeoutScaleCeiling
+	}
+	return scaled
+}
+
+func hostOversubscriptionFactor() int64 {
+	load, ok := hostLoadPerCPU()
+	if !ok || load <= 1 {
+		return 1
+	}
+	return int64(math.Ceil(load))
+}
+
+func hostLoadPerCPU() (float64, bool) {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return 0, false
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, false
+	}
+	load1, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, false
+	}
+	cpus := runtime.NumCPU()
+	if cpus <= 0 {
+		return 0, false
+	}
+	return load1 / float64(cpus), true
 }
 
 func TestE2E_HeadlessAgent_Success(t *testing.T) {

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -418,10 +418,10 @@ func e2eTimeoutScaleResolve() int64 {
 			return n
 		}
 	}
-	base := int64(1)
-	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
-		base = 4
+	if os.Getenv("CI") == "" && os.Getenv("GITHUB_ACTIONS") == "" {
+		return 1
 	}
+	base := int64(4)
 	scaled := base * hostOversubscriptionFactor()
 	if scaled < base {
 		return base

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -140,7 +140,7 @@ func TestExecVerifyChecks_TimeoutFailsClosed(t *testing.T) {
 func TestExecVerifyChecks_TimeoutRetryAbsorbsLoadSpike(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
-	slowOnce := "test -f .timeout-marker || { touch .timeout-marker; exec sleep 60; }"
+	slowOnce := "test -f .timeout-marker || { touch .timeout-marker; exec sleep 10; }"
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{slowOnce})
 	engine.SetVerifyTimeout(2 * time.Second)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -140,9 +140,9 @@ func TestExecVerifyChecks_TimeoutFailsClosed(t *testing.T) {
 func TestExecVerifyChecks_TimeoutRetryAbsorbsLoadSpike(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
-	slowOnce := "test -f .timeout-marker || { touch .timeout-marker; sleep 30; }"
+	slowOnce := "test -f .timeout-marker || { touch .timeout-marker; exec sleep 60; }"
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{slowOnce})
-	engine.SetVerifyTimeout(200 * time.Millisecond)
+	engine.SetVerifyTimeout(2 * time.Second)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -597,14 +597,14 @@ func TestRunSetup_TimeoutKillsProcessGroup(t *testing.T) {
 		WorktreesDir: wtDir,
 		LogsDir:      logsDir,
 		Logger:       discardLogger(),
-		SetupTimeout: 800 * time.Millisecond,
+		SetupTimeout: 5 * time.Second,
 	})
 
 	pidFile := filepath.Join(wtDir, "child.pid")
 	// Background a grandchild that writes its pid immediately (well before
 	// the setup timeout fires) then outlives `sh`, staying alive for the
 	// rest of the test unless the whole process group is killed.
-	cmd := fmt.Sprintf("nohup sh -c 'echo $$ > %q; sleep 10' >/dev/null 2>&1 & sleep 10", pidFile)
+	cmd := fmt.Sprintf("nohup sh -c 'echo $$ > %q; sleep 30' >/dev/null 2>&1 & sleep 30", pidFile)
 
 	err := m.runSetup(context.Background(), "task-timeout-pg", wtDir, []string{cmd})
 	if err == nil {

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -604,7 +604,7 @@ func TestRunSetup_TimeoutKillsProcessGroup(t *testing.T) {
 	// Background a grandchild that writes its pid immediately (well before
 	// the setup timeout fires) then outlives `sh`, staying alive for the
 	// rest of the test unless the whole process group is killed.
-	cmd := fmt.Sprintf("nohup sh -c 'echo $$ > %q; sleep 30' >/dev/null 2>&1 & sleep 30", pidFile)
+	cmd := fmt.Sprintf("nohup sh -c 'echo $$ > %q; sleep 10' >/dev/null 2>&1 & sleep 10", pidFile)
 
 	err := m.runSetup(context.Background(), "task-timeout-pg", wtDir, []string{cmd})
 	if err == nil {


### PR DESCRIPTION
## Motivation

Four Go tests pass in isolation but false-fail intermittently under
concurrent CI load, repeatedly blocking unrelated PRs. Each has a
timing weakness (a wall-clock budget racing subprocess spawn, or an
assertion read racing an async cleanup) that only bites when the host
is contended. Fix each at the root cause without weakening what the
test asserts.

> Changelog: test(flakes): deflake load-sensitive timing tests

## Implementation information

- `TestExecVerifyChecks_TimeoutRetryAbsorbsLoadSpike` (`internal/workflow`):
  the 200ms verify budget raced `sh` spawn, so under load the first
  attempt was killed before `touch`, the marker was never written, and
  both attempts timed out (flagged, not clean). The compound `sleep 30`
  also orphaned a child that kept the stdout pipe open, blocking
  `cmd.Wait()` for the full sleep (observed 30s+ runs). Use `exec sleep`
  so the deadline kill is prompt and a 2s budget that reliably clears
  spawn latency; attempt 1 still times out, the retry still passes.

- `TestRunSetup_TimeoutKillsProcessGroup` (`internal/worktree`): the
  800ms batch timeout raced the backgrounded grandchild writing its pid
  file; under load the group was torn down before the pid was written,
  so the test failed "grandchild never wrote pid file". Widen the
  timeout to 5s (grandchild reliably starts, still outlives it and is
  group-killed).

- `TestReattachAll_ReattachesLiveHeadlessAgent` (`internal/agent`): the
  registry `reg.Delete` runs in `markAgentDone`, which fires *after* the
  `onComplete` callback that releases the test's wait. The test then
  read the registry once and could observe the not-yet-deleted record.
  Poll for an empty registry with a bounded deadline instead.

- E2E `waitFor` scale (`internal/sybra`): the timeout multiplier was a
  static 4x in CI regardless of actual contention, so heavily
  oversubscribed runners still timed out (`TestE2E_RetryCount`,
  `TestE2E_Codex_TestVerdict_Fail_JSON`). Scale the base by measured
  host oversubscription (loadavg per CPU, read from `/proc/loadavg` on
  the Linux CI runner; no-op elsewhere), clamped to a ceiling. The
  scaled value is only a ceiling — passing tests return as soon as their
  condition holds, so this adds headroom without slowing the suite.

Verification: each fixed unit test passes `-race -count=20` under
concurrent CPU + fork/exec load; full `internal/workflow`,
`internal/worktree`, `internal/agent` suites and the e2e short suite
pass; `golangci-lint` clean on touched packages.
