### PR TITLE
fix(project): sign and attribute recovery commits

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -482,15 +482,7 @@ func AutoCommitUncommitted(ctx context.Context, wtPath, message string) bool {
 	if err := add.Run(); err != nil {
 		return false
 	}
-	// --no-verify skips repo pre-commit hooks (installed from .sybra.yaml) so a
-	// failing hook can't defeat this recovery path. -c user.* supplies a
-	// fallback identity for worktrees where the agent never configured one.
-	commit := exec.CommandContext(ctx, "git",
-		"-c", "user.name=Sybra",
-		"-c", "user.email=sybra@localhost",
-		"commit", "--no-verify", "--no-gpg-sign", "--signoff", "-m", message)
-	commit.Dir = wtPath
-	return commit.Run() == nil
+	return runRecoveryCommit(ctx, wtPath, message) == nil
 }
 
 // CheckpointCommit stages and commits the current worktree state with message.
@@ -514,19 +506,8 @@ func CheckpointCommit(ctx context.Context, wtPath, message string) (committed bo
 		return false, fmt.Errorf("git add -A: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 
-	// Mirror AutoCommitUncommitted's safety nets: --no-verify skips repo
-	// pre-commit hooks (installed from .sybra.yaml) so a failing/lint-dirty hook
-	// can't defeat a mid-work checkpoint, and -c user.* supplies a fallback
-	// identity for worktrees where the agent never configured one. Without these
-	// a checkpoint fails exactly when it matters most — mid-implementation, with
-	// code plausibly lint-dirty — turning the safety net into a hard failure.
-	commit := exec.CommandContext(ctx, "git",
-		"-c", "user.name=Sybra",
-		"-c", "user.email=sybra@localhost",
-		"commit", "--no-verify", "--no-gpg-sign", "--signoff", "-m", message)
-	commit.Dir = wtPath
-	if out, err := commit.CombinedOutput(); err != nil {
-		return false, fmt.Errorf("git commit checkpoint: %w: %s", err, strings.TrimSpace(string(out)))
+	if err := runRecoveryCommit(ctx, wtPath, message); err != nil {
+		return false, fmt.Errorf("checkpoint: %w", err)
 	}
 	return true, nil
 }

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -410,8 +410,8 @@ func TestAutoCommitUncommitted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
-	if !strings.Contains(string(bodyOut), "Signed-off-by: Sybra <sybra@localhost>") {
-		t.Errorf("commit body missing DCO trailer, got %q", string(bodyOut))
+	if !strings.Contains(string(bodyOut), "Signed-off-by: Test <test@test.com>") {
+		t.Errorf("recovery commit should sign off with the worktree identity, got %q", string(bodyOut))
 	}
 
 	// Idempotent: nothing left to commit on the now-clean tree.

--- a/internal/project/recovery_commit.go
+++ b/internal/project/recovery_commit.go
@@ -1,0 +1,53 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func gitIdentityConfigured(ctx context.Context, wtPath string) bool {
+	for _, key := range []string{"user.name", "user.email"} {
+		cmd := exec.CommandContext(ctx, "git", "config", "--get", key)
+		cmd.Dir = wtPath
+		out, err := cmd.Output()
+		if err != nil || strings.TrimSpace(string(out)) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func recoveryCommitArgs(message string, hasIdentity, sign bool) []string {
+	var args []string
+	if !hasIdentity {
+		args = append(args, "-c", "user.name=Sybra", "-c", "user.email=sybra@localhost")
+	}
+	args = append(args, "commit", "--no-verify", "--signoff")
+	if sign {
+		args = append(args, "-S")
+	} else {
+		args = append(args, "--no-gpg-sign")
+	}
+	return append(args, "-m", message)
+}
+
+func runRecoveryCommit(ctx context.Context, wtPath, message string) error {
+	hasIdentity := gitIdentityConfigured(ctx, wtPath)
+	sign := GPGSigningAvailable(ctx)
+	out, err := gitCommitOutput(ctx, wtPath, recoveryCommitArgs(message, hasIdentity, sign))
+	if err != nil && sign {
+		out, err = gitCommitOutput(ctx, wtPath, recoveryCommitArgs(message, hasIdentity, false))
+	}
+	if err != nil {
+		return fmt.Errorf("recovery commit: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func gitCommitOutput(ctx context.Context, wtPath string, args []string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = wtPath
+	return cmd.CombinedOutput()
+}

--- a/internal/project/recovery_commit_test.go
+++ b/internal/project/recovery_commit_test.go
@@ -1,0 +1,72 @@
+package project
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func isolateGitSigning(t *testing.T) {
+	t.Helper()
+	empty := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", empty)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+func TestRecoveryCommitArgs(t *testing.T) {
+	signedWithIdentity := recoveryCommitArgs("msg", true, true)
+	if slices.Contains(signedWithIdentity, "user.email=sybra@localhost") {
+		t.Error("should not inject the Sybra identity when the worktree has one")
+	}
+	if !slices.Contains(signedWithIdentity, "-S") || slices.Contains(signedWithIdentity, "--no-gpg-sign") {
+		t.Errorf("want -S and no --no-gpg-sign when signing, got %v", signedWithIdentity)
+	}
+
+	keyless := recoveryCommitArgs("msg", true, false)
+	if !slices.Contains(keyless, "--no-gpg-sign") || slices.Contains(keyless, "-S") {
+		t.Errorf("want --no-gpg-sign and no -S when keyless, got %v", keyless)
+	}
+
+	noIdentity := recoveryCommitArgs("msg", false, false)
+	if !slices.Contains(noIdentity, "user.name=Sybra") || !slices.Contains(noIdentity, "user.email=sybra@localhost") {
+		t.Errorf("want Sybra fallback identity when none configured, got %v", noIdentity)
+	}
+
+	for _, args := range [][]string{signedWithIdentity, keyless, noIdentity} {
+		if !slices.Contains(args, "--no-verify") || !slices.Contains(args, "--signoff") {
+			t.Errorf("recovery commit must always --no-verify --signoff, got %v", args)
+		}
+	}
+}
+
+func TestAutoCommitUncommitted_FallbackIdentityWhenNoneConfigured(t *testing.T) {
+	isolateGitSigning(t)
+
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "-C", dir, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "work.txt"), []byte("recovered\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !AutoCommitUncommitted(context.Background(), dir, "wip: recovered work") {
+		t.Fatal("expected AutoCommitUncommitted to commit via the Sybra fallback identity")
+	}
+
+	out, err := exec.Command("git", "-C", dir, "log", "-1", "--format=%an <%ae>%n%(trailers:key=Signed-off-by,valueonly)").Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "Sybra <sybra@localhost>") {
+		t.Errorf("expected Sybra fallback author and signoff, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Motivation

The `wip: auto-commit uncommitted implementation work` recovery commit landed
on PR branches GPG-unsigned and attributed to a `Sybra <sybra@localhost>` bot,
even though the surrounding agent commits were signed with the real identity.
`AutoCommitUncommitted` and `CheckpointCommit` hardcoded both `--no-gpg-sign`
and the bot identity, so the DCO-signoff work shipped for normal agent commits
(the prepare-commit-msg hook) never reached these paths — they bypass the hook
with `--no-verify` and self-add only a bot signoff.

> Changelog: fix(project): sign and attribute recovery commits

## Implementation information

- Route both recovery paths through `runRecoveryCommit`:
  - attribute to the worktree's own git identity when it resolves one, falling
    back to the Sybra bot only when none is configured;
  - GPG-sign when a signing key is available, retrying once with
    `--no-gpg-sign` if the signed attempt fails (e.g. a locked gpg-agent) so
    the safety-net commit is never lost;
  - keyless hosts (the Linux server) still commit unsigned exactly as before.
- `--no-verify` and `--signoff` are unchanged.
- Tests: `TestRecoveryCommitArgs` (argv wiring), an updated
  `TestAutoCommitUncommitted` (honours the worktree identity), and
  `TestAutoCommitUncommitted_FallbackIdentityWhenNoneConfigured` (bot fallback
  when no identity resolves, under isolated git config).

## Supporting documentation

The merge-commit recovery paths (`MergeOnto`, `TryCleanMerge`) share the same
`--no-gpg-sign` + bot-identity gap but need a distinct, conflict-aware fix;
left as a follow-up.
