### PR TITLE
feat(abtest): add gated review prompt variant

### DIFF
--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -1,6 +1,10 @@
 package abtest
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
 
 // Config controls deterministic A/B assignment for workflow agent runs.
 type Config struct {
@@ -19,13 +23,35 @@ type Config struct {
 // returned by DefaultConfig. Bump this whenever the built-in experiments'
 // roles, variants, or weights change in a way that persisted configs should
 // pick up automatically.
-const CurrentBuiltinVersion = 4
+const CurrentBuiltinVersion = 5
 
 // BuiltinExperimentIDs lists the experiment IDs owned by Sybra's shipped
 // defaults. A persisted config's experiment is only replaced during a builtin
 // reconcile if its ID appears here — every other experiment ID is treated as
 // user-authored and preserved verbatim.
-var BuiltinExperimentIDs = []string{"code-author-cheap", "code-author-maintenance-cheap", "fix-review-expensive", "review-expensive"}
+var BuiltinExperimentIDs = []string{
+	"code-author-cheap",
+	"code-author-maintenance-cheap",
+	"fix-review-expensive",
+	"review-expensive",
+	"review-tighten-instructions-pl-a2d853b2c1d9",
+}
+
+const ReviewTightenInstructionsPLA2D853B2C1D9 = `
+
+Review variant pl-a2d853b2c1d9: apply a stricter staff-code-review standard before returning a verdict.
+
+- Lead with concrete blocking defects only: correctness, security, data loss, broken workflows, test gaps that can hide a regression, or repository-rule violations.
+- For every finding, name the exact file/line evidence and the user-visible failure mode. If you cannot tie a concern to behavior or a repo rule, omit it.
+- Check that implementation and tests cover the task's current acceptance criteria, including edge cases and failure paths. Treat missing focused tests as a finding when the change is risky or user-visible.
+- Separate must-fix-before-merge issues from optional cleanup; do not block on style preferences, speculative rewrites, or unrelated refactors.
+- If no blocking issues remain, say that clearly and call out any residual test or runtime verification gap.
+`
+
+func digestString(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
 
 // Experiment selects among variants for matching workflow roles.
 type Experiment struct {
@@ -142,11 +168,38 @@ func DefaultConfig() Config {
 				Enabled:        &expEnabled,
 				AssignmentUnit: "stage",
 				Bracket:        "expensive",
-				Roles:          []string{"review", "plan"},
+				Roles:          []string{"plan"},
 				Variants: []Variant{
 					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
 					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
 					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Tier: "expensive", Weight: 1},
+				},
+			},
+			{
+				ID:             "review-tighten-instructions-pl-a2d853b2c1d9",
+				Kind:           "compound",
+				Enabled:        &expEnabled,
+				AssignmentUnit: "stage",
+				Bracket:        "expensive",
+				Subject:        &Subject{Role: "review"},
+				Roles:          []string{"review"},
+				Variants: []Variant{
+					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
+					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
+					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Tier: "expensive", Weight: 1},
+					{
+						ID:       "pl-a2d853b2c1d9-codex-gpt-5.5",
+						Provider: "codex",
+						Model:    "gpt-5.5",
+						Tier:     "expensive",
+						Version:  "pl-a2d853b2c1d9",
+						Digest:   digestString(ReviewTightenInstructionsPLA2D853B2C1D9),
+						PromptTransform: &PromptTransform{
+							Op:   "append",
+							Text: ReviewTightenInstructionsPLA2D853B2C1D9,
+						},
+						Weight: 1,
+					},
 				},
 			},
 		},

--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -93,6 +93,26 @@ type PromptTransform struct {
 	Text string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 
+// ApplyPromptTransformOpText rewrites prompt per op/text: "replace"/
+// "template" overwrite it outright, "prepend"/"append" splice text in, any
+// other value (including empty) leaves prompt unchanged. Op and text are
+// taken as plain strings rather than *PromptTransform so dispatch paths that
+// mirror PromptTransform as a local type (e.g. internal/workflow, to avoid
+// depending on internal/abtest in their launcher interface) can still share
+// this logic instead of reimplementing the switch.
+func ApplyPromptTransformOpText(prompt, op, text string) string {
+	switch strings.TrimSpace(op) {
+	case "replace", "template":
+		return text
+	case "prepend":
+		return text + prompt
+	case "append":
+		return prompt + text
+	default:
+		return prompt
+	}
+}
+
 // Assignment is the durable identity selected for a workflow stage.
 type Assignment struct {
 	ExperimentID    string

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -1,7 +1,9 @@
 package abtest
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -161,16 +163,72 @@ func TestDefaultConfigUsesExpensiveBracketForReviewRoles(t *testing.T) {
 				if err != nil || !ok {
 					t.Fatalf("Select ok=%v err=%v", ok, err)
 				}
-				if a.ExperimentID != "review-expensive" {
-					t.Fatalf("ExperimentID = %q, want review-expensive", a.ExperimentID)
+				wantExp := "review-expensive"
+				if role == "review" {
+					wantExp = "review-tighten-instructions-pl-a2d853b2c1d9"
+				}
+				if a.ExperimentID != wantExp {
+					t.Fatalf("ExperimentID = %q, want %s", a.ExperimentID, wantExp)
 				}
 				switch a.VariantID {
-				case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro":
+				case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro", "pl-a2d853b2c1d9-codex-gpt-5.5":
 				default:
 					t.Fatalf("VariantID = %q, want expensive variant", a.VariantID)
 				}
 			}
 		})
+	}
+}
+
+func TestDefaultConfigReviewTightenVariantIsDigestedPromptTransform(t *testing.T) {
+	cfg := DefaultConfig()
+	var found *Variant
+	for i := range cfg.Experiments {
+		if cfg.Experiments[i].ID != "review-tighten-instructions-pl-a2d853b2c1d9" {
+			continue
+		}
+		if cfg.Experiments[i].KindValue() != "compound" {
+			t.Fatalf("Kind = %q, want compound", cfg.Experiments[i].KindValue())
+		}
+		if cfg.Experiments[i].Subject == nil || cfg.Experiments[i].Subject.Role != "review" {
+			t.Fatalf("Subject = %+v, want role review", cfg.Experiments[i].Subject)
+		}
+		for j := range cfg.Experiments[i].Variants {
+			if cfg.Experiments[i].Variants[j].ID == "pl-a2d853b2c1d9-codex-gpt-5.5" {
+				found = &cfg.Experiments[i].Variants[j]
+			}
+		}
+	}
+	if found == nil {
+		t.Fatal("prompt-lab review variant not found")
+	}
+	if found.Version != "pl-a2d853b2c1d9" {
+		t.Fatalf("Version = %q, want proposal id", found.Version)
+	}
+	if found.PromptTransform == nil || found.PromptTransform.Op != "append" || found.PromptTransform.Text != ReviewTightenInstructionsPLA2D853B2C1D9 {
+		t.Fatalf("PromptTransform = %+v, want append of reviewed text", found.PromptTransform)
+	}
+	if want := digestString(ReviewTightenInstructionsPLA2D853B2C1D9); found.Digest != want {
+		t.Fatalf("Digest = %q, want %q", found.Digest, want)
+	}
+
+	data, err := os.ReadFile("../prompteval/testdata/promptlab-review-tighten-codex-variants.json")
+	if err != nil {
+		t.Fatalf("read offline fixture: %v", err)
+	}
+	var fixtures []struct {
+		ID     string `json:"id"`
+		Digest string `json:"digest"`
+		Prompt string `json:"prompt"`
+	}
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatalf("parse offline fixture: %v", err)
+	}
+	if len(fixtures) != 1 {
+		t.Fatalf("offline fixture count = %d, want 1", len(fixtures))
+	}
+	if fixtures[0].ID != found.ID || fixtures[0].Digest != found.Digest || fixtures[0].Prompt != found.PromptTransform.Text {
+		t.Fatalf("offline fixture = %+v, want id/digest/prompt from default variant", fixtures[0])
 	}
 }
 

