### PR TITLE
fix(review): wait for full CI before ready PR actions

### DIFF
--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -121,7 +121,7 @@ func MatchTaskPRs(prs []PullRequest, tasks []TaskMatcher) []PRIssue {
 		if !pr.IsDraft && pr.ActionableCount > 0 {
 			issues = append(issues, PRIssue{Kind: PRIssueComments, TaskID: tm.ID, PR: *pr})
 		}
-		if !pr.IsDraft && pr.Mergeable == "MERGEABLE" && (pr.CIStatus == "SUCCESS" || pr.CIStatus == "") {
+		if !pr.IsDraft && !pr.HasPendingChecks && pr.Mergeable == "MERGEABLE" && (pr.CIStatus == "SUCCESS" || pr.CIStatus == "") {
 			issues = append(issues, PRIssue{Kind: PRIssueReadyToMerge, TaskID: tm.ID, PR: *pr})
 		}
 	}

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -83,10 +83,22 @@ func TestMatchTaskPRs(t *testing.T) {
 			want:  []PRIssue{{Kind: PRIssueReadyToMerge, TaskID: "t1", PR: PullRequest{Number: 42, CIStatus: "SUCCESS", Mergeable: "MERGEABLE"}}},
 		},
 		{
+			name:  "mergeable with CI success but pending checks is still building",
+			prs:   []PullRequest{{Number: 42, CIStatus: "SUCCESS", HasPendingChecks: true, Mergeable: "MERGEABLE"}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  nil,
+		},
+		{
 			name:  "mergeable no CI checks → ready to merge",
 			prs:   []PullRequest{{Number: 42, CIStatus: "", Mergeable: "MERGEABLE"}},
 			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
 			want:  []PRIssue{{Kind: PRIssueReadyToMerge, TaskID: "t1", PR: PullRequest{Number: 42, CIStatus: "", Mergeable: "MERGEABLE"}}},
+		},
+		{
+			name:  "mergeable no CI aggregate but pending checks is still building",
+			prs:   []PullRequest{{Number: 42, CIStatus: "", HasPendingChecks: true, Mergeable: "MERGEABLE"}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  nil,
 		},
 		{
 			name:  "draft PR not ready to merge",

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -63,10 +63,11 @@ func (s PRState) HasPendingChecks() bool {
 
 // ReadyToMerge reports whether the PR is open, has no conflicts, and CI passes.
 func (s PRState) ReadyToMerge() bool {
+	ciStatus, pending := rollupFromContexts(s.StatusCheckRollup)
 	return s.State == "OPEN" &&
 		s.Mergeable == "MERGEABLE" &&
-		!s.HasPendingChecks() &&
-		(s.CIStatus() == "SUCCESS" || s.CIStatus() == "")
+		!pending &&
+		(ciStatus == "SUCCESS" || ciStatus == "")
 }
 
 // Resolved reports whether this PR needs no further pr-fix action: it

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -65,6 +65,7 @@ func (s PRState) HasPendingChecks() bool {
 func (s PRState) ReadyToMerge() bool {
 	return s.State == "OPEN" &&
 		s.Mergeable == "MERGEABLE" &&
+		!s.HasPendingChecks() &&
 		(s.CIStatus() == "SUCCESS" || s.CIStatus() == "")
 }
 

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -161,6 +161,10 @@ func TestPRState_ReadyToMerge(t *testing.T) {
 	}{
 		{"open mergeable no ci", PRState{State: "OPEN", Mergeable: "MERGEABLE"}, true},
 		{"open mergeable ci success", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []gqlCheckContext{{Typename: "StatusContext", State: "SUCCESS"}}}, true},
+		{"open mergeable success plus pending", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []gqlCheckContext{
+			{Typename: "StatusContext", State: "SUCCESS"},
+			{Typename: "StatusContext", State: "PENDING"},
+		}}, false},
 		{"not open", PRState{State: "MERGED", Mergeable: "MERGEABLE"}, false},
 		{"conflicting", PRState{State: "OPEN", Mergeable: "CONFLICTING"}, false},
 		{"unknown mergeable", PRState{State: "OPEN", Mergeable: "UNKNOWN"}, false},


### PR DESCRIPTION
## Summary
- prevent ready-to-merge handling while any gating PR check is still pending
- align PRState.ReadyToMerge with the same terminal-CI requirement
- add regression coverage for pending-check cases

## Tests
- go test ./internal/github
- go test ./internal/sybra/review
- pre-push hook: go test ./... and frontend svelte-check