### PR TITLE
feat(cluster): outbound follower client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -193,6 +193,15 @@ linters:
           - gosec
           - noctx
         path: _test\.go
+      # Cluster follower cert-pinning (internal/cluster/tls.go) trusts a leaf by
+      # its SHA-256 fingerprint over a plain LAN with no CA, so standard chain
+      # verification is deliberately disabled and replaced by a constant-time
+      # fingerprint check in VerifyConnection (runs every handshake). G402's
+      # InsecureSkipVerify warning is a false positive for this pinning idiom.
+      - linters:
+          - gosec
+        path: internal/cluster/tls\.go
+        text: "G402"
 
 formatters:
   enable:

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -1,0 +1,323 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+const maxResponseBody = 32 << 20
+
+const defaultCallTimeout = 30 * time.Second
+
+const healthProbeTimeout = 5 * time.Second
+
+// Node is a follower's addressable identity: an ordered endpoint list (most
+// preferred first), a bearer token, and an optional cert-pin fingerprint. The
+// leader builds it from a config.Follower; cluster keeps its own type so the
+// transport never imports internal/config.
+type Node struct {
+	Name      string
+	Endpoints []string
+	Token     string
+	TLSPin    string
+}
+
+// Client is a follower's outbound RPC client with ordered-endpoint failover.
+type Client struct {
+	node    Node
+	http    *http.Client
+	sseHTTP *http.Client
+	logger  *slog.Logger
+
+	mu     sync.Mutex
+	active int
+}
+
+// APIError is a structured non-2xx response from a follower's control plane,
+// decoded from the {error, code} envelope httpapi emits.
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+// Error implements error.
+func (e *APIError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("cluster: follower returned %d (%s): %s", e.Status, e.Code, e.Message)
+	}
+	return fmt.Sprintf("cluster: follower returned %d: %s", e.Status, e.Message)
+}
+
+// NewClient constructs a follower Client. When node.TLSPin is set, https
+// requests are verified against the pinned leaf fingerprint instead of a CA
+// chain (see pinnedTransport). A nil logger falls back to slog.Default().
+func NewClient(node Node, logger *slog.Logger) (*Client, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var transport http.RoundTripper
+	if strings.TrimSpace(node.TLSPin) != "" {
+		tr, err := pinnedTransport(node.TLSPin)
+		if err != nil {
+			return nil, err
+		}
+		transport = tr
+	}
+	return &Client{
+		node:    node,
+		http:    &http.Client{Timeout: defaultCallTimeout, Transport: transport},
+		sseHTTP: &http.Client{Transport: transport},
+		logger:  logger,
+	}, nil
+}
+
+// Name returns the node's roster name.
+func (c *Client) Name() string { return c.node.Name }
+
+// ActiveEndpoint returns the endpoint the client currently prefers, empty when
+// the node has no usable endpoints.
+func (c *Client) ActiveEndpoint() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	eps := c.usableEndpoints()
+	if len(eps) == 0 {
+		return ""
+	}
+	if c.active >= len(eps) {
+		c.active = 0
+	}
+	return eps[c.active]
+}
+
+// Call invokes service.method on the follower with the given args, retrying
+// across the node's endpoints in preference order until one is reachable. A
+// transport failure (dial/timeout) fails over to the next endpoint; a follower
+// that responds — even with an error status — is considered reachable and its
+// APIError is returned without further failover (the shared token/state makes
+// retrying other endpoints pointless). The reachable endpoint becomes the new
+// preferred one.
+func (c *Client) Call(ctx context.Context, service, method string, args ...any) (json.RawMessage, error) {
+	body, err := encodeArgs(args)
+	if err != nil {
+		return nil, fmt.Errorf("cluster: encode args for %s.%s: %w", service, method, err)
+	}
+	eps := c.snapshotEndpoints()
+	if len(eps) == 0 {
+		return nil, fmt.Errorf("cluster: node %q has no usable endpoints", c.node.Name)
+	}
+	start := c.activeIndex(len(eps))
+	var transportErrs []error
+	for i := range eps {
+		idx := (start + i) % len(eps)
+		raw, apiErr, transportErr := c.do(ctx, eps[idx], service, method, body)
+		if transportErr != nil {
+			transportErrs = append(transportErrs, fmt.Errorf("%s: %w", eps[idx], transportErr))
+			c.logger.Debug("cluster.endpoint.unreachable", "node", c.node.Name, "endpoint", eps[idx], "err", transportErr)
+			continue
+		}
+		c.setActive(idx)
+		if apiErr != nil {
+			return nil, apiErr
+		}
+		return raw, nil
+	}
+	return nil, fmt.Errorf("cluster: all %d endpoints unreachable for %s.%s: %w",
+		len(eps), service, method, errors.Join(transportErrs...))
+}
+
+// ProbeHealth checks the follower's GET /health across its endpoints in
+// preference order. It returns the first reachable endpoint and whether that
+// endpoint was a fallback (degraded: the preferred endpoint was down but a
+// later one answered). An error means no endpoint responded (offline). The
+// reachable endpoint becomes the new preferred one.
+func (c *Client) ProbeHealth(ctx context.Context) (endpoint string, degraded bool, err error) {
+	eps := c.snapshotEndpoints()
+	if len(eps) == 0 {
+		return "", false, fmt.Errorf("cluster: node %q has no usable endpoints", c.node.Name)
+	}
+	var errs []error
+	for i, ep := range eps {
+		pctx, cancel := context.WithTimeout(ctx, healthProbeTimeout)
+		e := c.probeOne(pctx, ep)
+		cancel()
+		if e == nil {
+			c.setActive(i)
+			return ep, i > 0, nil
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", ep, e))
+	}
+	return "", false, errors.Join(errs...)
+}
+
+func (c *Client) probeOne(ctx context.Context, base string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(base, "/")+"/health", http.NoBody)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("cluster: /health returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) do(ctx context.Context, base, service, method string, body []byte) (json.RawMessage, *APIError, error) {
+	url := strings.TrimRight(base, "/") + "/api/" + service + "/" + method
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.node.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.node.Token)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, parseAPIError(resp.StatusCode, respBody), nil
+	}
+	return json.RawMessage(respBody), nil, nil
+}
+
+func (c *Client) snapshotEndpoints() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.usableEndpoints()
+}
+
+func (c *Client) usableEndpoints() []string {
+	out := make([]string, 0, len(c.node.Endpoints))
+	for _, ep := range c.node.Endpoints {
+		if trimmed := strings.TrimSpace(ep); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func (c *Client) activeIndex(n int) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.active >= n {
+		c.active = 0
+	}
+	return c.active
+}
+
+func (c *Client) setActive(idx int) {
+	c.mu.Lock()
+	c.active = idx
+	c.mu.Unlock()
+}
+
+func encodeArgs(args []any) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(args)
+}
+
+func parseAPIError(status int, body []byte) *APIError {
+	e := &APIError{Status: status, Message: strings.TrimSpace(string(body))}
+	var env struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &env); err == nil && env.Error != "" {
+		e.Message = env.Error
+		e.Code = env.Code
+	}
+	return e
+}
+
+// AssignTask hands a task to the follower for execution (follower RPC lands in
+// P2 — TaskService.AssignTask).
+func (c *Client) AssignTask(ctx context.Context, t task.Task) error {
+	_, err := c.Call(ctx, "TaskService", "AssignTask", t)
+	return err
+}
+
+// GetTask fetches a task's current state from the follower.
+func (c *Client) GetTask(ctx context.Context, id string) (task.Task, error) {
+	raw, err := c.Call(ctx, "TaskService", "GetTask", id)
+	if err != nil {
+		return task.Task{}, err
+	}
+	return decode[task.Task](raw)
+}
+
+// ListTasks fetches all of the follower's tasks.
+func (c *Client) ListTasks(ctx context.Context) ([]task.Task, error) {
+	raw, err := c.Call(ctx, "TaskService", "ListTasks")
+	if err != nil {
+		return nil, err
+	}
+	return decode[[]task.Task](raw)
+}
+
+// StopAgent proxies a stop request for a running agent to the follower.
+func (c *Client) StopAgent(ctx context.Context, agentID string) error {
+	_, err := c.Call(ctx, "AgentService", "StopAgent", agentID)
+	return err
+}
+
+// SendMessage proxies a steering message to a follower's interactive agent.
+func (c *Client) SendMessage(ctx context.Context, agentID, text string) error {
+	_, err := c.Call(ctx, "AgentService", "SendMessage", agentID, text)
+	return err
+}
+
+// RespondApproval proxies a tool-approval decision to the follower.
+func (c *Client) RespondApproval(ctx context.Context, toolUseID string, approved bool) error {
+	_, err := c.Call(ctx, "AgentService", "RespondApproval", toolUseID, approved)
+	return err
+}
+
+// ApprovePlan proxies a plan approval to the follower and returns the updated
+// task.
+func (c *Client) ApprovePlan(ctx context.Context, id string) (task.Task, error) {
+	raw, err := c.Call(ctx, "PlanningService", "ApprovePlan", id)
+	if err != nil {
+		return task.Task{}, err
+	}
+	return decode[task.Task](raw)
+}
+
+func decode[T any](raw json.RawMessage) (T, error) {
+	var v T
+	if len(raw) == 0 {
+		return v, nil
+	}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return v, fmt.Errorf("cluster: decode response: %w", err)
+	}
+	return v, nil
+}

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -101,14 +102,22 @@ func (c *Client) ActiveEndpoint() string {
 	return eps[c.active]
 }
 
