### PR TITLE
Add OpenCode agent provider

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -483,7 +483,7 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
 	stage := fs.String("stage", "implement", "workflow entry stage: "+handoffStageCompactList())
 	rawStatus := fs.String("status", "", "raw task status to create without starting a workflow")
-	sourceProvider := fs.String("source-provider", "", "provider that produced the handed-off work: claude|codex|copilot")
+	sourceProvider := fs.String("source-provider", "", "provider that produced the handed-off work: claude|codex|copilot|opencode")
 	pr := fs.Int("pr", 0, "existing PR number to link when using --stage ready-pr")
 	extraTags := fs.String("tags", "", "extra comma-separated tags")
 	if err := fs.Parse(args); err != nil {
@@ -501,7 +501,7 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 		return fatal(jsonOut, "%v", srcErr)
 	}
 	if !rawStatusMode && handoffSource == "" && handoffStageRequiresSource(stageCfg.name) {
-		return fatal(jsonOut, "--stage %s requires --source-provider <claude|codex|copilot> so cross-provider review/testing is deterministic", *stage)
+		return fatal(jsonOut, "--stage %s requires --source-provider <claude|codex|copilot|opencode> so cross-provider review/testing is deterministic", *stage)
 	}
 
 	dir, dErr := resolveWorktreeDir(*wtDir)
@@ -1038,7 +1038,7 @@ func newUpdateFlags(fs *flag.FlagSet) updateFlags {
 		branch:            fs.String("branch", "", "Git branch name"),
 		pr:                fs.Int("pr", 0, "GitHub PR number"),
 		issue:             fs.String("issue", "", "ad-hoc reference issue URL annotation — does not affect PR auto-close linkage (see task.Issue, set only at creation)"),
-		sourceProvider:    fs.String("source-provider", "", "handoff source provider: claude|codex|copilot|none"),
+		sourceProvider:    fs.String("source-provider", "", "handoff source provider: claude|codex|copilot|opencode|none"),
 		statusReason:      fs.String("status-reason", "", "reason for status change"),
 		maxTurns:          fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)"),
 		reasoningEffort:   fs.String("reasoning-effort", "", "reasoning effort (all providers): low|medium|high|xhigh ('default' or 'none' clears the override)"),
@@ -1974,7 +1974,7 @@ Commands:
   get      [--compact] <id>
   create   --title TITLE [--body BODY] [--plan PLAN] [--plan-contract JSON] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL] [--allow-dup]
            TYPE: normal|debug|research
-  handoff  --title TITLE [--body BODY] [--plan PLAN | --plan-file PATH] [--project ID] [--worktree-dir DIR] [--stage STAGE | --status STATUS] [--source-provider claude|codex|copilot] [--pr N] [--mode MODE] [--tags t1,t2]
+  handoff  --title TITLE [--body BODY] [--plan PLAN | --plan-file PATH] [--project ID] [--worktree-dir DIR] [--stage STAGE | --status STATUS] [--source-provider claude|codex|copilot|opencode] [--pr N] [--mode MODE] [--tags t1,t2]
            Hand a task to Sybra at a workflow entry point, reusing the given git worktree
            (default: cwd). Project is derived from the worktree's origin remote
            when --project is omitted. STAGE (default implement):

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -473,7 +473,7 @@ must not start filing tasks before an operator opts in.
 ## ProvidersConfig (`providers`)
 
 ProvidersConfig groups per-machine routing for CLI providers (claude, codex,
-copilot) and their background health-check loop. A missing block defaults to
+copilot, opencode) and their background health-check loop. A missing block defaults to
 "all providers enabled, health check on, auto-failover on, 300s interval".
 
 | YAML key | Type | Default | Description |
@@ -482,6 +482,7 @@ copilot) and their background health-check loop. A missing block defaults to
 | `providers.claude` | `ProviderEntryConfig` | _(see below)_ |  |
 | `providers.codex` | `ProviderEntryConfig` | _(see below)_ |  |
 | `providers.copilot` | `ProviderEntryConfig` | _(see below)_ |  |
+| `providers.opencode` | `ProviderEntryConfig` | _(see below)_ |  |
 | `providers.limits` | `ProviderLimitsConfig` | _(see below)_ |  |
 | `providers.auto_failover` | `bool` | `true` |  |
 
@@ -515,6 +516,14 @@ copilot) and their background health-check loop. A missing block defaults to
 | `providers.copilot.enabled` | `bool` | `true` |  |
 | `providers.copilot.rate_limit_cooldown_seconds` | `int` | `900` |  |
 | `providers.copilot.monthly_subscription_usd` | `float64` |  | MonthlySubscriptionUSD is optional and used only for Stats value comparison. Zero means "not configured". |
+
+## ProviderEntryConfig (`providers.opencode`)
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `providers.opencode.enabled` | `bool` | `true` |  |
+| `providers.opencode.rate_limit_cooldown_seconds` | `int` | `900` |  |
+| `providers.opencode.monthly_subscription_usd` | `float64` |  | MonthlySubscriptionUSD is optional and used only for Stats value comparison. Zero means "not configured". |
 
 ## ProviderLimitsConfig (`providers.limits`)
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -1009,7 +1009,7 @@ export class ProviderLimitsConfig {
 
 /**
  * ProvidersConfig groups per-machine routing for CLI providers (claude, codex,
- * copilot) and their background health-check loop. A missing block defaults to
+ * copilot, opencode) and their background health-check loop. A missing block defaults to
  * "all providers enabled, health check on, auto-failover on, 300s interval".
  */
 export class ProvidersConfig {
@@ -1017,6 +1017,7 @@ export class ProvidersConfig {
     "claude": ProviderEntryConfig;
     "codex": ProviderEntryConfig;
     "copilot": ProviderEntryConfig;
+    "opencode": ProviderEntryConfig;
     "limits": ProviderLimitsConfig;
     "autoFailover": boolean;
 
@@ -1033,6 +1034,9 @@ export class ProvidersConfig {
         }
         if (!("copilot" in $$source)) {
             this["copilot"] = (new ProviderEntryConfig());
+        }
+        if (!("opencode" in $$source)) {
+            this["opencode"] = (new ProviderEntryConfig());
         }
         if (!("limits" in $$source)) {
             this["limits"] = (new ProviderLimitsConfig());
@@ -1052,7 +1056,8 @@ export class ProvidersConfig {
         const $$createField1_0 = $$createType8;
         const $$createField2_0 = $$createType8;
         const $$createField3_0 = $$createType8;
-        const $$createField4_0 = $$createType9;
+        const $$createField4_0 = $$createType8;
+        const $$createField5_0 = $$createType9;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("healthCheck" in $$parsedSource) {
             $$parsedSource["healthCheck"] = $$createField0_0($$parsedSource["healthCheck"]);
@@ -1066,8 +1071,11 @@ export class ProvidersConfig {
         if ("copilot" in $$parsedSource) {
             $$parsedSource["copilot"] = $$createField3_0($$parsedSource["copilot"]);
         }
+        if ("opencode" in $$parsedSource) {
+            $$parsedSource["opencode"] = $$createField4_0($$parsedSource["opencode"]);
+        }
         if ("limits" in $$parsedSource) {
-            $$parsedSource["limits"] = $$createField4_0($$parsedSource["limits"]);
+            $$parsedSource["limits"] = $$createField5_0($$parsedSource["limits"]);
         }
         return new ProvidersConfig($$parsedSource as Partial<ProvidersConfig>);
     }

--- a/frontend/src/components/ProviderLogo.svelte
+++ b/frontend/src/components/ProviderLogo.svelte
@@ -22,6 +22,12 @@
   <svg class={cls} role="img" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-label="GitHub Copilot">
     <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
   </svg>
+{:else if provider === 'opencode'}
+  <svg class={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-label="OpenCode">
+    <path stroke-linecap="round" stroke-linejoin="round" d="m8 7-5 5 5 5"/>
+    <path stroke-linecap="round" stroke-linejoin="round" d="m16 7 5 5-5 5"/>
+    <path stroke-linecap="round" d="m14 4-4 16"/>
+  </svg>
 {:else}
   <!-- Generic agent icon -->
   <svg class={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-label="Agent">

--- a/frontend/src/components/settings/AgentPanel.svelte
+++ b/frontend/src/components/settings/AgentPanel.svelte
@@ -39,6 +39,7 @@
         { value: 'claude', label: 'Claude' },
         { value: 'codex', label: 'Codex' },
         { value: 'copilot', label: 'Copilot' },
+        { value: 'opencode', label: 'OpenCode' },
       ]}
       bind:value={settings.agent.provider}
       modified={a.provider !== d.provider}

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte
@@ -29,7 +29,7 @@
       preferUnderused: true,
       backfillDays: 14,
     }
-    for (const name of ['claude', 'codex', 'copilot']) {
+    for (const name of ['claude', 'codex', 'copilot', 'opencode']) {
       providers[name] ??= { enabled: false, rateLimitCooldownSeconds: 900, monthlySubscriptionUsd: 0 }
       providers[name].monthlySubscriptionUsd ??= 0
     }
@@ -81,7 +81,7 @@
     }
   }
 
-  type ProviderName = 'claude' | 'codex' | 'copilot'
+  type ProviderName = 'claude' | 'codex' | 'copilot' | 'opencode'
 
   async function onProviderEnabledChange(name: ProviderName, e: Event) {
     const value = (e.target as HTMLInputElement).checked
@@ -145,7 +145,7 @@
       <div class="mb-3 text-xs text-error-500">{error}</div>
     {/if}
     <div class="flex flex-col gap-3">
-      {#each ['claude', 'codex', 'copilot'] as name (name)}
+      {#each ['claude', 'codex', 'copilot', 'opencode'] as name (name)}
         {@const p = map[name]}
         <div class="flex items-center justify-between gap-3 rounded border border-surface-200 bg-white px-3 py-2 dark:border-surface-700 dark:bg-surface-900">
           <div class="flex flex-col">

--- a/frontend/src/pages/Fleet.svelte
+++ b/frontend/src/pages/Fleet.svelte
@@ -48,6 +48,7 @@
       case 'claude': return 'Claude'
       case 'codex': return 'Codex'
       case 'copilot': return 'Copilot'
+      case 'opencode': return 'OpenCode'
       default: return provider || 'Provider'
     }
   }

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -103,6 +103,15 @@
     { value: 'auto', label: 'Auto' },
   ]
   let copilotDynamicModels = $state<ModelOption[]>([])
+  const opencodeFallbackModels: ModelOption[] = [
+    { value: '', label: 'Default (OpenRouter GLM 5.2)' },
+    { value: 'openrouter/z-ai/glm-5.2', label: 'OpenRouter: Z.ai GLM 5.2' },
+    { value: 'openrouter/deepseek/deepseek-v4-pro', label: 'OpenRouter: DeepSeek V4 Pro' },
+    { value: 'openrouter/deepseek/deepseek-v4-flash', label: 'OpenRouter: DeepSeek V4 Flash' },
+    { value: 'openrouter/z-ai/glm-4.5', label: 'OpenRouter: Z.ai GLM 4.5' },
+    { value: 'openrouter/qwen/qwen3-coder', label: 'OpenRouter: Qwen3 Coder' },
+    { value: 'ollama/qwen3-coder', label: 'Ollama: Qwen3 Coder' },
+  ]
   let providerHealthEnabled = $state(false)
 
   $effect(() => { load() })
@@ -189,6 +198,7 @@
     if (!settings) return [] as ModelOption[]
     if (settings.agent.provider === 'codex') return codexDynamicModels.length > 0 ? codexDynamicModels : codexFallbackModels
     if (settings.agent.provider === 'copilot') return copilotDynamicModels.length > 0 ? copilotDynamicModels : copilotFallbackModels
+    if (settings.agent.provider === 'opencode') return opencodeFallbackModels
     return [{ value: '', label: 'Default (Sonnet)' }, ...CLAUDE_MODEL_OPTIONS]
   })
 
@@ -220,7 +230,7 @@
       { id: 'notifications', label: 'Notifications', keywords: 'desktop macos notify', keys: ['notification'] },
     ] },
     { label: 'Agents', items: [
-      { id: 'agent', label: 'Defaults', keywords: 'provider model mode concurrent permissions fallback turns cost claude codex copilot log retention gzip compression size', keys: ['agent'] },
+      { id: 'agent', label: 'Defaults', keywords: 'provider model mode concurrent permissions fallback turns cost claude codex copilot opencode openrouter glm log retention gzip compression size', keys: ['agent'] },
       ...(providerHealthEnabled ? [{ id: 'provider-health' as TabId, label: 'Providers', keywords: 'health limits failover subscription', keys: ['providers'] as (keyof AppSettings)[] }] : []),
     ] },
     { label: 'Automation', items: [

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -73,6 +73,7 @@
       case 'claude': return 'Claude'
       case 'codex': return 'Codex'
       case 'copilot': return 'Copilot'
+      case 'opencode': return 'OpenCode'
       default: return provider || 'Provider'
     }
   }

