### PR TITLE
fix(workflow): retry transient verify commits git errors

### DIFF
--- a/internal/workflow/engine_retry.go
+++ b/internal/workflow/engine_retry.go
@@ -14,12 +14,13 @@ var (
 	prVerifyBackoffs = []time.Duration{2 * time.Second, 4 * time.Second, 6 * time.Second}
 	prVerifySleep    = time.Sleep
 
-	// verifyCommitsRetryBackoff is the delay before a single retry of
-	// `git log` in verify_commits — verify_commits runs immediately after
-	// the agent process exits, so a leftover .git/index.lock can transiently
-	// fail the first call. Indirected for tests.
-	verifyCommitsRetryBackoff = 500 * time.Millisecond
-	verifyCommitsRetrySleep   = time.Sleep
+	// verifyCommitsRetryBackoffs schedule bounded retries of transient
+	// ref/object visibility failures in verify_commits. The gate runs
+	// immediately after the agent process exits, so sandbox sync, ref writes,
+	// or leftover git locks can briefly make HEAD or its object unreadable.
+	// Indirected for tests.
+	verifyCommitsRetryBackoffs = []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second}
+	verifyCommitsRetrySleep    = time.Sleep
 
 	// classifyTaskRetryBackoffs schedules retries after a transient classify
 	// failure (rate limit, brief provider outage). classify_task replaced a

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -279,11 +279,7 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution,
 		}
 	}
 
-	output, err := e.gitLogAheadOfBase(wtPath)
-	if err != nil && !errors.Is(e.ctx.Err(), context.Canceled) && !errors.Is(e.ctx.Err(), context.DeadlineExceeded) {
-		verifyCommitsRetrySleep(verifyCommitsRetryBackoff)
-		output, err = e.gitLogAheadOfBase(wtPath)
-	}
+	output, err := e.gitLogAheadOfBaseWithRetry(taskID, wtPath)
 	if err != nil {
 		// Context cancellation indicates engine shutdown, not a worktree
 		// problem — leave task status alone so it resumes on next boot.
@@ -377,6 +373,26 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution,
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "commits verified"}, nil
 }
 
+func (e *Engine) gitLogAheadOfBaseWithRetry(taskID, wtPath string) ([]byte, error) {
+	output, err := e.gitLogAheadOfBase(wtPath)
+	for attempt := 0; err != nil && shouldRetryVerifyCommitsGitError(err, output); attempt++ {
+		if errors.Is(e.ctx.Err(), context.Canceled) || errors.Is(e.ctx.Err(), context.DeadlineExceeded) {
+			break
+		}
+		if attempt >= len(verifyCommitsRetryBackoffs) {
+			break
+		}
+		e.logger.Warn("workflow.verify-commits.retry",
+			"task_id", taskID,
+			"worktree", wtPath,
+			"attempt", attempt+1,
+			"err", err)
+		verifyCommitsRetrySleep(verifyCommitsRetryBackoffs[attempt])
+		output, err = e.gitLogAheadOfBase(wtPath)
+	}
+	return output, err
+}
+
 // branchMergedIntoBase reports whether HEAD is reachable from the resolved
 // origin base ref (i.e. HEAD is an ancestor of, or equal to, base). Used by
 // execVerifyCommits to distinguish "fix already merged into origin" from
