### PR TITLE
feat(promptlab): autonomous proposal loop

### DIFF
--- a/cmd/sybra-cli/prompt_lab.go
+++ b/cmd/sybra-cli/prompt_lab.go
@@ -62,7 +62,8 @@ func cmdPromptLabRun(cfg *config.Config, store *task.Manager, projStore *project
 
 	var filed []task.Task
 	if *fileTasks && !*dryRun {
-		filed, err = filePromptLabProposals(store, projStore, result)
+		cooldown := time.Duration(cfg.PromptLab.RefileCooldownDays * float64(24*time.Hour))
+		filed, err = filePromptLabProposals(store, projStore, result, cooldown)
 		if err != nil {
 			return fatal(jsonOut, "file proposals: %v", err)
 		}
@@ -81,7 +82,7 @@ const promptLabProjectID = "Automaat/sybra"
 // is EXPLICIT here, not inherited: fileHarnessProposals (harness_evolution.go)
 // does not scrub, so this filer builds and applies its own work-typed
 // blocklist per subject rather than assuming that precedent covers it too.
-func filePromptLabProposals(store *task.Manager, projStore *project.Store, result promptlab.RunResult) ([]task.Task, error) {
+func filePromptLabProposals(store *task.Manager, projStore *project.Store, result promptlab.RunResult, cooldown time.Duration) ([]task.Task, error) {
 	existing, err := store.List()
 	if err != nil {
 		return nil, err
@@ -89,7 +90,7 @@ func filePromptLabProposals(store *task.Manager, projStore *project.Store, resul
 	var filed []task.Task
 	for i := range result.Proposals {
 		p := result.Proposals[i]
-		if promptlab.HasProposal(existing, p.ID) {
+		if promptlab.HasProposal(existing, p.ID, cooldown, time.Now().UTC()) {
 			continue
 		}
 		body := scrubProposalBody(projStore, promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)

--- a/cmd/sybra-cli/prompt_lab.go
+++ b/cmd/sybra-cli/prompt_lab.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"slices"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -91,7 +89,7 @@ func filePromptLabProposals(store *task.Manager, projStore *project.Store, resul
 	var filed []task.Task
 	for i := range result.Proposals {
 		p := result.Proposals[i]
-		if _, ok := findExistingPromptLabProposal(existing, p.ID); ok {
+		if promptlab.HasProposal(existing, p.ID) {
 			continue
 		}
 		body := scrubProposalBody(projStore, promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)
@@ -145,22 +143,6 @@ func scrubProposalBody(projStore *project.Store, body string, projectIDs []strin
 		body, _ = scrub.Scrub(body, blocklist)
 	}
 	return body
-}
-
-func findExistingPromptLabProposal(tasks []task.Task, proposalID string) (task.Task, bool) {
-	marker := "Proposal ID:** `" + proposalID + "`"
-	for i := range tasks {
-		if task.IsTerminalStatus(tasks[i].Status) {
-			continue
-		}
-		if !slices.Contains(tasks[i].Tags, promptlab.ProposalTag) {
-			continue
-		}
-		if strings.Contains(tasks[i].Body, marker) {
-			return tasks[i], true
-		}
-	}
-	return task.Task{}, false
 }
 
 func printPromptLabResult(result promptlab.RunResult, filed []task.Task) {

--- a/cmd/sybra-cli/prompt_lab_test.go
+++ b/cmd/sybra-cli/prompt_lab_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/promptlab"
@@ -55,7 +56,7 @@ func TestFilePromptLabProposalsScrubsWorkTyped(t *testing.T) {
 	p := testProposal("pl-work-1", "implementation", []string{proj.ID})
 	result := promptlab.RunResult{Proposals: []promptlab.Proposal{p}}
 
-	filed, err := filePromptLabProposals(tasks, projects, result)
+	filed, err := filePromptLabProposals(tasks, projects, result, 30*24*time.Hour)
 	if err != nil {
 		t.Fatalf("filePromptLabProposals: %v", err)
 	}
@@ -91,7 +92,7 @@ func TestFilePromptLabProposalsLeavesPetUnredacted(t *testing.T) {
 	nilProjectProposal := testProposal("pl-nil-1", "review", nil)
 	result := promptlab.RunResult{Proposals: []promptlab.Proposal{petProposal, nilProjectProposal}}
 
-	filed, err := filePromptLabProposals(tasks, projects, result)
+	filed, err := filePromptLabProposals(tasks, projects, result, 30*24*time.Hour)
 	if err != nil {
 		t.Fatalf("filePromptLabProposals: %v", err)
 	}
@@ -116,14 +117,14 @@ func TestFilePromptLabProposalsSkipsDuplicates(t *testing.T) {
 	p := testProposal("pl-dup-1", "implementation", nil)
 	result := promptlab.RunResult{Proposals: []promptlab.Proposal{p}}
 
-	first, err := filePromptLabProposals(tasks, projects, result)
+	first, err := filePromptLabProposals(tasks, projects, result, 30*24*time.Hour)
 	if err != nil {
 		t.Fatalf("first file: %v", err)
 	}
 	if len(first) != 1 {
 		t.Fatalf("len(first) = %d, want 1", len(first))
 	}
-	second, err := filePromptLabProposals(tasks, projects, result)
+	second, err := filePromptLabProposals(tasks, projects, result, 30*24*time.Hour)
 	if err != nil {
 		t.Fatalf("second file: %v", err)
 	}
@@ -142,7 +143,7 @@ func TestFilePromptLabProposalsAssignsSybraProjectWhenRegistered(t *testing.T) {
 	}
 
 	p := testProposal("pl-sybra-1", "implementation", nil)
-	filed, err := filePromptLabProposals(tasks, projects, promptlab.RunResult{Proposals: []promptlab.Proposal{p}})
+	filed, err := filePromptLabProposals(tasks, projects, promptlab.RunResult{Proposals: []promptlab.Proposal{p}}, 30*24*time.Hour)
 	if err != nil {
 		t.Fatalf("filePromptLabProposals: %v", err)
 	}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -492,10 +492,18 @@ prompt, workflow, permission, retry, validator, or deployment changes itself.
 PromptLabConfig controls the automated Prompt Lab loop that scaffolds
 versioned prompt/skill variant proposals from fleet evidence (Evaluation
 report + stats). It never authors or applies prompt/skill text itself —
-every proposal is filed as a reviewed local task for a human (or a later
-agent run) to author and gate through the standard offline-eval + A/B
-path. Disabled by default: unlike HarnessEvolveConfig, a fresh install
-must not start filing tasks before an operator opts in.
+every proposal is filed as a local task whose authoring workflow gates the
+resulting variant through the standard offline-eval + A/B path. Disabled
+by default: unlike HarnessEvolveConfig, a fresh install must not start
+filing tasks before an operator opts in.
+
+AutoApprove starts a filed proposal's authoring workflow without waiting
+for a human click, making the loop autonomous end to end. It defaults to
+true (see Config.PromptLabAutoApprove): a proposal only ever scaffolds an
+*attempt*, and the barrier that actually protects production is
+prompteval.Gate.AllowEnrollment inside the authoring workflow, which is
+fail-closed and unaffected by this setting. A proposal carrying an
+explicit FAILED offline verdict is never auto-approved regardless.
 
 | YAML key | Type | Default | Description |
 |---|---|---|---|
@@ -505,6 +513,7 @@ must not start filing tasks before an operator opts in.
 | `prompt_lab.min_samples` | `int` |  |  |
 | `prompt_lab.min_effect_size` | `float64` |  |  |
 | `prompt_lab.max_proposals_per_run` | `int` |  |  |
+| `prompt_lab.auto_approve` | `*bool` | _(nil)_ |  |
 
 ## ExperienceConfig (`experience`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -505,6 +505,12 @@ prompteval.Gate.AllowEnrollment inside the authoring workflow, which is
 fail-closed and unaffected by this setting. A proposal carrying an
 explicit FAILED offline verdict is never auto-approved regardless.
 
+RefileCooldownDays is how long a subject stays suppressed after one of its
+proposals reaches done/cancelled. A proposal ID is a stable hash of
+(role, step, intent) over only two intents, so suppressing forever would
+let each role produce at most two proposals ever and then go silent —
+while never suppressing re-files the same ID every tick. Defaults to 30.
+
 | YAML key | Type | Default | Description |
 |---|---|---|---|
 | `prompt_lab.enabled` | `bool` |  |  |
@@ -514,6 +520,7 @@ explicit FAILED offline verdict is never auto-approved regardless.
 | `prompt_lab.min_effect_size` | `float64` |  |  |
 | `prompt_lab.max_proposals_per_run` | `int` |  |  |
 | `prompt_lab.auto_approve` | `*bool` | _(nil)_ |  |
+| `prompt_lab.refile_cooldown_days` | `float64` |  |  |
 
 ## ExperienceConfig (`experience`)
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/promptlabservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/promptlabservice.ts
@@ -7,12 +7,18 @@
  * "prompt-lab-proposal" + "requires-human", status human-required) until
  * approval, which starts the dedicated prompt-lab authoring workflow.
  * 
- * Approval is not necessarily a human: under prompt_lab.auto_approve
- * (default on) promptLabCoordinator approves each proposal as it files it,
- * making these methods the manual override rather than the only way
- * through. What gates production either way is
- * prompteval.Gate.AllowEnrollment inside the authoring workflow — approval
- * only buys a candidate the right to be authored and screened.
+ * Approval starts the authoring workflow; it does not certify the variant.
+ * It is not necessarily a human either: under prompt_lab.auto_approve
+ * promptLabCoordinator approves each proposal as it files it, making these
+ * methods the manual override rather than the only way through.
+ * 
+ * Approval carries no guarantee that the authored variant is screened before
+ * it enrolls in A/B. prompteval.Gate is only constructed when
+ * evaluation.offline.enabled is set, and a nil Engine.evalGate means offline
+ * verdicts do not gate enrollment at all. That is exactly why
+ * Config.PromptLabAutoApprove is hard-gated on the same flag: with the screen
+ * off, a human calling ApproveProposal is the last remaining barrier, so the
+ * unattended caller must not exist there.
  * @module
  */
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/promptlabservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/promptlabservice.ts
@@ -6,6 +6,13 @@
  * Wails-bound methods. Proposals are plain tasks (tagged
  * "prompt-lab-proposal" + "requires-human", status human-required) until
  * approval, which starts the dedicated prompt-lab authoring workflow.
+ * 
+ * Approval is not necessarily a human: under prompt_lab.auto_approve
+ * (default on) promptLabCoordinator approves each proposal as it files it,
+ * making these methods the manual override rather than the only way
+ * through. What gates production either way is
+ * prompteval.Gate.AllowEnrollment inside the authoring workflow — approval
+ * only buys a candidate the right to be authored and screened.
  * @module
  */
 
@@ -22,6 +29,11 @@ import * as task$0 from "../task/models.js";
  * in-progress, drops the requires-human tag, and starts the dedicated
  * prompt-lab authoring workflow. Errors without mutating if the task is not a
  * pending proposal (wrong status, or missing the prompt-lab-proposal tag).
+ * 
+ * promptLabCoordinator drives the same path unattended via autoApprove when
+ * prompt_lab.auto_approve is set, so every guard, dispatch, and
+ * revert-on-failure below must hold for a caller that is not a human; the
+ * two differ only in the progress note left in the task's decision log.
  */
 export function ApproveProposal(id: string): $CancellablePromise<task$0.Task> {
     return $Call.ByID(3299652469, id).then(($result: any) => {

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -204,6 +204,16 @@ func (c *Config) DefaultRequirePermissions() bool {
 	return true
 }
 
+// PromptLabAutoApprove returns the configured prompt_lab.auto_approve, or
+// true if unset. See PromptLabConfig for why autonomous approval is the
+// default once an operator has opted into the loop at all.
+func (c *Config) PromptLabAutoApprove() bool {
+	if c != nil && c.PromptLab.AutoApprove != nil {
+		return *c.PromptLab.AutoApprove
+	}
+	return true
+}
+
 // DefaultHeadlessSteerable returns the configured agent.headless_steerable
 // default, or true if unset.
 func (c *Config) DefaultHeadlessSteerable() bool {

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -204,11 +204,23 @@ func (c *Config) DefaultRequirePermissions() bool {
 	return true
 }
 
-// PromptLabAutoApprove returns the configured prompt_lab.auto_approve, or
-// true if unset. See PromptLabConfig for why autonomous approval is the
-// default once an operator has opted into the loop at all.
+// PromptLabAutoApprove reports whether a filed Prompt Lab proposal may start
+// its authoring workflow without a human click. Defaults to true, but is
+// hard-gated on evaluation.offline.enabled regardless of the setting.
+//
+// Auto-approve is only safe because a later gate screens the authored
+// variant before it enrolls in production A/B. That gate is not always
+// there: App.initWorkflowEngine only builds prompteval.Gate when
+// evaluation.offline.enabled is set, and Engine.evalGate == nil means
+// "offline eval verdicts do not gate A/B enrollment" (abtest.EligibleVariants
+// skips the check on a nil evalPassed). With the screen off, the human click
+// is the ONLY thing between an unscreened variant and production, so
+// removing it there would be a safety regression rather than autonomy.
 func (c *Config) PromptLabAutoApprove() bool {
-	if c != nil && c.PromptLab.AutoApprove != nil {
+	if c == nil || !c.Evaluation.Offline.Enabled {
+		return false
+	}
+	if c.PromptLab.AutoApprove != nil {
 		return *c.PromptLab.AutoApprove
 	}
 	return true
@@ -1191,6 +1203,9 @@ func applyPromptLabDefaults(cfg *Config) {
 	}
 	if p.MinEffectSize <= 0 {
 		p.MinEffectSize = 0.15
+	}
+	if p.RefileCooldownDays <= 0 {
+		p.RefileCooldownDays = 30
 	}
 	if p.MaxProposalsPerRun <= 0 {
 		p.MaxProposalsPerRun = 3

--- a/internal/config/config_promptlab.go
+++ b/internal/config/config_promptlab.go
@@ -3,10 +3,18 @@ package config
 // PromptLabConfig controls the automated Prompt Lab loop that scaffolds
 // versioned prompt/skill variant proposals from fleet evidence (Evaluation
 // report + stats). It never authors or applies prompt/skill text itself —
-// every proposal is filed as a reviewed local task for a human (or a later
-// agent run) to author and gate through the standard offline-eval + A/B
-// path. Disabled by default: unlike HarnessEvolveConfig, a fresh install
-// must not start filing tasks before an operator opts in.
+// every proposal is filed as a local task whose authoring workflow gates the
+// resulting variant through the standard offline-eval + A/B path. Disabled
+// by default: unlike HarnessEvolveConfig, a fresh install must not start
+// filing tasks before an operator opts in.
+//
+// AutoApprove starts a filed proposal's authoring workflow without waiting
+// for a human click, making the loop autonomous end to end. It defaults to
+// true (see Config.PromptLabAutoApprove): a proposal only ever scaffolds an
+// *attempt*, and the barrier that actually protects production is
+// prompteval.Gate.AllowEnrollment inside the authoring workflow, which is
+// fail-closed and unaffected by this setting. A proposal carrying an
+// explicit FAILED offline verdict is never auto-approved regardless.
 type PromptLabConfig struct {
 	Enabled            bool    `yaml:"enabled" json:"enabled"`
 	IntervalHours      float64 `yaml:"interval_hours" json:"intervalHours"`
@@ -14,4 +22,5 @@ type PromptLabConfig struct {
 	MinSamples         int     `yaml:"min_samples" json:"minSamples"`
 	MinEffectSize      float64 `yaml:"min_effect_size" json:"minEffectSize"`
 	MaxProposalsPerRun int     `yaml:"max_proposals_per_run" json:"maxProposalsPerRun"`
+	AutoApprove        *bool   `yaml:"auto_approve" json:"autoApprove"`
 }

--- a/internal/config/config_promptlab.go
+++ b/internal/config/config_promptlab.go
@@ -15,6 +15,12 @@ package config
 // prompteval.Gate.AllowEnrollment inside the authoring workflow, which is
 // fail-closed and unaffected by this setting. A proposal carrying an
 // explicit FAILED offline verdict is never auto-approved regardless.
+//
+// RefileCooldownDays is how long a subject stays suppressed after one of its
+// proposals reaches done/cancelled. A proposal ID is a stable hash of
+// (role, step, intent) over only two intents, so suppressing forever would
+// let each role produce at most two proposals ever and then go silent —
+// while never suppressing re-files the same ID every tick. Defaults to 30.
 type PromptLabConfig struct {
 	Enabled            bool    `yaml:"enabled" json:"enabled"`
 	IntervalHours      float64 `yaml:"interval_hours" json:"intervalHours"`
@@ -23,4 +29,5 @@ type PromptLabConfig struct {
 	MinEffectSize      float64 `yaml:"min_effect_size" json:"minEffectSize"`
 	MaxProposalsPerRun int     `yaml:"max_proposals_per_run" json:"maxProposalsPerRun"`
 	AutoApprove        *bool   `yaml:"auto_approve" json:"autoApprove"`
+	RefileCooldownDays float64 `yaml:"refile_cooldown_days" json:"refileCooldownDays"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1044,19 +1044,32 @@ func TestDefaultRequirePermissions(t *testing.T) {
 	}
 }
 
+// TestPromptLabAutoApprove pins the hard gate on evaluation.offline.enabled.
+// App.initWorkflowEngine only builds prompteval.Gate when that is set, and a
+// nil evalGate means A/B enrollment is not screened at all — so with the
+// screen off, auto-approve must stay off no matter what the operator asked
+// for, or an unscreened variant reaches production with no barrier left.
 func TestPromptLabAutoApprove(t *testing.T) {
 	t.Parallel()
 	boolPtr := func(b bool) *bool { return &b }
+	screenOn := func(p PromptLabConfig) *Config {
+		return &Config{PromptLab: p, Evaluation: EvaluationConfig{Offline: OfflineEvalConfig{Enabled: true}}}
+	}
+	screenOff := func(p PromptLabConfig) *Config {
+		return &Config{PromptLab: p, Evaluation: EvaluationConfig{Offline: OfflineEvalConfig{Enabled: false}}}
+	}
 
 	tests := []struct {
 		name string
 		cfg  *Config
 		want bool
 	}{
-		{"nil config", nil, true},
-		{"nil field", &Config{}, true},
-		{"explicit true", &Config{PromptLab: PromptLabConfig{AutoApprove: boolPtr(true)}}, true},
-		{"explicit false", &Config{PromptLab: PromptLabConfig{AutoApprove: boolPtr(false)}}, false},
+		{"nil config", nil, false},
+		{"screen off, unset", screenOff(PromptLabConfig{}), false},
+		{"screen off, explicit true", screenOff(PromptLabConfig{AutoApprove: boolPtr(true)}), false},
+		{"screen on, unset", screenOn(PromptLabConfig{}), true},
+		{"screen on, explicit true", screenOn(PromptLabConfig{AutoApprove: boolPtr(true)}), true},
+		{"screen on, explicit false", screenOn(PromptLabConfig{AutoApprove: boolPtr(false)}), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1073,17 +1086,33 @@ func TestPromptLabAutoApprove(t *testing.T) {
 func TestPromptLabAutoApproveSurvivesDefaults(t *testing.T) {
 	t.Parallel()
 	boolPtr := func(b bool) *bool { return &b }
+	screen := EvaluationConfig{Offline: OfflineEvalConfig{Enabled: true}}
 
-	cfg := &Config{PromptLab: PromptLabConfig{Enabled: true, AutoApprove: boolPtr(false)}}
+	cfg := &Config{PromptLab: PromptLabConfig{Enabled: true, AutoApprove: boolPtr(false)}, Evaluation: screen}
 	applyPromptLabDefaults(cfg)
 	if cfg.PromptLabAutoApprove() {
 		t.Fatal("explicit auto_approve: false must survive defaulting")
 	}
 
-	unset := &Config{PromptLab: PromptLabConfig{Enabled: true}}
+	unset := &Config{PromptLab: PromptLabConfig{Enabled: true}, Evaluation: screen}
 	applyPromptLabDefaults(unset)
 	if !unset.PromptLabAutoApprove() {
 		t.Fatal("unset auto_approve must default to true")
+	}
+}
+
+func TestPromptLabRefileCooldownDefault(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{PromptLab: PromptLabConfig{Enabled: true}}
+	applyPromptLabDefaults(cfg)
+	if cfg.PromptLab.RefileCooldownDays != 30 {
+		t.Fatalf("RefileCooldownDays = %v, want 30", cfg.PromptLab.RefileCooldownDays)
+	}
+
+	explicit := &Config{PromptLab: PromptLabConfig{Enabled: true, RefileCooldownDays: 7}}
+	applyPromptLabDefaults(explicit)
+	if explicit.PromptLab.RefileCooldownDays != 7 {
+		t.Fatalf("RefileCooldownDays = %v, want explicit 7 preserved", explicit.PromptLab.RefileCooldownDays)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1044,6 +1044,49 @@ func TestDefaultRequirePermissions(t *testing.T) {
 	}
 }
 
+func TestPromptLabAutoApprove(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{"nil config", nil, true},
+		{"nil field", &Config{}, true},
+		{"explicit true", &Config{PromptLab: PromptLabConfig{AutoApprove: boolPtr(true)}}, true},
+		{"explicit false", &Config{PromptLab: PromptLabConfig{AutoApprove: boolPtr(false)}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.cfg.PromptLabAutoApprove(); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPromptLabAutoApproveSurvivesDefaults guards the *bool: applyPromptLabDefaults
+// must not rewrite an explicit false into the true default.
+func TestPromptLabAutoApproveSurvivesDefaults(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(b bool) *bool { return &b }
+
+	cfg := &Config{PromptLab: PromptLabConfig{Enabled: true, AutoApprove: boolPtr(false)}}
+	applyPromptLabDefaults(cfg)
+	if cfg.PromptLabAutoApprove() {
+		t.Fatal("explicit auto_approve: false must survive defaulting")
+	}
+
+	unset := &Config{PromptLab: PromptLabConfig{Enabled: true}}
+	applyPromptLabDefaults(unset)
+	if !unset.PromptLabAutoApprove() {
+		t.Fatal("unset auto_approve must default to true")
+	}
+}
+
 func TestPlaywrightMCPEnabled(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/promptlab/propose.go
+++ b/internal/promptlab/propose.go
@@ -136,21 +136,37 @@ func ProposalIDMarker(proposalID string) string {
 	return "Proposal ID:** `" + proposalID + "`"
 }
 
-// HasProposal reports whether proposalID was already filed as a task in tasks.
+// HasProposal reports whether proposalID should be suppressed rather than
+// filed again, given the tasks already on the board.
 //
-// Terminal tasks count. A proposal ID is a stable hash of (role, workflow
-// step, intent), so a done proposal means that variant was already authored
-// and shipped, and a cancelled one means it was rejected — re-filing either
-// ignores a decision that was already made. Skipping terminal tasks here is
-// what let one proposal ID get filed four separate times as earlier copies
-// aged out into done/cancelled.
-func HasProposal(tasks []task.Task, proposalID string) bool {
+// A live (non-terminal) proposal always suppresses: it is still being worked.
+// A terminal one suppresses only until cooldown elapses from its last update.
+// Both halves matter and pull against each other:
+//
+// Ignoring terminal tasks entirely is what let pl-a2d853b2c1d9 get filed four
+// separate times — the ID is a stable hash of (role, step, intent), so every
+// tick re-proposed it as earlier copies aged into done/cancelled.
+//
+// Suppressing on terminal tasks forever is the opposite failure: with only two
+// candidate intents per subject, a role would get at most two proposals for the
+// lifetime of the board and then go permanently silent — including when the
+// shipped variant lost its A/B and the role is still weak. Auto-approve makes
+// that worse, not better, by churning proposals to terminal in hours.
+//
+// The cooldown is the bounded-rate middle: re-proposing a subject is allowed,
+// just not every tick. A zero or negative cooldown suppresses on any terminal
+// task (never re-file).
+func HasProposal(tasks []task.Task, proposalID string, cooldown time.Duration, now time.Time) bool {
 	marker := ProposalIDMarker(proposalID)
 	for i := range tasks {
-		if !slices.Contains(tasks[i].Tags, ProposalTag) {
+		t := &tasks[i]
+		if !slices.Contains(t.Tags, ProposalTag) || !strings.Contains(t.Body, marker) {
 			continue
 		}
-		if strings.Contains(tasks[i].Body, marker) {
+		if !task.IsTerminalStatus(t.Status) {
+			return true
+		}
+		if cooldown <= 0 || now.Sub(t.UpdatedAt) < cooldown {
 			return true
 		}
 	}

--- a/internal/promptlab/propose.go
+++ b/internal/promptlab/propose.go
@@ -2,9 +2,12 @@ package promptlab
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/task"
 )
 
 // candidateIntents are the directions promptlab may scaffold from a weak
@@ -124,4 +127,32 @@ func reviewGate(p Proposal) string {
 		return "requires human approval"
 	}
 	return "standard review"
+}
+
+// ProposalIDMarker is the substring RenderProposalBody emits for a proposal's
+// ID, and the key HasProposal matches on. It is defined next to the renderer
+// so the marker format and its parser can never drift apart.
+func ProposalIDMarker(proposalID string) string {
+	return "Proposal ID:** `" + proposalID + "`"
+}
+
+// HasProposal reports whether proposalID was already filed as a task in tasks.
+//
+// Terminal tasks count. A proposal ID is a stable hash of (role, workflow
+// step, intent), so a done proposal means that variant was already authored
+// and shipped, and a cancelled one means it was rejected — re-filing either
+// ignores a decision that was already made. Skipping terminal tasks here is
+// what let one proposal ID get filed four separate times as earlier copies
+// aged out into done/cancelled.
+func HasProposal(tasks []task.Task, proposalID string) bool {
+	marker := ProposalIDMarker(proposalID)
+	for i := range tasks {
+		if !slices.Contains(tasks[i].Tags, ProposalTag) {
+			continue
+		}
+		if strings.Contains(tasks[i].Body, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/promptlab/propose_test.go
+++ b/internal/promptlab/propose_test.go
@@ -1,0 +1,79 @@
+package promptlab
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func proposalTask(status task.Status, tags []string, proposalID string) task.Task {
+	return task.Task{
+		Status: status,
+		Tags:   tags,
+		Body:   RenderProposalBody(Proposal{ID: proposalID, Candidate: VariantCandidate{ID: proposalID}}),
+	}
+}
+
+// TestHasProposalCountsTerminalTasks pins the regression that let a single
+// proposal ID be filed four separate times: dedupe skipped terminal tasks,
+// so every tick re-filed a proposal whose earlier copies had aged into
+// done/cancelled.
+func TestHasProposalCountsTerminalTasks(t *testing.T) {
+	t.Parallel()
+	tags := []string{ProposalTag, "role:review"}
+
+	for _, status := range []task.Status{
+		task.StatusDone,
+		task.StatusCancelled,
+		task.StatusHumanRequired,
+		task.StatusTodo,
+		task.StatusInProgress,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+			tasks := []task.Task{proposalTask(status, tags, "pl-a2d853b2c1d9")}
+			if !HasProposal(tasks, "pl-a2d853b2c1d9") {
+				t.Fatalf("status %s: already-filed proposal must never be re-filed", status)
+			}
+		})
+	}
+}
+
+func TestHasProposalDistinguishesIDsAndTags(t *testing.T) {
+	t.Parallel()
+	tags := []string{ProposalTag, "role:review"}
+	tasks := []task.Task{proposalTask(task.StatusDone, tags, "pl-a2d853b2c1d9")}
+
+	if HasProposal(tasks, "pl-5cf660095cb8") {
+		t.Fatal("a different proposal ID must not match")
+	}
+	untagged := []task.Task{proposalTask(task.StatusDone, []string{"role:review"}, "pl-a2d853b2c1d9")}
+	if HasProposal(untagged, "pl-a2d853b2c1d9") {
+		t.Fatal("a task without the proposal tag must not match")
+	}
+	if HasProposal(nil, "pl-a2d853b2c1d9") {
+		t.Fatal("empty task list must not match")
+	}
+}
+
+// TestHasProposalMatchesRenderedBody guards the marker format against drifting
+// from the renderer that emits it.
+func TestHasProposalMatchesRenderedBody(t *testing.T) {
+	t.Parallel()
+	subject := WeakSubject{
+		Subject:    Subject{Role: "review"},
+		Metric:     "failure_rate",
+		Samples:    157,
+		EffectSize: 0.054,
+	}
+	proposals, _ := Propose([]WeakSubject{subject}, 0, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if len(proposals) == 0 {
+		t.Fatal("expected a proposal")
+	}
+	p := proposals[0]
+	filed := []task.Task{{Status: task.StatusDone, Tags: []string{ProposalTag}, Body: RenderProposalBody(p)}}
+	if !HasProposal(filed, p.ID) {
+		t.Fatalf("rendered body for %s must be matched by HasProposal", p.ID)
+	}
+}

--- a/internal/promptlab/propose_test.go
+++ b/internal/promptlab/propose_test.go
@@ -7,19 +7,24 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
-func proposalTask(status task.Status, tags []string, proposalID string) task.Task {
+var (
+	refNow   = time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	cooldown = 30 * 24 * time.Hour
+)
+
+func proposalTask(status task.Status, tags []string, proposalID string, updatedAt time.Time) task.Task {
 	return task.Task{
-		Status: status,
-		Tags:   tags,
-		Body:   RenderProposalBody(Proposal{ID: proposalID, Candidate: VariantCandidate{ID: proposalID}}),
+		Status:    status,
+		Tags:      tags,
+		UpdatedAt: updatedAt,
+		Body:      RenderProposalBody(Proposal{ID: proposalID, Candidate: VariantCandidate{ID: proposalID}}),
 	}
 }
 
-// TestHasProposalCountsTerminalTasks pins the regression that let a single
-// proposal ID be filed four separate times: dedupe skipped terminal tasks,
-// so every tick re-filed a proposal whose earlier copies had aged into
-// done/cancelled.
-func TestHasProposalCountsTerminalTasks(t *testing.T) {
+// TestHasProposalSuppressesWithinCooldown pins the four-duplicates regression:
+// dedupe skipped terminal tasks entirely, so a proposal whose earlier copies
+// had aged into done/cancelled was re-filed on every tick.
+func TestHasProposalSuppressesWithinCooldown(t *testing.T) {
 	t.Parallel()
 	tags := []string{ProposalTag, "role:review"}
 
@@ -32,27 +37,77 @@ func TestHasProposalCountsTerminalTasks(t *testing.T) {
 	} {
 		t.Run(string(status), func(t *testing.T) {
 			t.Parallel()
-			tasks := []task.Task{proposalTask(status, tags, "pl-a2d853b2c1d9")}
-			if !HasProposal(tasks, "pl-a2d853b2c1d9") {
-				t.Fatalf("status %s: already-filed proposal must never be re-filed", status)
+			tasks := []task.Task{proposalTask(status, tags, "pl-a2d853b2c1d9", refNow.Add(-time.Hour))}
+			if !HasProposal(tasks, "pl-a2d853b2c1d9", cooldown, refNow) {
+				t.Fatalf("status %s: a proposal filed an hour ago must not be re-filed", status)
 			}
 		})
+	}
+}
+
+// TestHasProposalRefilesTerminalAfterCooldown pins the other half: suppressing
+// on terminal tasks forever would cap each subject at two proposals for the
+// life of the board (two intents per subject) and then go permanently silent,
+// even while the role stays weak.
+func TestHasProposalRefilesTerminalAfterCooldown(t *testing.T) {
+	t.Parallel()
+	tags := []string{ProposalTag, "role:review"}
+	stale := refNow.Add(-cooldown - time.Hour)
+
+	for _, status := range []task.Status{task.StatusDone, task.StatusCancelled} {
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+			tasks := []task.Task{proposalTask(status, tags, "pl-a2d853b2c1d9", stale)}
+			if HasProposal(tasks, "pl-a2d853b2c1d9", cooldown, refNow) {
+				t.Fatalf("status %s: a subject must be re-proposable once cooldown elapses", status)
+			}
+		})
+	}
+}
+
+// TestHasProposalLiveProposalIgnoresCooldown pins that an in-flight proposal
+// suppresses regardless of age — cooldown governs re-proposing a decided
+// subject, not spawning a second copy of one still being worked.
+func TestHasProposalLiveProposalIgnoresCooldown(t *testing.T) {
+	t.Parallel()
+	tags := []string{ProposalTag, "role:review"}
+	ancient := refNow.Add(-10 * cooldown)
+
+	for _, status := range []task.Status{task.StatusHumanRequired, task.StatusTodo, task.StatusInProgress} {
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+			tasks := []task.Task{proposalTask(status, tags, "pl-a2d853b2c1d9", ancient)}
+			if !HasProposal(tasks, "pl-a2d853b2c1d9", cooldown, refNow) {
+				t.Fatalf("status %s: a live proposal must suppress at any age", status)
+			}
+		})
+	}
+}
+
+func TestHasProposalZeroCooldownNeverRefiles(t *testing.T) {
+	t.Parallel()
+	tags := []string{ProposalTag, "role:review"}
+	ancient := refNow.Add(-10 * cooldown)
+	tasks := []task.Task{proposalTask(task.StatusDone, tags, "pl-a2d853b2c1d9", ancient)}
+
+	if !HasProposal(tasks, "pl-a2d853b2c1d9", 0, refNow) {
+		t.Fatal("zero cooldown must suppress on any terminal task")
 	}
 }
 
 func TestHasProposalDistinguishesIDsAndTags(t *testing.T) {
 	t.Parallel()
 	tags := []string{ProposalTag, "role:review"}
-	tasks := []task.Task{proposalTask(task.StatusDone, tags, "pl-a2d853b2c1d9")}
+	tasks := []task.Task{proposalTask(task.StatusDone, tags, "pl-a2d853b2c1d9", refNow)}
 
-	if HasProposal(tasks, "pl-5cf660095cb8") {
+	if HasProposal(tasks, "pl-5cf660095cb8", cooldown, refNow) {
 		t.Fatal("a different proposal ID must not match")
 	}
-	untagged := []task.Task{proposalTask(task.StatusDone, []string{"role:review"}, "pl-a2d853b2c1d9")}
-	if HasProposal(untagged, "pl-a2d853b2c1d9") {
+	untagged := []task.Task{proposalTask(task.StatusDone, []string{"role:review"}, "pl-a2d853b2c1d9", refNow)}
+	if HasProposal(untagged, "pl-a2d853b2c1d9", cooldown, refNow) {
 		t.Fatal("a task without the proposal tag must not match")
 	}
-	if HasProposal(nil, "pl-a2d853b2c1d9") {
+	if HasProposal(nil, "pl-a2d853b2c1d9", cooldown, refNow) {
 		t.Fatal("empty task list must not match")
 	}
 }
@@ -67,13 +122,18 @@ func TestHasProposalMatchesRenderedBody(t *testing.T) {
 		Samples:    157,
 		EffectSize: 0.054,
 	}
-	proposals, _ := Propose([]WeakSubject{subject}, 0, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	proposals, _ := Propose([]WeakSubject{subject}, 0, refNow)
 	if len(proposals) == 0 {
 		t.Fatal("expected a proposal")
 	}
 	p := proposals[0]
-	filed := []task.Task{{Status: task.StatusDone, Tags: []string{ProposalTag}, Body: RenderProposalBody(p)}}
-	if !HasProposal(filed, p.ID) {
+	filed := []task.Task{{
+		Status:    task.StatusHumanRequired,
+		Tags:      []string{ProposalTag},
+		UpdatedAt: refNow,
+		Body:      RenderProposalBody(p),
+	}}
+	if !HasProposal(filed, p.ID, cooldown, refNow) {
 		t.Fatalf("rendered body for %s must be matched by HasProposal", p.ID)
 	}
 }

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -34,6 +34,9 @@ const promptLabProjectID = "Automaat/sybra"
 const promptLabNoProjectReason = "Prompt Lab proposal not auto-approved: project " + promptLabProjectID +
 	" is not registered, so the authoring workflow has no repo to open a worktree in. Register it, then approve."
 
+const promptLabNoProjectErr = "prompt-lab approval unavailable: project " + promptLabProjectID +
+	" is not registered, so the authoring workflow has no repo to open a worktree in"
+
 func newPromptLabCoordinator(
 	tasks *task.Manager,
 	projects *project.Store,

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -3,8 +3,6 @@ package sybra
 import (
 	"context"
 	"log/slog"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
@@ -28,9 +26,13 @@ type promptLabCoordinator struct {
 	cfg               *config.Config
 	allowsProjectType func(project.ProjectType) bool
 	scrubContext      func(projectID string) *WorkScrubContext
+	approve           func(taskID string) error
 }
 
 const promptLabProjectID = "Automaat/sybra"
+
+const promptLabNoProjectReason = "Prompt Lab proposal not auto-approved: project " + promptLabProjectID +
+	" is not registered, so the authoring workflow has no repo to open a worktree in. Register it, then approve."
 
 func newPromptLabCoordinator(
 	tasks *task.Manager,
@@ -40,6 +42,7 @@ func newPromptLabCoordinator(
 	cfg *config.Config,
 	allowsProjectType func(project.ProjectType) bool,
 	scrubContext func(string) *WorkScrubContext,
+	approve func(string) error,
 ) *promptLabCoordinator {
 	return &promptLabCoordinator{
 		tasks:             tasks,
@@ -49,6 +52,7 @@ func newPromptLabCoordinator(
 		cfg:               cfg,
 		allowsProjectType: allowsProjectType,
 		scrubContext:      scrubContext,
+		approve:           approve,
 	}
 }
 
@@ -97,7 +101,7 @@ func (c *promptLabCoordinator) tick(ctx context.Context) {
 		c.logger.Warn("promptlab.tick.failed", "err", err)
 		return
 	}
-	filed, err := c.fileScrubbedProposals(result)
+	filed, err := c.fileScrubbedProposals(ctx, result)
 	if err != nil {
 		c.logger.Warn("promptlab.file.failed", "err", err)
 		return
@@ -114,7 +118,7 @@ func (c *promptLabCoordinator) tick(ctx context.Context) {
 // here, not inherited: internal/harnessevolution's filer does not scrub, so
 // this coordinator builds and applies the blocklist itself rather than
 // assuming that precedent covers it too.
-func (c *promptLabCoordinator) fileScrubbedProposals(result promptlab.RunResult) ([]task.Task, error) {
+func (c *promptLabCoordinator) fileScrubbedProposals(ctx context.Context, result promptlab.RunResult) ([]task.Task, error) {
 	existing, err := c.tasks.List()
 	if err != nil {
 		return nil, err
@@ -125,7 +129,7 @@ func (c *promptLabCoordinator) fileScrubbedProposals(result promptlab.RunResult)
 		if !c.allowsAnyProject(p.Evidence.ProjectIDs) {
 			continue
 		}
-		if _, ok := findExistingPromptLabProposal(existing, p.ID); ok {
+		if promptlab.HasProposal(existing, p.ID) {
 			continue
 		}
 		body := c.scrubBody(promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)
@@ -146,10 +150,40 @@ func (c *promptLabCoordinator) fileScrubbedProposals(result promptlab.RunResult)
 		if err != nil {
 			return filed, err
 		}
+		c.maybeAutoApprove(ctx, created, p)
 		filed = append(filed, created)
 		existing = append(existing, created)
 	}
 	return filed, nil
+}
+
+func (c *promptLabCoordinator) maybeAutoApprove(ctx context.Context, t task.Task, p promptlab.Proposal) {
+	if c.approve == nil || !c.cfg.PromptLabAutoApprove() {
+		return
+	}
+	if ctx.Err() != nil {
+		c.logger.Warn("promptlab.auto_approve.skipped_shutdown", "task_id", t.ID, "proposal_id", p.ID)
+		return
+	}
+	if t.Status != task.StatusHumanRequired || p.Offline.Verdict == promptlab.VerdictFailed {
+		return
+	}
+	if t.ProjectID == "" {
+		c.logger.Warn("promptlab.auto_approve.skipped_no_project", "task_id", t.ID, "proposal_id", p.ID)
+		c.setStatusReason(t.ID, promptLabNoProjectReason)
+		return
+	}
+	if err := c.approve(t.ID); err != nil {
+		c.logger.Warn("promptlab.auto_approve.failed", "task_id", t.ID, "proposal_id", p.ID, "err", err)
+		return
+	}
+	c.logger.Info("promptlab.auto_approve", "task_id", t.ID, "proposal_id", p.ID)
+}
+
+func (c *promptLabCoordinator) setStatusReason(taskID, reason string) {
+	if _, err := c.tasks.Update(taskID, task.Update{StatusReason: &reason}); err != nil {
+		c.logger.Warn("promptlab.status_reason.failed", "task_id", taskID, "err", err)
+	}
 }
 
 func promptLabTargetProjectID(projects *project.Store) string {
@@ -195,25 +229,13 @@ func (c *promptLabCoordinator) scrubBody(body string, projectIDs []string) strin
 	return body
 }
 
-func findExistingPromptLabProposal(tasks []task.Task, proposalID string) (task.Task, bool) {
-	marker := "Proposal ID:** `" + proposalID + "`"
-	for i := range tasks {
-		if task.IsTerminalStatus(tasks[i].Status) {
-			continue
-		}
-		if !slices.Contains(tasks[i].Tags, promptlab.ProposalTag) {
-			continue
-		}
-		if strings.Contains(tasks[i].Body, marker) {
-			return tasks[i], true
-		}
-	}
-	return task.Task{}, false
-}
-
 // initPromptLab constructs the promptlab coordinator. Cheap to always build
 // (mirrors renovateCoordinator): the ticker itself no-ops when disabled, so
 // the coordinator can be built unconditionally without an extra guard here.
 func (a *App) initPromptLab() {
-	a.promptLab = newPromptLabCoordinator(a.tasks, a.projects, a.stats, a.logger, a.cfg, a.allowsProjectType, a.workScrubContextForTask)
+	a.promptLab = newPromptLabCoordinator(
+		a.tasks, a.projects, a.stats, a.logger, a.cfg,
+		a.allowsProjectType, a.workScrubContextForTask,
+		func(taskID string) error { return a.promptLabSvc.autoApprove(taskID) },
+	)
 }

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -129,7 +129,8 @@ func (c *promptLabCoordinator) fileScrubbedProposals(ctx context.Context, result
 		if !c.allowsAnyProject(p.Evidence.ProjectIDs) {
 			continue
 		}
-		if promptlab.HasProposal(existing, p.ID) {
+		cooldown := time.Duration(c.cfg.PromptLab.RefileCooldownDays * float64(24*time.Hour))
+		if promptlab.HasProposal(existing, p.ID, cooldown, time.Now().UTC()) {
 			continue
 		}
 		body := c.scrubBody(promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)
@@ -165,7 +166,7 @@ func (c *promptLabCoordinator) maybeAutoApprove(ctx context.Context, t task.Task
 		c.logger.Warn("promptlab.auto_approve.skipped_shutdown", "task_id", t.ID, "proposal_id", p.ID)
 		return
 	}
-	if t.Status != task.StatusHumanRequired || p.Offline.Verdict == promptlab.VerdictFailed {
+	if !isPendingProposalStatus(t.Status) || p.Offline.Verdict == promptlab.VerdictFailed {
 		return
 	}
 	if t.ProjectID == "" {

--- a/internal/sybra/app_promptlab_test.go
+++ b/internal/sybra/app_promptlab_test.go
@@ -94,6 +94,9 @@ func TestFileScrubbedProposals_NoOfflineScreenNoAutoApprove(t *testing.T) {
 	if len(approved) != 0 {
 		t.Fatalf("approved = %v, want none: an unscreened variant must not reach production A/B", approved)
 	}
+	if len(filed) != 1 {
+		t.Fatalf("filed %d proposals, want 1", len(filed))
+	}
 	if filed[0].Status != task.StatusHumanRequired {
 		t.Fatalf("status = %q, want human-required", filed[0].Status)
 	}
@@ -142,6 +145,9 @@ func TestFileScrubbedProposals_AutoApproveDisabled(t *testing.T) {
 	if len(approved) != 0 {
 		t.Fatalf("approved = %v, want none when auto_approve is off", approved)
 	}
+	if len(filed) != 1 {
+		t.Fatalf("filed %d proposals, want 1", len(filed))
+	}
 	if filed[0].Status != task.StatusHumanRequired {
 		t.Fatalf("status = %q, want human-required to await a human", filed[0].Status)
 	}
@@ -166,6 +172,9 @@ func TestFileScrubbedProposals_NeverAutoApprovesFailedVerdict(t *testing.T) {
 	}
 	if len(approved) != 0 {
 		t.Fatalf("approved = %v, want a failed verdict to stay with a human", approved)
+	}
+	if len(filed) != 1 {
+		t.Fatalf("filed %d proposals, want 1", len(filed))
 	}
 	if filed[0].Status != task.StatusHumanRequired {
 		t.Fatalf("status = %q, want human-required", filed[0].Status)
@@ -221,6 +230,9 @@ func TestFileScrubbedProposals_NoProjectSkipsAutoApprove(t *testing.T) {
 	}
 	if len(approved) != 0 {
 		t.Fatalf("approved = %v, want no dispatch that is certain to fail", approved)
+	}
+	if len(filed) != 1 {
+		t.Fatalf("filed %d proposals, want 1", len(filed))
 	}
 	got, err := c.tasks.Get(filed[0].ID)
 	if err != nil {

--- a/internal/sybra/app_promptlab_test.go
+++ b/internal/sybra/app_promptlab_test.go
@@ -60,7 +60,43 @@ func weakProposal(verdict promptlab.OfflineVerdict) promptlab.Proposal {
 }
 
 func promptLabCfg(autoApprove *bool) *config.Config {
-	return &config.Config{PromptLab: config.PromptLabConfig{Enabled: true, AutoApprove: autoApprove}}
+	return &config.Config{
+		PromptLab:  config.PromptLabConfig{Enabled: true, AutoApprove: autoApprove},
+		Evaluation: config.EvaluationConfig{Offline: config.OfflineEvalConfig{Enabled: true}},
+	}
+}
+
+// TestFileScrubbedProposals_NoOfflineScreenNoAutoApprove pins the hard gate:
+// App.initWorkflowEngine only builds prompteval.Gate when
+// evaluation.offline.enabled is set, and a nil evalGate means A/B enrollment
+// is not screened at all. With the screen off, the human click is the only
+// barrier left, so auto-approve must stay off no matter what the operator set
+// prompt_lab.auto_approve to.
+func TestFileScrubbedProposals_NoOfflineScreenNoAutoApprove(t *testing.T) {
+	t.Parallel()
+	on := true
+	var approved []string
+	cfg := &config.Config{
+		PromptLab:  config.PromptLabConfig{Enabled: true, AutoApprove: &on},
+		Evaluation: config.EvaluationConfig{Offline: config.OfflineEvalConfig{Enabled: false}},
+	}
+	c := setupPromptLabCoordinator(t, cfg, func(id string) error {
+		approved = append(approved, id)
+		return nil
+	})
+
+	filed, err := c.fileScrubbedProposals(context.Background(), promptlab.RunResult{
+		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictNoVerdict)},
+	})
+	if err != nil {
+		t.Fatalf("fileScrubbedProposals: %v", err)
+	}
+	if len(approved) != 0 {
+		t.Fatalf("approved = %v, want none: an unscreened variant must not reach production A/B", approved)
+	}
+	if filed[0].Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", filed[0].Status)
+	}
 }
 
 // TestFileScrubbedProposals_AutoApproveClosesTheLoop is the core autonomy
@@ -198,33 +234,51 @@ func TestFileScrubbedProposals_NoProjectSkipsAutoApprove(t *testing.T) {
 	}
 }
 
-// TestFileScrubbedProposals_ShutdownStopsAutoApprove bounds the ticker's
-// shutdown latency. approve dispatches the authoring workflow synchronously,
-// and that call runs worktree setup inline — measured at ~150s for this repo
-// (mise install + npm ci). App.Shutdown waits on the ticker's goroutine, so a
-// cancelled context must stop the loop handing out further multi-minute
-// blocks rather than serialize one per proposal.
+// TestFileScrubbedProposals_ShutdownStopsAutoApprove pins that a cancellation
+// arriving mid-tick stops the loop handing out FURTHER approvals. Each approve
+// dispatches the authoring workflow synchronously and that runs worktree setup
+// inline (~150s measured here: mise install + npm ci), and App.Shutdown waits
+// on the ticker's goroutine — so this bounds a multi-proposal tick to one such
+// block rather than one per proposal.
+//
+// It does NOT bound an already-started approve: approve takes no ctx and
+// DispatchEvent is uncancellable, so an in-flight worktree setup still runs to
+// completion. Cancelling before the first proposal would pass trivially
+// without testing the loop at all, so cancel from inside the first approve.
 func TestFileScrubbedProposals_ShutdownStopsAutoApprove(t *testing.T) {
 	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
 	var approved []string
 	c := setupPromptLabCoordinator(t, promptLabCfg(nil), func(id string) error {
 		approved = append(approved, id)
+		cancel()
 		return nil
 	})
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+
+	first := weakProposal(promptlab.VerdictNoVerdict)
+	second := weakProposal(promptlab.VerdictNoVerdict)
+	second.ID = "pl-5cf660095cb8"
+	second.Candidate.ID = second.ID
+	second.Title = "Prompt Lab: restructure context for role review"
 
 	filed, err := c.fileScrubbedProposals(ctx, promptlab.RunResult{
-		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictNoVerdict)},
+		Proposals: []promptlab.Proposal{first, second},
 	})
 	if err != nil {
 		t.Fatalf("fileScrubbedProposals: %v", err)
 	}
-	if len(approved) != 0 {
-		t.Fatalf("approved = %v, want no new dispatch once shutting down", approved)
+	if len(filed) != 2 {
+		t.Fatalf("filed %d proposals, want both persisted for the next tick", len(filed))
 	}
-	if len(filed) != 1 || filed[0].Status != task.StatusHumanRequired {
-		t.Fatalf("filed = %+v, want the proposal still persisted for the next tick", filed)
+	if len(approved) != 1 {
+		t.Fatalf("approved = %v, want only the pre-cancel proposal dispatched", approved)
+	}
+	got, err := c.tasks.Get(filed[1].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want the post-cancel proposal left for the next tick", got.Status)
 	}
 }
 

--- a/internal/sybra/app_promptlab_test.go
+++ b/internal/sybra/app_promptlab_test.go
@@ -1,0 +1,254 @@
+package sybra
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/promptlab"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func setupPromptLabCoordinator(t *testing.T, cfg *config.Config, approve func(string) error) *promptLabCoordinator {
+	t.Helper()
+	c := newPromptLabCoordinatorForTest(t, cfg, approve)
+	if _, err := c.projects.CreateMeta("https://github.com/Automaat/sybra.git", project.ProjectTypePet); err != nil {
+		t.Fatalf("CreateMeta: %v", err)
+	}
+	return c
+}
+
+func newPromptLabCoordinatorForTest(t *testing.T, cfg *config.Config, approve func(string) error) *promptLabCoordinator {
+	t.Helper()
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	projects, err := project.NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return newPromptLabCoordinator(
+		task.NewManager(store, nil),
+		projects,
+		nil,
+		slog.New(slog.DiscardHandler),
+		cfg,
+		func(project.ProjectType) bool { return true },
+		func(string) *WorkScrubContext { return nil },
+		approve,
+	)
+}
+
+func weakProposal(verdict promptlab.OfflineVerdict) promptlab.Proposal {
+	return promptlab.Proposal{
+		ID:      "pl-a2d853b2c1d9",
+		Subject: promptlab.Subject{Role: "review"},
+		Title:   "Prompt Lab: tighten instructions for role review",
+		Evidence: promptlab.WeakSubject{
+			Subject: promptlab.Subject{Role: "review"},
+			Metric:  "failure_rate",
+			Samples: 157,
+		},
+		Candidate:             promptlab.VariantCandidate{ID: "pl-a2d853b2c1d9", Intent: "tighten-instructions"},
+		Offline:               promptlab.OfflineResult{Verdict: verdict},
+		RequiresHumanApproval: verdict != promptlab.VerdictPassed,
+	}
+}
+
+func promptLabCfg(autoApprove *bool) *config.Config {
+	return &config.Config{PromptLab: config.PromptLabConfig{Enabled: true, AutoApprove: autoApprove}}
+}
+
+// TestFileScrubbedProposals_AutoApproveClosesTheLoop is the core autonomy
+// case: the stub evaluator can only ever return no-verdict, so without
+// auto-approve every filed proposal parks in human-required forever.
+func TestFileScrubbedProposals_AutoApproveClosesTheLoop(t *testing.T) {
+	t.Parallel()
+	var approved []string
+	c := setupPromptLabCoordinator(t, promptLabCfg(nil), func(id string) error {
+		approved = append(approved, id)
+		return nil
+	})
+
+	filed, err := c.fileScrubbedProposals(context.Background(), promptlab.RunResult{
+		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictNoVerdict)},
+	})
+	if err != nil {
+		t.Fatalf("fileScrubbedProposals: %v", err)
+	}
+	if len(filed) != 1 {
+		t.Fatalf("filed %d proposals, want 1", len(filed))
+	}
+	if len(approved) != 1 || approved[0] != filed[0].ID {
+		t.Fatalf("approved = %v, want auto-approve of %s (default is on)", approved, filed[0].ID)
+	}
+}
+
+func TestFileScrubbedProposals_AutoApproveDisabled(t *testing.T) {
+	t.Parallel()
+	off := false
+	var approved []string
+	c := setupPromptLabCoordinator(t, promptLabCfg(&off), func(id string) error {
+		approved = append(approved, id)
+		return nil
+	})
+
+	filed, err := c.fileScrubbedProposals(context.Background(), promptlab.RunResult{
+		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictNoVerdict)},
+	})
+	if err != nil {
+		t.Fatalf("fileScrubbedProposals: %v", err)
+	}
+	if len(approved) != 0 {
+		t.Fatalf("approved = %v, want none when auto_approve is off", approved)
+	}
+	if filed[0].Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required to await a human", filed[0].Status)
+	}
+}
+
+// TestFileScrubbedProposals_NeverAutoApprovesFailedVerdict guards the carve-out
+// that keeps auto-approve honest: a FAILED verdict is a real evaluator
+// rejecting the candidate, not the absent-text placeholder.
+func TestFileScrubbedProposals_NeverAutoApprovesFailedVerdict(t *testing.T) {
+	t.Parallel()
+	var approved []string
+	c := setupPromptLabCoordinator(t, promptLabCfg(nil), func(id string) error {
+		approved = append(approved, id)
+		return nil
+	})
+
+	filed, err := c.fileScrubbedProposals(context.Background(), promptlab.RunResult{
+		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictFailed)},
+	})
+	if err != nil {
+		t.Fatalf("fileScrubbedProposals: %v", err)
+	}
+	if len(approved) != 0 {
+		t.Fatalf("approved = %v, want a failed verdict to stay with a human", approved)
+	}
+	if filed[0].Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", filed[0].Status)
+	}
+}
+
+// TestFileScrubbedProposals_AutoApproveFailureKeepsTicking pins that a failed
+// approval leaves the task safely parked for a human instead of aborting the
+// rest of the tick.
+func TestFileScrubbedProposals_AutoApproveFailureKeepsTicking(t *testing.T) {
+	t.Parallel()
+	c := setupPromptLabCoordinator(t, promptLabCfg(nil), func(string) error {
+		return io.ErrUnexpectedEOF
+	})
+
+	filed, err := c.fileScrubbedProposals(context.Background(), promptlab.RunResult{
+		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictNoVerdict)},
+	})
+	if err != nil {
+		t.Fatalf("a failed auto-approve must not fail the tick: %v", err)
+	}
+	if len(filed) != 1 {
+		t.Fatalf("filed %d proposals, want the proposal still filed", len(filed))
+	}
+	got, err := c.tasks.Get(filed[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required so a human can still approve", got.Status)
+	}
+}
+
+// TestFileScrubbedProposals_NoProjectSkipsAutoApprove pins the live-reproduced
+// failure: with no project to assign, the authoring workflow starts and its
+// agent immediately dies on "no project_id: refusing to start agent without
+// isolated worktree", dumping the task back into human-required under a
+// status_reason that hides why. Park it up front with an actionable one
+// instead of laundering it through a guaranteed-failed dispatch.
+func TestFileScrubbedProposals_NoProjectSkipsAutoApprove(t *testing.T) {
+	t.Parallel()
+	var approved []string
+	c := newPromptLabCoordinatorForTest(t, promptLabCfg(nil), func(id string) error {
+		approved = append(approved, id)
+		return nil
+	})
+
+	filed, err := c.fileScrubbedProposals(context.Background(), promptlab.RunResult{
+		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictNoVerdict)},
+	})
+	if err != nil {
+		t.Fatalf("fileScrubbedProposals: %v", err)
+	}
+	if len(approved) != 0 {
+		t.Fatalf("approved = %v, want no dispatch that is certain to fail", approved)
+	}
+	got, err := c.tasks.Get(filed[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if got.StatusReason != promptLabNoProjectReason {
+		t.Fatalf("StatusReason = %q, want the actionable no-project reason", got.StatusReason)
+	}
+}
+
+// TestFileScrubbedProposals_ShutdownStopsAutoApprove bounds the ticker's
+// shutdown latency. approve dispatches the authoring workflow synchronously,
+// and that call runs worktree setup inline — measured at ~150s for this repo
+// (mise install + npm ci). App.Shutdown waits on the ticker's goroutine, so a
+// cancelled context must stop the loop handing out further multi-minute
+// blocks rather than serialize one per proposal.
+func TestFileScrubbedProposals_ShutdownStopsAutoApprove(t *testing.T) {
+	t.Parallel()
+	var approved []string
+	c := setupPromptLabCoordinator(t, promptLabCfg(nil), func(id string) error {
+		approved = append(approved, id)
+		return nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	filed, err := c.fileScrubbedProposals(ctx, promptlab.RunResult{
+		Proposals: []promptlab.Proposal{weakProposal(promptlab.VerdictNoVerdict)},
+	})
+	if err != nil {
+		t.Fatalf("fileScrubbedProposals: %v", err)
+	}
+	if len(approved) != 0 {
+		t.Fatalf("approved = %v, want no new dispatch once shutting down", approved)
+	}
+	if len(filed) != 1 || filed[0].Status != task.StatusHumanRequired {
+		t.Fatalf("filed = %+v, want the proposal still persisted for the next tick", filed)
+	}
+}
+
+// TestFileScrubbedProposals_SkipsAlreadyFiledTerminalProposal is the
+// four-duplicates regression at the filer level.
+func TestFileScrubbedProposals_SkipsAlreadyFiledTerminalProposal(t *testing.T) {
+	t.Parallel()
+	c := setupPromptLabCoordinator(t, promptLabCfg(nil), func(string) error { return nil })
+	p := weakProposal(promptlab.VerdictNoVerdict)
+
+	done := task.StatusDone
+	tags := []string{promptlab.ProposalTag, "role:review"}
+	if _, err := c.tasks.CreateFull(p.Title, promptlab.RenderProposalBody(p), task.AgentModeHeadless, task.Update{
+		Status: &done,
+		Tags:   &tags,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	filed, err := c.fileScrubbedProposals(context.Background(), promptlab.RunResult{Proposals: []promptlab.Proposal{p}})
+	if err != nil {
+		t.Fatalf("fileScrubbedProposals: %v", err)
+	}
+	if len(filed) != 0 {
+		t.Fatalf("filed %d proposals, want 0 — %s was already filed and completed", len(filed), p.ID)
+	}
+}

--- a/internal/sybra/svc_promptlab.go
+++ b/internal/sybra/svc_promptlab.go
@@ -35,12 +35,18 @@ const (
 // "prompt-lab-proposal" + "requires-human", status human-required) until
 // approval, which starts the dedicated prompt-lab authoring workflow.
 //
-// Approval is not necessarily a human: under prompt_lab.auto_approve
-// (default on) promptLabCoordinator approves each proposal as it files it,
-// making these methods the manual override rather than the only way
-// through. What gates production either way is
-// prompteval.Gate.AllowEnrollment inside the authoring workflow — approval
-// only buys a candidate the right to be authored and screened.
+// Approval starts the authoring workflow; it does not certify the variant.
+// It is not necessarily a human either: under prompt_lab.auto_approve
+// promptLabCoordinator approves each proposal as it files it, making these
+// methods the manual override rather than the only way through.
+//
+// Approval carries no guarantee that the authored variant is screened before
+// it enrolls in A/B. prompteval.Gate is only constructed when
+// evaluation.offline.enabled is set, and a nil Engine.evalGate means offline
+// verdicts do not gate enrollment at all. That is exactly why
+// Config.PromptLabAutoApprove is hard-gated on the same flag: with the screen
+// off, a human calling ApproveProposal is the last remaining barrier, so the
+// unattended caller must not exist there.
 type PromptLabService struct {
 	tasks          *task.Manager
 	artifacts      *artifact.Store
@@ -83,9 +89,11 @@ func (s *PromptLabService) approveProposal(id, progressNote string) (task.Task, 
 			Tags:         &tags,
 		}
 		if cur.ProjectID == "" {
-			if projectID := promptLabTargetProjectID(s.projects); projectID != "" {
-				update.ProjectID = &projectID
+			projectID := promptLabTargetProjectID(s.projects)
+			if projectID == "" {
+				return task.Update{}, errors.New(promptLabNoProjectErr)
 			}
+			update.ProjectID = &projectID
 		}
 		return update, nil
 	})

--- a/internal/sybra/svc_promptlab.go
+++ b/internal/sybra/svc_promptlab.go
@@ -21,6 +21,11 @@ import (
 const rejectedNoFeedbackReason = "rejected (no feedback provided)"
 
 const (
+	approvedProgressNote     = "Approved: started Prompt Lab variant authoring + offline eval workflow"
+	autoApprovedProgressNote = "Auto-approved (prompt_lab.auto_approve): started Prompt Lab variant authoring + offline eval workflow"
+)
+
+const (
 	promptLabAlreadyActiveWait = 500 * time.Millisecond
 	promptLabAlreadyActivePoll = 25 * time.Millisecond
 )
@@ -29,6 +34,13 @@ const (
 // Wails-bound methods. Proposals are plain tasks (tagged
 // "prompt-lab-proposal" + "requires-human", status human-required) until
 // approval, which starts the dedicated prompt-lab authoring workflow.
+//
+// Approval is not necessarily a human: under prompt_lab.auto_approve
+// (default on) promptLabCoordinator approves each proposal as it files it,
+// making these methods the manual override rather than the only way
+// through. What gates production either way is
+// prompteval.Gate.AllowEnrollment inside the authoring workflow — approval
+// only buys a candidate the right to be authored and screened.
 type PromptLabService struct {
 	tasks          *task.Manager
 	artifacts      *artifact.Store
@@ -40,7 +52,21 @@ type PromptLabService struct {
 // in-progress, drops the requires-human tag, and starts the dedicated
 // prompt-lab authoring workflow. Errors without mutating if the task is not a
 // pending proposal (wrong status, or missing the prompt-lab-proposal tag).
+//
+// promptLabCoordinator drives the same path unattended via autoApprove when
+// prompt_lab.auto_approve is set, so every guard, dispatch, and
+// revert-on-failure below must hold for a caller that is not a human; the
+// two differ only in the progress note left in the task's decision log.
 func (s *PromptLabService) ApproveProposal(id string) (task.Task, error) {
+	return s.approveProposal(id, approvedProgressNote)
+}
+
+func (s *PromptLabService) autoApprove(id string) error {
+	_, err := s.approveProposal(id, autoApprovedProgressNote)
+	return err
+}
+
+func (s *PromptLabService) approveProposal(id, progressNote string) (task.Task, error) {
 	t, err := s.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
 		if err := requirePendingProposal(cur); err != nil {
 			return task.Update{}, err
@@ -91,7 +117,7 @@ func (s *PromptLabService) ApproveProposal(id string) (task.Task, error) {
 		}
 	}
 
-	s.appendProgress(id, artifact.ProgressKindDecision, "Approved: started Prompt Lab variant authoring + offline eval workflow")
+	s.appendProgress(id, artifact.ProgressKindDecision, progressNote)
 	return t, nil
 }
 

--- a/internal/sybra/svc_promptlab.go
+++ b/internal/sybra/svc_promptlab.go
@@ -67,6 +67,9 @@ func (s *PromptLabService) autoApprove(id string) error {
 }
 
 func (s *PromptLabService) approveProposal(id, progressNote string) (task.Task, error) {
+	if s.workflowEngine == nil {
+		return task.Task{}, errors.New("prompt-lab approval unavailable: no workflow engine to start the authoring workflow")
+	}
 	t, err := s.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
 		if err := requirePendingProposal(cur); err != nil {
 			return task.Update{}, err
@@ -90,31 +93,29 @@ func (s *PromptLabService) approveProposal(id, progressNote string) (task.Task, 
 		return task.Task{}, err
 	}
 
-	if s.workflowEngine != nil {
-		matched, dispatchErr := s.workflowEngine.DispatchEvent(
-			id,
-			"task.status_changed",
-			map[string]string{"task.status": string(task.StatusInProgress)},
-			nil,
-		)
-		if !s.promptLabDispatchStarted(id, matched, dispatchErr) {
-			failure := "no prompt-lab workflow matched"
-			if dispatchErr != nil {
-				failure = dispatchErr.Error()
-			}
-			revertReason := "Prompt Lab approval failed to start authoring workflow: " + failure
-			status := task.StatusHumanRequired
-			tags := mergeTag(t.Tags, "requires-human")
-			reverted, revertErr := s.tasks.Update(id, task.Update{
-				Status:       &status,
-				StatusReason: &revertReason,
-				Tags:         tags,
-			})
-			if revertErr != nil {
-				return task.Task{}, fmt.Errorf("%s; additionally failed to restore human-required: %w", revertReason, revertErr)
-			}
-			return reverted, errors.New(revertReason)
+	matched, dispatchErr := s.workflowEngine.DispatchEvent(
+		id,
+		"task.status_changed",
+		map[string]string{"task.status": string(task.StatusInProgress)},
+		nil,
+	)
+	if !s.promptLabDispatchStarted(id, matched, dispatchErr) {
+		failure := "no prompt-lab workflow matched"
+		if dispatchErr != nil {
+			failure = dispatchErr.Error()
 		}
+		revertReason := "Prompt Lab approval failed to start authoring workflow: " + failure
+		status := task.StatusHumanRequired
+		tags := mergeTag(t.Tags, "requires-human")
+		reverted, revertErr := s.tasks.Update(id, task.Update{
+			Status:       &status,
+			StatusReason: &revertReason,
+			Tags:         tags,
+		})
+		if revertErr != nil {
+			return task.Task{}, fmt.Errorf("%s; additionally failed to restore human-required: %w", revertReason, revertErr)
+		}
+		return reverted, errors.New(revertReason)
 	}
 
 	s.appendProgress(id, artifact.ProgressKindDecision, progressNote)
@@ -183,10 +184,14 @@ func (s *PromptLabService) RejectProposal(id, feedback string) (task.Task, error
 // the race a stale browser tab could otherwise re-fire (double approve,
 // approve-after-reject, etc).
 func requirePendingProposal(cur task.Task) error {
-	if !slices.Contains(cur.Tags, promptlab.ProposalTag) || cur.Status != task.StatusHumanRequired {
+	if !slices.Contains(cur.Tags, promptlab.ProposalTag) || !isPendingProposalStatus(cur.Status) {
 		return fmt.Errorf("task %s is not a pending prompt-lab proposal (status=%s)", cur.ID, cur.Status)
 	}
 	return nil
+}
+
+func isPendingProposalStatus(s task.Status) bool {
+	return s == task.StatusHumanRequired || s == task.StatusTodo
 }
 
 // removeTag returns tags with every occurrence of target removed.

--- a/internal/sybra/svc_promptlab_test.go
+++ b/internal/sybra/svc_promptlab_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
+type parkedAgentLauncher struct{ workflow.AgentLauncher }
+
+func (parkedAgentLauncher) StartAgent(
+	_, _, _, _, _, _, _ string, _ []string, _, _ bool, _, _ string, _ workflow.AgentAssignment,
+) (agentID, startedDir, baselineRef string, err error) {
+	return "", "", "", workflow.ErrAgentPoolBusy
+}
+
 func setupPromptLabService(t *testing.T) *PromptLabService {
 	t.Helper()
 	a := setupApp(t)
@@ -28,7 +36,7 @@ func setupPromptLabService(t *testing.T) *PromptLabService {
 	engine := workflow.NewEngine(
 		wfStore,
 		&taskAdapter{tasks: a.tasks},
-		&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks},
+		parkedAgentLauncher{&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}},
 		a.logger,
 	)
 	engine.SetContext(t.Context())
@@ -155,6 +163,36 @@ func TestPromptLabService_autoApprove_StaleStatusGuard(t *testing.T) {
 				t.Fatalf("status mutated to %q, want unchanged %q", after.Status, status)
 			}
 		})
+	}
+}
+
+// TestPromptLabService_ApproveProposal_NoProjectFailsEarly pins that approval
+// does not mutate when no project can be assigned. Dispatching anyway starts
+// the authoring workflow whose agent dies on "no project_id: refusing to start
+// agent without isolated worktree", leaving the task in-progress-then-reverted
+// under a status_reason that hides the real cause — the failure live task
+// 3c2257dc recorded.
+func TestPromptLabService_ApproveProposal_NoProjectFailsEarly(t *testing.T) {
+	t.Parallel()
+	svc := setupPromptLabService(t)
+	if err := svc.projects.Delete(promptLabProjectID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "requires-human"})
+
+	if _, err := svc.ApproveProposal(created.ID); err == nil {
+		t.Fatal("ApproveProposal: want error when no project can be assigned")
+	}
+
+	after, err := svc.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required (no mutation)", after.Status)
+	}
+	if !slices.Contains(after.Tags, "requires-human") {
+		t.Fatalf("tags = %v, want requires-human retained so the GUI still lists it", after.Tags)
 	}
 }
 

--- a/internal/sybra/svc_promptlab_test.go
+++ b/internal/sybra/svc_promptlab_test.go
@@ -16,18 +16,39 @@ import (
 
 func setupPromptLabService(t *testing.T) *PromptLabService {
 	t.Helper()
-	store, err := task.NewStore(t.TempDir())
+	a := setupApp(t)
+
+	wfStore, err := workflow.NewStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	projects, err := project.NewStore(t.TempDir(), t.TempDir())
-	if err != nil {
+	if err := workflow.SyncBuiltins(wfStore); err != nil {
 		t.Fatal(err)
 	}
+	engine := workflow.NewEngine(
+		wfStore,
+		&taskAdapter{tasks: a.tasks},
+		&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks},
+		a.logger,
+	)
+	engine.SetContext(t.Context())
+
+	projects := a.projects
+	if projects == nil {
+		projects, err = project.NewStore(t.TempDir(), t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := projects.CreateMeta("https://github.com/Automaat/sybra.git", project.ProjectTypePet); err != nil {
+		t.Fatalf("CreateMeta: %v", err)
+	}
+
 	return &PromptLabService{
-		tasks:     task.NewManager(store, nil),
-		artifacts: artifact.New(t.TempDir()),
-		projects:  projects,
+		tasks:          a.tasks,
+		artifacts:      artifact.New(t.TempDir()),
+		projects:       projects,
+		workflowEngine: engine,
 	}
 }
 
@@ -117,7 +138,7 @@ func TestPromptLabService_autoApprove(t *testing.T) {
 // a human already rejected.
 func TestPromptLabService_autoApprove_StaleStatusGuard(t *testing.T) {
 	t.Parallel()
-	for _, status := range []task.Status{task.StatusCancelled, task.StatusDone, task.StatusInProgress, task.StatusTodo} {
+	for _, status := range []task.Status{task.StatusCancelled, task.StatusDone, task.StatusInProgress} {
 		t.Run(string(status), func(t *testing.T) {
 			t.Parallel()
 			svc := setupPromptLabService(t)
@@ -140,9 +161,6 @@ func TestPromptLabService_autoApprove_StaleStatusGuard(t *testing.T) {
 func TestPromptLabService_ApproveProposal_BackfillsSybraProject(t *testing.T) {
 	t.Parallel()
 	svc := setupPromptLabService(t)
-	if _, err := svc.projects.CreateMeta("https://github.com/Automaat/sybra.git", project.ProjectTypePet); err != nil {
-		t.Fatalf("CreateMeta: %v", err)
-	}
 	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "requires-human"})
 
 	got, err := svc.ApproveProposal(created.ID)
@@ -234,7 +252,7 @@ func TestPromptLabService_RejectProposal_WhitespaceOnlyFeedback(t *testing.T) {
 
 func TestPromptLabService_StaleStatusGuard(t *testing.T) {
 	t.Parallel()
-	for _, status := range []task.Status{task.StatusTodo, task.StatusCancelled, task.StatusDone, task.StatusInProgress} {
+	for _, status := range []task.Status{task.StatusCancelled, task.StatusDone, task.StatusInProgress} {
 		t.Run(string(status), func(t *testing.T) {
 			t.Parallel()
 			svc := setupPromptLabService(t)
@@ -304,10 +322,7 @@ func TestPromptLabService_DoubleApprove_Idempotency(t *testing.T) {
 
 func TestPromptLabService_AppendProgressFailure_BestEffort(t *testing.T) {
 	t.Parallel()
-	store, err := task.NewStore(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	svc := setupPromptLabService(t)
 	// Point the artifact store root at a regular file so any write under it
 	// fails at MkdirAll — simulating an AppendProgress failure without a
 	// custom fake, since artifact.Store has no interface seam.
@@ -316,11 +331,8 @@ func TestPromptLabService_AppendProgressFailure_BestEffort(t *testing.T) {
 		t.Fatal(err)
 	}
 	badRoot.Close()
+	svc.artifacts = artifact.New(badRoot.Name())
 
-	svc := &PromptLabService{
-		tasks:     task.NewManager(store, nil),
-		artifacts: artifact.New(badRoot.Name()),
-	}
 	created := createProposal(t, svc, task.StatusHumanRequired, []string{promptlab.ProposalTag, "requires-human"})
 
 	got, err := svc.ApproveProposal(created.ID)

--- a/internal/sybra/svc_promptlab_test.go
+++ b/internal/sybra/svc_promptlab_test.go
@@ -79,6 +79,64 @@ func TestPromptLabService_ApproveProposal(t *testing.T) {
 	}
 }
 
+// TestPromptLabService_autoApprove pins that the unattended path lands the
+// task in exactly the state a human click would, differing only in the
+// progress note — promptLabCoordinator relies on reusing every guard here.
+func TestPromptLabService_autoApprove(t *testing.T) {
+	t.Parallel()
+	svc := setupPromptLabService(t)
+	tags := []string{promptlab.ProposalTag, "role:test-runner", "requires-human"}
+	created := createProposal(t, svc, task.StatusHumanRequired, tags)
+
+	if err := svc.autoApprove(created.ID); err != nil {
+		t.Fatalf("autoApprove: %v", err)
+	}
+
+	got, err := svc.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress", got.Status)
+	}
+	if slices.Contains(got.Tags, "requires-human") {
+		t.Fatalf("tags = %v, want requires-human removed", got.Tags)
+	}
+
+	entries, err := svc.artifacts.ReadProgress(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Message != autoApprovedProgressNote {
+		t.Fatalf("progress entries = %+v, want the auto-approved note for audit", entries)
+	}
+}
+
+// TestPromptLabService_autoApprove_StaleStatusGuard pins that the unattended
+// caller cannot bypass requirePendingProposal — e.g. re-approving a proposal
+// a human already rejected.
+func TestPromptLabService_autoApprove_StaleStatusGuard(t *testing.T) {
+	t.Parallel()
+	for _, status := range []task.Status{task.StatusCancelled, task.StatusDone, task.StatusInProgress, task.StatusTodo} {
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+			svc := setupPromptLabService(t)
+			created := createProposal(t, svc, status, []string{promptlab.ProposalTag})
+
+			if err := svc.autoApprove(created.ID); err == nil {
+				t.Fatal("autoApprove: want error for non-pending status")
+			}
+			after, err := svc.tasks.Get(created.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after.Status != status {
+				t.Fatalf("status mutated to %q, want unchanged %q", after.Status, status)
+			}
+		})
+	}
+}
+
 func TestPromptLabService_ApproveProposal_BackfillsSybraProject(t *testing.T) {
 	t.Parallel()
 	svc := setupPromptLabService(t)


### PR DESCRIPTION
## Motivation

Prompt Lab could never advance a proposal without a human click, so the loop
was structurally incapable of the autonomy it was built for. `internal/promptlab`
mines fleet stats for weak roles and files proposals, but the production tick
never set `Options.Evaluator`, so `stubEvaluator` ran and always returned
`no-verdict`. `EvaluateProposal` maps anything but `passed` to
`RequiresHumanApproval`, so **100% of proposals were filed `human-required`
and stayed there forever** — no production path could ever produce a passing
verdict. Three proposals are parked on the live board today.

Dedupe also skipped terminal tasks while `proposalID` is a stable hash of
(role, step, intent), so a decided proposal was re-filed every tick. One ID
(`pl-a2d853b2c1d9`) was filed **four times**.

> Changelog: feat(promptlab): autonomous proposal loop

## Implementation information

`prompt_lab.auto_approve` (default true) hands each filed proposal to the
`prompt-lab-author` workflow via the same `approveProposal` path a GUI click
uses — same guards, same dispatch, same revert-on-failure, differing only in
the progress note left for audit.

**Autonomy is hard-gated on `evaluation.offline.enabled`.** The first draft
justified removing the human gate by claiming `prompteval.Gate.AllowEnrollment`
still screened variants downstream. Adversarial review proved that false:
`prompteval.Gate` is only constructed under `evaluation.offline.enabled`
(`app_init.go:1090`), which defaults to false, and `Engine.evalGate == nil`
means *"offline eval verdicts do not gate A/B enrollment"* —
`abtest.EligibleVariants` skips the check on a nil `evalPassed`. With the
screen off, the human click is the **only** barrier between an unscreened
variant and production A/B, so auto-approve now stays off there regardless of
the setting. A `VerdictFailed` proposal is never auto-approved either.

Other fixes this pulled in:

- **Refile cooldown** (`refile_cooldown_days`, default 30) instead of
  never-refile. Counting terminal tasks fixes the 4x duplicates but would cap
  each subject at two proposals for the life of the board (two intents per
  subject) and then go permanently silent — auto-approve makes that worse by
  churning proposals to terminal in hours. Cooldown is the bounded-rate middle.
- **No-project guard.** Reproduced live: with no project assigned the workflow
  starts and the agent instantly dies on `no project_id: refusing to start
  agent without isolated worktree`, dumping the task back to `human-required`
  under a `status_reason` that hides the cause — exactly what live task
  `3c2257dc` recorded. Now parks up front with an actionable reason.
- **`todo` counts as pending.** A PASSED verdict files as `todo` with no
  `requires-human` tag and is excluded from `task.created` dispatch, so the
  best-screened proposals were approvable by neither coordinator nor GUI.
- **Nil `workflowEngine` errors** instead of returning success, which left the
  task `in-progress` with no workflow and a decision log claiming otherwise.
- **Service tests now use a real workflow engine.** Every existing test
  silently ran the nil-engine branch, so `ApproveProposal`'s dispatch and
  revert had never been covered.

### Verification

`mise run verify` green. Beyond unit/e2e, both paths were driven against the
real `sybra-server` in an isolated `SYBRA_HOME` with fake provider CLIs:

- screen **off** → filed, no auto-approve, stays `human-required` (also holds
  with an explicit `auto_approve: true` — the gate cannot be overridden)
- screen **on** + project registered → `promptlab.auto_approve` → task
  `in-progress` → `prompt-lab-author` runs to completion, unattended
- cooldown re-files exactly once after elapse, then re-suppresses
- HTTP approve/reject, auth, and normal task dispatch unregressed

## Supporting documentation

`docs/CONFIG.md` regenerated for the two new keys.

### Open questions

- Three live `prompt_transform` variants (`checklist-append`,
  `heuristics-prepend`, `structured-verdict`) carry **no digest**, and
  `EligibleVariants` skips the eval check when `Digest == ""` — so they bypass
  the screen even once it is enabled. `prompt-lab-author.yaml` also tells the
  agent to author skill variants via `skill_aliases`, which have no digest
  field. Enforcing digests in `validateExperiment` would reject existing live
  configs at startup, so it is deliberately left to a follow-up PR.
- `ApproveProposal` is synchronous through inline worktree setup (~150s
  measured); pre-existing, unchanged here. A cancelled context stops *further*
  approvals but does not interrupt one in flight.