### PR TITLE
feat(workflow): auto-fix failed verify checks

### DIFF
--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -43,6 +43,10 @@ steps:
 
         {{acceptanceledger .Task.Body}}
         {{- end}}
+        {{- if getvar .Vars "verify_reask_note"}}
+
+        {{getvar .Vars "verify_reask_note"}}
+        {{- end}}
 
         Before committing broad/sweep changes ("everywhere", "all", "single
         utility", "unified", "no raw X remains"), derive and run a cheap

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -570,7 +570,7 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 	case StepDetectTampering:
 		return e.execDetectTampering(taskID, step, t)
 	case StepVerifyChecks:
-		return e.execVerifyChecks(taskID, step, t)
+		return e.execVerifyChecks(taskID, step, wfExec, t)
 	case StepRoutePRFixResult:
 		return e.execRoutePRFixResult(taskID, step, wfExec, t)
 	case StepRouteTestResult:

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,13 @@ const verifyChecksOutputTail = 8000
 // verifyBlessedTag lets a human accept a verify failure (e.g. a known-flaky
 // suite) and let the task proceed instead of re-blocking on every re-dispatch.
 const verifyBlessedTag = "verify-blessed"
+
+const (
+	verifyChecksImplStepID     = "implement"
+	verifyReaskNoteVar         = "verify_reask_note"
+	verifyChecksAutoFixCap     = 2
+	verifyChecksAutoFixBackoff = 90 * time.Second
+)
 
 // verifyChecksFlakeRetries is how many extra times a failed verify command is
 // re-run before the gate blocks. A single retry absorbs a nondeterministic
@@ -102,7 +110,7 @@ type verifyChecksReport struct {
 // exceeding the time budget (an agent could hang a test to dodge) — blocks.
 // Only engine-shutdown cancellation and the node_modules case fail open, so a
 // harness/infra problem never strands or misattributes work.
-func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+func (e *Engine) execVerifyChecks(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
 	if slices.Contains(t.Tags, verifyBlessedTag) {
 		e.logger.Info("workflow.verify-checks.blessed", "task_id", taskID)
 		return stepDone(step, "blessed")
@@ -176,7 +184,7 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 	if failedCmd != "" {
 		reason := "implementation does not pass the project verify suite: " + trimDiffLine(failedCmd) +
 			" — fix the code, or add the `verify-blessed` tag to override (e.g. a known-flaky suite)"
-		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
+		return e.autoFixOrFlagVerifyChecks(taskID, step, wfExec, t, reason, failedCmd, output)
 	}
 
 	e.logger.Info("workflow.verify-checks.clean", "task_id", taskID, "commands", len(cmds))
@@ -233,6 +241,47 @@ func (e *Engine) flagVerifyChecks(taskID string, step *Step, reason, detail stri
 	}
 	e.logger.Warn("workflow.verify-checks.flagged", "task_id", taskID, "detail", detail)
 	return stepDone(step, "flagged")
+}
+
+func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Execution, t TaskInfo, reason, failedCmd, output string) (StepOutput, error) {
+	if wfExec == nil {
+		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
+	}
+	key := "step." + step.ID + ".auto_fix"
+	attempts := parseWorkflowInt(wfExec.Variables[key])
+	if attempts >= verifyChecksAutoFixCap || wfExec.CountStep(verifyChecksImplStepID) == 0 {
+		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
+	}
+
+	wfExec.SetVar(key, strconv.Itoa(attempts+1))
+	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(verifyChecksAutoFixBackoff).Format(time.RFC3339))
+	wfExec.SetVar(verifyReaskNoteVar, buildVerifyReaskNote(failedCmd, output))
+	wfExec.ClearStepRecords(verifyChecksImplStepID)
+	wfExec.CurrentStep = verifyChecksImplStepID
+	wfExec.State = ExecWaiting
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		return StepOutput{}, fmt.Errorf("verify-checks: rewind to implement: %w", err)
+	}
+	retryReason := fmt.Sprintf("auto-fixing failed verify check (attempt %d/%d): %s",
+		attempts+1, verifyChecksAutoFixCap, trimDiffLine(failedCmd))
+	if err := e.tasks.UpdateTaskStatus(taskID, t.Status, retryReason); err != nil {
+		return StepOutput{}, err
+	}
+	e.logger.Info("workflow.verify-checks.auto-fix",
+		"task_id", taskID, "attempt", attempts+1, "cap", verifyChecksAutoFixCap, "cmd", trimDiffLine(failedCmd))
+	return StepOutput{}, errStepParked
+}
+
+func buildVerifyReaskNote(failedCmd, output string) string {
+	var b strings.Builder
+	b.WriteString("A prior implementation FAILED the project verify suite. Fix the ROOT CAUSE ")
+	b.WriteString("so the failing command passes on a clean run — do NOT weaken, skip, or edit ")
+	b.WriteString("the check to make it pass.\n\n## Failing verify command\n\n`")
+	b.WriteString(failedCmd)
+	b.WriteString("`\n\n## Output (tail)\n\n```\n")
+	b.WriteString(tailString(strings.TrimSpace(output), 3000))
+	b.WriteString("\n```")
+	return b.String()
 }
 
 // miseConfigNames are the mise config filenames that gate `mise exec` behind

