### PR TITLE
feat(sybra): auto-review unblocks + files issues

### DIFF
--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -246,6 +246,14 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 		h.logger.Error("human-review.task.get-on-complete", "task_id", taskID, "agent_id", ag.ID, "err", err)
 		return
 	}
+	final := finalAssistantText(ag)
+	v, source, parseErr := verdict.Parse(final)
+
+	if parseErr == nil && v.Decision == "unblocked" {
+		h.recordUnblocked(taskID, ag.ID, v, source)
+		return
+	}
+
 	if current.Status != task.StatusHumanRequired {
 		h.logger.Info("human-review.verdict.stale",
 			"task_id", taskID, "agent_id", ag.ID, "status", current.Status)
@@ -256,8 +264,6 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 		return
 	}
 
-	final := finalAssistantText(ag)
-	v, source, parseErr := verdict.Parse(final)
 	if parseErr != nil {
 		if ag.GetErrorKind() == "rate_limit" {
 			h.logger.Warn("human-review.verdict.deferred",
@@ -280,6 +286,7 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 
 	switch v.Decision {
 	case "human":
+		h.fileAutonomyIssue(taskID, ag.ID, v, h.workCtxForTask(taskID))
 		if h.appendNote(taskID, "Auto-review verdict: needs human", v.Summary) {
 			h.markVerdictRendered(taskID, ag.ID)
 		}
@@ -499,6 +506,51 @@ func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdict
 	})
 
 	h.blockOriginOnLocalBug(taskID, agentID, "Auto-review verdict: blocked by Sybra bug (scrubbed)", summary, newTask.ID, "")
+}
+
+func (h *humanReviewHandler) recordUnblocked(taskID, agentID string, v verdictDecision, source verdict.Source) {
+	h.logAudit(audit.EventHumanReviewVerdict, taskID, agentID, map[string]any{
+		"decision": v.Decision, "summary": v.Summary, "verdict_source": string(source),
+	})
+	h.fileAutonomyIssue(taskID, agentID, v, h.workCtxForTask(taskID))
+	if h.appendNote(taskID, "Auto-review: unblocked", v.Summary) {
+		h.markVerdictRendered(taskID, agentID)
+	}
+}
+
+func (h *humanReviewHandler) workCtxForTask(taskID string) *WorkScrubContext {
+	if h.workCtx == nil {
+		return nil
+	}
+	t, err := h.tasks.Get(taskID)
+	if err != nil {
+		return nil
+	}
+	return h.workCtx(t.ProjectID)
+}
+
+func (h *humanReviewHandler) fileAutonomyIssue(taskID, agentID string, v verdictDecision, wctx *WorkScrubContext) {
+	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
+		return
+	}
+	if wctx != nil {
+		sv := scrubVerdict(v, wctx)
+		tags := append([]string{"sybra-bug", "scrubbed", "autonomy"}, sv.IssueLabels...)
+		if _, err := h.tasks.CreateFull(sv.IssueTitle, sv.IssueBody, task.AgentModeHeadless, task.Update{Tags: &tags}); err != nil {
+			h.logger.Warn("human-review.autonomy.local.create", "task_id", taskID, "agent_id", agentID, "err", err)
+		}
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	created, url, err := h.sink.SubmitIssue(ctx, v.IssueTitle, v.IssueBody, v.IssueLabels)
+	if err != nil {
+		h.logger.Warn("human-review.autonomy.file", "task_id", taskID, "agent_id", agentID, "err", err)
+		return
+	}
+	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
+		"created": created, "url": url, "title": v.IssueTitle, "autonomy": true,
+	})
 }
 
 func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision) {
@@ -803,6 +855,17 @@ func (h *humanReviewHandler) logAudit(evt, taskID, agentID string, data map[stri
 // prompt is augmented with explicit redaction rules and the verdict will be
 // routed to a local sybra task instead of a public GH issue. The regex
 // scrubber is the floor — these instructions are the semantic ceiling.
+func writeAutonomyMandate(b *strings.Builder) {
+	b.WriteString("You are Sybra's autonomy agent (Sybra is a desktop task orchestrator). A user task just transitioned to status=human-required. Your job is NOT merely to diagnose — it is to get this task PROGRESSING again without a human wherever it is safe to do so, and to make Sybra more autonomous so this class of block never needs a human again. You run with full permissions and have git, gh, and sybra-cli. Work through three phases in order:\n\n")
+	b.WriteString("1. ROOT CAUSE — determine exactly why the task landed in human-required: a deterministic check failure (lint/test/build), a workflow misfire, an un-runnable gate (e.g. a manual smoke the harness cannot perform), an ambiguous spec, a missing credential, or an external system the agent cannot reach. Re-run the exact failing command in the task's worktree to confirm; never infer 'flaky/transient/infra' from reasoning alone.\n\n")
+	b.WriteString("2. UNBLOCK — do what you safely can to move the task forward:\n")
+	b.WriteString("   - Deterministic failures you can fix (lint/test/build): fix them in the task's worktree, re-run the exact check and SEE it pass, commit + push, then advance the task with sybra-cli (e.g. `sybra-cli update <id> --status ready-pr [--pr N]`) so it re-enters the pipeline.\n")
+	b.WriteString("   - Work is complete but stuck on a gate the harness genuinely cannot run: open or link a PR (`gh pr create` / `sybra-cli update <id> --pr N --status ready-pr`) and move it to review so CI + Copilot + a human reviewer verify it. Never fabricate or fake the verification you could not run.\n")
+	b.WriteString("   - A Sybra workflow bug: work around it to unblock the task if you safely can, and file an issue (phase 3).\n")
+	b.WriteString("   HARD LIMITS: never fabricate results, never force-merge a PR, never push code whose checks you did not run and see pass. Only LEAVE the task at human-required when a human genuinely must decide — scope, creative direction, missing credentials, or an unreachable external system.\n\n")
+	b.WriteString("3. AUTONOMY — for anything that needed a human, OR that you had to do by hand here, ask: 'how should Sybra have handled this itself?' If there is a real gap, prepare an issue (issue_* fields) describing the gap and the fix so the next occurrence is automatic. Every human-required transition is a bug in Sybra's autonomy until proven otherwise; this issue is often your most valuable output. Do NOT run `gh issue create` yourself — return the payload so the host files it (and scrubs it for work-typed projects).\n\n")
+}
+
 func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) string {
 	var b strings.Builder
 	b.WriteString("# Sybra auto-review of human-required transition\n\n")
@@ -814,7 +877,7 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) st
 		b.WriteString("- NEVER include author emails, customer names, or internal hostnames.\n")
 		b.WriteString("- DO describe the sybra bug abstractly: which workflow step misfired, which sybra subsystem is implicated, what state was inconsistent.\n\n")
 	}
-	b.WriteString("You are a diagnostic agent for Sybra (the desktop task orchestrator). A user task just transitioned to status=human-required. Decide whether this is genuinely a human-input situation or whether Sybra itself misbehaved (workflow misfire, agent mis-config, infrastructure flakiness, code bug). If it's a Sybra bug, prepare an issue payload — the host process will route it (local sybra task for work-typed projects, public GH issue otherwise).\n\n")
+	writeAutonomyMandate(&b)
 	b.WriteString("## Task\n")
 	fmt.Fprintf(&b, "- ID: %s\n- Title: %s\n- Status: %s\n", t.ID, t.Title, t.Status)
 	if t.StatusReason != "" {
@@ -825,6 +888,12 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) st
 	}
 	if t.PRNumber > 0 {
 		fmt.Fprintf(&b, "- PR: #%d\n", t.PRNumber)
+	}
+	if t.WorktreeDir != "" {
+		fmt.Fprintf(&b, "- Worktree (cd here to fix/verify/push the task's code): %s\n", t.WorktreeDir)
+	}
+	if t.Branch != "" {
+		fmt.Fprintf(&b, "- Branch: %s\n", t.Branch)
 	}
 	b.WriteString("\n### Task body\n")
 	b.WriteString(strings.TrimSpace(t.Body))
