### PR TITLE
feat(sybra): auto-close linked issue on task done

### DIFF
--- a/internal/sybra/app_close_issue_test.go
+++ b/internal/sybra/app_close_issue_test.go
@@ -1,0 +1,67 @@
+package sybra
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestCloseLinkedIssueOnDone_ClosesSameRepoIssue(t *testing.T) {
+	app, tasks := newUmbrellaGateApp(t)
+	var gotRepo, gotComment string
+	var gotNum, calls int
+	app.umbrellaCloseIssue = func(repo string, number int, comment string) error {
+		calls++
+		gotRepo, gotNum, gotComment = repo, number, comment
+		return nil
+	}
+
+	tk, err := tasks.CreateFull("done task", "", task.AgentModeHeadless, task.Update{
+		Issue:     task.Ptr("https://github.com/Automaat/sybra/issues/1849"),
+		ProjectID: task.Ptr("Automaat/sybra"),
+		PRNumber:  task.Ptr(42),
+		Status:    task.Ptr(task.StatusDone),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	app.closeLinkedIssueOnDone(tk.ID)
+
+	if calls != 1 || gotRepo != "Automaat/sybra" || gotNum != 1849 {
+		t.Fatalf("close called %d times repo=%q num=%d, want 1 Automaat/sybra 1849", calls, gotRepo, gotNum)
+	}
+	if !strings.Contains(gotComment, "#42") {
+		t.Errorf("comment should reference the merging PR, got %q", gotComment)
+	}
+}
+
+func TestCloseLinkedIssueOnDone_SkipsNoIssueAndCrossRepo(t *testing.T) {
+	app, tasks := newUmbrellaGateApp(t)
+	calls := 0
+	app.umbrellaCloseIssue = func(string, int, string) error { calls++; return nil }
+
+	noIssue, err := tasks.CreateFull("no issue", "", task.AgentModeHeadless, task.Update{
+		ProjectID: task.Ptr("Automaat/sybra"),
+		Status:    task.Ptr(task.StatusDone),
+	})
+	if err != nil {
+		t.Fatalf("create no-issue: %v", err)
+	}
+	crossRepo, err := tasks.CreateFull("cross repo", "", task.AgentModeHeadless, task.Update{
+		Issue:     task.Ptr("https://github.com/other/repo/issues/9"),
+		ProjectID: task.Ptr("Automaat/sybra"),
+		Status:    task.Ptr(task.StatusDone),
+	})
+	if err != nil {
+		t.Fatalf("create cross-repo: %v", err)
+	}
+
+	app.closeLinkedIssueOnDone(noIssue.ID)
+	app.closeLinkedIssueOnDone(crossRepo.ID)
+
+	if calls != 0 {
+		t.Errorf("expected no close for missing-issue or cross-repo tasks, got %d calls", calls)
+	}
+}

--- a/internal/sybra/app_close_issue_test.go
+++ b/internal/sybra/app_close_issue_test.go
@@ -18,7 +18,7 @@ func TestCloseLinkedIssueOnDone_ClosesSameRepoIssue(t *testing.T) {
 	}
 
 	tk, err := tasks.CreateFull("done task", "", task.AgentModeHeadless, task.Update{
-		Issue:     task.Ptr("https://github.com/Automaat/sybra/issues/1849"),
+		Issue:     task.Ptr("  https://github.com/Automaat/sybra/issues/1849\n"),
 		ProjectID: task.Ptr("Automaat/sybra"),
 		PRNumber:  task.Ptr(42),
 		Status:    task.Ptr(task.StatusDone),

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -483,10 +483,14 @@ func (a *App) initStatusHook() {
 
 func (a *App) closeLinkedIssueOnDone(taskID string) {
 	t, err := a.tasks.Get(taskID)
-	if err != nil || strings.TrimSpace(t.Issue) == "" {
+	if err != nil {
 		return
 	}
-	repo, num := github.ParseIssueURL(t.Issue)
+	issue := strings.TrimSpace(t.Issue)
+	if issue == "" {
+		return
+	}
+	repo, num := github.ParseIssueURL(issue)
 	if num == 0 || repo != t.ProjectID {
 		return
 	}
@@ -499,10 +503,10 @@ func (a *App) closeLinkedIssueOnDone(taskID string) {
 		comment = fmt.Sprintf("Completed by Sybra via #%d.", t.PRNumber)
 	}
 	if closeErr := closeFn(repo, num, comment); closeErr != nil {
-		a.logger.Warn("task.done.close-issue", "task_id", taskID, "issue", t.Issue, "err", closeErr)
+		a.logger.Warn("task.done.close-issue", "task_id", taskID, "issue", issue, "err", closeErr)
 		return
 	}
-	a.logger.Info("task.done.close-issue", "task_id", taskID, "issue", t.Issue)
+	a.logger.Info("task.done.close-issue", "task_id", taskID, "issue", issue)
 }
 
 func shouldReleaseTaskAgentsForStatus(status task.Status) bool {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -475,8 +475,34 @@ func (a *App) initStatusHook() {
 			a.dispatchStatusWorkflow(taskID, task.StatusTesting)
 		case string(task.StatusReadyPR):
 			a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
+		case string(task.StatusDone):
+			go a.closeLinkedIssueOnDone(taskID)
 		}
 	})
+}
+
+func (a *App) closeLinkedIssueOnDone(taskID string) {
+	t, err := a.tasks.Get(taskID)
+	if err != nil || strings.TrimSpace(t.Issue) == "" {
+		return
+	}
+	repo, num := github.ParseIssueURL(t.Issue)
+	if num == 0 || repo != t.ProjectID {
+		return
+	}
+	closeFn := a.umbrellaCloseIssue
+	if closeFn == nil {
+		closeFn = github.CloseIssue
+	}
+	comment := "Completed by Sybra."
+	if t.PRNumber > 0 {
+		comment = fmt.Sprintf("Completed by Sybra via #%d.", t.PRNumber)
+	}
+	if closeErr := closeFn(repo, num, comment); closeErr != nil {
+		a.logger.Warn("task.done.close-issue", "task_id", taskID, "issue", t.Issue, "err", closeErr)
+		return
+	}
+	a.logger.Info("task.done.close-issue", "task_id", taskID, "issue", t.Issue)
 }
 
 func shouldReleaseTaskAgentsForStatus(status task.Status) bool {

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -111,6 +111,7 @@ func setupManualQueueApp(t *testing.T, taskDir, queueDir string, maxConcurrent i
 	if err != nil {
 		t.Fatalf("agent.NewManager: %v", err)
 	}
+	t.Cleanup(func() { mgr.ShutdownWithGrace(2 * time.Second) })
 	q, err := agentqueue.New(queueDir, agentqueue.Options{}, logger)
 	if err != nil {
 		t.Fatalf("agentqueue.New: %v", err)


### PR DESCRIPTION
## Motivation

The `ensure_pr_closes_issue` workflow step injects `Closes #N` into a PR body only when the task carries a `PRNumber` and runs through the workflow. A hand-created or recovery PR bypasses it, leaving the linked issue open forever — e.g. #1846 (task parked by a transient push failure, then PR #1885 hand-created without a closing keyword; the issue stayed open until closed manually today).

> Changelog: feat(sybra): auto-close linked issue on task done

## Implementation information

- `closeLinkedIssueOnDone` fires from the central status observer (`app_init.go`) when a task reaches `done`: if it has a linked **same-repo** `Issue`, close it via `github.CloseIssue` (reused, same as umbrella close). A belt-and-suspenders over GitHub's merge-time auto-close.
- `gh issue close` is idempotent (exit 0 on already-closed), so the common case where the PR keyword already closed it is a safe no-op. Cross-repo and issue-less tasks are skipped.
- Also fixes a pre-existing flake in `TestManualQueueDrainPriorityAndWorkflowPreservation` (surfaced by the pre-push hook): the manual-queue test never shut down its agent manager, so fake-provider subprocesses raced `t.TempDir` cleanup. Now registers `ShutdownWithGrace`.

## Supporting documentation

Closes #1849 is unrelated; this makes #1846-style gaps impossible going forward.