### PR TITLE
fix(agent): reap idle/handed-off/orphaned agents

### DIFF
--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -90,6 +90,30 @@ func (m *Manager) FindAllRunningAgentsForTask(taskID string, role Role) []*Agent
 	return result
 }
 
+// StopAgents stops the provided agents without waiting for their goroutines to
+// exit. Callers that need deterministic teardown (task delete/worktree
+// cleanup) should use KillAgentsForTask instead.
+func (m *Manager) StopAgents(agents []*Agent) {
+	for _, a := range agents {
+		if a == nil {
+			continue
+		}
+		m.logger.Info("agent.stop-for-task", "agent_id", a.ID, "task_id", a.TaskID)
+		// Detached children do not observe stdin EOF or parent ctx cancel, so
+		// signal them directly before canceling to actually free the pool slot.
+		if a.isDetached() {
+			a.MarkStopped()
+			m.signalKill(a)
+		}
+		if a.cancel != nil {
+			a.cancel()
+		}
+		a.SetState(StateStopped)
+		a.convo.closeStdinPipe()
+		m.emit(events.AgentState(a.ID), a)
+	}
+}
+
 // KillAgentsForTask stops all running agents for the given task ID and waits
 // for their goroutines to exit (up to timeout). Safe to call from DeleteTask
 // before worktree cleanup.
@@ -103,23 +127,7 @@ func (m *Manager) KillAgentsForTask(taskID string, timeout time.Duration) {
 	}
 	m.mu.RUnlock()
 