-// Call invokes service.method on the follower with the given args, retrying
-// across the node's endpoints in preference order until one is reachable. A
-// transport failure (dial/timeout) fails over to the next endpoint; a follower
-// that responds — even with an error status — is considered reachable and its
-// APIError is returned without further failover (the shared token/state makes
-// retrying other endpoints pointless). The reachable endpoint becomes the new
-// preferred one.
+// Call invokes service.method on the follower and is the safe default for
+// callers that cannot vouch for idempotency: it fails over to another endpoint
+// only when the connection was never established (so the follower never saw the
+// request), never after a partial send. Read-only wrappers use callIdempotent,
+// which additionally fails over on any transport error and on a gateway-down
+// status (502/503/504 — a proxy fronting a dead backend). The reachable
+// endpoint becomes the new preferred one.
 func (c *Client) Call(ctx context.Context, service, method string, args ...any) (json.RawMessage, error) {
+	return c.call(ctx, false, service, method, args...)
+}
+
+func (c *Client) callIdempotent(ctx context.Context, service, method string, args ...any) (json.RawMessage, error) {
+	return c.call(ctx, true, service, method, args...)
+}
+
+func (c *Client) call(ctx context.Context, idempotent bool, service, method string, args ...any) (json.RawMessage, error) {
 	body, err := encodeArgs(args)
 	if err != nil {
 		return nil, fmt.Errorf("cluster: encode args for %s.%s: %w", service, method, err)
@@ -118,13 +127,21 @@ func (c *Client) Call(ctx context.Context, service, method string, args ...any) 
 		return nil, fmt.Errorf("cluster: node %q has no usable endpoints", c.node.Name)
 	}
 	start := c.activeIndex(len(eps))
-	var transportErrs []error
+	var failoverErrs []error
 	for i := range eps {
 		idx := (start + i) % len(eps)
 		raw, apiErr, transportErr := c.do(ctx, eps[idx], service, method, body)
 		if transportErr != nil {
-			transportErrs = append(transportErrs, fmt.Errorf("%s: %w", eps[idx], transportErr))
+			failoverErrs = append(failoverErrs, fmt.Errorf("%s: %w", eps[idx], transportErr))
 			c.logger.Debug("cluster.endpoint.unreachable", "node", c.node.Name, "endpoint", eps[idx], "err", transportErr)
+			if idempotent || isConnectError(transportErr) {
+				continue
+			}
+			return nil, fmt.Errorf("cluster: %s.%s failed on %s and is not safe to retry: %w", service, method, eps[idx], transportErr)
+		}
+		if apiErr != nil && idempotent && isGatewayDown(apiErr.Status) {
+			failoverErrs = append(failoverErrs, fmt.Errorf("%s: %w", eps[idx], apiErr))
+			c.logger.Debug("cluster.endpoint.gateway_down", "node", c.node.Name, "endpoint", eps[idx], "status", apiErr.Status)
 			continue
 		}
 		c.setActive(idx)
@@ -133,8 +150,22 @@ func (c *Client) Call(ctx context.Context, service, method string, args ...any) 
 		}
 		return raw, nil
 	}
-	return nil, fmt.Errorf("cluster: all %d endpoints unreachable for %s.%s: %w",
-		len(eps), service, method, errors.Join(transportErrs...))
+	return nil, fmt.Errorf("cluster: all %d endpoints failed for %s.%s: %w",
+		len(eps), service, method, errors.Join(failoverErrs...))
+}
+
+func isConnectError(err error) bool {
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return netErr.Op == "dial"
+	}
+	return false
+}
+
+func isGatewayDown(status int) bool {
+	return status == http.StatusBadGateway ||
+		status == http.StatusServiceUnavailable ||
+		status == http.StatusGatewayTimeout
 }
 
 // ProbeHealth checks the follower's GET /health across its endpoints in
