### PR TITLE
fix(project): shield generated paths from wip

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -11,6 +11,18 @@ setup:
   - (cd frontend && npm ci)
   - (cd frontend && npm run build:desktop)
 
+# Restored to HEAD before an agent-recovery auto-commit (SanitizeWorktree /
+# verify_commits) rather than preserved as-is. frontend/bindings/ is Wails
+# codegen output; wails3 is darwin-only and not installed on the Linux
+# server, so an agent that deletes/regenerates it there (e.g. following a
+# "wails3 generate bindings" instruction from CLAUDE.md) can leave the
+# directory wiped with no way to regenerate it in that environment. Without
+# this, the safety net that preserves uncommitted work committed that wiped
+# state as if it were real progress (task 02909563: 9641 deletions, broken
+# `npm run build:desktop`).
+protected_paths:
+  - frontend/bindings
+
 # Black-box testing guidance for the testing workflow. Test-runners must prefer
 # this runnable surface over static inspection: start the server, wait for
 # health, then drive at least one user/operator-facing probe.

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -478,6 +478,7 @@ func resolveRef(ctx context.Context, barePath, ref string) (string, bool) {
 // swallowed, matching the SanitizeWorktree call site this was extracted
 // from — callers must not depend on the commit having landed.
 func AutoCommitUncommitted(ctx context.Context, wtPath, message string) bool {
+	restoreProtectedPaths(ctx, wtPath)
 	statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 	statusCmd.Dir = wtPath
 	statusOut, err := statusCmd.Output()
@@ -490,6 +491,22 @@ func AutoCommitUncommitted(ctx context.Context, wtPath, message string) bool {
 		return false
 	}
 	return runRecoveryCommit(ctx, wtPath, message) == nil
+}
+
+func restoreProtectedPaths(ctx context.Context, wtPath string) {
+	cfg, err := LoadRepoConfig(wtPath)
+	if err != nil || cfg == nil {
+		return
+	}
+	for _, p := range cfg.ProtectedPaths {
+		p = strings.TrimSpace(p)
+		if p == "" || strings.Contains(p, "..") {
+			continue
+		}
+		restore := exec.CommandContext(ctx, "git", "checkout", "--", p)
+		restore.Dir = wtPath
+		_ = restore.Run()
+	}
 }
 
 // CheckpointCommit stages and commits the current worktree state with message.

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -500,13 +500,25 @@ func restoreProtectedPaths(ctx context.Context, wtPath string) {
 	}
 	for _, p := range cfg.ProtectedPaths {
 		p = strings.TrimSpace(p)
-		if p == "" || strings.Contains(p, "..") {
+		if !isSafeProtectedPath(p) {
 			continue
 		}
-		restore := exec.CommandContext(ctx, "git", "checkout", "--", p)
+		restore := exec.CommandContext(ctx, "git", "checkout", "--", ":(literal)"+p)
 		restore.Dir = wtPath
 		_ = restore.Run()
 	}
+}
+
+func isSafeProtectedPath(p string) bool {
+	if p == "" || strings.HasPrefix(p, "/") || strings.HasPrefix(p, ":") {
+		return false
+	}
+	for part := range strings.SplitSeq(p, "/") {
+		if part == "." || part == ".." {
+			return false
+		}
+	}
+	return true
 }
 
 // CheckpointCommit stages and commits the current worktree state with message.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -463,6 +463,89 @@ func TestAutoCommitUncommitted(t *testing.T) {
 	}
 }
 
