### PR TITLE
Auto-approve plans without open decisions

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -186,6 +186,7 @@ real-app/cluster load independently of Agent.MaxConcurrent.
 |---|---|---|---|
 | `orchestrator.dispatch_interval_seconds` | `int` |  | DispatchIntervalSeconds is the cadence of the cheap, latency-sensitive dispatch pass (start the orchestrator, release unblocked children). Kept short — and also fired on demand on every status change — so a freshly-ready task is not left idle for a full tick. Default 10. |
 | `orchestrator.maintenance_interval_seconds` | `int` |  | MaintenanceIntervalSeconds is the cadence of the expensive recovery/cleanup pass (resume stalled workflows, restart stale agents, prune orphan worktrees) which hits git and may spawn agents, so it must not run hot. Default 60. |
+| `orchestrator.auto_approve_plans_without_decisions` | `bool` |  | AutoApprovePlansWithoutDecisions lets the workflow engine advance a validated simple-task plan from plan-review to implementation when the planner explicitly recorded that there are no open human decisions. Default false. |
 | `orchestrator.pressure` | `PressureConfig` | _(see below)_ | Pressure configures the local resource-pressure admission gate that defers new agent dispatch while the host is short on disk, memory, or CPU headroom. See internal/pressure. |
 
 ## PressureConfig (`orchestrator.pressure`)

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -750,6 +750,14 @@ export class OrchestratorConfig {
     "maintenanceIntervalSeconds": number;
 
     /**
+     * AutoApprovePlansWithoutDecisions lets the workflow engine advance a
+     * validated simple-task plan from plan-review to implementation when the
+     * planner explicitly recorded that there are no open human decisions.
+     * Default false.
+     */
+    "autoApprovePlansWithoutDecisions": boolean;
+
+    /**
      * Pressure configures the local resource-pressure admission gate that
      * defers new agent dispatch while the host is short on disk, memory, or
      * CPU headroom. See internal/pressure.
@@ -764,6 +772,9 @@ export class OrchestratorConfig {
         if (!("maintenanceIntervalSeconds" in $$source)) {
             this["maintenanceIntervalSeconds"] = 0;
         }
+        if (!("autoApprovePlansWithoutDecisions" in $$source)) {
+            this["autoApprovePlansWithoutDecisions"] = false;
+        }
         if (!("pressure" in $$source)) {
             this["pressure"] = (new PressureConfig());
         }
@@ -775,10 +786,10 @@ export class OrchestratorConfig {
      * Creates a new OrchestratorConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): OrchestratorConfig {
-        const $$createField2_0 = $$createType5;
+        const $$createField3_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("pressure" in $$parsedSource) {
-            $$parsedSource["pressure"] = $$createField2_0($$parsedSource["pressure"]);
+            $$parsedSource["pressure"] = $$createField3_0($$parsedSource["pressure"]);
         }
         return new OrchestratorConfig($$parsedSource as Partial<OrchestratorConfig>);
     }

--- a/frontend/src/components/settings/OrchestratorPanel.svelte
+++ b/frontend/src/components/settings/OrchestratorPanel.svelte
@@ -2,6 +2,7 @@
   import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
   import Section from './fields/Section.svelte'
   import NumberField from './fields/NumberField.svelte'
+  import ToggleField from './fields/ToggleField.svelte'
   import AdvancedDisclosure from './fields/AdvancedDisclosure.svelte'
 
   interface Props {
@@ -28,5 +29,15 @@
         modified={o.maintenanceIntervalSeconds !== d.maintenanceIntervalSeconds}
         onreset={() => (settings.orchestrator.maintenanceIntervalSeconds = d.maintenanceIntervalSeconds)} />
     </div>
+  </AdvancedDisclosure>
+  <AdvancedDisclosure label="Plan review">
+    <ToggleField
+      label="Auto-approve plans without decisions"
+      description="Validated plans skip plan-review only when the planner explicitly recorded no open decisions."
+      keyPath="orchestrator.auto_approve_plans_without_decisions"
+      bind:checked={settings.orchestrator.autoApprovePlansWithoutDecisions}
+      modified={o.autoApprovePlansWithoutDecisions !== d.autoApprovePlansWithoutDecisions}
+      onreset={() => (settings.orchestrator.autoApprovePlansWithoutDecisions = d.autoApprovePlansWithoutDecisions)}
+    />
   </AdvancedDisclosure>
 </Section>

--- a/internal/config/config_orchestrator.go
+++ b/internal/config/config_orchestrator.go
@@ -11,6 +11,11 @@ type OrchestratorConfig struct {
 	// worktrees) which hits git and may spawn agents, so it must not run hot.
 	// Default 60.
 	MaintenanceIntervalSeconds int `yaml:"maintenance_interval_seconds" json:"maintenanceIntervalSeconds"`
+	// AutoApprovePlansWithoutDecisions lets the workflow engine advance a
+	// validated simple-task plan from plan-review to implementation when the
+	// planner explicitly recorded that there are no open human decisions.
+	// Default false.
+	AutoApprovePlansWithoutDecisions bool `yaml:"auto_approve_plans_without_decisions" json:"autoApprovePlansWithoutDecisions"`
 	// Pressure configures the local resource-pressure admission gate that
 	// defers new agent dispatch while the host is short on disk, memory, or
 	// CPU headroom. See internal/pressure.

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -882,9 +882,7 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetCostBudgetChecker(agentLauncher)
 	a.workflowEngine.SetAttemptWorktreeManager(&attemptWorktreeAdapter{tasks: a.tasks, mgr: a.worktrees})
 	a.workflowEngine.SetManualTestConfigGetter(&manualTestConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
-	a.configureTestingEscalation()
-	a.workflowEngine.SetMaxCheckpoints(a.cfg.MaxCheckpoints())
-	a.workflowEngine.SetABTestingConfig(a.cfg.ABTesting)
+	a.configureWorkflowPolicies()
 	if a.cfg.Evaluation.Offline.Enabled {
 		gate := prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline)
 		a.workflowEngine.SetEvalGate(gate)
@@ -962,6 +960,23 @@ func (a *App) initWorkflowEngine() {
 	}
 	// Workflow completion moves to wireServices so the callback closure binds
 	// to the completion.Handler constructed there.
+}
+
+func (a *App) configureWorkflowPolicies() {
+	a.configureTestingEscalation()
+	a.workflowEngine.SetMaxCheckpoints(a.cfg.MaxCheckpoints())
+	a.workflowEngine.SetABTestingConfig(a.cfg.ABTesting)
+	a.configurePlanAutoApproval()
+}
+
+func (a *App) configurePlanAutoApproval() {
+	a.workflowEngine.SetAutoApprovePlansWithoutDecisions(a.cfg.Orchestrator.AutoApprovePlansWithoutDecisions)
+	a.workflowEngine.SetPlanAutoApproveHook(func(t workflow.TaskInfo, reason string) {
+		a.logAudit(audit.EventPlanApproved, t.ID, "", map[string]any{
+			"auto":   true,
+			"reason": reason,
+		})
+	})
 }
 
 func (a *App) newWorkflowAgentLauncher() *agentAdapter {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -347,7 +347,9 @@ type Engine struct {
 	// dispatch scan, pruning admission-queue items whose task has gone
 	// missing, terminal, or already in-progress (agentqueue.Queue.Reconcile).
 	// nil disables reconciliation (no queue wired).
-	queueReconciler func()
+	queueReconciler                  func()
+	autoApprovePlansWithoutDecisions bool
+	planAutoApproveHook              func(TaskInfo, string)
 }
 
 // defaultTestAttempts is the generous absolute backstop for the testing →
@@ -392,6 +394,20 @@ func (e *Engine) SetContext(ctx context.Context) { e.ctx = ctx }
 // leader-follower mode a task homed on a remote follower executes there, and the
 // leader only mirrors its state. A nil gate (the default) runs every task.
 func (e *Engine) SetDispatchGate(gate func(TaskInfo) bool) { e.dispatchGate = gate }
+
+// SetAutoApprovePlansWithoutDecisions enables automatic approval of validated
+// simple-task plans whose decision sidecar explicitly says there are no open
+// human decisions.
+func (e *Engine) SetAutoApprovePlansWithoutDecisions(enabled bool) {
+	e.autoApprovePlansWithoutDecisions = enabled
+}
+
+// SetPlanAutoApproveHook installs an observer for auto-approved plans. It is
+// used by the app layer to write audit events without making workflow import
+// the audit package.
+func (e *Engine) SetPlanAutoApproveHook(hook func(TaskInfo, string)) {
+	e.planAutoApproveHook = hook
+}
 
 // Defs returns the workflow definition store.
 func (e *Engine) Defs() *Store { return e.store }

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/providerid"
@@ -585,7 +586,62 @@ func (e *Engine) execWaitHuman(taskID string, step *Step, wfExec *Execution) err
 
 	wfExec.State = ExecWaiting
 	e.logger.Info("workflow.wait-human", "task_id", taskID, "step", step.ID, "actions", step.Config.HumanActions)
-	return e.tasks.SetWorkflow(taskID, wfExec)
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		return err
+	}
+	e.maybeAutoApprovePlanReview(taskID, step)
+	return nil
+}
+
+func (e *Engine) maybeAutoApprovePlanReview(taskID string, step *Step) {
+	if !e.autoApprovePlansWithoutDecisions || step.ID != "review_plan" {
+		return
+	}
+	if !slices.Contains(step.Config.HumanActions, "approve") {
+		return
+	}
+
+	go func() {
+		// Let the caller unwind first so workflow completion/cascade callbacks
+		// run outside StartWorkflow/DispatchEvent marker scopes.
+		time.Sleep(10 * time.Millisecond)
+		t, err := e.tasks.GetTask(taskID)
+		if err != nil {
+			e.logger.Warn("workflow.plan-auto-approve.get", "task_id", taskID, "err", err)
+			return
+		}
+		if !e.shouldAutoApprovePlanReview(t) {
+			return
+		}
+		e.logger.Info("workflow.plan-auto-approve", "task_id", taskID, "reason", "no_open_decisions")
+		err = e.HandleHumanAction(taskID, "approve", map[string]string{
+			"auto_approved":       "true",
+			"auto_approve_reason": "no_open_decisions",
+		})
+		if err != nil {
+			e.logger.Warn("workflow.plan-auto-approve.approve", "task_id", taskID, "err", err)
+			return
+		}
+		if e.planAutoApproveHook != nil {
+			e.planAutoApproveHook(t, "no_open_decisions")
+		}
+	}()
+}
+
+func (e *Engine) shouldAutoApprovePlanReview(t TaskInfo) bool {
+	if t.Status != "plan-review" || t.Workflow == nil ||
+		t.Workflow.WorkflowID != "simple-task-plan" ||
+		t.Workflow.State != ExecWaiting ||
+		t.Workflow.CurrentStep != "review_plan" {
+		return false
+	}
+	if PlanHasOpenDecisions(t.PlanDecisions) {
+		return false
+	}
+	if strings.TrimSpace(t.PlanContract) == "" {
+		return false
+	}
+	return len(ValidatePlanContractForTask(t.PlanContract, t.ID, t.Body)) == 0
 }
 
 func (e *Engine) execSetStatus(taskID string, step *Step) (StepOutput, error) {

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -623,7 +623,12 @@ func (e *Engine) maybeAutoApprovePlanReview(taskID string, step *Step) {
 			return
 		}
 		if e.planAutoApproveHook != nil {
-			e.planAutoApproveHook(t, "no_open_decisions")
+			updated, getErr := e.tasks.GetTask(taskID)
+			if getErr != nil {
+				e.logger.Warn("workflow.plan-auto-approve.hook-task", "task_id", taskID, "err", getErr)
+				return
+			}
+			e.planAutoApproveHook(updated, "no_open_decisions")
 		}
 	}()
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4732,14 +4732,7 @@ func TestAutoApprovePlanReview_OpenDecisionsStayWaiting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(40 * time.Millisecond)
-	ti, _ := tasks.GetTask("t1")
-	if ti.Status != "plan-review" {
-		t.Errorf("Status = %q, want plan-review", ti.Status)
-	}
-	if ti.Workflow.State != ExecWaiting {
-		t.Errorf("State = %q, want ExecWaiting", ti.Workflow.State)
-	}
+	assertRemainsPlanReviewWaiting(t, tasks, "t1", 200*time.Millisecond)
 }
 
 func TestAutoApprovePlanReview_InvalidContractStaysWaiting(t *testing.T) {
@@ -4760,14 +4753,7 @@ func TestAutoApprovePlanReview_InvalidContractStaysWaiting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(40 * time.Millisecond)
-	ti, _ := tasks.GetTask("t1")
-	if ti.Status != "plan-review" {
-		t.Errorf("Status = %q, want plan-review", ti.Status)
-	}
-	if ti.Workflow.State != ExecWaiting {
-		t.Errorf("State = %q, want ExecWaiting", ti.Workflow.State)
-	}
+	assertRemainsPlanReviewWaiting(t, tasks, "t1", 200*time.Millisecond)
 }
 
 func startAutoApprovePlanReview(t *testing.T, task TaskInfo) (*Engine, *memTasks) {
@@ -4825,6 +4811,21 @@ func waitForTaskStatus(t *testing.T, tasks *memTasks, id, want string) {
 	}
 	ti, _ := tasks.GetTask(id)
 	t.Fatalf("timed out waiting for status %q, got %q", want, ti.Status)
+}
+
+func assertRemainsPlanReviewWaiting(t *testing.T, tasks *memTasks, id string, window time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		ti, err := tasks.GetTask(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ti.Status != "plan-review" || ti.Workflow == nil || ti.Workflow.State != ExecWaiting {
+			t.Fatalf("task left plan-review wait state: status=%q workflow=%+v", ti.Status, ti.Workflow)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestPlanReuse_ApproveReconcilesMissedWaitForStatus(t *testing.T) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4683,6 +4683,150 @@ func TestPlanReuse_ApproveAdvancesPastReviewPlan(t *testing.T) {
 	}
 }
 
+func TestAutoApprovePlanReview_NoOpenDecisionsAdvances(t *testing.T) {
+	engine, tasks := startAutoApprovePlanReview(t, TaskInfo{
+		ID:            "t1",
+		Status:        "planning",
+		PlanDecisions: "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.",
+		PlanContract:  validPlanContract("t1"),
+	})
+	engine.SetAutoApprovePlansWithoutDecisions(true)
+
+	step := autoApproveReviewStep()
+	wf := &Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "review_plan",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+	}
+	if err := engine.execWaitHuman("t1", step, wf); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForTaskStatus(t, tasks, "t1", "in-progress")
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow.State != ExecCompleted {
+		t.Errorf("State = %q, want ExecCompleted", ti.Workflow.State)
+	}
+	if got := ti.Workflow.Variables["human.auto_approved"]; got != "true" {
+		t.Errorf("human.auto_approved = %q, want true", got)
+	}
+}
+
+func TestAutoApprovePlanReview_OpenDecisionsStayWaiting(t *testing.T) {
+	engine, tasks := startAutoApprovePlanReview(t, TaskInfo{
+		ID:     "t1",
+		Status: "planning",
+		PlanDecisions: "# Decisions\n\n## Scope\nQuestion: Which scope?\nRecommended: Small\n\nOptions:\n" +
+			"- Small - Minimal change\n- Large - Broader change",
+		PlanContract: validPlanContract("t1"),
+	})
+	engine.SetAutoApprovePlansWithoutDecisions(true)
+
+	if err := engine.execWaitHuman("t1", autoApproveReviewStep(), &Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "review_plan",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "plan-review" {
+		t.Errorf("Status = %q, want plan-review", ti.Status)
+	}
+	if ti.Workflow.State != ExecWaiting {
+		t.Errorf("State = %q, want ExecWaiting", ti.Workflow.State)
+	}
+}
+
+func TestAutoApprovePlanReview_InvalidContractStaysWaiting(t *testing.T) {
+	engine, tasks := startAutoApprovePlanReview(t, TaskInfo{
+		ID:            "t1",
+		Status:        "planning",
+		PlanDecisions: "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.",
+		PlanContract:  strings.Replace(validPlanContract("t1"), `"task_id": "t1"`, `"task_id": "other"`, 1),
+	})
+	engine.SetAutoApprovePlansWithoutDecisions(true)
+
+	if err := engine.execWaitHuman("t1", autoApproveReviewStep(), &Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "review_plan",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "plan-review" {
+		t.Errorf("Status = %q, want plan-review", ti.Status)
+	}
+	if ti.Workflow.State != ExecWaiting {
+		t.Errorf("State = %q, want ExecWaiting", ti.Workflow.State)
+	}
+}
+
+func startAutoApprovePlanReview(t *testing.T, task TaskInfo) (*Engine, *memTasks) {
+	t.Helper()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(Definition{
+		ID: "simple-task-plan",
+		Steps: []Step{
+			{
+				ID:   "review_plan",
+				Type: StepWaitHuman,
+				Config: StepConfig{
+					Status:       "plan-review",
+					HumanActions: []string{"approve", "reject"},
+				},
+				Next: []Transition{{When: &Condition{Field: "vars.human_action", Operator: "equals", Value: "approve"}, GoTo: "done"}},
+			},
+			{
+				ID:     "done",
+				Type:   StepSetStatus,
+				Config: StepConfig{Status: "in-progress"},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tasks := newMemTasks()
+	tasks.Put(task)
+	return NewEngine(store, tasks, newMockAgents(), discardLogger()), tasks
+}
+
+func autoApproveReviewStep() *Step {
+	return &Step{
+		ID:   "review_plan",
+		Type: StepWaitHuman,
+		Config: StepConfig{
+			Status:       "plan-review",
+			HumanActions: []string{"approve", "reject"},
+		},
+	}
+}
+
+func waitForTaskStatus(t *testing.T, tasks *memTasks, id, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ti, err := tasks.GetTask(id)
+		if err == nil && ti.Status == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	ti, _ := tasks.GetTask(id)
+	t.Fatalf("timed out waiting for status %q, got %q", want, ti.Status)
+}
+
 func TestPlanReuse_ApproveReconcilesMissedWaitForStatus(t *testing.T) {
 	store := newTestStoreWith(t, "test-plan-reuse.yaml")
 	tasks := newMemTasks()

--- a/internal/workflow/plan_decisions.go
+++ b/internal/workflow/plan_decisions.go
@@ -1,0 +1,18 @@
+package workflow
+
+import "strings"
+
+// PlanHasOpenDecisions reports whether the planner's decision sidecar contains
+// human choices that must be reviewed before implementation. The planner prompt
+// requires an explicit "No open decisions" sentence when there are none; missing
+// or ambiguous content is treated conservatively as requiring human review.
+func PlanHasOpenDecisions(markdown string) bool {
+	text := strings.TrimSpace(markdown)
+	if text == "" {
+		return true
+	}
+	if strings.Contains(strings.ToLower(text), "no open decisions") {
+		return false
+	}
+	return true
+}

--- a/internal/workflow/plan_decisions.go
+++ b/internal/workflow/plan_decisions.go
@@ -11,8 +11,24 @@ func PlanHasOpenDecisions(markdown string) bool {
 	if text == "" {
 		return true
 	}
-	if strings.Contains(strings.ToLower(text), "no open decisions") {
-		return false
+	firstSubstantive := ""
+	for line := range strings.SplitSeq(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "## ") ||
+			strings.HasPrefix(strings.ToLower(trimmed), "question:") ||
+			strings.HasPrefix(strings.ToLower(trimmed), "recommended:") ||
+			strings.HasPrefix(strings.ToLower(trimmed), "options:") {
+			return true
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if firstSubstantive == "" {
+			firstSubstantive = trimmed
+		}
 	}
-	return true
+	return !strings.HasPrefix(strings.ToLower(firstSubstantive), "no open decisions")
 }

--- a/internal/workflow/plan_decisions_test.go
+++ b/internal/workflow/plan_decisions_test.go
@@ -1,0 +1,43 @@
+package workflow
+
+import "testing"
+
+func TestPlanHasOpenDecisions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "canonical no open decisions",
+			in:   "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.",
+			want: false,
+		},
+		{
+			name: "empty is conservative",
+			in:   "",
+			want: true,
+		},
+		{
+			name: "decision heading",
+			in:   "# Decisions\n\n## Scope\nQuestion: Which scope?\nRecommended: A\n\nOptions:\n- A - one\n- B - two",
+			want: true,
+		},
+		{
+			name: "ambiguous text without explicit no-open marker",
+			in:   "# Decisions\n\nAll set.",
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := PlanHasOpenDecisions(tc.in); got != tc.want {
+				t.Errorf("PlanHasOpenDecisions() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/plan_decisions_test.go
+++ b/internal/workflow/plan_decisions_test.go
@@ -30,6 +30,21 @@ func TestPlanHasOpenDecisions(t *testing.T) {
 			in:   "# Decisions\n\nAll set.",
 			want: true,
 		},
+		{
+			name: "copied instruction marker is not enough",
+			in:   "# Decisions\n\nIf there are no meaningful choices, write: No open decisions.\n\nNo open decisions.",
+			want: true,
+		},
+		{
+			name: "marker plus structured decision is open",
+			in:   "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.\n\n## Scope\nQuestion: Which scope?",
+			want: true,
+		},
+		{
+			name: "marker plus decision labels is open",
+			in:   "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.\n\nRecommended: Small\nOptions:\n- Small - minimal",
+			want: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- add an opt-in orchestrator setting to auto-approve validated simple-task plans when the plan decision sidecar explicitly says there are no open decisions
- keep the gate fail-closed: missing/ambiguous decisions or invalid/missing plan contracts remain in plan-review
- expose the setting in Settings and regenerate Wails config bindings/docs

## Tests
- GOCACHE=/private/tmp/sybra-go-build-cache go test ./internal/workflow
- GOCACHE=/private/tmp/sybra-go-build-cache go test ./internal/config -run TestConfigDocs_InSyncWithSource
- GOCACHE=/private/tmp/sybra-go-build-cache go test ./internal/sybra -run 'TestPlanningService_ApprovePlan'
- cd frontend && npm run check
- pre-push hook: go test ./... + frontend check