### PR TITLE
fix(review): cooldown inbound review redispatch

### DIFF
--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
+const inboundReviewRedispatchCooldown = 10 * time.Minute
+
 // orchestratorLoop runs two cadences. The cheap, latency-sensitive dispatch pass
 // (start the orchestrator, release unblocked children) fires on a fast ticker and
 // on demand via dispatchNudge, so a freshly-ready task isn't left idle. The
@@ -245,8 +247,13 @@ func boardReconcileWorkflowActive(t task.Task) bool {
 
 func inboundReviewNeedsAgent(t task.Task) bool {
 	switch t.ReviewPhase {
-	case "", "needs-approval":
+	case "":
 		return true
+	case "needs-approval":
+		if t.Workflow == nil || t.Workflow.CompletedAt == nil {
+			return true
+		}
+		return time.Since(*t.Workflow.CompletedAt) >= inboundReviewRedispatchCooldown
 	default:
 		return false
 	}

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -347,7 +347,7 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 		t.Fatal(err)
 	}
 	staleInboundReview := idle("stale-inbound-review", task.StatusInReview)
-	staleReviewCompletedAt := staleInboundReview.StatusChangedAt.Add(time.Second)
+	staleReviewCompletedAt := time.Now().Add(-inboundReviewRedispatchCooldown - time.Minute)
 	staleInboundReview, err = a.tasks.UpdateMap(staleInboundReview.ID, map[string]any{
 		"tags":         []string{"review"},
 		"project_id":   "Automaat/lightroom-mcp",
@@ -370,6 +370,24 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 		"project_id":   "Automaat/lightroom-mcp",
 		"pr_number":    152,
 		"review_phase": "approved",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recentInboundReview := idle("recent-inbound-review", task.StatusInReview)
+	recentReviewCompletedAt := time.Now().Add(-inboundReviewRedispatchCooldown / 2)
+	recentInboundReview, err = a.tasks.UpdateMap(recentInboundReview.ID, map[string]any{
+		"tags":         []string{"review"},
+		"project_id":   "Automaat/lightroom-mcp",
+		"pr_number":    153,
+		"review_phase": "needs-approval",
+		"workflow": &workflow.Execution{
+			WorkflowID:  "pr-review",
+			CurrentStep: "",
+			State:       workflow.ExecCompleted,
+			CompletedAt: &recentReviewCompletedAt,
+			Variables:   map[string]string{},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -521,6 +539,15 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	}
 	if gotApprovedInboundReview.Workflow != nil {
 		t.Fatalf("approved inbound review should stay idle, got %+v", gotApprovedInboundReview.Workflow)
+	}
+	gotRecentInboundReview, err := a.tasks.Get(recentInboundReview.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRecentInboundReview.Workflow == nil ||
+		gotRecentInboundReview.Workflow.WorkflowID != "pr-review" ||
+		gotRecentInboundReview.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("recent completed inbound review should not re-dispatch, got %+v", gotRecentInboundReview.Workflow)
 	}
 	gotCurrentTerminal, err := a.tasks.Get(currentTerminal.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add a cooldown before re-dispatching completed inbound PR review workflows still marked needs-approval
- keep stale needs-approval reviews eligible after the cooldown
- cover recent completed inbound reviews in the board reconciler test

## Tests
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses'
- go test ./... (pre-push hook)
- cd frontend && npm run check (pre-push hook)