### PR TITLE
ci(actions): auto-regenerate wails bindings on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,16 @@ jobs:
   check-wailsjs:
     name: Wails Bindings Sync
     runs-on: macos-15
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Same-repo PRs check out the head branch so regenerated bindings can
+          # be pushed back to it; empty on push/tag events falls back to the
+          # triggering ref.
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
@@ -164,10 +172,42 @@ jobs:
       - name: Regenerate bindings
         run: wails3 generate bindings -ts -clean -d frontend/bindings ./...
 
-      - name: Check for drift
+      - name: Regenerate api transport shims
+        # gen-api-shim consumes the freshly regenerated bindings, so a new
+        # Wails service gets both its binding and its api.ts/api-http.ts shims
+        # produced in the same pass.
+        run: go run ./cmd/gen-api-shim
+
+      - name: Commit and push regenerated bindings and shims
+        # Restricted to same-repo PRs — a fork PR's GITHUB_TOKEN is read-only
+        # and falls through to the drift gate. A GITHUB_TOKEN push never
+        # re-triggers workflows, so no loop; the generated files ride into the
+        # squash-merge.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          git diff --exit-code frontend/bindings/ || \
-            (echo "::error::Wails v3 bindings out of sync. Run 'wails3 generate bindings -ts -d frontend/bindings ./...'." && exit 1)
+          if git diff --quiet -- frontend/bindings/ frontend/src/lib/api.ts frontend/src/lib/api-http.ts; then
+            echo "bindings and api shims already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add frontend/bindings/ frontend/src/lib/api.ts frontend/src/lib/api-http.ts
+          git commit -s -m "chore(bindings): regenerate wails bindings and api shims"
+          git push origin HEAD:"$HEAD_REF"
+
+      - name: Check for drift
+        # Fork PRs and push/tag events cannot auto-commit, so the hard gate
+        # stays as the backstop and any drift there still fails red.
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          git diff --exit-code frontend/bindings/ frontend/src/lib/api.ts frontend/src/lib/api-http.ts || \
+            (echo "::error::Wails bindings / api shims out of sync. Run 'wails3 generate bindings -ts -d frontend/bindings ./...' and 'go run ./cmd/gen-api-shim'." && exit 1)
 
   check-api-shim-sync:
     name: API Shim Sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # Same-repo PRs check out the head branch so regenerated bindings can
-          # be pushed back to it; empty on push/tag events falls back to the
-          # triggering ref.
-          ref: ${{ github.head_ref }}
+          # Only same-repo PRs check out the head branch (so regenerated files
+          # can be pushed back). Fork PRs and push/tag events resolve to an
+          # empty ref and use the default checkout — a fork branch name would
+          # not resolve in this repo, and a fork cannot be pushed to.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
           persist-credentials: true
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1


### PR DESCRIPTION
## Motivation

Wails binding generation only runs on the `macos-15` runner (it's darwin-only), so a task that adds a **new Wails service** can't regenerate its bindings on the Linux server — it strands at the drift gate with no autonomous path forward. (Surfaced while investigating f8133f8f, though that task turned out to be an HTTP-only service — see #1910.)

> Changelog: ci(actions): auto-commit regenerated wails bindings + shims on PRs

## Implementation information

Turn the `Wails Bindings Sync` job from **fail-on-drift** into **auto-fix on same-repo PRs**:
- Regenerate bindings (`wails3 generate bindings`) **and** the api shims (`go run ./cmd/gen-api-shim`, which consumes the freshly regenerated bindings — so a new Wails service gets both its binding and its `api.ts`/`api-http.ts` shims in one pass).
- On a same-repo PR with drift: commit + push both to the PR head branch (job gets `permissions: contents: write`; checks out `head_ref`).
- Fork PRs and push/tag events keep the **hard drift gate** (read-only token there).
- `head_ref` is passed via `env` to avoid script injection (actionlint-clean).

### Caveats
- A `GITHUB_TOKEN` push does **not** re-trigger workflows (GitHub's loop guard), so the auto-pushed commit won't spawn a fresh run. The generated files ride into the squash-merge; if branch protection ever requires this check to pass on the exact HEAD sha, a manual re-run (or a PAT) would be needed. Flagging for review.
- Depends on #1910's robust `gen-api-shim` (skips missing/HTTP-only bindings) so the shim step never hard-fails.

## Supporting documentation

Fifth in the human-required-recoverability series (#1895, #1904, #1906, #1909). This one is infra behavior — worth a careful look before merge.