### PR TITLE
feat(agent): A/B-route pinned judgment surfaces

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/orchestratorservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/orchestratorservice.ts
@@ -28,11 +28,12 @@ export function IsOrchestratorRunning(): $CancellablePromise<boolean> {
 
 /**
  * StartOrchestrator launches the orchestrator as an in-app conversational
- * Claude agent rooted at ~/.sybra (where the brain CLAUDE.md + skills live).
- * The detector/dispatch loop runs in-process in the Go backend (see
+ * agent rooted at ~/.sybra (where the brain CLAUDE.md + skills live). The
+ * detector/dispatch loop runs in-process in the Go backend (see
  * LifecycleManager.startMonitorService); this session handles the
- * judgment-driven work on top of it, so it stays pinned to Claude even when
- * generic task agents can fail over to another provider.
+ * judgment-driven work on top of it. Provider is resolved through the A/B suite
+ * (ApplyABVariant) like any other role, and health/limit failover stays on so
+ * the brain is not stranded when its provider is unavailable.
  */
 export function StartOrchestrator(): $CancellablePromise<void> {
     return $Call.ByID(4069016469);

--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -146,13 +146,6 @@ func DefaultConfig() Config {
 				},
 			},
 			{
-				// Inert for review routing: simple-task-review.yaml pins both
-				// review steps to an explicit provider (claude for staff,
-				// cross for simple) instead of "ab"/"", so selectABVariant
-				// never runs for the review role. Kept as a built-in (rather
-				// than deleted) so a future workflow that opts a review step
-				// back into "ab" picks up a sane premium-tier default; the
-				// "plan" role is likewise routed by provider: cross today.
 				ID:             "review-expensive",
 				Enabled:        &expEnabled,
 				AssignmentUnit: "stage",

--- a/internal/agent/abvariant.go
+++ b/internal/agent/abvariant.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"os/exec"
+
+	"github.com/Automaat/sybra/internal/abtest"
+)
+
+var providerCLIAvailable = func(provider string) bool {
+	_, err := exec.LookPath(provider)
+	return err == nil
+}
+
+// ApplyABVariant selects an A/B variant for (taskID, role) and stamps the
+// chosen provider/model/effort and experiment attribution onto cfg. It is the
+// reuse point for dispatch sites outside the workflow engine (orchestrator,
+// human-review, staff PR review) so they route through the same A/B suite as
+// normal task agents instead of a hardcoded provider.
+//
+// Variants whose provider CLI is missing, config-disabled, unhealthy, or
+// rate-limited are filtered out before selection — the same eligibility gate
+// the workflow engine applies — so a variant is never assigned to a provider
+// that would crash at spawn (e.g. copilot enabled in config but absent on a
+// server host). When every variant is ineligible, A/B is disabled, or no
+// experiment matches role, cfg is returned unchanged and the provider follows
+// the manager default plus failover.
+//
+// DisableProviderFailover is deliberately left unset: a selected provider that
+// caps mid-flight fails over rather than parking (availability over clean
+// attribution).
+func (m *Manager) ApplyABVariant(cfg RunConfig, ab abtest.Config, taskID, role string) RunConfig {
+	allowed := func(provider string) bool {
+		return providerCLIAvailable(provider) &&
+			m.ProviderHealthy(provider) &&
+			!m.ProviderRateLimited(provider)
+	}
+	a, ok, err := abtest.SelectEligibleForContext(
+		ab,
+		abtest.SelectionContext{TaskID: taskID, Role: role},
+		allowed,
+		nil,
+	)
+	if err != nil || !ok {
+		return cfg
+	}
+	cfg.Provider = a.Provider
+	if a.Model != "" {
+		cfg.Model = a.Model
+	}
+	if a.ReasoningEffort != "" {
+		cfg.ReasoningEffort = a.ReasoningEffort
+	}
+	cfg.ExperimentID = a.ExperimentID
+	cfg.VariantID = a.VariantID
+	cfg.AssignmentUnit = a.AssignmentUnit
+	cfg.AssignmentKey = a.AssignmentKey
+	return cfg
+}

--- a/internal/agent/abvariant.go
+++ b/internal/agent/abvariant.go
@@ -34,11 +34,14 @@ func (m *Manager) ApplyABVariant(cfg RunConfig, ab abtest.Config, taskID, role s
 			m.ProviderHealthy(provider) &&
 			!m.ProviderRateLimited(provider)
 	}
+	m.mu.RLock()
+	evalPassed := m.evalPassed
+	m.mu.RUnlock()
 	a, ok, err := abtest.SelectEligibleForContext(
 		ab,
 		abtest.SelectionContext{TaskID: taskID, Role: role},
 		allowed,
-		nil,
+		evalPassed,
 	)
 	if err != nil || !ok {
 		return cfg

--- a/internal/agent/abvariant_test.go
+++ b/internal/agent/abvariant_test.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/abtest"
+)
+
+func stubProviderCLIAvailable(t *testing.T, avail func(string) bool) {
+	t.Helper()
+	prev := providerCLIAvailable
+	providerCLIAvailable = avail
+	t.Cleanup(func() { providerCLIAvailable = prev })
+}
+
+func reviewExperiment(variants ...abtest.Variant) abtest.Config {
+	enabled := true
+	return abtest.Config{
+		Enabled: &enabled,
+		Experiments: []abtest.Experiment{{
+			ID:       "review-test",
+			Enabled:  &enabled,
+			Roles:    []string{"review"},
+			Variants: variants,
+		}},
+	}
+}
+
+func TestApplyABVariant_DisabledLeavesConfigUnchanged(t *testing.T) {
+	stubProviderCLIAvailable(t, func(string) bool { return true })
+	m := &Manager{}
+
+	cfg := m.ApplyABVariant(RunConfig{Model: "opus"}, abtest.Config{}, "task-1", "review")
+
+	if cfg.Provider != "" || cfg.Model != "opus" || cfg.ExperimentID != "" {
+		t.Fatalf("unchanged config expected, got provider=%q model=%q exp=%q", cfg.Provider, cfg.Model, cfg.ExperimentID)
+	}
+}
+
+func TestApplyABVariant_AssignsEligibleProvider(t *testing.T) {
+	stubProviderCLIAvailable(t, func(string) bool { return true })
+	m := &Manager{}
+	ab := reviewExperiment(abtest.Variant{ID: "codex-only", Provider: "codex", Model: "gpt-5.5", Weight: 1})
+
+	cfg := m.ApplyABVariant(RunConfig{Model: "opus"}, ab, "task-1", "review")
+
+	if cfg.Provider != "codex" || cfg.Model != "gpt-5.5" {
+		t.Fatalf("provider/model = %q/%q, want codex/gpt-5.5", cfg.Provider, cfg.Model)
+	}
+	if cfg.ExperimentID != "review-test" || cfg.VariantID != "codex-only" {
+		t.Fatalf("attribution = %q/%q, want review-test/codex-only", cfg.ExperimentID, cfg.VariantID)
+	}
+	if cfg.DisableProviderFailover {
+		t.Fatal("DisableProviderFailover = true, want false (availability preferred)")
+	}
+}
+
+func TestApplyABVariant_SkipsProviderWithMissingCLI(t *testing.T) {
+	stubProviderCLIAvailable(t, func(p string) bool { return p != "copilot" })
+	m := &Manager{}
+	ab := reviewExperiment(abtest.Variant{ID: "copilot-only", Provider: "copilot", Model: "gemini-3.1-pro", Weight: 1})
+
+	cfg := m.ApplyABVariant(RunConfig{Model: "opus"}, ab, "task-1", "review")
+
+	if cfg.Provider != "" {
+		t.Fatalf("Provider = %q, want empty — a variant whose CLI is absent must not be assigned", cfg.Provider)
+	}
+	if cfg.Model != "opus" {
+		t.Fatalf("Model = %q, want opus (unchanged base)", cfg.Model)
+	}
+}
+
+func TestApplyABVariant_RoleMismatchLeavesConfigUnchanged(t *testing.T) {
+	stubProviderCLIAvailable(t, func(string) bool { return true })
+	m := &Manager{}
+	ab := reviewExperiment(abtest.Variant{ID: "codex-only", Provider: "codex", Model: "gpt-5.5", Weight: 1})
+
+	cfg := m.ApplyABVariant(RunConfig{Model: "opus"}, ab, "task-1", "implementation")
+
+	if cfg.Provider != "" || cfg.ExperimentID != "" {
+		t.Fatalf("unmatched role should leave config unchanged, got provider=%q exp=%q", cfg.Provider, cfg.ExperimentID)
+	}
+}

--- a/internal/agent/abvariant_test.go
+++ b/internal/agent/abvariant_test.go
@@ -70,6 +70,19 @@ func TestApplyABVariant_SkipsProviderWithMissingCLI(t *testing.T) {
 	}
 }
 
