### PR TITLE
fix(workflow): normalize contract criteria checkboxes

### DIFF
--- a/internal/workflow/engine_validate_plan_contract.go
+++ b/internal/workflow/engine_validate_plan_contract.go
@@ -248,16 +248,20 @@ func normalizeListItemText(text string) string {
 }
 
 func criterionCovered(source string, contractCriteria []string) bool {
-	source = normalizeCriterionWhitespace(source)
+	source = normalizeCriterionText(source)
 	if source == "" {
 		return true
 	}
 	for _, criterion := range contractCriteria {
-		if normalizeCriterionWhitespace(criterion) == source {
+		if normalizeCriterionText(criterion) == source {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeCriterionText(s string) string {
+	return normalizeCriterionWhitespace(normalizeListItemText(s))
 }
 
 func normalizeCriterionWhitespace(s string) string {

--- a/internal/workflow/engine_validate_plan_contract.go
+++ b/internal/workflow/engine_validate_plan_contract.go
@@ -261,6 +261,9 @@ func criterionCovered(source string, contractCriteria []string) bool {
 }
 
 func normalizeCriterionText(s string) string {
+	if item, ok := listItemText(strings.TrimSpace(s)); ok {
+		return normalizeCriterionWhitespace(item)
+	}
 	return normalizeCriterionWhitespace(normalizeListItemText(s))
 }
 

--- a/internal/workflow/engine_validate_plan_contract_test.go
+++ b/internal/workflow/engine_validate_plan_contract_test.go
@@ -226,15 +226,26 @@ func TestValidatePlanContractForTask_AcceptsCopiedContractCheckboxCriteria(t *te
 		"- [ ] Stats can group cost, duration, failures, and outcomes by actual skill execution mode.\n" +
 		"- [ ] No work-derived content or absolute work paths are exposed publicly.\n" +
 		"- [ ] Legacy data remains readable.\n"
-	contract := strings.Replace(validPlanContract("fa6919fc"),
-		`"acceptance_criteria": ["implementation prompt includes the contract"]`,
-		`"acceptance_criteria": [`+
-			`"[ ] Stats can group cost, duration, failures, and outcomes by actual skill execution mode.", `+
-			`"[ ] No work-derived content or absolute work paths are exposed publicly.", `+
-			`"[ ] Legacy data remains readable."]`, 1)
+	for _, tc := range []struct {
+		name   string
+		prefix string
+	}{
+		{name: "checkbox marker", prefix: "[ ] "},
+		{name: "list checkbox marker", prefix: "- [ ] "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			contract := strings.Replace(validPlanContract("fa6919fc"),
+				`"acceptance_criteria": ["implementation prompt includes the contract"]`,
+				`"acceptance_criteria": [`+
+					fmt.Sprintf("%q, ", tc.prefix+"Stats can group cost, duration, failures, and outcomes by actual skill execution mode.")+
+					fmt.Sprintf("%q, ", tc.prefix+"No work-derived content or absolute work paths are exposed publicly.")+
+					fmt.Sprintf("%q", tc.prefix+"Legacy data remains readable.")+
+					`]`, 1)
 
-	if problems := ValidatePlanContractForTask(contract, "fa6919fc", taskBody); len(problems) != 0 {
-		t.Fatalf("problems = %v, want none", problems)
+			if problems := ValidatePlanContractForTask(contract, "fa6919fc", taskBody); len(problems) != 0 {
+				t.Fatalf("problems = %v, want none", problems)
+			}
+		})
 	}
 }
 

--- a/internal/workflow/engine_validate_plan_contract_test.go
+++ b/internal/workflow/engine_validate_plan_contract_test.go
@@ -221,6 +221,23 @@ func TestValidatePlanContractForTask_AcceptsTaskCheckboxCriteria(t *testing.T) {
 	}
 }
 
+func TestValidatePlanContractForTask_AcceptsCopiedContractCheckboxCriteria(t *testing.T) {
+	taskBody := "## Acceptance Criteria\n\n" +
+		"- [ ] Stats can group cost, duration, failures, and outcomes by actual skill execution mode.\n" +
+		"- [ ] No work-derived content or absolute work paths are exposed publicly.\n" +
+		"- [ ] Legacy data remains readable.\n"
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"acceptance_criteria": ["implementation prompt includes the contract"]`,
+		`"acceptance_criteria": [`+
+			`"[ ] Stats can group cost, duration, failures, and outcomes by actual skill execution mode.", `+
+			`"[ ] No work-derived content or absolute work paths are exposed publicly.", `+
+			`"[ ] Legacy data remains readable."]`, 1)
+
+	if problems := ValidatePlanContractForTask(contract, "fa6919fc", taskBody); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none", problems)
+	}
+}
+
 func TestValidatePlanContractForTask_DoesNotFoldLooselyIndentedParagraphIntoCriterion(t *testing.T) {
 	taskBody := "## Acceptance Criteria\n\n" +
 		"- [ ] Legacy data remains readable.\n" +


### PR DESCRIPTION
## Summary
- normalize checkbox markers on plan-contract acceptance criteria before comparing with task source criteria
- keep strict wording checks intact while accepting copied  checklist markers
- add regression coverage for contract-side checklist markers

Closes #2060

## Tests
- go test ./internal/workflow -run 'TestValidatePlanContract|TestExecValidatePlanContract|TestPlanContractPromptJSON'
- go test ./internal/workflow
- pre-push hook: go test ./...; cd frontend && npm run check