### PR TITLE
fix(project): quarantine stale refs before fetch

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -393,6 +393,18 @@ func FetchOrigin(ctx context.Context, barePath string) error {
 			// refs/remotes/origin/*.
 			return runBare(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 		})
+		if err != nil && IsBadRefError(err) {
+			if _, repairErr := repairBareCloneLocked(ctx, barePath, ""); repairErr == nil {
+				retryErr := withLockRetry(func() error {
+					return runBare(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+				})
+				if retryErr == nil {
+					markFetched(barePath)
+					return nil
+				}
+			}
+			return err
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -402,6 +402,7 @@ func FetchOrigin(ctx context.Context, barePath string) error {
 					markFetched(barePath)
 					return nil
 				}
+				return retryErr
 			}
 			return err
 		}

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -76,7 +76,10 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 		}
 		badValue, _ := outputBare(ctx, barePath, "rev-parse", ref)
 		QuarantineRef(barePath, ref, strings.TrimSpace(badValue))
-		if delErr := runBare(ctx, barePath, "update-ref", "-d", ref); delErr == nil {
+		delErr := withLockRetry(func() error {
+			return runBare(ctx, barePath, "update-ref", "-d", ref)
+		})
+		if delErr == nil {
 			report.QuarantinedRefs = append(report.QuarantinedRefs, ref)
 		}
 	}
