### PR TITLE
fix(github): find fork PRs in create_pr guard

### DIFF
--- a/internal/github/pr_find.go
+++ b/internal/github/pr_find.go
@@ -15,10 +15,13 @@ import (
 var findPRRunner = ghRunCtx
 
 // FindPRForBranch returns the number of an open PR whose head is branch, if
-// one exists. head is the `gh pr list --head` value: a bare branch name, or
-// "fork-owner:branch" for a fork-hosted branch. found is false (with nil err)
-// when no PR matches; a non-nil err signals the lookup itself failed and the
-// caller cannot distinguish "no PR" from "could not check".
+// one exists. head may be a bare branch name or "fork-owner:branch"; since
+// `gh pr list --head` matches only the bare branch, the owner (when present)
+// is stripped for the query and then used to filter results by
+// headRepositoryOwner, so a same-named branch on another fork is not
+// mis-matched. found is false (with nil err) when no PR matches; a non-nil err
+// signals the lookup itself failed and the caller cannot distinguish "no PR"
+// from "could not check".
 func FindPRForBranch(ctx context.Context, repo, head string) (number int, found bool, err error) {
 	owner, branch := splitHead(head)
 	out, runErr := findPRRunner(ctx, "pr", "list",

--- a/internal/github/pr_find.go
+++ b/internal/github/pr_find.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // findPRRunner runs `gh pr list` for FindPRForBranch. A package var so tests
@@ -19,22 +20,32 @@ var findPRRunner = ghRunCtx
 // when no PR matches; a non-nil err signals the lookup itself failed and the
 // caller cannot distinguish "no PR" from "could not check".
 func FindPRForBranch(ctx context.Context, repo, head string) (number int, found bool, err error) {
+	owner, branch := splitHead(head)
 	out, runErr := findPRRunner(ctx, "pr", "list",
-		"--repo", repo, "--head", head, "--state", "open",
-		"--json", "number", "--limit", "1")
+		"--repo", repo, "--head", branch, "--state", "open",
+		"--json", "number,headRepositoryOwner", "--limit", "20")
 	if runErr != nil {
-		return 0, false, fmt.Errorf("gh pr list --head %s: %s: %w", head, sanitizeGHOutput(out), runErr)
+		return 0, false, fmt.Errorf("gh pr list --head %s: %s: %w", branch, sanitizeGHOutput(out), runErr)
 	}
 	var prs []struct {
-		Number int `json:"number"`
+		Number              int `json:"number"`
+		HeadRepositoryOwner struct {
+			Login string `json:"login"`
+		} `json:"headRepositoryOwner"`
 	}
 	if jsonErr := json.Unmarshal(out, &prs); jsonErr != nil {
 		return 0, false, fmt.Errorf("parse pr list: %w", jsonErr)
 	}
-	if len(prs) == 0 || prs[0].Number <= 0 {
-		return 0, false, nil
+	for _, pr := range prs {
+		if pr.Number <= 0 {
+			continue
+		}
+		if owner != "" && !strings.EqualFold(pr.HeadRepositoryOwner.Login, owner) {
+			continue
+		}
+		return pr.Number, true, nil
 	}
-	return prs[0].Number, true, nil
+	return 0, false, nil
 }
 
 // FindPRForBranchAnyState resolves the PR for a branch across every state so a
@@ -44,15 +55,19 @@ func FindPRForBranch(ctx context.Context, repo, head string) (number int, found 
 // when no unambiguous PR matches — several open PRs, or only closed-unmerged
 // ones, leave the caller to make no change.
 func FindPRForBranchAnyState(ctx context.Context, repo, head string) (number int, state string, found bool, err error) {
+	owner, branch := splitHead(head)
 	out, runErr := findPRRunner(ctx, "pr", "list",
-		"--repo", repo, "--head", head, "--state", "all",
-		"--json", "number,state", "--limit", "20")
+		"--repo", repo, "--head", branch, "--state", "all",
+		"--json", "number,state,headRepositoryOwner", "--limit", "20")
 	if runErr != nil {
-		return 0, "", false, fmt.Errorf("gh pr list --head %s --state all: %s: %w", head, sanitizeGHOutput(out), runErr)
+		return 0, "", false, fmt.Errorf("gh pr list --head %s --state all: %s: %w", branch, sanitizeGHOutput(out), runErr)
 	}
 	var prs []struct {
-		Number int    `json:"number"`
-		State  string `json:"state"`
+		Number              int    `json:"number"`
+		State               string `json:"state"`
+		HeadRepositoryOwner struct {
+			Login string `json:"login"`
+		} `json:"headRepositoryOwner"`
 	}
 	if jsonErr := json.Unmarshal(out, &prs); jsonErr != nil {
 		return 0, "", false, fmt.Errorf("parse pr list: %w", jsonErr)
@@ -60,6 +75,9 @@ func FindPRForBranchAnyState(ctx context.Context, repo, head string) (number int
 	var mergedNum, openNum, openCount int
 	for _, pr := range prs {
 		if pr.Number <= 0 {
+			continue
+		}
+		if owner != "" && !strings.EqualFold(pr.HeadRepositoryOwner.Login, owner) {
 			continue
 		}
 		switch pr.State {
@@ -79,4 +97,11 @@ func FindPRForBranchAnyState(ctx context.Context, repo, head string) (number int
 		return openNum, "OPEN", true, nil
 	}
 	return 0, "", false, nil
+}
+
+func splitHead(head string) (owner, branch string) {
+	if o, b, found := strings.Cut(head, ":"); found {
+		return o, b
+	}
+	return "", head
 }

--- a/internal/github/pr_find_test.go
+++ b/internal/github/pr_find_test.go
@@ -14,7 +14,7 @@ func TestFindPRForBranch_Found(t *testing.T) {
 	var gotArgs []string
 	findPRRunner = func(_ context.Context, args ...string) ([]byte, error) {
 		gotArgs = args
-		return []byte(`[{"number":77}]`), nil
+		return []byte(`[{"number":77,"headRepositoryOwner":{"login":"myfork"}}]`), nil
 	}
 
 	number, found, err := FindPRForBranch(context.Background(), "acme/widgets", "myfork:my-branch")
@@ -25,10 +25,45 @@ func TestFindPRForBranch_Found(t *testing.T) {
 		t.Fatalf("got (%d, %v), want (77, true)", number, found)
 	}
 	joined := strings.Join(gotArgs, " ")
-	for _, want := range []string{"pr list", "--repo acme/widgets", "--head myfork:my-branch", "--state open"} {
+	for _, want := range []string{"pr list", "--repo acme/widgets", "--head my-branch", "--state open"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("args %q missing %q", joined, want)
 		}
+	}
+	if strings.Contains(joined, "--head myfork:my-branch") {
+		t.Errorf("gh pr list --head must use the bare branch, got %q", joined)
+	}
+}
+
+func TestFindPRForBranch_ForkOwnerMismatchSkipped(t *testing.T) {
+	orig := findPRRunner
+	t.Cleanup(func() { findPRRunner = orig })
+	findPRRunner = func(context.Context, ...string) ([]byte, error) {
+		return []byte(`[{"number":88,"headRepositoryOwner":{"login":"someone-else"}}]`), nil
+	}
+
+	number, found, err := FindPRForBranch(context.Background(), "acme/widgets", "myfork:shared-branch")
+	if err != nil {
+		t.Fatalf("FindPRForBranch: %v", err)
+	}
+	if found || number != 0 {
+		t.Fatalf("got (%d, %v), want (0, false) — a PR from a different fork owner must not match", number, found)
+	}
+}
+
+func TestFindPRForBranch_BareBranchMatchesAnyOwner(t *testing.T) {
+	orig := findPRRunner
+	t.Cleanup(func() { findPRRunner = orig })
+	findPRRunner = func(context.Context, ...string) ([]byte, error) {
+		return []byte(`[{"number":91,"headRepositoryOwner":{"login":"acme"}}]`), nil
+	}
+
+	number, found, err := FindPRForBranch(context.Background(), "acme/widgets", "same-repo-branch")
+	if err != nil {
+		t.Fatalf("FindPRForBranch: %v", err)
+	}
+	if !found || number != 91 {
+		t.Fatalf("got (%d, %v), want (91, true)", number, found)
 	}
 }
 
@@ -92,6 +127,27 @@ func TestFindPRForBranchAnyState(t *testing.T) {
 				t.Errorf("args %q missing --state all", joined)
 			}
 		})
+	}
+}
+
+func TestFindPRForBranchAnyState_ForkOwnerFilter(t *testing.T) {
+	orig := findPRRunner
+	t.Cleanup(func() { findPRRunner = orig })
+	var gotArgs []string
+	findPRRunner = func(_ context.Context, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(`[{"number":5,"state":"OPEN","headRepositoryOwner":{"login":"other"}},{"number":6,"state":"OPEN","headRepositoryOwner":{"login":"myfork"}}]`), nil
+	}
+
+	number, state, found, err := FindPRForBranchAnyState(context.Background(), "acme/widgets", "myfork:b")
+	if err != nil {
+		t.Fatalf("FindPRForBranchAnyState: %v", err)
+	}
+	if !found || number != 6 || state != "OPEN" {
+		t.Fatalf("got (%d, %q, %v), want (6, OPEN, true) — owner filter must ignore the other fork", number, state, found)
+	}
+	if joined := strings.Join(gotArgs, " "); strings.Contains(joined, "--head myfork:b") {
+		t.Errorf("gh pr list --head must use the bare branch, got %q", joined)
 	}
 }
 

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -92,6 +92,9 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 		Body:  body,
 	})
 	if createErr != nil {
+		if num, ok := e.adoptExistingPROnConflict(taskID, t.ProjectID, headArg, createErr); ok {
+			return stepDone(step, fmt.Sprintf("pr #%d already existed, adopted", num))
+		}
 		return e.classifyPRGitError(taskID, step, wfExec, t, createErr, "create_pr")
 	}
 
@@ -103,6 +106,22 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 	}
 	e.logger.Info("workflow.create-pr.created", "task_id", taskID, "pr", number)
 	return stepDone(step, fmt.Sprintf("created pr #%d", number))
