### PR TITLE
build(build): lint in sybra verify gate

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -65,6 +65,7 @@ checks:
   verify:
     - mise exec -- bash scripts/check-api-shim-sync.sh
     - mise exec -- bash scripts/check-no-home-fallback.sh
+    - mise exec -- golangci-lint run ./internal/... ./cmd/...
     - mise exec -- go test ./internal/... ./cmd/...
     - (cd frontend && mise exec -- npm run build:web)
     - (cd frontend && mise exec -- npm run test:coverage)


### PR DESCRIPTION
## Motivation

Sybra's `checks.verify` gate (the pre-review, anti-reward-hacking phase) ran frontend tests + `go test` but **not `golangci-lint run`** — so a lint failure (e.g. funlen) escaped Sybra's own gate and only surfaced at CI. Since Sybra opens the PR *after* the gate, there was no PR, no CI, and no agent ever saw the lint failure. This is one of the gaps that let 29b6cf7e (#1849) get stuck (see #1928).

> Changelog: build(build): lint in sybra verify gate

## Implementation information

Add `golangci-lint run ./internal/... ./cmd/...` to `checks.verify`, scoped to match the existing `go test` targets — this avoids the root package's `//go:embed all:frontend/dist` (which needs a frontend build) while still catching the lint classes that dominate first-pass failures. Verified main is clean in this scope (0 issues).

## Supporting documentation

#1928 (structural gaps), #1927 (the task this surfaced from).