### PR TITLE
feat(gui): display agent queue position and depth

### DIFF
--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -127,37 +127,47 @@ type moduleImport struct {
 	lineIndex int
 }
 
+func lastCallLineByService(lines []string, services []service) map[string]int {
+	last := map[string]int{}
+	for i, line := range lines {
+		for _, svc := range services {
+			if strings.Contains(line, "call('"+svc.name+"'") {
+				last[svc.name] = i
+			}
+		}
+	}
+	return last
+}
+
+func collectShimNameSets(services []service, imports map[string]*moduleImport) (reserved, usedLocals map[string]bool) {
+	reserved = map[string]bool{}
+	for _, svc := range services {
+		for _, method := range svc.methods {
+			reserved[method] = true
+		}
+	}
+	usedLocals = map[string]bool{}
+	for _, mi := range imports {
+		for _, entry := range mi.entries {
+			usedLocals[entry.local] = true
+		}
+	}
+	return reserved, usedLocals
+}
+
 func fillAPIHTTP(src string, services []service, bindingDir string, skip map[string]bool) (out string, added []string, err error) {
 	lines := strings.Split(src, "\n")
 
 	existing := map[string]bool{}
-	reservedMethodNames := map[string]bool{}
-	for _, svc := range services {
-		for _, method := range svc.methods {
-			reservedMethodNames[method] = true
-		}
-	}
 	for _, line := range lines {
 		if m := apiHTTPFuncRe.FindStringSubmatch(line); m != nil {
 			existing[m[1]] = true
 		}
 	}
 	imports, localByModuleType, lastImportIdx := parseAPIHTTPImports(lines)
-	usedImportLocals := map[string]bool{}
-	for _, mi := range imports {
-		for _, entry := range mi.entries {
-			usedImportLocals[entry.local] = true
-		}
-	}
+	reservedMethodNames, usedImportLocals := collectShimNameSets(services, imports)
 
-	lastCallLine := map[string]int{}
-	for i, line := range lines {
-		for _, svc := range services {
-			if strings.Contains(line, "call('"+svc.name+"'") {
-				lastCallLine[svc.name] = i
-			}
-		}
-	}
+	lastCallLine := lastCallLineByService(lines, services)
 
 	var addedModules []string
 	pending := map[string][]importEntry{}

--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -127,47 +127,78 @@ type moduleImport struct {
 	lineIndex int
 }
 
-func lastCallLineByService(lines []string, services []service) map[string]int {
-	last := map[string]int{}
+func lastAPIHTTPCallLineByService(lines []string, services []service) map[string]int {
+	lastCallLine := map[string]int{}
 	for i, line := range lines {
 		for _, svc := range services {
 			if strings.Contains(line, "call('"+svc.name+"'") {
-				last[svc.name] = i
+				lastCallLine[svc.name] = i
 			}
 		}
 	}
-	return last
+	return lastCallLine
 }
 
-func collectShimNameSets(services []service, imports map[string]*moduleImport) (reserved, usedLocals map[string]bool) {
-	reserved = map[string]bool{}
+func buildAPIHTTPFunctionInserts(services []service, bindingDir string, skip, existing map[string]bool, lastCallLine map[string]int, addImport func(module, typeName string) string) (funcInserts map[int][]string, added []string, err error) {
+	funcInserts = map[int][]string{}
 	for _, svc := range services {
+		var bindingImports map[string]string
+		var bindingSrc string
 		for _, method := range svc.methods {
-			reserved[method] = true
+			if existing[method] || skip[method] {
+				continue
+			}
+			if bindingSrc == "" {
+				data, err := os.ReadFile(filepath.Join(bindingDir, bindingModuleBase(svc.name)+".ts"))
+				if err != nil {
+					return nil, nil, err
+				}
+				bindingSrc = string(data)
+				bindingImports = parseBindingImports(bindingSrc)
+			}
+			params, ret, ok := parseBindingSig(bindingSrc, method)
+			if !ok {
+				return nil, nil, fmt.Errorf("api-http.ts: no binding signature for %s.%s", svc.name, method)
+			}
+			anchor, ok := lastCallLine[svc.name]
+			if !ok {
+				return nil, nil, fmt.Errorf("api-http.ts: no existing block for service %q to place %q", svc.name, method)
+			}
+			sig, refs := renderParams(params, bindingImports, addImport)
+			retType := mapType(ret, bindingImports, addImport)
+			line := fmt.Sprintf("export function %s(%s): Promise<%s> { return call('%s', '%s'%s) }",
+				method, sig, retType, svc.name, method, refs)
+			funcInserts[anchor] = append(funcInserts[anchor], line)
+			added = append(added, method)
 		}
 	}
-	usedLocals = map[string]bool{}
-	for _, mi := range imports {
-		for _, entry := range mi.entries {
-			usedLocals[entry.local] = true
-		}
-	}
-	return reserved, usedLocals
+	return funcInserts, added, nil
 }
 
 func fillAPIHTTP(src string, services []service, bindingDir string, skip map[string]bool) (out string, added []string, err error) {
 	lines := strings.Split(src, "\n")
 
 	existing := map[string]bool{}
+	reservedMethodNames := map[string]bool{}
+	for _, svc := range services {
+		for _, method := range svc.methods {
+			reservedMethodNames[method] = true
+		}
+	}
 	for _, line := range lines {
 		if m := apiHTTPFuncRe.FindStringSubmatch(line); m != nil {
 			existing[m[1]] = true
 		}
 	}
 	imports, localByModuleType, lastImportIdx := parseAPIHTTPImports(lines)
-	reservedMethodNames, usedImportLocals := collectShimNameSets(services, imports)
+	usedImportLocals := map[string]bool{}
+	for _, mi := range imports {
+		for _, entry := range mi.entries {
+			usedImportLocals[entry.local] = true
+		}
+	}
 
-	lastCallLine := lastCallLineByService(lines, services)
+	lastCallLine := lastAPIHTTPCallLineByService(lines, services)
 
 	var addedModules []string
 	pending := map[string][]importEntry{}
@@ -198,37 +229,9 @@ func fillAPIHTTP(src string, services []service, bindingDir string, skip map[str
 		return local
 	}
 
-	funcInserts := map[int][]string{}
-	for _, svc := range services {
-		var bindingImports map[string]string
-		var bindingSrc string
-		for _, method := range svc.methods {
-			if existing[method] || skip[method] {
-				continue
-			}
-			if bindingSrc == "" {
-				data, err := os.ReadFile(filepath.Join(bindingDir, bindingModuleBase(svc.name)+".ts"))
-				if err != nil {
-					return "", nil, err
-				}
-				bindingSrc = string(data)
-				bindingImports = parseBindingImports(bindingSrc)
-			}
-			params, ret, ok := parseBindingSig(bindingSrc, method)
-			if !ok {
-				return "", nil, fmt.Errorf("api-http.ts: no binding signature for %s.%s", svc.name, method)
-			}
-			anchor, ok := lastCallLine[svc.name]
-			if !ok {
-				return "", nil, fmt.Errorf("api-http.ts: no existing block for service %q to place %q", svc.name, method)
-			}
-			sig, refs := renderParams(params, bindingImports, addImport)
-			retType := mapType(ret, bindingImports, addImport)
-			line := fmt.Sprintf("export function %s(%s): Promise<%s> { return call('%s', '%s'%s) }",
-				method, sig, retType, svc.name, method, refs)
-			funcInserts[anchor] = append(funcInserts[anchor], line)
-			added = append(added, method)
-		}
+	funcInserts, added, err := buildAPIHTTPFunctionInserts(services, bindingDir, skip, existing, lastCallLine, addImport)
+	if err != nil {
+		return "", nil, err
 	}
 
 	importInserts := map[int][]string{}

--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -131,12 +131,24 @@ func fillAPIHTTP(src string, services []service, bindingDir string, skip map[str
 	lines := strings.Split(src, "\n")
 
 	existing := map[string]bool{}
+	reservedMethodNames := map[string]bool{}
+	for _, svc := range services {
+		for _, method := range svc.methods {
+			reservedMethodNames[method] = true
+		}
+	}
 	for _, line := range lines {
 		if m := apiHTTPFuncRe.FindStringSubmatch(line); m != nil {
 			existing[m[1]] = true
 		}
 	}
 	imports, localByModuleType, lastImportIdx := parseAPIHTTPImports(lines)
+	usedImportLocals := map[string]bool{}
+	for _, mi := range imports {
+		for _, entry := range mi.entries {
+			usedImportLocals[entry.local] = true
+		}
+	}
 
 	lastCallLine := map[string]int{}
 	for i, line := range lines {
@@ -148,18 +160,32 @@ func fillAPIHTTP(src string, services []service, bindingDir string, skip map[str
 	}
 
 	var addedModules []string
-	pending := map[string][]string{}
+	pending := map[string][]importEntry{}
+	uniqueLocal := func(base string) string {
+		local := base
+		for i := 2; reservedMethodNames[local] || usedImportLocals[local]; i++ {
+			local = fmt.Sprintf("%s%d", base, i)
+		}
+		usedImportLocals[local] = true
+		return local
+	}
 	addImport := func(module, typeName string) string {
 		key := module + "." + typeName
 		if local, ok := localByModuleType[key]; ok {
 			return local
 		}
-		localByModuleType[key] = typeName
+		local := typeName
+		if reservedMethodNames[local] {
+			local = uniqueLocal(typeName + "Data")
+		} else {
+			usedImportLocals[local] = true
+		}
+		localByModuleType[key] = local
 		if _, seen := pending[module]; !seen {
 			addedModules = append(addedModules, module)
 		}
-		pending[module] = append(pending[module], typeName)
-		return typeName
+		pending[module] = append(pending[module], importEntry{name: typeName, local: local})
+		return local
 	}
 
 	funcInserts := map[int][]string{}
@@ -199,17 +225,11 @@ func fillAPIHTTP(src string, services []service, bindingDir string, skip map[str
 	for _, module := range addedModules {
 		mi, ok := imports[module]
 		if ok {
-			for _, name := range pending[module] {
-				mi.entries = append(mi.entries, importEntry{name: name, local: name})
-			}
+			mi.entries = append(mi.entries, pending[module]...)
 			lines[mi.lineIndex] = renderImportLine(module, mi.entries)
 			continue
 		}
-		var entries []importEntry
-		for _, name := range pending[module] {
-			entries = append(entries, importEntry{name: name, local: name})
-		}
-		importInserts[lastImportIdx] = append(importInserts[lastImportIdx], renderImportLine(module, entries))
+		importInserts[lastImportIdx] = append(importInserts[lastImportIdx], renderImportLine(module, pending[module]))
 	}
 
 	merged := map[int][]string{}

--- a/cmd/gen-api-shim/shim.go
+++ b/cmd/gen-api-shim/shim.go
@@ -216,7 +216,7 @@ func fillAPIHTTP(src string, services []service, bindingDir string, skip map[str
 			return local
 		}
 		local := typeName
-		if reservedMethodNames[local] {
+		if reservedMethodNames[local] || usedImportLocals[local] {
 			local = uniqueLocal(typeName + "Data")
 		} else {
 			usedImportLocals[local] = true

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
@@ -32,6 +32,15 @@ import * as application$0 from "../../../../wailsapp/wails/v3/pkg/application/mo
 import * as $models from "./models.js";
 
 /**
+ * AgentQueueSnapshot exposes the read-only queue snapshot to Wails/web clients.
+ */
+export function AgentQueueSnapshot(): $CancellablePromise<$models.AgentQueueSnapshot> {
+    return $Call.ByID(659722111).then(($result: any) => {
+        return $$createType0($result);
+    });
+}
+
+/**
  * Context returns the app's running context.
  */
 export function Context(): $CancellablePromise<context$0.Context> {
@@ -44,7 +53,7 @@ export function Context(): $CancellablePromise<context$0.Context> {
  */
 export function GetEvaluationReport(): $CancellablePromise<evaluation$0.Report> {
     return $Call.ByID(1201647697).then(($result: any) => {
-        return $$createType0($result);
+        return $$createType1($result);
     });
 }
 
@@ -55,7 +64,7 @@ export function GetEvaluationReport(): $CancellablePromise<evaluation$0.Report> 
  */
 export function GetLearningDigestStatus(): $CancellablePromise<learning$0.Status> {
     return $Call.ByID(3796704093).then(($result: any) => {
-        return $$createType1($result);
+        return $$createType2($result);
     });
 }
 
@@ -66,7 +75,7 @@ export function GetLearningDigestStatus(): $CancellablePromise<learning$0.Status
  */
 export function GetLifecyclePhases(): $CancellablePromise<evaluation$0.PhaseReport> {
     return $Call.ByID(842035659).then(($result: any) => {
-        return $$createType2($result);
+        return $$createType3($result);
     });
 }
 
@@ -78,7 +87,7 @@ export function GetLifecyclePhases(): $CancellablePromise<evaluation$0.PhaseRepo
  */
 export function GetMonitorReport(): $CancellablePromise<$models.MonitorReportBinding> {
     return $Call.ByID(936556103).then(($result: any) => {
-        return $$createType3($result);
+        return $$createType4($result);
     });
 }
 
@@ -87,7 +96,7 @@ export function GetMonitorReport(): $CancellablePromise<$models.MonitorReportBin
  */
 export function ListBackgroundOps(): $CancellablePromise<bgop$0.Operation[]> {
     return $Call.ByID(729571497).then(($result: any) => {
-        return $$createType5($result);
+        return $$createType6($result);
     });
 }
 
@@ -96,7 +105,7 @@ export function ListBackgroundOps(): $CancellablePromise<bgop$0.Operation[]> {
  */
 export function ListNotifications(): $CancellablePromise<notification$0.Notification[]> {
     return $Call.ByID(706012029).then(($result: any) => {
-        return $$createType7($result);
+        return $$createType8($result);
     });
 }
 
@@ -115,7 +124,7 @@ export function RegisterSpotlightHotkey(): $CancellablePromise<void> {
  */
 export function RunLearningDigestNow(): $CancellablePromise<learning$0.Digest> {
     return $Call.ByID(1773365246).then(($result: any) => {
-        return $$createType8($result);
+        return $$createType9($result);
     });
 }
 
@@ -185,19 +194,20 @@ export function StopChat(agentID: string): $CancellablePromise<void> {
  */
 export function V3Services(): $CancellablePromise<application$0.Service[]> {
     return $Call.ByID(1114222916).then(($result: any) => {
-        return $$createType10($result);
+        return $$createType11($result);
     });
 }
 
 // Private type creation functions
-const $$createType0 = evaluation$0.Report.createFrom;
-const $$createType1 = learning$0.Status.createFrom;
-const $$createType2 = evaluation$0.PhaseReport.createFrom;
-const $$createType3 = $models.MonitorReportBinding.createFrom;
-const $$createType4 = bgop$0.Operation.createFrom;
-const $$createType5 = $Create.Array($$createType4);
-const $$createType6 = notification$0.Notification.createFrom;
-const $$createType7 = $Create.Array($$createType6);
-const $$createType8 = learning$0.Digest.createFrom;
-const $$createType9 = application$0.Service.createFrom;
-const $$createType10 = $Create.Array($$createType9);
+const $$createType0 = $models.AgentQueueSnapshot.createFrom;
+const $$createType1 = evaluation$0.Report.createFrom;
+const $$createType2 = learning$0.Status.createFrom;
+const $$createType3 = evaluation$0.PhaseReport.createFrom;
+const $$createType4 = $models.MonitorReportBinding.createFrom;
+const $$createType5 = bgop$0.Operation.createFrom;
+const $$createType6 = $Create.Array($$createType5);
+const $$createType7 = notification$0.Notification.createFrom;
+const $$createType8 = $Create.Array($$createType7);
+const $$createType9 = learning$0.Digest.createFrom;
+const $$createType10 = application$0.Service.createFrom;
+const $$createType11 = $Create.Array($$createType10);

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/index.ts
@@ -37,6 +37,8 @@ export {
 };
 
 export {
+    AgentQueueSnapshot,
+    AgentQueueSnapshotItem,
     AppSettings,
     CodexModel,
     CopilotModel,

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
@@ -16,6 +16,98 @@ import * as config$0 from "../config/models.js";
 import * as monitor$0 from "../monitor/models.js";
 
 /**
+ * AgentQueueSnapshot is the read-only queued-agent view exposed to the GUI.
+ */
+export class AgentQueueSnapshot {
+    "depth": number;
+    "items": AgentQueueSnapshotItem[];
+
+    /** Creates a new AgentQueueSnapshot instance. */
+    constructor($$source: Partial<AgentQueueSnapshot> = {}) {
+        if (!("depth" in $$source)) {
+            this["depth"] = 0;
+        }
+        if (!("items" in $$source)) {
+            this["items"] = [];
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new AgentQueueSnapshot instance from a string or object.
+     */
+    static createFrom($$source: any = {}): AgentQueueSnapshot {
+        const $$createField1_0 = $$createType1;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("items" in $$parsedSource) {
+            $$parsedSource["items"] = $$createField1_0($$parsedSource["items"]);
+        }
+        return new AgentQueueSnapshot($$parsedSource as Partial<AgentQueueSnapshot>);
+    }
+}
+
+/**
+ * AgentQueueSnapshotItem is one queue row, ordered by Queue.Snapshot().
+ */
+export class AgentQueueSnapshotItem {
+    "taskId": string;
+    "role": string;
+    "position": number;
+    "depth": number;
+    "priority": string;
+    "effectivePriority": string;
+    "status": string;
+    "manual": boolean;
+    "mode": string;
+    "enqueued": string;
+
+    /** Creates a new AgentQueueSnapshotItem instance. */
+    constructor($$source: Partial<AgentQueueSnapshotItem> = {}) {
+        if (!("taskId" in $$source)) {
+            this["taskId"] = "";
+        }
+        if (!("role" in $$source)) {
+            this["role"] = "";
+        }
+        if (!("position" in $$source)) {
+            this["position"] = 0;
+        }
+        if (!("depth" in $$source)) {
+            this["depth"] = 0;
+        }
+        if (!("priority" in $$source)) {
+            this["priority"] = "";
+        }
+        if (!("effectivePriority" in $$source)) {
+            this["effectivePriority"] = "";
+        }
+        if (!("status" in $$source)) {
+            this["status"] = "";
+        }
+        if (!("manual" in $$source)) {
+            this["manual"] = false;
+        }
+        if (!("mode" in $$source)) {
+            this["mode"] = "";
+        }
+        if (!("enqueued" in $$source)) {
+            this["enqueued"] = "0001-01-01T00:00:00.000Z";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new AgentQueueSnapshotItem instance from a string or object.
+     */
+    static createFrom($$source: any = {}): AgentQueueSnapshotItem {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new AgentQueueSnapshotItem($$parsedSource as Partial<AgentQueueSnapshotItem>);
+    }
+}
+
+/**
  * AppSettings is the shape of data exchanged with the frontend for the config view.
  * 
  * Every section here is round-tripped by GetSettings → UpdateSettings. Adding a
@@ -122,25 +214,25 @@ export class AppSettings {
      * Creates a new AppSettings instance from a string or object.
      */
     static createFrom($$source: any = {}): AppSettings {
-        const $$createField0_0 = $$createType0;
-        const $$createField1_0 = $$createType1;
-        const $$createField2_0 = $$createType2;
-        const $$createField3_0 = $$createType3;
-        const $$createField4_0 = $$createType4;
-        const $$createField5_0 = $$createType5;
-        const $$createField6_0 = $$createType6;
-        const $$createField7_0 = $$createType7;
-        const $$createField8_0 = $$createType8;
-        const $$createField9_0 = $$createType9;
-        const $$createField10_0 = $$createType10;
-        const $$createField11_0 = $$createType11;
-        const $$createField12_0 = $$createType12;
-        const $$createField13_0 = $$createType13;
-        const $$createField14_0 = $$createType14;
-        const $$createField15_0 = $$createType15;
-        const $$createField16_0 = $$createType16;
-        const $$createField17_0 = $$createType17;
-        const $$createField18_0 = $$createType18;
+        const $$createField0_0 = $$createType2;
+        const $$createField1_0 = $$createType3;
+        const $$createField2_0 = $$createType4;
+        const $$createField3_0 = $$createType5;
+        const $$createField4_0 = $$createType6;
+        const $$createField5_0 = $$createType7;
+        const $$createField6_0 = $$createType8;
+        const $$createField7_0 = $$createType9;
+        const $$createField8_0 = $$createType10;
+        const $$createField9_0 = $$createType11;
+        const $$createField10_0 = $$createType12;
+        const $$createField11_0 = $$createType13;
+        const $$createField12_0 = $$createType14;
+        const $$createField13_0 = $$createType15;
+        const $$createField14_0 = $$createType16;
+        const $$createField15_0 = $$createType17;
+        const $$createField16_0 = $$createType18;
+        const $$createField17_0 = $$createType19;
+        const $$createField18_0 = $$createType20;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("agent" in $$parsedSource) {
             $$parsedSource["agent"] = $$createField0_0($$parsedSource["agent"]);
@@ -227,7 +319,7 @@ export class CodexModel {
      * Creates a new CodexModel instance from a string or object.
      */
     static createFrom($$source: any = {}): CodexModel {
-        const $$createField2_0 = $$createType17;
+        const $$createField2_0 = $$createType19;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("supported_reasoning_levels" in $$parsedSource) {
             $$parsedSource["supported_reasoning_levels"] = $$createField2_0($$parsedSource["supported_reasoning_levels"]);
@@ -372,7 +464,7 @@ export class MonitorReportBinding {
      * Creates a new MonitorReportBinding instance from a string or object.
      */
     static createFrom($$source: any = {}): MonitorReportBinding {
-        const $$createField2_0 = $$createType19;
+        const $$createField2_0 = $$createType21;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("report" in $$parsedSource) {
             $$parsedSource["report"] = $$createField2_0($$parsedSource["report"]);
@@ -454,8 +546,8 @@ export class TamperReportDTO {
      * Creates a new TamperReportDTO instance from a string or object.
      */
     static createFrom($$source: any = {}): TamperReportDTO {
-        const $$createField4_0 = $$createType17;
-        const $$createField5_0 = $$createType21;
+        const $$createField4_0 = $$createType19;
+        const $$createField5_0 = $$createType23;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("files" in $$parsedSource) {
             $$parsedSource["files"] = $$createField4_0($$parsedSource["files"]);
@@ -545,7 +637,7 @@ export class TaskAuditEventDTO {
      * Creates a new TaskAuditEventDTO instance from a string or object.
      */
     static createFrom($$source: any = {}): TaskAuditEventDTO {
-        const $$createField4_0 = $$createType22;
+        const $$createField4_0 = $$createType24;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("data" in $$parsedSource) {
             $$parsedSource["data"] = $$createField4_0($$parsedSource["data"]);
@@ -607,26 +699,28 @@ export class VersionInfo {
 }
 
 // Private type creation functions
-const $$createType0 = config$0.AgentDefaults.createFrom;
-const $$createType1 = config$0.NotificationConfig.createFrom;
-const $$createType2 = config$0.OrchestratorConfig.createFrom;
-const $$createType3 = LoggingSettings.createFrom;
-const $$createType4 = config$0.AuditConfig.createFrom;
-const $$createType5 = config$0.TodoistConfig.createFrom;
-const $$createType6 = config$0.RenovateConfig.createFrom;
-const $$createType7 = config$0.ProvidersConfig.createFrom;
-const $$createType8 = config$0.GitHubConfig.createFrom;
-const $$createType9 = config$0.MonitorConfig.createFrom;
-const $$createType10 = config$0.SelfMonitorConfig.createFrom;
-const $$createType11 = config$0.TriageConfig.createFrom;
-const $$createType12 = config$0.UmbrellaConfig.createFrom;
-const $$createType13 = config$0.TestingConfig.createFrom;
-const $$createType14 = config$0.ExperienceConfig.createFrom;
-const $$createType15 = config$0.MetricsConfig.createFrom;
-const $$createType16 = config$0.BrowserConfig.createFrom;
-const $$createType17 = $Create.Array($Create.Any);
-const $$createType18 = $Create.Map($Create.Any, $Create.Any);
-const $$createType19 = monitor$0.Report.createFrom;
-const $$createType20 = TamperFindingDTO.createFrom;
-const $$createType21 = $Create.Array($$createType20);
-const $$createType22 = $Create.Map($Create.Any, $Create.Any);
+const $$createType0 = AgentQueueSnapshotItem.createFrom;
+const $$createType1 = $Create.Array($$createType0);
+const $$createType2 = config$0.AgentDefaults.createFrom;
+const $$createType3 = config$0.NotificationConfig.createFrom;
+const $$createType4 = config$0.OrchestratorConfig.createFrom;
+const $$createType5 = LoggingSettings.createFrom;
+const $$createType6 = config$0.AuditConfig.createFrom;
+const $$createType7 = config$0.TodoistConfig.createFrom;
+const $$createType8 = config$0.RenovateConfig.createFrom;
+const $$createType9 = config$0.ProvidersConfig.createFrom;
+const $$createType10 = config$0.GitHubConfig.createFrom;
+const $$createType11 = config$0.MonitorConfig.createFrom;
+const $$createType12 = config$0.SelfMonitorConfig.createFrom;
+const $$createType13 = config$0.TriageConfig.createFrom;
+const $$createType14 = config$0.UmbrellaConfig.createFrom;
+const $$createType15 = config$0.TestingConfig.createFrom;
+const $$createType16 = config$0.ExperienceConfig.createFrom;
+const $$createType17 = config$0.MetricsConfig.createFrom;
+const $$createType18 = config$0.BrowserConfig.createFrom;
+const $$createType19 = $Create.Array($Create.Any);
+const $$createType20 = $Create.Map($Create.Any, $Create.Any);
+const $$createType21 = monitor$0.Report.createFrom;
+const $$createType22 = TamperFindingDTO.createFrom;
+const $$createType23 = $Create.Array($$createType22);
+const $$createType24 = $Create.Map($Create.Any, $Create.Any);

--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -17,7 +17,7 @@
   const { agent: a, onclick }: Props = $props()
 
   const linkedTask = $derived(a.taskId ? taskStore.tasks.get(a.taskId) : null)
-  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : undefined)
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask?.get(a.taskId) : undefined)
 
   const heading = $derived(agentDisplayName(a, linkedTask?.title))
   const subtitle = $derived(cleanAgentName(a.name))

--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -17,6 +17,7 @@
   const { agent: a, onclick }: Props = $props()
 
   const linkedTask = $derived(a.taskId ? taskStore.tasks.get(a.taskId) : null)
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : undefined)
 
   const heading = $derived(agentDisplayName(a, linkedTask?.title))
   const subtitle = $derived(cleanAgentName(a.name))
@@ -62,6 +63,14 @@
       {:else if phase === 'blocked'}
         <span class="text-xs text-tertiary-600 dark:text-tertiary-400">
           Awaiting tool approval
+        </span>
+      {:else if phase === 'queued'}
+        <span class="text-xs text-surface-400">
+          {#if queueInfo}
+            Waiting for a slot · Queue {queueInfo.position} of {queueInfo.depth}
+          {:else}
+            Waiting for a slot
+          {/if}
         </span>
       {/if}
     </div>

--- a/frontend/src/components/AgentCard.svelte.test.ts
+++ b/frontend/src/components/AgentCard.svelte.test.ts
@@ -59,6 +59,7 @@ describe('AgentCard', () => {
   afterEach(() => {
     cleanup()
     taskStore.tasks = new Map()
+    agentStore.queueByTask = new Map()
   })
 
   it('renders task title in heading when linked task is present', () => {
@@ -90,6 +91,23 @@ describe('AgentCard', () => {
   it('renders Queued label for idle state', () => {
     render(AgentCard, { props: { agent: makeAgent({ state: 'idle' }), onclick: () => {} } })
     expect(screen.getByText('Queued')).toBeDefined()
+  })
+
+  it('renders queued position/depth copy when queue metadata exists', () => {
+    agentStore.queueByTask = new Map([['task-1', {
+      taskId: 'task-1',
+      role: 'implementation',
+      position: 2,
+      depth: 5,
+      priority: 'medium',
+      effectivePriority: 'medium',
+      status: 'todo',
+      manual: true,
+      mode: 'headless',
+      enqueued: '2026-07-11T12:00:00Z',
+    }]])
+    render(AgentCard, { props: { agent: makeAgent({ state: 'queued' }), onclick: () => {} } })
+    expect(screen.getByText('Waiting for a slot · Queue 2 of 5')).toBeDefined()
   })
 
   it('renders Waiting state label for paused', () => {

--- a/frontend/src/components/AgentListRow.svelte
+++ b/frontend/src/components/AgentListRow.svelte
@@ -17,6 +17,7 @@
   const { agent: a, onclick }: Props = $props()
 
   const linkedTask = $derived(a.taskId ? taskStore.tasks.get(a.taskId) : null)
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : undefined)
   const heading = $derived(agentDisplayName(a, linkedTask?.title))
   const subtitle = $derived(cleanAgentName(a.name))
 
@@ -39,6 +40,8 @@
         return 'Waiting for reply'
       case 'blocked':
         return 'Awaiting tool approval'
+      case 'queued':
+        return queueInfo ? `Waiting for a slot · Queue ${queueInfo.position} of ${queueInfo.depth}` : 'Waiting for a slot'
       default:
         return subtitle && subtitle !== heading ? subtitle : ''
     }

--- a/frontend/src/components/AgentListRow.svelte
+++ b/frontend/src/components/AgentListRow.svelte
@@ -17,7 +17,7 @@
   const { agent: a, onclick }: Props = $props()
 
   const linkedTask = $derived(a.taskId ? taskStore.tasks.get(a.taskId) : null)
-  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : undefined)
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask?.get(a.taskId) : undefined)
   const heading = $derived(agentDisplayName(a, linkedTask?.title))
   const subtitle = $derived(cleanAgentName(a.name))
 

--- a/frontend/src/components/AgentListRow.svelte.test.ts
+++ b/frontend/src/components/AgentListRow.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 import AgentListRow from './AgentListRow.svelte'
+import { agentStore } from '../stores/agents.svelte.js'
 import { taskStore } from '../stores/tasks.svelte.js'
 import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
 import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
@@ -41,6 +42,7 @@ function makeTask(overrides: Record<string, unknown> = {}): Task {
 describe('AgentListRow', () => {
   afterEach(() => {
     cleanup()
+    agentStore.queueByTask = new Map()
     taskStore.tasks = new Map()
   })
 
@@ -56,6 +58,24 @@ describe('AgentListRow', () => {
     render(AgentListRow, { props: { agent: makeAgent(), onclick: () => {} } })
     expect(screen.getByText('sybra')).toBeDefined()
     expect(screen.getByText('$0.42')).toBeDefined()
+  })
+
+  it('renders queued position/depth copy for queued agents', () => {
+    agentStore.queueByTask = new Map([['task-1', {
+      taskId: 'task-1',
+      role: 'implementation',
+      position: 2,
+      depth: 5,
+      priority: 'medium',
+      effectivePriority: 'medium',
+      status: 'todo',
+      manual: true,
+      mode: 'headless',
+      enqueued: '2026-07-11T12:00:00Z',
+    }]])
+    render(AgentListRow, { props: { agent: makeAgent({ state: 'queued' }), onclick: () => {} } })
+    expect(screen.getByText('Waiting for a slot · Queue 2 of 5')).toBeDefined()
+    expect(screen.getByText('Queued')).toBeDefined()
   })
 
   it('strips the role prefix when there is no linked task', () => {

--- a/frontend/src/components/agent-view/AgentHeader.svelte
+++ b/frontend/src/components/agent-view/AgentHeader.svelte
@@ -23,7 +23,7 @@
   // Show the session name only when it adds something beyond the heading.
   const subtitle = $derived(cleanAgentName(a.name))
   const showSubtitle = $derived(subtitle.length > 0 && subtitle !== heading)
-  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : undefined)
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask?.get(a.taskId) : undefined)
 </script>
 
 <div class="flex flex-col gap-6">

--- a/frontend/src/components/agent-view/AgentHeader.svelte
+++ b/frontend/src/components/agent-view/AgentHeader.svelte
@@ -2,6 +2,7 @@
   import type { Agent } from '../../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import type { AgentPhase } from '$lib/agent-phases.js'
+  import { agentStore } from '../../stores/agents.svelte.js'
   import AgentStateBadge from '../AgentStateBadge.svelte'
   import { formatDateTime } from '$lib/dates.js'
   import { agentDisplayName, cleanAgentName, shortId } from '$lib/agent-name.js'
@@ -22,6 +23,7 @@
   // Show the session name only when it adds something beyond the heading.
   const subtitle = $derived(cleanAgentName(a.name))
   const showSubtitle = $derived(subtitle.length > 0 && subtitle !== heading)
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : undefined)
 </script>
 
 <div class="flex flex-col gap-6">
@@ -52,6 +54,14 @@
         <p class="mt-0.5 text-sm text-warning-600 dark:text-warning-400">
           Under review
         </p>
+      {:else if phase === 'queued'}
+        <p class="mt-0.5 text-sm text-surface-400">
+          {#if queueInfo}
+            Waiting for a slot · Queue {queueInfo.position} of {queueInfo.depth}
+          {:else}
+            Waiting for a slot
+          {/if}
+        </p>
       {/if}
     </div>
     <div class="flex items-center gap-2">
@@ -79,6 +89,12 @@
         >
           View task →
         </button>
+      </div>
+    {/if}
+    {#if queueInfo}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Queue</span>
+        <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{queueInfo.position} of {queueInfo.depth}</span>
       </div>
     {/if}
     {#if linkedTask?.branch}

--- a/frontend/src/components/agent-view/AgentViewBody.svelte
+++ b/frontend/src/components/agent-view/AgentViewBody.svelte
@@ -6,6 +6,7 @@
   import type { TimestampedStreamEvent, TimelineEntry } from '$lib/timeline.js'
   import type { PlanStep } from '$lib/plan-steps.js'
   import type { ToolUseSignal } from '$lib/workspace-tabs.js'
+  import { agentStore } from '../../stores/agents.svelte.js'
   import QueuedLayout from './QueuedLayout.svelte'
   import RunningLayout from './RunningLayout.svelte'
   import BlockedLayout from './BlockedLayout.svelte'
@@ -43,13 +44,15 @@
     latestToolUse,
     onnavigate,
   }: Props = $props()
+
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : null)
 </script>
 
 <div class="min-h-[60vh]">
   {#key phase}
     <div in:fade={{ duration: 180 }} out:fade={{ duration: 120 }}>
       {#if phase === 'queued'}
-        <QueuedLayout {linkedTask} />
+        <QueuedLayout {linkedTask} {queueInfo} />
       {:else if phase === 'running'}
         <RunningLayout
           {a}

--- a/frontend/src/components/agent-view/AgentViewBody.svelte
+++ b/frontend/src/components/agent-view/AgentViewBody.svelte
@@ -45,7 +45,7 @@
     onnavigate,
   }: Props = $props()
 
-  const queueInfo = $derived(a.taskId ? agentStore.queueByTask.get(a.taskId) : null)
+  const queueInfo = $derived(a.taskId ? agentStore.queueByTask?.get(a.taskId) : null)
 </script>
 
 <div class="min-h-[60vh]">

--- a/frontend/src/components/agent-view/QueuedLayout.svelte
+++ b/frontend/src/components/agent-view/QueuedLayout.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { fly } from 'svelte/transition'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import type { AgentQueueSnapshotItem } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 
   interface Props {
     linkedTask?: Task | null
+    queueInfo?: AgentQueueSnapshotItem | null
   }
 
-  const { linkedTask }: Props = $props()
+  const { linkedTask, queueInfo }: Props = $props()
 </script>
 
 <div class="flex flex-col gap-6" in:fly={{ y: 8, duration: 150 }}>
@@ -14,8 +16,17 @@
     <div class="mb-4 flex items-center gap-3">
       <span class="flex items-center gap-1.5 rounded-full bg-surface-200 px-3 py-1 text-sm font-medium text-surface-600 dark:bg-surface-700 dark:text-surface-300">
         <span class="h-2 w-2 animate-pulse rounded-full bg-surface-400"></span>
-        Agent starting…
+        Waiting for a slot
       </span>
+    </div>
+
+    <div class="mb-4 flex flex-wrap items-center gap-3 text-sm text-surface-500 dark:text-surface-400">
+      {#if queueInfo}
+        <span class="rounded bg-surface-200 px-2.5 py-1 font-medium dark:bg-surface-700">
+          Queue {queueInfo.position} of {queueInfo.depth}
+        </span>
+      {/if}
+      <span>Agent is queued and will start when a worker slot frees up.</span>
     </div>
 
     {#if linkedTask}
@@ -28,7 +39,7 @@
         {/if}
       </div>
     {:else}
-      <p class="text-sm text-surface-400">Agent hasn't started producing output yet.</p>
+      <p class="text-sm text-surface-400">Agent is waiting for a slot before it starts producing output.</p>
     {/if}
   </div>
 </div>

--- a/frontend/src/components/agent-view/agent-view-layouts.test.ts
+++ b/frontend/src/components/agent-view/agent-view-layouts.test.ts
@@ -94,9 +94,30 @@ function makeTask(overrides: Partial<Task> = {}): Task {
 describe('QueuedLayout', () => {
   afterEach(() => { cleanup() })
 
-  it('shows "Agent starting…" badge', () => {
+  it('shows "Waiting for a slot" badge', () => {
     render(QueuedLayout, { props: { linkedTask: null } })
-    expect(screen.getByText('Agent starting…')).toBeDefined()
+    expect(screen.getByText('Waiting for a slot')).toBeDefined()
+  })
+
+  it('shows queue position/depth when queue metadata is provided', () => {
+    render(QueuedLayout, {
+      props: {
+        linkedTask: null,
+        queueInfo: {
+          taskId: 'task-1',
+          role: 'implementation',
+          position: 2,
+          depth: 4,
+          priority: 'medium',
+          effectivePriority: 'medium',
+          status: 'todo',
+          manual: true,
+          mode: 'headless',
+          enqueued: '2026-07-11T12:00:00Z',
+        },
+      },
+    })
+    expect(screen.getByText('Queue 2 of 4')).toBeDefined()
   })
 
   it('shows task title when linkedTask provided', () => {
@@ -119,7 +140,7 @@ describe('QueuedLayout', () => {
 
   it('shows waiting message when no linkedTask', () => {
     render(QueuedLayout, { props: { linkedTask: null } })
-    expect(screen.getByText("Agent hasn't started producing output yet.")).toBeDefined()
+    expect(screen.getByText('Agent is waiting for a slot before it starts producing output.')).toBeDefined()
   })
 })
 

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -6,7 +6,7 @@ import type { ReviewComment, Task } from '../../bindings/github.com/Automaat/syb
 import type { Project, Worktree } from '../../bindings/github.com/Automaat/sybra/internal/project/models.js'
 import type { Issue, RenovatePR, ReviewSummary } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
 import type { LoopAgent } from '../../bindings/github.com/Automaat/sybra/internal/loopagent/models.js'
-import type { AppSettings, CodexModel, CopilotModel, LoopAgentRun, MonitorReportBinding, TamperReportDTO, TaskArtifactDTO, TaskAuditEventDTO, TaskSetupLogDTO, VersionInfo } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+import type { AppSettings, CodexModel, CopilotModel, LoopAgentRun, MonitorReportBinding, TamperReportDTO, TaskArtifactDTO, TaskAuditEventDTO, TaskSetupLogDTO, VersionInfo, AgentQueueSnapshot as AgentQueueSnapshotData } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 import type { Notification } from '../../bindings/github.com/Automaat/sybra/internal/notification/models.js'
 import type { StatsResponse } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
 import type { ProgressEntry } from '../../bindings/github.com/Automaat/sybra/internal/artifact/models.js'
@@ -101,6 +101,7 @@ export function SetDesktopNotifications(arg1: boolean): Promise<void> { return c
 export function StartAgent(arg1: string, arg2: string, arg3: string, arg4: boolean): Promise<Agent> { return call('App', 'StartAgent', arg1, arg2, arg3, arg4) }
 export function StartChat(arg1: string, arg2: string, arg3: string): Promise<Agent> { return call('App', 'StartChat', arg1, arg2, arg3) }
 export function StopChat(arg1: string): Promise<void> { return call('App', 'StopChat', arg1) }
+export function AgentQueueSnapshot(): Promise<AgentQueueSnapshotData> { return call('App', 'AgentQueueSnapshot') }
 
 // ConfigService
 export function GetSettings(): Promise<AppSettings> { return call('ConfigService', 'GetSettings') }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,6 +63,7 @@ export const SetDesktopNotifications = pick(AppSvc.SetDesktopNotifications, http
 export const StartAgent = pick(AppSvc.StartAgent, http.StartAgent)
 export const StartChat = pick(AppSvc.StartChat, http.StartChat)
 export const StopChat = pick(AppSvc.StopChat, http.StopChat)
+export const AgentQueueSnapshot = pick(AppSvc.AgentQueueSnapshot, http.AgentQueueSnapshot)
 
 // ConfigService
 export const GetSettings = pick(ConfigSvc.GetSettings, http.GetSettings)

--- a/frontend/src/stores/agents.svelte.test.ts
+++ b/frontend/src/stores/agents.svelte.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Agent, StreamEvent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
 
-// Mock Wails bindings
 const mockListAgents = vi.fn()
 const mockStartAgent = vi.fn()
 const mockStopAgent = vi.fn()
 const mockGetAgentOutput = vi.fn()
 const mockDiscoverAgents = vi.fn()
+const mockAgentQueueSnapshot = vi.fn()
 
 vi.mock('$lib/api', () => ({
   StartAgent: (...args: unknown[]) => mockStartAgent(...args),
@@ -14,9 +14,9 @@ vi.mock('$lib/api', () => ({
   StopAgent: (...args: unknown[]) => mockStopAgent(...args),
   GetAgentOutput: (...args: unknown[]) => mockGetAgentOutput(...args),
   DiscoverAgents: (...args: unknown[]) => mockDiscoverAgents(...args),
+  AgentQueueSnapshot: (...args: unknown[]) => mockAgentQueueSnapshot(...args),
 }))
 
-// Must import after mock setup
 const { agentStore } = await import('./agents.svelte.js')
 
 function makeAgent(overrides: Record<string, unknown> = {}): Agent {
@@ -33,16 +33,42 @@ function makeAgent(overrides: Record<string, unknown> = {}): Agent {
   }
 }
 
+function makeSnapshotItem(overrides: Record<string, unknown> = {}) {
+  return {
+    taskId: 'task-1',
+    role: 'implementation',
+    position: 1,
+    depth: 1,
+    priority: 'medium',
+    effectivePriority: 'medium',
+    status: 'todo',
+    manual: true,
+    mode: 'headless',
+    enqueued: '2026-07-11T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeSnapshot(items: Array<Record<string, unknown>> = []) {
+  return {
+    depth: items.length,
+    items,
+  }
+}
+
 describe('AgentStore', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Reset store state
     agentStore.agents = new Map()
     agentStore.outputs.clear()
     agentStore.stepTexts.clear()
+    agentStore.queueByTask = new Map()
     agentStore.error = ''
     agentStore.loading = false
     agentStore.stopPolling()
+    mockDiscoverAgents.mockResolvedValue([])
+    mockListAgents.mockResolvedValue([])
+    mockAgentQueueSnapshot.mockResolvedValue(makeSnapshot())
   })
 
   afterEach(() => {
@@ -51,8 +77,7 @@ describe('AgentStore', () => {
 
   describe('load', () => {
     it('fetches agents from backend', async () => {
-      const agents = [makeAgent({ id: 'a1' }), makeAgent({ id: 'a2' })]
-      mockDiscoverAgents.mockResolvedValue([])
+      const agents = [makeAgent({ id: 'a1' }), makeAgent({ id: 'a2', taskId: 'task-2' })]
       mockListAgents.mockResolvedValue(agents)
 
       await agentStore.load()
@@ -62,6 +87,67 @@ describe('AgentStore', () => {
       expect(agentStore.agents.size).toBe(2)
       expect(agentStore.agents.get('a1')).toBeDefined()
       expect(agentStore.agents.get('a2')).toBeDefined()
+    })
+
+    it('hydrates queued agents from the supplemental snapshot', async () => {
+      mockAgentQueueSnapshot.mockResolvedValue(makeSnapshot([
+        makeSnapshotItem({ taskId: 'task-queued', position: 2, depth: 3 }),
+      ]))
+
+      await agentStore.load()
+
+      const queued = agentStore.agents.get('queued-task-queued') as Record<string, unknown> | undefined
+      expect(queued).toBeDefined()
+      expect(queued?.state).toBe('queued')
+      expect(queued?.queuePosition).toBe(2)
+      expect(queued?.queueDepth).toBe(3)
+      expect(agentStore.queueByTask.get('task-queued')?.position).toBe(2)
+    })
+
+    it('prefers real agents over queued rows for the same task', async () => {
+      mockListAgents.mockResolvedValue([makeAgent({ id: 'real-1', taskId: 'task-1', state: 'running' })])
+      mockAgentQueueSnapshot.mockResolvedValue(makeSnapshot([
+        makeSnapshotItem({ taskId: 'task-1', position: 1, depth: 2 }),
+        makeSnapshotItem({ taskId: 'task-2', position: 2, depth: 2 }),
+      ]))
+
+      await agentStore.load()
+
+      expect(agentStore.agents.get('queued-task-1')).toBeUndefined()
+      expect(agentStore.byTask('task-1')?.id).toBe('real-1')
+      expect(agentStore.agents.get('queued-task-2')).toBeDefined()
+      expect((agentStore.agents.get('real-1') as Record<string, unknown>).queuePosition).toBe(1)
+    })
+
+    it('drops stale synthetic queued agents after a successful snapshot omits the task', async () => {
+      vi.useFakeTimers()
+      mockAgentQueueSnapshot.mockResolvedValue(makeSnapshot([
+        makeSnapshotItem({ taskId: 'task-stale' }),
+      ]))
+      await agentStore.load()
+      expect(agentStore.agents.get('queued-task-stale')).toBeDefined()
+
+      mockAgentQueueSnapshot.mockResolvedValue(makeSnapshot())
+      await vi.advanceTimersByTimeAsync(600)
+      await agentStore.load()
+
+      expect(agentStore.agents.get('queued-task-stale')).toBeUndefined()
+      expect(agentStore.queueByTask.get('task-stale')).toBeUndefined()
+      vi.useRealTimers()
+    })
+
+    it('keeps queued rows and avoids a store error when the snapshot fetch fails', async () => {
+      mockAgentQueueSnapshot.mockResolvedValue(makeSnapshot([
+        makeSnapshotItem({ taskId: 'task-queued' }),
+      ]))
+      await agentStore.load()
+
+      mockAgentQueueSnapshot.mockRejectedValue(new Error('queue unavailable'))
+      await agentStore.load()
+
+      expect(agentStore.error).toBe('')
+      expect(agentStore.agents.get('queued-task-queued')).toBeDefined()
+      expect(agentStore.queueByTask.get('task-queued')?.position).toBe(1)
     })
 
     it('handles null result', async () => {
@@ -74,7 +160,7 @@ describe('AgentStore', () => {
       expect(agentStore.error).toBe('')
     })
 
-    it('sets error on failure', async () => {
+    it('sets error on primary load failure', async () => {
       mockDiscoverAgents.mockRejectedValue(new Error('network error'))
 
       await agentStore.load()
@@ -83,11 +169,7 @@ describe('AgentStore', () => {
     })
 
     it('sets loading flag', async () => {
-      mockDiscoverAgents.mockResolvedValue([])
-      mockListAgents.mockResolvedValue([])
-
       const promise = agentStore.load()
-      // loading is set synchronously before await
       expect(agentStore.loading).toBe(true)
       await promise
       expect(agentStore.loading).toBe(false)
@@ -105,6 +187,21 @@ describe('AgentStore', () => {
       expect(result.id).toBe('new-1')
       expect(agentStore.agents.get('new-1')).toBeDefined()
       expect(agentStore.outputs.get('new-1')).toEqual([])
+    })
+
+    it('keeps a queued start successful even when queue refresh fails', async () => {
+      const queued = makeAgent({ id: 'queued-task-1', taskId: 'task-1', state: 'queued' })
+      mockStartAgent.mockResolvedValue(queued)
+      mockAgentQueueSnapshot.mockRejectedValue(new Error('snapshot down'))
+
+      await expect(agentStore.start('task-1', 'headless', 'do stuff', false)).resolves.toMatchObject({
+        id: 'queued-task-1',
+        state: 'queued',
+      })
+
+      expect(agentStore.agents.get('queued-task-1')).toBeDefined()
+      expect(agentStore.outputs.get('queued-task-1')).toEqual([])
+      expect(agentStore.error).toBe('')
     })
   })
 
@@ -252,8 +349,6 @@ describe('AgentStore', () => {
   describe('polling', () => {
     it('starts and stops interval', async () => {
       vi.useFakeTimers()
-      mockDiscoverAgents.mockResolvedValue([])
-      mockListAgents.mockResolvedValue([])
 
       agentStore.startPolling(5000)
 
@@ -272,14 +367,12 @@ describe('AgentStore', () => {
 
     it('replaces existing timer on restart', async () => {
       vi.useFakeTimers()
-      mockDiscoverAgents.mockResolvedValue([])
-      mockListAgents.mockResolvedValue([])
 
       agentStore.startPolling(5000)
-      agentStore.startPolling(5000) // should not double up
+      agentStore.startPolling(5000)
 
       await vi.advanceTimersByTimeAsync(5000)
-      expect(mockDiscoverAgents).toHaveBeenCalledTimes(1) // not 2
+      expect(mockDiscoverAgents).toHaveBeenCalledTimes(1)
 
       agentStore.stopPolling()
       vi.useRealTimers()

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -7,9 +7,14 @@ import {
   StartAgent,
   StartChat,
   StopChat,
+  AgentQueueSnapshot as FetchAgentQueueSnapshot,
 } from '$lib/api'
 import { StreamEvent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
 import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
+import type {
+  AgentQueueSnapshot,
+  AgentQueueSnapshotItem,
+} from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 import { EntityStore } from './entity-store.svelte.js'
 import { extractStepText } from '$lib/step-text.js'
 import type { TimestampedStreamEvent } from '$lib/timeline.js'
@@ -24,9 +29,72 @@ export type AgentTaskStatus = {
   running: boolean
 }
 
+type QueueAwareAgent = Agent & {
+  queuePosition?: number
+  queueDepth?: number
+  queuePriority?: string
+  queueEffectivePriority?: string
+  queueStatus?: string
+  queueManual?: boolean
+  queueRole?: string
+  queueEnqueued?: string
+}
+
+function syntheticQueuedAgentID(taskID: string): string {
+  return `queued-${taskID}`
+}
+
+function isSyntheticQueuedAgent(agent: Agent): boolean {
+  return Boolean(
+    agent.taskId &&
+    agent.state === 'queued' &&
+    agent.id === syntheticQueuedAgentID(agent.taskId),
+  )
+}
+
+function applyQueueMetadata(agent: Agent, row?: AgentQueueSnapshotItem): QueueAwareAgent {
+  const next = { ...agent } as QueueAwareAgent
+  if (!row) {
+    delete next.queuePosition
+    delete next.queueDepth
+    delete next.queuePriority
+    delete next.queueEffectivePriority
+    delete next.queueStatus
+    delete next.queueManual
+    delete next.queueRole
+    delete next.queueEnqueued
+    return next
+  }
+  next.queuePosition = row.position
+  next.queueDepth = row.depth
+  next.queuePriority = row.priority
+  next.queueEffectivePriority = row.effectivePriority
+  next.queueStatus = row.status
+  next.queueManual = row.manual
+  next.queueRole = row.role
+  next.queueEnqueued = row.enqueued
+  return next
+}
+
+function buildQueueMap(snapshot: AgentQueueSnapshot | null | undefined): Map<string, AgentQueueSnapshotItem> {
+  const map = new Map<string, AgentQueueSnapshotItem>()
+  for (const row of snapshot?.items ?? []) {
+    map.set(row.taskId, row)
+  }
+  return map
+}
+
+function mergeAgentsByID(primary: Agent[], secondary: Agent[]): Agent[] {
+  const merged = new Map<string, Agent>()
+  for (const agent of primary) merged.set(agent.id, agent)
+  for (const agent of secondary) merged.set(agent.id, agent)
+  return [...merged.values()]
+}
+
 class AgentStore extends EntityStore<Agent> {
   outputs = new SvelteMap<string, TimestampedStreamEvent[]>()
   stepTexts = new SvelteMap<string, string>()
+  queueByTask = $state<Map<string, AgentQueueSnapshotItem>>(new Map())
 
   // taskId → role flags for that task's running agents. Recomputed once when
   // the agent list changes; cards index into it by task id (see TaskCard).
@@ -51,17 +119,16 @@ class AgentStore extends EntityStore<Agent> {
   })
 
   constructor() {
+    let self: AgentStore
     super(
-      async () => {
-        await DiscoverAgents()
-        return ListAgents()
-      },
+      async () => self.loadAgents(),
       (a, b) => {
         const ta = a.startedAt ? new Date(a.startedAt).getTime() : 0
         const tb = b.startedAt ? new Date(b.startedAt).getTime() : 0
         return tb - ta
       },
     )
+    self = this
   }
 
   get agents() {
@@ -72,6 +139,8 @@ class AgentStore extends EntityStore<Agent> {
   }
 
   byTask(taskID: string): Agent | undefined {
+    const real = this.list.find((a) => a.taskId === taskID && !isSyntheticQueuedAgent(a))
+    if (real) return real
     return this.list.find((a) => a.taskId === taskID)
   }
 
@@ -82,8 +151,11 @@ class AgentStore extends EntityStore<Agent> {
 
   async start(taskID: string, mode: string, prompt: string, includeTaskDescription: boolean): Promise<Agent> {
     const result = await StartAgent(taskID, mode, prompt, includeTaskDescription)
-    this.set(result.id, result)
+    this.set(result.id, applyQueueMetadata(result, this.queueByTask.get(taskID)))
     this.outputs.set(result.id, [])
+    if (result.state === 'queued') {
+      await this.refreshQueueSnapshot()
+    }
     return result
   }
 
@@ -138,7 +210,74 @@ class AgentStore extends EntityStore<Agent> {
   }
 
   updateAgent(agentID: string, data: Agent): void {
-    this.set(agentID, data)
+    this.set(agentID, applyQueueMetadata(data, data.taskId ? this.queueByTask.get(data.taskId) : undefined))
+  }
+
+  private async loadAgents(): Promise<Agent[]> {
+    await DiscoverAgents()
+    const listed = await ListAgents()
+    try {
+      const snapshot = await FetchAgentQueueSnapshot()
+      return this.reconcileQueue(listed ?? [], snapshot, true)
+    } catch {
+      return this.reconcileQueue(listed ?? [], null, false)
+    }
+  }
+
+  private async refreshQueueSnapshot(): Promise<void> {
+    try {
+      const snapshot = await FetchAgentQueueSnapshot()
+      const realAgents = [...this.items.values()].filter((agent) => !isSyntheticQueuedAgent(agent))
+      this.replaceAgents(this.reconcileQueue(realAgents, snapshot, true))
+    } catch {
+      // Queue metadata is supplemental: a successful StartAgent/ListAgents path
+      // must stay usable even when the snapshot readout fails independently.
+    }
+  }
+
+  private reconcileQueue(realAgents: Agent[], snapshot: AgentQueueSnapshot | null, snapshotOK: boolean): Agent[] {
+    const queue = snapshotOK ? buildQueueMap(snapshot) : new Map(this.queueByTask)
+    this.queueByTask = queue
+
+    const previousSyntheticByTask = new Map<string, QueueAwareAgent>()
+    for (const agent of this.items.values()) {
+      if (agent.taskId && isSyntheticQueuedAgent(agent)) {
+        previousSyntheticByTask.set(agent.taskId, agent as QueueAwareAgent)
+      }
+    }
+
+    const withRealPrecedence = new Set<string>()
+    const mergedReal = mergeAgentsByID(realAgents, []).map((agent) => {
+      if (agent.taskId) withRealPrecedence.add(agent.taskId)
+      return applyQueueMetadata(agent, agent.taskId ? queue.get(agent.taskId) : undefined)
+    })
+
+    const synthetic: Agent[] = []
+    for (const [taskID, row] of queue.entries()) {
+      if (withRealPrecedence.has(taskID)) continue
+      const existing = previousSyntheticByTask.get(taskID)
+      synthetic.push(applyQueueMetadata(existing ?? {
+        id: syntheticQueuedAgentID(taskID),
+        taskId: taskID,
+        mode: row.mode || 'headless',
+        state: 'queued',
+        sessionId: '',
+        costUsd: 0,
+        startedAt: row.enqueued,
+        lastEventAt: row.enqueued,
+        external: false,
+      } as Agent, row))
+    }
+
+    return [...mergedReal, ...synthetic]
+  }
+
+  private replaceAgents(agents: Agent[]): void {
+    const map = new Map<string, Agent>()
+    for (const agent of agents) {
+      map.set(agent.id, agent)
+    }
+    this.agents = map
   }
 }
 

--- a/internal/agentqueue/order.go
+++ b/internal/agentqueue/order.go
@@ -53,6 +53,12 @@ func effectivePriority(it Item) task.Priority {
 	return floor
 }
 
+// EffectivePriority reports the item's display/dispatch priority after the
+// status-imposed floor is applied.
+func (it Item) EffectivePriority() task.Priority {
+	return effectivePriority(it)
+}
+
 // bumpTier raises p by exactly one priority tier, capped at PriorityUrgent.
 // Unrecognized values fold to PriorityLow (a one-tier bump from the bottom),
 // mirroring priorityRank which ranks both PriorityNone and unknown values at 0

--- a/internal/agentqueue/order_test.go
+++ b/internal/agentqueue/order_test.go
@@ -1,0 +1,66 @@
+package agentqueue
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestEffectivePriority(t *testing.T) {
+	tests := []struct {
+		name string
+		item Item
+		want task.Priority
+	}{
+		{
+			name: "declared priority wins when above floor",
+			item: Item{Priority: task.PriorityUrgent, Status: task.StatusTodo},
+			want: task.PriorityUrgent,
+		},
+		{
+			name: "review status floors to high",
+			item: Item{Priority: task.PriorityLow, Status: task.StatusInReview},
+			want: task.PriorityHigh,
+		},
+		{
+			name: "testing status floors to medium",
+			item: Item{Priority: task.PriorityNone, Status: task.StatusTesting},
+			want: task.PriorityMedium,
+		},
+		{
+			name: "normal status keeps none",
+			item: Item{Priority: task.PriorityNone, Status: task.StatusTodo},
+			want: task.PriorityNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.EffectivePriority(); got != tt.want {
+				t.Fatalf("EffectivePriority() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLessUsesStaticPriorityNotStarvationBoost(t *testing.T) {
+	now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	old := Item{
+		TaskID:   "old",
+		Priority: task.PriorityNone,
+		Enqueued: now.Add(-2 * time.Hour),
+	}
+	fresh := Item{
+		TaskID:   "fresh",
+		Priority: task.PriorityLow,
+		Enqueued: now,
+	}
+
+	if Less(old, fresh) {
+		t.Fatal("Less(old, fresh) = true, want static snapshot ordering to keep fresh ahead")
+	}
+	if !lessBoosted(old, fresh, now, time.Hour) {
+		t.Fatal("lessBoosted(old, fresh) = false, want starvation boost to affect dispatch only")
+	}
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -592,6 +592,14 @@ func (a *App) StartAgent(taskID, mode, prompt string, includeTaskDescription boo
 	return a.agentOrch.StartAgent(taskID, mode, prompt, includeTaskDescription, false)
 }
 
+// AgentQueueSnapshot exposes the read-only queue snapshot to Wails/web clients.
+func (a *App) AgentQueueSnapshot() AgentQueueSnapshot {
+	if a == nil || a.queueSvc == nil {
+		return AgentQueueSnapshot{Items: []AgentQueueSnapshotItem{}}
+	}
+	return a.queueSvc.AgentQueueSnapshot()
+}
+
 // StartChat creates a new interactive chat bound to projectID using the
 // requested provider ("claude" or "codex"). Each chat gets a dedicated
 // local-only worktree that is cleaned up when StopChat is called.

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -111,6 +111,7 @@ func setupManualQueueApp(t *testing.T, taskDir, queueDir string, maxConcurrent i
 	if err != nil {
 		t.Fatalf("agent.NewManager: %v", err)
 	}
+	t.Cleanup(func() { mgr.ShutdownWithGrace(2 * time.Second) })
 	q, err := agentqueue.New(queueDir, agentqueue.Options{}, logger)
 	if err != nil {
 		t.Fatalf("agentqueue.New: %v", err)

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -50,6 +50,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 			// RunLearningDigestNow excluded: it shells out to the claude CLI on
 			// every call — Wails/local-only, not exposed over HTTP.
 			"StartAgent",
+			"AgentQueueSnapshot",
 			"StartChat",
 			"StopChat",
 			"ListBackgroundOps",

--- a/internal/sybra/services_http_test.go
+++ b/internal/sybra/services_http_test.go
@@ -75,8 +75,55 @@ func TestQueueServiceHTTPAllowlist(t *testing.T) {
 	if status := post("SnapshotDepth"); status == http.StatusNotFound {
 		t.Errorf("SnapshotDepth should be reachable over HTTP, got %d", status)
 	}
+	if status := post("AgentQueueSnapshot"); status != http.StatusNotFound {
+		t.Errorf("QueueService.AgentQueueSnapshot must stay off the QueueService HTTP surface, got %d (want 404)", status)
+	}
 	if status := post("Snapshot"); status != http.StatusNotFound {
 		t.Errorf("Snapshot must NOT be reachable over HTTP, got %d (want 404)", status)
+	}
+}
+
+func TestAppHTTPAllowlist(t *testing.T) {
+	queue, err := agentqueue.New(t.TempDir(), agentqueue.Options{}, slog.Default())
+	if err != nil {
+		t.Fatalf("agentqueue.New: %v", err)
+	}
+	if added := queue.Offer(agentqueue.Item{
+		TaskID:   "queued-task",
+		Priority: task.PriorityNone,
+		Status:   task.StatusInReview,
+		Mode:     "headless",
+	}); !added {
+		t.Fatal("Offer(queued-task) returned false, want true")
+	}
+	a := &App{queueSvc: &QueueService{queue: queue}}
+
+	mux := http.NewServeMux()
+	httpapi.Mount(mux, ServiceRegistry(a), slog.Default())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Post(srv.URL+"/api/App/AgentQueueSnapshot", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST AgentQueueSnapshot: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("AgentQueueSnapshot status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var got AgentQueueSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode AgentQueueSnapshot response: %v", err)
+	}
+	if got.Depth != 1 || len(got.Items) != 1 {
+		t.Fatalf("AgentQueueSnapshot response = %+v, want single queued item", got)
+	}
+	if got.Items[0].TaskID != "queued-task" {
+		t.Fatalf("AgentQueueSnapshot item task = %q, want queued-task", got.Items[0].TaskID)
+	}
+	if got.Items[0].EffectivePriority != string(task.PriorityHigh) {
+		t.Fatalf("AgentQueueSnapshot effective priority = %q, want %q", got.Items[0].EffectivePriority, task.PriorityHigh)
 	}
 }
 

--- a/internal/sybra/svc_queue.go
+++ b/internal/sybra/svc_queue.go
@@ -1,11 +1,35 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/agentqueue"
+import (
+	"time"
+
+	"github.com/Automaat/sybra/internal/agentqueue"
+)
 
 // QueueDepthSnapshot is the HTTP-facing queue depth snapshot payload.
 type QueueDepthSnapshot struct {
 	Depth                int    `json:"depth"`
 	TopEffectivePriority string `json:"topEffectivePriority"`
+}
+
+// AgentQueueSnapshot is the read-only queued-agent view exposed to the GUI.
+type AgentQueueSnapshot struct {
+	Depth int                      `json:"depth"`
+	Items []AgentQueueSnapshotItem `json:"items"`
+}
+
+// AgentQueueSnapshotItem is one queue row, ordered by Queue.Snapshot().
+type AgentQueueSnapshotItem struct {
+	TaskID            string    `json:"taskId"`
+	Role              string    `json:"role"`
+	Position          int       `json:"position"`
+	Depth             int       `json:"depth"`
+	Priority          string    `json:"priority"`
+	EffectivePriority string    `json:"effectivePriority"`
+	Status            string    `json:"status"`
+	Manual            bool      `json:"manual"`
+	Mode              string    `json:"mode"`
+	Enqueued          time.Time `json:"enqueued"`
 }
 
 // QueueService exposes queue readouts over the HTTP control plane only.
@@ -15,7 +39,7 @@ type QueueService struct {
 
 // SnapshotDepth returns the current queue depth and top effective priority.
 func (s *QueueService) SnapshotDepth() QueueDepthSnapshot {
-	if s.queue == nil {
+	if s == nil || s.queue == nil {
 		return QueueDepthSnapshot{}
 	}
 	snap := s.queue.DepthSnapshot()
@@ -23,4 +47,32 @@ func (s *QueueService) SnapshotDepth() QueueDepthSnapshot {
 		Depth:                snap.Depth,
 		TopEffectivePriority: string(snap.TopEffectivePriority),
 	}
+}
+
+// AgentQueueSnapshot returns the queue's ordered items plus top-level depth.
+func (s *QueueService) AgentQueueSnapshot() AgentQueueSnapshot {
+	if s == nil || s.queue == nil {
+		return AgentQueueSnapshot{Items: []AgentQueueSnapshotItem{}}
+	}
+	snap := s.queue.Snapshot()
+	out := AgentQueueSnapshot{
+		Depth: len(snap),
+		Items: make([]AgentQueueSnapshotItem, 0, len(snap)),
+	}
+	for i := range snap {
+		it := snap[i]
+		out.Items = append(out.Items, AgentQueueSnapshotItem{
+			TaskID:            it.TaskID,
+			Role:              it.Role,
+			Position:          i + 1,
+			Depth:             len(snap),
+			Priority:          string(it.Priority),
+			EffectivePriority: string(it.EffectivePriority()),
+			Status:            string(it.Status),
+			Manual:            it.Manual,
+			Mode:              it.Mode,
+			Enqueued:          it.Enqueued,
+		})
+	}
+	return out
 }

--- a/internal/sybra/svc_queue_test.go
+++ b/internal/sybra/svc_queue_test.go
@@ -1,10 +1,12 @@
 package sybra
 
 import (
+	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/agentqueue"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -44,4 +46,101 @@ func TestQueueService_SnapshotDepth(t *testing.T) {
 	if got := nilSvc.SnapshotDepth(); got != (QueueDepthSnapshot{}) {
 		t.Fatalf("nil SnapshotDepth() = %+v, want zero value", got)
 	}
+}
+
+func TestQueueService_AgentQueueSnapshot(t *testing.T) {
+	queue, err := agentqueue.New(t.TempDir(), agentqueue.Options{StarvationBoostAfter: time.Hour}, slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("agentqueue.New: %v", err)
+	}
+
+	now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	if added := queue.Offer(agentqueue.Item{
+		TaskID:   "fresh-low",
+		Role:     string(agent.RoleImplementation),
+		Priority: task.PriorityLow,
+		Status:   task.StatusTodo,
+		Manual:   true,
+		Mode:     "headless",
+		Prompt:   "do not leak",
+		Enqueued: now,
+	}); !added {
+		t.Fatal("Offer(fresh-low) returned false, want true")
+	}
+	if added := queue.Offer(agentqueue.Item{
+		TaskID:   "old-none",
+		Role:     string(agent.RoleImplementation),
+		Priority: task.PriorityNone,
+		Status:   task.StatusInReview,
+		Manual:   false,
+		Mode:     "interactive",
+		Prompt:   "still do not leak",
+		Enqueued: now.Add(-2 * time.Hour),
+	}); !added {
+		t.Fatal("Offer(old-none) returned false, want true")
+	}
+
+	svc := &QueueService{queue: queue}
+	got := svc.AgentQueueSnapshot()
+	if got.Depth != 2 {
+		t.Fatalf("Depth = %d, want 2", got.Depth)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("len(Items) = %d, want 2", len(got.Items))
+	}
+	if got.Items[0].TaskID != "old-none" {
+		t.Fatalf("Items[0].TaskID = %q, want old-none (status floor/static snapshot ordering)", got.Items[0].TaskID)
+	}
+	if got.Items[0].Position != 1 || got.Items[0].Depth != 2 {
+		t.Fatalf("Items[0] queue numbers = position %d depth %d, want 1 and 2", got.Items[0].Position, got.Items[0].Depth)
+	}
+	if got.Items[0].EffectivePriority != string(task.PriorityHigh) {
+		t.Fatalf("Items[0].EffectivePriority = %q, want %q", got.Items[0].EffectivePriority, task.PriorityHigh)
+	}
+	if got.Items[1].TaskID != "fresh-low" {
+		t.Fatalf("Items[1].TaskID = %q, want fresh-low", got.Items[1].TaskID)
+	}
+	if got.Items[1].Position != 2 || got.Items[1].Depth != 2 {
+		t.Fatalf("Items[1] queue numbers = position %d depth %d, want 2 and 2", got.Items[1].Position, got.Items[1].Depth)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal(snapshot): %v", err)
+	}
+	if jsonContainsField(encoded, "prompt") {
+		t.Fatalf("snapshot JSON leaked prompt field: %s", encoded)
+	}
+
+	var nilSvc QueueService
+	nilSnap := nilSvc.AgentQueueSnapshot()
+	if nilSnap.Depth != 0 || len(nilSnap.Items) != 0 {
+		t.Fatalf("nil AgentQueueSnapshot() = %+v, want empty snapshot", nilSnap)
+	}
+}
+
+func jsonContainsField(data []byte, field string) bool {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	return mapContainsField(raw, field)
+}
+
+func mapContainsField(v any, field string) bool {
+	switch typed := v.(type) {
+	case map[string]any:
+		for k, child := range typed {
+			if k == field || mapContainsField(child, field) {
+				return true
+			}
+		}
+	case []any:
+		for i := range typed {
+			if mapContainsField(typed[i], field) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Motivation

Surface the agent queue in the GUI: show queued agents with position and depth instead of an error toast when the pool is saturated. Part of #1844 (priority dispatch queue).

> Changelog: feat(gui): display agent queue position and depth

## Implementation information

- New bound `AgentQueueSnapshot()` (position, effective priority, depth) + regenerated Wails bindings, re-exported via $lib/api.
- `agents.svelte.ts` renders the `queued` state (badge + position) and drops the error path for pool-busy manual starts; queued layout component.
- Backend queue ordering/snapshot in `internal/agentqueue` + `svc_queue`.
- Tests: `agents.svelte.test.ts`, `svc_queue_test.go`, `order_test.go`, HTTP service tests.

## Supporting documentation

Closes #1849. Note: Sybra escalated this to human because the isolated browser/server harness could not reliably saturate the agent pool to smoke the queued GUI end-to-end — a test-harness limitation, not an implementation defect. Automated checks + frontend unit tests pass; verification is via CI + review here.