@@ -267,7 +298,7 @@ func (c *Client) AssignTask(ctx context.Context, t task.Task) error {
 
 // GetTask fetches a task's current state from the follower.
 func (c *Client) GetTask(ctx context.Context, id string) (task.Task, error) {
-	raw, err := c.Call(ctx, "TaskService", "GetTask", id)
+	raw, err := c.callIdempotent(ctx, "TaskService", "GetTask", id)
 	if err != nil {
 		return task.Task{}, err
 	}
@@ -276,7 +307,7 @@ func (c *Client) GetTask(ctx context.Context, id string) (task.Task, error) {
 
 // ListTasks fetches all of the follower's tasks.
 func (c *Client) ListTasks(ctx context.Context) ([]task.Task, error) {
-	raw, err := c.Call(ctx, "TaskService", "ListTasks")
+	raw, err := c.callIdempotent(ctx, "TaskService", "ListTasks")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cluster/client_test.go
+++ b/internal/cluster/client_test.go
@@ -1,0 +1,156 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type stubFollower struct {
+	token    string
+	tasks    []task.Task
+	gotBody  []byte
+	gotPath  string
+	gotAuth  string
+	assigned *task.Task
+}
+
+func (s *stubFollower) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
+		s.gotPath = r.URL.Path
+		s.gotAuth = r.Header.Get("Authorization")
+		s.gotBody, _ = io.ReadAll(r.Body)
+		if s.token != "" && r.Header.Get("Authorization") != "Bearer "+s.token {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"error":"unauthorized","code":"unauthorized"}`)
+			return
+		}
+		switch r.URL.Path {
+		case "/api/TaskService/ListTasks":
+			_ = json.NewEncoder(w).Encode(s.tasks)
+		case "/api/TaskService/GetTask":
+			_ = json.NewEncoder(w).Encode(s.tasks[0])
+		case "/api/TaskService/AssignTask":
+			var args []task.Task
+			_ = json.Unmarshal(s.gotBody, &args)
+			if len(args) == 1 {
+				s.assigned = &args[0]
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"error":"unknown","code":"not_found"}`)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestClientListTasks(t *testing.T) {
+	stub := &stubFollower{token: "sekret", tasks: []task.Task{{ID: "a"}, {ID: "b"}}}
+	srv := stub.server(t)
+	client, err := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "sekret"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := client.ListTasks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].ID != "a" || got[1].ID != "b" {
+		t.Fatalf("ListTasks = %+v", got)
+	}
+	if stub.gotAuth != "Bearer sekret" {
+		t.Errorf("auth header = %q", stub.gotAuth)
+	}
+}
+
+func TestClientAssignTaskEncodesArgs(t *testing.T) {
+	stub := &stubFollower{token: "sekret"}
+	srv := stub.server(t)
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "sekret"}, nil)
+	if err := client.AssignTask(context.Background(), task.Task{ID: "z", Title: "hi"}); err != nil {
+		t.Fatal(err)
+	}
+	if stub.assigned == nil || stub.assigned.ID != "z" || stub.assigned.Title != "hi" {
+		t.Fatalf("assigned = %+v", stub.assigned)
+	}
+	if !strings.HasPrefix(string(stub.gotBody), "[") {
+		t.Errorf("body must be a JSON array, got %s", stub.gotBody)
+	}
+}
+
+func TestClientTokenRejection(t *testing.T) {
+	stub := &stubFollower{token: "right"}
+	srv := stub.server(t)
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "wrong"}, nil)
+	_, err := client.ListTasks(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *APIError, got %v", err)
+	}
+	if apiErr.Status != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", apiErr.Status)
+	}
+}
+
+func TestClientEndpointFailover(t *testing.T) {
+	stub := &stubFollower{token: "", tasks: []task.Task{{ID: "ok"}}}
+	live := stub.server(t)
+
+	dead := httptest.NewServer(http.NewServeMux())
+	deadURL := dead.URL
+	dead.Close()
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{deadURL, live.URL}}, nil)
+	got, err := client.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("failover did not reach the live endpoint: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("ListTasks after failover = %+v", got)
+	}
+	if client.ActiveEndpoint() != live.URL {
+		t.Errorf("active endpoint = %q, want %q (should re-select the reachable one)", client.ActiveEndpoint(), live.URL)
+	}
+}
+
+func TestClientAllEndpointsUnreachable(t *testing.T) {
+	d1 := httptest.NewServer(http.NewServeMux())
+	u1 := d1.URL
+	d1.Close()
+	d2 := httptest.NewServer(http.NewServeMux())
+	u2 := d2.URL
+	d2.Close()
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{u1, u2}}, nil)
+	_, err := client.ListTasks(context.Background())
+	if err == nil {
+		t.Fatal("want error when all endpoints are unreachable")
+	}
+	if !strings.Contains(err.Error(), "unreachable") {
+		t.Errorf("err = %v, want 'unreachable'", err)
+	}
+}
+
+func TestClientNoEndpoints(t *testing.T) {
+	client, _ := NewClient(Node{Name: "empty", Endpoints: []string{"", "  "}}, nil)
+	if _, err := client.ListTasks(context.Background()); err == nil {
+		t.Fatal("want error for a node with no usable endpoints")
+	}
+}

