### PR TITLE
fix(workflow): prevent avoidable human-required stalls

### DIFF
--- a/internal/agent/git_metadata_test.go
+++ b/internal/agent/git_metadata_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestGitMetadataRoots_LinkedWorktreeIncludesGitdirAndCommonDir(t *testing.T) {
+	root := t.TempDir()
+	worktree := filepath.Join(root, "worktrees", "task-1")
+	gitDir := filepath.Join(root, "clones", "repo.git", "worktrees", "task-1")
+	commonDir := filepath.Join(root, "clones", "repo.git")
+
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, ".git"), []byte("gitdir: "+gitDir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := gitMetadataRoots(worktree)
+	if err != nil {
+		t.Fatalf("gitMetadataRoots: %v", err)
+	}
+	want := []string{gitDir, commonDir}
+	for i, root := range want {
+		canon, err := canonicalizeRoot(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want[i] = canon
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("gitMetadataRoots = %v, want %v", got, want)
+	}
+}
+
+func TestGitMetadataRoots_NonGitWorktreeReturnsEmpty(t *testing.T) {
+	got, err := gitMetadataRoots(t.TempDir())
+	if err != nil {
+		t.Fatalf("gitMetadataRoots: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("gitMetadataRoots = %v, want empty", got)
+	}
+}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -340,6 +341,7 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)
 		return fmt.Errorf("agent.Run: sandbox worktree root: %w", err)
 	}
+	gitMetadata := m.resolveGitMetadataRoots(cfg.TaskID, canonWorktree)
 	canonSandboxHome, err := canonicalizeRoot(sandboxHome)
 	if err != nil {
 		m.logger.Error("agent.sandbox.failed", "task_id", cfg.TaskID, "err", err)
@@ -365,9 +367,10 @@ func (m *Manager) injectProcessSandbox(cfg *RunConfig) error {
 		return fmt.Errorf("agent.Run: sandbox profile: %w", err)
 	}
 
-	cfg.sandbox = enforceSpec(canonWorktree, canonSandboxHome, canonTmp, canonSharedCache, profilePath)
+	cfg.sandbox = enforceSpec(canonWorktree, gitMetadata, canonSandboxHome, canonTmp, canonSharedCache, profilePath)
 	m.logger.Info("agent.sandbox.enforce", "task_id", cfg.TaskID,
 		"worktree", canonWorktree, "sandbox_home", canonSandboxHome, "tmp", canonTmp,
+		"git_metadata", cfg.sandbox.gitMetadata,
 		"shared_cache", canonSharedCache, "claude_state", cfg.sandbox.claudeState,
 		"codex_state", cfg.sandbox.codexState, "copilot_state", cfg.sandbox.copilotState,
 		"opencode_state", cfg.sandbox.opencodeState,
@@ -395,10 +398,11 @@ func (m *Manager) reportSandboxRoot(taskID, name, root string) string {
 	return root
 }
 
-func enforceSpec(worktree, sandboxHome, tmp, sharedCache, profilePath string) sandboxSpec {
+func enforceSpec(worktree string, gitMetadata []string, sandboxHome, tmp, sharedCache, profilePath string) sandboxSpec {
 	return sandboxSpec{
 		mode:          "enforce",
 		worktree:      worktree,
+		gitMetadata:   slices.Clone(gitMetadata),
 		sandboxHome:   sandboxHome,
 		tmp:           tmp,
 		sharedCache:   sharedCache,
@@ -409,6 +413,92 @@ func enforceSpec(worktree, sandboxHome, tmp, sharedCache, profilePath string) sa
 		opencodeState: agentStateRoot(filepath.Join(".local", "share", "opencode"), sandboxHome),
 		toolCache:     agentStateRoot(".cache", sandboxHome),
 	}
+}
+
+func (m *Manager) resolveGitMetadataRoots(taskID, worktree string) []string {
+	roots, err := gitMetadataRoots(worktree)
+	if err != nil {
+		m.logger.Warn("agent.sandbox.git-metadata", "task_id", taskID, "err", err)
+		return nil
+	}
+	return roots
+}
+
+func gitMetadataRoots(worktree string) ([]string, error) {
+	gitPath := filepath.Join(worktree, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat .git: %w", err)
+	}
+	if info.IsDir() {
+		canon, err := canonicalizeRoot(gitPath)
+		if err != nil {
+			return nil, err
+		}
+		return []string{canon}, nil
+	}
+
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return nil, fmt.Errorf("read .git: %w", err)
+	}
+	firstLine, _, _ := strings.Cut(string(data), "\n")
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(firstLine), "gitdir:")
+	if !ok {
+		return nil, fmt.Errorf("unsupported .git file first line %q", strings.TrimSpace(firstLine))
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktree, gitDir)
+	}
+	canonGitDir, err := canonicalizeRoot(gitDir)
+	if err != nil {
+		return nil, fmt.Errorf("gitdir: %w", err)
+	}
+
+	roots := []string{canonGitDir}
+	if common := gitCommonDir(canonGitDir); common != "" {
+		canonCommon, err := canonicalizeRoot(common)
+		if err != nil {
+			return nil, fmt.Errorf("commondir: %w", err)
+		}
+		roots = append(roots, canonCommon)
+	}
+	return dedupeGitRoots(roots), nil
+}
+
+func gitCommonDir(gitDir string) string {
+	data, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	if err != nil {
+		return ""
+	}
+	common := strings.TrimSpace(string(data))
+	if common == "" {
+		return ""
+	}
+	if filepath.IsAbs(common) {
+		return common
+	}
+	return filepath.Join(gitDir, common)
+}
+
+func dedupeGitRoots(roots []string) []string {
+	seen := make(map[string]struct{}, len(roots))
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		out = append(out, root)
+	}
+	return out
 }
 
 func agentStateRoot(sub, fallback string) string {

--- a/internal/agent/procsandbox_linux.go
+++ b/internal/agent/procsandbox_linux.go
@@ -56,6 +56,7 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		cfg.sandbox.worktree, cfg.sandbox.sandboxHome, cfg.sandbox.tmp, cfg.sandbox.sharedCache,
 		cfg.sandbox.claudeState, cfg.sandbox.codexState, cfg.sandbox.copilotState, cfg.sandbox.opencodeState, cfg.sandbox.toolCache,
 	)
