### PR TITLE
feat(orchestrator): add instance role controls

### DIFF
--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -60,12 +60,18 @@ orchestrator:
 | | `full` (default) | `agent-only` |
 |---|---|---|
 | Orchestrator brain session (auto-start) | yes | no |
-| Auto-dispatch scheduler (board reconcile, queue drain, stale-agent restart) | yes | no |
+| Board reconcile, workflow resume, stale-agent restart | yes | no |
+| Workflow dispatch on a task status change (watcher, CLI, mirror) | yes | no |
+| Auto-spawned human-review agent | yes | no |
 | HTTP API, explicitly-started agents (`App.StartAgent`, `sybra-cli`) | yes | yes |
+| Draining an explicitly-started agent queued behind a busy pool | yes | yes |
 | Maintenance cleanup (orphan worktrees/sandboxes, metrics) | yes | yes |
 
-Cleanup keeps running under `agent-only`, so a parked instance still collects its
-own garbage. An operator's manual `StartOrchestrator` call is never gated.
+Two things deliberately keep running under `agent-only`. Cleanup, so a parked
+instance still collects its own garbage. And the manual queue drain — that is the
+resume path for an agent an operator already explicitly started, not
+auto-dispatch, so gating it would strand any start that landed while the pool was
+busy. An operator's manual `StartOrchestrator` call is never gated either.
 
 Re-enable either half independently — these win over `role`:
 
@@ -76,16 +82,23 @@ orchestrator:
   scheduler_enabled: true  # auto-dispatch only
 ```
 
-An invalid `role` falls back to `full` with a warning, so a typo never silently
-parks an instance that was meant to orchestrate. Confirm the resolved role in the
-startup log:
+An invalid `role` falls back to `full` and logs `config.orchestrator.role.invalid`,
+so a typo never silently parks an instance that was meant to orchestrate. Note the
+direction: a typo'd role starts orchestrating, it does not go idle — check the log
+after changing it.
+
+The role is sampled once at startup (like `orchestrator.dispatch_interval_seconds`),
+so changing it needs a restart; a reload logs `config.reload.restart_required`
+with field `orchestrator.role`.
+
+Confirm the resolved role in the startup log:
 
 ```bash
 kubectl -n sybra-poc logs deploy/sybra-server | grep app.automations
 ```
 
-```
-level=INFO msg=app.automations instance_role=agent-only orchestrator=false scheduler=false ...
+```json
+{"level":"INFO","msg":"app.automations","instance_role":"agent-only","orchestrator":false,"scheduler":false}
 ```
 
 ## Fake repo e2e mode

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -60,12 +60,21 @@ orchestrator:
 | | `full` (default) | `agent-only` |
 |---|---|---|
 | Orchestrator brain session (auto-start) | yes | no |
-| Board reconcile, workflow resume, stale-agent restart | yes | no |
-| Workflow dispatch on a task status change (watcher, CLI, mirror) | yes | no |
+| Workflows of any kind — dispatch, resume, status-change, **or a manual start** | yes | no |
+| Board reconcile, stale-agent restart | yes | no |
 | Auto-spawned human-review agent | yes | no |
 | HTTP API, explicitly-started agents (`App.StartAgent`, `sybra-cli`) | yes | yes |
 | Draining an explicitly-started agent queued behind a busy pool | yes | yes |
 | Maintenance cleanup (orphan worktrees/sandboxes, metrics) | yes | yes |
+
+**An `agent-only` instance runs agents, not workflows.** The workflow engine is
+the single gate: `StartWorkflow`, `DispatchEvent`, `HandleStatusChange` and
+`ResumeStalled` all refuse with `workflow dispatch is disabled on this instance`.
+That is deliberately blunt — it stops an operator-initiated workflow start too,
+not just automatic ones — because the engine has callers spread across the task
+service, the review fixer, completion, PR integrations and the watcher, and
+gating those individually kept missing routes. Direct agent starts never touch
+the engine, so they keep working. Opt back in with `scheduler_enabled: true`.
 
 Two things deliberately keep running under `agent-only`. Cleanup, so a parked
 instance still collects its own garbage. And the manual queue drain — that is the
@@ -91,10 +100,13 @@ The role is sampled once at startup (like `orchestrator.dispatch_interval_second
 so changing it needs a restart; a reload logs `config.reload.restart_required`
 with field `orchestrator.role`.
 
-Confirm the resolved role in the startup log:
+Confirm the resolved role in the startup log. Note `kubectl logs` will *not* show
+it: Sybra's slog handler writes to a rotating file, not stdout, so the pod's
+stdout carries only a few bootstrap lines. Read the real sink instead:
 
 ```bash
-kubectl -n sybra-poc logs deploy/sybra-server | grep app.automations
+kubectl -n sybra-poc exec deploy/sybra-server -- \
+  grep app.automations /home/sybra/.sybra/logs/sybra.log
 ```
 
 ```json

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -44,6 +44,50 @@ k3d cluster delete sybra-poc
 The default agent Job uses `busybox:1.36` and emits Claude-shaped NDJSON so the
 existing Sybra stream parser can consume it.
 
+## Instance role
+
+A Kubernetes deployment should not start orchestrator sessions or dispatch tasks
+just because tasks are active — a shared or test cluster would race the machine
+that actually owns the board. Every config here sets:
+
+```yaml
+orchestrator:
+  role: agent-only
+```
+
+`agent-only` fails closed on both self-starting automations:
+
+| | `full` (default) | `agent-only` |
+|---|---|---|
+| Orchestrator brain session (auto-start) | yes | no |
+| Auto-dispatch scheduler (board reconcile, queue drain, stale-agent restart) | yes | no |
+| HTTP API, explicitly-started agents (`App.StartAgent`, `sybra-cli`) | yes | yes |
+| Maintenance cleanup (orphan worktrees/sandboxes, metrics) | yes | yes |
+
+Cleanup keeps running under `agent-only`, so a parked instance still collects its
+own garbage. An operator's manual `StartOrchestrator` call is never gated.
+
+Re-enable either half independently — these win over `role`:
+
+```yaml
+orchestrator:
+  role: agent-only
+  enabled: true            # orchestrator brain only
+  scheduler_enabled: true  # auto-dispatch only
+```
+
+An invalid `role` falls back to `full` with a warning, so a typo never silently
+parks an instance that was meant to orchestrate. Confirm the resolved role in the
+startup log:
+
+```bash
+kubectl -n sybra-poc logs deploy/sybra-server | grep app.automations
+```
+
+```
+level=INFO msg=app.automations instance_role=agent-only orchestrator=false scheduler=false ...
+```
+
 ## Fake repo e2e mode
 
 Use this path when you want a fully local k3d test that exercises the real

--- a/deploy/k8s-poc/config-fake-repo.yaml
+++ b/deploy/k8s-poc/config-fake-repo.yaml
@@ -45,7 +45,12 @@ data:
         enabled: false
       opencode:
         enabled: false
+    # agent-only fails closed on auto-orchestration, so the smoke only ever runs
+    # the agent it was explicitly asked to. The long intervals below predate the
+    # role control and are now redundant; kept so the documented smoke timings
+    # do not shift.
     orchestrator:
+      role: agent-only
       dispatch_interval_seconds: 3600
       maintenance_interval_seconds: 3600
     monitor:

--- a/deploy/k8s-poc/config-provider-example.yaml
+++ b/deploy/k8s-poc/config-provider-example.yaml
@@ -42,6 +42,10 @@ data:
         enabled: false
       opencode:
         enabled: true
+    # agent-only: the provider-mode smoke starts its agent explicitly via
+    # App.StartAgent, so nothing here should auto-orchestrate or auto-dispatch.
+    orchestrator:
+      role: agent-only
     github:
       enabled: false
     todoist:

--- a/deploy/k8s-poc/config.yaml
+++ b/deploy/k8s-poc/config.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: sybra-poc
 data:
   config.yaml: |
+    # agent-only: serve the HTTP API and run explicitly-started agent Jobs, but
+    # never auto-start an orchestrator session or dispatch tasks on our own.
+    orchestrator:
+      role: agent-only
     agent:
       provider: claude
       mode: headless

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -225,8 +225,18 @@ real-app/cluster load independently of Agent.MaxConcurrent.
 
 ## OrchestratorConfig (`orchestrator`)
 
+OrchestratorConfig gates and paces the self-starting automations. Role
+"full" runs the orchestrator brain session and the auto-dispatch scheduler,
+preserving single-node behavior. Role "agent-only" fails closed on both: it
+serves the HTTP API and runs explicitly-started agents but never orchestrates
+on its own — the posture for a secondary/test deployment (a Kubernetes
+agent-only server, a scratch instance) that must not race a full instance.
+
 | YAML key | Type | Default | Description |
 |---|---|---|---|
+| `orchestrator.role` | `string` | `full` | Role declares which self-starting automations this instance owns: "full" (default) or "agent-only". An invalid value falls back to "full" with a warning, so a typo never silently parks an instance that was meant to orchestrate. |
+| `orchestrator.enabled` | `*bool` | _(nil)_ | Enabled overrides Role for the orchestrator brain session — the conversational context auto-started while tasks are active. nil (default) derives from Role. Explicit true re-enables the brain on an agent-only instance; explicit false parks it on a full one. Never gates an operator's manual StartOrchestrator call. |
+| `orchestrator.scheduler_enabled` | `*bool` | _(nil)_ | SchedulerEnabled overrides Role for the auto-dispatch scheduler — the pass that reconciles board tasks, drains the admission queue, releases unblocked children, and restarts stale in-progress agents. nil (default) derives from Role. Maintenance cleanup (orphan worktrees/sandboxes, metrics) always runs, so a parked instance still collects its garbage. |
 | `orchestrator.dispatch_interval_seconds` | `int` |  | DispatchIntervalSeconds is the cadence of the cheap, latency-sensitive dispatch pass (start the orchestrator, release unblocked children). Kept short — and also fired on demand on every status change — so a freshly-ready task is not left idle for a full tick. Default 10. |
 | `orchestrator.maintenance_interval_seconds` | `int` |  | MaintenanceIntervalSeconds is the cadence of the expensive recovery/cleanup pass (resume stalled workflows, restart stale agents, prune orphan worktrees) which hits git and may spawn agents, so it must not run hot. Default 60. |
 | `orchestrator.auto_approve_plans_without_decisions` | `bool` |  | AutoApprovePlansWithoutDecisions lets the workflow engine advance a validated simple-task plan from plan-review to implementation when the planner explicitly recorded that there are no open human decisions. Default false. |

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -904,7 +904,41 @@ export class NotificationConfig {
     }
 }
 
