### PR TITLE
fix(review): auto-merge Sybra's own App-bot PRs

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -172,6 +172,7 @@ export class PullRequest {
      * GitHub Copilot has submitted a review
      */
     "copilotReviewed": boolean;
+    "selfAuthoredBot": boolean;
     "createdAt": string;
     "updatedAt": string;
 
@@ -285,6 +286,9 @@ export class PullRequest {
         if (!("copilotReviewed" in $$source)) {
             this["copilotReviewed"] = false;
         }
+        if (!("selfAuthoredBot" in $$source)) {
+            this["selfAuthoredBot"] = false;
+        }
         if (!("createdAt" in $$source)) {
             this["createdAt"] = "";
         }
@@ -385,6 +389,7 @@ export class RenovatePR {
      * GitHub Copilot has submitted a review
      */
     "copilotReviewed": boolean;
+    "selfAuthoredBot": boolean;
     "createdAt": string;
     "updatedAt": string;
 
@@ -500,6 +505,9 @@ export class RenovatePR {
         if (!("copilotReviewed" in $$source)) {
             this["copilotReviewed"] = false;
         }
+        if (!("selfAuthoredBot" in $$source)) {
+            this["selfAuthoredBot"] = false;
+        }
         if (!("createdAt" in $$source)) {
             this["createdAt"] = "";
         }
@@ -539,13 +547,13 @@ export class RenovatePR {
      */
     static createFrom($$source: any = {}): RenovatePR {
         const $$createField7_0 = $$createType0;
-        const $$createField27_0 = $$createType2;
+        const $$createField28_0 = $$createType2;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("labels" in $$parsedSource) {
             $$parsedSource["labels"] = $$createField7_0($$parsedSource["labels"]);
         }
         if ("checkRuns" in $$parsedSource) {
-            $$parsedSource["checkRuns"] = $$createField27_0($$parsedSource["checkRuns"]);
+            $$parsedSource["checkRuns"] = $$createField28_0($$parsedSource["checkRuns"]);
         }
         return new RenovatePR($$parsedSource as Partial<RenovatePR>);
     }

--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -25,6 +25,7 @@ function makePR(overrides: Record<string, unknown> = {}) {
     feedbackSig: '',
     viewerHasApproved: false,
     copilotReviewed: false,
+    selfAuthoredBot: false,
     createdAt: '2026-04-01T00:00:00Z',
     updatedAt: '2026-04-01T00:00:00Z',
     sourcedViaRest: false,

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -401,6 +401,7 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 		FeedbackSig:       feedbackSig,
 		ViewerHasApproved: viewerApproved,
 		CopilotReviewed:   copilotReviewed,
+		SelfAuthoredBot:   isBot(n.Author.Type, n.Author.Login) && sameActor(n.Author.Login, viewer),
 		CreatedAt:         n.CreatedAt,
 		UpdatedAt:         n.UpdatedAt,
 		AutoMergeEnabled:  n.AutoMergeRequest != nil,

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -31,6 +31,7 @@ type PullRequest struct {
 	FeedbackSig       string `json:"feedbackSig"`
 	ViewerHasApproved bool   `json:"viewerHasApproved"`
 	CopilotReviewed   bool   `json:"copilotReviewed"` // GitHub Copilot has submitted a review
+	SelfAuthoredBot   bool   `json:"selfAuthoredBot"`
 	CreatedAt         string `json:"createdAt"`
 	UpdatedAt         string `json:"updatedAt"`
 	// BaseRefName is the PR's target branch (e.g. "main"). Used to pre-flight

--- a/internal/github/review_self_authored_test.go
+++ b/internal/github/review_self_authored_test.go
@@ -73,4 +73,7 @@ func TestFetchReviewsWith_KeepsSelfAuthoredBotPRDropsThirdParty(t *testing.T) {
 	if pr.CIStatus != "FAILURE" {
 		t.Errorf("CIStatus = %q, want FAILURE", pr.CIStatus)
 	}
+	if !pr.SelfAuthoredBot {
+		t.Errorf("SelfAuthoredBot = false, want true (bare bot login matches suffixed viewer)")
+	}
 }

--- a/internal/sybra/review/auto_merge_own_bot_test.go
+++ b/internal/sybra/review/auto_merge_own_bot_test.go
@@ -1,0 +1,40 @@
+package review
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/github"
+)
+
+func TestReadyForOwnBotAutoMerge(t *testing.T) {
+	t.Parallel()
+	base := github.PullRequest{SelfAuthoredBot: true, Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}
+	with := func(mut func(*github.PullRequest)) github.PullRequest {
+		p := base
+		mut(&p)
+		return p
+	}
+	cases := []struct {
+		name string
+		pr   github.PullRequest
+		want bool
+	}{
+		{"self bot green", base, true},
+		{"empty ci counts green", with(func(p *github.PullRequest) { p.CIStatus = "" }), true},
+		{"not self authored bot", with(func(p *github.PullRequest) { p.SelfAuthoredBot = false }), false},
+		{"ci failure", with(func(p *github.PullRequest) { p.CIStatus = "FAILURE" }), false},
+		{"conflicting", with(func(p *github.PullRequest) { p.Mergeable = "CONFLICTING" }), false},
+		{"changes requested", with(func(p *github.PullRequest) { p.ReviewDecision = "CHANGES_REQUESTED" }), false},
+		{"unresolved threads", with(func(p *github.PullRequest) { p.UnresolvedCount = 1 }), false},
+		{"rest sourced", with(func(p *github.PullRequest) { p.SourcedViaREST = true }), false},
+		{"draft", with(func(p *github.PullRequest) { p.IsDraft = true }), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := readyForOwnBotAutoMerge(tc.pr); got != tc.want {
+				t.Errorf("readyForOwnBotAutoMerge = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/review/automerge_test.go
+++ b/internal/sybra/review/automerge_test.go
@@ -156,6 +156,25 @@ func TestHandleAutoMerge_GatesOnCopilot(t *testing.T) {
 			wantMerged: true,
 		},
 		{
+			name:      "pet self-authored bot, no copilot -> merges (bypass)",
+			projectID: "pet-owner/pet-repo",
+			pr: github.PullRequest{
+				Repository: "pet-owner/pet-repo", Number: 16,
+				Mergeable: "MERGEABLE", CIStatus: "SUCCESS", CopilotReviewed: false, SelfAuthoredBot: true,
+			},
+			wantMerged: true,
+		},
+		{
+			name:      "pet self-authored bot, changes requested -> holds",
+			projectID: "pet-owner/pet-repo",
+			pr: github.PullRequest{
+				Repository: "pet-owner/pet-repo", Number: 17,
+				Mergeable: "MERGEABLE", CIStatus: "SUCCESS", CopilotReviewed: false,
+				SelfAuthoredBot: true, ReviewDecision: "CHANGES_REQUESTED",
+			},
+			wantMerged: false,
+		},
+		{
 			name:      "pet, copilot not reviewed -> holds",
 			projectID: "pet-owner/pet-repo",
 			pr: github.PullRequest{

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -82,6 +82,16 @@ func readyForCopilotAutoMerge(pr github.PullRequest) bool {
 		pr.ReviewDecision != "CHANGES_REQUESTED"
 }
 
+func readyForOwnBotAutoMerge(pr github.PullRequest) bool {
+	return pr.SelfAuthoredBot &&
+		!pr.SourcedViaREST &&
+		!pr.IsDraft &&
+		pr.Mergeable == "MERGEABLE" &&
+		(pr.CIStatus == "SUCCESS" || pr.CIStatus == "") &&
+		pr.UnresolvedCount == 0 &&
+		pr.ReviewDecision != "CHANGES_REQUESTED"
+}
+
 // readyToArmNativeAutoMerge reports whether a PR is ready to have GitHub's
 // native auto-merge armed: the same review-cycle gate as
 // readyForCopilotAutoMerge MINUS the CI-green requirement (native auto-merge
@@ -205,7 +215,7 @@ func (r *Handler) handleAutoMerge(issue github.PRIssue) {
 		// authored and never receive a Copilot review, so the Copilot gate would
 		// strand them. The ReadyToMerge issue already implies green + mergeable +
 		// !draft, so preserve their prior green auto-merge.
-		ready = renovateFix || readyForCopilotAutoMerge(issue.PR)
+		ready = renovateFix || readyForOwnBotAutoMerge(issue.PR) || readyForCopilotAutoMerge(issue.PR)
 	}
 	if !ready {
 		return


### PR DESCRIPTION
## Motivation

On the server, agents push under the GitHub App token, so PRs are authored
by `sybra-app[bot]`. GitHub Copilot never reviews bot-authored PRs, so
`readyForCopilotAutoMerge` (which requires `CopilotReviewed`) strands those
PRs in `awaiting-approval` **forever** — even though the same PRs auto-merge
when Sybra runs locally, where they're user-authored and Copilot reviews them.

This is a direct consequence of the App-token migration (which changed PR
authorship from the user to the bot). Result: #1823/#1824/#1834 sit green +
mergeable but never merge.

> Changelog: fix(review): auto-merge Sybra's own bot-authored PRs on green

## Implementation information

- `convertCommonPR` flags `SelfAuthoredBot` when the PR author is a bot whose
  login matches the search `viewer` (Sybra's own App identity — via the
  `sameActor` base-login match from #1855).
- New `readyForOwnBotAutoMerge`: same green / mergeable / no-unresolved-threads
  / not-`CHANGES_REQUESTED` gate as the Copilot path, **minus** the
  `CopilotReviewed` requirement. Mirrors the existing renovate-fix carve-out.
- Wired into `handleAutoMerge`:
  `renovateFix || readyForOwnBotAutoMerge || readyForCopilotAutoMerge`.

Safety preserved: `handleAutoMerge` is already pet-project-gated;
`CHANGES_REQUESTED` and unresolved threads still block; user-authored PRs are
unaffected (keep the Copilot gate). Restores exact local behaviour on the
server.

## Supporting documentation

Build (darwin + linux) + `golangci-lint` clean; table test for the gate +
`SelfAuthoredBot` assertion on the convert path. (Pre-push flaked once on
unrelated `internal/agent` conversational timing tests; they pass in isolation.)