### PR TITLE
fix(pr-fix): add flake outcome to result contract

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -68,6 +68,12 @@ type dispatchFixOptions struct {
 
 const PRFixResultContract = "\n\nBefore your final response, decide the outcome:\n" +
 	"- If you completed and pushed the fix, end with `SYBRA_PR_FIX_RESULT: continue`.\n" +
+	"- If this PR's diff is correct and CI failed for reasons unrelated to it — a " +
+	"flaky test, an infrastructure failure, or a breakage that reproduces on the " +
+	"base branch — end with `SYBRA_PR_FIX_RESULT: flake` and `SYBRA_PR_FIX_REASON: " +
+	"<what failed, and the evidence it is unrelated>`. Reporting `flake` with " +
+	"evidence is a complete and successful outcome. It is always the right answer " +
+	"over inventing a change you cannot causally justify.\n" +
 	"- If you intentionally stopped because the PR needs a human, end with " +
 	"`SYBRA_PR_FIX_RESULT: human-required` and `SYBRA_PR_FIX_REASON: <short reason>`."
 
@@ -334,14 +340,47 @@ func ciFailurePrompt(pr github.PullRequest) string {
 		"Fix failing CI on branch `%s` (PR #%d). "+
 			"Check the failing run with `gh run view --log-failed`, "+
 			"fix the code, commit and push. No unrelated changes.\n\n"+
-			"Never weaken, skip, delete, or hardcode tests, snapshots, or "+
-			"fixtures to make CI pass, and never edit CI config to neuter a "+
-			"gate — fix the underlying code. Tampering is detected and blocks "+
-			"the task.\n\n"+
-			"%s",
-		pr.HeadRefName, pr.Number, prFixPushPrompt(pr.HeadRefName, "Push to the same remote create-pr would target for this worktree:", true),
+			"%s\n\n%s\n\n%s",
+		pr.HeadRefName, pr.Number,
+		ciFailureDiagnosisRules(pr.BaseRefName),
+		prFixTamperingRules,
+		prFixPushPrompt(pr.HeadRefName, "Push to the same remote create-pr would target for this worktree:", true),
 	)
 }
+
+// Without a base-branch baseline agents blame the diff for infra/flake failures. EXC:FILE011:load-bearing-invariant
+func ciFailureDiagnosisRules(baseRef string) string {
+	base := "the base branch"
+	if baseRef != "" {
+		base = "`" + baseRef + "`"
+	}
+	return "Diagnose before you change anything:\n" +
+		"- Identify which jobs failed and why. A job that fails during setup, " +
+		"provisioning, or image pull is infrastructure, not your diff.\n" +
+		"- Before changing ANY code for a test failure, check whether the same job " +
+		"already fails on " + base + " (e.g. `gh run list --branch <base> " +
+		"--workflow <workflow> --limit 20`). If it does, the failure is not yours: " +
+		"report `flake` with that evidence.\n" +
+		"- State the causal link before you edit: how does this diff produce this " +
+		"exact failure? If you cannot answer that, you do not have a fix — report " +
+		"`flake` or `human-required` instead of guessing.\n" +
+		"- If the failure is transient and unrelated, re-run the failed jobs with " +
+		"`gh run rerun <run-id> --failed` and report `flake`. Never mint an empty " +
+		"or amended commit just to retrigger CI."
+}
+
+// Banning only test tampering redirects the pressure onto production defaults. EXC:FILE011:load-bearing-invariant
+const prFixTamperingRules = "Never weaken, skip, delete, or hardcode tests, " +
+	"snapshots, or fixtures to make CI pass, and never edit CI config to neuter a " +
+	"gate — fix the underlying code. Tampering is detected and blocks the task.\n\n" +
+	"The same prohibition covers product code: never change production defaults, " +
+	"timeouts, intervals, or retry counts to make a test pass. A failing or flaky " +
+	"test is never by itself evidence for a product-code change — only a " +
+	"demonstrated causal link is. Shortening an interval or widening a timeout so " +
+	"a suite goes green is tampering with a user-facing default, not a fix.\n\n" +
+	"Never force-push and never rewrite already-pushed history (`--force`, " +
+	"`--force-with-lease`, `commit --amend`, rebase onto a pushed base). Append a " +
+	"new commit instead; a force-push can destroy work this PR depends on."
 
 // prFixPushPrompt renders the create-pr-equivalent push snippet for a pr-fix
 // agent. When fenced is true it emits a standalone ```sh block (optionally

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -120,6 +120,63 @@ func TestCIFailurePrompt_DetectsForkRemote(t *testing.T) {
 	}
 }
 
