### PR TITLE
fix(codegen): skip shim gen for missing bindings

### DIFF
--- a/cmd/gen-api-shim/main.go
+++ b/cmd/gen-api-shim/main.go
@@ -46,11 +46,19 @@ func run(root string, checkOnly bool) error {
 		return err
 	}
 
-	nextTS, addedTS, err := fillAPITS(string(apiTS), services)
+	bindingDir := filepath.Join(root, bindingDirRel)
+	skip, skipReasons := unresolvableMethods(services, bindingDir)
+	if len(skipReasons) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"gen-api-shim: skipping %d method(s) with no Wails binding — regenerate bindings (`wails3 generate bindings`): %s\n",
+			len(skipReasons), strings.Join(skipReasons, ", "))
+	}
+
+	nextTS, addedTS, err := fillAPITS(string(apiTS), services, skip)
 	if err != nil {
 		return err
 	}
-	nextHTTP, addedHTTP, err := fillAPIHTTP(string(apiHTTP), services, filepath.Join(root, bindingDirRel))
+	nextHTTP, addedHTTP, err := fillAPIHTTP(string(apiHTTP), services, bindingDir, skip)
 	if err != nil {
 		return err
 	}

--- a/cmd/gen-api-shim/main.go
+++ b/cmd/gen-api-shim/main.go
@@ -47,11 +47,14 @@ func run(root string, checkOnly bool) error {
 	}
 
 	bindingDir := filepath.Join(root, bindingDirRel)
-	skip, skipReasons := unresolvableMethods(services, bindingDir)
-	if len(skipReasons) > 0 {
+	skip, skipReasons, err := unresolvableMethods(services, bindingDir)
+	if err != nil {
+		return err
+	}
+	if len(skip) > 0 {
 		fmt.Fprintf(os.Stderr,
 			"gen-api-shim: skipping %d method(s) with no Wails binding — regenerate bindings (`wails3 generate bindings`): %s\n",
-			len(skipReasons), strings.Join(skipReasons, ", "))
+			len(skip), strings.Join(skipReasons, ", "))
 	}
 
 	nextTS, addedTS, err := fillAPITS(string(apiTS), services, skip)

--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -18,11 +18,14 @@ var (
 	bindingImportP = "@wailsio/runtime"
 )
 
