### PR TITLE
feat(codegen): self-heal missing api shims

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -42,6 +42,7 @@ checks:
   # review/testing so generated files, goimports, and go.mod drift are fixed
   # in the worktree and committed before downstream validation.
   codegen:
+    - mise exec -- go run ./cmd/gen-api-shim
     - mise exec -- golangci-lint fmt ./...
     - mise exec -- go mod tidy
   # Verify suite run by the verify_checks workflow step (reward-hacking

--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -43,6 +43,7 @@ checks:
   # in the worktree and committed before downstream validation.
   codegen:
     - mise exec -- go run ./cmd/gen-api-shim
+    - mise exec -- go generate ./internal/config/...
     - mise exec -- golangci-lint fmt ./...
     - mise exec -- go mod tidy
   # Verify suite run by the verify_checks workflow step (reward-hacking

--- a/cmd/gen-api-shim/main.go
+++ b/cmd/gen-api-shim/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	servicesGoRel = "internal/sybra/services.go"
+	apiTSRel      = "frontend/src/lib/api.ts"
+	apiHTTPTSRel  = "frontend/src/lib/api-http.ts"
+	bindingDirRel = "frontend/bindings/github.com/Automaat/sybra/internal/sybra"
+	bindingBase   = "internal/sybra"
+	importPrefix  = "../../bindings/github.com/Automaat/sybra/"
+)
+
+func main() {
+	root := flag.String("root", ".", "repo root (defaults to the current directory)")
+	checkOnly := flag.Bool("check", false, "exit non-zero when shims are missing instead of writing them")
+	flag.Parse()
+
+	if err := run(*root, *checkOnly); err != nil {
+		fmt.Fprintln(os.Stderr, "gen-api-shim:", err)
+		os.Exit(1)
+	}
+}
+
+func run(root string, checkOnly bool) error {
+	services, err := parseServices(filepath.Join(root, servicesGoRel))
+	if err != nil {
+		return err
+	}
+
+	apiTSPath := filepath.Join(root, apiTSRel)
+	apiHTTPPath := filepath.Join(root, apiHTTPTSRel)
+	apiTS, err := os.ReadFile(apiTSPath)
+	if err != nil {
+		return err
+	}
+	apiHTTP, err := os.ReadFile(apiHTTPPath)
+	if err != nil {
+		return err
+	}
+
+	nextTS, addedTS, err := fillAPITS(string(apiTS), services)
+	if err != nil {
+		return err
+	}
+	nextHTTP, addedHTTP, err := fillAPIHTTP(string(apiHTTP), services, filepath.Join(root, bindingDirRel))
+	if err != nil {
+		return err
+	}
+
+	if len(addedTS) == 0 && len(addedHTTP) == 0 {
+		return nil
+	}
+	if checkOnly {
+		return fmt.Errorf("missing shims (run `go run ./cmd/gen-api-shim`): api.ts=%v api-http.ts=%v", addedTS, addedHTTP)
+	}
+
+	if len(addedTS) > 0 {
+		if err := os.WriteFile(apiTSPath, []byte(nextTS), 0o644); err != nil {
+			return err
+		}
+		fmt.Printf("api.ts: added %s\n", strings.Join(addedTS, ", "))
+	}
+	if len(addedHTTP) > 0 {
+		if err := os.WriteFile(apiHTTPPath, []byte(nextHTTP), 0o644); err != nil {
+			return err
+		}
+		fmt.Printf("api-http.ts: added %s\n", strings.Join(addedHTTP, ", "))
+	}
+	return nil
+}
+
+type service struct {
+	name    string
+	methods []string
+}
+
+var (
+	serviceHeaderRe = regexp.MustCompile(`^\s*"([A-Za-z][A-Za-z0-9]*)":\s*httpapi\.NewService\(`)
+	methodLineRe    = regexp.MustCompile(`^\s*"([A-Z][A-Za-z0-9_]*)",?\s*$`)
+)
+
+func parseServices(path string) ([]service, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var services []service
+	var cur *service
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if m := serviceHeaderRe.FindStringSubmatch(line); m != nil {
+			services = append(services, service{name: m[1]})
+			cur = &services[len(services)-1]
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		if trimmed := strings.TrimSpace(line); trimmed == ")," || trimmed == ")" {
+			cur = nil
+			continue
+		}
+		if m := methodLineRe.FindStringSubmatch(line); m != nil {
+			cur.methods = append(cur.methods, m[1])
+		}
+	}
+	if len(services) == 0 {
+		return nil, fmt.Errorf("no services parsed from %s — check the extraction regex", path)
+	}
+	return services, nil
+}
+
+func bindingModuleBase(serviceName string) string {
+	return strings.ToLower(serviceName)
+}
+
+func insertAfter(lines []string, inserts map[int][]string) []string {
+	if len(inserts) == 0 {
+		return lines
+	}
+	out := make([]string, 0, len(lines)+len(inserts))
+	for i, line := range lines {
+		out = append(out, line)
+		out = append(out, inserts[i]...)
+	}
+	return out
+}

