### PR TITLE
Disable GitHub automations on first run

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -225,7 +225,7 @@ requires a restart to take effect (see diffConfig's
 
 | YAML key | Type | Default | Description |
 |---|---|---|---|
-| `github.enabled` | `bool` | `true` | Enabled is the top-level kill-switch: false forces every GitHub automation off regardless of the sub-toggles below, so existing configs need no migration. true defers to IssuesEnabled/ReviewsEnabled. |
+| `github.enabled` | `bool` |  | Enabled is the top-level kill-switch: false forces every GitHub automation off regardless of the sub-toggles below. Fresh generated configs set this to false so first-run GitHub polling is opt-in. Legacy configs that omit this key keep the old enabled behavior during load. true defers to IssuesEnabled/ReviewsEnabled. |
 | `github.issues_enabled` | `bool` | `true` | IssuesEnabled gates the GitHub Issues fetcher specifically. Defaults to true (see DefaultConfig). Effective state is Enabled && IssuesEnabled — use RunsIssuesFetcher() rather than reading this field directly. |
 | `github.reviews_enabled` | `bool` | `true` | ReviewsEnabled gates PR reviewer poll registration specifically. Defaults to true (see DefaultConfig). Effective state is Enabled && ReviewsEnabled — use RunsReviewer() rather than reading this field directly. |
 | `github.poller_role` | `string` |  | PollerRole splits GitHub search polling (reviews/issues/renovate) across machines sharing one token. "primary" (or empty) runs the search pollers; "secondary" skips them so a sibling instance owns the searches and the shared token isn't billed twice. On-demand per-PR/issue calls still run on every machine — only the periodic searches are gated. |

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -463,8 +463,10 @@ export class GitHubAppConfig {
 export class GitHubConfig {
     /**
      * Enabled is the top-level kill-switch: false forces every GitHub
-     * automation off regardless of the sub-toggles below, so existing configs
-     * need no migration. true defers to IssuesEnabled/ReviewsEnabled.
+     * automation off regardless of the sub-toggles below. Fresh generated
+     * configs set this to false so first-run GitHub polling is opt-in. Legacy
+     * configs that omit this key keep the old enabled behavior during load.
+     * true defers to IssuesEnabled/ReviewsEnabled.
      */
     "enabled": boolean;
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -549,7 +549,6 @@ func DefaultConfig() *Config {
 			Author:  "app/renovate",
 		},
 		GitHub: GitHubConfig{
-			Enabled:        true,
 			IssuesEnabled:  true,
 			ReviewsEnabled: true,
 		},
@@ -735,6 +734,7 @@ func load(opts loadOptions) (*Config, error) {
 		if err := yaml.Unmarshal(data, cfg); err != nil {
 			return nil, err
 		}
+		applyLegacyGitHubDefault(data, cfg)
 	} else if os.IsNotExist(err) {
 		if writeErr := writeDefaultConfig(path); writeErr != nil {
 			return nil, writeErr
@@ -967,6 +967,44 @@ func applyAutoUpdateDefaults(cfg *Config) {
 	if cfg.AutoUpdate.RestartDelaySeconds <= 0 {
 		cfg.AutoUpdate.RestartDelaySeconds = 2
 	}
+}
+
+// applyLegacyGitHubDefault keeps sparse configs created before GitHub became
+// opt-in from silently disabling an existing setup. Fresh configs written by
+// writeDefaultConfig include github.enabled: false explicitly.
+func applyLegacyGitHubDefault(data []byte, cfg *Config) {
+	if cfg == nil || hasYAMLPath(data, "github", "enabled") {
+		return
+	}
+	cfg.GitHub.Enabled = true
+}
+
+func hasYAMLPath(data []byte, path ...string) bool {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return false
+	}
+	node := &root
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	for _, key := range path {
+		if node.Kind != yaml.MappingNode {
+			return false
+		}
+		found := false
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == key {
+				node = node.Content[i+1]
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // applyABTestingDefaults fills zero-value A/B testing config and reconciles
@@ -1348,7 +1386,7 @@ func writeDefaultConfig(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), configDirPerm); err != nil {
 		return err
 	}
-	return os.WriteFile(path, []byte("# Sybra configuration\n# All values are optional — defaults apply when omitted.\n"), configFilePerm)
+	return os.WriteFile(path, []byte("# Sybra configuration\n# GitHub automations are opt-in on first run.\ngithub:\n  enabled: false\n"), configFilePerm)
 }
 
 // tightenConfigPerms retrofits the config directory and file to 0o700/0o600

--- a/internal/config/config_github.go
+++ b/internal/config/config_github.go
@@ -2,8 +2,10 @@ package config
 
 type GitHubConfig struct {
 	// Enabled is the top-level kill-switch: false forces every GitHub
-	// automation off regardless of the sub-toggles below, so existing configs
-	// need no migration. true defers to IssuesEnabled/ReviewsEnabled.
+	// automation off regardless of the sub-toggles below. Fresh generated
+	// configs set this to false so first-run GitHub polling is opt-in. Legacy
+	// configs that omit this key keep the old enabled behavior during load.
+	// true defers to IssuesEnabled/ReviewsEnabled.
 	Enabled bool `yaml:"enabled" json:"enabled"`
 	// IssuesEnabled gates the GitHub Issues fetcher specifically. Defaults to
 	// true (see DefaultConfig). Effective state is Enabled && IssuesEnabled —

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -780,20 +780,98 @@ func TestAllowsProjectType(t *testing.T) {
 	}
 }
 
-func TestDefaultGitHubEnabled(t *testing.T) {
+func TestDefaultGitHubOptIn(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
-	if !cfg.GitHub.Enabled {
-		t.Error("default GitHub.Enabled should be true for backward compat")
+	if cfg.GitHub.Enabled {
+		t.Error("default GitHub.Enabled should be false for first-run opt-in")
 	}
 	if !cfg.GitHub.IssuesEnabled {
-		t.Error("default GitHub.IssuesEnabled should be true for backward compat")
+		t.Error("default GitHub.IssuesEnabled should be true so github.enabled=true enables issues")
 	}
 	if !cfg.GitHub.ReviewsEnabled {
-		t.Error("default GitHub.ReviewsEnabled should be true for backward compat")
+		t.Error("default GitHub.ReviewsEnabled should be true so github.enabled=true enables reviews")
 	}
 	if cfg.GitHub.NativeAutoMerge {
 		t.Error("default GitHub.NativeAutoMerge should be false (kill-switch, opt-in)")
+	}
+}
+
+func TestLoadMissingConfigCreatesGitHubOptOut(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.GitHub.Enabled {
+		t.Fatal("GitHub.Enabled = true, want false for fresh install")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var onDisk Config
+	if err := yamlv3.Unmarshal(data, &onDisk); err != nil {
+		t.Fatal(err)
+	}
+	if onDisk.GitHub.Enabled {
+		t.Fatalf("fresh config persisted GitHub.Enabled = true, want explicit false:\n%s", data)
+	}
+
+	reloaded, err := LoadNoPersist()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.GitHub.Enabled {
+		t.Fatal("GitHub.Enabled reloaded as true; fresh explicit opt-out must persist")
+	}
+}
+
+func TestLoadLegacyConfigWithoutGitHubEnabledKeepsGitHubOn(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantIssues  bool
+		wantReviews bool
+	}{
+		{
+			name:        "no github block",
+			yaml:        "logging:\n  level: debug\n",
+			wantIssues:  true,
+			wantReviews: true,
+		},
+		{
+			name:        "github block omits enabled",
+			yaml:        "github:\n  issues_enabled: false\n",
+			wantIssues:  false,
+			wantReviews: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("SYBRA_HOME", dir)
+			if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !cfg.GitHub.Enabled {
+				t.Fatal("GitHub.Enabled = false, want true for legacy config without explicit key")
+			}
+			if got := cfg.GitHub.RunsIssuesFetcher(); got != tt.wantIssues {
+				t.Errorf("RunsIssuesFetcher() = %v, want %v", got, tt.wantIssues)
+			}
+			if got := cfg.GitHub.RunsReviewer(); got != tt.wantReviews {
+				t.Errorf("RunsReviewer() = %v, want %v", got, tt.wantReviews)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- make fresh Sybra configs explicitly opt out of GitHub automations with github.enabled: false
- preserve existing setups by keeping legacy configs that omit github.enabled on the old enabled behavior
- update config docs and tests for fresh, legacy, and explicit GitHub settings

## Tests
- go test ./internal/config
- go test ./internal/sybra -run 'Test.*GitHub|Test.*Automation|TestRegisterPollHandlers|TestInitIssuesFetcher'
- golangci-lint run --allow-parallel-runners --new-from-rev=origin/main --timeout 2m ./...
- pre-push: go test ./... and cd frontend && npm run check