+	roots = dedupeRoots(append(roots, cfg.sandbox.gitMetadata...)...)
 	for _, root := range roots {
 		wrapped = append(wrapped, "--bind", root, root)
 	}

--- a/internal/agent/procsandbox_linux_test.go
+++ b/internal/agent/procsandbox_linux_test.go
@@ -12,6 +12,7 @@ func TestWrapInvocation_Linux_EnforceBindsOnlyWriteRoots(t *testing.T) {
 	cfg := &RunConfig{sandbox: sandboxSpec{
 		mode:          "enforce",
 		worktree:      "/data/wt",
+		gitMetadata:   []string{"/data/clones/repo.git/worktrees/task", "/data/clones/repo.git"},
 		sandboxHome:   "/data/home",
 		tmp:           "/tmp",
 		sharedCache:   "/data/cache",
@@ -28,7 +29,7 @@ func TestWrapInvocation_Linux_EnforceBindsOnlyWriteRoots(t *testing.T) {
 		t.Fatalf("expected read-only root + fresh dev/proc prefix, got: %s", joined)
 	}
 	for _, root := range []string{
-		"/data/wt", "/data/home", "/tmp", "/data/cache",
+		"/data/wt", "/data/clones/repo.git/worktrees/task", "/data/clones/repo.git", "/data/home", "/tmp", "/data/cache",
 		"/data/sybra/claude", "/data/sybra/codex", "/data/sybra/copilot", "/data/sybra/opencode", "/home/sybra/.cache",
 	} {
 		if !strings.Contains(joined, "--bind "+root+" "+root) {

--- a/internal/agent/procsandbox_state_test.go
+++ b/internal/agent/procsandbox_state_test.go
@@ -19,7 +19,7 @@ func TestEnforceSpec_ResolvesAgentStateRoots(t *testing.T) {
 	}
 
 	sandboxHome := t.TempDir()
-	spec := enforceSpec("/wt", sandboxHome, "/tmp", "/cache", "/profile")
+	spec := enforceSpec("/wt", nil, sandboxHome, "/tmp", "/cache", "/profile")
 
 	wantClaude, err := canonicalizeRoot(claude)
 	if err != nil {
@@ -41,7 +41,7 @@ func TestEnforceSpec_FallsBackWhenStateDirAbsent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	sandboxHome := t.TempDir()
 
-	spec := enforceSpec("/wt", sandboxHome, "/tmp", "/cache", "/profile")
+	spec := enforceSpec("/wt", nil, sandboxHome, "/tmp", "/cache", "/profile")
 
 	for name, got := range map[string]string{
 		"codexState":    spec.codexState,

--- a/internal/agent/runner_core.go
+++ b/internal/agent/runner_core.go
@@ -51,6 +51,7 @@ type sandboxSpec struct {
 	// never the default rollout posture.
 	mode        string
 	worktree    string
+	gitMetadata []string
 	sandboxHome string
 	tmp         string
 	sharedCache string

--- a/internal/workflow/engine_validate_plan_contract.go
+++ b/internal/workflow/engine_validate_plan_contract.go
@@ -188,13 +188,21 @@ func extractAcceptanceCriteria(body string) []string {
 			current.WriteString(item)
 			continue
 		}
-		if current.Len() > 0 && trimmed != "" {
+		if current.Len() > 0 && trimmed != "" && isIndentedMarkdownContinuation(line) {
 			current.WriteByte(' ')
 			current.WriteString(trimmed)
+			continue
+		}
+		if trimmed != "" {
+			flush()
 		}
 	}
 	flush()
 	return criteria
+}
+
+func isIndentedMarkdownContinuation(line string) bool {
+	return strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "\t")
 }
 
 func isMarkdownHeading(line string) bool {
@@ -214,7 +222,7 @@ func isAcceptanceCriteriaHeading(line string) bool {
 func listItemText(line string) (string, bool) {
 	for _, prefix := range []string{"- ", "* ", "+ "} {
 		if text, ok := strings.CutPrefix(line, prefix); ok {
-			return strings.TrimSpace(text), true
+			return normalizeListItemText(text), true
 		}
 	}
 	for i, r := range line {
@@ -222,11 +230,21 @@ func listItemText(line string) (string, bool) {
 			continue
 		}
 		if r == '.' && i > 0 && len(line) > i+1 && line[i+1] == ' ' {
-			return strings.TrimSpace(line[i+2:]), true
+			return normalizeListItemText(line[i+2:]), true
 		}
 		break
 	}
 	return "", false
+}
+
+func normalizeListItemText(text string) string {
+	text = strings.TrimSpace(text)
+	for _, marker := range []string{"[ ]", "[x]", "[X]"} {
+		if rest, ok := strings.CutPrefix(text, marker); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return text
 }
 
 func criterionCovered(source string, contractCriteria []string) bool {

--- a/internal/workflow/engine_validate_plan_contract_test.go
+++ b/internal/workflow/engine_validate_plan_contract_test.go
@@ -203,6 +203,37 @@ func TestValidatePlanContractForTask_AcceptsCopiedSourceAcceptanceCriteria(t *te
 	}
 }
 
+func TestValidatePlanContractForTask_AcceptsTaskCheckboxCriteria(t *testing.T) {
+	taskBody := "## Acceptance Criteria\n\n" +
+		"- [ ] Stats can group cost, duration, failures, and outcomes by actual skill execution mode.\n" +
+		"- [ ] No work-derived content or absolute work paths are exposed publicly.\n" +
+		"- [ ] Legacy data remains readable.\n\n" +
+		"**Test approach:** Add focused unit tests for the decision logic.\n"
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"acceptance_criteria": ["implementation prompt includes the contract"]`,
+		`"acceptance_criteria": [`+
+			`"Stats can group cost, duration, failures, and outcomes by actual skill execution mode.", `+
+			`"No work-derived content or absolute work paths are exposed publicly.", `+
+			`"Legacy data remains readable."]`, 1)
+
+	if problems := ValidatePlanContractForTask(contract, "fa6919fc", taskBody); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none", problems)
+	}
+}
+
+func TestValidatePlanContractForTask_DoesNotFoldLooselyIndentedParagraphIntoCriterion(t *testing.T) {
+	taskBody := "## Acceptance Criteria\n\n" +
+		"- [ ] Legacy data remains readable.\n" +
+		" This is a note paragraph, not part of the criterion.\n"
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"acceptance_criteria": ["implementation prompt includes the contract"]`,
+		`"acceptance_criteria": ["Legacy data remains readable."]`, 1)
+
+	if problems := ValidatePlanContractForTask(contract, "fa6919fc", taskBody); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none", problems)
+	}
+}
+
 func TestValidatePlanContractForTask_RequiresVerbatimSourceAcceptanceCriteria(t *testing.T) {
 	taskBody := "## Acceptance Criteria\n\n" +
 		"- Preserve Case exactly.\n"


### PR DESCRIPTION
## Summary
- allow enforced Linux agent sandboxes to write the Git metadata roots for linked worktrees, so merge/fetch/commit recovery can update worktree gitdir and common bare-clone state
- normalize task-list checkbox markers when validating plan-contract acceptance criteria, and stop folding later non-list paragraphs into the last criterion
- add regressions for linked-worktree metadata discovery and checkbox acceptance criteria

## Verification
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/workflow -run 'TestValidatePlanContract|TestExecValidatePlanContract'
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/agent -run 'TestGitMetadataRoots|TestWrapInvocation_Linux|TestDedupeRoots|TestPrepareRunConfig_Sandbox|TestInjectProcessSandbox|TestEnforceSpec'
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/agent ./internal/workflow
- pre-push hook: go test ./... and cd frontend && npm run check

Fixes the root causes observed in Sybra tasks 0e030a16 and 02909563.