+func TestApplyABVariant_EvalGateExcludesDigestedVariant(t *testing.T) {
+	stubProviderCLIAvailable(t, func(string) bool { return true })
+	m := &Manager{}
+	m.SetEvalPassed(func(variantID, digest string) bool { return false })
+	ab := reviewExperiment(abtest.Variant{ID: "codex-digested", Provider: "codex", Model: "gpt-5.5", Digest: "d1", Weight: 1})
+
+	cfg := m.ApplyABVariant(RunConfig{Model: "opus"}, ab, "task-1", "review")
+
+	if cfg.Provider != "" {
+		t.Fatalf("Provider = %q, want empty — an eval-failed digested variant must not enroll", cfg.Provider)
+	}
+}
+
 func TestApplyABVariant_RoleMismatchLeavesConfigUnchanged(t *testing.T) {
 	stubProviderCLIAvailable(t, func(string) bool { return true })
 	m := &Manager{}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/provider"
@@ -78,6 +79,7 @@ type Manager struct {
 	limitGate         LimitGate
 	limitPolicy       limits.Policy
 	limitSink         func(limits.Snapshot)
+	evalPassed        abtest.EvalPassed
 
 	// liveByProvider tracks in-flight agent counts per provider, incremented
 	// and decremented in lockstep with liveCount (registerRunningAgent,
@@ -494,6 +496,16 @@ func (m *Manager) signalKill(a *Agent) {
 func (m *Manager) SetHealthGate(g provider.HealthGate) {
 	m.mu.Lock()
 	m.gate = g
+	m.mu.Unlock()
+}
+
+// SetEvalPassed wires the offline-eval enrollment predicate consulted by
+// ApplyABVariant, so ad-hoc A/B dispatch sites gate digested variants on their
+// stored eval verdict exactly like the workflow engine. A nil predicate (the
+// default) leaves eval gating off.
+func (m *Manager) SetEvalPassed(fn abtest.EvalPassed) {
+	m.mu.Lock()
+	m.evalPassed = fn
 	m.mu.Unlock()
 }
 

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -184,11 +184,10 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 	h.mu.Unlock()
 
 	prompt := h.buildPrompt(t, wctx)
-	ag, err := h.agents.Run(agent.RunConfig{
+	ag, err := h.agents.Run(h.agents.ApplyABVariant(agent.RunConfig{
 		TaskID:                 taskID,
 		Name:                   agent.RoleHumanReview.AgentName(t.Title),
 		Mode:                   "headless",
-		Provider:               "claude",
 		Model:                  h.cfg.HumanReviewModel(),
 		Prompt:                 prompt,
 		Dir:                    h.cfg.HumanReview.SybraRepoDir,
@@ -196,7 +195,7 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		OneShot:                true,
 		OutputSchema:           verdict.Schema,
 		IgnoreConcurrencyLimit: true,
-	})
+	}, h.cfg.ABTesting, taskID, string(agent.RoleHumanReview)))
 	if err != nil {
 		h.mu.Lock()
 		delete(h.inflight, taskID)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -757,7 +757,12 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetMaxCheckpoints(a.cfg.MaxCheckpoints())
 	a.workflowEngine.SetABTestingConfig(a.cfg.ABTesting)
 	if a.cfg.Evaluation.Offline.Enabled {
-		a.workflowEngine.SetEvalGate(prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline))
+		gate := prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline)
+		a.workflowEngine.SetEvalGate(gate)
+		a.agents.SetEvalPassed(func(variantID, digest string) bool {
+			allow, _, gateErr := gate.AllowEnrollment(variantID, digest)
+			return gateErr == nil && allow
+		})
 	}
 	if a.artifacts != nil {
 		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -32,8 +32,6 @@ const (
 	reviewSmallFiles     = 5
 )
 
-const staffCodeReviewProvider = "claude"
-
 const TransientFetchWarnThreshold = 3
 
 // readyPRState is a cached "confirmed ready to merge" snapshot for a task's

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -184,7 +184,7 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", current.ProjectID, current.PRNumber)
 
-	ag, err := r.agents.Run(StaffCodeReviewRunConfig(current, prompt, dir, posture))
+	ag, err := r.agents.Run(r.agents.ApplyABVariant(StaffCodeReviewRunConfig(current, prompt, dir, posture), r.cfg.ABTesting, current.ID, string(agent.RoleReview)))
 	if err != nil {
 		return err
 	}
@@ -203,19 +203,22 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 	return nil
 }
 
+// StaffCodeReviewRunConfig builds the base run config for the GitHub-PR-triggered
+// staff review. Provider is left unset so the caller's Manager.ApplyABVariant
+// resolves it through the A/B suite (with failover on) or, when A/B is disabled,
+// the manager default. Model defaults to opus so the claude variant and any
+// A/B-disabled fallback keep their high-scrutiny model; an A/B pick overrides it.
+// MaxTurns is intentionally not inherited: review agents need enough turns to
+// fetch the PR, run the skill, and write findings.
 func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture string) agent.RunConfig {
 	return agent.RunConfig{
-		TaskID:                  t.ID,
-		Name:                    agent.RoleReview.AgentName(t.Title),
-		Mode:                    "headless",
-		Prompt:                  prompt,
-		Dir:                     dir,
-		Provider:                staffCodeReviewProvider,
-		Model:                   "opus",
-		DisableProviderFailover: true,
-		HeadlessPermissionMode:  posture,
-		// MaxTurns intentionally not inherited: review agents need
-		// enough turns to fetch the PR, run the skill, and write findings.
+		TaskID:                 t.ID,
+		Name:                   agent.RoleReview.AgentName(t.Title),
+		Mode:                   "headless",
+		Prompt:                 prompt,
+		Dir:                    dir,
+		Model:                  "opus",
+		HeadlessPermissionMode: posture,
 	}
 }
 

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -186,17 +186,17 @@ func assertPRFixPromptUsesResolvedPushRemote(t *testing.T, prompt, branch string
 	}
 }
 
