### PR TITLE
fix(github): preflight push credentials before PR recovery

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1251,11 +1251,7 @@ func scrubCredentialPreflightMessage(msg string) string {
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		lower := strings.ToLower(trimmed)
-		if trimmed == "" ||
-			strings.Contains(lower, "token:") ||
-			strings.Contains(lower, "oauth_token") ||
-			strings.Contains(lower, "ghp_") ||
-			strings.Contains(lower, "github_pat_") {
+		if trimmed == "" || containsGitHubCredentialMarker(lower) {
 			continue
 		}
 		kept = append(kept, trimmed)
@@ -1267,6 +1263,24 @@ func scrubCredentialPreflightMessage(msg string) string {
 		return "authentication check failed"
 	}
 	return strings.Join(kept, "; ")
+}
+
+func containsGitHubCredentialMarker(lower string) bool {
+	for _, marker := range []string{
+		"token:",
+		"oauth_token",
+		"ghp_",
+		"gho_",
+		"ghu_",
+		"ghs_",
+		"ghr_",
+		"github_pat_",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // RemoveWorktree deletes worktreePath and its `git worktree` registration

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -27,6 +27,10 @@ var (
 // ErrBranchMissing is returned by PushSync when the local branch ref does not exist.
 var ErrBranchMissing = errors.New("local branch ref does not exist")
 
+// ErrPushAuthPreflight is returned by PreflightPushCredentials when the
+// current process cannot authenticate to the configured GitHub push remote.
+var ErrPushAuthPreflight = errors.New("github push credential preflight failed")
+
 // ErrBranchDiverged is returned by ReconcileWithRemote when the local branch and
 // the remote branch head have genuinely diverged (neither is an ancestor of the
 // other). Proceeding would force-push over remote-only commits — e.g. a fix
@@ -1201,6 +1205,68 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 		return fmt.Errorf("%w: %w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, ErrRemoteAdvanced, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
 	}
 	return fmt.Errorf("%w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
+}
+
+// PreflightPushCredentials cheaply validates the GitHub credential path before
+// Sybra spends an agent turn or starts push-dependent git work. It intentionally
+// skips SSH and non-GitHub remotes: those either use OS-level ssh-agent state or
+// an unknown host-specific credential mechanism, so a false-negative preflight
+// would be worse than letting the actual push report the error.
+func PreflightPushCredentials(ctx context.Context, worktreePath string) error {
+	remote := PushRemote(ctx, worktreePath)
+	pushURL, err := executil.Output(ctx, worktreePath, "git", "remote", "get-url", "--push", remote)
+	if err != nil {
+		return fmt.Errorf("resolve push remote %s: %w", remote, err)
+	}
+	if !isGitHubHTTPSRemote(strings.TrimSpace(pushURL)) {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "gh", "auth", "status", "--hostname", "github.com")
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		msg = err.Error()
+	}
+	return fmt.Errorf("%w: gh auth status: %s", ErrPushAuthPreflight, scrubCredentialPreflightMessage(msg))
+}
+
+func isGitHubHTTPSRemote(remoteURL string) bool {
+	u, err := url.Parse(remoteURL)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), "github.com")
+}
+
+func scrubCredentialPreflightMessage(msg string) string {
+	lines := strings.Split(msg, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		lower := strings.ToLower(trimmed)
+		if trimmed == "" ||
+			strings.Contains(lower, "token:") ||
+			strings.Contains(lower, "oauth_token") ||
+			strings.Contains(lower, "ghp_") ||
+			strings.Contains(lower, "github_pat_") {
+			continue
+		}
+		kept = append(kept, trimmed)
+		if len(kept) >= 4 {
+			break
+		}
+	}
+	if len(kept) == 0 {
+		return "authentication check failed"
+	}
+	return strings.Join(kept, "; ")
 }
 
 // RemoveWorktree deletes worktreePath and its `git worktree` registration

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -90,13 +90,19 @@ func TestScrubCredentialPreflightMessage(t *testing.T) {
 		"github_pat_should_not_leak\n" +
 		"- The token in GH_TOKEN is invalid."
 	got := scrubCredentialPreflightMessage(msg)
-	for _, forbidden := range []string{"ghp_", "github_pat_", "token:"} {
+	for _, forbidden := range []string{"ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_", "token:"} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("scrubbed message leaked %q: %q", forbidden, got)
 		}
 	}
 	if !strings.Contains(got, "Failed to log in") || !strings.Contains(got, "GH_TOKEN is invalid") {
 		t.Fatalf("scrubbed message dropped useful auth context: %q", got)
+	}
+
+	for _, prefix := range []string{"gho_", "ghu_", "ghs_", "ghr_"} {
+		if got := scrubCredentialPreflightMessage(prefix + "should_not_leak"); strings.Contains(got, prefix) {
+			t.Fatalf("scrubbed message leaked %q: %q", prefix, got)
+		}
 	}
 }
 

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -63,6 +63,43 @@ func TestParseGitHubURL(t *testing.T) {
 	}
 }
 
