### PR TITLE
fix(workflow): reconcile requeued terminal workflows

### DIFF
--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -131,7 +131,7 @@ func (a *App) reconcileRunnableBoardTasks() {
 		if a.agents.HasRunningAgentForTask(t.ID) {
 			continue
 		}
-		if t.Workflow != nil {
+		if boardReconcileWorkflowActive(t) {
 			continue
 		}
 		switch t.Status {
@@ -144,6 +144,20 @@ func (a *App) reconcileRunnableBoardTasks() {
 			a.dispatchStatusWorkflow(t.ID, t.Status)
 		default:
 		}
+	}
+}
+
+func boardReconcileWorkflowActive(t task.Task) bool {
+	if t.Workflow == nil {
+		return false
+	}
+	switch t.Workflow.State {
+	case workflow.ExecCompleted, workflow.ExecFailed:
+		return t.Workflow.CompletedAt == nil ||
+			t.StatusChangedAt.IsZero() ||
+			!t.StatusChangedAt.After(*t.Workflow.CompletedAt)
+	default:
+		return true
 	}
 }
 

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
@@ -335,6 +336,34 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	todo := idle("idle-todo", task.StatusTodo)
 	planning := idle("idle-planning", task.StatusPlanning)
 	inProgress := idle("idle-in-progress", task.StatusInProgress)
+	requeuedPlanning := idle("requeued-planning", task.StatusPlanning)
+	requeuedCompletedAt := requeuedPlanning.StatusChangedAt.Add(-time.Hour)
+	requeuedPlanning, err := a.tasks.UpdateMap(requeuedPlanning.ID, map[string]any{
+		"workflow": &workflow.Execution{
+			WorkflowID:  "old-workflow",
+			CurrentStep: "",
+			State:       workflow.ExecCompleted,
+			CompletedAt: &requeuedCompletedAt,
+			Variables:   map[string]string{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentTerminal := idle("current-terminal", task.StatusTodo)
+	currentCompletedAt := currentTerminal.StatusChangedAt.Add(time.Hour)
+	currentTerminal, err = a.tasks.UpdateMap(currentTerminal.ID, map[string]any{
+		"workflow": &workflow.Execution{
+			WorkflowID:  "old-workflow",
+			CurrentStep: "",
+			State:       workflow.ExecCompleted,
+			CompletedAt: &currentCompletedAt,
+			Variables:   map[string]string{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	gatedTodo := idle("gated-todo", task.StatusTodo)
 	if _, err := a.tasks.UpdateMap(gatedTodo.ID, map[string]any{
 		"tags": []string{umbrella.GatedTag},
@@ -384,6 +413,7 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	}
 	assertWorkflow(todo.ID, "simple-task-plan")
 	assertWorkflow(planning.ID, "simple-task-plan")
+	assertWorkflow(requeuedPlanning.ID, "simple-task-plan")
 	assertWorkflow(inProgress.ID, "simple-task-implement")
 
 	gotActive, err := a.tasks.Get(active.ID)
@@ -400,6 +430,13 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	if gotGated.Workflow != nil {
 		t.Fatalf("umbrella-gated todo task should be left for releaseUnblockedChildren, got %+v", gotGated.Workflow)
 	}
+	gotCurrentTerminal, err := a.tasks.Get(currentTerminal.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotCurrentTerminal.Workflow == nil || gotCurrentTerminal.Workflow.WorkflowID != "old-workflow" || gotCurrentTerminal.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("current terminal workflow should be left alone, got %+v", gotCurrentTerminal.Workflow)
+	}
 	gotUmbrella, err := a.tasks.Get(umbrellaTask.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -408,7 +445,7 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 		t.Fatalf("synthetic umbrella task should be left alone, got %+v", gotUmbrella.Workflow)
 	}
 	if launcher.startCalls != 1 {
-		t.Fatalf("startCalls = %d, want 1 for stale in-progress only", launcher.startCalls)
+		t.Fatalf("startCalls = %d, want 1 for idle in-progress only", launcher.startCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- let the board reconciler restart runnable tasks whose current status was changed after their previous workflow reached a terminal state
- keep terminal workflows parked when they are still current
- preserve the umbrella-gated skip guard from the previous fix

## Verification
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses|TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates'
- pre-push: go test ./...
- pre-push: cd frontend && npm run check