### PR TITLE
fix(limits): bound codex exec wait on shutdown

### DIFF
--- a/internal/limits/live.go
+++ b/internal/limits/live.go
@@ -24,6 +24,7 @@ const (
 	claudeUserAgent     = "claude-code/2.1.0"
 	liveFetchTimeout    = 15 * time.Second
 	keychainTimeout     = 3 * time.Second
+	codexWaitDelay      = 5 * time.Second
 )
 
 type claudeCredentials struct {
@@ -269,6 +270,7 @@ func claudeUsageCycle(raw *claudeUsageWindow, windowMinutes int) (*CycleSnapshot
 
 func fetchCodexLiveSnapshot(ctx context.Context, capturedAt time.Time) (Snapshot, bool, error) {
 	cmd := exec.CommandContext(ctx, "codex", "-s", "read-only", "-a", "untrusted", "app-server")
+	cmd.WaitDelay = codexWaitDelay
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return Snapshot{}, false, err


### PR DESCRIPTION
## Motivation

Final root cause of the residual ~15s shutdown `wait_timeout` (fires on every shutdown, idle or not — captured via the #1905 goroutine dump). The live-limits poller (`startLiveLimitPolling` → `refreshLiveLimits` → `RefreshLiveSnapshots` → `fetchCodexLiveSnapshot`) runs a `codex app-server` subprocess and its `cmd.Wait()` hangs in `awaitGoroutines`: it already uses `exec.CommandContext(ctx)` (so `a.cancel()` kills codex), but a codex **grandchild** inherits the stderr/stdout pipe, so the I/O-copy goroutine never sees EOF and `Wait()` blocks — holding `App.Shutdown`'s `wg.Wait()` past the 15s backstop.

This is the second, independent cause of the shutdown hang (the first — the detached worktree setup batch — was fixed in #1896/#1897). Unlike that one it's not agent-conditional: the poller runs on a timer, so it hangs shutdown even with an idle fleet.

> Changelog: fix(limits): set WaitDelay on the codex live-limits exec so shutdown isn't blocked by grandchild-held pipes

## Implementation information

Set `cmd.WaitDelay = 5s` on the codex exec — Go's built-in remedy: after the process is signalled, `Wait` force-closes the inherited descriptors and returns within the delay, so the poller goroutine exits on `a.cancel()` and shutdown completes well under the 15s backstop.

## Supporting documentation

Goroutine 50 in the captured dump: `os/exec.(*Cmd).Wait → fetchCodexLiveSnapshot → RefreshLiveSnapshots → refreshLiveLimits → startLiveLimitPolling.func2` (live.go:289). The #1905 dump diagnostic is kept as permanent shutdown-hang hygiene (dormant when shutdowns are clean).