### PR TITLE
fix(review): park conflict recovery on pool-busy

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -748,6 +748,10 @@ func (r *Handler) RecoverStaleBranchConflict(taskID string) bool {
 	if err != nil || t.ProjectID == "" {
 		return false
 	}
+	if r.WorkflowEngine.WorkflowParkedWaiting(taskID, branchConflictFixWorkflowID) {
+		r.logger.Info("pr-monitor.branch-conflict.already-parked-waiting", "task_id", taskID)
+		return true
+	}
 	// No PR yet (still in implementation/review/testing, or at create_pr) —
 	// there is no PR to check out via the PR-numbered path below. Resolve the
 	// task's own branch by name instead. This never re-enters the PR-numbered

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -145,6 +145,39 @@ func TestRecoverStaleBranchConflict_ReturnsTrueWhenWorkflowStarts(t *testing.T) 
 	}
 }
 
+func TestRecoverStaleBranchConflict_LeavesParkedFixWorkflowWithoutBurningBudget(t *testing.T) {
+	r, tk := setupRebaseRecoveryHandler(t, false)
+	parked := &workflow.Execution{
+		WorkflowID:  branchConflictFixWorkflowID,
+		CurrentStep: "fix",
+		State:       workflow.ExecWaiting,
+	}
+	if _, err := r.tasks.Update(tk.ID, task.Update{Workflow: &parked}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("RecoverStaleBranchConflict returned false while its fix workflow was parked waiting")
+	}
+
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == task.StatusHumanRequired {
+		t.Fatalf("status = %q, want the task left parked, not escalated to human-required", got.Status)
+	}
+	if got.Workflow == nil || got.Workflow.WorkflowID != branchConflictFixWorkflowID || got.Workflow.State != workflow.ExecWaiting || got.Workflow.CurrentStep != "fix" {
+		t.Fatalf("workflow = %+v, want the parked branch-conflict-fix workflow untouched", got.Workflow)
+	}
+	if n := r.prTracker.Retries(tk.ID, branchConflictRetryKind); n != 0 {
+		t.Fatalf("branch-conflict retry budget = %d, want 0 (no agent ran, so nothing to charge)", n)
+	}
+	if n := r.prTracker.Retries(tk.ID, github.PRIssueConflict); n != 0 {
+		t.Fatalf("conflict retry budget = %d, want 0", n)
+	}
+}
+
 func setupRebaseRecoveryHandler(t *testing.T, withConflictWorkflow bool) (*Handler, task.Task) {
 	t.Helper()
 

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -318,16 +318,18 @@ func (e *Engine) HasActiveWorkflow(taskID string) bool {
 }
 
 // WorkflowParkedWaiting reports whether the task's active workflow is
-// workflowID and is currently parked mid-run in ExecWaiting (a non-empty
-// CurrentStep). This is the state a StepRunAgent step lands in when its
-// dispatch hit ErrAgentPoolBusy/ErrTestRunnerBusy/ErrDispatchInFlight — the
-// run persisted but no agent started, and ResumeStalled owns re-driving it
-// once a slot frees.
+// workflowID and is currently mid-run in ExecWaiting (a non-empty
+// CurrentStep). ExecWaiting is the general "workflow is live but this goroutine
+// is not advancing it" state a StepRunAgent step holds either while an agent it
+// started runs to completion, or while its dispatch parked on
+// ErrAgentPoolBusy/ErrTestRunnerBusy/ErrDispatchInFlight (run persisted, no
+// agent started) waiting for ResumeStalled to re-drive it once a slot frees.
 //
 // Branch-conflict recovery uses this to distinguish "a fix workflow already
-// dispatched and is waiting for the pool" from "no recovery in flight": in the
-// former case re-entering would cancel + re-dispatch that parked workflow and
-// burn a bounded retry-budget slot for a fix agent that never ran.
+// dispatched and is live" from "no recovery in flight". Either mid-run state is
+// a reason to leave the workflow alone: re-entering would cancel + re-dispatch
+// it, and for the parked-dispatch case that burns a bounded retry-budget slot
+// for a fix agent that never ran.
 func (e *Engine) WorkflowParkedWaiting(taskID, workflowID string) bool {
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil || t.Workflow == nil {

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -317,6 +317,27 @@ func (e *Engine) HasActiveWorkflow(taskID string) bool {
 	return t.Workflow.State != ExecCompleted && t.Workflow.State != ExecFailed
 }
 
+// WorkflowParkedWaiting reports whether the task's active workflow is
+// workflowID and is currently parked mid-run in ExecWaiting (a non-empty
+// CurrentStep). This is the state a StepRunAgent step lands in when its
+// dispatch hit ErrAgentPoolBusy/ErrTestRunnerBusy/ErrDispatchInFlight — the
+// run persisted but no agent started, and ResumeStalled owns re-driving it
+// once a slot frees.
+//
+// Branch-conflict recovery uses this to distinguish "a fix workflow already
+// dispatched and is waiting for the pool" from "no recovery in flight": in the
+// former case re-entering would cancel + re-dispatch that parked workflow and
+// burn a bounded retry-budget slot for a fix agent that never ran.
+func (e *Engine) WorkflowParkedWaiting(taskID, workflowID string) bool {
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil || t.Workflow == nil {
+		return false
+	}
+	return t.Workflow.WorkflowID == workflowID &&
+		t.Workflow.State == ExecWaiting &&
+		t.Workflow.CurrentStep != ""
+}
+
 // CancelWorkflow terminates a task's active workflow without running any
 // remaining steps. Stops in-flight agents for the task, marks the workflow
 // ExecCompleted with the cancellation reason recorded in variables, and


### PR DESCRIPTION
## Motivation

`RecoverStaleBranchConflict` re-enters on every poll while a rebase stays
blocked. When the agent pool is saturated, the branch-conflict-fix `fix` step
dispatches but immediately parks `ExecWaiting` on `ErrAgentPoolBusy` — no agent
ever runs — yet `dispatchBranchConflictRecovery` still `MarkHandled`s a
retry-budget slot. Successive polls cancel and re-dispatch the parked workflow,
spending the entire bounded budget on dispatches where nothing ran, then
escalate to `human-required` with a misleading "branch conflict recovery
attempted N time(s) and failed" reason.

Real-world hit: a task whose branch merged cleanly onto main sat stuck for
days in this loop, because the pool was deadlocked (#1861) so the reconcile
step never got a slot. The recovery burned its budget on phantom attempts
instead of waiting.

> Changelog: fix(review): park conflict recovery on pool-busy

## Implementation information

- New `workflow.Engine.WorkflowParkedWaiting(taskID, workflowID)` reports
  whether the task's active workflow is `workflowID` and parked mid-run in
  `ExecWaiting` (non-empty `CurrentStep`) — the state a `StepRunAgent` step
  lands in after `ErrAgentPoolBusy`/`ErrTestRunnerBusy`/`ErrDispatchInFlight`.
- `RecoverStaleBranchConflict` returns handled (no cancel, no re-dispatch, no
  `MarkHandled`) when a `branch-conflict-fix` workflow is already parked
  waiting for the task. `ResumeStalled` re-drives the parked `fix` step once a
  pool slot frees, so recovery self-heals rather than exhausting its budget.
- Regression test: a parked fix workflow is left untouched and neither the
  branch-conflict nor conflict retry budget is charged.

Addresses #1874; related to #1633 / #1863. Complements #1877 (the pool-reaper
fix that removes the saturation this loop mishandled).

## Supporting documentation

`go test ./internal/sybra/review/ ./internal/workflow/` and
`golangci-lint run` on both packages pass clean.
