### PR TITLE
feat(workflow): 3-way availability-aware cross

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ frontend/coverage/
 /synapse-server
 core.*
 /fake-codex
+/fake-copilot
 
 # Perf artifacts
 /perf-profiles/

--- a/cmd/fake-copilot/main.go
+++ b/cmd/fake-copilot/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func cleanEnvPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(filepath.Clean(p))
+	if err != nil {
+		return ""
+	}
+	tmpRoot := filepath.Clean(os.TempDir()) + string(filepath.Separator)
+	if !strings.HasPrefix(abs+string(filepath.Separator), tmpRoot) {
+		return ""
+	}
+	return abs
+}
+
+func popScenario() string {
+	if sf := cleanEnvPath(os.Getenv("FAKE_COPILOT_SCENARIO_FILE")); sf != "" {
+		data, err := os.ReadFile(sf)
+		if err == nil {
+			lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+			if len(lines) > 0 && lines[0] != "" {
+				scenario := strings.TrimSpace(lines[0])
+				_ = os.WriteFile(sf, []byte(strings.Join(lines[1:], "\n")), 0o644)
+				return scenario
+			}
+		}
+	}
+	if s := os.Getenv("FAKE_COPILOT_SCENARIO"); s != "" {
+		return s
+	}
+	return "success"
+}
+
+func sessionID() string {
+	for i, a := range os.Args {
+		if a == "--session-id" && i+1 < len(os.Args) {
+			return os.Args[i+1]
+		}
+	}
+	return "fake-copilot-session-1"
+}
+
+func emit(event map[string]any) {
+	data, _ := json.Marshal(event)
+	fmt.Println(string(data))
+	time.Sleep(10 * time.Millisecond)
+}
+
+func main() {
+	if logFile := cleanEnvPath(os.Getenv("FAKE_COPILOT_ARGS_LOG")); logFile != "" {
+		_ = os.WriteFile(logFile, []byte(strings.Join(os.Args[1:], "\n")), 0o644)
+	}
+
+	scenario := popScenario()
+	exitCode := 0
+	message := "Working on it..."
+	switch scenario {
+	case "fail_exit", "fail":
+		message = "command failed"
+		exitCode = 1
+	}
+
+	emit(map[string]any{"type": "assistant.message", "data": map[string]any{"content": message}})
+	emit(map[string]any{"type": "result", "sessionId": sessionID(), "exitCode": exitCode})
+	os.Exit(exitCode)
+}

