### PR TITLE
perf(watchdog): add run-rate circuit breaker

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -392,12 +392,18 @@ call (real-time loop detection), then stops/escalates/nudges based on the
 verdict. Enabled defaults to true — the watchdog is an always-on safety net,
 not an opt-in automation. Model selects the cheap judge model; LoopThreshold
 is the number of consecutive identical tool-call signatures that flags a loop.
+MaxRunsPerWindow and RunWindowMinutes bound how many agent runs of the same
+role a single task may accumulate within a trailing window before being
+escalated to human-required — a rate-based backstop for a redispatch loop
+that the dwell budget (hours) would only catch much later.
 
 | YAML key | Type | Default | Description |
 |---|---|---|---|
 | `watchdog.enabled` | `bool` | `true` |  |
 | `watchdog.model` | `string` |  |  |
 | `watchdog.loop_threshold` | `int` | `6` |  |
+| `watchdog.max_runs_per_window` | `int` |  |  |
+| `watchdog.run_window_minutes` | `int` |  |  |
 
 ## SelfMonitorConfig (`self_monitor`)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -402,8 +402,8 @@ that the dwell budget (hours) would only catch much later.
 | `watchdog.enabled` | `bool` | `true` |  |
 | `watchdog.model` | `string` |  |  |
 | `watchdog.loop_threshold` | `int` | `6` |  |
-| `watchdog.max_runs_per_window` | `int` |  |  |
-| `watchdog.run_window_minutes` | `int` |  |  |
+| `watchdog.max_runs_per_window` | `int` | `30` |  |
+| `watchdog.run_window_minutes` | `int` | `30` |  |
 
 ## SelfMonitorConfig (`self_monitor`)
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -581,8 +581,10 @@ func DefaultConfig() *Config {
 			Enabled: true,
 		},
 		Watchdog: WatchdogConfig{
-			Enabled:       true,
-			LoopThreshold: 6,
+			Enabled:          true,
+			LoopThreshold:    6,
+			MaxRunsPerWindow: 30,
+			RunWindowMinutes: 30,
 		},
 		ABTesting: abtest.DefaultConfig(),
 		AutoUpdate: AutoUpdateConfig{
@@ -1122,12 +1124,11 @@ func applyWatchdogDefaults(cfg *Config) {
 	if w.Model == "" {
 		w.Model = "claude-haiku-4-5-20251001"
 	}
-	if w.MaxRunsPerWindow <= 0 {
-		w.MaxRunsPerWindow = 30
-	}
-	if w.RunWindowMinutes <= 0 {
-		w.RunWindowMinutes = 30
-	}
+	// MaxRunsPerWindow and RunWindowMinutes are deliberately NOT defaulted
+	// here, same as LoopThreshold above — both are seeded by DefaultConfig
+	// (30/30), so a config missing the watchdog block keeps that default
+	// while an explicit 0 (disabling the run-rate check) survives instead
+	// of being clobbered back.
 }
 
 // applyEvaluationDefaults fills zero values for the Evaluation block so older

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -1122,6 +1122,12 @@ func applyWatchdogDefaults(cfg *Config) {
 	if w.Model == "" {
 		w.Model = "claude-haiku-4-5-20251001"
 	}
+	if w.MaxRunsPerWindow <= 0 {
+		w.MaxRunsPerWindow = 30
+	}
+	if w.RunWindowMinutes <= 0 {
+		w.RunWindowMinutes = 30
+	}
 }
 
 // applyEvaluationDefaults fills zero values for the Evaluation block so older

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -676,6 +676,12 @@ func TestLoadWatchdogRunRateDefaults(t *testing.T) {
 			wantMaxRuns:    50,
 			wantWindowMins: 15,
 		},
+		{
+			name:           "explicit zero disables the check and survives defaulting",
+			yaml:           "watchdog:\n  max_runs_per_window: 0\n  run_window_minutes: 0\n",
+			wantMaxRuns:    0,
+			wantWindowMins: 0,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -657,6 +657,47 @@ func TestLoadWatchdogDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadWatchdogRunRateDefaults(t *testing.T) {
+	tests := []struct {
+		name           string
+		yaml           string
+		wantMaxRuns    int
+		wantWindowMins int
+	}{
+		{
+			name:           "missing block defaults to 30 runs per 30m",
+			yaml:           "agent:\n  max_concurrent: 10\n",
+			wantMaxRuns:    30,
+			wantWindowMins: 30,
+		},
+		{
+			name:           "explicit overrides preserved",
+			yaml:           "watchdog:\n  max_runs_per_window: 50\n  run_window_minutes: 15\n",
+			wantMaxRuns:    50,
+			wantWindowMins: 15,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("SYBRA_HOME", dir)
+			if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(tc.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Watchdog.MaxRunsPerWindow != tc.wantMaxRuns {
+				t.Errorf("MaxRunsPerWindow = %d, want %d", cfg.Watchdog.MaxRunsPerWindow, tc.wantMaxRuns)
+			}
+			if cfg.Watchdog.RunWindowMinutes != tc.wantWindowMins {
+				t.Errorf("RunWindowMinutes = %d, want %d", cfg.Watchdog.RunWindowMinutes, tc.wantWindowMins)
+			}
+		})
+	}
+}
+
 func TestLoadEnvOverride(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	t.Setenv("SYBRA_LOG_LEVEL", "error")

--- a/internal/config/config_watchdog.go
+++ b/internal/config/config_watchdog.go
@@ -7,8 +7,14 @@ package config
 // verdict. Enabled defaults to true — the watchdog is an always-on safety net,
 // not an opt-in automation. Model selects the cheap judge model; LoopThreshold
 // is the number of consecutive identical tool-call signatures that flags a loop.
+// MaxRunsPerWindow and RunWindowMinutes bound how many agent runs of the same
+// role a single task may accumulate within a trailing window before being
+// escalated to human-required — a rate-based backstop for a redispatch loop
+// that the dwell budget (hours) would only catch much later.
 type WatchdogConfig struct {
-	Enabled       bool   `yaml:"enabled" json:"enabled"`
-	Model         string `yaml:"model" json:"model"`
-	LoopThreshold int    `yaml:"loop_threshold" json:"loopThreshold"`
+	Enabled          bool   `yaml:"enabled" json:"enabled"`
+	Model            string `yaml:"model" json:"model"`
+	LoopThreshold    int    `yaml:"loop_threshold" json:"loopThreshold"`
+	MaxRunsPerWindow int    `yaml:"max_runs_per_window" json:"maxRunsPerWindow"`
+	RunWindowMinutes int    `yaml:"run_window_minutes" json:"runWindowMinutes"`
 }

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -198,6 +198,10 @@ type Watchdog struct {
 	hasLiveHeadlessAgent func(taskID string) bool
 	pressureGate         *pressure.Gate
 	admitPressure        func() (bool, string)
+
+	// maxRunsPerWindow and runWindow drive checkRunRate — see its doc comment.
+	maxRunsPerWindow int
+	runWindow        time.Duration
 }
 
 // New creates a Watchdog. cfg.Model selects the cheap judge model and
@@ -232,6 +236,8 @@ func New(
 			}
 			return pressureGate.Admit()
 		},
+		maxRunsPerWindow: cfg.MaxRunsPerWindow,
+		runWindow:        time.Duration(cfg.RunWindowMinutes) * time.Minute,
 	}
 }
 
