### PR TITLE
fix(review): handle comments on draft PRs

### DIFF
--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -117,8 +117,9 @@ func MatchTaskPRs(prs []PullRequest, tasks []TaskMatcher) []PRIssue {
 		// reviewer had the last word. GitHub's reviewDecision can remain
 		// CHANGES_REQUESTED after every thread was answered or resolved, and the
 		// fix-review skill has no live thread left to process in that state.
-		// Skip drafts: the author is still iterating.
-		if !pr.IsDraft && pr.ActionableCount > 0 {
+		// Draft PRs still get review feedback from Copilot/humans; fix those
+		// comments before the author marks the PR ready.
+		if pr.ActionableCount > 0 {
 			issues = append(issues, PRIssue{Kind: PRIssueComments, TaskID: tm.ID, PR: *pr})
 		}
 		if !pr.IsDraft && !pr.HasPendingChecks && pr.Mergeable == "MERGEABLE" && (pr.CIStatus == "SUCCESS" || pr.CIStatus == "") {

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -140,10 +140,10 @@ func TestMatchTaskPRs(t *testing.T) {
 			want:  nil,
 		},
 		{
-			name:  "draft with comments is not fixed",
-			prs:   []PullRequest{{Number: 42, IsDraft: true, ReviewDecision: "CHANGES_REQUESTED", UnresolvedCount: 3}},
+			name:  "draft with comments is fixed",
+			prs:   []PullRequest{{Number: 42, IsDraft: true, ReviewDecision: "CHANGES_REQUESTED", UnresolvedCount: 3, ActionableCount: 1}},
 			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
-			want:  nil,
+			want:  []PRIssue{{Kind: PRIssueComments, TaskID: "t1"}},
 		},
 		{
 			name:  "CI failure and comments both trigger",

--- a/internal/sybra/review/pr_phase.go
+++ b/internal/sybra/review/pr_phase.go
@@ -52,19 +52,18 @@ func computePRPhase(s prSignals) string {
 		return PRPhaseFixing
 	case s.Mergeable == "CONFLICTING":
 		return PRPhaseFixing
-	// Still a draft (and not actively being fixed for CI/conflict): the human
-	// must mark it ready. This outranks the comment check because the monitor
-	// skips comment-fix dispatch on drafts (MatchTaskPRs gates on !IsDraft), so
-	// a draft with comments would otherwise imply a fix that never runs and
-	// hide the "mark ready" action.
-	case s.IsDraft:
-		return PRPhaseDraft
-	// Reviewers asked for changes (or left actionable threads — a reviewer had
-	// the last word): a fix-review agent is dispatched to address them. Threads
-	// the agent already replied to are unresolved but not actionable, so they
-	// surface as awaiting-approval (waiting on the reviewer), not changes.
+	// Actionable threads — a reviewer had the last word — dispatch a
+	// fix-review agent. ReviewDecision can stay CHANGES_REQUESTED after every
+	// thread was answered, so it only keeps the phase in "needs attention".
+	// Threads the agent already replied to are unresolved but not actionable,
+	// so they surface as awaiting-approval (waiting on the reviewer), not
+	// changes.
 	case s.ReviewDecision == "CHANGES_REQUESTED" || s.ActionableCount > 0:
 		return PRPhaseChangesRequested
+	// Still a draft (and not actively being fixed for CI/conflict/comments):
+	// the human must mark it ready.
+	case s.IsDraft:
+		return PRPhaseDraft
 	// CI is still running — wait it out.
 	case s.CIStatus == "PENDING" || s.HasPendingChecks:
 		return PRPhaseBuilding

--- a/internal/sybra/review/pr_phase_test.go
+++ b/internal/sybra/review/pr_phase_test.go
@@ -44,9 +44,9 @@ func TestComputePRPhase(t *testing.T) {
 			want: PRPhaseAwaitingApproval,
 		},
 		{
-			name: "draft with comments stays draft (comment-fix is skipped on drafts)",
+			name: "draft with comments → changes-requested",
 			sig:  prSignals{IsDraft: true, UnresolvedCount: 1, ActionableCount: 1},
-			want: PRPhaseDraft,
+			want: PRPhaseChangesRequested,
 		},
 		{
 			name: "draft with CI failure still shows fixing (CI-fix runs on drafts)",


### PR DESCRIPTION
## Summary
- dispatch PR comment-fix issues for actionable review threads even when the PR is still draft
- keep draft PRs blocked from ready-to-merge, but show draft PRs with actionable comments as changes-requested/fixing work
- update matcher and PR phase tests for the new behavior

## Verification
- GOCACHE=$PWD/.tmp-go-cache go test ./internal/github -run TestMatchTaskPRs
- GOCACHE=$PWD/.tmp-go-cache go test ./internal/sybra/review -run TestComputePRPhase
- GOCACHE=$PWD/.tmp-go-cache go test ./internal/github
- GOCACHE=$PWD/.tmp-go-cache go test ./internal/sybra/review
- pre-push hook: go test ./... and frontend svelte-check