### PR TITLE
feat(workflow): reask agents after watchdog hang

### DIFF
--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -43,6 +43,10 @@ steps:
 
         {{acceptanceledger .Task.Body}}
         {{- end}}
+        {{- if getvar .Vars "watchdog_reask_note"}}
+
+        {{getvar .Vars "watchdog_reask_note"}}
+        {{- end}}
 
         Before committing broad/sweep changes ("everywhere", "all", "single
         utility", "unified", "no raw X remains"), derive and run a cheap

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -639,6 +639,7 @@ func (e *Engine) rescheduleRunAgent(taskID, agentID string, step *Step, t TaskIn
 		return
 	}
 	e.clearCircuitBreakerOnSuccess(taskID, t.Workflow, step.ID)
+	e.clearWatchdogReaskNote(taskID, t.Workflow)
 }
 
 func (e *Engine) shouldRetryGhostPark(taskID, stepID string) bool {
@@ -966,6 +967,7 @@ func (e *Engine) ResumeStalled() {
 		} else {
 			e.clearTransientFetchRetry(fresh.ID, fresh.Workflow, step.ID)
 			e.clearCircuitBreakerOnSuccess(fresh.ID, fresh.Workflow, step.ID)
+			e.clearWatchdogReaskNote(fresh.ID, fresh.Workflow)
 		}
 	}
 }
@@ -1105,6 +1107,19 @@ func (e *Engine) clearTransientFetchRetry(taskID string, wf *Execution, stepID s
 	delete(wf.Variables, retryKey)
 	if err := e.tasks.SetWorkflow(taskID, wf); err != nil {
 		e.logger.Error("workflow.transient-fetch.clear", "task_id", taskID, "step", stepID, "err", err)
+	}
+}
+
+func (e *Engine) clearWatchdogReaskNote(taskID string, wf *Execution) {
+	if wf == nil || wf.Variables == nil {
+		return
+	}
+	if _, ok := wf.Variables[watchdogReaskNoteVar]; !ok {
+		return
+	}
+	delete(wf.Variables, watchdogReaskNoteVar)
+	if err := e.tasks.SetWorkflow(taskID, wf); err != nil {
+		e.logger.Error("workflow.watchdog-hang.reask-clear", "task_id", taskID, "err", err)
 	}
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -19,6 +19,7 @@ const (
 	watchdogHangStatusReasonPrefix  = "watchdog hang"
 	watchdogHangRetryVarPrefix      = "watchdog.hang_retry."
 	watchdogHangCleanRetryVarPrefix = "watchdog.hang_clean_retry."
+	watchdogReaskNoteVar            = "watchdog_reask_note"
 	maxWatchdogHangRetries          = 2
 	watchdogRateLimitStatusPrefix   = "watchdog: rate limit"
 	watchdogRateLimitRetryVarPrefix = "watchdog.rate_limit_retry."
@@ -1001,6 +1002,7 @@ func (e *Engine) handleWatchdogHangRetry(t *TaskInfo, step *Step) bool {
 		cleanRef = "HEAD"
 	}
 	t.Workflow.SetVar(watchdogHangCleanRetryKey(step.ID), cleanRef)
+	t.Workflow.SetVar(watchdogReaskNoteVar, buildWatchdogReaskNote(attempts+1))
 	if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
 		e.logger.Error("workflow.watchdog-hang.persist", "task_id", t.ID, "step", step.ID, "err", err)
 		return true
@@ -1017,6 +1019,24 @@ func (e *Engine) handleWatchdogHangRetry(t *TaskInfo, step *Step) bool {
 func isWatchdogHangReason(reason string) bool {
 	reason = strings.TrimSpace(reason)
 	return reason == watchdogHangStatusReasonPrefix || strings.HasPrefix(reason, watchdogHangStatusReasonPrefix+":")
+}
+
+func buildWatchdogReaskNote(attempt int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "⚠️ Your previous run on this step was TERMINATED because it produced no output "+
+		"for an extended period (watchdog hang) — attempt %d of %d. A hang almost always means a "+
+		"command blocked: the full test suite, a foreground server that never backgrounds, an "+
+		"interactive prompt, or a wedged build.\n\n", attempt, maxWatchdogHangRetries)
+	b.WriteString("To make forward progress this time:\n")
+	b.WriteString("- Do NOT run the whole suite (`mise run verify`, `go test ./...`, full `npm` builds). " +
+		"Sybra runs codegen and the verify suite deterministically AFTER you finish — build and test only " +
+		"the narrow packages you changed.\n")
+	b.WriteString("- Never launch a foreground long-running or interactive process; background any server " +
+		"and bound every command.\n")
+	b.WriteString("- Commit and push incrementally so partial progress survives a restart.\n")
+	b.WriteString("- If you are genuinely blocked, STOP and mark the task human-required with the specific " +
+		"blocker instead of looping.")
+	return b.String()
 }
 
 func (e *Engine) handleWatchdogRateLimitRetry(t *TaskInfo, step *Step) bool {

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -50,3 +50,21 @@ func TestBuildWatchdogReaskNote_AttemptCount(t *testing.T) {
 		t.Fatalf("buildWatchdogReaskNote(2) = %q", got)
 	}
 }
+
+func TestClearWatchdogReaskNote(t *testing.T) {
+	t.Parallel()
+	tasks := newMemTasks()
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID: "test-simple",
+		Variables:  map[string]string{watchdogReaskNoteVar: "stale hang guidance"},
+		StartedAt:  time.Now().UTC(),
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", Workflow: wf})
+
+	engine.clearWatchdogReaskNote("t1", wf)
+	if _, ok := wf.Variables[watchdogReaskNoteVar]; ok {
+		t.Fatal("watchdog reask note should be cleared on success")
+	}
+	engine.clearWatchdogReaskNote("t1", wf)
+}

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -1,0 +1,52 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleWatchdogHangRetry_SetsReaskNoteOnRetry(t *testing.T) {
+	t.Parallel()
+	tasks := newMemTasks()
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "test-simple",
+		CurrentStep: "implement",
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: "watchdog hang: no stream activity",
+		Workflow:     wf,
+	})
+	ti := TaskInfo{ID: "t1", Status: "in-progress", StatusReason: "watchdog hang: no stream activity", Workflow: wf}
+
+	escalated := engine.handleWatchdogHangRetry(&ti, &Step{ID: "implement", Type: StepRunAgent})
+	if escalated {
+		t.Fatal("first hang should retry, not escalate")
+	}
+	note := wf.Variables[watchdogReaskNoteVar]
+	if !strings.Contains(note, "watchdog hang") {
+		t.Fatalf("reask note missing hang context:\n%s", note)
+	}
+	if !strings.Contains(note, "attempt 1 of 2") {
+		t.Fatalf("reask note missing attempt count:\n%s", note)
+	}
+	if !strings.Contains(note, "go test ./...") {
+		t.Fatalf("reask note should steer the agent off the full suite:\n%s", note)
+	}
+	if !strings.Contains(note, "human-required") {
+		t.Fatalf("reask note should offer the human-required escape hatch:\n%s", note)
+	}
+}
+
+func TestBuildWatchdogReaskNote_AttemptCount(t *testing.T) {
+	t.Parallel()
+	if got := buildWatchdogReaskNote(2); !strings.Contains(got, "attempt 2 of 2") {
+		t.Fatalf("buildWatchdogReaskNote(2) = %q", got)
+	}
+}