--- a/internal/cluster/client_test.go
+++ b/internal/cluster/client_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+func mustClient(t *testing.T, node Node) *Client {
+	t.Helper()
+	c, err := NewClient(node, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c == nil {
+		t.Fatal("NewClient returned nil client")
+	}
+	return c
+}
+
 type stubFollower struct {
 	token    string
 	tasks    []task.Task
@@ -64,10 +76,7 @@ func (s *stubFollower) server(t *testing.T) *httptest.Server {
 func TestClientListTasks(t *testing.T) {
 	stub := &stubFollower{token: "sekret", tasks: []task.Task{{ID: "a"}, {ID: "b"}}}
 	srv := stub.server(t)
-	client, err := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "sekret"}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "sekret"})
 	got, err := client.ListTasks(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +92,7 @@ func TestClientListTasks(t *testing.T) {
 func TestClientAssignTaskEncodesArgs(t *testing.T) {
 	stub := &stubFollower{token: "sekret"}
 	srv := stub.server(t)
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "sekret"}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "sekret"})
 	if err := client.AssignTask(context.Background(), task.Task{ID: "z", Title: "hi"}); err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +107,7 @@ func TestClientAssignTaskEncodesArgs(t *testing.T) {
 func TestClientTokenRejection(t *testing.T) {
 	stub := &stubFollower{token: "right"}
 	srv := stub.server(t)
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "wrong"}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "wrong"})
 	_, err := client.ListTasks(context.Background())
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
@@ -117,7 +126,7 @@ func TestClientEndpointFailover(t *testing.T) {
 	deadURL := dead.URL
 	dead.Close()
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{deadURL, live.URL}}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{deadURL, live.URL}})
 	got, err := client.ListTasks(context.Background())
 	if err != nil {
 		t.Fatalf("failover did not reach the live endpoint: %v", err)
@@ -138,7 +147,7 @@ func TestClientAllEndpointsUnreachable(t *testing.T) {
 	u2 := d2.URL
 	d2.Close()
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{u1, u2}}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{u1, u2}})
 	_, err := client.ListTasks(context.Background())
 	if err == nil {
 		t.Fatal("want error when all endpoints are unreachable")
@@ -149,7 +158,7 @@ func TestClientAllEndpointsUnreachable(t *testing.T) {
 }
 
 func TestClientNoEndpoints(t *testing.T) {
-	client, _ := NewClient(Node{Name: "empty", Endpoints: []string{"", "  "}}, nil)
+	client := mustClient(t, Node{Name: "empty", Endpoints: []string{"", "  "}})
 	if _, err := client.ListTasks(context.Background()); err == nil {
 		t.Fatal("want error for a node with no usable endpoints")
 	}

--- a/internal/cluster/client_test.go
+++ b/internal/cluster/client_test.go
@@ -143,8 +143,8 @@ func TestClientAllEndpointsUnreachable(t *testing.T) {
 	if err == nil {
 		t.Fatal("want error when all endpoints are unreachable")
 	}
-	if !strings.Contains(err.Error(), "unreachable") {
-		t.Errorf("err = %v, want 'unreachable'", err)
+	if !strings.Contains(err.Error(), "all 2 endpoints failed") {
+		t.Errorf("err = %v, want 'all 2 endpoints failed'", err)
 	}
 }
 

--- a/internal/cluster/events.go
+++ b/internal/cluster/events.go
@@ -1,0 +1,114 @@
+package cluster
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Event is one decoded SSE frame from a follower's /events stream: the named
+// event and its JSON-encoded payload (matching internal/sse.Broker.ServeAll).
+type Event struct {
+	Name string
+	Data string
+}
+
+// Subscribe opens the follower's multiplexed SSE stream (/events) and returns a
+// channel of decoded events. It fails over across the node's endpoints in
+// preference order to find a reachable one, then streams until ctx is cancelled
+// or the connection drops, at which point the channel is closed. Reconnection is
+// the caller's responsibility (the Roster health loop drives it in P3).
+func (c *Client) Subscribe(ctx context.Context) (<-chan Event, error) {
+	eps := c.snapshotEndpoints()
+	if len(eps) == 0 {
+		return nil, fmt.Errorf("cluster: node %q has no usable endpoints", c.node.Name)
+	}
+	start := c.activeIndex(len(eps))
+	var errs []error
+	for i := range eps {
+		idx := (start + i) % len(eps)
+		body, err := c.openEvents(ctx, eps[idx])
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", eps[idx], err))
+			continue
+		}
+		c.setActive(idx)
+		ch := make(chan Event, eventChanBuf)
+		go c.pumpEvents(body, ch)
+		return ch, nil
+	}
+	return nil, fmt.Errorf("cluster: no reachable /events endpoint for node %q: %w", c.node.Name, errors.Join(errs...))
+}
+
+const eventChanBuf = 64
+
+func (c *Client) openEvents(ctx context.Context, base string) (io.ReadCloser, error) {
+	u := strings.TrimRight(base, "/") + "/events"
+	if c.node.Token != "" {
+		u += "?token=" + url.QueryEscape(c.node.Token)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	if c.node.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.node.Token)
+	}
+	resp, err := c.sseHTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("cluster: /events returned %d", resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+func (c *Client) pumpEvents(body io.ReadCloser, ch chan<- Event) {
+	defer close(ch)
+	defer func() { _ = body.Close() }()
+
+	reader := bufio.NewReader(body)
+	var name string
+	var data strings.Builder
+	flush := func() {
+		if data.Len() == 0 && name == "" {
+			return
+		}
+		evName := name
+		if evName == "" {
+			evName = "message"
+		}
+		ch <- Event{Name: evName, Data: data.String()}
+		name = ""
+		data.Reset()
+	}
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			trimmed := strings.TrimRight(line, "\r\n")
+			switch {
+			case trimmed == "":
+				flush()
+			case strings.HasPrefix(trimmed, ":"):
+			case strings.HasPrefix(trimmed, "event:"):
+				name = strings.TrimSpace(trimmed[len("event:"):])
+			case strings.HasPrefix(trimmed, "data:"):
+				if data.Len() > 0 {
+					data.WriteByte('\n')
+				}
+				data.WriteString(strings.TrimSpace(trimmed[len("data:"):]))
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}

--- a/internal/cluster/events.go
+++ b/internal/cluster/events.go
@@ -39,7 +39,7 @@ func (c *Client) Subscribe(ctx context.Context) (<-chan Event, error) {
 		}
 		c.setActive(idx)
 		ch := make(chan Event, eventChanBuf)
-		go c.pumpEvents(body, ch)
+		go c.pumpEvents(ctx, body, ch)
 		return ch, nil
 	}
 	return nil, fmt.Errorf("cluster: no reachable /events endpoint for node %q: %w", c.node.Name, errors.Join(errs...))
@@ -71,32 +71,28 @@ func (c *Client) openEvents(ctx context.Context, base string) (io.ReadCloser, er
 	return resp.Body, nil
 }
 
-func (c *Client) pumpEvents(body io.ReadCloser, ch chan<- Event) {
+func (c *Client) pumpEvents(ctx context.Context, body io.ReadCloser, ch chan<- Event) {
 	defer close(ch)
 	defer func() { _ = body.Close() }()
 
 	reader := bufio.NewReader(body)
 	var name string
 	var data strings.Builder
-	flush := func() {
-		if data.Len() == 0 && name == "" {
-			return
-		}
-		evName := name
-		if evName == "" {
-			evName = "message"
-		}
-		ch <- Event{Name: evName, Data: data.String()}
-		name = ""
-		data.Reset()
-	}
 	for {
 		line, err := reader.ReadString('\n')
 		if line != "" {
 			trimmed := strings.TrimRight(line, "\r\n")
 			switch {
 			case trimmed == "":
-				flush()
+				if name != "" || data.Len() > 0 {
+					select {
+					case ch <- Event{Name: eventName(name), Data: data.String()}:
+					case <-ctx.Done():
+						return
+					}
+					name = ""
+					data.Reset()
+				}
 			case strings.HasPrefix(trimmed, ":"):
 			case strings.HasPrefix(trimmed, "event:"):
 				name = strings.TrimSpace(trimmed[len("event:"):])
@@ -104,11 +100,18 @@ func (c *Client) pumpEvents(body io.ReadCloser, ch chan<- Event) {
 				if data.Len() > 0 {
 					data.WriteByte('\n')
 				}
-				data.WriteString(strings.TrimSpace(trimmed[len("data:"):]))
+				data.WriteString(strings.TrimPrefix(trimmed[len("data:"):], " "))
 			}
 		}
 		if err != nil {
 			return
 		}
 	}
+}
+
+func eventName(name string) string {
+	if name == "" {
+		return "message"
+	}
+	return name
 }

--- a/internal/cluster/events.go
+++ b/internal/cluster/events.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 )
 
@@ -48,11 +47,7 @@ func (c *Client) Subscribe(ctx context.Context) (<-chan Event, error) {
 const eventChanBuf = 64
 
 func (c *Client) openEvents(ctx context.Context, base string) (io.ReadCloser, error) {
-	u := strings.TrimRight(base, "/") + "/events"
-	if c.node.Token != "" {
-		u += "?token=" + url.QueryEscape(c.node.Token)
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(base, "/")+"/events", http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cluster/events_test.go
+++ b/internal/cluster/events_test.go
@@ -1,0 +1,78 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSubscribeDecodesFrames(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /events", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("token") != "tok" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server does not support flushing")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, ": heartbeat\n\n")
+		_, _ = fmt.Fprint(w, "event: task:updated\ndata: {\"id\":\"t1\"}\n\n")
+		_, _ = fmt.Fprint(w, "event: agent:state\ndata: {\"state\":\"running\"}\n\n")
+		flusher.Flush()
+		<-r.Context().Done()
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"}, nil)
+	ch, err := client.Subscribe(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := recvEvent(t, ch)
+	if first.Name != "task:updated" || first.Data != `{"id":"t1"}` {
+		t.Fatalf("first event = %+v", first)
+	}
+	second := recvEvent(t, ch)
+	if second.Name != "agent:state" || second.Data != `{"state":"running"}` {
+		t.Fatalf("second event = %+v", second)
+	}
+}
+
+func TestSubscribeTokenRejected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /events", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "bad"}, nil)
+	if _, err := client.Subscribe(context.Background()); err == nil {
+		t.Fatal("want error when /events rejects the token")
+	}
+}
+
+func recvEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Fatal("event channel closed early")
+		}
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE event")
+		return Event{}
+	}
+}

--- a/internal/cluster/events_test.go
+++ b/internal/cluster/events_test.go
@@ -15,7 +15,10 @@ import (
 func TestSubscribeDecodesFrames(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /events", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("token") != "tok" {
+		if r.URL.RawQuery != "" {
+			t.Errorf("token must not leak into the /events URL query, got %q", r.URL.RawQuery)
+		}
+		if r.Header.Get("Authorization") != "Bearer tok" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}

--- a/internal/cluster/events_test.go
+++ b/internal/cluster/events_test.go
@@ -2,9 +2,12 @@ package cluster
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -46,6 +49,95 @@ func TestSubscribeDecodesFrames(t *testing.T) {
 	second := recvEvent(t, ch)
 	if second.Name != "agent:state" || second.Data != `{"state":"running"}` {
 		t.Fatalf("second event = %+v", second)
+	}
+}
+
+func TestSubscribeMultiLineAndCRLF(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /events", func(w http.ResponseWriter, r *http.Request) {
+		flusher, _ := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "event: multi\ndata: line1\ndata: line2\n\n")
+		_, _ = fmt.Fprint(w, "event: crlf\r\ndata: {\"k\":\"v\"}\r\n\r\n")
+		flusher.Flush()
+		<-r.Context().Done()
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}}, nil)
+	ch, err := client.Subscribe(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	multi := recvEvent(t, ch)
+	if multi.Name != "multi" || multi.Data != "line1\nline2" {
+		t.Fatalf("multi-line frame = %+v, want data 'line1\\nline2'", multi)
+	}
+	crlf := recvEvent(t, ch)
+	if crlf.Name != "crlf" || crlf.Data != `{"k":"v"}` {
+		t.Fatalf("CRLF frame = %+v", crlf)
+	}
+}
+
+func TestSubscribeFailover(t *testing.T) {
+	dead := httptest.NewServer(http.NewServeMux())
+	deadURL := dead.URL
+	dead.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /events", func(w http.ResponseWriter, r *http.Request) {
+		flusher, _ := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "event: ok\ndata: 1\n\n")
+		flusher.Flush()
+		<-r.Context().Done()
+	})
+	live := httptest.NewServer(mux)
+	t.Cleanup(live.Close)
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{deadURL, live.URL}}, nil)
+	ch, err := client.Subscribe(t.Context())
+	if err != nil {
+		t.Fatalf("Subscribe should fail over to the live endpoint: %v", err)
+	}
+	if ev := recvEvent(t, ch); ev.Name != "ok" {
+		t.Fatalf("event = %+v", ev)
+	}
+	if client.ActiveEndpoint() != live.URL {
+		t.Errorf("active endpoint = %q, want %q", client.ActiveEndpoint(), live.URL)
+	}
+}
+
+func TestSubscribeOverPinnedTLS(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /events", func(w http.ResponseWriter, r *http.Request) {
+		flusher, _ := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "event: secure\ndata: 1\n\n")
+		flusher.Flush()
+		<-r.Context().Done()
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	sum := sha256.Sum256(srv.Certificate().Raw)
+	client, _ := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: hex.EncodeToString(sum[:])}, nil)
+	ch, err := client.Subscribe(t.Context())
+	if err != nil {
+		t.Fatalf("SSE over correctly-pinned TLS should connect: %v", err)
+	}
+	if ev := recvEvent(t, ch); ev.Name != "secure" {
+		t.Fatalf("event = %+v", ev)
+	}
+
+	wrong, _ := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: strings.Repeat("00", 32)}, nil)
+	if _, err := wrong.Subscribe(t.Context()); err == nil {
+		t.Fatal("SSE over a wrong pin must reject")
 	}
 }
 