+}
+
+func (e *Engine) adoptExistingPROnConflict(taskID, repo, headArg string, createErr error) (int, bool) {
+	if createErr == nil || !strings.Contains(strings.ToLower(createErr.Error()), "already exists") {
+		return 0, false
+	}
+	existing, ok := e.findExistingPRForBranch(repo, headArg)
+	if !ok {
+		return 0, false
+	}
+	if err := e.tasks.UpdateTaskPR(taskID, existing); err != nil {
+		e.logger.Warn("workflow.create-pr.adopt-existing", "task_id", taskID, "pr", existing, "err", err)
+		return 0, false
+	}
+	e.logger.Info("workflow.create-pr.adopt-existing", "task_id", taskID, "pr", existing)
+	return existing, true
 }
 
 // prWorktreeAndBranch resolves the on-disk worktree and branch used by

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -710,3 +710,42 @@ func TestClassifyPRGitError_UnclassifiedFailureParksOnceThenEscalates(t *testing
 		t.Errorf("status = %q, want human-required after exhausting push retries", ti.Status)
 	}
 }
+
+type raceThenFoundFinder struct{ n int }
+
+func (f *raceThenFoundFinder) FindPRForBranch(context.Context, string, string) (number int, found bool, err error) {
+	f.n++
+	if f.n == 1 {
+		return 0, false, nil
+	}
+	return 55, true, nil
+}
+
+func TestExecCreatePR_AdoptsExistingPROnAlreadyExistsConflict(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/my-branch")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+
+	tasks := newMemTasks()
+	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
+	tasks.Put(task)
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetPRFinder(&raceThenFoundFinder{})
+	engine.SetPRCreator(&fakePRCreator{err: errors.New(`a pull request for branch "acme:feat/my-branch" into branch "main" already exists: https://github.com/acme/widgets/pull/55`)})
+	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execCreatePR: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, output = %q", out.Status, out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.PRNumber != 55 {
+		t.Errorf("PRNumber = %d, want 55 (adopted existing PR)", ti.PRNumber)
+	}
+	if ti.Status == "human-required" {
+		t.Errorf("must not escalate to human-required when the PR already exists: %s", tasks.Reason("t1"))
+	}
+}