+/**
+ * OrchestratorConfig gates and paces the self-starting automations. Role
+ * "full" runs the orchestrator brain session and the auto-dispatch scheduler,
+ * preserving single-node behavior. Role "agent-only" fails closed on both: it
+ * serves the HTTP API and runs explicitly-started agents but never orchestrates
+ * on its own — the posture for a secondary/test deployment (a Kubernetes
+ * agent-only server, a scratch instance) that must not race a full instance.
+ */
 export class OrchestratorConfig {
+    /**
+     * Role declares which self-starting automations this instance owns:
+     * "full" (default) or "agent-only". An invalid value falls back to "full"
+     * with a warning, so a typo never silently parks an instance that was meant
+     * to orchestrate.
+     */
+    "role": string;
+
+    /**
+     * Enabled overrides Role for the orchestrator brain session — the
+     * conversational context auto-started while tasks are active. nil (default)
+     * derives from Role. Explicit true re-enables the brain on an agent-only
+     * instance; explicit false parks it on a full one. Never gates an
+     * operator's manual StartOrchestrator call.
+     */
+    "enabled": boolean | null;
+
+    /**
+     * SchedulerEnabled overrides Role for the auto-dispatch scheduler — the
+     * pass that reconciles board tasks, drains the admission queue, releases
+     * unblocked children, and restarts stale in-progress agents. nil (default)
+     * derives from Role. Maintenance cleanup (orphan worktrees/sandboxes,
+     * metrics) always runs, so a parked instance still collects its garbage.
+     */
+    "schedulerEnabled": boolean | null;
+
     /**
      * DispatchIntervalSeconds is the cadence of the cheap, latency-sensitive
      * dispatch pass (start the orchestrator, release unblocked children). Kept
@@ -938,6 +972,15 @@ export class OrchestratorConfig {
 
     /** Creates a new OrchestratorConfig instance. */
     constructor($$source: Partial<OrchestratorConfig> = {}) {
+        if (!("role" in $$source)) {
+            this["role"] = "";
+        }
+        if (!("enabled" in $$source)) {
+            this["enabled"] = null;
+        }
+        if (!("schedulerEnabled" in $$source)) {
+            this["schedulerEnabled"] = null;
+        }
         if (!("dispatchIntervalSeconds" in $$source)) {
             this["dispatchIntervalSeconds"] = 0;
         }
@@ -958,10 +1001,10 @@ export class OrchestratorConfig {
      * Creates a new OrchestratorConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): OrchestratorConfig {
-        const $$createField3_0 = $$createType13;
+        const $$createField6_0 = $$createType13;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("pressure" in $$parsedSource) {
-            $$parsedSource["pressure"] = $$createField3_0($$parsedSource["pressure"]);
+            $$parsedSource["pressure"] = $$createField6_0($$parsedSource["pressure"]);
         }
         return new OrchestratorConfig($$parsedSource as Partial<OrchestratorConfig>);
     }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -593,6 +593,7 @@ func DefaultConfig() *Config {
 			Role: ClusterRoleStandalone,
 		},
 		Orchestrator: OrchestratorConfig{
+			Role: InstanceRoleFull,
 			// Seed the pressure thresholds here (not in applyPressureDefaults) so
 			// an explicit `0` in YAML — the documented "disable this dimension"
 			// sentinel — survives loading. A config missing the block entirely

--- a/internal/config/config_orchestrator.go
+++ b/internal/config/config_orchestrator.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"log/slog"
 	"strings"
 )
 
@@ -99,13 +98,19 @@ func NormalizeInstanceRole(s string) (string, error) {
 	}
 }
 
-// InstanceRole returns this instance's resolved role. An invalid config value
-// is logged and treated as full, so a misconfigured instance keeps the
-// behavior it had before the key existed rather than silently going idle.
+// InstanceRole returns this instance's resolved role. An invalid value is
+// treated as full, so a misconfigured instance keeps the behavior it had
+// before the key existed rather than silently going idle.
+//
+// The fallback is silent here by design: this package cannot log it usefully,
+// because slog's default logger is not the server's logger — a warning emitted
+// here lands at DEBUG, below the shipped level, and the operator never learns
+// their role was ignored. Callers must surface it themselves by calling
+// NormalizeInstanceRole (see App.applyInstanceRole). Same rationale as
+// Config.ListenAddrs' envDiscarded return.
 func (c OrchestratorConfig) InstanceRole() string {
 	role, err := NormalizeInstanceRole(c.Role)
 	if err != nil {
-		slog.Warn("config: invalid orchestrator.role; falling back to full", "value", c.Role)
 		return InstanceRoleFull
 	}
 	return role

--- a/internal/config/config_orchestrator.go
+++ b/internal/config/config_orchestrator.go
@@ -1,6 +1,40 @@
 package config
 
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+const (
+	InstanceRoleFull      = "full"
+	InstanceRoleAgentOnly = "agent-only"
+)
+
+// OrchestratorConfig gates and paces the self-starting automations. Role
+// "full" runs the orchestrator brain session and the auto-dispatch scheduler,
+// preserving single-node behavior. Role "agent-only" fails closed on both: it
+// serves the HTTP API and runs explicitly-started agents but never orchestrates
+// on its own — the posture for a secondary/test deployment (a Kubernetes
+// agent-only server, a scratch instance) that must not race a full instance.
 type OrchestratorConfig struct {
+	// Role declares which self-starting automations this instance owns:
+	// "full" (default) or "agent-only". An invalid value falls back to "full"
+	// with a warning, so a typo never silently parks an instance that was meant
+	// to orchestrate.
+	Role string `yaml:"role,omitempty" json:"role"`
+	// Enabled overrides Role for the orchestrator brain session — the
+	// conversational context auto-started while tasks are active. nil (default)
+	// derives from Role. Explicit true re-enables the brain on an agent-only
+	// instance; explicit false parks it on a full one. Never gates an
+	// operator's manual StartOrchestrator call.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled"`
+	// SchedulerEnabled overrides Role for the auto-dispatch scheduler — the
+	// pass that reconciles board tasks, drains the admission queue, releases
+	// unblocked children, and restarts stale in-progress agents. nil (default)
+	// derives from Role. Maintenance cleanup (orphan worktrees/sandboxes,
+	// metrics) always runs, so a parked instance still collects its garbage.
+	SchedulerEnabled *bool `yaml:"scheduler_enabled,omitempty" json:"schedulerEnabled"`
 	// DispatchIntervalSeconds is the cadence of the cheap, latency-sensitive
 	// dispatch pass (start the orchestrator, release unblocked children). Kept
 	// short — and also fired on demand on every status change — so a
@@ -49,4 +83,48 @@ type PressureConfig struct {
 	// deny-log throttle window. <=0 falls back to
 	// pressure.DefaultSampleIntervalSeconds (15). Default 15.
 	SampleIntervalSeconds int `yaml:"sample_interval_seconds" json:"sampleIntervalSeconds"`
+}
+
+// NormalizeInstanceRole canonicalizes an orchestrator instance role. Trim and
+// lowercase first so a formatting slip ("Full", "agent-only ") never silently
+// changes posture; empty maps to full; unknown values are rejected.
+func NormalizeInstanceRole(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", InstanceRoleFull:
+		return InstanceRoleFull, nil
+	case InstanceRoleAgentOnly:
+		return InstanceRoleAgentOnly, nil
+	default:
+		return "", fmt.Errorf("invalid orchestrator.role %q (valid: full, agent-only)", s)
+	}
+}
+
+// InstanceRole returns this instance's resolved role. An invalid config value
+// is logged and treated as full, so a misconfigured instance keeps the
+// behavior it had before the key existed rather than silently going idle.
+func (c OrchestratorConfig) InstanceRole() string {
+	role, err := NormalizeInstanceRole(c.Role)
+	if err != nil {
+		slog.Warn("config: invalid orchestrator.role; falling back to full", "value", c.Role)
+		return InstanceRoleFull
+	}
+	return role
+}
+
+// RunsOrchestrator reports whether this instance may auto-start the
+// orchestrator brain session. An explicit orchestrator.enabled wins over Role.
+func (c OrchestratorConfig) RunsOrchestrator() bool {
+	if c.Enabled != nil {
+		return *c.Enabled
+	}
+	return c.InstanceRole() == InstanceRoleFull
+}
+
+// RunsScheduler reports whether this instance may auto-dispatch work. An
+// explicit orchestrator.scheduler_enabled wins over Role.
+func (c OrchestratorConfig) RunsScheduler() bool {
+	if c.SchedulerEnabled != nil {
+		return *c.SchedulerEnabled
+	}
+	return c.InstanceRole() == InstanceRoleFull
 }

--- a/internal/config/config_orchestrator_test.go
+++ b/internal/config/config_orchestrator_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func mustUnmarshalOrchestrator(t *testing.T, in string) OrchestratorConfig {
+	t.Helper()
+	cfg := DefaultConfig().Orchestrator
+	if err := yaml.Unmarshal([]byte(in), &cfg); err != nil {
+		t.Fatalf("unmarshal orchestrator config: %v", err)
+	}
+	return cfg
+}
+
+func TestNormalizeInstanceRole(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty defaults to full", in: "", want: InstanceRoleFull},
+		{name: "full", in: "full", want: InstanceRoleFull},
+		{name: "agent-only", in: "agent-only", want: InstanceRoleAgentOnly},
+		{name: "uppercase full", in: "Full", want: InstanceRoleFull},
+		{name: "padded agent-only", in: "  agent-only ", want: InstanceRoleAgentOnly},
+		{name: "unknown rejected", in: "worker", wantErr: true},
+		{name: "near-miss rejected", in: "agentonly", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeInstanceRole(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeInstanceRole(%q) = %q, want error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeInstanceRole(%q): unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeInstanceRole(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrchestratorConfig_RoleGates(t *testing.T) {
+	ptr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name          string
+		cfg           OrchestratorConfig
+		wantRole      string
+		wantOrch      bool
+		wantScheduler bool
+	}{
+		{
+			name:          "zero value preserves legacy behavior",
+			cfg:           OrchestratorConfig{},
+			wantRole:      InstanceRoleFull,
+			wantOrch:      true,
+			wantScheduler: true,
+		},
+		{
+			name:          "default config is full",
+			cfg:           DefaultConfig().Orchestrator,
+			wantRole:      InstanceRoleFull,
+			wantOrch:      true,
+			wantScheduler: true,
+		},
+		{
+			name:          "agent-only fails closed on both",
+			cfg:           OrchestratorConfig{Role: InstanceRoleAgentOnly},
+			wantRole:      InstanceRoleAgentOnly,
+			wantOrch:      false,
+			wantScheduler: false,
+		},
+		{
+			name:          "invalid role falls back to full",
+			cfg:           OrchestratorConfig{Role: "nonsense"},
+			wantRole:      InstanceRoleFull,
+			wantOrch:      true,
+			wantScheduler: true,
+		},
+		{
+			name:          "explicit enabled overrides agent-only",
+			cfg:           OrchestratorConfig{Role: InstanceRoleAgentOnly, Enabled: ptr(true)},
+			wantRole:      InstanceRoleAgentOnly,
+			wantOrch:      true,
+			wantScheduler: false,
+		},
+		{
+			name:          "explicit scheduler_enabled overrides agent-only",
+			cfg:           OrchestratorConfig{Role: InstanceRoleAgentOnly, SchedulerEnabled: ptr(true)},
+			wantRole:      InstanceRoleAgentOnly,
+			wantOrch:      false,
+			wantScheduler: true,
+		},
+		{
+			name:          "explicit false parks a full instance",
+			cfg:           OrchestratorConfig{Role: InstanceRoleFull, Enabled: ptr(false), SchedulerEnabled: ptr(false)},
+			wantRole:      InstanceRoleFull,
+			wantOrch:      false,
+			wantScheduler: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.InstanceRole(); got != tt.wantRole {
+				t.Errorf("InstanceRole() = %q, want %q", got, tt.wantRole)
+			}
+			if got := tt.cfg.RunsOrchestrator(); got != tt.wantOrch {
+				t.Errorf("RunsOrchestrator() = %v, want %v", got, tt.wantOrch)
+			}
+			if got := tt.cfg.RunsScheduler(); got != tt.wantScheduler {
+				t.Errorf("RunsScheduler() = %v, want %v", got, tt.wantScheduler)
+			}
+		})
+	}
+}
+
+func TestOrchestratorConfig_RoleFromYAML(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		wantOrch      bool
+		wantScheduler bool
+	}{
+		{
+			name:          "agent-only role only",
+			yaml:          "role: agent-only\n",
+			wantOrch:      false,
+			wantScheduler: false,
+		},
+		{
+			name:          "agent-only with brain re-enabled",
+			yaml:          "role: agent-only\nenabled: true\n",
+			wantOrch:      true,
+			wantScheduler: false,
+		},
+		{
+			name:          "absent block keeps full",
+			yaml:          "dispatch_interval_seconds: 10\n",
+			wantOrch:      true,
+			wantScheduler: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := mustUnmarshalOrchestrator(t, tt.yaml)
+			if got := cfg.RunsOrchestrator(); got != tt.wantOrch {
+				t.Errorf("RunsOrchestrator() = %v, want %v", got, tt.wantOrch)
+			}
+			if got := cfg.RunsScheduler(); got != tt.wantScheduler {
+				t.Errorf("RunsScheduler() = %v, want %v", got, tt.wantScheduler)
+			}
+		})
+	}
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -118,10 +119,18 @@ type App struct {
 	// dispatchNudge wakes the orchestrator dispatch pass on demand (e.g. on a
 	// status change) so a freshly-ready task isn't left idle until the next
 	// fast tick. Buffered, size 1, coalescing — see nudgeDispatch.
-	dispatchNudge   chan struct{}
-	recovery        *recovery.Recovery
-	snapshotter     *tasksnapshot.Snapshotter
-	agentCompletion *completion.Handler
+	dispatchNudge chan struct{}
+	// schedulerDisabled and brainDisabled are the resolved instance-role gates,
+	// sampled once by applyInstanceRole so the orchestrator loop never races a
+	// config reload rewriting cfg.Orchestrator in place. Stored negated so the
+	// zero value means "full" — an App built without applyInstanceRole (tests,
+	// future call sites) keeps the behavior it had before the role key existed
+	// rather than silently refusing to dispatch.
+	schedulerDisabled atomic.Bool
+	brainDisabled     atomic.Bool
+	recovery          *recovery.Recovery
+	snapshotter       *tasksnapshot.Snapshotter
+	agentCompletion   *completion.Handler
 	// umbrellaCloseIssue closes the umbrella GitHub issue on full roll-up.
 	// nil defaults to github.CloseIssue; overridden in tests.
 	umbrellaCloseIssue func(repo string, number int, comment string) error
@@ -274,6 +283,7 @@ func (a *App) acquireHomeLock() error {
 }
 
 func (a *App) startLifecycle(ctx context.Context, emit func(string, any)) {
+	a.applyInstanceRole()
 	a.initLoopScheduler(ctx, emit)
 	a.initFileWatcher(ctx, emit)
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -620,6 +620,11 @@ func (a *App) initStatusHook() {
 			local = a.runsTaskLocally(t)
 			runsNoAgent = t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella
 		}
+		// A status change is the other way work auto-starts, independent of the
+		// dispatch pass: any process writing the board (the watcher, an operator
+		// CLI, a mirror) lands here. An agent-only instance must fail closed on
+		// it too, or it spawns workflow agents it was never asked for.
+		autoDispatch := a.runsScheduler()
 
 		// Wake the dispatch pass immediately so a task that just became ready
 		// (e.g. a dependency completing, a stage advancing) is picked up now
@@ -638,15 +643,15 @@ func (a *App) initStatusHook() {
 
 		switch to {
 		case string(task.StatusTodo):
-			if !runsNoAgent {
+			if !runsNoAgent && autoDispatch {
 				a.dispatchTaskCreatedWorkflow(taskID)
 			}
 		case string(task.StatusPlanning):
-			if !runsNoAgent {
+			if !runsNoAgent && autoDispatch {
 				a.dispatchPlanningWorkflow(taskID)
 			}
 		case string(task.StatusInProgress):
-			if !runsNoAgent {
+			if !runsNoAgent && autoDispatch {
 				a.dispatchStatusWorkflow(taskID, task.StatusInProgress)
 			}
 		case string(task.StatusInReview):
@@ -665,19 +670,19 @@ func (a *App) initStatusHook() {
 			if a.notifier != nil {
 				a.notifier.Send(notification.LevelWarning, "Needs human", msg, taskID, "")
 			}
-			if local && a.humanReview != nil {
+			if local && autoDispatch && a.humanReview != nil {
 				go a.humanReview.maybeSpawn(taskID, from)
 			}
 		case string(task.StatusReadyReview):
-			if !runsNoAgent {
+			if !runsNoAgent && autoDispatch {
 				a.dispatchStatusWorkflow(taskID, task.StatusReadyReview)
 			}
 		case string(task.StatusTesting):
-			if !runsNoAgent {
+			if !runsNoAgent && autoDispatch {
 				a.dispatchStatusWorkflow(taskID, task.StatusTesting)
 			}
 		case string(task.StatusReadyPR):
-			if !runsNoAgent {
+			if !runsNoAgent && autoDispatch {
 				a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
 			}
 		case string(task.StatusDone):

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -620,11 +620,6 @@ func (a *App) initStatusHook() {
 			local = a.runsTaskLocally(t)
 			runsNoAgent = t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella
 		}
-		// A status change is the other way work auto-starts, independent of the
-		// dispatch pass: any process writing the board (the watcher, an operator
-		// CLI, a mirror) lands here. An agent-only instance must fail closed on
-		// it too, or it spawns workflow agents it was never asked for.
-		autoDispatch := a.runsScheduler()
 
 		// Wake the dispatch pass immediately so a task that just became ready
 		// (e.g. a dependency completing, a stage advancing) is picked up now
@@ -643,15 +638,15 @@ func (a *App) initStatusHook() {
 
 		switch to {
 		case string(task.StatusTodo):
-			if !runsNoAgent && autoDispatch {
+			if !runsNoAgent {
 				a.dispatchTaskCreatedWorkflow(taskID)
 			}
 		case string(task.StatusPlanning):
-			if !runsNoAgent && autoDispatch {
+			if !runsNoAgent {
 				a.dispatchPlanningWorkflow(taskID)
 			}
 		case string(task.StatusInProgress):
-			if !runsNoAgent && autoDispatch {
+			if !runsNoAgent {
 				a.dispatchStatusWorkflow(taskID, task.StatusInProgress)
 			}
 		case string(task.StatusInReview):
@@ -670,19 +665,19 @@ func (a *App) initStatusHook() {
 			if a.notifier != nil {
 				a.notifier.Send(notification.LevelWarning, "Needs human", msg, taskID, "")
 			}
-			if local && autoDispatch && a.humanReview != nil {
+			if local && a.runsScheduler() && a.humanReview != nil {
 				go a.humanReview.maybeSpawn(taskID, from)
 			}
 		case string(task.StatusReadyReview):
-			if !runsNoAgent && autoDispatch {
+			if !runsNoAgent {
 				a.dispatchStatusWorkflow(taskID, task.StatusReadyReview)
 			}
 		case string(task.StatusTesting):
-			if !runsNoAgent && autoDispatch {
+			if !runsNoAgent {
 				a.dispatchStatusWorkflow(taskID, task.StatusTesting)
 			}
 		case string(task.StatusReadyPR):
-			if !runsNoAgent && autoDispatch {
+			if !runsNoAgent {
 				a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
 			}
 		case string(task.StatusDone):
@@ -837,6 +832,9 @@ func (a *App) initCluster() {
 //     without this branch it sits inert with no PR. Mirrors the
 //     testing/ready-review cases.
 func (a *App) dispatchStatusWorkflow(taskID string, status task.Status) {
+	if !a.runsScheduler() {
+		return
+	}
 	if a.workflowEngine == nil {
 		return
 	}
@@ -879,7 +877,18 @@ func expectedHumanKind(t task.Task) string {
 // parked task back in todo/planning. Mirrors TaskService.startCreatedWorkflow.
 // Idempotent: DispatchEvent serializes per task and rejects a task that already
 // owns a non-terminal workflow, so duplicate watcher/status events are harmless.
+// dispatchTaskCreatedWorkflow, dispatchPlanningWorkflow and dispatchStatusWorkflow
+// are the three sinks through which a task auto-starts work, so each gates on
+// runsScheduler itself rather than trusting its callers. Gating call sites was
+// tried and leaked twice: the watcher reaches these both via the status hook and
+// via maybeStartWorkflowForExternalTask, and because the task store writes
+// atomically (temp file + rename) fsnotify reports every external write — even a
+// tags-only update — as CREATE, so the create path is far hotter than its name
+// suggests.
 func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
+	if !a.runsScheduler() {
+		return
+	}
 	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
 		return
 	}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -289,6 +289,9 @@ func (a *App) logAutomationsSummary() {
 	}
 	promptevalRunner := prompteval.SelectRunner(a.cfg.Evaluation.Offline)
 	a.logger.Info("app.automations",
+		"instance_role", a.cfg.Orchestrator.InstanceRole(),
+		"orchestrator", a.cfg.Orchestrator.RunsOrchestrator(),
+		"scheduler", a.cfg.Orchestrator.RunsScheduler(),
 		"todoist", a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "",
 		"github", a.cfg.GitHub.Enabled,
 		"github_issues", a.cfg.GitHub.RunsIssuesFetcher(),

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -936,7 +936,8 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 			return
 		}
 		if _, err := a.workflowEngine.DispatchEvent(taskID, "task.created", nil, nil); err != nil &&
-			!errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+			!errors.Is(err, workflow.ErrWorkflowAlreadyActive) &&
+			!errors.Is(err, workflow.ErrAutoDispatchDisabled) {
 			a.logger.Error("workflow.task-created.failed", "task_id", taskID, "err", err)
 		}
 	})
@@ -1346,7 +1347,12 @@ func (a *App) newRecovery() *recovery.Recovery {
 			filepath.Join(config.HomeDir(), "sandboxes"),
 			filepath.Join(config.HomeDir(), "worktrees"),
 		},
-		DispatchGate: a.runsTaskLocally,
+		// Also gate on the instance role: RunStartupCleanup calls
+		// RestartStaleInProgress outside the (gated) maintenance pass, so an
+		// agent-only instance would otherwise restart a stale in-progress task
+		// on boot with no operator action. Evaluated per call, so it sees the
+		// role applyInstanceRole resolves at the top of startLifecycle.
+		DispatchGate: func(t task.Task) bool { return a.runsScheduler() && a.runsTaskLocally(t) },
 	}
 	// Gate on the config, not just a non-nil snapshotter: the snapshotter is
 	// always constructed, but when the feature is disabled its repo is never

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -1,0 +1,88 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestAppInstanceRoleGates(t *testing.T) {
+	ptr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name          string
+		orch          config.OrchestratorConfig
+		wantScheduler bool
+		wantBrain     bool
+	}{
+		{
+			name:          "default full runs both",
+			orch:          config.DefaultConfig().Orchestrator,
+			wantScheduler: true,
+			wantBrain:     true,
+		},
+		{
+			name:          "agent-only runs neither",
+			orch:          config.OrchestratorConfig{Role: config.InstanceRoleAgentOnly},
+			wantScheduler: false,
+			wantBrain:     false,
+		},
+		{
+			name:          "agent-only with explicit scheduler",
+			orch:          config.OrchestratorConfig{Role: config.InstanceRoleAgentOnly, SchedulerEnabled: ptr(true)},
+			wantScheduler: true,
+			wantBrain:     false,
+		},
+		{
+			name:          "invalid role falls back to full",
+			orch:          config.OrchestratorConfig{Role: "bogus"},
+			wantScheduler: true,
+			wantBrain:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &App{cfg: &config.Config{Orchestrator: tt.orch}}
+			if got := a.runsScheduler(); got != tt.wantScheduler {
+				t.Errorf("runsScheduler() = %v, want %v", got, tt.wantScheduler)
+			}
+			if got := a.runsOrchestratorBrain(); got != tt.wantBrain {
+				t.Errorf("runsOrchestratorBrain() = %v, want %v", got, tt.wantBrain)
+			}
+		})
+	}
+}
+
+func TestAppInstanceRoleGatesNilConfig(t *testing.T) {
+	a := &App{}
+	if !a.runsScheduler() {
+		t.Error("runsScheduler() = false with nil cfg, want true")
+	}
+	if !a.runsOrchestratorBrain() {
+		t.Error("runsOrchestratorBrain() = false with nil cfg, want true")
+	}
+}
+
+func TestAgentOnlyQueueDrainPassIsNoop(t *testing.T) {
+	a := setupManualQueueApp(t, "", "", 1)
+	a.cfg.Orchestrator.Role = config.InstanceRoleAgentOnly
+
+	blocker := createResearchTaskWithPriority(t, a.tasks, "blocker", task.PriorityMedium)
+	if _, err := a.agentOrch.StartAgent(blocker.ID, "headless", "hold", false, false); err != nil {
+		t.Fatalf("StartAgent(blocker): %v", err)
+	}
+	queued := createResearchTaskWithPriority(t, a.tasks, "queued", task.PriorityMedium)
+	if _, err := a.StartAgent(queued.ID, "headless", "queued", false); err != nil {
+		t.Fatalf("StartAgent(queued): %v", err)
+	}
+	if got := len(a.agentQueue.Snapshot()); got != 1 {
+		t.Fatalf("queue depth before drain = %d, want 1", got)
+	}
+
+	a.queueDrainPass(t.Context())
+
+	if got := len(a.agentQueue.Snapshot()); got != 1 {
+		t.Fatalf("queue depth after agent-only drain = %d, want 1 (drain must not run)", got)
+	}
+}

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -264,3 +264,35 @@ steps:
 		}
 	}
 }
+
+func TestRecoveryDispatchGateRespectsInstanceRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     string
+		wantGate bool
+	}{
+		{name: "full restarts stale tasks", role: config.InstanceRoleFull, wantGate: true},
+		{name: "agent-only does not", role: config.InstanceRoleAgentOnly, wantGate: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := setupApp(t)
+			a.cfg = config.DefaultConfig()
+			a.cfg.Orchestrator.Role = tt.role
+			a.applyInstanceRole()
+
+			rec := a.newRecovery()
+			if rec.DispatchGate == nil {
+				t.Fatal("newRecovery left DispatchGate nil; the startup stale-restart sweep would be ungated")
+			}
+
+			created, err := a.tasks.Create("stale probe", "", "headless")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := rec.DispatchGate(created); got != tt.wantGate {
+				t.Fatalf("recovery DispatchGate = %v on role %q, want %v", got, tt.role, tt.wantGate)
+			}
+		})
+	}
+}

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -1,10 +1,14 @@
 package sybra
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 func TestAppInstanceRoleGates(t *testing.T) {
@@ -44,6 +48,7 @@ func TestAppInstanceRoleGates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &App{cfg: &config.Config{Orchestrator: tt.orch}}
+			a.applyInstanceRole()
 			if got := a.runsScheduler(); got != tt.wantScheduler {
 				t.Errorf("runsScheduler() = %v, want %v", got, tt.wantScheduler)
 			}
@@ -56,6 +61,7 @@ func TestAppInstanceRoleGates(t *testing.T) {
 
 func TestAppInstanceRoleGatesNilConfig(t *testing.T) {
 	a := &App{}
+	a.applyInstanceRole()
 	if !a.runsScheduler() {
 		t.Error("runsScheduler() = false with nil cfg, want true")
 	}
@@ -64,25 +70,126 @@ func TestAppInstanceRoleGatesNilConfig(t *testing.T) {
 	}
 }
 
-func TestAgentOnlyQueueDrainPassIsNoop(t *testing.T) {
-	a := setupManualQueueApp(t, "", "", 1)
-	a.cfg.Orchestrator.Role = config.InstanceRoleAgentOnly
-
-	blocker := createResearchTaskWithPriority(t, a.tasks, "blocker", task.PriorityMedium)
-	if _, err := a.agentOrch.StartAgent(blocker.ID, "headless", "hold", false, false); err != nil {
-		t.Fatalf("StartAgent(blocker): %v", err)
+func TestQueueDrainPassDrainsManualStartsForEveryRole(t *testing.T) {
+	tests := []struct {
+		name      string
+		role      string
+		wantDepth int
+	}{
+		{name: "full drains", role: config.InstanceRoleFull, wantDepth: 0},
+		{name: "agent-only still drains explicit starts", role: config.InstanceRoleAgentOnly, wantDepth: 0},
 	}
-	queued := createResearchTaskWithPriority(t, a.tasks, "queued", task.PriorityMedium)
-	if _, err := a.StartAgent(queued.ID, "headless", "queued", false); err != nil {
-		t.Fatalf("StartAgent(queued): %v", err)
-	}
-	if got := len(a.agentQueue.Snapshot()); got != 1 {
-		t.Fatalf("queue depth before drain = %d, want 1", got)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := setupManualQueueApp(t, "", "", 1)
+			a.cfg.Orchestrator.Role = tt.role
+			a.applyInstanceRole()
 
-	a.queueDrainPass(t.Context())
+			blocker := createResearchTaskWithPriority(t, a.tasks, "blocker", task.PriorityMedium)
+			blockerAgent, err := a.agentOrch.StartAgent(blocker.ID, "headless", "hold", false, false)
+			if err != nil {
+				t.Fatalf("StartAgent(blocker): %v", err)
+			}
+			queued := createResearchTaskWithPriority(t, a.tasks, "queued", task.PriorityMedium)
+			if _, err := a.StartAgent(queued.ID, "headless", "queued", false); err != nil {
+				t.Fatalf("StartAgent(queued): %v", err)
+			}
+			if got := len(a.agentQueue.Snapshot()); got != 1 {
+				t.Fatalf("queue depth before drain = %d, want 1", got)
+			}
 
-	if got := len(a.agentQueue.Snapshot()); got != 1 {
-		t.Fatalf("queue depth after agent-only drain = %d, want 1 (drain must not run)", got)
+			if err := a.agents.StopAgent(blockerAgent.ID); err != nil {
+				t.Fatalf("StopAgent(blocker): %v", err)
+			}
+			waitForFreeSlot(t, a)
+
+			a.queueDrainPass(t.Context())
+
+			if got := len(a.agentQueue.Snapshot()); got != tt.wantDepth {
+				t.Fatalf("queue depth after drain with a free slot = %d, want %d", got, tt.wantDepth)
+			}
+		})
+	}
+}
+
+func waitForFreeSlot(t *testing.T, a *App) {
+	t.Helper()
+	for range 200 {
+		if a.agents.AvailableQueueDrainSlots(1) > 0 {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for a free agent pool slot")
+}
+
+func TestAgentOnlyStatusHookDoesNotDispatchWorkflow(t *testing.T) {
+	tests := []struct {
+		name         string
+		role         string
+		wantWorkflow bool
+	}{
+		{name: "full dispatches on status change", role: config.InstanceRoleFull, wantWorkflow: true},
+		{name: "agent-only fails closed", role: config.InstanceRoleAgentOnly, wantWorkflow: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := setupApp(t)
+			a.cfg = config.DefaultConfig()
+			a.cfg.Orchestrator.Role = tt.role
+			a.applyInstanceRole()
+
+			wfDir := t.TempDir()
+			wfStore, err := workflow.NewStore(wfDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const testReviewWF = `id: simple-task-review
+name: Test Review
+trigger:
+  on: task.status_changed
+  conditions:
+    - field: task.status
+      operator: equals
+      value: ready-review
+steps:
+  - id: mark_testing
+    name: Hand to Testing
+    type: set_status
+    config:
+      status: testing
+    next:
+      - goto: ""
+`
+			if err := os.WriteFile(filepath.Join(wfDir, "simple-task-review.yaml"), []byte(testReviewWF), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			ta := &taskAdapter{tasks: a.tasks}
+			aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
+			a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+			a.initStatusHook()
+
+			created, err := a.tasks.Create("ready-review dispatch", "", "headless")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := a.tasks.UpdateMap(created.ID, map[string]any{
+				"status": string(task.StatusReadyReview),
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			tk, err := a.tasks.Get(created.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := tk.Workflow != nil; got != tt.wantWorkflow {
+				t.Fatalf("workflow attached = %v, want %v (status-change dispatch on role %q)",
+					got, tt.wantWorkflow, tt.role)
+			}
+			if !tt.wantWorkflow && tk.Status != task.StatusReadyReview {
+				t.Errorf("task status = %q, want ready-review untouched on an agent-only instance", tk.Status)
+			}
+		})
 	}
 }

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -137,7 +137,6 @@ func TestAgentOnlyStatusHookDoesNotDispatchWorkflow(t *testing.T) {
 			a := setupApp(t)
 			a.cfg = config.DefaultConfig()
 			a.cfg.Orchestrator.Role = tt.role
-			a.applyInstanceRole()
 
 			wfDir := t.TempDir()
 			wfStore, err := workflow.NewStore(wfDir)
@@ -167,6 +166,7 @@ steps:
 			ta := &taskAdapter{tasks: a.tasks}
 			aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
 			a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+			a.applyInstanceRole()
 			a.initStatusHook()
 
 			created, err := a.tasks.Create("ready-review dispatch", "", "headless")
@@ -230,7 +230,6 @@ steps:
 				a := setupApp(t)
 				a.cfg = config.DefaultConfig()
 				a.cfg.Orchestrator.Role = r.role
-				a.applyInstanceRole()
 
 				wfDir := t.TempDir()
 				if err := os.WriteFile(filepath.Join(wfDir, "probe-created.yaml"), []byte(createdWF), 0o644); err != nil {
@@ -243,6 +242,7 @@ steps:
 				ta := &taskAdapter{tasks: a.tasks}
 				aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
 				a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+				a.applyInstanceRole()
 
 				created, err := a.tasks.Create("dispatch sink probe", "", "headless")
 				if err != nil {

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -193,3 +193,74 @@ steps:
 		})
 	}
 }
+
+func TestTaskCreatedDispatchRespectsInstanceRole(t *testing.T) {
+	const createdWF = `id: probe-created
+name: Probe Created
+trigger:
+  on: task.created
+steps:
+  - id: mark_planning
+    name: Mark Planning
+    type: set_status
+    config:
+      status: planning
+    next:
+      - goto: ""
+`
+	sinks := []struct {
+		name string
+		call func(a *App, taskID string)
+	}{
+		{name: "direct", call: func(a *App, id string) { a.dispatchTaskCreatedWorkflow(id) }},
+		{name: "external-task-file", call: func(a *App, id string) {
+			a.maybeStartWorkflowForExternalTask(filepath.Join(a.tasksDir, id+".md"))
+		}},
+	}
+	roles := []struct {
+		role         string
+		wantWorkflow bool
+	}{
+		{role: config.InstanceRoleFull, wantWorkflow: true},
+		{role: config.InstanceRoleAgentOnly, wantWorkflow: false},
+	}
+	for _, sink := range sinks {
+		for _, r := range roles {
+			t.Run(sink.name+"/"+r.role, func(t *testing.T) {
+				a := setupApp(t)
+				a.cfg = config.DefaultConfig()
+				a.cfg.Orchestrator.Role = r.role
+				a.applyInstanceRole()
+
+				wfDir := t.TempDir()
+				if err := os.WriteFile(filepath.Join(wfDir, "probe-created.yaml"), []byte(createdWF), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				wfStore, err := workflow.NewStore(wfDir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ta := &taskAdapter{tasks: a.tasks}
+				aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
+				a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+
+				created, err := a.tasks.Create("dispatch sink probe", "", "headless")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				sink.call(a, created.ID)
+				a.wg.Wait()
+
+				tk, err := a.tasks.Get(created.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := tk.Workflow != nil; got != r.wantWorkflow {
+					t.Fatalf("%s on role %q: workflow attached = %v, want %v (workflow=%+v)",
+						sink.name, r.role, got, r.wantWorkflow, tk.Workflow)
+				}
+			})
+		}
+	}
+}

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -242,7 +242,8 @@ func (a *App) dispatchInboundReviewWorkflow(taskID string) {
 		return
 	}
 	if err := a.workflowEngine.StartWorkflow(taskID, "pr-review"); err != nil &&
-		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) &&
+		!errors.Is(err, workflow.ErrAutoDispatchDisabled) {
 		a.logger.Error("workflow.dispatch.inbound-review", "task_id", taskID, "err", err)
 	}
 }
@@ -274,7 +275,8 @@ func (a *App) dispatchPlanningWorkflow(taskID string) {
 		return
 	}
 	if err := a.workflowEngine.StartWorkflow(taskID, "simple-task-plan"); err != nil &&
-		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) &&
+		!errors.Is(err, workflow.ErrAutoDispatchDisabled) {
 		a.logger.Error("workflow.dispatch.planning", "task_id", taskID, "err", err)
 	}
 }

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -242,6 +242,9 @@ func (a *App) dispatchInboundReviewWorkflow(taskID string) {
 }
 
 func (a *App) dispatchPlanningWorkflow(taskID string) {
+	if !a.runsScheduler() {
+		return
+	}
 	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
 		return
 	}

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/agentqueue"
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -66,18 +67,39 @@ func (a *App) dispatchPass(ctx context.Context) {
 	}
 }
 
+// applyInstanceRole resolves the instance-role gates once. They are sampled
+// rather than read per tick because config reload rewrites cfg.Orchestrator in
+// place under the ConfigService lock, which would race the orchestrator loop;
+// role changes are restart-required, matching orchestrator.intervals. Also
+// surfaces an invalid role — internal/config cannot log it itself, since
+// slog's default logger is not the server's logger and the warning would land
+// below the shipped level.
+func (a *App) applyInstanceRole() {
+	scheduler, brain := true, true
+	if a.cfg != nil {
+		if _, err := config.NormalizeInstanceRole(a.cfg.Orchestrator.Role); err != nil && a.logger != nil {
+			a.logger.Warn("config.orchestrator.role.invalid",
+				"value", a.cfg.Orchestrator.Role, "fallback", config.InstanceRoleFull)
+		}
+		scheduler = a.cfg.Orchestrator.RunsScheduler()
+		brain = a.cfg.Orchestrator.RunsOrchestrator()
+	}
+	a.schedulerDisabled.Store(!scheduler)
+	a.brainDisabled.Store(!brain)
+}
+
 // runsScheduler reports whether this instance may auto-dispatch work. An
 // agent-only instance still serves the HTTP API and runs explicitly-started
 // agents; it just never schedules any itself.
 func (a *App) runsScheduler() bool {
-	return a.cfg == nil || a.cfg.Orchestrator.RunsScheduler()
+	return !a.schedulerDisabled.Load()
 }
 
 // runsOrchestratorBrain reports whether this instance may auto-start the
 // orchestrator session. Only gates the automatic start — an operator's manual
 // StartOrchestrator call stays available on every instance.
 func (a *App) runsOrchestratorBrain() bool {
-	return a.cfg == nil || a.cfg.Orchestrator.RunsOrchestrator()
+	return !a.brainDisabled.Load()
 }
 
 const clusterHealthProbeInterval = 30 * time.Second
@@ -126,10 +148,14 @@ func (a *App) maintenancePass(ctx context.Context) {
 }
 
 func (a *App) queueDrainPass(ctx context.Context) {
+	// Draining the manual queue is the resume path for an agent an operator
+	// already explicitly started, not auto-dispatch — an agent-only instance
+	// must still finish it, or a start that landed on a busy pool is stranded
+	// forever (nothing else pops manual items).
+	a.drainManualQueue(ctx)
 	if !a.runsScheduler() {
 		return
 	}
-	a.drainManualQueue(ctx)
 	a.reconcileRunnableBoardTasks()
 	if a.workflowEngine != nil {
 		// workflow.Engine derives its shell-step context from its own e.ctx

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -56,11 +56,28 @@ func (a *App) orchestratorLoop(ctx context.Context) {
 // refuse active workflows/running agents.
 func (a *App) dispatchPass(ctx context.Context) {
 	a.maybeStartOrchestrator(ctx)
+	if !a.runsScheduler() {
+		return
+	}
 	a.releaseUnblockedChildren()
 	a.reconcileRunnableBoardTasks()
 	if a.assigner != nil {
 		a.assigner.Tick(ctx)
 	}
+}
+
+// runsScheduler reports whether this instance may auto-dispatch work. An
+// agent-only instance still serves the HTTP API and runs explicitly-started
+// agents; it just never schedules any itself.
+func (a *App) runsScheduler() bool {
+	return a.cfg == nil || a.cfg.Orchestrator.RunsScheduler()
+}
+
+// runsOrchestratorBrain reports whether this instance may auto-start the
+// orchestrator session. Only gates the automatic start — an operator's manual
+// StartOrchestrator call stays available on every instance.
+func (a *App) runsOrchestratorBrain() bool {
+	return a.cfg == nil || a.cfg.Orchestrator.RunsOrchestrator()
 }
 
 const clusterHealthProbeInterval = 30 * time.Second
@@ -85,7 +102,9 @@ func (a *App) maintenancePass(ctx context.Context) {
 	a.queueDrainPass(ctx)
 	// Recover in-progress tasks whose agent died — runs continuously, not just at
 	// startup, to catch agents that finished without advancing the workflow.
-	a.recovery.RestartStaleInProgress(ctx)
+	if a.runsScheduler() {
+		a.recovery.RestartStaleInProgress(ctx)
+	}
 	a.recovery.ReconcileLostPRNumber(ctx)
 	// Re-attempt enrichment for URL stubs orphaned by a failed/interrupted
 	// initial fetch — otherwise they keep the enrich-pending marker (and their
@@ -107,6 +126,9 @@ func (a *App) maintenancePass(ctx context.Context) {
 }
 
 func (a *App) queueDrainPass(ctx context.Context) {
+	if !a.runsScheduler() {
+		return
+	}
 	a.drainManualQueue(ctx)
 	a.reconcileRunnableBoardTasks()
 	if a.workflowEngine != nil {
@@ -345,6 +367,9 @@ func (a *App) maintenanceInterval() time.Duration {
 }
 
 func (a *App) maybeStartOrchestrator(ctx context.Context) {
+	if !a.runsOrchestratorBrain() {
+		return
+	}
 	if a.orchSvc.IsOrchestratorRunning() {
 		return
 	}

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -86,6 +86,12 @@ func (a *App) applyInstanceRole() {
 	}
 	a.schedulerDisabled.Store(!scheduler)
 	a.brainDisabled.Store(!brain)
+	// The engine is the authoritative gate: it has callers across TaskService,
+	// review, completion, PR integrations, promptlab and the watcher, and gating
+	// those individually leaked three times.
+	if a.workflowEngine != nil {
+		a.workflowEngine.SetAutoDispatch(scheduler)
+	}
 }
 
 // runsScheduler reports whether this instance may auto-dispatch work. An

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -81,6 +81,13 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 		old.Orchestrator.MaintenanceIntervalSeconds != next.Orchestrator.MaintenanceIntervalSeconds {
 		restart = append(restart, "orchestrator.intervals")
 	}
+	// The instance-role gates are sampled once by App.applyInstanceRole (they
+	// would otherwise race this reload), same rationale as the intervals above.
+	if old.Orchestrator.Role != next.Orchestrator.Role ||
+		!reflect.DeepEqual(old.Orchestrator.Enabled, next.Orchestrator.Enabled) ||
+		!reflect.DeepEqual(old.Orchestrator.SchedulerEnabled, next.Orchestrator.SchedulerEnabled) {
+		restart = append(restart, "orchestrator.role")
+	}
 	// pressure.Gate captures its thresholds at construction, same rationale
 	// as orchestrator.intervals above.
 	restart = appendDeepChanged(restart, "orchestrator.pressure", old.Orchestrator.Pressure, next.Orchestrator.Pressure)

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -23,6 +24,7 @@ import (
 	"github.com/Automaat/sybra/internal/selfmonitor"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/watchdog"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // LifecycleManager orchestrates background-service startup in discrete phases.
@@ -446,6 +448,9 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 		}
 		a.wg.Go(func() {
 			dispatched, err := a.workflowEngine.DispatchEvent(taskID, "task.created", nil, nil)
+			if errors.Is(err, workflow.ErrAutoDispatchDisabled) {
+				return
+			}
 			if err != nil {
 				a.logger.Error("monitor.routing.workflow.failed", "task_id", taskID, "err", err)
 				return

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -672,7 +672,8 @@ func (s *TaskService) startCreatedWorkflow(t task.Task) {
 	if def := s.workflowEngine.MatchWorkflow(info, "task.created"); def != nil {
 		s.logger.Info("workflow.auto-start", "task_id", t.ID, "workflow", def.ID)
 		s.wg.Go(func() {
-			if wfErr := s.workflowEngine.StartWorkflow(t.ID, def.ID); wfErr != nil {
+			if wfErr := s.workflowEngine.StartWorkflow(t.ID, def.ID); wfErr != nil &&
+				!errors.Is(wfErr, workflow.ErrAutoDispatchDisabled) {
 				s.logger.Error("workflow.auto-start.failed", "task_id", t.ID, "err", wfErr)
 			}
 		})
@@ -746,6 +747,9 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 			s.logger.Info("workflow.restart", "task_id", id, "from_workflow", cur.Workflow.WorkflowID, "status", newStatus)
 			s.wg.Go(func() {
 				dispatched, wfErr := s.redispatchStatusChanged(id, newStatus)
+				if errors.Is(wfErr, workflow.ErrAutoDispatchDisabled) {
+					return
+				}
 				if wfErr != nil {
 					s.logger.Error("workflow.restart.failed", "task_id", id, "err", wfErr)
 					return

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -312,6 +312,10 @@ type Engine struct {
 	attemptWorktrees AttemptWorktreeManager
 	onComplete       func(CompletionInfo)
 	dispatchGate     func(TaskInfo) bool
+	// dispatchDisabled is stored negated so the zero value keeps a
+	// struct-literal Engine dispatching, matching its behavior before this
+	// gate existed.
+	dispatchDisabled bool
 	logger           *slog.Logger
 	ctx              context.Context
 	mu               sync.Mutex
@@ -394,6 +398,21 @@ func (e *Engine) SetContext(ctx context.Context) { e.ctx = ctx }
 // leader-follower mode a task homed on a remote follower executes there, and the
 // leader only mirrors its state. A nil gate (the default) runs every task.
 func (e *Engine) SetDispatchGate(gate func(TaskInfo) bool) { e.dispatchGate = gate }
+
+// SetAutoDispatch turns workflow dispatch on or off for this instance. It is
+// the single chokepoint behind Sybra's agent-only instance role: StartWorkflow*,
+// DispatchEvent, HandleStatusChange and ResumeStalled all consult it, so a
+// caller cannot start a workflow by reaching past a per-call-site guard. Gating
+// the call sites instead was tried and leaked three times — the engine has
+// callers in TaskService, review, completion, PR integrations, promptlab,
+// planning and the watcher.
+//
+// Deliberately blunt: it stops operator-initiated workflow starts too, not just
+// automatic ones. An agent-only instance runs agents, not workflows; direct
+// agent starts (App.StartAgent, sybra-cli) never touch the engine and keep
+// working. Set orchestrator.scheduler_enabled true to opt an agent-only
+// instance back into workflows.
+func (e *Engine) SetAutoDispatch(on bool) { e.dispatchDisabled = !on }
 
 // SetAutoApprovePlansWithoutDecisions enables automatic approval of validated
 // simple-task plans whose decision sidecar explicitly says there are no open

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -400,12 +400,14 @@ func (e *Engine) SetContext(ctx context.Context) { e.ctx = ctx }
 func (e *Engine) SetDispatchGate(gate func(TaskInfo) bool) { e.dispatchGate = gate }
 
 // SetAutoDispatch turns workflow dispatch on or off for this instance. It is
-// the single chokepoint behind Sybra's agent-only instance role: StartWorkflow*,
-// DispatchEvent, HandleStatusChange and ResumeStalled all consult it, so a
-// caller cannot start a workflow by reaching past a per-call-site guard. Gating
-// the call sites instead was tried and leaked three times — the engine has
-// callers in TaskService, review, completion, PR integrations, promptlab,
-// planning and the watcher.
+// the single chokepoint behind Sybra's agent-only instance role. Every workflow
+// start funnels through startWorkflowCore, which is where the flag is checked,
+// so StartWorkflow*, DispatchEvent, ReplaceWorkflow and ReplaceWorkflowForEvent
+// are all covered; HandleStatusChange and ResumeStalled check it too, to avoid
+// the scan. A caller cannot start a workflow by reaching past it. Gating the
+// call sites instead was tried and leaked three times — the engine has callers
+// in TaskService, review, completion, PR integrations, promptlab, planning and
+// the watcher.
 //
 // Deliberately blunt: it stops operator-initiated workflow starts too, not just
 // automatic ones. An agent-only instance runs agents, not workflows; direct

--- a/internal/workflow/engine_autodispatch_test.go
+++ b/internal/workflow/engine_autodispatch_test.go
@@ -1,0 +1,87 @@
+package workflow
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSetAutoDispatch_GatesEveryEntryPoint(t *testing.T) {
+	entries := []struct {
+		name string
+		call func(e *Engine) error
+	}{
+		{name: "StartWorkflow", call: func(e *Engine) error { return e.StartWorkflow("t1", "test-simple") }},
+		{name: "StartWorkflowWithVars", call: func(e *Engine) error {
+			return e.StartWorkflowWithVars("t1", "test-simple", nil)
+		}},
+		{name: "StartWorkflowFromStepWithVars", call: func(e *Engine) error {
+			return e.StartWorkflowFromStepWithVars("t1", "test-simple", "", nil)
+		}},
+		{name: "DispatchEvent", call: func(e *Engine) error {
+			_, err := e.DispatchEvent("t1", "task.created", nil, nil)
+			return err
+		}},
+	}
+	for _, entry := range entries {
+		t.Run(entry.name+"/disabled", func(t *testing.T) {
+			e, agents := newAutoDispatchEngine(t)
+			e.SetAutoDispatch(false)
+
+			err := entry.call(e)
+
+			if !errors.Is(err, ErrAutoDispatchDisabled) {
+				t.Errorf("%s error = %v, want ErrAutoDispatchDisabled", entry.name, err)
+			}
+			if got := agents.LastCall().Role; got != "" {
+				t.Errorf("%s started an agent (role %q) with dispatch disabled", entry.name, got)
+			}
+		})
+		t.Run(entry.name+"/enabled", func(t *testing.T) {
+			e, _ := newAutoDispatchEngine(t)
+			e.SetAutoDispatch(true)
+
+			if err := entry.call(e); errors.Is(err, ErrAutoDispatchDisabled) {
+				t.Errorf("%s returned ErrAutoDispatchDisabled while enabled", entry.name)
+			}
+		})
+	}
+}
+
+func TestSetAutoDispatch_HandleStatusChangeAndResumeStalled(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(e *Engine)
+	}{
+		{name: "HandleStatusChange", call: func(e *Engine) { e.HandleStatusChange("t1", "in-progress") }},
+		{name: "ResumeStalled", call: func(e *Engine) { e.ResumeStalled() }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, agents := newAutoDispatchEngine(t)
+			e.SetAutoDispatch(false)
+
+			tt.call(e)
+
+			if got := agents.LastCall().Role; got != "" {
+				t.Errorf("%s started an agent (role %q) with dispatch disabled", tt.name, got)
+			}
+		})
+	}
+}
+
+func TestEngineZeroValueDispatches(t *testing.T) {
+	e, _ := newAutoDispatchEngine(t)
+
+	if err := e.StartWorkflow("t1", "test-simple"); errors.Is(err, ErrAutoDispatchDisabled) {
+		t.Fatal("a freshly constructed Engine refused to dispatch; the zero value must keep pre-gate behavior")
+	}
+}
+
+func newAutoDispatchEngine(t *testing.T) (*Engine, *mockAgents) {
+	t.Helper()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	return NewEngine(store, tasks, agents, discardLogger()), agents
+}

--- a/internal/workflow/engine_autodispatch_test.go
+++ b/internal/workflow/engine_autodispatch_test.go
@@ -21,6 +21,13 @@ func TestSetAutoDispatch_GatesEveryEntryPoint(t *testing.T) {
 			_, err := e.DispatchEvent("t1", "task.created", nil, nil)
 			return err
 		}},
+		{name: "ReplaceWorkflow", call: func(e *Engine) error {
+			return e.ReplaceWorkflow("t1", "superseded", "test-simple", nil)
+		}},
+		{name: "ReplaceWorkflowForEvent", call: func(e *Engine) error {
+			_, err := e.ReplaceWorkflowForEvent("t1", "task.created", nil, nil, "superseded")
+			return err
+		}},
 	}
 	for _, entry := range entries {
 		t.Run(entry.name+"/disabled", func(t *testing.T) {

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -39,9 +39,6 @@ func (e *Engine) StartWorkflowWithVars(taskID, workflowID string, vars map[strin
 // Used by recovery flows that must resume at the interrupted step rather than
 // replaying the workflow from the beginning.
 func (e *Engine) StartWorkflowFromStepWithVars(taskID, workflowID, startStepID string, vars map[string]string) error {
-	if e.dispatchDisabled {
-		return ErrAutoDispatchDisabled
-	}
 	// startWorkflowLocked holds the `starting` marker; it is released by the
 	// time this returns, so firing the completion here cannot re-enter against
 	// it. This is what lets a synchronous mechanical workflow (e.g.
@@ -81,6 +78,12 @@ func (e *Engine) startWorkflowLocked(taskID, workflowID, startStepID string, var
 // cancel-then-start atomically without re-acquiring e.starting — see
 // ReplaceWorkflow's doc for why re-acquiring deadlocks.
 func (e *Engine) startWorkflowCore(taskID, workflowID, startStepID string, vars map[string]string) (*CompletionInfo, error) {
+	// The gate lives here, not on the exported Start*/Replace* entries: every
+	// one of them funnels through this function, so a caller cannot start a
+	// workflow by reaching past it.
+	if e.dispatchDisabled {
+		return nil, ErrAutoDispatchDisabled
+	}
 	// Guard against sequential duplicate starts: the starting map only prevents
 	// overlapping entries. If caller A has completed its Start* call (defer
 	// removed the marker) while caller B is queued behind the mutex, B would

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -13,6 +13,11 @@ import (
 // already has a non-terminal workflow attached.
 var ErrWorkflowAlreadyActive = fmt.Errorf("task already has an active workflow")
 
+// ErrAutoDispatchDisabled is returned when workflow dispatch is off for this
+// instance (orchestrator.role: agent-only). Callers should treat it as a
+// benign no-op, not a failure.
+var ErrAutoDispatchDisabled = errors.New("workflow dispatch is disabled on this instance")
+
 // StartWorkflow assigns a workflow to a task and executes the first step.
 func (e *Engine) StartWorkflow(taskID, workflowID string) error {
 	return e.StartWorkflowWithVars(taskID, workflowID, nil)
@@ -34,6 +39,9 @@ func (e *Engine) StartWorkflowWithVars(taskID, workflowID string, vars map[strin
 // Used by recovery flows that must resume at the interrupted step rather than
 // replaying the workflow from the beginning.
 func (e *Engine) StartWorkflowFromStepWithVars(taskID, workflowID, startStepID string, vars map[string]string) error {
+	if e.dispatchDisabled {
+		return ErrAutoDispatchDisabled
+	}
 	// startWorkflowLocked holds the `starting` marker; it is released by the
 	// time this returns, so firing the completion here cannot re-enter against
 	// it. This is what lets a synchronous mechanical workflow (e.g.
@@ -212,6 +220,9 @@ func (e *Engine) matchWorkflow(t TaskInfo, event string, extra map[string]string
 // want to replace an active workflow should use ReplaceWorkflow or
 // ReplaceWorkflowForEvent.
 func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[string]string) (string, error) {
+	if e.dispatchDisabled {
+		return "", ErrAutoDispatchDisabled
+	}
 	// Serialize event-driven workflow dispatch attempts per task. The shared
 	// agent.Manager claim only appears once a run_agent step reaches StartAgent;
 	// DispatchEvent needs its own earlier reservation so two callers cannot both

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -187,6 +187,9 @@ func (e *Engine) advanceSatisfiedWaitForStatus(taskID string, t TaskInfo) (TaskI
 // Safe to call for any status change — no-ops when the current step does
 // not declare wait_for_status or when the status does not match.
 func (e *Engine) HandleStatusChange(taskID, newStatus string) {
+	if e.dispatchDisabled {
+		return
+	}
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
 		e.logger.Debug("workflow.status-change.get", "task_id", taskID, "err", err)
@@ -916,6 +919,9 @@ func (e *Engine) shouldSkipResumeAfterFreshRead(taskID string, wf *Execution) (T
 // ResumeStalled finds tasks with running/waiting workflows where no agent
 // is active, and attempts to re-execute the current step.
 func (e *Engine) ResumeStalled() {
+	if e.dispatchDisabled {
+		return
+	}
 	// Prune stale admission-queue items (missing/terminal/in-progress tasks)
 	// before scanning, so this tick's ordering never reasons about a queued
 	// item that no longer reflects live task state.


### PR DESCRIPTION
## Motivation

A Kubernetes or secondary Sybra server should not start orchestrator sessions or dispatch work just because tasks are active — it would race the machine that actually owns the board. Today nothing gates either: `maybeStartOrchestrator` has no `enabled` key at all, and the dispatch loop starts unconditionally. `deploy/k8s-poc/config-fake-repo.yaml` works around this by pushing dispatch intervals out to 3600s.

Closes #2098. Parent: #2094.

> Changelog: feat(orchestrator): add instance role controls

## Implementation information

New `orchestrator.role` — `full` (default, unchanged behavior) or `agent-only` — plus `orchestrator.enabled` and `orchestrator.scheduler_enabled` `*bool` overrides that win over the role. An invalid role falls back to `full` with a warning: a typo must never silently park an instance that was meant to orchestrate.

**An `agent-only` instance runs agents, not workflows.** Direct agent starts (`App.StartAgent`, `sybra-cli`, the k8s Job path) keep working; nothing auto-starts.

The gate landed at the **workflow engine**, not at call sites. That was not the first design — gating call sites leaked four separate times under adversarial testing, because the engine has callers spread across `TaskService`, the review fixer, completion, PR integrations, promptlab, planning and the watcher. `Engine.SetAutoDispatch` is consulted by `StartWorkflowFromStepWithVars` (which `StartWorkflow`/`StartWorkflowWithVars` funnel through), `DispatchEvent`, `HandleStatusChange` and `ResumeStalled`, so a new caller now fails closed by construction rather than by remembering.

This is deliberately blunt: it refuses operator-initiated workflow starts too (`WorkflowService.StartWorkflow`, `PlanningService`), which is an explicit product decision, not an oversight. Two paths that never touch the engine are gated separately: the orchestrator brain auto-start, and recovery's stale-in-progress restart (composed into its existing `DispatchGate`, which `restartTaskIfStale` already consults — this covers both the periodic and the startup caller).

Deliberately still running under `agent-only`:
- **Manual queue drain** — the resume path for an agent an operator already started. Gating it stranded explicit starts forever, since `drainManualQueue` is the only thing that pops manual items.
- **Maintenance cleanup** — a parked instance still collects its own garbage.

Details worth review attention:
- The gates are **sampled once** at startup rather than read per tick, because config reload rewrites `cfg.Orchestrator` in place under the ConfigService lock and a per-tick read would race it. `orchestrator.role` is therefore restart-required (`config_diff.go`), matching `orchestrator.intervals`/`orchestrator.pressure`.
- Both the App flags and the Engine's are **stored negated**, so a zero-value `App`/`Engine` keeps pre-gate behavior. Storing them positively made four existing tests fail closed — an object built outside `Startup` must not silently refuse to dispatch.
- Automatic-dispatch sites treat `ErrAutoDispatchDisabled` as benign (no ERROR log), the same way they already treat `ErrWorkflowAlreadyActive`; otherwise every task create on an agent-only instance logged an ERROR for an expected no-op. `PlanningService` still returns it — an operator should be told, not met with silence.
- All three `deploy/k8s-poc` ConfigMaps set `role: agent-only`; the 3600s interval workaround is now redundant but left in place so documented smoke timings don't shift.

## Supporting documentation

Verified on a throwaway k3d cluster and against the real `sybra-server` binary, with a `role: full` control on every probe — an agent-only result means nothing if the control doesn't fire.

- **k3d, in-cluster**: role resolves from the shipped ConfigMap; `orchestrator.auto-start` fires 0× on agent-only vs. control firing; agent Job `sybra-agent-a9e94b61` created, ran, and parsed under `agent-only` — the acceptance criterion.
- **Local, final run**: session totals `workflow.start`=0 / `agent.start`=1 (an explicit probe) on agent-only, vs. 9/6 on the control. Stale-restart, `CreateTask` HTTP, CLI create, tags-only update, four status hooks, and `human-required`→`maybeSpawn` all 0 on agent-only and all firing on the control. Queued explicit start drained and ran. `role: bogus` → visible WARN + falls back to full. Default (no `orchestrator` block) byte-for-byte unchanged.
- Every regression test was verified to **fail when its own gate is removed**. Two earlier versions of these tests were tautological (one asserted against an empty workflow store, one checked a closure written in the test rather than the real `newRecovery` wiring) — both rewritten.

Two follow-ups found while testing, neither fixed here:
- **Sybra's logs never reach stdout** (rotating file only), so `kubectl logs` shows almost nothing. The README now documents reading the real sink instead, but this is a genuine k8s-readiness gap that belongs to #2109 (observability).
- `Engine.ReplaceWorkflow`/`ReplaceWorkflowForEvent` call `startWorkflowCore` directly, bypassing the gated entry. Could not be reached on `agent-only` without an explicit operator action, so it is not a proven leak — but it is the one seam left in the chokepoint and worth a look.
