### PR TITLE
fix(agentorch): translate pool-busy in recovery dispatch path

### DIFF
--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -415,6 +415,24 @@ func (o *Orchestrator) resolveDispatchDir(t task.Task, taskID, cleanRetryRef str
 	return t, d, nil
 }
 
+// translatePoolBusy maps the agent-package concurrency sentinel onto
+// workflow.ErrAgentPoolBusy so every caller of this package's dispatch
+// methods — the workflow engine's agentAdapter, the recovery loop's
+// RestartStaleInProgress, or a future caller — sees the same benign,
+// self-healing signal regardless of entry point. Without this translation at
+// the source, a caller that reaches agent.Manager.Run through this package
+// without its own wrapping (e.g. recovery.Recovery, which invokes
+// StartAgent/StartPRFixAgent directly) lets the raw agent.ErrMaxConcurrentReached
+// through to workflow.ClassifyAgentStartError, which then falls to the
+// generic "agent start failed" branch and writes a scary, non-suppressed
+// status_reason for a condition that resolves itself once a pool slot frees.
+func translatePoolBusy(err error) error {
+	if errors.Is(err, agent.ErrMaxConcurrentReached) {
+		return fmt.Errorf("%w: %w", workflow.ErrAgentPoolBusy, err)
+	}
+	return err
+}
+
 func (o *Orchestrator) StartAgentWithAssignment(taskID, mode, prompt string, includeTaskDescription, oneShot bool, cleanRetryRef string, assignment workflow.AgentAssignment) (*agent.Agent, string, error) {
 	// Serialize dispatch per task. Held across the whole start — including the
 	// multi-second worktree prep below, during which the agent is not yet
@@ -516,7 +534,7 @@ func (o *Orchestrator) StartAgentWithAssignment(taskID, mode, prompt string, inc
 	})
 	if err != nil {
 		o.handleProviderGateStartError(taskID, err)
-		return nil, "", err
+		return nil, "", translatePoolBusy(err)
 	}
 	o.recordImplAgentStart(ag, t, taskID, effMode, posture, requirePerm, oneShot, fullPrompt)
 	return ag, baselineRef, nil
@@ -943,7 +961,7 @@ func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 		SeedWorkingMemory: agent.RolePRFix.AuthorsCode(),
 	})
 	if err != nil {
-		return err
+		return translatePoolBusy(err)
 	}
 
 	skipPerm := !requirePerm && len(t.AllowedTools) == 0

--- a/internal/sybra/agentorch/agentorch_test.go
+++ b/internal/sybra/agentorch/agentorch_test.go
@@ -167,6 +167,81 @@ func TestStartPRFixAgent_TaskCostExceededBlocksDispatch(t *testing.T) {
 	}
 }
 
