### PR TITLE
fix(monitor): don't flag parked tasks as lost

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -524,10 +524,13 @@ func hasRunningAgentRun(runs []task.AgentRun) bool {
 	return false
 }
 
-const lostAgentReportMarker = "- Fingerprint: `" + string(KindLostAgent) + ":"
+const (
+	lostAgentReportHeader = "## Detection\n- Kind: `" + string(KindLostAgent) + "`"
+	lostAgentReportMarker = "- Fingerprint: `" + string(KindLostAgent) + ":"
+)
 
 func isLostAgentReport(t *task.Task) bool {
-	return strings.Contains(t.Body, lostAgentReportMarker)
+	return strings.Contains(t.Body, lostAgentReportHeader) && strings.Contains(t.Body, lostAgentReportMarker)
 }
 
 // lastHumanReviewVerdict returns the verdict from the most recent stopped

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/verdict"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // liveAgent is the minimal projection of agent.Agent the detector needs.
@@ -364,6 +365,12 @@ func detectLostAgents(in DetectInput) []Anomaly {
 		if active[t.ID] || live[t.ID] {
 			continue
 		}
+		if parkedAwaitingDispatch(t) {
+			continue
+		}
+		if isLostAgentReport(t) {
+			continue
+		}
 		// Skip if any running agent run started within the window. A freshly
 		// dispatched agent may not yet appear in the live list or have written
 		// its first audit event (e.g. during app restart recovery), so we wait
@@ -499,6 +506,28 @@ func projectAllowed(fn func(string) bool, projectID string) bool {
 		return true
 	}
 	return fn(projectID)
+}
+
+func parkedAwaitingDispatch(t *task.Task) bool {
+	if t.Workflow == nil || t.Workflow.State != workflow.ExecWaiting {
+		return false
+	}
+	return !hasRunningAgentRun(t.AgentRuns)
+}
+
+func hasRunningAgentRun(runs []task.AgentRun) bool {
+	for i := range runs {
+		if runs[i].State == "running" {
+			return true
+		}
+	}
+	return false
+}
+
+const lostAgentReportMarker = "- Fingerprint: `" + string(KindLostAgent) + ":"
+
+func isLostAgentReport(t *task.Task) bool {
+	return strings.Contains(t.Body, lostAgentReportMarker)
 }
 
 // lastHumanReviewVerdict returns the verdict from the most recent stopped

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 func defaultCfg() config.MonitorConfig {
@@ -306,6 +307,56 @@ func TestDetect(t *testing.T) {
 				Cfg:        cfg,
 			},
 			want: []AnomalyKind{KindLostAgent},
+		},
+		{
+			name: "lost_agent suppressed when workflow parked awaiting a dispatch slot",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTaskAt(now, "a", task.StatusInProgress, func(t *task.Task) {
+					t.AgentRuns = []task.AgentRun{
+						{AgentID: "x", State: "stopped", StartedAt: now.Add(-4 * time.Hour)},
+					}
+					t.Workflow = &workflow.Execution{
+						WorkflowID:  "simple-task-plan",
+						CurrentStep: "implement",
+						State:       workflow.ExecWaiting,
+					}
+				})},
+				LiveAgents: []liveAgent{},
+				Cfg:        cfg,
+			},
+			want: nil,
+		},
+		{
+			name: "lost_agent fires when workflow waiting but a running run is outside the window",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTaskAt(now, "a", task.StatusInProgress, func(t *task.Task) {
+					t.AgentRuns = []task.AgentRun{
+						{AgentID: "x", State: "running", StartedAt: now.Add(-20 * time.Minute)},
+					}
+					t.Workflow = &workflow.Execution{
+						WorkflowID:  "simple-task-plan",
+						CurrentStep: "implement",
+						State:       workflow.ExecWaiting,
+					}
+				})},
+				LiveAgents: []liveAgent{},
+				Cfg:        cfg,
+			},
+			want: []AnomalyKind{KindLostAgent},
+		},
+		{
+			name: "lost_agent suppressed for a task that is itself a monitor lost_agent report",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTaskAt(now, "a", task.StatusInProgress, func(t *task.Task) {
+					t.Body = "## Detection\n- Kind: `lost_agent`\n- Fingerprint: `lost_agent:3e2f0953`\n"
+				})},
+				LiveAgents: []liveAgent{},
+				Cfg:        cfg,
+			},
+			want: nil,
 		},
 		{
 			name: "lost_agent suppressed when task just transitioned to in-progress and dispatch hasn't recorded a run yet",

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -359,6 +359,18 @@ func TestDetect(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "lost_agent still fires when body only mentions the fingerprint without the monitor header",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTaskAt(now, "a", task.StatusInProgress, func(t *task.Task) {
+					t.Body = "Notes: earlier this looked like - Fingerprint: `lost_agent:3e2f0953` but it is real work.\n"
+				})},
+				LiveAgents: []liveAgent{},
+				Cfg:        cfg,
+			},
+			want: []AnomalyKind{KindLostAgent},
+		},
+		{
 			name: "lost_agent suppressed when task just transitioned to in-progress and dispatch hasn't recorded a run yet",
 			in: DetectInput{
 				Now: now,


### PR DESCRIPTION
## Motivation

Local Sybra floods the log with `lost_agent` remediations ("monitor: agent
lost") every 5-minute tick — individual tasks were "restarted" 50–69 times
over a day. Almost none are real: `detectLostAgents` flagged any in-progress
task with no live agent and no `agent.*` audit event in 15m, **ignoring
workflow state**. Two false-positive loops resulted.

1. **Pool backpressure.** With `agent.max_concurrent: 6` and a busy board, a
   run-agent step routinely hits the pool cap and the engine parks it in
   `ExecWaiting` (same for `ErrTestRunnerBusy` / `ErrDispatchInFlight`).
   `ResumeStalled` already re-drives these once a slot frees. But no agent was
   dispatched, so the detector saw "no live agent" and flagged `lost_agent`,
   kicking a redundant recovery that just re-parked the task every tick.

2. **Self-amplification.** A `lost_agent` files a GH issue; the issues fetcher
   ingests it as a board task; that task's own stalled dispatch is re-detected
   as `lost_agent`, filing another issue. The monitor manufactures the load it
   alarms about.

> Changelog: fix(monitor): don't flag parked tasks as lost

## Implementation information

Two guards added to `detectLostAgents` (`internal/monitor/detector.go`):

- **`parkedAwaitingDispatch`** — skips a task whose workflow is `ExecWaiting`
  and has no `running` AgentRun. A genuinely lost agent leaves a persisted
  `running` run behind, so that case is still flagged.
- **`isLostAgentReport`** — skips a task whose body carries the monitor
  `lost_agent` fingerprint marker (`- Fingerprint: ` + `` `lost_agent:` ``),
  the only signature triage never rewrites, breaking the
  lost_agent → issue → board-task → lost_agent loop.

Recovery is unaffected: parked tasks are already re-driven by `ResumeStalled`
on the maintenance loop, independent of the monitor's remediation.

Three table-driven cases added to `detector_test.go`: suppress-when-parked,
still-fire-when-a-running-run-is-outside-the-window, suppress-self-report.

## Supporting documentation

- `go test ./internal/monitor/... ./internal/recovery/...` — green
- `golangci-lint run ./internal/monitor/...` + `go vet` — 0 issues
