### PR TITLE
ci(actions): add k3d smoke for the Job runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,3 +434,30 @@ jobs:
           name: playwright-report-${{ matrix.provider }}
           path: frontend/test-results/
           retention-days: 7
+
+  smoke-k3d:
+    name: k3d Job Runner Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      # docker-build.yml cannot supply this image: it is path-filtered to the
+      # Dockerfile and uses load: false, so nothing k3d could import survives it.
+      # Hence load: true and a build of our own here.
+      - name: Build agent image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          tags: sybra-server:poc
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run k3d smoke
+        run: SMOKE_SKIP_BUILD=1 SMOKE_CLUSTER=sybra-ci scripts/smoke-k3d.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,5 +459,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Via the mise task, which carries the k3d/kubectl pins. Calling the
+      # script directly would run against whatever the runner happens to ship.
       - name: Run k3d smoke
-        run: SMOKE_SKIP_BUILD=1 SMOKE_CLUSTER=sybra-ci scripts/smoke-k3d.sh
+        env:
+          SMOKE_SKIP_BUILD: "1"
+          SMOKE_CLUSTER: sybra-ci
+        run: mise run smoke:k3d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,15 @@ jobs:
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
+      # The agent image is multi-GB and gets built, loaded into dockerd, then
+      # imported into the k3d node — three copies. A stock runner does not have
+      # the headroom, and the import OOM-kills the node rather than failing
+      # cleanly. These toolchains are not used by this job.
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /opt/hostedtoolcache/CodeQL /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h /
+
       # docker-build.yml cannot supply this image: it is path-filtered to the
       # Dockerfile and uses load: false, so nothing k3d could import survives it.
       # Hence load: true and a build of our own here.

--- a/.github/workflows/k3d-provider-smoke.yml
+++ b/.github/workflows/k3d-provider-smoke.yml
@@ -1,0 +1,71 @@
+name: k3d Provider Smoke
+
+# Release-validation counterpart to ci.yml's smoke-k3d job.
+#
+# smoke-k3d proves the Job runner's mechanics with fake-claude: deterministic,
+# free, and on every PR. It cannot prove that a real provider CLI actually runs
+# inside the agent image — the wrapper swaps argv[0] for SYBRA_K8S_PROVIDER_BIN,
+# so the real CLI's own launch path is never exercised there.
+#
+# This workflow closes that gap against OpenRouter, which costs real money and
+# needs a key. Hence manual-only: never on push or pull_request. Run it before
+# cutting a release, or after changing the agent image, the provider pins, or
+# the wrapper script.
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: OpenRouter model to drive the agent with
+        required: false
+        default: openrouter/deepseek/deepseek-v4-flash
+
+permissions:
+  contents: read
+
+concurrency:
+  group: k3d-provider-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: k3d Provider Smoke (OpenRouter)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Absent secret means an unconfigured fork or a repo without the key. Fail
+    # loudly rather than silently "passing" a spend-gated smoke that never ran.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Require OpenRouter key
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          if [ -z "$OPENROUTER_API_KEY" ]; then
+            echo "::error::OPENROUTER_API_KEY secret is not set; this smoke cannot run"
+            exit 1
+          fi
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build agent image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          tags: sybra-server:poc
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run provider smoke
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          SMOKE_MODEL: ${{ inputs.model }}
+        run: |
+          SMOKE_SKIP_BUILD=1 \
+          SMOKE_CLUSTER=sybra-provider-ci \
+          SMOKE_PROVIDER=opencode \
+          scripts/smoke-k3d.sh

--- a/.github/workflows/k3d-provider-smoke.yml
+++ b/.github/workflows/k3d-provider-smoke.yml
@@ -14,11 +14,6 @@ name: k3d Provider Smoke
 
 on:
   workflow_dispatch:
-    inputs:
-      model:
-        description: OpenRouter model to drive the agent with
-        required: false
-        default: openrouter/deepseek/deepseek-v4-flash
 
 permissions:
   contents: read
@@ -60,10 +55,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # The model is pinned in deploy/k8s-poc/config-provider-example.yaml; edit
+      # it there to validate a different one. Deliberately not a workflow input:
+      # nothing in the script consumed it, and a knob that silently does nothing
+      # is worse than no knob.
       - name: Run provider smoke
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          SMOKE_MODEL: ${{ inputs.model }}
         run: |
           SMOKE_SKIP_BUILD=1 \
           SMOKE_CLUSTER=sybra-provider-ci \

