### PR TITLE
feat(abtest): uniform weights across providers

### DIFF
--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -19,7 +19,7 @@ type Config struct {
 // returned by DefaultConfig. Bump this whenever the built-in experiments'
 // roles, variants, or weights change in a way that persisted configs should
 // pick up automatically.
-const CurrentBuiltinVersion = 3
+const CurrentBuiltinVersion = 4
 
 // BuiltinExperimentIDs lists the experiment IDs owned by Sybra's shipped
 // defaults. A persisted config's experiment is only replaced during a builtin
@@ -82,26 +82,16 @@ type Assignment struct {
 }
 
 // DefaultConfig returns the default A/B suite split by price bracket: code
-// author roles use cheap variants, while planning and review use premium
-// ones.
+// author roles use cheap variants, while planning and review use premium ones.
 //
-// The cheap bracket is split into two role-scoped experiments rather than one
-// shared bracket. The live evaluation scorecard (30d, 2026-07-05) grounds the
-// weights:
-//   - implementation: claude:sonnet:medium is the highest-quality/highest-cost
-//     option (failureRate 0.059, mergeRate 0.933, ~$2.58/run over 236 runs);
-//     codex:gpt-5.5 is comparable-to-better at a fraction of the cost
-//     (failureRate 0.038-0.13, mergeRate 1.0, ~$0.31/run); copilot:gpt-5.5
-//     lands respectably too (failureRate 0.021, mergeRate 0.833, ~$0.07/run).
-//     Weighted 1:2:1 (claude:codex:copilot) — codex takes the plurality,
-//     copilot gets a capped (not blanket) exposure, claude keeps a non-zero
-//     exploration/fallback floor.
-//   - fix-review/pr-fix/test-runner ("maintenance"): codex clearly wins on
-//     pr-fix (failureRate 0.036 vs claude's 0.084) and test-runner (0.037 vs
-//     claude's 0.268), and is only modestly behind claude on fix-review
-//     (0.095 vs 0.014). Copilot's maintenance-role sample is too thin to
-//     enable here (see decision log) — weighted 1:3 (claude:codex), no
-//     copilot, until more data justifies widening it.
+// Every experiment enrolls all three providers at equal weight (1:1:1) so each
+// role is genuinely runnable on any provider and the evaluation scorecard sees
+// balanced samples. This is the deliberate "equal agents" posture: rather than
+// hardcoding scorecard-derived weights (which favoured codex on implementation
+// and excluded copilot from maintenance), selection is uniform and the
+// scorecard informs later reweighting rather than a static bias. Watch the
+// per-provider breakdown after rollout — a provider that regresses a role can
+// be down-weighted here without code changes.
 func DefaultConfig() Config {
 	enabled := true
 	expEnabled := true
@@ -119,7 +109,7 @@ func DefaultConfig() Config {
 				Roles:          []string{"implementation"},
 				Variants: []Variant{
 					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
-					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 2},
+					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 1},
 					{ID: "copilot-sonnet", Provider: "copilot", Model: "claude-sonnet-4.6", Tier: "cheap", Weight: 1},
 				},
 			},
