### PR TITLE
fix(ingest): assign each task its own unique branch on ingest

### DIFF
--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -30,6 +30,15 @@ const issuesTransientWarnThreshold = 3
 // synapseIssueLabel is the GitHub label that triggers auto-creation of Sybra tasks.
 const synapseIssueLabel = "sybra"
 
+// branchKey identifies a project+branch pair for claimedBranches. A struct key
+// (rather than a "projectID|branch" string) avoids collisions between
+// different {projectID, branch} pairs when either component — branch names
+// are external GitHub input — happens to contain the delimiter.
+type branchKey struct {
+	projectID string
+	branch    string
+}
+
 // IssuesFetcher polls GitHub for assigned and labeled issues and syncs them to tasks.
 type IssuesFetcher struct {
 	tasks                 *task.Manager
@@ -279,13 +288,13 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 	}
 	issueURLs := make(map[string]struct{})
 	urlTitleTasks := make(map[string]string) // issue URL → task ID for URL-titled stubs
-	// claimedBranches tracks "projectID|branch" → owner (task ID, or the
+	// claimedBranches tracks {projectID, branch} → owner (task ID, or the
 	// issue URL for a task this pass is about to create) across the whole
 	// batch. Seeding it from the pre-batch snapshot and updating it as each
 	// issue in the batch claims a branch (see enrichLinkedViewerPR) prevents
 	// two issues in the SAME poll — e.g. one PR that closes more than one
 	// GitHub issue — from both claiming that PR's branch for their own task.
-	claimedBranches := make(map[string]string, len(tasks))
+	claimedBranches := make(map[branchKey]string, len(tasks))
 	for i := range tasks {
 		if tasks[i].Issue != "" {
 			issueURLs[tasks[i].Issue] = struct{}{}
@@ -294,7 +303,7 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 			urlTitleTasks[tasks[i].Title] = tasks[i].ID
 		}
 		if tasks[i].Branch != "" {
-			claimedBranches[tasks[i].ProjectID+"|"+tasks[i].Branch] = tasks[i].ID
+			claimedBranches[branchKey{tasks[i].ProjectID, tasks[i].Branch}] = tasks[i].ID
 		}
 	}
 	for i := range flat {
@@ -343,7 +352,7 @@ func (f *IssuesFetcher) expandUmbrellaIssue(issue *github.Issue) {
 
 // syncFlatIssue creates or enriches a single non-umbrella issue task, honoring
 // the dedup snapshot and project-type filter.
-func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]struct{}, urlTitleTasks map[string]string, claimedBranches map[string]string) {
+func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]struct{}, urlTitleTasks map[string]string, claimedBranches map[branchKey]string) {
 	if _, exists := issueURLs[issue.URL]; exists {
 		return
 	}
@@ -410,7 +419,7 @@ func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]
 // which happens when one PR closes more than one GitHub issue: only the first
 // issue processed gets to claim it, and any others are left without a linked
 // PR rather than racing for the same branch/worktree.
-func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update, claimedBranches map[string]string, ownerID string) {
+func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update, claimedBranches map[branchKey]string, ownerID string) {
 	if f.fetchIssueLinkedPRs == nil || f.viewerLogin == nil {
 		return
 	}
@@ -439,7 +448,7 @@ func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update
 		return
 	}
 	pr := mine[0]
-	key := issue.Repository + "|" + pr.HeadRefName
+	key := branchKey{issue.Repository, pr.HeadRefName}
 	if owner, taken := claimedBranches[key]; taken && owner != ownerID {
 		f.logger.Warn("issue-sync.linked-pr.branch-collision",
 			"issue", issue.URL, "pr", pr.Number, "branch", pr.HeadRefName, "owner", owner)

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -279,6 +279,13 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 	}
 	issueURLs := make(map[string]struct{})
 	urlTitleTasks := make(map[string]string) // issue URL → task ID for URL-titled stubs
