### PR TITLE
feat(config): cluster block + task node fields

### DIFF
--- a/cmd/gen-config-docs/main.go
+++ b/cmd/gen-config-docs/main.go
@@ -115,8 +115,8 @@ func exprString(e ast.Expr) (display, localType string) {
 		d, l := exprString(t.X)
 		return "*" + d, l
 	case *ast.ArrayType:
-		d, _ := exprString(t.Elt)
-		return "[]" + d, ""
+		d, l := exprString(t.Elt)
+		return "[]" + d, l
 	case *ast.MapType:
 		k, _ := exprString(t.Key)
 		v, _ := exprString(t.Value)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -535,9 +535,29 @@ follower's server cert/key for the TLS + cert-pin transport tier.
 |---|---|---|---|
 | `cluster.role` | `string` | `standalone` |  |
 | `cluster.bind_addr` | `string` |  |  |
-| `cluster.followers` | `[]Follower` |  |  |
+| `cluster.followers` | `[]Follower` | _(see below)_ |  |
 | `cluster.local_homes` | `[]string` |  |  |
 | `cluster.tls` | `ClusterTLS` | _(see below)_ |  |
+
+## Follower (`cluster.followers`)
+
+Follower is one entry in the leader's roster: a node the leader may assign
+projects to over the control plane. Name is stamped into task.AssignedNode.
+Endpoints are ordered most-preferred-first (e.g. a tailnet URL then a LAN IP)
+so tailnet flakiness falls back to LAN; failover across them lands in P1.
+AuthTokenEnv names the env var holding the bearer token so the secret never
+lands in config.yaml. Trusted marks a node cleared for work-typed tasks;
+Homes pins project ids to this follower; TLSPin is the expected SHA-256
+fingerprint of its server certificate.
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `cluster.followers.name` | `string` |  |  |
+| `cluster.followers.endpoints` | `[]string` |  |  |
+| `cluster.followers.auth_token_env` | `string` |  |  |
+| `cluster.followers.trusted` | `bool` |  |  |
+| `cluster.followers.homes` | `[]string` |  |  |
+| `cluster.followers.tls_pin` | `string` |  |  |
 
 ## ClusterTLS (`cluster.tls`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -44,6 +44,7 @@ machine.
 | `providers` | `ProvidersConfig` | _(see below)_ |  |
 | `metrics` | `MetricsConfig` | _(see below)_ |  |
 | `server` | `ServerConfig` | _(see below)_ |  |
+| `cluster` | `ClusterConfig` | _(see below)_ |  |
 | `auto_update` | `AutoUpdateConfig` | _(see below)_ |  |
 | `browser` | `BrowserConfig` | _(see below)_ |  |
 | `project_types` | `[]string` |  |  |
@@ -518,6 +519,35 @@ left empty — see applyServerDefaults.
 |---|---|---|---|
 | `server.auth_token` | `string` | `[redacted]` |  |
 | `server.allowed_origins` | `[]string` |  |  |
+
+## ClusterConfig (`cluster`)
+
+ClusterConfig configures leader-follower mode (umbrella #1803). The leader
+owns the canonical task store, polls Todoist/GitHub, and assigns work to
+followers by per-project homing; followers execute assigned tasks and stream
+state back. Default role "standalone" preserves single-node behavior, so the
+block requires zero migration. Role is "standalone", "leader", or "follower"
+(invalid falls back to standalone). BindAddr overrides a follower's
+control-plane bind. LocalHomes pins project ids to this node; TLS carries a
+follower's server cert/key for the TLS + cert-pin transport tier.
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `cluster.role` | `string` | `standalone` |  |
+| `cluster.bind_addr` | `string` |  |  |
+| `cluster.followers` | `[]Follower` |  |  |
+| `cluster.local_homes` | `[]string` |  |  |
+| `cluster.tls` | `ClusterTLS` | _(see below)_ |  |
+
+## ClusterTLS (`cluster.tls`)
+
+ClusterTLS holds a follower's server certificate/key paths for the TLS +
+cert-pin transport tier (P7 provides cert-gen). Empty = plain HTTP.
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `cluster.tls.cert_file` | `string` |  |  |
+| `cluster.tls.key_file` | `string` |  |  |
 
 ## AutoUpdateConfig (`auto_update`)
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -432,6 +432,9 @@ export class Task {
      * see internal/monitor/detector.go.
      */
     "statusChangedAt": string;
+    "assignedNode"?: string;
+    "mirrorRev"?: number;
+    "mirrorUpdatedAt"?: string | null;
     "body": string;
     "plan"?: string;
     "planContract"?: string;
@@ -551,7 +554,7 @@ export class Task {
         const $$createField18_0 = $$createType0;
         const $$createField37_0 = $$createType2;
         const $$createField38_0 = $$createType4;
-        const $$createField50_0 = $$createType5;
+        const $$createField53_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -569,7 +572,7 @@ export class Task {
             $$parsedSource["workflow"] = $$createField38_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField50_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField53_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Providers      ProvidersConfig      `yaml:"providers" json:"providers"`
 	Metrics        MetricsConfig        `yaml:"metrics" json:"metrics"`
 	Server         ServerConfig         `yaml:"server" json:"server"`
+	Cluster        ClusterConfig        `yaml:"cluster" json:"cluster"`
 	AutoUpdate     AutoUpdateConfig     `yaml:"auto_update" json:"autoUpdate"`
 	Browser        BrowserConfig        `yaml:"browser" json:"browser"`
 	ProjectTypes   []string             `yaml:"project_types" json:"projectTypes"`

--- a/internal/config/config_cluster.go
+++ b/internal/config/config_cluster.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"log/slog"
-	"net"
 	"net/url"
 	"os"
 	"slices"
@@ -169,11 +168,6 @@ func (f Follower) Encrypted() bool {
 	return true
 }
 
-var tailscaleCGNAT = func() *net.IPNet {
-	_, n, _ := net.ParseCIDR("100.64.0.0/10")
-	return n
-}()
-
 func endpointEncrypted(endpoint string) bool {
 	u, err := url.Parse(strings.TrimSpace(endpoint))
 	if err != nil || u.Host == "" {
@@ -186,14 +180,5 @@ func endpointEncrypted(endpoint string) bool {
 }
 
 func isTailscaleHost(host string) bool {
-	if host == "" {
-		return false
-	}
-	if strings.HasSuffix(strings.ToLower(host), ".ts.net") {
-		return true
-	}
-	if ip := net.ParseIP(host); ip != nil && tailscaleCGNAT != nil {
-		return tailscaleCGNAT.Contains(ip)
-	}
-	return false
+	return host != "" && strings.HasSuffix(strings.ToLower(host), ".ts.net")
 }

--- a/internal/config/config_cluster.go
+++ b/internal/config/config_cluster.go
@@ -1,0 +1,199 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+)
+
+const (
+	ClusterRoleStandalone = "standalone"
+	ClusterRoleLeader     = "leader"
+	ClusterRoleFollower   = "follower"
+)
+
+// ClusterConfig configures leader-follower mode (umbrella #1803). The leader
+// owns the canonical task store, polls Todoist/GitHub, and assigns work to
+// followers by per-project homing; followers execute assigned tasks and stream
+// state back. Default role "standalone" preserves single-node behavior, so the
+// block requires zero migration. Role is "standalone", "leader", or "follower"
+// (invalid falls back to standalone). BindAddr overrides a follower's
+// control-plane bind. LocalHomes pins project ids to this node; TLS carries a
+// follower's server cert/key for the TLS + cert-pin transport tier.
+type ClusterConfig struct {
+	Role       string     `yaml:"role,omitempty" json:"role"`
+	BindAddr   string     `yaml:"bind_addr,omitempty" json:"bindAddr"`
+	Followers  []Follower `yaml:"followers,omitempty" json:"followers"`
+	LocalHomes []string   `yaml:"local_homes,omitempty" json:"localHomes"`
+	TLS        ClusterTLS `yaml:"tls,omitempty" json:"tls"`
+}
+
+// ClusterTLS holds a follower's server certificate/key paths for the TLS +
+// cert-pin transport tier (P7 provides cert-gen). Empty = plain HTTP.
+type ClusterTLS struct {
+	CertFile string `yaml:"cert_file,omitempty" json:"certFile"`
+	KeyFile  string `yaml:"key_file,omitempty" json:"keyFile"`
+}
+
+// Follower is one entry in the leader's roster: a node the leader may assign
+// projects to over the control plane. Name is stamped into task.AssignedNode.
+// Endpoints are ordered most-preferred-first (e.g. a tailnet URL then a LAN IP)
+// so tailnet flakiness falls back to LAN; failover across them lands in P1.
+// AuthTokenEnv names the env var holding the bearer token so the secret never
+// lands in config.yaml. Trusted marks a node cleared for work-typed tasks;
+// Homes pins project ids to this follower; TLSPin is the expected SHA-256
+// fingerprint of its server certificate.
+type Follower struct {
+	Name         string   `yaml:"name" json:"name"`
+	Endpoints    []string `yaml:"endpoints" json:"endpoints"`
+	AuthTokenEnv string   `yaml:"auth_token_env,omitempty" json:"authTokenEnv"`
+	Trusted      bool     `yaml:"trusted,omitempty" json:"trusted"`
+	Homes        []string `yaml:"homes,omitempty" json:"homes"`
+	TLSPin       string   `yaml:"tls_pin,omitempty" json:"tlsPin"`
+}
+
+// NormalizeClusterRole canonicalizes a cluster role. Trim+lowercase first so a
+// formatting slip ("Leader", "follower ") never silently changes posture; empty
+// maps to standalone; unknown values are rejected.
+func NormalizeClusterRole(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", ClusterRoleStandalone:
+		return ClusterRoleStandalone, nil
+	case ClusterRoleLeader:
+		return ClusterRoleLeader, nil
+	case ClusterRoleFollower:
+		return ClusterRoleFollower, nil
+	default:
+		return "", fmt.Errorf("invalid cluster.role %q (valid: standalone, leader, follower)", s)
+	}
+}
+
+// ClusterRole returns this node's resolved cluster role. An invalid config
+// value is logged and treated as standalone so a misconfigured node never
+// silently becomes a leader or follower.
+func (c *Config) ClusterRole() string {
+	if c == nil {
+		return ClusterRoleStandalone
+	}
+	role, err := NormalizeClusterRole(c.Cluster.Role)
+	if err != nil {
+		slog.Warn("config: invalid cluster.role; falling back to standalone", "value", c.Cluster.Role)
+		return ClusterRoleStandalone
+	}
+	return role
+}
+
+// IsLeader reports whether this node is the cluster leader.
+func (c *Config) IsLeader() bool { return c.ClusterRole() == ClusterRoleLeader }
+
+// IsFollower reports whether this node is a cluster follower. Followers
+// hard-disable every inbound poller regardless of per-feature flags.
+func (c *Config) IsFollower() bool { return c.ClusterRole() == ClusterRoleFollower }
+
+// HomeNode describes the node that owns execution for a project. Name/URL/Token
+// are empty for local execution; Trusted and Encrypted are true locally (no
+// transport to secure); Local reports whether the project runs on this node.
+type HomeNode struct {
+	Name      string
+	URL       string
+	Token     string
+	Trusted   bool
+	Encrypted bool
+	Local     bool
+}
+
+// HomeNodeFor resolves which node owns execution for projectID. A project in a
+// follower's Homes routes to that follower; a project in LocalHomes, in no
+// roster, or on a non-leader node routes local. Per-project homing means the
+// first matching follower is authoritative.
+func (c *Config) HomeNodeFor(projectID string) HomeNode {
+	local := HomeNode{Trusted: true, Encrypted: true, Local: true}
+	if c == nil || !c.IsLeader() || projectID == "" {
+		return local
+	}
+	if slices.Contains(c.Cluster.LocalHomes, projectID) {
+		return local
+	}
+	for i := range c.Cluster.Followers {
+		f := c.Cluster.Followers[i]
+		if !slices.Contains(f.Homes, projectID) {
+			continue
+		}
+		return HomeNode{
+			Name:      f.Name,
+			URL:       f.PrimaryEndpoint(),
+			Token:     f.ResolveToken(),
+			Trusted:   f.Trusted,
+			Encrypted: f.Encrypted(),
+		}
+	}
+	return local
+}
+
+// PrimaryEndpoint returns the first configured endpoint, empty when none are
+// set. Failover across the remaining endpoints is the client's job (P1).
+func (f Follower) PrimaryEndpoint() string {
+	if len(f.Endpoints) == 0 {
+		return ""
+	}
+	return f.Endpoints[0]
+}
+
+// ResolveToken reads the follower's bearer token from AuthTokenEnv. Empty when
+// AuthTokenEnv is unset or the named variable is not present.
+func (f Follower) ResolveToken() string {
+	if f.AuthTokenEnv == "" {
+		return ""
+	}
+	return os.Getenv(f.AuthTokenEnv)
+}
+
+// Encrypted reports whether every path to this follower is confidential in
+// transit. It requires at least one endpoint and that all endpoints ride an
+// encrypted transport, since failover could route a work task over any of
+// them. The confidentiality guard (P4) reads this to keep work tasks off
+// cleartext links.
+func (f Follower) Encrypted() bool {
+	if len(f.Endpoints) == 0 {
+		return false
+	}
+	for _, ep := range f.Endpoints {
+		if !endpointEncrypted(ep) {
+			return false
+		}
+	}
+	return true
+}
+
+var tailscaleCGNAT = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
+func endpointEncrypted(endpoint string) bool {
+	u, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil || u.Host == "" {
+		return false
+	}
+	if strings.EqualFold(u.Scheme, "https") {
+		return true
+	}
+	return isTailscaleHost(u.Hostname())
+}
+
+func isTailscaleHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if strings.HasSuffix(strings.ToLower(host), ".ts.net") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil && tailscaleCGNAT != nil {
+		return tailscaleCGNAT.Contains(ip)
+	}
+	return false
+}

--- a/internal/config/config_cluster.go
+++ b/internal/config/config_cluster.go
@@ -136,10 +136,12 @@ func (c *Config) HomeNodeFor(projectID string) HomeNode {
 // PrimaryEndpoint returns the first configured endpoint, empty when none are
 // set. Failover across the remaining endpoints is the client's job (P1).
 func (f Follower) PrimaryEndpoint() string {
-	if len(f.Endpoints) == 0 {
-		return ""
+	for _, ep := range f.Endpoints {
+		if trimmed := strings.TrimSpace(ep); trimmed != "" {
+			return trimmed
+		}
 	}
-	return f.Endpoints[0]
+	return ""
 }
 
 // ResolveToken reads the follower's bearer token from AuthTokenEnv. Empty when
@@ -157,15 +159,17 @@ func (f Follower) ResolveToken() string {
 // them. The confidentiality guard (P4) reads this to keep work tasks off
 // cleartext links.
 func (f Follower) Encrypted() bool {
-	if len(f.Endpoints) == 0 {
-		return false
-	}
+	seen := false
 	for _, ep := range f.Endpoints {
+		if strings.TrimSpace(ep) == "" {
+			continue
+		}
+		seen = true
 		if !endpointEncrypted(ep) {
 			return false
 		}
 	}
-	return true
+	return seen
 }
 
 func endpointEncrypted(endpoint string) bool {

--- a/internal/config/config_cluster_test.go
+++ b/internal/config/config_cluster_test.go
@@ -1,0 +1,228 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeClusterRole(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", ClusterRoleStandalone, false},
+		{"standalone", ClusterRoleStandalone, false},
+		{"leader", ClusterRoleLeader, false},
+		{"follower", ClusterRoleFollower, false},
+		{"  Leader ", ClusterRoleLeader, false},
+		{"FOLLOWER", ClusterRoleFollower, false},
+		{"boss", "", true},
+	}
+	for _, c := range cases {
+		got, err := NormalizeClusterRole(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("NormalizeClusterRole(%q) err = nil, want error", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("NormalizeClusterRole(%q) err = %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("NormalizeClusterRole(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestClusterRoleAndPredicates(t *testing.T) {
+	var nilCfg *Config
+	if got := nilCfg.ClusterRole(); got != ClusterRoleStandalone {
+		t.Errorf("nil cfg ClusterRole = %q, want standalone", got)
+	}
+	if nilCfg.IsLeader() || nilCfg.IsFollower() {
+		t.Error("nil cfg must be neither leader nor follower")
+	}
+
+	leader := &Config{Cluster: ClusterConfig{Role: "leader"}}
+	if !leader.IsLeader() || leader.IsFollower() {
+		t.Error("leader config predicates wrong")
+	}
+
+	follower := &Config{Cluster: ClusterConfig{Role: "FOLLOWER"}}
+	if !follower.IsFollower() || follower.IsLeader() {
+		t.Error("follower config predicates wrong (case-insensitive)")
+	}
+
+	invalid := &Config{Cluster: ClusterConfig{Role: "nonsense"}}
+	if invalid.ClusterRole() != ClusterRoleStandalone {
+		t.Error("invalid role must fall back to standalone")
+	}
+	if invalid.IsLeader() || invalid.IsFollower() {
+		t.Error("invalid role must be neither leader nor follower")
+	}
+}
+
+func TestFollowerEncrypted(t *testing.T) {
+	cases := []struct {
+		name string
+		f    Follower
+		want bool
+	}{
+		{"no endpoints", Follower{}, false},
+		{"https", Follower{Endpoints: []string{"https://box.example:8443"}}, true},
+		{"tailnet magicdns", Follower{Endpoints: []string{"http://server.tailnet-1234.ts.net:8080"}}, true},
+		{"tailnet cgnat ip", Follower{Endpoints: []string{"http://100.101.102.103:8080"}}, true},
+		{"plain lan http", Follower{Endpoints: []string{"http://192.168.20.219:8080"}}, false},
+		{"mixed https+plain", Follower{Endpoints: []string{"https://box.ts.net", "http://192.168.20.219:8080"}}, false},
+		{"both encrypted", Follower{Endpoints: []string{"https://box.example", "http://100.64.0.1:8080"}}, true},
+		{"garbage", Follower{Endpoints: []string{"::not a url"}}, false},
+	}
+	for _, c := range cases {
+		if got := c.f.Encrypted(); got != c.want {
+			t.Errorf("%s: Encrypted() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFollowerResolveToken(t *testing.T) {
+	if got := (Follower{}).ResolveToken(); got != "" {
+		t.Errorf("empty AuthTokenEnv ResolveToken = %q, want empty", got)
+	}
+	t.Setenv("SYBRA_TEST_FOLLOWER_TOKEN", "secret-123")
+	f := Follower{AuthTokenEnv: "SYBRA_TEST_FOLLOWER_TOKEN"}
+	if got := f.ResolveToken(); got != "secret-123" {
+		t.Errorf("ResolveToken = %q, want secret-123", got)
+	}
+	missing := Follower{AuthTokenEnv: "SYBRA_TEST_FOLLOWER_TOKEN_UNSET"}
+	if got := missing.ResolveToken(); got != "" {
+		t.Errorf("unset env ResolveToken = %q, want empty", got)
+	}
+}
+
+func TestHomeNodeForRouting(t *testing.T) {
+	t.Setenv("SYBRA_TEST_FOLLOWER_TOKEN", "tok")
+	leader := &Config{Cluster: ClusterConfig{
+		Role:       "leader",
+		LocalHomes: []string{"owner/keep-local"},
+		Followers: []Follower{
+			{
+				Name:         "pet-box",
+				Endpoints:    []string{"https://pet.ts.net:8443"},
+				AuthTokenEnv: "SYBRA_TEST_FOLLOWER_TOKEN",
+				Trusted:      false,
+				Homes:        []string{"owner/pet-repo"},
+			},
+			{
+				Name:      "work-box",
+				Endpoints: []string{"http://192.168.20.219:8080"},
+				Trusted:   true,
+				Homes:     []string{"owner/work-repo"},
+			},
+		},
+	}}
+
+	remote := leader.HomeNodeFor("owner/pet-repo")
+	if remote.Local || remote.Name != "pet-box" {
+		t.Fatalf("pet-repo should route to pet-box, got %+v", remote)
+	}
+	if remote.URL != "https://pet.ts.net:8443" || remote.Token != "tok" {
+		t.Errorf("pet-box endpoint/token wrong: %+v", remote)
+	}
+	if remote.Trusted || !remote.Encrypted {
+		t.Errorf("pet-box should be untrusted + encrypted, got trusted=%v encrypted=%v", remote.Trusted, remote.Encrypted)
+	}
+
+	work := leader.HomeNodeFor("owner/work-repo")
+	if !work.Trusted || work.Encrypted {
+		t.Errorf("work-box should be trusted + unencrypted (plain LAN http), got %+v", work)
+	}
+
+	local := leader.HomeNodeFor("owner/keep-local")
+	if !local.Local || !local.Trusted || !local.Encrypted {
+		t.Errorf("LocalHomes project must route local (trusted+encrypted): %+v", local)
+	}
+
+	unknown := leader.HomeNodeFor("owner/never-seen")
+	if !unknown.Local {
+		t.Errorf("unrostered project must route local, got %+v", unknown)
+	}
+
+	empty := leader.HomeNodeFor("")
+	if !empty.Local {
+		t.Errorf("empty projectID must route local, got %+v", empty)
+	}
+
+	follower := &Config{Cluster: ClusterConfig{Role: "follower", Followers: leader.Cluster.Followers}}
+	if got := follower.HomeNodeFor("owner/pet-repo"); !got.Local {
+		t.Errorf("non-leader node must always route local, got %+v", got)
+	}
+}
+
+func TestLoadClusterBlockRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	yaml := []byte("cluster:\n" +
+		"  role: leader\n" +
+		"  bind_addr: \"0.0.0.0:8080\"\n" +
+		"  local_homes: [owner/local]\n" +
+		"  followers:\n" +
+		"    - name: pet-box\n" +
+		"      endpoints: [https://pet.ts.net:8443, http://100.64.0.9:8080]\n" +
+		"      auth_token_env: PET_TOKEN\n" +
+		"      trusted: false\n" +
+		"      homes: [owner/pet]\n" +
+		"      tls_pin: abc123\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.IsLeader() {
+		t.Fatal("role leader did not load")
+	}
+	if cfg.Cluster.BindAddr != "0.0.0.0:8080" {
+		t.Errorf("bind_addr = %q", cfg.Cluster.BindAddr)
+	}
+	if len(cfg.Cluster.Followers) != 1 {
+		t.Fatalf("followers len = %d", len(cfg.Cluster.Followers))
+	}
+	f := cfg.Cluster.Followers[0]
+	if f.Name != "pet-box" || f.AuthTokenEnv != "PET_TOKEN" || f.TLSPin != "abc123" {
+		t.Errorf("follower fields wrong: %+v", f)
+	}
+	if len(f.Endpoints) != 2 || len(f.Homes) != 1 {
+		t.Errorf("follower slices wrong: %+v", f)
+	}
+}
+
+func TestDefaultConfigClusterStandalone(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Cluster.Role != ClusterRoleStandalone {
+		t.Errorf("DefaultConfig cluster role = %q, want standalone", cfg.Cluster.Role)
+	}
+	if cfg.IsLeader() || cfg.IsFollower() {
+		t.Error("default config must be standalone (neither leader nor follower)")
+	}
+}
+
+func TestLoadOmittedClusterDefaultsStandalone(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("logging:\n  level: info\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ClusterRole() != ClusterRoleStandalone {
+		t.Errorf("omitted cluster block must default standalone, got %q", cfg.ClusterRole())
+	}
+}

--- a/internal/config/config_cluster_test.go
+++ b/internal/config/config_cluster_test.go
@@ -78,11 +78,32 @@ func TestFollowerEncrypted(t *testing.T) {
 		{"plain lan http", Follower{Endpoints: []string{"http://192.168.20.219:8080"}}, false},
 		{"mixed https+plain", Follower{Endpoints: []string{"https://box.ts.net", "http://192.168.20.219:8080"}}, false},
 		{"both encrypted", Follower{Endpoints: []string{"https://box.example", "http://node.corp.ts.net:8080"}}, true},
+		{"blank ignored when https present", Follower{Endpoints: []string{"https://box.example", "  "}}, true},
+		{"only blanks", Follower{Endpoints: []string{"", "   "}}, false},
 		{"garbage", Follower{Endpoints: []string{"::not a url"}}, false},
 	}
 	for _, c := range cases {
 		if got := c.f.Encrypted(); got != c.want {
 			t.Errorf("%s: Encrypted() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFollowerPrimaryEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		eps  []string
+		want string
+	}{
+		{"none", nil, ""},
+		{"first wins", []string{"https://a.example", "https://b.example"}, "https://a.example"},
+		{"skips blank leading", []string{"", "  ", "https://b.example"}, "https://b.example"},
+		{"trims whitespace", []string{"  https://a.example  "}, "https://a.example"},
+		{"all blank", []string{"", " "}, ""},
+	}
+	for _, c := range cases {
+		if got := (Follower{Endpoints: c.eps}).PrimaryEndpoint(); got != c.want {
+			t.Errorf("%s: PrimaryEndpoint() = %q, want %q", c.name, got, c.want)
 		}
 	}
 }

--- a/internal/config/config_cluster_test.go
+++ b/internal/config/config_cluster_test.go
@@ -74,10 +74,10 @@ func TestFollowerEncrypted(t *testing.T) {
 		{"no endpoints", Follower{}, false},
 		{"https", Follower{Endpoints: []string{"https://box.example:8443"}}, true},
 		{"tailnet magicdns", Follower{Endpoints: []string{"http://server.tailnet-1234.ts.net:8080"}}, true},
-		{"tailnet cgnat ip", Follower{Endpoints: []string{"http://100.101.102.103:8080"}}, true},
+		{"raw cgnat ip is ambiguous", Follower{Endpoints: []string{"http://100.101.102.103:8080"}}, false},
 		{"plain lan http", Follower{Endpoints: []string{"http://192.168.20.219:8080"}}, false},
 		{"mixed https+plain", Follower{Endpoints: []string{"https://box.ts.net", "http://192.168.20.219:8080"}}, false},
-		{"both encrypted", Follower{Endpoints: []string{"https://box.example", "http://100.64.0.1:8080"}}, true},
+		{"both encrypted", Follower{Endpoints: []string{"https://box.example", "http://node.corp.ts.net:8080"}}, true},
 		{"garbage", Follower{Endpoints: []string{"::not a url"}}, false},
 	}
 	for _, c := range cases {

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -486,6 +486,9 @@ func DefaultConfig() *Config {
 			},
 			AutoFailover: true,
 		},
+		Cluster: ClusterConfig{
+			Role: ClusterRoleStandalone,
+		},
 		TasksDir: defaultTasksDir(),
 	}
 }

--- a/internal/sybra/app_automation_routing_test.go
+++ b/internal/sybra/app_automation_routing_test.go
@@ -103,6 +103,41 @@ func TestPollHubReviewerRegistration_GitHubReviewToggles(t *testing.T) {
 	}
 }
 
+// TestPollHubFollowerDisablesAllPollers verifies the leader-follower gate:
+// a follower node registers no inbound pollers regardless of its GitHub flags,
+// since the leader owns task-source polling and pushes work via AssignTask.
+func TestPollHubFollowerDisablesAllPollers(t *testing.T) {
+	t.Parallel()
+
+	follower := &App{
+		cfg: &config.Config{
+			Cluster: config.ClusterConfig{Role: config.ClusterRoleFollower},
+			GitHub:  config.GitHubConfig{Enabled: true, ReviewsEnabled: true, IssuesEnabled: true},
+		},
+		logger:   discardLogger(),
+		reviewer: review.New(nil, nil, nil, nil, discardLogger(), nil, nil, nil, nil, nil, nil),
+	}
+	reg := &fakePollRegistrar{}
+	registerPollHandlers(follower, reg, nil)
+	if len(reg.registered) != 0 {
+		t.Errorf("follower registered pollers %v, want none", reg.registered)
+	}
+
+	leader := &App{
+		cfg: &config.Config{
+			Cluster: config.ClusterConfig{Role: config.ClusterRoleLeader},
+			GitHub:  config.GitHubConfig{Enabled: true, ReviewsEnabled: true, IssuesEnabled: true},
+		},
+		logger:   discardLogger(),
+		reviewer: review.New(nil, nil, nil, nil, discardLogger(), nil, nil, nil, nil, nil, nil),
+	}
+	regLeader := &fakePollRegistrar{}
+	registerPollHandlers(leader, regLeader, nil)
+	if !slices.Contains(regLeader.registered, "reviews") {
+		t.Errorf("leader should still register reviewer, got %v", regLeader.registered)
+	}
+}
+
 func TestRunsGitHubRateBudgetLoop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sybra/app_todoist.go
+++ b/internal/sybra/app_todoist.go
@@ -57,6 +57,10 @@ func (c *todoistCoordinator) init() {
 }
 
 func (c *todoistCoordinator) initLocked() {
+	if c.cfg.IsFollower() {
+		c.logger.Info("cluster.follower.todoist.disabled", "reason", "role=follower; leader owns task-source polling")
+		return
+	}
 	if !c.cfg.Todoist.Enabled || c.cfg.Todoist.APIToken == "" {
 		return
 	}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -560,6 +560,10 @@ type pollRegistrar interface {
 // out of startPollHub so tests can exercise the registration logic (e.g.
 // reviewer gating) directly against a fake pollRegistrar.
 func registerPollHandlers(a *App, reg pollRegistrar, issuesFetcher *poll.IssuesFetcher) {
+	if a.cfg.IsFollower() {
+		a.logger.Info("cluster.follower.pollers.disabled", "reason", "role=follower; leader owns task-source polling")
+		return
+	}
 	// Periodic GitHub search pollers (reviews/issues/renovate) only run on the
 	// primary instance — a "secondary" machine sharing the same token skips them
 	// so the shared rate budget isn't billed twice. Triage is local (no GitHub

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -397,6 +397,10 @@ type Task struct {
 	// see internal/monitor/detector.go.
 	StatusChangedAt time.Time `json:"statusChangedAt"`
 
+	AssignedNode    string     `json:"assignedNode,omitempty"`
+	MirrorRev       int64      `json:"mirrorRev,omitempty"`
+	MirrorUpdatedAt *time.Time `json:"mirrorUpdatedAt,omitempty"`
+
 	Body         string `json:"body"`
 	Plan         string `json:"plan,omitempty"`
 	PlanContract string `json:"planContract,omitempty"`

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -52,6 +52,9 @@ type taskFrontmatter struct {
 	CreatedAt              time.Time           `yaml:"created_at"`
 	UpdatedAt              time.Time           `yaml:"updated_at"`
 	StatusChangedAt        time.Time           `yaml:"status_changed_at,omitempty"`
+	AssignedNode           string              `yaml:"assigned_node,omitempty"`
+	MirrorRev              int64               `yaml:"mirror_rev,omitempty"`
+	MirrorUpdatedAt        *time.Time          `yaml:"mirror_updated_at,omitempty"`
 }
 
 type agentRunRecord struct {
@@ -129,6 +132,9 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		CreatedAt:              fm.CreatedAt,
 		UpdatedAt:              fm.UpdatedAt,
 		StatusChangedAt:        fm.StatusChangedAt,
+		AssignedNode:           fm.AssignedNode,
+		MirrorRev:              fm.MirrorRev,
+		MirrorUpdatedAt:        fm.MirrorUpdatedAt,
 		Body:                   body,
 	}
 	if t.TaskType == "" {
@@ -186,6 +192,9 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		CreatedAt:              t.CreatedAt,
 		UpdatedAt:              t.UpdatedAt,
 		StatusChangedAt:        t.StatusChangedAt,
+		AssignedNode:           t.AssignedNode,
+		MirrorRev:              t.MirrorRev,
+		MirrorUpdatedAt:        t.MirrorUpdatedAt,
 	}
 }
 

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -91,9 +91,12 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 			CompletedAt: &completedAt,
 			Variables:   map[string]string{"k": "v"},
 		},
-		CreatedAt: now.Add(-time.Hour),
-		UpdatedAt: now,
-		Body:      "body",
+		CreatedAt:       now.Add(-time.Hour),
+		UpdatedAt:       now,
+		AssignedNode:    "pet-box",
+		MirrorRev:       7,
+		MirrorUpdatedAt: &completedAt,
+		Body:            "body",
 	}
 
 	got := taskFromFrontmatter(frontmatterFromTask(original), original.Body)
@@ -306,6 +309,12 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.UpdatedAt = later
 	case "StatusChangedAt":
 		task.StatusChangedAt = later
+	case "AssignedNode":
+		task.AssignedNode = "pet-box"
+	case "MirrorRev":
+		task.MirrorRev = 7
+	case "MirrorUpdatedAt":
+		task.MirrorUpdatedAt = &later
 	default:
 		t.Fatalf("no persistence test value for Task.%s", name)
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1455,6 +1455,10 @@ func cloneTask(t Task) Task {
 		c := *t.ClosedAt
 		clone.ClosedAt = &c
 	}
+	if t.MirrorUpdatedAt != nil {
+		m := *t.MirrorUpdatedAt
+		clone.MirrorUpdatedAt = &m
+	}
 	if t.Workflow != nil {
 		wfClone := cloneWorkflow(*t.Workflow)
 		clone.Workflow = &wfClone

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1798,6 +1798,29 @@ func TestCloneTaskClosedAtNonAliased(t *testing.T) {
 	}
 }
 
+func TestCloneTaskMirrorUpdatedAtNonAliased(t *testing.T) {
+	t.Parallel()
+	ts := time.Now().UTC()
+	orig := Task{
+		ID:              "x",
+		MirrorUpdatedAt: &ts,
+		CreatedAt:       ts,
+		UpdatedAt:       ts,
+	}
+	clone := cloneTask(orig)
+	if clone.MirrorUpdatedAt == orig.MirrorUpdatedAt {
+		t.Error("clone.MirrorUpdatedAt shares pointer with original")
+	}
+	if !clone.MirrorUpdatedAt.Equal(*orig.MirrorUpdatedAt) {
+		t.Errorf("clone.MirrorUpdatedAt=%v, want %v", clone.MirrorUpdatedAt, orig.MirrorUpdatedAt)
+	}
+	newTs := ts.Add(time.Hour)
+	*clone.MirrorUpdatedAt = newTs
+	if orig.MirrorUpdatedAt.Equal(newTs) {
+		t.Error("mutating clone.MirrorUpdatedAt affected original")
+	}
+}
+
 func TestClosedAtYAMLRoundTrip(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1808,6 +1808,9 @@ func TestCloneTaskMirrorUpdatedAtNonAliased(t *testing.T) {
 		UpdatedAt:       ts,
 	}
 	clone := cloneTask(orig)
+	if clone.MirrorUpdatedAt == nil {
+		t.Fatal("clone.MirrorUpdatedAt is nil — cloneTask dropped the pointer")
+	}
 	if clone.MirrorUpdatedAt == orig.MirrorUpdatedAt {
 		t.Error("clone.MirrorUpdatedAt shares pointer with original")
 	}


### PR DESCRIPTION
## Motivation

P0 of the leader-follower umbrella (#1803). Lays the config + task-model
foundation every later phase builds on, with no behavior change for
existing single-node installs.

> Changelog: feat(config): cluster config block and task assigned-node field

## Implementation information

- **`internal/config/config_cluster.go`** — new `cluster` block:
  `ClusterConfig{Role, BindAddr, Followers, LocalHomes, TLS}` and
  `Follower{Name, Endpoints, AuthTokenEnv, Trusted, Homes, TLSPin}`.
  Helpers `IsLeader()`/`IsFollower()`, `NormalizeClusterRole` (invalid →
  standalone, fail-safe), and `HomeNodeFor(projectID)` returning the owning
  node (name/url/token/trusted/encrypted/local). Per-project homing: a
  project in a follower's `Homes` routes there; `LocalHomes`, unrostered,
  or non-leader nodes route local.
- **Follower poller gate** — `role: follower` hard-disables every inbound
  poller (`registerPollHandlers` early-returns; Todoist gated in
  `initLocked`) regardless of per-feature flags, since the leader owns
  task-source polling.
- **Task model** — `AssignedNode` / `MirrorRev` / `MirrorUpdatedAt` added to
  `model.go`, `persistence.go` frontmatter + both converters, with
  `cloneTask` deep-copying the new time pointer.
- **Encryption classification** — `Follower.Encrypted()` requires *every*
  endpoint to ride an encrypted transport (https or `.ts.net` MagicDNS),
  since reachable-first failover could otherwise route a work task over a
  plaintext fallback. Raw CGNAT IPs are intentionally *not* trusted as
  proof of a Tailscale path (shared RFC 6598 space). Feeds the P4 guard.
- **Docs** — `gen-config-docs` now recurses into `[]Follower`, documenting
  the roster keys in `CONFIG.md`.
- Default role `standalone` = zero migration.

### Verification

- `go test ./internal/config/... ./internal/task/... ./internal/sybra/... ./cmd/gen-config-docs/...` green; golangci clean; CONFIG.md drift test green; frontend `npm run check` green.
- Runtime: started `sybra-server` as `follower` (logs `cluster.follower.pollers.disabled` + `cluster.follower.todoist.disabled`, no pollers registered) and `leader` (logs `todoist.enabled`, pollers active). CLI `config dump`/`doctor` round-trip the block.

Adversarial code review + adversarial runtime testing run pre-PR; three review findings (clone aliasing, CGNAT false-positive, undocumented roster keys) fixed in the second commit.

Closes #1804