### PR TITLE
fix(agent): reap stale interactive survivors

### DIFF
--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Automaat/sybra/internal/events"
@@ -26,7 +27,9 @@ var errReattachedResultError = errors.New("agent: reattached run completed with 
 // reattachPIDPoll is how often a reattached agent's PID is checked for
 // liveness (there is no *exec.Cmd to Wait on). Var, not const, so tests
 // can shorten it.
-var reattachPIDPoll = time.Second
+var reattachPIDPoll atomic.Int64
+
+func init() { reattachPIDPoll.Store(int64(time.Second)) }
 
 // ReattachAll rebuilds in-memory agents for subprocesses recorded in the
 // registry that are still alive, and resumes streaming their output by
@@ -60,6 +63,12 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 		if r.Mode == "interactive" {
 			// codex and copilot are per-turn conversational agents recreated
 			// on restart; claude interactive reattaches to its live process.
+			if strings.TrimSpace(r.TaskID) != "" {
+				if reason := m.reattachStaleReason(r, time.Now().UTC()); reason != "" {
+					m.reapStaleSurvivor(r, reg, reason)
+					continue
+				}
+			}
 			prov, providerErr := lookupProvider(r.Provider)
 			if providerErr != nil {
 				m.logger.Warn("agent.reattach.provider", "id", r.ID, "provider", r.Provider, "err", providerErr)
@@ -439,7 +448,7 @@ func watchPID(ctx context.Context, pid int, procStart string, done chan struct{}
 		close(done)
 		return
 	}
-	t := time.NewTicker(reattachPIDPoll)
+	t := time.NewTicker(time.Duration(reattachPIDPoll.Load()))
 	defer t.Stop()
 	for {
 		select {

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -29,7 +29,7 @@ var errReattachedResultError = errors.New("agent: reattached run completed with 
 // can shorten it.
 var reattachPIDPoll atomic.Int64
 
-func init() { reattachPIDPoll.Store(int64(time.Second)) }
+func init() { reattachPIDPoll.Store(time.Second.Nanoseconds()) }
 
 // ReattachAll rebuilds in-memory agents for subprocesses recorded in the
 // registry that are still alive, and resumes streaming their output by

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -38,6 +38,10 @@ func assertAccountingInvariant(t *testing.T, m *Manager) {
 // per-provider dispatch cap silently desyncs after every restart that finds
 // in-flight agents.
 func TestReattachAccountingInvariant(t *testing.T) {
+	prev := reattachPIDPoll.Load()
+	reattachPIDPoll.Store((50 * time.Millisecond).Nanoseconds())
+	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
+
 	logDir := t.TempDir()
 	regDir := t.TempDir()
 	agentsLogDir := filepath.Join(logDir, "agents")

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -38,10 +38,6 @@ func assertAccountingInvariant(t *testing.T, m *Manager) {
 // per-provider dispatch cap silently desyncs after every restart that finds
 // in-flight agents.
 func TestReattachAccountingInvariant(t *testing.T) {
-	prevPoll := reattachPIDPoll
-	reattachPIDPoll = 30 * time.Millisecond
-	t.Cleanup(func() { reattachPIDPoll = prevPoll })
-
 	logDir := t.TempDir()
 	regDir := t.TempDir()
 	agentsLogDir := filepath.Join(logDir, "agents")
@@ -149,14 +145,82 @@ func TestReattachAccountingInvariant(t *testing.T) {
 	}
 }
 
+func TestReattachReapsStaleInteractiveTaskAgent(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	spawnSleeper := func(t *testing.T) *exec.Cmd {
+		t.Helper()
+		cmd := exec.Command("sleep", "30")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start sleeper: %v", err)
+		}
+		t.Cleanup(func() { _ = cmd.Process.Kill() })
+		go func() { _ = cmd.Wait() }()
+		return cmd
+	}
+
+	logDir := t.TempDir()
+	agentsLogDir := filepath.Join(logDir, "agents")
+	if err := os.MkdirAll(agentsLogDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	regDir := t.TempDir()
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete:        func(*Agent) {},
+	})
+
+	logFor := func(id string) string {
+		p := filepath.Join(agentsLogDir, id+".ndjson")
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	staleCmd := spawnSleeper(t)
+	orchCmd := spawnSleeper(t)
+	records := []Record{
+		{
+			ID: "task-agent", TaskID: "task-x", Mode: "interactive", Provider: "claude",
+			PID: staleCmd.Process.Pid, LogPath: logFor("task-agent"),
+			StartedAt:     time.Now().Add(-24 * time.Hour).UTC(),
+			ProcStartedAt: processStartString(context.Background(), staleCmd.Process.Pid),
+		},
+		{
+			ID: "orchestrator", Mode: "interactive", Provider: "claude",
+			PID: orchCmd.Process.Pid, LogPath: logFor("orchestrator"),
+			StartedAt:     time.Now().Add(-24 * time.Hour).UTC(),
+			ProcStartedAt: processStartString(context.Background(), orchCmd.Process.Pid),
+		},
+	}
+	for _, r := range records {
+		if err := m.reg.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	m.ReattachAll()
+
+	recs, err := m.reg.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	present := map[string]bool{}
+	for _, r := range recs {
+		present[r.ID] = true
+	}
+	if present["task-agent"] {
+		t.Errorf("stale interactive task agent must be reaped, but its record survives")
+	}
+	if !present["orchestrator"] {
+		t.Errorf("taskless orchestrator must NOT be reaped, but its record is gone")
+	}
+}
+
 func TestReattachReapsStaleSurvivors(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
-	prevPoll := reattachPIDPoll
-	reattachPIDPoll = 30 * time.Millisecond
 	prevGrace := stopSIGINTGrace
 	stopSIGINTGrace = 30 * time.Millisecond
 	t.Cleanup(func() {
-		reattachPIDPoll = prevPoll
 		stopSIGINTGrace = prevGrace
 	})
 

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -407,9 +407,9 @@ func TestRegistryDelete_RemovesFIFO(t *testing.T) {
 // record (no FIFO / empty StdinPath) reattaches tail-only and finalizes
 // when its single turn completes — no FIFO reopen required.
 func TestReattachInteractive_OneShotTailOnly(t *testing.T) {
-	prev := reattachPIDPoll
-	reattachPIDPoll = 50 * time.Millisecond
-	t.Cleanup(func() { reattachPIDPoll = prev })
+	prev := reattachPIDPoll.Load()
+	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()
 	regDir := t.TempDir()
@@ -471,9 +471,9 @@ func TestReattachInteractive_OneShotTailOnly(t *testing.T) {
 // conversational agent, rehydrates its buffer, reopens its FIFO, streams a
 // late event, and finalizes when the process exits.
 func TestReattachInteractive_ReattachesLiveAgent(t *testing.T) {
-	prev := reattachPIDPoll
-	reattachPIDPoll = 50 * time.Millisecond
-	t.Cleanup(func() { reattachPIDPoll = prev })
+	prev := reattachPIDPoll.Load()
+	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()
 	regDir := t.TempDir()
@@ -743,9 +743,9 @@ func TestSurviveHeadlessStoresAndReopensFIFO(t *testing.T) {
 // TestReattachInteractive_ReattachesLiveAgent for the conversational path),
 // so a steer message sent after reattach still reaches the child.
 func TestReattachHeadlessReopensFIFO(t *testing.T) {
-	prev := reattachPIDPoll
-	reattachPIDPoll = 50 * time.Millisecond
-	t.Cleanup(func() { reattachPIDPoll = prev })
+	prev := reattachPIDPoll.Load()
+	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()
 	regDir := t.TempDir()

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -408,7 +408,7 @@ func TestRegistryDelete_RemovesFIFO(t *testing.T) {
 // when its single turn completes — no FIFO reopen required.
 func TestReattachInteractive_OneShotTailOnly(t *testing.T) {
 	prev := reattachPIDPoll.Load()
-	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	reattachPIDPoll.Store((50 * time.Millisecond).Nanoseconds())
 	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()
@@ -472,7 +472,7 @@ func TestReattachInteractive_OneShotTailOnly(t *testing.T) {
 // late event, and finalizes when the process exits.
 func TestReattachInteractive_ReattachesLiveAgent(t *testing.T) {
 	prev := reattachPIDPoll.Load()
-	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	reattachPIDPoll.Store((50 * time.Millisecond).Nanoseconds())
 	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()
@@ -744,7 +744,7 @@ func TestSurviveHeadlessStoresAndReopensFIFO(t *testing.T) {
 // so a steer message sent after reattach still reaches the child.
 func TestReattachHeadlessReopensFIFO(t *testing.T) {
 	prev := reattachPIDPoll.Load()
-	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	reattachPIDPoll.Store((50 * time.Millisecond).Nanoseconds())
 	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -285,7 +285,7 @@ func TestReattachAlive_PIDReuseGuard(t *testing.T) {
 // the new result, and finalizes via onComplete when the process exits.
 func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 	prev := reattachPIDPoll.Load()
-	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	reattachPIDPoll.Store((50 * time.Millisecond).Nanoseconds())
 	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()
@@ -379,7 +379,7 @@ func TestManagerRunPersistsAndReattachesLiveHeadlessAgent(t *testing.T) {
 	// Exercises the full Run -> persisted registry record -> fresh manager
 	// ReattachAll path; sibling reattach tests start from injected records.
 	prev := reattachPIDPoll.Load()
-	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	reattachPIDPoll.Store((50 * time.Millisecond).Nanoseconds())
 	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	binDir := t.TempDir()

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -284,9 +284,9 @@ func TestReattachAlive_PIDReuseGuard(t *testing.T) {
 // asserts ReattachAll rebuilds the agent, rehydrates its buffer, streams
 // the new result, and finalizes via onComplete when the process exits.
 func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
-	prev := reattachPIDPoll
-	reattachPIDPoll = 50 * time.Millisecond
-	t.Cleanup(func() { reattachPIDPoll = prev })
+	prev := reattachPIDPoll.Load()
+	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	logDir := t.TempDir()
 	regDir := t.TempDir()
@@ -378,9 +378,9 @@ func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 func TestManagerRunPersistsAndReattachesLiveHeadlessAgent(t *testing.T) {
 	// Exercises the full Run -> persisted registry record -> fresh manager
 	// ReattachAll path; sibling reattach tests start from injected records.
-	prev := reattachPIDPoll
-	reattachPIDPoll = 50 * time.Millisecond
-	t.Cleanup(func() { reattachPIDPoll = prev })
+	prev := reattachPIDPoll.Load()
+	reattachPIDPoll.Store(int64(50 * time.Millisecond))
+	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	binDir := t.TempDir()
 	fakeClaude := filepath.Join(binDir, "claude")


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): reap stale task-bound interactive agents on reattach

Two agents were found holding pool slots for 15+ hours, re-adopted on every
app restart instead of being reaped: an interactive agent bound to a stuck
task, and the orchestrator. Root cause: #1818's reattach staleness gate
(`reattachStaleReason` + `reapStaleSurvivor`) is applied **only in the
headless path** of `ReattachAllContext`. The interactive branch reattaches
unconditionally, so a stale interactive agent (past the deadline, task
gone, or task status inconsistent) is always re-adopted — the wall-clock
watchdog can't catch it either because its run-clock resets on each
reattach.

## Implementation information

`ReattachAllContext` now runs the staleness gate for interactive agents
**that have a task_id**, reaping stale ones just like headless. Taskless
interactive agents — the orchestrator (`maybeStartOrchestrator`, stable
name, `IgnoreConcurrencyLimit`) is long-lived by design — are exempt, so
this never kills the orchestrator.

Also makes `reattachPIDPoll` an `atomic.Int64`. It is written by ~5 tests
(to shorten the liveness poll) and read by every `watchPID` goroutine; a
reattached live agent's `watchPID` could race a concurrent test write. The
new interactive-reattach coverage exposed this pre-existing data race;
atomic access fixes the whole class.

Tests:
- `TestReattachReapsStaleInteractiveTaskAgent` — a stale interactive
  task-bound survivor is reaped; a taskless orchestrator survivor is not.
- Full reattach + survive suite passes `-race -count=10` (was racy).