-	for _, a := range targets {
-		m.logger.Info("agent.kill-for-task", "agent_id", a.ID, "task_id", taskID)
-		// A detached subprocess cannot be killed via ctx-cancel or stdin EOF
-		// (own session, never-EOF FIFO stdin). Mark it stopped so its tailer
-		// finalizes, and signal it by PID so the process actually dies before
-		// the caller cleans up the worktree it is using.
-		if a.isDetached() {
-			a.MarkStopped()
-			m.signalKill(a)
-		}
-		if a.cancel != nil {
-			a.cancel()
-		}
-		a.SetState(StateStopped)
-		a.convo.closeStdinPipe()
-		m.emit(events.AgentState(a.ID), a)
-	}
+	m.StopAgents(targets)
 
 	deadline := time.After(timeout)
 	for _, a := range targets {

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -101,8 +101,8 @@ func (m *Manager) StopAgents(agents []*Agent) {
 		m.logger.Info("agent.stop-for-task", "agent_id", a.ID, "task_id", a.TaskID)
 		// Detached children do not observe stdin EOF or parent ctx cancel, so
 		// signal them directly before canceling to actually free the pool slot.
+		a.MarkStopped()
 		if a.isDetached() {
-			a.MarkStopped()
 			m.signalKill(a)
 		}
 		if a.cancel != nil {

--- a/internal/agent/orphan_sweep.go
+++ b/internal/agent/orphan_sweep.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 )
@@ -11,12 +12,12 @@ type providerProcess struct {
 	CWD     string
 }
 
-func (m *Manager) ReapOrphanProviderProcesses(roots []string) int {
+func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []string) int {
 	roots = canonicalProcessRoots(roots)
 	if len(roots) == 0 {
 		return 0
 	}
-	procs := listProviderProcessesUnderRoots(roots)
+	procs := listProviderProcessesUnderRoots(ctx, roots)
 	if len(procs) == 0 {
 		return 0
 	}

--- a/internal/agent/orphan_sweep.go
+++ b/internal/agent/orphan_sweep.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type providerProcess struct {
+	PID     int
+	Command string
+	CWD     string
+}
+
+func (m *Manager) ReapOrphanProviderProcesses(roots []string) int {
+	roots = canonicalProcessRoots(roots)
+	if len(roots) == 0 {
+		return 0
+	}
+	procs := listProviderProcessesUnderRoots(roots)
+	if len(procs) == 0 {
+		return 0
+	}
+	tracked := m.trackedPIDs()
+	reaped := 0
+	for _, proc := range procs {
+		if proc.PID <= 0 {
+			continue
+		}
+		if _, ok := tracked[proc.PID]; ok {
+			continue
+		}
+		m.logger.Warn("agent.orphan.reap", "pid", proc.PID, "cwd", proc.CWD, "command", proc.Command)
+		signalPID(proc.PID, stopSIGINTGrace)
+		reaped++
+	}
+	return reaped
+}
+
+func (m *Manager) trackedPIDs() map[int]struct{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	tracked := make(map[int]struct{}, len(m.agents))
+	for _, a := range m.agents {
+		if pid := a.GetPID(); pid > 0 {
+			tracked[pid] = struct{}{}
+		}
+		if cmd := a.GetCmd(); cmd != nil && cmd.Process != nil && cmd.Process.Pid > 0 {
+			tracked[cmd.Process.Pid] = struct{}{}
+		}
+	}
+	return tracked
+}
+
+func canonicalProcessRoots(roots []string) []string {
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			root = resolved
+		} else {
+			root = filepath.Clean(root)
+		}
+		out = append(out, root)
+	}
+	return out
+}
+
+func pathWithinRoots(path string, roots []string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	} else {
+		path = filepath.Clean(path)
+	}
+	for _, root := range roots {
+		if path == root || strings.HasPrefix(path, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isProviderProcessName(name string) bool {
+	name = strings.TrimSpace(strings.ToLower(filepath.Base(name)))
+	switch name {
+	case "claude", "codex", "copilot":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/agent/orphan_sweep_linux.go
+++ b/internal/agent/orphan_sweep_linux.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func listProviderProcessesUnderRoots(roots []string) []providerProcess {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	out := make([]providerProcess, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		cwd, err := os.Readlink(filepath.Join("/proc", entry.Name(), "cwd"))
+		if err != nil || !pathWithinRoots(cwd, roots) {
+			continue
+		}
+		cmd := linuxProcessName(entry.Name())
+		if !isProviderProcessName(cmd) {
+			continue
+		}
+		out = append(out, providerProcess{PID: pid, Command: cmd, CWD: cwd})
+	}
+	return out
+}
+
+func linuxProcessName(pid string) string {
+	data, err := os.ReadFile(filepath.Join("/proc", pid, "cmdline"))
+	if err == nil && len(data) > 0 {
+		if idx := bytesIndexByte(data, 0); idx >= 0 {
+			data = data[:idx]
+		}
+		if len(data) > 0 {
+			return filepath.Base(string(data))
+		}
+	}
+	data, err = os.ReadFile(filepath.Join("/proc", pid, "comm"))
+	if err != nil {
+		return ""
+	}
+	return filepath.Base(strings.TrimSpace(string(data)))
+}
+
+func bytesIndexByte(data []byte, target byte) int {
+	for i, b := range data {
+		if b == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/agent/orphan_sweep_linux.go
+++ b/internal/agent/orphan_sweep_linux.go
@@ -3,13 +3,14 @@
 package agent
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 )
 
-func listProviderProcessesUnderRoots(roots []string) []providerProcess {
+func listProviderProcessesUnderRoots(_ context.Context, roots []string) []providerProcess {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil

--- a/internal/agent/orphan_sweep_other.go
+++ b/internal/agent/orphan_sweep_other.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-func listProviderProcessesUnderRoots(roots []string) []providerProcess {
-	out, err := exec.CommandContext(context.Background(), "ps", "-axo", "pid=,command=").Output()
+func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []providerProcess {
+	out, err := exec.CommandContext(ctx, "ps", "-axo", "pid=,command=").Output()
 	if err != nil {
 		return nil
 	}
@@ -28,7 +28,7 @@ func listProviderProcessesUnderRoots(roots []string) []providerProcess {
 		if !isProviderProcessName(cmd) {
 			continue
 		}
-		cwdOut, err := exec.CommandContext(context.Background(), "lsof", "-a", "-d", "cwd", "-Fn", "-p", strconv.Itoa(pid)).Output()
+		cwdOut, err := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-Fn", "-p", strconv.Itoa(pid)).Output()
 		if err != nil {
 			continue
 		}

--- a/internal/agent/orphan_sweep_other.go
+++ b/internal/agent/orphan_sweep_other.go
@@ -1,0 +1,42 @@
+//go:build !linux
+
+package agent
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func listProviderProcessesUnderRoots(roots []string) []providerProcess {
+	out, err := exec.CommandContext(context.Background(), "ps", "-axo", "pid=,command=").Output()
+	if err != nil {
+		return nil
+	}
+	procs := make([]providerProcess, 0)
+	for line := range strings.SplitSeq(string(out), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		cmd := fields[1]
+		if !isProviderProcessName(cmd) {
+			continue
+		}
+		cwdOut, err := exec.CommandContext(context.Background(), "lsof", "-a", "-d", "cwd", "-Fn", "-p", strconv.Itoa(pid)).Output()
+		if err != nil {
+			continue
+		}
+		cwd := parseLsofCWD(string(cwdOut))
+		if !pathWithinRoots(cwd, roots) {
+			continue
+		}
+		procs = append(procs, providerProcess{PID: pid, Command: cmd, CWD: cwd})
+	}
+	return procs
+}

--- a/internal/agent/orphan_sweep_test.go
+++ b/internal/agent/orphan_sweep_test.go
@@ -24,7 +24,7 @@ func TestReapOrphanProviderProcesses(t *testing.T) {
 	root := t.TempDir()
 	proc := spawnProviderProcess(t, root)
 
-	if got := m.ReapOrphanProviderProcesses([]string{root}); got != 1 {
+	if got := m.ReapOrphanProviderProcesses(context.Background(), []string{root}); got != 1 {
 		t.Fatalf("reaped = %d, want 1", got)
 	}
 	waitForProcessExit(t, proc.Process.Pid)
@@ -43,7 +43,7 @@ func TestReapOrphanProviderProcesses_SkipsTrackedPID(t *testing.T) {
 	m.agents["tracked"] = &Agent{ID: "tracked", TaskID: "task-1", PID: proc.Process.Pid}
 	m.mu.Unlock()
 
-	if got := m.ReapOrphanProviderProcesses([]string{root}); got != 0 {
+	if got := m.ReapOrphanProviderProcesses(context.Background(), []string{root}); got != 0 {
 		t.Fatalf("reaped = %d, want 0 for tracked pid", got)
 	}
 	if !processAlive(proc.Process.Pid) {

--- a/internal/agent/orphan_sweep_test.go
+++ b/internal/agent/orphan_sweep_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestReapOrphanProviderProcesses(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only process enumeration test")
+	}
+
+	prevGrace := stopSIGINTGrace
+	stopSIGINTGrace = 20 * time.Millisecond
+	t.Cleanup(func() { stopSIGINTGrace = prevGrace })
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{})
+	root := t.TempDir()
+	proc := spawnProviderProcess(t, root)
+
+	if got := m.ReapOrphanProviderProcesses([]string{root}); got != 1 {
+		t.Fatalf("reaped = %d, want 1", got)
+	}
+	waitForProcessExit(t, proc.Process.Pid)
+}
+
+func TestReapOrphanProviderProcesses_SkipsTrackedPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only process enumeration test")
+	}
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{})
+	root := t.TempDir()
+	proc := spawnProviderProcess(t, root)
+
+	m.mu.Lock()
+	m.agents["tracked"] = &Agent{ID: "tracked", TaskID: "task-1", PID: proc.Process.Pid}
+	m.mu.Unlock()
+
+	if got := m.ReapOrphanProviderProcesses([]string{root}); got != 0 {
+		t.Fatalf("reaped = %d, want 0 for tracked pid", got)
+	}
+	if !processAlive(proc.Process.Pid) {
+		t.Fatal("tracked process was killed")
+	}
+}
+
+func spawnProviderProcess(t *testing.T, root string) *exec.Cmd {
+	t.Helper()
+
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("sleep not found: %v", err)
+	}
+	binDir := t.TempDir()
+	link := filepath.Join(binDir, "claude")
+	if err := os.Symlink(sleepPath, link); err != nil {
+		t.Fatalf("symlink sleep -> claude: %v", err)
+	}
+	cwd := filepath.Join(root, "sandboxes", "task-1", "sybra-home")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+	cmd := exec.Command(link, "30")
+	cmd.Dir = cwd
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start provider-shaped process: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	go func() { _ = cmd.Wait() }()
+	return cmd
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pid %d still alive after reap", pid)
+}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -589,7 +589,7 @@ func (m *Manager) reattachStaleReason(r Record, now time.Time) string {
 
 func staleForLiveAgent(status string) bool {
 	switch status {
-	case "todo", "new":
+	case "todo", "new", "human-required", "done", "cancelled":
 		return true
 	default:
 		return false

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -151,6 +151,11 @@ func TestReattachAccountingInvariant(t *testing.T) {
 
 func TestReattachReapsStaleInteractiveTaskAgent(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
+	prevGrace := stopSIGINTGrace
+	stopSIGINTGrace = 30 * time.Millisecond
+	t.Cleanup(func() {
+		stopSIGINTGrace = prevGrace
+	})
 	spawnSleeper := func(t *testing.T) *exec.Cmd {
 		t.Helper()
 		cmd := exec.Command("sleep", "30")
@@ -218,6 +223,17 @@ func TestReattachReapsStaleInteractiveTaskAgent(t *testing.T) {
 	if !present["orchestrator"] {
 		t.Errorf("taskless orchestrator must NOT be reaped, but its record is gone")
 	}
+	if err := orchCmd.Process.Kill(); err != nil {
+		t.Fatalf("kill reattached orchestrator process: %v", err)
+	}
+	deadline := time.After(5 * time.Second)
+	for m.RunningCount() > 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("reattached orchestrator did not stop; liveCount=%d", m.RunningCount())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
 }
 
 func TestReattachReapsStaleSurvivors(t *testing.T) {
@@ -263,6 +279,20 @@ func TestReattachReapsStaleSurvivors(t *testing.T) {
 				return Record{ID: "s1", TaskID: "task-x", Mode: "headless", Provider: "claude", PID: pid, StartedAt: time.Now().UTC()}
 			},
 			status: map[string]string{"task-x": "todo"},
+		},
+		{
+			name: "human-required task still has live agent",
+			record: func(pid int) Record {
+				return Record{ID: "s1", TaskID: "task-x", Mode: "headless", Provider: "claude", PID: pid, StartedAt: time.Now().UTC()}
+			},
+			status: map[string]string{"task-x": "human-required"},
+		},
+		{
+			name: "done task still has live agent",
+			record: func(pid int) Record {
+				return Record{ID: "s1", TaskID: "task-x", Mode: "headless", Provider: "claude", PID: pid, StartedAt: time.Now().UTC()}
+			},
+			status: map[string]string{"task-x": "done"},
 		},
 		{
 			name: "task deleted while down",

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -75,6 +75,7 @@ type Recovery struct {
 
 	LogDir       string
 	LogRetention time.Duration // 0 disables age-based pruning
+	OrphanRoots  []string
 
 	// TrashRetentionDays bounds how long a soft-deleted task (see
 	// task.Store.Delete) survives under the trash dir before
@@ -102,6 +103,9 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 	// stale, or restart them.
 	if reattached := r.Agents.ReattachAllContext(ctx); len(reattached) > 0 {
 		r.Logger.Info("recovery.reattach", "count", len(reattached))
+	}
+	if reaped := r.Agents.ReapOrphanProviderProcesses(r.OrphanRoots); reaped > 0 {
+		r.Logger.Info("recovery.orphan_reap", "count", reaped)
 	}
 	r.Worktrees.RepairAll(ctx)
 	r.gcOrphanChats(ctx)

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -104,7 +104,7 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 	if reattached := r.Agents.ReattachAllContext(ctx); len(reattached) > 0 {
 		r.Logger.Info("recovery.reattach", "count", len(reattached))
 	}
-	if reaped := r.Agents.ReapOrphanProviderProcesses(r.OrphanRoots); reaped > 0 {
+	if reaped := r.Agents.ReapOrphanProviderProcesses(ctx, r.OrphanRoots); reaped > 0 {
 		r.Logger.Info("recovery.orphan_reap", "count", reaped)
 	}
 	r.Worktrees.RepairAll(ctx)

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -126,6 +126,9 @@ type App struct {
 	// it to exercise scheduling/single-flight without spawning a real
 	// planner subprocess.
 	umbrellaRecoverFn func(tracker task.Task)
+	// taskAgentReleaser overrides releaseTaskAgents for tests. nil uses the
+	// live agent-manager-backed implementation.
+	taskAgentReleaser func(taskID string)
 
 	bgops *bgop.Tracker
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -412,6 +412,7 @@ func (a *App) limitPolicy() limits.Policy {
 
 func (a *App) initStatusHook() {
 	a.tasks.SetStatusChangeHook(func(taskID, from, to string) {
+		releaseTaskAgents := shouldReleaseTaskAgentsForStatus(task.Status(to))
 		data := map[string]any{"from": from, "to": to}
 		if to == string(task.StatusHumanRequired) {
 			if t, err := a.tasks.Get(taskID); err == nil {
@@ -432,6 +433,9 @@ func (a *App) initStatusHook() {
 		// never exit between turns) signal step completion.
 		if a.workflowEngine != nil {
 			a.workflowEngine.HandleStatusChange(taskID, to)
+		}
+		if releaseTaskAgents {
+			a.releaseTaskAgents(taskID)
 		}
 
 		switch to {
@@ -462,6 +466,47 @@ func (a *App) initStatusHook() {
 			a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
 		}
 	})
+}
+
+func shouldReleaseTaskAgentsForStatus(status task.Status) bool {
+	return status == task.StatusHumanRequired || task.IsTerminalStatus(status)
+}
+
+func (a *App) releaseTaskAgents(taskID string) {
+	if a.taskAgentReleaser != nil {
+		a.taskAgentReleaser(taskID)
+		return
+	}
+	if a.agents == nil {
+		return
+	}
+	targets := a.agents.FindAllRunningAgentsForTask(taskID, "")
+	if len(targets) == 0 {
+		return
+	}
+	filtered := make([]*agent.Agent, 0, len(targets))
+	for _, ag := range targets {
+		if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
+			continue
+		}
+		filtered = append(filtered, ag)
+	}
+	if len(filtered) == 0 {
+		return
+	}
+	go func(agentsToStop []*agent.Agent) {
+		for _, ag := range agentsToStop {
+			var err error
+			if ag.Mode == "headless" && ag.CompletedSuccessfully() {
+				err = a.agents.StopCompletedAgent(ag.ID)
+			} else {
+				err = a.agents.StopAgent(ag.ID)
+			}
+			if err != nil {
+				a.logger.Warn("task.status.release-agent", "task_id", taskID, "agent_id", ag.ID, "err", err)
+			}
+		}
+	}(filtered)
 }
 
 // dispatchStatusWorkflow starts the workflow matching a status-change event.
@@ -843,6 +888,10 @@ func (a *App) newRecovery() *recovery.Recovery {
 		LogDir:             a.logDir,
 		LogRetention:       retention,
 		TrashRetentionDays: a.cfg.DefaultTrashRetentionDays(),
+		OrphanRoots: []string{
+			filepath.Join(config.HomeDir(), "sandboxes"),
+			filepath.Join(config.HomeDir(), "worktrees"),
+		},
 	}
 	// Gate on the config, not just a non-nil snapshotter: the snapshotter is
 	// always constructed, but when the feature is disabled its repo is never

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -129,6 +129,34 @@ func TestApp_WatcherStatusHook_AdvancesWorkflow(t *testing.T) {
 	}
 }
 
+func TestApp_StatusHook_ReleasesTaskAgentsOnHandoffAndTerminal(t *testing.T) {
+	tests := []task.Status{task.StatusHumanRequired, task.StatusDone, task.StatusCancelled}
+	for _, target := range tests {
+		t.Run(string(target), func(t *testing.T) {
+			a := setupApp(t)
+			var released []string
+			a.taskAgentReleaser = func(taskID string) { released = append(released, taskID) }
+			a.initStatusHook()
+
+			created, err := a.tasks.Create("release task agents", "", "headless")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := a.tasks.Update(created.ID, task.Update{Status: task.Ptr(task.StatusInProgress)}); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := a.tasks.Update(created.ID, task.Update{Status: task.Ptr(target)}); err != nil {
+				t.Fatal(err)
+			}
+
+			if len(released) != 1 || released[0] != created.ID {
+				t.Fatalf("released = %v, want [%s]", released, created.ID)
+			}
+		})
+	}
+}
+
 // TestApp_StatusHook_ReadyReview_DispatchesReviewWorkflow verifies that
 // initStatusHook dispatches simple-task-review when a task is manually
 // moved to ready-review. Before this fix the ready-review case was absent

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -131,8 +132,15 @@ func TestApp_WatcherStatusHook_ReleasesTaskAgentsOnExternalHandoffAndTerminal(t 
 	for _, target := range tests {
 		t.Run(string(target), func(t *testing.T) {
 			a := setupApp(t)
-			var released []string
-			a.taskAgentReleaser = func(taskID string) { released = append(released, taskID) }
+			var (
+				releasedMu sync.Mutex
+				released   []string
+			)
+			a.taskAgentReleaser = func(taskID string) {
+				releasedMu.Lock()
+				released = append(released, taskID)
+				releasedMu.Unlock()
+			}
 			a.initStatusHook()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -177,9 +185,15 @@ func TestApp_WatcherStatusHook_ReleasesTaskAgentsOnExternalHandoffAndTerminal(t 
 			for {
 				select {
 				case <-deadline:
-					t.Fatalf("release not observed after external status change to %s; released=%v", target, released)
+					releasedMu.Lock()
+					snapshot := append([]string(nil), released...)
+					releasedMu.Unlock()
+					t.Fatalf("release not observed after external status change to %s; released=%v", target, snapshot)
 				case <-time.After(50 * time.Millisecond):
-					if len(released) == 1 && released[0] == created.ID {
+					releasedMu.Lock()
+					done := len(released) == 1 && released[0] == created.ID
+					releasedMu.Unlock()
+					if done {
 						return
 					}
 				}

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -42,9 +42,6 @@ func TestApp_WatcherStatusHook_AdvancesWorkflow(t *testing.T) {
 	// Mirror app.go's emit callback: forward task file events through
 	// task.Manager.OnExternalUpdate so cross-process writes participate
 	// in the same status-hook plumbing as in-process Manager updates.
-	// Mirror app.go's emit callback: forward task file events through
-	// task.Manager.OnExternalUpdate so cross-process writes participate
-	// in the same status-hook plumbing as in-process Manager updates.
 	emit := func(event string, data any) {
 		switch event {
 		case events.TaskCreated, events.TaskUpdated, events.TaskDeleted:
@@ -126,6 +123,68 @@ func TestApp_WatcherStatusHook_AdvancesWorkflow(t *testing.T) {
 				return // success — workflow advanced
 			}
 		}
+	}
+}
+
+func TestApp_WatcherStatusHook_ReleasesTaskAgentsOnExternalHandoffAndTerminal(t *testing.T) {
+	tests := []task.Status{task.StatusHumanRequired, task.StatusDone, task.StatusCancelled}
+	for _, target := range tests {
+		t.Run(string(target), func(t *testing.T) {
+			a := setupApp(t)
+			var released []string
+			a.taskAgentReleaser = func(taskID string) { released = append(released, taskID) }
+			a.initStatusHook()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			emit := func(event string, data any) {
+				switch event {
+				case events.TaskCreated, events.TaskUpdated, events.TaskDeleted:
+					if path, ok := data.(string); ok {
+						a.tasks.OnExternalUpdate(path)
+					}
+				}
+			}
+			w := watcher.New(a.tasksDir, emit, a.logger)
+			if err := w.Start(ctx); err != nil {
+				t.Fatal(err)
+			}
+			<-w.Ready()
+
+			created, err := a.tasks.Create("external release task agents", "", "headless")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := a.tasks.Update(created.ID, task.Update{Status: task.Ptr(task.StatusInProgress)}); err != nil {
+				t.Fatal(err)
+			}
+
+			current, err := a.tasks.Get(created.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			current.Status = target
+			data, err := task.Marshal(current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := fsutil.AtomicWrite(current.FilePath, data); err != nil {
+				t.Fatal(err)
+			}
+
+			deadline := time.After(5 * time.Second)
+			for {
+				select {
+				case <-deadline:
+					t.Fatalf("release not observed after external status change to %s; released=%v", target, released)
+				case <-time.After(50 * time.Millisecond):
+					if len(released) == 1 && released[0] == created.ID {
+						return
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -191,61 +191,150 @@ func (w *Watchdog) Run(ctx context.Context) {
 
 func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 	for _, ag := range w.agents.ListAgents() {
-		if ag.GetState() != agent.StateRunning || ag.Mode != "headless" || ag.External {
+		if ag.External {
 			continue
 		}
-		// A headless agent whose stream already ended in a successful terminal
-		// result is logically complete; its process just has not exited yet (a
-		// skill that spawns subagents can leave CC alive after the final
-		// result). The runner's post-result guard usually finalizes it within
-		// seconds, so never inspect or escalate such an agent — doing so flips
-		// a finished run to human-required on a false stall (task c4a0fda0).
-		// If it is still alive well past that grace, the runner's reaper isn't
-		// covering it (e.g. non-detached run, lost tailer); hard-stop it
-		// directly instead of leaving it to linger indefinitely.
-		if ag.CompletedSuccessfully() {
-			w.checkCompletedHang(ag, now)
+		state := ag.GetState()
+		switch ag.Mode {
+		case "headless":
+			if state != agent.StateRunning {
+				continue
+			}
+			if w.reapTaskAgentForStatus(ag) {
+				continue
+			}
+			// A headless agent whose stream already ended in a successful terminal
+			// result is logically complete; its process just has not exited yet (a
+			// skill that spawns subagents can leave CC alive after the final
+			// result). The runner's post-result guard usually finalizes it within
+			// seconds, so never inspect or escalate such an agent — doing so flips
+			// a finished run to human-required on a false stall (task c4a0fda0).
+			// If it is still alive well past that grace, the runner's reaper isn't
+			// covering it (e.g. non-detached run, lost tailer); hard-stop it
+			// directly instead of leaving it to linger indefinitely.
+			if ag.CompletedSuccessfully() {
+				w.checkCompletedHang(ag, now)
+				continue
+			}
+			w.inspectHeadless(ctx, s, now, ag)
+		case "interactive":
+			if state != agent.StateRunning && state != agent.StatePaused {
+				continue
+			}
+			w.reapIdleInteractive(ag, now)
+		default:
 			continue
 		}
-
-		stall := now.Sub(ag.GetLastEventAt())
-		total := now.Sub(ag.StartedAt)
-
-		t, err := w.tasks.Get(ag.TaskID)
-		var budget, sl time.Duration
-		if err == nil {
-			budget = sizeBudget(t.Tags)
-			sl = stallLimit(t.Tags)
-		} else {
-			budget = sizeBudget(nil)
-			sl = stallLimit(nil)
-		}
-
-		if reason := hardDeadlineBreach(ag, stall, total, sl, budget); reason != "" {
-			w.hardStop(ag, reason, stall, total)
-			continue
-		}
-
-		logPath := ag.GetLogPath()
-		if logPath == "" {
-			continue
-		}
-
-		trigger := decideTrigger(ag.ToolLoopStreak(), w.loopThreshold, ag.ToolLoopAcknowledged(), stall, sl, total, budget)
-		if trigger == "" {
-			continue
-		}
-		if !s.shouldInspect(ag.ID, now) {
-			continue
-		}
-
-		w.logger.Info("agent.watchdog.inspect",
-			"id", ag.ID, "trigger", trigger,
-			"loop_streak", ag.ToolLoopStreak(),
-			"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
-
-		w.wg.Go(func() { w.inspect(ctx, ag, t, trigger, int(stall.Seconds()), int(total.Seconds())) })
 	}
+}
+
+func (w *Watchdog) inspectHeadless(ctx context.Context, s *state, now time.Time, ag *agent.Agent) {
+	stall := now.Sub(ag.GetLastEventAt())
+	total := now.Sub(ag.StartedAt)
+
+	t, err := w.tasks.Get(ag.TaskID)
+	var budget, sl time.Duration
+	if err == nil {
+		budget = sizeBudget(t.Tags)
+		sl = stallLimit(t.Tags)
+	} else {
+		budget = sizeBudget(nil)
+		sl = stallLimit(nil)
+	}
+
+	if reason := hardDeadlineBreach(ag, stall, total, sl, budget); reason != "" {
+		w.hardStop(ag, reason, stall, total)
+		return
+	}
+
+	logPath := ag.GetLogPath()
+	if logPath == "" {
+		return
+	}
+
+	trigger := decideTrigger(ag.ToolLoopStreak(), w.loopThreshold, ag.ToolLoopAcknowledged(), stall, sl, total, budget)
+	if trigger == "" {
+		return
+	}
+	if !s.shouldInspect(ag.ID, now) {
+		return
+	}
+
+	w.logger.Info("agent.watchdog.inspect",
+		"id", ag.ID, "trigger", trigger,
+		"loop_streak", ag.ToolLoopStreak(),
+		"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
+
+	w.wg.Go(func() { w.inspect(ctx, ag, t, trigger, int(stall.Seconds()), int(total.Seconds())) })
+}
+
+func (w *Watchdog) reapTaskAgentForStatus(ag *agent.Agent) bool {
+	if ag.TaskID == "" || w.tasks == nil {
+		return false
+	}
+	t, err := w.tasks.Get(ag.TaskID)
+	if err != nil {
+		return false
+	}
+	if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
+		return false
+	}
+	if !shouldReleaseTaskAgentForStatus(t.Status) {
+		return false
+	}
+	w.logger.Warn("agent.watchdog.status_release",
+		"id", ag.ID, "task_id", ag.TaskID, "status", t.Status)
+	if err := w.stopForRelease(ag); err != nil {
+		w.logger.Error("agent.watchdog.status_release.stop_failed", "id", ag.ID, "err", err)
+	}
+	return true
+}
+
+func (w *Watchdog) reapIdleInteractive(ag *agent.Agent, now time.Time) {
+	if ag.TaskID == "" || w.tasks == nil {
+		return
+	}
+	t, err := w.tasks.Get(ag.TaskID)
+	if err != nil {
+		return
+	}
+	if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
+		return
+	}
+	if shouldReleaseTaskAgentForStatus(t.Status) {
+		w.logger.Warn("agent.watchdog.status_release",
+			"id", ag.ID, "task_id", ag.TaskID, "status", t.Status)
+		if err := w.stopForRelease(ag); err != nil {
+			w.logger.Error("agent.watchdog.status_release.stop_failed", "id", ag.ID, "err", err)
+		}
+		return
+	}
+	stall := now.Sub(ag.GetLastEventAt())
+	total := now.Sub(ag.StartedAt)
+	if reason := hardDeadlineBreach(ag, stall, total, stallLimit(t.Tags), sizeBudget(t.Tags)); reason != "" {
+		w.hardStop(ag, reason, stall, total)
+	}
+}
+
+func shouldReleaseTaskAgentForStatus(status task.Status) bool {
+	return status == task.StatusHumanRequired || task.IsTerminalStatus(status)
+}
+
+func (w *Watchdog) stopForRelease(ag *agent.Agent) error {
+	if ag.Mode == "headless" && ag.CompletedSuccessfully() {
+		stop := w.stopCompletedAgent
+		if stop == nil {
+			stop = w.stopAgent
+		}
+		if stop == nil {
+			return nil
+		}
+		return stop(ag.ID)
+	}
+	if w.stopAgent == nil {
+		return nil
+	}
+	return w.stopAgent(ag.ID)
 }
 
 // checkCompletedHang force-stops a headless agent that finished its work (a

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -474,6 +474,53 @@ func TestCheckCompletedHang_LiveBackgroundTaskExtendsGrace(t *testing.T) {
 	}
 }
 
+func TestReapIdleInteractive_ReleasesHumanRequiredTaskAgent(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("set human-required: %v", err)
+	}
+
+	stopped := ""
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: time.Now(), LastEventAt: time.Now()}
+	w.reapIdleInteractive(ag, time.Now())
+
+	if stopped != "a1" {
+		t.Fatalf("stopAgent called with %q, want a1", stopped)
+	}
+}
+
+func TestReapIdleInteractive_HardStopsHungTaskAgent(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	stopped := ""
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	now := time.Now()
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: now.Add(-time.Hour), LastEventAt: now.Add(-40 * time.Minute)}
+	w.reapIdleInteractive(ag, now)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.StatusReason != "watchdog hang: idle deadline exceeded" {
+		t.Fatalf("status_reason = %q, want watchdog idle deadline", got.StatusReason)
+	}
+	if stopped != "a1" {
+		t.Fatalf("stopAgent called with %q, want a1", stopped)
+	}
+}
+
 // TestApplyVerdict_NudgeLiveTransportDeliversInPlace covers the live-transport
 // path: an agent with a working SendPromptToAgent (interactive/conversational)
 // is steered in place and left running — no stop, no persisted steer.


### PR DESCRIPTION
## Motivation

Task agents were never released on `human-required`/terminal status changes and
orphaned provider processes under Sybra sandboxes/worktrees leaked across
restarts. Over days this saturated the global agent-pool concurrency cap, so
every new dispatch — including the branch-conflict-fix recovery's own `fix`
step — hit `agent-pool-busy` and stalled. The pool deadlock then blocked the
very tasks meant to recover, producing multi-day leaks and stuck recoveries.

> Changelog: fix(agent): reap idle/handed-off/orphaned agents

## Implementation information

- Release task agents when a task transitions to `human-required` or a terminal
  status (`internal/agent/manager_control.go`, status-hook wiring in
  `internal/sybra/app_init.go`).
- Sweep untracked provider processes rooted under Sybra sandboxes/worktrees at
  startup (`internal/agent/orphan_sweep*.go`, Linux + portable stubs).
- Broaden stale-reattach reaping to handed-off/terminal tasks
  (`internal/agent/reattach.go`).
- Extend the watchdog to stop stale interactive task agents
  (`internal/watchdog/agent.go`).
- Tests cover status-hook release, orphan sweeps, reattach reaping, and
  interactive idle cleanup.

Closes #1861.

## Supporting documentation

Merges cleanly onto current `main` (no file overlap with commits landed since
the branch point). The prior multi-day escalation on this branch was a phantom
branch-conflict loop, tracked separately as #1874 / #1633 / #1863.