@@ -105,7 +108,9 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 	}
 
 	if len(report.QuarantinedRefs) > 0 {
-		_ = runBare(ctx, barePath, "worktree", "prune")
+		_ = withLockRetry(func() error {
+			return runBare(ctx, barePath, "worktree", "prune")
+		})
 		report.PrunedWorktrees = true
 	}
 

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -1,0 +1,143 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type RepairReport struct {
+	QuarantinedRefs   []string
+	PrunedWorktrees   bool
+	RefetchedBranches []string
+}
+
+var QuarantineDir string
+
+var badRefMarkers = []string{
+	"fatal: bad object",
+	"bad object head",
+	"not a valid object name",
+	"invalid object",
+	"invalid revision range",
+	"missing object",
+	"unable to read sha1 file",
+	"object file",
+	"loose object",
+	"unknown revision",
+	"ambiguous argument",
+	"reference broken",
+}
+
+func IsBadRefError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range badRefMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func CommonDir(ctx context.Context, worktreePath string) (string, error) {
+	return gitCommonDir(ctx, worktreePath)
+}
+
+func RepairBareClone(ctx context.Context, barePath, taskBranch string) (RepairReport, error) {
+	var report RepairReport
+	err := withBareRepoLock(barePath, func() error {
+		var innerErr error
+		report, innerErr = repairBareCloneLocked(ctx, barePath, taskBranch)
+		return innerErr
+	})
+	return report, err
+}
+
+func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (RepairReport, error) {
+	var report RepairReport
+
+	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)", "refs/heads")
+	if err != nil {
+		return report, fmt.Errorf("enumerate refs/heads: %w", err)
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(refsOut), "\n") {
+		ref := strings.TrimSpace(line)
+		if ref == "" {
+			continue
+		}
+		if checkErr := runBare(ctx, barePath, "cat-file", "-e", ref+"^{object}"); checkErr == nil {
+			continue
+		}
+		badValue, _ := outputBare(ctx, barePath, "rev-parse", ref)
+		QuarantineRef(barePath, ref, strings.TrimSpace(badValue))
+		if delErr := runBare(ctx, barePath, "update-ref", "-d", ref); delErr == nil {
+			report.QuarantinedRefs = append(report.QuarantinedRefs, ref)
+		}
+	}
+
+	worktreesDir := filepath.Join(barePath, "worktrees")
+	entries, _ := os.ReadDir(worktreesDir)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		wtRef := "worktrees/" + entry.Name() + "/HEAD"
+		headBytes, readErr := os.ReadFile(filepath.Join(worktreesDir, entry.Name(), "HEAD"))
+		if readErr != nil {
+			continue
+		}
+		head := strings.TrimSpace(string(headBytes))
+		target := head
+		if trimmed, ok := strings.CutPrefix(head, "ref: "); ok {
+			target = strings.TrimSpace(trimmed)
+		}
+		if checkErr := runBare(ctx, barePath, "rev-parse", "--verify", target+"^{commit}"); checkErr == nil {
+			continue
+		}
+		QuarantineRef(barePath, wtRef, head)
+		report.QuarantinedRefs = append(report.QuarantinedRefs, wtRef)
+	}
+
+	if len(report.QuarantinedRefs) > 0 {
+		_ = runBare(ctx, barePath, "worktree", "prune")
+		report.PrunedWorktrees = true
+	}
+
+	refspecs := []string{"+refs/heads/*:refs/remotes/origin/*"}
+	if taskBranch != "" {
+		refspecs = append(refspecs, "+refs/heads/"+taskBranch+":refs/remotes/origin/"+taskBranch)
+	}
+	fetchArgs := append([]string{"fetch", "origin"}, refspecs...)
+	if fetchErr := runBare(ctx, barePath, fetchArgs...); fetchErr == nil {
+		report.RefetchedBranches = refspecs
+	}
+
+	return report, nil
+}
+
+func QuarantineRef(barePath, ref, badValue string) {
+	if QuarantineDir == "" {
+		return
+	}
+	if err := os.MkdirAll(QuarantineDir, 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(quarantineLogPath(barePath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "%s\t%s\t%s\t%s\n", time.Now().UTC().Format(time.RFC3339), barePath, ref, badValue)
+}
+
+func quarantineLogPath(barePath string) string {
+	replacer := strings.NewReplacer("/", "_", string(filepath.Separator), "_")
+	safe := replacer.Replace(filepath.Clean(barePath))
+	return filepath.Join(QuarantineDir, safe+".log")
+}

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -1,0 +1,135 @@
+package project
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func plantBadRef(t *testing.T, bare, ref string) {
+	t.Helper()
+	path := filepath.Join(bare, filepath.FromSlash(ref))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(strings.Repeat("f", 40)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchOrigin_RepairsPoisonedSiblingRef(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+
+	plantBadRef(t, bare, "refs/heads/dead-sibling")
+
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("FetchOrigin should repair the poisoned sibling ref and succeed, got: %v", err)
+	}
+
+	trackingRef := "refs/remotes/origin/" + branch
+	if _, err := outputBare(context.Background(), bare, "rev-parse", "--verify", trackingRef); err != nil {
+		t.Fatalf("good branch %s should still be fetchable after repair: %v", trackingRef, err)
+	}
+
+	if _, err := outputBare(context.Background(), bare, "rev-parse", "--verify", "refs/heads/dead-sibling"); err == nil {
+		t.Fatal("dead-sibling ref should have been removed by the repair pass")
+	}
+}
+
+func TestRepairBareClone_QuarantinesRefsAndWorktreeHead(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	origDir := QuarantineDir
+	quarantineDir := t.TempDir()
+	QuarantineDir = quarantineDir
+	t.Cleanup(func() { QuarantineDir = origDir })
+
+	plantBadRef(t, bare, "refs/heads/dead-sibling")
+	plantBadRef(t, bare, "worktrees/stale-wt/HEAD")
+
+	report, err := RepairBareClone(context.Background(), bare, "")
+	if err != nil {
+		t.Fatalf("RepairBareClone: %v", err)
+	}
+
+	if len(report.QuarantinedRefs) != 2 {
+		t.Fatalf("QuarantinedRefs = %v, want 2 entries (dead-sibling + stale worktree HEAD)", report.QuarantinedRefs)
+	}
+	if !report.PrunedWorktrees {
+		t.Fatal("PrunedWorktrees should be true when a broken ref was found")
+	}
+
+	entries, err := os.ReadDir(quarantineDir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("expected a quarantine log file, got entries=%v err=%v", entries, err)
+	}
+	logBytes, err := os.ReadFile(filepath.Join(quarantineDir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logBytes)
+	if !strings.Contains(log, "refs/heads/dead-sibling") {
+		t.Fatalf("quarantine log = %q, want it to mention the pruned ref instead of silently dropping it", log)
+	}
+	if !strings.Contains(log, strings.Repeat("f", 40)) {
+		t.Fatalf("quarantine log = %q, want it to record the bad SHA", log)
+	}
+}
+
+func TestRepairBareClone_NoOpOnCleanClone(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	report, err := RepairBareClone(context.Background(), bare, "")
+	if err != nil {
+		t.Fatalf("RepairBareClone: %v", err)
+	}
+	if len(report.QuarantinedRefs) != 0 {
+		t.Fatalf("QuarantinedRefs = %v, want none on a clean clone", report.QuarantinedRefs)
+	}
+	if report.PrunedWorktrees {
+		t.Fatal("PrunedWorktrees should be false when nothing was broken")
+	}
+}
+
+func TestIsBadRefError(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"fatal: bad object refs/heads/foo", true},
+		{"fatal: unable to read sha1 file", true},
+		{"connection refused", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		var err error
+		if tc.msg != "" {
+			err = testError(tc.msg)
+		}
+		if got := IsBadRefError(err); got != tc.want {
+			t.Errorf("IsBadRefError(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
+	}
+}
+
+type testError string
+
+func (e testError) Error() string { return string(e) }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -422,12 +422,7 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.prTracker = github.NewIssueTracker(30 * time.Minute)
 
-	// Bound how often FetchOrigin does a real network fetch per bare clone —
-	// fix/review/pr-fix prepares call it unconditionally on every dispatch, so
-	// without a TTL a tight cluster of dispatches against one repo (hundreds
-	// of pr-fix runs/month, see issue #1527) pays for a full-branch fetch on
-	// every single one.
-	project.FetchTTL = 60 * time.Second
+	configureProjectGitDefaults()
 	// Initialize domain services (dependency order: worktrees → agentOrch → reviewer, workflow)
 	a.worktrees = worktree.New(worktree.Config{
 		WorktreesDir:     a.worktreesDir,
@@ -455,6 +450,11 @@ func (a *App) Startup(ctx context.Context) error {
 	a.logger.Info("app.started")
 	started = true
 	return nil
+}
+
+func configureProjectGitDefaults() {
+	project.FetchTTL = 60 * time.Second
+	project.QuarantineDir = filepath.Join(config.HomeDir(), "quarantine")
 }
 
 // sandboxRetentionWindow translates the resolved sandbox.retention_hours

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -470,7 +470,11 @@ func (e *Engine) recoverVerifyCommitsRefs(taskID, wtPath string, t TaskInfo) boo
 
 	baseRef := resolveOriginBase(ctx, wtPath)
 	negotiationTips := verifyCommitsNegotiationTips(ctx, wtPath, baseRef)
-	for _, ref := range pruneBrokenVerifyCommitRefs(ctx, wtPath, branch) {
+	barePath, bareErr := project.CommonDir(ctx, wtPath)
+	if bareErr != nil {
+		barePath = ""
+	}
+	for _, ref := range pruneBrokenVerifyCommitRefs(ctx, wtPath, barePath, branch) {
 		e.logger.Warn("workflow.verify-commits.ref-recovery.pruned-broken-ref", "task_id", taskID, "ref", ref)
 	}
 	refspecs := []string{"+" + "refs/heads/" + branch + ":refs/remotes/origin/" + branch}
@@ -514,7 +518,7 @@ func verifyCommitsNegotiationTips(ctx context.Context, wtPath, baseRef string) [
 	return nil
 }
 
-func pruneBrokenVerifyCommitRefs(ctx context.Context, wtPath, taskBranch string) []string {
+func pruneBrokenVerifyCommitRefs(ctx context.Context, wtPath, barePath, taskBranch string) []string {
 	cmd := exec.CommandContext(ctx, "git", "for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes/origin")
 	cmd.Dir = wtPath
 	out, err := cmd.Output()
@@ -533,6 +537,12 @@ func pruneBrokenVerifyCommitRefs(ctx context.Context, wtPath, taskBranch string)
 		check.Dir = wtPath
 		if check.Run() == nil {
 			continue
+		}
+		if barePath != "" {
+			badValue := exec.CommandContext(ctx, "git", "rev-parse", ref)
+			badValue.Dir = wtPath
+			shaOut, _ := badValue.Output()
+			project.QuarantineRef(barePath, ref, strings.TrimSpace(string(shaOut)))
 		}
 		deleteCmd := exec.CommandContext(ctx, "git", "update-ref", "-d", ref)
 		deleteCmd.Dir = wtPath


### PR DESCRIPTION
## Motivation

Closes #2090. A single stale local ref in a project's shared bare
clone (`refs/heads/<branch>` or `worktrees/<id>/HEAD` pointing at a
missing object) poisons the wildcard `git fetch origin
+refs/heads/*:refs/remotes/origin/*` for *every* task against that
project — not just the task whose branch went bad. Observed affected
tasks on the server included `02909563`, `6846cb47`, `c78cd4eb`,
`7ad2337e`, `c6600b3b`, `da387f67`, and `eb73838a` — a single
`refs/heads/docs/...` ref pointing at a missing blob blocked worktree
creation and branch recovery for unrelated tasks in the same repo
until someone manually quarantined the ref and refetched.

> Changelog: fix(project): quarantine stale refs before fetch

## Implementation information

Added `internal/project/repair.go`:
- `IsBadRefError(err) bool` — string-matches the same "bad object /
  invalid object / unable to read sha1 file / ..." failure shapes
  already used by `internal/workflow/engine_steps_verify.go`'s
  verify-commits retry gate.
- `RepairBareClone`/`repairBareCloneLocked` — walks `refs/heads/*` and
  `worktrees/*/HEAD`, verifies each with `git cat-file -e`/`git
  rev-parse --verify`, and for anything broken: records it (ref name +
  bad SHA + timestamp) to a per-clone quarantine log under
  `~/.sybra/quarantine/` via the new `QuarantineRef` helper, deletes
  the broken ref, runs `git worktree prune`, then refetches. Nothing
  is deleted silently anymore — previously
  `pruneBrokenVerifyCommitRefs` (verify-commits' own narrow repair)
  just ran `git update-ref -d` with no record.
- `FetchOrigin` (`internal/project/git.go`) now retries once through
  the repair pass when a fetch fails with a bad-ref-shaped error,
  inside the same `withBareRepoLock` critical section it already
  holds (the repair function is unexported/lock-free internally so it
  can be called from both the standalone `RepairBareClone` entrypoint
  and from inside `FetchOrigin` without double-locking/deadlocking).
  Since `FetchOrigin` is the single chokepoint six worktree-prep
  functions and every transitive branch-conflict-recovery /
  stale-task-resume path already funnel through, this one change
  covers all of them.
- `pruneBrokenVerifyCommitRefs` (verify-commits' own recovery, the one
  path that doesn't go through `FetchOrigin`) now calls
  `project.QuarantineRef` before each delete instead of silently
  dropping the ref — same quarantine record, no behavior change to
  what gets pruned.
- `project.QuarantineDir` wired in `internal/sybra/app.go` next to the
  existing `project.FetchTTL` package-var wiring, both extracted into
  a small `configureProjectGitDefaults()` helper to keep `Startup`
  under the repo's function-length lint budget.

New tests in `internal/project/repair_test.go` plant a loose ref
pointing at a nonexistent 40-`f` SHA (the same repro technique already
proven in `internal/workflow/engine_test.go`'s
`TestExecVerifyCommits_FetchesMissingLocalHeadObject`) and assert:
- `FetchOrigin` against a bare clone with a poisoned sibling branch
  now succeeds (reproduces the exact `fatal: bad object
  refs/heads/...` error from the real incident, confirmed the test
  fails without the fix and passes with it).
- `RepairBareClone` quarantines both a broken `refs/heads/*` ref and a
  broken `worktrees/*/HEAD`, records the bad SHA in the quarantine
  log, and is a no-op on an already-clean clone.

## Supporting documentation

`mise run verify` passes end-to-end.