### PR TITLE
fix(workflow): plan agent bypasses no-project_id guard, runs in main repo dir

### DIFF
--- a/internal/monitor/dispatcher.go
+++ b/internal/monitor/dispatcher.go
@@ -143,6 +143,17 @@ func (d *agentDispatcher) resolveTarget(a Anomaly) (dir, taskID, name string) {
 			return path, a.TaskID, taskName
 		}
 	}
+	// A task with no project_id can never have an isolated worktree, now or
+	// later — never fall back to the shared repoDir for it. repoDir is a
+	// live, single, unsandboxed operator checkout (used for genuinely
+	// board-wide anomalies above); running a task-scoped agent there risks
+	// git-lock contention and stray writes against real dev work, the same
+	// bug class as the 2026-07-06 board-wipe (#1576). A task that DOES have a
+	// project but whose worktree isn't resolvable right now (in-flight prep,
+	// transient store hiccup) still falls back to repoDir below.
+	if t.ProjectID == "" {
+		return "", a.TaskID, taskName
+	}
 	return d.repoDir, a.TaskID, taskName
 }
 

--- a/internal/monitor/dispatcher_test.go
+++ b/internal/monitor/dispatcher_test.go
@@ -177,6 +177,31 @@ func TestDispatcher_PRGapFallsBackToRepoDirWhenWorktreeMissing(t *testing.T) {
 	}
 }
 