--- a/internal/agent/abvariant.go
+++ b/internal/agent/abvariant.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"os/exec"
-	"strings"
 
 	"github.com/Automaat/sybra/internal/abtest"
 )
@@ -66,14 +65,5 @@ func applyPromptTransform(prompt string, transform *abtest.PromptTransform) stri
 	if transform == nil {
 		return prompt
 	}
-	switch strings.TrimSpace(transform.Op) {
-	case "replace", "template":
-		return transform.Text
-	case "prepend":
-		return transform.Text + prompt
-	case "append":
-		return prompt + transform.Text
-	default:
-		return prompt
-	}
+	return abtest.ApplyPromptTransformOpText(prompt, transform.Op, transform.Text)
 }

--- a/internal/agent/abvariant.go
+++ b/internal/agent/abvariant.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"os/exec"
+	"strings"
 
 	"github.com/Automaat/sybra/internal/abtest"
 )
@@ -57,5 +58,22 @@ func (m *Manager) ApplyABVariant(cfg RunConfig, ab abtest.Config, taskID, role s
 	cfg.VariantID = a.VariantID
 	cfg.AssignmentUnit = a.AssignmentUnit
 	cfg.AssignmentKey = a.AssignmentKey
+	cfg.Prompt = applyPromptTransform(cfg.Prompt, a.PromptTransform)
 	return cfg
+}
+
+func applyPromptTransform(prompt string, transform *abtest.PromptTransform) string {
+	if transform == nil {
+		return prompt
+	}
+	switch strings.TrimSpace(transform.Op) {
+	case "replace", "template":
+		return transform.Text
+	case "prepend":
+		return transform.Text + prompt
+	case "append":
+		return prompt + transform.Text
+	default:
+		return prompt
+	}
 }

