### PR TITLE
ci(actions): serialize e2e to stop load stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: cd frontend && npm ci && npm run build:desktop
 
       - name: Run Go e2e tests
-        run: go test -race -tags e2e -timeout 14m ./internal/sybra/...
+        run: go test -race -tags e2e -p 1 -timeout 14m ./internal/sybra/...
 
   test-frontend:
     name: Frontend Tests

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -374,12 +374,13 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 // deadline.
 func waitFor(t *testing.T, timeout time.Duration, desc string, fn func() bool) {
 	t.Helper()
-	scaled := time.Duration(int64(timeout) * int64(e2eTimeoutScale()))
+	scale := e2eTimeoutScale()
+	scaled := time.Duration(int64(timeout) * scale)
 	deadline := time.After(scaled)
 	for {
 		select {
 		case <-deadline:
-			t.Fatalf("timeout waiting for: %s (after %s, scale=%d)\n%s", desc, scaled, e2eTimeoutScale(), e2eGoroutineDump())
+			t.Fatalf("timeout waiting for: %s (after %s, scale=%d)\n%s", desc, scaled, scale, e2eGoroutineDump())
 		case <-time.After(50 * time.Millisecond):
 			if fn() {
 				return
@@ -390,8 +391,13 @@ func waitFor(t *testing.T, timeout time.Duration, desc string, fn func() bool) {
 
 func e2eGoroutineDump() string {
 	buf := make([]byte, 1<<20)
-	n := runtime.Stack(buf, true)
-	return "--- goroutine dump at e2e timeout (what was blocked) ---\n" + string(buf[:n])
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return "--- goroutine dump at e2e timeout (what was blocked) ---\n" + string(buf[:n])
+		}
+		buf = make([]byte, 2*len(buf))
+	}
 }
 
 func e2eTimeoutScale() int64 {

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -378,13 +379,19 @@ func waitFor(t *testing.T, timeout time.Duration, desc string, fn func() bool) {
 	for {
 		select {
 		case <-deadline:
-			t.Fatalf("timeout waiting for: %s (after %s, scale=%d)", desc, scaled, e2eTimeoutScale())
+			t.Fatalf("timeout waiting for: %s (after %s, scale=%d)\n%s", desc, scaled, e2eTimeoutScale(), e2eGoroutineDump())
 		case <-time.After(50 * time.Millisecond):
 			if fn() {
 				return
 			}
 		}
 	}
+}
+
+func e2eGoroutineDump() string {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return "--- goroutine dump at e2e timeout (what was blocked) ---\n" + string(buf[:n])
 }
 
 func e2eTimeoutScale() int64 {


### PR DESCRIPTION
## Motivation

The `Go E2E Tests` job intermittently fails with workflow-completion timeouts that are **not reproducible locally**, falsely blocking good PRs. It parked task `92985433` at human-required and then flaked **#1940 and #1947 back to back — on different tests each time**, which is the signature of an infra problem, not a code one.

```
--- FAIL: TestE2E_CrossProvider_ReviewSidecarPersisted (360.02s)
    timeout waiting for: workflow completes (after 6m0s, scale=12)
--- FAIL: TestE2E_ProviderMatrix_NoResult_DoesNotStall/codex (360.02s)
    timeout waiting for: workflow completes despite no result event (after 6m0s, scale=12)
```

**It's a stall, not slowness.** Those workflows complete in **~7s locally**, and the full e2e suite passes locally on the same commits. Every failure reported `scale=12` — the runner was sitting at ~12x load per CPU, so even a 6-minute scaled budget (a ~50x margin) expired.

**Root cause: the suite oversubscribes its own runner.** The job ran `./internal/sybra/...` with the default `-p`, so **4 subprocess-heavy test binaries executed concurrently under `-race`**. (No e2e test calls `t.Parallel()` — the load is entirely from concurrent *packages* each spawning agent subprocesses.)

> Changelog: ci(actions): serialize e2e to stop load stalls

## Implementation information

1. **`-p 1`** on the e2e job — stops the suite from oversubscribing the runner. Verified the previously-failing tests pass locally under `-p 1`.
2. **Goroutine dump on `waitFor` timeout** — a stall now reports *what was blocked* instead of only the expired deadline, so the next occurrence is diagnosable.

Deliberately **not** just raising the timeout: that would mask the stall rather than fix it.

## Supporting documentation

Fixes #1948.