### PR TITLE
feat(cluster): manual task reassignment

### DIFF
--- a/cmd/sybra-cli/cluster.go
+++ b/cmd/sybra-cli/cluster.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/sybra/clusterlead"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+const clusterCmdTimeout = 60 * time.Second
+
+func cmdCluster(cfg *config.Config, tasks *task.Manager, projects *project.Store, args []string, jsonOut bool) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "usage: sybra-cli cluster <nodes|reassign> [flags]")
+	}
+	switch args[0] {
+	case "nodes":
+		return cmdClusterNodes(cfg, jsonOut)
+	case "reassign":
+		return cmdClusterReassign(cfg, tasks, projects, args[1:], jsonOut)
+	default:
+		return fatal(jsonOut, "unknown cluster command: %s", args[0])
+	}
+}
+
+func cmdClusterNodes(cfg *config.Config, jsonOut bool) int {
+	if !cfg.IsLeader() {
+		return fatal(jsonOut, "this node is not a cluster leader")
+	}
+	type nodeOut struct {
+		Name      string `json:"name"`
+		Endpoint  string `json:"endpoint"`
+		Trusted   bool   `json:"trusted"`
+		Encrypted bool   `json:"encrypted"`
+		Homes     int    `json:"homes"`
+	}
+	out := make([]nodeOut, 0, len(cfg.Cluster.Followers))
+	for i := range cfg.Cluster.Followers {
+		f := cfg.Cluster.Followers[i]
+		out = append(out, nodeOut{
+			Name:      f.Name,
+			Endpoint:  f.PrimaryEndpoint(),
+			Trusted:   f.Trusted,
+			Encrypted: f.Encrypted(),
+			Homes:     len(f.Homes),
+		})
+	}
+	if jsonOut {
+		return printJSON(out)
+	}
+	if len(out) == 0 {
+		fmt.Println("no followers configured")
+		return 0
+	}
+	for _, n := range out {
+		fmt.Printf("%-16s %-32s trusted=%-5v encrypted=%-5v homes=%d\n", n.Name, n.Endpoint, n.Trusted, n.Encrypted, n.Homes)
+	}
+	return 0
+}
+
+func cmdClusterReassign(cfg *config.Config, tasks *task.Manager, projects *project.Store, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("reassign", flag.ContinueOnError)
+	node := fs.String("node", "", `target node name, or "local" to bring the task back to the leader`)
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if fs.NArg() != 1 {
+		return fatal(jsonOut, "usage: sybra-cli cluster reassign <task-id> --node <name>")
+	}
+	taskID := fs.Arg(0)
+	if *node == "" {
+		return fatal(jsonOut, "--node is required")
+	}
+	if !cfg.IsLeader() {
+		return fatal(jsonOut, "this node is not a cluster leader")
+	}
+
+	logger := slog.Default()
+	roster, err := clusterlead.NewRoster(cfg, logger)
+	if err != nil {
+		return fatal(jsonOut, "build roster: %v", err)
+	}
+	assigner := clusterlead.NewAssigner(cfg, tasks, roster, isWorkProject(projects), nil, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), clusterCmdTimeout)
+	defer cancel()
+	if err := assigner.Reassign(ctx, taskID, *node); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if jsonOut {
+		return printJSON(map[string]string{"id": taskID, "node": *node})
+	}
+	fmt.Printf("reassigned %s to %s\n", taskID, *node)
+	return 0
+}
+
+func isWorkProject(projects *project.Store) func(string) bool {
+	return func(projectID string) bool {
+		if projectID == "" {
+			return false
+		}
+		if projects == nil {
+			return true
+		}
+		rawType, err := projects.RawType(projectID)
+		if err != nil {
+			return true
+		}
+		return rawType != project.ProjectTypePet
+	}
+}

--- a/cmd/sybra-cli/cluster.go
+++ b/cmd/sybra-cli/cluster.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
@@ -64,16 +65,29 @@ func cmdClusterNodes(cfg *config.Config, jsonOut bool) int {
 	return 0
 }
 