--- a/internal/agent/abvariant_test.go
+++ b/internal/agent/abvariant_test.go
@@ -55,6 +55,24 @@ func TestApplyABVariant_AssignsEligibleProvider(t *testing.T) {
 	}
 }
 
+func TestApplyABVariant_AppliesPromptTransform(t *testing.T) {
+	stubProviderCLIAvailable(t, func(string) bool { return true })
+	m := &Manager{}
+	ab := reviewExperiment(abtest.Variant{
+		ID:              "codex-prompt",
+		Provider:        "codex",
+		Model:           "gpt-5.5",
+		PromptTransform: &abtest.PromptTransform{Op: "append", Text: "\nUse the review variant."},
+		Weight:          1,
+	})
+
+	cfg := m.ApplyABVariant(RunConfig{Model: "opus", Prompt: "Run /staff-code-review"}, ab, "task-1", "review")
+
+	if want := "Run /staff-code-review\nUse the review variant."; cfg.Prompt != want {
+		t.Fatalf("Prompt = %q, want %q", cfg.Prompt, want)
+	}
+}
+
 func TestApplyABVariant_SkipsProviderWithMissingCLI(t *testing.T) {
 	stubProviderCLIAvailable(t, func(p string) bool { return p != "copilot" })
 	m := &Manager{}

--- a/internal/prompteval/testdata/promptlab-review-tighten-codex-variants.json
+++ b/internal/prompteval/testdata/promptlab-review-tighten-codex-variants.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "pl-a2d853b2c1d9-codex-gpt-5.5",
+    "digest": "dd292a14c07267500cff8fe4fba5c6dfb17fe8809b3ae545acd1794d2be3de84",
+    "prompt": "\n\nReview variant pl-a2d853b2c1d9: apply a stricter staff-code-review standard before returning a verdict.\n\n- Lead with concrete blocking defects only: correctness, security, data loss, broken workflows, test gaps that can hide a regression, or repository-rule violations.\n- For every finding, name the exact file/line evidence and the user-visible failure mode. If you cannot tie a concern to behavior or a repo rule, omit it.\n- Check that implementation and tests cover the task's current acceptance criteria, including edge cases and failure paths. Treat missing focused tests as a finding when the change is risky or user-visible.\n- Separate must-fix-before-merge issues from optional cleanup; do not block on style preferences, speculative rewrites, or unrelated refactors.\n- If no blocking issues remain, say that clearly and call out any residual test or runtime verification gap.\n",
+    "provider": "codex",
+    "model": "gpt-5.5",
+    "reasoningEffort": "medium"
+  }
+]

--- a/internal/prompteval/testdata/promptlab-review-tighten-golden.json
+++ b/internal/prompteval/testdata/promptlab-review-tighten-golden.json
@@ -1,0 +1,16 @@
+[
+  {
+    "caseId": "review-tighten-instructions-acceptance",
+    "input": "You are screening a candidate staff-code-review prompt variant. Reply with exactly REVIEW_PROMPT_ACCEPTED if the instructions above are coherent and safe to apply to a pull request review.",
+    "assertions": [
+      {
+        "type": "contains",
+        "value": "REVIEW_PROMPT_ACCEPTED"
+      },
+      {
+        "type": "not-contains",
+        "value": "ignore repository instructions"
+      }
+    ]
+  }
+]

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -188,7 +188,7 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 	h.mu.Unlock()
 
 	prompt := h.buildPrompt(t, wctx)