--- a/internal/agent/agent_sandbox.sb
+++ b/internal/agent/agent_sandbox.sb
@@ -18,4 +18,5 @@
   (subpath (param "CLAUDE_STATE"))
   (subpath (param "CODEX_STATE"))
   (subpath (param "COPILOT_STATE"))
+  (subpath (param "OPENCODE_STATE"))
   (subpath (param "TOOL_CACHE")))

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -22,7 +22,7 @@ func (m *Manager) SendPromptToAgent(agentID, text string) error {
 		return m.SendMessage(agentID, text)
 	}
 
-	// Per-turn conversational agents (codex/copilot): deliver via promptCh.
+	// Per-turn conversational agents (codex/copilot/opencode): deliver via promptCh.
 	if a.hasPromptChannel() {
 		return m.sendConvoPrompt(agentID, text)
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -330,36 +330,7 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 	}
 
 	if mode != "enforce" {
-		// report: log the resolved allowlist without wrapping the spawn, so
-		// the opaque provider CLI's would-be write footprint is visible from
-		// live runs before flipping this task/fleet to enforce. Canonicalize
-		// the roots the same way enforce mode would, so the report output is
-		// representative of what enforce would allow — but never fail the
-		// run closed on a canonicalization error; fall back to logging the
-		// raw (unresolved) roots instead.
-		logWorktree, logSandboxHome, logTmp, logShared := worktree, sandboxHome, tmp, sharedCache
-		if canon, err := canonicalizeRoot(worktree); err == nil {
-			logWorktree = canon
-		} else {
-			m.logger.Warn("agent.sandbox.report.canonicalize_failed", "task_id", cfg.TaskID, "root", "worktree", "err", err)
-		}
-		if canon, err := canonicalizeRoot(sandboxHome); err == nil {
-			logSandboxHome = canon
-		} else {
-			m.logger.Warn("agent.sandbox.report.canonicalize_failed", "task_id", cfg.TaskID, "root", "sandbox_home", "err", err)
-		}
-		if canon, err := canonicalizeRoot(tmp); err == nil {
-			logTmp = canon
-		} else {
-			m.logger.Warn("agent.sandbox.report.canonicalize_failed", "task_id", cfg.TaskID, "root", "tmp", "err", err)
-		}
-		if canon, err := canonicalizeRoot(sharedCache); err == nil {
-			logShared = canon
-		} else {
-			m.logger.Warn("agent.sandbox.report.canonicalize_failed", "task_id", cfg.TaskID, "root", "shared_cache", "err", err)
-		}
-		m.logger.Info("agent.sandbox.report", "task_id", cfg.TaskID,
-			"worktree", logWorktree, "sandbox_home", logSandboxHome, "tmp", logTmp, "shared_cache", logShared)
+		m.logProcessSandboxReport(cfg.TaskID, worktree, sandboxHome, tmp, sharedCache)
 		cfg.sandbox = sandboxSpec{mode: "off"}
 		return nil
 	}
@@ -399,22 +370,44 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		"worktree", canonWorktree, "sandbox_home", canonSandboxHome, "tmp", canonTmp,
 		"shared_cache", canonSharedCache, "claude_state", cfg.sandbox.claudeState,
 		"codex_state", cfg.sandbox.codexState, "copilot_state", cfg.sandbox.copilotState,
+		"opencode_state", cfg.sandbox.opencodeState,
 		"tool_cache", cfg.sandbox.toolCache, "profile", profilePath)
 	return nil
 }
 
+func (m *Manager) logProcessSandboxReport(taskID, worktree, sandboxHome, tmp, sharedCache string) {
+	// report logs the resolved allowlist without wrapping the spawn, so the
+	// provider CLI's would-be write footprint is visible before enforce rollout.
+	logWorktree := m.reportSandboxRoot(taskID, "worktree", worktree)
+	logSandboxHome := m.reportSandboxRoot(taskID, "sandbox_home", sandboxHome)
+	logTmp := m.reportSandboxRoot(taskID, "tmp", tmp)
+	logShared := m.reportSandboxRoot(taskID, "shared_cache", sharedCache)
+	m.logger.Info("agent.sandbox.report", "task_id", taskID,
+		"worktree", logWorktree, "sandbox_home", logSandboxHome, "tmp", logTmp, "shared_cache", logShared)
+}
+
+func (m *Manager) reportSandboxRoot(taskID, name, root string) string {
+	canon, err := canonicalizeRoot(root)
+	if err == nil {
+		return canon
+	}
+	m.logger.Warn("agent.sandbox.report.canonicalize_failed", "task_id", taskID, "root", name, "err", err)
+	return root
+}
+
 func enforceSpec(worktree, sandboxHome, tmp, sharedCache, profilePath string) sandboxSpec {
 	return sandboxSpec{
-		mode:         "enforce",
-		worktree:     worktree,
-		sandboxHome:  sandboxHome,
-		tmp:          tmp,
-		sharedCache:  sharedCache,
-		profilePath:  profilePath,
-		claudeState:  agentStateRoot(".claude", sandboxHome),
-		codexState:   agentStateRoot(".codex", sandboxHome),
-		copilotState: agentStateRoot(".copilot", sandboxHome),
-		toolCache:    agentStateRoot(".cache", sandboxHome),
+		mode:          "enforce",
+		worktree:      worktree,
+		sandboxHome:   sandboxHome,
+		tmp:           tmp,
+		sharedCache:   sharedCache,
+		profilePath:   profilePath,
+		claudeState:   agentStateRoot(".claude", sandboxHome),
+		codexState:    agentStateRoot(".codex", sandboxHome),
+		copilotState:  agentStateRoot(".copilot", sandboxHome),
+		opencodeState: agentStateRoot(filepath.Join(".local", "share", "opencode"), sandboxHome),
+		toolCache:     agentStateRoot(".cache", sandboxHome),
 	}
 }
 
