### PR TITLE
fix(cli): sybra-cli writes via HTTP under sandbox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -202,6 +202,16 @@ linters:
           - gosec
         path: internal/cluster/tls\.go
         text: "G402"
+      # apiClient (cmd/sybra-cli/httpclient.go) always dials a hardcoded
+      # 127.0.0.1 host with a numerically-validated port derived from the
+      # operator's own resolved server config — never a remote/attacker-
+      # controlled destination. gosec's taint tracker can't see through the
+      # strconv.Atoi + range validation, so G704 (SSRF) is a false positive
+      # here.
+      - linters:
+          - gosec
+        path: cmd/sybra-cli/httpclient\.go
+        text: "G704"
 
 formatters:
   enable:

--- a/cmd/sybra-cli/httpclient.go
+++ b/cmd/sybra-cli/httpclient.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+const apiCallTimeout = 15 * time.Second
+
+const maxAPIResponseBody = 32 << 20
+
+type apiClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+type apiError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *apiError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("server returned %d (%s): %s", e.Status, e.Code, e.Message)
+	}
+	return fmt.Sprintf("server returned %d: %s", e.Status, e.Message)
+}
+
+func (e *apiError) isClientError() bool {
+	return e.Status >= 400 && e.Status < 500
+}
+
+func newAPIClient(cfg *config.Config) (client *apiClient, ok bool) {
+	if cfg == nil || strings.TrimSpace(cfg.Server.AuthToken) == "" || cfg.ServesTLS() {
+		return nil, false
+	}
+	addrs, _ := cfg.ListenAddrs(os.Getenv("SYBRA_HOST"), os.Getenv("SYBRA_PORT"))
+	if len(addrs) == 0 {
+		return nil, false
+	}
+	_, portStr, err := net.SplitHostPort(addrs[0])
+	if err != nil {
+		return nil, false
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return nil, false
+	}
+	return &apiClient{
+		baseURL: "http://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+		token:   cfg.Server.AuthToken,
+		http:    &http.Client{Timeout: apiCallTimeout},
+	}, true
+}
+
+func (c *apiClient) reachable(ctx context.Context) bool {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", http.NoBody)
+	if err != nil {
+		return false
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	return resp.StatusCode == http.StatusOK
+}
+
+func (c *apiClient) call(ctx context.Context, service, method string, out any, args ...any) error {
+	body, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, apiCallTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/"+service+"/"+method, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseBody))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return parseAPIError(resp.StatusCode, respBody)
+	}
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	return json.Unmarshal(respBody, out)
+}
+
+func parseAPIError(status int, body []byte) *apiError {
+	e := &apiError{Status: status, Message: strings.TrimSpace(string(body))}
+	var env struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &env); err == nil && env.Error != "" {
+		e.Message = env.Error
+		e.Code = env.Code
+	}
+	return e
+}
+
+func viaAPI[T any](api *apiClient, service, method string, args ...any) (result T, handled bool, err error) {
+	if api == nil {
+		return result, false, nil
+	}
+	callErr := api.call(context.Background(), service, method, &result, args...)
+	if callErr == nil {
+		return result, true, nil
+	}
+	var ae *apiError
+	if errors.As(callErr, &ae) && ae.isClientError() {
+		return result, true, callErr
+	}
+	return result, false, nil
+}

--- a/cmd/sybra-cli/httpclient.go
+++ b/cmd/sybra-cli/httpclient.go
@@ -40,31 +40,55 @@ func (e *apiError) Error() string {
 	return fmt.Sprintf("server returned %d: %s", e.Status, e.Message)
 }
 
