### PR TITLE
feat(agent): unify model tier mappings

### DIFF
--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -46,7 +46,7 @@ Edit `~/.sybra/config.yaml`:
 ```yaml
 agent:
   provider: codex
-  model: gpt-5.5   # optional; gpt-5.5 is the default
+  model: gpt-5.4   # optional; gpt-5.4 is the cheap/sonnet-class default
 ```
 
 To revert to Claude:
@@ -62,7 +62,7 @@ Sybra maps generic aliases to provider-specific model IDs at runtime:
 
 | Sybra alias | Codex model |
 |---------------|-------------|
-| `sonnet` (default) | `gpt-5.5` |
+| `sonnet` (default) | `gpt-5.4` |
 | `opus` | `gpt-5.5` |
 | `haiku` | `gpt-5.4-mini` |
 | any other string | passed through verbatim |
@@ -75,7 +75,7 @@ Sybra spawns a `codex exec` subprocess per task:
 
 ```bash
 # Headless mode always uses bypass (regardless of RequirePermissions)
-codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.5 -C <worktree> "<prompt>"
+codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -C <worktree> "<prompt>"
 ```
 
 `--sandbox workspace-write` is intentionally not used in headless mode. That mode requests user approval for writes outside the workspace; in a headless run there is no TTY or UI to serve the approval prompt, so every such request is auto-rejected and the agent run fails. The worktree directory itself provides task isolation.

--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/modeltier"
 )
 
 // Config controls deterministic A/B assignment for workflow agent runs.