+// The prompt must name the PR's real base branch so the agent can run the
+// baseline check; a wrong or missing base silently disables the whole gate.
+func TestCIFailurePrompt_RequiresBaseBranchBaseline(t *testing.T) {
+	t.Parallel()
+
+	prompt := ciFailurePrompt(github.PullRequest{
+		Number:      1178,
+		HeadRefName: "fix/example",
+		BaseRefName: "release-2.14",
+	})
+
+	for _, want := range []string{"release-2.14", "gh run list --branch", "report `flake`"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("ci failure prompt missing %q; baseline gate is not stated:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestCIFailurePrompt_BaselineFallsBackWithoutBaseRef(t *testing.T) {
+	t.Parallel()
+
+	prompt := ciFailurePrompt(github.PullRequest{Number: 1178, HeadRefName: "fix/example"})
+
+	if !strings.Contains(prompt, "already fails on the base branch") {
+		t.Errorf("ci failure prompt with no BaseRefName must still ask for a baseline:\n%s", prompt)
+	}
+}
+
+// A ban on weakening tests alone just redirects the pressure onto production
+// defaults, which is the change class that reaches users.
+func TestCIFailurePrompt_BansProductCodeTamperingAndForcePush(t *testing.T) {
+	t.Parallel()
+
+	prompt := ciFailurePrompt(github.PullRequest{Number: 1178, HeadRefName: "fix/example"})
+
+	for _, want := range []string{
+		"never change production defaults",
+		"demonstrated causal link",
+		"Never force-push",
+		"Never weaken, skip, delete, or hardcode tests",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("ci failure prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestPRFixResultContract_OffersFlakeExit(t *testing.T) {
+	t.Parallel()
+
+	for _, want := range []string{"SYBRA_PR_FIX_RESULT: flake", "SYBRA_PR_FIX_RESULT: continue", "SYBRA_PR_FIX_RESULT: human-required"} {
+		if !strings.Contains(PRFixResultContract, want) {
+			t.Errorf("result contract missing %q; agents have no honest no-op exit:\n%s", want, PRFixResultContract)
+		}
+	}
+}
+
 func TestCommentsPrompt_DetectsForkRemote(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -83,8 +83,9 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		}
 	}
 	if output.Status == "completed" && currentStep.Config.Role == "pr-fix" {
-		requiresHuman, reason := classifyPRFixResult(output.Output)
-		wfExec.SetVar("step."+output.StepID+".pr_fix_requires_human", strconv.FormatBool(requiresHuman))
+		verdict, reason := classifyPRFixResult(output.Output)
+		wfExec.SetVar("step."+output.StepID+"."+PRFixVerdictVar, string(verdict))
+		wfExec.SetVar("step."+output.StepID+".pr_fix_requires_human", strconv.FormatBool(verdict == PRFixHuman))
 		wfExec.SetVar("step."+output.StepID+".pr_fix_reason", reason)
 	}
 

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -20,18 +20,44 @@ const ReviewHoldParkVar = "review_hold_park"
 
 const reviewHoldParkReason = "review-hold: replies drafted as a pending review — verify & submit on GitHub"
 
+// PRFixVerdict is the outcome a pr-fix agent reported via its SYBRA_PR_FIX_RESULT sentinel.
+type PRFixVerdict string
+
+// PRFixContinue means the agent pushed a fix.
+const PRFixContinue PRFixVerdict = "continue"
+
+// PRFixFlake means the diff is correct and CI failed for unrelated reasons.
+const PRFixFlake PRFixVerdict = "flake"
+
+// PRFixHuman means the agent intentionally stopped for a human.
+const PRFixHuman PRFixVerdict = "human-required"
+
+// PRFixVerdictVar is the execution variable holding a pr-fix step's PRFixVerdict.
+const PRFixVerdictVar = "pr_fix_verdict"
+
 func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
-	requiresHuman, reason := prFixRequiresHuman(wfExec)
-	// Deterministic park wins over the sentinel: in push mode the agent pushed
-	// and its own sentinel says `continue`, which must NOT release the hold.
+	verdict, reason := prFixVerdict(wfExec)
+	// In push mode the agent pushed and reports `continue`, which must NOT release the hold. EXC:FILE011:load-bearing-invariant
 	reviewHoldForced := false
-	if !requiresHuman && wfExec != nil && wfExec.Variables[ReviewHoldParkVar] == "true" {
-		requiresHuman = true
+	if verdict != PRFixHuman && wfExec != nil && wfExec.Variables[ReviewHoldParkVar] == "true" {
+		verdict = PRFixHuman
 		reason = reviewHoldParkReason
 		reviewHoldForced = true
 	}
-	if !requiresHuman {
+	if verdict == PRFixContinue {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "continue"}, nil
+	}
+	// A flake has no commit to verify, so parking or verify_commits would punish the honest answer. EXC:FILE011:load-bearing-invariant
+	if verdict == PRFixFlake {
+		msg := "pr-fix: CI failure unrelated to this PR"
+		if reason != "" {
+			msg += ": " + reason
+		}
+		if err := e.tasks.UpdateTaskStatus(taskID, "in-review", msg); err != nil {
+			return StepOutput{}, fmt.Errorf("route pr-fix result: set in-review after flake: %w", err)
+		}
+		e.logger.Info("workflow.pr-fix.flake", "task_id", taskID, "pr", t.PRNumber, "reason", reason)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
 	}
 	// The review-hold park exists because a pending review draft needs a human
 	// to submit it — that's true regardless of the remote PR's CI/mergeable
@@ -79,20 +105,29 @@ func (e *Engine) checkPRAlreadyResolved(taskID string, t TaskInfo, agentReason s
 	return fmt.Sprintf("pr-fix skipped park: PR #%d already resolved on remote (agent reported: %s)", t.PRNumber, agentReason), true
 }
 
-func prFixRequiresHuman(wfExec *Execution) (requiresHuman bool, reason string) {
+func prFixVerdict(wfExec *Execution) (verdict PRFixVerdict, reason string) {
 	if wfExec == nil {
-		return false, ""
+		return PRFixContinue, ""
 	}
 	stepID := wfExec.LastAgentStepID()
 	if stepID == "" {
-		return false, ""
+		return PRFixContinue, ""
 	}
 	if wfExec.Variables != nil {
+		if v := wfExec.Variables["step."+stepID+"."+PRFixVerdictVar]; v != "" {
+			switch PRFixVerdict(v) {
+			case PRFixHuman, PRFixFlake:
+				return PRFixVerdict(v), wfExec.Variables["step."+stepID+".pr_fix_reason"]
+			case PRFixContinue:
+				return PRFixContinue, ""
+			}
+		}
+		// An execution advanced by a pre-flake binary carries only the boolean. EXC:FILE011:load-bearing-invariant
 		switch wfExec.Variables["step."+stepID+".pr_fix_requires_human"] {
 		case "true":
-			return true, wfExec.Variables["step."+stepID+".pr_fix_reason"]
+			return PRFixHuman, wfExec.Variables["step."+stepID+".pr_fix_reason"]
 		case "false":
-			return false, ""
+			return PRFixContinue, ""
 		}
 	}
 	return classifyPRFixResult(lastPRFixOutput(wfExec, stepID))
@@ -111,18 +146,20 @@ func lastPRFixOutput(wfExec *Execution, stepID string) string {
 	return ""
 }
 
-func classifyPRFixResult(output string) (requiresHuman bool, reason string) {
+func classifyPRFixResult(output string) (verdict PRFixVerdict, reason string) {
 	if strings.TrimSpace(output) == "" {
-		return false, ""
+		return PRFixContinue, ""
 	}
 	matches := prFixSentinelRe.FindAllStringSubmatch(output, -1)
 	if len(matches) > 0 {
 		m := matches[len(matches)-1]
 		switch strings.ToLower(strings.TrimSpace(m[1])) {
 		case "human-required", "human_required", "human":
-			return true, extractPRFixReason(output)
+			return PRFixHuman, extractPRFixReason(output)
+		case "flake", "no-op", "no_op", "noop":
+			return PRFixFlake, extractPRFixReason(output)
 		case "continue", "ok", "done":
-			return false, ""
+			return PRFixContinue, ""
 		}
 	}
 
@@ -135,7 +172,7 @@ func classifyPRFixResult(output string) (requiresHuman bool, reason string) {
 	}
 	for _, phrase := range negativePhrases {
 		if strings.Contains(lower, phrase) {
-			return false, ""
+			return PRFixContinue, ""
 		}
 	}
 
@@ -157,10 +194,10 @@ func classifyPRFixResult(output string) (requiresHuman bool, reason string) {
 	}
 	for _, phrase := range humanPhrases {
 		if strings.Contains(lower, phrase) {
-			return true, "pr-fix agent requested human review: " + truncate(firstNonEmptyLine(output), 200)
+			return PRFixHuman, "pr-fix agent requested human review: " + truncate(firstNonEmptyLine(output), 200)
 		}
 	}
-	return false, ""
+	return PRFixContinue, ""
 }
 
 func extractPRFixReason(output string) string {

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -157,7 +157,7 @@ func classifyPRFixResult(output string) (verdict PRFixVerdict, reason string) {
 		case "human-required", "human_required", "human":
 			return PRFixHuman, extractPRFixReason(output)
 		case "flake", "no-op", "no_op", "noop":
-			return PRFixFlake, extractPRFixReason(output)
+			return PRFixFlake, sentinelReason(output)
 		case "continue", "ok", "done":
 			return PRFixContinue, ""
 		}
@@ -200,11 +200,19 @@ func classifyPRFixResult(output string) (verdict PRFixVerdict, reason string) {
 	return PRFixContinue, ""
 }
 
-func extractPRFixReason(output string) string {
+// Empty when the agent gave no reason; only human-required defaults its text. EXC:FILE011:load-bearing-invariant
+func sentinelReason(output string) string {
 	matches := prFixReasonRe.FindAllStringSubmatch(output, -1)
-	if len(matches) > 0 {
-		m := matches[len(matches)-1]
-		return truncate(strings.TrimSpace(m[1]), 200)
+	if len(matches) == 0 {
+		return ""
+	}
+	m := matches[len(matches)-1]
+	return truncate(strings.TrimSpace(m[1]), 200)
+}
+
+func extractPRFixReason(output string) string {
+	if reason := sentinelReason(output); reason != "" {
+		return reason
 	}
 	return "pr-fix agent requested human review"
 }

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -24,57 +24,75 @@ func TestClassifyPRFixResult(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name       string
-		output     string
-		wantHuman  bool
-		wantReason string
+		name        string
+		output      string
+		wantVerdict PRFixVerdict
+		wantReason  string
 	}{
 		{
 			name: "sentinel human required with reason",
 			output: "Aborted rebase.\nSYBRA_PR_FIX_RESULT: human-required\n" +
 				"SYBRA_PR_FIX_REASON: 5 conflicting files exceed the auto-resolve limit\n",
-			wantHuman:  true,
-			wantReason: "5 conflicting files exceed the auto-resolve limit",
+			wantVerdict: PRFixHuman,
+			wantReason:  "5 conflicting files exceed the auto-resolve limit",
 		},
 		{
-			name:      "sentinel continue",
-			output:    "Pushed fixes.\nSYBRA_PR_FIX_RESULT: continue\n",
-			wantHuman: false,
+			name:        "sentinel continue",
+			output:      "Pushed fixes.\nSYBRA_PR_FIX_RESULT: continue\n",
+			wantVerdict: PRFixContinue,
+		},
+		{
+			name: "sentinel flake with reason",
+			output: "The failing job also fails on main.\nSYBRA_PR_FIX_RESULT: flake\n" +
+				"SYBRA_PR_FIX_REASON: e2e provisioning timeout, reproduces on base\n",
+			wantVerdict: PRFixFlake,
+			wantReason:  "e2e provisioning timeout, reproduces on base",
+		},
+		{
+			name:        "sentinel no-op alias maps to flake",
+			output:      "Nothing to change.\nSYBRA_PR_FIX_RESULT: no-op\n",
+			wantVerdict: PRFixFlake,
 		},
 		{
 			name: "legacy conflict abort text",
 			output: "The rebase produced 5 conflicting files, which exceeds the limit of 3. " +
 				"As instructed, I ran git rebase --abort. This task requires human review.",
-			wantHuman:  true,
-			wantReason: "pr-fix agent requested human review: The rebase produced 5 conflicting files, which exceeds the limit of 3. As instructed, I ran git rebase --abort. This task requires human review.",
+			wantVerdict: PRFixHuman,
+			wantReason:  "pr-fix agent requested human review: The rebase produced 5 conflicting files, which exceeds the limit of 3. As instructed, I ran git rebase --abort. This task requires human review.",
 		},
 		{
-			name:      "negative human phrase",
-			output:    "The conflict is resolved; no human review is required.\nSYBRA_PR_FIX_RESULT: continue\n",
-			wantHuman: false,
+			name:        "negative human phrase",
+			output:      "The conflict is resolved; no human review is required.\nSYBRA_PR_FIX_RESULT: continue\n",
+			wantVerdict: PRFixContinue,
 		},
 		{
 			name: "last sentinel wins",
 			output: "Example contract:\nSYBRA_PR_FIX_RESULT: human-required\n\nActual result:\n" +
 				"SYBRA_PR_FIX_RESULT: continue\n",
-			wantHuman: false,
+			wantVerdict: PRFixContinue,
+		},
+		{
+			name: "flake sentinel beats an earlier contract echo",
+			output: "Contract says:\nSYBRA_PR_FIX_RESULT: human-required\n\nActual:\n" +
+				"SYBRA_PR_FIX_RESULT: flake\n",
+			wantVerdict: PRFixFlake,
 		},
 		{
 			name: "last reason wins",
 			output: "SYBRA_PR_FIX_REASON: example only\n" +
 				"SYBRA_PR_FIX_RESULT: human-required\n" +
 				"SYBRA_PR_FIX_REASON: real blocker\n",
-			wantHuman:  true,
-			wantReason: "real blocker",
+			wantVerdict: PRFixHuman,
+			wantReason:  "real blocker",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			gotHuman, gotReason := classifyPRFixResult(tc.output)
-			if gotHuman != tc.wantHuman {
-				t.Fatalf("human = %v, want %v", gotHuman, tc.wantHuman)
+			gotVerdict, gotReason := classifyPRFixResult(tc.output)
+			if gotVerdict != tc.wantVerdict {
+				t.Fatalf("verdict = %v, want %v", gotVerdict, tc.wantVerdict)
 			}
 			if tc.wantReason != "" && gotReason != tc.wantReason {
 				t.Errorf("reason = %q, want %q", gotReason, tc.wantReason)
@@ -124,6 +142,82 @@ func TestExecRoutePRFixResult_HumanRequiredStopsBeforeRelink(t *testing.T) {
 	}
 	if reason := tasks.Reason("t1"); !strings.Contains(reason, "Human review is required") {
 		t.Errorf("reason = %q, want agent output excerpt", reason)
+	}
+}
+
+// A flake verdict must not park a human and must not reach verify_commits,
+// which would fail the task for the missing commit the honest answer implies.
+func TestExecRoutePRFixResult_FlakeRoutesToInReviewWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "route_pr_fix_result",
+		State:       ExecRunning,
+		StepHistory: []StepRecord{{
+			StepID:    "fix",
+			Status:    "completed",
+			Output:    "Same job fails on base.\nSYBRA_PR_FIX_RESULT: flake\nSYBRA_PR_FIX_REASON: e2e provisioning timeout, reproduces on base\n",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", ProjectID: "acme/widgets", PRNumber: 1178, Workflow: wf})
+
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf, TaskInfo{ID: "t1", ProjectID: "acme/widgets", PRNumber: 1178})
+	if err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	if out.Output == "continue" {
+		t.Fatal("route output = continue, want the flake message so verify_commits is skipped")
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "in-review" {
+		t.Fatalf("status = %q, want in-review (a flake must never park a human)", got.Status)
+	}
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "reproduces on base") {
+		t.Errorf("reason = %q, want the agent's flake evidence", reason)
+	}
+}
+
+// A review-hold park must beat a flake sentinel: the drafted pending review
+// still needs a human to submit it regardless of why CI failed.
+func TestExecRoutePRFixResult_ReviewHoldParkBeatsFlake(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "route_pr_fix_result",
+		State:       ExecRunning,
+		StepHistory: []StepRecord{{
+			StepID:    "fix",
+			Status:    "completed",
+			Output:    "SYBRA_PR_FIX_RESULT: flake\n",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+		Variables: map[string]string{ReviewHoldParkVar: "true"},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", Workflow: wf})
+
+	if _, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf, TaskInfo{ID: "t1"}); err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required (review hold must beat a flake sentinel)", got.Status)
 	}
 }
 
@@ -278,9 +372,60 @@ func TestPRFixRequiresHuman_UsesLastAgentStepVars(t *testing.T) {
 		},
 	}
 
-	gotHuman, gotReason := prFixRequiresHuman(wf)
-	if gotHuman {
-		t.Fatalf("requiresHuman = true, reason %q; want explicit false from latest agent step", gotReason)
+	gotVerdict, gotReason := prFixVerdict(wf)
+	if gotVerdict != PRFixContinue {
+		t.Fatalf("verdict = %v, reason %q; want continue from latest agent step's explicit false var", gotVerdict, gotReason)
+	}
+}
+
+func TestPRFixVerdict_VerdictVarWinsOverLegacyBool(t *testing.T) {
+	t.Parallel()
+
+	wf := &Execution{
+		StepHistory: []StepRecord{{
+			StepID:  "fix",
+			Status:  "completed",
+			Output:  "SYBRA_PR_FIX_RESULT: flake\n",
+			AgentID: "agent-1",
+		}},
+		Variables: map[string]string{
+			"step.fix." + PRFixVerdictVar:    string(PRFixFlake),
+			"step.fix.pr_fix_requires_human": "false",
+			"step.fix.pr_fix_reason":         "unrelated e2e provisioning failure",
+		},
+	}
+
+	gotVerdict, gotReason := prFixVerdict(wf)
+	if gotVerdict != PRFixFlake {
+		t.Fatalf("verdict = %v, want %v", gotVerdict, PRFixFlake)
+	}
+	if gotReason != "unrelated e2e provisioning failure" {
+		t.Errorf("reason = %q, want the flake reason", gotReason)
+	}
+}
+
+func TestPRFixVerdict_LegacyExecutionWithoutVerdictVarParksHuman(t *testing.T) {
+	t.Parallel()
+
+	wf := &Execution{
+		StepHistory: []StepRecord{{
+			StepID:  "fix",
+			Status:  "completed",
+			Output:  "SYBRA_PR_FIX_RESULT: human-required\n",
+			AgentID: "agent-1",
+		}},
+		Variables: map[string]string{
+			"step.fix.pr_fix_requires_human": "true",
+			"step.fix.pr_fix_reason":         "needs a human",
+		},
+	}
+
+	gotVerdict, gotReason := prFixVerdict(wf)
+	if gotVerdict != PRFixHuman {
+		t.Fatalf("verdict = %v, want %v for a pre-flake execution", gotVerdict, PRFixHuman)
+	}
+	if gotReason != "needs a human" {
+		t.Errorf("reason = %q, want the legacy reason", gotReason)
 	}
 }
 

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -24,10 +24,11 @@ func TestClassifyPRFixResult(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name        string
-		output      string
-		wantVerdict PRFixVerdict
-		wantReason  string
+		name            string
+		output          string
+		wantVerdict     PRFixVerdict
+		wantReason      string
+		wantEmptyReason bool
 	}{
 		{
 			name: "sentinel human required with reason",
@@ -52,6 +53,12 @@ func TestClassifyPRFixResult(t *testing.T) {
 			name:        "sentinel no-op alias maps to flake",
 			output:      "Nothing to change.\nSYBRA_PR_FIX_RESULT: no-op\n",
 			wantVerdict: PRFixFlake,
+		},
+		{
+			name:            "flake without a reason sentinel reports no reason",
+			output:          "Nothing to change.\nSYBRA_PR_FIX_RESULT: flake\n",
+			wantVerdict:     PRFixFlake,
+			wantEmptyReason: true,
 		},
 		{
 			name: "legacy conflict abort text",
@@ -96,6 +103,9 @@ func TestClassifyPRFixResult(t *testing.T) {
 			}
 			if tc.wantReason != "" && gotReason != tc.wantReason {
 				t.Errorf("reason = %q, want %q", gotReason, tc.wantReason)
+			}
+			if tc.wantEmptyReason && gotReason != "" {
+				t.Errorf("reason = %q, want empty; a non-human verdict must not inherit the human-required default text", gotReason)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

Closes #2121.

The pr-fix result contract offered an agent exactly two doors: `continue` (I pushed a fix) or `human-required`. A CI failure that is a flake, an infra failure, or a breakage that already reproduces on the base branch fits neither.

Over 98 runs on one busy project, **exactly one escalated** — and its reason was precisely this case. Every other run pushed something. Two runs on the same task force-pushed an `--amend` of an unchanged tree purely to mint a new SHA and retrigger CI; one destroyed a merge commit doing it. Another, unable to weaken a flaky test (correctly forbidden), changed a production timing default to make it pass instead — and that merged.

The contract structurally rewarded fabricating a change. The tampering rule covered tests, snapshots, fixtures and CI config, but said nothing about product code — the one class that reaches users. And nothing asked the highest-value question on a flaky repo: does this job already fail on the base branch? Only 1 of 10 sampled runs checked, and it was the only one that got the right answer.

## Implementation information

- `PRFixResultContract` gains a `flake` verdict, stated as a complete and successful outcome.
- `route_pr_fix_result` routes `flake` to in-review. It has no commit, so parking a human and `verify_commits` would both punish the honest answer. A review-hold park still wins over it.
- `classifyPRFixResult` returns a three-way `PRFixVerdict` instead of a bool; `no-op`/`noop` are accepted aliases. The verdict is persisted to a new `pr_fix_verdict` step var, with the legacy `pr_fix_requires_human` bool still read as a fallback so a workflow mid-flight across the deploy routes correctly.
- `ciFailurePrompt` now requires a base-branch baseline before any code change for a test failure, and points at `gh run rerun --failed` for a transient one.
- The tampering ban extends to production defaults/timeouts/intervals, and force-push/history-rewrite is banned outright (the conflict prompts already banned it).

## Supporting documentation

Tests cover the flake verdict end-to-end, the review-hold precedence, both var-fallback directions, and the prompt rules. Verified `TestExecRoutePRFixResult_FlakeRoutesToInReviewWithoutCommit` fails without the routing change.

> Changelog: fix(pr-fix): add flake outcome to result contract