-	ag, err := h.agents.Run(h.agents.ApplyABVariant(agent.RunConfig{
+	cfg := h.agents.ApplyABVariant(agent.RunConfig{
 		TaskID:                 taskID,
 		Name:                   agent.RoleHumanReview.AgentName(t.Title),
 		Mode:                   "headless",
@@ -199,7 +199,8 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		OneShot:                true,
 		OutputSchema:           verdict.Schema,
 		IgnoreConcurrencyLimit: true,
-	}, h.cfg.ABTesting, taskID, string(agent.RoleHumanReview)))
+	}, h.cfg.ABTesting, taskID, string(agent.RoleHumanReview))
+	ag, err := h.agents.Run(cfg)
 	if err != nil {
 		h.mu.Lock()
 		delete(h.inflight, taskID)
@@ -219,7 +220,7 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		Provider:  ag.Provider,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
-		Prompt:    prompt,
+		Prompt:    cfg.Prompt,
 	}); err != nil {
 		h.logger.Error("human-review.add-run", "task_id", taskID, "agent_id", ag.ID, "err", err)
 	}

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -184,13 +184,14 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", current.ProjectID, current.PRNumber)
 
-	ag, err := r.agents.Run(r.agents.ApplyABVariant(StaffCodeReviewRunConfig(current, prompt, dir, posture), r.cfg.ABTesting, current.ID, string(agent.RoleReview)))
+	cfg := r.agents.ApplyABVariant(StaffCodeReviewRunConfig(current, prompt, dir, posture), r.cfg.ABTesting, current.ID, string(agent.RoleReview))
+	ag, err := r.agents.Run(cfg)
 	if err != nil {
 		return err
 	}
 	if err := r.tasks.AddRun(current.ID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RoleReview), Mode: "headless", State: string(agent.StateRunning), StartedAt: ag.StartedAt,
-		Prompt: prompt,
+		Prompt: cfg.Prompt,
 	}); err != nil {
 		r.logger.Error("task.add-run", "task_id", current.ID, "err", err)
 		if stopErr := r.agents.StopAgent(ag.ID); stopErr != nil {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -947,7 +947,8 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 	}
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
-	ag, err := s.agents.Run(s.agents.ApplyABVariant(review.StaffCodeReviewRunConfig(t, prompt, dir, posture), s.cfg.ABTesting, t.ID, string(agent.RoleReview)))
+	cfg := s.agents.ApplyABVariant(review.StaffCodeReviewRunConfig(t, prompt, dir, posture), s.cfg.ABTesting, t.ID, string(agent.RoleReview))
+	ag, err := s.agents.Run(cfg)
 	if err != nil {
 		return err
 	}
@@ -957,7 +958,7 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 		Mode:      "headless",
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
-		Prompt:    prompt,
+		Prompt:    cfg.Prompt,
 	}); err != nil {
 		s.logger.Error("task.add-run", "task_id", t.ID, "err", err)
 	}

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -404,16 +404,7 @@ func applyPromptTransform(prompt string, transform *PromptTransform) string {
 	if transform == nil {
 		return prompt
 	}
-	switch strings.TrimSpace(transform.Op) {
-	case "replace", "template":
-		return transform.Text
-	case "prepend":
-		return transform.Text + prompt
-	case "append":
-		return prompt + transform.Text
-	default:
-		return prompt
-	}
+	return abtest.ApplyPromptTransformOpText(prompt, transform.Op, transform.Text)
 }
 
 func workflowPromptTransform(in *abtest.PromptTransform) *PromptTransform {


### PR DESCRIPTION
## Summary
- add a review-specific compound A/B experiment for Prompt Lab proposal pl-a2d853b2c1d9
- add a digested Codex review prompt-transform variant plus offline eval fixtures
- apply prompt transforms for direct agent A/B dispatch paths such as staff review

## Verification
- go test ./internal/abtest ./internal/agent ./internal/config ./cmd/sybra-cli
- go run ./cmd/sybra-cli evaluation offline run --variants internal/prompteval/testdata/promptlab-review-tighten-codex-variants.json --golden internal/prompteval/testdata/promptlab-review-tighten-golden.json
- go run ./cmd/sybra-cli evaluation offline gate pl-a2d853b2c1d9-codex-gpt-5.5 dd292a14c07267500cff8fe4fba5c6dfb17fe8809b3ae545acd1794d2be3de84
- go test ./...
- golangci-lint run ./internal/abtest ./internal/agent
- pre-push hook: go test ./... and cd frontend && npm run check