### PR TITLE
feat(skills): copilot skills parity

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -893,6 +893,7 @@ func cmdInstallSkills(cfg *config.Config, jsonOut bool) int {
 		cfg.SkillsDir,
 		filepath.Join(home, ".claude", "skills"),
 		filepath.Join(home, ".codex", "skills"),
+		filepath.Join(home, ".copilot", "skills"),
 		filepath.Join(home, ".agents", "skills"),
 	}
 	if jsonOut {
@@ -1963,8 +1964,9 @@ Commands:
   triage classify --all        Classify every task with status=new.
 
   install-skills               Install/refresh Sybra's bundled skills into
-                               ~/.claude/skills, ~/.codex/skills, ~/.agents/skills
-                               (and the app skills dir) for Claude Code + Codex.
+                               ~/.claude/skills, ~/.codex/skills, ~/.copilot/skills,
+                               ~/.agents/skills (and the app skills dir) for
+                               Claude Code, Codex, and Copilot.
 
   artifact list <task-id>      List artifacts for a task.
   artifact get  <task-id> <name>  Print raw artifact bytes to stdout.

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -44,7 +44,7 @@ func (copilotProvider) BuildCommand(cfg RunConfig, model string) string {
 func (copilotProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
 	// --allow-all-tools is required for non-interactive mode; --no-ask-user
 	// stops the agent blocking on questions (no TTY/UI to answer them).
-	prompt := stripSkillInvocations(cfg.Prompt, discoverCodexSkills())
+	prompt := stripSkillInvocations(cfg.Prompt, discoverCopilotSkills())
 	args := []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
 	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -44,7 +44,8 @@ func (copilotProvider) BuildCommand(cfg RunConfig, model string) string {
 func (copilotProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
 	// --allow-all-tools is required for non-interactive mode; --no-ask-user
 	// stops the agent blocking on questions (no TTY/UI to answer them).
-	args := []string{"-p", cfg.Prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+	prompt := stripSkillInvocations(cfg.Prompt, discoverCodexSkills())
+	args := []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
 	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -380,6 +380,7 @@ func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, pro
 // first turn captures a session id (result event), subsequent turns pass
 // --session-id to resume the same conversation.
 func buildCopilotConvoArgs(a *Agent, prompt string) []string {
+	prompt = stripSkillInvocations(prompt, discoverCodexSkills())
 	args := []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
 	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -380,7 +380,7 @@ func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, pro
 // first turn captures a session id (result event), subsequent turns pass
 // --session-id to resume the same conversation.
 func buildCopilotConvoArgs(a *Agent, prompt string) []string {
-	prompt = stripSkillInvocations(prompt, discoverCodexSkills())
+	prompt = stripSkillInvocations(prompt, discoverCopilotSkills())
 	args := []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
 	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -83,6 +83,37 @@ func cloneSkillNames(names []string) []string {
 	return out
 }
 
+func discoverCopilotSkills() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return discoverCopilotSkillsInHome(home)
+}
+
+func discoverCopilotSkillsInHome(home string) []string {
+	seen := make(map[string]struct{}, 64)
+	for _, dir := range []string{
+		filepath.Join(home, ".copilot", "skills"),
+		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".claude", "skills"),
+		filepath.Join(home, ".codex", "skills"),
+	} {
+		for _, name := range listSkillDirs(dir) {
+			seen[name] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	return out
+}
+
 func discoverCodexSkillsInHome(home string) []string {
 	seen := make(map[string]struct{}, 64)
 	for _, name := range listSkillDirs(filepath.Join(home, ".codex", "skills")) {

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -26,6 +26,10 @@ func rewriteSkillInvocations(prompt string, skillNames []string) string {
 	return skillinvoke.RewriteInvocations(prompt, skillNames)
 }
 
+func stripSkillInvocations(prompt string, skillNames []string) string {
+	return skillinvoke.StripInvocations(prompt, skillNames)
+}
+
 // discoverCodexSkills returns the union of skill names sybra knows about for
 // the codex skill rewriter. A "known" skill is one whose name shows up in
 // any of: ~/.codex/skills/, ~/.claude/skills/, `codex plugin list --json`,

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -206,6 +206,19 @@ func TestDiscoverCodexSkillsUsesPluginListAndSkipsCodexCache(t *testing.T) {
 	}
 }
 
+func TestDiscoverCopilotSkillsScansCopilotAndAgentsDirs(t *testing.T) {
+	home := t.TempDir()
+	mkLocalSkill(t, filepath.Join(home, ".copilot", "skills"), "copilot-only")
+	mkLocalSkill(t, filepath.Join(home, ".agents", "skills"), "agents-shared")
+	mkLocalSkill(t, filepath.Join(home, ".claude", "skills"), "claude-shared")
+
+	got := discoverCopilotSkillsInHome(home)
+	want := []string{"agents-shared", "claude-shared", "copilot-only"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
 func TestListCodexPluginSourceSkillsRejectsInvalidFrontmatterName(t *testing.T) {
 	pluginRoot := t.TempDir()
 	singleSkillRoot := filepath.Join(pluginRoot, "opaque-dir")

--- a/internal/skillinvoke/skillinvoke.go
+++ b/internal/skillinvoke/skillinvoke.go
@@ -28,6 +28,18 @@ func NormalizeName(name string) (normalized string, ok bool) {
 // RewriteInvocations converts known slash skill invocations to Codex's
 // dollar-prefixed syntax.
 func RewriteInvocations(prompt string, skillNames []string) string {
+	return rewriteWithPrefix(prompt, skillNames, "$")
+}
+
+// StripInvocations converts known slash skill invocations to a bare skill name.
+// Copilot has no invocation prefix — skills are discovered from SKILL.md and
+// triggered by name/description — so a leading slash would name a command
+// Copilot cannot run; the bare name is the strongest trigger signal.
+func StripInvocations(prompt string, skillNames []string) string {
+	return rewriteWithPrefix(prompt, skillNames, "")
+}
+
+func rewriteWithPrefix(prompt string, skillNames []string, prefix string) string {
 	if prompt == "" || len(skillNames) == 0 {
 		return prompt
 	}
@@ -44,7 +56,7 @@ func RewriteInvocations(prompt string, skillNames []string) string {
 	last := 0
 	for _, m := range matches {
 		out.WriteString(prompt[last:m.start])
-		out.WriteByte('$')
+		out.WriteString(prefix)
 		out.WriteString(m.name)
 		last = m.end
 	}

--- a/internal/skillinvoke/skillinvoke_test.go
+++ b/internal/skillinvoke/skillinvoke_test.go
@@ -38,6 +38,15 @@ func TestRewriteInvocations(t *testing.T) {
 	}
 }
 
+func TestStripInvocations(t *testing.T) {
+	t.Parallel()
+	got := StripInvocations("Run /plan-critic, not /tmp/plan-critic or /plan-critic-extra.", []string{"plan", "plan-critic"})
+	want := "Run plan-critic, not /tmp/plan-critic or /plan-critic-extra."
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestContainsInvocation(t *testing.T) {
 	t.Parallel()
 	if !ContainsInvocation("Run /sybra-test now.", "sybra-test") {

--- a/internal/skillsync/syncer.go
+++ b/internal/skillsync/syncer.go
@@ -130,6 +130,7 @@ func (s *Syncer) destinations(primary, userHome string) []string {
 	for _, agentDir := range []string{
 		filepath.Join(userHome, ".claude", "skills"),
 		filepath.Join(userHome, ".codex", "skills"),
+		filepath.Join(userHome, ".copilot", "skills"),
 		filepath.Join(userHome, ".agents", "skills"),
 	} {
 		if filepath.Clean(primary) != filepath.Clean(agentDir) {

--- a/internal/skillsync/syncer_test.go
+++ b/internal/skillsync/syncer_test.go
@@ -424,6 +424,7 @@ func TestRunEmbeddedSkillsLandInAllDirsWhenGoModPresent(t *testing.T) {
 		primaryDst,
 		filepath.Join(userHome, ".claude", "skills"),
 		filepath.Join(userHome, ".codex", "skills"),
+		filepath.Join(userHome, ".copilot", "skills"),
 		filepath.Join(userHome, ".agents", "skills"),
 	}
 	for _, dir := range allDsts {
@@ -435,6 +436,44 @@ func TestRunEmbeddedSkillsLandInAllDirsWhenGoModPresent(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(dir, "repo-only", "SKILL.md")); err != nil {
 			t.Errorf("repo-only/SKILL.md missing from %s: %v", dir, err)
 		}
+	}
+}
+
+func TestRunPreservesUserCopilotSkillsPrunesSybraOrphans(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	primaryDst := filepath.Join(t.TempDir(), "app-skills")
+	userHome := t.TempDir()
+
+	copilotSkills := filepath.Join(userHome, ".copilot", "skills")
+	vendor := filepath.Join(copilotSkills, "vendor-skill")
+	stale := filepath.Join(copilotSkills, "sybra-stale")
+	for _, d := range []string{vendor, stale} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte("---\nname: x\ndescription: t\n---\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	newSyncer().Run(skillsync.Options{
+		RepoDir:     repoDir,
+		SkillsFS:    skills.FS,
+		PrimaryDst:  primaryDst,
+		UserHomeDir: userHome,
+	})
+
+	if _, err := os.Stat(filepath.Join(vendor, "SKILL.md")); err != nil {
+		t.Errorf("user copilot skill without sybra- prefix must survive sync: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("sybra- orphan in ~/.copilot/skills must be pruned; stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(copilotSkills, "sybra-test", "SKILL.md")); err != nil {
+		t.Errorf("bundled skill should land in ~/.copilot/skills: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Part of the "equal agents" umbrella (#1898). Copilot was the odd provider out for skills: skillsync mirrored the bundle to `~/.claude/skills`, `~/.codex/skills`, and `~/.agents/skills`, and codex got `/skill`→`$skill` invocation rewriting — but there was no explicit Copilot destination and no Copilot invocation handling.

## Spike results

Against the installed `GitHub Copilot CLI 1.0.70`:
- Copilot discovers skills from `~/.copilot/skills/` (Personal) and `~/.agents/skills/`, plus project `.claude/skills`. Verified end-to-end: a skill written as `~/.copilot/skills/<name>/SKILL.md` shows up in `copilot skill list`, so sybra's existing `<name>/SKILL.md` layout is discovered.
- Copilot lists skills by **description** and has **no** per-skill invocation prefix (`/` is reserved for built-in interactive commands like `/mcp`, `/skills`). So a literal `/skill-name` in a prompt names a command Copilot can't run — the bare name is the right trigger signal.

## Implementation information

- `skillsync.destinations()` adds `~/.copilot/skills`. Orphan pruning already iterates every destination and is scoped to the `sybra-` prefix, so **user-added copilot skills (`copilot skill add`) are never clobbered** — covered by a new end-to-end test that plants a vendor skill + a sybra orphan and asserts survive/prune.
- New `skillinvoke.StripInvocations` (+ `agent.stripSkillInvocations`) drops the leading slash from known skill invocations for Copilot prompts, wired into both the copilot headless and per-turn-convo builders — the copilot analog of codex's `$` rewrite.
- Fixed the `install-skills` destination report (CLI `--json` output + help text) which listed claude/codex/agents but not the copilot dir it now writes to.

An adversarial pre-PR review surfaced exactly these two gaps (invocation + CLI report drift) beyond the file sync; both are addressed here. It confirmed the pruning is safe (sybra-prefix-scoped) and discovery layout is correct.

## Residual / follow-ups

- Live confirmation that a bare-name prompt reliably triggers a Copilot skill (vs. description-only triggering) is best done via the manual/sybra-test e2e path.
- The home-nas systemd deploy symlinks `~/.claude`/`~/.codex` to persistent storage but not `~/.copilot`; synced copilot skills re-create idempotently each boot (harmless), worth a deploy follow-up if persistence is ever wanted.

Closes #1902

> Changelog: feat(skills): copilot skills parity
