### PR TITLE
fix(workflow): fail workflow on watchdog exhaust

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -991,6 +991,10 @@ func (e *Engine) handleWatchdogHangRetry(t *TaskInfo, step *Step) bool {
 	attempts := parseWorkflowInt(t.Workflow.Variables[retryKey])
 	if attempts >= maxWatchdogHangRetries {
 		reason := fmt.Sprintf("watchdog hang: retry budget exhausted after %d clean re-dispatches", attempts)
+		t.Workflow.State = ExecFailed
+		if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
+			e.logger.Error("workflow.watchdog-hang.persist", "task_id", t.ID, "step", step.ID, "err", err)
+		}
 		if err := e.tasks.UpdateTaskStatus(t.ID, "human-required", reason); err != nil {
 			e.logger.Error("workflow.watchdog-hang.escalate", "task_id", t.ID, "step", step.ID, "err", err)
 		} else {
@@ -1049,6 +1053,10 @@ func (e *Engine) handleWatchdogRateLimitRetry(t *TaskInfo, step *Step) bool {
 	attempts := parseWorkflowInt(t.Workflow.Variables[retryKey])
 	if attempts >= maxWatchdogRateLimitRetries {
 		reason := fmt.Sprintf("watchdog: rate limit retry budget exhausted after %d clean re-dispatches", attempts)
+		t.Workflow.State = ExecFailed
+		if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
+			e.logger.Error("workflow.watchdog-rate-limit.persist", "task_id", t.ID, "step", step.ID, "err", err)
+		}
 		if err := e.tasks.UpdateTaskStatus(t.ID, "human-required", reason); err != nil {
 			e.logger.Error("workflow.watchdog-rate-limit.escalate", "task_id", t.ID, "step", step.ID, "err", err)
 		} else {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1042,6 +1042,9 @@ func TestResumeStalled_WatchdogHangRetriesThenEscalates(t *testing.T) {
 			if got.Workflow.Variables[watchdogHangRetryKey("implement")] != tc.wantRetry {
 				t.Fatalf("hang retry var = %q, want %q", got.Workflow.Variables[watchdogHangRetryKey("implement")], tc.wantRetry)
 			}
+			if tc.wantStatus == "human-required" && got.Workflow.State != ExecFailed {
+				t.Fatalf("workflow state = %q, want ExecFailed so the operator can re-dispatch", got.Workflow.State)
+			}
 			if tc.wantStarts > 0 {
 				if got := agents.calls[0].CleanRetryRef; got != tc.wantClean {
 					t.Fatalf("clean retry ref = %q, want %q", got, tc.wantClean)


### PR DESCRIPTION
## Motivation

When the watchdog hang / rate-limit retry budget is exhausted, the branch flips the task to `human-required` but leaves the workflow in `ExecWaiting`. `DispatchFromHumanRequired` requires a terminal workflow, so the operator **cannot re-dispatch the task** — it is silently unrecoverable. Hit directly while trying to re-dispatch `438927af` (`409: task has active workflow, state=waiting`). The verify_checks escalation doesn't have this problem because it completes the workflow via the normal step-advance.

> Changelog: fix(workflow): mark workflow ExecFailed on watchdog exhaust

## Implementation information

- In both watchdog-hang and watchdog-rate-limit exhausted branches, set `Workflow.State = ExecFailed` + persist before flipping to `human-required`, mirroring the circuit-breaker escalation (`engine_events.go`): the halt becomes independent of `task.Status` (every resume path already ignores an `ExecFailed` workflow), and `DispatchFromHumanRequired` now accepts the task for a fresh dispatch.
- Extends the existing exhaustion test to assert `ExecFailed`.

## Supporting documentation

Fourth fix in the human-required-recoverability series (#1895, #1904, #1906). Note: this prevents *future* watchdog-exhausted tasks from stranding; an already-parked task (like 438927af) still needs a one-time workflow reset.