### PR TITLE
refactor(providerid): single source of truth

### DIFF
--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/skillinvoke"
 )
 
@@ -283,9 +284,7 @@ func validateVariant(expID string, v Variant) error {
 	if strings.TrimSpace(v.ID) == "" {
 		return fmt.Errorf("abtest: experiment %q has variant with empty id", expID)
 	}
-	switch v.Provider {
-	case "claude", "codex", "copilot":
-	default:
+	if !providerid.IsKnown(v.Provider) {
 		return fmt.Errorf("abtest: variant %q has invalid provider %q", v.ID, v.Provider)
 	}
 	if strings.TrimSpace(v.Model) == "" {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
 type EmitFunc func(event string, data any)
@@ -612,7 +613,7 @@ func (m *Manager) ProviderCanFailover(name string) bool {
 	if lg == nil {
 		return false
 	}
-	candidates := []string{"claude", "codex", "copilot"}
+	candidates := providerid.All()
 	if alt, _ := lg.ChooseProvider(resolved, candidates, healthy, lp); alt != "" {
 		return true
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/notes"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/google/uuid"
 )
 
@@ -687,7 +688,7 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (string, []providerGate
 		return (g == nil || g.IsHealthy(p)) && underCap(p)
 	}
 	var gateEvents []providerGateEvent
-	candidateProviders := []string{"claude", "codex", "copilot"}
+	candidateProviders := providerid.All()
 	if g != nil && !g.IsHealthy(resolved) {
 		if cfg.DisableProviderFailover {
 			reason := g.Reason(resolved)

--- a/internal/agent/orphan_sweep.go
+++ b/internal/agent/orphan_sweep.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
 type providerProcess struct {
@@ -89,10 +91,5 @@ func pathWithinRoots(path string, roots []string) bool {
 
 func isProviderProcessName(name string) bool {
 	name = strings.TrimSpace(strings.ToLower(filepath.Base(name)))
-	switch name {
-	case "claude", "codex", "copilot":
-		return true
-	default:
-		return false
-	}
+	return providerid.IsKnown(name)
 }

--- a/internal/agent/regate.go
+++ b/internal/agent/regate.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"maps"
+
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
 // regateForTurn re-consults provider health/limit gating for a per-turn
@@ -111,7 +113,7 @@ func (m *Manager) regate(ctx context.Context, a *Agent, cfg RunConfig, logWriter
 		return cfg, false, nil
 	}
 
-	candidateProviders := []string{"claude", "codex", "copilot"}
+	candidateProviders := providerid.All()
 	alt := firstHealthyProvider(current, candidateProviders, healthy)
 	if alt == "" && lg != nil {
 		if chosen, _ := lg.ChooseProvider(current, candidateProviders, healthy, lp); chosen != "" {

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -18,9 +18,10 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
-var providerOrder = []string{"claude", "codex", "copilot"}
+var providerOrder = providerid.All()
 
 const streamScannerBuffer = 4 * 1024 * 1024
 

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/llmexec"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
 const defaultMaxRepairs = 2
@@ -206,7 +207,7 @@ func avoidProvider(o llmexec.Options, avoid string) (llmexec.Options, error) {
 		o.Gate = avoidingGate{base: o.Gate, avoid: avoid}
 		return o, nil
 	}
-	for _, p := range []string{"claude", "codex", "copilot"} {
+	for _, p := range providerid.All() {
 		if p != avoid {
 			o.Provider = p
 			o.Gate = avoidingGate{base: o.Gate, avoid: avoid}

--- a/internal/loopagent/model.go
+++ b/internal/loopagent/model.go
@@ -43,7 +43,7 @@ func (la *LoopAgent) Validate() error {
 		return fmt.Errorf("loop agent interval_sec must be >= %d (got %d)", minIntervalSec, la.IntervalSec)
 	}
 	if la.Provider != "" && !providerid.IsKnown(la.Provider) {
-		return fmt.Errorf("loop agent provider must be claude, codex, or copilot (got %q)", la.Provider)
+		return fmt.Errorf("loop agent provider must be one of %s (got %q)", providerid.List(), la.Provider)
 	}
 	return nil
 }

--- a/internal/loopagent/model.go
+++ b/internal/loopagent/model.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
 // minIntervalSec is the lower bound for a loop's tick. Anything tighter than
@@ -40,7 +42,7 @@ func (la *LoopAgent) Validate() error {
 	if la.IntervalSec < minIntervalSec {
 		return fmt.Errorf("loop agent interval_sec must be >= %d (got %d)", minIntervalSec, la.IntervalSec)
 	}
-	if la.Provider != "" && la.Provider != "claude" && la.Provider != "codex" && la.Provider != "copilot" {
+	if la.Provider != "" && !providerid.IsKnown(la.Provider) {
 		return fmt.Errorf("loop agent provider must be claude, codex, or copilot (got %q)", la.Provider)
 	}
 	return nil

--- a/internal/loopagent/store_test.go
+++ b/internal/loopagent/store_test.go
@@ -34,7 +34,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "invalid provider",
 			la:      LoopAgent{Name: "x", Prompt: "/foo", IntervalSec: 60, Provider: "gpt4"},
-			wantErr: "provider must be claude, codex, or copilot",
+			wantErr: "provider must be one of claude, codex, copilot",
 		},
 		{
 			name: "codex provider accepted",

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
 // Status is a point-in-time health snapshot for a single provider.
@@ -38,7 +39,7 @@ type Config struct {
 // failoverPriority is the order auto-failover prefers healthy peers in.
 // Copilot is last: it is never chosen over claude/codex, but can be a
 // fallback target when both are unhealthy, and can itself fail over to them.
-var failoverPriority = []string{"claude", "codex", "copilot"}
+var failoverPriority = providerid.All()
 
 const defaultProbeErrorThreshold = 2
 

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -1,0 +1,13 @@
+package providerid
+
+import "slices"
+
+var all = []string{"claude", "codex", "copilot"}
+
+// All returns the ordered provider universe (failover priority: claude, codex,
+// copilot). Adding a fourth provider means appending it here plus registering
+// its agent.Provider impl and config entry. Callers must not mutate the result.
+func All() []string { return append([]string(nil), all...) }
+
+// IsKnown reports whether name is a provider id Sybra can dispatch to.
+func IsKnown(name string) bool { return slices.Contains(all, name) }

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -1,8 +1,15 @@
 package providerid
 
-import "slices"
+import (
+	"slices"
+	"strings"
+)
 
 var all = []string{"claude", "codex", "copilot"}
+
+// List returns the provider universe as a comma-separated string for use in
+// human-readable validation messages, so those messages stay single-sourced.
+func List() string { return strings.Join(all, ", ") }
 
 // All returns the ordered provider universe (failover priority: claude, codex,
 // copilot). Adding a fourth provider means appending it here plus registering

--- a/internal/providerid/providerid_test.go
+++ b/internal/providerid/providerid_test.go
@@ -1,0 +1,31 @@
+package providerid
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestAllReturnsFailoverOrderedCopy(t *testing.T) {
+	got := All()
+	want := []string{"claude", "codex", "copilot"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("All() = %v, want %v", got, want)
+	}
+	got[0] = "mutated"
+	if All()[0] != "claude" {
+		t.Fatal("All() must return a defensive copy; internal slice was mutated")
+	}
+}
+
+func TestIsKnown(t *testing.T) {
+	for _, p := range []string{"claude", "codex", "copilot"} {
+		if !IsKnown(p) {
+			t.Errorf("IsKnown(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"", "gpt", "gemini", "Claude"} {
+		if IsKnown(p) {
+			t.Errorf("IsKnown(%q) = true, want false", p)
+		}
+	}
+}

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -786,7 +787,7 @@ func BuildTaskStartPrompt(t task.Task, prompt string, includeTaskDescription boo
 // the requested provider. Rolls back on any failure so no orphans leak.
 func (o *Orchestrator) StartChat(projectID, providerName, prompt string) (*agent.Agent, error) {
 	prov := strings.ToLower(strings.TrimSpace(providerName))
-	if prov != "claude" && prov != "codex" && prov != "copilot" {
+	if !providerid.IsKnown(prov) {
 		return nil, fmt.Errorf("invalid provider %q: must be claude, codex, or copilot", providerName)
 	}
 	if strings.TrimSpace(projectID) == "" {

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -788,7 +788,7 @@ func BuildTaskStartPrompt(t task.Task, prompt string, includeTaskDescription boo
 func (o *Orchestrator) StartChat(projectID, providerName, prompt string) (*agent.Agent, error) {
 	prov := strings.ToLower(strings.TrimSpace(providerName))
 	if !providerid.IsKnown(prov) {
-		return nil, fmt.Errorf("invalid provider %q: must be claude, codex, or copilot", providerName)
+		return nil, fmt.Errorf("invalid provider %q: must be one of %s", providerName, providerid.List())
 	}
 	if strings.TrimSpace(projectID) == "" {
 		return nil, errors.New("project_id is required")

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/notification"
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
@@ -143,8 +144,7 @@ func (s *ConfigService) UpdateSettings(settings AppSettings) error {
 
 // validateSettings checks all editable fields for validity.
 func (s *ConfigService) validateSettings(settings AppSettings) error {
-	validProviders := map[string]bool{"": true, "claude": true, "codex": true, "copilot": true}
-	if !validProviders[settings.Agent.Provider] {
+	if settings.Agent.Provider != "" && !providerid.IsKnown(settings.Agent.Provider) {
 		return validationError(fmt.Sprintf("invalid provider: %q", settings.Agent.Provider))
 	}
 	if settings.Agent.Model != "" && !modelNameRe.MatchString(settings.Agent.Model) {

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -183,7 +183,7 @@ func ValidateAgentProvider(s string) (string, error) {
 		return "", nil
 	}
 	if !providerid.IsKnown(s) {
-		return "", fmt.Errorf("invalid provider %q (valid: claude, codex, copilot, or empty)", s)
+		return "", fmt.Errorf("invalid provider %q (valid: %s, or empty)", s, providerid.List())
 	}
 	return s, nil
 }

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
@@ -172,9 +173,7 @@ func ValidateReasoningEffort(s string) (string, error) {
 }
 
 // AllAgentProviders returns every supported CLI provider name in display order.
-func AllAgentProviders() []string { return []string{"claude", "codex", "copilot"} }
-
-var validAgentProviders = map[string]bool{"claude": true, "codex": true, "copilot": true}
+func AllAgentProviders() []string { return providerid.All() }
 
 // ValidateAgentProvider accepts the empty string (unset/default) or one of the
 // providers Sybra can dispatch. It is used for handoff provenance, not the
@@ -183,7 +182,7 @@ func ValidateAgentProvider(s string) (string, error) {
 	if s == "" {
 		return "", nil
 	}
-	if !validAgentProviders[s] {
+	if !providerid.IsKnown(s) {
 		return "", fmt.Errorf("invalid provider %q (valid: claude, codex, copilot, or empty)", s)
 	}
 	return s, nil


### PR DESCRIPTION
## Motivation

Part of the "equal agents" umbrella (#1898), and the foundational piece: the provider universe `{claude, codex, copilot}` was hardcoded as a literal across ~12 candidate/failover/validation sites, so adding a fourth provider meant a code sweep. This makes it a single source of truth.

## Implementation information

- New zero-internal-dependency leaf package `internal/providerid` exposing `All()` (ordered failover priority: claude, codex, copilot) and `IsKnown(name)`. Zero deps means every layer can consult it without an import cycle.
- Routed every site through it: `provider.failoverPriority`, agent candidate lists (`manager_run`, `regate`, `manager`) + `orphan_sweep` process-name check, `abtest` variant validation, `task.AllAgentProviders` + `ValidateAgentProvider` (removed the `validAgentProviders` map), `llmexec` provider order, `llmjob` avoid-loop, plus the three sites an adversarial review caught that I'd missed on the first pass: `svc_config.validateSettings` (which had the exact `map[string]bool` twin of the removed one), `loopagent.Validate`, and `agentorch.StartChat`.
- Behavior is unchanged: same ids, same failover order, same exact/case-sensitive match semantics, empty-allowed guards preserved where they existed.

A fourth provider is now a one-line append to `providerid.all` (plus registering its `agent.Provider` impl and config entry) — no candidate/failover/validation sweep.

The adversarial pre-PR review verified the mechanics (cross-package var-init order is safe, `All()` returns a defensive copy consumed read-only everywhere, no dropped imports/cycles) and is what surfaced the three additional un-migrated sites now included.

## Out of scope

`config.ProvidersConfig` keeps typed per-provider fields (each carries its own `Enabled`/cooldown/subscription settings) — that's intentional typed config, and a fourth provider adding a field there is consistent with appending to `providerid.all`, not a hidden literal.

Closes #1903

> Changelog: refactor(providerid): single source of truth