@@ -251,6 +257,7 @@ func (w *Watchdog) Run(ctx context.Context) {
 			w.tick(ctx, s, now)
 		case now := <-dwellTicker.C:
 			w.checkDwell(now)
+			w.checkRunRate(now)
 		}
 	}
 }

--- a/internal/watchdog/runrate.go
+++ b/internal/watchdog/runrate.go
@@ -65,7 +65,15 @@ func recentRunBurst(runs []task.AgentRun, now time.Time, window time.Duration) (
 		if runs[i].StartedAt.Before(cutoff) {
 			break
 		}
-		counts[runs[i].Role]++
+		// Legacy runs recorded Role as "" for implementation (see
+		// internal/stats/store.go's identical normalization); without this
+		// a burst split across old and new records would undercount on
+		// both buckets and never trip.
+		r := runs[i].Role
+		if r == "" {
+			r = "implementation"
+		}
+		counts[r]++
 	}
 	for r, c := range counts {
 		if c > count {

--- a/internal/watchdog/runrate.go
+++ b/internal/watchdog/runrate.go
@@ -31,6 +31,12 @@ func (w *Watchdog) checkRunRate(now time.Time) {
 		if t.Status != task.StatusInProgress {
 			continue
 		}
+		// Same exemption as checkDwell: a live headless agent may itself be
+		// producing the burst while genuinely recovering, and escalating
+		// here would get it force-stopped on the very next tick.
+		if w.hasLiveHeadlessAgent != nil && w.hasLiveHeadlessAgent(t.ID) {
+			continue
+		}
 		role, count := recentRunBurst(t.AgentRuns, now, w.runWindow)
 		if count < w.maxRunsPerWindow {
 			continue

--- a/internal/watchdog/runrate.go
+++ b/internal/watchdog/runrate.go
@@ -1,0 +1,70 @@
+package watchdog
+
+import (
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// checkRunRate escalates an in-progress task whose dispatch loop is
+// thrashing — many agent runs of the same role landing within a short
+// trailing window — rather than waiting for the dwell budget (hours) to
+// notice. See #2134: a task accumulated 1204 implementation runs over ~29h,
+// each ~18-90s apart and all costUsd:0/instant-stopped, before dwell finally
+// escalated it. MaxRunsPerWindow <= 0 disables the check.
+func (w *Watchdog) checkRunRate(now time.Time) {
+	if w.maxRunsPerWindow <= 0 || w.runWindow <= 0 {
+		return
+	}
+	tasks, err := w.tasks.List()
+	if err != nil {
+		w.logger.Warn("watchdog.runrate.list", "err", err)
+		return
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
+		if t.Status != task.StatusInProgress {
+			continue
+		}
+		role, count := recentRunBurst(t.AgentRuns, now, w.runWindow)
+		if count < w.maxRunsPerWindow {
+			continue
+		}
+		reason := fmt.Sprintf("run_rate: %d %q runs within %v — dispatch loop suspected", count, role, w.runWindow)
+		w.logger.Info("watchdog.runrate.escalate",
+			"task_id", t.ID, "role", role, "count", count, "window_m", w.runWindow.Minutes())
+		if _, err := w.tasks.Update(t.ID, task.Update{
+			Status:       task.Ptr(task.StatusHumanRequired),
+			StatusReason: task.Ptr(reason),
+		}); err != nil {
+			w.logger.Error("watchdog.runrate.update", "task_id", t.ID, "err", err)
+		}
+	}
+}
+
+// recentRunBurst returns the role with the most agent runs started within
+// the trailing window ending at now, and that role's count. Runs are always
+// appended chronologically (internal/task.Store.AddRunWithStatus), so a
+// task with thousands of historical runs is scanned only back to the window
+// boundary, not in full, once the burst itself has ended.
+func recentRunBurst(runs []task.AgentRun, now time.Time, window time.Duration) (role string, count int) {
+	cutoff := now.Add(-window)
+	counts := make(map[string]int)
+	for i := range slices.Backward(runs) {
+		if runs[i].StartedAt.Before(cutoff) {
+			break
+		}
+		counts[runs[i].Role]++
+	}
+	for r, c := range counts {
+		if c > count {
+			role, count = r, c
+		}
+	}
+	return role, count
+}

--- a/internal/watchdog/runrate_test.go
+++ b/internal/watchdog/runrate_test.go
@@ -1,0 +1,211 @@
+package watchdog
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func newInProgressTask(t *testing.T, mgr *task.Manager) task.Task {
+	t.Helper()
+	tk, err := mgr.Create("burst task", "## Description\nsome work", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = mgr.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInProgress)})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	return tk
+}
+
+func addRuns(t *testing.T, mgr *task.Manager, taskID, role string, n int, start time.Time, spacing time.Duration) {
+	t.Helper()
+	for i := range n {
+		if err := mgr.AddRun(taskID, task.AgentRun{
+			AgentID:   "agent",
+			Role:      role,
+			StartedAt: start.Add(time.Duration(i) * spacing),
+		}); err != nil {
+			t.Fatalf("add run: %v", err)
+		}
+	}
+}
+
+func TestCheckRunRate_EscalatesBurstOfSameRole(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk := newInProgressTask(t, mgr)
+
+	now := time.Now()
+	// 30 implementation runs, 18s apart, all inside the trailing 30m window.
+	addRuns(t, mgr, tk.ID, "implementation", 30, now.Add(-29*time.Minute), 18*time.Second)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 30, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if !strings.Contains(got.StatusReason, "run_rate") || !strings.Contains(got.StatusReason, "implementation") {
+		t.Fatalf("status reason = %q, want it to mention run_rate and the role", got.StatusReason)
+	}
+}
+
+func TestCheckRunRate_SkipsBelowThreshold(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk := newInProgressTask(t, mgr)
+
+	now := time.Now()
+	addRuns(t, mgr, tk.ID, "implementation", 29, now.Add(-29*time.Minute), 18*time.Second)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 30, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (29 runs is below the 30-run threshold)", got.Status)
+	}
+}
+
+func TestCheckRunRate_IgnoresRunsOutsideWindow(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk := newInProgressTask(t, mgr)
+
+	now := time.Now()
+	// 40 old runs well outside the window, then only 5 recent ones.
+	addRuns(t, mgr, tk.ID, "implementation", 40, now.Add(-5*time.Hour), time.Minute)
+	addRuns(t, mgr, tk.ID, "implementation", 5, now.Add(-4*time.Minute), time.Minute)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 30, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (old runs outside the window must not count)", got.Status)
+	}
+}
+
+func TestCheckRunRate_SkipsNonInProgressTask(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+
+	tk, err := mgr.Create("todo burst task", "## Description\nsome work", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = mgr.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusTodo)})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	now := time.Now()
+	addRuns(t, mgr, tk.ID, "implementation", 30, now.Add(-29*time.Minute), 18*time.Second)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 30, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusTodo {
+		t.Fatalf("status = %q, want todo (run-rate must only watch in-progress tasks)", got.Status)
+	}
+}
+
+func TestCheckRunRate_DoesNotSumAcrossRoles(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk := newInProgressTask(t, mgr)
+
+	now := time.Now()
+	// 20 implementation + 20 pr-fix runs inside the window — neither role
+	// alone reaches the 30-run threshold, so this must not escalate even
+	// though the task has 40 total runs in the window.
+	addRuns(t, mgr, tk.ID, "implementation", 20, now.Add(-29*time.Minute), time.Minute)
+	addRuns(t, mgr, tk.ID, "pr-fix", 20, now.Add(-29*time.Minute), time.Minute)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 30, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (no single role reached the threshold)", got.Status)
+	}
+}
+
+func TestCheckRunRate_DisabledWhenThresholdIsZero(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk := newInProgressTask(t, mgr)
+
+	now := time.Now()
+	addRuns(t, mgr, tk.ID, "implementation", 50, now.Add(-29*time.Minute), time.Second)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 0, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (maxRunsPerWindow<=0 disables the check)", got.Status)
+	}
+}
+
+func TestRecentRunBurst(t *testing.T) {
+	now := time.Now()
+	runs := []task.AgentRun{
+		{Role: "implementation", StartedAt: now.Add(-2 * time.Hour)}, // outside window
+		{Role: "implementation", StartedAt: now.Add(-20 * time.Minute)},
+		{Role: "implementation", StartedAt: now.Add(-10 * time.Minute)},
+		{Role: "pr-fix", StartedAt: now.Add(-5 * time.Minute)},
+	}
+	role, count := recentRunBurst(runs, now, 30*time.Minute)
+	if role != "implementation" || count != 2 {
+		t.Fatalf("recentRunBurst = (%q, %d), want (\"implementation\", 2)", role, count)
+	}
+
+	role, count = recentRunBurst(nil, now, 30*time.Minute)
+	if role != "" || count != 0 {
+		t.Fatalf("recentRunBurst(nil) = (%q, %d), want (\"\", 0)", role, count)
+	}
+}

