### PR TITLE
fix(dev): load home nas token from local file

### DIFF
--- a/scripts/sybra-dev-supervisor.sh
+++ b/scripts/sybra-dev-supervisor.sh
@@ -9,6 +9,12 @@ restart_marker="$sybra_home/restart-requested"
 mkdir -p "$sybra_home"
 rm -f "$restart_marker"
 
+follower_token_file="$sybra_home/home-nas-follower.token"
+if [ -z "${HOME_NAS_SYBRA_TOKEN:-}" ] && [ -f "$follower_token_file" ]; then
+  HOME_NAS_SYBRA_TOKEN="$(cat "$follower_token_file")"
+  export HOME_NAS_SYBRA_TOKEN
+fi
+
 sync_deps() {
   mise install || return $?
   if [ -f frontend/package-lock.json ]; then


### PR DESCRIPTION
## Summary
- load HOME_NAS_SYBRA_TOKEN from ~/.sybra/home-nas-follower.token when the environment variable is unset
- keep explicit HOME_NAS_SYBRA_TOKEN values taking precedence

## Tests
- bash -n scripts/sybra-dev-supervisor.sh
- git diff --check
- pre-push hook: go tests + frontend svelte-check