+func TestDispatcher_NoProjectIDNeverFallsBackToRepoDir(t *testing.T) {
+	rr := &recordingRunner{}
+	// No project_id at all: this task can never have an isolated worktree.
+	theTask := task.Task{ID: "abc123", Title: "Prompt Lab proposal"}
+	tasks := dispatcherTasksStub{task: theTask}
+	worktreeFn := func(task.Task) (string, bool) { return "", false }
+	d := newTestDispatcher(rr, tasks, worktreeFn)
+
+	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc123", Fingerprint: "stuck:abc123"}
+	if _, err := d.Dispatch(context.Background(), a); err == nil {
+		t.Fatal("want dispatch error when task has no project_id and no worktree")
+	}
+	if len(rr.calls) != 0 {
+		t.Errorf("runner must not be called for a project-less task, got %d calls", len(rr.calls))
+	}
+
+	ok, reason := d.Dispatchable(a)
+	if ok {
+		t.Error("want false: a project-less task must never dispatch into the shared repoDir")
+	}
+	if reason != "" {
+		t.Errorf("want silent skip (matches the known external-task case), got reason %q", reason)
+	}
+}
+
 func TestDispatcher_TaskGetErrorFallsBackToRepoDir(t *testing.T) {
 	rr := &recordingRunner{}
 	tasks := dispatcherTasksStub{err: errors.New("boom")}

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -950,7 +950,17 @@ func (r *Handler) dispatchBranchConflictRecovery(taskID, dir, base string, t tas
 		}
 		r.logger.Error("pr-monitor.branch-conflict.dispatch", "task_id", taskID, "err", err)
 		if resume.prior != nil {
-			if _, restoreErr := r.tasks.Update(taskID, task.Update{
+			// startWorkflowCore's surfaceInitialDispatchFailure may have already
+			// classified this same error as permanent and escalated the task to
+			// human-required underneath this call (ReplaceWorkflow/StartWorkflowWithVars
+			// → startWorkflowCore → surfaceStartFailureClassified). Restoring
+			// resume.status/prior here would silently clobber that escalation and
+			// resurrect the already-cancelled workflow. Mirror the sticky guard
+			// surfaceStartFailureClassified applies: leave a task a downstream
+			// handler already parked on a human alone.
+			if cur, getErr := r.tasks.Get(taskID); getErr == nil && cur.Status == task.StatusHumanRequired {
+				r.logger.Info("pr-monitor.branch-conflict.restore-skipped-escalated", "task_id", taskID)
+			} else if _, restoreErr := r.tasks.Update(taskID, task.Update{
 				Status:   task.Ptr(task.Status(resume.status)),
 				Workflow: task.Ptr(resume.prior),
 			}); restoreErr != nil {

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -1124,6 +1124,37 @@ func TestDispatchBranchConflictRecovery_PermanentErrorEscalatesImmediately(t *te
 	}
 }
 
+// TestDispatchBranchConflictRecovery_PreservesEscalationFromInitialDispatch is
+// the regression test for the restore-clobbers-escalation bug: a permanently
+// classified dispatch error (e.g. ErrNoProjectAssigned) causes
+// startWorkflowCore's surfaceInitialDispatchFailure to flip the task to
+// human-required *before* returning the error. The restore path must not then
+// overwrite that escalation back to the prior status/workflow — doing so would
+// resurrect the already-cancelled workflow and defeat the escalation.
+func TestDispatchBranchConflictRecovery_PreservesEscalationFromInitialDispatch(t *testing.T) {
+	launchErr := fmt.Errorf("task has no project_id: %w", workflow.ErrNoProjectAssigned)
+	r, tk := newDispatchFailureHandler(t, launchErr)
+	resume := r.captureBranchConflictResumeState(tk)
+	if _, err := r.WorkflowEngine.CancelWorkflow(tk.ID, "test: branch conflict recovery"); err != nil {
+		t.Fatalf("cancel prior workflow: %v", err)
+	}
+
+	if r.dispatchBranchConflictRecovery(tk.ID, "/tmp/does-not-matter", "main", tk, "deadbeef", resume, false) {
+		t.Fatal("want false: a permanent dispatch error must not report success")
+	}
+
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required preserved from the initial-dispatch escalation (restore must not clobber it)", got.Status)
+	}
+	if got.Workflow != nil && got.Workflow.WorkflowID == resume.workflowID {
+		t.Fatalf("prior workflow %q was resurrected by the restore — escalation defeated", resume.workflowID)
+	}
+}
+
 func TestBranchConflictFailureCountersAllowConcurrentTasks(t *testing.T) {
 	r := &Handler{logger: slog.New(slog.DiscardHandler)}
 	var wg sync.WaitGroup

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -122,7 +122,29 @@ func (e *Engine) startWorkflowCore(taskID, workflowID, startStepID string, vars 
 	if errors.Is(err, errBestOfNParked) {
 		return nil, errBestOfNParked
 	}
+	if err != nil {
+		e.surfaceInitialDispatchFailure(taskID, wfExec, start.ID, err)
+	}
 	return comp, err
+}
+
+// surfaceInitialDispatchFailure classifies and escalates a run_agent dispatch
+// error from the very first execution of a workflow (StartWorkflow*,
+// DispatchEvent). Without this, a permanent failure like ErrNoProjectAssigned
+// on the first attempt is only logged by the caller (see
+// maybeStartWorkflowForExternalTask's "workflow.external-create.failed") and
+// never flips the task to human-required or feeds the circuit breaker — the
+// task is left with a live, non-terminal workflow silently retried by
+// ResumeStalled and other recovery loops until ITS classification finally
+// fires, minutes later than necessary. Mirrors the equivalent call ResumeStalled
+// already makes after every resumed dispatch attempt.
+func (e *Engine) surfaceInitialDispatchFailure(taskID string, wfExec *Execution, fallbackStepID string, err error) {
+	currentStatus := ""
+	if t, getErr := e.tasks.GetTask(taskID); getErr == nil {
+		currentStatus = t.Status
+	}
+	stepID := dispatchFailureStepID(err, fallbackStepID)
+	e.surfaceStartFailure(taskID, currentStatus, err, wfExec, stepID)
 }
 
 // MatchWorkflow finds the best workflow for a task based on trigger conditions.

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -139,12 +139,20 @@ func (e *Engine) startWorkflowCore(taskID, workflowID, startStepID string, vars 
 // fires, minutes later than necessary. Mirrors the equivalent call ResumeStalled
 // already makes after every resumed dispatch attempt.
 func (e *Engine) surfaceInitialDispatchFailure(taskID string, wfExec *Execution, fallbackStepID string, err error) {
-	currentStatus := ""
-	if t, getErr := e.tasks.GetTask(taskID); getErr == nil {
-		currentStatus = t.Status
+	t, getErr := e.tasks.GetTask(taskID)
+	if getErr != nil {
+		// Without the current status we cannot preserve it for a non-permanent
+		// (transient) classification, and an empty target would be rejected by
+		// UpdateTaskStatus and swallowed under a misleading resume-stalled log.
+		// A store hiccup that blocks this read would block the status write too,
+		// so emit a dedicated signal and let a later ResumeStalled pass re-drive
+		// once the store recovers.
+		e.logger.Error("workflow.initial-dispatch.surface-read-failed",
+			"task_id", taskID, "err", getErr, "dispatch_err", err)
+		return
 	}
 	stepID := dispatchFailureStepID(err, fallbackStepID)
-	e.surfaceStartFailure(taskID, currentStatus, err, wfExec, stepID)
+	e.surfaceStartFailure(taskID, t.Status, err, wfExec, stepID)
 }
 
 // MatchWorkflow finds the best workflow for a task based on trigger conditions.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -113,6 +113,7 @@ type memTasks struct {
 	gets      map[string]int
 	onGet     func(id string, t *TaskInfo, count int)
 	appendErr error
+	failGet   bool
 }
 
 func newMemTasks() *memTasks {
@@ -155,9 +156,21 @@ func (m *memTasks) SetGetTaskHook(hook func(id string, t *TaskInfo, count int)) 
 	m.onGet = hook
 }
 
+// SetFailGet forces GetTask to error even when the task exists, simulating a
+// transient store read hiccup. Other operations (UpdateTaskStatus, etc.) keep
+// working, so it can model a read failure concurrent with a live task.
+func (m *memTasks) SetFailGet(fail bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failGet = fail
+}
+
 func (m *memTasks) GetTask(id string) (TaskInfo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.failGet {
+		return TaskInfo{}, fmt.Errorf("task %s: simulated store read failure", id)
+	}
 	t, ok := m.tasks[id]
 	if !ok {
 		return TaskInfo{}, fmt.Errorf("task %s not found", id)
@@ -5542,6 +5555,34 @@ func TestStartWorkflow_InitialDispatchFailure_EscalatesPermanentError(t *testing
 	}
 	if !strings.Contains(got.StatusReason, "no project could be assigned") {
 		t.Errorf("status reason = %q, want it to mention the classified no-project reason", got.StatusReason)
+	}
+}
+
+// TestSurfaceInitialDispatchFailure_ReadFailureDoesNotWriteEmptyStatus covers
+// the joint-failure edge: a store hiccup makes the current-status read fail at
+// the same moment a dispatch fails. Without the read guard, a non-permanent
+// classification would fall through with an empty target and push
+// UpdateTaskStatus(id, "", reason) — rejected and swallowed under a misleading
+// resume-stalled log while corrupting the task's status. The guard must skip
+// the surface entirely and leave the task's status untouched.
+func TestSurfaceInitialDispatchFailure_ReadFailureDoesNotWriteEmptyStatus(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	tasks.SetFailGet(true)
+	wf := &Execution{WorkflowID: "x", CurrentStep: "run_agent", State: ExecRunning}
+	// A non-permanent error would target the (now unreadable) current status.
+	engine.surfaceInitialDispatchFailure("t1", wf, "run_agent", fmt.Errorf("git fetch: timeout"))
+
+	tasks.SetFailGet(false)
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want unchanged in-progress (no empty-status write)", got.Status)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5513,6 +5513,38 @@ func TestExecRunAgent_RealSpawnErrorPropagates(t *testing.T) {
 	}
 }
 
+// TestStartWorkflow_InitialDispatchFailure_EscalatesPermanentError guards
+// against the workflow.external-create.failed gap: a permanent dispatch
+// error (e.g. ErrNoProjectAssigned) on the very FIRST execution of a
+// workflow — StartWorkflow/DispatchEvent, not a ResumeStalled retry — must
+// classify and escalate exactly like ResumeStalled already does. Before the
+// fix, startWorkflowCore returned the raw error to its caller (who only logs
+// it) and left the task's Workflow live/non-terminal, so the task silently
+// sat in limbo until some later resume attempt happened to escalate it.
+func TestStartWorkflow_InitialDispatchFailure_EscalatesPermanentError(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	agents := newMockAgents()
+	agents.SetFailSpawn(fmt.Errorf("task t1 has no project_id: refusing to start triage agent without isolated worktree: %w", ErrNoProjectAssigned))
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	if err := engine.StartWorkflow("t1", "test-simple"); err == nil {
+		t.Fatal("StartWorkflow should propagate the spawn error")
+	}
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required on the very first dispatch attempt", got.Status)
+	}
+	if !strings.Contains(got.StatusReason, "no project could be assigned") {
+		t.Errorf("status reason = %q, want it to mention the classified no-project reason", got.StatusReason)
+	}
+}
+
 // TestExecVerifyCommits_ParksWhileSiblingRunning asserts the step re-arms the
 // implement run_agent step and parks the workflow in ExecWaiting (returning
 // errStepParked) when another agent is still working the task — instead of


### PR DESCRIPTION
## Motivation

**Original title:** fix(workflow): plan agent bypasses project_id guard, runs in main repo dir

## What happened

Task 60e6506e ("Prompt Lab: tighten instructions for role human-review") has no `project_id` (promptlab evidence spans multiple projects with no `agent.default_project_id` configured — expected/correct per `agentorch.AutoAssignProject`'s design).

`sybra.log` around the plan step's first dispatch:

```
22:42:02.212 ERROR workflow.external-create.failed task_id=60e6506e err="start simple-task-plan: start agent: task 60e6506e has no project_id: refusing to start plan agent without isolated worktree: ..."
22:42:08.619 ERROR workflow.resume-stalled.exec       task_id=60e6506e err="start agent: task 60e6506e has no project_id: refusing to start plan agent without isolated worktree: ..."
22:42:10.968 INFO  agent.sandbox.report task_id=60e6506e worktree="/Users/marcin.skalski/sideprojects/synapse" sandbox_home=".../sandboxes/60e6506e/sybra-home"
22:42:10.968 INFO  agent.start id=b31ffd1b taskID=60e6506e mode=headless provider=claude model=sonnet
```

The `no project_id` guard (`internal/sybra/app_workflow.go:733`, `resolveWorktreeDir`) correctly refused the dispatch twice, but ~2 seconds later an agent (`b31ffd1b`) started anyway for the same task — with its working directory set to the live main-branch checkout (`/Users/marcin.skalski/sideprojects/synapse`), not the `config.HomeDir()` fallback that `app_workflow.go:681-688` explicitly documents as the fix for "the bug that caused branch changes on main":

```go
if cfg.Dir == "" {
    // System-role fallback (triage, plan, eval, …): no worktree required,
    // but the agent process still needs an existing cwd. Use the sybra
    // home dir rather than letting the process inherit Sybra's own cwd
    // (which in dev mode would be the sybra source repo — the bug that
    // caused branch changes on main).
    cfg.Dir = config.HomeDir()
}
```

The agent ran headless with `--dangerously-skip-permissions` (confirmed via `inspector: running with --dangerously-skip-permissions agent_id=b31ffd1b`) for 23 minutes in that directory, producing zero actual work (its NDJSON log — `/Users/marcin.skalski/.sybra/logs/agents/b31ffd1b-2026-07-10T20-42-10.ndjson` — contains only the initial `system/commands_changed` line, no assistant/tool_use turns). The watchdog eventually flagged it `stuck` and stopped it at 23:05:46.

The immediate retry reproduced the identical sequence:

```
23:06:15.510 ERROR workflow.resume-stalled.exec task_id=60e6506e err="... no project_id: refusing to start plan agent without isolated worktree ..."
23:06:16.569 INFO  agent.sandbox.report task_id=60e6506e worktree="/Users/marcin.skalski/sideprojects/synapse"
23:06:16.569 INFO  agent.start id=627bccef taskID=60e6506e mode=headless provider=claude model=sonnet
```

Only after this second stuck agent did `workflow.watchdog-hang.retry` finally route the task to `human-required` with the (accurate, but 23+ minutes late) reason "no project could be assigned."

## Repro

1. Create a task with no `project_id` and no `agent.default_project_id` configured, with 2+ projects registered (so `AutoAssignProject` legitimately no-ops).
2. Let it enter `simple-task-plan`'s `plan` step (`needs_worktree: true`).
3. Observe: the guard logs `workflow.external-create.failed` / `workflow.resume-stalled.exec` refusing the dispatch, but within seconds a headless agent starts anyway with `agent.sandbox.report worktree=<sybra source repo path>` instead of failing closed or falling back to `config.HomeDir()`.

## Suspected cause

There appears to be a second dispatch path for the `plan`/system-role step (invoked right after the guarded path fails — possibly the auto-review/human-review verdict flow, or a retry loop distinct from `resolveWorktreeDir`) that does not go through the `t.ProjectID == ""` guard at `app_workflow.go:733`, and whose `cfg.Dir == ""` fallback is not landing on `config.HomeDir()` as intended — instead the process inherits/receives the live main-repo working directory. This is a reintroduction of the exact previously-fixed "branch changes on main" bug class documented in the `app_workflow.go:681-688` comment, this time letting a `--dangerously-skip-permissions` agent run unsandboxed against the actual dev checkout for 23 minutes. Needs tracing of which caller launched `b31ffd1b`/`627bccef` outside `StartAgent`'s guarded path, and why `cfg.Dir` wasn't `config.HomeDir()`.

## Filing failure

GitHub issue filing failed, so Sybra created this local fallback task instead.

Error: gh issue create: could not add label: 'safety' not found: exit status 1

## Implementation information

See commit history for fix(workflow): plan agent bypasses no-project_id guard, runs in main repo dir.

_Generated by Sybra harness_