--- a/internal/workflow/engine_steps_verify_checks_autofix_test.go
+++ b/internal/workflow/engine_steps_verify_checks_autofix_test.go
@@ -1,0 +1,89 @@
+package workflow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func implementedExec() *Execution {
+	wf := &Execution{Variables: map[string]string{}, StartedAt: time.Now().UTC()}
+	now := time.Now().UTC()
+	wf.RecordStep(StepRecord{StepID: verifyChecksImplStepID, Status: "completed", StartedAt: now, EndedAt: now})
+	return wf
+}
+
+func TestExecVerifyChecks_AutoFixRewindsToImplement(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"echo boom >&2; exit 1"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	wf := implementedExec()
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	if out.StepID != "" || out.Status != "" {
+		t.Fatalf("parked output should be zero, got %+v", out)
+	}
+	if wf.CurrentStep != verifyChecksImplStepID {
+		t.Errorf("CurrentStep = %q, want %q", wf.CurrentStep, verifyChecksImplStepID)
+	}
+	if wf.State != ExecWaiting {
+		t.Errorf("State = %q, want %q", wf.State, ExecWaiting)
+	}
+	if wf.Variables["step.verify_checks.auto_fix"] != "1" {
+		t.Errorf("auto_fix counter = %q, want 1", wf.Variables["step.verify_checks.auto_fix"])
+	}
+	note := wf.Variables[verifyReaskNoteVar]
+	if !strings.Contains(note, "FAILED the project verify suite") || !strings.Contains(note, "exit 1") {
+		t.Errorf("reask note missing failure context:\n%s", note)
+	}
+	if wf.Variables[workflowRetryAfterVar] == "" {
+		t.Errorf("retry-after not set")
+	}
+	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress (not escalated on first failure)", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_AutoFixCapEscalates(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"exit 1"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	wf := implementedExec()
+	wf.Variables["step.verify_checks.auto_fix"] = "2"
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Errorf("Output = %q, want flagged", out.Output)
+	}
+	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required after cap", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_NoImplementStepEscalates(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"exit 1"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	wf := &Execution{Variables: map[string]string{}, StartedAt: time.Now().UTC()}
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Errorf("Output = %q, want flagged (no implement step to rewind to)", out.Output)
+	}
+	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -41,7 +41,7 @@ func TestExecVerifyChecks_NoGetterSkips(t *testing.T) {
 	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestExecVerifyChecks_NoCommandsSkips(t *testing.T) {
 	engine, tasks := newVerifyChecksEngine(t, t.TempDir(), nil)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestExecVerifyChecks_PassIsClean(t *testing.T) {
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{"true", "echo ok"})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestExecVerifyChecks_FailureFlags(t *testing.T) {
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{"true", "exit 1"})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestExecVerifyChecks_BlessedTagSkips(t *testing.T) {
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{"exit 1"}) // would fail
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(),
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil,
 		TaskInfo{ID: "t1", Tags: []string{"verify-blessed"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -131,7 +131,7 @@ func TestExecVerifyChecks_TimeoutFailsClosed(t *testing.T) {
 	engine.SetVerifyTimeout(150 * time.Millisecond)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestExecVerifyChecks_TimeoutRetryAbsorbsLoadSpike(t *testing.T) {
 	engine.SetVerifyTimeout(2 * time.Second)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestExecVerifyChecks_ToolchainHealRepairs(t *testing.T) {
 	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"touch .healed"})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestExecVerifyChecks_ToolchainHealMatchesDashNotFound(t *testing.T) {
 	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"touch .healed"})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestExecVerifyChecks_ToolchainHealSetupFailsEscalates(t *testing.T) {
 	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"false"})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestExecVerifyChecks_RealFailureSkipsToolchainHeal(t *testing.T) {
 	engine, tasks := newVerifyChecksEngineWithSetup(t, wt, cmds, []string{"touch .healed"})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestExecVerifyChecks_FlakeRetryPasses(t *testing.T) {
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{flaky})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -753,7 +753,7 @@ func TestExecVerifyChecks_RepairsCorruptedNodeModulesBeforeRunning(t *testing.T)
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{cmd})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/workflow/zz_adversarial_verify_checks_test.go
+++ b/internal/workflow/zz_adversarial_verify_checks_test.go
@@ -41,7 +41,7 @@ func TestAdversarialVerifyChecks_DoesNotHumanRequireWhenCorruptInstallRepairFail
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{cmd})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Motivation

`verify_checks` flipped a task straight to `human-required` on any failing command, with **no self-fix path**. A genuine but small code defect — a forgotten shim, a broken assertion, a build error — stranded work that an implementer could have fixed given the failure. Task `f8133f8f` is the canonical case: 5 agent runs never converged on a two-line shim fix because none were handed the exact failing command.

> Changelog: feat(workflow): auto-fix failed verify checks before escalating

## Implementation information

- On a `verify_checks` failure, instead of terminal `human-required`, rewind the workflow to the `implement` step with a **reask note** carrying the exact failing command + output tail (`verify_reask_note`, inlined into the implement prompt the same way `testing_reask_note` is). Bounded by a cap (2) + backoff, then escalate to `human-required` only after the cap.
- Mirrors the proven testing-workflow `parkTestingRetryOrEscalate` pattern (rewind to the agent step, `ExecWaiting`, `ResumeStalled` re-dispatches once idle+past backoff).
- **Guarded on the implement step having run** (`CountStep("implement") > 0`), so best-of-n (whose implementation is a `best_of_n` step, not `implement`) and handoff-at-verify tasks escalate exactly as before. `wfExec == nil` also falls through to the old behavior.
- Timeout failures still escalate directly (unchanged) — only deterministic command failures auto-fix.

## Supporting documentation

Complements #1895 (shim self-heal in codegen): that eliminates the shim drift class deterministically; this is the general net for any *other* self-fixable verify failure. Tests cover rewind-on-failure, cap-exhaustion escalation, and the no-implement-step guard.