### PR TITLE
fix(github): rerun transient CI failures

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -28,6 +28,7 @@ const (
 	EventPRCommentsDetected   = "pr_monitor.comments_detected"
 	EventPRFixAgentStarted    = "pr_monitor.fix_agent_started"
 	EventPRFixExhausted       = "pr_monitor.fix_exhausted"
+	EventPRCIFailureRerun     = "pr_monitor.ci_failure_rerun"
 	EventPRMerged             = "pr_monitor.merged"
 	EventPRClosed             = "pr_monitor.closed"
 	EventPRAutoMerged         = "pr_monitor.auto_merged"

--- a/internal/sybra/review/ci_failure_dispatch_test.go
+++ b/internal/sybra/review/ci_failure_dispatch_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -96,5 +97,131 @@ func TestPollAndMonitorPRs_CIFailureDispatchesFix(t *testing.T) {
 	}
 	if k := got.Workflow.Variables["pr_issue_kind"]; k != string(github.PRIssueCIFailure) {
 		t.Errorf("pr_issue_kind = %q, want %q", k, github.PRIssueCIFailure)
+	}
+}
+
+func TestPollAndMonitorPRs_CIFailureRerunsPetPRBeforeFixAgent(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(4242),
+		Branch:    task.Ptr("feat/x"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	failingPR := github.PullRequest{
+		Number:      4242,
+		Repository:  "o/r",
+		HeadRefName: "feat/x",
+		HeadSHA:     "sha-fail",
+		URL:         "https://github.com/o/r/pull/4242",
+		Mergeable:   "MERGEABLE",
+		CIStatus:    "FAILURE",
+		Author:      "me",
+	}
+
+	var rerunRepo string
+	var rerunNumber int
+	r := buildPRFixHandler(t, tasks, func() (github.ReviewSummary, error) {
+		return github.ReviewSummary{CreatedByMe: []github.PullRequest{failingPR}}, nil
+	})
+	if _, err := r.projects.CreateMeta("https://github.com/o/r", project.ProjectTypePet); err != nil {
+		t.Fatal(err)
+	}
+	r.rerunFailedChecks = func(repo string, number int) error {
+		rerunRepo = repo
+		rerunNumber = number
+		return nil
+	}
+
+	r.pollAndMonitorPRs(context.Background())
+
+	if rerunRepo != "o/r" || rerunNumber != 4242 {
+		t.Fatalf("rerun = %s#%d, want o/r#4242", rerunRepo, rerunNumber)
+	}
+	if got := r.prTracker.Retries(created.ID, ciInfraRerunKind); got != 1 {
+		t.Errorf("ci rerun retries = %d, want 1", got)
+	}
+	if got := r.prTracker.Retries(created.ID, github.PRIssueCIFailure); got != 0 {
+		t.Errorf("ci_failure retries = %d, want 0 (no fix agent dispatched)", got)
+	}
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil {
+		t.Fatal("unexpected pr-fix workflow; transient rerun should wait for GitHub checks")
+	}
+	if got.Status != task.StatusInReview {
+		t.Fatalf("status = %q, want in-review", got.Status)
+	}
+}
+
+func TestPollAndMonitorPRs_CIFailureRerunPermissionDenialParks(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(4242),
+		Branch:    task.Ptr("feat/x"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	failingPR := github.PullRequest{
+		Number:      4242,
+		Repository:  "o/r",
+		HeadRefName: "feat/x",
+		HeadSHA:     "sha-fail",
+		URL:         "https://github.com/o/r/pull/4242",
+		Mergeable:   "MERGEABLE",
+		CIStatus:    "FAILURE",
+		Author:      "me",
+	}
+
+	r := buildPRFixHandler(t, tasks, func() (github.ReviewSummary, error) {
+		return github.ReviewSummary{CreatedByMe: []github.PullRequest{failingPR}}, nil
+	})
+	if _, err := r.projects.CreateMeta("https://github.com/o/r", project.ProjectTypePet); err != nil {
+		t.Fatal(err)
+	}
+	r.rerunFailedChecks = func(string, int) error {
+		return fmt.Errorf("gh run rerun --failed: Resource not accessible by integration: exit status 1")
+	}
+
+	r.pollAndMonitorPRs(context.Background())
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil {
+		t.Fatal("unexpected pr-fix workflow after rerun permission denial")
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if got.StatusReason != ciInfraRerunPermissionReason {
+		t.Fatalf("statusReason = %q, want %q", got.StatusReason, ciInfraRerunPermissionReason)
 	}
 }

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -37,6 +37,7 @@ const prFixWorkflowID = "pr-fix"
 
 const branchConflictRetryKind = github.PRIssueBranchConflictNoPR
 const branchRecreateKind = github.PRIssueBranchRecreate
+const ciInfraRerunKind = github.PRIssueKind("ci_infra_rerun")
 
 const wtFailureLimit = 5
 
@@ -493,6 +494,13 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 		return false
 	}
 
+	if !opts.replaceActiveWorkflow &&
+		len(handle) == 1 &&
+		primary.Kind == github.PRIssueCIFailure &&
+		r.rerunCIFailure(t, primary) {
+		return true
+	}
+
 	dir, ok := r.prepareWorktree(ctx, t, primary)
 	if !ok {
 		return false
@@ -511,6 +519,56 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 	// contextcheck no longer flags this call site (verified with a clean
 	// build+lint cache), so no suppression directive is needed here.
 	return r.dispatchPRIssueWithOptions(t, primary, handle, coalescedFixPrompt(ctx, handle, reviewHoldFixSuffix(r.cfg)), dir, opts)
+}
+
+func (r *Handler) rerunCIFailure(t task.Task, issue github.PRIssue) bool {
+	if r.projects == nil || r.prTracker == nil || t.ProjectID == "" || issue.PR.Number <= 0 {
+		return false
+	}
+	proj, err := r.projects.Get(t.ProjectID)
+	if err != nil || proj.Type != project.ProjectTypePet {
+		return false
+	}
+	if !r.prTracker.ShouldHandle(t.ID, ciInfraRerunKind, issue.PR.HeadSHA) {
+		return false
+	}
+
+	rerun := r.rerunFailedChecks
+	if rerun == nil {
+		rerun = github.RerunFailedChecks
+	}
+	if err := rerun(issue.PR.Repository, issue.PR.Number); err != nil {
+		if isRerunPermissionDenied(err) {
+			if _, updateErr := r.tasks.Update(t.ID, task.Update{
+				Status:       task.Ptr(task.StatusHumanRequired),
+				StatusReason: task.Ptr(ciInfraRerunPermissionReason),
+			}); updateErr != nil {
+				r.logger.Error("pr-monitor.ci-rerun.permission-status",
+					"task_id", t.ID, "pr", issue.PR.Number, "err", updateErr)
+			}
+			r.logger.Warn("pr-monitor.ci-rerun.permission-denied",
+				"task_id", t.ID, "pr", issue.PR.Number, "err", err)
+			return true
+		}
+		r.logger.Warn("pr-monitor.ci-rerun.failed", "task_id", t.ID, "pr", issue.PR.Number, "err", err)
+		return false
+	}
+
+	r.prTracker.MarkHandled(t.ID, ciInfraRerunKind, issue.PR.HeadSHA)
+	r.evictReadyPRCache(issue.PR.Repository, issue.PR.Number)
+	r.logAudit(audit.EventPRCIFailureRerun, t.ID, "", map[string]any{
+		"pr": issue.PR.Number, "repo": issue.PR.Repository, "head_sha": issue.PR.HeadSHA,
+	})
+	r.logger.Info("pr-monitor.ci-rerun.started", "task_id", t.ID, "pr", issue.PR.Number)
+	return true
+}
+
+func isRerunPermissionDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "resource not accessible by integration")
 }
 
 // autoResolveConflict attempts the deterministic clean-merge fast-path for a

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -545,6 +545,7 @@ func (r *Handler) rerunCIFailure(t task.Task, issue github.PRIssue) bool {
 			}); updateErr != nil {
 				r.logger.Error("pr-monitor.ci-rerun.permission-status",
 					"task_id", t.ID, "pr", issue.PR.Number, "err", updateErr)
+				return false
 			}
 			r.logger.Warn("pr-monitor.ci-rerun.permission-denied",
 				"task_id", t.ID, "pr", issue.PR.Number, "err", err)

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -92,6 +92,9 @@ type Handler struct {
 	// mergePR performs the actual squash-merge; overridable in tests.
 	// nil falls back to github.MergePR.
 	mergePR func(repo string, number int) error
+	// rerunFailedChecks requests a rerun of the failed checks on a PR;
+	// overridable in tests. nil falls back to github.RerunFailedChecks.
+	rerunFailedChecks func(repo string, number int) error
 	// enableAutoMergeFn arms GitHub's native auto-merge on a PR; overridable in
 	// tests. nil falls back to github.EnableAutoMerge.
 	enableAutoMergeFn func(repo string, number int) error
@@ -218,6 +221,7 @@ func New(
 		dispatchFailures:    make(map[string]int),
 		authCircuit:         poll.NewAuthCircuit("reviews", logger),
 		mergePR:             github.MergePR,
+		rerunFailedChecks:   github.RerunFailedChecks,
 		enableAutoMergeFn:   github.EnableAutoMerge,
 		supportsAutoMergeFn: github.SupportsNativeAutoMerge,
 		mergePRViaREST:      github.MergePRViaREST,

--- a/internal/sybra/review/outbound.go
+++ b/internal/sybra/review/outbound.go
@@ -177,6 +177,7 @@ func (r *Handler) applyPRPhase(t *task.Task, phase string) {
 // never to a human- or agent-authored explanation that merely mentions a
 // check by name.
 const exhaustedFixReasonPrefix = "pr-monitor: auto-fix exhausted after "
+const ciInfraRerunPermissionReason = "CI failure is GitHub Actions infra; rerun requires higher GitHub permissions"
 
 // exhaustedFixReason renders the StatusReason escalateExhaustedFix parks a task
 // with. It is the sole producer of the string exhaustedFixReasonKind parses back
@@ -209,12 +210,11 @@ func exhaustedFixReasonKind(reason string) (github.PRIssueKind, bool) {
 }
 
 // humanRequiredBlockerReconcilable reports whether t is a human-required task
-// parked solely by the pr-monitor auto-fix-exhausted escalation for a
-// ci_failure or conflict issue — the only kinds a live PR probe can decide
-// resolved itself. Excludes watchdog stops, tamper flags, comment-review
-// exhaustion (no CI-state probe can tell whether reviewer feedback was
-// actually addressed), human-authored reasons, and tasks already reconciled
-// once (latch tag present, to prevent flip-flopping).
+// parked solely by a PR blocker a live PR probe can decide resolved itself.
+// Excludes watchdog stops, tamper flags, comment-review exhaustion (no CI-state
+// probe can tell whether reviewer feedback was actually addressed),
+// human-authored reasons, and tasks already reconciled once (latch tag present,
+// to prevent flip-flopping).
 func humanRequiredBlockerReconcilable(t *task.Task) (kind github.PRIssueKind, ok bool) {
 	if t == nil || t.TaskType == task.TaskTypeChat || slices.Contains(t.Tags, "review") {
 		return "", false
@@ -228,6 +228,9 @@ func humanRequiredBlockerReconcilable(t *task.Task) (kind github.PRIssueKind, ok
 	reason := strings.TrimSpace(t.StatusReason)
 	if workflow.IsTamperFlaggedReason(reason) {
 		return "", false
+	}
+	if reason == ciInfraRerunPermissionReason {
+		return github.PRIssueCIFailure, true
 	}
 	kind, ok = exhaustedFixReasonKind(reason)
 	if !ok {

--- a/internal/sybra/review/outbound.go
+++ b/internal/sybra/review/outbound.go
@@ -177,7 +177,7 @@ func (r *Handler) applyPRPhase(t *task.Task, phase string) {
 // never to a human- or agent-authored explanation that merely mentions a
 // check by name.
 const exhaustedFixReasonPrefix = "pr-monitor: auto-fix exhausted after "
-const ciInfraRerunPermissionReason = "CI failure is GitHub Actions infra; rerun requires higher GitHub permissions"
+const ciInfraRerunPermissionReason = "CI failure rerun requires higher GitHub permissions"
 
 // exhaustedFixReason renders the StatusReason escalateExhaustedFix parks a task
 // with. It is the sole producer of the string exhaustedFixReasonKind parses back

--- a/internal/sybra/review/outbound_test.go
+++ b/internal/sybra/review/outbound_test.go
@@ -427,6 +427,7 @@ func TestReconcileHumanRequiredBlockersFallbackProbe(t *testing.T) {
 		wantLatch  bool
 	}{
 		{"ci_failure cleared -> flips to in-review", exhaustedFixReason(3, github.PRIssueCIFailure), nil, func(string, int) (github.PRState, error) { return openMergeableGreenPR(), nil }, task.StatusInReview, true},
+		{"CI infra rerun permission cleared -> flips to in-review", ciInfraRerunPermissionReason, nil, func(string, int) (github.PRState, error) { return openMergeableGreenPR(), nil }, task.StatusInReview, true},
 		{"conflict cleared -> flips to in-review", exhaustedFixReason(3, github.PRIssueConflict), nil, func(string, int) (github.PRState, error) { return openMergeableGreenPR(), nil }, task.StatusInReview, true},
 		{"CI pending -> stays parked", exhaustedFixReason(3, github.PRIssueCIFailure), nil, func(string, int) (github.PRState, error) { return openMergeablePendingPR(), nil }, task.StatusHumanRequired, false},
 		{"CI unknown/empty -> stays parked", exhaustedFixReason(3, github.PRIssueCIFailure), nil, func(string, int) (github.PRState, error) { return openMergeableNoChecksPR(), nil }, task.StatusHumanRequired, false},


### PR DESCRIPTION
## Summary
- rerun failed GitHub checks directly for pet-project CI failures before spawning a PR-fix agent
- park tasks in human-required with a clear permission reason when the integration cannot rerun checks
- allow the human-required reconciler to recover those parked tasks once the PR becomes green

Fixes #1979

## Tests
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra/review -run 'TestPollAndMonitorPRs_CIFailure|TestReconcileHumanRequiredBlockersFallbackProbe'
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra/review

Note: local pre-push go test ./... was blocked by an unrelated existing goleak failure in internal/agent while this branch's touched review package passed.