-func TestStaffCodeReviewRunConfigPinsClaudeProvider(t *testing.T) {
+func TestStaffCodeReviewRunConfigLeavesProviderUnpinned(t *testing.T) {
 	cfg := StaffCodeReviewRunConfig(task.Task{ID: "review-task", Title: "Needs review"}, "Run /staff-code-review", t.TempDir(), "default")
 
-	if cfg.Provider != staffCodeReviewProvider {
-		t.Fatalf("Provider = %q, want %q", cfg.Provider, staffCodeReviewProvider)
+	if cfg.Provider != "" {
+		t.Fatalf("Provider = %q, want empty (resolved by Manager.ApplyABVariant / default)", cfg.Provider)
 	}
 	if cfg.Model != "opus" {
 		t.Fatalf("Model = %q, want opus", cfg.Model)
 	}
-	if !cfg.DisableProviderFailover {
-		t.Fatal("DisableProviderFailover = false, want true")
+	if cfg.DisableProviderFailover {
+		t.Fatal("DisableProviderFailover = true, want false (availability preferred)")
 	}
 }
 

--- a/internal/sybra/services_wire_agents.go
+++ b/internal/sybra/services_wire_agents.go
@@ -14,6 +14,9 @@ func (a *App) wireOrchestratorService(emit func(string, any)) {
 	a.orchSvc.audit = a.audit
 	a.orchSvc.logger = a.logger
 	a.orchSvc.emit = emit
+	if a.cfg != nil {
+		a.orchSvc.abTesting = a.cfg.ABTesting
+	}
 }
 
 func (a *App) wireAgentOrchestrator() {

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 
 	"github.com/Automaat/sybra/internal/abtest"
@@ -18,6 +19,14 @@ import (
 const orchestratorAgentName = "orchestrator"
 
 const orchestratorRole = "orchestrator"
+
+func orchestratorABKey() string {
+	host, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return host
+}
 
 // orchestratorKickoffPrompt is the first user message delivered to the
 // orchestrator brain so it actually takes a turn. The conversational runner
@@ -162,7 +171,7 @@ func (s *OrchestratorService) StartOrchestratorContext(ctx context.Context) erro
 		Dir:                    config.HomeDir(),
 		Prompt:                 orchestratorKickoffPrompt,
 		IgnoreConcurrencyLimit: true,
-	}, s.abTesting, "", orchestratorRole))
+	}, s.abTesting, orchestratorABKey(), orchestratorRole))
 	if err != nil {
 		return fmt.Errorf("start orchestrator agent: %w", err)
 	}

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
@@ -15,6 +16,8 @@ import (
 // orchestratorAgentName is the stable Name assigned to the orchestrator agent
 // so the frontend and tests can identify it in agent listings.
 const orchestratorAgentName = "orchestrator"
+
+const orchestratorRole = "orchestrator"
 
 // orchestratorKickoffPrompt is the first user message delivered to the
 // orchestrator brain so it actually takes a turn. The conversational runner
@@ -98,10 +101,11 @@ func selectOrchestratorSingleton(currentID string, agents []*agent.Agent) (keepI
 
 // OrchestratorService exposes orchestrator session operations as Wails-bound methods.
 type OrchestratorService struct {
-	agents *agent.Manager
-	audit  *audit.Logger
-	logger *slog.Logger
-	emit   func(string, any)
+	agents    *agent.Manager
+	audit     *audit.Logger
+	logger    *slog.Logger
+	emit      func(string, any)
+	abTesting abtest.Config
 
 	mu      sync.Mutex
 	agentID string
@@ -129,11 +133,12 @@ func (s *OrchestratorService) reconcileOrchestratorsLocked() string {
 }
 
 // StartOrchestrator launches the orchestrator as an in-app conversational
-// Claude agent rooted at ~/.sybra (where the brain CLAUDE.md + skills live).
-// The detector/dispatch loop runs in-process in the Go backend (see
+// agent rooted at ~/.sybra (where the brain CLAUDE.md + skills live). The
+// detector/dispatch loop runs in-process in the Go backend (see
 // LifecycleManager.startMonitorService); this session handles the
-// judgment-driven work on top of it, so it stays pinned to Claude even when
-// generic task agents can fail over to another provider.
+// judgment-driven work on top of it. Provider is resolved through the A/B suite
+// (ApplyABVariant) like any other role, and health/limit failover stays on so
+// the brain is not stranded when its provider is unavailable.
 func (s *OrchestratorService) StartOrchestrator() error {
 	return s.StartOrchestratorContext(context.Background())
 }
@@ -151,15 +156,13 @@ func (s *OrchestratorService) StartOrchestratorContext(ctx context.Context) erro
 		return conflictError("orchestrator already running")
 	}
 
-	a, err := s.agents.RunContext(ctx, agent.RunConfig{
-		Name:                    orchestratorAgentName,
-		Mode:                    "interactive",
-		Dir:                     config.HomeDir(),
-		Provider:                "claude",
-		Prompt:                  orchestratorKickoffPrompt,
-		IgnoreConcurrencyLimit:  true,
-		DisableProviderFailover: true,
-	})
+	a, err := s.agents.RunContext(ctx, s.agents.ApplyABVariant(agent.RunConfig{
+		Name:                   orchestratorAgentName,
+		Mode:                   "interactive",
+		Dir:                    config.HomeDir(),
+		Prompt:                 orchestratorKickoffPrompt,
+		IgnoreConcurrencyLimit: true,
+	}, s.abTesting, "", orchestratorRole))
 	if err != nil {
 		return fmt.Errorf("start orchestrator agent: %w", err)
 	}

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -902,7 +902,7 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 	}
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
-	ag, err := s.agents.Run(review.StaffCodeReviewRunConfig(t, prompt, dir, posture))
+	ag, err := s.agents.Run(s.agents.ApplyABVariant(review.StaffCodeReviewRunConfig(t, prompt, dir, posture), s.cfg.ABTesting, t.ID, string(agent.RoleReview)))
 	if err != nil {
 		return err
 	}

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -92,7 +92,7 @@ steps:
     type: run_agent
     config:
       role: plan
-      provider: claude
+      provider: ab
       mode: headless
       model: opus
       needs_worktree: true

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -129,10 +129,12 @@ steps:
     config:
       role: review
       mode: headless
-      # High-risk/staff review is pinned to claude, not routed by "cross" or
-      # the A/B suite — codex review fails ~2x more often than claude review
-      # (scorecard: 17% vs 9%) on the diffs that reach staff-level scrutiny.
-      provider: claude
+      # Routed through the A/B suite (review-expensive) for provider equality.
+      # Historically pinned to claude because codex review failed ~2x more often
+      # on staff-level diffs (scorecard: 17% vs 9%); uniform weights plus the
+      # eval scorecard are expected to re-balance this — watch the review
+      # breakdown per provider after rollout.
+      provider: ab
       needs_worktree: true
       max_retries: 2
       prompt: >-

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -478,7 +478,7 @@ func resolveProvider(stepProv string, wfExec *Execution, _ string, t TaskInfo) s
 			return crossProvider(p)
 		}
 		return ""