--- a/internal/watchdog/runrate_test.go
+++ b/internal/watchdog/runrate_test.go
@@ -233,8 +233,8 @@ func TestRecentRunBurst(t *testing.T) {
 		t.Fatalf("recentRunBurst = (%q, %d), want (\"implementation\", 2)", role, count)
 	}
 
-	role, count = recentRunBurst(nil, now, 30*time.Minute)
+	role, count = recentRunBurst([]task.AgentRun{}, now, 30*time.Minute)
 	if role != "" || count != 0 {
-		t.Fatalf("recentRunBurst(nil) = (%q, %d), want (\"\", 0)", role, count)
+		t.Fatalf("recentRunBurst(empty) = (%q, %d), want (\"\", 0)", role, count)
 	}
 }

--- a/internal/watchdog/runrate_test.go
+++ b/internal/watchdog/runrate_test.go
@@ -191,6 +191,35 @@ func TestCheckRunRate_DisabledWhenThresholdIsZero(t *testing.T) {
 	}
 }
 
+func TestCheckRunRate_SkipsTaskWithRunningAgent(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk := newInProgressTask(t, mgr)
+
+	now := time.Now()
+	addRuns(t, mgr, tk.ID, "implementation", 30, now.Add(-29*time.Minute), 18*time.Second)
+
+	w := &Watchdog{
+		tasks:                mgr,
+		logger:               slog.New(slog.DiscardHandler),
+		maxRunsPerWindow:     30,
+		runWindow:            30 * time.Minute,
+		hasLiveHeadlessAgent: func(taskID string) bool { return taskID == tk.ID },
+	}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (running agent should suppress run-rate escalation)", got.Status)
+	}
+}
+
 func TestRecentRunBurst(t *testing.T) {
 	now := time.Now()
 	runs := []task.AgentRun{

--- a/internal/watchdog/runrate_test.go
+++ b/internal/watchdog/runrate_test.go
@@ -238,3 +238,43 @@ func TestRecentRunBurst(t *testing.T) {
 		t.Fatalf("recentRunBurst(empty) = (%q, %d), want (\"\", 0)", role, count)
 	}
 }
+
+// Legacy runs recorded Role as "" for implementation; mixed with current
+// runs that spell it out, they must count as one bucket, not two.
+func TestRecentRunBurst_NormalizesLegacyEmptyRole(t *testing.T) {
+	now := time.Now()
+	runs := []task.AgentRun{
+		{Role: "", StartedAt: now.Add(-20 * time.Minute)},
+		{Role: "", StartedAt: now.Add(-15 * time.Minute)},
+		{Role: "implementation", StartedAt: now.Add(-10 * time.Minute)},
+		{Role: "implementation", StartedAt: now.Add(-5 * time.Minute)},
+	}
+	role, count := recentRunBurst(runs, now, 30*time.Minute)
+	if role != "implementation" || count != 4 {
+		t.Fatalf("recentRunBurst = (%q, %d), want (\"implementation\", 4)", role, count)
+	}
+}
+
+func TestCheckRunRate_EscalatesMixedLegacyAndCurrentRole(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk := newInProgressTask(t, mgr)
+
+	now := time.Now()
+	addRuns(t, mgr, tk.ID, "", 15, now.Add(-29*time.Minute), time.Minute)
+	addRuns(t, mgr, tk.ID, "implementation", 15, now.Add(-14*time.Minute), time.Minute)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 30, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+}


### PR DESCRIPTION
## Motivation

Task `02909563` dispatched 1204 `implementation`-role agent runs over ~29 hours, ~18-90s apart, every single one `costUsd:0`/instant-stopped, before the existing "dwell" circuit breaker (12h+ inactivity budget) finally noticed. Dwell only measures time-since-last-file-update — it has no concept of dispatch *volume*, so a fast redispatch loop where the task file keeps getting touched can run for nearly a day before anything intervenes.

## Implementation information

Added `checkRunRate` (`internal/watchdog/runrate.go`), ticking on the same 5-minute cadence as `checkDwell` in `Watchdog.Run()`. It escalates an in-progress task to `human-required` once a single agent role accumulates more than a configurable number of runs (`watchdog.max_runs_per_window`, default 30) within a trailing window (`watchdog.run_window_minutes`, default 30m) — counted by role so a healthy task cycling through plan→implement→review→pr-fix isn't penalized for the sum, only a genuine same-role thrash. `recentRunBurst` scans a task's `AgentRuns` backward from the most recent entry with an early break once past the window boundary, so a task with thousands of historical runs isn't rescanned in full every tick.

Two issues surfaced by an adversarial pre-PR review, both fixed in the second commit:
- `applyWatchdogDefaults` was clobbering an explicit `max_runs_per_window: 0` back to `30`, leaving no way to disable the check short of killing the whole watchdog. Moved the defaults into `DefaultConfig()` instead, matching the existing pattern `LoopThreshold` already uses, so an explicit `0` survives.
- The check was missing the `hasLiveHeadlessAgent` exemption its sibling `checkDwell` has — without it, a live agent genuinely recovering from a burst could get its task flipped to `human-required` and force-stopped by the reaper on the very next tick.

Independently re-verified both fixes and the core escalation behavior end-to-end against a real `task.Store`/`task.Manager` (not just the author's own unit tests) before opening this PR, including the exact threshold boundary (29 vs. 30 runs) and a mixed-role burst that sums over the threshold but should not trip it.

Out of scope for this PR: diagnosing/fixing task `02909563`'s own underlying stats-grouping bug, and confirming whether #2036's cluster-loop fix fully stopped redispatch for already-thrashing tasks — both called out as separate follow-ups in the issue.

Closes #2134

> Changelog: perf(watchdog): add run-rate circuit breaker