### PR TITLE
test(cli): clear SYBRA_CONTROL_HOME in TestMain

### DIFF
--- a/cmd/sybra-cli/httpclient_test.go
+++ b/cmd/sybra-cli/httpclient_test.go
@@ -95,8 +95,6 @@ func TestUpdate_UsesHTTPModeWhenFilesystemIsReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
-	t.Setenv("SYBRA_CONTROL_HOME", "")
-	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
 
 	code, out := runCLI(t, "--json", "create", "--title", "http mode target")
 	if code != 0 {
@@ -156,8 +154,6 @@ func TestUpdate_FailsClosedWhenNoServerAndFilesystemReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
-	t.Setenv("SYBRA_CONTROL_HOME", "")
-	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
 
 	code, out := runCLI(t, "--json", "create", "--title", "no server target")
 	if code != 0 {
@@ -189,8 +185,6 @@ func TestUpdate_ServerErrorNeverFallsBackToFilesystem(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
-	t.Setenv("SYBRA_CONTROL_HOME", "")
-	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
 
 	code, out := runCLI(t, "--json", "create", "--title", "server error target")
 	if code != 0 {
@@ -258,51 +252,5 @@ func TestUpdate_HomeFlagForcesFilesystemModeEvenWithServerRunning(t *testing.T) 
 	code, _ = runCLI(t, "--json", "--home", home, "update", id, "--status", "todo")
 	if code == 0 {
 		t.Fatal("--home must force filesystem mode even when a server is reachable; update against a read-only dir should fail")
-	}
-}
-
-// TestCreate_IsolationHoldsWhenControlHomeIsAmbientlySet guards against the
-// leak in #2136: SYBRA_CONTROL_HOME outranks SYBRA_HOME in run()'s home
-// precedence (cmd/sybra-cli/main.go), by design, so bare sybra-cli calls from
-// inside a task-scoped agent reach the real operator board. A test that only
-// clears SYBRA_HOME leaves that real board reachable if SYBRA_CONTROL_HOME is
-// already set in the ambient environment — exactly the condition inside any
-// Sybra-dispatched agent shell. This test simulates that ambient condition
-// and asserts a "decoy" real-board directory is never written to.
-func TestCreate_IsolationHoldsWhenControlHomeIsAmbientlySet(t *testing.T) {
-	decoyRealHome := t.TempDir()
-	decoyTasksDir := filepath.Join(decoyRealHome, "tasks")
-	if err := os.MkdirAll(decoyTasksDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("SYBRA_CONTROL_HOME", decoyRealHome)
-
-	home := t.TempDir()
-	tasksDir := filepath.Join(home, "tasks")
-	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("SYBRA_HOME", home)
-	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
-
-	code, out := runCLI(t, "--json", "create", "--title", "isolation probe")
-	if code != 0 {
-		t.Fatalf("create exit %d: %s", code, out)
-	}
-
-	decoy, err := task.NewStore(decoyTasksDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if list, err := decoy.List(); err != nil || len(list) != 0 {
-		t.Fatalf("task leaked into the ambient SYBRA_CONTROL_HOME decoy board: %v (err=%v); out=%s", list, err, out)
-	}
-
-	isolated, err := task.NewStore(tasksDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if list, err := isolated.List(); err != nil || len(list) != 1 {
-		t.Fatalf("expected exactly one task in the isolated dir, got %v (err=%v)", list, err)
 	}
 }

--- a/cmd/sybra-cli/httpclient_test.go
+++ b/cmd/sybra-cli/httpclient_test.go
@@ -95,6 +95,8 @@ func TestUpdate_UsesHTTPModeWhenFilesystemIsReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_CONTROL_HOME", "")
+	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
 
 	code, out := runCLI(t, "--json", "create", "--title", "http mode target")
 	if code != 0 {
@@ -154,6 +156,8 @@ func TestUpdate_FailsClosedWhenNoServerAndFilesystemReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_CONTROL_HOME", "")
+	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
 
 	code, out := runCLI(t, "--json", "create", "--title", "no server target")
 	if code != 0 {
@@ -185,6 +189,8 @@ func TestUpdate_ServerErrorNeverFallsBackToFilesystem(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_CONTROL_HOME", "")
+	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
 
 	code, out := runCLI(t, "--json", "create", "--title", "server error target")
 	if code != 0 {
@@ -252,5 +258,51 @@ func TestUpdate_HomeFlagForcesFilesystemModeEvenWithServerRunning(t *testing.T) 
 	code, _ = runCLI(t, "--json", "--home", home, "update", id, "--status", "todo")
 	if code == 0 {
 		t.Fatal("--home must force filesystem mode even when a server is reachable; update against a read-only dir should fail")
+	}
+}
+
+// TestCreate_IsolationHoldsWhenControlHomeIsAmbientlySet guards against the
+// leak in #2136: SYBRA_CONTROL_HOME outranks SYBRA_HOME in run()'s home
+// precedence (cmd/sybra-cli/main.go), by design, so bare sybra-cli calls from
+// inside a task-scoped agent reach the real operator board. A test that only
+// clears SYBRA_HOME leaves that real board reachable if SYBRA_CONTROL_HOME is
+// already set in the ambient environment — exactly the condition inside any
+// Sybra-dispatched agent shell. This test simulates that ambient condition
+// and asserts a "decoy" real-board directory is never written to.
+func TestCreate_IsolationHoldsWhenControlHomeIsAmbientlySet(t *testing.T) {
+	decoyRealHome := t.TempDir()
+	decoyTasksDir := filepath.Join(decoyRealHome, "tasks")
+	if err := os.MkdirAll(decoyTasksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SYBRA_CONTROL_HOME", decoyRealHome)
+
+	home := t.TempDir()
+	tasksDir := filepath.Join(home, "tasks")
+	if err := os.MkdirAll(tasksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_TASKS_DIR", tasksDir)
+
+	code, out := runCLI(t, "--json", "create", "--title", "isolation probe")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+
+	decoy, err := task.NewStore(decoyTasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list, err := decoy.List(); err != nil || len(list) != 0 {
+		t.Fatalf("task leaked into the ambient SYBRA_CONTROL_HOME decoy board: %v (err=%v); out=%s", list, err, out)
+	}
+
+	isolated, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list, err := isolated.List(); err != nil || len(list) != 1 {
+		t.Fatalf("expected exactly one task in the isolated dir, got %v (err=%v)", list, err)
 	}
 }

--- a/cmd/sybra-cli/testmain_test.go
+++ b/cmd/sybra-cli/testmain_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain force-clears SYBRA_CONTROL_HOME before any test in this package
+// runs. cmd/sybra-cli's run() gives SYBRA_CONTROL_HOME precedence over
+// SYBRA_HOME by design, so bare sybra-cli calls from inside a task-scoped
+// agent reach the real operator board. An ambient SYBRA_CONTROL_HOME is
+// exactly the environment any Sybra-dispatched agent runs in — including one
+// iterating on this package's own tests — so a test that isolates itself
+// with only t.Setenv("SYBRA_HOME", ...) still leaks onto the real board
+// (#2136). Clearing it once here, rather than patching each test, means a
+// future test can't reintroduce the same leak by simply forgetting to do so.
+// Tests that specifically need SYBRA_CONTROL_HOME set (e.g.
+// TestControlHomeEnv_WinsOverSybraHome) opt back in with their own
+// t.Setenv, which layers on top of this cleanly.
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("SYBRA_CONTROL_HOME")
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Motivation

9 real tasks appeared on the production board with titles that are literal fixture strings from `cmd/sybra-cli/httpclient_test.go` ("http mode target", "no server target", "server error target"). Those three tests only isolated themselves with `t.Setenv("SYBRA_HOME", ...)`, never clearing `SYBRA_CONTROL_HOME` — which outranks `SYBRA_HOME` in `run()`'s home precedence by design (so a task-scoped agent's bare `sybra-cli` calls reach the real operator board). Any Sybra-dispatched agent shell has `SYBRA_CONTROL_HOME` set ambiently, so running `go test ./cmd/sybra-cli/...` from inside one leaked the fixture tasks straight onto the real board.

## Implementation information

Considered patching the three vulnerable tests directly (adding `t.Setenv("SYBRA_CONTROL_HOME", "")` to each, matching the existing `setupStore()` helper used elsewhere in the package). Rejected: it fixes the three known instances but leaves the same mistake open for the next test someone adds to the package with no compiler/test signal.

Went with a package-level `TestMain` (`cmd/sybra-cli/testmain_test.go`) that force-clears `SYBRA_CONTROL_HOME` before any test runs, matching the existing `TestMain`-as-invariant-guard pattern already used in `internal/project` and `internal/worktree`. `TestControlHomeEnv_WinsOverSybraHome` (which deliberately needs `SYBRA_CONTROL_HOME` set) is unaffected — it sets its own value via `t.Setenv`, which layers cleanly on top of `TestMain`'s clear.

Verified the fix is load-bearing: reproduced the original leak on a clean `origin/main` worktree with `SYBRA_CONTROL_HOME` pointed at a decoy directory (task file lands in the decoy, test fails exactly as issue #2136 describes), then confirmed the same repro against this branch leaves the decoy completely empty. Full package suite, `-race -count=2`, build, and vet all pass.

Closes #2136

> Changelog: test(cli): clear SYBRA_CONTROL_HOME in TestMain