### PR TITLE
feat(cluster): follower AssignTask RPC

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
@@ -22,6 +22,19 @@ import * as task$0 from "../task/models.js";
 import * as $models from "./models.js";
 
 /**
+ * AssignTask persists a task pushed from the cluster leader into this
+ * follower's local store (leader-follower execution mirror, umbrella #1803).
+ * The task is written verbatim — the leader owns its canonical ID, status, and
+ * workflow — and the file watcher then dispatches it through the normal
+ * workflow, so nothing downstream changes. The pushed DTO is validated before
+ * it touches disk; a malformed task is rejected with a 400 rather than
+ * corrupting the board.
+ */
+export function AssignTask(t: task$0.Task): $CancellablePromise<void> {
+    return $Call.ByID(835614146, t);
+}
+
+/**
  * BlessTampering records a human bless for a tamper-flagged task and sends it
  * back to the review workflow.
  */

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -199,6 +199,7 @@ export function GetTask(arg1: string): Promise<Task> { return call('TaskService'
 export function ListTasks(): Promise<Array<Task>> { return call('TaskService', 'ListTasks') }
 export function ListTaskProgress(arg1: string): Promise<Array<ProgressEntry>> { return call('TaskService', 'ListTaskProgress', arg1) }
 export function UpdateTask(arg1: string, arg2: Record<string, unknown>): Promise<Task> { return call('TaskService', 'UpdateTask', arg1, arg2) }
+export function AssignTask(arg1: Task): Promise<void> { return call('TaskService', 'AssignTask', arg1) }
 
 // WorkflowService
 export function DeleteWorkflow(arg1: string): Promise<void> { return call('WorkflowService', 'DeleteWorkflow', arg1) }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -161,6 +161,7 @@ export const GetTask = pick(TaskSvc.GetTask, http.GetTask)
 export const ListTasks = pick(TaskSvc.ListTasks, http.ListTasks)
 export const ListTaskProgress = pick(TaskSvc.ListTaskProgress, http.ListTaskProgress)
 export const UpdateTask = pick(TaskSvc.UpdateTask, http.UpdateTask)
+export const AssignTask = pick(TaskSvc.AssignTask, http.AssignTask)
 
 // WorkflowService
 export const DeleteWorkflow = pick(WorkflowSvc.DeleteWorkflow, http.DeleteWorkflow)

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -85,6 +85,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 			"GetCopilotModels",
 		),
 		"TaskService": httpapi.NewService(a.taskSvc,
+			"AssignTask",
 			"BlessTampering",
 			"ListTasks",
 			"ListTaskArtifacts",

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -503,20 +503,18 @@ func (s *TaskService) AssignTask(t task.Task) error {
 			return validationError(err.Error())
 		}
 	}
-	_, getErr := s.tasks.Get(t.ID)
-	existed := getErr == nil
-	saved, err := s.tasks.Put(t)
+	saved, created, err := s.tasks.Put(t)
 	if err != nil {
 		return fmt.Errorf("assign task: %w", err)
 	}
-	if s.audit != nil && !existed {
+	if s.audit != nil && created {
 		_ = s.audit.Log(audit.Event{
 			Type:   audit.EventTaskCreated,
 			TaskID: saved.ID,
 			Data:   map[string]any{"source": "cluster_assign", "assigned_node": saved.AssignedNode, "status": string(saved.Status)},
 		})
 	}
-	s.logger.Info("cluster.task.assigned", "task", saved.ID, "existed", existed, "status", string(saved.Status), "assigned_node", saved.AssignedNode)
+	s.logger.Info("cluster.task.assigned", "task", saved.ID, "created", created, "status", string(saved.Status), "assigned_node", saved.AssignedNode)
 	return nil
 }
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -484,8 +484,8 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 // it touches disk; a malformed task is rejected with a 400 rather than
 // corrupting the board.
 func (s *TaskService) AssignTask(t task.Task) error {
-	if strings.TrimSpace(t.ID) == "" {
-		return validationError("assigned task must have an id")
+	if err := task.ValidateID(t.ID); err != nil {
+		return validationError(err.Error())
 	}
 	if strings.TrimSpace(t.Title) == "" {
 		return validationError("assigned task must have a title")

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -503,18 +503,20 @@ func (s *TaskService) AssignTask(t task.Task) error {
 			return validationError(err.Error())
 		}
 	}
+	_, getErr := s.tasks.Get(t.ID)
+	existed := getErr == nil
 	saved, err := s.tasks.Put(t)
 	if err != nil {
 		return fmt.Errorf("assign task: %w", err)
 	}
-	if s.audit != nil {
+	if s.audit != nil && !existed {
 		_ = s.audit.Log(audit.Event{
 			Type:   audit.EventTaskCreated,
 			TaskID: saved.ID,
 			Data:   map[string]any{"source": "cluster_assign", "assigned_node": saved.AssignedNode, "status": string(saved.Status)},
 		})
 	}
-	s.logger.Info("cluster.task.assigned", "task", saved.ID, "status", string(saved.Status), "assigned_node", saved.AssignedNode)
+	s.logger.Info("cluster.task.assigned", "task", saved.ID, "existed", existed, "status", string(saved.Status), "assigned_node", saved.AssignedNode)
 	return nil
 }
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -476,6 +476,48 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 	return s.CreateTaskWithInit(title, body, mode, task.Update{})
 }
 
+// AssignTask persists a task pushed from the cluster leader into this
+// follower's local store (leader-follower execution mirror, umbrella #1803).
+// The task is written verbatim — the leader owns its canonical ID, status, and
+// workflow — and the file watcher then dispatches it through the normal
+// workflow, so nothing downstream changes. The pushed DTO is validated before
+// it touches disk; a malformed task is rejected with a 400 rather than
+// corrupting the board.
+func (s *TaskService) AssignTask(t task.Task) error {
+	if strings.TrimSpace(t.ID) == "" {
+		return validationError("assigned task must have an id")
+	}
+	if strings.TrimSpace(t.Title) == "" {
+		return validationError("assigned task must have a title")
+	}
+	if _, err := task.ValidateStatus(string(t.Status)); err != nil {
+		return validationError(err.Error())
+	}
+	if t.AgentMode != "" {
+		if _, err := task.ValidateAgentMode(t.AgentMode); err != nil {
+			return validationError(err.Error())
+		}
+	}
+	if t.TaskType != "" {
+		if _, err := task.ValidateTaskType(string(t.TaskType)); err != nil {
+			return validationError(err.Error())
+		}
+	}
+	saved, err := s.tasks.Put(t)
+	if err != nil {
+		return fmt.Errorf("assign task: %w", err)
+	}
+	if s.audit != nil {
+		_ = s.audit.Log(audit.Event{
+			Type:   audit.EventTaskCreated,
+			TaskID: saved.ID,
+			Data:   map[string]any{"source": "cluster_assign", "assigned_node": saved.AssignedNode, "status": string(saved.Status)},
+		})
+	}
+	s.logger.Info("cluster.task.assigned", "task", saved.ID, "status", string(saved.Status), "assigned_node", saved.AssignedNode)
+	return nil
+}
+
 // CreateTaskWithInit is CreateTask plus caller-supplied initial field
 // overrides (e.g. TodoistID) applied atomically in the same first-write as
 // task creation. Callers that need a dedupe key persisted alongside the task

--- a/internal/sybra/svc_tasks_assign_test.go
+++ b/internal/sybra/svc_tasks_assign_test.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
@@ -69,6 +70,34 @@ func TestAssignTaskUpsertsOnRepeatedPush(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("upsert produced %d copies of leader-02, want 1", count)
+	}
+}
+
+func TestAssignTaskDispatchesStageStatus(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	var mu sync.Mutex
+	var fired []string
+	svc.tasks.SetStatusChangeHook(func(_, _, to string) {
+		mu.Lock()
+		fired = append(fired, to)
+		mu.Unlock()
+	})
+
+	pushed := task.Task{
+		ID:        "leader-stage",
+		Title:     "mid-workflow handoff",
+		Status:    task.StatusReadyReview,
+		AgentMode: task.AgentModeHeadless,
+	}
+	if err := svc.AssignTask(pushed); err != nil {
+		t.Fatalf("AssignTask: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(fired) != 1 || fired[0] != string(task.StatusReadyReview) {
+		t.Fatalf("status hook fired %v, want [ready-review] — otherwise the pushed stage never dispatches", fired)
 	}
 }
 

--- a/internal/sybra/svc_tasks_assign_test.go
+++ b/internal/sybra/svc_tasks_assign_test.go
@@ -1,0 +1,103 @@
+package sybra
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestAssignTaskPersistsVerbatim(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	pushed := task.Task{
+		ID:           "leader-01",
+		Title:        "Implement the thing",
+		Status:       task.StatusTodo,
+		AgentMode:    task.AgentModeHeadless,
+		ProjectID:    "owner/repo",
+		AssignedNode: "pet-box",
+		Body:         "## Description\nfrom the leader",
+	}
+	if err := svc.AssignTask(pushed); err != nil {
+		t.Fatalf("AssignTask: %v", err)
+	}
+
+	got, err := svc.GetTask("leader-01")
+	if err != nil {
+		t.Fatalf("GetTask after assign: %v", err)
+	}
+	if got.ID != "leader-01" || got.Title != "Implement the thing" {
+		t.Fatalf("mirror did not preserve identity: %+v", got)
+	}
+	if got.Status != task.StatusTodo || got.AssignedNode != "pet-box" || got.ProjectID != "owner/repo" {
+		t.Fatalf("mirror did not preserve fields: %+v", got)
+	}
+	if got.Body != "## Description\nfrom the leader" {
+		t.Fatalf("mirror did not preserve body: %q", got.Body)
+	}
+}
+
+func TestAssignTaskUpsertsOnRepeatedPush(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	base := task.Task{ID: "leader-02", Title: "t", Status: task.StatusTodo, AgentMode: task.AgentModeHeadless}
+	if err := svc.AssignTask(base); err != nil {
+		t.Fatal(err)
+	}
+	base.Status = task.StatusInProgress
+	if err := svc.AssignTask(base); err != nil {
+		t.Fatalf("second push (status update) should upsert: %v", err)
+	}
+	got, err := svc.GetTask("leader-02")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("upsert did not apply the new status: %s", got.Status)
+	}
+
+	all, err := svc.ListTasks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, tk := range all {
+		if tk.ID == "leader-02" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("upsert produced %d copies of leader-02, want 1", count)
+	}
+}
+
+func TestAssignTaskRejectsMalformed(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	cases := []struct {
+		name string
+		in   task.Task
+	}{
+		{"no id", task.Task{Title: "t", Status: task.StatusTodo}},
+		{"no title", task.Task{ID: "x", Status: task.StatusTodo}},
+		{"bad status", task.Task{ID: "x", Title: "t", Status: task.Status("bogus")}},
+		{"bad agent mode", task.Task{ID: "x", Title: "t", Status: task.StatusTodo, AgentMode: "telepathy"}},
+		{"bad task type", task.Task{ID: "x", Title: "t", Status: task.StatusTodo, TaskType: task.TaskType("weird")}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := svc.AssignTask(c.in)
+			if err == nil {
+				t.Fatal("want validation error")
+			}
+			var ce *clientError
+			if !errors.As(err, &ce) || ce.HTTPStatus() != 400 {
+				t.Fatalf("want 400 clientError, got %v", err)
+			}
+			if _, getErr := svc.GetTask("x"); getErr == nil {
+				t.Fatal("a rejected task must not have been written to the store")
+			}
+		})
+	}
+}

