### PR TITLE
fix(workflow): skip manual testing for small chores

### DIFF
--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -17,7 +17,9 @@ steps:
   # `notest`/docs/library scopes only exempt the app start; the test-runner
   # still has to provide CLI/test-harness evidence and always runs. `trivial`
   # skips review + testing for trivially mechanical tasks. `skip-testing`
-  # skips only this tester, preserving the earlier code-review gate.
+  # skips only this tester, preserving the earlier code-review gate. Small,
+  # non-test chores also skip this tester after code review; larger chores and
+  # chores that touch tests still get adversarial testing.
   - id: maybe_test
     name: Testing Decision
     type: condition
@@ -32,7 +34,34 @@ steps:
           operator: contains
           value: skip-testing
         goto: skip_testing
+      - when:
+          field: task.tags
+          operator: contains
+          value: chore
+        goto: maybe_skip_chore_size
       - goto: run_test
+
+  - id: maybe_skip_chore_size
+    name: Chore Testing Size Decision
+    type: condition
+    next:
+      - when:
+          field: task.tags
+          operator: contains
+          value: small
+        goto: maybe_skip_chore_test_tag
+      - goto: run_test
+
+  - id: maybe_skip_chore_test_tag
+    name: Chore Testing Risk Decision
+    type: condition
+    next:
+      - when:
+          field: task.tags
+          operator: contains
+          value: test
+        goto: run_test
+      - goto: skip_testing
 
   # Skip target: go straight to ready-pr, same terminus a PASS verdict reaches
   # via route_test below.

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -1266,6 +1266,66 @@ func TestBuiltinTestingTask_SkipTestingSkipsTester(t *testing.T) {
 	}
 }
 
+func TestBuiltinTestingTask_SmallNonTestChoreSkipsTester(t *testing.T) {
+	t.Parallel()
+
+	testingDef := mustBuiltinDefinition(t, "testing-task")
+	maybe := testingDef.StepByID("maybe_test")
+	if maybe == nil {
+		t.Fatal("maybe_test step not found in testing-task")
+		return
+	}
+	if got, err := ResolveTransition(maybe.Next, map[string]string{"task.tags": "backend,chore,small"}); err != nil || got != "maybe_skip_chore_size" {
+		t.Fatalf("maybe_test transition = %q, %v; want maybe_skip_chore_size, nil", got, err)
+	}
+
+	size := testingDef.StepByID("maybe_skip_chore_size")
+	if size == nil {
+		t.Fatal("maybe_skip_chore_size step not found in testing-task")
+		return
+	}
+	if got, err := ResolveTransition(size.Next, map[string]string{"task.tags": "backend,chore,small"}); err != nil || got != "maybe_skip_chore_test_tag" {
+		t.Fatalf("maybe_skip_chore_size transition = %q, %v; want maybe_skip_chore_test_tag, nil", got, err)
+	}
+
+	risk := testingDef.StepByID("maybe_skip_chore_test_tag")
+	if risk == nil {
+		t.Fatal("maybe_skip_chore_test_tag step not found in testing-task")
+		return
+	}
+	if got, err := ResolveTransition(risk.Next, map[string]string{"task.tags": "backend,chore,small"}); err != nil || got != "skip_testing" {
+		t.Fatalf("maybe_skip_chore_test_tag transition = %q, %v; want skip_testing, nil", got, err)
+	}
+}
+
+func TestBuiltinTestingTask_MediumChoreStillRunsTester(t *testing.T) {
+	t.Parallel()
+
+	testingDef := mustBuiltinDefinition(t, "testing-task")
+	size := testingDef.StepByID("maybe_skip_chore_size")
+	if size == nil {
+		t.Fatal("maybe_skip_chore_size step not found in testing-task")
+		return
+	}
+	if got, err := ResolveTransition(size.Next, map[string]string{"task.tags": "backend,chore,medium"}); err != nil || got != "run_test" {
+		t.Fatalf("maybe_skip_chore_size transition = %q, %v; want run_test, nil", got, err)
+	}
+}
+
+func TestBuiltinTestingTask_TestChoreStillRunsTester(t *testing.T) {
+	t.Parallel()
+
+	testingDef := mustBuiltinDefinition(t, "testing-task")
+	risk := testingDef.StepByID("maybe_skip_chore_test_tag")
+	if risk == nil {
+		t.Fatal("maybe_skip_chore_test_tag step not found in testing-task")
+		return
+	}
+	if got, err := ResolveTransition(risk.Next, map[string]string{"task.tags": "backend,test,chore,small"}); err != nil || got != "run_test" {
+		t.Fatalf("maybe_skip_chore_test_tag transition = %q, %v; want run_test, nil", got, err)
+	}
+}
+
 func mustBuiltinDefinition(t *testing.T, id string) *Definition {
 	t.Helper()
 	defs, err := BuiltinDefinitions()


### PR DESCRIPTION
## Summary
- route small non-test chores from testing directly to ready-pr after code review
- keep medium chores and test-affecting chores in adversarial testing
- add workflow transition tests for the chore skip policy

## Tests
- go test ./internal/workflow -run 'TestBuiltinTestingTask'
- go test ./internal/workflow
- pre-push hook: go test ./...; cd frontend && npm run check