### PR TITLE
fix(server): bound shutdown so self-restart exits

### DIFF
--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -134,6 +134,7 @@ func run() (int, error) {
 	select {
 	case <-ctx.Done():
 		logger.Info("server.shutdown")
+		go forceExitAfter(logger, shutdownHardDeadline, &restartRequested)
 		// 30s window covers the agent manager's 20s grace (giving SIGTERM'd
 		// claude/codex processes a chance to flush their final result event)
 		// plus headroom for HTTP handlers to drain. Previously 10s, which
@@ -153,6 +154,18 @@ func run() (int, error) {
 		return autoupdate.RestartExitCode, nil
 	}
 	return 0, nil
+}
+
+const shutdownHardDeadline = 60 * time.Second
+
+func forceExitAfter(logger *slog.Logger, d time.Duration, restart *atomic.Bool) {
+	time.Sleep(d)
+	code := 0
+	if restart.Load() {
+		code = autoupdate.RestartExitCode
+	}
+	logger.Error("shutdown.forced", "after", d.String(), "code", code)
+	os.Exit(code)
 }
 
 // buildMux wires every HTTP route the server exposes onto a fresh ServeMux:

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -529,7 +529,9 @@ func (a *App) Shutdown(_ context.Context) {
 	if a.cancel != nil {
 		a.cancel()
 	}
-	a.wg.Wait()
+	if !waitGroupTimeout(&a.wg, appShutdownWaitGrace) {
+		a.logger.Warn("app.shutdown.wait_timeout", "grace", appShutdownWaitGrace)
+	}
 	if a.agents != nil {
 		a.agents.Shutdown()
 	}
@@ -543,6 +545,22 @@ func (a *App) Shutdown(_ context.Context) {
 		a.homeUnlock = nil
 	}
 	a.logger.Info("app.stopped")
+}
+
+const appShutdownWaitGrace = 15 * time.Second
+
+func waitGroupTimeout(wg *sync.WaitGroup, grace time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(grace):
+		return false
+	}
 }
 
 // StartAgent delegates to agentorch.Orchestrator and is exposed as a Wails-bound method.

--- a/internal/sybra/app_shutdown_test.go
+++ b/internal/sybra/app_shutdown_test.go
@@ -1,0 +1,34 @@
+package sybra
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWaitGroupTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		block bool
+		grace time.Duration
+		want  bool
+	}{
+		{name: "completes within grace", block: false, grace: time.Second, want: true},
+		{name: "times out when a goroutine never finishes", block: true, grace: 10 * time.Millisecond, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wg sync.WaitGroup
+			wg.Add(1)
+			if !tt.block {
+				go wg.Done()
+			}
+			if got := waitGroupTimeout(&wg, tt.grace); got != tt.want {
+				t.Fatalf("waitGroupTimeout = %v, want %v", got, tt.want)
+			}
+			if tt.block {
+				wg.Done()
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Enabling autoupdate auto-deploy exposed a latent deadlock that takes the server down. `app.Shutdown()` called `a.wg.Wait()` unbounded, so a background goroutine that fails to honor context cancellation deadlocks shutdown forever — the process stops serving (HTTP listener closed) but never exits. This is the same hang that caused the earlier production outage.

It is **fatal for the autoupdate exit-42 self-restart** (used by auto-deploy): `systemd`'s `TimeoutStopSec` only bounds systemd-initiated stops, not a self-requested restart, so a hung server on the self-restart path is never recovered — every auto-deploy took the server down.

> Changelog: fix(server): bound app shutdown so the autoupdate self-restart always exits

## Implementation information

- `internal/sybra/app.go`: bound the WaitGroup wait via `waitGroupTimeout` (`appShutdownWaitGrace` = 15s); log `app.shutdown.wait_timeout` instead of blocking indefinitely.
- `cmd/sybra-server/main.go`: a `shutdownHardDeadline` (60s) watchdog force-exits with the correct code (42 on restart, else 0) as a backstop for any other shutdown-path hang, guaranteeing the exit-42 restart completes.
- `internal/sybra/app_shutdown_test.go`: table test for `waitGroupTimeout` (completes within grace vs times out).

## Supporting documentation

Discovered live: auto-deploy applied a new main SHA, requested restart, and `app.Shutdown` hung (`app.stopping` with no `app.stopped`); `systemctl restart` (systemd-initiated) recovered it. Fix keeps the server on `notify` until merged + deployed.