### PR TITLE
fix(workflow): dispatch front-of-pipeline status retries

### DIFF
--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -223,6 +223,60 @@ func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 	}
 }
 
+func TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates(t *testing.T) {
+	for _, target := range []task.Status{task.StatusTodo, task.StatusPlanning} {
+		t.Run(string(target), func(t *testing.T) {
+			taskSvc, app := setupTaskService(t)
+			app.workflowEngine = taskSvc.workflowEngine
+			app.initStatusHook()
+
+			tk := task.Task{
+				ID:        "external-retry-" + string(target),
+				Title:     "external retry " + string(target),
+				Status:    task.StatusHumanRequired,
+				AgentMode: task.AgentModeHeadless,
+				Workflow: &workflow.Execution{
+					WorkflowID:  "simple-task-plan",
+					CurrentStep: "triage",
+					State:       workflow.ExecFailed,
+					Variables:   map[string]string{},
+				},
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			}
+			path := filepath.Join(app.tasksDir, tk.ID+".md")
+			write := func(in task.Task) {
+				t.Helper()
+				data, err := task.Marshal(in)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := fsutil.AtomicWrite(path, data); err != nil {
+					t.Fatal(err)
+				}
+				app.tasks.OnExternalUpdate(path)
+			}
+
+			write(tk)
+			tk.Status = target
+			tk.UpdatedAt = time.Now().UTC()
+			write(tk)
+			app.wg.Wait()
+
+			got, err := app.tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.Workflow == nil || got.Workflow.WorkflowID != "simple-task-plan" {
+				t.Fatalf("external %s update did not restart task.created workflow, got %+v", target, got.Workflow)
+			}
+			if got.Workflow.State == workflow.ExecFailed {
+				t.Fatalf("external %s update kept stale failed workflow: %+v", target, got.Workflow)
+			}
+		})
+	}
+}
+
 func TestApp_MaybeStartWorkflowForExternalTask_RemoteMirrorDoesNotReroute(t *testing.T) {
 	fixture := setupRemoteMirrorFixture(t)
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -600,6 +600,10 @@ func (a *App) initStatusHook() {
 		}
 
 		switch to {
+		case string(task.StatusTodo), string(task.StatusPlanning):
+			a.dispatchTaskCreatedWorkflow(taskID)
+		case string(task.StatusInProgress):
+			a.dispatchStatusWorkflow(taskID, task.StatusInProgress)
 		case string(task.StatusInReview):
 			msg := taskID
 			if t, err := a.tasks.Get(taskID); err == nil {
@@ -813,38 +817,28 @@ func expectedHumanKind(t task.Task) string {
 	}
 }
 
-// maybeStartWorkflowForExternalTask starts the matching task.created workflow
-// for a task that appeared on disk outside the GUI CreateTask path — most
-// importantly via sybra-cli, the documented primary task interface. Without
-// this, CLI-created tasks never get a workflow and sit inert in todo: the
-// orchestrator can triage them but no implementation ever starts. Mirrors
-// TaskService.startCreatedWorkflow. Idempotent: DispatchEvent serializes per
-// task and rejects a task that already owns a non-terminal workflow, so the
-// watcher firing TaskCreated several times for one file is harmless.
-func (a *App) maybeStartWorkflowForExternalTask(path string) {
+// dispatchTaskCreatedWorkflow starts the matching task.created workflow for a
+// task that is ready to enter or re-enter the front of the pipeline. This is
+// used both for files created outside the GUI and for status updates that put a
+// parked task back in todo/planning. Mirrors TaskService.startCreatedWorkflow.
+// Idempotent: DispatchEvent serializes per task and rejects a task that already
+// owns a non-terminal workflow, so duplicate watcher/status events are harmless.
+func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
 		return
 	}
-	base := filepath.Base(path)
-	// Sidecar files (plan/critique/review) share the tasks dir and also fire
-	// TaskCreated; they are not tasks, so skip them up front rather than
-	// spending a goroutine + Get that would fail anyway.
-	if task.IsSidecarFile(base) {
-		return
-	}
-	id := strings.TrimSuffix(base, ".md")
-	if id == "" {
+	if taskID == "" {
 		return
 	}
 	a.wg.Go(func() {
-		t, err := a.tasks.Get(id)
+		t, err := a.tasks.Get(taskID)
 		if err != nil {
 			return
 		}
-		// Only fresh, pre-implementation tasks. simple-task-plan's trigger has
-		// no status condition, so without this guard a task.created dispatch
-		// could restart planning on an in-review/done task.
-		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
+		// Only front-of-pipeline tasks. simple-task-plan's trigger has no status
+		// condition, so without this guard a task.created dispatch could restart
+		// planning on an in-review/done task.
+		if t.Status != task.StatusNew && t.Status != task.StatusTodo && t.Status != task.StatusPlanning {
 			return
 		}
 		if !a.runsTaskLocally(t) {
@@ -856,7 +850,7 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 			}
 			if a.assigner != nil {
 				if _, err := a.assigner.Route(a.ctx, t); err != nil {
-					a.logger.Warn("cluster.assign.failed", "task_id", id, "err", err)
+					a.logger.Warn("cluster.assign.failed", "task_id", taskID, "err", err)
 				}
 			}
 			return
@@ -873,14 +867,37 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 			t.Workflow.State != workflow.ExecFailed {
 			return
 		}
-		if a.agents.HasRunningAgentForTask(id) {
+		if a.agents.HasRunningAgentForTask(taskID) {
 			return
 		}
-		if _, err := a.workflowEngine.DispatchEvent(id, "task.created", nil, nil); err != nil &&
+		if _, err := a.workflowEngine.DispatchEvent(taskID, "task.created", nil, nil); err != nil &&
 			!errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
-			a.logger.Error("workflow.external-create.failed", "task_id", id, "err", err)
+			a.logger.Error("workflow.task-created.failed", "task_id", taskID, "err", err)
 		}
 	})
+}
+
+// maybeStartWorkflowForExternalTask starts the matching task.created workflow
+// for a task that appeared on disk outside the GUI CreateTask path — most
+// importantly via sybra-cli, the documented primary task interface. Without
+// this, CLI-created tasks never get a workflow and sit inert in todo: the
+// orchestrator can triage them but no implementation ever starts.
+func (a *App) maybeStartWorkflowForExternalTask(path string) {
+	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
+		return
+	}
+	base := filepath.Base(path)
+	// Sidecar files (plan/critique/review) share the tasks dir and also fire
+	// TaskCreated; they are not tasks, so skip them up front rather than
+	// spending a goroutine + Get that would fail anyway.
+	if task.IsSidecarFile(base) {
+		return
+	}
+	id := strings.TrimSuffix(base, ".md")
+	if id == "" {
+		return
+	}
+	a.dispatchTaskCreatedWorkflow(id)
 }
 
 func (a *App) initAudit() {


### PR DESCRIPTION
## Summary
- dispatch task.created workflows when external/manual status updates put a task back in todo or planning
- dispatch in-progress status changes through the status hook as well
- share the task.created dispatch helper between file-created and status-retry paths

## Tests
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestApp_(MaybeStartWorkflowForExternalTask|StatusHookRestartsTodoAndPlanningExternalUpdates)|TestDispatchFromHumanRequired_WithStatusHook'
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra
- pre-push hook: go test ./... and frontend svelte-check