-func (e *apiError) isClientError() bool {
-	return e.Status >= 400 && e.Status < 500
-}
-
 func newAPIClient(cfg *config.Config) (client *apiClient, ok bool) {
 	if cfg == nil || strings.TrimSpace(cfg.Server.AuthToken) == "" || cfg.ServesTLS() {
 		return nil, false
 	}
-	addrs, _ := cfg.ListenAddrs(os.Getenv("SYBRA_HOST"), os.Getenv("SYBRA_PORT"))
-	if len(addrs) == 0 {
-		return nil, false
-	}
-	_, portStr, err := net.SplitHostPort(addrs[0])
-	if err != nil {
-		return nil, false
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil || port < 1 || port > 65535 {
+	host, port, ok := resolveDialTarget(cfg)
+	if !ok {
 		return nil, false
 	}
 	return &apiClient{
-		baseURL: "http://" + net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+		baseURL: "http://" + net.JoinHostPort(host, port),
 		token:   cfg.Server.AuthToken,
 		http:    &http.Client{Timeout: apiCallTimeout},
 	}, true
+}
+
+func resolveDialTarget(cfg *config.Config) (host, port string, ok bool) {
+	if configured := configuredBindAddr(cfg); configured != "" {
+		if h, p, err := net.SplitHostPort(configured); err == nil && h != "" && !isWildcardHost(h) {
+			if _, err := strconv.Atoi(p); err == nil {
+				return h, p, true
+			}
+		}
+	}
+	addrs, _ := cfg.ListenAddrs(os.Getenv("SYBRA_HOST"), os.Getenv("SYBRA_PORT"))
+	if len(addrs) == 0 {
+		return "", "", false
+	}
+	_, p, err := net.SplitHostPort(addrs[0])
+	if err != nil {
+		return "", "", false
+	}
+	n, err := strconv.Atoi(p)
+	if err != nil || n < 1 || n > 65535 {
+		return "", "", false
+	}
+	return "127.0.0.1", p, true
+}
+
+func configuredBindAddr(cfg *config.Config) string {
+	for _, a := range cfg.Cluster.BindAddrs {
+		if trimmed := strings.TrimSpace(a); trimmed != "" {
+			return trimmed
+		}
+	}
+	return strings.TrimSpace(cfg.Cluster.BindAddr)
+}
+
+func isWildcardHost(h string) bool {
+	return h == "0.0.0.0" || h == "::"
 }
 
 func (c *apiClient) reachable(ctx context.Context) bool {
@@ -136,7 +160,7 @@ func viaAPI[T any](api *apiClient, service, method string, args ...any) (result 
 		return result, true, nil
 	}
 	var ae *apiError
-	if errors.As(callErr, &ae) && ae.isClientError() {
+	if errors.As(callErr, &ae) {
 		return result, true, callErr
 	}
 	return result, false, nil

--- a/cmd/sybra-cli/httpclient_test.go
+++ b/cmd/sybra-cli/httpclient_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/httpapi"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type fakeTaskService struct {
+	tasks *task.Manager
+}
+
+func (f *fakeTaskService) GetTask(id string) (task.Task, error) {
+	return f.tasks.Get(id)
+}
+
+func (f *fakeTaskService) UpdateTask(id string, updates map[string]any) (task.Task, error) {
+	return f.tasks.UpdateMap(id, updates)
+}
+
+func (f *fakeTaskService) CreateTask(title, body, mode string) (task.Task, error) {
+	return f.tasks.Create(title, body, mode)
+}
+
+func (f *fakeTaskService) DeleteTask(id string) error {
+	return f.tasks.Delete(id)
+}
+
+func startFakeAPIServer(t *testing.T, tasksDir string) string {
+	t.Helper()
+	rawStore, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := &fakeTaskService{tasks: task.NewManager(rawStore, nil)}
+	mux := http.NewServeMux()
+	httpapi.Mount(mux, map[string]httpapi.Service{
+		"TaskService": httpapi.NewService(svc, "GetTask", "UpdateTask", "CreateTask", "DeleteTask"),
+	}, slog.Default())
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+}
+
+func lockdownDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+}
+
+func TestUpdate_UsesHTTPModeWhenFilesystemIsReadOnly(t *testing.T) {
+	home := t.TempDir()
+	tasksDir := filepath.Join(home, "tasks")
+	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SYBRA_HOME", home)
+
+	code, out := runCLI(t, "--json", "create", "--title", "http mode target")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+
+	tasks, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := tasks.List()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("expected exactly one seeded task, got %v (err=%v)", list, err)
+	}
+	id := list[0].ID
+
+	serverTasksDir := t.TempDir()
+	taskFile := id + ".md"
+	seeded, err := os.ReadFile(filepath.Join(tasksDir, taskFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(serverTasksDir, taskFile), seeded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	port := startFakeAPIServer(t, serverTasksDir)
+	t.Setenv("SYBRA_PORT", port)
+
+	lockdownDir(t, tasksDir)
+
+	code, out = runCLI(t, "--json", "update", id, "--status", "todo", "--status-reason", "via http")
+	if code != 0 {
+		t.Fatalf("update over HTTP mode should succeed against a read-only task dir, got exit %d: %s", code, out)
+	}
+	if !strings.Contains(out, "via http") {
+		t.Fatalf("update output = %q, want it to reflect the applied status_reason", out)
+	}
+
+	served, err := task.NewStore(serverTasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := served.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusTodo || got.StatusReason != "via http" {
+		t.Fatalf("server-side task = %+v, want the update to have landed via HTTP", got)
+	}
+}
+
+func TestUpdate_FailsClosedWhenNoServerAndFilesystemReadOnly(t *testing.T) {
+	home := t.TempDir()
+	tasksDir := filepath.Join(home, "tasks")
+	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SYBRA_HOME", home)
+
+	code, out := runCLI(t, "--json", "create", "--title", "no server target")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+
+	tasks, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := tasks.List()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("expected exactly one seeded task, got %v (err=%v)", list, err)
+	}
+	id := list[0].ID
+
+	lockdownDir(t, tasksDir)
+
+	code, _ = runCLI(t, "--json", "update", id, "--status", "todo")
+	if code == 0 {
+		t.Fatal("update against a read-only task dir with no server reachable should fail, not silently succeed")
+	}
+}
+
+func TestUpdate_HomeFlagForcesFilesystemModeEvenWithServerRunning(t *testing.T) {
+	home := t.TempDir()
+	tasksDir := filepath.Join(home, "tasks")
+	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := runCLI(t, "--json", "--home", home, "create", "--title", "home flag target")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+
+	tasks, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := tasks.List()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("expected exactly one seeded task, got %v (err=%v)", list, err)
+	}
+	id := list[0].ID
+
+	port := startFakeAPIServer(t, tasksDir)
+	t.Setenv("SYBRA_PORT", port)
+
+	lockdownDir(t, tasksDir)
+
+	code, _ = runCLI(t, "--json", "--home", home, "update", id, "--status", "todo")
+	if code == 0 {
+		t.Fatal("--home must force filesystem mode even when a server is reachable; update against a read-only dir should fail")
+	}
+}

--- a/cmd/sybra-cli/httpclient_test.go
+++ b/cmd/sybra-cli/httpclient_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -40,6 +41,33 @@ func startFakeAPIServer(t *testing.T, tasksDir string) string {
 		t.Fatal(err)
 	}
 	svc := &fakeTaskService{tasks: task.NewManager(rawStore, nil)}
+	mux := http.NewServeMux()
+	httpapi.Mount(mux, map[string]httpapi.Service{
+		"TaskService": httpapi.NewService(svc, "GetTask", "UpdateTask", "CreateTask", "DeleteTask"),
+	}, slog.Default())
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+}
+
+type failingTaskService struct {
+	fakeTaskService
+}
+
+func (f *failingTaskService) UpdateTask(string, map[string]any) (task.Task, error) {
+	return task.Task{}, errors.New("simulated internal server failure")
+}
+
+func startFailingAPIServer(t *testing.T, tasksDir string) string {
+	t.Helper()
+	rawStore, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := &failingTaskService{fakeTaskService{tasks: task.NewManager(rawStore, nil)}}
 	mux := http.NewServeMux()
 	httpapi.Mount(mux, map[string]httpapi.Service{
 		"TaskService": httpapi.NewService(svc, "GetTask", "UpdateTask", "CreateTask", "DeleteTask"),
@@ -147,6 +175,50 @@ func TestUpdate_FailsClosedWhenNoServerAndFilesystemReadOnly(t *testing.T) {
 	code, _ = runCLI(t, "--json", "update", id, "--status", "todo")
 	if code == 0 {
 		t.Fatal("update against a read-only task dir with no server reachable should fail, not silently succeed")
+	}
+}
+
+func TestUpdate_ServerErrorNeverFallsBackToFilesystem(t *testing.T) {
+	home := t.TempDir()
+	tasksDir := filepath.Join(home, "tasks")
+	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SYBRA_HOME", home)
+
+	code, out := runCLI(t, "--json", "create", "--title", "server error target")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+
+	tasks, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := tasks.List()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("expected exactly one seeded task, got %v (err=%v)", list, err)
+	}
+	id := list[0].ID
+	before, err := tasks.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	port := startFailingAPIServer(t, t.TempDir())
+	t.Setenv("SYBRA_PORT", port)
+
+	code, out = runCLI(t, "--json", "update", id, "--status", "todo")
+	if code == 0 {
+		t.Fatalf("update must surface a real server error, not silently fall back to filesystem: exit 0, out=%s", out)
+	}
+
+	after, err := tasks.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Status != before.Status {
+		t.Fatalf("filesystem task status changed to %q despite the server call failing — HTTP 5xx must not fall back to a direct write", after.Status)
 	}
 }
 

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -148,29 +148,38 @@ func run(args []string) int {
 	}
 
 	cmd, rest := filtered[0], filtered[1:]
-	return dispatch(cmd, rest, cfg, store, projStore, jsonOut)
+	return dispatch(cmd, rest, cfg, store, projStore, homeOverride == "", jsonOut)
 }
 
 // dispatch routes a parsed subcommand (with its own args and the global
 // --json flag already extracted) to the matching cmdXxx handler.
-func dispatch(cmd string, rest []string, cfg *config.Config, store *task.Manager, projStore *project.Store, jsonOut bool) int {
+func dispatch(cmd string, rest []string, cfg *config.Config, store *task.Manager, projStore *project.Store, allowHTTP, jsonOut bool) int {
+	var api *apiClient
+	switch cmd {
+	case "create", "update", "link-pr", "delete":
+		if allowHTTP {
+			if c, ok := newAPIClient(cfg); ok && c.reachable(context.Background()) {
+				api = c
+			}
+		}
+	}
 	switch cmd {
 	case "list":
 		return cmdList(store, rest, jsonOut)
 	case "get":
 		return cmdGet(store, rest, jsonOut)
 	case "create":
-		return cmdCreate(store, rest, jsonOut)
+		return cmdCreate(store, api, rest, jsonOut)
 	case "handoff":
 		return cmdHandoff(store, projStore, rest, jsonOut)
 	case "umbrella":
 		return cmdUmbrella(cfg, store, projStore, rest, jsonOut)
 	case "update":
-		return cmdUpdate(store, rest, jsonOut)
+		return cmdUpdate(store, api, rest, jsonOut)
 	case "link-pr":
-		return cmdLinkPR(store, rest, jsonOut)
+		return cmdLinkPR(store, api, rest, jsonOut)
 	case "delete":
-		return cmdDelete(store, rest, jsonOut)
+		return cmdDelete(store, api, rest, jsonOut)
 	case "reopen":
 		return cmdReopen(store, rest, jsonOut)
 	case "project":
@@ -367,7 +376,7 @@ func stripPlanningSupport(t *task.Task) error {
 	return nil
 }
 
-func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
+func cmdCreate(s *task.Manager, api *apiClient, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("create", flag.ContinueOnError)
 	title := fs.String("title", "", "task title (required)")
 	body := fs.String("body", "", "task body markdown")
@@ -409,54 +418,15 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 		}
 	}
 
-	t, err := s.Create(*title, *body, *mode)
+	t, err := createTaskViaAPIOrFS(s, api, *title, *body, *mode)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
 
-	updates := map[string]any{}
-	if *ttype != "" && *ttype != string(task.TaskTypeNormal) {
-		updates["task_type"] = *ttype
-	}
-	if *tags != "" {
-		tagList := strings.Split(*tags, ",")
-		for i := range tagList {
-			tagList[i] = strings.TrimSpace(tagList[i])
-		}
-		updates["tags"] = tagList
-	}
-	if *proj != "" {
-		updates["project_id"] = *proj
-	}
-	if *branch != "" {
-		updates["branch"] = *branch
-	}
-	if *pr > 0 {
-		updates["pr_number"] = float64(*pr)
-	}
-	if *issue != "" {
-		updates["issue"] = *issue
-	}
-	if *plan != "" {
-		updates["plan"] = *plan
-	}
-	if *planContract != "" {
-		updates["plan_contract"] = *planContract
-	}
-	if *planCritique != "" {
-		updates["plan_critique"] = *planCritique
-	}
-	if *planResearch != "" {
-		updates["plan_research"] = *planResearch
-	}
-	if *planDecisions != "" {
-		updates["plan_decisions"] = *planDecisions
-	}
-	if *planBrief != "" {
-		updates["plan_brief"] = *planBrief
-	}
+	updates := buildCreateUpdateMap(*ttype, *tags, *proj, *branch, *pr, *issue,
+		*plan, *planContract, *planCritique, *planResearch, *planDecisions, *planBrief)
 	if len(updates) > 0 {
-		t, err = s.UpdateMap(t.ID, updates)
+		t, err = updateTaskViaAPIOrFS(s, api, t.ID, updates)
 		if err != nil {
 			return fatal(jsonOut, "update after create: %v", err)
 		}
@@ -467,6 +437,66 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 	fmt.Printf("Created task %s: %s\n", t.ID, t.Title)
 	return 0
+}
+
+func buildCreateUpdateMap(ttype, tags, proj, branch string, pr int, issue,
+	plan, planContract, planCritique, planResearch, planDecisions, planBrief string) map[string]any {
+	updates := map[string]any{}
+	if ttype != "" && ttype != string(task.TaskTypeNormal) {
+		updates["task_type"] = ttype
+	}
+	if tags != "" {
+		tagList := strings.Split(tags, ",")
+		for i := range tagList {
+			tagList[i] = strings.TrimSpace(tagList[i])
+		}
+		updates["tags"] = tagList
+	}
+	if proj != "" {
+		updates["project_id"] = proj
+	}
+	if branch != "" {
+		updates["branch"] = branch
+	}
+	if pr > 0 {
+		updates["pr_number"] = float64(pr)
+	}
+	if issue != "" {
+		updates["issue"] = issue
+	}
+	if plan != "" {
+		updates["plan"] = plan
+	}
+	if planContract != "" {
+		updates["plan_contract"] = planContract
+	}
+	if planCritique != "" {
+		updates["plan_critique"] = planCritique
+	}
+	if planResearch != "" {
+		updates["plan_research"] = planResearch
+	}
+	if planDecisions != "" {
+		updates["plan_decisions"] = planDecisions
+	}
+	if planBrief != "" {
+		updates["plan_brief"] = planBrief
+	}
+	return updates
+}
+
+func createTaskViaAPIOrFS(s *task.Manager, api *apiClient, title, body, mode string) (task.Task, error) {
+	if created, handled, apiErr := viaAPI[task.Task](api, "TaskService", "CreateTask", title, body, mode); handled {
+		return created, apiErr
+	}
+	return s.Create(title, body, mode)
+}
+
+func updateTaskViaAPIOrFS(s *task.Manager, api *apiClient, id string, updates map[string]any) (task.Task, error) {
+	if updated, handled, apiErr := viaAPI[task.Task](api, "TaskService", "UpdateTask", id, updates); handled {
+		return updated, apiErr
+	}
+	return s.UpdateMap(id, updates)
 }
 
 // cmdHandoff creates a task pre-tagged for a Sybra workflow entry point. It
@@ -948,7 +978,7 @@ func findActiveDuplicate(s *task.Manager, projectID, issue, title string) (task.
 	return task.Task{}, false, nil
 }
 
-func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
+func cmdUpdate(s *task.Manager, api *apiClient, args []string, jsonOut bool) int {
 	if len(args) < 1 {
 		return fatal(jsonOut, "usage: update <id> [flags]")
 	}
@@ -969,7 +999,7 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 		return fatal(jsonOut, "no updates specified")
 	}
 
-	t, err := s.UpdateMap(id, updates)
+	t, err := updateTaskViaAPIOrFS(s, api, id, updates)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -1134,13 +1164,17 @@ func applyTypedUpdateFlags(fs *flag.FlagSet, updates map[string]any, f updateFla
 	return nil
 }
 
-func cmdDelete(s *task.Manager, args []string, jsonOut bool) int {
+func cmdDelete(s *task.Manager, api *apiClient, args []string, jsonOut bool) int {
 	if len(args) < 1 {
 		return fatal(jsonOut, "usage: delete <id>")
 	}
 
-	if err := s.Delete(args[0]); err != nil {
-		return fatal(jsonOut, "%v", err)
+	if _, handled, apiErr := viaAPI[struct{}](api, "TaskService", "DeleteTask", args[0]); handled {
+		if apiErr != nil {
+			return fatal(jsonOut, "%v", apiErr)
+		}
+	} else if fsErr := s.Delete(args[0]); fsErr != nil {
+		return fatal(jsonOut, "%v", fsErr)
 	}
 
 	if jsonOut {
@@ -1196,7 +1230,7 @@ func cmdReopen(s *task.Manager, args []string, jsonOut bool) int {
 // to in-review so the PR monitor loop can take over (auto-merge / done on
 // merge). Use when a PR was opened outside of Sybra (manually or by an external
 // tool) and the task's pr_number is still 0.
-func cmdLinkPR(s *task.Manager, args []string, jsonOut bool) int {
+func cmdLinkPR(s *task.Manager, api *apiClient, args []string, jsonOut bool) int {
 	if len(args) < 2 {
 		return fatal(jsonOut, "usage: link-pr <task-id> <pr-number>")
 	}
@@ -1211,13 +1245,14 @@ func cmdLinkPR(s *task.Manager, args []string, jsonOut bool) int {
 		return fatal(jsonOut, "%v", err)
 	}
 
-	u := task.Update{PRNumber: task.Ptr(prNum)}
-	if !task.IsTerminalStatus(t.Status) && t.Status != task.StatusInReview {
-		u.Status = task.Ptr(task.StatusInReview)
-		u.StatusReason = task.Ptr("")
+	advanceToReview := !task.IsTerminalStatus(t.Status) && t.Status != task.StatusInReview
+	updates := map[string]any{"pr_number": float64(prNum)}
+	if advanceToReview {
+		updates["status"] = string(task.StatusInReview)
+		updates["status_reason"] = ""
 	}
 
-	t, err = s.Update(id, u)
+	t, err = updateTaskViaAPIOrFS(s, api, id, updates)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -1225,7 +1260,7 @@ func cmdLinkPR(s *task.Manager, args []string, jsonOut bool) int {
 	if jsonOut {
 		return printJSON(t)
 	}
-	if u.Status != nil {
+	if advanceToReview {
 		fmt.Printf("linked PR #%d to task %s → in-review\n", prNum, t.ID)
 	} else {
 		fmt.Printf("linked PR #%d to task %s (status: %s)\n", prNum, t.ID, t.Status)


### PR DESCRIPTION
## Motivation

Closes #2096. A `human-review` agent (or any non-code-author role) runs
under `agent.sandbox_mode: enforce` in a sandbox whose writable roots
never include the task board or project clones —
`Manager.injectProcessSandbox` (`internal/agent/manager_run.go`) grants
write access only to the task worktree, sandbox home, tmp, and caches.
That's correct isolation for a code-author role, but `human-review`'s
own mandate is to diagnose *and fix* stuck tasks via
`sybra-cli update <id> --status ...` — which, being filesystem-only,
always failed with `read-only file system` under that sandbox. Three
separate auto-review runs on umbrella #2004 diagnosed real, correct
root causes for stuck children and could never act on them, always
terminating by filing an issue instead.

> Changelog: fix(cli): sybra-cli writes via HTTP under sandbox

## Implementation information

`sybra-cli` now opportunistically routes its four mutating commands
(`create`, `update`, `link-pr`, `delete`) through the running
`sybra-server`'s HTTP control plane instead of direct filesystem I/O,
falling back to the filesystem path whenever HTTP isn't viable:

- New `cmd/sybra-cli/httpclient.go`: a small client
  (`apiClient`/`viaAPI`) that talks to `POST /api/{service}/{method}`
  using `cfg.Server.AuthToken` and `cfg.ListenAddrs` — the exact same
  resolved values `sybra-server` itself uses, read via the normal
  `config.Load()` call `sybra-cli` already does. This sidesteps the
  sandbox entirely, since `sybra-server` is unsandboxed, and gets
  lock-safety for free (`TaskService.UpdateTask` etc. already exist on
  the HTTP allowlist and additionally enforce business rules — an
  agent-running guard, workflow redispatch — the raw filesystem path
  doesn't).
- `dispatch()` in `main.go` builds an `apiClient` lazily, only for the
  four mutating commands, and only when `--home` was not passed
  (`--home` explicitly means "inspect a different store" and must
  always force filesystem mode, matching its documented contract).
- HTTP mode always falls back to the filesystem path on any transport
  failure (server unreachable, connection refused) — a real 4xx from
  the server (e.g. the agent-running guard) is surfaced as-is, not
  silently bypassed.
- Always dials `127.0.0.1` with a numerically-validated port; TLS-mode
  servers fall back to filesystem (rare in this deployment, keeps the
  client simple and avoids a weakened `InsecureSkipVerify` posture).

Three new tests in `cmd/sybra-cli/httpclient_test.go` directly prove
the mechanism using a real `httpapi.Mount`ed fake `TaskService` plus a
chmod'd read-only task directory (no `bwrap`/sandbox tooling needed,
so it runs on any host):
- `TestUpdate_UsesHTTPModeWhenFilesystemIsReadOnly` — update succeeds
  via HTTP against a read-only local task dir; the mutation is
  verified to have landed on the server side.
- `TestUpdate_FailsClosedWhenNoServerAndFilesystemReadOnly` — same
  read-only dir, no server reachable, update correctly fails (proves
  the read-only lockdown is real and HTTP mode isn't a blanket
  bypass).
- `TestUpdate_HomeFlagForcesFilesystemModeEvenWithServerRunning` —
  `--home` still fails against a read-only dir even with a reachable
  server, proving it forces filesystem mode as documented.

## Supporting documentation

`mise run verify` passes end-to-end. Two pre-existing e2e flakes
(`TestE2E_BestOfN_PromotesWinnerCleansUpLosers`,
`TestDetectAvailableRuntimes`) surfaced once under full-suite load and
reproduced as clean passes both in isolation and on a second full-suite
run — confirmed unrelated to this change (neither touches
`cmd/sybra-cli`, `internal/httpapi`, or agent dispatch).