### PR TITLE
fix(workflow): recover planning cards via plan workflow

### DIFF
--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -135,15 +135,43 @@ func (a *App) reconcileRunnableBoardTasks() {
 			continue
 		}
 		switch t.Status {
-		case task.StatusNew, task.StatusTodo, task.StatusPlanning:
+		case task.StatusNew, task.StatusTodo:
 			if skipTaskCreatedWorkflow(t) {
 				continue
 			}
 			a.dispatchTaskCreatedWorkflow(t.ID)
+		case task.StatusPlanning:
+			a.dispatchPlanningWorkflow(t.ID)
 		case task.StatusInProgress, task.StatusReadyReview, task.StatusTesting, task.StatusReadyPR:
 			a.dispatchStatusWorkflow(t.ID, t.Status)
 		default:
 		}
+	}
+}
+
+func (a *App) dispatchPlanningWorkflow(taskID string) {
+	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
+		return
+	}
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return
+	}
+	if t.Status != task.StatusPlanning {
+		return
+	}
+	if !a.runsTaskLocally(t) {
+		return
+	}
+	if skipTaskCreatedWorkflow(t) {
+		return
+	}
+	if boardReconcileWorkflowActive(t) || a.agents.HasRunningAgentForTask(taskID) {
+		return
+	}
+	if err := a.workflowEngine.StartWorkflow(taskID, "simple-task-plan"); err != nil &&
+		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+		a.logger.Error("workflow.dispatch.planning", "task_id", taskID, "err", err)
 	}
 }
 

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -339,6 +339,7 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	requeuedPlanning := idle("requeued-planning", task.StatusPlanning)
 	requeuedCompletedAt := requeuedPlanning.StatusChangedAt.Add(-time.Hour)
 	requeuedPlanning, err := a.tasks.UpdateMap(requeuedPlanning.ID, map[string]any{
+		"tags": []string{"backend", "review"},
 		"workflow": &workflow.Execution{
 			WorkflowID:  "old-workflow",
 			CurrentStep: "",
@@ -367,6 +368,13 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	gatedTodo := idle("gated-todo", task.StatusTodo)
 	if _, err := a.tasks.UpdateMap(gatedTodo.ID, map[string]any{
 		"tags": []string{umbrella.GatedTag},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prPlanning := idle("pr-planning", task.StatusPlanning)
+	if _, err := a.tasks.UpdateMap(prPlanning.ID, map[string]any{
+		"pr_number": 123,
+		"tags":      []string{"backend", "review"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -429,6 +437,13 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	}
 	if gotGated.Workflow != nil {
 		t.Fatalf("umbrella-gated todo task should be left for releaseUnblockedChildren, got %+v", gotGated.Workflow)
+	}
+	gotPRPlanning, err := a.tasks.Get(prPlanning.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPRPlanning.Workflow != nil {
+		t.Fatalf("planning task with PR should not start simple-task-plan, got %+v", gotPRPlanning.Workflow)
 	}
 	gotCurrentTerminal, err := a.tasks.Get(currentTerminal.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- recover idle planning cards by starting simple-task-plan directly instead of replaying broad task.created triggers
- add regression coverage for a requeued planning card with a review tag so it cannot be misrouted into pr-review / PR #0

## Test
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses|TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates'
- pre-push: go test ./... and frontend svelte-check