### PR TITLE
fix(worktree): raise setup batch timeout to 10m

### DIFF
--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -24,7 +24,7 @@ type AgentChecker func(taskID string) bool
 // defaultSetupTimeout caps the entire SetupCommands batch per worktree.
 // Accommodates cold `mise install` / `npm ci` runs on first use of a project
 // but prevents stuck commands from blocking worktree creation forever.
-const defaultSetupTimeout = 5 * time.Minute
+const defaultSetupTimeout = 10 * time.Minute
 
 type Config struct {
 	WorktreesDir     string


### PR DESCRIPTION
## Motivation

> Changelog: fix(worktree): raise the worktree setup batch timeout to 10m

Under load, `npm ci` worktree setup exceeds the 5-minute batch timeout and
is SIGKILLed (`failed after 4m59s: signal: killed`), so tasks needing
frontend deps can't provision their worktree. Observed on the live server
after the re-run-setup-on-reuse fix (#1533) correctly re-runs `npm ci`,
which then times out.

## Implementation information

Bumps `defaultSetupTimeout` from 5m to 10m, giving cold `mise install` /
`npm ci` runs enough headroom under load while still bounding a genuinely
stuck command.