@@ -889,12 +958,13 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) st
 
 	b.WriteString("## Output protocol (REQUIRED)\n")
 	b.WriteString("Your final response is enforced to match a JSON schema. Return exactly these fields:\n\n")
-	b.WriteString("- `decision`: \"human\" | \"sybra_bug\"\n")
-	b.WriteString("- `summary`: one-sentence diagnosis\n")
-	b.WriteString("- `issue_title` (sybra_bug only): \"type(scope): short title\", must follow Sybra conventional commit format (e.g. fix(workflow): ...)\n")
-	b.WriteString("- `issue_body` (sybra_bug only): \"## What happened\\n...\\n\\n## Repro\\n...\\n\\n## Suspected cause\\n...\"\n")
-	b.WriteString("- `issue_labels` (sybra_bug only): array of label strings\n\n")
-	b.WriteString("If decision=human, set every issue_* field to null (the schema requires the keys to be present).\n")
+	b.WriteString("- `decision`: \"unblocked\" | \"human\" | \"sybra_bug\"\n")
+	b.WriteString("  - \"unblocked\": you moved the task forward yourself (fixed + pushed, opened/linked a PR, advanced its status) — it is no longer waiting on you.\n")
+	b.WriteString("  - \"human\": a human genuinely must act (scope, creative decision, missing credential, unreachable system); the task stays human-required.\n")
+	b.WriteString("  - \"sybra_bug\": you could not unblock it and the cause is a Sybra defect; the host files the issue and blocks the task pending the fix.\n")
+	b.WriteString("- `summary`: one sentence — what you did to unblock it, what a human must decide, or the diagnosis.\n")
+	b.WriteString("- `issue_title` / `issue_body` / `issue_labels`: the issue payload. REQUIRED for sybra_bug. For unblocked or human, fill these when there is a real Sybra autonomy gap worth tracking (the host files it) — leave null only when there is genuinely nothing to file. `issue_title` must be conventional-commit format (e.g. fix(workflow): ...); `issue_body` = \"## What happened\\n...\\n\\n## Repro\\n...\\n\\n## Suspected cause\\n...\\n\\n## Autonomy fix\\n...\".\n\n")
+	b.WriteString("Set unused issue_* fields to null (the schema requires the keys to be present).\n")
 	return b.String()
 }
 

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -250,7 +250,7 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 	v, source, parseErr := verdict.Parse(final)
 
 	if parseErr == nil && v.Decision == "unblocked" {
-		h.recordUnblocked(taskID, ag.ID, v, source)
+		h.recordUnblocked(current, ag.ID, v, source)
 		return
 	}
 