@@ -402,7 +418,40 @@ func (e *Engine) gitLogAheadOfBase(wtPath string) ([]byte, error) {
 	baseRef := resolveOriginBase(ctx, wtPath)
 	cmd := exec.CommandContext(ctx, "git", "log", baseRef+"..HEAD", "--oneline")
 	cmd.Dir = wtPath
-	return cmd.Output()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail == "" {
+			return out, fmt.Errorf("git log %s..HEAD: %w", baseRef, err)
+		}
+		return out, fmt.Errorf("git log %s..HEAD: %w: %s", baseRef, err, detail)
+	}
+	return out, nil
+}
+
+func shouldRetryVerifyCommitsGitError(err error, output []byte) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error() + "\n" + string(output))
+	for _, needle := range []string{
+		"bad object head",
+		"fatal: bad object",
+		"not a valid object name",
+		"invalid object",
+		"missing object",
+		"unable to read sha1 file",
+		"object file",
+		"loose object",
+		"unknown revision",
+		"ambiguous argument",
+		"reference broken",
+	} {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // diagnoseWorktreeState produces a short human-readable hint about why a

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6037,6 +6037,30 @@ func makeGitRepo(t *testing.T, withExtraCommit bool) string {
 	return dir
 }
 
+func withFakeGit(t *testing.T, script string) {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath git: %v", err)
+	}
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	script = strings.ReplaceAll(script, "{{REAL_GIT}}", realGit)
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
 // TestExecRunAgent_DispatchInFlightWaits asserts a run_agent step whose
 // StartAgent loses the per-task dispatch claim parks the workflow in
 // ExecWaiting (the claim holder's agent will drive it) rather than failing the
@@ -6454,6 +6478,109 @@ func TestExecVerifyCommits_RetriesAfterTransientFailure(t *testing.T) {
 	ti, _ := tasks.GetTask("t1")
 	if ti.Status != "in-progress" {
 		t.Errorf("task status = %q, want in-progress", ti.Status)
+	}
+}
+
+func TestExecVerifyCommits_RetriesTransientBadHEAD(t *testing.T) {
+	prevSleep := verifyCommitsRetrySleep
+	prevBackoffs := verifyCommitsRetryBackoffs
+	t.Cleanup(func() {
+		verifyCommitsRetrySleep = prevSleep
+		verifyCommitsRetryBackoffs = prevBackoffs
+	})
+	verifyCommitsRetrySleep = func(time.Duration) {}
+	verifyCommitsRetryBackoffs = []time.Duration{time.Nanosecond, time.Nanosecond}
+
+	wtDir := makeGitRepo(t, true /* withExtraCommit */)
+	countFile := filepath.Join(t.TempDir(), "git-log-count")
+	withFakeGit(t, `#!/bin/sh
+if [ "$1" = "log" ]; then
+  count=0
+  if [ -f "`+countFile+`" ]; then
+    count=$(cat "`+countFile+`")
+  fi
+  count=$((count + 1))
+  printf "%s" "$count" > "`+countFile+`"
+  if [ "$count" = "1" ]; then
+    echo "fatal: bad object HEAD" >&2
+    exit 128
+  fi
+fi
+exec "{{REAL_GIT}}" "$@"
+`)
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Output, "commits verified") {
+		t.Errorf("Output = %q, want 'commits verified'", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "in-progress" {
+		t.Errorf("task status = %q, want in-progress", ti.Status)
+	}
+	if got := strings.TrimSpace(readFile(t, countFile)); got != "2" {
+		t.Errorf("git log calls = %q, want 2", got)
+	}
+}
+
+func TestExecVerifyCommits_DurableBadHEADEscalatesAfterRetries(t *testing.T) {
+	prevSleep := verifyCommitsRetrySleep
+	prevBackoffs := verifyCommitsRetryBackoffs
+	t.Cleanup(func() {
+		verifyCommitsRetrySleep = prevSleep
+		verifyCommitsRetryBackoffs = prevBackoffs
+	})
+	verifyCommitsRetrySleep = func(time.Duration) {}
+	verifyCommitsRetryBackoffs = []time.Duration{time.Nanosecond, time.Nanosecond}
+
+	wtDir := makeGitRepo(t, true /* withExtraCommit */)
+	countFile := filepath.Join(t.TempDir(), "git-log-count")
+	withFakeGit(t, `#!/bin/sh
+if [ "$1" = "log" ]; then
+  count=0
+  if [ -f "`+countFile+`" ]; then
+    count=$(cat "`+countFile+`")
+  fi
+  count=$((count + 1))
+  printf "%s" "$count" > "`+countFile+`"
+  echo "fatal: bad object HEAD" >&2
+  exit 128
+fi
+exec "{{REAL_GIT}}" "$@"
+`)
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Output, "git error") {
+		t.Errorf("Output = %q, want git error", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "bad object HEAD") {
+		t.Errorf("status reason = %q, want bad object HEAD", reason)
+	}
+	if got := strings.TrimSpace(readFile(t, countFile)); got != "3" {
+		t.Errorf("git log calls = %q, want 3", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retry verify_commits on transient bad-HEAD/missing-object style git failures
- include git stderr in verification errors so retry classification and diagnostics can see the actual failure
- add regression coverage for transient bad HEAD clearing and durable bad HEAD escalating after bounded retries

Closes #2061

## Tests
- go test ./internal/workflow -run 'TestExecVerifyCommits'
- go test ./internal/workflow
- pre-push hook: go test ./...; cd frontend && npm run check