### PR TITLE
feat(agent): MCP parity across providers

### DIFF
--- a/internal/agent/mcp.go
+++ b/internal/agent/mcp.go
@@ -36,19 +36,6 @@ func buildPlaywrightMCPConfig(outputDir string, extraArgs []string) (string, err
 	return string(data), nil
 }
 
-// preparePlaywrightMCP attaches a headless Playwright MCP server to cfg when
-// every gate passes: the run is headless, the workflow dispatcher marked it
-// eligible (RoleTestRunner only — see agentAdapter.StartAgent),
-// config.PlaywrightMCPEnabled is true, and the FINAL resolved provider (after
-// health-gate failover) is claude. Keying off cfg.provider rather than the
-// raw requested provider is load-bearing: a test-runner run requested as
-// claude but failed over to codex must not spawn a claude-only MCP flag on a
-// codex invocation.
-//
-// A launcher preflight failure (evidence dir exclude, mkdir, missing npx) is
-// logged and swallowed — cfg.MCPConfigJSON stays empty and the run proceeds
-// exactly as it would with the feature off, so a broken preflight never blocks
-// dispatch of the underlying test-runner agent.
 func (m *Manager) preparePlaywrightMCP(cfg *RunConfig) {
 	if cfg.Mode != "headless" || !cfg.PlaywrightMCPEligible {
 		return
@@ -60,7 +47,7 @@ func (m *Manager) preparePlaywrightMCP(cfg *RunConfig) {
 	if !enabled {
 		return
 	}
-	if cfg.provider == nil || cfg.provider.Name() != "claude" {
+	if cfg.provider == nil {
 		return
 	}
 

--- a/internal/agent/mcp_render.go
+++ b/internal/agent/mcp_render.go
@@ -44,12 +44,15 @@ func renderCopilotMCPConfig(mcpJSON string) (string, error) {
 	}
 	rendered := make(map[string]any, len(servers))
 	for name, s := range servers {
-		rendered[name] = map[string]any{
+		server := map[string]any{
 			"type":    "local",
 			"command": s.Command,
-			"args":    s.Args,
 			"tools":   []string{"*"},
 		}
+		if len(s.Args) > 0 {
+			server["args"] = s.Args
+		}
+		rendered[name] = server
 	}
 	data, err := json.Marshal(map[string]any{"mcpServers": rendered})
 	if err != nil {

--- a/internal/agent/mcp_render.go
+++ b/internal/agent/mcp_render.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type mcpServerSpec struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+func parseMCPServers(mcpJSON string) (map[string]mcpServerSpec, error) {
+	if strings.TrimSpace(mcpJSON) == "" {
+		return map[string]mcpServerSpec{}, nil
+	}
+	var doc struct {
+		MCPServers map[string]mcpServerSpec `json:"mcpServers"`
+	}
+	if err := json.Unmarshal([]byte(mcpJSON), &doc); err != nil {
+		return nil, fmt.Errorf("agent: parse mcp config: %w", err)
+	}
+	return doc.MCPServers, nil
+}
+
+func sortedServerNames(servers map[string]mcpServerSpec) []string {
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func renderCopilotMCPConfig(mcpJSON string) (string, error) {
+	servers, err := parseMCPServers(mcpJSON)
+	if err != nil {
+		return "", err
+	}
+	if len(servers) == 0 {
+		return "", nil
+	}
+	rendered := make(map[string]any, len(servers))
+	for name, s := range servers {
+		rendered[name] = map[string]any{
+			"type":    "local",
+			"command": s.Command,
+			"args":    s.Args,
+			"tools":   []string{"*"},
+		}
+	}
+	data, err := json.Marshal(map[string]any{"mcpServers": rendered})
+	if err != nil {
+		return "", fmt.Errorf("agent: render copilot mcp config: %w", err)
+	}
+	return string(data), nil
+}
+
+func renderCodexMCPArgs(mcpJSON string) ([]string, error) {
+	servers, err := parseMCPServers(mcpJSON)
+	if err != nil {
+		return nil, err
+	}
+	if len(servers) == 0 {
+		return nil, nil
+	}
+	var args []string
+	for _, name := range sortedServerNames(servers) {
+		s := servers[name]
+		command, err := json.Marshal(s.Command)
+		if err != nil {
+			return nil, fmt.Errorf("agent: render codex mcp command: %w", err)
+		}
+		args = append(args, "-c", fmt.Sprintf("mcp_servers.%s.command=%s", name, command))
+		if len(s.Args) > 0 {
+			serverArgs, err := json.Marshal(s.Args)
+			if err != nil {
+				return nil, fmt.Errorf("agent: render codex mcp args: %w", err)
+			}
+			args = append(args, "-c", fmt.Sprintf("mcp_servers.%s.args=%s", name, serverArgs))
+		}
+	}
+	return args, nil
+}

--- a/internal/agent/mcp_render_test.go
+++ b/internal/agent/mcp_render_test.go
@@ -31,6 +31,19 @@ func TestRenderCopilotMCPConfig(t *testing.T) {
 	}
 }
 
+func TestRenderCopilotMCPConfig_OmitsNullArgs(t *testing.T) {
+	out, err := renderCopilotMCPConfig(`{"mcpServers":{"noargs":{"command":"foo"}}}`)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(out, "null") {
+		t.Fatalf("copilot config must not emit null args; got %s", out)
+	}
+	if strings.Contains(out, `"args"`) {
+		t.Fatalf("copilot config should omit args when none given; got %s", out)
+	}
+}
+
 func TestRenderCodexMCPArgs(t *testing.T) {
 	if out, err := renderCodexMCPArgs(""); err != nil || out != nil {
 		t.Fatalf("empty input: got %v err %v", out, err)

--- a/internal/agent/mcp_render_test.go
+++ b/internal/agent/mcp_render_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMCPServers_EmptyAndInvalid(t *testing.T) {
+	got, err := parseMCPServers("")
+	if err != nil || len(got) != 0 {
+		t.Fatalf("empty input: got %v err %v, want empty/nil", got, err)
+	}
+	if _, err := parseMCPServers("{not json"); err == nil {
+		t.Fatal("malformed JSON should error")
+	}
+}
+
+func TestRenderCopilotMCPConfig(t *testing.T) {
+	if out, err := renderCopilotMCPConfig(""); err != nil || out != "" {
+		t.Fatalf("empty input: got %q err %v", out, err)
+	}
+	in := `{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}`
+	out, err := renderCopilotMCPConfig(in)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{`"mcpServers"`, `"type":"local"`, `"tools":["*"]`, `"command":"npx"`, `"@playwright/mcp@latest"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("copilot config missing %q; got %s", want, out)
+		}
+	}
+}
+
+func TestRenderCodexMCPArgs(t *testing.T) {
+	if out, err := renderCodexMCPArgs(""); err != nil || out != nil {
+		t.Fatalf("empty input: got %v err %v", out, err)
+	}
+	in := `{"mcpServers":{"playwright":{"command":"npx","args":["-y","x"]}}}`
+	out, err := renderCodexMCPArgs(in)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	want := []string{"-c", `mcp_servers.playwright.command="npx"`, "-c", `mcp_servers.playwright.args=["-y","x"]`}
+	if len(out) != len(want) {
+		t.Fatalf("args = %v, want %v", out, want)
+	}
+	for i := range want {
+		if out[i] != want[i] {
+			t.Errorf("arg[%d] = %q, want %q", i, out[i], want[i])
+		}
+	}
+}
+
+func TestRenderCodexMCPArgs_DeterministicOrder(t *testing.T) {
+	in := `{"mcpServers":{"bravo":{"command":"b"},"alpha":{"command":"a"}}}`
+	out, err := renderCodexMCPArgs(in)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if len(out) < 4 || out[1] != `mcp_servers.alpha.command="a"` || out[3] != `mcp_servers.bravo.command="b"` {
+		t.Fatalf("servers not rendered in sorted order: %v", out)
+	}
+}

--- a/internal/agent/mcp_test.go
+++ b/internal/agent/mcp_test.go
@@ -173,22 +173,20 @@ func TestPreparePlaywrightMCP(t *testing.T) {
 		}
 	})
 
-	t.Run("non_claude_resolved_provider_leaves_mcp_config_json_empty", func(t *testing.T) {
-		// Eligibility/config enabled but the FINAL resolved provider is codex
-		// (e.g. this run failed over) — must not attach the claude-only flag.
+	t.Run("non_claude_resolved_provider_also_attaches_mcp_config", func(t *testing.T) {
 		m, _ := newTestManager(t)
 		m.playwrightMCPEnabled = true
 		wt := t.TempDir()
 		mustRunGit(t, wt, "init", "-b", "main")
 		cfg := RunConfig{Mode: "headless", Dir: wt, PlaywrightMCPEligible: true, provider: codexProvider{}}
 		m.preparePlaywrightMCP(&cfg)
-		if cfg.MCPConfigJSON != "" {
-			t.Errorf("expected empty MCPConfigJSON for non-claude resolved provider; got %q", cfg.MCPConfigJSON)
+		if cfg.MCPConfigJSON == "" {
+			t.Fatal("expected MCPConfigJSON to be set for a codex test-runner (provider parity)")
 		}
-		if slices.ContainsFunc(cfg.ExtraEnv, func(kv string) bool {
-			return strings.HasPrefix(kv, "PLAYWRIGHT_BROWSERS_PATH=") || strings.HasPrefix(kv, "npm_config_cache=")
+		if !slices.ContainsFunc(cfg.ExtraEnv, func(kv string) bool {
+			return strings.HasPrefix(kv, "PLAYWRIGHT_BROWSERS_PATH=")
 		}) {
-			t.Fatalf("non-claude provider must not inject playwright env, got %v", cfg.ExtraEnv)
+			t.Fatalf("expected playwright env injected for codex provider, got %v", cfg.ExtraEnv)
 		}
 	})
 

--- a/internal/agent/mcp_test.go
+++ b/internal/agent/mcp_test.go
@@ -183,10 +183,10 @@ func TestPreparePlaywrightMCP(t *testing.T) {
 		if cfg.MCPConfigJSON == "" {
 			t.Fatal("expected MCPConfigJSON to be set for a codex test-runner (provider parity)")
 		}
-		if !slices.ContainsFunc(cfg.ExtraEnv, func(kv string) bool {
-			return strings.HasPrefix(kv, "PLAYWRIGHT_BROWSERS_PATH=")
-		}) {
-			t.Fatalf("expected playwright env injected for codex provider, got %v", cfg.ExtraEnv)
+		for _, key := range []string{"PLAYWRIGHT_BROWSERS_PATH=", "npm_config_cache="} {
+			if !slices.ContainsFunc(cfg.ExtraEnv, func(kv string) bool { return strings.HasPrefix(kv, key) }) {
+				t.Fatalf("expected %s injected for codex provider, got %v", key, cfg.ExtraEnv)
+			}
 		}
 	})
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1253,11 +1253,7 @@ type RunConfig struct {
 	// dispatcher alongside PlaywrightMCPEligible; empty falls back to
 	// <Dir>/.sybra-evidence.
 	PlaywrightMCPOutputDir string
-	// MCPConfigJSON is the Claude --mcp-config JSON payload for the headless
-	// Playwright MCP server. Set only by Manager.preparePlaywrightMCP after
-	// the final provider resolves to claude and the launcher preflight
-	// succeeds. Claude-only: every other provider ignores this field.
-	MCPConfigJSON string
+	MCPConfigJSON          string
 	// provider is the implementation selected once at run start after health
 	// gates and failover. Replay paths that do not have RunConfig resolve from
 	// the persisted provider string instead.

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1240,13 +1240,7 @@ type RunConfig struct {
 	// (agentorch.ResolveSandboxMode) from the task's Sandbox toggle merged
 	// with config.DefaultSandboxMode(). Empty is treated as "report" by
 	// Manager.injectProcessSandbox.
-	SandboxMode string
-	// PlaywrightMCPEligible marks a run as a candidate for the headless
-	// Playwright MCP server (set by the workflow dispatcher for RoleTestRunner
-	// runs only; see agentAdapter.StartAgent). Actually attaching MCP
-	// additionally requires config.PlaywrightMCPEnabled, a headless run, and a
-	// final-resolved Claude provider — decided by
-	// Manager.preparePlaywrightMCP, never by the raw requested provider.
+	SandboxMode           string
 	PlaywrightMCPEligible bool
 	// PlaywrightMCPOutputDir is the per-task directory the Playwright MCP
 	// server writes screenshots/console logs to. Set by the workflow

--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -50,6 +50,13 @@ func (p codexProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headles
 	}
 	// Lifecycle hooks (fail-open: omitted when sybra-cli unresolvable or taskID unsafe).
 	args = append(args, buildCodexHookArgs(a.TaskID)...)
+	if cfg.MCPConfigJSON != "" {
+		mcpArgs, err := renderCodexMCPArgs(cfg.MCPConfigJSON)
+		if err != nil {
+			return headlessInvocation{}, err
+		}
+		args = append(args, mcpArgs...)
+	}
 	prompt := rewriteSkillInvocations(cfg.Prompt, discoverCodexSkills())
 	args = append(args, prompt)
 	return headlessInvocation{

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -49,6 +49,15 @@ func (copilotProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headles
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
+	if cfg.MCPConfigJSON != "" {
+		mcpConfig, err := renderCopilotMCPConfig(cfg.MCPConfigJSON)
+		if err != nil {
+			return headlessInvocation{}, err
+		}
+		if mcpConfig != "" {
+			args = append(args, "--additional-mcp-config", mcpConfig)
+		}
+	}
 	// Copilot only reports its session id on the terminal result event, so
 	// a resume id is available only for an intentional stop/restart. Use
 	// --session-id (unambiguous required-value flag) over --resume[=value].

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -2172,10 +2172,10 @@ func TestBuildHeadlessInvocation_OutputSchema(t *testing.T) {
 	})
 }
 
-// TestBuildHeadlessInvocation_PlaywrightMCP verifies --mcp-config and
-// --strict-mcp-config are always paired, only appear for claude, and never
-// appear when MCPConfigJSON is empty (the disabled/preflight-failed/non-claude
-// state Manager.preparePlaywrightMCP leaves cfg in).
+// TestBuildHeadlessInvocation_PlaywrightMCP verifies each provider renders the
+// canonical MCPConfigJSON into its own flag form (claude --mcp-config, codex -c
+// mcp_servers overrides, copilot --additional-mcp-config) and that all are a
+// no-op when MCPConfigJSON is empty.
 func TestBuildHeadlessInvocation_PlaywrightMCP(t *testing.T) {
 	t.Parallel()
 
@@ -2212,19 +2212,52 @@ func TestBuildHeadlessInvocation_PlaywrightMCP(t *testing.T) {
 		}
 	})
 
-	t.Run("codex_ignores_mcp_config_json", func(t *testing.T) {
-		// MCPConfigJSON is a Claude-only field; a non-claude provider must never
-		// see it, even if some upstream bug leaves it set on the RunConfig.
+	t.Run("codex_renders_mcp_config_as_c_overrides", func(t *testing.T) {
 		a := &Agent{ID: "a", Provider: "codex"}
-		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
-			Prompt:        "test",
-			MCPConfigJSON: `{"mcpServers":{}}`,
-		})
+		mcpJSON := `{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}`
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "test", MCPConfigJSON: mcpJSON})
 		if err != nil {
 			t.Fatalf("buildHeadlessInvocation: %v", err)
 		}
-		if slices.Contains(args, "--mcp-config") || slices.Contains(args, "--strict-mcp-config") {
-			t.Fatalf("mcp flags must not appear for codex; got %v", args)
+		if slices.Contains(args, "--mcp-config") {
+			t.Fatalf("codex must not use claude's --mcp-config flag; got %v", args)
+		}
+		if !slices.Contains(args, `mcp_servers.playwright.command="npx"`) {
+			t.Fatalf("codex missing mcp_servers command override; got %v", args)
+		}
+		if !slices.Contains(args, `mcp_servers.playwright.args=["-y","@playwright/mcp@latest"]`) {
+			t.Fatalf("codex missing mcp_servers args override; got %v", args)
+		}
+	})
+
+	t.Run("codex_empty_mcp_config_is_noop", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "test"})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		if slices.ContainsFunc(args, func(s string) bool { return strings.HasPrefix(s, "mcp_servers.") }) {
+			t.Fatalf("codex must not emit mcp_servers overrides when MCPConfigJSON empty; got %v", args)
+		}
+	})
+
+	t.Run("copilot_renders_additional_mcp_config", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "copilot"}
+		mcpJSON := `{"mcpServers":{"playwright":{"command":"npx","args":["-y","@playwright/mcp@latest"]}}}`
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "test", MCPConfigJSON: mcpJSON})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		idx := slices.Index(args, "--additional-mcp-config")
+		if idx < 0 || idx+1 >= len(args) {
+			t.Fatalf("copilot missing --additional-mcp-config; got %v", args)
+		}
+		payload := args[idx+1]
+		if !strings.Contains(payload, `"type":"local"`) || !strings.Contains(payload, `"tools":["*"]`) {
+			t.Fatalf("copilot mcp config must carry type/tools; got %s", payload)
+		}
+		if !strings.Contains(payload, `"command":"npx"`) {
+			t.Fatalf("copilot mcp config missing command; got %s", payload)
 		}
 	})
 }

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -735,10 +735,6 @@ func (a *agentAdapter) configureTestRunnerRun(cfg *agent.RunConfig, taskID strin
 	if role != agent.RoleTestRunner {
 		return
 	}
-	// Eligibility only — Manager.preparePlaywrightMCP decides whether to
-	// actually attach the MCP server, gated on config enablement and the
-	// FINAL resolved provider (not this raw role/provider check), so a
-	// test-runner that fails over to codex never gets a claude-only flag.
 	cfg.PlaywrightMCPEligible = true
 	cfg.PlaywrightMCPOutputDir = filepath.Join(cfg.Dir, worktree.EvidenceDirName)
 }


### PR DESCRIPTION
## Motivation

Part of the "equal agents" umbrella (#1898). Previously only Claude received the Playwright MCP server, so a test-runner that ran on (or failed over to) codex or copilot silently lost browser testing — a functional inequality between providers. This makes codex and copilot test-runners get the same Playwright MCP.

Per the issue, this was **spiked first** against the installed CLIs before implementing.

## Spike results

- **Codex** (`codex-cli 0.144.1`): MCP via `~/.codex/config.toml [mcp_servers.*]`, `codex mcp add`, and `-c` dotted-TOML overrides. Confirmed `-c 'mcp_servers.x.command="..."'` registers a server (via `codex mcp list`) and that `codex exec --ignore-user-config -c mcp_servers...` parses and runs.
- **Copilot** (`GitHub Copilot CLI 1.0.70`): `--additional-mcp-config <json>` takes inline JSON in the `~/.copilot/mcp-config.json` shape. Captured the exact format via `copilot mcp add --json` in an isolated HOME: `{"mcpServers":{"<name>":{"type":"local","command":...,"args":[...],"tools":["*"]}}}`.

## Implementation information

- `preparePlaywrightMCP` (`internal/agent/mcp.go`) drops the `provider.Name() != "claude"` gate; it now stamps the canonical MCP config onto `RunConfig.MCPConfigJSON` for any resolved provider, plus the `PLAYWRIGHT_BROWSERS_PATH`/`npm_config_cache` env (inherited by the MCP subprocess on every provider).
- New `internal/agent/mcp_render.go` renders the canonical server set per provider; each `BuildHeadlessInvocation` calls it:
  - claude — `--mcp-config <json> --strict-mcp-config` (unchanged)
  - codex — `-c mcp_servers.<name>.command/.args` (JSON encoding doubles as valid TOML; each `-c key=value` is a single argv element, no shell)
  - copilot — `--additional-mcp-config <json>` with per-server `type`/`tools` added
- Tests: new `mcp_render_test.go` (renderers, sorted order, edge cases); rewrote the old claude-only `mcp_test.go`/`runner_headless_test.go` assertions to verify per-provider rendering and parity.

An adversarial pre-PR review verdict was **CLEAN** — it proved codex's JSON⊆TOML escaping is always valid, confirmed the `-c` arg position is production-proven (matches existing `codexReasoningArgs`/hooks), and found no downstream `MCPConfigJSON`-implies-claude assumptions.

## Residual / follow-ups

- Live model *use* of the codex MCP (vs. flag registration, which is verified) is best confirmed via the manual/sybra-test e2e path.
- A config-driven MCP server list (vs. the hardcoded Playwright entry) and interactive-path MCP wiring are noted as future enhancements, not required for test-runner parity.

Closes #1901

> Changelog: feat(agent): MCP parity across providers