@@ -286,8 +286,8 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 
 	switch v.Decision {
 	case "human":
-		h.fileAutonomyIssue(taskID, ag.ID, v, h.workCtxForTask(taskID))
-		if h.appendNote(taskID, "Auto-review verdict: needs human", v.Summary) {
+		h.fileAutonomyIssue(taskID, current.ProjectID, ag.ID, v)
+		if h.appendNote(taskID, "Auto-review verdict: needs human", h.scrubForTask(current.ProjectID, v.Summary)) {
 			h.markVerdictRendered(taskID, ag.ID)
 		}
 	case "sybra_bug":
@@ -508,35 +508,38 @@ func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdict
 	h.blockOriginOnLocalBug(taskID, agentID, "Auto-review verdict: blocked by Sybra bug (scrubbed)", summary, newTask.ID, "")
 }
 
-func (h *humanReviewHandler) recordUnblocked(taskID, agentID string, v verdictDecision, source verdict.Source) {
-	h.logAudit(audit.EventHumanReviewVerdict, taskID, agentID, map[string]any{
+func (h *humanReviewHandler) recordUnblocked(current task.Task, agentID string, v verdictDecision, source verdict.Source) {
+	h.logAudit(audit.EventHumanReviewVerdict, current.ID, agentID, map[string]any{
 		"decision": v.Decision, "summary": v.Summary, "verdict_source": string(source),
 	})
-	h.fileAutonomyIssue(taskID, agentID, v, h.workCtxForTask(taskID))
-	if h.appendNote(taskID, "Auto-review: unblocked", v.Summary) {
-		h.markVerdictRendered(taskID, agentID)
+	h.fileAutonomyIssue(current.ID, current.ProjectID, agentID, v)
+	if h.appendNote(current.ID, "Auto-review: unblocked", h.scrubForTask(current.ProjectID, v.Summary)) {
+		h.markVerdictRendered(current.ID, agentID)
 	}
 }
 
-func (h *humanReviewHandler) workCtxForTask(taskID string) *WorkScrubContext {
+func (h *humanReviewHandler) workCtxFor(projectID string) *WorkScrubContext {
 	if h.workCtx == nil {
 		return nil
 	}
-	t, err := h.tasks.Get(taskID)
-	if err != nil {
-		return nil
-	}
-	return h.workCtx(t.ProjectID)
+	return h.workCtx(projectID)
 }
 
-func (h *humanReviewHandler) fileAutonomyIssue(taskID, agentID string, v verdictDecision, wctx *WorkScrubContext) {
+func (h *humanReviewHandler) fileAutonomyIssue(taskID, projectID, agentID string, v verdictDecision) {
 	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
 		return
 	}
-	if wctx != nil {
+	if wctx := h.workCtxFor(projectID); wctx != nil {
 		sv := scrubVerdict(v, wctx)
+		if _, ok := h.findExistingLocalBugTask(sv.IssueTitle); ok {
+			return
+		}
 		tags := append([]string{"sybra-bug", "scrubbed", "autonomy"}, sv.IssueLabels...)
-		if _, err := h.tasks.CreateFull(sv.IssueTitle, sv.IssueBody, task.AgentModeHeadless, task.Update{Tags: &tags}); err != nil {
+		init := task.Update{Tags: &tags}
+		if repo := strings.TrimSpace(h.cfg.HumanReviewRepo()); repo != "" {
+			init.ProjectID = &repo
+		}
+		if _, err := h.tasks.CreateFull(sv.IssueTitle, sv.IssueBody, task.AgentModeHeadless, init); err != nil {
 			h.logger.Warn("human-review.autonomy.local.create", "task_id", taskID, "agent_id", agentID, "err", err)
 		}
 		return

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -295,6 +295,70 @@ func TestOnComplete_HumanVerdict_AppendsNote(t *testing.T) {
 	}
 }
 
+func TestOnComplete_UnblockedVerdict_NotesAndDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Fix flaky test", "Original body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusReadyPR)}); err != nil {
+		t.Fatalf("advance to ready-pr: %v", err)
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type: "assistant",
+		Content: "```sybra-verdict\n" +
+			`{"decision":"unblocked","summary":"fixed lint, pushed, advanced to ready-pr"}` +
+			"\n```\n",
+	})
+	h.inflight[tk.ID] = "agent-1"
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if got.Status != task.StatusReadyPR {
+		t.Errorf("status: got %q want ready-pr (unblocked must not re-block or revert the agent's advance)", got.Status)
+	}
+	if got.BlockedByIssue != "" {
+		t.Errorf("BlockedByIssue: want empty, got %q", got.BlockedByIssue)
+	}
+	if !strings.Contains(got.Body, "Auto-review: unblocked") {
+		t.Errorf("expected unblocked note in body; got:\n%s", got.Body)
+	}
+	if sink.calls != 0 {
+		t.Errorf("sink should not be called without an issue payload; calls=%d", sink.calls)
+	}
+	if _, busy := h.inflight[tk.ID]; busy {
+		t.Errorf("inflight should be cleared after onComplete")
+	}
+}
+
+func TestBuildPrompt_IncludesUnblockAndAutonomyMandate(t *testing.T) {
+	t.Parallel()
+	h, _, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk := task.Task{
+		ID: "t1", Title: "x", Status: task.StatusHumanRequired,
+		Branch: "feat/queue", WorktreeDir: "/data/worktrees/queue",
+	}
+	p := h.buildPrompt(tk, nil)
+	for _, want := range []string{
+		"UNBLOCK", "AUTONOMY", "ROOT CAUSE", "unblocked",
+		"never fabricate", "/data/worktrees/queue", "feat/queue",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
 // TestOnComplete_BareJSONVerdict_HumanDecision drives onComplete with a bare
 // structured-output JSON assistant turn (verdict.SourceJSON) instead of the
 // legacy fenced ```sybra-verdict``` block — the production path introduced

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -43,7 +43,7 @@ const (
 // therefore modeled as nullable and listed as required; the model emits null
 // for them on a human verdict. Go decodes JSON null into the zero value
 // (empty string / nil slice), so normalize() sees them as absent.
-const Schema = `{"type":"object","properties":{"decision":{"type":"string","enum":["human","sybra_bug"]},"summary":{"type":"string"},"issue_title":{"type":["string","null"]},"issue_body":{"type":["string","null"]},"issue_labels":{"type":["array","null"],"items":{"type":"string"}}},"required":["decision","summary","issue_title","issue_body","issue_labels"],"additionalProperties":false}`
+const Schema = `{"type":"object","properties":{"decision":{"type":"string","enum":["human","sybra_bug","unblocked"]},"summary":{"type":"string"},"issue_title":{"type":["string","null"]},"issue_body":{"type":["string","null"]},"issue_labels":{"type":["array","null"],"items":{"type":"string"}}},"required":["decision","summary","issue_title","issue_body","issue_labels"],"additionalProperties":false}`
 
 var fenceRe = regexp.MustCompile("(?s)```\\s*sybra-verdict\\s*\\n(.*?)\\n```")
 
@@ -101,7 +101,7 @@ func normalize(v Decision, src Source) (Decision, Source, error) {
 	v.IssueTitle = strings.TrimSpace(v.IssueTitle)
 	v.IssueBody = strings.TrimSpace(v.IssueBody)
 	v.IssueLabels = normalizeLabels(v.IssueLabels)
-	if v.Decision != "human" && v.Decision != "sybra_bug" {
+	if v.Decision != "human" && v.Decision != "sybra_bug" && v.Decision != "unblocked" {
 		return Decision{}, "", fmt.Errorf("verdict: invalid decision %q", v.Decision)
 	}
 	if v.Summary == "" {

--- a/internal/verdict/verdict_test.go
+++ b/internal/verdict/verdict_test.go
@@ -61,6 +61,12 @@ func TestParse(t *testing.T) {
 			wantSource: SourceJSON,
 		},
 		{
+			name:       "unblocked decision valid",
+			input:      `{"decision":"unblocked","summary":"fixed lint, pushed, advanced to ready-pr"}`,
+			want:       Decision{Decision: "unblocked", Summary: "fixed lint, pushed, advanced to ready-pr"},
+			wantSource: SourceJSON,
+		},
+		{
 			name:    "invalid decision value",
 			input:   `{"decision":"maybe","summary":"x"}`,
 			wantErr: true,


### PR DESCRIPTION
## Motivation

The auto-review agent that fires on every `human-required` transition was diagnose-only — it emitted `human`|`sybra_bug` and, on `human`, just left the task parked. A task stuck on an un-runnable gate or a fixable deterministic failure never progressed on its own. The P4 GUI queue task (#1849) is the canonical example: it bounced implementation ↔ human-review indefinitely; a human had to open the PR, fix 22 frontend regressions + a lint failure, and advance it — exactly what an autonomy agent should do.

> Changelog: feat(sybra): auto-review unblocks + files issues

## Implementation information

Reframes the agent (`internal/sybra/app_human_review.go`) as Sybra's **autonomy agent** with a three-phase mandate: **root cause → unblock → file an autonomy issue**.

- **Unblock**: fix deterministic failures in the worktree (re-run + see them pass), commit + push, advance via `sybra-cli`; or open/link a PR for review when a gate genuinely can't run in the harness. Hard limits: never fabricate results, never force-merge, never push unverified code. Only leaves `human-required` when a human genuinely must decide.
- New **`unblocked`** verdict (`internal/verdict`), **exempt from the stale-status guard** (the agent intentionally moves the task off `human-required`).
- **Non-blocking autonomy-issue filing** on any verdict, routed through the existing **work-typed scrub → local task** path (the agent is told never to `gh issue create` itself; the host files + scrubs).

Tests: `unblocked` parse; `onComplete` unblocked path (note + no-block + stale-guard exemption); prompt mandate assertions. Lint 0, gofmt clean.

## Note on blast radius

This makes the auto-review agent push code, open PRs, and flip statuses autonomously (still gated by `human_review.enabled`). Guardrailed: verify-before-push, no force-merge, leave genuine-human cases. A granular `human_review.unblock` kill-switch is a sensible fast-follow.

## Supporting documentation

#1928 (the structural gap this closes), #1927 (the task that surfaced it).