### PR TITLE
fix(agent): inherit sandbox posture on every spawn

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -381,6 +381,7 @@ func (m *Manager) ReplaceRuntimeConfig(cfg ManagerRuntimeConfig) error {
 	m.maxInFlightPerProvider = cfg.MaxInFlightPerProvider
 	m.dispatchJitterMs = cfg.DispatchJitterMs
 	m.headlessSteerable = cfg.HeadlessSteerable
+	m.defaultSandboxMode = cfg.SandboxMode
 	m.playwrightMCPEnabled = cfg.PlaywrightMCPEnabled
 	m.playwrightMCPExtraArgs = cfg.PlaywrightMCPExtraArgs
 	m.mu.Unlock()

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -76,11 +76,13 @@ type Manager struct {
 	// stdin/stream-json shape that accepts mid-run steer messages. See
 	// RunConfig.HeadlessSteerable.
 	headlessSteerable bool
-	gate              provider.HealthGate
-	limitGate         LimitGate
-	limitPolicy       limits.Policy
-	limitSink         func(limits.Snapshot)
-	evalPassed        abtest.EvalPassed
+
+	defaultSandboxMode string
+	gate               provider.HealthGate
+	limitGate          LimitGate
+	limitPolicy        limits.Policy
+	limitSink          func(limits.Snapshot)
+	evalPassed         abtest.EvalPassed
 
 	// liveByProvider tracks in-flight agent counts per provider, incremented
 	// and decremented in lockstep with liveCount (registerRunningAgent,
@@ -213,6 +215,7 @@ type ManagerRuntimeConfig struct {
 	FallbackModel   string
 	LimitGate       LimitGate
 	LimitPolicy     limits.Policy
+	SandboxMode     string
 	// MaxInFlightPerProvider caps concurrent in-flight agents per provider.
 	// 0 disables the cap.
 	MaxInFlightPerProvider int
@@ -259,6 +262,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		maxInFlightPerProvider: cfg.Runtime.MaxInFlightPerProvider,
 		dispatchJitterMs:       cfg.Runtime.DispatchJitterMs,
 		headlessSteerable:      cfg.Runtime.HeadlessSteerable,
+		defaultSandboxMode:     cfg.Runtime.SandboxMode,
 		sandboxHome:            cfg.SandboxHome,
 		controlHome:            cfg.ControlHome,
 		deadAgentRetention:     defaultDeadAgentRetention,

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -294,7 +294,13 @@ func (m *Manager) injectSharedBuildCache(cfg *RunConfig) error {
 // this run's spec falls back to "off" (unwrapped) instead of erroring, so a
 // misconfigured or unsupported host cannot break the default posture.
 func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
-	mode, err := config.NormalizeSandboxMode(cfg.SandboxMode)
+	requested := cfg.SandboxMode
+	if strings.TrimSpace(requested) == "" {
+		m.mu.RLock()
+		requested = m.defaultSandboxMode
+		m.mu.RUnlock()
+	}
+	mode, err := config.NormalizeSandboxMode(requested)
 	if err != nil {
 		return fmt.Errorf("agent.Run: sandbox mode: %w", err)
 	}

--- a/internal/agent/procsandbox_posture_test.go
+++ b/internal/agent/procsandbox_posture_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func newPostureManager(mode string) *Manager {
+	return &Manager{defaultSandboxMode: mode, logger: slog.New(slog.DiscardHandler)}
+}
+
+func TestInjectProcessSandbox_UnsetModeInheritsConfiguredPosture(t *testing.T) {
+	m := newPostureManager("enforce")
+
+	cfg := &RunConfig{}
+	_ = m.injectProcessSandbox(cfg)
+
+	if cfg.SandboxMode != "enforce" {
+		t.Fatalf("SandboxMode = %q, want enforce: a dispatch path that leaves SandboxMode unset "+
+			"must inherit the operator's configured posture, not silently fall back to report and "+
+			"run the agent unsandboxed", cfg.SandboxMode)
+	}
+}
+
+func TestInjectProcessSandbox_ExplicitModeWinsOverDefault(t *testing.T) {
+	m := newPostureManager("enforce")
+
+	cfg := &RunConfig{SandboxMode: "off"}
+	if err := m.injectProcessSandbox(cfg); err != nil {
+		t.Fatalf("injectProcessSandbox: %v", err)
+	}
+
+	if cfg.SandboxMode != "off" {
+		t.Errorf("SandboxMode = %q, want off: an explicit per-task opt-out must still win", cfg.SandboxMode)
+	}
+	if cfg.sandbox.mode != "off" {
+		t.Errorf("sandbox.mode = %q, want off", cfg.sandbox.mode)
+	}
+}

--- a/internal/agent/procsandbox_posture_test.go
+++ b/internal/agent/procsandbox_posture_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -12,13 +13,33 @@ func newPostureManager(mode string) *Manager {
 func TestInjectProcessSandbox_UnsetModeInheritsConfiguredPosture(t *testing.T) {
 	m := newPostureManager("enforce")
 
-	cfg := &RunConfig{}
-	_ = m.injectProcessSandbox(cfg)
+	cfg := &RunConfig{Dir: t.TempDir()}
+	err := m.injectProcessSandbox(cfg)
+	if err != nil && !strings.Contains(err.Error(), "enforce sandbox mode requires sandbox-exec") {
+		t.Fatalf("injectProcessSandbox: %v", err)
+	}
 
 	if cfg.SandboxMode != "enforce" {
 		t.Fatalf("SandboxMode = %q, want enforce: a dispatch path that leaves SandboxMode unset "+
 			"must inherit the operator's configured posture, not silently fall back to report and "+
 			"run the agent unsandboxed", cfg.SandboxMode)
+	}
+}
+
+func TestReplaceRuntimeConfigUpdatesDefaultSandboxPosture(t *testing.T) {
+	m := newPostureManager("report")
+
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{SandboxMode: "enforce"}); err != nil {
+		t.Fatalf("ReplaceRuntimeConfig: %v", err)
+	}
+
+	cfg := &RunConfig{Dir: t.TempDir()}
+	err := m.injectProcessSandbox(cfg)
+	if err != nil && !strings.Contains(err.Error(), "enforce sandbox mode requires sandbox-exec") {
+		t.Fatalf("injectProcessSandbox: %v", err)
+	}
+	if cfg.SandboxMode != "enforce" {
+		t.Fatalf("SandboxMode = %q, want enforce after live config reload", cfg.SandboxMode)
 	}
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -333,6 +333,7 @@ func (a *App) agentRuntimeConfig(cfg *config.Config) agent.ManagerRuntimeConfig 
 		MaxInFlightPerProvider: cfg.Providers.Limits.MaxInFlightPerProvider,
 		DispatchJitterMs:       cfg.Agent.DispatchJitterMs,
 		HeadlessSteerable:      cfg.DefaultHeadlessSteerable(),
+		SandboxMode:            cfg.DefaultSandboxMode(),
 		PlaywrightMCPEnabled:   cfg.PlaywrightMCPEnabled(),
 		PlaywrightMCPExtraArgs: cfg.PlaywrightMCPExtraArgs(),
 	}

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -262,6 +262,7 @@ func (s *ConfigService) managerRuntimeConfig(cfg config.Config) agent.ManagerRun
 		MaxInFlightPerProvider: cfg.Providers.Limits.MaxInFlightPerProvider,
 		DispatchJitterMs:       cfg.Agent.DispatchJitterMs,
 		HeadlessSteerable:      cfg.DefaultHeadlessSteerable(),
+		SandboxMode:            cfg.DefaultSandboxMode(),
 		PlaywrightMCPEnabled:   cfg.PlaywrightMCPEnabled(),
 		PlaywrightMCPExtraArgs: cfg.PlaywrightMCPExtraArgs(),
 	}


### PR DESCRIPTION
## Motivation

**Sandbox bypass.** Enabling `sandbox_mode: enforce` on the server sandboxed only *some* agents. Same task, ten minutes apart:

```
10:13:41  agent.sandbox.enforce   task=65d22ec3  (implementation) -> bwrap-wrapped
10:23:20  agent.sandbox.report    task=65d22ec3  (pr-fix)         -> UNWRAPPED
```

`injectProcessSandbox` normalizes `cfg.SandboxMode` — a per-`RunConfig` field that **only `agentorch` populates** (via `ResolveSandboxMode`). Dispatch paths that build a `RunConfig` directly — `internal/sybra/review`'s pr-fix/review dispatch (`inbound.go:115`), and any future spawn site — leave it empty, and an empty value normalizes to `"report"`. The agent then runs **completely unsandboxed even though the operator configured enforce**.

`newProviderCmd` already guarantees that no spawn site can obtain an unwrapped process *by construction*. The **posture had no such guarantee**: forgetting one call silently opted an entire dispatch path out of the sandbox.

> Changelog: fix(agent): inherit sandbox posture on every spawn

## Implementation information

Carry the configured mode on the `Manager` (`ManagerRuntimeConfig.SandboxMode`, wired from `cfg.DefaultSandboxMode()` in both the startup and live-settings-reload builders) and fall back to it when a `RunConfig` leaves `SandboxMode` unset. Every spawn now inherits the operator's posture regardless of dispatch path; an explicit per-task opt-out (`sandbox: false`) still wins.

Regression tests pin both halves: an unset mode inherits `enforce` rather than silently degrading to `report`, and an explicit `off` still overrides.

## Verification

Found by driving a real agent through `enforce` on the live server (not by inspection). The implementation agent came up bwrap-wrapped and completed cleanly — result parsed, cost and session captured — while the pr-fix agent for the *same task* was spawned straight from `sybra-server` with no bwrap parent.

## Supporting documentation

Follow-up to #1951 / #1595.