### PR TITLE
fix(agent): bound orphan process sweep

### DIFF
--- a/internal/agent/orphan_sweep.go
+++ b/internal/agent/orphan_sweep.go
@@ -12,6 +12,8 @@ import (
 
 const orphanSweepTimeout = 2 * time.Second
 
+var orphanSweepDefaultContext = context.Background()
+
 type providerProcess struct {
 	PID     int
 	Command string
@@ -23,13 +25,13 @@ type trackedAgentSnapshot struct {
 	State State
 }
 
-func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []string) int {
+func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []string) int { //nolint:contextcheck // Nil is a legacy caller contract; normalize it before deriving the bounded sweep context.
 	roots = canonicalProcessRoots(roots)
 	if len(roots) == 0 {
 		return 0
 	}
 	if ctx == nil {
-		return 0
+		ctx = orphanSweepDefaultContext
 	}
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, orphanSweepTimeout)

--- a/internal/agent/orphan_sweep.go
+++ b/internal/agent/orphan_sweep.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+const orphanSweepTimeout = 2 * time.Second
 
 type providerProcess struct {
 	PID     int
@@ -25,6 +28,13 @@ func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []strin
 	if len(roots) == 0 {
 		return 0
 	}
+	if ctx == nil {
+		return 0
+	}
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, orphanSweepTimeout)
+	defer cancel()
+
 	procs := listProviderProcessesUnderRoots(ctx, roots)
 	if len(procs) == 0 {
 		return 0

--- a/internal/agent/orphan_sweep_linux.go
+++ b/internal/agent/orphan_sweep_linux.go
@@ -10,13 +10,21 @@ import (
 	"strings"
 )
 
-func listProviderProcessesUnderRoots(_ context.Context, roots []string) []providerProcess {
+func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []providerProcess {
+	if ctx == nil {
+		return nil
+	}
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil
 	}
 	out := make([]providerProcess, 0)
 	for _, entry := range entries {
+		select {
+		case <-ctx.Done():
+			return out
+		default:
+		}
 		if !entry.IsDir() {
 			continue
 		}
@@ -28,8 +36,8 @@ func listProviderProcessesUnderRoots(_ context.Context, roots []string) []provid
 		if err != nil || !pathWithinRoots(cwd, roots) {
 			continue
 		}
-		cmd := linuxProcessName(entry.Name())
-		owner := linuxMCPOwner(entry.Name())
+		cmd := linuxProcessName(ctx, entry.Name())
+		owner := linuxMCPOwner(ctx, entry.Name())
 		if owner.AgentID == "" && !isProviderProcessName(cmd) {
 			continue
 		}
@@ -38,7 +46,10 @@ func listProviderProcessesUnderRoots(_ context.Context, roots []string) []provid
 	return out
 }
 
-func linuxProcessName(pid string) string {
+func linuxProcessName(ctx context.Context, pid string) string {
+	if ctx == nil || ctx.Err() != nil {
+		return ""
+	}
 	data, err := os.ReadFile(filepath.Join("/proc", pid, "cmdline"))
 	if err == nil && len(data) > 0 {
 		if idx := bytesIndexByte(data, 0); idx >= 0 {
@@ -47,6 +58,9 @@ func linuxProcessName(pid string) string {
 		if len(data) > 0 {
 			return filepath.Base(string(data))
 		}
+	}
+	if ctx.Err() != nil {
+		return ""
 	}
 	data, err = os.ReadFile(filepath.Join("/proc", pid, "comm"))
 	if err != nil {
@@ -64,7 +78,10 @@ func bytesIndexByte(data []byte, target byte) int {
 	return -1
 }
 
-func linuxMCPOwner(pid string) mcpOwner {
+func linuxMCPOwner(ctx context.Context, pid string) mcpOwner {
+	if ctx == nil || ctx.Err() != nil {
+		return mcpOwner{}
+	}
 	data, err := os.ReadFile(filepath.Join("/proc", pid, "environ"))
 	if err != nil || len(data) == 0 {
 		return mcpOwner{}

--- a/internal/agent/orphan_sweep_other.go
+++ b/internal/agent/orphan_sweep_other.go
@@ -14,7 +14,13 @@ func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []prov
 	if err != nil {
 		return nil
 	}
-	procs := make([]providerProcess, 0)
+	type candidate struct {
+		pid   int
+		cmd   string
+		owner mcpOwner
+	}
+	candidates := make([]candidate, 0)
+	pids := make([]string, 0)
 	for line := range strings.SplitSeq(string(out), "\n") {
 		fields := strings.Fields(strings.TrimSpace(line))
 		if len(fields) < 2 {
@@ -29,15 +35,55 @@ func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []prov
 		if owner.AgentID == "" && !isProviderProcessName(cmd) {
 			continue
 		}
-		cwdOut, err := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-Fn", "-p", strconv.Itoa(pid)).Output()
-		if err != nil {
-			continue
-		}
-		cwd := parseLsofCWD(string(cwdOut))
+		candidates = append(candidates, candidate{pid: pid, cmd: cmd, owner: owner})
+		pids = append(pids, strconv.Itoa(pid))
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	cwds := lsofCWDsByPID(ctx, pids)
+	procs := make([]providerProcess, 0, len(candidates))
+	for _, cand := range candidates {
+		cwd := cwds[cand.pid]
 		if !pathWithinRoots(cwd, roots) {
 			continue
 		}
-		procs = append(procs, providerProcess{PID: pid, Command: cmd, CWD: cwd, Owner: owner})
+		procs = append(procs, providerProcess{PID: cand.pid, Command: cand.cmd, CWD: cwd, Owner: cand.owner})
 	}
 	return procs
+}
+
+func lsofCWDsByPID(ctx context.Context, pids []string) map[int]string {
+	out := make(map[int]string)
+	if len(pids) == 0 {
+		return out
+	}
+	cwdOut, err := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-Fn", "-p", strings.Join(pids, ",")).Output()
+	if err != nil {
+		return out
+	}
+	return parseLsofCWDs(string(cwdOut))
+}
+
+func parseLsofCWDs(output string) map[int]string {
+	out := make(map[int]string)
+	pid := 0
+	prev := ""
+	for line := range strings.SplitSeq(output, "\n") {
+		if value, ok := strings.CutPrefix(line, "p"); ok {
+			if parsed, err := strconv.Atoi(value); err == nil {
+				pid = parsed
+			} else {
+				pid = 0
+			}
+			prev = line
+			continue
+		}
+		if prev == "fcwd" && strings.HasPrefix(line, "n") && pid > 0 {
+			out[pid] = line[1:]
+		}
+		prev = line
+	}
+	return out
 }

--- a/internal/agent/orphan_sweep_other.go
+++ b/internal/agent/orphan_sweep_other.go
@@ -59,7 +59,7 @@ func lsofCWDsByPID(ctx context.Context, pids []string) map[int]string {
 	if len(pids) == 0 {
 		return out
 	}
-	cwdOut, err := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-Fn", "-p", strings.Join(pids, ",")).Output()
+	cwdOut, err := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-Fpn", "-p", strings.Join(pids, ",")).Output()
 	if err != nil {
 		return out
 	}

--- a/internal/agent/orphan_sweep_other_test.go
+++ b/internal/agent/orphan_sweep_other_test.go
@@ -1,0 +1,42 @@
+//go:build !linux
+
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestParseLsofCWDs(t *testing.T) {
+	t.Parallel()
+
+	got := parseLsofCWDs("p123\nfcwd\nn/tmp/one\nftxt\nn/usr/bin/claude\np456\nfcwd\nn/tmp/two with spaces\n")
+	if got[123] != "/tmp/one" {
+		t.Fatalf("pid 123 cwd = %q, want /tmp/one", got[123])
+	}
+	if got[456] != "/tmp/two with spaces" {
+		t.Fatalf("pid 456 cwd = %q, want /tmp/two with spaces", got[456])
+	}
+}
+
+func TestParseLsofCWDsSkipsMalformedPID(t *testing.T) {
+	t.Parallel()
+
+	got := parseLsofCWDs("pbad\nfcwd\nn/tmp/bad\np789\nftxt\nn/usr/bin/codex\n")
+	if len(got) != 0 {
+		t.Fatalf("cwds = %#v, want empty", got)
+	}
+}
+
+func TestReapOrphanProviderProcessesCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{})
+
+	if got := m.ReapOrphanProviderProcesses(ctx, []string{t.TempDir()}); got != 0 {
+		t.Fatalf("reaped = %d, want 0 for canceled scan", got)
+	}
+}

--- a/internal/agent/orphan_sweep_test.go
+++ b/internal/agent/orphan_sweep_test.go
@@ -120,6 +120,21 @@ func TestReapOrphanProviderProcesses_SkipsInteractiveOwnedMCPHelper(t *testing.T
 	}
 }
 
+func TestReapOrphanProviderProcesses_CanceledContextLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only process enumeration test")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{})
+
+	if got := m.ReapOrphanProviderProcesses(ctx, []string{t.TempDir()}); got != 0 {
+		t.Fatalf("reaped = %d, want 0 for canceled scan", got)
+	}
+}
+
 func TestOrphanSweepRootsForAgent_UsesResolvedSandboxHome(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- bound orphan provider process sweeps with a caller-scoped timeout
- batch BSD/macOS lsof cwd lookup instead of starting one lsof process per candidate PID
- add parser/cancellation coverage for the non-Linux orphan sweep path

## Why
Prompt Lab verify runs could fail in internal/agent goleak checks because the orphan sweep launched unbounded ps/lsof work while marking agents done. That parked otherwise successful Prompt Lab tasks in human-required during verify_checks.

## Validation
- GOCACHE=/private/tmp/sybra-rebased-agent-gocache go test ./internal/agent
- GOCACHE=/private/tmp/sybra-rebased-lint-gocache GOLANGCI_LINT_CACHE=/private/tmp/sybra-rebased-golangci-cache golangci-lint run ./internal/agent
- GOCACHE=/private/tmp/sybra-rebased-verify-gocache mise exec -- go test ./internal/... ./cmd/...
- pre-push hook passed after rebase