### PR TITLE
fix(cluster): mirror planning sidecars from followers

### DIFF
--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -258,6 +258,73 @@ func TestMirrorClearsSidecarWhenFollowerClears(t *testing.T) {
 	}
 }
 
+func TestMirrorMirrorsPlanningSidecars(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := mgr.Put(task.Task{ID: "task-pet", Status: task.StatusTodo, AssignedNode: "pet-box", UpdatedAt: t0}); err != nil {
+		t.Fatal(err)
+	}
+
+	follower := task.Task{
+		ID:            "task-pet",
+		Status:        task.StatusPlanReview,
+		AssignedNode:  "pet-box",
+		Plan:          "the plan",
+		PlanContract:  `{"task_id":"task-pet"}`,
+		PlanCritique:  "the critique",
+		PlanResearch:  "the research",
+		PlanDecisions: "# Decisions\n\nNo open decisions.",
+		PlanBrief:     "the brief",
+		CodeReview:    "the review",
+		UpdatedAt:     t0.Add(time.Hour),
+	}
+	if !mirror.applyFollowerTask("pet-box", follower) {
+		t.Fatal("apply follower sidecars")
+	}
+
+	got, err := mgr.Get("task-pet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Plan != follower.Plan ||
+		got.PlanContract != follower.PlanContract ||
+		got.PlanCritique != follower.PlanCritique ||
+		got.PlanResearch != follower.PlanResearch ||
+		got.PlanDecisions != follower.PlanDecisions ||
+		got.PlanBrief != follower.PlanBrief ||
+		got.CodeReview != follower.CodeReview {
+		t.Fatalf("mirrored sidecars mismatch:\n got: %+v\nwant: %+v", got, follower)
+	}
+
+	cleared := task.Task{
+		ID:           "task-pet",
+		Status:       task.StatusInProgress,
+		AssignedNode: "pet-box",
+		UpdatedAt:    t0.Add(2 * time.Hour),
+	}
+	if !mirror.applyFollowerTask("pet-box", cleared) {
+		t.Fatal("apply cleared follower sidecars")
+	}
+
+	got, err = mgr.Get("task-pet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Plan != "" ||
+		got.PlanContract != "" ||
+		got.PlanCritique != "" ||
+		got.PlanResearch != "" ||
+		got.PlanDecisions != "" ||
+		got.PlanBrief != "" ||
+		got.CodeReview != "" {
+		t.Fatalf("cleared follower sidecars should clear leader sidecars: %+v", got)
+	}
+}
+
 func TestMirrorIgnoresUnownedTask(t *testing.T) {
 	cfg := leaderConfig("http://unused", []string{"owner/pet"})
 	roster, _ := NewRoster(cfg, nil)

--- a/internal/sybra/clusterlead/merge_test.go
+++ b/internal/sybra/clusterlead/merge_test.go
@@ -25,21 +25,26 @@ func TestMergeAuthoritySplit(t *testing.T) {
 		MirrorRev:    4,
 	}
 	follower := task.Task{
-		ID:           "task-1",
-		ProjectID:    "attacker/evil",
-		AssignedNode: "somewhere-else",
-		Title:        "follower renamed it",
-		Issue:        "https://github.com/attacker/evil/issues/1",
-		Status:       task.StatusInReview,
-		StatusReason: "review drafted",
-		Branch:       "feat/x",
-		WorktreeDir:  "/wt/task-1",
-		PRNumber:     42,
-		Reviewed:     true,
-		Outcome:      "merged",
-		Plan:         "the plan",
-		CodeReview:   "the review",
-		UpdatedAt:    t1,
+		ID:            "task-1",
+		ProjectID:     "attacker/evil",
+		AssignedNode:  "somewhere-else",
+		Title:         "follower renamed it",
+		Issue:         "https://github.com/attacker/evil/issues/1",
+		Status:        task.StatusInReview,
+		StatusReason:  "review drafted",
+		Branch:        "feat/x",
+		WorktreeDir:   "/wt/task-1",
+		PRNumber:      42,
+		Reviewed:      true,
+		Outcome:       "merged",
+		Plan:          "the plan",
+		PlanContract:  `{"task_id":"task-1"}`,
+		PlanCritique:  "the critique",
+		PlanResearch:  "the research",
+		PlanDecisions: "# Decisions\n\nNo open decisions.",
+		PlanBrief:     "the brief",
+		CodeReview:    "the review",
+		UpdatedAt:     t1,
 	}
 
 	out, ok := Merge(canonical, follower)
@@ -55,7 +60,13 @@ func TestMergeAuthoritySplit(t *testing.T) {
 
 	if out.Status != task.StatusInReview || out.StatusReason != "review drafted" ||
 		out.Branch != "feat/x" || out.WorktreeDir != "/wt/task-1" || out.PRNumber != 42 ||
-		!out.Reviewed || out.Outcome != "merged" || out.Plan != "the plan" || out.CodeReview != "the review" {
+		!out.Reviewed || out.Outcome != "merged" || out.Plan != "the plan" ||
+		out.PlanContract != `{"task_id":"task-1"}` ||
+		out.PlanCritique != "the critique" ||
+		out.PlanResearch != "the research" ||
+		out.PlanDecisions != "# Decisions\n\nNo open decisions." ||
+		out.PlanBrief != "the brief" ||
+		out.CodeReview != "the review" {
 		t.Errorf("execution fields must be follower-authoritative: %+v", out)
 	}
 

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -170,6 +170,18 @@ func (m *Mirror) writeSidecars(t task.Task) error {
 	if err := store.PlanContracts().Write(t.ID, t.PlanContract); err != nil {
 		return err
 	}
+	if err := store.PlanCritiques().Write(t.ID, t.PlanCritique); err != nil {
+		return err
+	}
+	if err := store.PlanResearch().Write(t.ID, t.PlanResearch); err != nil {
+		return err
+	}
+	if err := store.PlanDecisions().Write(t.ID, t.PlanDecisions); err != nil {
+		return err
+	}
+	if err := store.PlanBrief().Write(t.ID, t.PlanBrief); err != nil {
+		return err
+	}
 	if err := store.CodeReviews().Write(t.ID, t.CodeReview); err != nil {
 		return err
 	}
@@ -207,6 +219,10 @@ func Merge(canonical, follower task.Task) (task.Task, bool) {
 	out.Body = follower.Body
 	out.Plan = follower.Plan
 	out.PlanContract = follower.PlanContract
+	out.PlanCritique = follower.PlanCritique
+	out.PlanResearch = follower.PlanResearch
+	out.PlanDecisions = follower.PlanDecisions
+	out.PlanBrief = follower.PlanBrief
 	out.CodeReview = follower.CodeReview
 
 	out.MirrorRev = canonical.MirrorRev + 1


### PR DESCRIPTION
## Summary
- mirror all planning sidecars from follower-owned tasks back to the leader
- include plan decisions, brief, research, and critique in follower-authoritative merge state
- add regression coverage for mirrored planning sidecars

## Verification
- go test ./internal/sybra/clusterlead
- pre-push hook: go test ./... and cd frontend && npm run check