--- a/internal/cluster/events_test.go
+++ b/internal/cluster/events_test.go
@@ -36,7 +36,7 @@ func TestSubscribeDecodesFrames(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"})
 	ch, err := client.Subscribe(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestSubscribeMultiLineAndCRLF(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{srv.URL}})
 	ch, err := client.Subscribe(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +99,7 @@ func TestSubscribeFailover(t *testing.T) {
 	live := httptest.NewServer(mux)
 	t.Cleanup(live.Close)
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{deadURL, live.URL}}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{deadURL, live.URL}})
 	ch, err := client.Subscribe(t.Context())
 	if err != nil {
 		t.Fatalf("Subscribe should fail over to the live endpoint: %v", err)
@@ -126,7 +126,7 @@ func TestSubscribeOverPinnedTLS(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	sum := sha256.Sum256(srv.Certificate().Raw)
-	client, _ := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: hex.EncodeToString(sum[:])}, nil)
+	client := mustClient(t, Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: hex.EncodeToString(sum[:])})
 	ch, err := client.Subscribe(t.Context())
 	if err != nil {
 		t.Fatalf("SSE over correctly-pinned TLS should connect: %v", err)
@@ -135,7 +135,7 @@ func TestSubscribeOverPinnedTLS(t *testing.T) {
 		t.Fatalf("event = %+v", ev)
 	}
 
-	wrong, _ := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: strings.Repeat("00", 32)}, nil)
+	wrong := mustClient(t, Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: strings.Repeat("00", 32)})
 	if _, err := wrong.Subscribe(t.Context()); err == nil {
 		t.Fatal("SSE over a wrong pin must reject")
 	}
@@ -149,7 +149,7 @@ func TestSubscribeTokenRejected(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "bad"}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "bad"})
 	if _, err := client.Subscribe(context.Background()); err == nil {
 		t.Fatal("want error when /events rejects the token")
 	}

--- a/internal/cluster/failover_test.go
+++ b/internal/cluster/failover_test.go
@@ -1,0 +1,103 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func resetServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("no hijacker")
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		_ = conn.Close()
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestMutatingRPCNoRetryAfterPartialSend(t *testing.T) {
+	reset := resetServer(t)
+	stub := &stubFollower{tasks: []task.Task{{ID: "ok"}}}
+	live := stub.server(t)
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{reset.URL, live.URL}}, nil)
+
+	err := client.AssignTask(context.Background(), task.Task{ID: "z"})
+	if err == nil {
+		t.Fatal("AssignTask should fail: the request may have been delivered to the reset endpoint")
+	}
+	if stub.assigned != nil {
+		t.Fatalf("mutating RPC must NOT fail over after a partial send; live endpoint saw assign %+v", stub.assigned)
+	}
+
+	got, err := client.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("idempotent ListTasks should fail over to the live endpoint: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("ListTasks after failover = %+v", got)
+	}
+}
+
+func gatewayDownServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, "gateway down")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGatewayDownFailsOverForIdempotent(t *testing.T) {
+	down := gatewayDownServer(t, http.StatusServiceUnavailable)
+	stub := &stubFollower{tasks: []task.Task{{ID: "ok"}}}
+	live := stub.server(t)
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{down.URL, live.URL}}, nil)
+	got, err := client.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("503 gateway-down should fail over for idempotent read: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("ListTasks = %+v", got)
+	}
+}
+
+func TestGatewayDownReturnedForMutating(t *testing.T) {
+	down := gatewayDownServer(t, http.StatusBadGateway)
+	stub := &stubFollower{}
+	live := stub.server(t)
+
+	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{down.URL, live.URL}}, nil)
+	err := client.AssignTask(context.Background(), task.Task{ID: "z"})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("mutating RPC should return the 502 APIError, not fail over; got %v", err)
+	}
+	if apiErr.Status != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", apiErr.Status)
+	}
+	if stub.assigned != nil {
+		t.Error("mutating RPC must not have reached the live endpoint on a 502")
+	}
+}

