### PR TITLE
fix(umbrella): keep stuck children from consuming slots

### DIFF
--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -156,7 +156,6 @@ func accumulateChild(st *umbrellaState, t *task.Task) {
 		st.anyCancelled = true
 	case task.StatusHumanRequired:
 		st.anyHR = true
-		st.active++ // a stuck child still occupies a slot until resolved
 	case task.StatusBlocked:
 		if slices.Contains(t.Tags, umbrellaGatedTag) {
 			// Gate-blocked, awaiting its dependencies — not stuck, handled by
@@ -167,9 +166,10 @@ func accumulateChild(st *umbrellaState, t *task.Task) {
 		// a human-review flip for a contained Sybra bug). depsSatisfied requires
 		// a dependency to reach Done, so a dependent chain waiting on this child
 		// would otherwise stall forever with no escalation. Surface it like any
-		// other stuck child.
+		// other stuck child, but do not count it against the parallelism cap:
+		// blocked work cannot make progress, and consuming all slots would freeze
+		// unrelated ready children under the same umbrella.
 		st.anyBlocked = true
-		st.active++ // a stuck child still occupies a slot until resolved
 	default:
 		if isRunningChild(t.Status) && !slices.Contains(t.Tags, umbrellaGatedTag) {
 			st.active++
@@ -181,7 +181,7 @@ func accumulateChild(st *umbrellaState, t *task.Task) {
 // i.e. it has been released and is somewhere in the pipeline but not finished.
 func isRunningChild(s task.Status) bool {
 	switch s {
-	case task.StatusBlocked, task.StatusNew, task.StatusDone, task.StatusCancelled:
+	case task.StatusBlocked, task.StatusNew, task.StatusHumanRequired, task.StatusDone, task.StatusCancelled:
 		return false
 	default:
 		return true

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -88,6 +88,36 @@ func TestReleaseUnblockedChildren_HaltChainFlagsTracker(t *testing.T) {
 	}
 }
 
+func TestReleaseUnblockedChildren_StuckChildDoesNotConsumeParallelSlot(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 1)
+
+	stuck, err := m.CreateFull("stuck", "", task.AgentModeHeadless, task.Update{
+		Issue:         task.Ptr("Automaat/sybra#1"),
+		UmbrellaIssue: task.Ptr(umb),
+		Status:        task.Ptr(task.StatusHumanRequired),
+	})
+	if err != nil {
+		t.Fatalf("create stuck child: %v", err)
+	}
+	ready := mkChild(t, m, "ready", "Automaat/sybra#2", umb, nil, task.StatusTodo)
+
+	app.releaseUnblockedChildren()
+
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
+		t.Fatalf("tracker = %q, want human-required on stuck child", got)
+	}
+	if got := mustStatus(t, m, stuck.ID); got != task.StatusHumanRequired {
+		t.Fatalf("stuck child = %q, want human-required", got)
+	}
+	readyTask := mustTask(t, m, ready.ID)
+	if readyTask.Status != task.StatusTodo || slices.Contains(readyTask.Tags, umbrellaGatedTag) {
+		t.Fatalf("ready child was not released despite free slot: status=%q tags=%v", readyTask.Status, readyTask.Tags)
+	}
+}
+
 // TestReleaseUnblockedChildren_NonGatedBlockedChildEscalates covers the
 // stall this fix closes: a human-review flip of one child to `blocked`
 // (without the umbrella-gated tag) must not freeze the whole sub-DAG at


### PR DESCRIPTION
## Summary
- stop counting human-required and non-gated blocked umbrella children against max-parallel slots
- keep tracker escalation unchanged so stuck children still surface as human-required
- add a regression test for a saturated umbrella cap with an independent ready child

## Tests
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestReleaseUnblockedChildren|TestTrackerRollup'
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra
- pre-push hook: go test ./...; cd frontend && npm run check