### PR TITLE
fix(orch): wire SetContext unconditionally

### DIFF
--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -422,6 +422,7 @@ func (a *App) Startup(ctx context.Context) error {
 		LiveAgentChecker: a.agents.HasLiveRegisteredAgentForTask,
 	})
 	a.agentOrch = agentorch.New(a.tasks, a.projects, a.agents, a.audit, a.logger, a.worktrees, a.cfg)
+	a.agentOrch.SetContext(ctx)
 	a.reviewer = review.New(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees, a.renovatePRsForMonitor, a.cfg, a.experience)
 
 	a.initWorkflowEngine()

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -763,9 +763,6 @@ func (a *App) initWorkflowEngine() {
 		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})
 	}
 	a.workflowEngine.SetContext(a.ctx)
-	if a.agentOrch != nil {
-		a.agentOrch.SetContext(a.ctx)
-	}
 	// Recover worktree-prep rebase conflicts via the conflict pr-fix instead of
 	// escalating to a human. Wired here (not at construction) because the
 	// orchestrator is built before the reviewer. Routed through


### PR DESCRIPTION
## Motivation

Copilot review of #1896 (the shutdown-cancel fix) caught a real latent gap: `agentOrch.SetContext(a.ctx)` was wired inside `initWorkflowEngine()`, which **early-returns** when workflows are disabled (`SYBRA_DISABLE_WORKFLOWS=1`) or the workflow store fails to init. In those configs `SetContext` never ran, `o.ctx` stayed nil, and `baseCtx()` silently fell back to `context.Background()` — so the shutdown deadlock fix was inert. (Production is unaffected — the server runs workflows — but it's a correctness gap.)

> Changelog: fix(orch): wire orchestrator context at construction so shutdown-cancel always applies

## Implementation information

Move `agentOrch.SetContext(...)` out of `initWorkflowEngine` to immediately after the orchestrator is constructed in `Startup`, passing the already-cancellable local `ctx` (identical to `a.ctx` at that point, and inherited so it satisfies `contextcheck`). This guarantees the wiring runs regardless of workflow configuration.

## Supporting documentation

Empirically validated on the live server: after #1896 auto-deployed, the pre-fix shutdown hit `app.shutdown.wait_timeout` (the diagnosed hang) and the `waitGroupTimeout` backstop recovered it cleanly in 15s. Follow-up to #1894 and #1896.