--- a/internal/cluster/failover_test.go
+++ b/internal/cluster/failover_test.go
@@ -37,7 +37,7 @@ func TestMutatingRPCNoRetryAfterPartialSend(t *testing.T) {
 	stub := &stubFollower{tasks: []task.Task{{ID: "ok"}}}
 	live := stub.server(t)
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{reset.URL, live.URL}}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{reset.URL, live.URL}})
 
 	err := client.AssignTask(context.Background(), task.Task{ID: "z"})
 	if err == nil {
@@ -73,7 +73,7 @@ func TestGatewayDownFailsOverForIdempotent(t *testing.T) {
 	stub := &stubFollower{tasks: []task.Task{{ID: "ok"}}}
 	live := stub.server(t)
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{down.URL, live.URL}}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{down.URL, live.URL}})
 	got, err := client.ListTasks(context.Background())
 	if err != nil {
 		t.Fatalf("503 gateway-down should fail over for idempotent read: %v", err)
@@ -88,7 +88,7 @@ func TestGatewayDownReturnedForMutating(t *testing.T) {
 	stub := &stubFollower{}
 	live := stub.server(t)
 
-	client, _ := NewClient(Node{Name: "n1", Endpoints: []string{down.URL, live.URL}}, nil)
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{down.URL, live.URL}})
 	err := client.AssignTask(context.Background(), task.Task{ID: "z"})
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {

--- a/internal/cluster/integration_test.go
+++ b/internal/cluster/integration_test.go
@@ -68,14 +68,23 @@ func realServer(t *testing.T, token string, svc *fakeTaskService) (*httptest.Ser
 	return srv, broker
 }
 
+func mustClient(t *testing.T, node cluster.Node) *cluster.Client {
+	t.Helper()
+	c, err := cluster.NewClient(node, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c == nil {
+		t.Fatal("NewClient returned nil client")
+	}
+	return c
+}
+
 func TestClientAgainstRealHTTPAPI(t *testing.T) {
 	svc := &fakeTaskService{tasks: []task.Task{{ID: "t1", Title: "one"}, {ID: "t2"}}}
 	srv, _ := realServer(t, "tok", svc)
 
-	client, err := cluster.NewClient(cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := mustClient(t, cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"})
 
 	got, err := client.ListTasks(context.Background())
 	if err != nil {
@@ -106,7 +115,7 @@ func TestClientAgainstRealHTTPAPI(t *testing.T) {
 func TestClientTokenRejectedByRealServer(t *testing.T) {
 	svc := &fakeTaskService{}
 	srv, _ := realServer(t, "right", svc)
-	client, _ := cluster.NewClient(cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "wrong"}, nil)
+	client := mustClient(t, cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "wrong"})
 	if _, err := client.ListTasks(context.Background()); err == nil {
 		t.Fatal("real server must reject a wrong token")
 	}
@@ -115,7 +124,7 @@ func TestClientTokenRejectedByRealServer(t *testing.T) {
 func TestSubscribeAgainstRealBroker(t *testing.T) {
 	svc := &fakeTaskService{}
 	srv, broker := realServer(t, "tok", svc)
-	client, _ := cluster.NewClient(cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"}, nil)
+	client := mustClient(t, cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"})
 
 	ch, err := client.Subscribe(t.Context())
 	if err != nil {

--- a/internal/cluster/integration_test.go
+++ b/internal/cluster/integration_test.go
@@ -1,0 +1,140 @@
+package cluster_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/cluster"
+	"github.com/Automaat/sybra/internal/httpapi"
+	"github.com/Automaat/sybra/internal/sse"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type fakeTaskService struct {
+	tasks    []task.Task
+	assigned []task.Task
+}
+
+func (f *fakeTaskService) ListTasks() ([]task.Task, error) { return f.tasks, nil }
+
+func (f *fakeTaskService) GetTask(id string) (task.Task, error) {
+	for i := range f.tasks {
+		if f.tasks[i].ID == id {
+			return f.tasks[i], nil
+		}
+	}
+	return task.Task{}, nil
+}
+
+func (f *fakeTaskService) AssignTask(t task.Task) error {
+	f.assigned = append(f.assigned, t)
+	return nil
+}
+
+func realServer(t *testing.T, token string, svc *fakeTaskService) (*httptest.Server, *sse.Broker) {
+	t.Helper()
+	broker := sse.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	mux.HandleFunc("GET /events", broker.ServeAll)
+	httpapi.Mount(mux, map[string]httpapi.Service{
+		"TaskService": httpapi.NewService(svc, "ListTasks", "GetTask", "AssignTask"),
+	}, slog.Default())
+
+	authed := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			mux.ServeHTTP(w, r)
+			return
+		}
+		tok := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if tok == "" {
+			tok = r.URL.Query().Get("token")
+		}
+		if tok != token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		mux.ServeHTTP(w, r)
+	})
+	srv := httptest.NewServer(authed)
+	t.Cleanup(srv.Close)
+	return srv, broker
+}
+
+func TestClientAgainstRealHTTPAPI(t *testing.T) {
+	svc := &fakeTaskService{tasks: []task.Task{{ID: "t1", Title: "one"}, {ID: "t2"}}}
+	srv, _ := realServer(t, "tok", svc)
+
+	client, err := cluster.NewClient(cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := client.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks against real httpapi: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "t1" {
+		t.Fatalf("ListTasks = %+v", got)
+	}
+
+	one, err := client.GetTask(context.Background(), "t1")
+	if err != nil || one.Title != "one" {
+		t.Fatalf("GetTask = %+v, err %v", one, err)
+	}
+
+	if err := client.AssignTask(context.Background(), task.Task{ID: "t3"}); err != nil {
+		t.Fatalf("AssignTask against real httpapi: %v", err)
+	}
+	if len(svc.assigned) != 1 || svc.assigned[0].ID != "t3" {
+		t.Fatalf("server did not receive the assigned task: %+v", svc.assigned)
+	}
+
+	endpoint, degraded, err := client.ProbeHealth(context.Background())
+	if err != nil || degraded || endpoint != srv.URL {
+		t.Fatalf("ProbeHealth endpoint=%q degraded=%v err=%v", endpoint, degraded, err)
+	}
+}
+
+func TestClientTokenRejectedByRealServer(t *testing.T) {
+	svc := &fakeTaskService{}
+	srv, _ := realServer(t, "right", svc)
+	client, _ := cluster.NewClient(cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "wrong"}, nil)
+	if _, err := client.ListTasks(context.Background()); err == nil {
+		t.Fatal("real server must reject a wrong token")
+	}
+}
+
+func TestSubscribeAgainstRealBroker(t *testing.T) {
+	svc := &fakeTaskService{}
+	srv, broker := realServer(t, "tok", svc)
+	client, _ := cluster.NewClient(cluster.Node{Name: "n1", Endpoints: []string{srv.URL}, Token: "tok"}, nil)
+
+	ch, err := client.Subscribe(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broker.Emit("task:updated", map[string]string{"id": "t9"})
+	}()
+
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Fatal("event channel closed before an event arrived")
+		}
+		if ev.Name != "task:updated" || !strings.Contains(ev.Data, "t9") {
+			t.Fatalf("event = %+v", ev)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for an event from the real broker")
+	}
+}

--- a/internal/cluster/roster.go
+++ b/internal/cluster/roster.go
@@ -141,8 +141,10 @@ func (r *Roster) ProbeNode(ctx context.Context, name string, now time.Time) Node
 }
 
 // SetHealthFromEvent lets a live SSE liveness signal update a node's status
-// between /health polls: a received event marks the node online, a stream drop
-// marks it offline (until the next successful probe reclassifies it).
+// between /health polls: a received event lifts an offline/unknown node to
+// online (a degraded node stays degraded, since an event only proves *some*
+// endpoint answered, not that the preferred one recovered), and a stream drop
+// marks the node offline until the next successful probe reclassifies it.
 func (r *Roster) SetHealthFromEvent(name string, online bool, now time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/cluster/roster.go
+++ b/internal/cluster/roster.go
@@ -114,7 +114,7 @@ func (r *Roster) ProbeAll(ctx context.Context, now time.Time) []NodeHealth {
 // ProbeNode health-probes a single follower and updates its health snapshot.
 func (r *Roster) ProbeNode(ctx context.Context, name string, now time.Time) NodeHealth {
 	client, ok := r.Client(name)
-	if !ok {
+	if !ok || client == nil {
 		return NodeHealth{Name: name, Status: StatusUnknown}
 	}
 	endpoint, degraded, err := client.ProbeHealth(ctx)

--- a/internal/cluster/roster.go
+++ b/internal/cluster/roster.go
@@ -1,0 +1,177 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Status is a follower's liveness as seen by the leader.
+type Status string
+
+const (
+	StatusOnline   Status = "online"
+	StatusDegraded Status = "degraded"
+	StatusOffline  Status = "offline"
+	StatusUnknown  Status = "unknown"
+)
+
+// NodeHealth is a point-in-time liveness snapshot for one follower. Status is
+// online when the preferred endpoint answers /health, degraded when only a
+// fallback endpoint answers, and offline when none do.
+type NodeHealth struct {
+	Name           string
+	Status         Status
+	ActiveEndpoint string
+	LastChecked    time.Time
+	LastError      string
+}
+
+// Roster holds the leader's follower Clients and their last observed health.
+type Roster struct {
+	logger *slog.Logger
+
+	mu      sync.RWMutex
+	order   []string
+	clients map[string]*Client
+	health  map[string]NodeHealth
+}
+
+// NewRoster builds a Roster of Clients from the configured follower nodes.
+// Duplicate node names are rejected. A nil logger falls back to slog.Default().
+func NewRoster(nodes []Node, logger *slog.Logger) (*Roster, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	r := &Roster{
+		logger:  logger,
+		clients: make(map[string]*Client, len(nodes)),
+		health:  make(map[string]NodeHealth, len(nodes)),
+	}
+	for _, n := range nodes {
+		if n.Name == "" {
+			return nil, fmt.Errorf("cluster: follower node has no name")
+		}
+		if _, dup := r.clients[n.Name]; dup {
+			return nil, fmt.Errorf("cluster: duplicate follower node name %q", n.Name)
+		}
+		client, err := NewClient(n, logger)
+		if err != nil {
+			return nil, fmt.Errorf("cluster: node %q: %w", n.Name, err)
+		}
+		r.order = append(r.order, n.Name)
+		r.clients[n.Name] = client
+		r.health[n.Name] = NodeHealth{Name: n.Name, Status: StatusUnknown}
+	}
+	return r, nil
+}
+
+// Names returns the follower node names in roster order.
+func (r *Roster) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]string(nil), r.order...)
+}
+
+// Client returns the Client for the named follower.
+func (r *Roster) Client(name string) (*Client, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.clients[name]
+	return c, ok
+}
+
+// Health returns the last observed health for every follower, in roster order.
+func (r *Roster) Health() []NodeHealth {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]NodeHealth, 0, len(r.order))
+	for _, name := range r.order {
+		out = append(out, r.health[name])
+	}
+	return out
+}
+
+// ProbeAll health-probes every follower concurrently and updates the roster's
+// health snapshot, returning the fresh snapshots in roster order.
+func (r *Roster) ProbeAll(ctx context.Context, now time.Time) []NodeHealth {
+	names := r.Names()
+	var wg sync.WaitGroup
+	for _, name := range names {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			r.ProbeNode(ctx, name, now)
+		}(name)
+	}
+	wg.Wait()
+	return r.Health()
+}
+
+// ProbeNode health-probes a single follower and updates its health snapshot.
+func (r *Roster) ProbeNode(ctx context.Context, name string, now time.Time) NodeHealth {
+	client, ok := r.Client(name)
+	if !ok {
+		return NodeHealth{Name: name, Status: StatusUnknown}
+	}
+	endpoint, degraded, err := client.ProbeHealth(ctx)
+	h := NodeHealth{Name: name, LastChecked: now}
+	switch {
+	case err != nil:
+		h.Status = StatusOffline
+		h.LastError = err.Error()
+	case degraded:
+		h.Status = StatusDegraded
+		h.ActiveEndpoint = endpoint
+	default:
+		h.Status = StatusOnline
+		h.ActiveEndpoint = endpoint
+	}
+	r.mu.Lock()
+	prev := r.health[name]
+	r.health[name] = h
+	r.mu.Unlock()
+	if prev.Status != h.Status {
+		r.logger.Info("cluster.node.health", "node", name, "status", string(h.Status), "endpoint", h.ActiveEndpoint, "err", h.LastError)
+	}
+	return h
+}
+
+// SetHealthFromEvent lets a live SSE liveness signal update a node's status
+// between /health polls: a received event marks the node online, a stream drop
+// marks it offline (until the next successful probe reclassifies it).
+func (r *Roster) SetHealthFromEvent(name string, online bool, now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	h, ok := r.health[name]
+	if !ok {
+		return
+	}
+	h.LastChecked = now
+	if online {
+		if h.Status == StatusOffline || h.Status == StatusUnknown {
+			h.Status = StatusOnline
+		}
+	} else {
+		h.Status = StatusOffline
+	}
+	r.health[name] = h
+}
+
+// OnlineNames returns the names of followers currently online or degraded
+// (reachable), sorted for stable output.
+func (r *Roster) OnlineNames() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []string
+	for name, h := range r.health {
+		if h.Status == StatusOnline || h.Status == StatusDegraded {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/cluster/roster_test.go
+++ b/internal/cluster/roster_test.go
@@ -77,11 +77,20 @@ func TestRosterSetHealthFromEvent(t *testing.T) {
 	}
 	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
 	roster.SetHealthFromEvent("n1", true, now)
-	if got := roster.Health()[0].Status; got != StatusOnline {
+	if got := statusOf(t, roster); got != StatusOnline {
 		t.Errorf("after online event status = %s, want online", got)
 	}
 	roster.SetHealthFromEvent("n1", false, now)
-	if got := roster.Health()[0].Status; got != StatusOffline {
+	if got := statusOf(t, roster); got != StatusOffline {
 		t.Errorf("after drop event status = %s, want offline", got)
 	}
+}
+
+func statusOf(t *testing.T, roster *Roster) Status {
+	t.Helper()
+	h := roster.Health()
+	if len(h) == 0 {
+		t.Fatal("roster has no health entries")
+	}
+	return h[0].Status
 }

--- a/internal/cluster/roster_test.go
+++ b/internal/cluster/roster_test.go
@@ -1,0 +1,87 @@
+package cluster
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func healthServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestRosterRejectsDuplicateAndUnnamed(t *testing.T) {
+	if _, err := NewRoster([]Node{{Name: ""}}, nil); err == nil {
+		t.Error("want error for an unnamed node")
+	}
+	if _, err := NewRoster([]Node{{Name: "a"}, {Name: "a"}}, nil); err == nil {
+		t.Error("want error for a duplicate node name")
+	}
+}
+
+func TestRosterProbeStatuses(t *testing.T) {
+	live := healthServer(t)
+
+	dead := httptest.NewServer(http.NewServeMux())
+	deadURL := dead.URL
+	dead.Close()
+
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	roster, err := NewRoster([]Node{
+		{Name: "online", Endpoints: []string{live.URL}},
+		{Name: "degraded", Endpoints: []string{deadURL, live.URL}},
+		{Name: "offline", Endpoints: []string{deadURL}},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	roster.ProbeAll(context.Background(), now)
+	byName := map[string]NodeHealth{}
+	for _, h := range roster.Health() {
+		byName[h.Name] = h
+	}
+
+	if byName["online"].Status != StatusOnline {
+		t.Errorf("online node status = %s", byName["online"].Status)
+	}
+	if byName["degraded"].Status != StatusDegraded {
+		t.Errorf("degraded node status = %s (want degraded — primary down, fallback up)", byName["degraded"].Status)
+	}
+	if byName["degraded"].ActiveEndpoint != live.URL {
+		t.Errorf("degraded active endpoint = %q, want fallback %q", byName["degraded"].ActiveEndpoint, live.URL)
+	}
+	if byName["offline"].Status != StatusOffline {
+		t.Errorf("offline node status = %s", byName["offline"].Status)
+	}
+
+	online := roster.OnlineNames()
+	if len(online) != 2 {
+		t.Errorf("OnlineNames = %v, want online+degraded", online)
+	}
+}
+
+func TestRosterSetHealthFromEvent(t *testing.T) {
+	roster, err := NewRoster([]Node{{Name: "n1", Endpoints: []string{"http://x"}}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+	roster.SetHealthFromEvent("n1", true, now)
+	if got := roster.Health()[0].Status; got != StatusOnline {
+		t.Errorf("after online event status = %s, want online", got)
+	}
+	roster.SetHealthFromEvent("n1", false, now)
+	if got := roster.Health()[0].Status; got != StatusOffline {
+		t.Errorf("after drop event status = %s, want offline", got)
+	}
+}

--- a/internal/cluster/tls.go
+++ b/internal/cluster/tls.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ParsePin normalizes a cert-pin fingerprint: a hex SHA-256 (64 hex chars,
+// with optional colons or "sha256:" prefix) of a follower's leaf certificate.
+func ParsePin(pin string) ([]byte, error) {
+	clean := strings.ToLower(strings.TrimSpace(pin))
+	clean = strings.TrimPrefix(clean, "sha256:")
+	clean = strings.ReplaceAll(clean, ":", "")
+	raw, err := hex.DecodeString(clean)
+	if err != nil {
+		return nil, fmt.Errorf("cluster: invalid tls_pin %q: %w", pin, err)
+	}
+	if len(raw) != sha256.Size {
+		return nil, fmt.Errorf("cluster: tls_pin must be a %d-byte SHA-256 (%d hex chars), got %d bytes", sha256.Size, sha256.Size*2, len(raw))
+	}
+	return raw, nil
+}
+
+func pinnedTransport(pin string) (*http.Transport, error) {
+	want, err := ParsePin(pin)
+	if err != nil {
+		return nil, err
+	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true,
+			VerifyConnection: func(cs tls.ConnectionState) error {
+				if len(cs.PeerCertificates) == 0 {
+					return errors.New("cluster: follower presented no certificate")
+				}
+				got := sha256.Sum256(cs.PeerCertificates[0].Raw)
+				if subtle.ConstantTimeCompare(got[:], want) != 1 {
+					return fmt.Errorf("cluster: cert pin mismatch (got sha256:%x)", got)
+				}
+				return nil
+			},
+		},
+	}
+	return tr, nil
+}

--- a/internal/cluster/tls.go
+++ b/internal/cluster/tls.go
@@ -32,20 +32,23 @@ func pinnedTransport(pin string) (*http.Transport, error) {
 	if err != nil {
 		return nil, err
 	}
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true,
-			VerifyConnection: func(cs tls.ConnectionState) error {
-				if len(cs.PeerCertificates) == 0 {
-					return errors.New("cluster: follower presented no certificate")
-				}
-				got := sha256.Sum256(cs.PeerCertificates[0].Raw)
-				if subtle.ConstantTimeCompare(got[:], want) != 1 {
-					return fmt.Errorf("cluster: cert pin mismatch (got sha256:%x)", got)
-				}
-				return nil
-			},
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("cluster: http.DefaultTransport is not *http.Transport")
+	}
+	tr := base.Clone()
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return errors.New("cluster: follower presented no certificate")
+			}
+			got := sha256.Sum256(cs.PeerCertificates[0].Raw)
+			if subtle.ConstantTimeCompare(got[:], want) != 1 {
+				return fmt.Errorf("cluster: cert pin mismatch (got sha256:%x)", got)
+			}
+			return nil
 		},
 	}
 	return tr, nil

--- a/internal/cluster/tls_test.go
+++ b/internal/cluster/tls_test.go
@@ -55,10 +55,7 @@ func TestClientTLSPinAcceptAndReject(t *testing.T) {
 	sum := sha256.Sum256(srv.Certificate().Raw)
 	correctPin := hex.EncodeToString(sum[:])
 
-	accept, err := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: correctPin}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	accept := mustClient(t, Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: correctPin})
 	got, err := accept.ListTasks(context.Background())
 	if err != nil {
 		t.Fatalf("correct pin should connect: %v", err)
@@ -68,10 +65,7 @@ func TestClientTLSPinAcceptAndReject(t *testing.T) {
 	}
 
 	wrongPin := strings.Repeat("00", 32)
-	reject, err := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: wrongPin}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	reject := mustClient(t, Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: wrongPin})
 	if _, err := reject.ListTasks(context.Background()); err == nil {
 		t.Fatal("wrong pin must reject the connection")
 	}

--- a/internal/cluster/tls_test.go
+++ b/internal/cluster/tls_test.go
@@ -1,0 +1,89 @@
+package cluster
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestParsePin(t *testing.T) {
+	good := strings.Repeat("ab", 32)
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"plain hex", good, false},
+		{"sha256 prefix", "sha256:" + good, false},
+		{"colon separated", strings.Join(splitPairs(good), ":"), false},
+		{"uppercase", strings.ToUpper(good), false},
+		{"too short", "abcd", true},
+		{"not hex", strings.Repeat("zz", 32), true},
+		{"empty", "", true},
+	}
+	for _, c := range cases {
+		_, err := ParsePin(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("%s: ParsePin err = %v, wantErr %v", c.name, err, c.wantErr)
+		}
+	}
+}
+
+func splitPairs(s string) []string {
+	var out []string
+	for i := 0; i+2 <= len(s); i += 2 {
+		out = append(out, s[i:i+2])
+	}
+	return out
+}
+
+func TestClientTLSPinAcceptAndReject(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, _ *http.Request) {
+		_ = writeJSON(w, []task.Task{{ID: "pinned"}})
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	sum := sha256.Sum256(srv.Certificate().Raw)
+	correctPin := hex.EncodeToString(sum[:])
+
+	accept, err := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: correctPin}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := accept.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("correct pin should connect: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "pinned" {
+		t.Fatalf("ListTasks = %+v", got)
+	}
+
+	wrongPin := strings.Repeat("00", 32)
+	reject, err := NewClient(Node{Name: "tls", Endpoints: []string{srv.URL}, TLSPin: wrongPin}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reject.ListTasks(context.Background()); err == nil {
+		t.Fatal("wrong pin must reject the connection")
+	}
+}
+
+func TestNewClientInvalidPin(t *testing.T) {
+	if _, err := NewClient(Node{Name: "bad", Endpoints: []string{"https://x"}, TLSPin: "nothex"}, nil); err == nil {
+		t.Fatal("want error for an invalid tls_pin")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) error {
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(v)
+}


### PR DESCRIPTION
## Motivation

P1 of the leader-follower umbrella (#1803). Adds the leader's outbound
transport to follower nodes — the plumbing P3's assigner/mirror needs.
Parallel with P2. No behavior change until a leader is wired up.

> Changelog: feat(cluster): outbound follower client with health failover and cert pinning

## Implementation information

New top-level `internal/cluster` package (narrow `Node` type, never imports
`internal/sybra` — mirrors `internal/recovery`):

- **`Client`** speaks the existing control plane the web GUI uses (`POST
  /api/{service}/{method}`, `Authorization: Bearer`, JSON-array body) with
  typed `AssignTask`/`GetTask`/`ListTasks` and proxied
  `StopAgent`/`SendMessage`/`RespondApproval`/`ApprovePlan`.
- **Multi-endpoint failover** — each call walks the node's ordered endpoints
  and re-selects the first reachable one, so a flaky tailnet URL falls back
  to a LAN IP automatically.
- **`EventStream`** (`Subscribe`) decodes the `/events` SSE frames
  (`internal/sse` format) into a channel, ctx-bound so a stalled consumer
  can't leak the goroutine/connection.
- **`Roster`** tracks per-node health (`online`/`degraded`/`offline`) from
  `/health` probes plus SSE liveness.
- **TLS-pin** — verifies a follower's leaf cert by SHA-256 fingerprint
  instead of a CA chain (encryption + identity over a plain LAN), enforced
  in `VerifyConnection` on both the RPC and SSE transports.

### Safety decisions (from adversarial review)

- **Idempotent-only auto-failover.** `Call` (the default for mutating RPCs)
  fails over *only* when the connection was never established (dial error),
  never after a partial send — so a mid-request reset can't double-assign a
  task. Read-only wrappers use unconditional failover, including on
  gateway-down (502/503/504) statuses.

### Note on the gosec exclusion

Fingerprint-only cert pinning has no CA to anchor to, so
`internal/cluster/tls.go` must set `InsecureSkipVerify` and verify the leaf
SHA-256 itself in `VerifyConnection` (the standard Go pinning idiom). The
repo's klaudiush policy forbids inline `//nolint`, so gosec G402 is excluded
for that one file via a documented scoped rule in `.golangci.yml` rather than
an inline directive.

### Verification

- `go test -race ./internal/cluster/...` green; golangci clean.
- Adversarial code review + adversarial runtime testing run pre-PR.
- **Integration test drives the real `httpapi` dispatcher + `sse` broker**
  (not a stub): wire format, bearer rejection, live SSE emit, health probe —
  locking the client to the exact contract P3 targets.
- Table-driven coverage: endpoint failover, idempotency gate, gateway-down,
  pinned-cert accept/reject, SSE multi-line + CRLF frames, SSE failover, SSE
  over pinned TLS, token rejection.

Closes #1805