+	// claimedBranches tracks "projectID|branch" → owner (task ID, or the
+	// issue URL for a task this pass is about to create) across the whole
+	// batch. Seeding it from the pre-batch snapshot and updating it as each
+	// issue in the batch claims a branch (see enrichLinkedViewerPR) prevents
+	// two issues in the SAME poll — e.g. one PR that closes more than one
+	// GitHub issue — from both claiming that PR's branch for their own task.
+	claimedBranches := make(map[string]string, len(tasks))
 	for i := range tasks {
 		if tasks[i].Issue != "" {
 			issueURLs[tasks[i].Issue] = struct{}{}
@@ -286,9 +293,12 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 		if strings.HasPrefix(tasks[i].Title, "https://github.com/") {
 			urlTitleTasks[tasks[i].Title] = tasks[i].ID
 		}
+		if tasks[i].Branch != "" {
+			claimedBranches[tasks[i].ProjectID+"|"+tasks[i].Branch] = tasks[i].ID
+		}
 	}
 	for i := range flat {
-		f.syncFlatIssue(&flat[i], issueURLs, urlTitleTasks)
+		f.syncFlatIssue(&flat[i], issueURLs, urlTitleTasks, claimedBranches)
 	}
 }
 
@@ -333,7 +343,7 @@ func (f *IssuesFetcher) expandUmbrellaIssue(issue *github.Issue) {
 
 // syncFlatIssue creates or enriches a single non-umbrella issue task, honoring
 // the dedup snapshot and project-type filter.
-func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]struct{}, urlTitleTasks map[string]string) {
+func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]struct{}, urlTitleTasks map[string]string, claimedBranches map[string]string) {
 	if _, exists := issueURLs[issue.URL]; exists {
 		return
 	}
@@ -354,7 +364,7 @@ func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]
 			Issue:     task.Ptr(issue.URL),
 			ProjectID: task.Ptr(issue.Repository),
 		}
-		f.enrichLinkedViewerPR(issue, &u)
+		f.enrichLinkedViewerPR(issue, &u, claimedBranches, taskID)
 		if issue.Body != "" {
 			u.Body = task.Ptr(issue.Body)
 		}
@@ -371,7 +381,11 @@ func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]
 		Status:    task.Ptr(task.StatusTodo),
 		ProjectID: task.Ptr(issue.Repository),
 	}
-	f.enrichLinkedViewerPR(issue, &u)
+	// The task doesn't exist yet, so its real ID is unknown here — claim the
+	// branch under the issue's own URL instead. That's still a stable,
+	// unique-enough token to block a second issue in this same batch from
+	// claiming the same branch (see claimedBranches above).
+	f.enrichLinkedViewerPR(issue, &u, claimedBranches, issue.URL)
 	if len(issue.Labels) > 0 {
 		labels := issue.Labels
 		u.Tags = &labels
@@ -388,7 +402,15 @@ func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]
 	f.logger.Info("issue-sync.created", "task_id", t.ID, "issue", issue.URL)
 }
 
-func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update) {
+// enrichLinkedViewerPR looks up the viewer's own PR linked to issue and, if
+// found, links it and moves the task to in-review. ownerID identifies the
+// task this enrichment is for (its real ID for an existing task, or the
+// issue's own URL when the task doesn't exist yet). claimedBranches guards
+// against two different tasks in this batch claiming the same PR's branch —
+// which happens when one PR closes more than one GitHub issue: only the first
+// issue processed gets to claim it, and any others are left without a linked
+// PR rather than racing for the same branch/worktree.
+func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update, claimedBranches map[string]string, ownerID string) {
 	if f.fetchIssueLinkedPRs == nil || f.viewerLogin == nil {
 		return
 	}
@@ -416,7 +438,15 @@ func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update
 		}
 		return
 	}
-	u.PRNumber = task.Ptr(mine[0].Number)
-	u.Branch = task.Ptr(mine[0].HeadRefName)
+	pr := mine[0]
+	key := issue.Repository + "|" + pr.HeadRefName
+	if owner, taken := claimedBranches[key]; taken && owner != ownerID {
+		f.logger.Warn("issue-sync.linked-pr.branch-collision",
+			"issue", issue.URL, "pr", pr.Number, "branch", pr.HeadRefName, "owner", owner)
+		return
+	}
+	claimedBranches[key] = ownerID
+	u.PRNumber = task.Ptr(pr.Number)
+	u.Branch = task.Ptr(pr.HeadRefName)
 	u.Status = task.Ptr(task.StatusInReview)
 }