### PR DESCRIPTION
## Motivation

The workflow watchdog kills an agent that produces no output for too long and re-dispatches the same step with the **same prompt** — blind. A run that hung (running the full test suite, a wedged build, a foreground server that never backgrounds) re-hangs identically each attempt and never converges, burning the retry budget straight to `human-required`. Task `438927af` is the canonical case: `watchdog-hang.retry 1/2`, `2/2`, `exhausted` → human, with a broken build (`undefined: agentqueue`) + stale docs underneath.

> Changelog: feat(workflow): guide hung agents on watchdog re-dispatch

## Implementation information

- On each watchdog-hang re-dispatch (`handleWatchdogHangRetry`), set a `watchdog_reask_note` carrying the attempt count + concrete guidance: don't run the whole suite (codegen + verify run deterministically *after* the agent), never launch a foreground long-running process, commit incrementally, and mark `human-required` if genuinely blocked.
- Inlined into the implement prompt the same way the existing test-failure / acceptance-ledger reask notes are (`{{getvar .Vars "watchdog_reask_note"}}`).
- Existing retry→escalate behavior is unchanged (the note is set only on the retry path, not on escalation).

## Supporting documentation

Third of three fixes for the `438927af` / `f8133f8f` human-required classes: #1895 (shim + config-docs self-heal in codegen), #1904 (verify_checks auto-fix loop), and this (watchdog re-dispatch guidance). Together they let the fleet converge on the small, self-fixable defects that were stranding tasks.