### PR TITLE
feat(board): add manual review-link task entry

### DIFF
--- a/frontend/src/components/InlineReviewAdd.svelte
+++ b/frontend/src/components/InlineReviewAdd.svelte
@@ -4,7 +4,17 @@
 
   // Mirrors github.ParsePRURL (internal/github/client.go) — a fast client-side
   // check; the backend remains the source of truth for what actually enriches.
-  const PR_URL_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/
+  // Anchored so a PR number followed by anything other than "/" (e.g. a
+  // "?diff=split" or "#discussion_r123" glued onto the number from a copied
+  // browser URL) fails here instead of silently becoming a plain task with a
+  // garbage title — ParsePRURL's own strconv.Atoi on that path segment would
+  // reject it the same way.
+  const PR_URL_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+(\/.*)?$/
+
+  function stripQueryAndFragment(url: string): string {
+    const i = url.search(/[?#]/)
+    return i === -1 ? url : url.slice(0, i)
+  }
 
   let active = $state(false)
   let link = $state('')
@@ -22,7 +32,7 @@
   }
 
   async function submit() {
-    const url = link.trim()
+    const url = stripQueryAndFragment(link.trim())
     if (!url) return
     if (!PR_URL_RE.test(url)) {
       notificationStore.pushLocal(

--- a/frontend/src/components/InlineReviewAdd.svelte
+++ b/frontend/src/components/InlineReviewAdd.svelte
@@ -2,15 +2,19 @@
   import { taskStore } from '../stores/tasks.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
 
-  // Mirrors github.ParsePRURL (internal/github/client.go) — a fast client-side
-  // check; the backend remains the source of truth for what actually enriches.
-  // Anchored so a PR number followed by anything other than "/" (e.g. a
-  // "?diff=split" or "#discussion_r123" glued onto the number from a copied
-  // browser URL) fails here instead of silently becoming a plain task with a
-  // garbage title — ParsePRURL's own strconv.Atoi on that path segment would
-  // reject it the same way. The number is captured (not just \d+-matched) so
-  // isValidPRURL can also reject "pull/0", matching ParsePRURL's n==0 check.
+  // Validates the URL after stripQueryAndFragment has already removed any
+  // "?diff=split"/"#discussion_r123" noise, so this only needs to mirror
+  // github.ParsePRURL's (internal/github/client.go) structural shape on the
+  // cleaned string — the backend remains the source of truth for what
+  // actually enriches. The number is captured (not just \d+-matched) so
+  // isValidPRURL can reject "pull/0" and huge numbers, matching ParsePRURL's
+  // n==0 check and strconv.Atoi's overflow rejection respectively.
   const PR_URL_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)(?:\/.*)?$/
+
+  // Real GitHub PR numbers are nowhere near this long; capping digit count
+  // sidesteps JS Number precision loss on huge strings entirely, rather than
+  // trying to replicate strconv.Atoi's exact int64 overflow point.
+  const MAX_PR_NUMBER_DIGITS = 10
 
   function stripQueryAndFragment(url: string): string {
     const i = url.search(/[?#]/)
@@ -19,7 +23,8 @@
 
   function isValidPRURL(url: string): boolean {
     const m = PR_URL_RE.exec(url)
-    return m !== null && Number(m[1]) !== 0
+    if (!m) return false
+    return m[1].length <= MAX_PR_NUMBER_DIGITS && Number(m[1]) !== 0
   }
 
   let active = $state(false)

--- a/frontend/src/components/InlineReviewAdd.svelte
+++ b/frontend/src/components/InlineReviewAdd.svelte
@@ -8,12 +8,18 @@
   // "?diff=split" or "#discussion_r123" glued onto the number from a copied
   // browser URL) fails here instead of silently becoming a plain task with a
   // garbage title — ParsePRURL's own strconv.Atoi on that path segment would
-  // reject it the same way.
-  const PR_URL_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+(\/.*)?$/
+  // reject it the same way. The number is captured (not just \d+-matched) so
+  // isValidPRURL can also reject "pull/0", matching ParsePRURL's n==0 check.
+  const PR_URL_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)(?:\/.*)?$/
 
   function stripQueryAndFragment(url: string): string {
     const i = url.search(/[?#]/)
     return i === -1 ? url : url.slice(0, i)
+  }
+
+  function isValidPRURL(url: string): boolean {
+    const m = PR_URL_RE.exec(url)
+    return m !== null && Number(m[1]) !== 0
   }
 
   let active = $state(false)
@@ -34,7 +40,7 @@
   async function submit() {
     const url = stripQueryAndFragment(link.trim())
     if (!url) return
-    if (!PR_URL_RE.test(url)) {
+    if (!isValidPRURL(url)) {
       notificationStore.pushLocal(
         'error',
         'Invalid link',

--- a/frontend/src/components/InlineReviewAdd.svelte
+++ b/frontend/src/components/InlineReviewAdd.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { taskStore } from '../stores/tasks.svelte.js'
+  import { notificationStore } from '../stores/notifications.svelte.js'
+
+  // Mirrors github.ParsePRURL (internal/github/client.go) — a fast client-side
+  // check; the backend remains the source of truth for what actually enriches.
+  const PR_URL_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/
+
+  let active = $state(false)
+  let link = $state('')
+  let inputRef = $state<HTMLInputElement | null>(null)
+
+  function open() {
+    active = true
+    link = ''
+    requestAnimationFrame(() => inputRef?.focus())
+  }
+
+  function dismiss() {
+    active = false
+    link = ''
+  }
+
+  async function submit() {
+    const url = link.trim()
+    if (!url) return
+    if (!PR_URL_RE.test(url)) {
+      notificationStore.pushLocal(
+        'error',
+        'Invalid link',
+        'Paste a GitHub PR URL, e.g. https://github.com/owner/repo/pull/123',
+      )
+      return
+    }
+    link = ''
+    try {
+      await taskStore.create(url, '', 'headless')
+    } catch (err) {
+      notificationStore.pushLocal('error', 'Create failed', String(err))
+      return
+    }
+    requestAnimationFrame(() => inputRef?.focus())
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submit()
+    } else if (e.key === 'Escape') {
+      dismiss()
+    }
+  }
+</script>
+
+{#if active}
+  <input
+    bind:this={inputRef}
+    bind:value={link}
+    type="text"
+    placeholder="Paste a GitHub PR link…"
+    class="w-full rounded-md border border-surface-300 bg-surface-50 px-2 py-2.5 text-base outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-600 dark:bg-surface-800 md:py-1.5 md:text-sm"
+    onkeydown={handleKeydown}
+    onblur={dismiss}
+  />
+{:else}
+  <button
+    type="button"
+    class="tap flex w-full items-center gap-1 rounded-md px-2 py-2.5 text-sm opacity-60 transition-opacity active:bg-surface-200 active:opacity-100 dark:active:bg-surface-800 md:py-1.5 md:hover:bg-surface-200 md:hover:opacity-100 dark:md:hover:bg-surface-800"
+    onclick={open}
+    title="Add a task with a link to review"
+  >
+    <span class="text-base leading-none">+</span> Add review link
+  </button>
+{/if}

--- a/frontend/src/components/InlineReviewAdd.svelte.test.ts
+++ b/frontend/src/components/InlineReviewAdd.svelte.test.ts
@@ -67,6 +67,29 @@ describe('InlineReviewAdd', () => {
     })
   })
 
+  it('accepts a PR number with leading zeros', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/007' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('https://github.com/owner/repo/pull/007', '', 'headless')
+    })
+  })
+
+  it('rejects PR number 0 without calling create', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/0' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockPushLocal).toHaveBeenCalled()
+    })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
   it('rejects a non-PR link without calling create', async () => {
     render(InlineReviewAdd)
     await fireEvent.click(screen.getByRole('button'))

--- a/frontend/src/components/InlineReviewAdd.svelte.test.ts
+++ b/frontend/src/components/InlineReviewAdd.svelte.test.ts
@@ -78,6 +78,18 @@ describe('InlineReviewAdd', () => {
     })
   })
 
+  it('rejects a PR number too large to safely represent, without calling create', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/99999999999999999999' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockPushLocal).toHaveBeenCalled()
+    })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
   it('rejects PR number 0 without calling create', async () => {
     render(InlineReviewAdd)
     await fireEvent.click(screen.getByRole('button'))

--- a/frontend/src/components/InlineReviewAdd.svelte.test.ts
+++ b/frontend/src/components/InlineReviewAdd.svelte.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
+
+const mockCreate = vi.fn()
+const mockPushLocal = vi.fn()
+
+vi.mock('../stores/tasks.svelte.js', () => ({
+  taskStore: {
+    create: (...args: unknown[]) => mockCreate(...args),
+  },
+}))
+vi.mock('../stores/notifications.svelte.js', () => ({
+  notificationStore: { pushLocal: (...args: unknown[]) => mockPushLocal(...args) },
+}))
+
+const InlineReviewAdd = (await import('./InlineReviewAdd.svelte')).default
+
+describe('InlineReviewAdd', () => {
+  beforeEach(() => {
+    mockCreate.mockReset()
+    mockPushLocal.mockReset()
+    mockCreate.mockResolvedValue({ id: 'new1' })
+  })
+  afterEach(cleanup)
+
+  it('renders the trigger button', () => {
+    render(InlineReviewAdd)
+    expect(screen.getByText('Add review link')).toBeDefined()
+  })
+
+  it('click reveals the input', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    expect(await screen.findByPlaceholderText('Paste a GitHub PR link…')).toBeDefined()
+  })
+
+  it('Enter on a valid PR link creates the task', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/123' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('https://github.com/owner/repo/pull/123', '', 'headless')
+    })
+  })
+
+  it('strips a query/fragment glued onto the PR number before creating', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/123#discussion_r1' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('https://github.com/owner/repo/pull/123', '', 'headless')
+    })
+  })
+
+  it('accepts a trailing path segment after the PR number', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/123/files' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('https://github.com/owner/repo/pull/123/files', '', 'headless')
+    })
+  })
+
+  it('rejects a non-PR link without calling create', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/issues/123' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockPushLocal).toHaveBeenCalled()
+    })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('Escape dismisses without creating', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/123' } })
+    await fireEvent.keyDown(input, { key: 'Escape' })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('empty link on Enter is a no-op', async () => {
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('create error surfaces notification', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'))
+    render(InlineReviewAdd)
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Paste a GitHub PR link…')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'https://github.com/owner/repo/pull/123' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockPushLocal).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -5,6 +5,7 @@
   import type { UmbrellaProgress } from '../lib/umbrella-progress.js'
   import TaskCard from './TaskCard.svelte'
   import InlineTaskAdd from './InlineTaskAdd.svelte'
+  import InlineReviewAdd from './InlineReviewAdd.svelte'
   import ClusterHealth from './ClusterHealth.svelte'
   import { clusterStore } from '../stores/cluster.svelte.js'
   import { agentStore } from '../stores/agents.svelte.js'
@@ -204,6 +205,9 @@
               Nothing to review.
             </p>
           {/if}
+          <div class="px-2 pb-2">
+            <InlineReviewAdd />
+          </div>
         {:else if col.kind !== 'umbrella'}
           <div class="px-2 pb-2">
             <InlineTaskAdd status={col.status} />


### PR DESCRIPTION
## Motivation

The "To Review" board column auto-populates from GitHub polling, but there
was no way to add a review task manually — every other column has a "+ Add
task" button at the bottom, but this one had none.

## Implementation information

Adds `InlineReviewAdd.svelte`, wired into the "To Review" lane in
`TaskBoardView.svelte`, mirroring the existing `InlineTaskAdd` pattern. The
input takes a pasted GitHub PR link rather than a free-text title.

No backend changes were needed: `TaskService.CreateTaskWithInit` already
detects a GitHub PR URL passed as a task's title and asynchronously enriches
it (`enrichFromPR`) with the real title, project, PR number, and — when the
PR isn't the viewer's own — a `review` tag, the same mechanism the GitHub
poller itself uses. This button just gives that existing path a manual entry
point scoped to the To Review lane.

Client-side validation mirrors `github.ParsePRURL` (`internal/github/client.go`)
closely enough to reject obviously-wrong input before ever calling the
backend: it strips a `?query`/`#fragment` glued onto the PR number (common
when copying a link from a browser), and rejects PR number `0` the same way
`ParsePRURL`'s `n == 0` check does, while still accepting leading-zero
numbers like `007` (mirrors `strconv.Atoi` behavior exactly rather than just
digit-matching).

Two rounds of adversarial review/testing surfaced and fixed both of the above
issues before this PR; see commit history.

### Open questions

Manual testing also reproduced a known, pre-existing, and shared limitation:
pasting a syntactically-valid PR URL whose number doesn't correspond to a real
PR (e.g. a typo'd/huge number) creates a task that never finishes enriching —
`enrichFromPR`'s `gh pr view` fails, it logs and returns with no user-facing
error and only a 1-hour retry cooldown. This is not introduced by this diff:
it's reachable identically today through the pre-existing "+ Add task"
title field or the New Task dialog's title field on any board column, since
they funnel through the same `CreateTaskWithInit`/`enrichFromPR` path. Fixing
it properly (surfacing enrichment failure/staleness generically) is a
separate, larger piece of work and out of scope here — flagging so it isn't
mistaken for something this PR should have caught.

> Changelog: feat(board): add manual review-link task entry