+func TestIsGitHubHTTPSRemote(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		remote string
+		want   bool
+	}{
+		{"https://github.com/Automaat/sybra.git", true},
+		{"http://github.com/Automaat/sybra.git", true},
+		{"git@github.com:Automaat/sybra.git", false},
+		{"ssh://git@github.com/Automaat/sybra.git", false},
+		{"https://gitlab.com/Automaat/sybra.git", false},
+		{"not a url", false},
+	}
+	for _, tt := range tests {
+		if got := isGitHubHTTPSRemote(tt.remote); got != tt.want {
+			t.Errorf("isGitHubHTTPSRemote(%q) = %v, want %v", tt.remote, got, tt.want)
+		}
+	}
+}
+
+func TestScrubCredentialPreflightMessage(t *testing.T) {
+	t.Parallel()
+	msg := "X Failed to log in to github.com using token (GH_TOKEN)\n" +
+		"token: ghp_should_not_leak\n" +
+		"github_pat_should_not_leak\n" +
+		"- The token in GH_TOKEN is invalid."
+	got := scrubCredentialPreflightMessage(msg)
+	for _, forbidden := range []string{"ghp_", "github_pat_", "token:"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("scrubbed message leaked %q: %q", forbidden, got)
+		}
+	}
+	if !strings.Contains(got, "Failed to log in") || !strings.Contains(got, "GH_TOKEN is invalid") {
+		t.Fatalf("scrubbed message dropped useful auth context: %q", got)
+	}
+}
+
 func TestSplitOwnerRepo(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/sybra/review/automerge_test.go
+++ b/internal/sybra/review/automerge_test.go
@@ -917,11 +917,12 @@ func TestHandleTaskPRIssues_ExhaustedRetryParksOnlyWhenNoSiblingHandleable(t *te
 	}
 
 	r := &Handler{
-		logger:         logger,
-		tasks:          tasks,
-		agents:         agentMgr,
-		prTracker:      prTracker,
-		WorkflowEngine: engine,
+		logger:          logger,
+		tasks:           tasks,
+		agents:          agentMgr,
+		prTracker:       prTracker,
+		WorkflowEngine:  engine,
+		pushPreflightFn: stubPushPreflight(nil),
 	}
 
 	pr := github.PullRequest{

--- a/internal/sybra/review/autoresolve_test.go
+++ b/internal/sybra/review/autoresolve_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -146,6 +147,7 @@ func newAutoResolveHarness(t *testing.T, autoResolveEnabled bool) *autoResolveHa
 		cfg: &config.Config{GitHub: config.GitHubConfig{
 			AutoResolveCleanMerges: autoResolveEnabled,
 		}},
+		pushPreflightFn: stubPushPreflight(nil),
 	}
 	return &autoResolveHarness{
 		r:        r,
@@ -188,6 +190,10 @@ func stubPush(err error) func(context.Context, string, string) error {
 	return func(context.Context, string, string) error { return err }
 }
 
+func stubPushPreflight(err error) func(context.Context, string) error {
+	return func(context.Context, string) error { return err }
+}
+
 func currentHEAD(t *testing.T, dir string) string {
 	t.Helper()
 	out, err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "HEAD").CombinedOutput()
@@ -195,6 +201,33 @@ func currentHEAD(t *testing.T, dir string) string {
 		t.Fatalf("git rev-parse HEAD: %v: %s", err, out)
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func TestDispatchFixIssues_PushPreflightFailureBlocksAgentDispatch(t *testing.T) {
+	h := newAutoResolveHarness(t, false)
+	tk, pr := h.newConflictTask(t)
+	h.r.pushPreflightFn = stubPushPreflight(errors.New("github push credential preflight failed: gh auth status: Bad credentials"))
+
+	ok := h.r.dispatchFixIssues(context.Background(), tk.ID, []github.PRIssue{
+		{Kind: github.PRIssueConflict, TaskID: tk.ID, PR: pr},
+	})
+	if !ok {
+		t.Fatal("dispatchFixIssues = false, want true (credential blocker handled)")
+	}
+
+	got, err := h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want none; preflight must block before pr-fix agent dispatch", got.Workflow)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if !strings.Contains(got.StatusReason, "GitHub push credential preflight failed before starting PR fix") {
+		t.Fatalf("status reason = %q, want push credential preflight reason", got.StatusReason)
+	}
 }
 
 // TestAutoResolveConflict_CreatedSkipsAgent is the acceptance criterion at the

--- a/internal/sybra/review/ci_failure_dispatch_test.go
+++ b/internal/sybra/review/ci_failure_dispatch_test.go
@@ -38,14 +38,15 @@ func buildPRFixHandler(t *testing.T, tasks *task.Manager, fetchReviewsFn func() 
 		logger,
 	)
 	return &Handler{
-		logger:         logger,
-		emit:           func(string, any) {},
-		tasks:          tasks,
-		projects:       projects,
-		agents:         agentMgr,
-		prTracker:      github.NewIssueTracker(time.Minute),
-		WorkflowEngine: engine,
-		fetchReviewsFn: fetchReviewsFn,
+		logger:          logger,
+		emit:            func(string, any) {},
+		tasks:           tasks,
+		projects:        projects,
+		agents:          agentMgr,
+		prTracker:       github.NewIssueTracker(time.Minute),
+		WorkflowEngine:  engine,
+		fetchReviewsFn:  fetchReviewsFn,
+		pushPreflightFn: stubPushPreflight(nil),
 	}
 }
 

--- a/internal/sybra/review/coalesce_test.go
+++ b/internal/sybra/review/coalesce_test.go
@@ -105,11 +105,12 @@ func TestDispatchFixIssues_ReviewHoldSetsParkVar(t *testing.T) {
 	}
 
 	r := &Handler{
-		logger:         logger,
-		tasks:          tasks,
-		agents:         agentMgr,
-		prTracker:      github.NewIssueTracker(time.Minute),
-		WorkflowEngine: engine,
+		logger:          logger,
+		tasks:           tasks,
+		agents:          agentMgr,
+		prTracker:       github.NewIssueTracker(time.Minute),
+		WorkflowEngine:  engine,
+		pushPreflightFn: stubPushPreflight(nil),
 		// push mode: the agent pushes and would emit `continue`; the park var
 		// must still force human-required.
 		cfg: &config.Config{ReviewHold: config.ReviewHoldConfig{Enabled: true, Mode: config.ReviewHoldModePush}},
@@ -204,11 +205,12 @@ func TestHandleMatchedPRIssues_CoalescesFixIssues(t *testing.T) {
 	}
 
 	r := &Handler{
-		logger:         logger,
-		tasks:          tasks,
-		agents:         agentMgr,
-		prTracker:      github.NewIssueTracker(time.Minute),
-		WorkflowEngine: engine,
+		logger:          logger,
+		tasks:           tasks,
+		agents:          agentMgr,
+		prTracker:       github.NewIssueTracker(time.Minute),
+		WorkflowEngine:  engine,
+		pushPreflightFn: stubPushPreflight(nil),
 	}
 
 	pr := github.PullRequest{

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/executil"
@@ -340,7 +341,7 @@ func prFixPushPrompt(branch, intro string, fenced bool) string {
 	b.WriteString("PUSH_REMOTE=origin\n")
 	b.WriteString("if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n")
 	b.WriteString("PUSH_URL=$(git remote get-url --push \"$PUSH_REMOTE\")\n")
-	b.WriteString("case \"$PUSH_URL\" in https://github.com/*|http://github.com/*) gh auth status --hostname github.com >/dev/null ;; esac\n")
+	b.WriteString("case \"$PUSH_URL\" in https://github.com/*|http://github.com/*|https://github.com:[0-9]*/*|http://github.com:[0-9]*/*) gh auth status --hostname github.com >/dev/null ;; esac\n")
 	fmt.Fprintf(&b, "git push \"$PUSH_REMOTE\" HEAD:%s", branch)
 	if fenced {
 		b.WriteString("\n```")
@@ -548,10 +549,18 @@ func (r *Handler) preflightPushCredentials(ctx context.Context, taskID, dir stri
 }
 
 func truncatePushPreflightReason(s string, limit int) string {
+	s = strings.ToValidUTF8(s, "")
 	if limit <= 0 || len(s) <= limit {
 		return s
 	}
-	return strings.TrimSpace(s[:limit]) + "..."
+	var b strings.Builder
+	for _, r := range s {
+		if b.Len()+utf8.RuneLen(r) > limit {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return strings.TrimSpace(b.String()) + "..."
 }
 
 func (r *Handler) rerunCIFailure(t task.Task, issue github.PRIssue) bool {

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -339,6 +339,8 @@ func prFixPushPrompt(branch, intro string, fenced bool) string {
 	}
 	b.WriteString("PUSH_REMOTE=origin\n")
 	b.WriteString("if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n")
+	b.WriteString("PUSH_URL=$(git remote get-url --push \"$PUSH_REMOTE\")\n")
+	b.WriteString("case \"$PUSH_URL\" in https://github.com/*|http://github.com/*) gh auth status --hostname github.com >/dev/null ;; esac\n")
 	fmt.Fprintf(&b, "git push \"$PUSH_REMOTE\" HEAD:%s", branch)
 	if fenced {
 		b.WriteString("\n```")
@@ -506,6 +508,10 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 		return false
 	}
 
+	if admit, handled := r.preflightPushCredentials(ctx, t.ID, dir); !admit {
+		return handled
+	}
+
 	if !opts.replaceActiveWorkflow &&
 		r.cfg != nil && r.cfg.GitHub.AutoResolveCleanMerges &&
 		len(handle) == 1 && handle[0].Kind == github.PRIssueConflict &&
@@ -519,6 +525,33 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 	// contextcheck no longer flags this call site (verified with a clean
 	// build+lint cache), so no suppression directive is needed here.
 	return r.dispatchPRIssueWithOptions(t, primary, handle, coalescedFixPrompt(ctx, handle, reviewHoldFixSuffix(r.cfg)), dir, opts)
+}
+
+func (r *Handler) preflightPushCredentials(ctx context.Context, taskID, dir string) (admit, handled bool) {
+	preflight := r.pushPreflightFn
+	if preflight == nil {
+		preflight = project.PreflightPushCredentials
+	}
+	if err := preflight(ctx, dir); err != nil {
+		reason := "GitHub push credential preflight failed before starting PR fix: " + truncatePushPreflightReason(err.Error(), 240)
+		if _, updateErr := r.tasks.Update(taskID, task.Update{
+			Status:       task.Ptr(task.StatusHumanRequired),
+			StatusReason: task.Ptr(reason),
+		}); updateErr != nil {
+			r.logger.Error("pr-monitor.push-preflight.status", "task_id", taskID, "err", updateErr)
+			return false, false
+		}
+		r.logger.Warn("pr-monitor.push-preflight.failed", "task_id", taskID, "err", err)
+		return false, true
+	}
+	return true, false
+}
+
+func truncatePushPreflightReason(s string, limit int) string {
+	if limit <= 0 || len(s) <= limit {
+		return s
+	}
+	return strings.TrimSpace(s[:limit]) + "..."
 }
 
 func (r *Handler) rerunCIFailure(t task.Task, issue github.PRIssue) bool {
@@ -952,6 +985,9 @@ func (r *Handler) recoverBranchConflictNoPR(t task.Task) bool {
 	}
 	if !r.allowPreparedWorktree(taskID, dir) {
 		return false
+	}
+	if admit, handled := r.preflightPushCredentials(ctx, taskID, dir); !admit {
+		return handled
 	}
 	// Refetch: PrepareForBranchFix's ensureBranch call may have just set
 	// t.Branch for the first time (a task whose worktree never got created

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -167,6 +167,10 @@ type Handler struct {
 	// pushSyncFn pushes the fast-path's clean merge commit. Overridable in
 	// tests; nil falls back to project.PushSync.
 	pushSyncFn func(ctx context.Context, worktreePath, branch string) error
+	// pushPreflightFn validates the push credential path before push-dependent
+	// fix workflows spend agent turns or mutate worktrees. Overridable in
+	// tests; nil falls back to project.PreflightPushCredentials.
+	pushPreflightFn func(ctx context.Context, worktreePath string) error
 }
 
 // agentLogin returns the GitHub login the fix agent posts as.
@@ -233,6 +237,7 @@ func New(
 		experience:          experienceStore,
 		tryCleanMergeFn:     project.TryCleanMerge,
 		pushSyncFn:          project.PushSync,
+		pushPreflightFn:     project.PreflightPushCredentials,
 	}
 }
 

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -347,8 +347,9 @@ func setupRebaseRecoveryHandler(t *testing.T, withConflictWorkflow bool) (*Handl
 			Tasks:        tasks,
 			Logger:       slog.New(slog.DiscardHandler),
 		}),
-		WorkflowEngine: engine,
-		wtFailures:     make(map[string]int),
+		WorkflowEngine:  engine,
+		wtFailures:      make(map[string]int),
+		pushPreflightFn: stubPushPreflight(nil),
 		fetchKnownPRFn: func(repo string, number int) (github.PullRequest, bool, error) {
 			if repo != "owner/repo" || number != 42 {
 				return github.PullRequest{}, false, nil
@@ -584,8 +585,9 @@ func setupBranchConflictNoPRHandler(t *testing.T, initialStatus task.Status, pri
 			Tasks:        tasks,
 			Logger:       slog.New(slog.DiscardHandler),
 		}),
-		WorkflowEngine: engine,
-		wtFailures:     make(map[string]int),
+		WorkflowEngine:  engine,
+		wtFailures:      make(map[string]int),
+		pushPreflightFn: stubPushPreflight(nil),
 	}
 
 	tk, err := tasks.Create("no pr rebase recover", "", task.AgentModeHeadless)
@@ -670,6 +672,32 @@ func TestRecoverBranchConflictNoPR_ReturnsTrueAndDispatchesRecoveryWorkflow(t *t
 	}
 	if r.prTracker.Retries(tk.ID, github.PRIssueConflict) != 0 {
 		t.Fatal("PR conflict retry budget should stay untouched for no-PR recovery")
+	}
+}
+
+func TestRecoverBranchConflictNoPR_PushPreflightFailureBlocksRecoveryWorkflow(t *testing.T) {
+	r, tk := setupBranchConflictNoPRHandler(t, task.StatusTesting, nil)
+	r.pushPreflightFn = stubPushPreflight(errors.New("github push credential preflight failed: gh auth status: Bad credentials"))
+
+	if !r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("RecoverStaleBranchConflict returned false, want handled credential blocker")
+	}
+
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want no branch-conflict-fix workflow after preflight failure", got.Workflow)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if !strings.Contains(got.StatusReason, "GitHub push credential preflight failed before starting PR fix") {
+		t.Fatalf("status reason = %q, want push credential preflight reason", got.StatusReason)
+	}
+	if r.prTracker.Retries(tk.ID, github.PRIssueBranchConflictNoPR) != 0 {
+		t.Fatal("branch-conflict retry budget was marked handled even though recovery workflow did not start")
 	}
 }
 

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
@@ -157,7 +158,7 @@ func assertPRFixPromptUsesResolvedPushRemote(t *testing.T, prompt, branch string
 		"PUSH_REMOTE=origin",
 		"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi",
 		"PUSH_URL=$(git remote get-url --push \"$PUSH_REMOTE\")",
-		"case \"$PUSH_URL\" in https://github.com/*|http://github.com/*) gh auth status --hostname github.com >/dev/null ;; esac",
+		"case \"$PUSH_URL\" in https://github.com/*|http://github.com/*|https://github.com:[0-9]*/*|http://github.com:[0-9]*/*) gh auth status --hostname github.com >/dev/null ;; esac",
 		"git push \"$PUSH_REMOTE\" HEAD:" + branch,
 	} {
 		if !strings.Contains(prompt, want) {
@@ -185,6 +186,16 @@ func assertPRFixPromptUsesResolvedPushRemote(t *testing.T, prompt, branch string
 	}
 	if open {
 		t.Fatalf("prompt has an unclosed code fence (%d markers):\n%s", fences, prompt)
+	}
+}
+
+func TestTruncatePushPreflightReasonKeepsValidUTF8(t *testing.T) {
+	got := truncatePushPreflightReason("prefix \xff café suffix", 12)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated reason is invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("truncated reason = %q, want ellipsis", got)
 	}
 }
 

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -156,6 +156,8 @@ func assertPRFixPromptUsesResolvedPushRemote(t *testing.T, prompt, branch string
 	for _, want := range []string{
 		"PUSH_REMOTE=origin",
 		"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi",
+		"PUSH_URL=$(git remote get-url --push \"$PUSH_REMOTE\")",
+		"case \"$PUSH_URL\" in https://github.com/*|http://github.com/*) gh auth status --hostname github.com >/dev/null ;; esac",
 		"git push \"$PUSH_REMOTE\" HEAD:" + branch,
 	} {
 		if !strings.Contains(prompt, want) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -199,6 +199,14 @@ type PRHeadFetcher interface {
 	FetchPRHeadSHA(ctx context.Context, repo string, number int) (string, error)
 }
 
+// PushCredentialPreflighter validates that the current process can authenticate
+// to the worktree's configured push remote before push-dependent workflow
+// steps spend more work or attempt a real push. Engine operates with a nil
+// preflighter by falling back to project.PreflightPushCredentials.
+type PushCredentialPreflighter interface {
+	PreflightPushCredentials(ctx context.Context, worktreePath string) error
+}
+
 // PRCreator opens a new GitHub pull request for an already-pushed branch via
 // `gh pr create`, run inside the task's worktree so gh resolves the same
 // repo/fork context an interactive invocation would. Used by the `create_pr`
@@ -289,6 +297,7 @@ type Engine struct {
 	prReviewers      PRReviewRequester
 	prStates         PRStateFetcher
 	prHeads          PRHeadFetcher
+	pushPreflight    PushCredentialPreflighter
 	prCreator        PRCreator
 	prFinder         PRFinder
 	prContentGen     PRContentGenerator
@@ -402,6 +411,13 @@ func (e *Engine) SetPRStateFetcher(f PRStateFetcher) { e.prStates = f }
 // SetPRHeadFetcher wires an implementation used by `push_branch` to verify a
 // push landed. Leaving it unset skips the verification.
 func (e *Engine) SetPRHeadFetcher(f PRHeadFetcher) { e.prHeads = f }
+
+// SetPushCredentialPreflighter wires the push-auth preflight used before
+// `push_branch` and `create_pr` attempt a real git push. Leaving it unset uses
+// project.PreflightPushCredentials.
+func (e *Engine) SetPushCredentialPreflighter(p PushCredentialPreflighter) {
+	e.pushPreflight = p
+}
 
 // SetPRCreator wires an implementation of `gh pr create` used by the
 // `create_pr` step. Leaving it unset flips the task to human-required when

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -175,6 +175,10 @@ func (e *Engine) humanRequiredPR(taskID string, step *Step, reason string) (Step
 func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t TaskInfo, wtPath, branch string) (out StepOutput, err error, ok bool) {
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
+	if preflightErr := e.preflightPushCredentials(ctx, wtPath); preflightErr != nil {
+		out, err = e.classifyPRGitError(taskID, step, wfExec, t, preflightErr, "push credential preflight")
+		return out, err, false
+	}
 	pushErr := project.PushSync(ctx, wtPath, branch)
 	if pushErr == nil {
 		return StepOutput{}, nil, true
@@ -214,6 +218,13 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 
 	out, err = e.classifyPRGitError(taskID, step, wfExec, t, pushErr, "git push")
 	return out, err, false
+}
+
+func (e *Engine) preflightPushCredentials(ctx context.Context, wtPath string) error {
+	if e.pushPreflight != nil {
+		return e.pushPreflight.PreflightPushCredentials(ctx, wtPath)
+	}
+	return project.PreflightPushCredentials(ctx, wtPath)
 }
 
 // tryConflictRecovery attempts autonomous branch-conflict recovery for a

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -122,6 +122,18 @@ func (f *fakePRContentGenerator) GeneratePRContent(context.Context, string, stri
 	return f.title, f.body, f.err
 }
 
+type fakePushPreflighter struct {
+	err   error
+	calls int
+	paths []string
+}
+
+func (f *fakePushPreflighter) PreflightPushCredentials(_ context.Context, wtPath string) error {
+	f.calls++
+	f.paths = append(f.paths, wtPath)
+	return f.err
+}
+
 func TestExecPushBranch_Success(t *testing.T) {
 	_, wtPath := newPRWorktree(t, "feat/existing-pr")
 	commitFile(t, wtPath, "change.txt", "feat: task work")
@@ -143,6 +155,41 @@ func TestExecPushBranch_Success(t *testing.T) {
 	ti, _ := tasks.GetTask("t1")
 	if ti.Status != "ready-pr" {
 		t.Errorf("task status = %q, want unchanged ready-pr", ti.Status)
+	}
+}
+
+func TestExecPushBranch_PreflightAuthFailureParksBeforePush(t *testing.T) {
+	wtPath := t.TempDir()
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	preflight := &fakePushPreflighter{err: errors.New("github push credential preflight failed: gh auth status: Bad credentials")}
+	engine.SetPushCredentialPreflighter(preflight)
+
+	wfExec := &Execution{Variables: map[string]string{}}
+	_, err := engine.execPushBranch("t1", newPushBranchStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	if preflight.calls != 1 {
+		t.Fatalf("preflight calls = %d, want 1", preflight.calls)
+	}
+	if got := preflight.paths[0]; got != wtPath {
+		t.Fatalf("preflight path = %q, want %q", got, wtPath)
+	}
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Status != "ready-pr" {
+		t.Fatalf("status = %q, want ready-pr", ti.Status)
+	}
+	if ti.StatusReason != prCreateAuthRetryReason {
+		t.Fatalf("status reason = %q, want %q", ti.StatusReason, prCreateAuthRetryReason)
+	}
+	if wfExec.Variables[prCreateAuthAttemptsVar] != "1" {
+		t.Fatalf("%s = %q, want 1", prCreateAuthAttemptsVar, wfExec.Variables[prCreateAuthAttemptsVar])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a GitHub HTTPS push credential preflight that validates gh auth before push-dependent work
- run the preflight before workflow push_branch and before PR fix / branch-conflict recovery dispatch
- park credential failures without spending a recovery agent turn, with scrubbed operator-visible status reasons

Fixes #1982

## Tests
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/project ./internal/workflow ./internal/sybra/review
- pre-push hook: go test ./... and cd frontend && npm run check