### PR TITLE
feat(scheduler): gate work on machine pressure

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -199,10 +199,10 @@ requires a restart to take effect (see diffConfig's
 | YAML key | Type | Default | Description |
 |---|---|---|---|
 | `orchestrator.pressure.enabled` | `bool` | `true` | Enabled turns the gate on. Default true. When false, New returns a nil *Gate and every dispatch path admits unconditionally — the same as running without this feature at all. |
-| `orchestrator.pressure.min_disk_free_percent` | `float64` |  | MinDiskFreePercent is the minimum percentage of free disk space (on the filesystem holding SYBRA_HOME) below which new dispatch is deferred. <=0 disables this dimension. Default 5. |
-| `orchestrator.pressure.min_mem_available_percent` | `float64` |  | MinMemAvailablePercent is the minimum percentage of available memory (reclaimable caches counted as available, matching the kernel's own notion of headroom) below which new dispatch is deferred. <=0 disables this dimension. Default 8. |
-| `orchestrator.pressure.max_load_per_cpu` | `float64` |  | MaxLoadPerCPU is the maximum 1-minute load average, normalized by CPU count, above which new dispatch is deferred. <=0 disables this dimension. Default 8.0. |
-| `orchestrator.pressure.sample_interval_seconds` | `int` |  | SampleIntervalSeconds is both the resource-sample cache TTL and the deny-log throttle window. <=0 falls back to pressure.DefaultSampleIntervalSeconds (15). Default 15. |
+| `orchestrator.pressure.min_disk_free_percent` | `float64` | `5` | MinDiskFreePercent is the minimum percentage of free disk space (on the filesystem holding SYBRA_HOME) below which new dispatch is deferred. <=0 disables this dimension. Default 5. |
+| `orchestrator.pressure.min_mem_available_percent` | `float64` | `8` | MinMemAvailablePercent is the minimum percentage of available memory (reclaimable caches counted as available, matching the kernel's own notion of headroom) below which new dispatch is deferred. <=0 disables this dimension. Default 8. |
+| `orchestrator.pressure.max_load_per_cpu` | `float64` | `8` | MaxLoadPerCPU is the maximum 1-minute load average, normalized by CPU count, above which new dispatch is deferred. <=0 disables this dimension. Default 8.0. |
+| `orchestrator.pressure.sample_interval_seconds` | `int` | `15` | SampleIntervalSeconds is both the resource-sample cache TTL and the deny-log throttle window. <=0 falls back to pressure.DefaultSampleIntervalSeconds (15). Default 15. |
 
 ## TodoistConfig (`todoist`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -186,6 +186,23 @@ real-app/cluster load independently of Agent.MaxConcurrent.
 |---|---|---|---|
 | `orchestrator.dispatch_interval_seconds` | `int` |  | DispatchIntervalSeconds is the cadence of the cheap, latency-sensitive dispatch pass (start the orchestrator, release unblocked children). Kept short — and also fired on demand on every status change — so a freshly-ready task is not left idle for a full tick. Default 10. |
 | `orchestrator.maintenance_interval_seconds` | `int` |  | MaintenanceIntervalSeconds is the cadence of the expensive recovery/cleanup pass (resume stalled workflows, restart stale agents, prune orphan worktrees) which hits git and may spawn agents, so it must not run hot. Default 60. |
+| `orchestrator.pressure` | `PressureConfig` | _(see below)_ | Pressure configures the local resource-pressure admission gate that defers new agent dispatch while the host is short on disk, memory, or CPU headroom. See internal/pressure. |
+
+## PressureConfig (`orchestrator.pressure`)
+
+PressureConfig configures internal/pressure.Gate, the local
+resource-pressure admission gate consulted before dispatching new agent
+work. Thresholds are captured once at Gate construction, so a change here
+requires a restart to take effect (see diffConfig's
+"orchestrator.pressure" restart entry).
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `orchestrator.pressure.enabled` | `bool` | `true` | Enabled turns the gate on. Default true. When false, New returns a nil *Gate and every dispatch path admits unconditionally — the same as running without this feature at all. |
+| `orchestrator.pressure.min_disk_free_percent` | `float64` |  | MinDiskFreePercent is the minimum percentage of free disk space (on the filesystem holding SYBRA_HOME) below which new dispatch is deferred. <=0 disables this dimension. Default 5. |
+| `orchestrator.pressure.min_mem_available_percent` | `float64` |  | MinMemAvailablePercent is the minimum percentage of available memory (reclaimable caches counted as available, matching the kernel's own notion of headroom) below which new dispatch is deferred. <=0 disables this dimension. Default 8. |
+| `orchestrator.pressure.max_load_per_cpu` | `float64` |  | MaxLoadPerCPU is the maximum 1-minute load average, normalized by CPU count, above which new dispatch is deferred. <=0 disables this dimension. Default 8.0. |
+| `orchestrator.pressure.sample_interval_seconds` | `int` |  | SampleIntervalSeconds is both the resource-sample cache TTL and the deny-log throttle window. <=0 falls back to pressure.DefaultSampleIntervalSeconds (15). Default 15. |
 
 ## TodoistConfig (`todoist`)
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/index.ts
@@ -13,6 +13,7 @@ export {
     NotificationConfig,
     OrchestratorConfig,
     PlaywrightMCPConfig,
+    PressureConfig,
     ProviderEntryConfig,
     ProviderHealthCheckConfig,
     ProviderLimitsConfig,

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -726,6 +726,13 @@ export class OrchestratorConfig {
      */
     "maintenanceIntervalSeconds": number;
 
+    /**
+     * Pressure configures the local resource-pressure admission gate that
+     * defers new agent dispatch while the host is short on disk, memory, or
+     * CPU headroom. See internal/pressure.
+     */
+    "pressure": PressureConfig;
+
     /** Creates a new OrchestratorConfig instance. */
     constructor($$source: Partial<OrchestratorConfig> = {}) {
         if (!("dispatchIntervalSeconds" in $$source)) {
@@ -733,6 +740,9 @@ export class OrchestratorConfig {
         }
         if (!("maintenanceIntervalSeconds" in $$source)) {
             this["maintenanceIntervalSeconds"] = 0;
+        }
+        if (!("pressure" in $$source)) {
+            this["pressure"] = (new PressureConfig());
         }
 
         Object.assign(this, $$source);
@@ -742,7 +752,11 @@ export class OrchestratorConfig {
      * Creates a new OrchestratorConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): OrchestratorConfig {
+        const $$createField2_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("pressure" in $$parsedSource) {
+            $$parsedSource["pressure"] = $$createField2_0($$parsedSource["pressure"]);
+        }
         return new OrchestratorConfig($$parsedSource as Partial<OrchestratorConfig>);
     }
 }
@@ -781,12 +795,86 @@ export class PlaywrightMCPConfig {
      * Creates a new PlaywrightMCPConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): PlaywrightMCPConfig {
-        const $$createField1_0 = $$createType5;
+        const $$createField1_0 = $$createType6;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("extraArgs" in $$parsedSource) {
             $$parsedSource["extraArgs"] = $$createField1_0($$parsedSource["extraArgs"]);
         }
         return new PlaywrightMCPConfig($$parsedSource as Partial<PlaywrightMCPConfig>);
+    }
+}
+
+/**
+ * PressureConfig configures internal/pressure.Gate, the local
+ * resource-pressure admission gate consulted before dispatching new agent
+ * work. Thresholds are captured once at Gate construction, so a change here
+ * requires a restart to take effect (see diffConfig's
+ * "orchestrator.pressure" restart entry).
+ */
+export class PressureConfig {
+    /**
+     * Enabled turns the gate on. Default true. When false, New returns a nil
+     * *Gate and every dispatch path admits unconditionally — the same as
+     * running without this feature at all.
+     */
+    "enabled": boolean;
+
+    /**
+     * MinDiskFreePercent is the minimum percentage of free disk space (on the
+     * filesystem holding SYBRA_HOME) below which new dispatch is deferred.
+     * <=0 disables this dimension. Default 5.
+     */
+    "minDiskFreePercent": number;
+
+    /**
+     * MinMemAvailablePercent is the minimum percentage of available memory
+     * (reclaimable caches counted as available, matching the kernel's own
+     * notion of headroom) below which new dispatch is deferred. <=0 disables
+     * this dimension. Default 8.
+     */
+    "minMemAvailablePercent": number;
+
+    /**
+     * MaxLoadPerCPU is the maximum 1-minute load average, normalized by CPU
+     * count, above which new dispatch is deferred. <=0 disables this
+     * dimension. Default 8.0.
+     */
+    "maxLoadPerCpu": number;
+
+    /**
+     * SampleIntervalSeconds is both the resource-sample cache TTL and the
+     * deny-log throttle window. <=0 falls back to
+     * pressure.DefaultSampleIntervalSeconds (15). Default 15.
+     */
+    "sampleIntervalSeconds": number;
+
+    /** Creates a new PressureConfig instance. */
+    constructor($$source: Partial<PressureConfig> = {}) {
+        if (!("enabled" in $$source)) {
+            this["enabled"] = false;
+        }
+        if (!("minDiskFreePercent" in $$source)) {
+            this["minDiskFreePercent"] = 0;
+        }
+        if (!("minMemAvailablePercent" in $$source)) {
+            this["minMemAvailablePercent"] = 0;
+        }
+        if (!("maxLoadPerCpu" in $$source)) {
+            this["maxLoadPerCpu"] = 0;
+        }
+        if (!("sampleIntervalSeconds" in $$source)) {
+            this["sampleIntervalSeconds"] = 0;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new PressureConfig instance from a string or object.
+     */
+    static createFrom($$source: any = {}): PressureConfig {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new PressureConfig($$parsedSource as Partial<PressureConfig>);
     }
 }
 
@@ -939,11 +1027,11 @@ export class ProvidersConfig {
      * Creates a new ProvidersConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): ProvidersConfig {
-        const $$createField0_0 = $$createType6;
-        const $$createField1_0 = $$createType7;
-        const $$createField2_0 = $$createType7;
-        const $$createField3_0 = $$createType7;
-        const $$createField4_0 = $$createType8;
+        const $$createField0_0 = $$createType7;
+        const $$createField1_0 = $$createType8;
+        const $$createField2_0 = $$createType8;
+        const $$createField3_0 = $$createType8;
+        const $$createField4_0 = $$createType9;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("healthCheck" in $$parsedSource) {
             $$parsedSource["healthCheck"] = $$createField0_0($$parsedSource["healthCheck"]);
@@ -1096,7 +1184,7 @@ export class SelfMonitorConfig {
      * Creates a new SelfMonitorConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): SelfMonitorConfig {
-        const $$createField6_0 = $$createType5;
+        const $$createField6_0 = $$createType6;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("autoActCategories" in $$parsedSource) {
             $$parsedSource["autoActCategories"] = $$createField6_0($$parsedSource["autoActCategories"]);
@@ -1296,7 +1384,8 @@ const $$createType1 = PlaywrightMCPConfig.createFrom;
 const $$createType2 = QueueConfig.createFrom;
 const $$createType3 = GitHubAppConfig.createFrom;
 const $$createType4 = $Create.Map($Create.Any, $Create.Any);
-const $$createType5 = $Create.Array($Create.Any);
-const $$createType6 = ProviderHealthCheckConfig.createFrom;
-const $$createType7 = ProviderEntryConfig.createFrom;
-const $$createType8 = ProviderLimitsConfig.createFrom;
+const $$createType5 = PressureConfig.createFrom;
+const $$createType6 = $Create.Array($Create.Any);
+const $$createType7 = ProviderHealthCheckConfig.createFrom;
+const $$createType8 = ProviderEntryConfig.createFrom;
+const $$createType9 = ProviderLimitsConfig.createFrom;

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/sys v0.45.0
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -89,6 +89,11 @@ const (
 	// audit log can see which tasks are running with unrestricted file-write
 	// access instead of only discovering it after an incident.
 	EventAgentSandboxDisabled = "agent.sandbox_disabled"
+	// EventAgentDeferredPressure records that a new agent dispatch was parked
+	// because the local host was under disk/memory/load pressure. Distinct from
+	// agent.start_failed: this is a benign defer that ResumeStalled re-drives
+	// automatically once pressure clears.
+	EventAgentDeferredPressure = "agent.deferred_pressure"
 	// EventAgentCheckpoint records a turn-ceiling checkpoint handoff attempt.
 	// Data.reason distinguishes a committed handoff ("checkpoint") from a
 	// failed commit ("checkpoint_failed").

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -556,7 +556,17 @@ func DefaultConfig() *Config {
 			Role: ClusterRoleStandalone,
 		},
 		Orchestrator: OrchestratorConfig{
-			Pressure: PressureConfig{Enabled: true},
+			// Seed the pressure thresholds here (not in applyPressureDefaults) so
+			// an explicit `0` in YAML — the documented "disable this dimension"
+			// sentinel — survives loading. A config missing the block entirely
+			// keeps these seeds; a config that sets a threshold to 0 keeps its 0.
+			Pressure: PressureConfig{
+				Enabled:                true,
+				MinDiskFreePercent:     5,
+				MinMemAvailablePercent: 8,
+				MaxLoadPerCPU:          8.0,
+				SampleIntervalSeconds:  15,
+			},
 		},
 		TasksDir: defaultTasksDir(),
 	}
@@ -1174,21 +1184,19 @@ func applyOrchestratorDefaults(cfg *Config) {
 	applyPressureDefaults(cfg)
 }
 
-// applyPressureDefaults fills zero values for the Pressure block. Enabled
-// stays true from DefaultConfig's seed, so a config predating this feature
-// (or one missing the block entirely) behaves identically to a fresh
-// install; an explicit `enabled: false` survives untouched.
+// applyPressureDefaults fills the Pressure block. The thresholds
+// (MinDiskFreePercent, MinMemAvailablePercent, MaxLoadPerCPU) are seeded in
+// DefaultConfig, NOT here: their documented `<=0 disables this dimension`
+// sentinel means an explicit `0` in YAML must survive loading, so defaulting
+// them on `<=0` would silently re-enable a signal the operator turned off. A
+// config missing the block entirely keeps the DefaultConfig seeds; a config
+// that sets one threshold to 0 keeps its 0.
+//
+// SampleIntervalSeconds is different — its `<=0` means "fall back to the
+// default", not "disable" — so it is safe to normalize here (pressure.Gate
+// also falls back internally).
 func applyPressureDefaults(cfg *Config) {
 	p := &cfg.Orchestrator.Pressure
-	if p.MinDiskFreePercent <= 0 {
-		p.MinDiskFreePercent = 5
-	}
-	if p.MinMemAvailablePercent <= 0 {
-		p.MinMemAvailablePercent = 8
-	}
-	if p.MaxLoadPerCPU <= 0 {
-		p.MaxLoadPerCPU = 8.0
-	}
 	if p.SampleIntervalSeconds <= 0 {
 		p.SampleIntervalSeconds = 15
 	}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -555,6 +555,9 @@ func DefaultConfig() *Config {
 		Cluster: ClusterConfig{
 			Role: ClusterRoleStandalone,
 		},
+		Orchestrator: OrchestratorConfig{
+			Pressure: PressureConfig{Enabled: true},
+		},
 		TasksDir: defaultTasksDir(),
 	}
 }
@@ -1167,6 +1170,27 @@ func applyOrchestratorDefaults(cfg *Config) {
 	}
 	if cfg.Orchestrator.MaintenanceIntervalSeconds <= 0 {
 		cfg.Orchestrator.MaintenanceIntervalSeconds = 60
+	}
+	applyPressureDefaults(cfg)
+}
+
+// applyPressureDefaults fills zero values for the Pressure block. Enabled
+// stays true from DefaultConfig's seed, so a config predating this feature
+// (or one missing the block entirely) behaves identically to a fresh
+// install; an explicit `enabled: false` survives untouched.
+func applyPressureDefaults(cfg *Config) {
+	p := &cfg.Orchestrator.Pressure
+	if p.MinDiskFreePercent <= 0 {
+		p.MinDiskFreePercent = 5
+	}
+	if p.MinMemAvailablePercent <= 0 {
+		p.MinMemAvailablePercent = 8
+	}
+	if p.MaxLoadPerCPU <= 0 {
+		p.MaxLoadPerCPU = 8.0
+	}
+	if p.SampleIntervalSeconds <= 0 {
+		p.SampleIntervalSeconds = 15
 	}
 }
 

--- a/internal/config/config_orchestrator.go
+++ b/internal/config/config_orchestrator.go
@@ -11,4 +11,37 @@ type OrchestratorConfig struct {
 	// worktrees) which hits git and may spawn agents, so it must not run hot.
 	// Default 60.
 	MaintenanceIntervalSeconds int `yaml:"maintenance_interval_seconds" json:"maintenanceIntervalSeconds"`
+	// Pressure configures the local resource-pressure admission gate that
+	// defers new agent dispatch while the host is short on disk, memory, or
+	// CPU headroom. See internal/pressure.
+	Pressure PressureConfig `yaml:"pressure" json:"pressure"`
+}
+
+// PressureConfig configures internal/pressure.Gate, the local
+// resource-pressure admission gate consulted before dispatching new agent
+// work. Thresholds are captured once at Gate construction, so a change here
+// requires a restart to take effect (see diffConfig's
+// "orchestrator.pressure" restart entry).
+type PressureConfig struct {
+	// Enabled turns the gate on. Default true. When false, New returns a nil
+	// *Gate and every dispatch path admits unconditionally — the same as
+	// running without this feature at all.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// MinDiskFreePercent is the minimum percentage of free disk space (on the
+	// filesystem holding SYBRA_HOME) below which new dispatch is deferred.
+	// <=0 disables this dimension. Default 5.
+	MinDiskFreePercent float64 `yaml:"min_disk_free_percent" json:"minDiskFreePercent"`
+	// MinMemAvailablePercent is the minimum percentage of available memory
+	// (reclaimable caches counted as available, matching the kernel's own
+	// notion of headroom) below which new dispatch is deferred. <=0 disables
+	// this dimension. Default 8.
+	MinMemAvailablePercent float64 `yaml:"min_mem_available_percent" json:"minMemAvailablePercent"`
+	// MaxLoadPerCPU is the maximum 1-minute load average, normalized by CPU
+	// count, above which new dispatch is deferred. <=0 disables this
+	// dimension. Default 8.0.
+	MaxLoadPerCPU float64 `yaml:"max_load_per_cpu" json:"maxLoadPerCpu"`
+	// SampleIntervalSeconds is both the resource-sample cache TTL and the
+	// deny-log throttle window. <=0 falls back to
+	// pressure.DefaultSampleIntervalSeconds (15). Default 15.
+	SampleIntervalSeconds int `yaml:"sample_interval_seconds" json:"sampleIntervalSeconds"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,6 +172,65 @@ func TestLoadExperienceDefaults(t *testing.T) {
 	}
 }
 
+// TestLoadPressureDefaults locks in that a config missing the pressure block
+// (or the whole orchestrator block) resolves to the seeded thresholds.
+func TestLoadPressureDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := cfg.Orchestrator.Pressure
+	if !p.Enabled {
+		t.Fatal("pressure.enabled = false, want true")
+	}
+	if p.MinDiskFreePercent != 5 {
+		t.Fatalf("pressure.min_disk_free_percent = %v, want 5", p.MinDiskFreePercent)
+	}
+	if p.MinMemAvailablePercent != 8 {
+		t.Fatalf("pressure.min_mem_available_percent = %v, want 8", p.MinMemAvailablePercent)
+	}
+	if p.MaxLoadPerCPU != 8.0 {
+		t.Fatalf("pressure.max_load_per_cpu = %v, want 8", p.MaxLoadPerCPU)
+	}
+	if p.SampleIntervalSeconds != 15 {
+		t.Fatalf("pressure.sample_interval_seconds = %d, want 15", p.SampleIntervalSeconds)
+	}
+}
+
+// TestLoadPressureExplicitZeroDisablesDimension locks in the documented
+// `<=0 disables this dimension` escape hatch: an explicit 0 for a pressure
+// threshold must survive defaulting rather than being rewritten to its seed.
+func TestLoadPressureExplicitZeroDisablesDimension(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	yaml := []byte("orchestrator:\n  pressure:\n    min_disk_free_percent: 0\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := cfg.Orchestrator.Pressure
+	if p.MinDiskFreePercent != 0 {
+		t.Fatalf("pressure.min_disk_free_percent = %v, want 0 (disabled)", p.MinDiskFreePercent)
+	}
+	// The untouched dimensions keep their seeds.
+	if p.MinMemAvailablePercent != 8 {
+		t.Fatalf("pressure.min_mem_available_percent = %v, want 8", p.MinMemAvailablePercent)
+	}
+	if p.MaxLoadPerCPU != 8.0 {
+		t.Fatalf("pressure.max_load_per_cpu = %v, want 8", p.MaxLoadPerCPU)
+	}
+}
+
 func TestLoadAutoUpdateDefaults(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("SYBRA_HOME", dir)

--- a/internal/pressure/gate.go
+++ b/internal/pressure/gate.go
@@ -1,8 +1,10 @@
 package pressure
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"time"
 
@@ -26,7 +28,7 @@ type Gate struct {
 	logger         *slog.Logger
 	// sampleFn is swapped out in tests so Admit's threshold/caching logic is
 	// exercised without real syscalls.
-	sampleFn func(probeDir string) Sample
+	sampleFn func(probeDir string) (Sample, error)
 
 	mu         sync.Mutex
 	cached     Sample
@@ -54,7 +56,9 @@ func New(cfg config.PressureConfig, probeDir string, logger *slog.Logger) *Gate 
 		interval:       interval,
 		probeDir:       probeDir,
 		logger:         logger,
-		sampleFn:       readSample,
+		sampleFn: func(probeDir string) (Sample, error) {
+			return readSample(probeDir), nil
+		},
 	}
 }
 
@@ -69,7 +73,14 @@ func (g *Gate) Admit() (ok bool, reason string) {
 	if g == nil {
 		return true, ""
 	}
-	s := g.sample()
+	s, err := g.sample()
+	if err != nil {
+		if !errors.Is(err, errAllSignalsUnreadable) && g.logger != nil {
+			g.logger.Warn("pressure.gate.sample", "err", err)
+		}
+		g.clearReason()
+		return true, ""
+	}
 	switch {
 	case thresholdTripped(s.DiskFreePct, g.minDiskFreePct, true):
 		reason = fmt.Sprintf("disk free %.1f%% below minimum %.1f%%", s.DiskFreePct, g.minDiskFreePct)
@@ -78,6 +89,7 @@ func (g *Gate) Admit() (ok bool, reason string) {
 	case thresholdTripped(s.LoadPerCPU, g.maxLoadPerCPU, false):
 		reason = fmt.Sprintf("load per cpu %.2f exceeds maximum %.2f", s.LoadPerCPU, g.maxLoadPerCPU)
 	default:
+		g.clearReason()
 		return true, ""
 	}
 	g.recordDeny(reason)
@@ -88,7 +100,7 @@ func (g *Gate) Admit() (ok bool, reason string) {
 // currently denying dispatch, the last tripped reason — for the UI/CLI to
 // explain a pressure park without forcing a fresh sample. A nil Gate reports
 // a zero Sample and no reason.
-func (g *Gate) Status() (Sample, string) {
+func (g *Gate) Status() (sample Sample, reason string) {
 	if g == nil {
 		return Sample{}, ""
 	}
@@ -97,20 +109,33 @@ func (g *Gate) Status() (Sample, string) {
 	return g.cached, g.lastReason
 }
 
+var errAllSignalsUnreadable = errors.New("all resource-pressure signals unreadable")
+
 // sample returns the cached Sample, refreshing it when older than interval.
-func (g *Gate) sample() Sample {
+func (g *Gate) sample() (Sample, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if !g.cachedAt.IsZero() && time.Since(g.cachedAt) < g.interval {
-		return g.cached
+		return g.cached, nil
 	}
 	fn := g.sampleFn
 	if fn == nil {
-		fn = readSample
+		fn = func(probeDir string) (Sample, error) {
+			return readSample(probeDir), nil
+		}
 	}
-	g.cached = fn(g.probeDir)
+	sample, err := fn(g.probeDir)
+	if err != nil {
+		return Sample{}, err
+	}
+	g.cached = sample
 	g.cachedAt = time.Now()
-	return g.cached
+	if math.IsNaN(sample.DiskFreePct) &&
+		math.IsNaN(sample.MemAvailablePct) &&
+		math.IsNaN(sample.LoadPerCPU) {
+		return g.cached, errAllSignalsUnreadable
+	}
+	return g.cached, nil
 }
 
 // recordDeny stashes the latest deny reason for Status and logs it, throttled
@@ -125,6 +150,12 @@ func (g *Gate) recordDeny(reason string) {
 	}
 	g.mu.Unlock()
 	if shouldLog && g.logger != nil {
-		g.logger.Warn("pressure.gate.deny", "reason", reason)
+		g.logger.Warn("pressure.gate.deferred", "reason", reason)
 	}
+}
+
+func (g *Gate) clearReason() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.lastReason = ""
 }

--- a/internal/pressure/gate.go
+++ b/internal/pressure/gate.go
@@ -17,8 +17,9 @@ import (
 const DefaultSampleIntervalSeconds = 15
 
 // Gate is a local resource-pressure admission gate consulted before
-// dispatching new agent work. A nil *Gate is safe to call: every method
-// treats it as "gating disabled" and admits unconditionally — see New.
+// dispatching new agent work. A nil *Gate is safe to call: every method treats
+// it as "gating disabled" and admits unconditionally. Call sites may still keep
+// explicit nil guards when they need enabled-only side effects such as audit.
 type Gate struct {
 	minDiskFreePct float64
 	minMemAvailPct float64
@@ -114,28 +115,42 @@ var errAllSignalsUnreadable = errors.New("all resource-pressure signals unreadab
 // sample returns the cached Sample, refreshing it when older than interval.
 func (g *Gate) sample() (Sample, error) {
 	g.mu.Lock()
-	defer g.mu.Unlock()
 	if !g.cachedAt.IsZero() && time.Since(g.cachedAt) < g.interval {
-		return g.cached, nil
+		sample := g.cached
+		g.mu.Unlock()
+		if allSignalsUnreadable(sample) {
+			return sample, errAllSignalsUnreadable
+		}
+		return sample, nil
 	}
 	fn := g.sampleFn
+	probeDir := g.probeDir
+	g.mu.Unlock()
+
 	if fn == nil {
 		fn = func(probeDir string) (Sample, error) {
 			return readSample(probeDir), nil
 		}
 	}
-	sample, err := fn(g.probeDir)
+	sample, err := fn(probeDir)
 	if err != nil {
 		return Sample{}, err
 	}
+
+	g.mu.Lock()
 	g.cached = sample
 	g.cachedAt = time.Now()
-	if math.IsNaN(sample.DiskFreePct) &&
-		math.IsNaN(sample.MemAvailablePct) &&
-		math.IsNaN(sample.LoadPerCPU) {
-		return g.cached, errAllSignalsUnreadable
+	g.mu.Unlock()
+	if allSignalsUnreadable(sample) {
+		return sample, errAllSignalsUnreadable
 	}
-	return g.cached, nil
+	return sample, nil
+}
+
+func allSignalsUnreadable(sample Sample) bool {
+	return math.IsNaN(sample.DiskFreePct) &&
+		math.IsNaN(sample.MemAvailablePct) &&
+		math.IsNaN(sample.LoadPerCPU)
 }
 
 // recordDeny stashes the latest deny reason for Status and logs it, throttled

--- a/internal/pressure/gate.go
+++ b/internal/pressure/gate.go
@@ -1,0 +1,130 @@
+package pressure
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// DefaultSampleIntervalSeconds is used both as the sample cache TTL and the
+// deny-log throttle window when config.PressureConfig.SampleIntervalSeconds
+// is unset or non-positive.
+const DefaultSampleIntervalSeconds = 15
+
+// Gate is a local resource-pressure admission gate consulted before
+// dispatching new agent work. A nil *Gate is safe to call: every method
+// treats it as "gating disabled" and admits unconditionally — see New.
+type Gate struct {
+	minDiskFreePct float64
+	minMemAvailPct float64
+	maxLoadPerCPU  float64
+	interval       time.Duration
+	probeDir       string
+	logger         *slog.Logger
+	// sampleFn is swapped out in tests so Admit's threshold/caching logic is
+	// exercised without real syscalls.
+	sampleFn func(probeDir string) Sample
+
+	mu         sync.Mutex
+	cached     Sample
+	cachedAt   time.Time
+	lastReason string
+	lastLogAt  time.Time
+}
+
+// New constructs a Gate from cfg. Returns a genuine nil *Gate when
+// cfg.Enabled is false — every method on a nil *Gate is safe to call and
+// always admits, so callers never need a separate "is gating on" check
+// before wiring one in.
+func New(cfg config.PressureConfig, probeDir string, logger *slog.Logger) *Gate {
+	if !cfg.Enabled {
+		return nil
+	}
+	interval := time.Duration(cfg.SampleIntervalSeconds) * time.Second
+	if cfg.SampleIntervalSeconds <= 0 {
+		interval = DefaultSampleIntervalSeconds * time.Second
+	}
+	return &Gate{
+		minDiskFreePct: cfg.MinDiskFreePercent,
+		minMemAvailPct: cfg.MinMemAvailablePercent,
+		maxLoadPerCPU:  cfg.MaxLoadPerCPU,
+		interval:       interval,
+		probeDir:       probeDir,
+		logger:         logger,
+		sampleFn:       readSample,
+	}
+}
+
+// Admit reports whether new agent work should be dispatched right now. A
+// false result carries a single-line human-readable reason naming the
+// tripped signal, for the caller's status_reason/log. A nil Gate, a sampler
+// that returns an all-NaN sample (every signal unreadable), and every
+// individual NaN signal all fail OPEN — pressure gating only ever blocks
+// dispatch on a signal it could actually read past its configured
+// threshold.
+func (g *Gate) Admit() (ok bool, reason string) {
+	if g == nil {
+		return true, ""
+	}
+	s := g.sample()
+	switch {
+	case thresholdTripped(s.DiskFreePct, g.minDiskFreePct, true):
+		reason = fmt.Sprintf("disk free %.1f%% below minimum %.1f%%", s.DiskFreePct, g.minDiskFreePct)
+	case thresholdTripped(s.MemAvailablePct, g.minMemAvailPct, true):
+		reason = fmt.Sprintf("memory available %.1f%% below minimum %.1f%%", s.MemAvailablePct, g.minMemAvailPct)
+	case thresholdTripped(s.LoadPerCPU, g.maxLoadPerCPU, false):
+		reason = fmt.Sprintf("load per cpu %.2f exceeds maximum %.2f", s.LoadPerCPU, g.maxLoadPerCPU)
+	default:
+		return true, ""
+	}
+	g.recordDeny(reason)
+	return false, reason
+}
+
+// Status returns the most recently cached sample and, when the gate is
+// currently denying dispatch, the last tripped reason — for the UI/CLI to
+// explain a pressure park without forcing a fresh sample. A nil Gate reports
+// a zero Sample and no reason.
+func (g *Gate) Status() (Sample, string) {
+	if g == nil {
+		return Sample{}, ""
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.cached, g.lastReason
+}
+
+// sample returns the cached Sample, refreshing it when older than interval.
+func (g *Gate) sample() Sample {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if !g.cachedAt.IsZero() && time.Since(g.cachedAt) < g.interval {
+		return g.cached
+	}
+	fn := g.sampleFn
+	if fn == nil {
+		fn = readSample
+	}
+	g.cached = fn(g.probeDir)
+	g.cachedAt = time.Now()
+	return g.cached
+}
+
+// recordDeny stashes the latest deny reason for Status and logs it, throttled
+// to roughly once per interval so a burst of parked dispatch attempts
+// against the same underlying condition doesn't flood the log.
+func (g *Gate) recordDeny(reason string) {
+	g.mu.Lock()
+	g.lastReason = reason
+	shouldLog := g.lastLogAt.IsZero() || time.Since(g.lastLogAt) >= g.interval
+	if shouldLog {
+		g.lastLogAt = time.Now()
+	}
+	g.mu.Unlock()
+	if shouldLog && g.logger != nil {
+		g.logger.Warn("pressure.gate.deny", "reason", reason)
+	}
+}

--- a/internal/pressure/gate.go
+++ b/internal/pressure/gate.go
@@ -97,19 +97,6 @@ func (g *Gate) Admit() (ok bool, reason string) {
 	return false, reason
 }
 
-// Status returns the most recently cached sample and, when the gate is
-// currently denying dispatch, the last tripped reason — for the UI/CLI to
-// explain a pressure park without forcing a fresh sample. A nil Gate reports
-// a zero Sample and no reason.
-func (g *Gate) Status() (sample Sample, reason string) {
-	if g == nil {
-		return Sample{}, ""
-	}
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.cached, g.lastReason
-}
-
 var errAllSignalsUnreadable = errors.New("all resource-pressure signals unreadable")
 
 // sample returns the cached Sample, refreshing it when older than interval.

--- a/internal/pressure/gate_test.go
+++ b/internal/pressure/gate_test.go
@@ -1,0 +1,136 @@
+package pressure
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+func testGate(t *testing.T, cfg config.PressureConfig, sample Sample) *Gate {
+	t.Helper()
+	g := New(cfg, "/tmp", nil)
+	if g == nil {
+		return nil
+	}
+	g.sampleFn = func(string) Sample { return sample }
+	return g
+}
+
+func TestAdmit(t *testing.T) {
+	baseCfg := config.PressureConfig{
+		Enabled:                true,
+		MinDiskFreePercent:     5,
+		MinMemAvailablePercent: 8,
+		MaxLoadPerCPU:          8,
+		SampleIntervalSeconds:  15,
+	}
+
+	cases := []struct {
+		name       string
+		cfg        config.PressureConfig
+		sample     Sample
+		wantAdmit  bool
+		wantReason string
+	}{
+		{
+			name:      "healthy sample admits",
+			cfg:       baseCfg,
+			sample:    Sample{DiskFreePct: 50, MemAvailablePct: 50, LoadPerCPU: 1},
+			wantAdmit: true,
+		},
+		{
+			name:       "disk threshold trips independently",
+			cfg:        baseCfg,
+			sample:     Sample{DiskFreePct: 1, MemAvailablePct: 50, LoadPerCPU: 1},
+			wantAdmit:  false,
+			wantReason: "disk free",
+		},
+		{
+			name:       "memory threshold trips independently",
+			cfg:        baseCfg,
+			sample:     Sample{DiskFreePct: 50, MemAvailablePct: 1, LoadPerCPU: 1},
+			wantAdmit:  false,
+			wantReason: "memory available",
+		},
+		{
+			name:       "load threshold trips independently",
+			cfg:        baseCfg,
+			sample:     Sample{DiskFreePct: 50, MemAvailablePct: 50, LoadPerCPU: 99},
+			wantAdmit:  false,
+			wantReason: "load per cpu",
+		},
+		{
+			name:      "NaN signal is skipped even though it would otherwise trip",
+			cfg:       baseCfg,
+			sample:    Sample{DiskFreePct: math.NaN(), MemAvailablePct: 50, LoadPerCPU: 1},
+			wantAdmit: true,
+		},
+		{
+			name:      "sampler failure (all-NaN sample) fails open",
+			cfg:       baseCfg,
+			sample:    Sample{DiskFreePct: math.NaN(), MemAvailablePct: math.NaN(), LoadPerCPU: math.NaN()},
+			wantAdmit: true,
+		},
+		{
+			name: "threshold <= 0 disables that dimension",
+			cfg: config.PressureConfig{
+				Enabled:                true,
+				MinDiskFreePercent:     0, // disabled
+				MinMemAvailablePercent: 8,
+				MaxLoadPerCPU:          8,
+				SampleIntervalSeconds:  15,
+			},
+			sample:    Sample{DiskFreePct: 0.01, MemAvailablePct: 50, LoadPerCPU: 1},
+			wantAdmit: true,
+		},
+		{
+			name:      "disabled gate admits",
+			cfg:       config.PressureConfig{Enabled: false},
+			sample:    Sample{DiskFreePct: 0, MemAvailablePct: 0, LoadPerCPU: 999},
+			wantAdmit: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := testGate(t, tc.cfg, tc.sample)
+			ok, reason := g.Admit()
+			if ok != tc.wantAdmit {
+				t.Fatalf("Admit() ok = %v, want %v (reason=%q)", ok, tc.wantAdmit, reason)
+			}
+			if tc.wantReason != "" && !strings.Contains(reason, tc.wantReason) {
+				t.Fatalf("reason = %q, want substring %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestAdmitCachesSampleWithinTTL(t *testing.T) {
+	g := New(config.PressureConfig{Enabled: true, MaxLoadPerCPU: 8, SampleIntervalSeconds: 60}, "/tmp", nil)
+	calls := 0
+	g.sampleFn = func(string) Sample {
+		calls++
+		return Sample{DiskFreePct: 50, MemAvailablePct: 50, LoadPerCPU: 1}
+	}
+	for range 5 {
+		if ok, _ := g.Admit(); !ok {
+			t.Fatalf("Admit() = false, want true")
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("sampleFn called %d times, want 1 (cache should serve repeats within TTL)", calls)
+	}
+}
+
+func TestNewCoercesNonPositiveSampleInterval(t *testing.T) {
+	g := New(config.PressureConfig{Enabled: true, MaxLoadPerCPU: 8, SampleIntervalSeconds: 0}, "/tmp", nil)
+	if g == nil {
+		t.Fatal("New returned nil for an enabled config")
+	}
+	if g.interval != DefaultSampleIntervalSeconds*time.Second {
+		t.Fatalf("interval = %v, want %v", g.interval, DefaultSampleIntervalSeconds*time.Second)
+	}
+}

--- a/internal/pressure/gate_test.go
+++ b/internal/pressure/gate_test.go
@@ -123,6 +123,9 @@ func TestAdmitFailsOpenOnSamplerError(t *testing.T) {
 
 func TestAdmitCachesSampleWithinTTL(t *testing.T) {
 	g := New(config.PressureConfig{Enabled: true, MaxLoadPerCPU: 8, SampleIntervalSeconds: 60}, "/tmp", nil)
+	if g == nil {
+		t.Fatal("New returned nil for enabled gate")
+	}
 	calls := 0
 	g.sampleFn = func(string) (Sample, error) {
 		calls++

--- a/internal/pressure/gate_test.go
+++ b/internal/pressure/gate_test.go
@@ -15,7 +15,7 @@ func testGate(t *testing.T, cfg config.PressureConfig, sample Sample) *Gate {
 	if g == nil {
 		return nil
 	}
-	g.sampleFn = func(string) Sample { return sample }
+	g.sampleFn = func(string) (Sample, error) { return sample, nil }
 	return g
 }
 
@@ -108,12 +108,25 @@ func TestAdmit(t *testing.T) {
 	}
 }
 
+func TestAdmitFailsOpenOnSamplerError(t *testing.T) {
+	g := New(config.PressureConfig{Enabled: true, MaxLoadPerCPU: 8, SampleIntervalSeconds: 15}, "/tmp", nil)
+	if g == nil {
+		t.Fatal("New returned nil for enabled gate")
+	}
+	g.sampleFn = func(string) (Sample, error) {
+		return Sample{}, assertError("probe failed")
+	}
+	if ok, reason := g.Admit(); !ok || reason != "" {
+		t.Fatalf("Admit() = (%v, %q), want fail-open true/empty", ok, reason)
+	}
+}
+
 func TestAdmitCachesSampleWithinTTL(t *testing.T) {
 	g := New(config.PressureConfig{Enabled: true, MaxLoadPerCPU: 8, SampleIntervalSeconds: 60}, "/tmp", nil)
 	calls := 0
-	g.sampleFn = func(string) Sample {
+	g.sampleFn = func(string) (Sample, error) {
 		calls++
-		return Sample{DiskFreePct: 50, MemAvailablePct: 50, LoadPerCPU: 1}
+		return Sample{DiskFreePct: 50, MemAvailablePct: 50, LoadPerCPU: 1}, nil
 	}
 	for range 5 {
 		if ok, _ := g.Admit(); !ok {
@@ -134,3 +147,7 @@ func TestNewCoercesNonPositiveSampleInterval(t *testing.T) {
 		t.Fatalf("interval = %v, want %v", g.interval, DefaultSampleIntervalSeconds*time.Second)
 	}
 }
+
+type assertError string
+
+func (e assertError) Error() string { return string(e) }

--- a/internal/pressure/sample.go
+++ b/internal/pressure/sample.go
@@ -1,0 +1,32 @@
+// Package pressure gates new agent dispatch on local resource pressure
+// (disk, memory, CPU load) so a saturated host defers expensive work instead
+// of piling more agents onto a machine that is already struggling.
+package pressure
+
+import "math"
+
+// Sample captures a point-in-time read of local resource pressure signals.
+// NaN in any field means that signal could not be read (unsupported OS,
+// missing /proc, a failed syscall) — an unreadable signal is never itself
+// treated as pressure; see thresholdTripped.
+type Sample struct {
+	DiskFreePct     float64
+	MemAvailablePct float64
+	LoadPerCPU      float64
+}
+
+// thresholdTripped reports whether value has crossed threshold in the
+// configured "bad" direction. below=true means lower-is-worse (a percent-free
+// signal like disk/memory); below=false means higher-is-worse (a load
+// signal). threshold<=0 disables the check ("skip" — the operator left this
+// dimension unconfigured). A NaN value — the signal could not be read — also
+// always skips: an absent signal must never itself be treated as pressure.
+func thresholdTripped(value, threshold float64, below bool) bool {
+	if threshold <= 0 || math.IsNaN(value) {
+		return false
+	}
+	if below {
+		return value < threshold
+	}
+	return value > threshold
+}

--- a/internal/pressure/sample_darwin.go
+++ b/internal/pressure/sample_darwin.go
@@ -1,0 +1,81 @@
+//go:build darwin
+
+package pressure
+
+import (
+	"encoding/binary"
+	"math"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// readSample takes a best-effort point-in-time reading of disk, memory, and
+// load pressure. Every signal is independent: a failure reading one (e.g. a
+// missing sysctl on a locked-down CI image) never prevents the others from
+// reporting, and never itself counts as pressure — it surfaces as NaN.
+func readSample(probeDir string) Sample {
+	return Sample{
+		DiskFreePct:     diskFreePct(probeDir),
+		MemAvailablePct: memAvailablePct(),
+		LoadPerCPU:      loadPerCPU(),
+	}
+}
+
+func diskFreePct(dir string) float64 {
+	var st unix.Statfs_t
+	if err := unix.Statfs(dir, &st); err != nil || st.Blocks == 0 {
+		return math.NaN()
+	}
+	return float64(st.Bavail) / float64(st.Blocks) * 100
+}
+
+// memAvailablePct approximates macOS's notion of "available" memory as
+// free+inactive pages over total physical memory. Darwin aggressively uses
+// free RAM for filesystem cache, so a raw free-page count alone would
+// false-trigger pressure under completely normal operation — inactive pages
+// are reclaimable the same way Linux's MemAvailable counts reclaimable cache.
+func memAvailablePct() float64 {
+	total, err := unix.SysctlUint64("hw.memsize")
+	if err != nil || total == 0 {
+		return math.NaN()
+	}
+	pageSize, err := unix.SysctlUint32("hw.pagesize")
+	if err != nil || pageSize == 0 {
+		return math.NaN()
+	}
+	free, ferr := unix.SysctlUint32("vm.page_free_count")
+	inactive, ierr := unix.SysctlUint32("vm.page_inactive_count")
+	if ferr != nil || ierr != nil {
+		return math.NaN()
+	}
+	available := uint64(free+inactive) * uint64(pageSize)
+	return float64(available) / float64(total) * 100
+}
+
+// loadPerCPU reads the BSD `struct loadavg` (vm.loadavg) — three fixed-point
+// load averages scaled by fscale, of which only the 1-minute figure is used
+// — and normalizes it by CPU count so the configured threshold is portable
+// across differently-sized hosts.
+//
+//	struct loadavg {
+//	    fixpt_t ldavg[3]; // 3x uint32, offset 0
+//	    long    fscale;   // 8-byte aligned, offset 16 on LP64
+//	};
+func loadPerCPU() float64 {
+	raw, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil || len(raw) < 24 {
+		return math.NaN()
+	}
+	ld0 := binary.LittleEndian.Uint32(raw[0:4])
+	fscale := binary.LittleEndian.Uint64(raw[16:24])
+	if fscale == 0 {
+		return math.NaN()
+	}
+	cpus := runtime.NumCPU()
+	if cpus <= 0 {
+		return math.NaN()
+	}
+	load1 := float64(ld0) / float64(fscale)
+	return load1 / float64(cpus)
+}

--- a/internal/pressure/sample_linux.go
+++ b/internal/pressure/sample_linux.go
@@ -1,0 +1,93 @@
+//go:build linux
+
+package pressure
+
+import (
+	"math"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// readSample takes a best-effort point-in-time reading of disk, memory, and
+// load pressure. Every signal is independent: a failure reading one (e.g. an
+// unreadable /proc/meminfo) never prevents the others from reporting, and
+// never itself counts as pressure — it surfaces as NaN.
+func readSample(probeDir string) Sample {
+	return Sample{
+		DiskFreePct:     diskFreePct(probeDir),
+		MemAvailablePct: memAvailablePct(),
+		LoadPerCPU:      loadPerCPU(),
+	}
+}
+
+func diskFreePct(dir string) float64 {
+	var st unix.Statfs_t
+	if err := unix.Statfs(dir, &st); err != nil || st.Blocks == 0 {
+		return math.NaN()
+	}
+	return float64(st.Bavail) / float64(st.Blocks) * 100
+}
+
+// memAvailablePct reads /proc/meminfo's MemAvailable (the kernel's own
+// estimate of memory available for new allocations without swapping,
+// accounting for reclaimable caches) against MemTotal.
+func memAvailablePct() float64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return math.NaN()
+	}
+	var total, avail float64
+	haveTotal, haveAvail := false, false
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "MemTotal:":
+			if v, pErr := strconv.ParseFloat(fields[1], 64); pErr == nil {
+				total = v
+				haveTotal = true
+			}
+		case "MemAvailable:":
+			if v, pErr := strconv.ParseFloat(fields[1], 64); pErr == nil {
+				avail = v
+				haveAvail = true
+			}
+		}
+		if haveTotal && haveAvail {
+			break
+		}
+	}
+	if !haveTotal || !haveAvail || total == 0 {
+		return math.NaN()
+	}
+	return avail / total * 100
+}
+
+// loadPerCPU reads /proc/loadavg's 1-minute load average, normalized by CPU
+// count so the configured threshold is portable across differently-sized
+// hosts.
+func loadPerCPU() float64 {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return math.NaN()
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return math.NaN()
+	}
+	load1, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return math.NaN()
+	}
+	cpus := runtime.NumCPU()
+	if cpus <= 0 {
+		return math.NaN()
+	}
+	return load1 / float64(cpus)
+}

--- a/internal/pressure/sample_linux.go
+++ b/internal/pressure/sample_linux.go
@@ -42,7 +42,7 @@ func memAvailablePct() float64 {
 	}
 	var total, avail float64
 	haveTotal, haveAvail := false, false
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue

--- a/internal/pressure/sample_other.go
+++ b/internal/pressure/sample_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin
+
+package pressure
+
+import "math"
+
+func readSample(string) Sample {
+	return Sample{
+		DiskFreePct:     math.NaN(),
+		MemAvailablePct: math.NaN(),
+		LoadPerCPU:      math.NaN(),
+	}
+}

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/bgop"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/pressure"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/providerid"
@@ -143,6 +144,10 @@ type Orchestrator struct {
 	bgops     *bgop.Tracker
 	logger    *slog.Logger
 	audit     *audit.Logger
+	// pressureGate defers new work when the local host is short on disk,
+	// memory, or CPU headroom. Late-bound via SetPressureGate so startup can
+	// construct it from config after New returns. Nil disables gating.
+	pressureGate *pressure.Gate
 	// queue is the admission queue a workflow implementation dispatch falls
 	// back to when the agent pool is saturated (see StartAgentWithAssignment's
 	// admissionGate). Late-bound via SetQueue once agentqueue.New succeeds at
@@ -193,6 +198,11 @@ func (o *Orchestrator) SetSandboxes(sandboxes *sandbox.Manager) {
 // SetBgops late-binds the background-operation tracker once it exists.
 func (o *Orchestrator) SetBgops(bgops *bgop.Tracker) {
 	o.bgops = bgops
+}
+
+// SetPressureGate late-binds the local resource-pressure admission gate.
+func (o *Orchestrator) SetPressureGate(gate *pressure.Gate) {
+	o.pressureGate = gate
 }
 
 // SetConflictRecovery late-binds the autonomous conflict-recovery callback
@@ -534,6 +544,12 @@ func (o *Orchestrator) startAgent(ctx context.Context, taskID, mode, prompt stri
 	}
 	effMode, dir, requirePerm, skipWT := ResolveExecution(t, mode, researchDir, o.cfg)
 	ignoreConcurrencyLimit := effMode == "interactive"
+	if !ignoreConcurrencyLimit && o.pressureGate != nil {
+		if admit, reason := o.pressureGate.Admit(); !admit {
+			o.LogAudit(audit.EventAgentDeferredPressure, taskID, "", map[string]any{"reason": reason})
+			return nil, "", fmt.Errorf("%w: %s", workflow.ErrResourcePressure, reason)
+		}
+	}
 
 	if ag, baselineRef, err, handled := o.handleSaturatedDispatch(t, taskID, effMode, prompt, includeTaskDescription, skipWT, ignoreConcurrencyLimit, opts); handled {
 		return ag, baselineRef, err

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Automaat/sybra/internal/notification"
 	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/prcontent"
+	"github.com/Automaat/sybra/internal/pressure"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/prompteval"
 	"github.com/Automaat/sybra/internal/provider"
@@ -849,7 +850,7 @@ func (a *App) initWorkflowEngine() {
 	if syncErr := workflow.SyncBuiltins(wfStore); syncErr != nil {
 		a.logger.Error("workflow.sync-builtins", "err", syncErr)
 	}
-	agentLauncher := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks, projects: a.projects, sandboxes: a.sandboxes, experience: a.experience}
+	agentLauncher := a.newWorkflowAgentLauncher()
 	a.workflowEngine = workflow.NewEngine(
 		wfStore,
 		&taskAdapter{tasks: a.tasks, projects: a.projects},
@@ -956,6 +957,22 @@ func (a *App) initWorkflowEngine() {
 	}
 	// Workflow completion moves to wireServices so the callback closure binds
 	// to the completion.Handler constructed there.
+}
+
+func (a *App) newWorkflowAgentLauncher() *agentAdapter {
+	pressureGate := pressure.New(a.cfg.Orchestrator.Pressure, config.HomeDir(), a.logger)
+	if a.agentOrch != nil {
+		a.agentOrch.SetPressureGate(pressureGate)
+	}
+	return &agentAdapter{
+		agents:     a.agents,
+		agentOrch:  a.agentOrch,
+		tasks:      a.tasks,
+		projects:   a.projects,
+		sandboxes:  a.sandboxes,
+		experience: a.experience,
+		pressure:   pressureGate,
+	}
 }
 
 // configureTestingEscalation wires the testing→escalation config knobs onto

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Automaat/sybra/internal/experience"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/prcontent"
+	"github.com/Automaat/sybra/internal/pressure"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
@@ -595,6 +596,7 @@ type agentAdapter struct {
 	projects   *project.Store
 	sandboxes  *sandbox.Manager
 	experience *experience.Store
+	pressure   *pressure.Gate
 }
 
 func translatePoolBusy(err error) error {
@@ -986,6 +988,22 @@ func (a *agentAdapter) TryClaimDispatch(taskID string) (workflow.DispatchClaim, 
 
 func (a *agentAdapter) IsDispatching(taskID string) bool {
 	return a.agents.IsDispatching(taskID)
+}
+
+func (a *agentAdapter) AdmitDispatch(role, mode string) (admit bool, reason string) {
+	if mode == "interactive" || a.pressure == nil {
+		return true, ""
+	}
+	admit, reason = a.pressure.Admit()
+	if !admit {
+		a.agentOrch.LogAudit(audit.EventAgentDeferredPressure, "", "", map[string]any{
+			"role":   role,
+			"mode":   mode,
+			"reason": reason,
+		})
+		return false, reason
+	}
+	return true, ""
 }
 
 // CheckTaskCostBudget implements workflow.CostBudgetChecker for the

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -990,13 +990,13 @@ func (a *agentAdapter) IsDispatching(taskID string) bool {
 	return a.agents.IsDispatching(taskID)
 }
 
-func (a *agentAdapter) AdmitDispatch(role, mode string) (admit bool, reason string) {
+func (a *agentAdapter) AdmitDispatch(taskID, role, mode string) (admit bool, reason string) {
 	if mode == "interactive" || a.pressure == nil {
 		return true, ""
 	}
 	admit, reason = a.pressure.Admit()
 	if !admit {
-		a.agentOrch.LogAudit(audit.EventAgentDeferredPressure, "", "", map[string]any{
+		a.agentOrch.LogAudit(audit.EventAgentDeferredPressure, taskID, "", map[string]any{
 			"role":   role,
 			"mode":   mode,
 			"reason": reason,

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -81,6 +81,9 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 		old.Orchestrator.MaintenanceIntervalSeconds != next.Orchestrator.MaintenanceIntervalSeconds {
 		restart = append(restart, "orchestrator.intervals")
 	}
+	// pressure.Gate captures its thresholds at construction, same rationale
+	// as orchestrator.intervals above.
+	restart = appendDeepChanged(restart, "orchestrator.pressure", old.Orchestrator.Pressure, next.Orchestrator.Pressure)
 	if !reflect.DeepEqual(old.Audit, next.Audit) {
 		hot = append(hot, "audit")
 	}

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -826,6 +826,9 @@ func (b *blockingAgentLauncher) ProviderRateLimited(string) bool  { return false
 func (b *blockingAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (b *blockingAgentLauncher) ProviderHealthy(string) bool      { return true }
 func (b *blockingAgentLauncher) IsDispatching(string) bool        { return false }
+func (b *blockingAgentLauncher) AdmitDispatch(string, string) (admit bool, reason string) {
+	return true, ""
+}
 
 // TestDispatchBranchConflictRecovery_QueuesRetryInsteadOfGivingUpWhenMarkerHeld
 // locks the fix for dispatchBranchConflictRecovery's own re-dispatch call: a
@@ -1066,6 +1069,9 @@ func (f *failingAgentLauncher) ProviderRateLimited(string) bool  { return false 
 func (f *failingAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (f *failingAgentLauncher) ProviderHealthy(string) bool      { return false }
 func (f *failingAgentLauncher) IsDispatching(string) bool        { return false }
+func (f *failingAgentLauncher) AdmitDispatch(string, string) (admit bool, reason string) {
+	return true, ""
+}
 func (f *failingAgentLauncher) TryClaimDispatch(string) (workflow.DispatchClaim, bool) {
 	return nil, true
 }

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -826,7 +826,7 @@ func (b *blockingAgentLauncher) ProviderRateLimited(string) bool  { return false
 func (b *blockingAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (b *blockingAgentLauncher) ProviderHealthy(string) bool      { return true }
 func (b *blockingAgentLauncher) IsDispatching(string) bool        { return false }
-func (b *blockingAgentLauncher) AdmitDispatch(string, string) (admit bool, reason string) {
+func (b *blockingAgentLauncher) AdmitDispatch(string, string, string) (admit bool, reason string) {
 	return true, ""
 }
 
@@ -1069,7 +1069,7 @@ func (f *failingAgentLauncher) ProviderRateLimited(string) bool  { return false 
 func (f *failingAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (f *failingAgentLauncher) ProviderHealthy(string) bool      { return false }
 func (f *failingAgentLauncher) IsDispatching(string) bool        { return false }
-func (f *failingAgentLauncher) AdmitDispatch(string, string) (admit bool, reason string) {
+func (f *failingAgentLauncher) AdmitDispatch(string, string, string) (admit bool, reason string) {
 	return true, ""
 }
 func (f *failingAgentLauncher) TryClaimDispatch(string) (workflow.DispatchClaim, bool) {

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -246,3 +246,7 @@ func (a *agentAdapter) ProviderHealthy(provider string) bool {
 func (a *agentAdapter) IsDispatching(taskID string) bool {
 	return a.agents.IsDispatching(taskID)
 }
+
+func (a *agentAdapter) AdmitDispatch(role, mode string) (bool, string) {
+	return true, ""
+}

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -247,6 +247,6 @@ func (a *agentAdapter) IsDispatching(taskID string) bool {
 	return a.agents.IsDispatching(taskID)
 }
 
-func (a *agentAdapter) AdmitDispatch(role, mode string) (bool, string) {
+func (a *agentAdapter) AdmitDispatch(role, mode string) (admit bool, reason string) {
 	return true, ""
 }

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -247,6 +247,6 @@ func (a *agentAdapter) IsDispatching(taskID string) bool {
 	return a.agents.IsDispatching(taskID)
 }
 
-func (a *agentAdapter) AdmitDispatch(role, mode string) (admit bool, reason string) {
+func (a *agentAdapter) AdmitDispatch(string, string, string) (admit bool, reason string) {
 	return true, ""
 }

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -44,7 +44,7 @@ func (f *fakeAgentLauncher) ProviderRateLimited(string) bool  { return false }
 func (f *fakeAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (f *fakeAgentLauncher) ProviderHealthy(string) bool      { return true }
 func (f *fakeAgentLauncher) IsDispatching(string) bool        { return false }
-func (f *fakeAgentLauncher) AdmitDispatch(string, string) (admit bool, reason string) {
+func (f *fakeAgentLauncher) AdmitDispatch(string, string, string) (admit bool, reason string) {
 	return true, ""
 }
 

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -44,6 +44,9 @@ func (f *fakeAgentLauncher) ProviderRateLimited(string) bool  { return false }
 func (f *fakeAgentLauncher) ProviderCanFailover(string) bool  { return false }
 func (f *fakeAgentLauncher) ProviderHealthy(string) bool      { return true }
 func (f *fakeAgentLauncher) IsDispatching(string) bool        { return false }
+func (f *fakeAgentLauncher) AdmitDispatch(string, string) (admit bool, reason string) {
+	return true, ""
+}
 
 // setupDispatchTestService builds a TaskService whose workflow engine is
 // wired to a fakeAgentLauncher instead of the real agent.Manager-backed

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -76,6 +76,14 @@ type AgentLauncher interface {
 	// by a dispatcher outside the engine's own visibility (e.g. recovery) is
 	// never missed.
 	IsDispatching(taskID string) bool
+	// AdmitDispatch consults the local resource-pressure gate (internal/pressure)
+	// before a run_agent/best_of_n/parallel step spawns a new agent process.
+	// Interactive mode always admits (a human is waiting on it) and an
+	// implementation with no gate wired always admits — this is a Layer-1 peek
+	// called BEFORE the (potentially expensive) worktree-prep/StartAgent path,
+	// so a saturated host defers new work without ever touching the worktree.
+	// admit=false carries a human-readable reason for the caller to park with.
+	AdmitDispatch(role, mode string) (admit bool, reason string)
 }
 
 // DispatchClaim is the workflow-visible handle for a held per-task dispatch

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -83,7 +83,7 @@ type AgentLauncher interface {
 	// called BEFORE the (potentially expensive) worktree-prep/StartAgent path,
 	// so a saturated host defers new work without ever touching the worktree.
 	// admit=false carries a human-readable reason for the caller to park with.
-	AdmitDispatch(role, mode string) (admit bool, reason string)
+	AdmitDispatch(taskID, role, mode string) (admit bool, reason string)
 }
 
 // DispatchClaim is the workflow-visible handle for a held per-task dispatch

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1256,7 +1256,10 @@ func (e *Engine) surfaceStartFailureClassified(taskID, currentStatus string, err
 	// task to human-required for something that self-heals when the cooldown
 	// window expires. Only genuine failures (bad worktree, missing project,
 	// crashes) — and auth failures that need a human login — feed the breaker.
-	if wf != nil && stepID != "" && !isTransientCapacityError(err) {
+	// isDeferredNotFailed excludes resource-pressure defers the same way: they
+	// surface a status_reason (unlike the fully-silent transient sentinels)
+	// but must never accumulate toward the breaker.
+	if wf != nil && stepID != "" && !isTransientCapacityError(err) && !isDeferredNotFailed(err) {
 		attempts, trip := recordCircuitBreakerFailure(wf, stepID, time.Now())
 		if trip {
 			// The status skip in resumeSkipReasonForStatus alone is not a

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -140,6 +140,14 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	if mode == "" {
 		mode = "headless"
 	}
+	if admit, reason := e.agents.AdmitDispatch(step.Config.Role, mode); !admit {
+		if err := e.tasks.UpdateTaskStatus(taskID, ctx.Task.Status, reason); err != nil {
+			return err
+		}
+		wfExec.State = ExecWaiting
+		e.logger.Info("workflow.run-agent.resource-pressure", "task_id", taskID, "step", step.ID, "reason", reason)
+		return e.tasks.SetWorkflow(taskID, wfExec)
+	}
 
 	model := step.Config.Model
 	if model == "" {

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -140,8 +140,10 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	if mode == "" {
 		mode = "headless"
 	}
-	if admit, reason := e.agents.AdmitDispatch(step.Config.Role, mode); !admit {
-		if err := e.tasks.UpdateTaskStatus(taskID, ctx.Task.Status, reason); err != nil {
+	if admit, reason := e.agents.AdmitDispatch(taskID, step.Config.Role, mode); !admit {
+		err := fmt.Errorf("%w: %s", ErrResourcePressure, reason)
+		classifiedReason, _ := ClassifyAgentStartError(err)
+		if err := e.tasks.UpdateTaskStatus(taskID, ctx.Task.Status, classifiedReason); err != nil {
 			return err
 		}
 		wfExec.State = ExecWaiting

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -169,6 +169,16 @@ func (e *Engine) execBestOfN(taskID string, def *Definition, step *Step, wfExec 
 // (VariantID=attempt_N, AssignmentUnit=bestofn-attempt) independent of the
 // trimmable Execution state above.
 func (e *Engine) spawnBestOfNAttempt(taskID string, step *Step, wfExec *Execution, parentCtx TemplateContext, attemptID string, status *AttemptStatus) error {
+	mode := step.Config.Mode
+	if mode == "" || mode == "interactive" {
+		// Attempts must terminate on their own so the parent can advance —
+		// same rationale as spawnParallelChild's oneShot=false headless-only
+		// requirement.
+		mode = "headless"
+	}
+	if admit, reason := e.agents.AdmitDispatch(step.Config.Role, mode); !admit {
+		return fmt.Errorf("%w: %s", ErrResourcePressure, reason)
+	}
 	dir, branch, err := e.attemptWorktrees.PrepareAttempt(taskID, attemptID)
 	if err != nil {
 		return fmt.Errorf("prepare attempt worktree: %w", err)
@@ -177,13 +187,6 @@ func (e *Engine) spawnBestOfNAttempt(taskID string, step *Step, wfExec *Executio
 	status.Branch = branch
 
 	attemptCtx := parentCtx
-	mode := step.Config.Mode
-	if mode == "" || mode == "interactive" {
-		// Attempts must terminate on their own so the parent can advance —
-		// same rationale as spawnParallelChild's oneShot=false headless-only
-		// requirement.
-		mode = "headless"
-	}
 	model := step.Config.Model
 	if model == "" {
 		model = "sonnet"

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -176,7 +176,7 @@ func (e *Engine) spawnBestOfNAttempt(taskID string, step *Step, wfExec *Executio
 		// requirement.
 		mode = "headless"
 	}
-	if admit, reason := e.agents.AdmitDispatch(step.Config.Role, mode); !admit {
+	if admit, reason := e.agents.AdmitDispatch(taskID, step.Config.Role, mode); !admit {
 		return fmt.Errorf("%w: %s", ErrResourcePressure, reason)
 	}
 	dir, branch, err := e.attemptWorktrees.PrepareAttempt(taskID, attemptID)

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -117,6 +117,9 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	if mode == "" {
 		mode = "headless"
 	}
+	if admit, reason := e.agents.AdmitDispatch(child.Config.Role, mode); !admit {
+		return fmt.Errorf("%w: %s", ErrResourcePressure, reason)
+	}
 	model := child.Config.Model
 	if model == "" {
 		model = "sonnet"

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -117,7 +117,7 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	if mode == "" {
 		mode = "headless"
 	}
-	if admit, reason := e.agents.AdmitDispatch(child.Config.Role, mode); !admit {
+	if admit, reason := e.agents.AdmitDispatch(taskID, child.Config.Role, mode); !admit {
 		return fmt.Errorf("%w: %s", ErrResourcePressure, reason)
 	}
 	model := child.Config.Model

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -583,7 +583,7 @@ func (m *mockAgents) IsDispatching(taskID string) bool {
 	return m.dispatchClaimed[taskID]
 }
 
-func (m *mockAgents) AdmitDispatch(role, mode string) (admit bool, reason string) {
+func (m *mockAgents) AdmitDispatch(taskID, role, mode string) (admit bool, reason string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.admitDenyReason == "" {
@@ -5731,7 +5731,7 @@ func TestExecRunAgent_ResourcePressureParksWithoutConsumingSteer(t *testing.T) {
 	if wfExec.State != ExecWaiting {
 		t.Fatalf("workflow state = %s, want waiting", wfExec.State)
 	}
-	if got := tasks.Reason("t1"); got != "disk free 1.0% below minimum 5.0%" {
+	if got := tasks.Reason("t1"); got != "work paused: machine under resource pressure — disk free 1.0% below minimum 5.0%" {
 		t.Fatalf("status_reason = %q", got)
 	}
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -402,6 +402,7 @@ type mockAgents struct {
 	failSpawnOnce     error
 	startGate         chan struct{}
 	startEntered      chan struct{}
+	admitDenyReason   string // when non-empty, AdmitDispatch denies with this reason
 }
 
 type panicStartAgents struct{ *mockAgents }
@@ -580,6 +581,23 @@ func (m *mockAgents) IsDispatching(taskID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.dispatchClaimed[taskID]
+}
+
+func (m *mockAgents) AdmitDispatch(role, mode string) (bool, string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.admitDenyReason == "" {
+		return true, ""
+	}
+	return false, m.admitDenyReason
+}
+
+// SetAdmitDispatch arms the mock so AdmitDispatch denies with reason. Pass
+// "" to disarm (the default: always admit).
+func (m *mockAgents) SetAdmitDispatch(reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.admitDenyReason = reason
 }
 
 type mockDispatchClaim struct {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -583,7 +583,7 @@ func (m *mockAgents) IsDispatching(taskID string) bool {
 	return m.dispatchClaimed[taskID]
 }
 
-func (m *mockAgents) AdmitDispatch(role, mode string) (bool, string) {
+func (m *mockAgents) AdmitDispatch(role, mode string) (admit bool, reason string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.admitDenyReason == "" {
@@ -5701,6 +5701,48 @@ func TestExecRunAgent_ConsumesSupervisorSteer(t *testing.T) {
 	}
 	if got := agents.LastCall().Prompt; got != "do the work" {
 		t.Fatalf("second dispatch prompt = %q, want unsteered (steer already consumed)", got)
+	}
+}
+
+func TestExecRunAgent_ResourcePressureParksWithoutConsumingSteer(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
+	tasks.SetSteer("t1", "keep this steer")
+	agents.SetAdmitDispatch("disk free 1.0% below minimum 5.0%")
+
+	step := &Step{
+		ID:     "implement",
+		Type:   StepRunAgent,
+		Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "do the work"},
+	}
+	wfExec := &Execution{WorkflowID: "test-simple", CurrentStep: "implement", State: ExecRunning, Variables: map[string]string{}}
+	ctx := TemplateContext{Task: TaskInfo{ID: "t1", Status: "in-progress"}, Step: *step, Vars: wfExec.Variables}
+
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := agents.CallCount(); got != 0 {
+		t.Fatalf("StartAgent call count = %d, want 0", got)
+	}
+	if wfExec.State != ExecWaiting {
+		t.Fatalf("workflow state = %s, want waiting", wfExec.State)
+	}
+	if got := tasks.Reason("t1"); got != "disk free 1.0% below minimum 5.0%" {
+		t.Fatalf("status_reason = %q", got)
+	}
+
+	agents.SetAdmitDispatch("")
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+	got := agents.LastCall().Prompt
+	want := "Supervisor course-correction: keep this steer\n\ndo the work"
+	if got != want {
+		t.Fatalf("prompt after pressure clears = %q, want %q", got, want)
 	}
 }
 

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -98,7 +98,7 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 		// dispatch-plumbing sentinels above, this names an operator-visible
 		// machine condition, so it DOES surface a status_reason (see
 		// isDeferredNotFailed for why it still never feeds the breaker).
-		reason = "work paused: machine under resource pressure — " + strings.TrimPrefix(err.Error(), "agent dispatch deferred: ")
+		reason = "work paused: machine under resource pressure — " + resourcePressureDetail(err)
 		return truncateReason(reason), false
 	case errors.Is(err, worktreeerr.ErrAgentRunning):
 		// Transient: PrepareForTask refused to rebase a worktree a tracked
@@ -185,6 +185,23 @@ func isDeferredNotFailed(err error) bool {
 
 func isTransientFetchReason(reason string) bool {
 	return strings.TrimSpace(reason) == transientFetchStatusReason
+}
+
+func resourcePressureDetail(err error) string {
+	if err == nil {
+		return "local resource pressure"
+	}
+	msg := err.Error()
+	base := ErrResourcePressure.Error()
+	_, suffix, ok := strings.Cut(msg, base)
+	if !ok {
+		return "local resource pressure"
+	}
+	detail := strings.TrimSpace(strings.TrimPrefix(suffix, ":"))
+	if detail == "" {
+		return "local resource pressure"
+	}
+	return detail
 }
 
 // truncateReason caps a status_reason to startReasonMaxLen bytes with an

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -39,6 +39,18 @@ var ErrTestRunnerBusy = errors.New("test-runner concurrency cap reached")
 // transient "too many agents running" is not a dispatch fault.
 var ErrAgentPoolBusy = errors.New("agent pool concurrency cap reached")
 
+// ErrResourcePressure is returned by an agent-start path when
+// internal/pressure.Gate denies dispatch because the local host is short on
+// disk, memory, or CPU headroom. Unlike ErrDispatchInFlight/ErrTestRunnerBusy/
+// ErrAgentPoolBusy — which are suppressed to an empty status_reason because
+// the condition is invisible and self-explanatory — resource pressure is an
+// operator-actionable machine condition, so it DOES surface a status_reason
+// (see ClassifyAgentStartError) while still being excluded from the circuit
+// breaker (see isDeferredNotFailed): a host under sustained pressure would
+// otherwise trip the breaker and wrongly escalate to human-required for a
+// condition that resolves on its own once load drops.
+var ErrResourcePressure = errors.New("agent dispatch deferred: local resource pressure")
+
 // ErrNoProjectAssigned is returned by an agent-start path when a task needs
 // an isolated worktree but has no project_id, and auto-assignment could not
 // resolve one (no agent.default_project_id configured, and more than one
@@ -81,6 +93,13 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 		return "", false
 	case errors.Is(err, ErrAgentPoolBusy):
 		return "", false
+	case errors.Is(err, ErrResourcePressure):
+		// Transient and self-healing once load drops — but unlike the benign
+		// dispatch-plumbing sentinels above, this names an operator-visible
+		// machine condition, so it DOES surface a status_reason (see
+		// isDeferredNotFailed for why it still never feeds the breaker).
+		reason = "work paused: machine under resource pressure — " + strings.TrimPrefix(err.Error(), "agent dispatch deferred: ")
+		return truncateReason(reason), false
 	case errors.Is(err, worktreeerr.ErrAgentRunning):
 		// Transient: PrepareForTask refused to rebase a worktree a tracked
 		// agent is still live in. The agent's own completion (or a later
@@ -147,9 +166,21 @@ func transientAgentStartError(err error) bool {
 	return errors.Is(err, ErrDispatchInFlight) ||
 		errors.Is(err, ErrTestRunnerBusy) ||
 		errors.Is(err, ErrAgentPoolBusy) ||
+		errors.Is(err, ErrResourcePressure) ||
 		errors.Is(err, worktreeerr.ErrTransientFetch) ||
 		errors.Is(err, worktreeerr.ErrAgentRunning) ||
 		errors.Is(err, provider.ErrProviderUnhealthy)
+}
+
+// isDeferredNotFailed reports whether err represents a benign defer that must
+// never feed the circuit breaker (see surfaceStartFailureClassified), even
+// though — unlike the other transient sentinels — it DOES surface a
+// status_reason via ClassifyAgentStartError. A host under sustained resource
+// pressure would otherwise accumulate breaker failures for every parked
+// dispatch attempt and wrongly escalate to human-required for a condition
+// that self-heals once load drops.
+func isDeferredNotFailed(err error) bool {
+	return errors.Is(err, ErrResourcePressure)
 }
 
 func isTransientFetchReason(reason string) bool {

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -95,6 +95,11 @@ func TestClassifyAgentStartError(t *testing.T) {
 			name: "agent pool busy yields empty and transient",
 			err:  fmt.Errorf("start agent: %w", ErrAgentPoolBusy),
 		},
+		{
+			name:         "resource pressure is transient with surfaced reason",
+			err:          fmt.Errorf("start agent: %w: disk free 1.0%% below minimum 5.0%%", ErrResourcePressure),
+			wantContains: "machine under resource pressure — disk free 1.0% below minimum 5.0%",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -115,6 +120,23 @@ func TestClassifyAgentStartError(t *testing.T) {
 				t.Errorf("reason length %d exceeds cap %d", len(reason), startReasonMaxLen)
 			}
 		})
+	}
+}
+
+func TestClassifyAgentStartError_ResourcePressureExcludedFromBreaker(t *testing.T) {
+	err := fmt.Errorf("start agent: %w: disk free 1.0%% below minimum 5.0%%", ErrResourcePressure)
+	reason, permanent := ClassifyAgentStartError(err)
+	if permanent {
+		t.Fatal("resource pressure must not be permanent")
+	}
+	if reason == "" {
+		t.Fatal("resource pressure reason must not be empty")
+	}
+	if !transientAgentStartError(err) {
+		t.Fatal("resource pressure must be transient")
+	}
+	if !isDeferredNotFailed(err) {
+		t.Fatal("resource pressure must be excluded from the breaker")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a pressure gate for disk, memory, and CPU/load before expensive agent dispatch
- defer non-interactive workflow work under pressure while leaving interactive work admitted
- surface pressure pauses through task status reasons, logs, and audit events

Fixes #1958

## Notes
Recovered from Sybra server task 771b9acc: implementation had completed and local verification had passed, but the server could not push because its GitHub HTTPS token was invalid.