### PR TITLE
fix(workflow): skip gated tasks during board reconcile

### DIFF
--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -136,6 +136,9 @@ func (a *App) reconcileRunnableBoardTasks() {
 		}
 		switch t.Status {
 		case task.StatusNew, task.StatusTodo, task.StatusPlanning:
+			if skipTaskCreatedWorkflow(t) {
+				continue
+			}
 			a.dispatchTaskCreatedWorkflow(t.ID)
 		case task.StatusInProgress, task.StatusReadyReview, task.StatusTesting, task.StatusReadyPR:
 			a.dispatchStatusWorkflow(t.ID, t.Status)

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
@@ -334,6 +335,12 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	todo := idle("idle-todo", task.StatusTodo)
 	planning := idle("idle-planning", task.StatusPlanning)
 	inProgress := idle("idle-in-progress", task.StatusInProgress)
+	gatedTodo := idle("gated-todo", task.StatusTodo)
+	if _, err := a.tasks.UpdateMap(gatedTodo.ID, map[string]any{
+		"tags": []string{umbrella.GatedTag},
+	}); err != nil {
+		t.Fatal(err)
+	}
 	umbrellaTask := idle("synthetic-umbrella", task.StatusInProgress)
 	if _, err := a.tasks.UpdateMap(umbrellaTask.ID, map[string]any{
 		"task_type": string(task.TaskTypeUmbrella),
@@ -385,6 +392,13 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	}
 	if gotActive.Workflow == nil || gotActive.Workflow.WorkflowID != "simple-task-plan" || gotActive.Workflow.State != workflow.ExecWaiting {
 		t.Fatalf("active workflow should be left alone, got %+v", gotActive.Workflow)
+	}
+	gotGated, err := a.tasks.Get(gatedTodo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotGated.Workflow != nil {
+		t.Fatalf("umbrella-gated todo task should be left for releaseUnblockedChildren, got %+v", gotGated.Workflow)
 	}
 	gotUmbrella, err := a.tasks.Get(umbrellaTask.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- make the periodic runnable-board reconciler reuse the task-created skip guard for new/todo/planning tasks
- add regression coverage that umbrella-gated todo children stay parked for releaseUnblockedChildren instead of being flat-dispatched

## Verification
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses|TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates'
- pre-push: go test ./...
- pre-push: cd frontend && npm run check