### PR TITLE
fix(workflow): recover downstream stages after terminal workflows

### DIFF
--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -244,6 +244,9 @@ func TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates(t *testing.T) {
 				CreatedAt: time.Now().UTC(),
 				UpdatedAt: time.Now().UTC(),
 			}
+			if target == task.StatusPlanning {
+				tk.Tags = []string{"backend", "review"}
+			}
 			path := filepath.Join(app.tasksDir, tk.ID+".md")
 			write := func(in task.Task) {
 				t.Helper()

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -600,8 +600,10 @@ func (a *App) initStatusHook() {
 		}
 
 		switch to {
-		case string(task.StatusTodo), string(task.StatusPlanning):
+		case string(task.StatusTodo):
 			a.dispatchTaskCreatedWorkflow(taskID)
+		case string(task.StatusPlanning):
+			a.dispatchPlanningWorkflow(taskID)
 		case string(task.StatusInProgress):
 			a.dispatchStatusWorkflow(taskID, task.StatusInProgress)
 		case string(task.StatusInReview):

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -166,7 +166,10 @@ func (a *App) dispatchPlanningWorkflow(taskID string) {
 	if skipTaskCreatedWorkflow(t) {
 		return
 	}
-	if boardReconcileWorkflowActive(t) || a.agents.HasRunningAgentForTask(taskID) {
+	if t.Workflow != nil && t.Workflow.State != workflow.ExecCompleted && t.Workflow.State != workflow.ExecFailed {
+		return
+	}
+	if a.agents.HasRunningAgentForTask(taskID) {
 		return
 	}
 	if err := a.workflowEngine.StartWorkflow(taskID, "simple-task-plan"); err != nil &&

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -184,6 +184,11 @@ func boardReconcileWorkflowActive(t task.Task) bool {
 	}
 	switch t.Workflow.State {
 	case workflow.ExecCompleted, workflow.ExecFailed:
+		switch t.Status {
+		case task.StatusInProgress, task.StatusReadyReview, task.StatusTesting, task.StatusReadyPR:
+			return false
+		default:
+		}
 		return t.Workflow.CompletedAt == nil ||
 			t.StatusChangedAt.IsZero() ||
 			!t.StatusChangedAt.After(*t.Workflow.CompletedAt)

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -336,9 +336,24 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	todo := idle("idle-todo", task.StatusTodo)
 	planning := idle("idle-planning", task.StatusPlanning)
 	inProgress := idle("idle-in-progress", task.StatusInProgress)
+	var err error
+	postPlanInProgress := idle("post-plan-in-progress", task.StatusInProgress)
+	postPlanCompletedAt := postPlanInProgress.StatusChangedAt.Add(time.Second)
+	postPlanInProgress, err = a.tasks.UpdateMap(postPlanInProgress.ID, map[string]any{
+		"workflow": &workflow.Execution{
+			WorkflowID:  "simple-task-plan",
+			CurrentStep: "",
+			State:       workflow.ExecCompleted,
+			CompletedAt: &postPlanCompletedAt,
+			Variables:   map[string]string{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	requeuedPlanning := idle("requeued-planning", task.StatusPlanning)
 	requeuedCompletedAt := requeuedPlanning.StatusChangedAt.Add(-time.Hour)
-	requeuedPlanning, err := a.tasks.UpdateMap(requeuedPlanning.ID, map[string]any{
+	requeuedPlanning, err = a.tasks.UpdateMap(requeuedPlanning.ID, map[string]any{
 		"tags": []string{"backend", "review"},
 		"workflow": &workflow.Execution{
 			WorkflowID:  "old-workflow",
@@ -423,6 +438,7 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	assertWorkflow(planning.ID, "simple-task-plan")
 	assertWorkflow(requeuedPlanning.ID, "simple-task-plan")
 	assertWorkflow(inProgress.ID, "simple-task-implement")
+	assertWorkflow(postPlanInProgress.ID, "simple-task-implement")
 
 	gotActive, err := a.tasks.Get(active.ID)
 	if err != nil {
@@ -459,8 +475,8 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	if gotUmbrella.Workflow == nil || gotUmbrella.Workflow.WorkflowID != "old-workflow" || gotUmbrella.Workflow.State != workflow.ExecFailed {
 		t.Fatalf("synthetic umbrella task should be left alone, got %+v", gotUmbrella.Workflow)
 	}
-	if launcher.startCalls != 1 {
-		t.Fatalf("startCalls = %d, want 1 for idle in-progress only", launcher.startCalls)
+	if launcher.startCalls != 2 {
+		t.Fatalf("startCalls = %d, want 2 for idle and post-plan in-progress tasks", launcher.startCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- let board reconciliation dispatch downstream status workflows even when the previous workflow is already terminal
- preserve terminal-workflow blocking for front-of-pipeline statuses so todo/planning replay stays conservative
- add regression coverage for an in-progress task left behind after simple-task-plan completes

## Test
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses|TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates'
- pre-push: go test ./... and frontend svelte-check