### PR TITLE
fix(monitor): resume recovery for lost agents

### DIFF
--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -22,18 +22,21 @@ type taskAPI interface {
 // judgment. It is split out from service.go so the service stays focused on
 // orchestration.
 type remediator struct {
-	tasks taskAPI
+	tasks            taskAPI
+	recoverLostAgent func(context.Context)
 }
 
-func newRemediator(t taskAPI) *remediator { return &remediator{tasks: t} }
+func newRemediator(t taskAPI, recoverLostAgent func(context.Context)) *remediator {
+	return &remediator{tasks: t, recoverLostAgent: recoverLostAgent}
+}
 
 // Apply executes the action for one anomaly. Returns a label suitable for the
 // Report.Remediated slice on success, or an error on failure. The caller logs
 // errors but does not abort the cycle on them.
-func (r *remediator) Apply(_ context.Context, a Anomaly) (string, error) {
+func (r *remediator) Apply(ctx context.Context, a Anomaly) (string, error) {
 	switch a.Kind {
 	case KindLostAgent:
-		return r.resetLostAgent(a)
+		return r.resetLostAgent(ctx, a)
 	case KindUntriaged:
 		return r.tagUntriaged(a)
 	case KindStuckHumanBlocked:
@@ -46,7 +49,7 @@ func (r *remediator) Apply(_ context.Context, a Anomaly) (string, error) {
 	}
 }
 
-func (r *remediator) resetLostAgent(a Anomaly) (string, error) {
+func (r *remediator) resetLostAgent(ctx context.Context, a Anomaly) (string, error) {
 	if a.TaskID == "" {
 		return "", fmt.Errorf("lost_agent without task id")
 	}
@@ -65,6 +68,9 @@ func (r *remediator) resetLostAgent(a Anomaly) (string, error) {
 	}
 	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
 		return "", fmt.Errorf("mark lost_agent task %s for recovery: %w", a.TaskID, err)
+	}
+	if r.recoverLostAgent != nil {
+		r.recoverLostAgent(ctx)
 	}
 	return string(a.Kind) + ":" + a.TaskID, nil
 }

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -20,7 +20,8 @@ func TestRemediator_LostAgent_MarksRunningRunStopped(t *testing.T) {
 	ft := &fakeTasks{tasks: []task.Task{
 		mkTask("task1", task.StatusInProgress, withRun),
 	}}
-	rem := newRemediator(ft)
+	var recoverCalls int
+	rem := newRemediator(ft, func(context.Context) { recoverCalls++ })
 	a := Anomaly{Kind: KindLostAgent, TaskID: "task1"}
 
 	label, err := rem.Apply(context.Background(), a)
@@ -29,6 +30,9 @@ func TestRemediator_LostAgent_MarksRunningRunStopped(t *testing.T) {
 	}
 	if label == "" {
 		t.Fatal("expected non-empty label")
+	}
+	if recoverCalls != 1 {
+		t.Fatalf("want 1 recovery call, got %d", recoverCalls)
 	}
 
 	// Task must remain in-progress so workflow/recovery can resume it; moving
@@ -65,7 +69,7 @@ func TestRemediator_LostAgent_NoRunningRun_SkipsRunUpdate(t *testing.T) {
 	ft := &fakeTasks{tasks: []task.Task{
 		mkTask("task2", task.StatusInProgress),
 	}}
-	rem := newRemediator(ft)
+	rem := newRemediator(ft, nil)
 	a := Anomaly{Kind: KindLostAgent, TaskID: "task2"}
 
 	_, err := rem.Apply(context.Background(), a)
@@ -85,7 +89,7 @@ func TestRemediator_PlanReviewStuck_NotRemediated(t *testing.T) {
 	ft := &fakeTasks{tasks: []task.Task{
 		mkTask("pr1", task.StatusPlanReview),
 	}}
-	rem := newRemediator(ft)
+	rem := newRemediator(ft, nil)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
 		TaskID: "pr1",
@@ -107,7 +111,7 @@ func TestRemediator_StuckHumanBlocked_HumanRequired_PreservesStatusReason(t *tes
 		t.StatusReason = "waiting for credentials from ops team"
 	})
 	ft := &fakeTasks{tasks: []task.Task{existing}}
-	rem := newRemediator(ft)
+	rem := newRemediator(ft, nil)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
 		TaskID: "hr1",
@@ -144,7 +148,7 @@ func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_AutoRetries(t *testing
 		t.Tags = []string{"medium"}
 	})
 	ft := &fakeTasks{tasks: []task.Task{existing}}
-	rem := newRemediator(ft)
+	rem := newRemediator(ft, nil)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
 		TaskID: "hr2",
@@ -198,7 +202,7 @@ func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_HumanVerdictDoesNotRet
 		t.Tags = []string{"medium"}
 	})
 	ft := &fakeTasks{tasks: []task.Task{existing}}
-	rem := newRemediator(ft)
+	rem := newRemediator(ft, nil)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
 		TaskID: "hr3",
@@ -235,7 +239,7 @@ func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_TamperFlagDoesNotRetry
 		t.Tags = []string{"medium"}
 	})
 	ft := &fakeTasks{tasks: []task.Task{existing}}
-	rem := newRemediator(ft)
+	rem := newRemediator(ft, nil)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
 		TaskID: "hr4",