--- a/internal/sybra/svc_tasks_assign_test.go
+++ b/internal/sybra/svc_tasks_assign_test.go
@@ -80,6 +80,9 @@ func TestAssignTaskRejectsMalformed(t *testing.T) {
 		in   task.Task
 	}{
 		{"no id", task.Task{Title: "t", Status: task.StatusTodo}},
+		{"path traversal id", task.Task{ID: "../../etc/passwd", Title: "t", Status: task.StatusTodo}},
+		{"slash in id", task.Task{ID: "a/b", Title: "t", Status: task.StatusTodo}},
+		{"dotdot id", task.Task{ID: "..", Title: "t", Status: task.StatusTodo}},
 		{"no title", task.Task{ID: "x", Status: task.StatusTodo}},
 		{"bad status", task.Task{ID: "x", Title: "t", Status: task.Status("bogus")}},
 		{"bad agent mode", task.Task{ID: "x", Title: "t", Status: task.StatusTodo, AgentMode: "telepathy"}},

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -206,24 +206,47 @@ func (m *Manager) CreateFull(title, body, mode string, init Update) (Task, error
 	return t, nil
 }
 
-// Put writes a fully-formed task verbatim (upsert by ID) and emits the matching
-// lifecycle event so the orchestrator and frontend react immediately. It is the
-// leader-follower execution mirror's write path: a first push emits
-// task:created, a subsequent push (e.g. a leader-side status change) emits
-// task:updated. See Store.Put.
+// Put writes a fully-formed task verbatim (upsert by ID) and drives the same
+// lifecycle side-effects an in-process create/update would, so the pushed task
+// dispatches through the normal workflow. It is the leader-follower execution
+// mirror's write path: a first push emits task:created (todo/new tasks then
+// dispatch via the external-task path), a subsequent push emits task:updated,
+// and any status change — including a fresh push that lands directly at a stage
+// like ready-review/testing/ready-pr — fires the status hook so stage dispatch
+// runs. The fired-status dedupe is recorded under the per-task lock so the file
+// watcher this write wakes cannot double-fire the hook. See Store.Put.
 func (m *Manager) Put(t Task) (Task, error) {
-	_, getErr := m.store.Get(t.ID)
+	mu := m.lockFor(t.ID)
+	mu.Lock()
+
+	prev, getErr := m.store.Get(t.ID)
 	existed := getErr == nil
 	saved, err := m.store.Put(t)
 	if err != nil {
+		mu.Unlock()
 		return saved, err
 	}
-	m.recordFiredStatus(saved.ID, string(saved.Status))
+
+	prevStatus := ""
 	if existed {
+		prevStatus = string(prev.Status)
+	}
+	newStatus := string(saved.Status)
+	fireHook := m.onStatusHook != nil && newStatus != prevStatus
+	if fireHook {
+		m.recordFiredStatus(saved.ID, newStatus)
+	}
+	mu.Unlock()
+
+	if existed {
+		metrics.TaskUpdated()
 		m.emitter.Emit(events.TaskUpdated, saved.FilePath)
 	} else {
 		metrics.TaskCreated()
 		m.emitter.Emit(events.TaskCreated, saved.FilePath)
+	}
+	if fireHook {
+		m.onStatusHook(saved.ID, prevStatus, newStatus)
 	}
 	return saved, nil
 }

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -214,17 +214,19 @@ func (m *Manager) CreateFull(title, body, mode string, init Update) (Task, error
 // and any status change — including a fresh push that lands directly at a stage
 // like ready-review/testing/ready-pr — fires the status hook so stage dispatch
 // runs. The fired-status dedupe is recorded under the per-task lock so the file
-// watcher this write wakes cannot double-fire the hook. See Store.Put.
-func (m *Manager) Put(t Task) (Task, error) {
+// watcher this write wakes cannot double-fire the hook. The returned bool
+// reports whether the task was newly created (vs an in-place update). See
+// Store.Put.
+func (m *Manager) Put(t Task) (Task, bool, error) {
 	mu := m.lockFor(t.ID)
 	mu.Lock()
 
-	prev, getErr := m.store.Get(t.ID)
+	prev, getErr := m.store.read(t.ID)
 	existed := getErr == nil
 	saved, err := m.store.Put(t)
 	if err != nil {
 		mu.Unlock()
-		return saved, err
+		return saved, false, err
 	}
 
 	prevStatus := ""
@@ -248,7 +250,7 @@ func (m *Manager) Put(t Task) (Task, error) {
 	if fireHook {
 		m.onStatusHook(saved.ID, prevStatus, newStatus)
 	}
-	return saved, nil
+	return saved, !existed, nil
 }
 
 // CreateChat persists a synthetic chat task and emits task:created.

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -206,6 +206,28 @@ func (m *Manager) CreateFull(title, body, mode string, init Update) (Task, error
 	return t, nil
 }
 
+// Put writes a fully-formed task verbatim (upsert by ID) and emits the matching
+// lifecycle event so the orchestrator and frontend react immediately. It is the
+// leader-follower execution mirror's write path: a first push emits
+// task:created, a subsequent push (e.g. a leader-side status change) emits
+// task:updated. See Store.Put.
+func (m *Manager) Put(t Task) (Task, error) {
+	_, getErr := m.store.Get(t.ID)
+	existed := getErr == nil
+	saved, err := m.store.Put(t)
+	if err != nil {
+		return saved, err
+	}
+	m.recordFiredStatus(saved.ID, string(saved.Status))
+	if existed {
+		m.emitter.Emit(events.TaskUpdated, saved.FilePath)
+	} else {
+		metrics.TaskCreated()
+		m.emitter.Emit(events.TaskCreated, saved.FilePath)
+	}
+	return saved, nil
+}
+
 // CreateChat persists a synthetic chat task and emits task:created.
 func (m *Manager) CreateChat(projectID string) (Task, error) {
 	t, err := m.store.CreateChat(projectID)

--- a/internal/task/manager_put_test.go
+++ b/internal/task/manager_put_test.go
@@ -22,7 +22,7 @@ func TestManagerPutFiresStatusHookForStageStatus(t *testing.T) {
 		mu.Unlock()
 	})
 
-	if _, err := m.Put(Task{ID: "leader-1", Title: "t", Status: StatusReadyReview, AgentMode: AgentModeHeadless}); err != nil {
+	if _, _, err := m.Put(Task{ID: "leader-1", Title: "t", Status: StatusReadyReview, AgentMode: AgentModeHeadless}); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
@@ -51,12 +51,16 @@ func TestManagerPutFiresHookOnTransition(t *testing.T) {
 	})
 
 	base := Task{ID: "leader-2", Title: "t", Status: StatusInProgress, AgentMode: AgentModeHeadless}
-	if _, err := m.Put(base); err != nil {
+	if _, created, err := m.Put(base); err != nil {
 		t.Fatal(err)
+	} else if !created {
+		t.Error("first Put should report created=true")
 	}
 	base.Status = StatusTesting
-	if _, err := m.Put(base); err != nil {
+	if _, created, err := m.Put(base); err != nil {
 		t.Fatal(err)
+	} else if created {
+		t.Error("second Put (upsert) should report created=false")
 	}
 
 	mu.Lock()
@@ -81,11 +85,11 @@ func TestManagerPutNoHookWhenStatusUnchanged(t *testing.T) {
 	})
 
 	base := Task{ID: "leader-3", Title: "t", Status: StatusTodo, AgentMode: AgentModeHeadless}
-	if _, err := m.Put(base); err != nil {
+	if _, _, err := m.Put(base); err != nil {
 		t.Fatal(err)
 	}
 	base.Title = "renamed"
-	if _, err := m.Put(base); err != nil {
+	if _, _, err := m.Put(base); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/task/manager_put_test.go
+++ b/internal/task/manager_put_test.go
@@ -1,0 +1,97 @@
+package task
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/events"
+)
+
+type hookCall struct {
+	id, from, to string
+}
+
+func TestManagerPutFiresStatusHookForStageStatus(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+	var mu sync.Mutex
+	var calls []hookCall
+	m.SetStatusChangeHook(func(id, from, to string) {
+		mu.Lock()
+		calls = append(calls, hookCall{id, from, to})
+		mu.Unlock()
+	})
+
+	if _, err := m.Put(Task{ID: "leader-1", Title: "t", Status: StatusReadyReview, AgentMode: AgentModeHeadless}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 1 {
+		t.Fatalf("status hook fired %d times, want 1 (stage dispatch would never run otherwise)", len(calls))
+	}
+	if calls[0].to != string(StatusReadyReview) || calls[0].from != "" {
+		t.Fatalf("hook call = %+v, want from='' to=ready-review", calls[0])
+	}
+	if names := emitter.names(); len(names) != 1 || names[0] != events.TaskCreated {
+		t.Fatalf("events = %v, want [task:created]", names)
+	}
+}
+
+func TestManagerPutFiresHookOnTransition(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+	var mu sync.Mutex
+	var calls []hookCall
+	m.SetStatusChangeHook(func(id, from, to string) {
+		mu.Lock()
+		calls = append(calls, hookCall{id, from, to})
+		mu.Unlock()
+	})
+
+	base := Task{ID: "leader-2", Title: "t", Status: StatusInProgress, AgentMode: AgentModeHeadless}
+	if _, err := m.Put(base); err != nil {
+		t.Fatal(err)
+	}
+	base.Status = StatusTesting
+	if _, err := m.Put(base); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 2 {
+		t.Fatalf("hook fired %d times, want 2 (initial + transition)", len(calls))
+	}
+	if calls[1].from != string(StatusInProgress) || calls[1].to != string(StatusTesting) {
+		t.Fatalf("transition hook = %+v, want in-progress->testing", calls[1])
+	}
+}
+
+func TestManagerPutNoHookWhenStatusUnchanged(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+	var mu sync.Mutex
+	fired := 0
+	m.SetStatusChangeHook(func(string, string, string) {
+		mu.Lock()
+		fired++
+		mu.Unlock()
+	})
+
+	base := Task{ID: "leader-3", Title: "t", Status: StatusTodo, AgentMode: AgentModeHeadless}
+	if _, err := m.Put(base); err != nil {
+		t.Fatal(err)
+	}
+	base.Title = "renamed"
+	if _, err := m.Put(base); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if fired != 1 {
+		t.Fatalf("hook fired %d times, want 1 (only the initial create; a title-only re-push must not re-fire)", fired)
+	}
+}

--- a/internal/task/slug.go
+++ b/internal/task/slug.go
@@ -29,6 +29,25 @@ func ValidateSlug(s string) error {
 	return nil
 }
 
+var validIDRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+// ValidateID rejects task IDs that could traverse or corrupt the tasks
+// directory when written as "<id>.md". This matters for externally-supplied
+// IDs — notably a leader-pushed task in cluster mode (TaskService.AssignTask) —
+// since Store.Create's own IDs are always safe UUID prefixes.
+func ValidateID(id string) error {
+	if id == "" {
+		return errors.New("task id must not be empty")
+	}
+	if len(id) > 64 {
+		return fmt.Errorf("task id %q exceeds 64 chars", id)
+	}
+	if !validIDRe.MatchString(id) {
+		return fmt.Errorf("invalid task id %q: use only letters, digits, hyphens, and underscores", id)
+	}
+	return nil
+}
+
 // Slugify converts a title into a filesystem-safe slug.
 // Returns "task" for empty or all-special-character inputs.
 func Slugify(title string) string {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -586,8 +586,8 @@ func applyCreateInit(t *Task, init Update, now time.Time) {
 // normal workflow. Marshal persists frontmatter + body; sidecars are not
 // written by this path.
 func (s *Store) Put(t Task) (Task, error) {
-	if t.ID == "" {
-		return Task{}, fmt.Errorf("task id is required")
+	if err := ValidateID(t.ID); err != nil {
+		return Task{}, err
 	}
 	now := time.Now().UTC()
 	if t.CreatedAt.IsZero() {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -578,6 +578,42 @@ func applyCreateInit(t *Task, init Update, now time.Time) {
 	}
 }
 
+// Put writes a fully-formed task to the store verbatim (upsert by ID),
+// preserving the caller-supplied ID, status, workflow, and timestamps rather
+// than minting new ones. It is the leader-follower execution mirror's write
+// path (TaskService.AssignTask): the leader owns the canonical task and pushes
+// it here, and the follower's file watcher then dispatches it through the
+// normal workflow. Marshal persists frontmatter + body; sidecars are not
+// written by this path.
+func (s *Store) Put(t Task) (Task, error) {
+	if t.ID == "" {
+		return Task{}, fmt.Errorf("task id is required")
+	}
+	now := time.Now().UTC()
+	if t.CreatedAt.IsZero() {
+		t.CreatedAt = now
+	}
+	if t.UpdatedAt.IsZero() {
+		t.UpdatedAt = now
+	}
+	if t.StatusChangedAt.IsZero() {
+		t.StatusChangedAt = t.UpdatedAt
+	}
+	if t.TaskType == "" {
+		t.TaskType = TaskTypeNormal
+	}
+	data, err := Marshal(t)
+	if err != nil {
+		return Task{}, err
+	}
+	t.FilePath = filepath.Join(s.dir, t.ID+".md")
+	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
+		return Task{}, fmt.Errorf("write task file: %w", err)
+	}
+	s.storeTaskCache(t)
+	return t, nil
+}
+
 // CreateChat creates a synthetic chat task bound to projectID. Chat tasks are
 // hidden from the task list UI and never restart on app reboot. The slug is
 // "chat-<8char>" so the worktree DirName is distinctive.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -602,7 +602,7 @@ func (s *Store) Put(t Task) (Task, error) {
 	if t.TaskType == "" {
 		t.TaskType = TaskTypeNormal
 	}
-	data, err := Marshal(t)
+	data, err := marshalTask(t, false)
 	if err != nil {
 		return Task{}, err
 	}

--- a/internal/task/store_put_test.go
+++ b/internal/task/store_put_test.go
@@ -15,6 +15,7 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 	}
 
 	created := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 7, 2, 15, 30, 0, 0, time.UTC)
 	in := Task{
 		ID:           "mirror-1",
 		Title:        "pushed",
@@ -23,7 +24,7 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 		AssignedNode: "box",
 		MirrorRev:    3,
 		CreatedAt:    created,
-		UpdatedAt:    created,
+		UpdatedAt:    updated,
 		Body:         "body text",
 	}
 	saved, err := store.Put(in)
@@ -43,6 +44,9 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 	}
 	if !got.CreatedAt.Equal(created) {
 		t.Errorf("Put overwrote CreatedAt: %v", got.CreatedAt)
+	}
+	if !got.UpdatedAt.Equal(updated) {
+		t.Errorf("Put overwrote leader-supplied UpdatedAt: got %v, want %v", got.UpdatedAt, updated)
 	}
 
 	in.Status = StatusReadyPR

--- a/internal/task/store_put_test.go
+++ b/internal/task/store_put_test.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -63,13 +65,20 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 	}
 }
 
-func TestStorePutRequiresID(t *testing.T) {
+func TestStorePutRejectsUnsafeID(t *testing.T) {
 	t.Parallel()
-	store, err := NewStore(t.TempDir())
+	dir := t.TempDir()
+	store, err := NewStore(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Put(Task{Title: "no id"}); err == nil {
-		t.Fatal("Put must reject a task with no ID")
+	canary := filepath.Join(dir, "..", "escaped.md")
+	for _, id := range []string{"", "..", "../escaped", "a/b", "a\\b", ".hidden", "../../etc/passwd"} {
+		if _, err := store.Put(Task{ID: id, Title: "x", Status: StatusTodo}); err == nil {
+			t.Errorf("Put must reject unsafe id %q", id)
+		}
+	}
+	if _, err := os.Stat(canary); !os.IsNotExist(err) {
+		t.Fatalf("a traversal id escaped the tasks dir: %s exists", canary)
 	}
 }

--- a/internal/task/store_put_test.go
+++ b/internal/task/store_put_test.go
@@ -1,0 +1,75 @@
+package task
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStorePutVerbatimAndUpsert(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	in := Task{
+		ID:           "mirror-1",
+		Title:        "pushed",
+		Status:       StatusInProgress,
+		AgentMode:    AgentModeHeadless,
+		AssignedNode: "box",
+		MirrorRev:    3,
+		CreatedAt:    created,
+		UpdatedAt:    created,
+		Body:         "body text",
+	}
+	saved, err := store.Put(in)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if saved.FilePath == "" {
+		t.Error("Put should set FilePath")
+	}
+
+	got, err := store.Get("mirror-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != "mirror-1" || got.Status != StatusInProgress || got.AssignedNode != "box" || got.MirrorRev != 3 {
+		t.Fatalf("Put did not persist verbatim: %+v", got)
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Errorf("Put overwrote CreatedAt: %v", got.CreatedAt)
+	}
+
+	in.Status = StatusReadyPR
+	if _, err := store.Put(in); err != nil {
+		t.Fatalf("second Put (upsert): %v", err)
+	}
+	got, _ = store.Get("mirror-1")
+	if got.Status != StatusReadyPR {
+		t.Errorf("upsert status = %s, want ready-pr", got.Status)
+	}
+	all, _ := store.List()
+	n := 0
+	for i := range all {
+		if all[i].ID == "mirror-1" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("upsert produced %d copies, want 1", n)
+	}
+}
+
+func TestStorePutRequiresID(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Put(Task{Title: "no id"}); err == nil {
+		t.Fatal("Put must reject a task with no ID")
+	}
+}


### PR DESCRIPTION
## Motivation

P2 of the leader-follower umbrella (#1803). Adds the entry point for a
leader-pushed task on a follower — the follower's execution-mirror write
path. Parallel with P1. No behavior change for standalone installs.

> Changelog: feat(cluster): follower AssignTask RPC

## Implementation information

- **`TaskService.AssignTask(task)`** validates the pushed DTO and writes it
  to the local store verbatim via a new `task.Store.Put` / `task.Manager.Put`
  (upsert by ID, preserving the leader's id/status/workflow). Added to the
  `TaskService` allowlist; bindings + api shims regenerated.
- **Dispatch** — `Manager.Put` fires the status-change hook on any status
  change (mirroring `UpdateFn` under the per-task lock, with the same
  file-watcher dedupe), so a task pushed directly at — or transitioned to —
  `ready-review`/`testing`/`ready-pr` runs its stage dispatch, while fresh
  `todo` pushes dispatch via the external-task path. Nothing downstream
  changes.

### Security (from adversarial review)

The pushed `t.ID` is composed into `<id>.md` under the tasks dir, so an
unvalidated leader-supplied ID like `../../etc/passwd` would escape it (the
#1576 board-wipe blast radius, now network-reachable). New `task.ValidateID`
(safe charset, no path separators/dots) is enforced in both `Store.Put` and
`AssignTask` (rejected with a 400).

### Verification

- `go test -race ./internal/task/... ./internal/sybra/...` green; golangci +
  nilaway clean; frontend check green; bindings/shim in sync.
- Adversarial code review + adversarial runtime testing run pre-PR.
- **Real-server probe**: started `sybra-server`, drove the live
  `POST /api/TaskService/AssignTask` — a valid task persists and round-trips;
  a pushed `ready-review` fires stage dispatch; `../../etc/passwd`, a missing
  title, a bad status → 400 (no filesystem escape); no token → 401.
- Tests assert the dispatch half of the acceptance criteria (hook fires on a
  pushed stage status and on a transition; no re-fire on a title-only push).

Closes #1806