### PR TITLE
fix(workflow): route planning status hook to plan workflow

### DIFF
--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -244,6 +244,9 @@ func TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates(t *testing.T) {
 				CreatedAt: time.Now().UTC(),
 				UpdatedAt: time.Now().UTC(),
 			}
+			if target == task.StatusPlanning {
+				tk.Tags = []string{"backend", "review"}
+			}
 			path := filepath.Join(app.tasksDir, tk.ID+".md")
 			write := func(in task.Task) {
 				t.Helper()

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -600,8 +600,10 @@ func (a *App) initStatusHook() {
 		}
 
 		switch to {
-		case string(task.StatusTodo), string(task.StatusPlanning):
+		case string(task.StatusTodo):
 			a.dispatchTaskCreatedWorkflow(taskID)
+		case string(task.StatusPlanning):
+			a.dispatchPlanningWorkflow(taskID)
 		case string(task.StatusInProgress):
 			a.dispatchStatusWorkflow(taskID, task.StatusInProgress)
 		case string(task.StatusInReview):

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -166,7 +166,10 @@ func (a *App) dispatchPlanningWorkflow(taskID string) {
 	if skipTaskCreatedWorkflow(t) {
 		return
 	}
-	if boardReconcileWorkflowActive(t) || a.agents.HasRunningAgentForTask(taskID) {
+	if t.Workflow != nil && t.Workflow.State != workflow.ExecCompleted && t.Workflow.State != workflow.ExecFailed {
+		return
+	}
+	if a.agents.HasRunningAgentForTask(taskID) {
 		return
 	}
 	if err := a.workflowEngine.StartWorkflow(taskID, "simple-task-plan"); err != nil &&


### PR DESCRIPTION
## Summary
- route status changes to planning through the direct simple-task-plan recovery path instead of broad task.created matching
- allow explicit planning requeues to replace terminal failed workflows even when older executions lack completed_at
- extend the external update regression with a review-tagged planning task

## Test
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses|TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates'
- pre-push: go test ./... and frontend svelte-check