### PR TITLE
fix(workflow): isolate verify commits ref recovery

### DIFF
--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -469,6 +469,10 @@ func (e *Engine) recoverVerifyCommitsRefs(taskID, wtPath string, t TaskInfo) boo
 	}
 
 	baseRef := resolveOriginBase(ctx, wtPath)
+	negotiationTips := verifyCommitsNegotiationTips(ctx, wtPath, baseRef)
+	for _, ref := range pruneBrokenVerifyCommitRefs(ctx, wtPath, branch) {
+		e.logger.Warn("workflow.verify-commits.ref-recovery.pruned-broken-ref", "task_id", taskID, "ref", ref)
+	}
 	refspecs := []string{"+" + "refs/heads/" + branch + ":refs/remotes/origin/" + branch}
 	if baseBranch, ok := strings.CutPrefix(baseRef, "origin/"); ok && baseBranch != "" && baseBranch != "HEAD" {
 		refspecs = append(refspecs, "+"+"refs/heads/"+baseBranch+":refs/remotes/origin/"+baseBranch)
@@ -484,8 +488,8 @@ func (e *Engine) recoverVerifyCommitsRefs(taskID, wtPath string, t TaskInfo) boo
 	}
 
 	args := []string{"fetch", "--no-tags", "--no-recurse-submodules"}
-	if baseRef != "" && revParseRef(ctx, wtPath, baseRef) {
-		args = append(args, "--negotiation-tip="+baseRef)
+	for _, tip := range negotiationTips {
+		args = append(args, "--negotiation-tip="+tip)
 	}
 	args = append(args, "origin")
 	args = append(args, refspecs...)
@@ -500,10 +504,53 @@ func (e *Engine) recoverVerifyCommitsRefs(taskID, wtPath string, t TaskInfo) boo
 	return true
 }
 
-func revParseRef(ctx context.Context, wtPath, ref string) bool {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", ref)
+func verifyCommitsNegotiationTips(ctx context.Context, wtPath, baseRef string) []string {
+	if baseRef == "" {
+		return nil
+	}
+	if sha := revParseCommit(ctx, wtPath, baseRef); sha != "" {
+		return []string{sha}
+	}
+	return nil
+}
+
+func pruneBrokenVerifyCommitRefs(ctx context.Context, wtPath, taskBranch string) []string {
+	cmd := exec.CommandContext(ctx, "git", "for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes/origin")
 	cmd.Dir = wtPath
-	return cmd.Run() == nil
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	keepLocalBranch := "refs/heads/" + taskBranch
+	var pruned []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		ref := strings.TrimSpace(line)
+		if ref == "" || ref == keepLocalBranch {
+			continue
+		}
+		check := exec.CommandContext(ctx, "git", "cat-file", "-e", ref+"^{object}")
+		check.Dir = wtPath
+		if check.Run() == nil {
+			continue
+		}
+		deleteCmd := exec.CommandContext(ctx, "git", "update-ref", "-d", ref)
+		deleteCmd.Dir = wtPath
+		if deleteCmd.Run() == nil {
+			pruned = append(pruned, ref)
+		}
+	}
+	return pruned
+}
+
+func revParseCommit(ctx context.Context, wtPath, ref string) string {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", ref+"^{commit}")
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // diagnoseWorktreeState produces a short human-readable hint about why a

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6676,6 +6676,14 @@ func TestExecVerifyCommits_FetchesMissingLocalHeadObject(t *testing.T) {
 		t.Fatalf("origin/fix/missing-object = %q, want %q", got, head)
 	}
 
+	badSiblingRef := filepath.Join(wtDir, ".git", "refs", "heads", "feat", "bad-sibling")
+	if err := os.MkdirAll(filepath.Dir(badSiblingRef), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(badSiblingRef, []byte(strings.Repeat("f", 40)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	objectPath := filepath.Join(wtDir, ".git", "objects", head[:2], head[2:])
 	if err := os.Remove(objectPath); err != nil {
 		t.Fatalf("remove local head object %s: %v", objectPath, err)
@@ -6699,6 +6707,9 @@ func TestExecVerifyCommits_FetchesMissingLocalHeadObject(t *testing.T) {
 	}
 	if got := strings.TrimSpace(runGitAt(t, wtDir, "cat-file", "-t", head)); got != "commit" {
 		t.Fatalf("recovered object type = %q, want commit", got)
+	}
+	if _, err := os.Stat(badSiblingRef); !os.IsNotExist(err) {
+		t.Fatalf("broken sibling ref still exists after recovery: stat err=%v", err)
 	}
 	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
 		t.Fatalf("task status = %q, want unchanged in-progress", ti.Status)


### PR DESCRIPTION
## Summary
- diagnose human-required tasks 6846cb47, 2a220813, and 02909563 as the same verify_commits git-store failure
- preserve a valid base SHA as the fetch negotiation tip before deleting stale refs
- prune broken sibling refs during verify_commits recovery so one corrupt task branch cannot poison unrelated task fetches

## Why
The affected tasks all failed at verify_commits with origin/main..HEAD being unresolved. Logs showed recovery fetch failing on a broken local ref for task 02909563 while verifying other branches, so a corrupt sibling ref in the shared clone could strand unrelated tasks in human-required.

## Tests
- go test ./internal/workflow -run TestExecVerifyCommits_FetchesMissingLocalHeadObject
- go test ./internal/workflow
- push hook: go test ./... and frontend svelte-check