### PR TITLE
fix(worktree): rebranch on branch collision

### DIFF
--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -133,7 +133,7 @@ func callPhase(fn func(string), phase string) {
 }
 
 func (m *Manager) ensureBranch(t task.Task, branch string) {
-	if t.Branch != "" {
+	if t.Branch == branch {
 		return
 	}
 	if _, err := m.tasks.Update(t.ID, task.Update{Branch: task.Ptr(branch)}); err != nil {

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -808,6 +808,41 @@ func TestHasMiseConfig(t *testing.T) {
 // errors (not silent logs). This is the regression guard for the aa9ba123
 // class of failure where agents start on a worktree missing required
 // toolchain.
+func TestPrepareForTask_RunsBootstrap(t *testing.T) {
+	h := prepareHarness(t, []string{"touch bootstrap-marker"}, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("bootstrap task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("PrepareForTask: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(path, "bootstrap-marker")); statErr != nil {
+		t.Errorf("bootstrap marker missing in worktree — SetupCommands did not run: %v", statErr)
+	}
+
+	// Setup log must exist and include the command.
+	logPath := filepath.Join(h.logsDir, "worktrees", tk.ID+"-setup.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read setup log: %v", err)
+	}
+	if !strings.Contains(string(data), "bootstrap-marker") {
+		t.Errorf("setup log missing command: %s", data)
+	}
+}
+
 func TestPrepareForTask_RebranchesOnBranchCollision(t *testing.T) {
 	h := prepareHarness(t, nil, 30*time.Second)
 	ctx := context.Background()
@@ -857,41 +892,6 @@ func TestPrepareForTask_RebranchesOnBranchCollision(t *testing.T) {
 	}
 	if t2.Branch == t1.Branch {
 		t.Fatalf("t2 branch %q still collides with t1 — should have re-derived a unique branch", t2.Branch)
-	}
-}
-
-func TestPrepareForTask_RunsBootstrap(t *testing.T) {
-	h := prepareHarness(t, []string{"touch bootstrap-marker"}, 30*time.Second)
-
-	tk, err := h.tasks.Store().Create("bootstrap task", "", "headless")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
-		t.Fatal(err)
-	}
-	tk, err = h.tasks.Get(tk.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	path, err := h.m.PrepareForTask(context.Background(), tk, nil)
-	if err != nil {
-		t.Fatalf("PrepareForTask: %v", err)
-	}
-
-	if _, statErr := os.Stat(filepath.Join(path, "bootstrap-marker")); statErr != nil {
-		t.Errorf("bootstrap marker missing in worktree — SetupCommands did not run: %v", statErr)
-	}
-
-	// Setup log must exist and include the command.
-	logPath := filepath.Join(h.logsDir, "worktrees", tk.ID+"-setup.log")
-	data, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read setup log: %v", err)
-	}
-	if !strings.Contains(string(data), "bootstrap-marker") {
-		t.Errorf("setup log missing command: %s", data)
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -808,6 +808,58 @@ func TestHasMiseConfig(t *testing.T) {
 // errors (not silent logs). This is the regression guard for the aa9ba123
 // class of failure where agents start on a worktree missing required
 // toolchain.
+func TestPrepareForTask_RebranchesOnBranchCollision(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+	ctx := context.Background()
+
+	mk := func(title string) task.Task {
+		tk, err := h.tasks.Store().Create(title, "", "headless")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+			t.Fatal(err)
+		}
+		got, err := h.tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	t1 := mk("fix: first task")
+	if _, err := h.m.PrepareForTask(ctx, t1, nil); err != nil {
+		t.Fatalf("PrepareForTask t1: %v", err)
+	}
+	t1, err := h.tasks.Get(t1.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if t1.Branch == "" {
+		t.Fatal("t1 branch not set after prepare")
+	}
+
+	t2 := mk("fix: second task")
+	if _, err := h.tasks.Update(t2.ID, task.Update{Branch: task.Ptr(t1.Branch)}); err != nil {
+		t.Fatal(err)
+	}
+	t2, err = h.tasks.Get(t2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := h.m.PrepareForTask(ctx, t2, nil); err != nil {
+		t.Fatalf("PrepareForTask t2 with colliding branch: %v", err)
+	}
+	t2, err = h.tasks.Get(t2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if t2.Branch == t1.Branch {
+		t.Fatalf("t2 branch %q still collides with t1 — should have re-derived a unique branch", t2.Branch)
+	}
+}
+
 func TestPrepareForTask_RunsBootstrap(t *testing.T) {
 	h := prepareHarness(t, []string{"touch bootstrap-marker"}, 30*time.Second)
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -296,6 +296,7 @@ func (m *Manager) branchCollidesWithOtherWorktree(ctx context.Context, clonePath
 	}
 	wts, err := project.ListWorktrees(ctx, clonePath)
 	if err != nil {
+		m.logger.Warn("worktree.branch-collision.list", "clone", clonePath, "err", err)
 		return "", false
 	}
 	want := filepath.Clean(wtPath)

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
@@ -197,6 +198,7 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 	wtBranch := branchNameForTask(t)
 	baseRef := worktreeBaseRef(proj.WorktreeBaseRef, branch)
 
+	wtBranch = m.resolveTaskBranch(ctx, t, proj.ClonePath, wtPath, wtBranch)
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		callPhase(onPhase, "Checking worktree…")
 		usable, err := m.healOrRecreate(ctx, t.ID, proj.ClonePath, wtPath, wtBranch)
@@ -269,6 +271,40 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 	m.ensureBranch(t, wtBranch)
 	m.seedWorktree(ctx, t, wtPath, wtBranch)
 	return wtPath, nil
+}
+
+func (m *Manager) resolveTaskBranch(ctx context.Context, t task.Task, clonePath, wtPath, wtBranch string) string {
+	other, ok := m.branchCollidesWithOtherWorktree(ctx, clonePath, wtBranch, wtPath)
+	if !ok {
+		return wtBranch
+	}
+	unique := branchPrefixForTask(t) + "/" + t.DirName()
+	if unique == wtBranch {
+		return wtBranch
+	}
+	m.logger.Warn("worktree.branch-collision.rederive",
+		"task_id", t.ID, "stored", wtBranch, "other", other, "rederived", unique)
+	if _, uErr := m.tasks.Update(t.ID, task.Update{Branch: task.Ptr(unique)}); uErr != nil {
+		m.logger.Warn("worktree.branch-collision.persist", "task_id", t.ID, "err", uErr)
+	}
+	return unique
+}
+
+func (m *Manager) branchCollidesWithOtherWorktree(ctx context.Context, clonePath, branch, wtPath string) (string, bool) {
+	if branch == "" {
+		return "", false
+	}
+	wts, err := project.ListWorktrees(ctx, clonePath)
+	if err != nil {
+		return "", false
+	}
+	want := filepath.Clean(wtPath)
+	for _, w := range wts {
+		if w.Branch == branch && filepath.Clean(w.Path) != want {
+			return w.Path, true
+		}
+	}
+	return "", false
 }
 
 func (m *Manager) runPrepareSetup(ctx context.Context, taskID, wtPath string, proj project.Project, label string, onPhase func(string)) error {
@@ -482,6 +518,7 @@ func (m *Manager) PrepareForChat(ctx context.Context, t task.Task, onPhase func(
 	wtBranch := branchNameForTask(t)
 	baseRef := worktreeBaseRef(proj.WorktreeBaseRef, branch)
 
+	wtBranch = m.resolveTaskBranch(ctx, t, proj.ClonePath, wtPath, wtBranch)
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		usable, err := m.healOrRecreate(ctx, t.ID, proj.ClonePath, wtPath, wtBranch)
 		if err != nil {


### PR DESCRIPTION
## Motivation

> Changelog: fix(worktree): re-derive a task's branch when it collides with another worktree

Running an agent on a task failed with a raw git error when the task's
stored `Branch` was a *different* task's branch (a data collision from
cross-assigned branch fields during work-task ingestion): `git worktree
add … fatal: '<branch>' is already used by worktree at '<other>'`.
`branchNameForTask` honors a stored `Branch` verbatim, so once corrupted,
worktree prep can never succeed — it just surfaces the git error.

## Implementation information

`PrepareForTask` and `PrepareForChat` now call `resolveTaskBranch` before
creating/checking-out the worktree. It lists existing worktrees
(`ListWorktrees`) and, if the resolved branch is already checked out in a
*different* task's worktree, re-derives this task's own unique branch
(`branchPrefixForTask/DirName-<taskid>`), persists it, and proceeds. Sybra
self-heals the collision instead of erroring; a task with a clean, unused
branch is unaffected (no extra work).

Test `TestPrepareForTask_RebranchesOnBranchCollision`: task B given task
A's branch is re-branched to a unique value on prepare, with no error.