--- a/internal/poll/issues_test.go
+++ b/internal/poll/issues_test.go
@@ -528,6 +528,113 @@ func TestIssuesFetcher_SyncIssuesToTasks_LinkedViewerPR(t *testing.T) {
 	}
 }
 
+// TestIssuesFetcher_SyncIssuesToTasks_TwoIssuesLinkedToSamePR_OnlyOneClaimsBranch
+// is a regression test for #696bc049: a single PR can close more than one
+// GitHub issue, so two distinct issues in the SAME poll batch can both
+// resolve to the same viewer-authored linked PR. Without a guard, both
+// resulting tasks would persist the identical Branch and later collide when
+// each tries to provision its own git worktree on that branch. Only the
+// first issue processed should claim the branch/PR link; the second must
+// stay a plain todo task rather than cross-claim a sibling's branch.
+func TestIssuesFetcher_SyncIssuesToTasks_TwoIssuesLinkedToSamePR_OnlyOneClaimsBranch(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+
+	sharedPR := github.PullRequest{Number: 99, HeadRefName: "fix/shared-pr", Author: "me"}
+	env.fetcher.fetchIssueLinkedPRs = func(repo string, issueNumber int) ([]github.PullRequest, error) {
+		return []github.PullRequest{sharedPR}, nil
+	}
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{
+		{
+			Number:     10,
+			Title:      "first issue closed by the shared PR",
+			URL:        "https://github.com/acme/pet1/issues/10",
+			Repository: "acme/pet1",
+		},
+		{
+			Number:     11,
+			Title:      "second issue also closed by the shared PR",
+			URL:        "https://github.com/acme/pet1/issues/11",
+			Repository: "acme/pet1",
+		},
+	})
+
+	tasks, err := env.tasks.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("task count = %d, want 2", len(tasks))
+	}
+	var claimed, unclaimed int
+	for _, tsk := range tasks {
+		switch {
+		case tsk.Branch == "fix/shared-pr" && tsk.PRNumber == 99 && tsk.Status == task.StatusInReview:
+			claimed++
+		case tsk.Branch == "" && tsk.PRNumber == 0 && tsk.Status == task.StatusTodo:
+			unclaimed++
+		default:
+			t.Fatalf("unexpected task state: %+v", tsk)
+		}
+	}
+	if claimed != 1 || unclaimed != 1 {
+		t.Fatalf("claimed = %d, unclaimed = %d, want exactly one of each (no duplicate branch assignment)", claimed, unclaimed)
+	}
+}
+
+// TestIssuesFetcher_SyncIssuesToTasks_LinkedPRBranchAlreadyOwnedKeepsTodo
+// covers the cross-poll variant of the same regression: a prior poll already
+// created a task owning a branch (e.g. via an earlier issue closed by the
+// same PR). A later poll processing a different issue that GitHub also links
+// to that PR must not cross-assign the already-claimed branch onto the new
+// task.
+func TestIssuesFetcher_SyncIssuesToTasks_LinkedPRBranchAlreadyOwnedKeepsTodo(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+
+	owner, err := env.tasks.CreateFull("earlier task", "", "headless", task.Update{
+		ProjectID: task.Ptr("acme/pet1"),
+		Branch:    task.Ptr("fix/shared-pr"),
+		PRNumber:  task.Ptr(99),
+		Status:    task.Ptr(task.StatusInReview),
+	})
+	if err != nil {
+		t.Fatalf("create owner task: %v", err)
+	}
+
+	env.fetcher.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) {
+		return []github.PullRequest{{Number: 99, HeadRefName: "fix/shared-pr", Author: "me"}}, nil
+	}
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{{
+		Number:     12,
+		Title:      "later issue also closed by the same PR",
+		URL:        "https://github.com/acme/pet1/issues/12",
+		Repository: "acme/pet1",
+	}})
+
+	tasks, err := env.tasks.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("task count = %d, want 2", len(tasks))
+	}
+	for _, tsk := range tasks {
+		if tsk.ID == owner.ID {
+			continue
+		}
+		if tsk.Branch != "" || tsk.PRNumber != 0 || tsk.Status != task.StatusTodo {
+			t.Fatalf("new task = %+v, want plain todo with no branch/PR cross-assigned from the owner task", tsk)
+		}
+	}
+}
+
 func TestIssuesFetcher_SyncIssuesToTasks_URLTitleLinkedViewerPR(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -842,9 +842,9 @@ func (s *TaskService) enrichFromPR(taskID, repo string, number int) {
 	}
 	if branch, ok := s.claimIngestBranch(repo, pr.HeadRefName, taskID); ok {
 		u.Branch = task.Ptr(branch)
-	} else {
-		s.logger.Warn("enrich-pr.branch-collision", "task_id", taskID, "pr", number, "branch", pr.HeadRefName)
 	}
+	// claimIngestBranch already logs the reason (list failure vs. collision)
+	// on rejection; no need to duplicate/relabel it here.
 	// Replace tags with the PR's labels (possibly empty), which also clears the
 	// enrich-pending marker set on the URL stub at creation.
 	labels := pr.Labels
@@ -968,13 +968,13 @@ func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
 			u.PRNumber = task.Ptr(linked.Number)
 			u.Branch = task.Ptr(branch)
 			u.Status = task.Ptr(task.StatusInReview)
-		} else {
-			// This PR's branch already belongs to a different task — e.g. one
-			// PR closes more than one GitHub issue, and another issue's task
-			// already claimed it. Leave this task's own PR link unclaimed
-			// rather than have two tasks race to own the same branch/worktree.
-			s.logger.Warn("enrich-issue.linked-pr.branch-collision", "task_id", taskID, "issue", issue.URL, "pr", linked.Number)
 		}