--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -274,9 +274,18 @@ func splitTopLevel(s string) []string {
 }
 
 func mapType(t string, bindingImports map[string]string, addImport func(string, string) string) string {
-	t = stripNull(strings.TrimSpace(t))
-	if strings.HasSuffix(t, "[]") {
-		return "Array<" + mapType(t[:len(t)-2], bindingImports, addImport) + ">"
+	t = strings.TrimSpace(t)
+	if inner, ok := strings.CutSuffix(t, ")[]"); ok && strings.HasPrefix(inner, "(") {
+		return "Array<" + mapType(inner[1:], bindingImports, addImport) + ">"
+	}
+	if inner, ok := strings.CutSuffix(t, "[]"); ok {
+		return "Array<" + mapType(inner, bindingImports, addImport) + ">"
+	}
+	if strings.HasPrefix(t, "(") && strings.HasSuffix(t, ")") {
+		return mapType(t[1:len(t)-1], bindingImports, addImport)
+	}
+	if s := stripNull(t); s != t {
+		return mapType(s, bindingImports, addImport)
 	}
 	if strings.HasPrefix(t, "Array<") && strings.HasSuffix(t, ">") {
 		return "Array<" + mapType(t[len("Array<"):len(t)-1], bindingImports, addImport) + ">"

--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	apiTSConstRe   = regexp.MustCompile(`^export const ([A-Za-z0-9_]+)\b`)
+	apiTSImportRe  = regexp.MustCompile(`^import \* as (\w+) from '[^']*/([a-z0-9]+)\.js'`)
+	apiHTTPFuncRe  = regexp.MustCompile(`^export (?:async )?function ([A-Za-z0-9_]+)\b`)
+	apiHTTPImpRe   = regexp.MustCompile(`^import type \{ (.*) \} from '([^']*)'`)
+	bindingImpRe   = regexp.MustCompile(`^import \* as ([A-Za-z0-9_$]+) from "([^"]+)"`)
+	bindingImportP = "@wailsio/runtime"
+)
+
+func fillAPITS(src string, services []service) (out string, added []string, err error) {
+	lines := strings.Split(src, "\n")
+
+	existing := map[string]bool{}
+	aliasByBase := map[string]string{}
+	lastAliasLine := map[string]int{}
+	for i, line := range lines {
+		if m := apiTSConstRe.FindStringSubmatch(line); m != nil {
+			existing[m[1]] = true
+		}
+		if m := apiTSImportRe.FindStringSubmatch(line); m != nil {
+			aliasByBase[m[2]] = m[1]
+		}
+		if _, rest, ok := strings.Cut(line, " = pick("); ok {
+			if alias, _, ok := strings.Cut(rest, "."); ok {
+				lastAliasLine[alias] = i
+			}
+		}
+	}
+
+	inserts := map[int][]string{}
+	for _, svc := range services {
+		alias := aliasByBase[bindingModuleBase(svc.name)]
+		if alias == "" {
+			continue
+		}
+		for _, method := range svc.methods {
+			if existing[method] {
+				continue
+			}
+			anchor, ok := lastAliasLine[alias]
+			if !ok {
+				return "", nil, fmt.Errorf("api.ts: no existing block for alias %q to place %q", alias, method)
+			}
+			line := fmt.Sprintf("export const %s = pick(%s.%s, http.%s)", method, alias, method, method)
+			inserts[anchor] = append(inserts[anchor], line)
+			added = append(added, method)
+		}
+	}
+
+	return strings.Join(insertAfter(lines, inserts), "\n"), added, nil
+}
+
+func parseAPIHTTPImports(lines []string) (imports map[string]*moduleImport, localByModuleType map[string]string, lastImportIdx int) {
+	imports = map[string]*moduleImport{}
+	localByModuleType = map[string]string{}
+	for i, line := range lines {
+		if strings.HasPrefix(line, "import ") {
+			lastImportIdx = i
+		}
+		m := apiHTTPImpRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		module := strings.TrimSuffix(strings.TrimPrefix(m[2], importPrefix), ".js")
+		mi := &moduleImport{module: module, lineIndex: i}
+		for raw := range strings.SplitSeq(m[1], ",") {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			name, local := raw, raw
+			if parts := strings.SplitN(raw, " as ", 2); len(parts) == 2 {
+				name, local = strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+			}
+			mi.entries = append(mi.entries, importEntry{name: name, local: local})
+			localByModuleType[module+"."+name] = local
+		}
+		imports[module] = mi
+	}
+	return imports, localByModuleType, lastImportIdx
+}
+
+type importEntry struct {
+	name  string
+	local string
+}
+
+type moduleImport struct {
+	module    string
+	entries   []importEntry
+	lineIndex int
+}
+
+func fillAPIHTTP(src string, services []service, bindingDir string) (out string, added []string, err error) {
+	lines := strings.Split(src, "\n")
+
+	existing := map[string]bool{}
+	for _, line := range lines {
+		if m := apiHTTPFuncRe.FindStringSubmatch(line); m != nil {
+			existing[m[1]] = true
+		}
+	}
+	imports, localByModuleType, lastImportIdx := parseAPIHTTPImports(lines)
+
+	lastCallLine := map[string]int{}
+	for i, line := range lines {
+		for _, svc := range services {
+			if strings.Contains(line, "call('"+svc.name+"'") {
+				lastCallLine[svc.name] = i
+			}
+		}
+	}
+
+	var addedModules []string
+	pending := map[string][]string{}
+	addImport := func(module, typeName string) string {
+		key := module + "." + typeName
+		if local, ok := localByModuleType[key]; ok {
+			return local
+		}
+		localByModuleType[key] = typeName
+		if _, seen := pending[module]; !seen {
+			addedModules = append(addedModules, module)
+		}
+		pending[module] = append(pending[module], typeName)
+		return typeName
+	}
+
+	funcInserts := map[int][]string{}
+	for _, svc := range services {
+		var bindingImports map[string]string
+		var bindingSrc string
+		for _, method := range svc.methods {
+			if existing[method] {
+				continue
+			}
+			if bindingSrc == "" {
+				data, err := os.ReadFile(filepath.Join(bindingDir, bindingModuleBase(svc.name)+".ts"))
+				if err != nil {
+					return "", nil, err
+				}
+				bindingSrc = string(data)
+				bindingImports = parseBindingImports(bindingSrc)
+			}
+			params, ret, ok := parseBindingSig(bindingSrc, method)
+			if !ok {
+				return "", nil, fmt.Errorf("api-http.ts: no binding signature for %s.%s", svc.name, method)
+			}
+			anchor, ok := lastCallLine[svc.name]
+			if !ok {
+				return "", nil, fmt.Errorf("api-http.ts: no existing block for service %q to place %q", svc.name, method)
+			}
+			sig, refs := renderParams(params, bindingImports, addImport)
+			retType := mapType(ret, bindingImports, addImport)
+			line := fmt.Sprintf("export function %s(%s): Promise<%s> { return call('%s', '%s'%s) }",
+				method, sig, retType, svc.name, method, refs)
+			funcInserts[anchor] = append(funcInserts[anchor], line)
+			added = append(added, method)
+		}
+	}
+
+	importInserts := map[int][]string{}
+	for _, module := range addedModules {
+		mi, ok := imports[module]
+		if ok {
+			for _, name := range pending[module] {
+				mi.entries = append(mi.entries, importEntry{name: name, local: name})
+			}
+			lines[mi.lineIndex] = renderImportLine(module, mi.entries)
+			continue
+		}
+		var entries []importEntry
+		for _, name := range pending[module] {
+			entries = append(entries, importEntry{name: name, local: name})
+		}
+		importInserts[lastImportIdx] = append(importInserts[lastImportIdx], renderImportLine(module, entries))
+	}
+
+	merged := map[int][]string{}
+	for idx, v := range funcInserts {
+		merged[idx] = append(merged[idx], v...)
+	}
+	for idx, v := range importInserts {
+		merged[idx] = append(merged[idx], v...)
+	}
+	return strings.Join(insertAfter(lines, merged), "\n"), added, nil
+}
+
+func renderImportLine(module string, entries []importEntry) string {
+	var parts []string
+	for _, e := range entries {
+		if e.name == e.local {
+			parts = append(parts, e.name)
+		} else {
+			parts = append(parts, e.name+" as "+e.local)
+		}
+	}
+	return fmt.Sprintf("import type { %s } from '%s%s.js'", strings.Join(parts, ", "), importPrefix, module)
+}
+
+func parseBindingImports(src string) map[string]string {
+	out := map[string]string{}
+	for line := range strings.SplitSeq(src, "\n") {
+		if strings.Contains(line, bindingImportP) {
+			continue
+		}
+		if m := bindingImpRe.FindStringSubmatch(line); m != nil {
+			rel := strings.TrimSuffix(m[2], ".js")
+			out[m[1]] = path.Clean(path.Join(bindingBase, rel))
+		}
+	}
+	return out
+}
+
+func parseBindingSig(src, method string) (params, ret string, ok bool) {
+	re := regexp.MustCompile(`(?m)^export function ` + regexp.QuoteMeta(method) + `\((.*)\): \$CancellablePromise<(.*)> \{`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		return "", "", false
+	}
+	return m[1], m[2], true
+}
+
+func renderParams(params string, bindingImports map[string]string, addImport func(string, string) string) (sig, refs string) {
+	params = strings.TrimSpace(params)
+	if params == "" {
+		return "", ""
+	}
+	var sigParts, refParts []string
+	for i, raw := range splitTopLevel(params) {
+		typ := "unknown"
+		if _, after, ok := strings.Cut(raw, ":"); ok {
+			typ = strings.TrimSpace(after)
+		}
+		arg := fmt.Sprintf("arg%d", i+1)
+		sigParts = append(sigParts, arg+": "+mapType(typ, bindingImports, addImport))
+		refParts = append(refParts, arg)
+	}
+	return strings.Join(sigParts, ", "), ", " + strings.Join(refParts, ", ")
+}
+
+func splitTopLevel(s string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := range len(s) {
+		switch s[i] {
+		case '<', '(', '{', '[':
+			depth++
+		case '>', ')', '}', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if start < len(s) {
+		out = append(out, strings.TrimSpace(s[start:]))
+	}
+	return out
+}
+
+func mapType(t string, bindingImports map[string]string, addImport func(string, string) string) string {
+	t = stripNull(strings.TrimSpace(t))
+	if strings.HasSuffix(t, "[]") {
+		return "Array<" + mapType(t[:len(t)-2], bindingImports, addImport) + ">"
+	}
+	if strings.HasPrefix(t, "Array<") && strings.HasSuffix(t, ">") {
+		return "Array<" + mapType(t[len("Array<"):len(t)-1], bindingImports, addImport) + ">"
+	}
+	switch t {
+	case "string", "number", "boolean", "void", "any", "unknown", "null", "":
+		return t
+	}
+	if strings.Contains(t, ".") {
+		i := strings.LastIndex(t, ".")
+		alias, name := t[:i], t[i+1:]
+		module := bindingImports[alias]
+		if module == "" {
+			if alias == "$models" {
+				module = bindingBase + "/models"
+			} else {
+				return name
+			}
+		}
+		return addImport(module, name)
+	}
+	return t
+}
+
+func stripNull(t string) string {
+	if !strings.Contains(t, "|") {
+		return t
+	}
+	var kept []string
+	for part := range strings.SplitSeq(t, "|") {
+		part = strings.TrimSpace(part)
+		if part == "null" || part == "undefined" || part == "" {
+			continue
+		}
+		kept = append(kept, part)
+	}
+	return strings.Join(kept, " | ")
+}

--- a/cmd/gen-api-shim/shim_test.go
+++ b/cmd/gen-api-shim/shim_test.go
@@ -31,6 +31,8 @@ func TestMapType(t *testing.T) {
 		{"array", "task$0.Task[]", "Array<Task>", "internal/task/models.Task"},
 		{"array_other_pkg", "artifact$0.ProgressEntry[]", "Array<ProgressEntry>", "internal/artifact/models.ProgressEntry"},
 		{"strip_null", "task$0.Task | null", "Task", "internal/task/models.Task"},
+		{"nullable_union_array", "(task$0.Task | null)[]", "Array<Task>", "internal/task/models.Task"},
+		{"nullable_single_paren", "(task$0.Task | null)", "Task", "internal/task/models.Task"},
 		{"models_alias", "$models.TamperReportDTO", "TamperReportDTO", "internal/sybra/models.TamperReportDTO"},
 	}
 	for _, tt := range tests {

--- a/cmd/gen-api-shim/shim_test.go
+++ b/cmd/gen-api-shim/shim_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func recordingAddImport(seen *[]string) func(string, string) string {
+	return func(module, name string) string {
+		*seen = append(*seen, module+"."+name)
+		return name
+	}
+}
+
+func TestMapType(t *testing.T) {
+	bindingImports := map[string]string{
+		"task$0":     "internal/task/models",
+		"artifact$0": "internal/artifact/models",
+	}
+	tests := []struct {
+		name string
+		in   string
+		want string
+		imp  string
+	}{
+		{"primitive", "string", "string", ""},
+		{"void", "void", "void", ""},
+		{"namespaced", "task$0.Task", "Task", "internal/task/models.Task"},
+		{"array", "task$0.Task[]", "Array<Task>", "internal/task/models.Task"},
+		{"array_other_pkg", "artifact$0.ProgressEntry[]", "Array<ProgressEntry>", "internal/artifact/models.ProgressEntry"},
+		{"strip_null", "task$0.Task | null", "Task", "internal/task/models.Task"},
+		{"models_alias", "$models.TamperReportDTO", "TamperReportDTO", "internal/sybra/models.TamperReportDTO"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seen []string
+			got := mapType(tt.in, bindingImports, recordingAddImport(&seen))
+			if got != tt.want {
+				t.Fatalf("mapType(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if tt.imp != "" && (len(seen) != 1 || seen[0] != tt.imp) {
+				t.Fatalf("mapType(%q) imports = %v, want [%q]", tt.in, seen, tt.imp)
+			}
+			if tt.imp == "" && len(seen) != 0 {
+				t.Fatalf("mapType(%q) unexpected imports %v", tt.in, seen)
+			}
+		})
+	}
+}
+
+func TestSplitTopLevel(t *testing.T) {
+	got := splitTopLevel("title: string, init: Map<string, Update>, n: number")
+	want := []string{"title: string", "init: Map<string, Update>", "n: number"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("splitTopLevel = %v, want %v", got, want)
+	}
+}
+
+func TestFillAPITS(t *testing.T) {
+	src := strings.Join([]string{
+		"import * as TaskSvc from '../../bindings/github.com/Automaat/sybra/internal/sybra/taskservice.js'",
+		"import * as http from './api-http.js'",
+		"",
+		"// TaskService",
+		"export const GetTask = pick(TaskSvc.GetTask, http.GetTask)",
+	}, "\n")
+	services := []service{{name: "TaskService", methods: []string{"GetTask", "DeleteTask"}}}
+
+	out, added, err := fillAPITS(src, services)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 1 || added[0] != "DeleteTask" {
+		t.Fatalf("added = %v, want [DeleteTask]", added)
+	}
+	if !strings.Contains(out, "export const DeleteTask = pick(TaskSvc.DeleteTask, http.DeleteTask)") {
+		t.Fatalf("missing DeleteTask shim:\n%s", out)
+	}
+	if !strings.Contains(out, "export const GetTask = pick(TaskSvc.GetTask, http.GetTask)") {
+		t.Fatalf("clobbered existing GetTask:\n%s", out)
+	}
+
+	out2, added2, err := fillAPITS(out, services)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added2) != 0 || out2 != out {
+		t.Fatalf("second pass not a no-op: added=%v", added2)
+	}
+}
+
+func TestFillAPIHTTP(t *testing.T) {
+	bindingDir := t.TempDir()
+	binding := strings.Join([]string{
+		`import { Call as $Call, CancellablePromise as $CancellablePromise } from "@wailsio/runtime";`,
+		`import * as task$0 from "../task/models.js";`,
+		`export function DeleteTask(id: string): $CancellablePromise<void> {`,
+		`    return $Call.ByID(1, id);`,
+		`}`,
+		`export function CreateTaskWithInit(title: string, init: task$0.Update): $CancellablePromise<task$0.Task> {`,
+		`    return $Call.ByID(2, title, init);`,
+		`}`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(bindingDir, "taskservice.ts"), []byte(binding), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := strings.Join([]string{
+		"import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'",
+		"",
+		"async function call<T>(): Promise<T> { return undefined as T }",
+		"",
+		"// TaskService",
+		"export function GetTask(arg1: string): Promise<Task> { return call('TaskService', 'GetTask', arg1) }",
+	}, "\n")
+	services := []service{{name: "TaskService", methods: []string{"GetTask", "DeleteTask", "CreateTaskWithInit"}}}
+
+	out, added, err := fillAPIHTTP(src, services, bindingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 2 {
+		t.Fatalf("added = %v, want 2", added)
+	}
+	wantLines := []string{
+		"export function DeleteTask(arg1: string): Promise<void> { return call('TaskService', 'DeleteTask', arg1) }",
+		"export function CreateTaskWithInit(arg1: string, arg2: Update): Promise<Task> { return call('TaskService', 'CreateTaskWithInit', arg1, arg2) }",
+		"import type { Task, Update } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'",
+	}
+	for _, w := range wantLines {
+		if !strings.Contains(out, w) {
+			t.Fatalf("missing line:\n%s\n--- output ---\n%s", w, out)
+		}
+	}
+	if strings.Count(out, "internal/task/models.js'") != 1 {
+		t.Fatalf("duplicate task/models import:\n%s", out)
+	}
+
+	out2, added2, err := fillAPIHTTP(out, services, bindingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added2) != 0 || out2 != out {
+		t.Fatalf("second pass not a no-op: added=%v", added2)
+	}
+}
+
+func TestParseServices(t *testing.T) {
+	dir := t.TempDir()
+	src := strings.Join([]string{
+		"package sybra",
+		"func x() {",
+		`	"TaskService": httpapi.NewService(a.taskSvc,`,
+		`		"GetTask",`,
+		`		"DeleteTask",`,
+		`	),`,
+		`	"App": httpapi.NewService(a,`,
+		`		"StartAgent",`,
+		`	),`,
+		"}",
+	}, "\n")
+	path := filepath.Join(dir, "services.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := parseServices(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].name != "TaskService" || len(got[0].methods) != 2 || got[1].name != "App" {
+		t.Fatalf("parseServices = %+v", got)
+	}
+}


### PR DESCRIPTION
## Motivation

Every HTTP-allowlisted Wails method needs a hand-written transport shim in `frontend/src/lib/api.ts` (`export const`) and `frontend/src/lib/api-http.ts` (`export function`). When an implementation adds a method to the `services.go` allowlist but forgets the shim, the change passes review but fails the `check-api-shim-sync` verify gate — and `verify_checks` flips the task straight to `human-required` with no auto-fix path. api-shim drift is a documented dominant first-pass failure class, so this recurs.

> Changelog: feat(codegen): self-heal missing api transport shims

## Implementation information

- New `cmd/gen-api-shim`: an **append-only** generator. It reads the `services.go` allowlist, and for each method missing a shim pulls its typed signature from the already-generated Wails bindings (`frontend/bindings/...`), maps the types (`nsAlias$N.T` → resolved, `T[]` → `Array<T>`, strips `| null`), reuses existing `api-http.ts` import aliases (e.g. `Report as EvaluationReportData`) or injects a new import, and appends the shim under its service block. Existing lines — including hand-written specials like `OpenWorktree`/`OpenInAppBrowser`/`EventsOn` — are never rewritten, so a synchronized tree is a no-op.
- Wired as the **first** `checks.codegen` command in `.sybra.yaml`, so the codegen gate regenerates and commits the shim before `verify_checks` runs. `check-api-shim-sync.sh` stays in the verify suite as the guard for any case the generator can't cover (e.g. a rare name-clash needing a manual alias).
- Table-driven tests cover type mapping, top-level splitting, service parsing, and idempotent append for both files.

Verified end-to-end: deleting shims regenerates them byte-identically; allowlisting a method whose return/param type isn't yet imported injects the import and `npm run check` (tsc) passes with 0 errors.

## Supporting documentation

Addresses the `human-required` failure mode hit by task `f8133f8f` (queue-depth snapshot RPC): the implementation added the method to the HTTP allowlist but never wrote the frontend shims, and 5 prior agent runs never converged on the two-line fix.