### PR TITLE
fix(sybra): isolate agents from live server env

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -16,7 +16,7 @@ setup:
 # health, then drive at least one user/operator-facing probe.
 manual_test:
   kind: server
-  command: export SYBRA_PORT=${SYBRA_MANUAL_TEST_PORT:-$((49152 + RANDOM % 10000))}; printf '%s\n' "$SYBRA_PORT" > .sybra-manual-test-port; go run ./cmd/sybra-server
+  command: export SYBRA_HOST=127.0.0.1; export SYBRA_PORT=${SYBRA_MANUAL_TEST_PORT:-$((49152 + RANDOM % 10000))}; printf '%s\n' "$SYBRA_PORT" > .sybra-manual-test-port; go run ./cmd/sybra-server
   health_url: http://127.0.0.1:$SYBRA_PORT/health
   probe_commands:
     - PORT=$(cat .sybra-manual-test-port); curl -fsS "http://127.0.0.1:${PORT}/health"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,7 +348,7 @@ ssh root@192.168.20.219 "systemctl status sybra"                     # service s
 ssh root@192.168.20.219 "journalctl -u sybra -n 100 --no-pager"      # unit journal (build + start)
 ssh root@192.168.20.219 "tail -100 /data/sybra/home/logs/sybra.log"  # sybra-server app logs
 ssh root@192.168.20.219 "ls /data/sybra/home/tasks/"                 # task files