--- a/.github/workflows/k3d-provider-smoke.yml
+++ b/.github/workflows/k3d-provider-smoke.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Run provider smoke
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: |
-          SMOKE_SKIP_BUILD=1 \
-          SMOKE_CLUSTER=sybra-provider-ci \
-          SMOKE_PROVIDER=opencode \
-          scripts/smoke-k3d.sh
+          SMOKE_SKIP_BUILD: "1"
+          SMOKE_CLUSTER: sybra-provider-ci
+          SMOKE_PROVIDER: opencode
+        run: mise run smoke:k3d

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -113,9 +113,34 @@ kubectl -n sybra-poc exec deploy/sybra-server -- \
 {"level":"INFO","msg":"app.automations","instance_role":"agent-only","orchestrator":false,"scheduler":false}
 ```
 
+## Automated smoke
+
+`scripts/smoke-k3d.sh` runs the "Fake repo e2e mode" flow below end to end and
+asserts it, so the Job runner has regression cover without a model API key or
+any provider spend. CI runs it on every PR as the `k3d Job Runner Smoke` job.
+
+```bash
+mise run smoke:k3d              # build, run, tear down
+SMOKE_KEEP=1 mise run smoke:k3d # leave the cluster up to poke at it
+```
+
+It needs `docker`, and `k3d`/`kubectl` come from `mise install`. It never
+touches your kubectl context: the cluster is created with
+`--kubeconfig-update-default=false` and every command runs against an isolated
+kubeconfig, so a `sybra-poc` cluster or a work context nearby is safe.
+
+Deliberately excluded from `mise run verify`, which stays a fast deterministic
+pre-commit loop — this needs Docker and a real cluster.
+
+For a real-model run against OpenRouter, see the manual
+`.github/workflows/k3d-provider-smoke.yml` (needs an `OPENROUTER_API_KEY`
+secret) or run `SMOKE_PROVIDER=opencode OPENROUTER_API_KEY=... mise run
+smoke:k3d` locally. That path costs money, so it never runs on a PR.
+
 ## Fake repo e2e mode
 
-Use this path when you want a fully local k3d test that exercises the real
+The manual version of what the smoke automates. Use this path when you want a
+fully local k3d test that exercises the real
 Sybra project/worktree path without model API keys or GitHub pushes. The server
 and agent Job share the `sybra-home` PVC, the Job runs `/usr/local/bin/fake-claude`,
 and the fake provider writes `k8s-agent-output.txt` into the checked-out repo.
@@ -210,14 +235,9 @@ kubectl -n sybra-poc exec deploy/sybra-server -- \
     --data '[]' \
   | jq '.[] | select(.taskId == "'$TASK_ID'") | {id, taskId, state, command, provider, model, costUsd}'
 
-kubectl -n sybra-poc exec deploy/sybra-server -- \
-  sybra-cli --json get "$TASK_ID" \
-  | jq -r .worktreeDir
-
 WT=$(
   kubectl -n sybra-poc exec deploy/sybra-server -- \
-    sybra-cli --json get "$TASK_ID" \
-  | jq -r .worktreeDir
+    sh -ceu "ls -d /home/sybra/.sybra/worktrees/*$TASK_ID | head -1"
 )
 kubectl -n sybra-poc exec deploy/sybra-server -- \
   sh -ceu "test -f '$WT/k8s-agent-output.txt' && cat '$WT/k8s-agent-output.txt' && git -C '$WT' log --oneline -2"
@@ -341,8 +361,7 @@ Verify the branch commit and runtime behavior in the server worktree:
 ```bash
 WT=$(
   kubectl -n sybra-poc exec deploy/sybra-server -- \
-    sybra-cli --json get "$TASK_ID" \
-  | jq -r .worktreeDir
+    sh -ceu "ls -d /home/sybra/.sybra/worktrees/*$TASK_ID | head -1"
 )
 
 kubectl -n sybra-poc exec deploy/sybra-server -- \

--- a/internal/agent/k8s_job_runner.go
+++ b/internal/agent/k8s_job_runner.go
@@ -439,7 +439,10 @@ fi
 status=$?
 set -e
 if [ "$status" -eq 0 ] && [ -n "${SYBRA_K8S_GIT_REMOTE:-}" ]; then
-	if ! git diff --quiet || ! git diff --cached --quiet; then
+	# git status --porcelain, not git diff: diff only sees tracked files, so an
+	# agent that created a new file (the common case) produced no commit and the
+	# push below silently reported "Everything up-to-date", losing the work.
+	if [ -n "$(git status --porcelain)" ]; then
 		git add -A
 		git commit -m "chore: persist k8s agent changes" || true
 	fi

--- a/internal/agent/k8s_job_runner_test.go
+++ b/internal/agent/k8s_job_runner_test.go
@@ -159,3 +159,17 @@ func TestK8sProviderCommandWrapsGitWorkspace(t *testing.T) {
 		}
 	}
 }
