### PR TITLE
fix(github): monitor self-authored bot PRs

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -434,7 +434,7 @@ func convertPRs(nodes []gqlPR, viewer string) []PullRequest {
 	prs := make([]PullRequest, 0, len(nodes))
 	for i := range nodes {
 		n := &nodes[i]
-		if isBot(n.Author.Type, n.Author.Login) {
+		if isBot(n.Author.Type, n.Author.Login) && !strings.EqualFold(n.Author.Login, viewer) {
 			continue
 		}
 		prs = append(prs, convertCommonPR(n, viewer))

--- a/internal/github/review_self_authored_test.go
+++ b/internal/github/review_self_authored_test.go
@@ -1,0 +1,76 @@
+package github
+
+import "testing"
+
+func TestFetchReviewsWith_KeepsSelfAuthoredBotPRDropsThirdParty(t *testing.T) {
+	t.Parallel()
+	createdResponse := `{
+		"data": {
+			"viewer": {"login": "sybra-app[bot]"},
+			"search": {
+				"nodes": [
+					{
+						"number": 4242,
+						"title": "my own PR with failing CI",
+						"url": "https://github.com/o/r/pull/4242",
+						"headRefName": "feat/x",
+						"author": {"login": "sybra-app[bot]", "type": "Bot"},
+						"repository": {"name": "r", "nameWithOwner": "o/r"},
+						"labels": {"nodes": []},
+						"commits": {"nodes": [{
+							"commit": {
+								"oid": "sha-fail",
+								"statusCheckRollup": {
+									"state": "FAILURE",
+									"contexts": {"nodes": [
+										{"__typename": "CheckRun", "name": "build", "status": "COMPLETED", "conclusion": "FAILURE"}
+									]}
+								}
+							}
+						}]},
+						"reviewThreads": {"nodes": []},
+						"latestReviews": {"nodes": []}
+					},
+					{
+						"number": 9001,
+						"title": "renovate PR authored by a third-party bot",
+						"url": "https://github.com/o/r/pull/9001",
+						"headRefName": "renovate/dep",
+						"author": {"login": "renovate[bot]", "type": "Bot"},
+						"repository": {"name": "r", "nameWithOwner": "o/r"},
+						"labels": {"nodes": []},
+						"commits": {"nodes": [{"commit": {"oid": "sha-reno", "statusCheckRollup": {"state": "SUCCESS", "contexts": {"nodes": []}}}}]},
+						"reviewThreads": {"nodes": []},
+						"latestReviews": {"nodes": []}
+					}
+				]
+			}
+		}
+	}`
+	emptyResponse := `{
+		"data": {
+			"viewer": {"login": "sybra-app[bot]"},
+			"search": {"nodes": []}
+		}
+	}`
+
+	fe := &sequenceExecer{outputs: [][]byte{
+		[]byte(createdResponse),
+		[]byte(emptyResponse),
+		[]byte(emptyResponse),
+	}}
+	summary, err := fetchReviewsWith(fe)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.CreatedByMe) != 1 {
+		t.Fatalf("CreatedByMe len = %d, want 1 (self-authored app-bot PR kept, third-party renovate bot dropped)", len(summary.CreatedByMe))
+	}
+	pr := summary.CreatedByMe[0]
+	if pr.Number != 4242 {
+		t.Errorf("kept PR number = %d, want 4242 (the self-authored one)", pr.Number)
+	}
+	if pr.CIStatus != "FAILURE" {
+		t.Errorf("CIStatus = %q, want FAILURE", pr.CIStatus)
+	}
+}

--- a/internal/sybra/review/ci_failure_dispatch_test.go
+++ b/internal/sybra/review/ci_failure_dispatch_test.go
@@ -1,0 +1,100 @@
+package review
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+func buildPRFixHandler(t *testing.T, tasks *task.Manager, fetchReviewsFn func() (github.ReviewSummary, error)) *Handler {
+	t.Helper()
+	logger := slog.New(slog.DiscardHandler)
+	projects, err := project.NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wfStore, wfErr := workflow.NewStore(filepath.Join(t.TempDir(), "workflows"))
+	if wfErr != nil {
+		t.Fatal(wfErr)
+	}
+	if err := os.WriteFile(filepath.Join(wfStore.Dir(), "test-pr-fix.yaml"),
+		[]byte(mechanicalPRFixYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(
+		wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+	return &Handler{
+		logger:         logger,
+		emit:           func(string, any) {},
+		tasks:          tasks,
+		projects:       projects,
+		agents:         agentMgr,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		WorkflowEngine: engine,
+		fetchReviewsFn: fetchReviewsFn,
+	}
+}
+
+func TestPollAndMonitorPRs_CIFailureDispatchesFix(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:   task.Ptr(task.StatusInReview),
+		PRNumber: task.Ptr(4242),
+		Branch:   task.Ptr("feat/x"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	failingPR := github.PullRequest{
+		Number:      4242,
+		Repository:  "o/r",
+		HeadRefName: "feat/x",
+		HeadSHA:     "sha-fail",
+		URL:         "https://github.com/o/r/pull/4242",
+		Mergeable:   "MERGEABLE",
+		CIStatus:    "FAILURE",
+		Author:      "me",
+	}
+
+	r := buildPRFixHandler(t, tasks, func() (github.ReviewSummary, error) {
+		return github.ReviewSummary{CreatedByMe: []github.PullRequest{failingPR}}, nil
+	})
+
+	r.pollAndMonitorPRs(context.Background())
+
+	if got := r.prTracker.Retries(created.ID, github.PRIssueCIFailure); got != 1 {
+		t.Errorf("ci_failure retries = %d, want 1 (a pr-fix dispatch marks it handled)", got)
+	}
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil {
+		t.Fatal("no pr-fix workflow dispatched for a failing-CI in-review PR")
+	}
+	if k := got.Workflow.Variables["pr_issue_kind"]; k != string(github.PRIssueCIFailure) {
+		t.Errorf("pr_issue_kind = %q, want %q", k, github.PRIssueCIFailure)
+	}
+}


### PR DESCRIPTION
## Motivation

Regression from the GitHub App-token migration (#1817). Once Sybra
authenticates via the App installation token, it authors its **own** PRs as
`sybra-app[bot]` (GraphQL `author.type == "Bot"`).

`internal/github/client.go` `convertPRs` drops every bot-authored PR via
`isBot`. So the reviews **search** poller (`author:@me` → `convertPRs`)
silently excluded the app's own PRs from `CreatedByMe` → `MatchTaskPRs` had
nothing to match → no `PRIssueCIFailure` → `pr-fix` was **never dispatched**
for a red PR. Because the filter is stateless, it re-applied every poll and
**never self-recovered across restarts** — the board sat frozen with failing
PRs stuck in `in-review` while the pollers looked healthy.

> Changelog: fix(github): keep monitoring PRs Sybra authors under GitHub App auth

## Implementation information

- `convertPRs`: keep a bot-authored PR when its `author` equals the search
  `viewer` (the app's own identity); third-party bots (renovate/copilot)
  stay filtered. `viewer` was already threaded in but unused for the decision.
- Regression tests:
  - `internal/github` — `fetchReviewsWith` keeps a `sybra-app[bot]`-authored
    failing-CI PR and still drops a `renovate[bot]` PR.
  - `internal/sybra/review` — end-to-end: an in-review task with a failing-CI
    PR dispatches a `pr-fix` workflow.

Note: the per-PR monitor path (`convertCommonPR`, used by
`poller_role: secondary`) never applied `isBot`, so only the primary
search-poller path was affected — this reconciles them for self-authored PRs.

## Supporting documentation

Confirmed by reproduction: the github-level test failed before the one-line
change and passes after; `golangci-lint` clean; both platforms build.