### PR TITLE
fix(project): force-remove dead worktree refs

### DIFF
--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -62,6 +62,8 @@ func RepairBareClone(ctx context.Context, barePath, taskBranch string) (RepairRe
 func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (RepairReport, error) {
 	var report RepairReport
 
+	releaseDeadWorktreeRefs(ctx, barePath, &report)
+
 	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)", "refs/heads")
 	if err != nil {
 		return report, fmt.Errorf("enumerate refs/heads: %w", err)
@@ -84,33 +86,7 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 		}
 	}
 
-	worktreesDir := filepath.Join(barePath, "worktrees")
-	entries, _ := os.ReadDir(worktreesDir)
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		wtRef := "worktrees/" + entry.Name() + "/HEAD"
-		headBytes, readErr := os.ReadFile(filepath.Join(worktreesDir, entry.Name(), "HEAD"))
-		if readErr != nil {
-			continue
-		}
-		head := strings.TrimSpace(string(headBytes))
-		target := head
-		if trimmed, ok := strings.CutPrefix(head, "ref: "); ok {
-			target = strings.TrimSpace(trimmed)
-		}
-		if checkErr := runBare(ctx, barePath, "rev-parse", "--verify", target+"^{commit}"); checkErr == nil {
-			continue
-		}
-		QuarantineRef(barePath, wtRef, head)
-		report.QuarantinedRefs = append(report.QuarantinedRefs, wtRef)
-	}
-
 	if len(report.QuarantinedRefs) > 0 {
-		_ = withLockRetry(func() error {
-			return runBare(ctx, barePath, "worktree", "prune")
-		})
 		report.PrunedWorktrees = true
 	}
 
@@ -124,6 +100,49 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 	}
 
 	return report, nil
