### PR TITLE
fix(review): protect approved PRs from auto fixes

### DIFF
--- a/internal/sybra/review/autoresolve_test.go
+++ b/internal/sybra/review/autoresolve_test.go
@@ -298,6 +298,73 @@ func TestAutoResolveConflict_CreatedSkipsAgent(t *testing.T) {
 	}
 }
 
+func TestAutoResolveConflict_ApprovedPRSkipsCleanMergeAndDispatchesAgent(t *testing.T) {
+	h := newAutoResolveHarness(t, true)
+	tk, pr := h.newConflictTask(t)
+	pr.ReviewDecision = "APPROVED"
+	mergeCalled := false
+	pushCalled := false
+	h.r.tryCleanMergeFn = func(context.Context, string, string) (project.CleanMergeResult, error) {
+		mergeCalled = true
+		return project.CleanMergeCreated, nil
+	}
+	h.r.pushSyncFn = func(context.Context, string, string) error {
+		pushCalled = true
+		return nil
+	}
+
+	ok := h.r.dispatchFixIssues(context.Background(), tk.ID, []github.PRIssue{
+		{Kind: github.PRIssueConflict, TaskID: tk.ID, PR: pr},
+	})
+	if !ok {
+		t.Fatal("dispatchFixIssues = false, want true (agent dispatched)")
+	}
+	if mergeCalled {
+		t.Fatal("tryCleanMergeFn called; approved PR must skip clean-merge auto-resolve")
+	}
+	if pushCalled {
+		t.Fatal("pushSyncFn called; approved PR must not receive a branch-mutating push")
+	}
+	got, err := h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil {
+		t.Fatal("no workflow dispatched; approved PR should still get a fix agent")
+	}
+	if got.Status == task.StatusHumanRequired {
+		t.Fatalf("status = %q, want agent dispatch instead of parking", got.Status)
+	}
+	prompt := got.Workflow.Variables["prompt"]
+	if !strings.Contains(prompt, "Approval preservation") {
+		t.Fatalf("prompt missing approval-preservation guard:\n%s", prompt)
+	}
+}
+
+func TestPrepareWorktree_ApprovedCIFailureUsesPRHeadCheckout(t *testing.T) {
+	h := newAutoResolveHarness(t, false)
+	tk, pr := h.newConflictTask(t)
+	pr.CIStatus = "FAILURE"
+	pr.Mergeable = "MERGEABLE"
+	pr.ReviewDecision = "APPROVED"
+
+	dir, ok := h.r.prepareWorktree(context.Background(), tk, github.PRIssue{
+		Kind:   github.PRIssueCIFailure,
+		TaskID: tk.ID,
+		PR:     pr,
+	})
+	if !ok {
+		t.Fatal("prepareWorktree rejected approved CI fix")
+	}
+	out, err := exec.Command("git", "-C", dir, "branch", "--show-current").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch --show-current: %v: %s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != pr.HeadRefName {
+		t.Fatalf("checked-out branch = %q, want PR head %q", got, pr.HeadRefName)
+	}
+}
+
 // TestAutoResolveConflict_ConflictFallsThroughToAgent covers a merge that
 // genuinely reports conflicting hunks: the fast-path must not mark anything
 // handled and the normal pr-fix workflow must still be dispatched.

--- a/internal/sybra/review/ci_failure_dispatch_test.go
+++ b/internal/sybra/review/ci_failure_dispatch_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,6 +99,62 @@ func TestPollAndMonitorPRs_CIFailureDispatchesFix(t *testing.T) {
 	}
 	if k := got.Workflow.Variables["pr_issue_kind"]; k != string(github.PRIssueCIFailure) {
 		t.Errorf("pr_issue_kind = %q, want %q", k, github.PRIssueCIFailure)
+	}
+}
+
+func TestPollAndMonitorPRs_ApprovedCIFailureDispatchesFixAgent(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:   task.Ptr(task.StatusInReview),
+		PRNumber: task.Ptr(4242),
+		Branch:   task.Ptr("feat/x"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	failingPR := github.PullRequest{
+		Number:         4242,
+		Repository:     "o/r",
+		HeadRefName:    "feat/x",
+		HeadSHA:        "sha-fail",
+		URL:            "https://github.com/o/r/pull/4242",
+		Mergeable:      "MERGEABLE",
+		CIStatus:       "FAILURE",
+		ReviewDecision: "APPROVED",
+		Author:         "me",
+	}
+
+	r := buildPRFixHandler(t, tasks, func() (github.ReviewSummary, error) {
+		return github.ReviewSummary{CreatedByMe: []github.PullRequest{failingPR}}, nil
+	})
+
+	r.pollAndMonitorPRs(context.Background())
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil {
+		t.Fatal("no pr-fix workflow dispatched for an approved failing-CI PR")
+	}
+	if got.Status == task.StatusHumanRequired {
+		t.Fatalf("status = %q, want agent dispatch instead of parking", got.Status)
+	}
+	prompt := got.Workflow.Variables["prompt"]
+	if !strings.Contains(prompt, "Approval preservation") {
+		t.Fatalf("prompt missing approval-preservation guard:\n%s", prompt)
+	}
+	if retries := r.prTracker.Retries(created.ID, github.PRIssueCIFailure); retries != 1 {
+		t.Fatalf("ci_failure retries = %d, want 1; fix was dispatched", retries)
 	}
 }
 

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -449,6 +449,14 @@ func coalescedFixPrompt(ctx context.Context, issues []github.PRIssue, holdSuffix
 	}) {
 		prompt += holdSuffix
 	}