+		// Else: this PR's branch already belongs to a different task — e.g.
+		// one PR closes more than one GitHub issue, and another issue's task
+		// already claimed it — or the ownership check itself failed to read.
+		// Leave this task's own PR link unclaimed rather than have two tasks
+		// race to own the same branch/worktree; claimIngestBranch already
+		// logged the specific reason.
 	} else if len(linkedPRs) > 0 {
 		if viewerPRs := s.viewerLinkedPRCount(linkedPRs); viewerPRs > 1 {
 			s.logger.Warn("enrich-issue.linked-prs.ambiguous", "task_id", taskID, "count", viewerPRs)

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -838,8 +838,12 @@ func (s *TaskService) enrichFromPR(taskID, repo string, number int) {
 		Title:     task.Ptr(pr.Title),
 		ProjectID: task.Ptr(repo),
 		PRNumber:  task.Ptr(pr.Number),
-		Branch:    task.Ptr(pr.HeadRefName),
 		Slug:      task.Ptr(slug),
+	}
+	if branch, ok := s.claimIngestBranch(repo, pr.HeadRefName, taskID); ok {
+		u.Branch = task.Ptr(branch)
+	} else {
+		s.logger.Warn("enrich-pr.branch-collision", "task_id", taskID, "pr", number, "branch", pr.HeadRefName)
 	}
 	// Replace tags with the PR's labels (possibly empty), which also clears the
 	// enrich-pending marker set on the URL stub at creation.
@@ -960,9 +964,17 @@ func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
 		// ReconcilePendingEnrichment to find and retry it — inert forever.
 		labels = append(labels, enrichPendingTag)
 	} else if linked, ok := s.singleViewerLinkedPR(linkedPRs); ok {
-		u.PRNumber = task.Ptr(linked.Number)
-		u.Branch = task.Ptr(linked.HeadRefName)
-		u.Status = task.Ptr(task.StatusInReview)
+		if branch, ok := s.claimIngestBranch(repo, linked.HeadRefName, taskID); ok {
+			u.PRNumber = task.Ptr(linked.Number)
+			u.Branch = task.Ptr(branch)
+			u.Status = task.Ptr(task.StatusInReview)
+		} else {
+			// This PR's branch already belongs to a different task — e.g. one
+			// PR closes more than one GitHub issue, and another issue's task
+			// already claimed it. Leave this task's own PR link unclaimed
+			// rather than have two tasks race to own the same branch/worktree.
+			s.logger.Warn("enrich-issue.linked-pr.branch-collision", "task_id", taskID, "issue", issue.URL, "pr", linked.Number)
+		}
 	} else if len(linkedPRs) > 0 {
 		if viewerPRs := s.viewerLinkedPRCount(linkedPRs); viewerPRs > 1 {
 			s.logger.Warn("enrich-issue.linked-prs.ambiguous", "task_id", taskID, "count", viewerPRs)
@@ -1227,6 +1239,30 @@ func (s *TaskService) viewerLoginFunc() func() string {
 		return s.viewerLogin
 	}
 	return github.ViewerLogin
+}
+
+// claimIngestBranch returns (branch, true) unless branch is already the
+// Branch of a different live task in projectID, in which case it returns
+// ("", false) so the caller leaves the task's Branch unset — branchNameForTask
+// then derives a task-unique fallback from the task's own id instead of
+// cross-assigning a sibling's branch. A List failure fails closed (treated as
+// a collision): losing a real branch link on a transient read error is
+// strictly safer than risking two tasks racing to own the same worktree.
+func (s *TaskService) claimIngestBranch(projectID, branch, excludeTaskID string) (string, bool) {
+	if branch == "" {
+		return "", false
+	}
+	all, err := s.tasks.List()
+	if err != nil {
+		s.logger.Warn("ingest.branch-guard.list", "err", err)
+		return "", false
+	}
+	if owner, taken := task.BranchOwnedByOther(all, projectID, branch, excludeTaskID); taken {
+		s.logger.Warn("ingest.branch-guard.collision",
+			"task_id", excludeTaskID, "owner_task_id", owner, "branch", branch, "project_id", projectID)
+		return "", false
+	}
+	return branch, true
 }
 
 func (s *TaskService) singleViewerLinkedPR(prs []github.PullRequest) (github.PullRequest, bool) {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -1132,6 +1132,107 @@ func TestTaskService_EnrichFromIssue_LinkedPRsFailureKeepsPendingMarker(t *testi
 	}
 }
 
+// TestTaskService_EnrichFromIssue_LinkedPRBranchAlreadyOwnedSkipsBranch is a
+// regression test for #696bc049: a PR can close more than one GitHub issue,
+// so enrichFromIssue's linked-PR discovery can resolve to a PR/branch that a
+// different, already-existing task already owns. Cross-assigning that
+// branch onto this task too would make both tasks fight over the same git
+// worktree. The guard must leave this task's PR link unclaimed instead.
+func TestTaskService_EnrichFromIssue_LinkedPRBranchAlreadyOwnedSkipsBranch(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	owner, err := svc.tasks.CreateFull("earlier task", "", "headless", task.Update{
+		ProjectID: task.Ptr("owner/repo"),
+		Branch:    task.Ptr("fix/shared-pr"),
+		PRNumber:  task.Ptr(99),
+		Status:    task.Ptr(task.StatusInReview),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		return github.Issue{
+			Number:     42,
+			Title:      "later issue closed by the same PR",
+			URL:        "https://github.com/owner/repo/issues/42",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) {
+		return []github.PullRequest{{Number: 99, HeadRefName: "fix/shared-pr", Author: "me"}}, nil
+	}
+	svc.viewerLogin = func() string { return "me" }
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/42", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Branch != "" || got.PRNumber != 0 || got.Status == task.StatusInReview {
+		t.Fatalf("task = %+v, want no branch/PR cross-assigned from task %s", got, owner.ID)
+	}
+	if got.Title != "later issue closed by the same PR" {
+		t.Fatalf("Title = %q, want the real issue title even though the branch was skipped", got.Title)
+	}
+
+	ownerStillOwns, err := svc.GetTask(owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ownerStillOwns.Branch != "fix/shared-pr" || ownerStillOwns.PRNumber != 99 {
+		t.Fatalf("owner task = %+v, want its original branch/PR untouched", ownerStillOwns)
+	}
+}
+
+// TestTaskService_EnrichFromPR_BranchAlreadyOwnedSkipsBranch mirrors the
+// issue-side regression test above for the direct PR-URL enrichment path:
+// pasting a PR URL whose head branch is already owned by a different task
+// must not persist that branch onto the new task too.
+func TestTaskService_EnrichFromPR_BranchAlreadyOwnedSkipsBranch(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	owner, err := svc.tasks.CreateFull("earlier task", "", "headless", task.Update{
+		ProjectID: task.Ptr("owner/repo"),
+		Branch:    task.Ptr("fix/shared-pr"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc.fetchPR = func(string, int) (github.PullRequest, error) {
+		return github.PullRequest{
+			Number:      7,
+			Title:       "a PR reusing another task's branch",
+			HeadRefName: "fix/shared-pr",
+			Author:      "me",
+		}, nil
+	}
+	svc.viewerLogin = func() string { return "me" }
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/pull/7", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Branch != "" {
+		t.Fatalf("Branch = %q, want empty (must not cross-assign task %s's branch)", got.Branch, owner.ID)
+	}
+	if got.Title != "a PR reusing another task's branch" {
+		t.Fatalf("Title = %q, want the real PR title even though the branch was skipped", got.Title)
+	}
+}
+
 // TestTaskService_ReconcilePendingEnrichment_RetriesAfterLinkedPRsFailure
 // covers the recovery half of the above: once the title has already been
 // rewritten to the real issue title (so it no longer parses as a GitHub

--- a/internal/task/branch.go
+++ b/internal/task/branch.go
@@ -1,0 +1,24 @@
+package task
+
+// BranchOwnedByOther reports whether some task in tasks, other than
+// excludeTaskID, already holds branch within projectID. Ingestion paths that
+// derive a task's Branch from an external source (a linked PR's head ref) use
+// this before persisting it, so a PR that cross-references more than one
+// GitHub issue can never leave two sybra tasks claiming the same branch — the
+// second task's worktree would otherwise fail to provision ("branch already
+// used by worktree at ...").
+func BranchOwnedByOther(tasks []Task, projectID, branch, excludeTaskID string) (ownerID string, ok bool) {
+	if branch == "" {
+		return "", false
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if t.ID == excludeTaskID {
+			continue
+		}
+		if t.ProjectID == projectID && t.Branch == branch {
+			return t.ID, true
+		}
+	}
+	return "", false
+}

--- a/internal/task/branch_test.go
+++ b/internal/task/branch_test.go
@@ -1,0 +1,63 @@
+package task
+
+import "testing"
+
+func TestBranchOwnedByOther(t *testing.T) {
+	tasks := []Task{
+		{ID: "a", ProjectID: "owner/repo", Branch: "fix/foo-abcd1234"},
+		{ID: "b", ProjectID: "owner/repo", Branch: "fix/bar-ef567890"},
+		{ID: "c", ProjectID: "other/repo", Branch: "fix/foo-abcd1234"},
+	}
+
+	tests := []struct {
+		name          string
+		projectID     string
+		branch        string
+		excludeTaskID string
+		wantOwner     string
+		wantOK        bool
+	}{
+		{
+			name:      "empty branch never collides",
+			projectID: "owner/repo",
+			branch:    "",
+			wantOK:    false,
+		},
+		{
+			name:      "no owner in project",
+			projectID: "owner/repo",
+			branch:    "fix/unclaimed-00000000",
+			wantOK:    false,
+		},
+		{
+			name:      "different project with same branch string does not collide",
+			projectID: "unrelated/repo",
+			branch:    "fix/foo-abcd1234",
+			wantOK:    false,
+		},
+		{
+			name:      "collides with a different task in the same project",
+			projectID: "owner/repo",
+			branch:    "fix/foo-abcd1234",
+			wantOwner: "a",
+			wantOK:    true,
+		},
+		{
+			name:          "excluding the owning task itself is not a collision",
+			projectID:     "owner/repo",
+			branch:        "fix/foo-abcd1234",
+			excludeTaskID: "a",
+			wantOK:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, ok := BranchOwnedByOther(tasks, tt.projectID, tt.branch, tt.excludeTaskID)
+			if ok != tt.wantOK || owner != tt.wantOwner {
+				t.Fatalf("BranchOwnedByOther(%q, %q, %q) = (%q, %v), want (%q, %v)",
+					tt.projectID, tt.branch, tt.excludeTaskID, owner, ok, tt.wantOwner, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ingested tasks previously could collide on branch names when created in bulk; this generates a unique branch per task via a new internal/task/branch helper and wires it through issue polling and task creation. Adds coverage in internal/task/branch_test.go, internal/poll/issues_test.go, and internal/sybra/svc_tasks_test.go.