### PR TITLE
fix(triage): preserve prompt-lab gating tags/status on reclassify

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1958,7 +1958,8 @@ Commands:
            waiting) for tasks that landed in the window — where time is spent.
   health   [--severity warning|critical] [--category CATEGORY]
 
-  triage classify <id>         Classify a single task via claude -p and apply the verdict.
+  triage classify <id>         Classify a single task (must have status=new) via claude -p
+                               and apply the verdict.
   triage classify --all        Classify every task with status=new.
 
   install-skills               Install/refresh Sybra's bundled skills into

--- a/cmd/sybra-cli/prompt_lab.go
+++ b/cmd/sybra-cli/prompt_lab.go
@@ -93,7 +93,7 @@ func filePromptLabProposals(store *task.Manager, projStore *project.Store, resul
 			continue
 		}
 		body := scrubProposalBody(projStore, promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)
-		tags := []string{"prompt-lab-proposal", "role:" + p.Subject.Role}
+		tags := []string{promptlab.ProposalTag, "role:" + p.Subject.Role}
 		status := task.StatusTodo
 		if p.RequiresHumanApproval {
 			tags = append(tags, "requires-human")
@@ -137,7 +137,7 @@ func findExistingPromptLabProposal(tasks []task.Task, proposalID string) (task.T
 		if task.IsTerminalStatus(tasks[i].Status) {
 			continue
 		}
-		if !slices.Contains(tasks[i].Tags, "prompt-lab-proposal") {
+		if !slices.Contains(tasks[i].Tags, promptlab.ProposalTag) {
 			continue
 		}
 		if strings.Contains(tasks[i].Body, marker) {

--- a/cmd/sybra-cli/triage.go
+++ b/cmd/sybra-cli/triage.go
@@ -86,6 +86,16 @@ func cmdTriageClassify(
 		if getErr != nil {
 			return fatal(jsonOut, "get %s: %v", id, getErr)
 		}
+		// Mirror the --all path (restricted to status=new above) and the
+		// poll-based auto-triage handler (internal/poll/triage.go), which both
+		// only ever classify fresh tasks. Without this guard, classifying an
+		// arbitrary id can reclassify a task another subsystem owns outside the
+		// triage pipeline — e.g. a human-required Prompt Lab proposal, whose
+		// gating tags/status Apply must not touch (see internal/triage/apply.go).
+		if t.Status != task.StatusNew {
+			return fatal(jsonOut, "task %s has status %q, not %q — triage classify only reclassifies fresh tasks",
+				id, t.Status, task.StatusNew)
+		}
 		targets = append(targets, t)
 	default:
 		return fatal(jsonOut, "usage: triage classify <id> | triage classify --all")

--- a/cmd/sybra-cli/triage_test.go
+++ b/cmd/sybra-cli/triage_test.go
@@ -91,6 +91,7 @@ func TestCmdTriageClassifyRefusesNonNewTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("project.NewStore: %v", err)
 	}
+	t.Setenv("SYBRA_HOME", dir)
 	cfg := config.DefaultConfig()
 
 	code, _ := captureStdout(t, func() int {

--- a/cmd/sybra-cli/triage_test.go
+++ b/cmd/sybra-cli/triage_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/triage"
@@ -57,5 +59,55 @@ func TestClassifyOneFailureMarksRetryableAndPreservesTaskFields(t *testing.T) {
 	}
 	if !strings.Contains(got.StatusReason, "provider subprocess exited") {
 		t.Errorf("status_reason = %q, want classifier detail", got.StatusReason)
+	}
+}
+
+// TestCmdTriageClassifyRefusesNonNewTask locks in the single-id `triage
+// classify <id>` entry point matching the status=new filter the --all path
+// and the poll-based auto-triage handler already apply. Without this guard,
+// classifying an arbitrary id can reclassify a task outside the triage
+// pipeline's ownership — e.g. a human-required Prompt Lab proposal whose
+// gating tags/status must survive untouched (see internal/triage/apply.go's
+// promptLabProposalTag).
+func TestCmdTriageClassifyRefusesNonNewTask(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(filepath.Join(dir, "tasks"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	created, err := mgr.Create("pending human decision", "body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	humanRequired := task.StatusHumanRequired
+	tags := []string{"prompt-lab-proposal", "requires-human"}
+	created, err = mgr.Update(created.ID, task.Update{Status: &humanRequired, Tags: &tags})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	ps, err := project.NewStore(filepath.Join(dir, "projects"), filepath.Join(dir, "clones"))
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+	cfg := config.DefaultConfig()
+
+	code, _ := captureStdout(t, func() int {
+		return cmdTriageClassify(cfg, mgr, ps, []string{created.ID}, true)
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit classifying a non-new task")
+	}
+
+	got, err := mgr.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status = %s, want unchanged human-required", got.Status)
+	}
+	if !slices.Equal(got.Tags, tags) {
+		t.Errorf("tags = %v, want unchanged %v", got.Tags, tags)
 	}
 }

--- a/cmd/sybra-cli/triage_test.go
+++ b/cmd/sybra-cli/triage_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/triage"
 )
@@ -67,8 +68,7 @@ func TestClassifyOneFailureMarksRetryableAndPreservesTaskFields(t *testing.T) {
 // and the poll-based auto-triage handler already apply. Without this guard,
 // classifying an arbitrary id can reclassify a task outside the triage
 // pipeline's ownership — e.g. a human-required Prompt Lab proposal whose
-// gating tags/status must survive untouched (see internal/triage/apply.go's
-// promptLabProposalTag).
+// gating tags/status must survive untouched (see promptlab.ProposalTag).
 func TestCmdTriageClassifyRefusesNonNewTask(t *testing.T) {
 	dir := t.TempDir()
 	store, err := task.NewStore(filepath.Join(dir, "tasks"))
@@ -81,7 +81,7 @@ func TestCmdTriageClassifyRefusesNonNewTask(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	humanRequired := task.StatusHumanRequired
-	tags := []string{"prompt-lab-proposal", "requires-human"}
+	tags := []string{promptlab.ProposalTag, "requires-human"}
 	created, err = mgr.Update(created.ID, task.Update{Status: &humanRequired, Tags: &tags})
 	if err != nil {
 		t.Fatalf("Update: %v", err)

--- a/internal/promptlab/model.go
+++ b/internal/promptlab/model.go
@@ -13,6 +13,11 @@ import (
 	"time"
 )
 
+// ProposalTag marks local Sybra tasks filed from Prompt Lab proposals. These
+// tasks are reviewed and advanced by PromptLabService, not by normal triage or
+// task.created workflow dispatch.
+const ProposalTag = "prompt-lab-proposal"
+
 // Subject identifies a role/workflow-step slice of the fleet whose
 // prompt/skill may be underperforming.
 type Subject struct {

--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 )
@@ -22,10 +23,10 @@ func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 	// write simulates the cross-process file write sybra-cli performs: it
 	// bypasses the in-process task.Manager (AtomicWrite straight to disk),
 	// then primes the Manager cache the way app.go's emit callback does.
-	write := func(id string, status task.Status) string {
+	write := func(id string, status task.Status, tags ...string) string {
 		tk := task.Task{
 			ID: id, Title: "ext " + id, Status: status,
-			AgentMode: task.AgentModeHeadless, CreatedAt: time.Now().UTC(),
+			AgentMode: task.AgentModeHeadless, Tags: tags, CreatedAt: time.Now().UTC(),
 		}
 		data, err := task.Marshal(tk)
 		if err != nil {
@@ -49,6 +50,19 @@ func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 	}
 	if tk.Workflow == nil || tk.Workflow.WorkflowID != "simple-task-plan" {
 		t.Fatalf("fresh todo task: expected simple-task-plan workflow attached, got %+v", tk.Workflow)
+	}
+
+	// Prompt Lab proposal tasks may be todo, but they are reviewed and
+	// advanced by PromptLabService rather than task.created workflows.
+	promptLabPath := write("ext-promptlab", task.StatusTodo, promptlab.ProposalTag, "role:review")
+	app.maybeStartWorkflowForExternalTask(promptLabPath)
+	app.wg.Wait()
+	pl, err := app.tasks.Get("ext-promptlab")
+	if err != nil {
+		t.Fatalf("get ext-promptlab: %v", err)
+	}
+	if pl.Workflow != nil {
+		t.Fatalf("prompt-lab proposal: expected no workflow, got %+v", pl.Workflow)
 	}
 
 	// Idempotency: re-firing onto a task that already owns an active workflow

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -127,7 +127,7 @@ func (c *promptLabCoordinator) fileScrubbedProposals(result promptlab.RunResult)
 			continue
 		}
 		body := c.scrubBody(promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)
-		tags := []string{"prompt-lab-proposal", "role:" + p.Subject.Role}
+		tags := []string{promptlab.ProposalTag, "role:" + p.Subject.Role}
 		status := task.StatusTodo
 		if p.RequiresHumanApproval {
 			tags = append(tags, "requires-human")
@@ -185,7 +185,7 @@ func findExistingPromptLabProposal(tasks []task.Task, proposalID string) (task.T
 		if task.IsTerminalStatus(tasks[i].Status) {
 			continue
 		}
-		if !slices.Contains(tasks[i].Tags, "prompt-lab-proposal") {
+		if !slices.Contains(tasks[i].Tags, promptlab.ProposalTag) {
 			continue
 		}
 		if strings.Contains(tasks[i].Body, marker) {

--- a/internal/sybra/services_http_test.go
+++ b/internal/sybra/services_http_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/httpapi"
 	"github.com/Automaat/sybra/internal/learning"
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -98,7 +99,7 @@ func TestPromptLabServiceHTTPAllowlist(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	staleStatus := task.StatusTodo
-	staleTags := []string{"prompt-lab-proposal"}
+	staleTags := []string{promptlab.ProposalTag}
 	stale, err := mgr.CreateFull("Stale proposal", "body", task.AgentModeInteractive, task.Update{
 		Status: &staleStatus,
 		Tags:   &staleTags,
@@ -127,7 +128,7 @@ func TestPromptLabServiceHTTPAllowlist(t *testing.T) {
 	}
 
 	pendingStatus := task.StatusHumanRequired
-	pendingTags := []string{"prompt-lab-proposal", "requires-human"}
+	pendingTags := []string{promptlab.ProposalTag, "requires-human"}
 	pending, err := mgr.CreateFull("Pending proposal", "body", task.AgentModeInteractive, task.Update{
 		Status: &pendingStatus,
 		Tags:   &pendingTags,

--- a/internal/sybra/svc_promptlab.go
+++ b/internal/sybra/svc_promptlab.go
@@ -18,7 +18,7 @@ const rejectedNoFeedbackReason = "rejected (no feedback provided)"
 
 // PromptLabService exposes Prompt Lab proposal approve/reject operations as
 // Wails-bound methods. Proposals are plain tasks (tagged
-// promptlab.ProposalTag + "requires-human", status human-required) with no
+// "prompt-lab-proposal" + "requires-human", status human-required) with no
 // workflow attached, so approve/reject are direct task.Manager transitions
 // rather than workflow-engine actions.
 type PromptLabService struct {

--- a/internal/sybra/svc_promptlab.go
+++ b/internal/sybra/svc_promptlab.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/artifact"
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -17,7 +18,7 @@ const rejectedNoFeedbackReason = "rejected (no feedback provided)"
 
 // PromptLabService exposes Prompt Lab proposal approve/reject operations as
 // Wails-bound methods. Proposals are plain tasks (tagged
-// "prompt-lab-proposal" + "requires-human", status human-required) with no
+// promptlab.ProposalTag + "requires-human", status human-required) with no
 // workflow attached, so approve/reject are direct task.Manager transitions
 // rather than workflow-engine actions.
 type PromptLabService struct {
@@ -86,7 +87,7 @@ func (s *PromptLabService) RejectProposal(id, feedback string) (task.Task, error
 // the race a stale browser tab could otherwise re-fire (double approve,
 // approve-after-reject, etc).
 func requirePendingProposal(cur task.Task) error {
-	if !slices.Contains(cur.Tags, "prompt-lab-proposal") || cur.Status != task.StatusHumanRequired {
+	if !slices.Contains(cur.Tags, promptlab.ProposalTag) || cur.Status != task.StatusHumanRequired {
 		return fmt.Errorf("task %s is not a pending prompt-lab proposal (status=%s)", cur.ID, cur.Status)
 	}
 	return nil

--- a/internal/sybra/svc_promptlab_test.go
+++ b/internal/sybra/svc_promptlab_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/artifact"
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -36,7 +37,7 @@ func createProposal(t *testing.T, svc *PromptLabService, status task.Status, tag
 func TestPromptLabService_ApproveProposal(t *testing.T) {
 	t.Parallel()
 	svc := setupPromptLabService(t)
-	tags := []string{"prompt-lab-proposal", "role:test-runner", "requires-human", "requires-human"}
+	tags := []string{promptlab.ProposalTag, "role:test-runner", "requires-human", "requires-human"}
 	created := createProposal(t, svc, task.StatusHumanRequired, tags)
 	stale := "some stale reason"
 	if _, err := svc.tasks.Update(created.ID, task.Update{StatusReason: &stale}); err != nil {
@@ -56,7 +57,7 @@ func TestPromptLabService_ApproveProposal(t *testing.T) {
 	if slices.Contains(got.Tags, "requires-human") {
 		t.Fatalf("tags = %v, want requires-human fully removed", got.Tags)
 	}
-	if !slices.Contains(got.Tags, "prompt-lab-proposal") || !slices.Contains(got.Tags, "role:test-runner") {
+	if !slices.Contains(got.Tags, promptlab.ProposalTag) || !slices.Contains(got.Tags, "role:test-runner") {
 		t.Fatalf("tags = %v, want prompt-lab-proposal and role tags preserved", got.Tags)
 	}
 
@@ -72,7 +73,7 @@ func TestPromptLabService_ApproveProposal(t *testing.T) {
 func TestPromptLabService_RejectProposal_WithFeedback(t *testing.T) {
 	t.Parallel()
 	svc := setupPromptLabService(t)
-	created := createProposal(t, svc, task.StatusHumanRequired, []string{"prompt-lab-proposal", "role:test-runner", "requires-human"})
+	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "role:test-runner", "requires-human"})
 
 	got, err := svc.RejectProposal(created.ID, "not worth it")
 	if err != nil {
@@ -100,7 +101,7 @@ func TestPromptLabService_RejectProposal_WithFeedback(t *testing.T) {
 func TestPromptLabService_RejectProposal_EmptyFeedback(t *testing.T) {
 	t.Parallel()
 	svc := setupPromptLabService(t)
-	created := createProposal(t, svc, task.StatusHumanRequired, []string{"prompt-lab-proposal", "requires-human"})
+	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "requires-human"})
 
 	got, err := svc.RejectProposal(created.ID, "")
 	if err != nil {
@@ -125,7 +126,7 @@ func TestPromptLabService_RejectProposal_EmptyFeedback(t *testing.T) {
 func TestPromptLabService_RejectProposal_WhitespaceOnlyFeedback(t *testing.T) {
 	t.Parallel()
 	svc := setupPromptLabService(t)
-	created := createProposal(t, svc, task.StatusHumanRequired, []string{"prompt-lab-proposal", "requires-human"})
+	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "requires-human"})
 
 	got, err := svc.RejectProposal(created.ID, "   \n\t  ")
 	if err != nil {
@@ -153,7 +154,7 @@ func TestPromptLabService_StaleStatusGuard(t *testing.T) {
 		t.Run(string(status), func(t *testing.T) {
 			t.Parallel()
 			svc := setupPromptLabService(t)
-			created := createProposal(t, svc, status, []string{"prompt-lab-proposal", "requires-human"})
+			created := createProposal(t, svc, status, []string{promptlab.ProposalTag, "requires-human"})
 
 			if _, err := svc.ApproveProposal(created.ID); err == nil {
 				t.Fatal("ApproveProposal: want error for non-pending status")
@@ -200,7 +201,7 @@ func TestPromptLabService_MissingTagGuard(t *testing.T) {
 func TestPromptLabService_DoubleApprove_Idempotency(t *testing.T) {
 	t.Parallel()
 	svc := setupPromptLabService(t)
-	created := createProposal(t, svc, task.StatusHumanRequired, []string{"prompt-lab-proposal", "requires-human"})
+	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "requires-human"})
 
 	if _, err := svc.ApproveProposal(created.ID); err != nil {
 		t.Fatalf("first ApproveProposal: %v", err)
@@ -236,7 +237,7 @@ func TestPromptLabService_AppendProgressFailure_BestEffort(t *testing.T) {
 		tasks:     task.NewManager(store, nil),
 		artifacts: artifact.New(badRoot.Name()),
 	}
-	created := createProposal(t, svc, task.StatusHumanRequired, []string{"prompt-lab-proposal", "requires-human"})
+	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "requires-human"})
 
 	got, err := svc.ApproveProposal(created.ID)
 	if err != nil {

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"slices"
 
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -46,6 +47,12 @@ func skipTaskCreatedWorkflow(t task.Task) bool {
 	// A stub awaiting async enrichment is dispatched by the enrich step, not
 	// the emit path — skip until the real title/labels land.
 	if slices.Contains(t.Tags, enrichPendingTag) {
+		return true
+	}
+	// Prompt Lab proposal tasks are reviewed and advanced by
+	// PromptLabService. A todo-status proposal is still not a normal
+	// task.created workflow candidate.
+	if slices.Contains(t.Tags, promptlab.ProposalTag) {
 		return true
 	}
 	// An umbrella-gated child must be held for releaseUnblockedChildren, not

--- a/internal/sybra/workflow_dispatch_test.go
+++ b/internal/sybra/workflow_dispatch_test.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"testing"
 
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -25,5 +26,12 @@ func TestSkipTaskCreatedWorkflowUmbrellaTaskType(t *testing.T) {
 	tsk := task.Task{TaskType: task.TaskTypeUmbrella, Tags: []string{"backend"}}
 	if !skipTaskCreatedWorkflow(tsk) {
 		t.Error("expected a TaskType=umbrella task to skip task:created dispatch, even without a marker tag")
+	}
+}
+
+func TestSkipTaskCreatedWorkflowPromptLabProposal(t *testing.T) {
+	tsk := task.Task{Status: task.StatusTodo, Tags: []string{promptlab.ProposalTag, "role:review"}}
+	if !skipTaskCreatedWorkflow(tsk) {
+		t.Error("expected prompt-lab proposal task to skip task:created dispatch")
 	}
 }

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -16,6 +16,21 @@ import (
 // (see escapeHatchTags) and the umbrella dependency gate marker.
 var preservedTags = append(append([]string{}, escapeHatchTags...), umbrella.GatedTag)
 
+// promptLabProposalTag marks a task as a Prompt Lab proposal filed directly by
+// PromptLabService (internal/sybra/app_promptlab.go's fileScrubbedProposals):
+// gating tags (prompt-lab-proposal, role:<x>, optionally requires-human),
+// status human-required, and deliberately no project_id or workflow attached
+// — approve/reject is a direct task.Manager transition
+// (PromptLabService.ApproveProposal/RejectProposal), never a triage route.
+// The classifier's controlled vocabulary doesn't know these tags, so a
+// wholesale tag/status rewrite would silently drop the human-approval gate
+// and reroute the task into a workflow it was never meant to enter (it has no
+// project_id, so run_agent fails closed with ErrNoProjectAssigned and the
+// task bounces to human-required with a misleading reason). Apply must skip
+// the tag and status rewrite entirely whenever this tag is present, no matter
+// which entry point triggered the reclassify.
+const promptLabProposalTag = "prompt-lab-proposal"
+
 const umbrellaNormalTypeStatusReason = "☂️-titled task has task_type=normal, not umbrella — " +
 	"guard blocked dispatch to avoid a wasted implement run; " +
 	"manually expand it from the issue URL, add the notumbrella tag to opt out, " +
@@ -34,6 +49,10 @@ const umbrellaGuardOptOutTag = "notumbrella"
 // which feeds into routing rules (work projects force interactive mode).
 func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project) (task.Task, error) {
 	updates := make(map[string]any, 8)
+
+	// A prompt-lab proposal's tags and status are gating state owned by
+	// PromptLabService, not the classifier — see promptLabProposalTag.
+	promptLabGated := slices.Contains(t.Tags, promptLabProposalTag)
 
 	// t.ProjectID is sticky: once set (e.g. by the GitHub issue fetcher at
 	// task creation), the classifier's free-text guess must never override
@@ -82,7 +101,7 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 		updates["body"] = body
 	}
 
-	if len(v.Tags) > 0 {
+	if len(v.Tags) > 0 && !promptLabGated {
 		// Preserve routing tags the classifier vocabulary excludes
 		// (escape-hatch opt-outs, umbrella gate marker) — replacing tags
 		// wholesale would otherwise silently drop them.
@@ -102,32 +121,36 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 		updates["project_id"] = projectID
 	}
 
-	status := RouteStatus(v.Size, v.Type, projectType)
 	// pr-fix tasks (system-created to fix an existing PR) must never enter the
 	// planning phase — they go straight to implementation. Override any route
 	// that would park them in planning.
 	isPRFix := isPRFixTask(t)
-	if isPRFix {
-		status = task.StatusTodo
-	}
-	updates["status"] = string(status)
-	// No status_reason on successful triage: the field is reserved for
-	// attention-worthy states (monitor/watchdog/blocked), which the UI renders
-	// as a warning. Setting "status" without a reason makes the store clear any
-	// stale reason (e.g. "monitor: awaiting triage").
+	if !promptLabGated {
+		status := RouteStatus(v.Size, v.Type, projectType)
+		if isPRFix {
+			status = task.StatusTodo
+		}
+		updates["status"] = string(status)
+		// No status_reason on successful triage: the field is reserved for
+		// attention-worthy states (monitor/watchdog/blocked), which the UI
+		// renders as a warning. Setting "status" without a reason makes the
+		// store clear any stale reason (e.g. "monitor: awaiting triage").
 
-	// A ☂️-titled task that never went through the GitHub issue fetcher (e.g.
-	// manual sybra-cli create) keeps task_type=normal and is invisible to the
-	// umbrella gate (internal/sybra/app_umbrella_gate.go), which filters
-	// strictly on TaskTypeUmbrella. Dispatching it as a flat implement task
-	// wastes a full run before the agent discovers there's no direct code
-	// surface. Catch it here — before dispatch — and park it for a human to
-	// either expand it from its issue URL, opt it out, or fix the title.
-	if !isPRFix && t.TaskType != task.TaskTypeUmbrella &&
-		!slices.Contains(t.Tags, umbrellaGuardOptOutTag) &&
-		umbrella.IsUmbrellaIssue(newTitle, t.Tags) {
-		updates["status"] = string(task.StatusHumanRequired)
-		updates["status_reason"] = umbrellaNormalTypeStatusReason
+		// A ☂️-titled task that never went through the GitHub issue fetcher
+		// (e.g. manual sybra-cli create) keeps task_type=normal and is
+		// invisible to the umbrella gate
+		// (internal/sybra/app_umbrella_gate.go), which filters strictly on
+		// TaskTypeUmbrella. Dispatching it as a flat implement task wastes a
+		// full run before the agent discovers there's no direct code
+		// surface. Catch it here — before dispatch — and park it for a
+		// human to either expand it from its issue URL, opt it out, or fix
+		// the title.
+		if !isPRFix && t.TaskType != task.TaskTypeUmbrella &&
+			!slices.Contains(t.Tags, umbrellaGuardOptOutTag) &&
+			umbrella.IsUmbrellaIssue(newTitle, t.Tags) {
+			updates["status"] = string(task.StatusHumanRequired)
+			updates["status_reason"] = umbrellaNormalTypeStatusReason
+		}
 	}
 
 	updated, err := mgr.UpdateMap(t.ID, updates)

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -15,21 +16,6 @@ import (
 // would silently break routing the task depends on: escape-hatch opt-outs
 // (see escapeHatchTags) and the umbrella dependency gate marker.
 var preservedTags = append(append([]string{}, escapeHatchTags...), umbrella.GatedTag)
-
-// promptLabProposalTag marks a task as a Prompt Lab proposal filed directly by
-// PromptLabService (internal/sybra/app_promptlab.go's fileScrubbedProposals):
-// gating tags (prompt-lab-proposal, role:<x>, optionally requires-human),
-// status human-required, and deliberately no project_id or workflow attached
-// — approve/reject is a direct task.Manager transition
-// (PromptLabService.ApproveProposal/RejectProposal), never a triage route.
-// The classifier's controlled vocabulary doesn't know these tags, so a
-// wholesale tag/status rewrite would silently drop the human-approval gate
-// and reroute the task into a workflow it was never meant to enter (it has no
-// project_id, so run_agent fails closed with ErrNoProjectAssigned and the
-// task bounces to human-required with a misleading reason). Apply must skip
-// the tag and status rewrite entirely whenever this tag is present, no matter
-// which entry point triggered the reclassify.
-const promptLabProposalTag = "prompt-lab-proposal"
 
 const umbrellaNormalTypeStatusReason = "☂️-titled task has task_type=normal, not umbrella — " +
 	"guard blocked dispatch to avoid a wasted implement run; " +
@@ -50,9 +36,12 @@ const umbrellaGuardOptOutTag = "notumbrella"
 func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project) (task.Task, error) {
 	updates := make(map[string]any, 8)
 
-	// A prompt-lab proposal's tags and status are gating state owned by
-	// PromptLabService, not the classifier — see promptLabProposalTag.
-	promptLabGated := slices.Contains(t.Tags, promptLabProposalTag)
+	// A prompt-lab proposal is owned by PromptLabService, not triage. It may
+	// be filed as todo or human-required, but in both cases the proposal text
+	// and routing fields stay under PromptLabService approval/rejection.
+	if slices.Contains(t.Tags, promptlab.ProposalTag) {
+		return t, nil
+	}
 
 	// t.ProjectID is sticky: once set (e.g. by the GitHub issue fetcher at
 	// task creation), the classifier's free-text guess must never override
@@ -101,7 +90,7 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 		updates["body"] = body
 	}
 
-	if len(v.Tags) > 0 && !promptLabGated {
+	if len(v.Tags) > 0 {
 		// Preserve routing tags the classifier vocabulary excludes
 		// (escape-hatch opt-outs, umbrella gate marker) — replacing tags
 		// wholesale would otherwise silently drop them.
@@ -125,32 +114,30 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	// planning phase — they go straight to implementation. Override any route
 	// that would park them in planning.
 	isPRFix := isPRFixTask(t)
-	if !promptLabGated {
-		status := RouteStatus(v.Size, v.Type, projectType)
-		if isPRFix {
-			status = task.StatusTodo
-		}
-		updates["status"] = string(status)
-		// No status_reason on successful triage: the field is reserved for
-		// attention-worthy states (monitor/watchdog/blocked), which the UI
-		// renders as a warning. Setting "status" without a reason makes the
-		// store clear any stale reason (e.g. "monitor: awaiting triage").
+	status := RouteStatus(v.Size, v.Type, projectType)
+	if isPRFix {
+		status = task.StatusTodo
+	}
+	updates["status"] = string(status)
+	// No status_reason on successful triage: the field is reserved for
+	// attention-worthy states (monitor/watchdog/blocked), which the UI
+	// renders as a warning. Setting "status" without a reason makes the
+	// store clear any stale reason (e.g. "monitor: awaiting triage").
 
-		// A ☂️-titled task that never went through the GitHub issue fetcher
-		// (e.g. manual sybra-cli create) keeps task_type=normal and is
-		// invisible to the umbrella gate
-		// (internal/sybra/app_umbrella_gate.go), which filters strictly on
-		// TaskTypeUmbrella. Dispatching it as a flat implement task wastes a
-		// full run before the agent discovers there's no direct code
-		// surface. Catch it here — before dispatch — and park it for a
-		// human to either expand it from its issue URL, opt it out, or fix
-		// the title.
-		if !isPRFix && t.TaskType != task.TaskTypeUmbrella &&
-			!slices.Contains(t.Tags, umbrellaGuardOptOutTag) &&
-			umbrella.IsUmbrellaIssue(newTitle, t.Tags) {
-			updates["status"] = string(task.StatusHumanRequired)
-			updates["status_reason"] = umbrellaNormalTypeStatusReason
-		}
+	// A ☂️-titled task that never went through the GitHub issue fetcher
+	// (e.g. manual sybra-cli create) keeps task_type=normal and is
+	// invisible to the umbrella gate
+	// (internal/sybra/app_umbrella_gate.go), which filters strictly on
+	// TaskTypeUmbrella. Dispatching it as a flat implement task wastes a
+	// full run before the agent discovers there's no direct code
+	// surface. Catch it here — before dispatch — and park it for a
+	// human to either expand it from its issue URL, opt it out, or fix
+	// the title.
+	if !isPRFix && t.TaskType != task.TaskTypeUmbrella &&
+		!slices.Contains(t.Tags, umbrellaGuardOptOutTag) &&
+		umbrella.IsUmbrellaIssue(newTitle, t.Tags) {
+		updates["status"] = string(task.StatusHumanRequired)
+		updates["status_reason"] = umbrellaNormalTypeStatusReason
 	}
 
 	updated, err := mgr.UpdateMap(t.ID, updates)

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -138,15 +139,17 @@ func TestApplyPreservesUmbrellaGatedTag(t *testing.T) {
 
 func TestApplyPreservesPromptLabProposalTagsAndStatus(t *testing.T) {
 	mgr := newTestManager(t)
-	created, err := mgr.Create("Prompt Lab: tighten instructions for role review", "", task.AgentModeHeadless)
+	created, err := mgr.Create("Prompt Lab: tighten instructions for role review", "proposal body", task.AgentModeInteractive)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	// PromptLabService.fileScrubbedProposals sets these before any triage
-	// pass runs — no project_id, no workflow, status human-required.
-	humanRequired := task.StatusHumanRequired
-	tags := []string{"prompt-lab-proposal", "role:review", "requires-human"}
-	created, err = mgr.Update(created.ID, task.Update{Status: &humanRequired, Tags: &tags})
+	// pass runs. Proposals may be todo or human-required, but their routing
+	// fields stay owned by PromptLabService until approval/rejection.
+	todo := task.StatusTodo
+	projectID := ""
+	tags := []string{promptlab.ProposalTag, "role:review"}
+	created, err = mgr.Update(created.ID, task.Update{Status: &todo, ProjectID: &projectID, Tags: &tags})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -155,24 +158,41 @@ func TestApplyPreservesPromptLabProposalTagsAndStatus(t *testing.T) {
 	// returns a verdict from the classifier's controlled vocabulary, which
 	// knows nothing about the prompt-lab gating tags.
 	v := Verdict{
-		Title: created.Title,
-		Tags:  []string{"backend", "docs", "medium", "chore"},
-		Size:  "medium",
-		Type:  "chore",
-		Mode:  "headless",
+		Title:       "chore(prompt): rewritten by classifier",
+		Description: "classifier-generated replacement body",
+		Tags:        []string{"backend", "docs", "medium", "chore"},
+		Size:        "medium",
+		Type:        "chore",
+		Mode:        "headless",
+		ProjectID:   "example-org/example-repo",
 	}
-	updated, err := Apply(mgr, created, v, nil)
+	projects := []project.Project{
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypePet},
+	}
+	updated, err := Apply(mgr, created, v, projects)
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	if !slices.Equal(updated.Tags, created.Tags) {
 		t.Errorf("tags: got %v, want unchanged %v", updated.Tags, created.Tags)
 	}
-	if updated.Status != task.StatusHumanRequired {
-		t.Errorf("status: got %s, want unchanged human-required", updated.Status)
+	if updated.Status != task.StatusTodo {
+		t.Errorf("status: got %s, want unchanged todo", updated.Status)
 	}
 	if updated.StatusReason != "" {
 		t.Errorf("status_reason: got %q, want empty (untouched)", updated.StatusReason)
+	}
+	if updated.AgentMode != task.AgentModeInteractive {
+		t.Errorf("agent_mode: got %q, want unchanged interactive", updated.AgentMode)
+	}
+	if updated.ProjectID != "" {
+		t.Errorf("project_id: got %q, want unchanged empty", updated.ProjectID)
+	}
+	if updated.Title != created.Title {
+		t.Errorf("title: got %q, want unchanged %q", updated.Title, created.Title)
+	}
+	if updated.Body != created.Body {
+		t.Errorf("body: got %q, want unchanged %q", updated.Body, created.Body)
 	}
 }
 

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -136,6 +136,46 @@ func TestApplyPreservesUmbrellaGatedTag(t *testing.T) {
 	}
 }
 
+func TestApplyPreservesPromptLabProposalTagsAndStatus(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("Prompt Lab: tighten instructions for role review", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// PromptLabService.fileScrubbedProposals sets these before any triage
+	// pass runs — no project_id, no workflow, status human-required.
+	humanRequired := task.StatusHumanRequired
+	tags := []string{"prompt-lab-proposal", "role:review", "requires-human"}
+	created, err = mgr.Update(created.ID, task.Update{Status: &humanRequired, Tags: &tags})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// A reclassify pass (e.g. an ungated `sybra-cli triage classify <id>`)
+	// returns a verdict from the classifier's controlled vocabulary, which
+	// knows nothing about the prompt-lab gating tags.
+	v := Verdict{
+		Title: created.Title,
+		Tags:  []string{"backend", "docs", "medium", "chore"},
+		Size:  "medium",
+		Type:  "chore",
+		Mode:  "headless",
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !slices.Equal(updated.Tags, created.Tags) {
+		t.Errorf("tags: got %v, want unchanged %v", updated.Tags, created.Tags)
+	}
+	if updated.Status != task.StatusHumanRequired {
+		t.Errorf("status: got %s, want unchanged human-required", updated.Status)
+	}
+	if updated.StatusReason != "" {
+		t.Errorf("status_reason: got %q, want empty (untouched)", updated.StatusReason)
+	}
+}
+
 func TestApplyGuardsUmbrellaTitledTaskWithNormalType(t *testing.T) {
 	mgr := newTestManager(t)
 	created, err := mgr.Create("☂️ refactor(orchestrator): converge implement→test loop under retry cap", "", task.AgentModeHeadless)

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -20,6 +20,11 @@ trigger:
     - field: task.tags
       operator: not_contains
       value: renovate-fix
+    # Prompt Lab proposals are advanced by PromptLabService approval/rejection,
+    # not by the ordinary task.created triage/planning pipeline.
+    - field: task.tags
+      operator: not_contains
+      value: prompt-lab-proposal
 steps:
   # Deterministic classification: calls the Go triage classifier
   # (internal/triage) directly, no agent session involved. Previously this


### PR DESCRIPTION
## Motivation

Prompt Lab proposal tasks are intentionally created with gating tags (`prompt-lab-proposal`, `requires-human`, `role:review`), status `human-required`, and no workflow. They are meant to be approved via direct task manager transitions, not workflow execution. However, reclassification via `sybra-cli triage classify` was wiping these tags and status, causing the task to be incorrectly routed into `simple-task-implement`. The resulting workflow step would fail with a misleading "no project could be assigned" error, retry-loop on watchdog hangs, and bounce back to `human-required` with lost context about the original approval gate.

## Implementation information

- Preserve Prompt Lab gating tags (`prompt-lab-proposal`, `requires-human`, `role:review`) during triage reclassification by adding them to the protected set, preventing classifier results from overwriting task metadata that controls workflow routing and approval gates.
- Short-circuit tag and status rewrites when a task has `prompt-lab-proposal` tag, treating such tasks as governance-gated rather than workflow-routed.
- Gate the single-ID `sybra-cli triage classify <id>` path to match the `--all` and auto-poll behavior, refusing to re-triage tasks already in `human-required` status to prevent disrupting approval flows.
- Add early validation in workflow dispatch to detect project-less, gated tasks and fail closed with clear messaging instead of entering retry loops.

_Generated by Sybra harness_