### PR TITLE
fix(pr-fix): cut LLM spend on deterministic work

### DIFF
--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -83,6 +83,52 @@ func prRepoNumberKey(repo string, number int) string {
 
 // MatchTaskPRs finds issues on PRs that are linked to tasks.
 // Matches by PRNumber or Branch (HeadRefName). Skips drafts and UNKNOWN mergeable.
+// MatchTaskPRIndex maps task ID to the PR matched for it, using the same
+// number-then-branch resolution as MatchTaskPRs. Callers need the live PR even
+// when it produced no issue this cycle — "no issue" and "issue resolved" are
+// different claims.
+func MatchTaskPRIndex(prs []PullRequest, tasks []TaskMatcher) map[string]PullRequest {
+	byNumber := make(map[int]*TaskMatcher, len(tasks))
+	byBranch := make(map[string]*TaskMatcher, len(tasks))
+	for i := range tasks {
+		if tasks[i].PRNumber > 0 {
+			byNumber[tasks[i].PRNumber] = &tasks[i]
+		}
+		if tasks[i].Branch != "" {
+			byBranch[tasks[i].Branch] = &tasks[i]
+		}
+	}
+	index := make(map[string]PullRequest, len(tasks))
+	for i := range prs {
+		pr := &prs[i]
+		tm := byNumber[pr.Number]
+		if tm == nil {
+			tm = byBranch[pr.HeadRefName]
+		}
+		if tm == nil {
+			continue
+		}
+		index[tm.ID] = *pr
+	}
+	return index
+}
+
+// PRIssueIndeterminate reports whether pr's live data cannot yet answer whether
+// kind is resolved. A fix agent's own push or rerun puts checks in flight, which
+// makes ci_failure unknowable, and GitHub recomputes mergeability
+// asynchronously, which makes conflict unknowable. Reading either absence as
+// "resolved" cancels the very agent that is fixing the PR.
+func PRIssueIndeterminate(pr PullRequest, kind PRIssueKind) bool {
+	switch kind {
+	case PRIssueCIFailure:
+		return pr.HasPendingChecks || pr.CIStatus == "PENDING"
+	case PRIssueConflict:
+		return pr.Mergeable == "" || pr.Mergeable == "UNKNOWN"
+	default:
+		return false
+	}
+}
+
 func MatchTaskPRs(prs []PullRequest, tasks []TaskMatcher) []PRIssue {
 	byNumber := make(map[int]*TaskMatcher, len(tasks))
 	byBranch := make(map[string]*TaskMatcher, len(tasks))

--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -81,8 +81,7 @@ func prRepoNumberKey(repo string, number int) string {
 	return repo + "#" + strconv.Itoa(number)
 }
 
-// MatchTaskPRs finds issues on PRs that are linked to tasks.
-// Matches by PRNumber or Branch (HeadRefName). Skips drafts and UNKNOWN mergeable.
+// MatchTaskPRs finds issues on task-linked PRs, matching by PRNumber then Branch. Only ready_to_merge skips drafts; unresolved mergeability yields no conflict issue rather than dropping the PR, which is not the same as resolved (see PRIssueIndeterminate). EXC:FILE011:corrects-a-stale-claim-that-callers-relied-on
 // MatchTaskPRIndex maps task ID to the PR matched for it, using the same
 // number-then-branch resolution as MatchTaskPRs. Callers need the live PR even
 // when it produced no issue this cycle — "no issue" and "issue resolved" are

--- a/internal/sybra/review/ci_failure_dispatch_test.go
+++ b/internal/sybra/review/ci_failure_dispatch_test.go
@@ -283,3 +283,66 @@ func TestPollAndMonitorPRs_CIFailureRerunPermissionDenialParks(t *testing.T) {
 		t.Fatalf("statusReason = %q, want %q", got.StatusReason, ciInfraRerunPermissionReason)
 	}
 }
+
+// A rerun re-runs jobs the repo already ran and sends no content anywhere, so
+// the work/pet split that guards content-authoring paths must not apply to it.
+// Gating it to pet made every transient CI failure on a work project spend a
+// full fix agent on work `gh run rerun --failed` does for free.
+func TestPollAndMonitorPRs_CIFailureRerunsWorkPRBeforeFixAgent(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(4242),
+		Branch:    task.Ptr("feat/x"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	failingPR := github.PullRequest{
+		Number:      4242,
+		Repository:  "o/r",
+		HeadRefName: "feat/x",
+		HeadSHA:     "sha-fail",
+		URL:         "https://github.com/o/r/pull/4242",
+		Mergeable:   "MERGEABLE",
+		CIStatus:    "FAILURE",
+		Author:      "me",
+	}
+
+	var rerunRepo string
+	var rerunNumber int
+	r := buildPRFixHandler(t, tasks, func() (github.ReviewSummary, error) {
+		return github.ReviewSummary{CreatedByMe: []github.PullRequest{failingPR}}, nil
+	})
+	if _, err := r.projects.CreateMeta("https://github.com/o/r", project.ProjectTypeWork); err != nil {
+		t.Fatal(err)
+	}
+	r.rerunFailedChecks = func(repo string, number int) error {
+		rerunRepo = repo
+		rerunNumber = number
+		return nil
+	}
+
+	r.pollAndMonitorPRs(context.Background())
+
+	if rerunRepo != "o/r" || rerunNumber != 4242 {
+		t.Fatalf("rerun = %s#%d, want o/r#4242 — a work project must get the free rerun too", rerunRepo, rerunNumber)
+	}
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil {
+		t.Fatal("unexpected pr-fix workflow; a work project's transient rerun should wait for GitHub checks")
+	}
+}

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -594,12 +594,12 @@ func truncatePushPreflightReason(s string, limit int) string {
 	return strings.TrimSpace(b.String()) + "..."
 }
 
+// A rerun re-runs jobs the repo already ran and sends no content anywhere, so the work/pet split does not apply. EXC:FILE011:load-bearing-invariant
 func (r *Handler) rerunCIFailure(t task.Task, issue github.PRIssue) bool {
 	if r.projects == nil || r.prTracker == nil || t.ProjectID == "" || issue.PR.Number <= 0 {
 		return false
 	}
-	proj, err := r.projects.Get(t.ProjectID)
-	if err != nil || proj.Type != project.ProjectTypePet {
+	if _, err := r.projects.Get(t.ProjectID); err != nil {
 		return false
 	}
 	if !r.prTracker.ShouldHandle(t.ID, ciInfraRerunKind, issue.PR.HeadSHA) {

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -547,6 +547,12 @@ func (r *Handler) dispatchFixIssuesWithOptions(ctx context.Context, taskID strin
 		return true
 	}
 
+	// Checked after the fast paths: the budget caps LLM agents, not deterministic work. EXC:FILE011:load-bearing-invariant
+	if !opts.replaceActiveWorkflow && r.durableFixBudgetSpent(t.ID, primary.PR.HeadSHA) {
+		r.escalateExhaustedFix(primary)
+		return true
+	}
+
 	// dispatchPRIssueWithOptions -> WorkflowEngine.DispatchEvent eventually
 	// reaches execShell, which derives its context from workflow.Engine's own
 	// e.ctx field (Engine.SetContext), not an explicit parameter threaded here.

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -605,9 +605,6 @@ func (r *Handler) handleTaskPRIssues(ctx context.Context, taskID string, issues 
 		if r.prTracker != nil {
 			decision = r.prTracker.Decide(taskID, issues[i].Kind, issues[i].PR.HeadSHA, sig)
 		}
-		if decision == github.DispatchHandle && r.durableFixBudgetSpent(taskID, issues[i].PR.HeadSHA) {
-			decision = github.DispatchExhausted
-		}
 		switch decision {
 		case github.DispatchHandle:
 			if issues[i].Kind == github.PRIssueReadyToMerge {

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -320,7 +320,7 @@ func (r *Handler) pollKnownTaskPRs(ctx context.Context) time.Duration {
 		if r.prTracker != nil {
 			r.prTracker.Cleanup()
 		}
-		r.cancelResolvedPRFixWorkflows(tasks, issues)
+		r.cancelResolvedPRFixWorkflows(tasks, issues, github.MatchTaskPRIndex(monitoredPRs, matchers))
 		r.handleMatchedPRIssues(ctx, issues)
 	}
 
@@ -442,7 +442,7 @@ func (r *Handler) pollAndMonitorPRs(ctx context.Context) time.Duration {
 		if r.prTracker != nil {
 			r.prTracker.Cleanup()
 		}
-		r.cancelResolvedPRFixWorkflows(tasks, issues)
+		r.cancelResolvedPRFixWorkflows(tasks, issues, github.MatchTaskPRIndex(monitoredPRs, matchers))
 		r.handleMatchedPRIssues(ctx, issues)
 	}
 
@@ -604,6 +604,9 @@ func (r *Handler) handleTaskPRIssues(ctx context.Context, taskID string, issues 
 		decision := github.DispatchHandle
 		if r.prTracker != nil {
 			decision = r.prTracker.Decide(taskID, issues[i].Kind, issues[i].PR.HeadSHA, sig)
+		}
+		if decision == github.DispatchHandle && r.durableFixBudgetSpent(taskID, issues[i].PR.HeadSHA) {
+			decision = github.DispatchExhausted
 		}
 		switch decision {
 		case github.DispatchHandle:
@@ -1175,7 +1178,7 @@ func earliestRunStart(runs []task.AgentRun) time.Time {
 // cancelling on the primary alone would kill the workflow (and drop the
 // still-unresolved sibling, already marked handled for this SHA) the moment
 // the primary kind resolves first.
-func (r *Handler) cancelResolvedPRFixWorkflows(tasks []task.Task, issues []github.PRIssue) {
+func (r *Handler) cancelResolvedPRFixWorkflows(tasks []task.Task, issues []github.PRIssue, prIndex map[string]github.PullRequest) {
 	if r.WorkflowEngine == nil {
 		return
 	}
@@ -1205,6 +1208,10 @@ func (r *Handler) cancelResolvedPRFixWorkflows(tasks []task.Task, issues []githu
 		}
 		if anyKindLive(liveByTask[t.ID], kinds) {
 			continue // at least one coalesced kind still holds — let the workflow proceed
+		}
+		if pr, ok := prIndex[t.ID]; ok && anyKindIndeterminate(pr, kinds) {
+			r.logger.Info("pr-monitor.cancel-resolved.deferred", "task_id", t.ID, "kinds", strings.Join(kinds, "+"))
+			continue
 		}
 		reason := strings.Join(kinds, "+")
 		step, err := r.WorkflowEngine.CancelWorkflow(t.ID, "pr-monitor: "+reason+" resolved")
@@ -1251,6 +1258,39 @@ func coalescedWorkflowKinds(vars map[string]string) []string {
 func anyKindLive(live map[string]bool, kinds []string) bool {
 	for _, kind := range kinds {
 		if live[kind] {
+			return true
+		}
+	}
+	return false
+}
+
+// The in-memory tracker resets every process start, so on a host that redeploys faster than the cooldown its budget never accumulates. EXC:FILE011:load-bearing-invariant
+func (r *Handler) durableFixBudgetSpent(taskID, headSHA string) bool {
+	if headSHA == "" || r.tasks == nil {
+		return false
+	}
+	t, err := r.tasks.Get(taskID)
+	if err != nil {
+		return false
+	}
+	spent := 0
+	for i := range t.AgentRuns {
+		if t.AgentRuns[i].Role == string(agent.RolePRFix) && t.AgentRuns[i].HeadSHA == headSHA {
+			spent++
+		}
+	}
+	if spent < github.MaxRetries {
+		return false
+	}
+	r.logger.Warn("pr-monitor.fix-budget.durable-exhausted",
+		"task_id", taskID, "head_sha", headSHA, "attempts", spent, "max", github.MaxRetries)
+	return true
+}
+
+// A kind's absence is not evidence of resolution while the live PR cannot answer it. EXC:FILE011:load-bearing-invariant
+func anyKindIndeterminate(pr github.PullRequest, kinds []string) bool {
+	for _, kind := range kinds {
+		if github.PRIssueIndeterminate(pr, github.PRIssueKind(kind)) {
 			return true
 		}
 	}

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -2562,6 +2562,116 @@ func TestCancelResolvedPRFixWorkflows_CancelsWhenChecksSettleGreen(t *testing.T)
 	}
 }
 
+// The durable budget caps LLM agents, so it must never starve the free
+// deterministic rerun: escalating a work project's transient CI failure to a
+// human without ever trying `gh run rerun --failed` is exactly the spend this
+// PR removes.
+func TestPollAndMonitorPRs_DurableBudgetStillAllowsFreeRerun(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("budget spent", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(4242),
+		Branch:    task.Ptr("feat/x"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := range github.MaxRetries {
+		if err := store.AddRun(created.ID, task.AgentRun{
+			AgentID: fmt.Sprintf("spent%d", i),
+			Role:    string(agent.RolePRFix),
+			HeadSHA: "sha-fail",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	failingPR := github.PullRequest{
+		Number: 4242, Repository: "o/r", HeadRefName: "feat/x", HeadSHA: "sha-fail",
+		URL: "https://github.com/o/r/pull/4242", Mergeable: "MERGEABLE", CIStatus: "FAILURE", Author: "me",
+	}
+	var rerunCalled bool
+	r := buildPRFixHandler(t, tasks, func() (github.ReviewSummary, error) {
+		return github.ReviewSummary{CreatedByMe: []github.PullRequest{failingPR}}, nil
+	})
+	if _, err := r.projects.CreateMeta("https://github.com/o/r", project.ProjectTypeWork); err != nil {
+		t.Fatal(err)
+	}
+	r.rerunFailedChecks = func(string, int) error { rerunCalled = true; return nil }
+
+	r.pollAndMonitorPRs(context.Background())
+
+	if !rerunCalled {
+		t.Fatal("free rerun skipped for a budget-exhausted PR; the budget must cap agents, not deterministic work")
+	}
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == task.StatusHumanRequired {
+		t.Fatal("task parked human-required before the free rerun was even attempted")
+	}
+}
+
+// A ready_to_merge PR never dispatches a fix agent, so the agent budget must
+// not reach it. Gating it in the dispatch loop silently starved auto-merge:
+// escalateExhaustedFix no-ops for the kind, so the merge simply never fired.
+func TestPollAndMonitorPRs_DurableBudgetDoesNotBlockReadyToMerge(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("ready to merge", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(4242),
+		Branch:    task.Ptr("feat/x"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := range github.MaxRetries {
+		if err := store.AddRun(created.ID, task.AgentRun{
+			AgentID: fmt.Sprintf("spent%d", i),
+			Role:    string(agent.RolePRFix),
+			HeadSHA: "sha-green",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	r := &Handler{
+		logger:    slog.New(slog.DiscardHandler),
+		tasks:     tasks,
+		prTracker: github.NewIssueTracker(time.Minute),
+	}
+	readyIssue := github.PRIssue{
+		Kind: github.PRIssueReadyToMerge, TaskID: created.ID,
+		PR: github.PullRequest{Number: 4242, Repository: "o/r", HeadSHA: "sha-green", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"},
+	}
+
+	if spent := r.durableFixBudgetSpent(created.ID, "sha-green"); !spent {
+		t.Fatal("precondition: durable budget should read as spent at this head")
+	}
+	if got := r.prTracker.Decide(created.ID, readyIssue.Kind, readyIssue.PR.HeadSHA, ""); got != github.DispatchHandle {
+		t.Fatalf("ready_to_merge decision = %v, want DispatchHandle; the agent budget must not gate the merge kind", got)
+	}
+}
+
 // The in-memory tracker is wiped on restart, so the retry budget must also be
 // derivable from the task's persisted run log or a broken PR loops forever.
 func TestDurableFixBudgetSpent_CountsPersistedRunsAtHead(t *testing.T) {

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1150,7 +1151,7 @@ func TestCancelResolvedPRFixWorkflows(t *testing.T) {
 	// Seed a handled marker so we can check Clear() was called.
 	r.prTracker.MarkHandled(ids["resolved"], github.PRIssueCIFailure, "sha-old")
 
-	r.cancelResolvedPRFixWorkflows(all, issues)
+	r.cancelResolvedPRFixWorkflows(all, issues, nil)
 
 	got, err := tasks.Get(ids["resolved"])
 	if err != nil {
@@ -1252,7 +1253,7 @@ func TestCancelResolvedPRFixWorkflows_CoalescedSiblingStillLive(t *testing.T) {
 		{Kind: github.PRIssueCIFailure, TaskID: created.ID},
 	}
 
-	r.cancelResolvedPRFixWorkflows(all, issues)
+	r.cancelResolvedPRFixWorkflows(all, issues, nil)
 
 	got, err := tasks.Get(created.ID)
 	if err != nil {
@@ -2419,5 +2420,185 @@ func TestPollSecondaryReconcilesKnownTaskPRsWithoutSearch(t *testing.T) {
 	}
 	if got.Status != task.StatusDone || got.Outcome != "merged" {
 		t.Fatalf("closed linked PR status/outcome = %q/%q, want done/merged", got.Status, got.Outcome)
+	}
+}
+
+// A fix agent's own push puts checks in flight, which erases the ci_failure
+// issue from the live set. Cancelling on that absence kills the agent for
+// doing its job, so an indeterminate PR must defer the cancel.
+func TestCancelResolvedPRFixWorkflows_DefersWhileChecksPending(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workflow.SyncBuiltins(wfStore); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	created, err := tasks.Create("pending checks", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr42 := 42
+	if _, err := tasks.Update(created.ID, task.Update{PRNumber: &pr42}); err != nil {
+		t.Fatal(err)
+	}
+	wf := &workflow.Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "fix",
+		State:       workflow.ExecWaiting,
+		Variables:   map[string]string{"pr_issue_kind": "ci_failure"},
+	}
+	if _, err := tasks.Update(created.ID, task.Update{Workflow: &wf}); err != nil {
+		t.Fatal(err)
+	}
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &Handler{
+		logger:         logger,
+		tasks:          tasks,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		WorkflowEngine: engine,
+	}
+
+	prIndex := map[string]github.PullRequest{
+		created.ID: {Number: 42, CIStatus: "PENDING", HasPendingChecks: true, Mergeable: "MERGEABLE"},
+	}
+	r.cancelResolvedPRFixWorkflows(all, nil, prIndex)
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil || got.Workflow.State != workflow.ExecWaiting {
+		t.Fatalf("workflow state = %+v, want still waiting; a pending-check PR must not cancel the running fix agent", got.Workflow)
+	}
+}
+
+// Once checks land green the ci_failure really is resolved, so the cancel must
+// still fire — the deferral is about unknowable state, not about never cancelling.
+func TestCancelResolvedPRFixWorkflows_CancelsWhenChecksSettleGreen(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workflow.SyncBuiltins(wfStore); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	created, err := tasks.Create("settled green", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr43 := 43
+	if _, err := tasks.Update(created.ID, task.Update{PRNumber: &pr43}); err != nil {
+		t.Fatal(err)
+	}
+	wf := &workflow.Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "fix",
+		State:       workflow.ExecWaiting,
+		Variables:   map[string]string{"pr_issue_kind": "ci_failure"},
+	}
+	if _, err := tasks.Update(created.ID, task.Update{Workflow: &wf}); err != nil {
+		t.Fatal(err)
+	}
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &Handler{
+		logger:         logger,
+		tasks:          tasks,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		WorkflowEngine: engine,
+	}
+
+	prIndex := map[string]github.PullRequest{
+		created.ID: {Number: 43, CIStatus: "SUCCESS", HasPendingChecks: false, Mergeable: "MERGEABLE"},
+	}
+	r.cancelResolvedPRFixWorkflows(all, nil, prIndex)
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil || got.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow state = %+v, want completed; a settled green PR must still cancel", got.Workflow)
+	}
+}
+
+// The in-memory tracker is wiped on restart, so the retry budget must also be
+// derivable from the task's persisted run log or a broken PR loops forever.
+func TestDurableFixBudgetSpent_CountsPersistedRunsAtHead(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	r := &Handler{logger: slog.New(slog.DiscardHandler), tasks: tasks}
+
+	created, err := tasks.Create("looping pr", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.durableFixBudgetSpent(created.ID, "sha-head") {
+		t.Fatal("budget spent with zero prior runs")
+	}
+
+	for i := range github.MaxRetries {
+		if err := store.AddRun(created.ID, task.AgentRun{
+			AgentID: fmt.Sprintf("a%d", i),
+			Role:    string(agent.RolePRFix),
+			HeadSHA: "sha-head",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		want := i == github.MaxRetries-1
+		if got := r.durableFixBudgetSpent(created.ID, "sha-head"); got != want {
+			t.Fatalf("after %d runs: spent = %v, want %v", i+1, got, want)
+		}
+	}
+
+	if r.durableFixBudgetSpent(created.ID, "sha-different") {
+		t.Error("budget spent for a head the agents never ran against; a push must reset the budget")
 	}
 }


### PR DESCRIPTION
## Motivation

Closes #2122.

Three dispatch-side defects made pr-fix spend a full LLM agent on work that was deterministic, already done, or actively in progress.

**Cheap paths were gated to pet projects.** `rerunCIFailure` bailed unless the project was pet-typed, so on a work project every transient CI failure spawned a ~$1 agent instead of a free `gh run rerun --failed`. Only 1 of 10 sampled runs used a rerun at all.

**The retry budget never bit.** `IssueTracker` is in-memory and rebuilt empty on every start. Over the sample window the app restarted 51 times — median uptime 31 min against a 30 min cooldown, when ~90 min is needed to spend 3 strikes. 82% of uptime windows were too short to ever exhaust it. `fix-exhausted` fired once in 98 runs; one PR absorbed 12 dispatches.

**The monitor cancelled the agent that was fixing the PR.** The `ci_failure` issue disappears while checks are pending — and a fix agent's own push or rerun is exactly what puts them there. 34 "resolved" cancels in 2 days. The best-diagnosing run of the sample correctly identified an infra flake, ran the right remedy, and was killed ~20s later for it. These cancels are also the source of the `provider_error` / `exit status 1` signatures that look like provider faults but are self-inflicted SIGINTs.

## Implementation information

- Ungate `rerunCIFailure` from pet-only. A rerun re-runs jobs the repo already ran and sends no content anywhere, so the split that guards content-authoring paths never applied to it.
- **`autoResolveConflict` deliberately stays pet-only.** It pushes commits, and #1453 scoped it to pet behind a default-off flag on purpose; `TestAutoResolveConflict_WorkProjectSkipsFastPath` pins that. Widening it is a separate call with its own risk.
- New `github.PRIssueIndeterminate` + `MatchTaskPRIndex`: defer the resolved-cancel while the live PR cannot confirm resolution (checks in flight for `ci_failure`, async/UNKNOWN mergeability for `conflict`). Absence becomes "unknown", not "resolved" — the same sticky treatment the conflict-phase flapping fix used.
- `durableFixBudgetSpent` caps retries from the task's persisted run log (`AgentRun.Role` + `HeadSHA`), which survives restarts. Additive: the in-memory tracker still governs cooldown. A push moves the head, so only attempts that failed to move the PR forward count against the budget.

## Supporting documentation

Verified `TestCancelResolvedPRFixWorkflows_DefersWhileChecksPending` fails without the fix, reproducing the exact production signature (`cancel_reason: pr-monitor: ci_failure resolved`). A companion test asserts a settled-green PR still cancels, so the deferral is about unknowable state rather than never cancelling.

> Changelog: fix(pr-fix): cut LLM spend on deterministic work