+	if slices.ContainsFunc(issues, func(i github.PRIssue) bool {
+		return prHasCurrentApproval(i.PR)
+	}) {
+		prompt += "\n\nApproval preservation:\n" +
+			"- This PR is already approved. Do not merge/rebase/update the base branch or push a clean/base-only merge that only changes the merge-base.\n" +
+			"- Push only if you make a substantive code, test, or documentation fix for the failing CI, conflict, or review feedback.\n" +
+			"- If no substantive fix is needed, stop without pushing and report `SYBRA_PR_FIX_RESULT: human-required` with the reason."
+	}
 	return prompt
 }
 
@@ -516,6 +524,7 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 	if !opts.replaceActiveWorkflow &&
 		r.cfg != nil && r.cfg.GitHub.AutoResolveCleanMerges &&
 		len(handle) == 1 && handle[0].Kind == github.PRIssueConflict &&
+		!prHasCurrentApproval(primary.PR) &&
 		r.autoResolveConflict(ctx, t, primary.PR, dir) {
 		return true
 	}
@@ -526,6 +535,10 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 	// contextcheck no longer flags this call site (verified with a clean
 	// build+lint cache), so no suppression directive is needed here.
 	return r.dispatchPRIssueWithOptions(t, primary, handle, coalescedFixPrompt(ctx, handle, reviewHoldFixSuffix(r.cfg)), dir, opts)
+}
+
+func prHasCurrentApproval(pr github.PullRequest) bool {
+	return pr.ReviewDecision == "APPROVED" || pr.RESTApproved
 }
 
 func (r *Handler) preflightPushCredentials(ctx context.Context, taskID, dir string) (admit, handled bool) {
@@ -1388,8 +1401,12 @@ func (r *Handler) prepareWorktree(ctx context.Context, t task.Task, issue github
 		wtErr error
 	)
 	// Conflict and comment fixes operate on the PR's existing branch, so check
-	// it out (PrepareForFix). A CI fix re-runs on a fresh worktree.
-	if issue.Kind == github.PRIssueConflict || issue.Kind == github.PRIssueComments {
+	// it out (PrepareForFix). A CI fix normally re-runs on a fresh worktree, but
+	// approved PRs must also use the branch-preserving fix path: PrepareForTask
+	// rebases onto base and can fall back to an additive merge before the agent
+	// starts, which changes the merge-base and can dismiss an existing approval
+	// even when the agent would make no substantive fix.
+	if issue.Kind == github.PRIssueConflict || issue.Kind == github.PRIssueComments || prHasCurrentApproval(issue.PR) {
 		d, wtErr = r.worktrees.PrepareForFix(ctx, t, issue.PR.Number)
 	} else {
 		d, wtErr = r.worktrees.PrepareForTask(ctx, t, nil)


### PR DESCRIPTION
## Summary
- keep PR-fix agents running after a PR is approved
- avoid approval-invalidating no-op/base-only branch updates by using the PR-head checkout path for approved PR fixes
- skip deterministic clean-merge auto-resolve on approved PRs, so Sybra does not push a merge-base-only update without agent judgment
- add approval-preservation instructions to PR-fix prompts so agents push only substantive fixes after approval

## Root cause
Sybra's PR-fix path could mutate an already-approved PR branch without a real code fix. For a lone CI failure, worktree prep used the normal task path, which rebases onto base and can fall back to an additive merge before the agent starts. For clean conflicts, the deterministic auto-resolve path could merge base and push directly. On repos that dismiss stale approvals when the merge-base changes, GitHub records the approval dismissal against the Sybra GitHub actor.

## Fixed behavior
Approved PRs still get agents for failing CI, conflicts, and review comments. The change only prevents Sybra from doing a base-only update that changes the merge-base without a substantive fix.

## Tests
- go test -count=1 ./internal/sybra/review
- pre-push: go test ./...; frontend npm run check