+func splitLeadingID(args []string) (id string, rest []string) {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		return args[0], args[1:]
+	}
+	return "", args
+}
+
 func cmdClusterReassign(cfg *config.Config, tasks *task.Manager, projects *project.Store, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("reassign", flag.ContinueOnError)
 	node := fs.String("node", "", `target node name, or "local" to bring the task back to the leader`)
-	if err := fs.Parse(args); err != nil {
+
+	taskID, rest := splitLeadingID(args)
+	if err := fs.Parse(rest); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
-	if fs.NArg() != 1 {
+	if taskID == "" && fs.NArg() == 1 {
+		taskID = fs.Arg(0)
+	} else if taskID != "" && fs.NArg() > 0 {
 		return fatal(jsonOut, "usage: sybra-cli cluster reassign <task-id> --node <name>")
 	}
-	taskID := fs.Arg(0)
+	if taskID == "" {
+		return fatal(jsonOut, "usage: sybra-cli cluster reassign <task-id> --node <name>")
+	}
 	if *node == "" {
 		return fatal(jsonOut, "--node is required")
 	}

--- a/cmd/sybra-cli/cluster_test.go
+++ b/cmd/sybra-cli/cluster_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+func TestSplitLeadingID(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantID   string
+		wantRest []string
+	}{
+		{
+			name:     "documented id-first order",
+			args:     []string{"task-1", "--node", "pet-box"},
+			wantID:   "task-1",
+			wantRest: []string{"--node", "pet-box"},
+		},
+		{
+			name:     "flags-first order still works",
+			args:     []string{"--node", "pet-box", "task-1"},
+			wantID:   "",
+			wantRest: []string{"--node", "pet-box", "task-1"},
+		},
+		{
+			name:     "no args",
+			args:     nil,
+			wantID:   "",
+			wantRest: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, rest := splitLeadingID(tc.args)
+			if id != tc.wantID {
+				t.Fatalf("id = %q, want %q", id, tc.wantID)
+			}
+			if len(rest) != len(tc.wantRest) {
+				t.Fatalf("rest = %v, want %v", rest, tc.wantRest)
+			}
+			for i := range rest {
+				if rest[i] != tc.wantRest[i] {
+					t.Fatalf("rest = %v, want %v", rest, tc.wantRest)
+				}
+			}
+		})
+	}
+}

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -175,6 +175,8 @@ func dispatch(cmd string, rest []string, cfg *config.Config, store *task.Manager
 		return cmdReopen(store, rest, jsonOut)
 	case "project":
 		return cmdProject(projStore, rest, jsonOut)
+	case "cluster":
+		return cmdCluster(cfg, store, projStore, rest, jsonOut)
 	case "audit":
 		return cmdAudit(cfg, rest, jsonOut)
 	case "board":
@@ -1945,6 +1947,9 @@ Commands:
   project create --url <github-url> [--type pet|work]
   project update <id> --type pet|work
   project delete <id>
+
+  cluster nodes
+  cluster reassign <task-id> --node <name>   ("local" brings it back to the leader)
 
   audit    [--since DURATION|DATE] [--until DATE] [--type TYPE] [--task ID] [--summary]
   board    (status counts + in-progress/plan-review/human-required task lists)

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/clusterservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/clusterservice.ts
@@ -76,6 +76,16 @@ export function ListNodeAgents(): $CancellablePromise<(agent$0.Agent | null)[]> 
 }
 
 /**
+ * ReassignTask moves a task to an explicitly named node ("local" brings it back
+ * to the leader), overriding its project's configured home. The old node's
+ * agents for the task are stopped first when it is still reachable, so a
+ * merely-degraded follower cannot keep driving the branch alongside the new one.
+ */
+export function ReassignTask(taskID: string, node: string): $CancellablePromise<void> {
+    return $Call.ByID(3580635212, taskID, node);
+}
+
+/**
  * RejectPlanOnNode proxies a plan rejection (with feedback) to the named
  * follower.
  */

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -433,6 +433,7 @@ export class Task {
      */
     "statusChangedAt": string;
     "assignedNode"?: string;
+    "nodeOverride"?: string;
     "mirrorRev"?: number;
     "mirrorUpdatedAt"?: string | null;
     "body": string;
@@ -554,7 +555,7 @@ export class Task {
         const $$createField18_0 = $$createType0;
         const $$createField37_0 = $$createType2;
         const $$createField38_0 = $$createType4;
-        const $$createField53_0 = $$createType5;
+        const $$createField54_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -572,7 +573,7 @@ export class Task {
             $$parsedSource["workflow"] = $$createField38_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField53_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField54_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -12,6 +12,8 @@
   import TaskTagEditor from './TaskTagEditor.svelte'
   import TaskDueDateEditor from './TaskDueDateEditor.svelte'
   import TaskMaxTurnsEditor from './TaskMaxTurnsEditor.svelte'
+  import TaskNodeAssignment from './TaskNodeAssignment.svelte'
+  import { clusterStore } from '../../stores/cluster.svelte.js'
 
   interface Props {
     task: Task
@@ -124,6 +126,13 @@
       {/if}
     </button>
   </dd>
+
+  {#if clusterStore.enabled}
+    <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Node</dt>
+    <dd>
+      <TaskNodeAssignment {task} />
+    </dd>
+  {/if}
 
   {#if task.projectId}
     <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Branch</dt>

--- a/frontend/src/components/task-detail/TaskNodeAssignment.svelte
+++ b/frontend/src/components/task-detail/TaskNodeAssignment.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { Server } from '@lucide/svelte'
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { clusterStore } from '../../stores/cluster.svelte.js'
+  import { taskStore } from '../../stores/tasks.svelte.js'
+
+  interface Props {
+    task: Task
+  }
+
+  const { task }: Props = $props()
+
+  const LOCAL = 'local'
+
+  let busy = $state(false)
+  let error = $state('')
+
+  const current = $derived(task.assignedNode || LOCAL)
+  const status = $derived(clusterStore.statusOf(task.assignedNode))
+  const options = $derived([LOCAL, ...clusterStore.names])
+
+  async function reassign(node: string) {
+    if (node === current || busy) return
+    busy = true
+    error = ''
+    try {
+      await taskStore.reassign(task.id, node)
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      busy = false
+    }
+  }
+</script>
+
+{#if clusterStore.enabled}
+  <div class="flex items-center gap-1.5" data-testid="task-node-assignment">
+    <Server size={13} class="shrink-0 text-surface-400" />
+    <select
+      class="bg-transparent font-mono text-surface-700 disabled:opacity-50 dark:text-surface-300"
+      value={current}
+      disabled={busy}
+      aria-label="Execution node"
+      title={task.assignedNode ? `node ${task.assignedNode}: ${status || 'unknown'}` : 'runs on the leader'}
+      onchange={(e) => reassign((e.currentTarget as HTMLSelectElement).value)}
+    >
+      {#each options as node (node)}
+        <option value={node}>{node}</option>
+      {/each}
+    </select>
+    {#if error}
+      <span class="text-xs text-error-500" data-testid="task-node-error">{error}</span>
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/components/task-detail/TaskNodeAssignment.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskNodeAssignment.svelte.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte'
+
+const mockReassign = vi.fn()
+
+vi.mock('../../stores/tasks.svelte.js', () => ({
+  taskStore: { reassign: (...args: unknown[]) => mockReassign(...args) },
+}))
+
+vi.mock('../../stores/cluster.svelte.js', () => ({
+  clusterStore: {
+    get enabled() {
+      return clusterEnabled
+    },
+    get names() {
+      return clusterNames
+    },
+    statusOf: (n: string | undefined) => (n === 'pet-box' ? 'online' : ''),
+  },
+}))
+
+let clusterEnabled = true
+let clusterNames: string[] = ['pet-box', 'gpu-box']
+
+const TaskNodeAssignment = (await import('./TaskNodeAssignment.svelte')).default
+
+function task(overrides: Record<string, unknown> = {}) {
+  return { id: 't1', title: 'x', status: 'in-progress', ...overrides } as never
+}
+
+describe('TaskNodeAssignment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clusterEnabled = true
+    clusterNames = ['pet-box', 'gpu-box']
+    mockReassign.mockResolvedValue(undefined)
+  })
+
+  afterEach(cleanup)
+
+  it('renders nothing when the instance is not a cluster leader', () => {
+    clusterEnabled = false
+    render(TaskNodeAssignment, { props: { task: task() } })
+    expect(screen.queryByTestId('task-node-assignment')).toBeNull()
+  })
+
+  it('shows local for a task with no assigned node', () => {
+    render(TaskNodeAssignment, { props: { task: task() } })
+    const select = screen.getByLabelText('Execution node') as HTMLSelectElement
+    expect(select.value).toBe('local')
+  })
+
+  it('offers local plus every roster node', () => {
+    render(TaskNodeAssignment, { props: { task: task({ assignedNode: 'pet-box' }) } })
+    const options = screen.getAllByRole('option').map((o) => (o as HTMLOptionElement).value)
+    expect(options).toEqual(['local', 'pet-box', 'gpu-box'])
+  })
+
+  it('reassigns to the node the operator picks', async () => {
+    render(TaskNodeAssignment, { props: { task: task({ assignedNode: 'pet-box' }) } })
+    const select = screen.getByLabelText('Execution node')
+    await fireEvent.change(select, { target: { value: 'gpu-box' } })
+    await waitFor(() => expect(mockReassign).toHaveBeenCalledWith('t1', 'gpu-box'))
+  })
+
+  it('brings a task home when local is picked', async () => {
+    render(TaskNodeAssignment, { props: { task: task({ assignedNode: 'pet-box' }) } })
+    await fireEvent.change(screen.getByLabelText('Execution node'), { target: { value: 'local' } })
+    await waitFor(() => expect(mockReassign).toHaveBeenCalledWith('t1', 'local'))
+  })
+
+  it('does not reassign a task to the node it already runs on', async () => {
+    render(TaskNodeAssignment, { props: { task: task({ assignedNode: 'pet-box' }) } })
+    await fireEvent.change(screen.getByLabelText('Execution node'), { target: { value: 'pet-box' } })
+    expect(mockReassign).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a refusal from the backend instead of failing silently', async () => {
+    mockReassign.mockRejectedValue(new Error('work task withheld from untrusted node: "gpu-box"'))
+    render(TaskNodeAssignment, { props: { task: task({ assignedNode: 'pet-box' }) } })
+    await fireEvent.change(screen.getByLabelText('Execution node'), { target: { value: 'gpu-box' } })
+    await waitFor(() => {
+      expect(screen.getByTestId('task-node-error').textContent).toContain('withheld from untrusted node')
+    })
+  })
+})

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -220,6 +220,7 @@ export function RejectPlanOnNode(arg1: string, arg2: string, arg3: string): Prom
 export function ListNodeAgents(): Promise<Array<Agent>> { return call('ClusterService', 'ListNodeAgents') }
 export function GetAgentOutputOnNode(arg1: string, arg2: string): Promise<Array<StreamEvent>> { return call('ClusterService', 'GetAgentOutputOnNode', arg1, arg2) }
 export function GetConvoOutputOnNode(arg1: string, arg2: string): Promise<Array<ConvoEvent>> { return call('ClusterService', 'GetConvoOutputOnNode', arg1, arg2) }
+export function ReassignTask(arg1: string, arg2: string): Promise<void> { return call('ClusterService', 'ReassignTask', arg1, arg2) }
 
 // Shared EventSource for the multiplexed /events SSE stream.
 // All EventsOn subscriptions funnel through a single connection.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -183,6 +183,7 @@ export const RejectPlanOnNode = pick(ClusterSvc.RejectPlanOnNode, http.RejectPla
 export const ListNodeAgents = pick(ClusterSvc.ListNodeAgents, http.ListNodeAgents)
 export const GetAgentOutputOnNode = pick(ClusterSvc.GetAgentOutputOnNode, http.GetAgentOutputOnNode)
 export const GetConvoOutputOnNode = pick(ClusterSvc.GetConvoOutputOnNode, http.GetConvoOutputOnNode)
+export const ReassignTask = pick(ClusterSvc.ReassignTask, http.ReassignTask)
 
 // Runtime events and browser utilities.
 //

--- a/frontend/src/stores/tasks.svelte.ts
+++ b/frontend/src/stores/tasks.svelte.ts
@@ -7,6 +7,7 @@ import {
   DeleteTask,
   ApprovePlan,
   ApprovePlanOnNode,
+  ReassignTask,
   RejectPlanOnNode,
   RejectPlan,
   SendPlanMessage,
@@ -156,6 +157,11 @@ class TaskStore extends EntityStore<Task> {
     }
     const result = await RejectPlan(id, feedback)
     this.set(result.id, result)
+  }
+
+  async reassign(id: string, node: string): Promise<void> {
+    await ReassignTask(id, node)
+    await this.patchOne(id)
   }
 
   async sendPlanMessage(id: string, message: string): Promise<void> {

--- a/internal/config/config_cluster.go
+++ b/internal/config/config_cluster.go
@@ -105,6 +105,37 @@ type HomeNode struct {
 	Local     bool
 }
 
+// LocalNodeName is the reserved node name for the leader itself. Manual
+// reassignment accepts it to bring a task home when every follower is down.
+const LocalNodeName = "local"
+
+// HomeNodeByName resolves a node by roster name, for operations that target a
+// node explicitly instead of following the project's configured home (manual
+// reassignment). Reports ok=false for an unknown name, so a typo can never be
+// mistaken for the leader and silently run work meant for a follower.
+func (c *Config) HomeNodeByName(name string) (HomeNode, bool) {
+	if name == LocalNodeName {
+		return HomeNode{Trusted: true, Encrypted: true, Local: true}, true
+	}
+	if c == nil {
+		return HomeNode{}, false
+	}
+	for i := range c.Cluster.Followers {
+		f := c.Cluster.Followers[i]
+		if f.Name != name {
+			continue
+		}
+		return HomeNode{
+			Name:      f.Name,
+			URL:       f.PrimaryEndpoint(),
+			Token:     f.ResolveToken(),
+			Trusted:   f.Trusted,
+			Encrypted: f.Encrypted(),
+		}, true
+	}
+	return HomeNode{}, false
+}
+
 // HomeNodeFor resolves which node owns execution for projectID. A project in a
 // follower's Homes routes to that follower; a project in LocalHomes, in no
 // roster, or on a non-leader node routes local. Per-project homing means the

--- a/internal/config/config_cluster.go
+++ b/internal/config/config_cluster.go
@@ -109,6 +109,22 @@ type HomeNode struct {
 // reassignment accepts it to bring a task home when every follower is down.
 const LocalNodeName = "local"
 
+// HomeNodeForTask resolves which node owns execution for a task. An operator's
+// manual override wins over the project's configured home — otherwise the
+// assigner would recompute the config home on its next tick and drag the task
+// straight back to the node it was evacuated from. An override naming a node
+// that no longer exists in the roster falls back to the config home, so a
+// removed follower cannot strand a task on a name nothing resolves.
+func (c *Config) HomeNodeForTask(projectID, override string) HomeNode {
+	if override == "" {
+		return c.HomeNodeFor(projectID)
+	}
+	if home, ok := c.HomeNodeByName(override); ok {
+		return home
+	}
+	return c.HomeNodeFor(projectID)
+}
+
 // HomeNodeByName resolves a node by roster name, for operations that target a
 // node explicitly instead of following the project's configured home (manual
 // reassignment). Reports ok=false for an unknown name, so a typo can never be

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -603,6 +603,7 @@ func (a *App) initCluster() {
 	a.mirror = clusterlead.NewMirror(a.cfg, a.tasks, roster, a.logger, 0)
 	if a.clusterSvc != nil {
 		a.clusterSvc.setRoster(roster)
+		a.clusterSvc.setAssigner(a.assigner)
 	}
 	a.logger.Info("cluster.leader.enabled", "followers", roster.Names())
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -559,7 +559,7 @@ func (a *App) releaseTaskAgents(taskID string) {
 }
 
 func (a *App) runsTaskLocally(t task.Task) bool {
-	return a.cfg == nil || a.cfg.HomeNodeFor(t.ProjectID).Local
+	return a.cfg == nil || a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride).Local
 }
 
 func (a *App) isWorkProject(projectID string) bool {
@@ -583,7 +583,7 @@ func (a *App) auditClusterBlock(taskID, node, reason string) {
 func (a *App) initCluster() {
 	if a.workflowEngine != nil {
 		a.workflowEngine.SetDispatchGate(func(ti workflow.TaskInfo) bool {
-			return a.cfg == nil || a.cfg.HomeNodeFor(ti.ProjectID).Local
+			return a.cfg == nil || a.cfg.HomeNodeForTask(ti.ProjectID, ti.NodeOverride).Local
 		})
 	}
 	if a.cfg == nil || !a.cfg.IsLeader() {
@@ -600,6 +600,7 @@ func (a *App) initCluster() {
 	}
 	a.clusterRoster = roster
 	a.assigner = clusterlead.NewAssigner(a.cfg, a.tasks, roster, a.isWorkProject, a.auditClusterBlock, a.logger)
+	a.assigner.SetStopLocalAgents(a.releaseTaskAgents)
 	a.mirror = clusterlead.NewMirror(a.cfg, a.tasks, roster, a.logger, 0)
 	if a.clusterSvc != nil {
 		a.clusterSvc.setRoster(roster)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -277,6 +277,7 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 		AgentMode:             t.AgentMode,
 		Priority:              string(t.Priority),
 		ProjectID:             t.ProjectID,
+		NodeOverride:          t.NodeOverride,
 		HandoffSourceProvider: t.HandoffSourceProvider,
 		PRNumber:              t.PRNumber,
 		Branch:                t.Branch,

--- a/internal/sybra/clusterlead/assigner.go
+++ b/internal/sybra/clusterlead/assigner.go
@@ -26,6 +26,16 @@ type Assigner struct {
 	isWorkProject func(projectID string) bool
 	auditBlock    func(taskID, node, reason string)
 	logger        *slog.Logger
+
+	stopLocalAgents func(taskID string)
+}
+
+// SetStopLocalAgents supplies the hook Reassign uses to stop the leader's own
+// agents for a task before it is moved onto a follower. Without it, a task
+// running locally would keep its local agent alive while the new node starts a
+// second one on the same branch.
+func (a *Assigner) SetStopLocalAgents(stop func(taskID string)) {
+	a.stopLocalAgents = stop
 }
 
 // NewAssigner constructs an Assigner. isWorkProject classifies a project as
@@ -59,7 +69,7 @@ func (a *Assigner) Tick(ctx context.Context) {
 		if task.IsTerminalStatus(t.Status) || t.TaskType == task.TaskTypeChat || t.Status == task.StatusBlocked {
 			continue
 		}
-		home := a.cfg.HomeNodeFor(t.ProjectID)
+		home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 		if home.Local || t.AssignedNode == home.Name {
 			continue
 		}
@@ -77,7 +87,7 @@ func (a *Assigner) Tick(ctx context.Context) {
 // idempotent: the follower's AssignTask upserts by id, so a repeated push is
 // harmless.
 func (a *Assigner) Route(ctx context.Context, t task.Task) (routed bool, err error) {
-	home := a.cfg.HomeNodeFor(t.ProjectID)
+	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local {
 		return false, nil
 	}

--- a/internal/sybra/clusterlead/reassign.go
+++ b/internal/sybra/clusterlead/reassign.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
@@ -21,20 +22,46 @@ var ErrUnknownNode = errors.New("unknown cluster node")
 // not both trusted and encrypted. Safe for a caller to surface.
 var ErrConfidentiality = errors.New("work task withheld from untrusted node")
 
+// ErrCannotDrainLocal reports that a task running on the leader cannot be moved
+// by this caller, because it has no way to stop the leader's own agents — the
+// CLI builds its own Assigner and does not own the running server's agent
+// manager. Failing closed beats letting two agents drive one branch. Safe for a
+// caller to surface.
+var ErrCannotDrainLocal = errors.New("cannot stop the leader's agents from here")
+
+func mayHaveLiveAgent(t task.Task) bool {
+	if task.IsTerminalStatus(t.Status) {
+		return false
+	}
+	return t.Status != task.StatusNew && t.Status != task.StatusTodo
+}
+
 // Reassign moves a task to an explicitly named node, overriding its project's
 // configured home. This is the manual escape hatch for a dead or degraded
 // follower: the new node re-provisions its own worktree from the branch, since
 // a worktree is not transferable between machines.
 //
-// The confidentiality guard still applies — a manual reassignment must not be a
+// It records NodeOverride, not just AssignedNode. AssignedNode is where the task
+// last ran; the routing authority is HomeNodeForTask, and without an override it
+// recomputes the project's configured home on the next tick — which would drag
+// the task straight back onto the node the operator just evacuated.
+//
+// The confidentiality guard still applies: a manual reassignment must not be a
 // way to route a work task onto an untrusted or cleartext node.
 //
-// Ordering matters. The canonical AssignedNode is written BEFORE the task is
-// pushed, because the mirror ignores any follower whose name no longer matches
-// canonical.AssignedNode: that is what makes a late update from the old node —
-// including one from a dead follower that comes back — unable to clobber the
-// task after it has moved.
+// Reassigning a task to the node it already runs on only pins the override: it
+// must not drain, clear the worktree, or re-push, since that run is live.
+//
+// The canonical record is written BEFORE the push, because the mirror ignores
+// any follower whose name no longer matches canonical.AssignedNode — that is
+// what stops a revived dead follower from clobbering a task that has moved. If
+// the push then fails, the move is rolled back so the task is never left
+// pointing at a node that never received it.
 func (a *Assigner) Reassign(ctx context.Context, taskID, node string) error {
+	node = strings.TrimSpace(node)
+	if node == "" {
+		return fmt.Errorf("%w: %q", ErrUnknownNode, node)
+	}
 	t, err := a.tasks.Get(taskID)
 	if err != nil {
 		return fmt.Errorf("clusterlead: load %s: %w", taskID, err)
@@ -52,36 +79,89 @@ func (a *Assigner) Reassign(ctx context.Context, taskID, node string) error {
 
 	previous := t.AssignedNode
 	if previous == home.Name {
-		return nil
+		return a.pinOverride(taskID, node)
 	}
-	a.drainNode(ctx, previous, t)
-
-	t.AssignedNode = home.Name
-	t.WorktreeDir = ""
-	t.MirrorRev = 0
-	t.MirrorUpdatedAt = nil
-	if _, _, err := a.tasks.Put(t); err != nil {
-		return fmt.Errorf("clusterlead: stamp node on %s: %w", t.ID, err)
+	if previous == "" && a.stopLocalAgents == nil && mayHaveLiveAgent(t) {
+		return fmt.Errorf("%w: %s is running on the leader and this caller cannot stop its agents; reassign it from the board",
+			ErrCannotDrainLocal, taskID)
 	}
+	a.drainTask(ctx, previous, t)
 
+	moved, err := a.stampNode(taskID, node, home.Name)
+	if err != nil {
+		return err
+	}
 	if home.Local {
-		a.logger.Info("cluster.reassign", "task", t.ID, "from", previous, "to", config.LocalNodeName)
+		a.logger.Info("cluster.reassign", "task", taskID, "from", previous, "to", config.LocalNodeName)
 		return nil
 	}
 
 	client, ok := a.roster.Client(home.Name)
 	if !ok || client == nil {
+		a.rollbackNode(taskID, previous, moved)
 		return fmt.Errorf("clusterlead: no follower client for node %q", home.Name)
 	}
-	if err := client.AssignTask(ctx, t); err != nil {
-		return fmt.Errorf("clusterlead: assign %s to %s: %w", t.ID, home.Name, err)
+	if err := client.AssignTask(ctx, moved); err != nil {
+		a.rollbackNode(taskID, previous, moved)
+		return fmt.Errorf("clusterlead: assign %s to %s: %w", taskID, home.Name, err)
 	}
-	a.logger.Info("cluster.reassign", "task", t.ID, "from", previous, "to", home.Name)
+	a.logger.Info("cluster.reassign", "task", taskID, "from", previous, "to", home.Name)
 	return nil
 }
 
-func (a *Assigner) drainNode(ctx context.Context, node string, t task.Task) {
+func (a *Assigner) pinOverride(taskID, override string) error {
+	cur, err := a.tasks.Get(taskID)
+	if err != nil {
+		return fmt.Errorf("clusterlead: reload %s: %w", taskID, err)
+	}
+	if cur.NodeOverride == override {
+		return nil
+	}
+	cur.NodeOverride = override
+	if _, _, err := a.tasks.Put(cur); err != nil {
+		return fmt.Errorf("clusterlead: pin node on %s: %w", taskID, err)
+	}
+	return nil
+}
+
+func (a *Assigner) stampNode(taskID, override, assigned string) (task.Task, error) {
+	cur, err := a.tasks.Get(taskID)
+	if err != nil {
+		return task.Task{}, fmt.Errorf("clusterlead: reload %s: %w", taskID, err)
+	}
+	cur.NodeOverride = override
+	cur.AssignedNode = assigned
+	cur.WorktreeDir = ""
+	cur.MirrorRev = 0
+	cur.MirrorUpdatedAt = nil
+	saved, _, err := a.tasks.Put(cur)
+	if err != nil {
+		return task.Task{}, fmt.Errorf("clusterlead: stamp node on %s: %w", taskID, err)
+	}
+	return saved, nil
+}
+
+func (a *Assigner) rollbackNode(taskID, previous string, moved task.Task) {
+	cur, err := a.tasks.Get(taskID)
+	if err != nil {
+		a.logger.Error("cluster.reassign.rollback.failed", "task", taskID, "err", err)
+		return
+	}
+	if cur.AssignedNode != moved.AssignedNode {
+		return
+	}
+	cur.AssignedNode = previous
+	cur.NodeOverride = ""
+	if _, _, err := a.tasks.Put(cur); err != nil {
+		a.logger.Error("cluster.reassign.rollback.failed", "task", taskID, "err", err)
+		return
+	}
+	a.logger.Warn("cluster.reassign.rolled_back", "task", taskID, "node", previous)
+}
+
+func (a *Assigner) drainTask(ctx context.Context, node string, t task.Task) {
 	if node == "" {
+		a.drainLocal(t)
 		return
 	}
 	client, ok := a.roster.Client(node)
@@ -106,4 +186,12 @@ func (a *Assigner) drainNode(ctx context.Context, node string, t task.Task) {
 		}
 		a.logger.Info("cluster.reassign.drain.stopped", "task", t.ID, "node", node, "agent", ag.ID)
 	}
+}
+
+func (a *Assigner) drainLocal(t task.Task) {
+	if a.stopLocalAgents == nil {
+		return
+	}
+	a.stopLocalAgents(t.ID)
+	a.logger.Info("cluster.reassign.drain.stopped_local", "task", t.ID)
 }

--- a/internal/sybra/clusterlead/reassign.go
+++ b/internal/sybra/clusterlead/reassign.go
@@ -78,6 +78,7 @@ func (a *Assigner) Reassign(ctx context.Context, taskID, node string) error {
 	}
 
 	previous := t.AssignedNode
+	previousOverride := t.NodeOverride
 	if previous == home.Name {
 		return a.pinOverride(taskID, node)
 	}
@@ -98,11 +99,11 @@ func (a *Assigner) Reassign(ctx context.Context, taskID, node string) error {
 
 	client, ok := a.roster.Client(home.Name)
 	if !ok || client == nil {
-		a.rollbackNode(taskID, previous, moved)
+		a.rollbackNode(taskID, previous, previousOverride, moved)
 		return fmt.Errorf("clusterlead: no follower client for node %q", home.Name)
 	}
 	if err := client.AssignTask(ctx, moved); err != nil {
-		a.rollbackNode(taskID, previous, moved)
+		a.rollbackNode(taskID, previous, previousOverride, moved)
 		return fmt.Errorf("clusterlead: assign %s to %s: %w", taskID, home.Name, err)
 	}
 	a.logger.Info("cluster.reassign", "task", taskID, "from", previous, "to", home.Name)
@@ -141,7 +142,7 @@ func (a *Assigner) stampNode(taskID, override, assigned string) (task.Task, erro
 	return saved, nil
 }
 
-func (a *Assigner) rollbackNode(taskID, previous string, moved task.Task) {
+func (a *Assigner) rollbackNode(taskID, previous, previousOverride string, moved task.Task) {
 	cur, err := a.tasks.Get(taskID)
 	if err != nil {
 		a.logger.Error("cluster.reassign.rollback.failed", "task", taskID, "err", err)
@@ -151,7 +152,7 @@ func (a *Assigner) rollbackNode(taskID, previous string, moved task.Task) {
 		return
 	}
 	cur.AssignedNode = previous
-	cur.NodeOverride = ""
+	cur.NodeOverride = previousOverride
 	if _, _, err := a.tasks.Put(cur); err != nil {
 		a.logger.Error("cluster.reassign.rollback.failed", "task", taskID, "err", err)
 		return

--- a/internal/sybra/clusterlead/reassign.go
+++ b/internal/sybra/clusterlead/reassign.go
@@ -1,0 +1,109 @@
+package clusterlead
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+const drainOldNodeTimeout = 10 * time.Second
+
+// ErrUnknownNode is an operator-facing refusal: its text is the operator's own
+// input, so a caller may surface it. Any other Reassign failure may wrap a
+// follower's response and must be sanitized before it reaches a client.
+var ErrUnknownNode = errors.New("unknown cluster node")
+
+// ErrConfidentiality reports that a work task was withheld from a node that is
+// not both trusted and encrypted. Safe for a caller to surface.
+var ErrConfidentiality = errors.New("work task withheld from untrusted node")
+
+// Reassign moves a task to an explicitly named node, overriding its project's
+// configured home. This is the manual escape hatch for a dead or degraded
+// follower: the new node re-provisions its own worktree from the branch, since
+// a worktree is not transferable between machines.
+//
+// The confidentiality guard still applies — a manual reassignment must not be a
+// way to route a work task onto an untrusted or cleartext node.
+//
+// Ordering matters. The canonical AssignedNode is written BEFORE the task is
+// pushed, because the mirror ignores any follower whose name no longer matches
+// canonical.AssignedNode: that is what makes a late update from the old node —
+// including one from a dead follower that comes back — unable to clobber the
+// task after it has moved.
+func (a *Assigner) Reassign(ctx context.Context, taskID, node string) error {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return fmt.Errorf("clusterlead: load %s: %w", taskID, err)
+	}
+	home, ok := a.cfg.HomeNodeByName(node)
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrUnknownNode, node)
+	}
+	if !home.Local && a.isWorkProject(t.ProjectID) && (!home.Trusted || !home.Encrypted) {
+		if a.auditBlock != nil {
+			a.auditBlock(t.ID, home.Name, "manual reassignment to an untrusted or cleartext node")
+		}
+		return fmt.Errorf("%w: %q (trusted=%v encrypted=%v)", ErrConfidentiality, home.Name, home.Trusted, home.Encrypted)
+	}
+
+	previous := t.AssignedNode
+	if previous == home.Name {
+		return nil
+	}
+	a.drainNode(ctx, previous, t)
+
+	t.AssignedNode = home.Name
+	t.WorktreeDir = ""
+	t.MirrorRev = 0
+	t.MirrorUpdatedAt = nil
+	if _, _, err := a.tasks.Put(t); err != nil {
+		return fmt.Errorf("clusterlead: stamp node on %s: %w", t.ID, err)
+	}
+
+	if home.Local {
+		a.logger.Info("cluster.reassign", "task", t.ID, "from", previous, "to", config.LocalNodeName)
+		return nil
+	}
+
+	client, ok := a.roster.Client(home.Name)
+	if !ok || client == nil {
+		return fmt.Errorf("clusterlead: no follower client for node %q", home.Name)
+	}
+	if err := client.AssignTask(ctx, t); err != nil {
+		return fmt.Errorf("clusterlead: assign %s to %s: %w", t.ID, home.Name, err)
+	}
+	a.logger.Info("cluster.reassign", "task", t.ID, "from", previous, "to", home.Name)
+	return nil
+}
+
+func (a *Assigner) drainNode(ctx context.Context, node string, t task.Task) {
+	if node == "" {
+		return
+	}
+	client, ok := a.roster.Client(node)
+	if !ok || client == nil {
+		return
+	}
+	drainCtx, cancel := context.WithTimeout(ctx, drainOldNodeTimeout)
+	defer cancel()
+
+	agents, err := client.ListAgents(drainCtx)
+	if err != nil {
+		a.logger.Warn("cluster.reassign.drain.unreachable", "task", t.ID, "node", node, "err", err)
+		return
+	}
+	for _, ag := range agents {
+		if ag == nil || ag.TaskID != t.ID {
+			continue
+		}
+		if err := client.StopAgent(drainCtx, ag.ID); err != nil {
+			a.logger.Warn("cluster.reassign.drain.stop_failed", "task", t.ID, "node", node, "agent", ag.ID, "err", err)
+			continue
+		}
+		a.logger.Info("cluster.reassign.drain.stopped", "task", t.ID, "node", node, "agent", ag.ID)
+	}
+}

--- a/internal/sybra/clusterlead/reassign_test.go
+++ b/internal/sybra/clusterlead/reassign_test.go
@@ -106,7 +106,7 @@ func TestReassignRepushesToNewNodeAndClearsWorktree(t *testing.T) {
 	newSrv := newNode.server(t)
 
 	a, tasks := newReassignFixture(t, []config.Follower{
-		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true},
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true, Homes: []string{"acme/x"}},
 		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
 	}, nil)
 
@@ -114,6 +114,7 @@ func TestReassignRepushesToNewNodeAndClearsWorktree(t *testing.T) {
 	seedTask(t, tasks, task.Task{
 		ID:              "t1",
 		Title:           "move me",
+		ProjectID:       "acme/x",
 		Status:          task.StatusInProgress,
 		AssignedNode:    "old-box",
 		WorktreeDir:     "/on/old/box/wt",
@@ -165,10 +166,10 @@ func TestReassignStopsAgentsOnTheOldNode(t *testing.T) {
 	newSrv := newNode.server(t)
 
 	a, tasks := newReassignFixture(t, []config.Follower{
-		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true},
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true, Homes: []string{"acme/x"}},
 		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
 	}, nil)
-	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "old-box"})
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", ProjectID: "acme/x", Status: task.StatusInProgress, AssignedNode: "old-box"})
 
 	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
 		t.Fatalf("Reassign: %v", err)
@@ -187,10 +188,10 @@ func TestReassignProceedsWhenOldNodeIsDead(t *testing.T) {
 	dead.Close()
 
 	a, tasks := newReassignFixture(t, []config.Follower{
-		{Name: "dead-box", Endpoints: []string{dead.URL}, Trusted: true},
+		{Name: "dead-box", Endpoints: []string{dead.URL}, Trusted: true, Homes: []string{"acme/x"}},
 		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
 	}, nil)
-	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "dead-box"})
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", ProjectID: "acme/x", Status: task.StatusInProgress, AssignedNode: "dead-box"})
 
 	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
 		t.Fatalf("a dead old node must not block the escape hatch: %v", err)
@@ -205,9 +206,9 @@ func TestReassignHomeBringsTaskBackToLeader(t *testing.T) {
 	oldSrv := oldNode.server(t)
 
 	a, tasks := newReassignFixture(t, []config.Follower{
-		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true},
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true, Homes: []string{"acme/x"}},
 	}, nil)
-	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "old-box", WorktreeDir: "/remote/wt"})
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", ProjectID: "acme/x", Status: task.StatusInProgress, AssignedNode: "old-box", WorktreeDir: "/remote/wt"})
 
 	if err := a.Reassign(t.Context(), "t1", config.LocalNodeName); err != nil {
 		t.Fatalf("Reassign local: %v", err)
@@ -243,7 +244,7 @@ func TestReassignCannotBypassConfidentialityGuard(t *testing.T) {
 	srv := untrusted.server(t)
 
 	a, tasks := newReassignFixture(t, []config.Follower{
-		{Name: "untrusted-box", Endpoints: []string{srv.URL}, Trusted: false},
+		{Name: "untrusted-box", Endpoints: []string{srv.URL}, Trusted: false, Homes: []string{"acme/private"}},
 	}, func(string) bool { return true })
 	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusTodo, ProjectID: "acme/private"})
 
@@ -264,9 +265,9 @@ func TestReassignIsIdempotentForTheSameNode(t *testing.T) {
 	node := &followerRecorder{}
 	srv := node.server(t)
 	a, tasks := newReassignFixture(t, []config.Follower{
-		{Name: "box", Endpoints: []string{srv.URL}, Trusted: true},
+		{Name: "box", Endpoints: []string{srv.URL}, Trusted: true, Homes: []string{"acme/x"}},
 	}, nil)
-	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "box", WorktreeDir: "/wt"})
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", ProjectID: "acme/x", Status: task.StatusInProgress, AssignedNode: "box", WorktreeDir: "/wt"})
 
 	if err := a.Reassign(t.Context(), "t1", "box"); err != nil {
 		t.Fatalf("Reassign: %v", err)
@@ -284,10 +285,10 @@ func TestReassignedTaskIgnoresStaleMirrorFromOldNode(t *testing.T) {
 	oldNode := &followerRecorder{}
 	newNode := &followerRecorder{}
 	a, tasks := newReassignFixture(t, []config.Follower{
-		{Name: "old-box", Endpoints: []string{oldNode.server(t).URL}, Trusted: true},
+		{Name: "old-box", Endpoints: []string{oldNode.server(t).URL}, Trusted: true, Homes: []string{"acme/x"}},
 		{Name: "new-box", Endpoints: []string{newNode.server(t).URL}, Trusted: true},
 	}, nil)
-	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "old-box"})
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", ProjectID: "acme/x", Status: task.StatusInProgress, AssignedNode: "old-box"})
 
 	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
 		t.Fatalf("Reassign: %v", err)
@@ -350,5 +351,143 @@ func TestReassignUnknownNodeMessageNamesTheNode(t *testing.T) {
 	err := a.Reassign(context.Background(), "t1", "ghost")
 	if err == nil || !strings.Contains(err.Error(), "ghost") {
 		t.Fatalf("operator needs to see which node was rejected, got %v", err)
+	}
+}
+
+func TestReassignSurvivesTheNextAssignerTick(t *testing.T) {
+	oldNode := &followerRecorder{}
+	newNode := &followerRecorder{}
+	oldSrv := oldNode.server(t)
+	newSrv := newNode.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true, Homes: []string{"acme/x"}},
+		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{
+		ID: "t1", Title: "x", ProjectID: "acme/x",
+		Status: task.StatusInProgress, AssignedNode: "old-box",
+	})
+
+	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
+		t.Fatalf("Reassign: %v", err)
+	}
+	a.Tick(t.Context())
+
+	got, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AssignedNode != "new-box" {
+		t.Fatalf("the assigner dragged the task back to its config home: node=%q", got.AssignedNode)
+	}
+	if len(oldNode.assignedTasks()) != 0 {
+		t.Fatalf("the assigner re-pushed the task to the node it was evacuated from: %+v", oldNode.assignedTasks())
+	}
+}
+
+func TestBringHomeSurvivesTheNextAssignerTick(t *testing.T) {
+	oldNode := &followerRecorder{}
+	oldSrv := oldNode.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true, Homes: []string{"acme/x"}},
+	}, nil)
+	seedTask(t, tasks, task.Task{
+		ID: "t1", Title: "x", ProjectID: "acme/x",
+		Status: task.StatusInProgress, AssignedNode: "old-box",
+	})
+
+	if err := a.Reassign(t.Context(), "t1", config.LocalNodeName); err != nil {
+		t.Fatalf("Reassign local: %v", err)
+	}
+	a.Tick(t.Context())
+
+	got, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AssignedNode != "" {
+		t.Fatalf("a task brought home was re-routed to %q", got.AssignedNode)
+	}
+	if len(oldNode.assignedTasks()) != 0 {
+		t.Fatalf("a task brought home was pushed back to a follower: %+v", oldNode.assignedTasks())
+	}
+	if !a.cfg.HomeNodeForTask(got.ProjectID, got.NodeOverride).Local {
+		t.Fatal("the leader's dispatch gates read HomeNodeForTask; a task brought home must resolve local")
+	}
+}
+
+func TestReassignRollsBackWhenTheNewNodeRejectsThePush(t *testing.T) {
+	oldNode := &followerRecorder{}
+	oldSrv := oldNode.server(t)
+	deadNew := httptest.NewServer(http.NewServeMux())
+	deadNew.Close()
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true, Homes: []string{"acme/x"}},
+		{Name: "sick-box", Endpoints: []string{deadNew.URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{
+		ID: "t1", Title: "x", ProjectID: "acme/x",
+		Status: task.StatusInProgress, AssignedNode: "old-box",
+	})
+
+	if err := a.Reassign(t.Context(), "t1", "sick-box"); err == nil {
+		t.Fatal("want an error when the target node cannot be reached")
+	}
+	got, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AssignedNode != "old-box" || got.NodeOverride != "" {
+		t.Fatalf("a failed push must not strand the task on a node that never received it: node=%q override=%q",
+			got.AssignedNode, got.NodeOverride)
+	}
+}
+
+func TestReassignStopsTheLeadersOwnAgentsWhenMovingOffLocal(t *testing.T) {
+	newNode := &followerRecorder{}
+	newSrv := newNode.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
+	}, nil)
+	var stopped []string
+	a.SetStopLocalAgents(func(taskID string) { stopped = append(stopped, taskID) })
+
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress})
+
+	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
+		t.Fatalf("Reassign: %v", err)
+	}
+	if len(stopped) != 1 || stopped[0] != "t1" {
+		t.Fatalf("the leader's own agent must be stopped before a follower starts one on the same branch, stopped=%v", stopped)
+	}
+}
+
+func TestReassignRefusesToMoveALocalRunWhenItCannotDrainIt(t *testing.T) {
+	newNode := &followerRecorder{}
+	newSrv := newNode.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress})
+
+	err := a.Reassign(t.Context(), "t1", "new-box")
+	if !errors.Is(err, ErrCannotDrainLocal) {
+		t.Fatalf("a caller with no way to stop the leader's agents must fail closed, got %v", err)
+	}
+	if len(newNode.assignedTasks()) != 0 {
+		t.Fatalf("task was pushed while a local agent may still drive the branch: %+v", newNode.assignedTasks())
+	}
+}
+
+func TestReassignRejectsEmptyNode(t *testing.T) {
+	a, tasks := newReassignFixture(t, nil, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusTodo})
+	if err := a.Reassign(t.Context(), "t1", "   "); !errors.Is(err, ErrUnknownNode) {
+		t.Fatalf("a blank node must be rejected, not resolved to an unnamed follower, got %v", err)
 	}
 }

--- a/internal/sybra/clusterlead/reassign_test.go
+++ b/internal/sybra/clusterlead/reassign_test.go
@@ -1,0 +1,354 @@
+package clusterlead
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type followerRecorder struct {
+	mu       sync.Mutex
+	assigned []task.Task
+	stopped  []string
+	agents   []map[string]any
+}
+
+func (f *followerRecorder) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/TaskService/AssignTask", func(w http.ResponseWriter, r *http.Request) {
+		var args []task.Task
+		_ = json.NewDecoder(r.Body).Decode(&args)
+		f.mu.Lock()
+		if len(args) > 0 {
+			f.assigned = append(f.assigned, args[0])
+		}
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`null`))
+	})
+	mux.HandleFunc("/api/AgentService/ListAgents", func(w http.ResponseWriter, _ *http.Request) {
+		f.mu.Lock()
+		agents := f.agents
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(agents)
+	})
+	mux.HandleFunc("/api/AgentService/StopAgent", func(w http.ResponseWriter, r *http.Request) {
+		var args []string
+		_ = json.NewDecoder(r.Body).Decode(&args)
+		f.mu.Lock()
+		if len(args) > 0 {
+			f.stopped = append(f.stopped, args[0])
+		}
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`null`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (f *followerRecorder) assignedTasks() []task.Task {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]task.Task(nil), f.assigned...)
+}
+
+func (f *followerRecorder) stoppedAgents() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.stopped...)
+}
+
+func newReassignFixture(t *testing.T, followers []config.Follower, isWork func(string) bool) (*Assigner, *task.Manager) {
+	t.Helper()
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(store, nil)
+	cfg := &config.Config{Cluster: config.ClusterConfig{Role: config.ClusterRoleLeader, Followers: followers}}
+	roster, err := NewRoster(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("NewRoster: %v", err)
+	}
+	if isWork == nil {
+		isWork = func(string) bool { return false }
+	}
+	return NewAssigner(cfg, tasks, roster, isWork, nil, slog.Default()), tasks
+}
+
+func seedTask(t *testing.T, tasks *task.Manager, seed task.Task) task.Task {
+	t.Helper()
+	saved, _, err := tasks.Put(seed)
+	if err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	return saved
+}
+
+func TestReassignRepushesToNewNodeAndClearsWorktree(t *testing.T) {
+	oldNode := &followerRecorder{}
+	newNode := &followerRecorder{}
+	oldSrv := oldNode.server(t)
+	newSrv := newNode.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true},
+		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
+	}, nil)
+
+	mirrored := time.Now()
+	seedTask(t, tasks, task.Task{
+		ID:              "t1",
+		Title:           "move me",
+		Status:          task.StatusInProgress,
+		AssignedNode:    "old-box",
+		WorktreeDir:     "/on/old/box/wt",
+		Branch:          "feat/x",
+		MirrorRev:       7,
+		MirrorUpdatedAt: &mirrored,
+	})
+
+	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
+		t.Fatalf("Reassign: %v", err)
+	}
+
+	got, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AssignedNode != "new-box" {
+		t.Fatalf("assigned_node = %q, want new-box", got.AssignedNode)
+	}
+	if got.WorktreeDir != "" {
+		t.Fatalf("worktree must be cleared (it is not transferable), got %q", got.WorktreeDir)
+	}
+	if got.Branch != "feat/x" {
+		t.Fatalf("branch is the handoff artifact and must survive, got %q", got.Branch)
+	}
+	if got.MirrorRev != 0 || got.MirrorUpdatedAt != nil {
+		t.Fatalf("mirror clock must reset for the new node, got rev=%d at=%v", got.MirrorRev, got.MirrorUpdatedAt)
+	}
+
+	pushed := newNode.assignedTasks()
+	if len(pushed) != 1 || pushed[0].ID != "t1" {
+		t.Fatalf("task was not pushed to the new node: %+v", pushed)
+	}
+	if pushed[0].AssignedNode != "new-box" {
+		t.Fatalf("pushed task carries node %q, want new-box", pushed[0].AssignedNode)
+	}
+	if got := oldNode.assignedTasks(); len(got) != 0 {
+		t.Fatalf("task must not be re-pushed to the old node: %+v", got)
+	}
+}
+
+func TestReassignStopsAgentsOnTheOldNode(t *testing.T) {
+	oldNode := &followerRecorder{agents: []map[string]any{
+		{"id": "a-mine", "taskId": "t1", "state": "running"},
+		{"id": "a-other", "taskId": "t2", "state": "running"},
+	}}
+	newNode := &followerRecorder{}
+	oldSrv := oldNode.server(t)
+	newSrv := newNode.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true},
+		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "old-box"})
+
+	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
+		t.Fatalf("Reassign: %v", err)
+	}
+
+	stopped := oldNode.stoppedAgents()
+	if len(stopped) != 1 || stopped[0] != "a-mine" {
+		t.Fatalf("the old node's agent for this task must be stopped (else two agents drive one branch), stopped=%v", stopped)
+	}
+}
+
+func TestReassignProceedsWhenOldNodeIsDead(t *testing.T) {
+	newNode := &followerRecorder{}
+	newSrv := newNode.server(t)
+	dead := httptest.NewServer(http.NewServeMux())
+	dead.Close()
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "dead-box", Endpoints: []string{dead.URL}, Trusted: true},
+		{Name: "new-box", Endpoints: []string{newSrv.URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "dead-box"})
+
+	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
+		t.Fatalf("a dead old node must not block the escape hatch: %v", err)
+	}
+	if pushed := newNode.assignedTasks(); len(pushed) != 1 {
+		t.Fatalf("task was not moved off the dead node: %+v", pushed)
+	}
+}
+
+func TestReassignHomeBringsTaskBackToLeader(t *testing.T) {
+	oldNode := &followerRecorder{}
+	oldSrv := oldNode.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "old-box", Endpoints: []string{oldSrv.URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "old-box", WorktreeDir: "/remote/wt"})
+
+	if err := a.Reassign(t.Context(), "t1", config.LocalNodeName); err != nil {
+		t.Fatalf("Reassign local: %v", err)
+	}
+	got, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AssignedNode != "" {
+		t.Fatalf("a task brought home must have an empty assigned_node (that is what the local dispatch gate reads), got %q", got.AssignedNode)
+	}
+	if got.WorktreeDir != "" {
+		t.Fatalf("worktree must be cleared, got %q", got.WorktreeDir)
+	}
+}
+
+func TestReassignRejectsUnknownNode(t *testing.T) {
+	a, tasks := newReassignFixture(t, nil, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusTodo})
+
+	err := a.Reassign(t.Context(), "t1", "ghost")
+	if !errors.Is(err, ErrUnknownNode) {
+		t.Fatalf("want ErrUnknownNode, got %v", err)
+	}
+	got, _ := tasks.Get("t1")
+	if got.AssignedNode != "" {
+		t.Fatalf("a rejected reassignment must not move the task, got node %q", got.AssignedNode)
+	}
+}
+
+func TestReassignCannotBypassConfidentialityGuard(t *testing.T) {
+	untrusted := &followerRecorder{}
+	srv := untrusted.server(t)
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "untrusted-box", Endpoints: []string{srv.URL}, Trusted: false},
+	}, func(string) bool { return true })
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusTodo, ProjectID: "acme/private"})
+
+	err := a.Reassign(t.Context(), "t1", "untrusted-box")
+	if !errors.Is(err, ErrConfidentiality) {
+		t.Fatalf("a manual reassignment must not be a way around the work-data guard, got %v", err)
+	}
+	if pushed := untrusted.assignedTasks(); len(pushed) != 0 {
+		t.Fatalf("work task was pushed to an untrusted node: %+v", pushed)
+	}
+	got, _ := tasks.Get("t1")
+	if got.AssignedNode != "" {
+		t.Fatalf("blocked reassignment must not stamp the node, got %q", got.AssignedNode)
+	}
+}
+
+func TestReassignIsIdempotentForTheSameNode(t *testing.T) {
+	node := &followerRecorder{}
+	srv := node.server(t)
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "box", Endpoints: []string{srv.URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "box", WorktreeDir: "/wt"})
+
+	if err := a.Reassign(t.Context(), "t1", "box"); err != nil {
+		t.Fatalf("Reassign: %v", err)
+	}
+	if pushed := node.assignedTasks(); len(pushed) != 0 {
+		t.Fatalf("reassigning to the node it already runs on must be a no-op, not a re-push: %+v", pushed)
+	}
+	got, _ := tasks.Get("t1")
+	if got.WorktreeDir != "/wt" {
+		t.Fatalf("a no-op reassignment must not destroy the live worktree, got %q", got.WorktreeDir)
+	}
+}
+
+func TestReassignedTaskIgnoresStaleMirrorFromOldNode(t *testing.T) {
+	oldNode := &followerRecorder{}
+	newNode := &followerRecorder{}
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "old-box", Endpoints: []string{oldNode.server(t).URL}, Trusted: true},
+		{Name: "new-box", Endpoints: []string{newNode.server(t).URL}, Trusted: true},
+	}, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusInProgress, AssignedNode: "old-box"})
+
+	if err := a.Reassign(t.Context(), "t1", "new-box"); err != nil {
+		t.Fatalf("Reassign: %v", err)
+	}
+
+	canonical, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	cfg := &config.Config{Cluster: config.ClusterConfig{Role: config.ClusterRoleLeader}}
+	mirror := NewMirror(cfg, tasks, a.roster, slog.Default(), 0)
+
+	revived := canonical
+	revived.AssignedNode = "old-box"
+	revived.Status = task.StatusDone
+	revived.UpdatedAt = time.Now().Add(time.Hour)
+
+	if applied := mirror.applyFollowerTask("old-box", revived); applied {
+		t.Fatal("a dead follower that comes back must not clobber a task that has moved")
+	}
+	after, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if after.Status == task.StatusDone {
+		t.Fatalf("stale mirror from the old node overwrote canonical status: %s", after.Status)
+	}
+	if after.AssignedNode != "new-box" {
+		t.Fatalf("stale mirror stole the task back to %q", after.AssignedNode)
+	}
+}
+
+func TestClusterNodesListsFollowers(t *testing.T) {
+	cfg := &config.Config{Cluster: config.ClusterConfig{
+		Role: config.ClusterRoleLeader,
+		Followers: []config.Follower{
+			{Name: "pet-box", Endpoints: []string{"https://pet.example.ts.net"}, Trusted: true, Homes: []string{"a/b"}},
+		},
+	}}
+	home, ok := cfg.HomeNodeByName("pet-box")
+	if !ok {
+		t.Fatal("HomeNodeByName missed a configured follower")
+	}
+	if !home.Trusted || !home.Encrypted {
+		t.Fatalf("https follower must resolve trusted+encrypted, got %+v", home)
+	}
+	if _, ok := cfg.HomeNodeByName("nope"); ok {
+		t.Fatal("unknown node must not resolve")
+	}
+	local, ok := cfg.HomeNodeByName(config.LocalNodeName)
+	if !ok || !local.Local || local.Name != "" {
+		t.Fatalf("local must resolve to the leader with an empty name, got %+v", local)
+	}
+}
+
+func TestReassignUnknownNodeMessageNamesTheNode(t *testing.T) {
+	a, tasks := newReassignFixture(t, nil, nil)
+	seedTask(t, tasks, task.Task{ID: "t1", Title: "x", Status: task.StatusTodo})
+	err := a.Reassign(context.Background(), "t1", "ghost")
+	if err == nil || !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("operator needs to see which node was rejected, got %v", err)
+	}
+}