@@ -23,7 +25,7 @@ type Config struct {
 // returned by DefaultConfig. Bump this whenever the built-in experiments'
 // roles, variants, or weights change in a way that persisted configs should
 // pick up automatically.
-const CurrentBuiltinVersion = 5
+const CurrentBuiltinVersion = 6
 
 // BuiltinExperimentIDs lists the experiment IDs owned by Sybra's shipped
 // defaults. A persisted config's experiment is only replaced during a builtin
@@ -130,8 +132,8 @@ type Assignment struct {
 // DefaultConfig returns the default A/B suite split by price bracket: code
 // author roles use cheap variants, while planning and review use premium ones.
 //
-// Every experiment enrolls all three providers at equal weight (1:1:1) so each
-// role is genuinely runnable on any provider and the evaluation scorecard sees
+// Every experiment enrolls each supported provider at equal weight so each role
+// is genuinely runnable on any provider and the evaluation scorecard sees
 // balanced samples. This is the deliberate "equal agents" posture: rather than
 // hardcoding scorecard-derived weights (which favoured codex on implementation
 // and excluded copilot from maintenance), selection is uniform and the
@@ -142,6 +144,8 @@ func DefaultConfig() Config {
 	enabled := true
 	expEnabled := true
 	builtinVersion := CurrentBuiltinVersion
+	cheap := modeltier.Models(modeltier.Cheap)
+	expensive := modeltier.Models(modeltier.Expensive)
 	return Config{
 		Enabled:              &enabled,
 		MinSamplesPerVariant: 20,
@@ -155,8 +159,9 @@ func DefaultConfig() Config {
 				Roles:          []string{"implementation"},
 				Variants: []Variant{
 					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
-					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 1},
-					{ID: "copilot-sonnet", Provider: "copilot", Model: "claude-sonnet-4.6", Tier: "cheap", Weight: 1},
+					{ID: "codex-gpt-5.4", Provider: "codex", Model: cheap["codex"], Tier: "cheap", Weight: 1},
+					{ID: "copilot-sonnet", Provider: "copilot", Model: cheap["copilot"], Tier: "cheap", Weight: 1},
+					{ID: "opencode-deepseek-v4-flash", Provider: "opencode", Model: cheap["opencode"], Tier: "cheap", Weight: 1},
 				},
 			},
 			{
@@ -167,8 +172,9 @@ func DefaultConfig() Config {
 				Roles:          []string{"pr-fix", "test-runner"},
 				Variants: []Variant{
 					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
-					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 1},
-					{ID: "copilot-sonnet", Provider: "copilot", Model: "claude-sonnet-4.6", Tier: "cheap", Weight: 1},
+					{ID: "codex-gpt-5.4", Provider: "codex", Model: cheap["codex"], Tier: "cheap", Weight: 1},
+					{ID: "copilot-sonnet", Provider: "copilot", Model: cheap["copilot"], Tier: "cheap", Weight: 1},
+					{ID: "opencode-deepseek-v4-flash", Provider: "opencode", Model: cheap["opencode"], Tier: "cheap", Weight: 1},
 				},
 			},
 			{
@@ -179,8 +185,9 @@ func DefaultConfig() Config {
 				Roles:          []string{"fix-review"},
 				Variants: []Variant{
 					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
-					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
-					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Tier: "expensive", Weight: 1},
+					{ID: "codex-gpt-5.5", Provider: "codex", Model: expensive["codex"], Tier: "expensive", Weight: 1},
+					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: expensive["copilot"], Tier: "expensive", Weight: 1},
+					{ID: "opencode-glm-5.2", Provider: "opencode", Model: expensive["opencode"], Tier: "expensive", Weight: 1},
 				},
 			},
 			{
@@ -191,8 +198,9 @@ func DefaultConfig() Config {
 				Roles:          []string{"plan"},
 				Variants: []Variant{
 					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
-					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
-					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Tier: "expensive", Weight: 1},
+					{ID: "codex-gpt-5.5", Provider: "codex", Model: expensive["codex"], Tier: "expensive", Weight: 1},
+					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: expensive["copilot"], Tier: "expensive", Weight: 1},
+					{ID: "opencode-glm-5.2", Provider: "opencode", Model: expensive["opencode"], Tier: "expensive", Weight: 1},
 				},
 			},
 			{
@@ -205,12 +213,13 @@ func DefaultConfig() Config {
 				Roles:          []string{"review"},
 				Variants: []Variant{
 					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
-					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
-					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Tier: "expensive", Weight: 1},
+					{ID: "codex-gpt-5.5", Provider: "codex", Model: expensive["codex"], Tier: "expensive", Weight: 1},
+					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: expensive["copilot"], Tier: "expensive", Weight: 1},
+					{ID: "opencode-glm-5.2", Provider: "opencode", Model: expensive["opencode"], Tier: "expensive", Weight: 1},
 					{
 						ID:       "pl-a2d853b2c1d9-codex-gpt-5.5",
 						Provider: "codex",
-						Model:    "gpt-5.5",
+						Model:    expensive["codex"],
 						Tier:     "expensive",
 						Version:  "pl-a2d853b2c1d9",
 						Digest:   digestString(ReviewTightenInstructionsPLA2D853B2C1D9),

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -93,9 +93,9 @@ func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
 		experimentID string
 		variantIDs   []string
 	}{
-		{"implementation", "code-author-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
-		{"test-runner", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
-		{"pr-fix", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet"}},
+		{"implementation", "code-author-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet", "opencode-deepseek-v4-flash"}},
+		{"test-runner", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet", "opencode-deepseek-v4-flash"}},
+		{"pr-fix", "code-author-maintenance-cheap", []string{"claude-sonnet", "codex-gpt-5.4", "copilot-sonnet", "opencode-deepseek-v4-flash"}},
 	}
 	for _, tt := range cases {
 		t.Run(tt.role, func(t *testing.T) {
@@ -116,8 +116,9 @@ func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
 }
 
 // TestDefaultConfigEnrollsEveryProviderUniformly locks the "equal agents"
-// posture: every default experiment enrolls all three providers at weight 1 so
-// no role is shut out of any provider and the scorecard sees balanced samples.
+// posture: every default experiment enrolls every supported provider at weight
+// 1 so no role is shut out of any provider and the scorecard sees balanced
+// samples.
 func TestDefaultConfigEnrollsEveryProviderUniformly(t *testing.T) {
 	cfg := DefaultConfig()
 	for _, exp := range cfg.Experiments {
@@ -128,7 +129,7 @@ func TestDefaultConfigEnrollsEveryProviderUniformly(t *testing.T) {
 			}
 			providers[v.Provider] = true
 		}
-		for _, p := range []string{"claude", "codex", "copilot"} {
+		for _, p := range []string{"claude", "codex", "copilot", "opencode"} {
 			if !providers[p] {
 				t.Errorf("experiment %q is missing provider %q", exp.ID, p)
 			}
@@ -147,7 +148,7 @@ func TestDefaultConfigUsesExpensiveBracketForFixReview(t *testing.T) {
 			t.Fatalf("ExperimentID = %q, want fix-review-expensive", a.ExperimentID)
 		}
 		switch a.VariantID {
-		case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro":
+		case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro", "opencode-glm-5.2":
 		default:
 			t.Fatalf("VariantID = %q, want an expensive fix-review variant", a.VariantID)
 		}
@@ -171,7 +172,7 @@ func TestDefaultConfigUsesExpensiveBracketForReviewRoles(t *testing.T) {
 					t.Fatalf("ExperimentID = %q, want %s", a.ExperimentID, wantExp)
 				}
 				switch a.VariantID {
-				case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro", "pl-a2d853b2c1d9-codex-gpt-5.5":
+				case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro", "opencode-glm-5.2", "pl-a2d853b2c1d9-codex-gpt-5.5":
 				default:
 					t.Fatalf("VariantID = %q, want expensive variant", a.VariantID)
 				}

--- a/internal/agent/copilot_stream_test.go
+++ b/internal/agent/copilot_stream_test.go
@@ -265,8 +265,8 @@ func TestNormalizeModelCopilot(t *testing.T) {
 	tests := map[string]string{
 		"":                copilotDefaultModel,
 		"sonnet":          copilotDefaultModel,
-		"opus":            copilotDefaultModel,
-		"haiku":           copilotDefaultModel,
+		"opus":            "gemini-3.1-pro-preview",
+		"haiku":           "gpt-5-mini",
 		"gpt-5.3-codex":   "gpt-5.3-codex",
 		"claude-opus-4.6": "claude-opus-4.6",
 		"auto":            "auto",

--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -63,7 +63,7 @@ func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (Inspect
 
 	v, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[InspectorVerdict]{
 		Name:     "inspect",
-		Tier:     llmjob.Cheap,
+		Tier:     llmjob.SuperCheap,
 		Schema:   inspectorVerdictSchema,
 		Validate: validateInspectorVerdict,
 	}, llmexec.Options{Logger: logger, Models: claudeModelOverride(in.Model)})

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -934,7 +934,7 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex default model mapping",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.5",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4",
 		},
 		{
 			name:    "codex maps haiku to mini",
@@ -944,7 +944,7 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex with RequirePermissions uses workspace-write sandbox",
 			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox workspace-write --model gpt-5.5",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox workspace-write --model gpt-5.4",
 		},
 		{
 			name:    "fable alias",
@@ -967,9 +967,9 @@ func TestBuildCommand(t *testing.T) {
 			wantCmd: "claude --dangerously-skip-permissions --model sonnet",
 		},
 		{
-			name:    "codex fable maps to gpt-5.5",
+			name:    "codex fable passes through as explicit model",
 			cfg:     RunConfig{Provider: "codex", Model: "fable"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.5",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model fable",
 		},
 		{
 			name:    "codex 1m suffix not stripped — rejected by safeArgRe",
@@ -979,7 +979,7 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex with reasoning effort high",
 			cfg:     RunConfig{Provider: "codex", ReasoningEffort: "high"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.5 -c model_reasoning_effort=high",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -c model_reasoning_effort=high",
 		},
 	}
 
@@ -1018,7 +1018,10 @@ func TestNormalizeModel(t *testing.T) {
 		{prov: "claude", model: "fable[1m] ", want: "fable"},      // trailing whitespace stripped first
 		{prov: "claude", model: "foo[1m]bar", want: "foo[1m]bar"}, // only trailing stripped
 		// Codex path — no [1m] stripping
-		{prov: "codex", model: "fable", want: "gpt-5.5"},
+		{prov: "codex", model: "", want: "gpt-5.4"},
+		{prov: "codex", model: "sonnet", want: "gpt-5.4"},
+		{prov: "codex", model: "fable", want: "fable"},
+		{prov: "codex", model: "opus", want: "gpt-5.5"},
 		{prov: "codex", model: "haiku", want: "gpt-5.4-mini"},
 		{prov: "codex", model: "gpt-5.4[1m]", want: "gpt-5.4[1m]"}, // unchanged on codex path
 	}
@@ -1045,12 +1048,12 @@ func TestCodexSandboxDisabledViaEnv(t *testing.T) {
 		{
 			name:    "codex default with sandbox disabled",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.5",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.4",
 		},
 		{
 			name:    "codex RequirePermissions honored as danger-full-access when sandbox disabled",
 			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.5",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.4",
 		},
 	}
 

--- a/internal/agent/opencode_stream_test.go
+++ b/internal/agent/opencode_stream_test.go
@@ -3,9 +3,15 @@ package agent
 import "testing"
 
 func TestOpenCodeProviderNormalizeModel(t *testing.T) {
-	for _, in := range []string{"", "sonnet", "opus", "haiku"} {
-		if got := normalizeModel("opencode", in); got != opencodeDefaultModel {
-			t.Errorf("normalizeModel(opencode, %q) = %q, want %q", in, got, opencodeDefaultModel)
+	tests := map[string]string{
+		"":       opencodeDefaultModel,
+		"sonnet": opencodeDefaultModel,
+		"opus":   "openrouter/z-ai/glm-5.2",
+		"haiku":  "openrouter/qwen/qwen3-32b",
+	}
+	for in, want := range tests {
+		if got := normalizeModel("opencode", in); got != want {
+			t.Errorf("normalizeModel(opencode, %q) = %q, want %q", in, got, want)
 		}
 	}
 	if got := normalizeModel("opencode", "openrouter/qwen/qwen3-coder"); got != "openrouter/qwen/qwen3-coder" {

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
 )
 
@@ -26,8 +27,8 @@ func (claudeProvider) NormalizeModel(model string) string {
 	// Stripping before safeArgRe keeps the validator strict — it intentionally
 	// rejects '[' and ']'. Scoped to the Claude path; Codex strings untouched.
 	model = stripContextSuffix(model)
-	if strings.TrimSpace(model) == "" {
-		return "sonnet"
+	if resolved, ok := modeltier.NormalizeAlias("claude", model); ok {
+		return resolved
 	}
 	return model
 }

--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
 )
 
@@ -19,14 +20,10 @@ func (codexProvider) Name() string { return "codex" }
 func (codexProvider) NormalizeModel(model string) string {
 	// Codex models come from `codex debug models` and never carry a [1m]
 	// suffix — a stray suffix stays untouched and is rejected by safeArgRe.
-	switch strings.TrimSpace(model) {
-	case "", "sonnet", "opus", "fable":
-		return "gpt-5.5"
-	case "haiku":
-		return "gpt-5.4-mini"
-	default:
-		return model
+	if resolved, ok := modeltier.NormalizeAlias("codex", model); ok {
+		return resolved
 	}
+	return model
 }
 
 func (p codexProvider) BuildCommand(cfg RunConfig, model string) string {

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -4,15 +4,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
 )
 
 // copilotDefaultModel is the model Copilot agents use when none is specified.
-// Per the integration decision the default is the latest GPT model available
-// in the installed Copilot binary's registry. If a user's Copilot plan lacks
-// this slug, `copilot --model` errors at exec time — pin a newer slug or
-// "auto" here when that happens.
-const copilotDefaultModel = "gpt-5.5"
+// It is Sybra's provider-specific cheap/sonnet-class Copilot model.
+var copilotDefaultModel = modeltier.Model(modeltier.Cheap, "copilot")
 
 type copilotProvider struct {
 	baseProvider
@@ -26,15 +24,13 @@ func (copilotProvider) Name() string { return "copilot" }
 
 func (copilotProvider) NormalizeModel(model string) string {
 	// The provider-agnostic short aliases (and the empty default the chat
-	// path passes) map to the latest GPT. Full Copilot slugs
+	// path passes) map through Sybra's shared model tiers. Full Copilot slugs
 	// (claude-opus-4.6, gpt-5.5, gemini-3.1-pro-preview, ...) selected
 	// in the model picker pass through untouched.
-	switch strings.TrimSpace(model) {
-	case "", "sonnet", "opus", "haiku", "fable":
-		return copilotDefaultModel
-	default:
-		return model
+	if resolved, ok := modeltier.NormalizeAlias("copilot", model); ok {
+		return resolved
 	}
+	return model
 }
 
 func (copilotProvider) BuildCommand(cfg RunConfig, model string) string {

--- a/internal/agent/provider_opencode.go
+++ b/internal/agent/provider_opencode.go
@@ -4,10 +4,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
 )
 
-const opencodeDefaultModel = "openrouter/z-ai/glm-5.2"
+var opencodeDefaultModel = modeltier.Model(modeltier.Cheap, "opencode")
 
 type opencodeProvider struct {
 	baseProvider
@@ -20,12 +21,10 @@ func init() {
 func (opencodeProvider) Name() string { return "opencode" }
 
 func (opencodeProvider) NormalizeModel(model string) string {
-	switch strings.TrimSpace(model) {
-	case "", "sonnet", "opus", "haiku", "fable":
-		return opencodeDefaultModel
-	default:
-		return model
+	if resolved, ok := modeltier.NormalizeAlias("opencode", model); ok {
+		return resolved
 	}
+	return model
 }
 
 func (p opencodeProvider) BuildCommand(cfg RunConfig, model string) string {

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -799,7 +799,7 @@ func load(opts loadOptions) (*Config, error) {
 		cfg.Triage.PollSeconds = 60
 	}
 	// Triage.Model intentionally has no default override here: an empty
-	// model lets triage.FallbackClassifier fall through to its llmjob.Cheap
+	// model lets triage.FallbackClassifier fall through to its llmjob.SuperCheap
 	// tier (haiku), which is ~10x cheaper than sonnet for a structured
 	// classification job. A non-empty value (set explicitly by a user)
 	// still overrides the tier via claudeModelOverride.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -266,8 +266,8 @@ func TestLoadAutoUpdateDefaults(t *testing.T) {
 
 // TestLoadTriageModelDefaultsEmpty locks in that Triage.Model is left empty
 // by default rather than defaulted to "sonnet". An empty model lets
-// triage.FallbackClassifier fall through to its llmjob.Cheap tier (haiku);
-// a "sonnet" default here would silently override that cheap tier on every
+// triage.FallbackClassifier fall through to its llmjob.SuperCheap tier (haiku);
+// a "sonnet" default here would silently override that super-cheap tier on every
 // install (see internal/triage/classifier.go's claudeModelOverride).
 func TestLoadTriageModelDefaultsEmpty(t *testing.T) {
 	dir := t.TempDir()
@@ -278,7 +278,7 @@ func TestLoadTriageModelDefaultsEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg.Triage.Model != "" {
-		t.Fatalf("triage.model = %q, want empty (cheap tier)", cfg.Triage.Model)
+		t.Fatalf("triage.model = %q, want empty (super-cheap tier)", cfg.Triage.Model)
 	}
 	if cfg.Triage.PollSeconds != 60 {
 		t.Fatalf("triage.poll_seconds = %d, want 60", cfg.Triage.PollSeconds)

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -223,6 +223,15 @@ func TestRunSetsSuperCheapTierModels(t *testing.T) {
 	}
 }
 
+func TestStandardTierIsCheapAlias(t *testing.T) {
+	if Standard != Cheap {
+		t.Fatalf("Standard = %d, want Cheap alias %d", Standard, Cheap)
+	}
+	if !reflect.DeepEqual(modelsFor(Standard), modelsFor(Cheap)) {
+		t.Fatalf("Standard models differ from Cheap models")
+	}
+}
+
 func TestRunPreservesExplicitModels(t *testing.T) {
 	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
 		want := map[string]string{"claude": "opus", "codex": "gpt-5.4", "copilot": "claude-sonnet-4.6", "opencode": "openrouter/deepseek/deepseek-v4-flash"}

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -195,7 +195,7 @@ func TestRunAvoidProviderExcludedFromOrder(t *testing.T) {
 
 func TestRunSetsTierModels(t *testing.T) {
 	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
-		want := map[string]string{"claude": "haiku", "codex": "gpt-5.4-mini", "copilot": "gpt-5-mini"}
+		want := map[string]string{"claude": "sonnet", "codex": "gpt-5.4", "copilot": "claude-sonnet-4.6", "opencode": "openrouter/deepseek/deepseek-v4-flash"}
 		if !reflect.DeepEqual(opts.Models, want) {
 			t.Fatalf("models = %#v, want %#v", opts.Models, want)
 		}
@@ -208,9 +208,24 @@ func TestRunSetsTierModels(t *testing.T) {
 	}
 }
 
+func TestRunSetsSuperCheapTierModels(t *testing.T) {
+	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
+		want := map[string]string{"claude": "haiku", "codex": "gpt-5.4-mini", "copilot": "gpt-5-mini", "opencode": "openrouter/qwen/qwen3-32b"}
+		if !reflect.DeepEqual(opts.Models, want) {
+			t.Fatalf("models = %#v, want %#v", opts.Models, want)
+		}
+		return llmexec.Result{Provider: "claude", Text: `{"ok":true}`}, nil
+	})
+	defer restore()
+
+	if _, _, err := Run(context.Background(), "prompt", Spec[testOut]{Name: "models", Tier: SuperCheap}, llmexec.Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
 func TestRunPreservesExplicitModels(t *testing.T) {
 	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
-		want := map[string]string{"claude": "opus", "codex": "gpt-5.4-mini", "copilot": "gpt-5-mini"}
+		want := map[string]string{"claude": "opus", "codex": "gpt-5.4", "copilot": "claude-sonnet-4.6", "opencode": "openrouter/deepseek/deepseek-v4-flash"}
 		if !reflect.DeepEqual(opts.Models, want) {
 			t.Fatalf("models = %#v, want %#v", opts.Models, want)
 		}
@@ -251,7 +266,7 @@ func TestModelsForClones(t *testing.T) {
 	got := modelsFor(Standard)
 	got["claude"] = "mutated"
 	again := modelsFor(Standard)
-	if again["claude"] != "sonnet" || again["codex"] != "gpt-5.5" || again["copilot"] != "claude-sonnet-4.6" {
+	if again["claude"] != "sonnet" || again["codex"] != "gpt-5.4" || again["copilot"] != "claude-sonnet-4.6" || again["opencode"] != "openrouter/deepseek/deepseek-v4-flash" {
 		t.Fatalf("modelsFor did not clone standard row: %#v", again)
 	}
 }

--- a/internal/llmjob/tier.go
+++ b/internal/llmjob/tier.go
@@ -1,33 +1,30 @@
 package llmjob
 
-import "maps"
+import (
+	"maps"
+
+	"github.com/Automaat/sybra/internal/modeltier"
+)
 
 // Tier describes the cost/capability class for a short structured LLM job.
 type Tier int
 
 const (
-	Cheap Tier = iota
+	// SuperCheap is the haiku/mini class for small structured jobs.
+	SuperCheap Tier = iota
+	// Cheap is the sonnet-class default for ordinary coding/reasoning jobs.
+	Cheap
+	// Standard is kept as a compatibility alias for Cheap.
 	Standard
+	// Deep is the opus/deep class for high-scrutiny jobs.
 	Deep
 )
 
 var tierModels = map[Tier]map[string]string{
-	Cheap: {
-		"claude": "haiku",
-		"codex":  "gpt-5.4-mini",
-		// GPT-5 mini and GPT-4.1 are Copilot's no-premium-request tiers.
-		"copilot": "gpt-5-mini",
-	},
-	Standard: {
-		"claude":  "sonnet",
-		"codex":   "gpt-5.5",
-		"copilot": "claude-sonnet-4.6",
-	},
-	Deep: {
-		"claude":  "opus",
-		"codex":   "gpt-5.5",
-		"copilot": "gemini-3.1-pro-preview",
-	},
+	SuperCheap: modeltier.Models(modeltier.SuperCheap),
+	Cheap:      modeltier.Models(modeltier.Cheap),
+	Standard:   modeltier.Models(modeltier.Cheap),
+	Deep:       modeltier.Models(modeltier.Expensive),
 }
 
 func modelsFor(t Tier) map[string]string {
@@ -35,6 +32,10 @@ func modelsFor(t Tier) map[string]string {
 	if !ok {
 		row = tierModels[Standard]
 	}
+	return cloneModels(row)
+}
+
+func cloneModels(row map[string]string) map[string]string {
 	out := make(map[string]string, len(row))
 	maps.Copy(out, row)
 	return out

--- a/internal/llmjob/tier.go
+++ b/internal/llmjob/tier.go
@@ -15,15 +15,14 @@ const (
 	// Cheap is the sonnet-class default for ordinary coding/reasoning jobs.
 	Cheap
 	// Standard is kept as a compatibility alias for Cheap.
-	Standard
+	Standard = Cheap
 	// Deep is the opus/deep class for high-scrutiny jobs.
-	Deep
+	Deep Tier = iota
 )
 
 var tierModels = map[Tier]map[string]string{
 	SuperCheap: modeltier.Models(modeltier.SuperCheap),
 	Cheap:      modeltier.Models(modeltier.Cheap),
-	Standard:   modeltier.Models(modeltier.Cheap),
 	Deep:       modeltier.Models(modeltier.Expensive),
 }
 

--- a/internal/modeltier/tier.go
+++ b/internal/modeltier/tier.go
@@ -1,0 +1,72 @@
+package modeltier
+
+import (
+	"maps"
+	"strings"
+)
+
+// Tier names Sybra's provider-neutral model cost/capability classes.
+type Tier string
+
+const (
+	// SuperCheap is the haiku/mini class for small structured jobs.
+	SuperCheap Tier = "super_cheap"
+	// Cheap is the sonnet-class default for ordinary code-authoring work.
+	Cheap Tier = "cheap"
+	// Expensive is the opus/deep class for high-scrutiny planning/review.
+	Expensive Tier = "expensive"
+)
+
+var models = map[Tier]map[string]string{
+	SuperCheap: {
+		"claude":   "haiku",
+		"codex":    "gpt-5.4-mini",
+		"copilot":  "gpt-5-mini",
+		"opencode": "openrouter/qwen/qwen3-32b",
+	},
+	Cheap: {
+		"claude":   "sonnet",
+		"codex":    "gpt-5.4",
+		"copilot":  "claude-sonnet-4.6",
+		"opencode": "openrouter/deepseek/deepseek-v4-flash",
+	},
+	Expensive: {
+		"claude":   "opus",
+		"codex":    "gpt-5.5",
+		"copilot":  "gemini-3.1-pro-preview",
+		"opencode": "openrouter/z-ai/glm-5.2",
+	},
+}
+
+// Models returns a defensive copy of the provider model map for tier.
+func Models(tier Tier) map[string]string {
+	row, ok := models[tier]
+	if !ok {
+		row = models[Cheap]
+	}
+	out := make(map[string]string, len(row))
+	maps.Copy(out, row)
+	return out
+}
+
+// Model returns the provider-specific model for tier, or an empty string when
+// the provider has no mapping.
+func Model(tier Tier, provider string) string {
+	return models[tier][provider]
+}
+
+// NormalizeAlias maps Sybra's provider-neutral model aliases to a concrete
+// provider model. The boolean is false when model is already provider-specific
+// and should pass through unchanged.
+func NormalizeAlias(provider, model string) (string, bool) {
+	switch strings.TrimSpace(model) {
+	case "", "sonnet":
+		return Model(Cheap, provider), true
+	case "haiku":
+		return Model(SuperCheap, provider), true
+	case "opus":
+		return Model(Expensive, provider), true
+	default:
+		return model, false
+	}
+}

--- a/internal/modeltier/tier.go
+++ b/internal/modeltier/tier.go
@@ -59,14 +59,20 @@ func Model(tier Tier, provider string) string {
 // provider model. The boolean is false when model is already provider-specific
 // and should pass through unchanged.
 func NormalizeAlias(provider, model string) (string, bool) {
+	var tier Tier
 	switch strings.TrimSpace(model) {
 	case "", "sonnet":
-		return Model(Cheap, provider), true
+		tier = Cheap
 	case "haiku":
-		return Model(SuperCheap, provider), true
+		tier = SuperCheap
 	case "opus":
-		return Model(Expensive, provider), true
+		tier = Expensive
 	default:
 		return model, false
 	}
+	resolved := Model(tier, provider)
+	if strings.TrimSpace(resolved) == "" {
+		return model, false
+	}
+	return resolved, true
 }

--- a/internal/modeltier/tier_test.go
+++ b/internal/modeltier/tier_test.go
@@ -1,0 +1,25 @@
+package modeltier
+
+import "testing"
+
+func TestNormalizeAliasRejectsUnknownProvider(t *testing.T) {
+	for _, alias := range []string{"", "sonnet", "haiku", "opus"} {
+		got, ok := NormalizeAlias("unknown", alias)
+		if ok {
+			t.Fatalf("NormalizeAlias(unknown, %q) ok=true with model %q, want ok=false", alias, got)
+		}
+		if got != alias {
+			t.Fatalf("NormalizeAlias(unknown, %q) = %q, want original alias", alias, got)
+		}
+	}
+}
+
+func TestNormalizeAliasMapsKnownProvider(t *testing.T) {
+	got, ok := NormalizeAlias("opencode", "opus")
+	if !ok {
+		t.Fatal("NormalizeAlias(opencode, opus) ok=false, want true")
+	}
+	if got != "openrouter/z-ai/glm-5.2" {
+		t.Fatalf("NormalizeAlias(opencode, opus) = %q", got)
+	}
+}

--- a/internal/prcontent/generate.go
+++ b/internal/prcontent/generate.go
@@ -50,7 +50,7 @@ type FallbackGenerator struct {
 func (g *FallbackGenerator) Generate(ctx context.Context, req Request) (Content, error) {
 	c, _, err := llmjob.Run(ctx, buildPrompt(req), llmjob.Spec[Content]{
 		Name:     "pr-content",
-		Tier:     llmjob.Cheap,
+		Tier:     llmjob.SuperCheap,
 		Validate: validateContent,
 	}, llmexec.Options{
 		Logger: g.Logger,

--- a/internal/selfmonitor/judge.go
+++ b/internal/selfmonitor/judge.go
@@ -57,7 +57,7 @@ func selfMonitorTier(model string) llmjob.Tier {
 	case strings.Contains(model, "opus"):
 		return llmjob.Deep
 	case strings.Contains(model, "haiku"):
-		return llmjob.Cheap
+		return llmjob.SuperCheap
 	default:
 		return llmjob.Standard
 	}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -529,7 +529,7 @@ func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
 				"--json",
 				"--skip-git-repo-check",
 				"--dangerously-bypass-approvals-and-sandbox",
-				"--model\ngpt-5.5",
+				"--model\ngpt-5.4",
 			} {
 				if !strings.Contains(args, want) {
 					t.Errorf("expected %q in args:\n%s", want, args)

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -31,7 +31,7 @@ type FallbackClassifier struct {
 func (c *FallbackClassifier) Classify(ctx context.Context, t task.Task, projects []project.Project) (Verdict, error) {
 	v, _, err := llmjob.Run(ctx, buildPrompt(t, projects), llmjob.Spec[Verdict]{
 		Name:     "triage",
-		Tier:     llmjob.Cheap,
+		Tier:     llmjob.SuperCheap,
 		Schema:   Schema,
 		Validate: ValidateVerdict,
 	}, llmexec.Options{


### PR DESCRIPTION
## Summary
- add a shared modeltier package for provider-neutral super_cheap, cheap, and expensive model mappings
- route Claude, Codex, Copilot, and OpenCode alias normalization through the shared tier catalog
- move small structured jobs to SuperCheap while keeping code-authoring defaults on cheap/sonnet-class models
- add OpenCode A/B variants using DeepSeek V4 Flash for cheap and GLM 5.2 for expensive

## Verification
- go test ./internal/modeltier ./internal/llmjob ./internal/abtest ./internal/config ./internal/triage ./internal/prcontent ./internal/selfmonitor
- go test ./internal/agent -run 'TestNormalizeModel|TestNormalizeModelCopilot|TestOpenCodeProviderNormalizeModel|TestCodexSandboxDisabledViaEnv'
- pre-push hook: go test ./... and frontend svelte-check passed