### PR TITLE
fix(review): close merged PRs despite stale agents

### DIFF
--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -770,7 +770,9 @@ func (r *Handler) evictReadyPRCache(repo string, number int) {
 
 // advanceClosedTaskPRs moves tasks whose linked PR is no longer open to done,
 // stamping the terminal outcome and emitting the audit + task.landed events the
-// evaluation scorecard reads. Skips tasks with a still-running agent.
+// evaluation scorecard reads. If an agent is still running for a task whose PR
+// already landed, the terminal GitHub state wins: stop the agent first, then
+// close the task.
 func (r *Handler) advanceClosedTaskPRs(ctx context.Context, monitoredPRs []github.PullRequest, closedMatchers []github.TaskMatcher) {
 	fetchFn := github.FetchPRState
 	if r.fetchPRStateFn != nil {
@@ -783,8 +785,8 @@ func (r *Handler) advanceClosedTaskPRsWithFetch(ctx context.Context, monitoredPR
 	closedPRs := github.DetectClosedTaskPRs(monitoredPRs, closedMatchers, fetchFn)
 	for _, c := range closedPRs {
 		if r.agents.HasRunningAgentForTask(c.TaskID) {
-			r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
-			continue
+			r.logger.Info("pr-monitor.closed-stop-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
+			r.agents.KillAgentsForTask(c.TaskID, 10*time.Second)
 		}
 		// Flip to done immediately with the base outcome — the status transition
 		// must never wait on GitHub enrichment.

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -2189,6 +2189,60 @@ func TestAdvanceClosedTaskPRs_CancelsStaleWorkflow(t *testing.T) {
 	}
 }
 
+func TestAdvanceClosedTaskPRs_ClosesDespiteRunningAgentClaim(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+
+	created, err := tasks.Create("Task with merged PR and stale agent", "", string(task.AgentModeInteractive))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(1445),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	claim, ok := agentMgr.TryClaimDispatch(created.ID)
+	if !ok {
+		t.Fatal("claim dispatch")
+	}
+	defer claim.Release()
+	if !agentMgr.HasRunningAgentForTask(created.ID) {
+		t.Fatal("test setup: task should read as running")
+	}
+
+	r := &Handler{
+		logger: logger, emit: func(string, any) {},
+		tasks:     tasks,
+		agents:    agentMgr,
+		prTracker: github.NewIssueTracker(time.Minute),
+	}
+
+	r.advanceClosedTaskPRsWithFetch(
+		context.Background(),
+		nil,
+		[]github.TaskMatcher{{ID: created.ID, PRNumber: 1445, ProjectID: "o/r"}},
+		func(string, int) (github.PRState, error) { return github.PRState{State: "MERGED"}, nil },
+	)
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusDone || got.Outcome != "merged" {
+		t.Fatalf("status/outcome = %q/%q, want done/merged", got.Status, got.Outcome)
+	}
+}
+
 func TestAdvanceClosedTaskPRs_ClosedUnmergedCancelsNotDone(t *testing.T) {
 	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
 	if err != nil {


### PR DESCRIPTION
## Summary
- stop stale/running task agents when a linked PR is already terminal instead of skipping closure
- let the PR monitor mark merged PR tasks done immediately after stopping the agent
- add regression coverage for a merged PR whose task still reads as running

## Why
Task 01db7167 had PR #17423 merged, but every review poll logged pr-monitor.closed-skip-running-agent because a reattached Claude process was still considered running. The task stayed in-review indefinitely even though GitHub was terminal.

## Tests
- go test ./internal/sybra/review -run 'TestAdvanceClosedTaskPRs_(ClosesDespiteRunningAgentClaim|CancelsStaleWorkflow|ClosedUnmergedCancelsNotDone)'
- go test ./internal/sybra/review
- push hook: go test ./... and frontend svelte-check