### PR TITLE
feat(agent): auto-detect installed AI runtimes

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/index.ts
@@ -48,6 +48,7 @@ export {
     LoggingSettings,
     LoopAgentRun,
     MonitorReportBinding,
+    RuntimeInfo,
     TamperFindingDTO,
     TamperReportDTO,
     TaskArtifactDTO,

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/infoservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/infoservice.ts
@@ -15,13 +15,24 @@ import { Call as $Call, CancellablePromise as $CancellablePromise, Create as $Cr
 import * as $models from "./models.js";
 
 /**
+ * GetAvailableRuntimes returns the cached PATH snapshot for known AI runtimes.
+ * The snapshot is warmed eagerly during app startup and lazily guarded here so
+ * zero-value InfoService instances stay usable in tests.
+ */
+export function GetAvailableRuntimes(): $CancellablePromise<$models.RuntimeInfo[]> {
+    return $Call.ByID(626028529).then(($result: any) => {
+        return $$createType1($result);
+    });
+}
+
+/**
  * GetCodexModels runs `codex debug models` once per session and returns the
  * parsed model catalog. Returns an empty slice when codex is unavailable or
  * the output cannot be parsed — callers should fall back to a built-in list.
  */
 export function GetCodexModels(): $CancellablePromise<$models.CodexModel[]> {
     return $Call.ByID(2281056322).then(($result: any) => {
-        return $$createType1($result);
+        return $$createType3($result);
     });
 }
 
@@ -35,7 +46,7 @@ export function GetCodexModels(): $CancellablePromise<$models.CodexModel[]> {
  */
 export function GetCopilotModels(): $CancellablePromise<$models.CopilotModel[]> {
     return $Call.ByID(1155897229).then(($result: any) => {
-        return $$createType3($result);
+        return $$createType5($result);
     });
 }
 
@@ -44,13 +55,15 @@ export function GetCopilotModels(): $CancellablePromise<$models.CopilotModel[]> 
  */
 export function GetVersion(): $CancellablePromise<$models.VersionInfo> {
     return $Call.ByID(2557760771).then(($result: any) => {
-        return $$createType4($result);
+        return $$createType6($result);
     });
 }
 
 // Private type creation functions
-const $$createType0 = $models.CodexModel.createFrom;
+const $$createType0 = $models.RuntimeInfo.createFrom;
 const $$createType1 = $Create.Array($$createType0);
-const $$createType2 = $models.CopilotModel.createFrom;
+const $$createType2 = $models.CodexModel.createFrom;
 const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = $models.VersionInfo.createFrom;
+const $$createType4 = $models.CopilotModel.createFrom;
+const $$createType5 = $Create.Array($$createType4);
+const $$createType6 = $models.VersionInfo.createFrom;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
@@ -505,6 +505,42 @@ export class MonitorReportBinding {
     }
 }
 
+/**
+ * RuntimeInfo is the read-only detected state for one known CLI runtime.
+ */
+export class RuntimeInfo {
+    "id": string;
+    "name": string;
+    "installed": boolean;
+    "path"?: string;
+    "version"?: string;
+    "error"?: string;
+    "informationalOnly"?: boolean;
+
+    /** Creates a new RuntimeInfo instance. */
+    constructor($$source: Partial<RuntimeInfo> = {}) {
+        if (!("id" in $$source)) {
+            this["id"] = "";
+        }
+        if (!("name" in $$source)) {
+            this["name"] = "";
+        }
+        if (!("installed" in $$source)) {
+            this["installed"] = false;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new RuntimeInfo instance from a string or object.
+     */
+    static createFrom($$source: any = {}): RuntimeInfo {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new RuntimeInfo($$parsedSource as Partial<RuntimeInfo>);
+    }
+}
+
 export class TamperFindingDTO {
     "file": string;
     "category": string;

--- a/frontend/src/components/settings/AgentPanel.svelte
+++ b/frontend/src/components/settings/AgentPanel.svelte
@@ -11,11 +11,12 @@
     defaults: AppSettings
     modelOptions: { value: string; label: string }[]
     runtimes: RuntimeInfo[]
+    runtimeStatus?: 'loading' | 'ready' | 'failed'
     /** Force the advanced disclosure open (search/modified-filter match). */
     advancedOpen?: boolean
   }
 
-  let { settings = $bindable(), defaults, modelOptions, runtimes, advancedOpen = false }: Props = $props()
+  let { settings = $bindable(), defaults, modelOptions, runtimes, runtimeStatus = 'ready', advancedOpen = false }: Props = $props()
   const a = $derived(settings.agent)
   const d = $derived(defaults.agent)
 
@@ -73,8 +74,12 @@
         <span class="text-xs text-surface-500 dark:text-surface-400">Read-only startup snapshot from PATH</span>
       </div>
     </div>
-    {#if runtimes.length === 0}
+    {#if runtimeStatus === 'loading'}
+      <p class="text-xs text-surface-500 dark:text-surface-400">Runtime scan loading.</p>
+    {:else if runtimeStatus === 'failed'}
       <p class="text-xs text-surface-500 dark:text-surface-400">Runtime scan unavailable.</p>
+    {:else if runtimes.length === 0}
+      <p class="text-xs text-surface-500 dark:text-surface-400">No known runtimes found.</p>
     {:else}
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {#each runtimes as runtime (runtime.id)}

--- a/frontend/src/components/settings/AgentPanel.svelte
+++ b/frontend/src/components/settings/AgentPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+  import type { AppSettings, RuntimeInfo } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
   import Section from './fields/Section.svelte'
   import SelectField from './fields/SelectField.svelte'
   import NumberField from './fields/NumberField.svelte'
@@ -10,11 +10,12 @@
     settings: AppSettings
     defaults: AppSettings
     modelOptions: { value: string; label: string }[]
+    runtimes: RuntimeInfo[]
     /** Force the advanced disclosure open (search/modified-filter match). */
     advancedOpen?: boolean
   }
 
-  let { settings = $bindable(), defaults, modelOptions, advancedOpen = false }: Props = $props()
+  let { settings = $bindable(), defaults, modelOptions, runtimes, advancedOpen = false }: Props = $props()
   const a = $derived(settings.agent)
   const d = $derived(defaults.agent)
 
@@ -63,6 +64,45 @@
       bind:value={settings.agent.maxConcurrent}
       modified={a.maxConcurrent !== d.maxConcurrent}
       onreset={() => (settings.agent.maxConcurrent = d.maxConcurrent)} />
+  </div>
+
+  <div class="mt-4 rounded-lg border border-surface-200 bg-white p-4 dark:border-surface-700 dark:bg-surface-900">
+    <div class="mb-3 flex items-center justify-between gap-3">
+      <div class="flex flex-col">
+        <h3 class="text-sm font-medium text-surface-800 dark:text-surface-100">Detected runtimes</h3>
+        <span class="text-xs text-surface-500 dark:text-surface-400">Read-only startup snapshot from PATH</span>
+      </div>
+    </div>
+    {#if runtimes.length === 0}
+      <p class="text-xs text-surface-500 dark:text-surface-400">Runtime scan unavailable.</p>
+    {:else}
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {#each runtimes as runtime (runtime.id)}
+          <div class="rounded-lg border border-surface-200 bg-surface-50 px-3 py-2 dark:border-surface-700 dark:bg-surface-800">
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-surface-800 dark:text-surface-100">{runtime.name}</span>
+              <span class="rounded px-1.5 py-0.5 text-xs {runtime.installed ? 'bg-success-500/15 text-success-700 dark:text-success-300' : 'bg-surface-300 text-surface-600 dark:bg-surface-700 dark:text-surface-300'}">
+                {runtime.installed ? 'installed' : 'missing'}
+              </span>
+              {#if runtime.informationalOnly}
+                <span class="rounded px-1.5 py-0.5 text-xs bg-primary-500/10 text-primary-700 dark:text-primary-300">info only</span>
+              {/if}
+            </div>
+            <div class="mt-2 flex flex-col gap-1">
+              <span class="font-mono text-[11px] text-surface-500 dark:text-surface-400">
+                {runtime.path || 'Not found on PATH'}
+              </span>
+              {#if runtime.version}
+                <span class="text-xs text-surface-600 dark:text-surface-300">Version: {runtime.version}</span>
+              {/if}
+              {#if runtime.error}
+                <span class="text-xs text-warning-700 dark:text-warning-300">Probe: {runtime.error}</span>
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
   </div>
 
   <AdvancedDisclosure open={advancedOpen}>

--- a/frontend/src/components/settings/AgentPanel.svelte.test.ts
+++ b/frontend/src/components/settings/AgentPanel.svelte.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
+
+const AgentPanel = (await import('./AgentPanel.svelte')).default
+
+function buildSettings() {
+  return {
+    agent: {
+      provider: 'claude',
+      model: 'sonnet',
+      mode: 'headless',
+      maxConcurrent: 3,
+      requirePermissions: null,
+      surviveRestart: null,
+      fallbackModel: '',
+      maxCostUsd: 0,
+      maxTurns: 0,
+      bashTimeoutSeconds: 0,
+      retryWatchdog: 0,
+      dispatchJitterMs: 0,
+      logRetentionDays: 14,
+      logGzipAfterDays: 3,
+      logRetentionMaxSizeMb: 1024,
+      approvalPort: 0,
+      headlessPermissionMode: '',
+    },
+  } as never
+}
+
+describe('AgentPanel', () => {
+  it('renders detected runtimes with installed, missing, and probe-error states', () => {
+    render(AgentPanel, {
+      props: {
+        settings: buildSettings(),
+        defaults: buildSettings(),
+        modelOptions: [{ value: 'sonnet', label: 'Sonnet' }],
+        runtimes: [
+          { id: 'claude', name: 'Claude Code', installed: true, path: '/tmp/claude', version: 'Claude 1.2.3' },
+          { id: 'codex', name: 'Codex', installed: false, path: '', version: '', error: '' },
+          { id: 'opencode', name: 'OpenCode', installed: true, path: '/tmp/opencode', version: '', error: 'version probe timed out after 1.5s' },
+          { id: 'hermes', name: 'Hermes', installed: true, path: '/tmp/hermes', version: 'Hermes 0.8.0', informationalOnly: true },
+        ],
+      },
+    })
+
+    expect(screen.getByText('Detected runtimes')).toBeDefined()
+    expect(screen.getByText('Claude Code')).toBeDefined()
+    expect(screen.getAllByText('Codex').length).toBeGreaterThan(0)
+    expect(screen.getByText('Hermes')).toBeDefined()
+    expect(screen.getAllByText('installed').length).toBeGreaterThan(0)
+    expect(screen.getByText('missing')).toBeDefined()
+    expect(screen.getByText('Version: Claude 1.2.3')).toBeDefined()
+    expect(screen.getByText('Not found on PATH')).toBeDefined()
+    expect(screen.getByText('Probe: version probe timed out after 1.5s')).toBeDefined()
+    expect(screen.getByText('info only')).toBeDefined()
+  })
+})

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte
@@ -7,7 +7,7 @@
     SetProviderEnabled,
   } from '$lib/api'
   import * as ev from '../../lib/events.js'
-  import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+  import type { AppSettings, RuntimeInfo } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 
   interface Props {
     settings: AppSettings
@@ -15,10 +15,11 @@
     // parent (Settings) so the rail entry and this pane share one source of
     // truth — the tab is never shown while the panel renders blank.
     enabled: boolean
+    runtimes: RuntimeInfo[]
     onsettingschange: () => void
   }
 
-  const { settings, enabled, onsettingschange }: Props = $props()
+  const { settings, enabled, runtimes, onsettingschange }: Props = $props()
 
   function ensureProviderLimitDefaults() {
     const providers = settings.providers as any
@@ -82,6 +83,15 @@
   }
 
   type ProviderName = 'claude' | 'codex' | 'copilot' | 'opencode'
+  const providerNames: ProviderName[] = ['claude', 'codex', 'copilot', 'opencode']
+  const runtimeProviderNames = new Set<ProviderName>(['claude', 'codex', 'opencode'])
+
+  const runtimeMap = $derived.by(() => {
+    const next: Record<string, RuntimeInfo> = {}
+    for (const runtime of runtimes) next[runtime.id] = runtime
+    return next
+  })
+  const hermesRuntime = $derived.by(() => runtimeMap.hermes)
 
   async function onProviderEnabledChange(name: ProviderName, e: Event) {
     const value = (e.target as HTMLInputElement).checked
@@ -136,6 +146,10 @@
     if (p.reason === 'disabled') return 'bg-surface-300 text-surface-600 dark:bg-surface-600 dark:text-surface-300'
     return 'bg-error-500/20 text-error-600 dark:text-error-300'
   }
+
+  function showRuntime(name: ProviderName): boolean {
+    return runtimeProviderNames.has(name)
+  }
 </script>
 
 {#if enabled}
@@ -145,8 +159,9 @@
       <div class="mb-3 text-xs text-error-500">{error}</div>
     {/if}
     <div class="flex flex-col gap-3">
-      {#each ['claude', 'codex', 'copilot', 'opencode'] as name (name)}
+      {#each providerNames as name (name)}
         {@const p = map[name]}
+        {@const runtime = runtimeMap[name]}
         <div class="flex items-center justify-between gap-3 rounded border border-surface-200 bg-white px-3 py-2 dark:border-surface-700 dark:bg-surface-900">
           <div class="flex flex-col">
             <div class="flex items-center gap-2">
@@ -159,6 +174,17 @@
             </div>
             {#if p?.detail}
               <span class="text-xs text-surface-500 dark:text-surface-400">{p.detail}</span>
+            {/if}
+            {#if showRuntime(name) && runtime}
+              <span class="font-mono text-[11px] text-surface-500 dark:text-surface-400">
+                {runtime.installed ? runtime.path : 'CLI not found on PATH'}
+              </span>
+              {#if runtime.version}
+                <span class="text-xs text-surface-500 dark:text-surface-400">version: {runtime.version}</span>
+              {/if}
+              {#if runtime.error}
+                <span class="text-xs text-warning-700 dark:text-warning-300">probe: {runtime.error}</span>
+              {/if}
             {/if}
             {#if p?.lastCheck}
               <span class="text-xs text-surface-500 dark:text-surface-400">last check: {new Date(p.lastCheck).toLocaleTimeString()}</span>
@@ -189,6 +215,26 @@
           </div>
         </div>
       {/each}
+      {#if hermesRuntime}
+        <div class="flex items-center justify-between gap-3 rounded border border-dashed border-surface-300 bg-surface-100 px-3 py-2 dark:border-surface-700 dark:bg-surface-900/60">
+          <div class="flex flex-col">
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-surface-800 dark:text-surface-100">{hermesRuntime.name}</span>
+              <span class="rounded px-1.5 py-0.5 text-xs bg-primary-500/10 text-primary-700 dark:text-primary-300">informational only</span>
+            </div>
+            <span class="font-mono text-[11px] text-surface-500 dark:text-surface-400">
+              {hermesRuntime.installed ? hermesRuntime.path : 'CLI not found on PATH'}
+            </span>
+            {#if hermesRuntime.version}
+              <span class="text-xs text-surface-500 dark:text-surface-400">version: {hermesRuntime.version}</span>
+            {/if}
+            {#if hermesRuntime.error}
+              <span class="text-xs text-warning-700 dark:text-warning-300">probe: {hermesRuntime.error}</span>
+            {/if}
+          </div>
+          <span class="text-xs text-surface-500 dark:text-surface-400">No provider toggle</span>
+        </div>
+      {/if}
       <label class="flex cursor-pointer items-center gap-3 pt-2">
         <input
           type="checkbox"

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
@@ -21,10 +21,20 @@ function buildSettings() {
       claude: { enabled: true },
       codex: { enabled: false },
       copilot: { enabled: true },
+      opencode: { enabled: true },
       autoFailover: false,
       healthCheck: { intervalSeconds: 30 },
     },
   } as never
+}
+
+function buildRuntimes() {
+  return [
+    { id: 'claude', name: 'Claude Code', installed: true, path: '/tmp/claude', version: 'Claude 1.2.3' },
+    { id: 'codex', name: 'Codex', installed: false, path: '', version: '', error: '' },
+    { id: 'opencode', name: 'OpenCode', installed: true, path: '/tmp/opencode', version: '', error: 'version probe timed out after 1.5s' },
+    { id: 'hermes', name: 'Hermes', installed: true, path: '/tmp/hermes', version: 'Hermes 0.8.0', informationalOnly: true },
+  ]
 }
 
 describe('ProviderHealthPanel', () => {
@@ -45,7 +55,7 @@ describe('ProviderHealthPanel', () => {
 
   it('renders nothing when provider health is disabled', async () => {
     const { container } = render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), enabled: false, onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: false, runtimes: buildRuntimes(), onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(container.querySelector('h2')).toBeNull()
@@ -54,7 +64,7 @@ describe('ProviderHealthPanel', () => {
 
   it('renders Providers section with both rows when enabled', async () => {
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), enabled: true, onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: true, runtimes: buildRuntimes(), onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(screen.getByText('Providers')).toBeDefined()
@@ -65,7 +75,7 @@ describe('ProviderHealthPanel', () => {
 
   it('shows healthy badge for claude and rate-limited reason for codex', async () => {
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), enabled: true, onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: true, runtimes: buildRuntimes(), onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(screen.getByText('healthy')).toBeDefined()
@@ -76,7 +86,7 @@ describe('ProviderHealthPanel', () => {
   it('toggling auto-failover calls SetProviderAutoFailover + onsettingschange', async () => {
     const onsettingschange = vi.fn()
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), enabled: true, onsettingschange },
+      props: { settings: buildSettings(), enabled: true, runtimes: buildRuntimes(), onsettingschange },
     })
     await waitFor(() => screen.getByText('Providers'))
     const cb = screen.getByLabelText(/Auto-failover/) as HTMLInputElement
@@ -89,10 +99,25 @@ describe('ProviderHealthPanel', () => {
 
   it('subscribes to ProviderHealth events on mount', async () => {
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), enabled: true, onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: true, runtimes: buildRuntimes(), onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(mockEventsOn).toHaveBeenCalled()
+    })
+  })
+
+  it('shows runtime path/version beside provider rows and Hermes as informational-only', async () => {
+    render(ProviderHealthPanel, {
+      props: { settings: buildSettings(), enabled: true, runtimes: buildRuntimes(), onsettingschange: vi.fn() },
+    })
+    await waitFor(() => {
+      expect(screen.getByText('/tmp/claude')).toBeDefined()
+      expect(screen.getByText('version: Claude 1.2.3')).toBeDefined()
+      expect(screen.getByText('CLI not found on PATH')).toBeDefined()
+      expect(screen.getByText('probe: version probe timed out after 1.5s')).toBeDefined()
+      expect(screen.getByText('Hermes')).toBeDefined()
+      expect(screen.getByText('informational only')).toBeDefined()
+      expect(screen.getByText('No provider toggle')).toBeDefined()
     })
   })
 })

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -6,7 +6,7 @@ import type { ReviewComment, Task } from '../../bindings/github.com/Automaat/syb
 import type { Project, Worktree } from '../../bindings/github.com/Automaat/sybra/internal/project/models.js'
 import type { Issue, RenovatePR, ReviewSummary } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
 import type { LoopAgent } from '../../bindings/github.com/Automaat/sybra/internal/loopagent/models.js'
-import type { AppSettings, ClusterNodeDTO, CodexModel, CopilotModel, LoopAgentRun, MonitorReportBinding, TamperReportDTO, TaskArtifactDTO, TaskAuditEventDTO, TaskSetupLogDTO, VersionInfo, AgentQueueSnapshot as AgentQueueSnapshotData } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+import type { AppSettings, ClusterNodeDTO, CodexModel, CopilotModel, LoopAgentRun, MonitorReportBinding, RuntimeInfo, TamperReportDTO, TaskArtifactDTO, TaskAuditEventDTO, TaskSetupLogDTO, VersionInfo, AgentQueueSnapshot as AgentQueueSnapshotData } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 import type { Notification } from '../../bindings/github.com/Automaat/sybra/internal/notification/models.js'
 import type { StatsResponse } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
 import type { ProgressEntry } from '../../bindings/github.com/Automaat/sybra/internal/artifact/models.js'
@@ -112,6 +112,7 @@ export function GetRawConfig(): Promise<string> { return call('ConfigService', '
 export function SaveRawConfig(arg1: string): Promise<void> { return call('ConfigService', 'SaveRawConfig', arg1) }
 
 // InfoService
+export function GetAvailableRuntimes(): Promise<RuntimeInfo[]> { return call('InfoService', 'GetAvailableRuntimes') }
 export function GetCodexModels(): Promise<CodexModel[]> { return call('InfoService', 'GetCodexModels') }
 export function GetCopilotModels(): Promise<CopilotModel[]> { return call('InfoService', 'GetCopilotModels') }
 export function GetVersion(): Promise<VersionInfo> { return call('InfoService', 'GetVersion') }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -75,6 +75,7 @@ export const GetRawConfig = pick(ConfigSvc.GetRawConfig, http.GetRawConfig)
 export const SaveRawConfig = pick(ConfigSvc.SaveRawConfig, http.SaveRawConfig)
 
 // InfoService
+export const GetAvailableRuntimes = pick(InfoSvc.GetAvailableRuntimes, http.GetAvailableRuntimes)
 export const GetCodexModels = pick(InfoSvc.GetCodexModels, http.GetCodexModels)
 export const GetCopilotModels = pick(InfoSvc.GetCopilotModels, http.GetCopilotModels)
 export const GetVersion = pick(InfoSvc.GetVersion, http.GetVersion)

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -2,10 +2,10 @@
   import { onMount } from 'svelte'
   import {
     GetSettings, GetDefaultSettings, UpdateSettings, UpdateTodoistToken,
-    GetVersion, GetCodexModels, GetCopilotModels, ProviderHealthEnabled,
+    GetVersion, GetCodexModels, GetCopilotModels, GetAvailableRuntimes, ProviderHealthEnabled,
   } from '$lib/api'
   import { CLAUDE_MODEL_OPTIONS } from '$lib/claude-models'
-  import type { AppSettings } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+  import type { AppSettings, RuntimeInfo } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
   import ProviderHealthPanel from '../components/settings/ProviderHealthPanel.svelte'
   import LoggingPanel from '../components/settings/LoggingPanel.svelte'
   import TodoistPanel from '../components/settings/TodoistPanel.svelte'
@@ -113,6 +113,7 @@
     { value: 'ollama/qwen3-coder', label: 'Ollama: Qwen3 Coder' },
   ]
   let providerHealthEnabled = $state(false)
+  let availableRuntimes = $state<RuntimeInfo[]>([])
 
   $effect(() => { load() })
 
@@ -128,6 +129,9 @@
     }).catch(() => {})
     GetCopilotModels().then(models => {
       if (models && models.length > 0) copilotDynamicModels = models.map(m => ({ value: m.slug, label: m.display_name }))
+    }).catch(() => {})
+    GetAvailableRuntimes().then(runtimes => {
+      if (runtimes && runtimes.length > 0) availableRuntimes = runtimes
     }).catch(() => {})
     ProviderHealthEnabled().then(v => { providerHealthEnabled = v }).catch(() => {})
   })
@@ -403,10 +407,10 @@
           {/if}
 
           {#if active === 'agent'}
-            <AgentPanel bind:settings {defaults} {modelOptions} advancedOpen={query.trim().length > 0} />
+            <AgentPanel bind:settings {defaults} {modelOptions} runtimes={availableRuntimes} advancedOpen={query.trim().length > 0} />
           {/if}
           {#if active === 'provider-health'}
-            <ProviderHealthPanel {settings} enabled={providerHealthEnabled} onsettingschange={syncOriginal} />
+            <ProviderHealthPanel {settings} enabled={providerHealthEnabled} runtimes={availableRuntimes} onsettingschange={syncOriginal} />
           {/if}
           {#if active === 'orchestrator'}
             <OrchestratorPanel bind:settings {defaults} />

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -114,6 +114,7 @@
   ]
   let providerHealthEnabled = $state(false)
   let availableRuntimes = $state<RuntimeInfo[]>([])
+  let runtimeStatus = $state<'loading' | 'ready' | 'failed'>('loading')
 
   $effect(() => { load() })
 
@@ -131,8 +132,12 @@
       if (models && models.length > 0) copilotDynamicModels = models.map(m => ({ value: m.slug, label: m.display_name }))
     }).catch(() => {})
     GetAvailableRuntimes().then(runtimes => {
-      if (runtimes && runtimes.length > 0) availableRuntimes = runtimes
-    }).catch(() => {})
+      availableRuntimes = runtimes ?? []
+      runtimeStatus = 'ready'
+    }).catch(() => {
+      availableRuntimes = []
+      runtimeStatus = 'failed'
+    })
     ProviderHealthEnabled().then(v => { providerHealthEnabled = v }).catch(() => {})
   })
 
@@ -407,7 +412,7 @@
           {/if}
 
           {#if active === 'agent'}
-            <AgentPanel bind:settings {defaults} {modelOptions} runtimes={availableRuntimes} advancedOpen={query.trim().length > 0} />
+            <AgentPanel bind:settings {defaults} {modelOptions} runtimes={availableRuntimes} {runtimeStatus} advancedOpen={query.trim().length > 0} />
           {/if}
           {#if active === 'provider-health'}
             <ProviderHealthPanel {settings} enabled={providerHealthEnabled} runtimes={availableRuntimes} onsettingschange={syncOriginal} />

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -10,6 +10,7 @@ const mockSaveRawConfig = vi.fn()
 const mockGetVersion = vi.fn()
 const mockGetCodexModels = vi.fn()
 const mockGetCopilotModels = vi.fn()
+const mockGetAvailableRuntimes = vi.fn()
 const mockProviderHealthEnabled = vi.fn()
 const mockGetProviderHealth = vi.fn()
 const mockSetProviderAutoFailover = vi.fn()
@@ -26,6 +27,7 @@ vi.mock('$lib/api', () => ({
   GetVersion: (...args: unknown[]) => mockGetVersion(...args),
   GetCodexModels: (...args: unknown[]) => mockGetCodexModels(...args),
   GetCopilotModels: (...args: unknown[]) => mockGetCopilotModels(...args),
+  GetAvailableRuntimes: (...args: unknown[]) => mockGetAvailableRuntimes(...args),
   ProviderHealthEnabled: (...args: unknown[]) => mockProviderHealthEnabled(...args),
   GetProviderHealth: (...args: unknown[]) => mockGetProviderHealth(...args),
   SetProviderAutoFailover: (...args: unknown[]) => mockSetProviderAutoFailover(...args),
@@ -109,6 +111,13 @@ describe('Settings', () => {
     mockGetVersion.mockResolvedValue({ server: 'v1.0.0', client: 'v1.0.0' })
     mockGetCodexModels.mockResolvedValue([])
     mockGetCopilotModels.mockResolvedValue([])
+    mockGetAvailableRuntimes.mockReset()
+    mockGetAvailableRuntimes.mockResolvedValue([
+      { id: 'claude', name: 'Claude Code', installed: true, path: '/tmp/claude', version: 'Claude 1.2.3' },
+      { id: 'codex', name: 'Codex', installed: false, path: '', version: '', error: '' },
+      { id: 'opencode', name: 'OpenCode', installed: true, path: '/tmp/opencode', version: '', error: 'version probe timed out after 1.5s' },
+      { id: 'hermes', name: 'Hermes', installed: true, path: '/tmp/hermes', version: 'Hermes 0.8.0', informationalOnly: true },
+    ])
     mockProviderHealthEnabled.mockResolvedValue(false)
     mockGetProviderHealth.mockResolvedValue([])
     mockEventsOn.mockReturnValue(vi.fn())
@@ -350,6 +359,30 @@ describe('Settings', () => {
     await vi.waitFor(() => expect(mockProviderHealthEnabled).toHaveBeenCalled())
     await vi.waitFor(() => expect(screen.getByRole('button', { name: 'Defaults' })).toBeDefined())
     expect(screen.queryByRole('button', { name: 'Providers' })).toBeNull()
+  })
+
+  it('loads available runtimes on mount even when provider health is disabled', async () => {
+    mockGetSettings.mockResolvedValue(baseSettings())
+    mockProviderHealthEnabled.mockResolvedValue(false)
+    render(Settings)
+    await vi.waitFor(() => expect(mockGetAvailableRuntimes).toHaveBeenCalled())
+    await goTo('Defaults')
+    await vi.waitFor(() => {
+      expect(screen.getByText('Detected runtimes')).toBeDefined()
+      expect(screen.getByText('Version: Claude 1.2.3')).toBeDefined()
+    })
+  })
+
+  it('tolerates runtime discovery failure without blocking Settings load', async () => {
+    mockGetSettings.mockResolvedValue(baseSettings())
+    mockGetAvailableRuntimes.mockRejectedValue(new Error('runtime unavailable'))
+    render(Settings)
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    await goTo('Defaults')
+    await vi.waitFor(() => {
+      expect(screen.getByText('Agent defaults')).toBeDefined()
+      expect(screen.getByText('Runtime scan unavailable.')).toBeDefined()
+    })
   })
 
   it('renders Color Scheme options (system, light, dark)', () => {

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -9,6 +9,7 @@ import (
 // wireServices populates the Wails-bound service structs that were pre-allocated
 // in NewApp(). Must be called after all dependencies are initialized.
 func (a *App) wireServices(emit func(string, any)) {
+	a.infoSvc.primeRuntimeSnapshot()
 	a.wireReviewServices()
 	a.wireTaskService()
 	a.wirePlanningService()
@@ -83,6 +84,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 			"GetVersion",
 			"GetCodexModels",
 			"GetCopilotModels",
+			"GetAvailableRuntimes",
 		),
 		"TaskService": httpapi.NewService(a.taskSvc,
 			"AssignTask",

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -9,7 +9,7 @@ import (
 // wireServices populates the Wails-bound service structs that were pre-allocated
 // in NewApp(). Must be called after all dependencies are initialized.
 func (a *App) wireServices(emit func(string, any)) {
-	a.infoSvc.primeRuntimeSnapshot()
+	go a.infoSvc.primeRuntimeSnapshot()
 	a.wireReviewServices()
 	a.wireTaskService()
 	a.wirePlanningService()

--- a/internal/sybra/svc_info.go
+++ b/internal/sybra/svc_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os/exec"
+	"slices"
 	"sync"
 
 	"github.com/Automaat/sybra/internal/version"
@@ -29,8 +30,11 @@ type CopilotModel struct {
 
 // InfoService exposes build metadata to the frontend.
 type InfoService struct {
-	once        sync.Once
-	codexModels []CodexModel
+	once              sync.Once
+	codexModels       []CodexModel
+	runtimeOnce       sync.Once
+	availableRuntimes []RuntimeInfo
+	detectRuntimes    func() []RuntimeInfo
 }
 
 // GetVersion returns version information for the running server binary.
@@ -46,6 +50,14 @@ func (s *InfoService) GetCodexModels() []CodexModel {
 		s.codexModels = fetchCodexModels()
 	})
 	return s.codexModels
+}
+
+// GetAvailableRuntimes returns the cached PATH snapshot for known AI runtimes.
+// The snapshot is warmed eagerly during app startup and lazily guarded here so
+// zero-value InfoService instances stay usable in tests.
+func (s *InfoService) GetAvailableRuntimes() []RuntimeInfo {
+	s.primeRuntimeSnapshot()
+	return slices.Clone(s.availableRuntimes)
 }
 
 func fetchCodexModels() []CodexModel {

--- a/internal/sybra/svc_info_runtimes.go
+++ b/internal/sybra/svc_info_runtimes.go
@@ -94,7 +94,21 @@ func formatRuntimeProbeError(ctx context.Context, err error, output []byte, time
 	}
 	msg = strings.Join(strings.Fields(msg), " ")
 	if len(msg) > runtimeProbeErrorMax {
-		msg = msg[:runtimeProbeErrorMax-1] + "…"
+		msg = truncateRuntimeProbeError(msg)
 	}
 	return msg
+}
+
+func truncateRuntimeProbeError(msg string) string {
+	const suffix = "..."
+	limit := runtimeProbeErrorMax - len(suffix)
+	var b strings.Builder
+	for _, r := range msg {
+		next := string(r)
+		if b.Len()+len(next) > limit {
+			break
+		}
+		b.WriteString(next)
+	}
+	return b.String() + suffix
 }

--- a/internal/sybra/svc_info_runtimes.go
+++ b/internal/sybra/svc_info_runtimes.go
@@ -1,0 +1,100 @@
+package sybra
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	runtimeProbeTimeout  = 1500 * time.Millisecond
+	runtimeProbeErrorMax = 160
+	runtimeVersionArg    = "--version"
+)
+
+type runtimeSpec struct {
+	id                string
+	name              string
+	binary            string
+	informationalOnly bool
+	versionArgs       []string
+}
+
+var knownRuntimeSpecs = []runtimeSpec{
+	{id: "claude", name: "Claude Code", binary: "claude", versionArgs: []string{runtimeVersionArg}},
+	{id: "codex", name: "Codex", binary: "codex", versionArgs: []string{runtimeVersionArg}},
+	{id: "opencode", name: "OpenCode", binary: "opencode", versionArgs: []string{runtimeVersionArg}},
+	{id: "hermes", name: "Hermes", binary: "hermes", informationalOnly: true, versionArgs: []string{runtimeVersionArg}},
+}
+
+// RuntimeInfo is the read-only detected state for one known CLI runtime.
+type RuntimeInfo struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Installed         bool   `json:"installed"`
+	Path              string `json:"path,omitempty"`
+	Version           string `json:"version,omitempty"`
+	Error             string `json:"error,omitempty"`
+	InformationalOnly bool   `json:"informationalOnly,omitempty"`
+}
+
+func (s *InfoService) primeRuntimeSnapshot() {
+	s.runtimeOnce.Do(func() {
+		detect := s.detectRuntimes
+		if detect == nil {
+			detect = detectAvailableRuntimes
+		}
+		s.availableRuntimes = detect()
+	})
+}
+
+func detectAvailableRuntimes() []RuntimeInfo {
+	out := make([]RuntimeInfo, 0, len(knownRuntimeSpecs))
+	for _, spec := range knownRuntimeSpecs {
+		info := RuntimeInfo{
+			ID:                spec.id,
+			Name:              spec.name,
+			InformationalOnly: spec.informationalOnly,
+		}
+		path, err := exec.LookPath(spec.binary)
+		if err != nil {
+			out = append(out, info)
+			continue
+		}
+		info.Installed = true
+		info.Path = path
+		info.Version, info.Error = probeRuntimeVersion(path, spec.versionArgs, runtimeProbeTimeout)
+		out = append(out, info)
+	}
+	return out
+}
+
+func probeRuntimeVersion(path string, args []string, timeout time.Duration) (version, probeErr string) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, path, args...).CombinedOutput()
+	if err != nil {
+		return "", formatRuntimeProbeError(ctx, err, out, timeout)
+	}
+	return strings.TrimSpace(string(out)), ""
+}
+
+func formatRuntimeProbeError(ctx context.Context, err error, output []byte, timeout time.Duration) string {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Sprintf("version probe timed out after %s", timeout)
+	}
+	msg := strings.TrimSpace(string(bytes.TrimSpace(output)))
+	if msg == "" {
+		msg = err.Error()
+	}
+	msg = strings.Join(strings.Fields(msg), " ")
+	if len(msg) > runtimeProbeErrorMax {
+		msg = msg[:runtimeProbeErrorMax-1] + "…"
+	}
+	return msg
+}

--- a/internal/sybra/svc_info_runtimes_test.go
+++ b/internal/sybra/svc_info_runtimes_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestDetectAvailableRuntimes(t *testing.T) {
@@ -79,6 +80,20 @@ func TestRuntimeProbeTimeout(t *testing.T) {
 	}
 	if !strings.Contains(probeErr, "timed out") {
 		t.Fatalf("probeErr = %q", probeErr)
+	}
+}
+
+func TestRuntimeProbeErrorTruncationStaysWithinByteLimit(t *testing.T) {
+	longErr := strings.Repeat("failure ", 40) + "ą"
+	got := truncateRuntimeProbeError(longErr)
+	if len(got) > runtimeProbeErrorMax {
+		t.Fatalf("truncated error length = %d, want <= %d", len(got), runtimeProbeErrorMax)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("truncated error = %q, want ASCII suffix", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated error is not valid UTF-8: %q", got)
 	}
 }
 

--- a/internal/sybra/svc_info_runtimes_test.go
+++ b/internal/sybra/svc_info_runtimes_test.go
@@ -56,7 +56,7 @@ func TestRuntimeProbeCommandFailure(t *testing.T) {
 	path := filepath.Join(dir, "codex")
 	writeRuntimeExe(t, path, "#!/bin/sh\necho 'fatal: broken login' >&2\nexit 7\n")
 
-	version, probeErr := probeRuntimeVersion(path, []string{"--version"}, 200*time.Millisecond)
+	version, probeErr := probeRuntimeVersion(path, []string{"--version"}, 2*time.Second)
 	if version != "" {
 		t.Fatalf("version = %q, want empty", version)
 	}

--- a/internal/sybra/svc_info_runtimes_test.go
+++ b/internal/sybra/svc_info_runtimes_test.go
@@ -1,0 +1,129 @@
+package sybra
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectAvailableRuntimes(t *testing.T) {
+	dir := t.TempDir()
+	writeRuntimeExe(t, filepath.Join(dir, "claude"), "#!/bin/sh\nprintf 'Claude 1.2.3\\n'\n")
+	writeRuntimeExe(t, filepath.Join(dir, "opencode"), "#!/bin/sh\nprintf 'OpenCode 0.9.0\\n'\n")
+	writeRuntimeExe(t, filepath.Join(dir, "hermes"), "#!/bin/sh\nprintf 'Hermes 2.0.0\\n'\n")
+	t.Setenv("PATH", dir)
+
+	got := detectAvailableRuntimes()
+	if len(got) != len(knownRuntimeSpecs) {
+		t.Fatalf("len(runtimes) = %d, want %d", len(got), len(knownRuntimeSpecs))
+	}
+
+	claude := runtimeByID(t, got, "claude")
+	if !claude.Installed {
+		t.Fatal("claude should be installed")
+	}
+	if claude.Path != filepath.Join(dir, "claude") {
+		t.Fatalf("claude path = %q", claude.Path)
+	}
+	if claude.Version != "Claude 1.2.3" {
+		t.Fatalf("claude version = %q", claude.Version)
+	}
+	if claude.Error != "" {
+		t.Fatalf("claude error = %q, want empty", claude.Error)
+	}
+
+	codex := runtimeByID(t, got, "codex")
+	if codex.Installed {
+		t.Fatal("codex should be missing")
+	}
+	if codex.Path != "" || codex.Version != "" || codex.Error != "" {
+		t.Fatalf("missing codex should be empty metadata, got %#v", codex)
+	}
+
+	hermes := runtimeByID(t, got, "hermes")
+	if !hermes.InformationalOnly {
+		t.Fatal("hermes should be informational-only")
+	}
+	if hermes.Version != "Hermes 2.0.0" {
+		t.Fatalf("hermes version = %q", hermes.Version)
+	}
+}
+
+func TestRuntimeProbeCommandFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex")
+	writeRuntimeExe(t, path, "#!/bin/sh\necho 'fatal: broken login' >&2\nexit 7\n")
+
+	version, probeErr := probeRuntimeVersion(path, []string{"--version"}, 200*time.Millisecond)
+	if version != "" {
+		t.Fatalf("version = %q, want empty", version)
+	}
+	if !strings.Contains(probeErr, "fatal: broken login") {
+		t.Fatalf("probeErr = %q", probeErr)
+	}
+	if len(probeErr) > runtimeProbeErrorMax {
+		t.Fatalf("probeErr length = %d, want <= %d", len(probeErr), runtimeProbeErrorMax)
+	}
+}
+
+func TestRuntimeProbeTimeout(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "opencode")
+	writeRuntimeExe(t, path, "#!/bin/sh\nsleep 1\nprintf 'late\\n'\n")
+
+	version, probeErr := probeRuntimeVersion(path, []string{"--version"}, 50*time.Millisecond)
+	if version != "" {
+		t.Fatalf("version = %q, want empty", version)
+	}
+	if !strings.Contains(probeErr, "timed out") {
+		t.Fatalf("probeErr = %q", probeErr)
+	}
+}
+
+func TestInfoServiceGetAvailableRuntimesCachesStartupSnapshot(t *testing.T) {
+	svc := &InfoService{
+		detectRuntimes: func() []RuntimeInfo {
+			return []RuntimeInfo{{ID: "claude", Name: "Claude Code", Installed: true, Version: "Claude 9.9.9"}}
+		},
+	}
+
+	svc.primeRuntimeSnapshot()
+	svc.detectRuntimes = func() []RuntimeInfo {
+		return []RuntimeInfo{{ID: "claude", Name: "Claude Code", Installed: false}}
+	}
+
+	first := svc.GetAvailableRuntimes()
+	second := svc.GetAvailableRuntimes()
+	if len(first) != 1 || first[0].Version != "Claude 9.9.9" {
+		t.Fatalf("first snapshot = %#v", first)
+	}
+	if len(second) != 1 || second[0].Version != "Claude 9.9.9" {
+		t.Fatalf("second snapshot = %#v", second)
+	}
+
+	first[0].Version = "mutated"
+	third := svc.GetAvailableRuntimes()
+	if third[0].Version != "Claude 9.9.9" {
+		t.Fatalf("cached snapshot should be cloned, got %#v", third)
+	}
+}
+
+func runtimeByID(t *testing.T, runtimes []RuntimeInfo, id string) RuntimeInfo {
+	t.Helper()
+	for _, runtime := range runtimes {
+		if runtime.ID == id {
+			return runtime
+		}
+	}
+	t.Fatalf("runtime %q not found in %#v", id, runtimes)
+	return RuntimeInfo{}
+}
+
+func writeRuntimeExe(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #442.

## Summary
- detect known AI runtimes at startup and expose them through InfoService
- surface installed/missing runtime state in Settings
- include focused backend and frontend coverage

## Tests
- env GOCACHE=/tmp/sybra-gocache go test ./internal/sybra -run 'TestInfoService.*Runtime|Test.*AvailableRuntime|Test.*RuntimeProbe|TestDetectAvailableRuntimes'
- pre-push hook: go test ./...; cd frontend && npm run check