### PR TITLE
fix(github): match self bot PRs by base login

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -434,7 +434,7 @@ func convertPRs(nodes []gqlPR, viewer string) []PullRequest {
 	prs := make([]PullRequest, 0, len(nodes))
 	for i := range nodes {
 		n := &nodes[i]
-		if isBot(n.Author.Type, n.Author.Login) && !strings.EqualFold(n.Author.Login, viewer) {
+		if isBot(n.Author.Type, n.Author.Login) && !sameActor(n.Author.Login, viewer) {
 			continue
 		}
 		prs = append(prs, convertCommonPR(n, viewer))
@@ -444,6 +444,14 @@ func convertPRs(nodes []gqlPR, viewer string) []PullRequest {
 
 func isBot(typeName, login string) bool {
 	return typeName == "Bot" || strings.Contains(login, "[bot]")
+}
+
+func sameActor(a, b string) bool {
+	strip := func(s string) string {
+		return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(s)), "[bot]")
+	}
+	base := strip(a)
+	return base != "" && base == strip(b)
 }
 
 // IsCopilotReviewer reports whether a review-author login belongs to GitHub

--- a/internal/github/review_self_authored_test.go
+++ b/internal/github/review_self_authored_test.go
@@ -14,7 +14,7 @@ func TestFetchReviewsWith_KeepsSelfAuthoredBotPRDropsThirdParty(t *testing.T) {
 						"title": "my own PR with failing CI",
 						"url": "https://github.com/o/r/pull/4242",
 						"headRefName": "feat/x",
-						"author": {"login": "sybra-app[bot]", "type": "Bot"},
+						"author": {"login": "sybra-app", "type": "Bot"},
 						"repository": {"name": "r", "nameWithOwner": "o/r"},
 						"labels": {"nodes": []},
 						"commits": {"nodes": [{


### PR DESCRIPTION
## Motivation

Follow-up to #1841, which did not actually fix the reviews poller. The
`reviews.poll` diagnostics added in #1851 proved it on the live server:

```
reviews.poll monitored=3 monitored_prs=[56,55,27] eligible=3 issues=0
```

The monitored PRs were **renovate** PRs (in `Automaat/flip`), never the
sybra task PRs (#1823/#1824/#1834). So `MatchTaskPRs` matched nothing →
no `PRIssueCIFailure` → `pr-fix` never dispatched → the board couldn't
self-heal.

Root cause: #1841 kept self-authored bot PRs by comparing `author.login`
to the search `viewer.login` with `EqualFold`. But GitHub GraphQL returns
a bot's `author.login` **without** the `[bot]` suffix (`sybra-app`) while
`viewer.login` carries it (`sybra-app[bot]`). They never matched, so the
app's own PRs stayed dropped from `CreatedByMe`. (The #1841 test only
passed because its fixture wrongly used the suffixed author form.)

> Changelog: fix(github): keep monitoring Sybra's own PRs under GitHub App auth

## Implementation information

- Compare on the base login via `sameActor`: both sides lowercased and
  stripped of a trailing `[bot]`. `sybra-app` ↔ `sybra-app[bot]` now match;
  third-party bots (renovate/copilot) still drop.
- Corrected the regression-test fixture to the real bare-login form
  (`author.login: "sybra-app"`) so it reproduces the production bug and
  fails against the old `EqualFold` comparison.

## Supporting documentation

Build (darwin + linux) + `golangci-lint` clean; github tests pass. Confirmed
against the live query: `viewer.login=sybra-app[bot]`, `author.login=sybra-app`.