### PR TITLE
fix(agent): load Codex config for skill invocations

### DIFF
--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	providerpkg "github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/skillinvoke"
 )
 
 type codexProvider struct{}
@@ -34,7 +35,8 @@ func (p codexProvider) BuildCommand(cfg RunConfig, model string) string {
 }
 
 func (p codexProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
-	args := []string{"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
+	skillNames := discoverCodexSkills()
+	args := codexExecBaseArgs(cfg.Prompt, skillNames)
 	// headless=true: --sandbox workspace-write requires approval prompts
 	// which auto-reject in headless mode (no TTY/UI). Always bypass.
 	args = append(args, p.SandboxArgs(cfg.RequirePermissions, true)...)
@@ -57,13 +59,31 @@ func (p codexProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headles
 		}
 		args = append(args, mcpArgs...)
 	}
-	prompt := rewriteSkillInvocations(cfg.Prompt, discoverCodexSkills())
+	prompt := rewriteSkillInvocations(cfg.Prompt, skillNames)
 	args = append(args, prompt)
 	return headlessInvocation{
 		name:    "codex",
 		args:    args,
 		command: "codex " + strings.Join(args, " "),
 	}, nil
+}
+
+func codexExecBaseArgs(prompt string, skillNames []string) []string {
+	args := []string{"exec", "--json", "--skip-git-repo-check"}
+	if !containsKnownSkillInvocation(prompt, skillNames) {
+		args = append(args, "--ignore-user-config")
+	}
+	args = append(args, "--ignore-rules")
+	return args
+}
+
+func containsKnownSkillInvocation(prompt string, skillNames []string) bool {
+	for _, name := range skillNames {
+		if skillinvoke.ContainsInvocation(prompt, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func (codexProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {

--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	providerpkg "github.com/Automaat/sybra/internal/provider"
-	"github.com/Automaat/sybra/internal/skillinvoke"
 )
 
 type codexProvider struct{}
@@ -36,7 +35,8 @@ func (p codexProvider) BuildCommand(cfg RunConfig, model string) string {
 
 func (p codexProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
 	skillNames := discoverCodexSkills()
-	args := codexExecBaseArgs(cfg.Prompt, skillNames)
+	prompt := rewriteSkillInvocations(cfg.Prompt, skillNames)
+	args := codexExecBaseArgs(prompt != cfg.Prompt)
 	// headless=true: --sandbox workspace-write requires approval prompts
 	// which auto-reject in headless mode (no TTY/UI). Always bypass.
 	args = append(args, p.SandboxArgs(cfg.RequirePermissions, true)...)
@@ -59,7 +59,6 @@ func (p codexProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headles
 		}
 		args = append(args, mcpArgs...)
 	}
-	prompt := rewriteSkillInvocations(cfg.Prompt, skillNames)
 	args = append(args, prompt)
 	return headlessInvocation{
 		name:    "codex",
@@ -68,22 +67,13 @@ func (p codexProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headles
 	}, nil
 }
 
-func codexExecBaseArgs(prompt string, skillNames []string) []string {
+func codexExecBaseArgs(loadUserConfig bool) []string {
 	args := []string{"exec", "--json", "--skip-git-repo-check"}
-	if !containsKnownSkillInvocation(prompt, skillNames) {
+	if !loadUserConfig {
 		args = append(args, "--ignore-user-config")
 	}
 	args = append(args, "--ignore-rules")
 	return args
-}
-
-func containsKnownSkillInvocation(prompt string, skillNames []string) bool {
-	for _, name := range skillNames {
-		if skillinvoke.ContainsInvocation(prompt, name) {
-			return true
-		}
-	}
-	return false
 }
 
 func (codexProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -357,7 +357,8 @@ func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
 }
 
 func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, provider Provider) []string {
-	args := []string{"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
+	skillNames := discoverCodexSkills()
+	args := codexExecBaseArgs(prompt, skillNames)
 	// headless=false: interactive (conversational) mode has a human present
 	// who can approve sandbox prompts via the UI.
 	args = append(args, provider.SandboxArgs(cfg.RequirePermissions, false)...)
@@ -370,7 +371,7 @@ func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, pro
 	}
 	// Lifecycle hooks (fail-open: omitted when sybra-cli unresolvable or taskID unsafe).
 	args = append(args, buildCodexHookArgs(a.TaskID)...)
-	args = append(args, rewriteSkillInvocations(prompt, discoverCodexSkills()))
+	args = append(args, rewriteSkillInvocations(prompt, skillNames))
 	return args
 }
 

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -358,7 +358,8 @@ func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
 
 func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, provider Provider) []string {
 	skillNames := discoverCodexSkills()
-	args := codexExecBaseArgs(prompt, skillNames)
+	rewrittenPrompt := rewriteSkillInvocations(prompt, skillNames)
+	args := codexExecBaseArgs(rewrittenPrompt != prompt)
 	// headless=false: interactive (conversational) mode has a human present
 	// who can approve sandbox prompts via the UI.
 	args = append(args, provider.SandboxArgs(cfg.RequirePermissions, false)...)
@@ -371,7 +372,7 @@ func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, pro
 	}
 	// Lifecycle hooks (fail-open: omitted when sybra-cli unresolvable or taskID unsafe).
 	args = append(args, buildCodexHookArgs(a.TaskID)...)
-	args = append(args, rewriteSkillInvocations(prompt, skillNames))
+	args = append(args, rewrittenPrompt)
 	return args
 }
 

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -103,8 +103,43 @@ func TestBuildHeadlessInvocation_CodexConvertsAliasedSkill(t *testing.T) {
 	if got != "Run $sybra-test-v2 now" {
 		t.Fatalf("prompt arg = %q, want Codex dollar invocation", got)
 	}
+	if slices.Contains(inv.args, "--ignore-user-config") {
+		t.Fatalf("Codex skill invocation args included --ignore-user-config: %v", inv.args)
+	}
 	if strings.Contains(got, "/sybra-test") || strings.Contains(got, "$sybra-test now") {
 		t.Fatalf("prompt was not fully aliased before Codex rewrite: %q", got)
+	}
+}
+
+func TestBuildHeadlessInvocation_CodexKeepsUserConfigIgnoredWithoutSkill(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resetCodexSkillsCache(t)
+	mkLocalSkill(t, filepath.Join(home, ".codex", "skills"), "staff-code-review")
+	withCodexPluginListJSON(t, []byte(`{"installed":[]}`))
+
+	inv, err := (codexProvider{}).BuildHeadlessInvocation(&Agent{ID: "a", Provider: "codex"}, RunConfig{Prompt: "Review this directly"})
+	if err != nil {
+		t.Fatalf("BuildHeadlessInvocation: %v", err)
+	}
+	if !slices.Contains(inv.args, "--ignore-user-config") {
+		t.Fatalf("Codex non-skill args omitted --ignore-user-config: %v", inv.args)
+	}
+}
+
+func TestBuildCodexConvoArgsWithProvider_LoadsUserConfigForSkill(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resetCodexSkillsCache(t)
+	mkLocalSkill(t, filepath.Join(home, ".codex", "skills"), "staff-code-review")
+	withCodexPluginListJSON(t, []byte(`{"installed":[]}`))
+
+	args := buildCodexConvoArgs(&Agent{ID: "a", Provider: "codex"}, RunConfig{}, "Run /staff-code-review")
+	if slices.Contains(args, "--ignore-user-config") {
+		t.Fatalf("Codex convo skill args included --ignore-user-config: %v", args)
+	}
+	if got := args[len(args)-1]; got != "Run $staff-code-review" {
+		t.Fatalf("prompt arg = %q, want Codex dollar invocation", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow Codex runs that invoke known skills to load user config so enabled skill plugins are visible
- keep `--ignore-user-config` for ordinary Codex runs
- cover headless and conversational Codex skill invocation argv behavior with regression tests

## Verification
- `go test ./internal/agent`
- push hook ran Go tests and `frontend npm run check` successfully