### PR TITLE
fix(workflow): fetch missing branch objects before verify

### DIFF
--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -279,7 +279,7 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution,
 		}
 	}
 
-	output, err := e.gitLogAheadOfBaseWithRetry(taskID, wtPath)
+	output, err := e.gitLogAheadOfBaseWithRetry(taskID, wtPath, t)
 	if err != nil {
 		// Context cancellation indicates engine shutdown, not a worktree
 		// problem — leave task status alone so it resumes on next boot.
@@ -373,8 +373,11 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution,
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "commits verified"}, nil
 }
 
-func (e *Engine) gitLogAheadOfBaseWithRetry(taskID, wtPath string) ([]byte, error) {
+func (e *Engine) gitLogAheadOfBaseWithRetry(taskID, wtPath string, t TaskInfo) ([]byte, error) {
 	output, err := e.gitLogAheadOfBase(wtPath)
+	if err != nil && shouldRetryVerifyCommitsGitError(err, output) && e.recoverVerifyCommitsRefs(taskID, wtPath, t) {
+		output, err = e.gitLogAheadOfBase(wtPath)
+	}
 	for attempt := 0; err != nil && shouldRetryVerifyCommitsGitError(err, output); attempt++ {
 		if errors.Is(e.ctx.Err(), context.Canceled) || errors.Is(e.ctx.Err(), context.DeadlineExceeded) {
 			break
@@ -439,6 +442,7 @@ func shouldRetryVerifyCommitsGitError(err error, output []byte) bool {
 		"fatal: bad object",
 		"not a valid object name",
 		"invalid object",
+		"invalid revision range",
 		"missing object",
 		"unable to read sha1 file",
 		"object file",
@@ -452,6 +456,54 @@ func shouldRetryVerifyCommitsGitError(err error, output []byte) bool {
 		}
 	}
 	return false
+}
+
+func (e *Engine) recoverVerifyCommitsRefs(taskID, wtPath string, t TaskInfo) bool {
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+
+	branch := strings.TrimSpace(t.Branch)
+	if branch == "" || strings.HasPrefix(branch, "-") || strings.Contains(branch, "..") || strings.Contains(branch, " ") {
+		e.logger.Warn("workflow.verify-commits.ref-recovery.skip", "task_id", taskID, "branch", branch)
+		return false
+	}
+
+	baseRef := resolveOriginBase(ctx, wtPath)
+	refspecs := []string{"+" + "refs/heads/" + branch + ":refs/remotes/origin/" + branch}
+	if baseBranch, ok := strings.CutPrefix(baseRef, "origin/"); ok && baseBranch != "" && baseBranch != "HEAD" {
+		refspecs = append(refspecs, "+"+"refs/heads/"+baseBranch+":refs/remotes/origin/"+baseBranch)
+	}
+
+	deleteCmd := exec.CommandContext(ctx, "git", "update-ref", "-d", "refs/remotes/origin/"+branch)
+	deleteCmd.Dir = wtPath
+	_ = deleteCmd.Run()
+	if baseBranch, ok := strings.CutPrefix(baseRef, "origin/"); ok && baseBranch != "" && baseBranch != "HEAD" {
+		deleteBaseCmd := exec.CommandContext(ctx, "git", "update-ref", "-d", "refs/remotes/origin/"+baseBranch)
+		deleteBaseCmd.Dir = wtPath
+		_ = deleteBaseCmd.Run()
+	}
+
+	args := []string{"fetch", "--no-tags", "--no-recurse-submodules"}
+	if baseRef != "" && revParseRef(ctx, wtPath, baseRef) {
+		args = append(args, "--negotiation-tip="+baseRef)
+	}
+	args = append(args, "origin")
+	args = append(args, refspecs...)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = wtPath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		e.logger.Warn("workflow.verify-commits.ref-recovery.failed", "task_id", taskID, "branch", branch, "err", err, "output", strings.TrimSpace(string(out)))
+		return false
+	}
+	e.logger.Warn("workflow.verify-commits.ref-recovery.fetched", "task_id", taskID, "branch", branch, "base", baseRef)
+	return true
+}
+
+func revParseRef(ctx context.Context, wtPath, ref string) bool {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", ref)
+	cmd.Dir = wtPath
+	return cmd.Run() == nil
 }
 
 // diagnoseWorktreeState produces a short human-readable hint about why a

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6037,6 +6037,22 @@ func makeGitRepo(t *testing.T, withExtraCommit bool) string {
 	return dir
 }
 
+func runGitAt(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := gitCombinedAt(dir, args...)
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return out
+}
+
+func gitCombinedAt(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 func withFakeGit(t *testing.T, script string) {
 	t.Helper()
 	realGit, err := exec.LookPath("git")
@@ -6581,6 +6597,74 @@ exec "{{REAL_GIT}}" "$@"
 	}
 	if got := strings.TrimSpace(readFile(t, countFile)); got != "3" {
 		t.Errorf("git log calls = %q, want 3", got)
+	}
+}
+
+func TestExecVerifyCommits_FetchesMissingLocalHeadObject(t *testing.T) {
+	prevSleep := verifyCommitsRetrySleep
+	prevBackoffs := verifyCommitsRetryBackoffs
+	t.Cleanup(func() {
+		verifyCommitsRetrySleep = prevSleep
+		verifyCommitsRetryBackoffs = prevBackoffs
+	})
+	verifyCommitsRetrySleep = func(time.Duration) {}
+	verifyCommitsRetryBackoffs = []time.Duration{time.Nanosecond}
+
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	runGitAt(t, "", "init", "--bare", remote)
+
+	wtDir := t.TempDir()
+	runGitAt(t, wtDir, "init", "-b", "main")
+	runGitAt(t, wtDir, "config", "user.email", "test@test.com")
+	runGitAt(t, wtDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(wtDir, "README.md"), []byte("init\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, wtDir, "add", "README.md")
+	runGitAt(t, wtDir, "commit", "-m", "init")
+	runGitAt(t, wtDir, "remote", "add", "origin", remote)
+	runGitAt(t, wtDir, "push", "-u", "origin", "main")
+	runGitAt(t, wtDir, "checkout", "-b", "fix/missing-object")
+	if err := os.WriteFile(filepath.Join(wtDir, "change.txt"), []byte("change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, wtDir, "add", "change.txt")
+	runGitAt(t, wtDir, "commit", "-m", "feat: task work")
+	head := strings.TrimSpace(runGitAt(t, wtDir, "rev-parse", "HEAD"))
+	runGitAt(t, wtDir, "push", "-u", "origin", "HEAD:fix/missing-object")
+	runGitAt(t, wtDir, "fetch", "origin",
+		"+refs/heads/fix/missing-object:refs/remotes/origin/fix/missing-object",
+		"+refs/heads/main:refs/remotes/origin/main")
+	if got := strings.TrimSpace(runGitAt(t, wtDir, "rev-parse", "refs/remotes/origin/fix/missing-object")); got != head {
+		t.Fatalf("origin/fix/missing-object = %q, want %q", got, head)
+	}
+
+	objectPath := filepath.Join(wtDir, ".git", "objects", head[:2], head[2:])
+	if err := os.Remove(objectPath); err != nil {
+		t.Fatalf("remove local head object %s: %v", objectPath, err)
+	}
+	if out, err := gitCombinedAt(wtDir, "status", "--short", "--branch"); err == nil || !strings.Contains(out, "bad object HEAD") {
+		t.Fatalf("git status after object removal err=%v out=%q, want bad object HEAD", err, out)
+	}
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", Branch: "fix/missing-object"})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1", Branch: "fix/missing-object"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Output, "commits verified") {
+		t.Fatalf("Output = %q, reason = %q, want commits verified after fetch recovery", out.Output, tasks.Reason("t1"))
+	}
+	if got := strings.TrimSpace(runGitAt(t, wtDir, "cat-file", "-t", head)); got != "commit" {
+		t.Fatalf("recovered object type = %q, want commit", got)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Fatalf("task status = %q, want unchanged in-progress", ti.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary
- recover verify_commits bad-HEAD/missing-object failures by fetching the task branch and base ref before retrying
- delete stale remote-tracking refs before the recovery fetch so Git does not treat missing local objects as already up to date
- add a regression test where HEAD points at a commit that exists on origin but is missing locally

Fixes #2066

## Verification
- TMPDIR=/private/tmp go test ./internal/workflow
- pre-push hook: go test ./... and frontend svelte-check