### PR TITLE
fix(agent): keep checkpoint reason past cost guard

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -82,11 +82,12 @@ type Agent struct {
 	// one provider turn instead of surviving as reusable chats.
 	oneShot bool
 	// PluginErrors holds plugin load failures from the most recent init event.
-	PluginErrors     []string `json:"pluginErrors,omitempty"`
-	EscalationReason string   `json:"escalationReason,omitempty"`
-	ErrorKind        string   `json:"errorKind,omitempty"`
-	ErrorMsg         string   `json:"errorMsg,omitempty"`
-	AwaitingApproval bool     `json:"awaitingApproval,omitempty"`
+	PluginErrors []string `json:"pluginErrors,omitempty"`
+	// Read across packages to route a stopped run; writers must use EscalationReason* constants. EXC:FILE011:load-bearing-invariant
+	EscalationReason string `json:"escalationReason,omitempty"`
+	ErrorKind        string `json:"errorKind,omitempty"`
+	ErrorMsg         string `json:"errorMsg,omitempty"`
+	AwaitingApproval bool   `json:"awaitingApproval,omitempty"`
 	// Resumable is set when the agent was stopped intentionally via StopAgent
 	// and CC exited with a valid session_id, meaning the next run can pass
 	// --resume to continue the conversation.
@@ -778,6 +779,20 @@ func (a *Agent) AckToolLoop() {
 func (a *Agent) ToolLoopAcknowledged() bool {
 	return a.loops.acknowledged()
 }
+
+// EscalationReasonCost marks a run stopped for breaching MaxCostUSD.
+const EscalationReasonCost = "cost"
+
+// EscalationReasonTurns marks a run stopped at the turn ceiling awaiting a human.
+const EscalationReasonTurns = "turns"
+
+// EscalationReasonCheckpoint marks a run whose work was committed at the turn
+// ceiling and which must be rescheduled onto a fresh agent. Never overwrite it:
+// the handoff is routed off this exact value.
+const EscalationReasonCheckpoint = "checkpoint"
+
+// EscalationReasonCheckpointFailed marks a turn-ceiling run whose checkpoint commit failed.
+const EscalationReasonCheckpointFailed = "checkpoint_failed"
 
 // SetEscalationReason updates the escalation reason string.
 func (a *Agent) SetEscalationReason(reason string) {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -794,6 +794,14 @@ const EscalationReasonCheckpoint = "checkpoint"
 // EscalationReasonCheckpointFailed marks a turn-ceiling run whose checkpoint commit failed.
 const EscalationReasonCheckpointFailed = "checkpoint_failed"
 
+// IsCheckpointEscalation reports whether reason records a turn-ceiling
+// checkpoint outcome. Both values steer terminal handling — one reschedules the
+// handoff, the other stamps errCheckpointCommitFailed — so neither may be
+// overwritten by a later guardrail that fires on the same run.
+func IsCheckpointEscalation(reason string) bool {
+	return reason == EscalationReasonCheckpoint || reason == EscalationReasonCheckpointFailed
+}
+
 // SetEscalationReason updates the escalation reason string.
 func (a *Agent) SetEscalationReason(reason string) {
 	a.mu.Lock()

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1057,7 +1057,7 @@ func (m *Manager) checkCostGuardrail(a *Agent, costNow, maxCost float64) bool {
 	m.logger.Warn("agent.guardrail.cost", "id", a.ID, "cost", costNow, "limit", maxCost)
 	a.MarkStopped()
 	// Stamping "cost" over a checkpoint discards a handoff whose work is already committed. EXC:FILE011:load-bearing-invariant
-	if a.GetEscalationReason() != EscalationReasonCheckpoint {
+	if !IsCheckpointEscalation(a.GetEscalationReason()) {
 		a.SetEscalationReason(EscalationReasonCost)
 	}
 	a.setCompletedByResult(true)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -305,7 +305,7 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 	}
 
 	stderrOut := stderrBuf.String()
-	if a.WasStopped() && a.GetEscalationReason() == "cost" {
+	if a.WasStopped() && a.GetEscalationReason() == EscalationReasonCost {
 		a.SetExitErr(errCostGuardrailExceeded)
 		logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 		return false, nil
@@ -464,7 +464,7 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
 		stderrOut = string(b)
 	}
-	if a.WasStopped() && a.GetEscalationReason() == "cost" {
+	if a.WasStopped() && a.GetEscalationReason() == EscalationReasonCost {
 		a.SetExitErr(errCostGuardrailExceeded)
 		logAttemptStderr(m.logger, "agent.headless.stderr", a.ID, stderrOut, a.GetExitErr())
 		return false, nil
@@ -510,7 +510,7 @@ func (m *Manager) resolveHeadlessAttemptExit(a *Agent, waitErr error, stderrOut 
 // guard stopped, deriving completion from the terminal result event rather
 // than the kill signal that appears in the process wait error.
 func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
-	if a.GetEscalationReason() == "checkpoint_failed" {
+	if a.GetEscalationReason() == EscalationReasonCheckpointFailed {
 		a.SetExitErr(errCheckpointCommitFailed)
 		return
 	}
@@ -1056,7 +1056,10 @@ func (m *Manager) warnIfResultHasLiveBackgroundTasks(a *Agent) {
 func (m *Manager) checkCostGuardrail(a *Agent, costNow, maxCost float64) bool {
 	m.logger.Warn("agent.guardrail.cost", "id", a.ID, "cost", costNow, "limit", maxCost)
 	a.MarkStopped()
-	a.SetEscalationReason("cost")
+	// Stamping "cost" over a checkpoint discards a handoff whose work is already committed. EXC:FILE011:load-bearing-invariant
+	if a.GetEscalationReason() != EscalationReasonCheckpoint {
+		a.SetEscalationReason(EscalationReasonCost)
+	}
 	a.setCompletedByResult(true)
 	m.emit(events.AgentEscalation(a.ID), EscalationEvent{
 		Reason:  "cost",
@@ -1100,7 +1103,7 @@ func (m *Manager) checkTurnsGuardrail(ctx context.Context, a *Agent) bool {
 		m.logger.Info("agent.guardrail.turns.auto_continued", "id", a.ID, "turns", turns, "new_limit", newLimit)
 		return true
 	}
-	a.SetEscalationReason("turns")
+	a.SetEscalationReason(EscalationReasonTurns)
 	m.emit(events.AgentEscalation(a.ID), EscalationEvent{
 		Reason:    "turns",
 		TurnCount: turns,
@@ -1126,7 +1129,7 @@ func (m *Manager) checkTurnsGuardrail(ctx context.Context, a *Agent) bool {
 func (m *Manager) checkpointAndHandoff(ctx context.Context, a *Agent, turns, maxTurns int) bool {
 	worktreeDir := strings.TrimSpace(a.sessionCWD)
 	if worktreeDir == "" {
-		a.SetEscalationReason("checkpoint_failed")
+		a.SetEscalationReason(EscalationReasonCheckpointFailed)
 		a.MarkStopped()
 		a.setCompletedByResult(true)
 		m.logger.Error("agent.guardrail.turns.checkpoint_failed",
@@ -1138,7 +1141,7 @@ func (m *Manager) checkpointAndHandoff(ctx context.Context, a *Agent, turns, max
 	msg := fmt.Sprintf("chore(checkpoint): preserve progress at turn %d\n\nSybra checkpointed this run at the per-run turn ceiling (%d turns) before handing off to a fresh agent.", turns, maxTurns)
 	committed, err := project.CheckpointCommit(ctx, worktreeDir, msg)
 	if err != nil {
-		a.SetEscalationReason("checkpoint_failed")
+		a.SetEscalationReason(EscalationReasonCheckpointFailed)
 		a.MarkStopped()
 		a.setCompletedByResult(true)
 		m.logger.Error("agent.guardrail.turns.checkpoint_failed",
@@ -1147,7 +1150,7 @@ func (m *Manager) checkpointAndHandoff(ctx context.Context, a *Agent, turns, max
 		return false
 	}
 
-	a.SetEscalationReason("checkpoint")
+	a.SetEscalationReason(EscalationReasonCheckpoint)
 	a.MarkStopped()
 	a.setCompletedByResult(true)
 	m.logger.Info("agent.guardrail.turns.checkpoint",

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -2838,6 +2838,28 @@ func TestCheckCostGuardrail_PreservesCheckpointEscalationReason(t *testing.T) {
 	}
 }
 
+// finalizeFromResult stamps errCheckpointCommitFailed off "checkpoint_failed",
+// so letting a late result event overwrite it with "cost" would finalize a run
+// whose checkpoint commit failed as though nothing had gone wrong, and would
+// also drop its EventAgentCheckpoint audit record.
+func TestCheckCostGuardrail_PreservesCheckpointFailedEscalationReason(t *testing.T) {
+	t.Parallel()
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{
+		Runtime: ManagerRuntimeConfig{DefaultProvider: "claude"},
+	})
+
+	ag := &Agent{ID: "a3", TaskID: "t3", done: make(chan struct{})}
+	ag.SetEscalationReason(EscalationReasonCheckpointFailed)
+
+	if keepGoing := m.checkCostGuardrail(ag, 8.19, 5.0); keepGoing {
+		t.Fatal("checkCostGuardrail = true, want false")
+	}
+	if got := ag.GetEscalationReason(); got != EscalationReasonCheckpointFailed {
+		t.Fatalf("escalation reason = %q, want %q; a failed checkpoint must not finalize as a plain cost stop", got, EscalationReasonCheckpointFailed)
+	}
+}
+
 // A run that never checkpointed must still be labelled "cost" so it flows
 // through the bounded failed-completion path rather than a reschedule.
 func TestCheckCostGuardrail_StampsCostWhenNoCheckpoint(t *testing.T) {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -2808,3 +2808,51 @@ done
 	}
 	return dir
 }
+
+// A checkpoint handoff commits the run's work and sets escalation reason
+// "checkpoint"; internal/sybra/completion routes RescheduleCheckpointedAgent
+// off that exact value. The terminal result event lands after the checkpoint
+// and carries the run's total cost, so a run that checkpointed past the cost
+// ceiling had its reason stamped to "cost" — silently converting a handoff
+// into a plain failure and orphaning the committed work. This is the same bug
+// class TestGuardrails_CostHardStop_CompletedTurnIsNotAFailure pins for
+// completedByResult.
+func TestCheckCostGuardrail_PreservesCheckpointEscalationReason(t *testing.T) {
+	t.Parallel()
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{
+		Runtime: ManagerRuntimeConfig{DefaultProvider: "claude"},
+	})
+
+	ag := &Agent{ID: "a1", TaskID: "t1", done: make(chan struct{})}
+	ag.SetEscalationReason(EscalationReasonCheckpoint)
+
+	if keepGoing := m.checkCostGuardrail(ag, 8.19, 5.0); keepGoing {
+		t.Fatal("checkCostGuardrail = true, want false (a cost breach always stops the run)")
+	}
+	if got := ag.GetEscalationReason(); got != EscalationReasonCheckpoint {
+		t.Fatalf("escalation reason = %q, want %q; the cost ceiling must not discard a committed checkpoint handoff", got, EscalationReasonCheckpoint)
+	}
+	if !ag.WasStopped() {
+		t.Error("WasStopped() = false, want true")
+	}
+}
+
+// A run that never checkpointed must still be labelled "cost" so it flows
+// through the bounded failed-completion path rather than a reschedule.
+func TestCheckCostGuardrail_StampsCostWhenNoCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{
+		Runtime: ManagerRuntimeConfig{DefaultProvider: "claude"},
+	})
+
+	ag := &Agent{ID: "a2", TaskID: "t2", done: make(chan struct{})}
+
+	if keepGoing := m.checkCostGuardrail(ag, 8.19, 5.0); keepGoing {
+		t.Fatal("checkCostGuardrail = true, want false")
+	}
+	if got := ag.GetEscalationReason(); got != EscalationReasonCost {
+		t.Fatalf("escalation reason = %q, want %q", got, EscalationReasonCost)
+	}
+}

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -203,7 +203,7 @@ func (h *Handler) OnComplete(ag *agent.Agent) {
 		auditData["premium_requests"] = premiumRequests
 	}
 	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, auditData)
-	if reason := ag.GetEscalationReason(); reason == agent.EscalationReasonCheckpoint || reason == agent.EscalationReasonCheckpointFailed {
+	if reason := ag.GetEscalationReason(); agent.IsCheckpointEscalation(reason) {
 		h.logAudit(audit.EventAgentCheckpoint, ag.TaskID, ag.ID, map[string]any{
 			"reason":     reason,
 			"turn_count": ag.GetTurnCount(),

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -203,7 +203,7 @@ func (h *Handler) OnComplete(ag *agent.Agent) {
 		auditData["premium_requests"] = premiumRequests
 	}
 	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, auditData)
-	if reason := ag.GetEscalationReason(); reason == "checkpoint" || reason == "checkpoint_failed" {
+	if reason := ag.GetEscalationReason(); reason == agent.EscalationReasonCheckpoint || reason == agent.EscalationReasonCheckpointFailed {
 		h.logAudit(audit.EventAgentCheckpoint, ag.TaskID, ag.ID, map[string]any{
 			"reason":     reason,
 			"turn_count": ag.GetTurnCount(),
@@ -450,9 +450,9 @@ func classifyStall(ag *agent.Agent, exitErr error) (stalled, rateLimited, malfor
 	// Cost guardrails intentionally hard-stop the subprocess, but they are a
 	// budget failure, not an infra stall. Let them flow through the bounded
 	// failed-completion path instead of ClearAgentStep/ResumeStalled.
-	costStopped := ag.WasStopped() && ag.GetEscalationReason() == "cost"
-	checkpointFailed := ag.WasStopped() && ag.GetEscalationReason() == "checkpoint_failed"
-	checkpointStopped = ag.WasStopped() && ag.GetEscalationReason() == "checkpoint"
+	costStopped := ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCost
+	checkpointFailed := ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpointFailed
+	checkpointStopped = ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpoint
 	stopStalled = ag.WasStopped() && !ag.WasCompletedByResult() && !costStopped && !checkpointFailed && !checkpointStopped
 	stalled = isSignalKill(exitErr) || stopStalled || rateLimited || malformedTool || checkpointStopped
 	return stalled, rateLimited, malformedTool, stopStalled, checkpointStopped


### PR DESCRIPTION
## Motivation

Closes #2123. Codex metering and the `max_turns` unit are split out to #2124 — see below.

A turn-ceiling checkpoint commits the run's work and sets escalation reason `"checkpoint"`; `internal/sybra/completion` routes `RescheduleCheckpointedAgent` off that exact value. The terminal result event lands a beat later carrying the run's total cost, so any run that checkpointed past `max_cost_usd` had its reason stamped to `"cost"` by `checkCostGuardrail` — `classifyStall` then saw `checkpointStopped=false`, dropped the handoff, and finalized the run as a plain failure with its committed work orphaned.

The $5 line alone decided survival: **6 checkpoints fired, 2 survived.** $4.65 and $4.31 rescheduled; $5.71, $5.28 and $8.19 were lost. `checkpoint retry budget exhausted` has never fired, because the clobber prevents the counter from incrementing.

The ceiling cannot prevent that spend anyway — providers report cost only on the terminal result, so `GetCostUSD()` is 0 for the whole run and a breach is always already paid for. Discarding the handoff just makes the next dispatch re-derive everything from scratch, which costs more than it saves. One PR burned ~$17.65 across 6 agents, each re-discovering what the last one knew.

`checkCostGuardrail`'s own doc comment already documents this exact bug class for `completedByResult`; the checkpoint reason needed identical protection.

## Implementation information

- `checkCostGuardrail` no longer overwrites a `"checkpoint"` escalation reason. It still stops the run and still stamps `"cost"` on every run that did not checkpoint, so a plain overspend keeps flowing through the bounded failed-completion path. `max_checkpoints` (default 3) bounds the follow-on runs.
- Promote the reason strings to exported constants (`agent.EscalationReasonCost` and friends) and adopt them in `internal/agent` and `internal/sybra/completion`. They were literals duplicated across three packages with no shared definition, which is what let the clobber go unnoticed.

**Deferred to #2124, deliberately:** codex cost metering looked like a one-liner (`stats.EstimateCostDetailed` exists, no import cycle) but `AddResultStats` treats cost as a cumulative per-session total, and whether codex's `turn.completed` usage is cumulative or per-turn decides the wiring. A wrong guess either disables the ceiling or trips it early — on the provider arm that currently performs best, so it needs verification against real NDJSON rather than a guess here.

## Supporting documentation

Verified `TestCheckCostGuardrail_PreservesCheckpointEscalationReason` fails without the fix. A companion test pins that a non-checkpointed run is still labelled `"cost"`.

> Changelog: fix(agent): keep checkpoint reason past cost guard