### PR TITLE
fix(orch): cancel worktree prep on shutdown

### DIFF
--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -150,6 +150,7 @@ type Orchestrator struct {
 	// the nil guards even if app.go's init order changes to close the window;
 	// the ordering is easy to regress silently.
 	conflictRecovery func(taskID string) bool
+	ctx              context.Context
 }
 
 // New constructs an Orchestrator. Sandboxes and Bgops are late-bound fields,
@@ -189,6 +190,17 @@ func (o *Orchestrator) SetBgops(bgops *bgop.Tracker) {
 // once the review.Handler that implements it exists.
 func (o *Orchestrator) SetConflictRecovery(fn func(taskID string) bool) {
 	o.conflictRecovery = fn
+}
+
+// SetContext late-binds the app root context so dispatch-path worktree/sandbox
+// prep is cancelled on shutdown instead of running detached to its own timeout.
+func (o *Orchestrator) SetContext(ctx context.Context) { o.ctx = ctx }
+
+func (o *Orchestrator) baseCtx() context.Context {
+	if o.ctx != nil {
+		return o.ctx
+	}
+	return context.Background()
 }
 
 // Sandboxes returns the late-bound sandbox manager, for callers (e.g.
@@ -382,10 +394,7 @@ func (o *Orchestrator) resolveDispatchDir(t task.Task, taskID, cleanRetryRef str
 		}
 	}
 	opID, onPhase := o.startWorktreeOp("Preparing worktree: "+t.Title, t.ProjectID, taskID)
-	// context.Background(): StartAgentWithAssignment is reached from both
-	// App.StartAgent (Wails-bound, no ctx) and workflow.AgentDispatcher.StartAgent
-	// (fixed interface signature, no ctx) — no real context to thread here.
-	d, wtErr := o.worktrees.PrepareForTask(context.Background(), t, onPhase)
+	d, wtErr := o.worktrees.PrepareForTask(o.baseCtx(), t, onPhase)
 	if wtErr != nil {
 		o.failWorktreeOp(opID, wtErr)
 		// A tracked agent is still live in this worktree (see
@@ -793,9 +802,7 @@ func (o *Orchestrator) StartChat(projectID, providerName, prompt string) (*agent
 	}
 
 	opID, onPhase := o.startWorktreeOp("Preparing chat worktree", projectID, t.ID)
-	// context.Background(): StartChat is reached from App.StartChat, a
-	// Wails-bound method with no ctx parameter.
-	dir, err := o.worktrees.PrepareForChat(context.Background(), t, onPhase)
+	dir, err := o.worktrees.PrepareForChat(o.baseCtx(), t, onPhase)
 	if err != nil {
 		o.failWorktreeOp(opID, err)
 		if delErr := o.tasks.Delete(t.ID); delErr != nil {
@@ -932,10 +939,7 @@ func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 			return fmt.Errorf("task %s has no project_id: refusing to start pr-fix agent without isolated worktree: %w", taskID, workflow.ErrNoProjectAssigned)
 		}
 		opID, onPhase := o.startWorktreeOp("Preparing worktree: "+t.Title, t.ProjectID, taskID)
-		// context.Background(): StartPRFixAgent implements the recovery package's
-		// Orchestrator interface, a fixed func(taskID string) error signature
-		// invoked from the background stale-agent recovery loop with no ctx.
-		d, wtErr := o.worktrees.PrepareForTask(context.Background(), t, onPhase)
+		d, wtErr := o.worktrees.PrepareForTask(o.baseCtx(), t, onPhase)
 		if wtErr != nil {
 			o.failWorktreeOp(opID, wtErr)
 			return fmt.Errorf("worktree required: %w", wtErr)

--- a/internal/sybra/agentorch/context_test.go
+++ b/internal/sybra/agentorch/context_test.go
@@ -1,0 +1,26 @@
+package agentorch
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBaseCtxFallsBackToBackground(t *testing.T) {
+	o := &Orchestrator{}
+	if o.baseCtx() != context.Background() {
+		t.Fatal("nil app ctx must fall back to context.Background()")
+	}
+}
+
+func TestBaseCtxPropagatesCancel(t *testing.T) {
+	o := &Orchestrator{}
+	ctx, cancel := context.WithCancel(context.Background())
+	o.SetContext(ctx)
+	if o.baseCtx() != ctx {
+		t.Fatal("baseCtx must return the set app ctx")
+	}
+	cancel()
+	if o.baseCtx().Err() == nil {
+		t.Fatal("cancelling the app ctx must propagate through baseCtx (worktree prep aborts on shutdown)")
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -763,6 +763,9 @@ func (a *App) initWorkflowEngine() {
 		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})
 	}
 	a.workflowEngine.SetContext(a.ctx)
+	if a.agentOrch != nil {
+		a.agentOrch.SetContext(a.ctx)
+	}
 	// Recover worktree-prep rebase conflicts via the conflict pr-fix instead of
 	// escalating to a human. Wired here (not at construction) because the
 	// orchestrator is built before the reviewer. Routed through


### PR DESCRIPTION
## Motivation

Root cause of the server shutdown deadlock (follow-up to the bounded-wait mitigation in #1894). `Orchestrator` dispatch ran the worktree **setup batch** (`mise install` / `npm ci` / git clone, up to a 10m timeout) via `PrepareForTask(context.Background(), ...)` (`agentorch.go`). `App.Shutdown` cancels `a.ctx` then waits on `a.wg`, but the `Background()`-anchored setup context never saw that cancel, so any `a.wg` goroutine mid-dispatch blocked until setup finished on its own — deadlocking shutdown **whenever an agent was being dispatched** (and far longer when the setup subprocess zombied under the old Docker PID-1). That exactly matched the observed conditional hang.

> Changelog: fix(orch): thread app context into worktree prep so shutdown cancels it

## Implementation information

- `agentorch.Orchestrator`: add a late-bound `ctx` field + `SetContext` (mirroring `workflow.Engine.SetContext`) + a nil-safe `baseCtx()`.
- Thread `o.baseCtx()` into the setup-batch sites — `PrepareForTask` (StartAgentWithAssignment + StartPRFixAgent) and `PrepareForChat` — so `a.cancel()` aborts setup on shutdown. Quick git/fs ops (sandbox start, worktree remove, retry reset) intentionally left on `Background()` so fast cleanup isn't cut off mid-op.
- Wire `SetContext(a.ctx)` in startup beside `workflowEngine.SetContext`.
- The `waitGroupTimeout` backstop from #1894 stays as defense-in-depth.
- test: `baseCtx` fallback + cancel propagation.

## Supporting documentation

Root-caused by auditing every `a.wg` goroutine for cancel-compliance; the setup batch was the only multi-minute detached-context blocker on the dispatch path.