-	case "":
+	case "", "ab":
 		return ""
 	default:
 		return stepProv

--- a/internal/workflow/handoff_test.go
+++ b/internal/workflow/handoff_test.go
@@ -136,8 +136,8 @@ func TestBuiltinHandoffReview_SkipsToReview(t *testing.T) {
 		t.Fatal("simple-task-review code_review_staff step not found")
 		return
 	}
-	if staff.Config.Provider != "claude" {
-		t.Errorf("simple-task-review code_review_staff provider = %q, want claude", staff.Config.Provider)
+	if staff.Config.Provider != "ab" {
+		t.Errorf("simple-task-review code_review_staff provider = %q, want ab", staff.Config.Provider)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Part of the "equal agents" umbrella (#1898): every role should be runnable on any enabled provider, selected by the A/B suite, not hard-pinned to Claude. This un-pins the judgment surfaces (WS1) — the orchestrator brain, human-review, and staff PR review — plus the plan and staff-review workflow steps.

The staff-review + plan pins were previously justified by scorecard data (codex review failed ~2x more on staff diffs). Per an explicit decision, they are un-pinned anyway for full equality; uniform weights + eval monitoring (#1900) are expected to re-balance, and the per-provider review breakdown should be watched after rollout.

## Implementation information

- New `Manager.ApplyABVariant` (`internal/agent/abvariant.go`) resolves provider/model/effort + attribution for dispatch sites outside the workflow engine. It filters variants by CLI-on-PATH, health, and rate-limit — the same eligibility gate the engine applies — so a provider enabled in config but absent on a host (e.g. copilot on the server) is never assigned; the dispatch degrades to the manager default instead of crashing at spawn.
- Failover is left ON (no `DisableProviderFailover`): a rate-limited assigned provider fails over rather than parking — availability over clean attribution, per the decision.
- Un-pinned sites: `svc_orchestrator.go`, `app_human_review.go`, staff review (`review/inbound.go` + `svc_tasks.go`); removed `const staffCodeReviewProvider`.
- YAML: `simple-task-plan.yaml` and `simple-task-review.yaml` staff step flipped `provider: claude` → `provider: ab`.
- `resolveProvider` now treats the `"ab"` sentinel like `""`, so a step whose experiment yields no eligible variant defers to the default instead of leaking the literal `"ab"` to the manager (latent bug surfaced by the plan-step flip).
- Tests: new `internal/agent/abvariant_test.go` (assignment, missing-CLI skip, role-mismatch, disabled); updated review + handoff assertions.

Alternatives considered: routing these through a free function with `providerAllowed=nil` (rejected — an adversarial review showed it could assign a missing-CLI provider and crash the spawn with no failover).

Closes #1899

> Changelog: feat(agent): A/B-route pinned judgment surfaces