+func TestAutoCommitUncommitted_RestoresProtectedPathBeforeCommitting(t *testing.T) {
+	t.Parallel()
+
+	dir := initRepoWithCommit(t)
+	if err := os.MkdirAll(filepath.Join(dir, "frontend", "bindings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "frontend", "bindings", "app.ts"), []byte("export {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".sybra.yaml"), []byte("protected_paths:\n  - frontend/bindings\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", dir, "add", "."},
+		{"git", "-C", dir, "commit", "-m", "seed bindings"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := os.RemoveAll(filepath.Join(dir, "frontend", "bindings")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "real-work.txt"), []byte("finished work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := AutoCommitUncommitted(context.Background(), dir, "wip: recovered work"); !got {
+		t.Fatal("expected a commit for the unrelated real-work.txt change")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "frontend", "bindings", "app.ts")); err != nil {
+		t.Fatalf("frontend/bindings/app.ts should have been restored from HEAD, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "real-work.txt")); err != nil {
+		t.Fatalf("real-work.txt should still be present and committed: %v", err)
+	}
+
+	statusOut, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if strings.TrimSpace(string(statusOut)) != "" {
+		t.Fatalf("worktree still dirty after commit: %q", statusOut)
+	}
+}
+
+func TestAutoCommitUncommitted_ProtectedPathOnlyDeletionCommitsNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := initRepoWithCommit(t)
+	if err := os.MkdirAll(filepath.Join(dir, "frontend", "bindings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "frontend", "bindings", "app.ts"), []byte("export {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".sybra.yaml"), []byte("protected_paths:\n  - frontend/bindings\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", dir, "add", "."},
+		{"git", "-C", dir, "commit", "-m", "seed bindings"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := os.RemoveAll(filepath.Join(dir, "frontend", "bindings")); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := AutoCommitUncommitted(context.Background(), dir, "wip: should not commit"); got {
+		t.Fatal("a protected-path-only deletion must be restored, not preserved as a commit")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "frontend", "bindings", "app.ts")); err != nil {
+		t.Fatalf("frontend/bindings/app.ts should have been restored from HEAD, got: %v", err)
+	}
+}
+
 func TestSanitizeWorktree_AbortsRebase(t *testing.T) {
 	t.Parallel()
 	src := initRepoWithCommit(t)

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -463,6 +463,29 @@ func TestAutoCommitUncommitted(t *testing.T) {
 	}
 }
 
+func TestIsSafeProtectedPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"frontend/bindings", true},
+		{"vendor", true},
+		{"", false},
+		{"/etc/passwd", false},
+		{"../outside", false},
+		{"frontend/../../../etc", false},
+		{"frontend/./bindings", false},
+		{":(exclude)frontend", false},
+		{":(glob)**", false},
+	}
+	for _, tc := range cases {
+		if got := isSafeProtectedPath(tc.path); got != tc.want {
+			t.Errorf("isSafeProtectedPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
 func TestAutoCommitUncommitted_RestoresProtectedPathBeforeCommitting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -44,7 +44,8 @@ type RepoConfig struct {
 	Setup []string `yaml:"setup,omitempty" json:"setup,omitempty"`
 	// ManualTest tells the testing workflow how this project can be exercised
 	// through a user/operator-facing surface instead of only via unit tests.
-	ManualTest *ManualTestConfig `yaml:"manual_test,omitempty" json:"manualTest,omitempty"`
+	ManualTest     *ManualTestConfig `yaml:"manual_test,omitempty" json:"manualTest,omitempty"`
+	ProtectedPaths []string          `yaml:"protected_paths,omitempty" json:"protectedPaths,omitempty"`
 }
 
 // ManualTestKind identifies the runnable surface a test-runner should drive.


### PR DESCRIPTION
## Motivation

Task `02909563` (a child of umbrella #2004, `feat(stats): record
requested and executed skills`) landed in `human-required` on a
`setup on reused worktree: setup command "(cd frontend && npm run
build:desktop)" failed` circuit-breaker trip. The worktree's HEAD
commit was `wip: auto-commit uncommitted agent work` (from
`SanitizeWorktree`'s safety net) — `git show --stat` on it showed 69
files changed, 117 insertions, 9641 deletions: the entire
`frontend/bindings/` tree deleted, alongside genuine Go implementation
work in `internal/stats`/`internal/sybra`.

`wails3` (the tool that regenerates `frontend/bindings/`) is
darwin/wails3-only — CI's own `verify:` check list explicitly excludes
Wails bindings generation for exactly this reason, and the server host
only has `mise` installed, no wails3 CLI (see CLAUDE.md "Toolchain on
the server host"). So an agent on the Linux server that deletes or
attempts to regenerate `frontend/bindings/` has no way to actually
regenerate it — and `AutoCommitUncommitted` (used by both
`SanitizeWorktree` and `verify_commits` recovery as a "preserve
uncommitted work" safety net before a reset) had no way to distinguish
that broken, un-regenerable intermediate state from real work in
progress. It just ran `git add -A && commit`, capturing and preserving
the wipe as if it were legitimate.

> Changelog: fix(project): shield generated paths from wip

## Implementation information

Added `RepoConfig.ProtectedPaths` (`internal/project/model.go`,
`.sybra.yaml` key `protected_paths`) — an opt-in list of generated/
vendored paths a repo declares as never-safe-to-auto-commit-as-deleted.
`AutoCommitUncommitted` (`internal/project/git.go`) now runs `git
checkout -- <path>` for each declared protected path before its
existing `git status`/`add -A`/commit sequence, so any deletion or
modification under that path is silently reverted to HEAD first.
Two direct consequences, both covered by new tests:
- A commit that mixes real work with a protected-path wipe now
  captures only the real work; the protected path is restored.
- A commit whose *only* change is a protected-path wipe now commits
  nothing at all (matches `AutoCommitUncommitted`'s existing "clean
  tree → no commit" contract) instead of creating an empty-content
  "preserved" commit.

This repo's own `.sybra.yaml` now declares `protected_paths:
[frontend/bindings]`, closing the loop on the actual incident. Any
other repo Sybra manages is unaffected unless it opts in the same way.

New tests in `internal/project/git_test.go`:
- `TestAutoCommitUncommitted_RestoresProtectedPathBeforeCommitting` —
  mixed real-work + protected-path-deletion working tree; asserts the
  protected path is restored and the real work still lands in the
  commit.
- `TestAutoCommitUncommitted_ProtectedPathOnlyDeletionCommitsNothing`
  — protected-path-only deletion; asserts no commit is made and the
  path is restored.

Both fail on `git.go` reverted to its pre-fix state (confirmed) and
pass with the fix; the existing `TestAutoCommitUncommitted` baseline
(no `.sybra.yaml`, i.e. no protected paths configured) is unaffected.

## Supporting documentation

`mise run verify` passes end-to-end.