### PR TITLE
fix(cli): gate HTTP mode on SYBRA_CONTROL_HOME

### DIFF
--- a/cmd/sybra-cli/httpclient_test.go
+++ b/cmd/sybra-cli/httpclient_test.go
@@ -95,6 +95,7 @@ func TestUpdate_UsesHTTPModeWhenFilesystemIsReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_CONTROL_HOME", home)
 
 	code, out := runCLI(t, "--json", "create", "--title", "http mode target")
 	if code != 0 {
@@ -154,6 +155,7 @@ func TestUpdate_FailsClosedWhenNoServerAndFilesystemReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_CONTROL_HOME", home)
 
 	code, out := runCLI(t, "--json", "create", "--title", "no server target")
 	if code != 0 {
@@ -185,6 +187,7 @@ func TestUpdate_ServerErrorNeverFallsBackToFilesystem(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_CONTROL_HOME", home)
 
 	code, out := runCLI(t, "--json", "create", "--title", "server error target")
 	if code != 0 {
@@ -222,12 +225,66 @@ func TestUpdate_ServerErrorNeverFallsBackToFilesystem(t *testing.T) {
 	}
 }
 
+func TestUpdate_StaysFilesystemOnlyWithoutControlHomeEvenWhenServerReachable(t *testing.T) {
+	home := t.TempDir()
+	tasksDir := filepath.Join(home, "tasks")
+	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_CONTROL_HOME", "")
+
+	code, out := runCLI(t, "--json", "create", "--title", "isolated test target")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+
+	tasks, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := tasks.List()
+	if err != nil || len(list) != 1 {
+		t.Fatalf("expected exactly one seeded task, got %v (err=%v)", list, err)
+	}
+	id := list[0].ID
+
+	otherTasksDir := t.TempDir()
+	port := startFakeAPIServer(t, otherTasksDir)
+	t.Setenv("SYBRA_PORT", port)
+
+	code, out = runCLI(t, "--json", "update", id, "--status", "todo", "--status-reason", "must stay local")
+	if code != 0 {
+		t.Fatalf("update exit %d: %s", code, out)
+	}
+	if !strings.Contains(out, "must stay local") {
+		t.Fatalf("update output = %q, want it to reflect the applied status_reason", out)
+	}
+
+	served, err := task.NewStore(otherTasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := served.Get(id); err == nil {
+		t.Fatal("update must not have reached the reachable server: a test without SYBRA_CONTROL_HOME must never use HTTP mode even when SYBRA_PORT happens to point at a live server")
+	}
+
+	got, err := tasks.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusTodo || got.StatusReason != "must stay local" {
+		t.Fatalf("filesystem task = %+v, want the update to have landed locally", got)
+	}
+}
+
 func TestUpdate_HomeFlagForcesFilesystemModeEvenWithServerRunning(t *testing.T) {
 	home := t.TempDir()
 	tasksDir := filepath.Join(home, "tasks")
 	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("SYBRA_CONTROL_HOME", t.TempDir())
 
 	code, out := runCLI(t, "--json", "--home", home, "create", "--title", "home flag target")
 	if code != 0 {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -147,8 +147,10 @@ func run(args []string) int {
 		return fatal(jsonOut, "%v", err)
 	}
 
+	allowHTTP := homeOverride == "" && os.Getenv("SYBRA_CONTROL_HOME") != ""
+
 	cmd, rest := filtered[0], filtered[1:]
-	return dispatch(cmd, rest, cfg, store, projStore, homeOverride == "", jsonOut)
+	return dispatch(cmd, rest, cfg, store, projStore, allowHTTP, jsonOut)
 }
 
 // dispatch routes a parsed subcommand (with its own args and the global


### PR DESCRIPTION
## Motivation

> Changelog: fix(cli): gate HTTP mode on SYBRA_CONTROL_HOME

`cmd/sybra-cli`'s HTTP fallback mode fired whenever `--home` wasn't
passed, regardless of whether `SYBRA_CONTROL_HOME` was set. Tests that
isolate purely via `SYBRA_HOME` (the common pattern) could still
attempt HTTP mode if ambient `SYBRA_PORT` happened to point at a
reachable server, hitting a real endpoint with the wrong/isolated
token and getting a 401 — which the fail-closed "never fall back on a
real response" guard then turns into a hard failure instead of the
intended isolated filesystem write.

## Implementation information

- Gate `allowHTTP` on `homeOverride == "" && os.Getenv("SYBRA_CONTROL_HOME") != ""`
  instead of just `homeOverride == ""`.
- Updated the 4 existing `TestUpdate_*` tests to explicitly set
  `SYBRA_CONTROL_HOME` where HTTP mode is intended to fire.
- Added `TestUpdate_StaysFilesystemOnlyWithoutControlHomeEvenWhenServerReachable`,
  which plants a reachable fake server via `SYBRA_PORT` but explicitly
  clears `SYBRA_CONTROL_HOME`, asserting the update lands only on the
  local filesystem store and never reaches the fake server. Verified
  this test fails against the pre-fix code and passes after.

## Supporting documentation

N/A