+// TestStartPRFixAgent_PoolBusyTranslatesToWorkflowSentinel pins the fix for
+// the lost_agent false-positive on task 3e2f0953: recovery.Recovery calls
+// StartPRFixAgent directly (internal/recovery/stale.go), bypassing the
+// workflow-engine agentAdapter that previously was the only caller
+// translating agent.ErrMaxConcurrentReached into workflow.ErrAgentPoolBusy.
+// Without translating at the source, a benign, self-healing "pool full"
+// condition reached workflow.ClassifyAgentStartError as a raw error it
+// doesn't recognize, which fell through to the generic "agent start failed"
+// branch and wrote a scary, non-suppressed status_reason for a task that was
+// only waiting for a slot to free — not one whose agent actually died.
+func TestStartPRFixAgent_PoolBusyTranslatesToWorkflowSentinel(t *testing.T) {
+	ts, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tm := task.NewManager(ts, nil)
+
+	am, err := agent.NewManager(t.Context(), func(string, any) {}, discardSlogLogger(), t.TempDir(), agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{DefaultProvider: "claude", MaxConcurrent: 1},
+		SandboxHome: func(string) (string, error) {
+			return t.TempDir(), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.NewManager: %v", err)
+	}
+
+	// TaskTypeResearch + a real ResearchMachineDir skips worktree/project
+	// setup entirely (see ResolveExecution), so the dispatch reaches
+	// o.agents.Run directly without any git/project plumbing. Disabling
+	// require_permissions avoids the "needs a running approval server"
+	// error a gated headless run would hit first.
+	noPermissions := false
+	o := New(tm, nil, am, nil, discardSlogLogger(), nil, &config.Config{
+		Agent: config.AgentDefaults{
+			ResearchMachineDir: t.TempDir(),
+			RequirePermissions: &noPermissions,
+		},
+	})
+
+	first, err := tm.Create("occupies the only pool slot", "", "headless")
+	if err != nil {
+		t.Fatalf("task Create (first): %v", err)
+	}
+	if _, err := tm.Update(first.ID, task.Update{TaskType: task.Ptr(task.TaskTypeResearch)}); err != nil {
+		t.Fatalf("Update (first): %v", err)
+	}
+	if err := o.StartPRFixAgent(first.ID); err != nil {
+		t.Fatalf("StartPRFixAgent(first) unexpected err: %v", err)
+	}
+
+	second, err := tm.Create("hits the concurrency cap", "", "headless")
+	if err != nil {
+		t.Fatalf("task Create (second): %v", err)
+	}
+	if _, err := tm.Update(second.ID, task.Update{TaskType: task.Ptr(task.TaskTypeResearch)}); err != nil {
+		t.Fatalf("Update (second): %v", err)
+	}
+
+	err = o.StartPRFixAgent(second.ID)
+	if err == nil {
+		t.Fatal("expected pool-busy error once the single slot is saturated, got nil")
+	}
+	if !errors.Is(err, workflow.ErrAgentPoolBusy) {
+		t.Fatalf("err = %v, want wrapping workflow.ErrAgentPoolBusy", err)
+	}
+	reason, permanent := workflow.ClassifyAgentStartError(err)
+	if reason != "" {
+		t.Errorf("reason = %q, want suppressed (empty) for a benign, self-healing pool-busy condition", reason)
+	}
+	if permanent {
+		t.Error("pool-busy must never classify as permanent — a slot frees on its own")
+	}
+}
+
 // TestPickImplementationResumeSession pins two regression guards on the
 // resume-session walker:
 //

--- a/internal/sybra/agentorch/agentorch_test.go
+++ b/internal/sybra/agentorch/agentorch_test.go
@@ -184,6 +184,20 @@ func TestStartPRFixAgent_PoolBusyTranslatesToWorkflowSentinel(t *testing.T) {
 	}
 	tm := task.NewManager(ts, nil)
 
+	// Fake claude CLI on PATH so the first dispatch can actually "start" and
+	// saturate the pool without spending real model credits or failing with
+	// an exec-not-found error on a machine without the CLI installed.
+	fakebin := t.TempDir()
+	fakeClaude := filepath.Join(fakebin, "claude")
+	if err := os.WriteFile(fakeClaude, []byte("#!/usr/bin/env bash\n"+
+		"printf '{\"type\":\"system\",\"session_id\":\"fake-session\"}\\n'\n"+
+		"sleep 5\n"+
+		"printf '{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"fake-session\",\"result\":\"done\",\"total_cost_usd\":0.01,\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\\n'\n"),
+		0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", fakebin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	am, err := agent.NewManager(t.Context(), func(string, any) {}, discardSlogLogger(), t.TempDir(), agent.ManagerConfig{
 		Runtime: agent.ManagerRuntimeConfig{DefaultProvider: "claude", MaxConcurrent: 1},
 		SandboxHome: func(string) (string, error) {
@@ -217,6 +231,7 @@ func TestStartPRFixAgent_PoolBusyTranslatesToWorkflowSentinel(t *testing.T) {
 	if err := o.StartPRFixAgent(first.ID); err != nil {
 		t.Fatalf("StartPRFixAgent(first) unexpected err: %v", err)
 	}
+	t.Cleanup(func() { am.KillAgentsForTask(first.ID, 5*time.Second) })
 
 	second, err := tm.Create("hits the concurrency cap", "", "headless")
 	if err != nil {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -589,9 +589,13 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	// PrepareForFix) bypasses the orchestrator's worktree path and uses the
 	// caller-provided dir directly.
 	if (role == "" || role == string(agent.RoleImplementation)) && dir == "" {
+		// agentOrch.StartAgentWithAssignment already translates
+		// agent.ErrMaxConcurrentReached into workflow.ErrAgentPoolBusy at the
+		// source, so every caller (this adapter, recovery.Recovery) sees the
+		// same benign sentinel without needing its own wrap here.
 		ag, baselineRef, err := a.agentOrch.StartAgentWithAssignment(taskID, mode, prompt, false, oneShot, cleanRetryRef, assignment)
 		if err != nil {
-			return "", "", "", translatePoolBusy(err)
+			return "", "", "", err
 		}
 		return ag.ID, "", baselineRef, nil
 	}


### PR DESCRIPTION
## Motivation

The monitor detected repeated `lost_agent` errors for task 3e2f0953. Investigation revealed these were false positives caused by the recovery dispatch mechanism not properly distinguishing between a lost agent process and agent pool saturation.

## Implementation information

- Translated pool-busy state handling in agentorch's recovery dispatch path
- Ensures pool capacity constraints are properly distinguished from actual agent process failures
- Prevents false-positive lost_agent alerts when the agent pool is at capacity

_Generated by Sybra harness_