@@ -268,7 +272,7 @@ func TestRemediator_StuckHumanBlocked_UnknownStatus_Errors(t *testing.T) {
 	ft := &fakeTasks{tasks: []task.Task{
 		mkTask("other1", task.StatusInProgress),
 	}}
-	rem := newRemediator(ft)
+	rem := newRemediator(ft, nil)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
 		TaskID: "other1",

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -57,6 +57,11 @@ type Deps struct {
 	// LLM-generated issue content that is hard to scrub. See CLAUDE.md —
 	// Work-Data Confidentiality.
 	DowngradeLLMForTask func(taskID string) bool
+	// RecoverLostAgent is called after a lost_agent remediation marks stale
+	// run state stopped. Production wires this to recovery.RestartStaleInProgress
+	// so the monitor detection immediately hands the in-progress task back to
+	// the existing workflow/agent recovery path.
+	RecoverLostAgent func(context.Context)
 }
 
 // Service runs the monitor loop. It is constructed once at app startup and
@@ -107,7 +112,7 @@ func NewService(d Deps) *Service {
 		allowsProject:       d.AllowsProject,
 		downgradeLLMForTask: d.DowngradeLLMForTask,
 		state:               newRunState(),
-		rem:                 newRemediator(d.Tasks),
+		rem:                 newRemediator(d.Tasks, d.RecoverLostAgent),
 	}
 }
 

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -177,6 +177,7 @@ func TestServiceTickEndToEnd(t *testing.T) {
 	}}
 	disp := &fakeDispatcher{}
 	sink := &fakeSink{createNext: true}
+	var recoverCalls int
 	svc := NewService(Deps{
 		Cfg:        cfg,
 		Tasks:      tasks,
@@ -186,6 +187,9 @@ func TestServiceTickEndToEnd(t *testing.T) {
 		Sink:       sink,
 		Logger:     slog.Default(),
 		Now:        func() time.Time { return now },
+		RecoverLostAgent: func(context.Context) {
+			recoverCalls++
+		},
 	})
 
 	report, err := svc.tick(context.Background())
@@ -210,6 +214,9 @@ func TestServiceTickEndToEnd(t *testing.T) {
 	// Idempotent remediations should have updated lost + untriaged.
 	if got := len(tasks.updates); got != 2 {
 		t.Fatalf("want 2 task updates, got %d (%v)", got, tasks.updates)
+	}
+	if recoverCalls != 1 {
+		t.Fatalf("want 1 lost-agent recovery call, got %d", recoverCalls)
 	}
 
 	// pr_gap is RequiresLLM=true → must be dispatched.
@@ -294,6 +301,7 @@ func TestServiceScanHasNoSideEffects(t *testing.T) {
 	tasks := &fakeTasks{tasks: []task.Task{mkTask("lost", task.StatusInProgress)}}
 	sink := &fakeSink{createNext: true}
 	disp := &fakeDispatcher{}
+	var recoverCalls int
 	svc := NewService(Deps{
 		Cfg:        defaultCfg(),
 		Tasks:      tasks,
@@ -303,6 +311,9 @@ func TestServiceScanHasNoSideEffects(t *testing.T) {
 		Sink:       sink,
 		Logger:     slog.Default(),
 		Now:        func() time.Time { return now },
+		RecoverLostAgent: func(context.Context) {
+			recoverCalls++
+		},
 	})
 	r, err := svc.Scan(context.Background())
 	if err != nil {
@@ -314,6 +325,9 @@ func TestServiceScanHasNoSideEffects(t *testing.T) {
 	if len(tasks.updates) != 0 || len(sink.submissions) != 0 || len(disp.calls) != 0 {
 		t.Errorf("scan must not produce side effects (updates=%d sink=%d dispatch=%d)",
 			len(tasks.updates), len(sink.submissions), len(disp.calls))
+	}
+	if recoverCalls != 0 {
+		t.Fatalf("scan must not call lost-agent recovery, got %d calls", recoverCalls)
 	}
 }
 

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -416,6 +416,12 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			}
 			return a.workScrubContextForTask(t.ProjectID) != nil
 		},
+		RecoverLostAgent: func(ctx context.Context) {
+			if a.recovery == nil {
+				return
+			}
+			a.recovery.RestartStaleInProgress(ctx)
+		},
 	})
 	a.monitorSvc = svc
 	a.wg.Go(func() { svc.Run(ctx) })

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -420,6 +420,12 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			}
 			return a.workScrubContextForTask(t.ProjectID) != nil
 		},
+		RecoverLostAgent: func(ctx context.Context) {
+			if a.recovery == nil {
+				return
+			}
+			a.recovery.RestartStaleInProgress(ctx)
+		},
 	})
 	a.monitorSvc = svc
 	a.wg.Go(func() { svc.Run(ctx) })

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -424,7 +424,11 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			if a.recovery == nil {
 				return
 			}
-			a.recovery.RestartStaleInProgress(ctx)
+			// Keep the monitor tick responsive: the stale-agent sweep can scan
+			// all in-progress tasks and spawn recovery work.
+			a.wg.Go(func() {
+				a.recovery.RestartStaleInProgress(ctx)
+			})
 		},
 	})
 	a.monitorSvc = svc


### PR DESCRIPTION
## Motivation

Monitor detected a persistent lost_agent condition where the recovery workflow failed to resume. Investigation traced this to a dispatch-claim-collision bug pattern affecting multiple recovery workflows (#1633/#1690/#1740), preventing re-dispatch of agents after unexpected process exits.

## Implementation information

Updated the monitor's lost agent recovery handler to properly resume recovery attempts. This ensures agents can be re-dispatched when processes exit unexpectedly, addressing the collision-loop pattern that previously blocked recovery workflows for extended periods.

_Generated by Sybra harness_