--- a/internal/sybra/e2e_crossprovider_test.go
+++ b/internal/sybra/e2e_crossprovider_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
-// setupCrossProviderEnv creates an e2e env with both fake-claude and fake-codex
-// on PATH, separate scenario files for each provider, and the test-review-fix
+// setupCrossProviderEnv creates an e2e env with fake-claude, fake-codex, and
+// fake-copilot on PATH, separate scenario files for each provider, and the test-review-fix
 // workflow loaded.
 func setupCrossProviderEnv(t *testing.T, defaultProvider string, claudeScenarios, codexScenarios, copilotScenarios []string) *e2eEnv {
 	t.Helper()

--- a/internal/sybra/e2e_crossprovider_test.go
+++ b/internal/sybra/e2e_crossprovider_test.go
@@ -17,7 +17,7 @@ import (
 // setupCrossProviderEnv creates an e2e env with both fake-claude and fake-codex
 // on PATH, separate scenario files for each provider, and the test-review-fix
 // workflow loaded.
-func setupCrossProviderEnv(t *testing.T, defaultProvider string, claudeScenarios, codexScenarios []string) *e2eEnv {
+func setupCrossProviderEnv(t *testing.T, defaultProvider string, claudeScenarios, codexScenarios, copilotScenarios []string) *e2eEnv {
 	t.Helper()
 
 	claudeSF := filepath.Join(t.TempDir(), "claude-scenarios.txt")
@@ -28,12 +28,18 @@ func setupCrossProviderEnv(t *testing.T, defaultProvider string, claudeScenarios
 	if err := os.WriteFile(codexSF, []byte(strings.Join(codexScenarios, "\n")), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	copilotSF := filepath.Join(t.TempDir(), "copilot-scenarios.txt")
+	if err := os.WriteFile(copilotSF, []byte(strings.Join(copilotScenarios, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	env := setupE2EProvider(t, defaultProvider, "")
 	t.Setenv("FAKE_CLAUDE_SCENARIO_FILE", claudeSF)
 	t.Setenv("FAKE_CODEX_SCENARIO_FILE", codexSF)
+	t.Setenv("FAKE_COPILOT_SCENARIO_FILE", copilotSF)
 	t.Setenv("FAKE_CLAUDE_SCENARIO", "")
 	t.Setenv("FAKE_CODEX_SCENARIO", "")
+	t.Setenv("FAKE_COPILOT_SCENARIO", "")
 
 	// Load test-review-fix workflow.
 	src, err := os.ReadFile("../../internal/workflow/testdata/test-review-fix.yaml")
@@ -58,6 +64,7 @@ func TestE2E_CrossProvider_ReviewThenFix(t *testing.T) {
 	env := setupCrossProviderEnv(t, "claude",
 		[]string{"success", "success"}, // claude: implement, fix_review
 		[]string{"success"},            // codex: code_review (cross)
+		nil,
 	)
 
 	created, err := env.tasks.Create("cross-provider review test", "", "headless")
@@ -122,6 +129,7 @@ func TestE2E_CrossProvider_ReviewSidecarPersisted(t *testing.T) {
 	env := setupCrossProviderEnv(t, "claude",
 		[]string{"success", "success"},  // claude: implement, fix_review
 		[]string{"code_review_success"}, // codex: code_review writes sidecar via CLI
+		nil,
 	)
 
 	created, err := env.tasks.Create("review sidecar persisted", "", "headless")
@@ -173,6 +181,7 @@ func TestE2E_CrossProvider_NoreviewTagSkipsReview(t *testing.T) {
 	env := setupCrossProviderEnv(t, "claude",
 		[]string{"success"}, // claude: implement only
 		[]string{},          // codex: nothing (review skipped)
+		nil,
 	)
 
 	created, err := env.tasks.Create("noreview test", "", "headless")
@@ -239,6 +248,7 @@ func TestE2E_CrossProvider_ReviewUsesOppositeProvider(t *testing.T) {
 	env := setupCrossProviderEnv(t, "claude",
 		[]string{"success", "success"}, // claude: implement, fix_review
 		[]string{"success"},            // codex: code_review
+		nil,
 	)
 	t.Setenv("FAKE_CODEX_ARGS_LOG", codexArgsLog)
 	t.Setenv("FAKE_CLAUDE_ARGS_LOG", claudeArgsLog)
@@ -284,17 +294,18 @@ func TestE2E_CrossProvider_ReviewUsesOppositeProvider(t *testing.T) {
 
 // TestE2E_CrossProvider_ReviewUsesOppositeProvider_DefaultCodex verifies the
 // inverse routing: when default provider is codex, provider: cross dispatches
-// the review step to claude.
+// the review step to copilot (the next available provider after codex in the rotation).
 func TestE2E_CrossProvider_ReviewUsesOppositeProvider_DefaultCodex(t *testing.T) {
 	codexArgsLog := filepath.Join(t.TempDir(), "codex-args.log")
-	claudeArgsLog := filepath.Join(t.TempDir(), "claude-args.log")
+	copilotArgsLog := filepath.Join(t.TempDir(), "copilot-args.log")
 
 	env := setupCrossProviderEnv(t, "codex",
-		[]string{"success"},            // claude: code_review (cross)
-		[]string{"success", "success"}, // codex: implement, fix_review
+		nil,
+		[]string{"success", "success"},
+		[]string{"success"},
 	)
 	t.Setenv("FAKE_CODEX_ARGS_LOG", codexArgsLog)
-	t.Setenv("FAKE_CLAUDE_ARGS_LOG", claudeArgsLog)
+	t.Setenv("FAKE_COPILOT_ARGS_LOG", copilotArgsLog)
 
 	created, err := env.tasks.Create("provider verify inverse test", "", "headless")
 	if err != nil {
@@ -322,15 +333,15 @@ func TestE2E_CrossProvider_ReviewUsesOppositeProvider_DefaultCodex(t *testing.T)
 		t.Fatalf("workflow state = %q, want completed (step: %s)", tk.Workflow.State, tk.Workflow.CurrentStep)
 	}
 
-	if _, err := os.Stat(claudeArgsLog); err != nil {
-		t.Fatalf("claude args log not written — review step did not invoke claude: %v", err)
+	if _, err := os.Stat(copilotArgsLog); err != nil {
+		t.Fatalf("copilot args log not written — review step did not invoke copilot: %v", err)
 	}
-	claudeArgs, err := os.ReadFile(claudeArgsLog)
+	copilotArgs, err := os.ReadFile(copilotArgsLog)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(claudeArgs), "Review") {
-		t.Errorf("claude invocation should contain review prompt, got:\n%s", string(claudeArgs))
+	if !strings.Contains(string(copilotArgs), "Review") {
+		t.Errorf("copilot invocation should contain review prompt, got:\n%s", string(copilotArgs))
 	}
 
 	if _, err := os.Stat(codexArgsLog); err != nil {

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -115,6 +115,11 @@ func buildTestBinaries(t *testing.T) string {
 			testBuildErr = "build fake-codex: " + err.Error() + "\n" + string(out)
 			return
 		}
+		cmd = exec.Command("go", "build", "-o", filepath.Join(dir, "copilot"), "../../cmd/fake-copilot")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			testBuildErr = "build fake-copilot: " + err.Error() + "\n" + string(out)
+			return
+		}
 		// Build real sybra-cli.
 		cmd = exec.Command("go", "build", "-o", filepath.Join(dir, "sybra-cli"), "../../cmd/sybra-cli")
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -837,9 +842,11 @@ func setupE2EMultiProvider(t *testing.T, provider string, scenarios []string) *e
 	env := setupE2EProvider(t, provider, "")
 	t.Setenv("FAKE_CLAUDE_SCENARIO_FILE", sf)
 	t.Setenv("FAKE_CODEX_SCENARIO_FILE", sf)
+	t.Setenv("FAKE_COPILOT_SCENARIO_FILE", sf)
 	// Clear static scenario so file takes priority.
 	t.Setenv("FAKE_CLAUDE_SCENARIO", "")
 	t.Setenv("FAKE_CODEX_SCENARIO", "")
+	t.Setenv("FAKE_COPILOT_SCENARIO", "")
 	env.scenarioFile = sf
 	return env
 }
@@ -4201,8 +4208,8 @@ func TestE2E_CrossProvider_FlipsFromLatestMixedHistory(t *testing.T) {
 	if providerByStep["second"] != "codex" {
 		t.Fatalf("second provider = %q, want codex", providerByStep["second"])
 	}
-	if providerByStep["third"] != "claude" {
-		t.Fatalf("third provider = %q, want claude (cross flip from codex)", providerByStep["third"])
+	if providerByStep["third"] != "copilot" {
+		t.Fatalf("third provider = %q, want copilot (cross rotates codex->copilot)", providerByStep["third"])
 	}
 }
 
@@ -4504,8 +4511,9 @@ func TestE2E_ProviderBinaryFlap_SecondStepFallsBackDeterministically(t *testing.
 		return gErr == nil && tk.Workflow != nil && tk.Workflow.CurrentStep == "first" && tk.Workflow.State == workflow.ExecWaiting
 	})
 
-	// Remove claude binary before second step starts; cross from codex wants
-	// claude and must deterministically fall back to default codex.
+	// Only codex + sybra-cli on PATH: cross from codex rotates to copilot then
+	// claude, but neither is installed, so it deterministically falls back to
+	// default codex.
 	subset := stageProviderPath(t, "codex", "sybra-cli")
 	t.Setenv("PATH", subset)
 

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/abtest"
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/skillinvoke"
 )
 
@@ -519,12 +520,26 @@ func isCodeAuthorRole(role string) bool {
 }
 
 func crossProvider(provider string) string {
-	switch normalizeWorkflowProvider(provider) {
-	case "codex", "copilot":
-		return "claude"
-	default:
-		return "codex"
+	author := normalizeWorkflowProvider(provider)
+	order := providerid.All()
+	start := slices.Index(order, author)
+	if start < 0 {
+		start = slices.Index(order, "claude")
 	}
+	firstDifferent := ""
+	for i := 1; i <= len(order); i++ {
+		cand := order[(start+i)%len(order)]
+		if cand == author {
+			continue
+		}
+		if firstDifferent == "" {
+			firstDifferent = cand
+		}
+		if providerAvailable(cand) {
+			return cand
+		}
+	}
+	return firstDifferent
 }
 
 func normalizeWorkflowProvider(provider string) string {

--- a/internal/workflow/provider_resolution_test.go
+++ b/internal/workflow/provider_resolution_test.go
@@ -2,7 +2,15 @@ package workflow
 
 import "testing"
 
+func stubCrossAvailability(t *testing.T) {
+	t.Helper()
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+}
+
 func TestResolveProviderCrossUsesCurrentWorkflowHistory(t *testing.T) {
+	stubCrossAvailability(t)
 	wf := &Execution{StepHistory: []StepRecord{
 		{StepID: "implement", Provider: "claude"},
 		{StepID: "set_ready_review"},
@@ -21,6 +29,7 @@ func TestResolveProviderCrossUsesCurrentWorkflowHistory(t *testing.T) {
 }
 
 func TestResolveProviderCrossUsesCodeAuthorRunBeforeHandoffSource(t *testing.T) {
+	stubCrossAvailability(t)
 	tk := TaskInfo{
 		HandoffSourceProvider: "codex",
 		AgentRuns: []AgentRunInfo{
@@ -35,6 +44,7 @@ func TestResolveProviderCrossUsesCodeAuthorRunBeforeHandoffSource(t *testing.T) 
 }
 
 func TestResolveProviderCrossIgnoresReviewRunsForTaskProvenance(t *testing.T) {
+	stubCrossAvailability(t)
 	tk := TaskInfo{
 		AgentRuns: []AgentRunInfo{
 			{Role: "implementation", Provider: "claude"},
@@ -48,16 +58,18 @@ func TestResolveProviderCrossIgnoresReviewRunsForTaskProvenance(t *testing.T) {
 	}
 }
 
-func TestResolveProviderCrossUsesHandoffSourceProvider(t *testing.T) {
+func TestResolveProviderCrossRotatesCodexToCopilot(t *testing.T) {
+	stubCrossAvailability(t)
 	tk := TaskInfo{HandoffSourceProvider: "codex"}
 
 	got := resolveProvider("cross", &Execution{}, "codex", tk)
-	if got != "claude" {
-		t.Fatalf("provider = %q, want claude", got)
+	if got != "copilot" {
+		t.Fatalf("provider = %q, want copilot (codex rotates to copilot)", got)
 	}
 }
 
-func TestResolveProviderCrossCopilotFallsBackToClaude(t *testing.T) {
+func TestResolveProviderCrossRotatesCopilotToClaude(t *testing.T) {
+	stubCrossAvailability(t)
 	tk := TaskInfo{HandoffSourceProvider: "copilot"}
 
 	got := resolveProvider("cross", &Execution{}, "codex", tk)
@@ -66,7 +78,32 @@ func TestResolveProviderCrossCopilotFallsBackToClaude(t *testing.T) {
 	}
 }
 
+func TestResolveProviderCrossSkipsUnavailableRotationTarget(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(p string) bool { return p != "copilot" }
+	t.Cleanup(func() { providerAvailable = prev })
+	tk := TaskInfo{HandoffSourceProvider: "codex"}
+
+	got := resolveProvider("cross", &Execution{}, "codex", tk)
+	if got != "claude" {
+		t.Fatalf("provider = %q, want claude (copilot unavailable, rotate past it)", got)
+	}
+}
+
+func TestResolveProviderCrossAllUnavailableReturnsFirstDifferent(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return false }
+	t.Cleanup(func() { providerAvailable = prev })
+	tk := TaskInfo{HandoffSourceProvider: "codex"}
+
+	got := resolveProvider("cross", &Execution{}, "codex", tk)
+	if got != "copilot" {
+		t.Fatalf("provider = %q, want copilot (first different in rotation; resolveAgentVariant strips it to default)", got)
+	}
+}
+
 func TestResolveProviderCrossWithoutProvenanceDefersToDefaultProvider(t *testing.T) {
+	stubCrossAvailability(t)
 	got := resolveProvider("cross", &Execution{}, "claude", TaskInfo{})
 	if got != "" {
 		t.Fatalf("provider = %q, want empty default-provider sentinel", got)


### PR DESCRIPTION
## Motivation

Follow-up to WS2 (#1900), split out of the "equal agents" umbrella (#1898). The A/B suite already gives copilot equality for the high-value roles, but the lighter-weight `cross` heuristic (simple review, plan-critic, test-runner, pr-review) still only paired claude↔codex — copilot was never a `cross` target. Generalizing it was blocked on e2e harness work: the cross tests only built fake `claude` + `codex`, so a rotation to copilot would spawn the uncontrolled real copilot CLI and hang.

## Implementation information

- **`crossProvider`** (`internal/workflow/engine_steps_agent.go`) now rotates over `providerid.All()` (claude→codex→copilot→claude): from the code author it returns the next provider in rotation whose CLI is installed (`providerAvailable`), skipping unavailable ones. If none is installed it returns the first different provider and the existing `resolveAgentVariant` availability check strips it to the default. On a two-provider host (e.g. the server, claude+codex) codex-authored code still gets a real different reviewer (claude) instead of collapsing to the author.
- **`cmd/fake-copilot`** — the missing test double, emitting copilot's `assistant.message` + `result{exitCode}` JSON (verified against `ParseCopilotLine`), honoring `FAKE_COPILOT_SCENARIO(_FILE)` / `FAKE_COPILOT_ARGS_LOG` exactly like `fake-codex`. Wired into `buildTestBinaries` and the cross/multi-provider e2e setups; `.gitignore` gets `/fake-copilot` alongside the other doubles.
- Tests: cross unit tests now cover codex→copilot rotation, skip-unavailable, and all-unavailable fallback; the two cross e2e tests that flip from codex now assert the review lands on copilot (`_DefaultCodex`) / step `third` is copilot (`FlipsFromLatestMixedHistory`).

An adversarial pre-PR review walked the rotation for every author value and traced the fake-copilot JSON through the parser — both correct — and caught the missing `.gitignore` entry (a stray root build artifact) plus a stale test comment, both fixed here.

Closes #1914

> Changelog: feat(workflow): 3-way availability-aware cross