@@ -530,9 +523,9 @@ func (m *Manager) startAgentRunner(ctx context.Context, a *Agent, cfg RunConfig,
 	case "headless":
 		go m.runHeadless(ctx, a, cfg)
 	case "interactive":
-		// codex and copilot use the per-turn conversational runner (each turn
+		// codex, copilot, and opencode use the per-turn conversational runner (each turn
 		// spawns a fresh process); claude uses the persistent approval-hook
-		// runner. Copilot's permission model is CLI-flag based (no HTTP
+		// runner. Copilot/OpenCode permission models are CLI-flag based (no HTTP
 		// approval hook), so the per-turn shape fits it like codex.
 		if prov.UsesPerTurnConvo() {
 			a.setPromptChannel(make(chan string, 1))

--- a/internal/agent/opencode_stream_test.go
+++ b/internal/agent/opencode_stream_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import "testing"
+
+func TestOpenCodeProviderNormalizeModel(t *testing.T) {
+	for _, in := range []string{"", "sonnet", "opus", "haiku"} {
+		if got := normalizeModel("opencode", in); got != opencodeDefaultModel {
+			t.Errorf("normalizeModel(opencode, %q) = %q, want %q", in, got, opencodeDefaultModel)
+		}
+	}
+	if got := normalizeModel("opencode", "openrouter/qwen/qwen3-coder"); got != "openrouter/qwen/qwen3-coder" {
+		t.Errorf("explicit model changed: %q", got)
+	}
+}
+
+func TestOpenCodeBuildHeadlessInvocation(t *testing.T) {
+	a := &Agent{Provider: "opencode", Model: "openrouter/z-ai/glm-5.2", ReasoningEffort: "high", sessionCWD: "/tmp/wt"}
+	inv, err := providerByName("opencode").BuildHeadlessInvocation(a, RunConfig{Prompt: "do it"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.name != "opencode" {
+		t.Fatalf("name = %q, want opencode", inv.name)
+	}
+	want := []string{"run", "--format", "json", "--auto", "--model", "openrouter/z-ai/glm-5.2", "--variant", "high", "--dir", "/tmp/wt", "do it"}
+	if len(inv.args) != len(want) {
+		t.Fatalf("args = %#v, want %#v", inv.args, want)
+	}
+	for i := range want {
+		if inv.args[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q; all=%#v", i, inv.args[i], want[i], inv.args)
+		}
+	}
+}
+
+func TestParseOpenCodeLineAssistantAndTool(t *testing.T) {
+	assistant, err := ParseOpenCodeLine([]byte(`{"type":"assistant.message","sessionId":"sess-1","data":{"content":"hi","outputTokens":3,"toolRequests":[{"toolCallId":"call-1","name":"bash","arguments":{"command":"go test ./..."}}]}}`))
+	if err != nil {
+		t.Fatalf("assistant parse: %v", err)
+	}
+	se := opencodeEventToStreamEvent(assistant)
+	if se.Type != "assistant" || se.Content != "hi" || se.SessionID != "sess-1" || se.OutputTokens != 3 || se.ToolCalls != 1 {
+		t.Fatalf("assistant stream event = %+v", se)
+	}
+
+	toolResult, err := ParseOpenCodeLine([]byte(`{"type":"tool.execution_complete","data":{"toolCallId":"call-1","success":false,"result":"failed"}}`))
+	if err != nil {
+		t.Fatalf("tool parse: %v", err)
+	}
+	ce := opencodeEventToConvoEvent(toolResult)
+	if ce.Type != "user" || len(ce.ToolResults) != 1 || ce.ToolResults[0].ToolUseID != "call-1" || !ce.ToolResults[0].IsError {
+		t.Fatalf("tool convo event = %+v", ce)
+	}
+}
+
+func TestParseOpenCodeLineResultUsageAndError(t *testing.T) {
+	result, err := ParseOpenCodeLine([]byte(`{"type":"result","sessionId":"sess-2","message":"done","usage":{"inputTokens":10,"outputTokens":4,"cacheReadInputTokens":6,"reasoningTokens":2,"costUSD":0.01}}`))
+	if err != nil {
+		t.Fatalf("result parse: %v", err)
+	}
+	se := opencodeEventToStreamEvent(result)
+	if se.Type != "result" || se.SessionID != "sess-2" || se.Content != "done" || se.InputTokens != 10 || se.OutputTokens != 4 || se.CacheReadInputTokens != 6 || se.ReasoningTokens != 2 || se.CostUSD != 0.01 {
+		t.Fatalf("result stream event = %+v", se)
+	}
+
+	failed, err := ParseOpenCodeLine([]byte(`{"type":"error","errorType":"rate_limit","code":429,"message":"too many requests"}`))
+	if err != nil {
+		t.Fatalf("error parse: %v", err)
+	}
+	se = opencodeEventToStreamEvent(failed)
+	if se.Type != "result" || se.Subtype != "error" || se.ErrorType != "rate_limit" || se.ErrorStatus != 429 {
+		t.Fatalf("error stream event = %+v", se)
+	}
+}

--- a/internal/agent/procsandbox_darwin.go
+++ b/internal/agent/procsandbox_darwin.go
@@ -115,6 +115,7 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		"-D", "CLAUDE_STATE="+sandboxRootOr(cfg.sandbox.claudeState, home),
 		"-D", "CODEX_STATE="+sandboxRootOr(cfg.sandbox.codexState, home),
 		"-D", "COPILOT_STATE="+sandboxRootOr(cfg.sandbox.copilotState, home),
+		"-D", "OPENCODE_STATE="+sandboxRootOr(cfg.sandbox.opencodeState, home),
 		"-D", "TOOL_CACHE="+sandboxRootOr(cfg.sandbox.toolCache, home),
 		name,
 	)

--- a/internal/agent/procsandbox_linux.go
+++ b/internal/agent/procsandbox_linux.go
@@ -54,7 +54,7 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 	}
 	roots := dedupeRoots(
 		cfg.sandbox.worktree, cfg.sandbox.sandboxHome, cfg.sandbox.tmp, cfg.sandbox.sharedCache,
-		cfg.sandbox.claudeState, cfg.sandbox.codexState, cfg.sandbox.copilotState, cfg.sandbox.toolCache,
+		cfg.sandbox.claudeState, cfg.sandbox.codexState, cfg.sandbox.copilotState, cfg.sandbox.opencodeState, cfg.sandbox.toolCache,
 	)
 	for _, root := range roots {
 		wrapped = append(wrapped, "--bind", root, root)

--- a/internal/agent/procsandbox_linux_test.go
+++ b/internal/agent/procsandbox_linux_test.go
@@ -10,15 +10,16 @@ import (
 
 func TestWrapInvocation_Linux_EnforceBindsOnlyWriteRoots(t *testing.T) {
 	cfg := &RunConfig{sandbox: sandboxSpec{
-		mode:         "enforce",
-		worktree:     "/data/wt",
-		sandboxHome:  "/data/home",
-		tmp:          "/tmp",
-		sharedCache:  "/data/cache",
-		claudeState:  "/data/sybra/claude",
-		codexState:   "/data/sybra/codex",
-		copilotState: "/data/sybra/copilot",
-		toolCache:    "/home/sybra/.cache",
+		mode:          "enforce",
+		worktree:      "/data/wt",
+		sandboxHome:   "/data/home",
+		tmp:           "/tmp",
+		sharedCache:   "/data/cache",
+		claudeState:   "/data/sybra/claude",
+		codexState:    "/data/sybra/codex",
+		copilotState:  "/data/sybra/copilot",
+		opencodeState: "/data/sybra/opencode",
+		toolCache:     "/home/sybra/.cache",
 	}}
 	_, args := wrapInvocation("claude", []string{"-p", "hi"}, cfg)
 
@@ -28,7 +29,7 @@ func TestWrapInvocation_Linux_EnforceBindsOnlyWriteRoots(t *testing.T) {
 	}
 	for _, root := range []string{
 		"/data/wt", "/data/home", "/tmp", "/data/cache",
-		"/data/sybra/claude", "/data/sybra/codex", "/data/sybra/copilot", "/home/sybra/.cache",
+		"/data/sybra/claude", "/data/sybra/codex", "/data/sybra/copilot", "/data/sybra/opencode", "/home/sybra/.cache",
 	} {
 		if !strings.Contains(joined, "--bind "+root+" "+root) {
 			t.Errorf("write root %q not bound read-write: %s", root, joined)

--- a/internal/agent/procsandbox_state_test.go
+++ b/internal/agent/procsandbox_state_test.go
@@ -44,8 +44,9 @@ func TestEnforceSpec_FallsBackWhenStateDirAbsent(t *testing.T) {
 	spec := enforceSpec("/wt", sandboxHome, "/tmp", "/cache", "/profile")
 
 	for name, got := range map[string]string{
-		"codexState":   spec.codexState,
-		"copilotState": spec.copilotState,
+		"codexState":    spec.codexState,
+		"copilotState":  spec.copilotState,
+		"opencodeState": spec.opencodeState,
 	} {
 		if got != sandboxHome {
 			t.Errorf("%s = %q, want fallback to sandboxHome %q — an absent state dir must not produce an empty write root", name, got, sandboxHome)

--- a/internal/agent/provider_opencode.go
+++ b/internal/agent/provider_opencode.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"strings"
+	"time"
+
+	providerpkg "github.com/Automaat/sybra/internal/provider"
+)
+
+const opencodeDefaultModel = "openrouter/z-ai/glm-5.2"
+
+type opencodeProvider struct {
+	baseProvider
+}
+
+func init() {
+	registerAgentProvider(opencodeProvider{})
+}
+
+func (opencodeProvider) Name() string { return "opencode" }
+
+func (opencodeProvider) NormalizeModel(model string) string {
+	switch strings.TrimSpace(model) {
+	case "", "sonnet", "opus", "haiku", "fable":
+		return opencodeDefaultModel
+	default:
+		return model
+	}
+}
+
+func (p opencodeProvider) BuildCommand(cfg RunConfig, model string) string {
+	return buildOpenCodeCommand(model, cfg.ReasoningEffort, cfg.Dir, false)
+}
+
+func (p opencodeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
+	args := buildOpenCodeRunArgs(a, cfg, cfg.Prompt)
+	return headlessInvocation{
+		name:    "opencode",
+		args:    args,
+		command: "opencode " + strings.Join(args, " "),
+	}, nil
+}
+
+func (opencodeProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
+	oe, err := ParseOpenCodeLine(line)
+	if err != nil {
+		return StreamEvent{}, err
+	}
+	return opencodeEventToStreamEvent(oe), nil
+}
+
+func (opencodeProvider) UsesPerTurnConvo() bool { return true }
+
+func (p opencodeProvider) BuildPerTurnConvoInvocation(a *Agent, cfg RunConfig, prompt string) perTurnConvoInvocation {
+	return perTurnConvoInvocation{bin: "opencode", args: buildOpenCodeRunArgs(a, cfg, prompt)}
+}
+
+func (opencodeProvider) ParseConvoLine(line []byte) (ConvoEvent, error) {
+	oe, err := ParseOpenCodeLine(line)
+	if err != nil {
+		return ConvoEvent{}, err
+	}
+	return opencodeEventToConvoEvent(oe), nil
+}
+
+func (opencodeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+	return providerpkg.ClassifyOpenCodeError(sample)
+}
+
+func buildOpenCodeRunArgs(a *Agent, cfg RunConfig, prompt string) []string {
+	args := []string{"run", "--format", "json", "--auto"}
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	args = append(args, opencodeReasoningArgs(a.ReasoningEffort)...)
+	if a.sessionCWD != "" {
+		args = append(args, "--dir", a.sessionCWD)
+	} else if cfg.Dir != "" {
+		args = append(args, "--dir", cfg.Dir)
+	}
+	if sid := a.GetSessionID(); sid != "" {
+		args = append(args, "--session", sid)
+	}
+	args = append(args, prompt)
+	return args
+}
+
+func buildOpenCodeCommand(model, effort, dir string, includePrompt bool) string {
+	parts := []string{"opencode", "run", "--format", "json", "--auto"}
+	if model != "" {
+		parts = append(parts, "--model", model)
+	}
+	parts = append(parts, opencodeReasoningArgs(effort)...)
+	if dir != "" {
+		parts = append(parts, "--dir", dir)
+	}
+	if includePrompt {
+		parts = append(parts, "<prompt>")
+	}
+	return strings.Join(parts, " ")
+}
+
+func opencodeReasoningArgs(effort string) []string {
+	switch effort {
+	case "low", "medium", "high", "xhigh":
+		return []string{"--variant", effort}
+	default:
+		return nil
+	}
+}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -272,7 +272,7 @@ func convoResumeState(evs []ConvoEvent) State {
 	return StatePaused
 }
 
-// reattachPerTurnConvo recreates a per-turn (codex/copilot) conversational
+// reattachPerTurnConvo recreates a per-turn (codex/copilot/opencode) conversational
 // agent after a restart.
 // Codex convo has no persistent process between its independent per-turn
 // invocations, so there is nothing to reattach to: rebuild the idle agent,

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -120,9 +120,60 @@ func copilotEventToConvoEvent(e CopilotEvent) ConvoEvent {
 	return ev
 }
 
-// runPerTurnConversational runs a per-turn provider (codex/copilot) in
+// opencodeEventToConvoEvent converts OpenCode JSON output into the rich
+// conversational event shape. Tool results map to "user" for consistency with
+// Claude/Codex/Copilot streams.
+func opencodeEventToConvoEvent(e OpenCodeEvent) ConvoEvent {
+	ev := ConvoEvent{
+		Type:      e.Type,
+		Subtype:   e.Subtype,
+		SessionID: e.SessionID,
+		Timestamp: time.Now().UTC(),
+		Raw:       e.Raw,
+	}
+	switch e.Type {
+	case "assistant":
+		if e.Message != nil {
+			ev.Text = e.Message.Text
+			ev.ToolUses = e.Message.ToolUses
+		}
+		ev.OutputTokens = e.OutputTokens
+	case "tool_use":
+		if e.Message != nil {
+			ev.ToolUses = e.Message.ToolUses
+		}
+	case "tool_result":
+		ev.Type = "user"
+		if e.Message != nil {
+			results := make([]ToolResultBlock, len(e.Message.ToolResults))
+			copy(results, e.Message.ToolResults)
+			for i := range results {
+				if len(results[i].Content) > 2000 {
+					results[i].Content = results[i].Content[:2000] + "..."
+				}
+			}
+			ev.ToolResults = results
+		}
+	case "result":
+		if e.Result != nil {
+			ev.Text = e.Result.Text
+			ev.SessionID = e.Result.SessionID
+			ev.CostUSD = e.Result.CostUSD
+			ev.InputTokens = e.Result.InputTokens
+			ev.OutputTokens = e.Result.OutputTokens
+			ev.CacheReadInputTokens = e.Result.CacheReadInputTokens
+			ev.ReasoningTokens = e.Result.ReasoningTokens
+			ev.ErrorType = e.Result.ErrorType
+			ev.ErrorStatus = e.Result.ErrorStatus
+		}
+	}
+	return ev
+}
+
+// runPerTurnConversational runs a per-turn provider (codex/copilot/opencode) in
 // interactive conversational mode. Each turn spawns a fresh process
-// (`codex exec --json` or `copilot -p --output-format json`). After the turn's
+// (`codex exec --json`, `copilot -p --output-format json`, or
+// `opencode run --format json`). After the turn's
 // terminal result the agent transitions to StatePaused and waits for the next
 // prompt on promptCh. OneShot skips the wait and exits after the first turn.
 //
@@ -263,7 +314,8 @@ func (m *Manager) waitPerTurnPrompt(ctx context.Context, a *Agent) (string, bool
 }
 
 // runConvoTurn runs one per-turn provider process (`codex exec --json` or
-// `copilot -p --output-format json`) and streams output as ConvoEvents.
+// `copilot -p --output-format json`, or `opencode run --format json`) and
+// streams output as ConvoEvents.
 // Returns true only when the turn produced a terminal result and exited cleanly.
 func (m *Manager) runConvoTurn(ctx context.Context, a *Agent, cfg RunConfig, prompt string, logWriter io.Writer) bool {
 	bin, args, err := buildPerTurnConvoArgs(a, cfg, prompt)
@@ -488,7 +540,7 @@ func (m *Manager) streamPerTurnConvoOutput(a *Agent, stdout io.Reader, outFile i
 }
 
 // parseConvoEvent parses one per-turn NDJSON line into a ConvoEvent using the
-// provider-appropriate parser. Only codex/copilot use the per-turn path;
+// provider-appropriate parser. Only codex/copilot/opencode use the per-turn path;
 // claude conversational is handled in runner_convo.go.
 func parseConvoEvent(provider string, line []byte) (ConvoEvent, error) {
 	prov, err := lookupProvider(provider)
@@ -510,7 +562,7 @@ const convoProviderMarkerVersion = 1
 // can parse each segment of a mixed-provider log with the right parser
 // instead of guessing from the agent's current (possibly since-switched)
 // provider. The field name is namespaced so it can never collide with a
-// genuine codex/copilot JSON line.
+// genuine codex/copilot/opencode JSON line.
 type convoProviderMarker struct {
 	Marker   string `json:"__sybra_provider_marker__"`
 	Version  int    `json:"version"`
@@ -546,7 +598,7 @@ func parseProviderMarkerLine(line []byte) (string, bool) {
 	return mark.Provider, true
 }
 
-// rehydratePerTurnConvoFromLog replays a per-turn (codex/copilot)
+// rehydratePerTurnConvoFromLog replays a per-turn (codex/copilot/opencode)
 // conversational agent's log into its convo buffer (and session id) without
 // emitting events, so a recreated agent shows its prior chat history after a
 // restart. The log may cover more than one provider if a mid-run switch
@@ -620,7 +672,7 @@ func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 	a.SetSessionID(sessionID)
 }
 
-// sendConvoPrompt delivers a follow-up prompt to a per-turn (codex/copilot)
+// sendConvoPrompt delivers a follow-up prompt to a per-turn (codex/copilot/opencode)
 // conversational agent via its prompt channel.
 func (m *Manager) sendConvoPrompt(agentID, text string) error {
 	a, err := m.GetAgent(agentID)

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -309,7 +309,7 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 		return false, nil
 	}
 	// Detached survival for interactive Claude agents (this path is only
-	// reached for Claude; codex/copilot use runPerTurnConversational). A one-shot run
+	// reached for Claude; codex/copilot/opencode use runPerTurnConversational). A one-shot run
 	// passes its prompt as an argument (no stdin); interactive sessions use a
 	// never-EOF FIFO for follow-ups.
 	if m.survives() {

--- a/internal/agent/runner_core.go
+++ b/internal/agent/runner_core.go
@@ -10,7 +10,7 @@ import (
 )
 
 // newProviderCmd is the sole constructor for a provider CLI subprocess. Every
-// exec.CommandContext spawn of a provider binary (claude/codex/copilot, in
+// exec.CommandContext spawn of a provider binary (claude/codex/copilot/opencode, in
 // any of headless-pipe, headless-survive, persistent-convo, convo-survive,
 // or per-turn-convo mode) must go through here so a single seam can wrap the
 // invocation for OS-level sandboxing (see wrapInvocation in
@@ -56,10 +56,11 @@ type sandboxSpec struct {
 	sharedCache string
 	profilePath string
 
-	claudeState  string
-	codexState   string
-	copilotState string
-	toolCache    string
+	claudeState   string
+	codexState    string
+	copilotState  string
+	opencodeState string
+	toolCache     string
 }
 
 // attemptEventsFrom slices the events produced since prevLen out of all,

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -201,6 +201,51 @@ func copilotEventToStreamEvent(e CopilotEvent) StreamEvent {
 	return ev
 }
 
+// opencodeEventToStreamEvent converts OpenCode JSON output into the same
+// lightweight event shape used by the headless runner.
+func opencodeEventToStreamEvent(e OpenCodeEvent) StreamEvent {
+	ev := StreamEvent{Type: e.Type, Subtype: e.Subtype, SessionID: e.SessionID}
+	switch e.Type {
+	case "assistant":
+		if e.Message != nil {
+			ev.Content = e.Message.Text
+			ev.ToolCalls = len(e.Message.ToolUses)
+			ev.toolSig = toolSignature(e.Message.ToolUses)
+			ev.toolUses = e.Message.ToolUses
+		}
+		ev.OutputTokens = e.OutputTokens
+	case "tool_use":
+		if e.Message != nil && len(e.Message.ToolUses) > 0 {
+			cmd, _ := e.Message.ToolUses[0].Input["command"].(string)
+			if cmd == "" {
+				cmd, _ = e.Message.ToolUses[0].Input["input"].(string)
+			}
+			ev.Content = cmd
+			ev.ToolCalls = len(e.Message.ToolUses)
+			ev.toolSig = toolSignature(e.Message.ToolUses)
+			ev.toolUses = e.Message.ToolUses
+		}
+	case "tool_result":
+		if e.Message != nil && len(e.Message.ToolResults) > 0 {
+			ev.Content = e.Message.ToolResults[0].Content
+			ev.toolResults = e.Message.ToolResults
+		}
+	case "result":
+		if e.Result != nil {
+			ev.Content = e.Result.Text
+			ev.SessionID = e.Result.SessionID
+			ev.CostUSD = e.Result.CostUSD
+			ev.InputTokens = e.Result.InputTokens
+			ev.OutputTokens = e.Result.OutputTokens
+			ev.CacheReadInputTokens = e.Result.CacheReadInputTokens
+			ev.ReasoningTokens = e.Result.ReasoningTokens
+			ev.ErrorType = e.Result.ErrorType
+			ev.ErrorStatus = e.Result.ErrorStatus
+		}
+	}
+	return ev
+}
+
 // formatHeadlessAssistant produces the flat content string for headless assistant
 // events: joined text parts followed by "[name] cmd/desc" tool use lines.
 func formatHeadlessAssistant(msg *ClaudeMessage) string {

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -91,6 +91,20 @@ type CopilotEvent struct {
 	Result       *ClaudeResult
 }
 
+// OpenCodeEvent is the shared envelope for OpenCode JSON output
+// (`opencode run --format json`). OpenCode supports many providers, so the
+// parser is intentionally tolerant of both OpenCode-native event names and the
+// assistant/tool/result shapes used by the other CLIs.
+type OpenCodeEvent struct {
+	Type         string
+	Subtype      string
+	SessionID    string
+	OutputTokens int
+	Raw          json.RawMessage
+	Message      *ClaudeMessage
+	Result       *ClaudeResult
+}
+
 type claudeEnvelope struct {
 	Type            string                `json:"type"`
 	Subtype         string                `json:"subtype"`
@@ -229,6 +243,64 @@ type copilotUsage struct {
 	PremiumRequests float64 `json:"premiumRequests"`
 }
 
+type opencodeEnvelope struct {
+	Type           string          `json:"type"`
+	Subtype        string          `json:"subtype"`
+	SessionID      string          `json:"sessionId"`
+	SessionIDSnake string          `json:"session_id"`
+	ExitCode       int             `json:"exitCode"`
+	Code           int             `json:"code"`
+	ErrorType      string          `json:"errorType"`
+	ErrorTypeSnake string          `json:"error_type"`
+	Error          string          `json:"error"`
+	Message        string          `json:"message"`
+	Content        string          `json:"content"`
+	Text           string          `json:"text"`
+	Data           json.RawMessage `json:"data"`
+	Usage          *opencodeUsage  `json:"usage"`
+}
+
+type opencodeUsage struct {
+	InputTokens               int     `json:"inputTokens"`
+	InputTokensSnake          int     `json:"input_tokens"`
+	OutputTokens              int     `json:"outputTokens"`
+	OutputTokensSnake         int     `json:"output_tokens"`
+	CacheReadInputTokens      int     `json:"cacheReadInputTokens"`
+	CacheReadInputTokensSnake int     `json:"cache_read_input_tokens"`
+	ReasoningTokens           int     `json:"reasoningTokens"`
+	ReasoningTokensSnake      int     `json:"reasoning_tokens"`
+	CostUSD                   float64 `json:"costUSD"`
+	CostUSDSnake              float64 `json:"cost_usd"`
+}
+
+type opencodeData struct {
+	ID           string             `json:"id"`
+	Content      string             `json:"content"`
+	Text         string             `json:"text"`
+	Message      string             `json:"message"`
+	OutputTokens int                `json:"outputTokens"`
+	ToolCallID   string             `json:"toolCallId"`
+	ToolID       string             `json:"toolId"`
+	ToolName     string             `json:"toolName"`
+	Name         string             `json:"name"`
+	Arguments    json.RawMessage    `json:"arguments"`
+	Input        json.RawMessage    `json:"input"`
+	Success      *bool              `json:"success"`
+	Error        string             `json:"error"`
+	Result       json.RawMessage    `json:"result"`
+	ToolRequests []opencodeToolCall `json:"toolRequests"`
+	ToolCalls    []opencodeToolCall `json:"toolCalls"`
+}
+
+type opencodeToolCall struct {
+	ID         string          `json:"id"`
+	ToolCallID string          `json:"toolCallId"`
+	Name       string          `json:"name"`
+	ToolName   string          `json:"toolName"`
+	Arguments  json.RawMessage `json:"arguments"`
+	Input      json.RawMessage `json:"input"`
+}
+
 // ParseCopilotLine parses one line of GitHub Copilot CLI stream-json output.
 // Ephemeral and structural lines collapse to a zero-Type CopilotEvent that
 // callers skip. The returned Raw is an independent copy safe to keep after the
@@ -327,6 +399,223 @@ func ParseCopilotLine(line []byte) (CopilotEvent, error) {
 		// content for the headless model — skip them.
 		return CopilotEvent{Raw: rawCopy}, nil
 	}
+}
+
+// ParseOpenCodeLine parses one line of OpenCode JSON output. Unknown structural
+// lines collapse to a zero-Type event so callers can keep streaming across new
+// OpenCode event types without failing the whole run.
+func ParseOpenCodeLine(line []byte) (OpenCodeEvent, error) {
+	var raw opencodeEnvelope
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return OpenCodeEvent{}, fmt.Errorf("unmarshal: %w", err)
+	}
+	rawCopy := copyRaw(line)
+	sessionID := firstNonEmpty(raw.SessionID, raw.SessionIDSnake)
+	eventType := strings.ToLower(strings.TrimSpace(raw.Type))
+
+	switch eventType {
+	case "assistant.message", "assistant", "message", "agent_message", "message.updated":
+		msg := &ClaudeMessage{Role: "assistant", Text: firstNonEmpty(raw.Content, raw.Text, raw.Message)}
+		outTokens := 0
+		if len(raw.Data) > 0 {
+			data := parseOpenCodeData(raw.Data)
+			if msg.Text == "" {
+				msg.Text = firstNonEmpty(data.Content, data.Text, data.Message)
+			}
+			outTokens = data.OutputTokens
+			msg.ToolUses = append(msg.ToolUses, opencodeToolCalls(data.ToolRequests)...)
+			msg.ToolUses = append(msg.ToolUses, opencodeToolCalls(data.ToolCalls)...)
+		}
+		if raw.Usage != nil && outTokens == 0 {
+			outTokens = raw.Usage.outputTokens()
+		}
+		return OpenCodeEvent{Type: "assistant", SessionID: sessionID, OutputTokens: outTokens, Raw: rawCopy, Message: msg}, nil
+
+	case "tool.execution_start", "tool.started", "tool.start", "tool_use", "tool.call":
+		data := parseOpenCodeData(raw.Data)
+		tool := ToolUseBlock{
+			ID:    firstNonEmpty(data.ToolCallID, data.ToolID, data.ID),
+			Name:  opencodeToolDisplayName(firstNonEmpty(data.ToolName, data.Name)),
+			Input: opencodeInputMap(firstRaw(data.Arguments, data.Input)),
+		}
+		return OpenCodeEvent{Type: "tool_use", SessionID: sessionID, Raw: rawCopy, Message: &ClaudeMessage{
+			Role:     "assistant",
+			ToolUses: []ToolUseBlock{tool},
+		}}, nil
+
+	case "tool.execution_complete", "tool.completed", "tool.complete", "tool_result", "tool.result":
+		data := parseOpenCodeData(raw.Data)
+		success := data.Success == nil || *data.Success
+		content := firstNonEmpty(data.Error, opencodeRawContent(data.Result), raw.Content, raw.Text, raw.Message)
+		return OpenCodeEvent{Type: "tool_result", SessionID: sessionID, Raw: rawCopy, Message: &ClaudeMessage{
+			Role: "user",
+			ToolResults: []ToolResultBlock{{
+				ToolUseID: firstNonEmpty(data.ToolCallID, data.ToolID, data.ID),
+				Content:   content,
+				IsError:   !success || data.Error != "",
+			}},
+		}}, nil
+
+	case "result", "session.idle", "session.completed", "turn.completed", "run.completed":
+		r := &ClaudeResult{
+			SessionID:   sessionID,
+			Text:        firstNonEmpty(raw.Content, raw.Text, raw.Message),
+			ErrorType:   firstNonEmpty(raw.ErrorType, raw.ErrorTypeSnake),
+			ErrorStatus: firstNonZero(raw.Code, raw.ExitCode),
+		}
+		if raw.Usage != nil {
+			r.InputTokens = raw.Usage.inputTokens()
+			r.OutputTokens = raw.Usage.outputTokens()
+			r.CacheReadInputTokens = raw.Usage.cacheReadInputTokens()
+			r.ReasoningTokens = raw.Usage.reasoningTokens()
+			r.CostUSD = raw.Usage.costUSD()
+		}
+		subtype := ""
+		if raw.Subtype != "" {
+			subtype = raw.Subtype
+		} else if r.ErrorStatus != 0 || r.ErrorType != "" || raw.Error != "" {
+			subtype = "error"
+			if r.Text == "" {
+				r.Text = raw.Error
+			}
+		}
+		r.Subtype = subtype
+		return OpenCodeEvent{Type: "result", Subtype: subtype, SessionID: sessionID, Raw: rawCopy, Result: r}, nil
+
+	case "error":
+		status := firstNonZero(raw.Code, raw.ExitCode)
+		return OpenCodeEvent{
+			Type:    "result",
+			Subtype: "error",
+			Raw:     rawCopy,
+			Result: &ClaudeResult{
+				Subtype:     "error",
+				SessionID:   sessionID,
+				Text:        firstNonEmpty(raw.Error, raw.Message, raw.Content, raw.Text),
+				ErrorType:   firstNonEmpty(raw.ErrorType, raw.ErrorTypeSnake, "error"),
+				ErrorStatus: status,
+			},
+		}, nil
+
+	case "session.created", "session.updated", "session":
+		return OpenCodeEvent{Type: "init", SessionID: sessionID, Raw: rawCopy}, nil
+
+	default:
+		return OpenCodeEvent{Raw: rawCopy}, nil
+	}
+}
+
+func parseOpenCodeData(raw json.RawMessage) opencodeData {
+	var data opencodeData
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &data)
+	}
+	return data
+}
+
+func opencodeToolCalls(calls []opencodeToolCall) []ToolUseBlock {
+	out := make([]ToolUseBlock, 0, len(calls))
+	for _, c := range calls {
+		out = append(out, ToolUseBlock{
+			ID:    firstNonEmpty(c.ToolCallID, c.ID),
+			Name:  opencodeToolDisplayName(firstNonEmpty(c.ToolName, c.Name)),
+			Input: opencodeInputMap(firstRaw(c.Arguments, c.Input)),
+		})
+	}
+	return out
+}
+
+func opencodeInputMap(raw json.RawMessage) map[string]any {
+	out := map[string]any{}
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return out
+	}
+	if json.Unmarshal(raw, &out) == nil {
+		return out
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil && s != "" {
+		out["input"] = s
+		return out
+	}
+	out["input"] = string(raw)
+	return out
+}
+
+func opencodeRawContent(raw json.RawMessage) string {
+	return copilotResultContent(raw)
+}
+
+func opencodeToolDisplayName(name string) string {
+	if strings.EqualFold(name, "bash") || strings.EqualFold(name, "shell") {
+		return "Bash"
+	}
+	if name == "" {
+		return "Tool"
+	}
+	return name
+}
+
+func firstRaw(items ...json.RawMessage) json.RawMessage {
+	for _, item := range items {
+		if len(item) > 0 && !bytes.Equal(item, []byte("null")) {
+			return item
+		}
+	}
+	return nil
+}
+
+func firstNonEmpty(items ...string) string {
+	for _, item := range items {
+		if item != "" {
+			return item
+		}
+	}
+	return ""
+}
+
+func firstNonZero(items ...int) int {
+	for _, item := range items {
+		if item != 0 {
+			return item
+		}
+	}
+	return 0
+}
+
+func (u opencodeUsage) inputTokens() int {
+	if u.InputTokens != 0 {
+		return u.InputTokens
+	}
+	return u.InputTokensSnake
+}
+
+func (u opencodeUsage) outputTokens() int {
+	if u.OutputTokens != 0 {
+		return u.OutputTokens
+	}
+	return u.OutputTokensSnake
+}
+
+func (u opencodeUsage) cacheReadInputTokens() int {
+	if u.CacheReadInputTokens != 0 {
+		return u.CacheReadInputTokens
+	}
+	return u.CacheReadInputTokensSnake
+}
+
+func (u opencodeUsage) reasoningTokens() int {
+	if u.ReasoningTokens != 0 {
+		return u.ReasoningTokens
+	}
+	return u.ReasoningTokensSnake
+}
+
+func (u opencodeUsage) costUSD() float64 {
+	if u.CostUSD != 0 {
+		return u.CostUSD
+	}
+	return u.CostUSDSnake
 }
 
 // copilotToolInput builds the ToolUseBlock.Input map from a Copilot tool's

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -576,9 +576,10 @@ func DefaultConfig() *Config {
 				Enabled:         true,
 				IntervalSeconds: 300,
 			},
-			Claude:  ProviderEntryConfig{Enabled: true, RateLimitCooldownSeconds: 900},
-			Codex:   ProviderEntryConfig{Enabled: true, RateLimitCooldownSeconds: 900},
-			Copilot: ProviderEntryConfig{Enabled: true, RateLimitCooldownSeconds: 900},
+			Claude:   ProviderEntryConfig{Enabled: true, RateLimitCooldownSeconds: 900},
+			Codex:    ProviderEntryConfig{Enabled: true, RateLimitCooldownSeconds: 900},
+			Copilot:  ProviderEntryConfig{Enabled: true, RateLimitCooldownSeconds: 900},
+			OpenCode: ProviderEntryConfig{Enabled: true, RateLimitCooldownSeconds: 900},
 			Limits: ProviderLimitsConfig{
 				Enabled:                 true,
 				SessionThresholdPercent: 85,
@@ -1310,6 +1311,9 @@ func applyProvidersDefaults(cfg *Config) {
 	}
 	if cfg.Providers.Copilot.RateLimitCooldownSeconds <= 0 {
 		cfg.Providers.Copilot.RateLimitCooldownSeconds = 900
+	}
+	if cfg.Providers.OpenCode.RateLimitCooldownSeconds <= 0 {
+		cfg.Providers.OpenCode.RateLimitCooldownSeconds = 900
 	}
 	if cfg.Providers.Limits.SessionThresholdPercent <= 0 {
 		cfg.Providers.Limits.SessionThresholdPercent = 85

--- a/internal/config/config_providers.go
+++ b/internal/config/config_providers.go
@@ -1,13 +1,14 @@
 package config
 
 // ProvidersConfig groups per-machine routing for CLI providers (claude, codex,
-// copilot) and their background health-check loop. A missing block defaults to
+// copilot, opencode) and their background health-check loop. A missing block defaults to
 // "all providers enabled, health check on, auto-failover on, 300s interval".
 type ProvidersConfig struct {
 	HealthCheck  ProviderHealthCheckConfig `yaml:"health_check" json:"healthCheck"`
 	Claude       ProviderEntryConfig       `yaml:"claude" json:"claude"`
 	Codex        ProviderEntryConfig       `yaml:"codex" json:"codex"`
 	Copilot      ProviderEntryConfig       `yaml:"copilot" json:"copilot"`
+	OpenCode     ProviderEntryConfig       `yaml:"opencode" json:"opencode"`
 	Limits       ProviderLimitsConfig      `yaml:"limits" json:"limits"`
 	AutoFailover bool                      `yaml:"auto_failover" json:"autoFailover"`
 }

--- a/internal/limits/model.go
+++ b/internal/limits/model.go
@@ -3,9 +3,10 @@ package limits
 import "time"
 
 const (
-	ProviderClaude  = "claude"
-	ProviderCodex   = "codex"
-	ProviderCopilot = "copilot"
+	ProviderClaude   = "claude"
+	ProviderCodex    = "codex"
+	ProviderCopilot  = "copilot"
+	ProviderOpenCode = "opencode"
 
 	SourceStream       = "stream"
 	SourceSessionFiles = "session-files"
@@ -115,9 +116,10 @@ func DefaultPolicy() Policy {
 		PreferUnderused:         true,
 		SubscriptionMonthlyUSD:  map[string]float64{},
 		ProviderEnabled: map[string]bool{
-			ProviderClaude:  true,
-			ProviderCodex:   true,
-			ProviderCopilot: true,
+			ProviderClaude:   true,
+			ProviderCodex:    true,
+			ProviderCopilot:  true,
+			ProviderOpenCode: true,
 		},
 	}
 }

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -230,7 +230,7 @@ func (s *Store) Summary(policy Policy) Summary {
 	defer s.mu.Unlock()
 
 	now := s.now().UTC()
-	providers := []string{ProviderClaude, ProviderCodex, ProviderCopilot}
+	providers := []string{ProviderClaude, ProviderCodex, ProviderCopilot, ProviderOpenCode}
 	out := make([]ProviderSummary, 0, len(providers))
 	for _, provider := range providers {
 		snap := s.snapshots[provider]

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -160,6 +160,8 @@ func normalizeProvider(p string) string {
 		return "codex"
 	case "copilot":
 		return "copilot"
+	case "opencode":
+		return "opencode"
 	default:
 		return ""
 	}
@@ -237,6 +239,13 @@ func invocation(p, prompt, model string, disableTools bool, schemaPath string) (
 			args = append(args, "--model", model)
 		}
 		return "copilot", args, ""
+	case "opencode":
+		args := []string{"run", "--format", "json", "--auto"}
+		if model != "" {
+			args = append(args, "--model", model)
+		}
+		args = append(args, prompt)
+		return "opencode", args, ""
 	default:
 		args := []string{"-p", prompt, "--output-format", "json"}
 		if disableTools {
@@ -258,6 +267,9 @@ func parseProviderText(p string, raw []byte) (text string, costUSD float64, err 
 		return text, 0, err
 	case "copilot":
 		text, err := parseCopilotText(raw)
+		return text, 0, err
+	case "opencode":
+		text, err := parseOpenCodeText(raw)
 		return text, 0, err
 	default:
 		return parseClaudeText(raw)
@@ -344,6 +356,72 @@ func parseCopilotText(raw []byte) (string, error) {
 	return final, nil
 }
 
+func parseOpenCodeText(raw []byte) (string, error) {
+	var final string
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, streamScannerBuffer), streamScannerBuffer)
+	for scanner.Scan() {
+		var ev struct {
+			Type    string          `json:"type"`
+			Content string          `json:"content"`
+			Text    string          `json:"text"`
+			Message string          `json:"message"`
+			Error   string          `json:"error"`
+			Data    json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			return "", err
+		}
+		if strings.Contains(strings.ToLower(ev.Type), "error") {
+			msg := firstNonEmpty(ev.Error, ev.Message, ev.Text, ev.Content)
+			if msg == "" {
+				msg = ev.Type
+			}
+			return "", errors.New(msg)
+		}
+		if strings.Contains(strings.ToLower(ev.Type), "assistant") {
+			if text := firstNonEmpty(ev.Content, ev.Text, ev.Message, openCodeDataText(ev.Data)); text != "" {
+				final = text
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(final) == "" {
+		return "", errors.New("no assistant message in opencode output")
+	}
+	return final, nil
+}
+
+func openCodeDataText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strings.TrimSpace(s)
+	}
+	var data struct {
+		Content string `json:"content"`
+		Text    string `json:"text"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return ""
+	}
+	return firstNonEmpty(data.Content, data.Text, data.Message)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 func classifyError(p, stderrOut, content string) (provider.Signal, string, time.Duration) {
 	sample := provider.ErrorSample{Stderr: stderrOut, Content: content}
 	switch p {
@@ -351,6 +429,8 @@ func classifyError(p, stderrOut, content string) (provider.Signal, string, time.
 		return provider.ClassifyCodexError(sample)
 	case "copilot":
 		return provider.ClassifyCopilotError(sample)
+	case "opencode":
+		return provider.ClassifyOpenCodeError(sample)
 	default:
 		return provider.ClassifyClaudeError(sample)
 	}

--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -107,6 +107,29 @@ printf '%s\n' '{"type":"assistant.message","data":{"content":"{\"ok\":true}"}}'
 	}
 }
 
+func TestRunJSONPassesOpenCodeModel(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "opencode"), `#!/bin/bash
+if [[ "$*" != *"--model openrouter/z-ai/glm-5.2"* ]]; then
+  echo "missing model flag: $*" >&2
+  exit 7
+fi
+printf '%s\n' '{"type":"assistant.message","data":{"content":"{\"ok\":true}"}}'
+`)
+	t.Setenv("PATH", dir)
+
+	res, err := RunJSON(context.Background(), "classify", Options{
+		Provider: "opencode",
+		Models:   map[string]string{"opencode": "openrouter/z-ai/glm-5.2"},
+	})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "opencode" {
+		t.Fatalf("provider = %q, want opencode", res.Provider)
+	}
+}
+
 func TestRunJSONFallsBackOnCodexUsageLimit(t *testing.T) {
 	dir := t.TempDir()
 	writeExe(t, filepath.Join(dir, "claude"), `#!/bin/sh
@@ -154,6 +177,19 @@ func TestParseCopilotTextAllowsLargeStreamLine(t *testing.T) {
 	got, err := parseCopilotText(raw)
 	if err != nil {
 		t.Fatalf("parseCopilotText: %v", err)
+	}
+	if got != text {
+		t.Fatalf("text length = %d, want %d", len(got), len(text))
+	}
+}
+
+func TestParseOpenCodeTextAllowsLargeStreamLine(t *testing.T) {
+	text := strings.Repeat("x", 2*1024*1024)
+	raw := fmt.Appendf(nil, `{"type":"assistant.message","data":{"content":"%s"}}`, text)
+
+	got, err := parseOpenCodeText(raw)
+	if err != nil {
+		t.Fatalf("parseOpenCodeText: %v", err)
 	}
 	if got != text {
 		t.Fatalf("text length = %d, want %d", len(got), len(text))
@@ -308,14 +344,18 @@ exit 1
 echo "rate limit exceeded" >&2
 exit 1
 `)
+	writeExe(t, filepath.Join(dir, "opencode"), `#!/bin/sh
+echo "rate limit exceeded" >&2
+exit 1
+`)
 	t.Setenv("PATH", dir)
 
 	res, err := RunJSON(context.Background(), "classify", Options{})
 	if err == nil {
 		t.Fatal("RunJSON: want error when every provider fails")
 	}
-	if res.Provider != "copilot" {
-		t.Fatalf("provider = %q, want copilot (last candidate tried)", res.Provider)
+	if res.Provider != "opencode" {
+		t.Fatalf("provider = %q, want opencode (last candidate tried)", res.Provider)
 	}
 }
 

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -22,14 +22,16 @@ type Status struct {
 
 // Config controls the Checker's probe schedule and failover policy.
 type Config struct {
-	Interval          time.Duration
-	ClaudeEnabled     bool
-	CodexEnabled      bool
-	CopilotEnabled    bool
-	AutoFailover      bool
-	ClaudeRLCooldown  time.Duration
-	CodexRLCooldown   time.Duration
-	CopilotRLCooldown time.Duration
+	Interval           time.Duration
+	ClaudeEnabled      bool
+	CodexEnabled       bool
+	CopilotEnabled     bool
+	OpenCodeEnabled    bool
+	AutoFailover       bool
+	ClaudeRLCooldown   time.Duration
+	CodexRLCooldown    time.Duration
+	CopilotRLCooldown  time.Duration
+	OpenCodeRLCooldown time.Duration
 	// ProbeErrorThreshold is the number of consecutive generic probe_error
 	// results required before a provider is marked unhealthy. Auth and
 	// rate-limit states still apply immediately.
@@ -87,10 +89,11 @@ type Checker struct {
 	emit   func(event string, data any)
 	logger *slog.Logger
 
-	probeClaude  func(ctx context.Context) (Status, error)
-	probeCodex   func(ctx context.Context) (Status, error)
-	probeCopilot func(ctx context.Context) (Status, error)
-	now          func() time.Time
+	probeClaude   func(ctx context.Context) (Status, error)
+	probeCodex    func(ctx context.Context) (Status, error)
+	probeCopilot  func(ctx context.Context) (Status, error)
+	probeOpenCode func(ctx context.Context) (Status, error)
+	now           func() time.Time
 }
 
 // New constructs a Checker. Zero-value config fields are filled with defaults.
@@ -106,6 +109,9 @@ func New(cfg Config, emit func(string, any), logger *slog.Logger) *Checker {
 	}
 	if cfg.CopilotRLCooldown <= 0 {
 		cfg.CopilotRLCooldown = 15 * time.Minute
+	}
+	if cfg.OpenCodeRLCooldown <= 0 {
+		cfg.OpenCodeRLCooldown = 15 * time.Minute
 	}
 	if cfg.ProbeErrorThreshold <= 0 {
 		cfg.ProbeErrorThreshold = defaultProbeErrorThreshold
@@ -125,12 +131,14 @@ func New(cfg Config, emit func(string, any), logger *slog.Logger) *Checker {
 		probeClaude:   ProbeClaude,
 		probeCodex:    ProbeCodex,
 		probeCopilot:  ProbeCopilot,
+		probeOpenCode: ProbeOpenCode,
 		now:           time.Now,
 	}
 	// Seed defaults so Snapshot returns something meaningful before first probe.
 	c.statuses["claude"] = &Status{Provider: "claude", Healthy: cfg.ClaudeEnabled, Reason: initialReason(cfg.ClaudeEnabled)}
 	c.statuses["codex"] = &Status{Provider: "codex", Healthy: cfg.CodexEnabled, Reason: initialReason(cfg.CodexEnabled)}
 	c.statuses["copilot"] = &Status{Provider: "copilot", Healthy: cfg.CopilotEnabled, Reason: initialReason(cfg.CopilotEnabled)}
+	c.statuses["opencode"] = &Status{Provider: "opencode", Healthy: cfg.OpenCodeEnabled, Reason: initialReason(cfg.OpenCodeEnabled)}
 	return c
 }
 
@@ -159,14 +167,15 @@ func (c *Checker) Run(ctx context.Context) {
 
 func (c *Checker) checkAll(ctx context.Context) {
 	var wg sync.WaitGroup
-	var claudeStatus, codexStatus, copilotStatus Status
-	var claudeErr, codexErr, copilotErr error
-	var doClaude, doCodex, doCopilot bool
+	var claudeStatus, codexStatus, copilotStatus, openCodeStatus Status
+	var claudeErr, codexErr, copilotErr, openCodeErr error
+	var doClaude, doCodex, doCopilot, doOpenCode bool
 
 	c.mu.RLock()
 	doClaude = c.cfg.ClaudeEnabled
 	doCodex = c.cfg.CodexEnabled
 	doCopilot = c.cfg.CopilotEnabled
+	doOpenCode = c.cfg.OpenCodeEnabled
 	c.mu.RUnlock()
 
 	if doClaude {
@@ -184,9 +193,14 @@ func (c *Checker) checkAll(ctx context.Context) {
 			copilotStatus, copilotErr = c.probeCopilot(ctx)
 		})
 	}
+	if doOpenCode {
+		wg.Go(func() {
+			openCodeStatus, openCodeErr = c.probeOpenCode(ctx)
+		})
+	}
 	wg.Wait()
 
-	results := make([]probeResult, 0, 3)
+	results := make([]probeResult, 0, 4)
 	if doClaude {
 		results = append(results, probeResult{provider: "claude", status: claudeStatus, err: claudeErr})
 	}
@@ -195,6 +209,9 @@ func (c *Checker) checkAll(ctx context.Context) {
 	}
 	if doCopilot {
 		results = append(results, probeResult{provider: "copilot", status: copilotStatus, err: copilotErr})
+	}
+	if doOpenCode {
+		results = append(results, probeResult{provider: "opencode", status: openCodeStatus, err: openCodeErr})
 	}
 	c.applyProbeResults(ctx, results)
 }
@@ -481,6 +498,8 @@ func (c *Checker) providerEnabledLocked(provider string) bool {
 		return c.cfg.CodexEnabled
 	case "copilot":
 		return c.cfg.CopilotEnabled
+	case "opencode":
+		return c.cfg.OpenCodeEnabled
 	default:
 		return false
 	}
@@ -515,6 +534,8 @@ func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, rea
 			cooldown = c.cfg.CodexRLCooldown
 		case "copilot":
 			cooldown = c.cfg.CopilotRLCooldown
+		case "opencode":
+			cooldown = c.cfg.OpenCodeRLCooldown
 		default:
 			cooldown = 15 * time.Minute
 		}
@@ -563,6 +584,8 @@ func (c *Checker) SetProviderEnabled(provider string, v bool) {
 		prev, c.cfg.CodexEnabled = c.cfg.CodexEnabled, v
 	case "copilot":
 		prev, c.cfg.CopilotEnabled = c.cfg.CopilotEnabled, v
+	case "opencode":
+		prev, c.cfg.OpenCodeEnabled = c.cfg.OpenCodeEnabled, v
 	default:
 		c.mu.Unlock()
 		return

--- a/internal/provider/probes.go
+++ b/internal/provider/probes.go
@@ -119,6 +119,30 @@ func ProbeCopilot(ctx context.Context) (Status, error) {
 	return st, nil
 }
 
+// ProbeOpenCode checks OpenCode CLI liveness. Provider-specific credentials
+// (OpenRouter, Z.AI, local OpenAI-compatible endpoints, etc.) are selected by
+// the model/config for a run, so this probe deliberately avoids spending an LLM
+// request. Auth and rate-limit failures are learned from passive run signals.
+func ProbeOpenCode(ctx context.Context) (Status, error) {
+	cctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "opencode", "--version")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if isLoggedOutStderr(stderr.String()) {
+			return Status{Provider: "opencode", Healthy: false, Reason: "logged_out", LastCheck: time.Now()}, nil
+		}
+		return Status{Provider: "opencode", Healthy: false, Reason: "probe_error", Detail: err.Error(), LastCheck: time.Now()}, err
+	}
+	st := Status{Provider: "opencode", Healthy: true, Reason: "ok", LastCheck: time.Now()}
+	if v := strings.TrimSpace(stdout.String()); v != "" {
+		st.Detail = v
+	}
+	return st, nil
+}
+
 // copilotTokenEnvVar returns the name of the first set, non-empty Copilot auth
 // token env var, or "" if none is set.
 func copilotTokenEnvVar() string {

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -205,6 +205,34 @@ func ClassifyCopilotError(s ErrorSample) (Signal, string, time.Duration) {
 	return SignalNone, "", 0
 }
 
+// ClassifyOpenCodeError classifies OpenCode CLI failures. OpenCode can front
+// many providers, so keep the patterns generic and avoid provider-specific
+// assumptions beyond common HTTP/auth/rate-limit vocabulary.
+func ClassifyOpenCodeError(s ErrorSample) (Signal, string, time.Duration) {
+	if s.ErrorStatus == 401 || s.ErrorStatus == 403 {
+		return SignalAuthFailure, "logged_out", 0
+	}
+	if s.ErrorStatus == 429 {
+		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0
+	}
+	hay := strings.ToLower(strings.Join([]string{s.ErrorType, s.Stderr, s.Content}, "\n"))
+	switch {
+	case strings.Contains(hay, "not authenticated"),
+		strings.Contains(hay, "not logged in"),
+		strings.Contains(hay, "unauthorized"),
+		strings.Contains(hay, "invalid api key"),
+		strings.Contains(hay, "missing api key"):
+		return SignalAuthFailure, "logged_out", 0
+	case strings.Contains(hay, "rate limit"),
+		strings.Contains(hay, "too many requests"),
+		strings.Contains(hay, "quota"),
+		strings.Contains(hay, "insufficient credits"),
+		strings.Contains(hay, "credit balance"):
+		return SignalRateLimit, "rate_limited", 0
+	}
+	return SignalNone, "", 0
+}
+
 func containsRateLimitContent(content string, cleanResult bool, broadNeedles ...string) bool {
 	if !cleanResult {
 		return containsAny(content, broadNeedles...)

--- a/internal/providerid/providerid.go
+++ b/internal/providerid/providerid.go
@@ -5,15 +5,14 @@ import (
 	"strings"
 )
 
-var all = []string{"claude", "codex", "copilot"}
+var all = []string{"claude", "codex", "copilot", "opencode"}
 
 // List returns the provider universe as a comma-separated string for use in
 // human-readable validation messages, so those messages stay single-sourced.
 func List() string { return strings.Join(all, ", ") }
 
 // All returns the ordered provider universe (failover priority: claude, codex,
-// copilot). Adding a fourth provider means appending it here plus registering
-// its agent.Provider impl and config entry. Callers must not mutate the result.
+// copilot, opencode). Callers must not mutate the result.
 func All() []string { return append([]string(nil), all...) }
 
 // IsKnown reports whether name is a provider id Sybra can dispatch to.

--- a/internal/providerid/providerid_test.go
+++ b/internal/providerid/providerid_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAllReturnsFailoverOrderedCopy(t *testing.T) {
 	got := All()
-	want := []string{"claude", "codex", "copilot"}
+	want := []string{"claude", "codex", "copilot", "opencode"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("All() = %v, want %v", got, want)
 	}
@@ -18,7 +18,7 @@ func TestAllReturnsFailoverOrderedCopy(t *testing.T) {
 }
 
 func TestIsKnown(t *testing.T) {
-	for _, p := range []string{"claude", "codex", "copilot"} {
+	for _, p := range []string{"claude", "codex", "copilot", "opencode"} {
 		if !IsKnown(p) {
 			t.Errorf("IsKnown(%q) = false, want true", p)
 		}

--- a/internal/skills/data/sybra-handoff.md
+++ b/internal/skills/data/sybra-handoff.md
@@ -3,7 +3,7 @@ name: sybra-handoff
 description: Hand a researched, already-decided task off to Sybra for autonomous implementation or cross-provider review/testing. Use after you have explored a problem in an Orca (or any) git worktree, agreed on the approach, and want Sybra to skip its own planning and start at the right stage — reusing this exact worktree. Triggers on "hand this off to Sybra", "let Sybra implement this", "ship this to Sybra", "handoff to sybra". Works under Claude Code, Codex, and Copilot.
 allowed-tools: Bash
 user-invocable: true
-argument-hint: "[--stage STAGE | --status STATUS] [--title \"...\"] [--plan-file PATH] [--worktree-dir DIR] [--source-provider claude|codex|copilot] [--pr N]"
+argument-hint: "[--stage STAGE | --status STATUS] [--title \"...\"] [--plan-file PATH] [--worktree-dir DIR] [--source-provider claude|codex|copilot|opencode] [--pr N]"
 ---
 
 # Sybra Handoff
@@ -122,7 +122,7 @@ such as `review`; handoff tasks must stay in the internal simple-task workflow.
    sybra-cli handoff \
      --title "feat(auth): add jwt refresh middleware" \
      --body  "One-paragraph problem statement + the research context Sybra needs." \
-     --source-provider "<claude|codex|copilot>" \
+     --source-provider "<claude|codex|copilot|opencode>" \
      --plan-file ./.sybra-handoff-plan.md
    ```
    Set `--source-provider` to the provider running this skill: Claude Code uses

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -419,14 +419,16 @@ func (a *App) limitPolicy() limits.Policy {
 	p.WeeklyThresholdPercent = a.cfg.Providers.Limits.WeeklyThresholdPercent
 	p.PreferUnderused = a.cfg.Providers.Limits.PreferUnderused
 	p.SubscriptionMonthlyUSD = map[string]float64{
-		"claude":  a.cfg.Providers.Claude.MonthlySubscriptionUSD,
-		"codex":   a.cfg.Providers.Codex.MonthlySubscriptionUSD,
-		"copilot": a.cfg.Providers.Copilot.MonthlySubscriptionUSD,
+		"claude":   a.cfg.Providers.Claude.MonthlySubscriptionUSD,
+		"codex":    a.cfg.Providers.Codex.MonthlySubscriptionUSD,
+		"copilot":  a.cfg.Providers.Copilot.MonthlySubscriptionUSD,
+		"opencode": a.cfg.Providers.OpenCode.MonthlySubscriptionUSD,
 	}
 	p.ProviderEnabled = map[string]bool{
-		"claude":  a.cfg.Providers.Claude.Enabled,
-		"codex":   a.cfg.Providers.Codex.Enabled,
-		"copilot": a.cfg.Providers.Copilot.Enabled,
+		"claude":   a.cfg.Providers.Claude.Enabled,
+		"codex":    a.cfg.Providers.Codex.Enabled,
+		"copilot":  a.cfg.Providers.Copilot.Enabled,
+		"opencode": a.cfg.Providers.OpenCode.Enabled,
 	}
 	return p
 }
@@ -795,14 +797,16 @@ func (a *App) initProviderHealth(ctx context.Context, emit func(string, any)) {
 		return
 	}
 	pc := provider.New(provider.Config{
-		Interval:          time.Duration(a.cfg.Providers.HealthCheck.IntervalSeconds) * time.Second,
-		ClaudeEnabled:     a.cfg.Providers.Claude.Enabled,
-		CodexEnabled:      a.cfg.Providers.Codex.Enabled,
-		CopilotEnabled:    a.cfg.Providers.Copilot.Enabled,
-		AutoFailover:      a.cfg.Providers.AutoFailover,
-		ClaudeRLCooldown:  time.Duration(a.cfg.Providers.Claude.RateLimitCooldownSeconds) * time.Second,
-		CodexRLCooldown:   time.Duration(a.cfg.Providers.Codex.RateLimitCooldownSeconds) * time.Second,
-		CopilotRLCooldown: time.Duration(a.cfg.Providers.Copilot.RateLimitCooldownSeconds) * time.Second,
+		Interval:           time.Duration(a.cfg.Providers.HealthCheck.IntervalSeconds) * time.Second,
+		ClaudeEnabled:      a.cfg.Providers.Claude.Enabled,
+		CodexEnabled:       a.cfg.Providers.Codex.Enabled,
+		CopilotEnabled:     a.cfg.Providers.Copilot.Enabled,
+		OpenCodeEnabled:    a.cfg.Providers.OpenCode.Enabled,
+		AutoFailover:       a.cfg.Providers.AutoFailover,
+		ClaudeRLCooldown:   time.Duration(a.cfg.Providers.Claude.RateLimitCooldownSeconds) * time.Second,
+		CodexRLCooldown:    time.Duration(a.cfg.Providers.Codex.RateLimitCooldownSeconds) * time.Second,
+		CopilotRLCooldown:  time.Duration(a.cfg.Providers.Copilot.RateLimitCooldownSeconds) * time.Second,
+		OpenCodeRLCooldown: time.Duration(a.cfg.Providers.OpenCode.RateLimitCooldownSeconds) * time.Second,
 	}, emit, a.logger)
 	a.providerHealth = pc
 	a.agents.SetHealthGate(pc)

--- a/internal/sybra/svc_provider_health.go
+++ b/internal/sybra/svc_provider_health.go
@@ -56,6 +56,8 @@ func (s *IntegrationService) SetProviderEnabled(name string, enabled bool) error
 		s.cfg.Providers.Codex.Enabled = enabled
 	case "copilot":
 		s.cfg.Providers.Copilot.Enabled = enabled
+	case "opencode":
+		s.cfg.Providers.OpenCode.Enabled = enabled
 	default:
 		return fmt.Errorf("unknown provider %q", name)
 	}

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -551,6 +551,8 @@ func normalizeWorkflowProvider(provider string) string {
 		return "codex"
 	case "copilot":
 		return "copilot"
+	case "opencode":
+		return "opencode"
 	default:
 		return ""
 	}

--- a/internal/workflow/provider_resolution_test.go
+++ b/internal/workflow/provider_resolution_test.go
@@ -68,13 +68,13 @@ func TestResolveProviderCrossRotatesCodexToCopilot(t *testing.T) {
 	}
 }
 
-func TestResolveProviderCrossRotatesCopilotToClaude(t *testing.T) {
+func TestResolveProviderCrossRotatesCopilotToOpenCode(t *testing.T) {
 	stubCrossAvailability(t)
 	tk := TaskInfo{HandoffSourceProvider: "copilot"}
 
 	got := resolveProvider("cross", &Execution{}, "codex", tk)
-	if got != "claude" {
-		t.Fatalf("provider = %q, want claude", got)
+	if got != "opencode" {
+		t.Fatalf("provider = %q, want opencode", got)
 	}
 }
 
@@ -85,8 +85,8 @@ func TestResolveProviderCrossSkipsUnavailableRotationTarget(t *testing.T) {
 	tk := TaskInfo{HandoffSourceProvider: "codex"}
 
 	got := resolveProvider("cross", &Execution{}, "codex", tk)
-	if got != "claude" {
-		t.Fatalf("provider = %q, want claude (copilot unavailable, rotate past it)", got)
+	if got != "opencode" {
+		t.Fatalf("provider = %q, want opencode (copilot unavailable, rotate past it)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add OpenCode as a fourth Sybra provider with headless and per-turn conversational execution
- parse OpenCode JSON streams into Sybra stream/conversation events and classify provider errors
- wire OpenCode through config defaults, provider health, limits, sandbox state, CLI help, settings UI, stats/fleet labels, and generated config docs/bindings
- add OpenRouter model choices for GLM 5.2, DeepSeek V4 Pro, and DeepSeek V4 Flash
- extend llmexec and cross-provider workflow rotation to understand OpenCode

## Verification
- go test ./internal/provider ./internal/providerid ./internal/limits ./internal/agent ./internal/sybra ./cmd/sybra-cli ./cmd/gen-config-docs
- cd frontend && npm run check
- cd frontend && npm test -- Settings.svelte.test.ts
- npm run build:desktop
- pre-push: go test ./... and frontend svelte-check