@@ -131,7 +121,8 @@ func DefaultConfig() Config {
 				Roles:          []string{"pr-fix", "test-runner"},
 				Variants: []Variant{
 					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
-					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 3},
+					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 1},
+					{ID: "copilot-sonnet", Provider: "copilot", Model: "claude-sonnet-4.6", Tier: "cheap", Weight: 1},
 				},
 			},
 			{
@@ -143,6 +134,7 @@ func DefaultConfig() Config {
 				Variants: []Variant{
 					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
 					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
+					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Tier: "expensive", Weight: 1},
 				},
 			},
 			{

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -92,8 +92,8 @@ func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
 		variantIDs   []string
 	}{
 		{"implementation", "code-author-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
-		{"test-runner", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
-		{"pr-fix", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4"}},
+		{"test-runner", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
+		{"pr-fix", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
 	}
 	for _, tt := range cases {
 		t.Run(tt.role, func(t *testing.T) {
@@ -113,18 +113,22 @@ func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
 	}
 }
 
-// TestDefaultConfigScopesCopilotToImplementation locks the "capped, not
-// blanket" copilot requirement: the maintenance-role experiment
-// (fix-review/pr-fix/test-runner) must never surface a copilot variant, only
-// the implementation-scoped experiment may.
-func TestDefaultConfigScopesCopilotToImplementation(t *testing.T) {
+// TestDefaultConfigEnrollsEveryProviderUniformly locks the "equal agents"
+// posture: every default experiment enrolls all three providers at weight 1 so
+// no role is shut out of any provider and the scorecard sees balanced samples.
+func TestDefaultConfigEnrollsEveryProviderUniformly(t *testing.T) {
 	cfg := DefaultConfig()
 	for _, exp := range cfg.Experiments {
-		if exp.ID == "code-author-maintenance-cheap" {
-			for _, v := range exp.Variants {
-				if v.Provider == "copilot" {
-					t.Fatalf("code-author-maintenance-cheap must not include a copilot variant, got %+v", v)
-				}
+		providers := map[string]bool{}
+		for _, v := range exp.Variants {
+			if v.Weight != 1 {
+				t.Errorf("experiment %q variant %q weight = %d, want 1 (uniform)", exp.ID, v.ID, v.Weight)
+			}
+			providers[v.Provider] = true
+		}
+		for _, p := range []string{"claude", "codex", "copilot"} {
+			if !providers[p] {
+				t.Errorf("experiment %q is missing provider %q", exp.ID, p)
 			}
 		}
 	}
@@ -141,9 +145,9 @@ func TestDefaultConfigUsesExpensiveBracketForFixReview(t *testing.T) {
 			t.Fatalf("ExperimentID = %q, want fix-review-expensive", a.ExperimentID)
 		}
 		switch a.VariantID {
-		case "claude-opus", "codex-gpt-5.5":
+		case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro":
 		default:
-			t.Fatalf("VariantID = %q, want claude-opus or codex-gpt-5.5", a.VariantID)
+			t.Fatalf("VariantID = %q, want an expensive fix-review variant", a.VariantID)
 		}
 	}
 }

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -251,7 +251,7 @@ func TestModelsForClones(t *testing.T) {
 	got := modelsFor(Standard)
 	got["claude"] = "mutated"
 	again := modelsFor(Standard)
-	if again["claude"] != "sonnet" || again["codex"] != "gpt-5.5" || again["copilot"] != "" {
+	if again["claude"] != "sonnet" || again["codex"] != "gpt-5.5" || again["copilot"] != "claude-sonnet-4.6" {
 		t.Fatalf("modelsFor did not clone standard row: %#v", again)
 	}
 }

--- a/internal/llmjob/tier.go
+++ b/internal/llmjob/tier.go
@@ -21,12 +21,12 @@ var tierModels = map[Tier]map[string]string{
 	Standard: {
 		"claude":  "sonnet",
 		"codex":   "gpt-5.5",
-		"copilot": "",
+		"copilot": "claude-sonnet-4.6",
 	},
 	Deep: {
 		"claude":  "opus",
 		"codex":   "gpt-5.5",
-		"copilot": "",
+		"copilot": "gemini-3.1-pro-preview",
 	},
 }
 


### PR DESCRIPTION
## Motivation

Part of the "equal agents" umbrella (#1898). WS2 makes the default A/B suite uniform so every role is genuinely runnable on any enabled provider, instead of the scorecard-tuned weights that favoured codex on implementation and excluded copilot from the maintenance and fix-review roles.

Per the "use recommended (uniform weights) + all providers" decision, selection is now equal odds; the evaluation scorecard informs later reweighting rather than a hardcoded bias. This trades the documented codex-implementation edge for balanced exposure — watch the per-provider breakdown after rollout and down-weight any provider that regresses a role (config-only, no code change).

## Implementation information

- **Uniform A/B weights** (`internal/abtest/model.go`): every experiment enrolls claude/codex/copilot at weight 1. Added copilot variants to `code-author-maintenance-cheap` (pr-fix/test-runner) and `fix-review-expensive`, which previously had none.
- **Builtin version bump** 3→4 so persisted configs reconcile to the uniform experiments; `reconcileBuiltinExperiments` writes a versioned backup first and preserves user-authored experiments.
- **Copilot tier models** (`internal/llmjob/tier.go`): filled the empty Standard/Deep copilot slots (`claude-sonnet-4.6` / `gemini-3.1-pro-preview`) so triage/eval/judge jobs can run on copilot as a real candidate instead of falling through.
- Tests: rewrote the "copilot scoped to implementation" test into `TestDefaultConfigEnrollsEveryProviderUniformly` (asserts all-1 weights + all three providers per experiment); updated cheap/fix-review variant-set assertions and the llmjob tier clone test.

### Descoped to follow-up (#1914)

The `crossProvider` heuristic (simple review / plan-critic / test-runner / pr-review) still pairs claude↔codex. Generalizing it to a 3-way availability-aware rotation is coupled to non-trivial e2e harness work (there is no `fake-copilot`, so a rotation to copilot spawns the uncontrolled real CLI and hangs the cross e2e tests). The A/B suite already delivers copilot equality for the highest-value roles; the cross generalization + `fake-copilot` harness is split into #1914.

An adversarial pre-PR review confirmed the builtin-version migration, variant validation, model consistency, and llmjob empty-model handling are all sound, and flagged the cross-rotation e2e issue that drove the descope.

Closes #1900

> Changelog: feat(abtest): uniform weights across providers
