### PR TITLE
Monitor linked task PRs during review polling

### DIFF
--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -405,6 +405,7 @@ func (r *Handler) pollAndMonitorPRs(ctx context.Context) time.Duration {
 	r.emit("reviews:updated", summary)
 
 	monitoredPRs := r.monitoredPRs(summary)
+	monitoredPRs = r.includeKnownTaskPRs(tasks, monitoredPRs)
 
 	// Recover PRs orphaned by a workflow that exited before linking — e.g. a
 	// task stranded in human-required while a late-finishing agent opened the
@@ -1270,6 +1271,63 @@ func (r *Handler) monitoredPRs(summary github.ReviewSummary) []github.PullReques
 	prs = append(prs, summary.CreatedByMe...)
 	prs = append(prs, renovatePRs...)
 	return prs
+}
+
+// includeKnownTaskPRs folds linked task PRs into the search-backed monitor
+// result. FetchReviews is intentionally search-based and can miss PRs created
+// by another machine/account in the cluster; linked task metadata is the
+// canonical fallback for those outbound PRs.
+func (r *Handler) includeKnownTaskPRs(tasks []task.Task, monitoredPRs []github.PullRequest) []github.PullRequest {
+	selection := r.selectKnownPRPoll(tasks)
+	if r.logger != nil {
+		r.logger.Info("reviews.poll.bounded",
+			"selected", selection.selectedPRs,
+			"deferred", selection.deferredPRs,
+			"capped", selection.cappedPRs)
+	}
+
+	seen := make(map[string]struct{}, len(monitoredPRs))
+	for i := range monitoredPRs {
+		pr := &monitoredPRs[i]
+		if pr.Repository == "" || pr.Number == 0 {
+			continue
+		}
+		seen[prRefCacheKey(pr.Repository, pr.Number)] = struct{}{}
+	}
+
+	matchers := make([]github.TaskMatcher, 0, len(selection.tasks))
+	for i := range selection.tasks {
+		tk := &selection.tasks[i]
+		if !knownPRPollEligible(tk) {
+			continue
+		}
+		matchers = append(matchers, github.TaskMatcher{
+			ID:        tk.ID,
+			PRNumber:  tk.PRNumber,
+			Branch:    tk.Branch,
+			ProjectID: tk.ProjectID,
+		})
+	}
+	if len(matchers) == 0 {
+		return monitoredPRs
+	}
+
+	knownPRs := r.fetchKnownTaskPRs(matchers)
+	if len(knownPRs) == 0 {
+		return monitoredPRs
+	}
+	out := make([]github.PullRequest, 0, len(monitoredPRs)+len(knownPRs))
+	out = append(out, monitoredPRs...)
+	for i := range knownPRs {
+		pr := &knownPRs[i]
+		key := prRefCacheKey(pr.Repository, pr.Number)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, *pr)
+	}
+	return out
 }
 
 // prMonitorEligible decides whether the PR monitor should consider a task

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -1303,6 +1303,66 @@ func TestMonitoredPRs(t *testing.T) {
 	}
 }
 
+func TestIncludeKnownTaskPRsAddsLinkedPRsMissingFromSearch(t *testing.T) {
+	searchPR := github.PullRequest{Repository: "owner/repo", Number: 1, Author: "me"}
+	searchLinkedPR := github.PullRequest{Repository: "Automaat/sybra", Number: 99, Author: "me"}
+	knownPR := github.PullRequest{
+		Repository: "Automaat/sybra",
+		Number:     2047,
+		HeadSHA:    "known-sha",
+		UpdatedAt:  "2026-07-15T05:00:00Z",
+	}
+
+	var fetched []github.PRRef
+	r := &Handler{
+		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
+			fetched = append([]github.PRRef(nil), refs...)
+			return []github.MonitorPRResult{{
+				Repo:   "Automaat/sybra",
+				Number: 99,
+				PR:     searchLinkedPR,
+				Open:   true,
+			}, {
+				Repo:   "Automaat/sybra",
+				Number: 2047,
+				PR:     knownPR,
+				Open:   true,
+			}}
+		},
+	}
+
+	got := r.includeKnownTaskPRs([]task.Task{
+		{
+			ID:        "already-search",
+			Status:    task.StatusInReview,
+			ProjectID: "Automaat/sybra",
+			PRNumber:  99,
+			UpdatedAt: time.Date(2026, 7, 15, 5, 1, 0, 0, time.UTC),
+		},
+		{
+			ID:        "40420f5e",
+			Status:    task.StatusInReview,
+			ProjectID: "Automaat/sybra",
+			PRNumber:  2047,
+			UpdatedAt: time.Date(2026, 7, 15, 5, 0, 0, 0, time.UTC),
+		},
+	}, []github.PullRequest{searchPR, searchLinkedPR})
+
+	if len(fetched) != 2 {
+		t.Fatalf("fetched refs = %+v, want two known linked PR refs", fetched)
+	}
+	if fetched[0].Repo != "Automaat/sybra" || fetched[0].Number != 99 ||
+		fetched[1].Repo != "Automaat/sybra" || fetched[1].Number != 2047 {
+		t.Fatalf("fetched refs = %+v, want Automaat/sybra#99 and Automaat/sybra#2047", fetched)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (got %+v)", len(got), got)
+	}
+	if got[0].Number != 1 || got[1].Number != 99 || got[2].Number != 2047 {
+		t.Fatalf("numbers = [%d %d %d], want [1 99 2047]", got[0].Number, got[1].Number, got[2].Number)
+	}
+}
+
 // TestTriageReviewSmall guards the reviewSmallAdditions (40) and
 // reviewSmallFiles (5) thresholds. Both conditions must hold for the PR to be
 // routed to human-required; if either meets or exceeds its limit the review


### PR DESCRIPTION
## Summary
- include known linked task PRs in the normal search-backed review poll
- keep existing bounded known-PR scheduling and dedupe against search results
- add regression coverage for a linked Sybra task PR missing from GitHub search results

## Why
The previous automerge fix deployed, but the local leader's review poll did not monitor follower-authored Sybra PRs (#2047/#2050/#2051/#2052/#2054). The home-nas node is a follower and disables GitHub pollers, so those linked PRs must be folded into the leader's monitor from task metadata.

## Tests
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra/review -run 'TestIncludeKnownTaskPRsAddsLinkedPRsMissingFromSearch|TestMonitoredPRs|TestHandleAutoMerge_GatesOnCopilot'
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra/review
- pre-push: go test ./...; frontend npm run check