--- a/internal/sybra/clusterlead/reassign_test.go
+++ b/internal/sybra/clusterlead/reassign_test.go
@@ -491,3 +491,42 @@ func TestReassignRejectsEmptyNode(t *testing.T) {
 		t.Fatalf("a blank node must be rejected, not resolved to an unnamed follower, got %v", err)
 	}
 }
+
+func TestRollbackKeepsTheOperatorsPreviousPin(t *testing.T) {
+	nodeB := &followerRecorder{}
+	bSrv := nodeB.server(t)
+	sick := httptest.NewServer(http.NewServeMux())
+	sick.Close()
+
+	a, tasks := newReassignFixture(t, []config.Follower{
+		{Name: "node-a", Endpoints: []string{"http://127.0.0.1:1"}, Trusted: true, Homes: []string{"acme/x"}},
+		{Name: "node-b", Endpoints: []string{bSrv.URL}, Trusted: true},
+		{Name: "node-c", Endpoints: []string{sick.URL}, Trusted: true},
+	}, nil)
+
+	seedTask(t, tasks, task.Task{
+		ID: "t1", Title: "x", ProjectID: "acme/x",
+		Status: task.StatusInProgress, AssignedNode: "node-b", NodeOverride: "node-b",
+	})
+
+	if err := a.Reassign(t.Context(), "t1", "node-c"); err == nil {
+		t.Fatal("want an error when the target refuses the push")
+	}
+
+	got, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AssignedNode != "node-b" || got.NodeOverride != "node-b" {
+		t.Fatalf("a failed push must restore the operator's pin, got node=%q override=%q", got.AssignedNode, got.NodeOverride)
+	}
+
+	a.Tick(t.Context())
+	after, err := tasks.Get("t1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if after.AssignedNode != "node-b" {
+		t.Fatalf("after a failed push the assigner dragged the task back to its config home: %q", after.AssignedNode)
+	}
+}

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -114,6 +114,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 		"ClusterService": httpapi.NewService(a.clusterSvc,
 			"GetNodes",
 			"ListNodeAgents",
+			"ReassignTask",
 			"GetAgentOutputOnNode",
 			"GetConvoOutputOnNode",
 			"StopAgentOnNode",

--- a/internal/sybra/svc_cluster.go
+++ b/internal/sybra/svc_cluster.go
@@ -90,7 +90,8 @@ func (s *ClusterService) ReassignTask(taskID, node string) error {
 	if s.logger != nil {
 		s.logger.Error("cluster.reassign.failed", "task", taskID, "node", node, "err", err)
 	}
-	if errors.Is(err, clusterlead.ErrUnknownNode) || errors.Is(err, clusterlead.ErrConfidentiality) {
+	if errors.Is(err, clusterlead.ErrUnknownNode) || errors.Is(err, clusterlead.ErrConfidentiality) ||
+		errors.Is(err, clusterlead.ErrCannotDrainLocal) {
 		return validationError(err.Error())
 	}
 	return fmt.Errorf("reassign task %s to node %s failed", taskID, node)

--- a/internal/sybra/svc_cluster.go
+++ b/internal/sybra/svc_cluster.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/cluster"
+	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 )
 
 const (
@@ -34,9 +36,10 @@ type ClusterNodeDTO struct {
 // board does see a node's endpoint, surfaced for health diagnostics). The roster
 // is nil (all methods degrade to empty/errors) on a non-leader node.
 type ClusterService struct {
-	logger *slog.Logger
-	mu     sync.RWMutex
-	roster *cluster.Roster
+	logger   *slog.Logger
+	mu       sync.RWMutex
+	roster   *cluster.Roster
+	assigner *clusterlead.Assigner
 }
 
 func (s *ClusterService) setRoster(r *cluster.Roster) {
@@ -45,10 +48,52 @@ func (s *ClusterService) setRoster(r *cluster.Roster) {
 	s.mu.Unlock()
 }
 
+func (s *ClusterService) setAssigner(a *clusterlead.Assigner) {
+	s.mu.Lock()
+	s.assigner = a
+	s.mu.Unlock()
+}
+
 func (s *ClusterService) getRoster() *cluster.Roster {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.roster
+}
+
+func (s *ClusterService) getAssigner() *clusterlead.Assigner {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.assigner
+}
+
+// ReassignTask moves a task to an explicitly named node ("local" brings it back
+// to the leader), overriding its project's configured home. The old node's
+// agents for the task are stopped first when it is still reachable, so a
+// merely-degraded follower cannot keep driving the branch alongside the new one.
+func (s *ClusterService) ReassignTask(taskID, node string) error {
+	if strings.TrimSpace(taskID) == "" {
+		return validationError("task id is required")
+	}
+	if strings.TrimSpace(node) == "" {
+		return validationError("node is required")
+	}
+	a := s.getAssigner()
+	if a == nil {
+		return validationError("this node is not a cluster leader")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), nodeCallTimeout)
+	defer cancel()
+	err := a.Reassign(ctx, taskID, node)
+	if err == nil {
+		return nil
+	}
+	if s.logger != nil {
+		s.logger.Error("cluster.reassign.failed", "task", taskID, "node", node, "err", err)
+	}
+	if errors.Is(err, clusterlead.ErrUnknownNode) || errors.Is(err, clusterlead.ErrConfidentiality) {
+		return validationError(err.Error())
+	}
+	return fmt.Errorf("reassign task %s to node %s failed", taskID, node)
 }
 
 // GetNodes returns the follower roster with live health for the aggregated

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -578,7 +578,7 @@ func (s *TaskService) startCreatedWorkflow(t task.Task) {
 	if s.workflowEngine == nil || t.Status != task.StatusTodo {
 		return
 	}
-	if s.cfg != nil && !s.cfg.HomeNodeFor(t.ProjectID).Local {
+	if s.cfg != nil && !s.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride).Local {
 		return
 	}
 	// pr-fix / ordinary existing-PR tasks are driven outside task.created.

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -398,6 +398,7 @@ type Task struct {
 	StatusChangedAt time.Time `json:"statusChangedAt"`
 
 	AssignedNode    string     `json:"assignedNode,omitempty"`
+	NodeOverride    string     `json:"nodeOverride,omitempty"`
 	MirrorRev       int64      `json:"mirrorRev,omitempty"`
 	MirrorUpdatedAt *time.Time `json:"mirrorUpdatedAt,omitempty"`
 

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -53,6 +53,7 @@ type taskFrontmatter struct {
 	UpdatedAt              time.Time           `yaml:"updated_at"`
 	StatusChangedAt        time.Time           `yaml:"status_changed_at,omitempty"`
 	AssignedNode           string              `yaml:"assigned_node,omitempty"`
+	NodeOverride           string              `yaml:"node_override,omitempty"`
 	MirrorRev              int64               `yaml:"mirror_rev,omitempty"`
 	MirrorUpdatedAt        *time.Time          `yaml:"mirror_updated_at,omitempty"`
 }
@@ -133,6 +134,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		UpdatedAt:              fm.UpdatedAt,
 		StatusChangedAt:        fm.StatusChangedAt,
 		AssignedNode:           fm.AssignedNode,
+		NodeOverride:           fm.NodeOverride,
 		MirrorRev:              fm.MirrorRev,
 		MirrorUpdatedAt:        fm.MirrorUpdatedAt,
 		Body:                   body,
@@ -193,6 +195,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		UpdatedAt:              t.UpdatedAt,
 		StatusChangedAt:        t.StatusChangedAt,
 		AssignedNode:           t.AssignedNode,
+		NodeOverride:           t.NodeOverride,
 		MirrorRev:              t.MirrorRev,
 		MirrorUpdatedAt:        t.MirrorUpdatedAt,
 	}

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -94,6 +94,7 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		CreatedAt:       now.Add(-time.Hour),
 		UpdatedAt:       now,
 		AssignedNode:    "pet-box",
+		NodeOverride:    "gpu-box",
 		MirrorRev:       7,
 		MirrorUpdatedAt: &completedAt,
 		Body:            "body",
@@ -311,6 +312,8 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.StatusChangedAt = later
 	case "AssignedNode":
 		task.AssignedNode = "pet-box"
+	case "NodeOverride":
+		task.NodeOverride = "gpu-box"
 	case "MirrorRev":
 		task.MirrorRev = 7
 	case "MirrorUpdatedAt":

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -35,6 +35,7 @@ type TaskInfo struct {
 	Priority              string
 	ProjectID             string
 	ProjectType           string
+	NodeOverride          string
 	HandoffSourceProvider string
 	PRNumber              int
 	Branch                string


### PR DESCRIPTION
## Motivation

A task homed on a follower that dies or degrades had no escape hatch: per-project
homing is static config, so the task stayed pinned to a box that could no longer
run it (#1803). P6 lets an operator move a task to another node — or back to the
leader — from the board or the CLI.

> Changelog: feat(cluster): manual task reassignment across nodes

## Implementation information

**The override has to be authoritative.** The first cut recorded only
`AssignedNode`, which is where a task *last ran*. The routing authority is the
project's configured home, so the assigner recomputed it on its next tick and
dragged the task straight back onto the node it had just been evacuated from —
agents stopped, worktree wiped. Reassignment now records a `NodeOverride` that
beats the config home, and **all five** routing/dispatch gates resolve through
`HomeNodeForTask` (assigner tick + route, `runsTaskLocally`, the workflow
dispatch gate, `startCreatedWorkflow`). `"local"` is a reserved target that
brings a task home when every follower is down.

**Moving a task is a handoff, not a copy.** The new node re-provisions its own
worktree from the branch (a worktree is not transferable), so `WorktreeDir` is
cleared and `Branch` is kept. A *degraded* follower is still reachable, so its
agents for the task are stopped first — otherwise two agents drive one branch.
A genuinely dead node is skipped and the move proceeds.

**Ordering and failure.** The canonical record is written before the push, so a
follower that comes back cannot clobber a task that has moved (the mirror already
rejects any follower that is not the task's assigned node). If the push then
fails, the move rolls back **including the operator's previous pin** — clearing
it would send the task back to its config home, i.e. the node being evacuated,
with no agent. Reassigning to the node a task already runs on only pins the
override: no drain, no worktree wipe, no re-push.

**Reassignment is not a hole in the confidentiality guard** (#1808): a work-typed
project is still refused on a node that is not both trusted and encrypted, and
the refusal is audited. The CLI cannot stop the running server's agents, so it
fails closed rather than forking a branch when asked to move a task that is
running on the leader.

## Testing

Verified on a live leader + three followers with recording proxies (every remote
claim read from the follower's own request log, never a 200 from the leader):
reassignment survives 10+ real assigner ticks; a control run that strips the
override shows the task dragged back within 12s, proving the ticks were live and
the override is what suppresses it. Also covered: failed push rolls back and keeps
the pin; old node drained before the new one starts; dead node skipped; a revived
follower cannot steal the task back; work-typed refused on both HTTP and CLI;
`local` is genuinely dispatchable, not stranded; standalone unaffected.

Go tests + golangci + nilaway green; 1955 frontend tests, svelte-check 0 errors.

## Open questions

Two pre-existing issues surfaced while testing, both untouched by this branch and
worth their own tickets: `sybra-cli --json` emits invalid JSON when an error
message contains quotes (naive formatting in `fatal()`), and disabling
`providers.health_check` nil-panics on the first classifier run.

Closes #1810