### PR TITLE
fix(monitor): ensure caller-supplied labels before issue create

### DIFF
--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -82,7 +82,6 @@ func (s *GHIssueSink) Submit(ctx context.Context, a Anomaly, body string) (bool,
 // succeeded.
 func (s *GHIssueSink) SubmitIssue(ctx context.Context, title, body string, extraLabels []string) (created bool, url string, err error) {
 	s.labelsOnce.Do(func() { s.ensureLabels(ctx) })
-	s.ensureExtraLabels(ctx, extraLabels)
 
 	num, foundURL, err := s.findOpenIssue(ctx, title)
 	if err != nil {
@@ -95,6 +94,7 @@ func (s *GHIssueSink) SubmitIssue(ctx context.Context, title, body string, extra
 		}
 		return false, foundURL, nil
 	}
+	s.ensureExtraLabels(ctx, extraLabels)
 	var lb strings.Builder
 	lb.WriteString(s.label)
 	for _, extra := range extraLabels {
@@ -154,13 +154,23 @@ func (s *GHIssueSink) ensureLabels(ctx context.Context) {
 // Same best-effort discipline as ensureLabels: an already-exists error is
 // fine, and any other error is swallowed so the create call below still
 // surfaces label problems if the label genuinely can't be used.
+//
+// Only called on the create path (num == 0 in SubmitIssue) since labels are
+// only attached there, not on the comment path — this also avoids spending a
+// gh call per extra label on the far more common dedup-hit path.
+//
+// The "--" before extra stops gh from parsing a caller-supplied label that
+// happens to start with "-" (e.g. LLM output like "-1-of-3") as a flag; without
+// it gh fails with "unknown shorthand flag", the create is silently swallowed,
+// and the later issue-create call reproduces the same "label not found"
+// failure this fix targets, just for a dash-prefixed label.
 func (s *GHIssueSink) ensureExtraLabels(ctx context.Context, extraLabels []string) {
 	for _, extra := range extraLabels {
 		extra = strings.TrimSpace(extra)
 		if extra == "" || extra == s.label || extra == "bug" {
 			continue
 		}
-		_, _ = s.exec.run(ctx, append(s.repoArgs(), "label", "create", extra)...)
+		_, _ = s.exec.run(ctx, append(s.repoArgs(), "label", "create", "--", extra)...)
 	}
 }
 

--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -94,22 +94,16 @@ func (s *GHIssueSink) SubmitIssue(ctx context.Context, title, body string, extra
 		}
 		return false, foundURL, nil
 	}
-	s.ensureExtraLabels(ctx, extraLabels)
-	var lb strings.Builder
-	lb.WriteString(s.label)
-	for _, extra := range extraLabels {
-		extra = strings.TrimSpace(extra)
-		if extra == "" || extra == s.label {
-			continue
-		}
-		lb.WriteString(",")
-		lb.WriteString(extra)
-	}
-	out, err := s.exec.run(ctx, append(s.repoArgs(), "issue", "create",
+	labels := issueCreateLabels(s.label, extraLabels)
+	s.ensureExtraLabels(ctx, labels[1:])
+	args := append(s.repoArgs(), "issue", "create",
 		"--title", title,
 		"--body", attribution.Append(body),
-		"--label", lb.String(),
-	)...)
+	)
+	for _, label := range labels {
+		args = append(args, "--label", label)
+	}
+	out, err := s.exec.run(ctx, args...)
 	if err != nil {
 		return false, "", classifyGHError("gh issue create", out, err)
 	}
@@ -149,11 +143,11 @@ func (s *GHIssueSink) ensureLabels(ctx context.Context) {
 // issue_labels array from a human-review LLM verdict) that ensureLabels
 // doesn't already cover. Without this, gh issue create hard-fails outright
 // when a caller names a label that doesn't exist on the repo yet, discarding
-// an otherwise-valid issue and forcing a local fallback task instead (see
-// task baecc515: "could not add label: 'duplicate-candidate' not found").
-// Same best-effort discipline as ensureLabels: an already-exists error is
-// fine, and any other error is swallowed so the create call below still
-// surfaces label problems if the label genuinely can't be used.
+// an otherwise-valid issue and forcing the filing path down its fallback
+// task/issue route. Same best-effort discipline as ensureLabels: an
+// already-exists error is fine, and any other error is swallowed so the
+// create call below still surfaces label problems if the label genuinely
+// can't be used.
 //
 // Only called on the create path (num == 0 in SubmitIssue) since labels are
 // only attached there, not on the comment path — this also avoids spending a
@@ -172,6 +166,23 @@ func (s *GHIssueSink) ensureExtraLabels(ctx context.Context, extraLabels []strin
 		}
 		_, _ = s.exec.run(ctx, append(s.repoArgs(), "label", "create", "--", extra)...)
 	}
+}
+
+func issueCreateLabels(primary string, extraLabels []string) []string {
+	labels := []string{primary}
+	seen := map[string]struct{}{primary: {}}
+	for _, extra := range extraLabels {
+		extra = strings.TrimSpace(extra)
+		if extra == "" {
+			continue
+		}
+		if _, dup := seen[extra]; dup {
+			continue
+		}
+		labels = append(labels, extra)
+		seen[extra] = struct{}{}
+	}
+	return labels
 }
 
 func (s *GHIssueSink) findOpenIssue(ctx context.Context, title string) (number int, url string, err error) {

--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -82,6 +82,7 @@ func (s *GHIssueSink) Submit(ctx context.Context, a Anomaly, body string) (bool,
 // succeeded.
 func (s *GHIssueSink) SubmitIssue(ctx context.Context, title, body string, extraLabels []string) (created bool, url string, err error) {
 	s.labelsOnce.Do(func() { s.ensureLabels(ctx) })
+	s.ensureExtraLabels(ctx, extraLabels)
 
 	num, foundURL, err := s.findOpenIssue(ctx, title)
 	if err != nil {
@@ -142,6 +143,25 @@ func (s *GHIssueSink) ensureLabels(ctx context.Context) {
 	// label-related problems if any.
 	_, _ = s.exec.run(ctx, append(s.repoArgs(), "label", "create", s.label, "--color", "BFD4F2", "--description", "Opened by sybra monitor")...)
 	_, _ = s.exec.run(ctx, append(s.repoArgs(), "label", "create", "bug", "--color", "D73A4A", "--description", "Something isn't working")...)
+}
+
+// ensureExtraLabels best-effort creates caller-supplied labels (e.g. an
+// issue_labels array from a human-review LLM verdict) that ensureLabels
+// doesn't already cover. Without this, gh issue create hard-fails outright
+// when a caller names a label that doesn't exist on the repo yet, discarding
+// an otherwise-valid issue and forcing a local fallback task instead (see
+// task baecc515: "could not add label: 'duplicate-candidate' not found").
+// Same best-effort discipline as ensureLabels: an already-exists error is
+// fine, and any other error is swallowed so the create call below still
+// surfaces label problems if the label genuinely can't be used.
+func (s *GHIssueSink) ensureExtraLabels(ctx context.Context, extraLabels []string) {
+	for _, extra := range extraLabels {
+		extra = strings.TrimSpace(extra)
+		if extra == "" || extra == s.label || extra == "bug" {
+			continue
+		}
+		_, _ = s.exec.run(ctx, append(s.repoArgs(), "label", "create", extra)...)
+	}
 }
 
 func (s *GHIssueSink) findOpenIssue(ctx context.Context, title string) (number int, url string, err error) {

--- a/internal/monitor/issuesink_test.go
+++ b/internal/monitor/issuesink_test.go
@@ -104,8 +104,8 @@ func TestGHIssueSink_DedupMissCreates(t *testing.T) {
 	if !containsPair(got, "--body", attribution.Append("body")) {
 		t.Errorf("missing body: %v", got)
 	}
-	if !containsPair(got, "--label", "monitor,bug") {
-		t.Errorf("missing label pair: %v", got)
+	if !containsLabelArgs(got, "monitor", "bug") {
+		t.Errorf("missing label args: %v", got)
 	}
 	if len(fe.callsMatching("issue", "comment")) != 0 {
 		t.Errorf("should not comment on dedup miss")
@@ -196,8 +196,8 @@ func TestGHIssueSink_EnsuresExtraLabelsBeforeCreate(t *testing.T) {
 	if len(creates) != 1 {
 		t.Fatalf("want 1 issue create call, got %d", len(creates))
 	}
-	if !containsPair(creates[0], "--label", "monitor,duplicate-candidate,bug") {
-		t.Errorf("wrong label list: %v", creates[0])
+	if !containsLabelArgs(creates[0], "monitor", "duplicate-candidate", "bug") {
+		t.Errorf("wrong label args: %v", creates[0])
 	}
 }
 
@@ -219,6 +219,24 @@ func TestGHIssueSink_ExtraLabelStartingWithDashIsNotParsedAsFlag(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected a `--` separated label create call for -1-of-3, got %v", labelCreates)
+	}
+}
+
+func TestGHIssueSink_CreatePreservesCommaContainingLabelAsSingleArg(t *testing.T) {
+	fe := &fakeExecer{listResp: []byte(`[]`)}
+	s := newTestSink(fe)
+
+	_, _, err := s.SubmitIssue(context.Background(), "title", "body", []string{"ops,infra"})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	creates := fe.callsMatching("issue", "create")
+	if len(creates) != 1 {
+		t.Fatalf("want 1 issue create call, got %d", len(creates))
+	}
+	if !containsLabelArgs(creates[0], "monitor", "ops,infra") {
+		t.Fatalf("expected comma-containing label to stay a single argv token, got %v", creates[0])
 	}
 }
 
@@ -398,6 +416,15 @@ func containsPair(args []string, key, val string) bool {
 		}
 	}
 	return false
+}
+
+func containsLabelArgs(args []string, labels ...string) bool {
+	for _, label := range labels {
+		if !containsPair(args, "--label", label) {
+			return false
+		}
+	}
+	return true
 }
 
 // verify the fakeExecer actually satisfies the ghExecer interface at compile

--- a/internal/monitor/issuesink_test.go
+++ b/internal/monitor/issuesink_test.go
@@ -184,7 +184,7 @@ func TestGHIssueSink_EnsuresExtraLabelsBeforeCreate(t *testing.T) {
 	}
 	found := false
 	for _, c := range labelCreates {
-		if len(c) >= 3 && c[2] == "duplicate-candidate" {
+		if len(c) >= 4 && c[2] == "--" && c[3] == "duplicate-candidate" {
 			found = true
 		}
 	}
@@ -198,6 +198,55 @@ func TestGHIssueSink_EnsuresExtraLabelsBeforeCreate(t *testing.T) {
 	}
 	if !containsPair(creates[0], "--label", "monitor,duplicate-candidate,bug") {
 		t.Errorf("wrong label list: %v", creates[0])
+	}
+}
+
+func TestGHIssueSink_ExtraLabelStartingWithDashIsNotParsedAsFlag(t *testing.T) {
+	fe := &fakeExecer{listResp: []byte(`[]`)}
+	s := newTestSink(fe)
+
+	_, _, err := s.SubmitIssue(context.Background(), "title", "body", []string{"-1-of-3"})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	labelCreates := fe.callsMatching("label", "create")
+	found := false
+	for _, c := range labelCreates {
+		if len(c) >= 4 && c[2] == "--" && c[3] == "-1-of-3" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a `--` separated label create call for -1-of-3, got %v", labelCreates)
+	}
+}
+
+func TestGHIssueSink_ExtraLabelsNotEnsuredOnCommentPath(t *testing.T) {
+	fe := &fakeExecer{
+		listResp: []byte(`[{"number":87,"title":"title"}]`),
+	}
+	s := newTestSink(fe)
+
+	_, _, err := s.SubmitIssue(context.Background(), "title", "body", []string{"duplicate-candidate"})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	labelCreates := fe.callsMatching("label", "create")
+	// Only monitor + bug (ensureLabels, once) — extraLabels are only attached
+	// on the create branch, so they must not be ensured on a dedup hit.
+	if len(labelCreates) != 2 {
+		t.Fatalf("want 2 label create calls (ensureLabels only), got %d: %v", len(labelCreates), labelCreates)
+	}
+	for _, c := range labelCreates {
+		if len(c) >= 3 && c[2] == "duplicate-candidate" {
+			t.Fatalf("extra label should not be created on comment path, got %v", labelCreates)
+		}
+	}
+
+	if len(fe.callsMatching("issue", "create")) != 0 {
+		t.Errorf("should not create on dedup hit")
 	}
 }
 

--- a/internal/monitor/issuesink_test.go
+++ b/internal/monitor/issuesink_test.go
@@ -166,6 +166,41 @@ func TestGHIssueSink_LabelsEnsuredOnce(t *testing.T) {
 	}
 }
 
+func TestGHIssueSink_EnsuresExtraLabelsBeforeCreate(t *testing.T) {
+	fe := &fakeExecer{listResp: []byte(`[]`)}
+	s := newTestSink(fe)
+
+	_, _, err := s.SubmitIssue(context.Background(), "title", "body", []string{"duplicate-candidate", "bug", "  ", "monitor"})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	labelCreates := fe.callsMatching("label", "create")
+	// monitor + bug (ensureLabels, once) + duplicate-candidate (ensureExtraLabels).
+	// "bug" and "monitor" from extraLabels are skipped since ensureLabels
+	// already covers them.
+	if len(labelCreates) != 3 {
+		t.Fatalf("want 3 label create calls, got %d: %v", len(labelCreates), labelCreates)
+	}
+	found := false
+	for _, c := range labelCreates {
+		if len(c) >= 3 && c[2] == "duplicate-candidate" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a label create call for duplicate-candidate, got %v", labelCreates)
+	}
+
+	creates := fe.callsMatching("issue", "create")
+	if len(creates) != 1 {
+		t.Fatalf("want 1 issue create call, got %d", len(creates))
+	}
+	if !containsPair(creates[0], "--label", "monitor,duplicate-candidate,bug") {
+		t.Errorf("wrong label list: %v", creates[0])
+	}
+}
+
 func TestGHIssueSink_ClassifiesRateLimit(t *testing.T) {
 	fe := &fakeExecer{
 		listResp:   []byte(`[]`),


### PR DESCRIPTION
## Motivation

GitHub issue filing fails when caller-supplied labels don't exist in the repository, causing monitor-generated tasks to fall back to local Sybra creation instead of opening a public issue for tracking.

## Implementation information

Ensure all caller-supplied labels are created via `gh label create` before passing them to `gh issue create`. The create path now normalizes labels, skips blanks/duplicates already covered by the primary label, and passes labels as repeated `--label` args so caller-supplied names remain single argv values instead of being reparsed from a comma-joined list. This allows the monitor to successfully file issues even when labels need to be created on demand.

_Generated by Sybra harness_
