### PR TITLE
chore(server): dump goroutines on shutdown hang

### DIFF
--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -14,7 +14,9 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -531,7 +533,7 @@ func (a *App) Shutdown(_ context.Context) {
 		a.cancel()
 	}
 	if !waitGroupTimeout(&a.wg, appShutdownWaitGrace) {
-		a.logger.Warn("app.shutdown.wait_timeout", "grace", appShutdownWaitGrace)
+		a.logger.Warn("app.shutdown.wait_timeout", "grace", appShutdownWaitGrace, "stacks", a.dumpGoroutineStacks())
 	}
 	if a.agents != nil {
 		a.agents.Shutdown()
@@ -562,6 +564,19 @@ func waitGroupTimeout(wg *sync.WaitGroup, grace time.Duration) bool {
 	case <-time.After(grace):
 		return false
 	}
+}
+
+func (a *App) dumpGoroutineStacks() string {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	if a.logDir == "" {
+		return "no logDir; " + fmt.Sprintf("%d goroutines", runtime.NumGoroutine())
+	}
+	path := filepath.Join(a.logDir, "shutdown-stacks.txt")
+	if err := os.WriteFile(path, buf[:n], 0o644); err != nil {
+		return "dump failed: " + err.Error()
+	}
+	return path
 }
 
 // StartAgent delegates to agentorch.Orchestrator and is exposed as a Wails-bound method.


### PR DESCRIPTION
## Motivation

After the shutdown-cancel fixes (#1894/#1896/#1897), the `waitGroupTimeout` backstop still fires ~15s on **every** shutdown — even with an idle fleet (`in_progress: 0`), so a goroutine *other than* the now-cancellable worktree setup batch never honors ctx cancel within 15s. Static audit of all `a.wg` goroutines could not pin it. The system self-recovers (no outage/data-loss), but the residual should be eliminated.

> Changelog: skip

## Implementation information

On the `app.shutdown.wait_timeout` path, write a full `runtime.Stack(all)` dump to `<logDir>/shutdown-stacks.txt` (path surfaced in the warn log). The next hung shutdown names the exact stuck goroutine for a targeted fix, then this diagnostic can be reverted.

## Supporting documentation

Empirical: the residual 15s `wait_timeout` reproduces on every auto-deploy shutdown regardless of fleet activity.