+
+func TestK8sProviderWrapperCommitsUntrackedFiles(t *testing.T) {
+	script := k8sProviderWrapperScript()
+
+	if !strings.Contains(script, "git status --porcelain") {
+		t.Errorf("wrapper script must gate its commit on `git status --porcelain`:\n%s", script)
+	}
+	// `git diff` only reports tracked files, so gating on it skipped the commit
+	// whenever the agent created a new file — and the push then reported
+	// "Everything up-to-date" and silently dropped the work.
+	if strings.Contains(script, "git diff --quiet") {
+		t.Errorf("wrapper script gates its commit on `git diff`, which cannot see a newly created file:\n%s", script)
+	}
+}

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -668,6 +668,11 @@ func (s *TaskService) startCreatedWorkflow(t task.Task) {
 	if skipTaskCreatedWorkflow(t) {
 		return
 	}
+	// An agent-only instance refuses the start below, so bail before announcing
+	// an auto-start that will not happen — the log line read like a leak.
+	if !s.workflowEngine.AutoDispatchEnabled() {
+		return
+	}
 	info := taskToInfo(t)
 	if def := s.workflowEngine.MatchWorkflow(info, "task.created"); def != nil {
 		s.logger.Info("workflow.auto-start", "task_id", t.ID, "workflow", def.ID)
@@ -738,7 +743,7 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 	// and flipped status back to `planning` instead of running implement.
 	// DispatchEvent matches against current trigger conditions, which is what
 	// the user wants: in-progress → simple-task-implement.
-	if s.workflowEngine != nil {
+	if s.workflowEngine != nil && s.workflowEngine.AutoDispatchEnabled() {
 		if newStatus, ok := updates["status"].(string); ok &&
 			newStatus == string(task.StatusInProgress) &&
 			cur.Workflow != nil &&

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -270,6 +270,12 @@ func applyTagsField(u *Update, k string, v any) error {
 		cp := make([]string, len(tv))
 		copy(cp, tv)
 		u.Tags = &cp
+	case []any:
+		parts, err := stringSlice(k, tv)
+		if err != nil {
+			return err
+		}
+		u.Tags = &parts
 	case string:
 		parts := strings.Split(tv, ",")
 		u.Tags = &parts
@@ -279,12 +285,33 @@ func applyTagsField(u *Update, k string, v any) error {
 	return nil
 }
 
+// stringSlice coerces a JSON-decoded array. Every update that arrives over HTTP
+// (the CLI writes that way, and so does the web GUI) decodes to []any, never
+// []string — without this, any tags/depends_on update 500s.
+func stringSlice(k string, in []any) ([]string, error) {
+	out := make([]string, 0, len(in))
+	for _, e := range in {
+		s, ok := e.(string)
+		if !ok {
+			return nil, fmt.Errorf("field %q: want a string element, got %T", k, e)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
 func applyDependsOnField(u *Update, k string, v any) error {
 	switch dv := v.(type) {
 	case []string:
 		cp := make([]string, len(dv))
 		copy(cp, dv)
 		u.DependsOn = &cp
+	case []any:
+		parts, err := stringSlice(k, dv)
+		if err != nil {
+			return err
+		}
+		u.DependsOn = &parts
 	case string:
 		// Comma-separated shorthand from the CLI; trim and drop empties so a
 		// trailing comma or stray space cannot inject a blank dependency ref

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -285,6 +285,21 @@ func applyTagsField(u *Update, k string, v any) error {
 	return nil
 }
 
+// compactRefs trims and drops empty dependency refs. A blank ref is worse than a
+// loud error: umbrella.Build skips empty keys, so depsSatisfied never finds one
+// and the child task stays blocked forever. Applied to every shape — the
+// comma-separated CLI shorthand guarded against this, but a JSON array
+// ["t1", ""] reached the same field unguarded.
+func compactRefs(in []string) []string {
+	var out []string
+	for _, p := range in {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // stringSlice coerces a JSON-decoded array. Every update that arrives over HTTP
 // (the CLI writes that way, and so does the web GUI) decodes to []any, never
 // []string — without this, any tags/depends_on update 500s.
@@ -303,25 +318,17 @@ func stringSlice(k string, in []any) ([]string, error) {
 func applyDependsOnField(u *Update, k string, v any) error {
 	switch dv := v.(type) {
 	case []string:
-		cp := make([]string, len(dv))
-		copy(cp, dv)
-		u.DependsOn = &cp
+		parts := compactRefs(dv)
+		u.DependsOn = &parts
 	case []any:
-		parts, err := stringSlice(k, dv)
+		raw, err := stringSlice(k, dv)
 		if err != nil {
 			return err
 		}
+		parts := compactRefs(raw)
 		u.DependsOn = &parts
 	case string:
-		// Comma-separated shorthand from the CLI; trim and drop empties so a
-		// trailing comma or stray space cannot inject a blank dependency ref
-		// (which would otherwise resolve to "" and never satisfy).
-		var parts []string
-		for p := range strings.SplitSeq(dv, ",") {
-			if p = strings.TrimSpace(p); p != "" {
-				parts = append(parts, p)
-			}
-		}
+		parts := compactRefs(strings.Split(dv, ","))
 		u.DependsOn = &parts
 	default:
 		return fmt.Errorf("field %q: want []string or string, got %T", k, v)

--- a/internal/task/update_json_array_test.go
+++ b/internal/task/update_json_array_test.go
@@ -1,0 +1,58 @@
+package task
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestApplyMapFields_JSONDecodedArrays(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    []string
+		field   string
+		wantErr bool
+	}{
+		{name: "tags from json array", body: `{"tags":["a","b"]}`, field: "tags", want: []string{"a", "b"}},
+		{name: "tags empty json array", body: `{"tags":[]}`, field: "tags", want: []string{}},
+		{name: "tags comma string", body: `{"tags":"a,b"}`, field: "tags", want: []string{"a", "b"}},
+		{name: "tags non-string element", body: `{"tags":["a",7]}`, field: "tags", wantErr: true},
+		{name: "depends_on from json array", body: `{"depends_on":["t1","t2"]}`, field: "depends_on", want: []string{"t1", "t2"}},
+		{name: "depends_on non-string element", body: `{"depends_on":[{"x":1}]}`, field: "depends_on", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m map[string]any
+			if err := json.Unmarshal([]byte(tt.body), &m); err != nil {
+				t.Fatalf("unmarshal fixture: %v", err)
+			}
+
+			u, err := UpdateFromMap(m)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("UpdateFromMap(%s) = %+v, want error", tt.body, u)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UpdateFromMap(%s): %v", tt.body, err)
+			}
+			got := u.Tags
+			if tt.field == "depends_on" {
+				got = u.DependsOn
+			}
+			if got == nil {
+				t.Fatalf("%s not set", tt.field)
+			}
+			if len(*got) != len(tt.want) {
+				t.Fatalf("%s = %v, want %v", tt.field, *got, tt.want)
+			}
+			for i := range tt.want {
+				if (*got)[i] != tt.want[i] {
+					t.Fatalf("%s = %v, want %v", tt.field, *got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/task/update_json_array_test.go
+++ b/internal/task/update_json_array_test.go
@@ -19,6 +19,10 @@ func TestApplyMapFields_JSONDecodedArrays(t *testing.T) {
 		{name: "tags non-string element", body: `{"tags":["a",7]}`, field: "tags", wantErr: true},
 		{name: "depends_on from json array", body: `{"depends_on":["t1","t2"]}`, field: "depends_on", want: []string{"t1", "t2"}},
 		{name: "depends_on non-string element", body: `{"depends_on":[{"x":1}]}`, field: "depends_on", wantErr: true},
+		{name: "depends_on drops blank element", body: `{"depends_on":["t1",""]}`, field: "depends_on", want: []string{"t1"}},
+		{name: "depends_on drops whitespace element", body: `{"depends_on":["t1","  "]}`, field: "depends_on", want: []string{"t1"}},
+		{name: "depends_on trims elements", body: `{"depends_on":[" t1 "]}`, field: "depends_on", want: []string{"t1"}},
+		{name: "depends_on drops trailing comma", body: `{"depends_on":"t1,"}`, field: "depends_on", want: []string{"t1"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -416,6 +416,12 @@ func (e *Engine) SetDispatchGate(gate func(TaskInfo) bool) { e.dispatchGate = ga
 // instance back into workflows.
 func (e *Engine) SetAutoDispatch(on bool) { e.dispatchDisabled = !on }
 
+// AutoDispatchEnabled reports whether this instance dispatches workflows. The
+// gate in startWorkflowCore is what actually enforces it; this lets a caller
+// avoid announcing an auto-start that is about to be refused, and avoid
+// spawning a goroutine that would only no-op.
+func (e *Engine) AutoDispatchEnabled() bool { return !e.dispatchDisabled }
+
 // SetAutoApprovePlansWithoutDecisions enables automatic approval of validated
 // simple-task plans whose decision sidecar explicitly says there are no open
 // human decisions.

--- a/mise.toml
+++ b/mise.toml
@@ -3,8 +3,6 @@ go = "1.26.5"
 node = "24"
 hadolint = "2.14.0"
 golangci-lint = "2.12.2"
-k3d = "5.9.0"
-kubectl = "1.36.2"
 
 [tasks."hooks:install"]
 run = "git config core.hooksPath .githooks"
@@ -142,6 +140,12 @@ run = "./bin/sybra-perf -scenario soak -duration 5m -concurrency 4 -event-interv
 depends = ["perf:build"]
 description = "Long-running soak scenario with heap/goroutine profiles for leak detection"
 
+# Tools are task-scoped, not in [tools]: the production deploy runs `mise
+# install` in ExecStartPre (deploy/bin/sybra-build.sh), where a failed download
+# is swallowed by keep_last_good_or_fail and silently pins the box to the old
+# binary. A k8s tool only this task needs has no business in that path, or in
+# the 12 CI jobs that never use it.
 [tasks."smoke:k3d"]
 description = "k3d smoke for the Kubernetes agent-Job runner (fake provider, no API keys)"
+tools = { k3d = "5.9.0", kubectl = "1.36.2" }
 run = "scripts/smoke-k3d.sh"

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,8 @@ go = "1.26.5"
 node = "24"
 hadolint = "2.14.0"
 golangci-lint = "2.12.2"
+k3d = "5.9.0"
+kubectl = "1.36.2"
 
 [tasks."hooks:install"]
 run = "git config core.hooksPath .githooks"
@@ -58,9 +60,9 @@ description = "Run all linters"
 # outcome depends only on repo state, not on ambient CI infra. Intentionally
 # excludes gates that need external advisory DBs or a browser and so cannot
 # run reliably as a pre-commit loop: lint-nilaway (installs nilaway),
-# security (govulncheck + npm audit hit the advisory DBs), and the e2e job
-# (Playwright + chromium + a live server). CI remains the source of truth for
-# those three.
+# security (govulncheck + npm audit hit the advisory DBs), the e2e job
+# (Playwright + chromium + a live server), and smoke:k3d (Docker + a real k3d
+# cluster). CI remains the source of truth for those four.
 [tasks.verify]
 run = [
   "cd frontend && npm ci && npm run build:desktop",
@@ -139,3 +141,7 @@ description = "Run the task-store CRUD churn scenario"
 run = "./bin/sybra-perf -scenario soak -duration 5m -concurrency 4 -event-interval 200ms -fake-claude ./bin/fake-claude -pprof-dir ./perf-profiles"
 depends = ["perf:build"]
 description = "Long-running soak scenario with heap/goroutine profiles for leak detection"
+
+[tasks."smoke:k3d"]
+description = "k3d smoke for the Kubernetes agent-Job runner (fake provider, no API keys)"
+run = "scripts/smoke-k3d.sh"

--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -84,9 +84,14 @@ if [ "${SMOKE_SKIP_BUILD:-0}" != "1" ]; then
   docker build -t "$IMAGE" "$REPO_ROOT"
 fi
 
+# Single node on purpose: `k3d image import` loads the image into every node, and
+# the agent image is multi-GB (node + three provider CLIs), so `--agents 1`
+# imported it twice and OOM-killed the node on a CI runner (exit 137, then the
+# API server fell over). This smoke exercises the Job runner, not multi-node
+# scheduling, so the extra node bought nothing.
 log "Creating cluster $CLUSTER"
 k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
-k3d cluster create "$CLUSTER" --agents 1 --wait \
+k3d cluster create "$CLUSTER" --agents 0 --wait \
   --kubeconfig-update-default=false --kubeconfig-switch-context=false
 k3d kubeconfig get "$CLUSTER" > "$KUBECONFIG"
 

--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -152,10 +152,14 @@ updated_at: "2026-07-14T00:00:00Z"
 YAML
 '
 
+# A real model needs the literal spelled out; fake-claude ignores the prompt and
+# writes the same marker either way, so both providers land on one assertion set.
+PROMPT="Create a file named k8s-agent-output.txt in the repository root, containing exactly this line and nothing else: changed by k8s fake agent"
+
 log "Creating task"
 TASK_ID=$(in_pod sybra-cli --json create \
   --title "k3d smoke: fake repo agent job" \
-  --body "Run fake Claude in a Kubernetes Job and write a repo marker file." \
+  --body "$PROMPT" \
   --mode headless --project FakeOrg/k8s-testbed \
   --tags handoff-manual,k8s-smoke --allow-dup | jq -r .id)
 [ -n "$TASK_ID" ] && [ "$TASK_ID" != "null" ] || fail "could not create task"
@@ -167,10 +171,37 @@ echo "task: $TASK_ID"
 log "Starting agent"
 in_pod curl -sS -X POST 'http://127.0.0.1:8080/api/App/StartAgent' \
   -H 'Authorization: Bearer poc-token' -H 'Content-Type: application/json' \
-  --data "[\"$TASK_ID\",\"headless\",\"Write the Kubernetes fake repo marker file.\",true]" >/dev/null
+  --data "$(jq -nc --arg t "$TASK_ID" --arg p "$PROMPT" '[$t,"headless",$p,true]')" >/dev/null
 
+# `kubectl wait -l <selector>` does NOT wait for a resource to appear: with no
+# match it exits 1 immediately and ignores --timeout. StartAgent returns as soon
+# as the agent is registered and the Job is POSTed later from a goroutine (after
+# a git detect + push), so the Job reliably does not exist yet here. Poll for it.
 log "Waiting for the agent Job"
-kc wait --for=condition=complete job -l app.kubernetes.io/name=sybra-agent --timeout="${TIMEOUT}s"
+JOB=""
+for _ in $(seq 1 60); do
+  JOB=$(kc get job -l app.kubernetes.io/name=sybra-agent -o name 2>/dev/null | head -1)
+  [ -n "$JOB" ] && break
+  sleep 1
+done
+[ -n "$JOB" ] || fail "no agent Job appeared within 60s"
+
+# Polled rather than `kubectl wait --for=condition=complete`: with backoffLimit 0
+# a failed Job never satisfies `complete`, so a real failure would burn the whole
+# timeout before reporting. This reports it immediately.
+deadline=$(( $(date +%s) + TIMEOUT ))
+while :; do
+  succeeded=$(kc get "$JOB" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)
+  failed=$(kc get "$JOB" -o jsonpath='{.status.failed}' 2>/dev/null || true)
+  [ "${succeeded:-0}" != "0" ] && [ -n "${succeeded:-}" ] && break
+  if [ "${failed:-0}" != "0" ] && [ -n "${failed:-}" ]; then
+    fail "agent Job $JOB failed"
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    fail "agent Job $JOB did not finish within ${TIMEOUT}s"
+  fi
+  sleep 2
+done
 
 # A completed Job is not a finalized agent: the runner polls on a 750ms ticker
 # and still has to drain the pod's final logs, fast-forward the worktree, and
@@ -178,11 +209,13 @@ kc wait --for=condition=complete job -l app.kubernetes.io/name=sybra-agent --tim
 # state=running.
 log "Waiting for the agent to finalize"
 AGENT=""
-for _ in $(seq 1 60); do
+finalize_deadline=$(( $(date +%s) + TIMEOUT ))
+while :; do
   AGENT=$(in_pod curl -sS -X POST 'http://127.0.0.1:8080/api/AgentService/ListAgents' \
     -H 'Authorization: Bearer poc-token' -H 'Content-Type: application/json' --data '[]' \
     | jq -c --arg t "$TASK_ID" '[.[] | select(.taskId == $t)] | last')
   [ "$(echo "$AGENT" | jq -r '.state // empty')" = "stopped" ] && break
+  [ "$(date +%s)" -ge "$finalize_deadline" ] && break
   sleep 2
 done
 [ "$AGENT" != "null" ] && [ -n "$AGENT" ] || fail "no agent recorded for task $TASK_ID"
@@ -201,14 +234,23 @@ check() {
 # 1. Job spawn — the agent ran as a Kubernetes Job, not a local subprocess.
 check "command prefix" '.command | startswith("kubernetes job/")' "true"
 check "state" '.state' "stopped"
+
 # 2. Log parsing — these values exist only if Sybra parsed the pod's NDJSON.
-#    fake-claude's result event reports exactly this cost/token triple, so a
-#    wrong number means the stream parser broke, and 0 would mean the runner
-#    silently fell back to fake mode's inline script instead of the provider.
-check "provider" '.provider' "claude"
-check "costUsd" '.costUsd' "0.01"
-check "inputTokens" '.inputTokens' "100"
-check "outputTokens" '.outputTokens' "50"
+if [ "$PROVIDER" = "fake" ]; then
+  # fake-claude's result event reports exactly this triple, so a wrong number
+  # means the stream parser broke, and 0 would mean the runner silently fell
+  # back to fake mode's inline script instead of running the provider.
+  check "provider" '.provider' "claude"
+  check "costUsd" '.costUsd' "0.01"
+  check "inputTokens" '.inputTokens' "100"
+  check "outputTokens" '.outputTokens' "50"
+else
+  # A real model's numbers are not fixed, so assert only that the parser
+  # extracted them at all: 0/absent means the result event was never read.
+  check "provider" '.provider' "opencode"
+  check "cost parsed" '(.costUsd // 0) > 0' "true"
+  check "tokens parsed" '((.inputTokens // 0) > 0) and ((.outputTokens // 0) > 0)' "true"
+fi
 
 # Task.WorktreeDir is only populated for an adopted worktree (the handoff
 # path); a normal agent run derives worktrees/<slug>-<id> and never writes the

--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Deterministic k3d smoke for the Kubernetes agent-Job runner.
+#
+# Automates deploy/k8s-poc/README.md's "Fake repo e2e mode": stands up a k3d
+# cluster, deploys sybra-server, seeds a project backed by a local bare repo on
+# the PVC, and runs one headless agent as a Kubernetes Job. The Job runs
+# fake-claude, so the whole path is exercised with no model API keys and no
+# provider spend.
+#
+# Five things the Job runner has to get right, each asserted below:
+#   1. Job spawn      — a sybra-agent-<id> Job is created and completes
+#   2. Log parsing    — Sybra parses the pod's NDJSON (cost/tokens/session)
+#   3. Commit         — the wrapper commits the agent's file change
+#   4. Push-back      — the branch is pushed to the PVC-backed origin
+#   5. Fast-forward   — the server-side worktree picks the change up
+#
+# Never touches the caller's kubectl context: the cluster is created with
+# --kubeconfig-update-default=false and every command runs against an isolated
+# kubeconfig in a temp dir.
+#
+# SMOKE_PROVIDER=opencode swaps fake-claude for the real OpenCode CLI against
+# OpenRouter. That path costs money and needs OPENROUTER_API_KEY, so it is
+# opt-in and never runs on a PR — see .github/workflows/k3d-provider-smoke.yml.
+# It exists because the fake path can never prove the real provider CLI launches
+# inside the agent image: the wrapper swaps argv[0] for SYBRA_K8S_PROVIDER_BIN,
+# so fake-claude replaces the very launch it would need to exercise.
+#
+# Usage:
+#   scripts/smoke-k3d.sh              # full run, then tear down
+#   SMOKE_KEEP=1 scripts/smoke-k3d.sh # leave the cluster up for debugging
+#   SMOKE_SKIP_BUILD=1 ...            # reuse an existing sybra-server:poc
+#   SMOKE_PROVIDER=opencode ...       # real OpenRouter run (costs money)
+set -euo pipefail
+
+PROVIDER="${SMOKE_PROVIDER:-fake}"
+CLUSTER="${SMOKE_CLUSTER:-sybra-smoke}"
+NS=sybra-poc
+IMAGE=sybra-server:poc
+KEEP="${SMOKE_KEEP:-0}"
+TIMEOUT="${SMOKE_TIMEOUT:-240}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORK="$(mktemp -d)"
+export KUBECONFIG="$WORK/kubeconfig"
+
+log() { printf '\n=== %s\n' "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; exit 1; }
+
+kc() { kubectl --context "k3d-$CLUSTER" -n "$NS" "$@"; }
+in_pod() { kc exec deploy/sybra-server -- "$@"; }
+
+dump_diagnostics() {
+  printf '\n===== DIAGNOSTICS =====\n' >&2
+  kc get pods,jobs -o wide 2>&1 | head -30 >&2 || true
+  # Sybra's slog handler writes to a rotating file, not stdout, so `kubectl logs`
+  # on the server shows almost nothing — the real sink is on the PVC.
+  in_pod tail -100 /home/sybra/.sybra/logs/sybra.log 2>&1 | tail -60 >&2 || true
+  printf '\n--- agent job pods ---\n' >&2
+  for p in $(kc get pods -l app.kubernetes.io/name=sybra-agent -o name 2>/dev/null); do
+    printf '\n--- %s ---\n' "$p" >&2
+    kc logs "$p" 2>&1 | tail -30 >&2 || true
+  done
+}
+
+cleanup() {
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then dump_diagnostics || true; fi
+  if [ "$KEEP" = "1" ]; then
+    printf '\nSMOKE_KEEP=1 — cluster %s left up. KUBECONFIG=%s\n' "$CLUSTER" "$KUBECONFIG" >&2
+  else
+    k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+    rm -rf "$WORK"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+for bin in docker k3d kubectl jq; do
+  command -v "$bin" >/dev/null 2>&1 || fail "$bin is required but not on PATH"
+done
+
+if [ "${SMOKE_SKIP_BUILD:-0}" != "1" ]; then
+  log "Building $IMAGE"
+  docker build -t "$IMAGE" "$REPO_ROOT"
+fi
+
+log "Creating cluster $CLUSTER"
+k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+k3d cluster create "$CLUSTER" --agents 1 --wait \
+  --kubeconfig-update-default=false --kubeconfig-switch-context=false
+k3d kubeconfig get "$CLUSTER" > "$KUBECONFIG"
+
+log "Importing $IMAGE"
+k3d image import "$IMAGE" -c "$CLUSTER"
+
+log "Applying manifests ($PROVIDER)"
+kubectl --context "k3d-$CLUSTER" apply -k "$REPO_ROOT/deploy/k8s-poc"
+
+case "$PROVIDER" in
+  fake) CONFIG=config-fake-repo.yaml ;;
+  opencode)
+    CONFIG=config-provider-example.yaml
+    [ -n "${OPENROUTER_API_KEY:-}" ] || fail "SMOKE_PROVIDER=opencode needs OPENROUTER_API_KEY"
+    kc create secret generic sybra-provider-api-keys \
+      --from-literal=openrouter_api_key="$OPENROUTER_API_KEY" \
+      --from-literal=github_token="${GITHUB_TOKEN:-}" \
+      --dry-run=client -o yaml | kubectl --context "k3d-$CLUSTER" apply -f -
+    ;;
+  *) fail "unknown SMOKE_PROVIDER '$PROVIDER' (want: fake, opencode)" ;;
+esac
+
+# These configs declare the same ConfigMap name, so this swaps sybra-config
+# wholesale. The mount is a subPath, which never receives ConfigMap updates, so
+# the restart below is mandatory rather than cosmetic.
+kubectl --context "k3d-$CLUSTER" apply -f "$REPO_ROOT/deploy/k8s-poc/$CONFIG"
+kc rollout restart deployment/sybra-server
+kc rollout status deployment/sybra-server --timeout=180s
+
+log "Seeding fake repo project"
+in_pod sh -ceu '
+HOME_DIR=/home/sybra/.sybra
+OWNER=FakeOrg
+REPO=k8s-testbed
+SRC=/tmp/k8s-testbed-src
+BARE="$HOME_DIR/clones/$OWNER/$REPO.git"
+
+rm -rf "$SRC" "$BARE"
+mkdir -p "$HOME_DIR/clones/$OWNER" "$HOME_DIR/projects"
+git init -b main "$SRC"
+git -C "$SRC" config user.email fake-repo@example.invalid
+git -C "$SRC" config user.name "Fake Repo"
+printf "hello from fake repo\n" > "$SRC/README.md"
+git -C "$SRC" add README.md
+git -C "$SRC" commit -q -m "chore: seed fake repo"
+git clone -q --bare "$SRC" "$BARE"
+git --git-dir="$BARE" config remote.origin.url "$BARE"
+git --git-dir="$BARE" config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git --git-dir="$BARE" config receive.denyCurrentBranch updateInstead
+git --git-dir="$BARE" update-ref refs/remotes/origin/main "$(git --git-dir="$BARE" rev-parse refs/heads/main)"
+cat > "$HOME_DIR/projects/$OWNER--$REPO.yaml" <<YAML
+id: $OWNER/$REPO
+name: $REPO
+owner: $OWNER
+repo: $REPO
+url: https://github.com/$OWNER/$REPO.git
+clone_path: $BARE
+type: pet
+status: ready
+worktree_base_ref: fresh
+created_at: "2026-07-14T00:00:00Z"
+updated_at: "2026-07-14T00:00:00Z"
+YAML
+'
+
+log "Creating task"
+TASK_ID=$(in_pod sybra-cli --json create \
+  --title "k3d smoke: fake repo agent job" \
+  --body "Run fake Claude in a Kubernetes Job and write a repo marker file." \
+  --mode headless --project FakeOrg/k8s-testbed \
+  --tags handoff-manual,k8s-smoke --allow-dup | jq -r .id)
+[ -n "$TASK_ID" ] && [ "$TASK_ID" != "null" ] || fail "could not create task"
+echo "task: $TASK_ID"
+
+# Deliberately App.StartAgent, not the task-created workflow: this smoke proves
+# the Job backend, so it must not depend on triage/planning behaviour. The
+# shipped config is orchestrator.role=agent-only, which never auto-dispatches.
+log "Starting agent"
+in_pod curl -sS -X POST 'http://127.0.0.1:8080/api/App/StartAgent' \
+  -H 'Authorization: Bearer poc-token' -H 'Content-Type: application/json' \
+  --data "[\"$TASK_ID\",\"headless\",\"Write the Kubernetes fake repo marker file.\",true]" >/dev/null
+
+log "Waiting for the agent Job"
+kc wait --for=condition=complete job -l app.kubernetes.io/name=sybra-agent --timeout="${TIMEOUT}s"
+
+# A completed Job is not a finalized agent: the runner polls on a 750ms ticker
+# and still has to drain the pod's final logs, fast-forward the worktree, and
+# record the result. Asserting straight off `kubectl wait` races that and reads
+# state=running.
+log "Waiting for the agent to finalize"
+AGENT=""
+for _ in $(seq 1 60); do
+  AGENT=$(in_pod curl -sS -X POST 'http://127.0.0.1:8080/api/AgentService/ListAgents' \
+    -H 'Authorization: Bearer poc-token' -H 'Content-Type: application/json' --data '[]' \
+    | jq -c --arg t "$TASK_ID" '[.[] | select(.taskId == $t)] | last')
+  [ "$(echo "$AGENT" | jq -r '.state // empty')" = "stopped" ] && break
+  sleep 2
+done
+[ "$AGENT" != "null" ] && [ -n "$AGENT" ] || fail "no agent recorded for task $TASK_ID"
+
+log "Asserting"
+echo "$AGENT" | jq .
+
+check() {
+  local label="$1" expr="$2" want="$3"
+  local got
+  got=$(echo "$AGENT" | jq -r "$expr")
+  [ "$got" = "$want" ] || fail "$label = '$got', want '$want'"
+  printf '  ok  %s = %s\n' "$label" "$got"
+}
+
+# 1. Job spawn — the agent ran as a Kubernetes Job, not a local subprocess.
+check "command prefix" '.command | startswith("kubernetes job/")' "true"
+check "state" '.state' "stopped"
+# 2. Log parsing — these values exist only if Sybra parsed the pod's NDJSON.
+#    fake-claude's result event reports exactly this cost/token triple, so a
+#    wrong number means the stream parser broke, and 0 would mean the runner
+#    silently fell back to fake mode's inline script instead of the provider.
+check "provider" '.provider' "claude"
+check "costUsd" '.costUsd' "0.01"
+check "inputTokens" '.inputTokens' "100"
+check "outputTokens" '.outputTokens' "50"
+
+# Task.WorktreeDir is only populated for an adopted worktree (the handoff
+# path); a normal agent run derives worktrees/<slug>-<id> and never writes the
+# field back, so glob for it rather than reading it off the task.
+WT=$(in_pod sh -ceu "ls -d /home/sybra/.sybra/worktrees/*$TASK_ID 2>/dev/null | head -1" | tr -d '\r')
+[ -n "$WT" ] || fail "no worktree found for task $TASK_ID under ~/.sybra/worktrees"
+
+# 3/4/5. The marker file reaches the server-side worktree only if the in-pod
+# wrapper committed it, pushed the branch to the PVC-backed origin, and the
+# server fast-forwarded from it.
+in_pod sh -ceu "test -f '$WT/k8s-agent-output.txt'" \
+  || fail "k8s-agent-output.txt missing from the server worktree — push-back or fast-forward failed"
+in_pod grep -q 'changed by k8s fake agent' "$WT/k8s-agent-output.txt" \
+  || fail "k8s-agent-output.txt has unexpected content"
+printf '  ok  marker file fast-forwarded into %s\n' "$WT"
+
+in_pod git -C "$WT" log --oneline -3 | grep -q 'persist k8s agent changes' \
+  || fail "no 'chore: persist k8s agent changes' commit in the worktree — the wrapper did not commit"
+printf '  ok  agent commit present\n'
+
+log "PASS — k3d agent-Job smoke green"


### PR DESCRIPTION
## Motivation

The Kubernetes Job runner had no automated cover at all. Its unit tests never touch `Run`, `createJob`, `pushK8sGitWorkspace` or `syncK8sGitWorkspace`; the PoC was proven by hand, once. So CI could not catch a regression in the one path the whole k8s backend depends on.

It also blocks the rest of #2094: almost every remaining subissue is k8s-behavioural, and without a harness each one needs a hand-rolled cluster to verify honestly. Pulled forward from last in the umbrella order for that reason.

Closes #2113. Parent: #2094.

> Changelog: ci(actions): add k3d smoke for the Job runner

## Implementation information

`scripts/smoke-k3d.sh` automates the README's "Fake repo e2e mode" and asserts it: cluster up → deploy → seed a project backed by a bare repo on the PVC → run one headless agent as a Job → assert → tear down. It drives `fake-claude`, so it is deterministic and spends nothing. CI runs it on every PR as `k3d Job Runner Smoke`; `mise run smoke:k3d` runs it locally.

Choices worth review attention:

- **Log parsing is asserted via fake-claude's exact `costUsd 0.01 / 100 / 50` triple, not a non-zero check.** `0` would mean the runner silently fell back to fake mode's inline `busybox` script instead of running the provider — a green-but-meaningless pass.
- **The image is tagged `sybra-server:poc`**, exactly as the README documents, so the smoke exercises the shipped manifests unmodified rather than a bespoke overlay.
- **The cluster is created with `--kubeconfig-update-default=false` against an isolated kubeconfig.** An earlier throwaway-cluster run found the default context was a *work GKE cluster*; this cannot touch it, or a local `sybra-poc`.
- `smoke-k3d` builds its own image: `docker-build.yml` is path-filtered to the Dockerfile and uses `load: false`, so nothing importable survives it.
- **Excluded from `mise run verify`** per that task's own stated rule (needs Docker + a real cluster). The exclusion comment is updated rather than silently diverging.
- `k3d-provider-smoke.yml` adds the manual OpenRouter run: `workflow_dispatch` only, fails loudly without the key. It exists because the fake path can never prove the real provider CLI launches inside the image — the wrapper swaps `argv[0]` for `SYBRA_K8S_PROVIDER_BIN`, so fake-claude replaces the very launch it would need to exercise.
- **k3d/kubectl are pinned on the task, not in `[tools]`.** The production deploy runs `mise install` in `ExecStartPre`, where a failed download is swallowed by `keep_last_good_or_fail` — which exits 0, silently pinning the box to the old binary while systemd reports healthy. A k8s tool only this task needs has no business in that path, nor in the 12 CI jobs that never use it.

## The smoke found four real defects on `main` before it landed

Two are production bugs, fixed here in their own commits:

1. **`fix(agent)`: the Job wrapper never committed newly-created files.** It gated on `git diff --quiet || git diff --cached --quiet` — both tracked-only. An agent that *created* a file (the common case) produced no commit; the push reported `Everything up-to-date`; the Job still exited 0, Sybra still parsed a successful result with real cost, and the agent still finalized `stopped`. **The work was silently gone.** This survived because the PoC was proven by editing an existing tracked file in the testbed repo — the one verified path happened to be the only working one.
2. **`fix(task)`: `tags`/`depends_on` rejected `[]any`**, which is what every JSON body decodes to. Since sybra-cli started writing over HTTP, `sybra-cli create --tags` 500s with `want []string or string, got []interface {}` — taking the k8s-poc README's own documented command with it. The web GUI posts arrays the same way.

Two are cosmetic, fixed in the CI commit:

3. The README's `jq -r .worktreeDir` reads returned null — that field is only set for an *adopted* worktree; a normal run derives `worktrees/<slug>-<id>` and never writes it back.
4. `agent-only` logged `workflow.auto-start` / `workflow.restart` and then no-opped, which read like a gate leak. New `Engine.AutoDispatchEnabled()` lets callers skip announcing a dispatch that will be refused, and skip spawning a goroutine that would only no-op.

## Supporting documentation

Verified by running the real thing on a real k3d cluster — the final run is green end to end:

```
ok  command prefix = true
ok  state = stopped
ok  provider = claude
ok  costUsd = 0.01
ok  inputTokens = 100
ok  outputTokens = 50
ok  marker file fast-forwarded into /home/sybra/.sybra/worktrees/k3d-smoke-fake-repo-agent-job-fa64cb27
ok  agent commit present
PASS — k3d agent-Job smoke green
```

**The push-back/fast-forward assertions are not tautological**, which was the obvious worry given the Job mounts the same `sybra-home` PVC as the server. The agent's workdir is `/tmp/sybra-workspace/repo` — container-local, not the PVC — so the marker file can only reach the server's worktree via commit → push → `pull --ff-only`. Empirically: those assertions *failed* while the commit bug was live and passed once it was fixed.

Each bug fix has a test verified to fail without the fix. One flake in the harness itself (asserting before the runner had finalized — `kubectl wait` returns on Job completion, but the runner polls on a 750ms ticker and still has to drain logs and fast-forward) was root-caused into a finalize poll rather than re-run.

**The provider path is proven too.** `SMOKE_PROVIDER=opencode` ran end to end against real OpenRouter on a k3d cluster — the first time that path has been exercised since the PoC:

```
ok  provider = opencode
ok  cost parsed = true
ok  tokens parsed = true
ok  marker file fast-forwarded into ~/.sybra/worktrees/k3d-smoke-fake-repo-agent-job-62748750
ok  agent commit present
PASS
```

`costUsd 0.00071505`, 9444 in / 98 out, `openrouter/deepseek/deepseek-v4-flash`. Assertions there check that cost/tokens were *parsed at all* rather than pinning fake-claude's exact triple, since a real model's numbers vary. This is the check the fake path structurally cannot make: it proves the real OpenCode CLI launches inside the agent image and its work survives the push-back.

**Still needed to run it in CI:** an `OPENROUTER_API_KEY` repo secret. The workflow fails loudly without one rather than reporting a green check for a smoke that never ran.

## Adversarial review found one blocker I would have shipped

`kubectl wait -l <selector>` does **not** wait for a resource to appear — with no match it exits 1 immediately and ignores `--timeout` (reproduced in 65–131ms against the pinned kubectl, not 240s). `StartAgent` returns before the Job is POSTed (that happens in a goroutine, after a git detect + push), so both sides of the race are ~100ms. It passed on darwin and in CI only because Docker Desktop's VM hop inflates the script's side; a native-docker runner shrinks exactly the margin that was hiding it. Now polls for the Job, then polls its status — which also reports a *failed* Job immediately instead of burning the full timeout (`backoffLimit: 0` means `Failed` never satisfies `condition=complete`).

The same review independently confirmed the push-back assertions are load-bearing, and that `git status --porcelain` is correct here (the wrapper git-excludes `NOTES.md`/`.sybra-context.md` *before* the check, and porcelain hides ignored files, so it reports exactly what `git add -A` stages).
