### PR TITLE
perf(project): reuse worktrees and cache git fetches for fix/review roles

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -313,14 +313,26 @@ func TrackedFilesAtDefaultBranch(ctx context.Context, barePath string) ([]string
 
 // FetchOrigin fetches origin's heads into barePath's refs/remotes/origin/*
 // under the bare-repo lock, retrying transient git-fetch lock contention.
+// Skips the actual network fetch when a prior call already refreshed this
+// bare clone within FetchTTL (see git_lock.go) — checked under the same lock
+// that serializes concurrent callers, so a burst of prepares against one repo
+// pays for exactly one fetch.
 func FetchOrigin(ctx context.Context, barePath string) error {
 	return withBareRepoLock(barePath, func() error {
-		return withLockRetry(func() error {
+		if fetchIsFresh(barePath) {
+			return nil
+		}
+		err := withLockRetry(func() error {
 			// Explicit refspec heals bare repos cloned before remote.origin.fetch
 			// was configured, where `git fetch origin` silently skipped updating
 			// refs/remotes/origin/*.
 			return runBare(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 		})
+		if err != nil {
+			return err
+		}
+		markFetched(barePath)
+		return nil
 	})
 }
 

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -363,14 +363,26 @@ func TrackedFilesAtDefaultBranch(ctx context.Context, barePath string) ([]string
 
 // FetchOrigin fetches origin's heads into barePath's refs/remotes/origin/*
 // under the bare-repo lock, retrying transient git-fetch lock contention.
+// Skips the actual network fetch when a prior call already refreshed this
+// bare clone within FetchTTL (see git_lock.go) — checked under the same lock
+// that serializes concurrent callers, so a burst of prepares against one repo
+// pays for exactly one fetch.
 func FetchOrigin(ctx context.Context, barePath string) error {
 	return withBareRepoLock(barePath, func() error {
-		return withLockRetry(func() error {
+		if fetchIsFresh(barePath) {
+			return nil
+		}
+		err := withLockRetry(func() error {
 			// Explicit refspec heals bare repos cloned before remote.origin.fetch
 			// was configured, where `git fetch origin` silently skipped updating
 			// refs/remotes/origin/*.
 			return runBare(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 		})
+		if err != nil {
+			return err
+		}
+		markFetched(barePath)
+		return nil
 	})
 }
 

--- a/internal/project/git_lock.go
+++ b/internal/project/git_lock.go
@@ -67,3 +67,40 @@ func withLockRetry(fn func() error) error {
 	}
 	return err
 }
+
+// FetchTTL bounds how often FetchOrigin performs a real network fetch
+// against a given bare clone. Fix/review/pr-fix dispatch flows call
+// FetchOrigin unconditionally on every prepare, so at hundreds of pr-fix
+// runs/month against the same handful of repos most of those fetches land
+// within seconds of the previous one and pull nothing new. Zero (the
+// default) disables caching, so tests that push a commit to a bare clone's
+// origin and immediately re-prepare still observe it; production wiring
+// (App.Startup) sets a real interval.
+var FetchTTL time.Duration
+
+// lastFetchAt records, per cleaned bare-clone path, the last time
+// FetchOrigin actually ran `git fetch`. Combined with withBareRepoLock (which
+// already serializes same-process callers against one bare repo), checking
+// this under the lock makes repeat FetchOrigin calls within FetchTTL both
+// single-flighted and cache-skipped: only the first caller in a burst pays
+// for the network round trip.
+var lastFetchAt sync.Map // map[string]time.Time
+
+// fetchTTLNow is indirected so tests can control freshness without sleeping.
+var fetchTTLNow = time.Now
+
+func fetchIsFresh(barePath string) bool {
+	if FetchTTL <= 0 {
+		return false
+	}
+	v, ok := lastFetchAt.Load(filepath.Clean(barePath))
+	if !ok {
+		return false
+	}
+	t, ok := v.(time.Time)
+	return ok && fetchTTLNow().Sub(t) < FetchTTL
+}
+
+func markFetched(barePath string) {
+	lastFetchAt.Store(filepath.Clean(barePath), fetchTTLNow())
+}

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseGitHubURL(t *testing.T) {
@@ -174,6 +175,70 @@ func TestFetchOriginNoRemote(t *testing.T) {
 	err := FetchOrigin(context.Background(), bare)
 	if err == nil {
 		t.Fatal("expected error fetching from repo with no origin")
+	}
+}
+
+// TestFetchOriginTTLSkipsRepeatFetch proves the FetchTTL cache added for
+// issue #1527: within TTL, a second FetchOrigin call against the same bare
+// clone must not see a commit pushed to origin after the first call — the
+// second call is served from cache, not a real fetch. Not t.Parallel(): it
+// mutates the package-level FetchTTL/fetchTTLNow globals and must not race
+// other tests that call FetchOrigin expecting TTL disabled (the default).
+func TestFetchOriginTTLSkipsRepeatFetch(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+
+	now := time.Now()
+	origTTL, origNow := FetchTTL, fetchTTLNow
+	FetchTTL = 60 * time.Second
+	fetchTTLNow = func() time.Time { return now }
+	t.Cleanup(func() {
+		FetchTTL, fetchTTLNow = origTTL, origNow
+		lastFetchAt.Delete(filepath.Clean(bare))
+	})
+
+	trackingRef := "refs/remotes/origin/" + branch
+	revParse := func() string {
+		t.Helper()
+		out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "rev-parse", "--verify", trackingRef).CombinedOutput()
+		if err != nil {
+			t.Fatalf("rev-parse %s: %v: %s", trackingRef, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("initial FetchOrigin: %v", err)
+	}
+	before := revParse()
+
+	// Push a new commit to origin, then re-fetch a moment later (still well
+	// inside the TTL window). The cached call must be a no-op.
+	if out, err := exec.Command("git", "-C", src, "commit", "--allow-empty", "-m", "ttl-probe").CombinedOutput(); err != nil {
+		t.Fatalf("commit: %v: %s", err, out)
+	}
+	now = now.Add(1 * time.Second)
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("cached FetchOrigin: %v", err)
+	}
+	if afterCached := revParse(); afterCached != before {
+		t.Fatalf("cached FetchOrigin call fetched anyway: tracking ref moved from %s to %s", before, afterCached)
+	}
+
+	// Once the TTL elapses, the next call must pick up the new commit.
+	now = now.Add(60 * time.Second)
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("post-TTL FetchOrigin: %v", err)
+	}
+	if afterExpired := revParse(); afterExpired == before {
+		t.Fatal("post-TTL FetchOrigin did not refresh the tracking ref")
 	}
 }
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -384,6 +384,12 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.prTracker = github.NewIssueTracker(30 * time.Minute)
 
+	// Bound how often FetchOrigin does a real network fetch per bare clone —
+	// fix/review/pr-fix prepares call it unconditionally on every dispatch, so
+	// without a TTL a tight cluster of dispatches against one repo (hundreds
+	// of pr-fix runs/month, see issue #1527) pays for a full-branch fetch on
+	// every single one.
+	project.FetchTTL = 60 * time.Second
 	// Initialize domain services (dependency order: worktrees → agentOrch → reviewer, workflow)
 	a.worktrees = worktree.New(worktree.Config{
 		WorktreesDir:     a.worktreesDir,

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -12,9 +12,24 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/Automaat/sybra/internal/project"
 )
 
+// preventFetchTTLLeak guards against Startup's project.FetchTTL = 60s
+// mutation leaking into other tests sharing this package's test binary — the
+// same discipline internal/project/git_test.go's TestFetchOriginTTLSkipsRepeatFetch
+// applies when it mutates that global directly. Without this, a Startup call
+// here permanently enables fetch caching for every later test in the binary,
+// including ones (e.g. app_workflow_test.go's conflict-recovery harness) that
+// rely on FetchOrigin always doing a real fetch.
+func preventFetchTTLLeak(t *testing.T) {
+	t.Helper()
+	orig := project.FetchTTL
+	t.Cleanup(func() { project.FetchTTL = orig })
+}
+
 func TestAppStartupWiresSubsystemsAndServices(t *testing.T) {
+	preventFetchTTLLeak(t)
 	home := t.TempDir()
 	t.Setenv("SYBRA_HOME", home)
 	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
@@ -73,6 +88,7 @@ func (r *startupEventRecorder) snapshot() []string {
 }
 
 func TestAppStartup_SecondInstanceOnSameHomeFailsFast(t *testing.T) {
+	preventFetchTTLLeak(t)
 	home := t.TempDir()
 	t.Setenv("SYBRA_HOME", home)
 	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
@@ -110,6 +126,7 @@ func TestAppStartup_SecondInstanceOnSameHomeFailsFast(t *testing.T) {
 }
 
 func TestAppStartup_ReleasesHomeLockOnStartupFailure(t *testing.T) {
+	preventFetchTTLLeak(t)
 	home := t.TempDir()
 	t.Setenv("SYBRA_HOME", home)
 	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -207,6 +207,99 @@ func TestPrepareForFix_FallsBackToPRHead(t *testing.T) {
 	}
 }
 
+// TestPrepareForFix_ReusesHealthyWorktree is the regression for issue #1527:
+// PrepareForFix used to unconditionally RemoveWorktreeReconcile + recreate
+// the fix worktree on every dispatch, re-running setup (mise install, npm
+// ci, npm run build:desktop) even when nothing about the worktree needed to
+// change. A second dispatch against a healthy worktree already on the fix
+// branch must reuse it — skipping setup entirely — while still picking up
+// any commit pushed to the branch since the first dispatch.
+func TestPrepareForFix_ReusesHealthyWorktree(t *testing.T) {
+	h := prepareHarness(t, []string{"sh -c 'echo run >> setup-count.txt'"}, 0)
+
+	const prNumber = 11
+	const branch = "fix/reuse-me"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	// setup-count.txt is a byproduct of the setup command, not agent work —
+	// gitignore it so SanitizeWorktree's auto-commit-uncommitted-work step
+	// doesn't turn it into a local-only commit that diverges from the next
+	// remote push and defeats reuse.
+	if err := os.WriteFile(filepath.Join(h.src, ".gitignore"), []byte("setup-count.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "gitignore setup byproduct")
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "initial fix commit")
+	srcGit("checkout", "main")
+
+	h.m.prBranch = func(_ string, _ int) (string, error) { return branch, nil }
+
+	tk, err := h.tasks.Create("reuse fix worktree", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{"project_id": h.proj.ID})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForFix(context.Background(), tk, prNumber)
+	if err != nil {
+		t.Fatalf("PrepareForFix (initial): %v", err)
+	}
+	setupCountPath := filepath.Join(wtPath, "setup-count.txt")
+	countAfterFirst, err := os.ReadFile(setupCountPath)
+	if err != nil {
+		t.Fatalf("read setup-count.txt: %v", err)
+	}
+	if got := strings.Count(string(countAfterFirst), "run"); got != 1 {
+		t.Fatalf("setup ran %d times on initial prepare, want 1", got)
+	}
+
+	// A second commit lands on the fix branch (e.g. pushed from another
+	// clone) before the next dispatch.
+	srcGit("checkout", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature2.txt"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "second fix commit")
+	srcGit("checkout", "main")
+
+	got, err := h.m.PrepareForFix(context.Background(), tk, prNumber)
+	if err != nil {
+		t.Fatalf("PrepareForFix (reuse): %v", err)
+	}
+	if got != wtPath {
+		t.Fatalf("reused path = %q, want the same worktree %q", got, wtPath)
+	}
+
+	// Setup must not have re-run.
+	countAfterSecond, err := os.ReadFile(setupCountPath)
+	if err != nil {
+		t.Fatalf("read setup-count.txt after reuse: %v", err)
+	}
+	if got := strings.Count(string(countAfterSecond), "run"); got != 1 {
+		t.Fatalf("setup ran %d times across both prepares, want 1 (setup must be skipped on reuse)", got)
+	}
+
+	// The worktree must be fast-forwarded to the new remote commit.
+	if _, err := os.Stat(filepath.Join(got, "feature2.txt")); err != nil {
+		t.Errorf("reused worktree missing feature2.txt from the second remote commit: %v", err)
+	}
+}
+
 // TestPrepareForFix_SetupFailureDoesNotBlock is the regression test for
 // issue #1454: a project whose setup: command fails (e.g. the PR under
 // repair broke the build) must not prevent PrepareForFix from creating the

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+func signoffHookPath(t *testing.T, wtPath string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", wtPath, "rev-parse", "--git-common-dir").CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolve git common dir: %v: %s", err, out)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtPath, gitDir)
+	}
+	return filepath.Join(gitDir, "hooks", "prepare-commit-msg")
+}
+
 // TestPrepareForTask_AdoptsExternalWorktree verifies that a task carrying an
 // explicit WorktreeDir is run in that directory verbatim: PrepareForTask
 // returns the external path, records its branch, drops the identity beacon,
@@ -266,6 +279,13 @@ func TestPrepareForFix_ReusesHealthyWorktree(t *testing.T) {
 	if got := strings.Count(string(countAfterFirst), "run"); got != 1 {
 		t.Fatalf("setup ran %d times on initial prepare, want 1", got)
 	}
+	hookPath := signoffHookPath(t, wtPath)
+	if err := os.Remove(hookPath); err != nil {
+		t.Fatalf("remove signoff hook: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "config", "--unset", "core.hooksPath").CombinedOutput(); err != nil {
+		t.Fatalf("unset core.hooksPath: %v: %s", err, out)
+	}
 
 	// A second commit lands on the fix branch (e.g. pushed from another
 	// clone) before the next dispatch.
@@ -297,6 +317,9 @@ func TestPrepareForFix_ReusesHealthyWorktree(t *testing.T) {
 	// The worktree must be fast-forwarded to the new remote commit.
 	if _, err := os.Stat(filepath.Join(got, "feature2.txt")); err != nil {
 		t.Errorf("reused worktree missing feature2.txt from the second remote commit: %v", err)
+	}
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Errorf("signoff hook was not restored on reuse: %v", err)
 	}
 }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -388,6 +388,53 @@ func (m *Manager) adoptWorktree(ctx context.Context, t task.Task, onPhase func(s
 	return wtPath, nil
 }
 
+// reuseFixWorktree is the fix/branch-fix analogue of PrepareForTask's
+// healOrRecreate + reconcile fast path: PrepareForFix and PrepareForBranchFix
+// used to unconditionally RemoveWorktreeReconcile any existing worktree and
+// recreate it from scratch (full setup: mise install, npm ci, npm run
+// build:desktop) on every single dispatch, even though a healthy worktree
+// already checked out on the right branch just needs its remote fast-forwarded.
+// Returns (true, nil) when wtPath is now healthy, on wantBranch, and synced to
+// the latest remote head — the caller can skip setup entirely, mirroring
+// PrepareForTask's genuine-reuse path. Returns (false, nil) when there was
+// nothing to reuse (no worktree, unhealthy, wrong branch, or the remote sync
+// hit a conflict) — in every such case wtPath has already been removed, so
+// the caller's normal create-fresh path runs unmodified.
+func (m *Manager) reuseFixWorktree(ctx context.Context, taskID, clonePath, wtPath, wantBranch string) (bool, error) {
+	if _, statErr := os.Stat(wtPath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat worktree %s: %w", wtPath, statErr)
+	}
+	usable, err := m.healOrRecreate(ctx, taskID, clonePath, wtPath, wantBranch)
+	if err != nil {
+		return false, err
+	}
+	if !usable {
+		return false, nil
+	}
+	if err := project.SanitizeWorktree(ctx, wtPath); err != nil {
+		m.logger.Warn("fix.worktree.sanitize", "task_id", taskID, "err", err)
+	}
+	// Fast-forward the branch to the live remote head (e.g. a fix pushed from
+	// another clone/machine since this worktree was last used). Unlike
+	// PrepareForTask's reused path there is no rebase here — fix worktrees
+	// check out the PR/task branch directly. Any failure (dirty, diverged,
+	// transient network) falls back to a clean recreate rather than risk
+	// handing the fixer a stale or half-synced checkout; the reused worktree
+	// was always freshly recreated before this change, so recreation on
+	// failure is strictly no worse than the prior behavior.
+	if err := project.ReconcileWithRemote(ctx, wtPath, wantBranch); err != nil {
+		m.logger.Warn("fix.worktree.reconcile-failed-recreate", "task_id", taskID, "branch", wantBranch, "err", err)
+		if rerr := project.RemoveWorktreeReconcile(ctx, clonePath, wtPath); rerr != nil {
+			return false, fmt.Errorf("remove worktree after reconcile failure: %w", rerr)
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
 // finalizeWorktree runs post-checkout hooks shared by the "reuse existing
 // worktree" and "checkout existing branch" fast-paths in PrepareForTask.
 func (m *Manager) finalizeWorktree(ctx context.Context, t task.Task, wtPath, wtBranch string, proj project.Project) (string, error) {
@@ -510,7 +557,10 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 		m.logger.Warn("review.worktree.signoff-hook", "task_id", t.ID, "err", err)
 	}
 	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
+	// Review is read-only and never builds anything — skip the desktop build
+	// step other roles' setup pulls in (see filterNonAuthoringSetup).
+	setupCmds := filterNonAuthoringSetup(m.resolveTrustedSetupCommands(ctx, proj))
+	if err := m.runSetup(ctx, t.ID, wtPath, setupCmds); err != nil {
 		return "", fmt.Errorf("review setup: %w", err)
 	}
 	return wtPath, nil
@@ -544,14 +594,21 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	branch := branchNameForTask(t)
 	wtPath := m.PathFor(t)
 
-	// Remove stale worktree, same rationale as PrepareForFix.
-	switch _, statErr := os.Stat(wtPath); {
-	case statErr == nil:
-		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
-			return "", fmt.Errorf("remove stale branch-fix worktree: %w", err)
+	// Reuse a healthy worktree already on the task's branch, same rationale
+	// and fallback-to-recreate behavior as PrepareForFix.
+	reused, err := m.reuseFixWorktree(ctx, t.ID, proj.ClonePath, wtPath, branch)
+	if err != nil {
+		return "", fmt.Errorf("reuse branch-fix worktree: %w", err)
+	}
+	if reused {
+		m.ensureBranch(t, branch)
+		m.logger.Info("branch-fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
+		if t.RunRole != "pr-fix" {
+			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
+				m.logger.Warn("branch-fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+			}
 		}
-	case !os.IsNotExist(statErr):
-		return "", fmt.Errorf("stat branch-fix worktree %s: %w", wtPath, statErr)
+		return wtPath, nil
 	}
 
 	originRef := "refs/remotes/origin/" + branch
@@ -661,16 +718,23 @@ func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) 
 
 	wtPath := m.PathFor(t)
 
-	// Remove stale worktree — previous agent may have left dirty state, or a
-	// prior `worktree prune` (or crash) dropped the admin entry while the
-	// checkout dir survived (orphan). RemoveWorktreeReconcile handles both.
-	switch _, statErr := os.Stat(wtPath); {
-	case statErr == nil:
-		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
-			return "", fmt.Errorf("remove stale fix worktree: %w", err)
+	// Reuse a healthy worktree already on the fix branch — fast-forwarded to
+	// the latest remote head, no setup re-run. Only when that isn't possible
+	// (no worktree, unhealthy, wrong branch, or a remote conflict) does the
+	// stale worktree get removed and recreated from scratch below.
+	reused, err := m.reuseFixWorktree(ctx, t.ID, proj.ClonePath, wtPath, branch)
+	if err != nil {
+		return "", fmt.Errorf("reuse fix worktree: %w", err)
+	}
+	if reused {
+		m.ensureBranch(t, branch)
+		m.logger.Info("fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
+		if t.RunRole != "pr-fix" {
+			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
+				m.logger.Warn("fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+			}
 		}
-	case !os.IsNotExist(statErr):
-		return "", fmt.Errorf("stat fix worktree %s: %w", wtPath, statErr)
+		return wtPath, nil
 	}
 
 	originRef := "refs/remotes/origin/" + branch

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -397,6 +397,53 @@ func (m *Manager) adoptWorktree(ctx context.Context, t task.Task, onPhase func(s
 	return wtPath, nil
 }
 
+// reuseFixWorktree is the fix/branch-fix analogue of PrepareForTask's
+// healOrRecreate + reconcile fast path: PrepareForFix and PrepareForBranchFix
+// used to unconditionally RemoveWorktreeReconcile any existing worktree and
+// recreate it from scratch (full setup: mise install, npm ci, npm run
+// build:desktop) on every single dispatch, even though a healthy worktree
+// already checked out on the right branch just needs its remote fast-forwarded.
+// Returns (true, nil) when wtPath is now healthy, on wantBranch, and synced to
+// the latest remote head — the caller can skip setup entirely, mirroring
+// PrepareForTask's genuine-reuse path. Returns (false, nil) when there was
+// nothing to reuse (no worktree, unhealthy, wrong branch, or the remote sync
+// hit a conflict) — in every such case wtPath has already been removed, so
+// the caller's normal create-fresh path runs unmodified.
+func (m *Manager) reuseFixWorktree(ctx context.Context, taskID, clonePath, wtPath, wantBranch string) (bool, error) {
+	if _, statErr := os.Stat(wtPath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat worktree %s: %w", wtPath, statErr)
+	}
+	usable, err := m.healOrRecreate(ctx, taskID, clonePath, wtPath, wantBranch)
+	if err != nil {
+		return false, err
+	}
+	if !usable {
+		return false, nil
+	}
+	if err := project.SanitizeWorktree(ctx, wtPath); err != nil {
+		m.logger.Warn("fix.worktree.sanitize", "task_id", taskID, "err", err)
+	}
+	// Fast-forward the branch to the live remote head (e.g. a fix pushed from
+	// another clone/machine since this worktree was last used). Unlike
+	// PrepareForTask's reused path there is no rebase here — fix worktrees
+	// check out the PR/task branch directly. Any failure (dirty, diverged,
+	// transient network) falls back to a clean recreate rather than risk
+	// handing the fixer a stale or half-synced checkout; the reused worktree
+	// was always freshly recreated before this change, so recreation on
+	// failure is strictly no worse than the prior behavior.
+	if err := project.ReconcileWithRemote(ctx, wtPath, wantBranch); err != nil {
+		m.logger.Warn("fix.worktree.reconcile-failed-recreate", "task_id", taskID, "branch", wantBranch, "err", err)
+		if rerr := project.RemoveWorktreeReconcile(ctx, clonePath, wtPath); rerr != nil {
+			return false, fmt.Errorf("remove worktree after reconcile failure: %w", rerr)
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
 // finalizeWorktree runs post-checkout hooks shared by the "reuse existing
 // worktree" and "checkout existing branch" fast-paths in PrepareForTask.
 func (m *Manager) finalizeWorktree(ctx context.Context, t task.Task, wtPath, wtBranch string, proj project.Project) (string, error) {
@@ -519,7 +566,10 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 		m.logger.Warn("review.worktree.signoff-hook", "task_id", t.ID, "err", err)
 	}
 	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
+	// Review is read-only and never builds anything — skip the desktop build
+	// step other roles' setup pulls in (see filterNonAuthoringSetup).
+	setupCmds := filterNonAuthoringSetup(m.resolveTrustedSetupCommands(ctx, proj))
+	if err := m.runSetup(ctx, t.ID, wtPath, setupCmds); err != nil {
 		return "", fmt.Errorf("review setup: %w", err)
 	}
 	return wtPath, nil
@@ -553,14 +603,21 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	branch := branchNameForTask(t)
 	wtPath := m.PathFor(t)
 
-	// Remove stale worktree, same rationale as PrepareForFix.
-	switch _, statErr := os.Stat(wtPath); {
-	case statErr == nil:
-		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
-			return "", fmt.Errorf("remove stale branch-fix worktree: %w", err)
+	// Reuse a healthy worktree already on the task's branch, same rationale
+	// and fallback-to-recreate behavior as PrepareForFix.
+	reused, err := m.reuseFixWorktree(ctx, t.ID, proj.ClonePath, wtPath, branch)
+	if err != nil {
+		return "", fmt.Errorf("reuse branch-fix worktree: %w", err)
+	}
+	if reused {
+		m.ensureBranch(t, branch)
+		m.logger.Info("branch-fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
+		if t.RunRole != "pr-fix" {
+			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
+				m.logger.Warn("branch-fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+			}
 		}
-	case !os.IsNotExist(statErr):
-		return "", fmt.Errorf("stat branch-fix worktree %s: %w", wtPath, statErr)
+		return wtPath, nil
 	}
 
 	originRef := "refs/remotes/origin/" + branch
@@ -670,16 +727,23 @@ func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) 
 
 	wtPath := m.PathFor(t)
 
-	// Remove stale worktree — previous agent may have left dirty state, or a
-	// prior `worktree prune` (or crash) dropped the admin entry while the
-	// checkout dir survived (orphan). RemoveWorktreeReconcile handles both.
-	switch _, statErr := os.Stat(wtPath); {
-	case statErr == nil:
-		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
-			return "", fmt.Errorf("remove stale fix worktree: %w", err)
+	// Reuse a healthy worktree already on the fix branch — fast-forwarded to
+	// the latest remote head, no setup re-run. Only when that isn't possible
+	// (no worktree, unhealthy, wrong branch, or a remote conflict) does the
+	// stale worktree get removed and recreated from scratch below.
+	reused, err := m.reuseFixWorktree(ctx, t.ID, proj.ClonePath, wtPath, branch)
+	if err != nil {
+		return "", fmt.Errorf("reuse fix worktree: %w", err)
+	}
+	if reused {
+		m.ensureBranch(t, branch)
+		m.logger.Info("fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
+		if t.RunRole != "pr-fix" {
+			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
+				m.logger.Warn("fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+			}
 		}
-	case !os.IsNotExist(statErr):
-		return "", fmt.Errorf("stat fix worktree %s: %w", wtPath, statErr)
+		return wtPath, nil
 	}
 
 	originRef := "refs/remotes/origin/" + branch

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -611,6 +611,9 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	}
 	if reused {
 		m.ensureBranch(t, branch)
+		if err := project.InstallSignoffHook(ctx, wtPath); err != nil {
+			m.logger.Warn("branch-fix.worktree.signoff-hook", "task_id", t.ID, "err", err)
+		}
 		m.logger.Info("branch-fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
 		if t.RunRole != "pr-fix" {
 			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
@@ -737,6 +740,9 @@ func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) 
 	}
 	if reused {
 		m.ensureBranch(t, branch)
+		if err := project.InstallSignoffHook(ctx, wtPath); err != nil {
+			m.logger.Warn("fix.worktree.signoff-hook", "task_id", t.ID, "err", err)
+		}
 		m.logger.Info("fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
 		if t.RunRole != "pr-fix" {
 			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -388,6 +388,53 @@ func (m *Manager) adoptWorktree(ctx context.Context, t task.Task, onPhase func(s
 	return wtPath, nil
 }
 
+// reuseFixWorktree is the fix/branch-fix analogue of PrepareForTask's
+// healOrRecreate + reconcile fast path: PrepareForFix and PrepareForBranchFix
+// used to unconditionally RemoveWorktreeReconcile any existing worktree and
+// recreate it from scratch (full setup: mise install, npm ci, npm run
+// build:desktop) on every single dispatch, even though a healthy worktree
+// already checked out on the right branch just needs its remote fast-forwarded.
+// Returns (true, nil) when wtPath is now healthy, on wantBranch, and synced to
+// the latest remote head — the caller can skip setup entirely, mirroring
+// PrepareForTask's genuine-reuse path. Returns (false, nil) when there was
+// nothing to reuse (no worktree, unhealthy, wrong branch, or the remote sync
+// hit a conflict) — in every such case wtPath has already been removed, so
+// the caller's normal create-fresh path runs unmodified.
+func (m *Manager) reuseFixWorktree(ctx context.Context, taskID, clonePath, wtPath, wantBranch string) (bool, error) {
+	if _, statErr := os.Stat(wtPath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat worktree %s: %w", wtPath, statErr)
+	}
+	usable, err := m.healOrRecreate(ctx, taskID, clonePath, wtPath, wantBranch)
+	if err != nil {
+		return false, err
+	}
+	if !usable {
+		return false, nil
+	}
+	if err := project.SanitizeWorktree(ctx, wtPath); err != nil {
+		m.logger.Warn("fix.worktree.sanitize", "task_id", taskID, "err", err)
+	}
+	// Fast-forward the branch to the live remote head (e.g. a fix pushed from
+	// another clone/machine since this worktree was last used). Unlike
+	// PrepareForTask's reused path there is no rebase here — fix worktrees
+	// check out the PR/task branch directly. Any failure (dirty, diverged,
+	// transient network) falls back to a clean recreate rather than risk
+	// handing the fixer a stale or half-synced checkout; the reused worktree
+	// was always freshly recreated before this change, so recreation on
+	// failure is strictly no worse than the prior behavior.
+	if err := project.ReconcileWithRemote(ctx, wtPath, wantBranch); err != nil {
+		m.logger.Warn("fix.worktree.reconcile-failed-recreate", "task_id", taskID, "branch", wantBranch, "err", err)
+		if rerr := project.RemoveWorktreeReconcile(ctx, clonePath, wtPath); rerr != nil {
+			return false, fmt.Errorf("remove worktree after reconcile failure: %w", rerr)
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
 // finalizeWorktree runs post-checkout hooks shared by the "reuse existing
 // worktree" and "checkout existing branch" fast-paths in PrepareForTask.
 func (m *Manager) finalizeWorktree(ctx context.Context, t task.Task, wtPath, wtBranch string, proj project.Project) (string, error) {
@@ -507,7 +554,10 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 		return "", fmt.Errorf("create review worktree: %w", err)
 	}
 	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveTrustedSetupCommands(ctx, proj)); err != nil {
+	// Review is read-only and never builds anything — skip the desktop build
+	// step other roles' setup pulls in (see filterNonAuthoringSetup).
+	setupCmds := filterNonAuthoringSetup(m.resolveTrustedSetupCommands(ctx, proj))
+	if err := m.runSetup(ctx, t.ID, wtPath, setupCmds); err != nil {
 		return "", fmt.Errorf("review setup: %w", err)
 	}
 	return wtPath, nil
@@ -541,14 +591,21 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	branch := branchNameForTask(t)
 	wtPath := m.PathFor(t)
 
-	// Remove stale worktree, same rationale as PrepareForFix.
-	switch _, statErr := os.Stat(wtPath); {
-	case statErr == nil:
-		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
-			return "", fmt.Errorf("remove stale branch-fix worktree: %w", err)
+	// Reuse a healthy worktree already on the task's branch, same rationale
+	// and fallback-to-recreate behavior as PrepareForFix.
+	reused, err := m.reuseFixWorktree(ctx, t.ID, proj.ClonePath, wtPath, branch)
+	if err != nil {
+		return "", fmt.Errorf("reuse branch-fix worktree: %w", err)
+	}
+	if reused {
+		m.ensureBranch(t, branch)
+		m.logger.Info("branch-fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
+		if t.RunRole != "pr-fix" {
+			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
+				m.logger.Warn("branch-fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+			}
 		}
-	case !os.IsNotExist(statErr):
-		return "", fmt.Errorf("stat branch-fix worktree %s: %w", wtPath, statErr)
+		return wtPath, nil
 	}
 
 	originRef := "refs/remotes/origin/" + branch
@@ -655,16 +712,23 @@ func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) 
 
 	wtPath := m.PathFor(t)
 
-	// Remove stale worktree — previous agent may have left dirty state, or a
-	// prior `worktree prune` (or crash) dropped the admin entry while the
-	// checkout dir survived (orphan). RemoveWorktreeReconcile handles both.
-	switch _, statErr := os.Stat(wtPath); {
-	case statErr == nil:
-		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
-			return "", fmt.Errorf("remove stale fix worktree: %w", err)
+	// Reuse a healthy worktree already on the fix branch — fast-forwarded to
+	// the latest remote head, no setup re-run. Only when that isn't possible
+	// (no worktree, unhealthy, wrong branch, or a remote conflict) does the
+	// stale worktree get removed and recreated from scratch below.
+	reused, err := m.reuseFixWorktree(ctx, t.ID, proj.ClonePath, wtPath, branch)
+	if err != nil {
+		return "", fmt.Errorf("reuse fix worktree: %w", err)
+	}
+	if reused {
+		m.ensureBranch(t, branch)
+		m.logger.Info("fix.worktree.reused", "task_id", t.ID, "path", wtPath, "branch", branch)
+		if t.RunRole != "pr-fix" {
+			if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
+				m.logger.Warn("fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+			}
 		}
-	case !os.IsNotExist(statErr):
-		return "", fmt.Errorf("stat fix worktree %s: %w", wtPath, statErr)
+		return wtPath, nil
 	}
 
 	originRef := "refs/remotes/origin/" + branch

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -69,6 +69,92 @@ func TestPrepareForBranchFix_ExistingBranch(t *testing.T) {
 	}
 }
 
+// TestPrepareForBranchFix_ReusesHealthyWorktree mirrors
+// TestPrepareForFix_ReusesHealthyWorktree: a second dispatch against a
+// healthy worktree already on the task's branch must reuse it (no setup
+// re-run), while still fast-forwarding to any commit pushed in the meantime.
+func TestPrepareForBranchFix_ReusesHealthyWorktree(t *testing.T) {
+	h := prepareHarness(t, []string{"sh -c 'echo run >> setup-count.txt'"}, 0)
+
+	const branch = "fix/branch-reuse-me"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	// setup-count.txt is a byproduct of the setup command, not agent work —
+	// gitignore it so SanitizeWorktree's auto-commit-uncommitted-work step
+	// doesn't turn it into a local-only commit that diverges from the next
+	// remote push and defeats reuse.
+	if err := os.WriteFile(filepath.Join(h.src, ".gitignore"), []byte("setup-count.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "gitignore setup byproduct")
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "initial branch commit")
+	srcGit("checkout", "main")
+
+	tk, err := h.tasks.Create("reuse branch fix worktree", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"branch":     branch,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForBranchFix(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchFix (initial): %v", err)
+	}
+	setupCountPath := filepath.Join(wtPath, "setup-count.txt")
+	countAfterFirst, err := os.ReadFile(setupCountPath)
+	if err != nil {
+		t.Fatalf("read setup-count.txt: %v", err)
+	}
+	if got := strings.Count(string(countAfterFirst), "run"); got != 1 {
+		t.Fatalf("setup ran %d times on initial prepare, want 1", got)
+	}
+
+	srcGit("checkout", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature2.txt"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "second branch commit")
+	srcGit("checkout", "main")
+
+	got, err := h.m.PrepareForBranchFix(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchFix (reuse): %v", err)
+	}
+	if got != wtPath {
+		t.Fatalf("reused path = %q, want the same worktree %q", got, wtPath)
+	}
+
+	countAfterSecond, err := os.ReadFile(setupCountPath)
+	if err != nil {
+		t.Fatalf("read setup-count.txt after reuse: %v", err)
+	}
+	if got := strings.Count(string(countAfterSecond), "run"); got != 1 {
+		t.Fatalf("setup ran %d times across both prepares, want 1 (setup must be skipped on reuse)", got)
+	}
+
+	if _, err := os.Stat(filepath.Join(got, "feature2.txt")); err != nil {
+		t.Errorf("reused worktree missing feature2.txt from the second remote commit: %v", err)
+	}
+}
+
 // TestPrepareForBranchFix_SetupFailureDoesNotBlock is the regression test for
 // issue #1454: a project whose setup: command fails (e.g. a broken build)
 // must not prevent PrepareForBranchFix from creating the fix worktree — that

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -125,6 +125,13 @@ func TestPrepareForBranchFix_ReusesHealthyWorktree(t *testing.T) {
 	if got := strings.Count(string(countAfterFirst), "run"); got != 1 {
 		t.Fatalf("setup ran %d times on initial prepare, want 1", got)
 	}
+	hookPath := signoffHookPath(t, wtPath)
+	if err := os.Remove(hookPath); err != nil {
+		t.Fatalf("remove signoff hook: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "config", "--unset", "core.hooksPath").CombinedOutput(); err != nil {
+		t.Fatalf("unset core.hooksPath: %v: %s", err, out)
+	}
 
 	srcGit("checkout", branch)
 	if err := os.WriteFile(filepath.Join(h.src, "feature2.txt"), []byte("y"), 0o644); err != nil {
@@ -152,6 +159,9 @@ func TestPrepareForBranchFix_ReusesHealthyWorktree(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(got, "feature2.txt")); err != nil {
 		t.Errorf("reused worktree missing feature2.txt from the second remote commit: %v", err)
+	}
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Errorf("signoff hook was not restored on reuse: %v", err)
 	}
 }
 

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -277,6 +278,27 @@ func (m *Manager) resolveTrustedSetupCommands(ctx context.Context, proj project.
 			"total", len(merged))
 	}
 	return merged
+}
+
+// desktopBuildSetupMarker matches the desktop production build step
+// (`npm run build:desktop`) that .sybra.yaml setup blocks use so `go build`
+// has something to //go:embed. A code-authoring role needs it; a read-only
+// PR review worktree never builds anything, so running it there is pure
+// waste (issue #1527).
+const desktopBuildSetupMarker = "build:desktop"
+
+// filterNonAuthoringSetup drops setup commands that exist only to prepare a
+// worktree for building/embedding, for roles that never build — currently
+// just PrepareForReview's detached-HEAD, read-only checkout.
+func filterNonAuthoringSetup(commands []string) []string {
+	filtered := make([]string, 0, len(commands))
+	for _, c := range commands {
+		if strings.Contains(c, desktopBuildSetupMarker) {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered
 }
 
 func (m *Manager) installChecks(ctx context.Context, wtPath string, proj project.Project) {

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -280,12 +280,12 @@ func (m *Manager) resolveTrustedSetupCommands(ctx context.Context, proj project.
 	return merged
 }
 
-// desktopBuildSetupMarker matches the desktop production build step
-// (`npm run build:desktop`) that .sybra.yaml setup blocks use so `go build`
-// has something to //go:embed. A code-authoring role needs it; a read-only
-// PR review worktree never builds anything, so running it there is pure
-// waste (issue #1527).
-const desktopBuildSetupMarker = "build:desktop"
+// desktopBuildSetupMarker matches the actual desktop production build
+// invocation (`npm run build:desktop`) that .sybra.yaml setup blocks use so
+// `go build` has something to //go:embed. A code-authoring role needs it; a
+// read-only PR review worktree never builds anything, so running it there is
+// pure waste (issue #1527).
+const desktopBuildSetupMarker = "npm run build:desktop"
 
 // filterNonAuthoringSetup drops setup commands that exist only to prepare a
 // worktree for building/embedding, for roles that never build — currently

--- a/internal/worktree/setup_trust_test.go
+++ b/internal/worktree/setup_trust_test.go
@@ -136,3 +136,77 @@ func TestPrepareForReview_UntrustedRepoSetupNotExecuted(t *testing.T) {
 		t.Errorf("trusted default-branch setup command did not run: %v", err)
 	}
 }
+
+// TestPrepareForReview_SkipsDesktopBuildSetup is the regression for issue
+// #1527: PrepareForReview is read-only and never builds anything, so the
+// desktop production build step other roles' .sybra.yaml setup pulls in
+// (`npm run build:desktop`) is pure waste there. A fix worktree, by
+// contrast, is code-authoring and must still run it.
+func TestPrepareForReview_SkipsDesktopBuildSetup(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	setupYAML := "setup:\n  - touch always-marker\n  - \"sh -c 'npm run build:desktop >/dev/null 2>&1 || true; touch build-desktop-marker'\"\n"
+	if err := os.WriteFile(filepath.Join(h.src, ".sybra.yaml"), []byte(setupYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "setup with desktop build step")
+	shaOut, err := exec.Command("git", "-C", h.src, "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse: %v: %s", err, shaOut)
+	}
+	// PrepareForReview always checks out the PR head via
+	// refs/pull/<N>/head (see FetchPRHead) regardless of branch resolution.
+	srcGit("update-ref", "refs/pull/66/head", strings.TrimSpace(string(shaOut)))
+
+	const prNumber = 66
+	h.m.prBranch = func(_ string, _ int) (string, error) { return "main", nil }
+
+	tk, err := h.tasks.Create("review skips desktop build", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"pr_number":  prNumber,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForReview(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForReview: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "always-marker")); err != nil {
+		t.Errorf("non-build setup command did not run on review: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "build-desktop-marker")); err == nil {
+		t.Error("build:desktop-marked setup command ran on a read-only review worktree")
+	}
+
+	// Sibling fix worktree, same repo state: the desktop build step must
+	// still run there — it's a code-authoring role.
+	fixTk, err := h.tasks.Create("fix still builds desktop", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	fixTk, err = h.tasks.UpdateMap(fixTk.ID, map[string]any{"project_id": h.proj.ID})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	fixPath, err := h.m.PrepareForFix(context.Background(), fixTk, prNumber)
+	if err != nil {
+		t.Fatalf("PrepareForFix: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fixPath, "build-desktop-marker")); err != nil {
+		t.Errorf("build:desktop-marked setup command did not run on a fix worktree: %v", err)
+	}
+}

--- a/internal/worktree/setup_trust_test.go
+++ b/internal/worktree/setup_trust_test.go
@@ -210,3 +210,28 @@ func TestPrepareForReview_SkipsDesktopBuildSetup(t *testing.T) {
 		t.Errorf("build:desktop-marked setup command did not run on a fix worktree: %v", err)
 	}
 }
+
+func TestFilterNonAuthoringSetup_OnlySkipsActualDesktopBuildInvocation(t *testing.T) {
+	commands := []string{
+		"npm ci",
+		"npm run build:desktop",
+		"sh -c 'npm run build:desktop >/dev/null 2>&1 || true; touch build-desktop-marker'",
+		"printf 'build:desktop is mentioned but not executed\\n'",
+		"make build:desktop-assets",
+	}
+
+	filtered := filterNonAuthoringSetup(commands)
+
+	if len(filtered) != 3 {
+		t.Fatalf("filtered command count = %d, want 3; filtered=%q", len(filtered), filtered)
+	}
+	if filtered[0] != "npm ci" {
+		t.Fatalf("filtered[0] = %q, want npm ci", filtered[0])
+	}
+	if filtered[1] != "printf 'build:desktop is mentioned but not executed\\n'" {
+		t.Fatalf("filtered[1] = %q, want the non-executing build:desktop mention to remain", filtered[1])
+	}
+	if filtered[2] != "make build:desktop-assets" {
+		t.Fatalf("filtered[2] = %q, want the unrelated build target to remain", filtered[2])
+	}
+}


### PR DESCRIPTION
Fix/review-role agents now reuse an existing worktree instead of recreating it on every retry, cutting redundant clone/checkout churn. Git fetches are cached with a TTL so repeated fetch calls within a short window skip the network round trip.

Closes https://github.com/Automaat/sybra/issues/1527