### PR TITLE
fix(workflow): resume parked create_pr/push steps

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -773,6 +773,15 @@ func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
 	}
 }
 
+func isResumableStepType(t StepType) bool {
+	switch t {
+	case StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepCreatePR, StepPushBranch:
+		return true
+	default:
+		return false
+	}
+}
+
 func dispatchPriorityRank(status string) int {
 	switch status {
 	case "in-review", "ready-pr":
@@ -901,11 +910,7 @@ func (e *Engine) ResumeStalled() {
 			}
 		}
 
-		// Only resume async agent steps where no agent is running, plus
-		// classify_task: it's synchronous but can park in ExecWaiting on
-		// engine shutdown mid-classify (see engine_steps_classify.go), and
-		// nothing else re-drives a parked sync step.
-		if step.Type != StepRunAgent && step.Type != StepParallel && step.Type != StepBestOfN && step.Type != StepClassifyTask {
+		if !isResumableStepType(step.Type) {
 			continue
 		}
 		if retryAt, ok := workflowRetryAfter(t.Workflow); ok && time.Now().Before(retryAt) {

--- a/internal/workflow/engine_resume_pr_steps_test.go
+++ b/internal/workflow/engine_resume_pr_steps_test.go
@@ -67,3 +67,49 @@ func TestResumeStalled_ResumesParkedCreatePR(t *testing.T) {
 		t.Fatalf("PRNumber = %d, want 42 — parked create_pr was not resumed (status=%q reason=%q)", ti.PRNumber, ti.Status, tasks.Reason("t1"))
 	}
 }
+
+func TestResumeStalled_ResumesParkedPushBranch(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/my-branch")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+	local := headSHA(t, wtPath)
+
+	store := newTestStore(t)
+	if err := store.Save(Definition{
+		ID:   "push-wf",
+		Name: "push wf",
+		Steps: []Step{
+			{ID: "push_existing_pr", Name: "Push Branch", Type: StepPushBranch, Next: []Transition{{GoTo: ""}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "ready-pr",
+		Branch:    "feat/my-branch",
+		PRNumber:  7,
+		ProjectID: "acme/widgets",
+		Workflow: &Execution{
+			WorkflowID:  "push-wf",
+			CurrentStep: "push_existing_pr",
+			State:       ExecWaiting,
+			Variables: map[string]string{
+				workflowRetryAfterVar: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+	})
+
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetPRHeadFetcher(&fakePRHeadFetcher{sha: local})
+
+	engine.ResumeStalled()
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow.State != ExecCompleted || ti.Workflow.CurrentStep != "" {
+		t.Fatalf("workflow state = %v at step %q, want completed — parked push_existing_pr was not resumed (reason=%q)",
+			ti.Workflow.State, ti.Workflow.CurrentStep, tasks.Reason("t1"))
+	}
+}

--- a/internal/workflow/engine_resume_pr_steps_test.go
+++ b/internal/workflow/engine_resume_pr_steps_test.go
@@ -1,0 +1,69 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsResumableStepType(t *testing.T) {
+	resumable := []StepType{StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepCreatePR, StepPushBranch}
+	for _, st := range resumable {
+		if !isResumableStepType(st) {
+			t.Errorf("isResumableStepType(%q) = false, want true", st)
+		}
+	}
+	notResumable := []StepType{StepSetStatus, StepCondition, StepShell, StepWaitHuman, StepSyncBranch}
+	for _, st := range notResumable {
+		if isResumableStepType(st) {
+			t.Errorf("isResumableStepType(%q) = true, want false", st)
+		}
+	}
+}
+
+func TestResumeStalled_ResumesParkedCreatePR(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/my-branch")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+
+	store := newTestStore(t)
+	if err := store.Save(Definition{
+		ID:   "pr-wf",
+		Name: "pr wf",
+		Steps: []Step{
+			{ID: "create_pr", Name: "Create PR", Type: StepCreatePR, Next: []Transition{{GoTo: ""}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:          "t1",
+		Status:      "ready-pr",
+		Branch:      "feat/my-branch",
+		ProjectID:   "acme/widgets",
+		ProjectType: "pet",
+		Title:       "feat(x): y",
+		Body:        "body",
+		Workflow: &Execution{
+			WorkflowID:  "pr-wf",
+			CurrentStep: "create_pr",
+			State:       ExecWaiting,
+			Variables: map[string]string{
+				workflowRetryAfterVar: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+	})
+
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	creator := &fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)}
+	engine.SetPRCreator(creator)
+	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
+
+	engine.ResumeStalled()
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.PRNumber != 42 {
+		t.Fatalf("PRNumber = %d, want 42 — parked create_pr was not resumed (status=%q reason=%q)", ti.PRNumber, ti.Status, tasks.Reason("t1"))
+	}
+}


### PR DESCRIPTION
## Motivation

A task that reached `create_pr` (or `push_existing_pr`) and hit a transient
push/PR-create flake parked itself in `ExecWaiting` via `parkStepForRetry`
with a 15-minute `retry_after`. But `ResumeStalled` only re-drives async
agent steps plus `classify_task` — it skipped every other synchronous step.
So the parked `create_pr` was never re-driven: the task sat at `ready-pr`
indefinitely with no PR, no CI, and no agent. Observed live on a task whose
branch was already fully pushed — the flake was purely transient, yet the
workflow never retried.

> Changelog: fix(workflow): resume parked create_pr/push steps

## Implementation information

- Extract the resume allowlist into `isResumableStepType` and add
  `StepCreatePR` / `StepPushBranch` alongside the existing resumable types.
  The resume path already anticipated sync steps (its `fireComplete` handling
  is documented as defensive for exactly this case).
- `TestResumeStalled_ResumesParkedCreatePR` reproduces the stuck-at-`ready-pr`
  scenario end-to-end (fails without the fix: PR is never created) and
  `TestIsResumableStepType` locks the allowlist.

## Supporting documentation

`create_pr`/`push_existing_pr` are synchronous steps (`StepCreatePR` /
`StepPushBranch`) that own a `parkStepForRetry` backoff in
`classifyPRGitError`; they were migrated off the old create-pr agent but never
added to the resume allowlist.