+}
+
+func releaseDeadWorktreeRefs(ctx context.Context, barePath string, report *RepairReport) {
+	worktreesDir := filepath.Join(barePath, "worktrees")
+	entries, _ := os.ReadDir(worktreesDir)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		wtAdminDir := filepath.Join(worktreesDir, entry.Name())
+		wtRef := "worktrees/" + entry.Name() + "/HEAD"
+		headBytes, readErr := os.ReadFile(filepath.Join(wtAdminDir, "HEAD"))
+		if readErr != nil {
+			continue
+		}
+		head := strings.TrimSpace(string(headBytes))
+		target := head
+		if trimmed, ok := strings.CutPrefix(head, "ref: "); ok {
+			target = strings.TrimSpace(trimmed)
+		}
+		if checkErr := runBare(ctx, barePath, "rev-parse", "--verify", target+"^{commit}"); checkErr == nil {
+			continue
+		}
+		QuarantineRef(barePath, wtRef, head)
+		report.QuarantinedRefs = append(report.QuarantinedRefs, wtRef)
+		if checkoutPath := worktreeCheckoutPath(wtAdminDir); checkoutPath != "" {
+			_ = withLockRetry(func() error {
+				return runBare(ctx, barePath, "worktree", "remove", "--force", checkoutPath)
+			})
+		}
+	}
+	_ = withLockRetry(func() error {
+		return runBare(ctx, barePath, "worktree", "prune")
+	})
+}
+
+func worktreeCheckoutPath(adminDir string) string {
+	gitdirBytes, err := os.ReadFile(filepath.Join(adminDir, "gitdir"))
+	if err != nil {
+		return ""
+	}
+	gitdirPath := strings.TrimSpace(string(gitdirBytes))
+	return strings.TrimSuffix(gitdirPath, string(filepath.Separator)+".git")
 }
 
 func QuarantineRef(barePath, ref, badValue string) {

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -132,6 +132,8 @@ func TestRepairBareClone_DeletesRefStillCheckedOutByDeadWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{
+		{"-C", wtPath, "config", "user.email", "test@test.com"},
+		{"-C", wtPath, "config", "user.name", "Test"},
 		{"-C", wtPath, "add", "."},
 		{"-C", wtPath, "commit", "-m", "extra"},
 	} {

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -106,6 +107,58 @@ func TestRepairBareClone_NoOpOnCleanClone(t *testing.T) {
 	}
 	if report.PrunedWorktrees {
 		t.Fatal("PrunedWorktrees should be false when nothing was broken")
+	}
+}
+
+func TestRepairBareClone_DeletesRefStillCheckedOutByDeadWorktree(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "task-branch", "origin/"+branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "extra.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "add", "."},
+		{"-C", wtPath, "commit", "-m", "extra"},
+	} {
+		if out, cmdErr := exec.Command("git", args...).CombinedOutput(); cmdErr != nil {
+			t.Fatalf("git %v: %v: %s", args, cmdErr, out)
+		}
+	}
+	headOut, err := exec.Command("git", "-C", wtPath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	headSHA := strings.TrimSpace(string(headOut))
+	objPath := filepath.Join(bare, "objects", headSHA[:2], headSHA[2:])
+	if err := os.Remove(objPath); err != nil {
+		t.Fatalf("corrupt commit object: %v", err)
+	}
+
+	origDir := QuarantineDir
+	QuarantineDir = t.TempDir()
+	t.Cleanup(func() { QuarantineDir = origDir })
+
+	if _, err := RepairBareClone(context.Background(), bare, ""); err != nil {
+		t.Fatalf("RepairBareClone: %v", err)
+	}
+
+	if _, err := outputBare(context.Background(), bare, "rev-parse", "--verify", "refs/heads/task-branch"); err == nil {
+		t.Fatal("dead task-branch ref should have been deleted, but a live worktree HEAD still pinned it")
 	}
 }
 


### PR DESCRIPTION
## Motivation

> Changelog: fix(project): force-remove dead worktree refs

While tracing why `refs/heads/feat/feat-stats-record-requested-and-02909563`
kept poisoning fetches against the shared production bare clone (cascading
`human-required` onto several unrelated tasks), `repairBareCloneLocked`'s
worktree-quarantine pass turned out to only *log* a dead worktree's broken
HEAD — it never actually tore the worktree admin entry down. `git worktree
prune` only removes admin entries whose on-disk checkout directory is
already gone, so a live-but-corrupt worktree (task never cleaned up, HEAD
commit object missing) keeps its administrative entry — and therefore keeps
its branch ref checked out — indefinitely.

Note: this hardening does not by itself explain the 7+ hour persistence
observed in production (a synthetic reproduction showed the existing code
already deletes the branch ref even with a live worktree HEAD pointing at
it — `update-ref -d` isn't blocked by worktree checkout status in this git
version, unlike `branch -d`). The actual production recurrence is more
likely the task's own push step repeatedly re-writing the same
never-valid commit back into the bare clone on every retry. This change is
still a real correctness fix for the general case where a repair pass
finds a dead worktree pointing at a missing object.

## Implementation information

- Reordered `repairBareCloneLocked`: the worktree scan now runs first,
  via a new `releaseDeadWorktreeRefs` helper, before the refs/heads pass.
- A worktree whose HEAD resolves to a missing commit is now
  `git worktree remove --force`'d (using its checkout path, read from the
  admin dir's `gitdir` file) instead of only quarantine-logged, so it no
  longer lingers as a phantom admin entry.
- Added `TestRepairBareClone_DeletesRefStillCheckedOutByDeadWorktree`,
  which creates a real `git worktree add` checkout, corrupts its HEAD
  commit's loose object, and asserts the branch ref is actually gone
  after `RepairBareClone`.
- Existing repair/fetch tests (`TestRepairBareClone_*`,
  `TestFetchOrigin_RepairsPoisonedSiblingRef`, `TestIsBadRefError`) all
  still pass unchanged.

## Supporting documentation

N/A