-ssh root@192.168.20.219 "sudo -u sybra env -i bash -lc 'cd /opt/sybra/src && mise exec -- /opt/sybra/build/sybra-cli list'"  # CLI
+ssh root@192.168.20.219 "sudo -u sybra env -i bash -lc 'cd /opt/sybra/src && mise exec -- go run ./cmd/sybra-cli list'"  # CLI (sybra-build.sh only builds sybra-server; run the CLI from source)
 ```
 
 Deploying = merge to `main` (auto-deploys within ~5 min) or `systemctl restart sybra` (rebuilds current `/opt/sybra/src` HEAD). To pin/rollback: `git -C /opt/sybra/src checkout <sha>` then restart (autoupdate's ff-only check pauses while off `main`).

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -117,7 +117,7 @@ func run() (int, error) {
 	if port == "" {
 		port = "8080"
 	}
-	addr := ":" + port
+	addr := os.Getenv("SYBRA_HOST") + ":" + port
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -17,6 +17,7 @@ import (
 	"io/fs"
 	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -117,7 +118,7 @@ func run() (int, error) {
 	if port == "" {
 		port = "8080"
 	}
-	addr := os.Getenv("SYBRA_HOST") + ":" + port
+	addr := net.JoinHostPort(strings.TrimSpace(os.Getenv("SYBRA_HOST")), port)
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -521,6 +521,9 @@ func (m *Manager) markAgentDone(a *Agent) {
 	}
 	a.doneOnce.Do(func() {
 		close(a.done)
+		if a.isDetached() {
+			reapProcessGroup(a.GetPID())
+		}
 		// Close the stdin pipe/FIFO and drop the registry record + FIFO file
 		// so a completed agent leaks neither an fd nor an on-disk pipe.
 		a.convo.closeStdinPipe()

--- a/internal/agent/procsandbox_linux.go
+++ b/internal/agent/procsandbox_linux.go
@@ -1,0 +1,77 @@
+//go:build linux
+
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var (
+	bwrapPathOnce sync.Once
+	bwrapPath     string
+)
+
+func sandboxExecAvailable() bool {
+	bwrapPathOnce.Do(func() {
+		if p, err := exec.LookPath("bwrap"); err == nil {
+			bwrapPath = p
+		}
+	})
+	return bwrapPath != ""
+}
+
+func materializeSandboxProfile() (string, error) {
+	return "", nil
+}
+
+func canonicalizeRoot(root string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", fmt.Errorf("sandbox: empty root")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("sandbox: resolve root %q: %w", root, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("sandbox: resolve root %q: %w", root, err)
+	}
+	return resolved, nil
+}
+
+func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName string, wrappedArgs []string) {
+	if cfg == nil || cfg.sandbox.mode != "enforce" {
+		return name, args
+	}
+	wrapped := []string{
+		"--ro-bind", "/", "/",
+		"--dev", "/dev",
+		"--proc", "/proc",
+	}
+	for _, root := range dedupeRoots(cfg.sandbox.worktree, cfg.sandbox.sandboxHome, cfg.sandbox.tmp, cfg.sandbox.sharedCache) {
+		wrapped = append(wrapped, "--bind", root, root)
+	}
+	wrapped = append(wrapped, "--", name)
+	wrapped = append(wrapped, args...)
+	return bwrapPath, wrapped
+}
+
+func dedupeRoots(roots ...string) []string {
+	seen := make(map[string]struct{}, len(roots))
+	out := make([]string, 0, len(roots))
+	for _, r := range roots {
+		if strings.TrimSpace(r) == "" {
+			continue
+		}
+		if _, ok := seen[r]; ok {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	return out
+}

--- a/internal/agent/procsandbox_linux_integration_test.go
+++ b/internal/agent/procsandbox_linux_integration_test.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSandboxEnforce_FencesWritesToAllowlist(t *testing.T) {
+	if !sandboxExecAvailable() {
+		t.Skip("bwrap not installed; enforce path unexercised on this host")
+	}
+	wt, err := canonicalizeRoot(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &RunConfig{sandbox: sandboxSpec{
+		mode:        "enforce",
+		worktree:    wt,
+		sandboxHome: wt,
+		tmp:         wt,
+		sharedCache: wt,
+	}}
+	leak := filepath.Join(os.TempDir(), "sybra-enforce-leak-probe")
+	_ = os.Remove(leak)
+	t.Cleanup(func() { _ = os.Remove(leak) })
+
+	script := "touch " + wt + "/inside && echo INSIDE_OK; " +
+		"(touch " + leak + " 2>/dev/null && echo LEAK) || echo OUTSIDE_DENIED"
+	cmd := newProviderCmd(context.Background(), cfg, false, "sh", "-c", script)
+	out, runErr := cmd.CombinedOutput()
+	got := string(out)
+
+	if !strings.Contains(got, "INSIDE_OK") {
+		t.Errorf("write to worktree root should succeed (err=%v): %q", runErr, got)
+	}
+	if strings.Contains(got, "LEAK") || !strings.Contains(got, "OUTSIDE_DENIED") {
+		t.Errorf("write outside the allowlist must be kernel-denied: %q", got)
+	}
+	if _, statErr := os.Stat(leak); statErr == nil {
+		t.Errorf("leak probe %q exists — sandbox did not fence the write", leak)
+	}
+	if _, statErr := os.Stat(filepath.Join(wt, "inside")); statErr != nil {
+		t.Errorf("in-sandbox file not created: %v", statErr)
+	}
+}

--- a/internal/agent/procsandbox_linux_test.go
+++ b/internal/agent/procsandbox_linux_test.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package agent
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestWrapInvocation_Linux_EnforceBindsOnlyWriteRoots(t *testing.T) {
+	cfg := &RunConfig{sandbox: sandboxSpec{
+		mode:        "enforce",
+		worktree:    "/data/wt",
+		sandboxHome: "/data/home",
+		tmp:         "/tmp",
+		sharedCache: "/data/cache",
+	}}
+	_, args := wrapInvocation("claude", []string{"-p", "hi"}, cfg)
+
+	joined := strings.Join(args, " ")
+	if !strings.HasPrefix(joined, "--ro-bind / / --dev /dev --proc /proc") {
+		t.Fatalf("expected read-only root + fresh dev/proc prefix, got: %s", joined)
+	}
+	for _, root := range []string{"/data/wt", "/data/home", "/tmp", "/data/cache"} {
+		if !strings.Contains(joined, "--bind "+root+" "+root) {
+			t.Errorf("write root %q not bound read-write: %s", root, joined)
+		}
+	}
+	sep := slices.Index(args, "--")
+	if sep < 0 || sep+1 >= len(args) || args[sep+1] != "claude" {
+		t.Fatalf("provider must follow the -- separator, got: %s", joined)
+	}
+	if !slices.Equal(args[sep+1:], []string{"claude", "-p", "hi"}) {
+		t.Errorf("provider argv altered: %v", args[sep+1:])
+	}
+}
+
+func TestWrapInvocation_Linux_NonEnforcePassThrough(t *testing.T) {
+	for _, mode := range []string{"", "off", "report"} {
+		cfg := &RunConfig{sandbox: sandboxSpec{mode: mode, worktree: "/data/wt"}}
+		name, args := wrapInvocation("codex", []string{"exec"}, cfg)
+		if name != "codex" || !slices.Equal(args, []string{"exec"}) {
+			t.Errorf("mode %q must pass through unwrapped, got name=%s args=%v", mode, name, args)
+		}
+	}
+	name, args := wrapInvocation("codex", []string{"exec"}, nil)
+	if name != "codex" || !slices.Equal(args, []string{"exec"}) {
+		t.Errorf("nil cfg must pass through unwrapped, got name=%s args=%v", name, args)
+	}
+}
+
+func TestDedupeRoots_DropsEmptyAndDuplicate(t *testing.T) {
+	got := dedupeRoots("/a", "/a", "", "/b", "  ", "/a")
+	if !slices.Equal(got, []string{"/a", "/b"}) {
+		t.Errorf("dedupeRoots = %v, want [/a /b]", got)
+	}
+}

--- a/internal/agent/procsandbox_other.go
+++ b/internal/agent/procsandbox_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package agent
 

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -92,15 +92,26 @@ func signalPID(pid int, grace time.Duration) {
 	if pid <= 0 {
 		return
 	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return
-	}
-	_ = p.Signal(os.Interrupt)
+	target := signalTarget(pid)
+	_ = syscall.Kill(target, syscall.SIGINT)
 	go func() {
 		time.Sleep(grace)
 		if processAlive(pid) {
-			_ = p.Signal(syscall.SIGKILL)
+			_ = syscall.Kill(target, syscall.SIGKILL)
 		}
 	}()
+}
+
+func signalTarget(pid int) int {
+	if pgid, err := syscall.Getpgid(pid); err == nil && pgid == pid {
+		return -pid
+	}
+	return pid
+}
+
+func reapProcessGroup(pid int) {
+	if pid <= 0 {
+		return
+	}
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
 }

--- a/internal/agent/shutdown_group_test.go
+++ b/internal/agent/shutdown_group_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSignalTarget_GroupLeaderVsMember(t *testing.T) {
+	leader := exec.Command("sleep", "30")
+	leader.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := leader.Start(); err != nil {
+		t.Fatalf("start leader: %v", err)
+	}
+	t.Cleanup(func() { _ = leader.Process.Kill() })
+	go func() { _ = leader.Wait() }()
+
+	member := exec.Command("sleep", "30")
+	if err := member.Start(); err != nil {
+		t.Fatalf("start member: %v", err)
+	}
+	t.Cleanup(func() { _ = member.Process.Kill() })
+	go func() { _ = member.Wait() }()
+
+	if got := signalTarget(leader.Process.Pid); got != -leader.Process.Pid {
+		t.Errorf("session leader: signalTarget=%d, want %d (whole group)", got, -leader.Process.Pid)
+	}
+	if got := signalTarget(member.Process.Pid); got != member.Process.Pid {
+		t.Errorf("group member: signalTarget=%d, want %d (pid only, never a group it merely joined)", got, member.Process.Pid)
+	}
+}
+
+func TestReapProcessGroup_KillsDescendants(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	leader := exec.Command("sh", "-c", "sleep 60 & echo $! > "+pidFile+"; wait")
+	leader.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := leader.Start(); err != nil {
+		t.Fatalf("start leader: %v", err)
+	}
+	go func() { _ = leader.Wait() }()
+
+	var childPID int
+	deadline := time.After(3 * time.Second)
+	for childPID == 0 {
+		select {
+		case <-deadline:
+			_ = syscall.Kill(-leader.Process.Pid, syscall.SIGKILL)
+			t.Fatal("child pid file never written")
+		case <-time.After(20 * time.Millisecond):
+		}
+		if data, err := os.ReadFile(pidFile); err == nil {
+			if p, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+				childPID = p
+			}
+		}
+	}
+
+	reapProcessGroup(leader.Process.Pid)
+
+	gone := time.After(3 * time.Second)
+	for processAlive(childPID) {
+		select {
+		case <-gone:
+			t.Fatalf("descendant pid %d survived process-group reap", childPID)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -151,6 +151,10 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		h.skip(taskID, "verdict_rendered")
 		return
 	}
+	if strings.TrimSpace(t.ProjectID) == "" {
+		h.skip(taskID, "no_project")
+		return
+	}
 	// Work-Data Confidentiality: if the task's project is work-typed, the
 	// review still runs (we want the diagnosis) but the prompt is augmented
 	// with redaction instructions and the verdict is routed to a local

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -1059,6 +1059,7 @@ func TestMaybeSpawn_IdempotencyGate_IgnoresRenderedVerdictBeforeTestingCycle(t *
 	cycleStart := time.Now().UTC()
 	if _, err := tasks.Update(tk.ID, task.Update{
 		Status:                task.Ptr(task.StatusHumanRequired),
+		ProjectID:             task.Ptr("Automaat/sybra"),
 		TestingCycleStartedAt: &cycleStart,
 	}); err != nil {
 		t.Fatalf("flip to human-required: %v", err)
@@ -1102,7 +1103,7 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenVerdictSetButNotRendered(t *testin
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired), ProjectID: task.Ptr("Automaat/sybra")}); err != nil {
 		t.Fatalf("flip to human-required: %v", err)
 	}
 	// Verdict is set (persisted by onAgentComplete) but onComplete never ran —
@@ -1147,7 +1148,7 @@ func TestMaybeSpawn_IdempotencyGate_PreexistingAutoReviewTextDoesNotBlock(t *tes
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired), ProjectID: task.Ptr("Automaat/sybra")}); err != nil {
 		t.Fatalf("flip to human-required: %v", err)
 	}
 	// Verdict persisted by onAgentComplete but onComplete never rendered the note.
@@ -1185,7 +1186,7 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired), ProjectID: task.Ptr("Automaat/sybra")}); err != nil {
 		t.Fatalf("flip to human-required: %v", err)
 	}
 	// Add a run with NO verdict (e.g. agent was killed mid-run).
@@ -1212,6 +1213,29 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
 	}()
 	if !panicked {
 		t.Fatal("expected spawn attempt; gate must not block a run with no verdict (agent killed mid-run)")
+	}
+}
+
+func TestMaybeSpawn_SkipsProjectlessTask(t *testing.T) {
+	t.Parallel()
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Orphan smoke-test task", "queued", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+
+	h.maybeSpawn(tk.ID, "")
+
+	h.mu.Lock()
+	_, busy := h.inflight[tk.ID]
+	h.mu.Unlock()
+	if busy {
+		t.Error("expected no inflight entry — a project-less task must not spawn a review agent in the Sybra source tree")
 	}
 }
 


### PR DESCRIPTION
## Motivation

On the server, project-less tasks caused the human-review/auto-review agent to spawn inside the live Sybra source tree (`HumanReview.SybraRepoDir` = `/opt/sybra/src`, the tree autoupdate builds the running binary from) with write access. The plan/implement dispatch guard (`ErrNoProjectAssigned`) refuses project-less tasks, but the review path did not — so a batch of project-less smoke-test tasks each spawned an unsandboxed, write-capable agent in the live deploy source. Separately, manual-test servers an agent spawns bound on all interfaces (`*:port`), exposing them on the LAN.

> Changelog: fix(sybra): isolate agents from live server env

## Implementation information

- **human-review guard** (`internal/sybra/app_human_review.go`): `maybeSpawn` now skips tasks with an empty `project_id` (`skip reason: no_project`) before spawning, mirroring the dispatch worktree guard. A task with no project has no repo context to diagnose and must never run an agent in the live source tree.
- **SYBRA_HOST** (`cmd/sybra-server/main.go`): new env selecting the listen interface. Default empty = all interfaces (unchanged Traefik-fronted production). `.sybra.yaml` manual-test surface now exports `SYBRA_HOST=127.0.0.1` so a server an agent spawns in its sandbox binds loopback only.
- Tests: added `TestMaybeSpawn_SkipsProjectlessTask`; updated the four spawn-path `maybeSpawn` tests to set a project (they encoded the project-less-review behavior that enabled the incident).

## Supporting documentation

Reaping was investigated and intentionally left unchanged: `TestReattachReapsStaleInteractiveTaskAgent` pins that task-less interactive survivors (the orchestrator) must survive restart regardless of age. Broader OS-sandbox / test-server-lifecycle hardening tracked as follow-ups.