### PR TITLE
feat(cluster): leader assigner and mirror

### DIFF
--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -79,6 +79,8 @@ type Recovery struct {
 	LogRetention time.Duration // 0 disables age-based pruning
 	OrphanRoots  []string
 
+	DispatchGate func(task.Task) bool
+
 	// TrashRetentionDays bounds how long a soft-deleted task (see
 	// task.Store.Delete) survives under the trash dir before
 	// pruneTrash permanently removes it. A negative value disables

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -333,6 +333,64 @@ func TestRunStartupCleanup_PruneTrashZeroUsesDefaultRetention(t *testing.T) {
 // in-progress task whose latest agent run started seconds ago is left
 // alone (no respawn) so a hot-reloaded App doesn't race a still-living
 // subprocess from the prior lifecycle.
+func TestRestartStaleSkipsGatedTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("remote", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/pet"
+	if _, err := tasks.Update(created.ID, task.Update{Status: &inProg, ProjectID: &projID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ag-1",
+		Mode:      "headless",
+		State:     string(agent.StateRunning),
+		StartedAt: time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+		DispatchGate: func(tk task.Task) bool { return tk.ProjectID != "owner/pet" },
+	}
+	r.RestartStaleInProgress(context.Background())
+	wg.Wait()
+
+	if stub.startCalls != 0 {
+		t.Errorf("gated (remote-homed) task was restarted %d times; want 0 — the leader must not run a follower's task", stub.startCalls)
+	}
+}
+
 func TestRestartStaleSkipsRecentRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -35,6 +35,9 @@ func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
 		if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
 			continue
 		}
+		if r.DispatchGate != nil && !r.DispatchGate(t) {
+			continue
+		}
 		if t.Status != task.StatusInProgress {
 			continue
 		}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Automaat/sybra/internal/spotlight"
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
+	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/completion"
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/task"
@@ -92,6 +93,8 @@ type App struct {
 	learningDigestSvc *learning.Service
 	agentOrch         *agentorch.Orchestrator
 	reviewer          *review.Handler
+	assigner          *clusterlead.Assigner
+	mirror            *clusterlead.Mirror
 	workflowEngine    *workflow.Engine
 	workflowStore     *workflow.Store
 	todoist           *todoistCoordinator
@@ -434,6 +437,8 @@ func (a *App) Startup(ctx context.Context) error {
 	a.reviewer = review.New(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees, a.renovatePRsForMonitor, a.cfg, a.experience)
 
 	a.initWorkflowEngine()
+
+	a.initCluster()
 
 	a.initAgentConfig()
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -435,6 +435,11 @@ func (a *App) initStatusHook() {
 		}
 		a.logAudit(audit.EventTaskStatusChanged, taskID, "", data)
 
+		local := true
+		if t, err := a.tasks.Get(taskID); err == nil {
+			local = a.runsTaskLocally(t)
+		}
+
 		// Wake the dispatch pass immediately so a task that just became ready
 		// (e.g. a dependency completing, a stage advancing) is picked up now
 		// instead of waiting for the next fast tick.
@@ -443,10 +448,10 @@ func (a *App) initStatusHook() {
 		// Advance workflows whose current run_agent step declares a
 		// matching wait_for_status. This is how interactive agents (which
 		// never exit between turns) signal step completion.
-		if a.workflowEngine != nil {
+		if local && a.workflowEngine != nil {
 			a.workflowEngine.HandleStatusChange(taskID, to)
 		}
-		if releaseTaskAgents {
+		if local && releaseTaskAgents {
 			a.releaseTaskAgents(taskID)
 		}
 
@@ -467,7 +472,7 @@ func (a *App) initStatusHook() {
 			if a.notifier != nil {
 				a.notifier.Send(notification.LevelWarning, "Needs human", msg, taskID, "")
 			}
-			if a.humanReview != nil {
+			if local && a.humanReview != nil {
 				go a.humanReview.maybeSpawn(taskID, from)
 			}
 		case string(task.StatusReadyReview):
@@ -477,7 +482,9 @@ func (a *App) initStatusHook() {
 		case string(task.StatusReadyPR):
 			a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
 		case string(task.StatusDone):
-			go a.closeLinkedIssueOnDone(taskID)
+			if local {
+				go a.closeLinkedIssueOnDone(taskID)
+			}
 		}
 	})
 }
@@ -1026,6 +1033,7 @@ func (a *App) newRecovery() *recovery.Recovery {
 			filepath.Join(config.HomeDir(), "sandboxes"),
 			filepath.Join(config.HomeDir(), "worktrees"),
 		},
+		DispatchGate: a.runsTaskLocally,
 	}
 	// Gate on the config, not just a non-nil snapshotter: the snapshotter is
 	// always constructed, but when the feature is disabled its repo is never

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Automaat/sybra/internal/recovery"
 	"github.com/Automaat/sybra/internal/skillsync"
 	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/triage"
@@ -550,6 +551,33 @@ func (a *App) releaseTaskAgents(taskID string) {
 	}(filtered)
 }
 
+func (a *App) runsTaskLocally(t task.Task) bool {
+	return a.cfg == nil || a.cfg.HomeNodeFor(t.ProjectID).Local
+}
+
+func (a *App) initCluster() {
+	if a.workflowEngine != nil {
+		a.workflowEngine.SetDispatchGate(func(ti workflow.TaskInfo) bool {
+			return a.cfg == nil || a.cfg.HomeNodeFor(ti.ProjectID).Local
+		})
+	}
+	if a.cfg == nil || !a.cfg.IsLeader() {
+		return
+	}
+	roster, err := clusterlead.NewRoster(a.cfg, a.logger)
+	if err != nil {
+		a.logger.Error("cluster.roster.init.failed", "err", err)
+		return
+	}
+	if roster == nil || len(roster.Names()) == 0 {
+		a.logger.Info("cluster.leader.no-followers")
+		return
+	}
+	a.assigner = clusterlead.NewAssigner(a.cfg, a.tasks, roster, a.logger)
+	a.mirror = clusterlead.NewMirror(a.cfg, a.tasks, roster, a.logger, 0)
+	a.logger.Info("cluster.leader.enabled", "followers", roster.Names())
+}
+
 // dispatchStatusWorkflow starts the workflow matching a status-change event.
 //
 // ErrWorkflowAlreadyActive is benign for these status transitions:
@@ -575,6 +603,9 @@ func (a *App) releaseTaskAgents(taskID string) {
 //     testing/ready-review cases.
 func (a *App) dispatchStatusWorkflow(taskID string, status task.Status) {
 	if a.workflowEngine == nil {
+		return
+	}
+	if t, err := a.tasks.Get(taskID); err == nil && !a.runsTaskLocally(t) {
 		return
 	}
 
@@ -639,6 +670,14 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 		// no status condition, so without this guard a task.created dispatch
 		// could restart planning on an in-review/done task.
 		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
+			return
+		}
+		if !a.runsTaskLocally(t) {
+			if a.assigner != nil {
+				if _, err := a.assigner.Route(a.ctx, t); err != nil {
+					a.logger.Warn("cluster.assign.failed", "task_id", id, "err", err)
+				}
+			}
 			return
 		}
 		// pr-fix / ordinary existing-PR tasks are driven outside task.created.

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -52,6 +52,9 @@ func (a *App) orchestratorLoop(ctx context.Context) {
 func (a *App) dispatchPass(ctx context.Context) {
 	a.maybeStartOrchestrator(ctx)
 	a.releaseUnblockedChildren()
+	if a.assigner != nil {
+		a.assigner.Tick(ctx)
+	}
 }
 
 // maintenancePass runs the expensive, git/agent-touching recovery and cleanup.

--- a/internal/sybra/clusterlead/assigner.go
+++ b/internal/sybra/clusterlead/assigner.go
@@ -1,0 +1,90 @@
+package clusterlead
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Automaat/sybra/internal/cluster"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// Assigner routes a leader's canonical tasks to the follower that homes their
+// project: it pushes the task via the follower control plane and stamps
+// AssignedNode on the canonical copy so the local dispatch paths (gated on
+// HomeNodeFor) leave it to the follower. Inert on a non-leader node.
+type Assigner struct {
+	cfg    *config.Config
+	tasks  *task.Manager
+	roster *cluster.Roster
+	logger *slog.Logger
+}
+
+// NewAssigner constructs an Assigner. A nil logger falls back to slog.Default().
+func NewAssigner(cfg *config.Config, tasks *task.Manager, roster *cluster.Roster, logger *slog.Logger) *Assigner {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Assigner{cfg: cfg, tasks: tasks, roster: roster, logger: logger}
+}
+
+// Tick scans the canonical store and routes every non-terminal task whose
+// project homes on a remote follower and that has not been routed there yet. It
+// is idempotent: a task already stamped with its home node is skipped, so
+// re-running the tick never re-pushes. Inert on a non-leader node.
+func (a *Assigner) Tick(ctx context.Context) {
+	if a.cfg == nil || !a.cfg.IsLeader() || a.tasks == nil || a.roster == nil {
+		return
+	}
+	tasks, err := a.tasks.List()
+	if err != nil {
+		a.logger.Warn("cluster.assign.list.failed", "err", err)
+		return
+	}
+	for i := range tasks {
+		t := tasks[i]
+		if task.IsTerminalStatus(t.Status) || t.TaskType == task.TaskTypeChat {
+			continue
+		}
+		home := a.cfg.HomeNodeFor(t.ProjectID)
+		if home.Local || t.AssignedNode == home.Name {
+			continue
+		}
+		if _, err := a.Route(ctx, t); err != nil {
+			a.logger.Warn("cluster.assign.failed", "task", t.ID, "node", home.Name, "err", err)
+			continue
+		}
+		a.logger.Info("cluster.assign.routed", "task", t.ID, "node", home.Name)
+	}
+}
+
+// Route pushes task t to its home follower and stamps AssignedNode on the
+// canonical copy. It returns routed=false with no error when the task homes
+// locally (the caller keeps the existing local path). Routing is best-effort
+// idempotent: the follower's AssignTask upserts by id, so a repeated push is
+// harmless.
+func (a *Assigner) Route(ctx context.Context, t task.Task) (routed bool, err error) {
+	home := a.cfg.HomeNodeFor(t.ProjectID)
+	if home.Local {
+		return false, nil
+	}
+	client, ok := a.roster.Client(home.Name)
+	if !ok || client == nil {
+		return false, fmt.Errorf("clusterlead: no follower client for node %q", home.Name)
+	}
+	push := t
+	push.AssignedNode = home.Name
+	if err := client.AssignTask(ctx, push); err != nil {
+		return false, fmt.Errorf("clusterlead: assign %s to %s: %w", t.ID, home.Name, err)
+	}
+	cur, err := a.tasks.Get(t.ID)
+	if err != nil {
+		return true, fmt.Errorf("clusterlead: reload %s after assign: %w", t.ID, err)
+	}
+	cur.AssignedNode = home.Name
+	if _, _, err := a.tasks.Put(cur); err != nil {
+		return true, fmt.Errorf("clusterlead: stamp assigned_node on %s: %w", t.ID, err)
+	}
+	return true, nil
+}

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -1,0 +1,217 @@
+package clusterlead
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type followerStub struct {
+	mu       sync.Mutex
+	assigned []task.Task
+	tasks    []task.Task
+}
+
+func (f *followerStub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		switch r.URL.Path {
+		case "/api/TaskService/AssignTask":
+			var args []task.Task
+			_ = json.Unmarshal(body, &args)
+			if len(args) == 1 {
+				f.mu.Lock()
+				f.assigned = append(f.assigned, args[0])
+				f.mu.Unlock()
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/api/TaskService/ListTasks":
+			f.mu.Lock()
+			_ = json.NewEncoder(w).Encode(f.tasks)
+			f.mu.Unlock()
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (f *followerStub) lastAssigned() (task.Task, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.assigned) == 0 {
+		return task.Task{}, false
+	}
+	return f.assigned[len(f.assigned)-1], true
+}
+
+func leaderConfig(followerURL string, homes []string) *config.Config {
+	return &config.Config{Cluster: config.ClusterConfig{
+		Role: config.ClusterRoleLeader,
+		Followers: []config.Follower{{
+			Name:      "pet-box",
+			Endpoints: []string{followerURL},
+			Homes:     homes,
+		}},
+	}}
+}
+
+func newManager(t *testing.T) *task.Manager {
+	t.Helper()
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return task.NewManager(store, task.EmitterFunc(func(string, any) {}))
+}
+
+func TestAssignerRoutesRemoteAndStamps(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	assigner := NewAssigner(cfg, mgr, roster, nil)
+
+	if _, _, err := mgr.Put(task.Task{ID: "task-pet", Title: "t", Status: task.StatusTodo, ProjectID: "owner/pet"}); err != nil {
+		t.Fatal(err)
+	}
+	cur, _ := mgr.Get("task-pet")
+
+	routed, err := assigner.Route(context.Background(), cur)
+	if err != nil || !routed {
+		t.Fatalf("Route remote: routed=%v err=%v", routed, err)
+	}
+	got, ok := stub.lastAssigned()
+	if !ok || got.ID != "task-pet" || got.AssignedNode != "pet-box" {
+		t.Fatalf("follower did not receive the assigned task with node stamp: %+v", got)
+	}
+	after, _ := mgr.Get("task-pet")
+	if after.AssignedNode != "pet-box" {
+		t.Errorf("canonical AssignedNode = %q, want pet-box", after.AssignedNode)
+	}
+}
+
+func TestAssignerLeavesLocalTaskAlone(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	assigner := NewAssigner(cfg, mgr, roster, nil)
+
+	local := task.Task{ID: "task-local", Title: "t", Status: task.StatusTodo, ProjectID: "owner/other"}
+	routed, err := assigner.Route(context.Background(), local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if routed {
+		t.Error("a locally-homed task must not be routed to a follower")
+	}
+	if _, ok := stub.lastAssigned(); ok {
+		t.Error("follower received a task it should not have")
+	}
+}
+
+func TestAssignerTickIsIdempotent(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	assigner := NewAssigner(cfg, mgr, roster, nil)
+
+	if _, _, err := mgr.Put(task.Task{ID: "task-pet", Title: "t", Status: task.StatusTodo, ProjectID: "owner/pet"}); err != nil {
+		t.Fatal(err)
+	}
+	assigner.Tick(context.Background())
+	assigner.Tick(context.Background())
+
+	stub.mu.Lock()
+	n := len(stub.assigned)
+	stub.mu.Unlock()
+	if n != 1 {
+		t.Errorf("Tick pushed the task %d times, want 1 (idempotent after AssignedNode stamped)", n)
+	}
+}
+
+func TestMirrorApplyConvergesAndDropsStale(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "task-pet", Title: "leader title", Status: task.StatusTodo,
+		ProjectID: "owner/pet", AssignedNode: "pet-box", CreatedAt: t0, UpdatedAt: t0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	newer := task.Task{
+		ID: "task-pet", Title: "follower title", Status: task.StatusInReview,
+		ProjectID: "attacker/x", AssignedNode: "elsewhere", Branch: "feat/x", UpdatedAt: t0.Add(time.Hour),
+	}
+	if !mirror.applyFollowerTask("pet-box", newer) {
+		t.Fatal("newer follower state must apply")
+	}
+	got, _ := mgr.Get("task-pet")
+	if got.Status != task.StatusInReview || got.Branch != "feat/x" {
+		t.Errorf("execution not mirrored: %+v", got)
+	}
+	if got.Title != "leader title" || got.ProjectID != "owner/pet" || got.AssignedNode != "pet-box" {
+		t.Errorf("identity was overwritten by follower: %+v", got)
+	}
+	if got.MirrorRev != 1 {
+		t.Errorf("MirrorRev = %d, want 1", got.MirrorRev)
+	}
+
+	stale := newer
+	stale.Status = task.StatusTodo
+	stale.UpdatedAt = t0.Add(30 * time.Minute)
+	if mirror.applyFollowerTask("pet-box", stale) {
+		t.Error("stale (older UpdatedAt) follower state must be dropped")
+	}
+	got, _ = mgr.Get("task-pet")
+	if got.Status != task.StatusInReview || got.MirrorRev != 1 {
+		t.Errorf("stale update mutated canonical: %+v", got)
+	}
+}
+
+func TestMirrorIgnoresUnownedTask(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	if _, _, err := mgr.Put(task.Task{ID: "task-x", Status: task.StatusTodo, AssignedNode: "other-node", UpdatedAt: time.Unix(1, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	follower := task.Task{ID: "task-x", Status: task.StatusDone, UpdatedAt: time.Unix(100, 0)}
+	if mirror.applyFollowerTask("pet-box", follower) {
+		t.Error("a task not assigned to this node must not be mirrored from it")
+	}
+
+	if mirror.applyFollowerTask("pet-box", task.Task{ID: "ghost", UpdatedAt: time.Unix(100, 0)}) {
+		t.Error("a task the leader does not own must be ignored")
+	}
+}

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -197,6 +197,34 @@ func TestMirrorApplyConvergesAndDropsStale(t *testing.T) {
 	}
 }
 
+func TestMirrorClearsSidecarWhenFollowerClears(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := mgr.Put(task.Task{ID: "task-pet", Status: task.StatusTodo, AssignedNode: "pet-box", UpdatedAt: t0}); err != nil {
+		t.Fatal(err)
+	}
+
+	withPlan := task.Task{ID: "task-pet", Status: task.StatusPlanning, AssignedNode: "pet-box", Plan: "the plan", UpdatedAt: t0.Add(time.Hour)}
+	if !mirror.applyFollowerTask("pet-box", withPlan) {
+		t.Fatal("apply with plan")
+	}
+	if got, _ := mgr.Get("task-pet"); got.Plan != "the plan" {
+		t.Fatalf("plan not mirrored: %q", got.Plan)
+	}
+
+	cleared := task.Task{ID: "task-pet", Status: task.StatusInProgress, AssignedNode: "pet-box", Plan: "", UpdatedAt: t0.Add(2 * time.Hour)}
+	if !mirror.applyFollowerTask("pet-box", cleared) {
+		t.Fatal("apply with cleared plan")
+	}
+	if got, _ := mgr.Get("task-pet"); got.Plan != "" {
+		t.Errorf("follower cleared its plan but leader kept stale sidecar: %q", got.Plan)
+	}
+}
+
 func TestMirrorIgnoresUnownedTask(t *testing.T) {
 	cfg := leaderConfig("http://unused", []string{"owner/pet"})
 	roster, _ := NewRoster(cfg, nil)

--- a/internal/sybra/clusterlead/merge_test.go
+++ b/internal/sybra/clusterlead/merge_test.go
@@ -1,0 +1,131 @@
+package clusterlead
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/cluster"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestMergeAuthoritySplit(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+
+	canonical := task.Task{
+		ID:           "task-1",
+		ProjectID:    "owner/repo",
+		AssignedNode: "pet-box",
+		Title:        "leader ingested title",
+		Issue:        "https://github.com/owner/repo/issues/9",
+		TodoistID:    "td-1",
+		Status:       task.StatusTodo,
+		CreatedAt:    t0,
+		UpdatedAt:    t0,
+		MirrorRev:    4,
+	}
+	follower := task.Task{
+		ID:           "task-1",
+		ProjectID:    "attacker/evil",
+		AssignedNode: "somewhere-else",
+		Title:        "follower renamed it",
+		Issue:        "https://github.com/attacker/evil/issues/1",
+		Status:       task.StatusInReview,
+		StatusReason: "review drafted",
+		Branch:       "feat/x",
+		WorktreeDir:  "/wt/task-1",
+		PRNumber:     42,
+		Reviewed:     true,
+		Outcome:      "merged",
+		Plan:         "the plan",
+		CodeReview:   "the review",
+		UpdatedAt:    t1,
+	}
+
+	out, ok := Merge(canonical, follower)
+	if !ok {
+		t.Fatal("newer follower state must apply")
+	}
+
+	if out.ProjectID != "owner/repo" || out.AssignedNode != "pet-box" ||
+		out.Title != "leader ingested title" || out.Issue != canonical.Issue ||
+		out.TodoistID != "td-1" || !out.CreatedAt.Equal(t0) {
+		t.Errorf("identity fields must stay leader-authoritative: %+v", out)
+	}
+
+	if out.Status != task.StatusInReview || out.StatusReason != "review drafted" ||
+		out.Branch != "feat/x" || out.WorktreeDir != "/wt/task-1" || out.PRNumber != 42 ||
+		!out.Reviewed || out.Outcome != "merged" || out.Plan != "the plan" || out.CodeReview != "the review" {
+		t.Errorf("execution fields must be follower-authoritative: %+v", out)
+	}
+
+	if out.MirrorRev != 5 {
+		t.Errorf("MirrorRev = %d, want 5 (bumped once)", out.MirrorRev)
+	}
+	if out.MirrorUpdatedAt == nil || !out.MirrorUpdatedAt.Equal(t1) {
+		t.Errorf("MirrorUpdatedAt must track the follower clock (%v), got %v", t1, out.MirrorUpdatedAt)
+	}
+}
+
+func TestMergeDropsStaleAndOutOfOrder(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	applied := t0.Add(2 * time.Hour)
+	canonical := task.Task{ID: "task-1", AssignedNode: "n", Status: task.StatusInReview, MirrorRev: 7, MirrorUpdatedAt: &applied}
+
+	cases := []struct {
+		name              string
+		followerUpdatedAt time.Time
+		wantOK            bool
+	}{
+		{"older than applied is dropped", applied.Add(-time.Hour), false},
+		{"equal to applied is dropped", applied, false},
+		{"newer than applied applies", applied.Add(time.Minute), true},
+	}
+	for _, c := range cases {
+		follower := task.Task{ID: "task-1", AssignedNode: "n", Status: task.StatusTodo, UpdatedAt: c.followerUpdatedAt}
+		out, ok := Merge(canonical, follower)
+		if ok != c.wantOK {
+			t.Errorf("%s: ok = %v, want %v", c.name, ok, c.wantOK)
+		}
+		if !ok {
+			if out.MirrorRev != 7 || out.Status != task.StatusInReview {
+				t.Errorf("%s: a dropped update must not mutate canonical: %+v", c.name, out)
+			}
+		} else if out.MirrorRev != 8 {
+			t.Errorf("%s: applied MirrorRev = %d, want 8", c.name, out.MirrorRev)
+		}
+	}
+}
+
+func TestMergeFirstApplyWhenNeverMirrored(t *testing.T) {
+	canonical := task.Task{ID: "task-1", AssignedNode: "n", Status: task.StatusTodo, MirrorRev: 0}
+	follower := task.Task{ID: "task-1", AssignedNode: "n", Status: task.StatusInProgress, UpdatedAt: time.Unix(1, 0)}
+	out, ok := Merge(canonical, follower)
+	if !ok {
+		t.Fatal("first-ever mirror (nil MirrorUpdatedAt) must apply")
+	}
+	if out.MirrorRev != 1 || out.Status != task.StatusInProgress {
+		t.Errorf("first apply = %+v, want rev 1 + in-progress", out)
+	}
+}
+
+func TestTaskIDFromEvent(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventName string
+		eventData string
+		want      string
+	}{
+		{"task path", "task:updated", "/data/sybra/tasks/abc123.md", "abc123"},
+		{"quoted path", "task:created", `"/x/y/def456.md"`, "def456"},
+		{"non-task event", "agent:state", "/x/abc.md", ""},
+		{"empty", "task:updated", "", ""},
+		{"traversal basename resolves to basename", "task:updated", "/x/../y.md", "y"},
+	}
+	for _, c := range cases {
+		got := taskIDFromEvent(cluster.Event{Name: c.eventName, Data: c.eventData})
+		if got != c.want {
+			t.Errorf("%s: taskIDFromEvent = %q, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -1,0 +1,257 @@
+package clusterlead
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/cluster"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// DefaultReconcileInterval is how often the mirror re-lists each follower's
+// tasks, covering silent SSE drops and a leader restart.
+const DefaultReconcileInterval = 30 * time.Second
+
+// Mirror keeps the leader's canonical store in sync with follower execution
+// state. Per follower it consumes the SSE event stream (for immediacy) and runs
+// a reconcile ticker (for durability), applying both through one authority
+// merge: execution fields are follower-authoritative, identity/assignment
+// fields stay leader-authoritative, and a per-task monotonic clock drops stale
+// or out-of-order updates.
+type Mirror struct {
+	cfg      *config.Config
+	tasks    *task.Manager
+	roster   *cluster.Roster
+	logger   *slog.Logger
+	interval time.Duration
+}
+
+// NewMirror constructs a Mirror. A nil logger falls back to slog.Default(); a
+// non-positive interval falls back to DefaultReconcileInterval.
+func NewMirror(cfg *config.Config, tasks *task.Manager, roster *cluster.Roster, logger *slog.Logger, interval time.Duration) *Mirror {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if interval <= 0 {
+		interval = DefaultReconcileInterval
+	}
+	return &Mirror{cfg: cfg, tasks: tasks, roster: roster, logger: logger, interval: interval}
+}
+
+// Run starts, per follower, an SSE consumer and a reconcile ticker, and blocks
+// until ctx is cancelled. Inert on a non-leader node or with no roster.
+func (m *Mirror) Run(ctx context.Context) {
+	if m.cfg == nil || !m.cfg.IsLeader() || m.roster == nil {
+		return
+	}
+	var wg sync.WaitGroup
+	for _, name := range m.roster.Names() {
+		wg.Add(2)
+		go func(name string) { defer wg.Done(); m.streamLoop(ctx, name) }(name)
+		go func(name string) { defer wg.Done(); m.reconcileLoop(ctx, name) }(name)
+	}
+	wg.Wait()
+}
+
+func (m *Mirror) reconcileLoop(ctx context.Context, node string) {
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	m.reconcileNode(ctx, node)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.reconcileNode(ctx, node)
+		}
+	}
+}
+
+func (m *Mirror) reconcileNode(ctx context.Context, node string) {
+	client, ok := m.roster.Client(node)
+	if !ok || client == nil {
+		return
+	}
+	tasks, err := client.ListTasks(ctx)
+	if err != nil {
+		m.logger.Debug("cluster.mirror.reconcile.failed", "node", node, "err", err)
+		return
+	}
+	for i := range tasks {
+		m.applyFollowerTask(node, tasks[i])
+	}
+}
+
+func (m *Mirror) streamLoop(ctx context.Context, node string) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		client, ok := m.roster.Client(node)
+		if !ok || client == nil {
+			return
+		}
+		ch, err := client.Subscribe(ctx)
+		if err != nil {
+			m.logger.Debug("cluster.mirror.subscribe.failed", "node", node, "err", err)
+			if !sleepCtx(ctx, m.interval) {
+				return
+			}
+			continue
+		}
+		m.consume(ctx, node, client, ch)
+	}
+}
+
+func (m *Mirror) consume(ctx context.Context, node string, client *cluster.Client, ch <-chan cluster.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, open := <-ch:
+			if !open {
+				return
+			}
+			id := taskIDFromEvent(ev)
+			if id == "" {
+				continue
+			}
+			follower, err := client.GetTask(ctx, id)
+			if err != nil {
+				m.logger.Debug("cluster.mirror.fetch.failed", "node", node, "task", id, "err", err)
+				continue
+			}
+			m.applyFollowerTask(node, follower)
+		}
+	}
+}
+
+func (m *Mirror) applyFollowerTask(node string, follower task.Task) bool {
+	canonical, err := m.tasks.Get(follower.ID)
+	if err != nil {
+		return false
+	}
+	if canonical.AssignedNode != node {
+		return false
+	}
+	merged, ok := Merge(canonical, follower)
+	if !ok {
+		return false
+	}
+	if _, _, err := m.tasks.Put(merged); err != nil {
+		m.logger.Warn("cluster.mirror.apply.failed", "node", node, "task", follower.ID, "err", err)
+		return false
+	}
+	m.writeSidecars(merged)
+	m.logger.Debug("cluster.mirror.applied", "node", node, "task", follower.ID, "status", string(merged.Status), "rev", merged.MirrorRev)
+	return true
+}
+
+func (m *Mirror) writeSidecars(t task.Task) {
+	if m.tasks == nil {
+		return
+	}
+	store := m.tasks.Store()
+	if t.Plan != "" {
+		_ = store.Plans().Write(t.ID, t.Plan)
+	}
+	if t.PlanContract != "" {
+		_ = store.PlanContracts().Write(t.ID, t.PlanContract)
+	}
+	if t.CodeReview != "" {
+		_ = store.CodeReviews().Write(t.ID, t.CodeReview)
+	}
+}
+
+// Merge produces the canonical task's next state from a follower's reported
+// state. Execution fields (status, agent runs, worktree/branch/PR, workflow,
+// review phases, sidecars) are follower-authoritative; identity and assignment
+// fields (id, project, assigned_node, ingested title, issue refs, created_at)
+// stay leader-authoritative. It returns ok=false when the follower state is not
+// newer than the last applied (stale or out-of-order), so the caller drops it.
+// MirrorRev increments per applied update and MirrorUpdatedAt tracks the
+// follower clock of the applied state.
+func Merge(canonical, follower task.Task) (task.Task, bool) {
+	if canonical.MirrorUpdatedAt != nil && !follower.UpdatedAt.After(*canonical.MirrorUpdatedAt) {
+		return canonical, false
+	}
+	out := canonical
+
+	out.Status = follower.Status
+	out.StatusReason = follower.StatusReason
+	out.StatusChangedAt = follower.StatusChangedAt
+	out.AgentRuns = follower.AgentRuns
+	out.Workflow = follower.Workflow
+	out.WorktreeDir = follower.WorktreeDir
+	out.Branch = follower.Branch
+	out.PRNumber = follower.PRNumber
+	out.PRPhase = follower.PRPhase
+	out.ReviewPhase = follower.ReviewPhase
+	out.Reviewed = follower.Reviewed
+	out.RunRole = follower.RunRole
+	out.Outcome = follower.Outcome
+	out.MergeCommit = follower.MergeCommit
+	out.Body = follower.Body
+	out.Plan = follower.Plan
+	out.PlanContract = follower.PlanContract
+	out.CodeReview = follower.CodeReview
+
+	out.MirrorRev = canonical.MirrorRev + 1
+	followerUpdated := follower.UpdatedAt
+	out.MirrorUpdatedAt = &followerUpdated
+	out.UpdatedAt = follower.UpdatedAt
+	return out, true
+}
+
+func taskIDFromEvent(ev cluster.Event) string {
+	if !strings.HasPrefix(ev.Name, "task:") {
+		return ""
+	}
+	base := filepath.Base(strings.TrimSpace(ev.Data))
+	base = strings.Trim(base, "\"")
+	id := strings.TrimSuffix(base, ".md")
+	if id == "" || id == "." || strings.ContainsAny(id, `/\`) {
+		return ""
+	}
+	return id
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func nodesFromConfig(cfg *config.Config) []cluster.Node {
+	if cfg == nil {
+		return nil
+	}
+	nodes := make([]cluster.Node, 0, len(cfg.Cluster.Followers))
+	for i := range cfg.Cluster.Followers {
+		f := cfg.Cluster.Followers[i]
+		nodes = append(nodes, cluster.Node{
+			Name:      f.Name,
+			Endpoints: f.Endpoints,
+			Token:     f.ResolveToken(),
+			TLSPin:    f.TLSPin,
+		})
+	}
+	return nodes
+}
+
+// NewRoster builds a cluster.Roster from the leader's configured followers. The
+// returned roster is empty (Names() is nil) when there are no followers; callers
+// check that rather than a nil roster.
+func NewRoster(cfg *config.Config, logger *slog.Logger) (*cluster.Roster, error) {
+	return cluster.NewRoster(nodesFromConfig(cfg), logger)
+}

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -164,20 +164,14 @@ func (m *Mirror) writeSidecars(t task.Task) error {
 		return nil
 	}
 	store := m.tasks.Store()
-	if t.Plan != "" {
-		if err := store.Plans().Write(t.ID, t.Plan); err != nil {
-			return err
-		}
+	if err := store.Plans().Write(t.ID, t.Plan); err != nil {
+		return err
 	}
-	if t.PlanContract != "" {
-		if err := store.PlanContracts().Write(t.ID, t.PlanContract); err != nil {
-			return err
-		}
+	if err := store.PlanContracts().Write(t.ID, t.PlanContract); err != nil {
+		return err
 	}
-	if t.CodeReview != "" {
-		if err := store.CodeReviews().Write(t.ID, t.CodeReview); err != nil {
-			return err
-		}
+	if err := store.CodeReviews().Write(t.ID, t.CodeReview); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -29,6 +29,7 @@ type Mirror struct {
 	roster   *cluster.Roster
 	logger   *slog.Logger
 	interval time.Duration
+	applyMu  sync.Mutex
 }
 
 // NewMirror constructs a Mirror. A nil logger falls back to slog.Default(); a
@@ -132,6 +133,9 @@ func (m *Mirror) consume(ctx context.Context, node string, client *cluster.Clien
 }
 
 func (m *Mirror) applyFollowerTask(node string, follower task.Task) bool {
+	m.applyMu.Lock()
+	defer m.applyMu.Unlock()
+
 	canonical, err := m.tasks.Get(follower.ID)
 	if err != nil {
 		return false
@@ -143,29 +147,39 @@ func (m *Mirror) applyFollowerTask(node string, follower task.Task) bool {
 	if !ok {
 		return false
 	}
+	if err := m.writeSidecars(merged); err != nil {
+		m.logger.Warn("cluster.mirror.sidecar.failed", "node", node, "task", follower.ID, "err", err)
+		return false
+	}
 	if _, _, err := m.tasks.Put(merged); err != nil {
 		m.logger.Warn("cluster.mirror.apply.failed", "node", node, "task", follower.ID, "err", err)
 		return false
 	}
-	m.writeSidecars(merged)
 	m.logger.Debug("cluster.mirror.applied", "node", node, "task", follower.ID, "status", string(merged.Status), "rev", merged.MirrorRev)
 	return true
 }
 
-func (m *Mirror) writeSidecars(t task.Task) {
+func (m *Mirror) writeSidecars(t task.Task) error {
 	if m.tasks == nil {
-		return
+		return nil
 	}
 	store := m.tasks.Store()
 	if t.Plan != "" {
-		_ = store.Plans().Write(t.ID, t.Plan)
+		if err := store.Plans().Write(t.ID, t.Plan); err != nil {
+			return err
+		}
 	}
 	if t.PlanContract != "" {
-		_ = store.PlanContracts().Write(t.ID, t.PlanContract)
+		if err := store.PlanContracts().Write(t.ID, t.PlanContract); err != nil {
+			return err
+		}
 	}
 	if t.CodeReview != "" {
-		_ = store.CodeReviews().Write(t.ID, t.CodeReview)
+		if err := store.CodeReviews().Write(t.ID, t.CodeReview); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // Merge produces the canonical task's next state from a follower's reported

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -69,6 +69,9 @@ func (lm *LifecycleManager) StartManagers(ctx context.Context, emit func(string,
 func (lm *LifecycleManager) StartPollers(ctx context.Context, emit func(string, any), issuesFetcher *poll.IssuesFetcher) {
 	a := lm.app
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
+	if a.mirror != nil {
+		a.wg.Go(func() { a.mirror.Run(ctx) })
+	}
 	lm.startAppAuthLoop(ctx)
 	lm.startRateBudgetLoop(ctx)
 	lm.startPollHub(ctx, issuesFetcher)

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -578,6 +578,9 @@ func (s *TaskService) startCreatedWorkflow(t task.Task) {
 	if s.workflowEngine == nil || t.Status != task.StatusTodo {
 		return
 	}
+	if s.cfg != nil && !s.cfg.HomeNodeFor(t.ProjectID).Local {
+		return
+	}
 	// pr-fix / ordinary existing-PR tasks are driven outside task.created.
 	// Explicit handoff entry points are the exception: they intentionally route
 	// through task.created even when a PR number is already known.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1607,10 +1607,10 @@ func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
 	if err != nil {
 		return err
 	}
+	now := time.Now().UTC()
 	if status != nil {
 		oldStatus := t.Status
 		t.Status = *status
-		now := time.Now().UTC()
 		if oldStatus != t.Status {
 			t.StatusChangedAt = now
 		} else {
@@ -1624,10 +1624,11 @@ func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
 			t.ClosedAt = nil
 		}
 	} else {
-		backfillStatusChangedAt(&t, time.Now().UTC())
+		backfillStatusChangedAt(&t, now)
 	}
 	t.AgentRuns = append(t.AgentRuns, run)
-	d, err := Marshal(t)
+	t.UpdatedAt = now
+	d, err := marshalTask(t, false)
 	if err != nil {
 		return err
 	}
@@ -1808,8 +1809,10 @@ func (s *Store) UpdateRun(taskID, agentID string, patch RunPatch) error {
 	if !found {
 		return fmt.Errorf("agent run %s not found for task %s", agentID, taskID)
 	}
-	backfillStatusChangedAt(&t, time.Now().UTC())
-	d, err := Marshal(t)
+	now := time.Now().UTC()
+	backfillStatusChangedAt(&t, now)
+	t.UpdatedAt = now
+	d, err := marshalTask(t, false)
 	if err != nil {
 		return err
 	}

--- a/internal/task/store_addrun_updatedat_test.go
+++ b/internal/task/store_addrun_updatedat_test.go
@@ -1,0 +1,75 @@
+package task
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAddRunBumpsUpdatedAtConsistently(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := store.Create("t", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := created.UpdatedAt
+
+	time.Sleep(2 * time.Millisecond)
+	inProg := StatusInProgress
+	if err := store.AddRunWithStatus(created.ID, AgentRun{AgentID: "a1", State: "running", StartedAt: time.Now()}, &inProg); err != nil {
+		t.Fatal(err)
+	}
+
+	fromDisk, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fromDisk.UpdatedAt.After(before) {
+		t.Errorf("AddRunWithStatus did not advance UpdatedAt on disk: before=%v after=%v", before, fromDisk.UpdatedAt)
+	}
+	if fromDisk.Status != StatusInProgress {
+		t.Errorf("status = %s, want in-progress", fromDisk.Status)
+	}
+
+	listed, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cached Task
+	for i := range listed {
+		if listed[i].ID == created.ID {
+			cached = listed[i]
+		}
+	}
+	if !cached.UpdatedAt.Equal(fromDisk.UpdatedAt) {
+		t.Errorf("cache (List) UpdatedAt %v disagrees with disk (Get) %v — the mirror clock would be non-monotonic across paths", cached.UpdatedAt, fromDisk.UpdatedAt)
+	}
+}
+
+func TestUpdateRunBumpsUpdatedAt(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := store.Create("t", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddRun(created.ID, AgentRun{AgentID: "a1", State: "running", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	mid, _ := store.Get(created.ID)
+
+	time.Sleep(2 * time.Millisecond)
+	if err := store.UpdateRun(created.ID, "a1", RunPatch{HeadSHA: Ptr("abc123")}); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := store.Get(created.ID)
+	if !after.UpdatedAt.After(mid.UpdatedAt) {
+		t.Errorf("UpdateRun did not advance UpdatedAt: mid=%v after=%v", mid.UpdatedAt, after.UpdatedAt)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -301,6 +301,7 @@ type Engine struct {
 	costBudget       CostBudgetChecker
 	attemptWorktrees AttemptWorktreeManager
 	onComplete       func(CompletionInfo)
+	dispatchGate     func(TaskInfo) bool
 	logger           *slog.Logger
 	ctx              context.Context
 	mu               sync.Mutex
@@ -370,6 +371,12 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 // context.WithTimeout(parent, shellTimeout) so they are cancelled when
 // the parent context is cancelled (e.g. on app shutdown).
 func (e *Engine) SetContext(ctx context.Context) { e.ctx = ctx }
+
+// SetDispatchGate installs a predicate that reports whether a task should run
+// its workflow on this node. ResumeStalled skips any task the gate rejects — in
+// leader-follower mode a task homed on a remote follower executes there, and the
+// leader only mirrors its state. A nil gate (the default) runs every task.
+func (e *Engine) SetDispatchGate(gate func(TaskInfo) bool) { e.dispatchGate = gate }
 
 // Defs returns the workflow definition store.
 func (e *Engine) Defs() *Store { return e.store }

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -884,6 +884,9 @@ func (e *Engine) ResumeStalled() {
 		if t.Workflow == nil || t.Workflow.CurrentStep == "" {
 			continue
 		}
+		if e.dispatchGate != nil && !e.dispatchGate(*t) {
+			continue
+		}
 		switch t.Workflow.State {
 		case ExecCompleted, ExecFailed:
 			continue


### PR DESCRIPTION
## Motivation

P3 of the leader-follower umbrella (#1803) — the core: the leader routes
polled tasks to their home node and keeps the canonical store in sync with
follower execution. Depends on P1 + P2 (both merged). No behavior change for
standalone installs (the gate is a no-op when `HomeNodeFor` always resolves
local).

> Changelog: feat(cluster): leader assigner and canonical mirror

## Implementation information

New `internal/sybra/clusterlead` (nested under the god-package per the
extraction rule):

- **Assigner** — each dispatch tick (and on task creation) it routes every
  non-terminal task whose project homes on a remote follower: pushes the task
  (`AssignedNode` stamped) via the follower control plane and stamps the
  canonical copy. Idempotent (skips an already-stamped task); local tasks keep
  the existing path.
- **Mirror** — per follower, consumes the SSE stream (immediacy) plus a 30s
  reconcile ticker (durability, restart recovery), applying both through one
  authority `Merge`: execution fields (status, agent_runs, worktree/branch/PR,
  workflow, sidecars) are follower-authoritative; identity (id, project,
  assigned_node, ingested title, created_at) stays leader-authoritative. A
  per-task follower clock (`MirrorUpdatedAt`) drops stale/out-of-order updates;
  `MirrorRev` bumps per apply.
- **Dispatch gate** — the leader must never locally run a remote-homed task.
  Gated on `HomeNodeFor`: the two `task.created` entry points,
  `dispatchStatusWorkflow`, the workflow engine's `ResumeStalled` (new
  `SetDispatchGate`), `recovery.RestartStaleInProgress` (new `DispatchGate`),
  and the status hook's execution side effects (`HandleStatusChange`,
  `humanReview.maybeSpawn`, `closeLinkedIssueOnDone`).

### Notable correctness fix

`AddRun`/`AddRunWithStatus`/`UpdateRun` now set `UpdatedAt` and cache it
consistently with disk. Previously the run-append path bumped `UpdatedAt` only
in the marshalled bytes, so the in-memory cache (`List`) and disk (`Get`)
disagreed — which would have made the mirror's monotonic clock non-monotonic
and silently dropped a follower's `todo→in-progress` flip.

### Verification

- `go test -race ./internal/task/... ./internal/sybra/... ./internal/recovery/... ./internal/workflow/...` green; golangci + nilaway clean; no bindings drift.
- Adversarial code review + adversarial runtime testing run pre-PR (the review caught the `RestartStaleInProgress` double-execution path, the non-monotonic mirror clock, a non-atomic apply race, and ungated status-hook side effects — all fixed).
- **Two-node runtime probe**: a real leader server routed a created task to a
  real follower server (follower received it with `assignedNode=pet-box`,
  leader stamped it, **zero** local agents spawned on the leader); the follower
  then ran the task through its stages autonomously and the leader's canonical
  mirror tracked every transition (`mirrorRev` 1→8) while preserving
  leader-authoritative identity.
- Unit tests: `Merge` authority matrix, staleness/out-of-order drop, first-apply;
  assigner local-vs-remote routing + idempotency; mirror convergence + unowned-task
  ignore; recovery skips a gated task; `AddRun`/`UpdateRun` advance `UpdatedAt`
  consistently across cache and disk.

Closes #1807