### PR TITLE
fix(dispatch): never dispatch umbrella trackers

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -580,8 +580,10 @@ func (a *App) initStatusHook() {
 		a.logAudit(audit.EventTaskStatusChanged, taskID, "", data)
 
 		local := true
+		runsNoAgent := false
 		if t, err := a.tasks.Get(taskID); err == nil {
 			local = a.runsTaskLocally(t)
+			runsNoAgent = t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella
 		}
 
 		// Wake the dispatch pass immediately so a task that just became ready
@@ -597,11 +599,6 @@ func (a *App) initStatusHook() {
 		}
 		if local && releaseTaskAgents {
 			a.releaseTaskAgents(taskID)
-		}
-
-		runsNoAgent := false
-		if t, err := a.tasks.Get(taskID); err == nil {
-			runsNoAgent = t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella
 		}
 
 		switch to {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -599,13 +599,24 @@ func (a *App) initStatusHook() {
 			a.releaseTaskAgents(taskID)
 		}
 
+		runsNoAgent := false
+		if t, err := a.tasks.Get(taskID); err == nil {
+			runsNoAgent = t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella
+		}
+
 		switch to {
 		case string(task.StatusTodo):
-			a.dispatchTaskCreatedWorkflow(taskID)
+			if !runsNoAgent {
+				a.dispatchTaskCreatedWorkflow(taskID)
+			}
 		case string(task.StatusPlanning):
-			a.dispatchPlanningWorkflow(taskID)
+			if !runsNoAgent {
+				a.dispatchPlanningWorkflow(taskID)
+			}
 		case string(task.StatusInProgress):
-			a.dispatchStatusWorkflow(taskID, task.StatusInProgress)
+			if !runsNoAgent {
+				a.dispatchStatusWorkflow(taskID, task.StatusInProgress)
+			}
 		case string(task.StatusInReview):
 			msg := taskID
 			if t, err := a.tasks.Get(taskID); err == nil {
@@ -626,11 +637,17 @@ func (a *App) initStatusHook() {
 				go a.humanReview.maybeSpawn(taskID, from)
 			}
 		case string(task.StatusReadyReview):
-			a.dispatchStatusWorkflow(taskID, task.StatusReadyReview)
+			if !runsNoAgent {
+				a.dispatchStatusWorkflow(taskID, task.StatusReadyReview)
+			}
 		case string(task.StatusTesting):
-			a.dispatchStatusWorkflow(taskID, task.StatusTesting)
+			if !runsNoAgent {
+				a.dispatchStatusWorkflow(taskID, task.StatusTesting)
+			}
 		case string(task.StatusReadyPR):
-			a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
+			if !runsNoAgent {
+				a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
+			}
 		case string(task.StatusDone):
 			if local {
 				go a.closeLinkedIssueOnDone(taskID)

--- a/internal/sybra/monitor_cluster_test.go
+++ b/internal/sybra/monitor_cluster_test.go
@@ -219,9 +219,6 @@ func TestLeaderMonitorRoutesRemoteLostAgentAndMirrorConverges(t *testing.T) {
 	if len(report.Remediated) != 1 || report.Remediated[0] != "lost_agent:"+remote.ID {
 		t.Fatalf("remediated = %v, want lost_agent:%s", report.Remediated, remote.ID)
 	}
-	if orch.startedCount() != 1 {
-		t.Fatalf("remote recovery starts = %d, want 1", orch.startedCount())
-	}
 
 	waitForMonitorCluster(t, "mirror convergence after remote recovery", func() bool {
 		got, err := leaderTasks.Get(remote.ID)
@@ -238,6 +235,9 @@ func TestLeaderMonitorRoutesRemoteLostAgentAndMirrorConverges(t *testing.T) {
 			first.State == string(agent.StateStopped) &&
 			got.StatusReason == "monitor: agent lost; recovery will resume"
 	})
+	if orch.startedCount() != 1 {
+		t.Fatalf("remote recovery starts = %d, want 1", orch.startedCount())
+	}
 
 	got, err := leaderTasks.Get(remote.ID)
 	if err != nil {

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -334,11 +334,14 @@ func TestApp_StatusHook_SkipsAgentDispatchForUmbrellaTracker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := a.tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInProgress)})
-	if err != nil {
+	if _, err := a.tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInProgress)}); err != nil {
 		t.Fatal(err)
 	}
 
+	got, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got.Workflow != nil {
 		t.Fatalf("workflow = %+v, want nil — an umbrella tracker must never have simple-task-implement dispatched against it", got.Workflow)
 	}

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -309,6 +309,44 @@ func TestDispatchFromHumanRequired_WithStatusHook(t *testing.T) {
 	})
 }
 
+// TestApp_StatusHook_SkipsAgentDispatchForUmbrellaTracker reproduces the
+// production bug (task 33aa3f62 / issue #2004): app_umbrella_gate.go's
+// rollupTrackers rolls an umbrella tracker back to in-progress (e.g. after a
+// stuck child resolves), initStatusHook dispatches simple-task-implement for
+// that transition same as any other task, the implement step then tries to
+// start an agent against a tracker that runs none, and after three rejected
+// attempts within 15 minutes the circuit breaker force-escalates the tracker
+// to human-required — a state no human retry can actually resolve, since the
+// tracker will never successfully run an "implement" agent. initStatusHook
+// must skip dispatch entirely for umbrella (and chat) task types, exactly as
+// reconcileRunnableBoardTasks already does.
+func TestApp_StatusHook_SkipsAgentDispatchForUmbrellaTracker(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+	a.initStatusHook()
+
+	tk, err := a.tasks.CreateFull("umbrella tracker", "", task.AgentModeHeadless, task.Update{
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusHumanRequired),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := a.tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInProgress)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want nil — an umbrella tracker must never have simple-task-implement dispatched against it", got.Workflow)
+	}
+	if launcher.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0 — an umbrella tracker runs no agent", launcher.startCalls)
+	}
+}
+
 func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T) {
 	launcher := &fakeAgentLauncher{}
 	svc, a := setupDispatchTestService(t, launcher)


### PR DESCRIPTION
## Motivation

Task 33aa3f62 (umbrella #2004) sat in `human-required` with reason
`circuit breaker: agent start failed: start agent: task 33aa3f62 is an
umbrella tracker; it runs no agent (tripped after 3 dispatch failures
for step "implement" within 15m0s)`. All 17 still-unclaimed subissues
under it were stuck in `blocked` waiting on the tracker.

> Changelog: fix(dispatch): never dispatch umbrella trackers

Root cause: `app_umbrella_gate.go`'s `rollupTrackers` rolls a tracker
back to `in-progress` whenever it isn't cyclic/human-required/blocked/
cancelled/failing-expand/fully-done (e.g. after a stuck child
resolves). That status change fires `initStatusHook`
(`internal/sybra/app_init.go`), which dispatches
`simple-task-implement` for any task's `in-progress` transition with
no `TaskType` guard. The implement step then calls `agentorch.startAgent`,
which correctly refuses to run an agent for an umbrella tracker — but
that refusal is an untyped `fmt.Errorf`, so the workflow circuit
breaker treats it as a generic failure, retries twice more, and force-
escalates to `human-required` after the third rejection within 15
minutes. That's a state no human can actually resolve by retrying: a
tracker will never successfully run an "implement" agent.

`reconcileRunnableBoardTasks` (`app_orchestrator.go`) already excludes
`TaskTypeChat`/`TaskTypeUmbrella` before making the identical
`dispatchStatusWorkflow` call — `initStatusHook` was simply missing
the same guard.

## Implementation information

Add the same `TaskType != chat/umbrella` guard `initStatusHook` was
missing, gating every status-triggered dispatch call
(`dispatchTaskCreatedWorkflow`, `dispatchPlanningWorkflow`,
`dispatchStatusWorkflow`) in the hook's switch. Notification and
`closeLinkedIssueOnDone` cases are left untouched since those are
still valid for tracker tasks.

Added a regression test
(`TestApp_StatusHook_SkipsAgentDispatchForUmbrellaTracker`) that
creates an umbrella tracker, drives it `human-required → in-progress`
through the real hook + real builtin workflow store, and asserts no
workflow gets attached and no agent-start call happens. Verified the
test fails without the fix (reverted `app_init.go`, test failed) and
passes with it.

## Supporting documentation

`mise run verify` passes end-to-end.