### PR DESCRIPTION
## Motivation

Task `e150a89b` re-entered `create_pr` (thanks to the resume fix in the prior
PR) but escalated to **human-required** with:

> a pull request for branch "Automaat:feat/…-e150a89b" into branch "master" already exists: https://github.com/kumahq/kuma/pull/17321

The PR was already open — `create_pr`'s idempotency guard just couldn't see it.
The guard passes `headArg` (`"owner:branch"`, the form `gh pr create --head`
needs for a fork-hosted branch) to `FindPRForBranch`, but `gh pr list --head`
matches only the **bare branch name** and returns `[]` for `"owner:branch"`.
Verified against the live repo:

```
gh pr list --repo kumahq/kuma --head "Automaat:feat/…-e150a89b"  → []
gh pr list --repo kumahq/kuma --head "feat/…-e150a89b"           → [#17321]
```

So the pre-create lookup missed the existing fork PR, `create_pr` ran, and
GitHub rejected the duplicate → human-required.

> Changelog: fix(github): find fork PRs in create_pr guard

## Implementation information

- `FindPRForBranch` / `FindPRForBranchAnyState` split the head into
  `owner` + `branch`, query `gh pr list` with the **bare branch**, and filter
  results by `headRepositoryOwner` — so a same-named branch on a *different*
  fork can't be mis-adopted.
- `execCreatePR` additionally adopts the existing PR when `CreatePR` still
  fails with `already exists` (a race: the PR appears between the guard and
  the create call), re-checking via the now-correct finder rather than
  escalating.
- Tests: fork-head stripping + owner-filter (`internal/github`), and an
  adopt-on-conflict regression that parks/escalates without the fix
  (`internal/workflow`).

## Supporting documentation

Follows the two prior fixes for this task: resume of parked `create_pr` steps
(#1888) and recovery-commit signing (#1889).