-func unresolvableMethods(services []service, bindingDir string) (skip map[string]bool, reasons []string) {
+func unresolvableMethods(services []service, bindingDir string) (skip map[string]bool, reasons []string, err error) {
 	skip = map[string]bool{}
 	for _, svc := range services {
-		data, err := os.ReadFile(filepath.Join(bindingDir, bindingModuleBase(svc.name)+".ts"))
-		if err != nil {
+		data, readErr := os.ReadFile(filepath.Join(bindingDir, bindingModuleBase(svc.name)+".ts"))
+		if readErr != nil {
+			if !os.IsNotExist(readErr) {
+				return nil, nil, readErr
+			}
 			for _, m := range svc.methods {
 				skip[m] = true
 			}
@@ -37,7 +40,7 @@ func unresolvableMethods(services []service, bindingDir string) (skip map[string
 			}
 		}
 	}
-	return skip, reasons
+	return skip, reasons, nil
 }
 
 func fillAPITS(src string, services []service, skip map[string]bool) (out string, added []string, err error) {

--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -18,7 +18,29 @@ var (
 	bindingImportP = "@wailsio/runtime"
 )
 
-func fillAPITS(src string, services []service) (out string, added []string, err error) {
+func unresolvableMethods(services []service, bindingDir string) (skip map[string]bool, reasons []string) {
+	skip = map[string]bool{}
+	for _, svc := range services {
+		data, err := os.ReadFile(filepath.Join(bindingDir, bindingModuleBase(svc.name)+".ts"))
+		if err != nil {
+			for _, m := range svc.methods {
+				skip[m] = true
+			}
+			reasons = append(reasons, fmt.Sprintf("%s.* (no binding %s.ts)", svc.name, bindingModuleBase(svc.name)))
+			continue
+		}
+		src := string(data)
+		for _, m := range svc.methods {
+			if _, _, ok := parseBindingSig(src, m); !ok {
+				skip[m] = true
+				reasons = append(reasons, svc.name+"."+m+" (no binding signature)")
+			}
+		}
+	}
+	return skip, reasons
+}
+
+func fillAPITS(src string, services []service, skip map[string]bool) (out string, added []string, err error) {
 	lines := strings.Split(src, "\n")
 
 	existing := map[string]bool{}
@@ -45,7 +67,7 @@ func fillAPITS(src string, services []service) (out string, added []string, err 
 			continue
 		}
 		for _, method := range svc.methods {
-			if existing[method] {
+			if existing[method] || skip[method] {
 				continue
 			}
 			anchor, ok := lastAliasLine[alias]
@@ -102,7 +124,7 @@ type moduleImport struct {
 	lineIndex int
 }
 
-func fillAPIHTTP(src string, services []service, bindingDir string) (out string, added []string, err error) {
+func fillAPIHTTP(src string, services []service, bindingDir string, skip map[string]bool) (out string, added []string, err error) {
 	lines := strings.Split(src, "\n")
 
 	existing := map[string]bool{}
@@ -142,7 +164,7 @@ func fillAPIHTTP(src string, services []service, bindingDir string) (out string,
 		var bindingImports map[string]string
 		var bindingSrc string
 		for _, method := range svc.methods {
-			if existing[method] {
+			if existing[method] || skip[method] {
 				continue
 			}
 			if bindingSrc == "" {

--- a/cmd/gen-api-shim/shim_test.go
+++ b/cmd/gen-api-shim/shim_test.go
@@ -193,7 +193,10 @@ func TestUnresolvableMethods(t *testing.T) {
 		{name: "QueueService", methods: []string{"SnapshotDepth"}},
 	}
 
-	skip, reasons := unresolvableMethods(services, bindingDir)
+	skip, reasons, err := unresolvableMethods(services, bindingDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if skip["GetTask"] {
 		t.Error("GetTask has a binding signature and must not be skipped")
 	}

--- a/cmd/gen-api-shim/shim_test.go
+++ b/cmd/gen-api-shim/shim_test.go
@@ -70,7 +70,7 @@ func TestFillAPITS(t *testing.T) {
 	}, "\n")
 	services := []service{{name: "TaskService", methods: []string{"GetTask", "DeleteTask"}}}
 
-	out, added, err := fillAPITS(src, services)
+	out, added, err := fillAPITS(src, services, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestFillAPITS(t *testing.T) {
 		t.Fatalf("clobbered existing GetTask:\n%s", out)
 	}
 
-	out2, added2, err := fillAPITS(out, services)
+	out2, added2, err := fillAPITS(out, services, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestFillAPIHTTP(t *testing.T) {
 	}, "\n")
 	services := []service{{name: "TaskService", methods: []string{"GetTask", "DeleteTask", "CreateTaskWithInit"}}}
 
-	out, added, err := fillAPIHTTP(src, services, bindingDir)
+	out, added, err := fillAPIHTTP(src, services, bindingDir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestFillAPIHTTP(t *testing.T) {
 		t.Fatalf("duplicate task/models import:\n%s", out)
 	}
 
-	out2, added2, err := fillAPIHTTP(out, services, bindingDir)
+	out2, added2, err := fillAPIHTTP(out, services, bindingDir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,5 +173,61 @@ func TestParseServices(t *testing.T) {
 	}
 	if len(got) != 2 || got[0].name != "TaskService" || len(got[0].methods) != 2 || got[1].name != "App" {
 		t.Fatalf("parseServices = %+v", got)
+	}
+}
+
+func TestUnresolvableMethods(t *testing.T) {
+	t.Parallel()
+	bindingDir := t.TempDir()
+	binding := strings.Join([]string{
+		`import { CancellablePromise as $CancellablePromise } from "@wailsio/runtime";`,
+		`export function GetTask(id: string): $CancellablePromise<string> {`,
+		`    return $Call.ByID(1, id);`,
+		`}`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(bindingDir, "taskservice.ts"), []byte(binding), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	services := []service{
+		{name: "TaskService", methods: []string{"GetTask", "NewlyAdded"}},
+		{name: "QueueService", methods: []string{"SnapshotDepth"}},
+	}
+
+	skip, reasons := unresolvableMethods(services, bindingDir)
+	if skip["GetTask"] {
+		t.Error("GetTask has a binding signature and must not be skipped")
+	}
+	if !skip["NewlyAdded"] {
+		t.Error("NewlyAdded has no binding signature and must be skipped")
+	}
+	if !skip["SnapshotDepth"] {
+		t.Error("SnapshotDepth's service has no binding file and must be skipped")
+	}
+	if len(reasons) != 2 {
+		t.Fatalf("reasons = %v, want 2", reasons)
+	}
+}
+
+func TestFillAPIHTTP_SkipsMissingBinding(t *testing.T) {
+	t.Parallel()
+	bindingDir := t.TempDir()
+	src := strings.Join([]string{
+		"async function call<T>(): Promise<T> { return undefined as T }",
+		"",
+		"// QueueService",
+		"export function Existing(): Promise<void> { return call('QueueService', 'Existing') }",
+	}, "\n")
+	services := []service{{name: "QueueService", methods: []string{"Existing", "SnapshotDepth"}}}
+	skip := map[string]bool{"SnapshotDepth": true}
+
+	out, added, err := fillAPIHTTP(src, services, bindingDir, skip)
+	if err != nil {
+		t.Fatalf("must not error on a skipped missing-binding method: %v", err)
+	}
+	if len(added) != 0 {
+		t.Fatalf("added = %v, want none (SnapshotDepth skipped, Existing already present)", added)
+	}
+	if strings.Contains(out, "SnapshotDepth") {
+		t.Fatalf("skipped method must not be emitted:\n%s", out)
 	}
 }

--- a/scripts/check-api-shim-sync.sh
+++ b/scripts/check-api-shim-sync.sh
@@ -36,11 +36,24 @@ read_lines_into() {
   done
 }
 
-# Exported Go method names allowlisted for HTTP dispatch, e.g. `"GetTask",`.
-# Restricted to capitalized identifiers so this doesn't also match unrelated
-# quoted strings (import paths, package names) elsewhere in the file. Uses
-# BRE grep + sed instead of PCRE (-P) so this also runs on macOS/BSD grep.
-read_lines_into methods < <(grep -oE '^[[:space:]]*"[A-Z][A-Za-z0-9_]*",?$' "${SERVICES_GO}" | sed -E 's/^[[:space:]]*"([A-Za-z0-9_]+)",?$/\1/' | sort -u)
+# Only Wails-bound services need frontend shims. An HTTP-only control-plane
+# service (in the HTTP allowlist but with no wails3 binding, e.g. QueueService)
+# has no api.ts pick() counterpart and no frontend caller, so it is exempt —
+# gated below by whether its binding file exists. Portable awk for BSD + gawk;
+# the capitalized-only method regex still skips import paths and package names.
+BINDING_DIR="frontend/bindings/github.com/Automaat/sybra/internal/sybra"
+read_lines_into methods < <(awk -v bdir="${BINDING_DIR}" '
+  /httpapi\.NewService\(/ {
+    svc = $0
+    sub(/^[[:space:]]*"/, "", svc)
+    sub(/".*/, "", svc)
+    wails = (system("test -f \"" bdir "/" tolower(svc) ".ts\"") == 0)
+    next
+  }
+  /^[[:space:]]*"[A-Z][A-Za-z0-9_]*",?[[:space:]]*$/ {
+    if (wails) { m = $0; sub(/^[[:space:]]*"/, "", m); sub(/",?[[:space:]]*$/, "", m); print m }
+  }
+' "${SERVICES_GO}" | sort -u)
 
 if [[ "${#methods[@]}" -eq 0 ]]; then
   echo "::error::no methods parsed from ${SERVICES_GO} — check the extraction regex" >&2


### PR DESCRIPTION
## Motivation

`gen-api-shim` (added in #1895) hard-errored when an allowlisted method's Wails binding file was absent — a brand-new service whose bindings weren't regenerated (bindings are darwin/CI-generated, not produced on the Linux server). A non-zero exit flagged the **codegen gate** straight to `human-required`. Task `f8133f8f` hit this: it adds a new `QueueService` but `queueservice.ts` does not exist, so the generator crashed the gate instead of the failure surfacing cleanly at verify.

> Changelog: fix(codegen): skip missing-binding methods in api shim gen

## Implementation information

- `unresolvableMethods` pre-computes methods with no binding file or no signature; both `fillAPITS` and `fillAPIHTTP` skip them (both shim lines reference the binding, so neither is generatable without it).
- `run()` emits a single stderr warning naming the skipped methods and pointing at `wails3 generate bindings`, then exits **cleanly**.
- A genuinely missing shim is still caught downstream by `check-api-shim-sync` (verify), and the missing binding by the Wails bindings-sync CI gate — no longer a codegen-gate crash.
- Tests: `unresolvableMethods` (missing file + missing signature) and `fillAPIHTTP` skip behavior.

## Supporting documentation

Follow-up to #1895. Note: this makes the generator robust, but f8133f8f's underlying blocker (a new Wails service needs bindings regenerated, which the Linux server can't do) is tracked separately.