### PR TITLE
fix(workflow): ignore stale completions from wrong role

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -273,6 +273,7 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	// a manual implementation agent completing during a code_review step) and
 	// must be dropped to prevent it from advancing the wrong step.
 	spawnedStep, tracked := e.lookupAgentStep(c.AgentID)
+	defs := completionDefinitionCache{engine: e, task: t}
 	if !tracked {
 		spawnedStep = t.Workflow.CurrentStep
 		if e.hasTrackedAgentForTaskStep(taskID, spawnedStep) {
@@ -280,6 +281,14 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 				"task_id", taskID, "agent_id", c.AgentID, "reason", "untracked-ignored", "current_step", spawnedStep)
 			e.clearAgentStep(c.AgentID)
 			return
+		}
+		if runRole := agentRunRole(t.AgentRuns, c.AgentID); runRole != "" {
+			if def, ok := defs.get(); ok && !untrackedCompletionMatchesCurrentStep(def, spawnedStep, runRole) {
+				e.logger.Info("workflow.agent-complete.bail",
+					"task_id", taskID, "agent_id", c.AgentID, "reason", "untracked-role-mismatch", "current_step", spawnedStep)
+				e.clearAgentStep(c.AgentID)
+				return
+			}
 		}
 	}
 
@@ -289,7 +298,12 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	}
 
 	if c.Success {
-		e.importSidecarIfConfigured(taskID, spawnedStep, t)
+		if def, ok := defs.get(); ok {
+			e.importSidecarIfConfiguredFromDef(taskID, spawnedStep, t, def)
+		} else {
+			e.logger.Info("workflow.agent-complete.bail",
+				"task_id", taskID, "agent_id", c.AgentID, "reason", "workflow-definition-unavailable", "current_step", spawnedStep)
+		}
 	}
 
 	if e.recorder != nil {
@@ -379,6 +393,50 @@ func (e *Engine) hasTrackedAgentForTaskStep(taskID, stepID string) bool {
 
 func pendingStepStartKey(taskID, stepID string) string {
 	return taskID + "|" + stepID
+}
+
+type completionDefinitionCache struct {
+	engine *Engine
+	task   TaskInfo
+	def    *Definition
+}
+
+func (c *completionDefinitionCache) get() (*Definition, bool) {
+	if c.def != nil {
+		return c.def, true
+	}
+	if c.task.Workflow == nil || c.task.Workflow.WorkflowID == "" {
+		return nil, false
+	}
+	def, err := c.engine.store.Get(c.task.Workflow.WorkflowID)
+	if err != nil {
+		return nil, false
+	}
+	c.def = &def
+	return c.def, true
+}
+
+func agentRunRole(runs []AgentRunInfo, agentID string) string {
+	if agentID == "" {
+		return ""
+	}
+	for i := range slices.Backward(runs) {
+		if runs[i].AgentID == agentID {
+			return runs[i].Role
+		}
+	}
+	return ""
+}
+
+func untrackedCompletionMatchesCurrentStep(def *Definition, stepID, runRole string) bool {
+	if def == nil || stepID == "" || runRole == "" {
+		return true
+	}
+	step := def.StepByID(stepID)
+	if step == nil || step.Type != StepRunAgent || step.Config.Role == "" {
+		return true
+	}
+	return step.Config.Role == runRole
 }
 
 // markStepStarting records that a run_agent step's agent-start sequence

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -32,6 +32,13 @@ func (e *Engine) importSidecarIfConfigured(taskID, stepID string, info TaskInfo)
 	if err != nil {
 		return
 	}
+	e.importSidecarIfConfiguredFromDef(taskID, stepID, info, &def)
+}
+
+func (e *Engine) importSidecarIfConfiguredFromDef(taskID, stepID string, info TaskInfo, def *Definition) {
+	if info.Workflow == nil || def == nil {
+		return
+	}
 	step := def.StepByID(stepID)
 	if step == nil || step.Type != StepRunAgent {
 		return

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4271,6 +4271,43 @@ func TestHandleAgentComplete_PendingStepStartDropsStaleCompletion(t *testing.T) 
 	}
 }
 
+func TestHandleAgentComplete_UntrackedRoleMismatchDoesNotAdvanceCurrentStep(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+		AgentRuns: []AgentRunInfo{
+			{AgentID: "plan-agent", Role: "plan"},
+		},
+	})
+
+	engine.HandleAgentComplete("t1", AgentCompletion{
+		AgentID: "plan-agent",
+		Result:  "late plan completion",
+		Success: true,
+	})
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow.CurrentStep != "implement" {
+		t.Fatalf("CurrentStep = %q, want implement — plan completion must not satisfy implementation step",
+			ti.Workflow.CurrentStep)
+	}
+	if len(ti.Workflow.StepHistory) != 0 {
+		t.Fatalf("StepHistory = %+v, want no recorded implementation completion", ti.Workflow.StepHistory)
+	}
+}
+
 func TestPendingStepStartRefcountKeepsWinnerClaimed(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Summary
- prevent untracked late agent completions from being credited to the current workflow step when the recorded agent role does not match the step role
- add a regression test for a late plan-agent completion trying to satisfy an implementation step

## Root cause
Task 01db7167 hit a stale-completion race: the implementation workflow parked after a dispatch-in-flight path, then a late completion from the previous plan/address-critique agent was untracked and got attributed to the current implement step. That made Sybra verify/close/clean the task as if implementation had completed. The later recovery implementation agent produced a real PR, but because the workflow had already been corrupted, the board showed it as lost/in-progress until manual repair.

## Tests
- GOCACHE=/Users/marcin.skalski/orca/workspaces/synapse/analyze-token-usage/.tmp-go-cache GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/Users/marcin.skalski/orca/workspaces/synapse/analyze-token-usage/.tmp-empty-gitconfig go test ./internal/workflow -run 'TestHandleAgentComplete_UntrackedRoleMismatchDoesNotAdvanceCurrentStep|TestHandleAgentComplete_PendingStepStartDropsStaleCompletion|TestExecRunAgent_DispatchInFlightWaits'
- GOCACHE=/Users/marcin.skalski/orca/workspaces/synapse/analyze-token-usage/.tmp-go-cache GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/Users/marcin.skalski/orca/workspaces/synapse/analyze-token-usage/.tmp-empty-gitconfig go test ./internal/workflow
- pre-push hook: go test ./... and frontend svelte-check