### PR TITLE
fix(watchdog): verify before escalating loop stops

### DIFF
--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -116,8 +116,12 @@ func (m *Manager) StopAgents(agents []*Agent) {
 
 // KillAgentsForTask stops all running agents for the given task ID and waits
 // for their goroutines to exit (up to timeout). Safe to call from DeleteTask
-// before worktree cleanup.
-func (m *Manager) KillAgentsForTask(taskID string, timeout time.Duration) {
+// before worktree cleanup. allExited is false when the deadline hit before
+// every targeted agent's goroutine confirmed exit — callers that need to know
+// whether it is now actually safe to touch the task's worktree (as opposed to
+// callers that just want a best-effort stop, like DeleteTask) must check it
+// rather than assume a timed-out call still stopped everything.
+func (m *Manager) KillAgentsForTask(taskID string, timeout time.Duration) (allExited bool) {
 	m.mu.RLock()
 	var targets []*Agent
 	for _, a := range m.agents {
@@ -138,9 +142,10 @@ func (m *Manager) KillAgentsForTask(taskID string, timeout time.Duration) {
 		case <-a.done:
 		case <-deadline:
 			m.logger.Warn("agent.kill-timeout", "agent_id", a.ID, "task_id", taskID)
-			return
+			return false
 		}
 	}
+	return true
 }
 
 func (m *Manager) StopAgent(agentID string) error {

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -48,7 +48,13 @@ func (lm *LifecycleManager) StartManagers(ctx context.Context, emit func(string,
 	a := lm.app
 
 	if a.cfg.Watchdog.Enabled {
-		wdog := watchdog.New(a.agents, a.tasks, a.logger, emit, &a.wg, a.cfg.Watchdog, a.getPressureGate())
+		verifyNow := func(vctx context.Context, taskID string) (verified, passed bool, failedCmd, output string, err error) {
+			if a.workflowEngine == nil {
+				return false, false, "", "", nil
+			}
+			return a.workflowEngine.VerifyTaskNow(vctx, taskID)
+		}
+		wdog := watchdog.New(a.agents, a.tasks, a.logger, emit, &a.wg, a.cfg.Watchdog, a.getPressureGate(), verifyNow)
 		a.wg.Go(func() { wdog.Run(ctx) })
 	} else {
 		a.logger.Info("watchdog.disabled")

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -175,6 +175,12 @@ type Watchdog struct {
 
 	inspectAgent func(context.Context, *slog.Logger, agent.InspectInput) (agent.InspectorVerdict, error)
 	stopAgent    func(string) error
+	// killAgentsForTask stops a task's agent(s) and blocks until the process(es)
+	// actually exit (or timeout). Used instead of stopAgent wherever something
+	// is about to touch the task's worktree right after stopping — e.g.
+	// verdictStatusFromVerify's on-demand verify re-run — so it never races a
+	// not-yet-dead agent process still writing to the same files (#2155).
+	killAgentsForTask func(taskID string, timeout time.Duration)
 	// stopCompletedAgent stops a headless agent that already produced a clean
 	// terminal result, marking it completed-by-result first so the runner
 	// finalizes it as a success rather than treating the kill signal as a
@@ -231,6 +237,7 @@ func New(
 		loopThreshold:        cfg.LoopThreshold,
 		inspectAgent:         agent.Inspect,
 		stopAgent:            agents.StopAgent,
+		killAgentsForTask:    agents.KillAgentsForTask,
 		stopCompletedAgent:   agents.StopCompletedAgent,
 		nudgeAgent:           agents.SendPromptToAgent,
 		recordProviderSignal: agents.RecordProviderSignal,
@@ -659,6 +666,10 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 		if w.stopAlreadyCompleted(ag) {
 			return
 		}
+		if ag.TaskID != "" && (trigger == "loop" || trigger == "budget") && verdict.ReasonKind == "" {
+			w.stopAndVerifyAmbiguousLoop(ctx, ag, verdict)
+			return
+		}
 		// Set the task state before stopping so the completion callback sees the
 		// intended recovery path. rate_limit is already handled above regardless
 		// of trigger. Of what remains: a stall stop is a retryable hang; the
@@ -680,8 +691,6 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 				if verdict.Reason != "" {
 					reason = "watchdog hang: " + verdict.Reason
 				}
-			} else if (trigger == "loop" || trigger == "budget") && verdict.ReasonKind == "" {
-				status, reason = w.verdictStatusFromVerify(ctx, ag.TaskID, reason)
 			}
 			if _, err := w.tasks.Update(ag.TaskID, task.Update{
 				Status:       task.Ptr(status),
@@ -729,21 +738,57 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 	}
 }
 
-// stopForRateLimit handles a "stop" verdict whose ReasonKind is "rate_limit":
-// a provider rate/quota limit, not a genuine hang or reward-hacking loop.
-// This reuses the same recovery machinery already trusted for a structured
-// 429 (internal/agent/runner_headless_retry.go): mark the agent's error kind
-// so the completion handler's isRateLimitedRun check recognizes the stop as
-// rate-limited and calls RescheduleRateLimitedAgent instead of stranding the
-// task in human-required, and report the signal to the provider health gate
-// so it applies the same cooldown/failover as the clean-429 case. The task is
-// left in-progress — human-required is reserved for genuine reward-hacking
-// loops per #1310's scoping.
 // verifyNowTimeout bounds a single on-demand verify re-run triggered by an
 // ambiguous loop/budget stop verdict — generous enough for a real test suite,
 // short enough that a hung verify command cannot indefinitely delay the
 // escalation decision it exists to inform.
 const verifyNowTimeout = 5 * time.Minute
+
+// killForVerifyTimeout bounds how long stopAndVerifyAmbiguousLoop waits for
+// the stopped agent's process to actually exit before re-running verify in
+// its worktree, matching the existing KillAgentsForTask convention used
+// elsewhere (internal/sybra/svc_tasks.go, internal/sybra/review/handler.go).
+const killForVerifyTimeout = 10 * time.Second
+
+// stopAndVerifyAmbiguousLoop handles an unclassified ("") loop/budget stop
+// verdict — the judge's own prompt biases it toward leaving ReasonKind empty
+// whenever reward-hacking is merely possible rather than confidently picking
+// generic_stall, so this is the exact ambiguous case a stale/wrong stop lands
+// in (#2147, #2155). Re-runs the task's verify suite before trusting it,
+// instead of the unconditional escalation every other non-benign stop gets.
+//
+// The agent must be fully stopped — not just signaled — before verify runs,
+// or the two can race on the same worktree files (a still-writing agent
+// mid-loop vs. a concurrent build/test in the same directory), so this uses
+// killAgentsForTask (stop-and-wait) rather than the fire-and-forget stopAgent
+// every other path in applyVerdict uses. An interim status is written first
+// so the completion callback sees an intended recovery path immediately,
+// matching the stall/generic_stall convention, rather than leaving the task
+// on its pre-stop status for the duration of the verify re-run.
+func (w *Watchdog) stopAndVerifyAmbiguousLoop(ctx context.Context, ag *agent.Agent, verdict agent.InspectorVerdict) {
+	judgeReason := "watchdog stop"
+	if verdict.Reason != "" {
+		judgeReason = "watchdog: " + verdict.Reason
+	}
+	if _, err := w.tasks.Update(ag.TaskID, task.Update{
+		Status:       task.Ptr(task.StatusInProgress),
+		StatusReason: task.Ptr("watchdog hang: verifying before deciding — " + judgeReason),
+	}); err != nil {
+		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
+	}
+	if w.killAgentsForTask != nil {
+		w.killAgentsForTask(ag.TaskID, killForVerifyTimeout)
+	} else if err := w.stopAgent(ag.ID); err != nil {
+		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
+	}
+	status, reason := w.verdictStatusFromVerify(ctx, ag.TaskID, judgeReason)
+	if _, err := w.tasks.Update(ag.TaskID, task.Update{
+		Status:       task.Ptr(status),
+		StatusReason: task.Ptr(reason),
+	}); err != nil {
+		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
+	}
+}
 
 // verdictStatusFromVerify decides the task status/reason for an unclassified
 // ("") loop or budget stop verdict by re-running the task's verify suite
@@ -783,6 +828,16 @@ func trimTail(failedCmd, output string, n int) string {
 	return failedCmd + "\n" + tail
 }
 
+// stopForRateLimit handles a "stop" verdict whose ReasonKind is "rate_limit":
+// a provider rate/quota limit, not a genuine hang or reward-hacking loop.
+// This reuses the same recovery machinery already trusted for a structured
+// 429 (internal/agent/runner_headless_retry.go): mark the agent's error kind
+// so the completion handler's isRateLimitedRun check recognizes the stop as
+// rate-limited and calls RescheduleRateLimitedAgent instead of stranding the
+// task in human-required, and report the signal to the provider health gate
+// so it applies the same cooldown/failover as the clean-429 case. The task is
+// left in-progress — human-required is reserved for genuine reward-hacking
+// loops per #1310's scoping.
 func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict agent.InspectorVerdict) {
 	reason := "watchdog: rate limit"
 	if verdict.Reason != "" {

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -202,6 +202,11 @@ type Watchdog struct {
 	// maxRunsPerWindow and runWindow drive checkRunRate — see its doc comment.
 	maxRunsPerWindow int
 	runWindow        time.Duration
+
+	// verifyNow re-runs a task's verify suite before applyVerdict escalates an
+	// ambiguous loop-stop, so a stale judge verdict doesn't strand honest work
+	// (#2155). Nil falls through to unconditional escalation.
+	verifyNow func(ctx context.Context, taskID string) (verified, passed bool, failedCmd, output string, err error)
 }
 
 // New creates a Watchdog. cfg.Model selects the cheap judge model and
@@ -214,6 +219,7 @@ func New(
 	wg *sync.WaitGroup,
 	cfg config.WatchdogConfig,
 	pressureGate *pressure.Gate,
+	verifyNow func(ctx context.Context, taskID string) (verified, passed bool, failedCmd, output string, err error),
 ) *Watchdog {
 	return &Watchdog{
 		agents:               agents,
@@ -238,6 +244,7 @@ func New(
 		},
 		maxRunsPerWindow: cfg.MaxRunsPerWindow,
 		runWindow:        time.Duration(cfg.RunWindowMinutes) * time.Minute,
+		verifyNow:        verifyNow,
 	}
 }
 
@@ -630,7 +637,7 @@ func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, tr
 		"reason_kind", verdict.ReasonKind)
 
 	w.emit(events.AgentStuck(ag.ID), verdict)
-	w.applyVerdict(ag, trigger, verdict)
+	w.applyVerdict(ctx, ag, trigger, verdict)
 
 	// Acknowledge a loop-triggered inspection that left the agent running, so the
 	// same unchanged signature does not re-trigger every debounce window. Skip
@@ -642,7 +649,7 @@ func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, tr
 	}
 }
 
-func (w *Watchdog) applyVerdict(ag *agent.Agent, trigger string, verdict agent.InspectorVerdict) {
+func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger string, verdict agent.InspectorVerdict) {
 	switch verdict.Recommendation {
 	case "stop":
 		if verdict.ReasonKind == "rate_limit" {
@@ -673,6 +680,8 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, trigger string, verdict agent.I
 				if verdict.Reason != "" {
 					reason = "watchdog hang: " + verdict.Reason
 				}
+			} else if (trigger == "loop" || trigger == "budget") && verdict.ReasonKind == "" {
+				status, reason = w.verdictStatusFromVerify(ctx, ag.TaskID, reason)
 			}
 			if _, err := w.tasks.Update(ag.TaskID, task.Update{
 				Status:       task.Ptr(status),
@@ -730,6 +739,50 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, trigger string, verdict agent.I
 // so it applies the same cooldown/failover as the clean-429 case. The task is
 // left in-progress — human-required is reserved for genuine reward-hacking
 // loops per #1310's scoping.
+// verifyNowTimeout bounds a single on-demand verify re-run triggered by an
+// ambiguous loop/budget stop verdict — generous enough for a real test suite,
+// short enough that a hung verify command cannot indefinitely delay the
+// escalation decision it exists to inform.
+const verifyNowTimeout = 5 * time.Minute
+
+// verdictStatusFromVerify decides the task status/reason for an unclassified
+// ("") loop or budget stop verdict by re-running the task's verify suite
+// instead of trusting the judge's ambiguous call outright (#2155). judgeReason
+// is the fallback human-required reason if nothing can be verified. Returns
+// StatusInProgress with a "watchdog hang" reason when verify passes (treated
+// the same as a generic_stall false alarm), StatusHumanRequired with the
+// fresh failing command/output when verify still fails, and StatusHumanRequired
+// with judgeReason when verification itself was not possible (no worktree, no
+// configured verify commands, or w.verifyNow is nil) or errored.
+func (w *Watchdog) verdictStatusFromVerify(ctx context.Context, taskID, judgeReason string) (status task.Status, reason string) {
+	if w.verifyNow == nil {
+		return task.StatusHumanRequired, judgeReason
+	}
+	vctx, cancel := context.WithTimeout(ctx, verifyNowTimeout)
+	defer cancel()
+	verified, passed, failedCmd, output, err := w.verifyNow(vctx, taskID)
+	if !verified || err != nil {
+		return task.StatusHumanRequired, judgeReason
+	}
+	if passed {
+		return task.StatusInProgress, "watchdog hang: verify suite passed on re-check — loop stop was a false positive"
+	}
+	return task.StatusHumanRequired, "watchdog: verify suite still fails after loop stop: " + trimTail(failedCmd, output, 500)
+}
+
+// trimTail appends a bounded tail of output to failedCmd so the escalation
+// reason carries real evidence without ballooning the task's status_reason.
+func trimTail(failedCmd, output string, n int) string {
+	tail := output
+	if len(tail) > n {
+		tail = "…" + tail[len(tail)-n:]
+	}
+	if tail == "" {
+		return failedCmd
+	}
+	return failedCmd + "\n" + tail
+}
+
 func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict agent.InspectorVerdict) {
 	reason := "watchdog: rate limit"
 	if verdict.Reason != "" {

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -180,7 +180,7 @@ type Watchdog struct {
 	// is about to touch the task's worktree right after stopping — e.g.
 	// verdictStatusFromVerify's on-demand verify re-run — so it never races a
 	// not-yet-dead agent process still writing to the same files (#2155).
-	killAgentsForTask func(taskID string, timeout time.Duration)
+	killAgentsForTask func(taskID string, timeout time.Duration) (allExited bool)
 	// stopCompletedAgent stops a headless agent that already produced a clean
 	// terminal result, marking it completed-by-result first so the runner
 	// finalizes it as a success rather than treating the kill signal as a
@@ -776,12 +776,16 @@ func (w *Watchdog) stopAndVerifyAmbiguousLoop(ctx context.Context, ag *agent.Age
 	}); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
+	confirmedStopped := true
 	if w.killAgentsForTask != nil {
-		w.killAgentsForTask(ag.TaskID, killForVerifyTimeout)
+		confirmedStopped = w.killAgentsForTask(ag.TaskID, killForVerifyTimeout)
 	} else if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
 	}
-	status, reason := w.verdictStatusFromVerify(ctx, ag.TaskID, judgeReason)
+	status, reason := task.StatusHumanRequired, "watchdog: could not confirm agent stopped before verify — "+judgeReason
+	if confirmedStopped {
+		status, reason = w.verdictStatusFromVerify(ctx, ag.TaskID, judgeReason)
+	}
 	if _, err := w.tasks.Update(ag.TaskID, task.Update{
 		Status:       task.Ptr(status),
 		StatusReason: task.Ptr(reason),
@@ -820,7 +824,7 @@ func (w *Watchdog) verdictStatusFromVerify(ctx context.Context, taskID, judgeRea
 func trimTail(failedCmd, output string, n int) string {
 	tail := output
 	if len(tail) > n {
-		tail = "…" + tail[len(tail)-n:]
+		tail = "…" + strings.ToValidUTF8(tail[len(tail)-n:], "")
 	}
 	if tail == "" {
 		return failedCmd

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -541,6 +541,59 @@ func TestApplyVerdict_LoopStopWithEmptyReasonKindVerifiesFirst(t *testing.T) {
 	}
 }
 
+// TestApplyVerdict_EmptyReasonKindWaitsForKillBeforeVerify covers #2155's
+// race fix: the agent must be fully stopped (via killAgentsForTask, which
+// blocks until the process exits) before verify re-runs in its worktree, not
+// merely signaled via the fire-and-forget stopAgent every other stop path
+// uses. Also pins the ordering: an interim in-progress status is written
+// before the kill, and verifyNow only runs after the kill call returns.
+func TestApplyVerdict_EmptyReasonKindWaitsForKillBeforeVerify(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	var order []string
+	stopAgentCalled := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopAgentCalled = true; return nil },
+		killAgentsForTask: func(taskID string, timeout time.Duration) {
+			order = append(order, "kill")
+			if taskID != tk.ID {
+				t.Errorf("killAgentsForTask taskID = %q, want %q", taskID, tk.ID)
+			}
+			if timeout <= 0 {
+				t.Errorf("killAgentsForTask timeout = %v, want positive", timeout)
+			}
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("get task mid-kill: %v", err)
+			}
+			if got.Status != task.StatusInProgress || !strings.Contains(got.StatusReason, "verifying before deciding") {
+				t.Errorf("status before kill returns = %q/%q, want an interim in-progress hang reason already written", got.Status, got.StatusReason)
+			}
+		},
+		verifyNow: func(context.Context, string) (bool, bool, string, string, error) {
+			order = append(order, "verify")
+			return true, true, "", "", nil
+		},
+	}
+
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "agent stuck, unclear why",
+		Recommendation: "stop",
+		ReasonKind:     "",
+	})
+
+	if stopAgentCalled {
+		t.Error("stopAgent must not be called when killAgentsForTask is wired")
+	}
+	want := []string{"kill", "verify"}
+	if len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
+		t.Fatalf("call order = %v, want %v", order, want)
+	}
+}
+
 // TestApplyVerdict_GenericStallAndRewardHackingSkipVerify pins that only an
 // unclassified ("") ReasonKind triggers the verify re-check — generic_stall
 // keeps its existing unconditional-retry treatment and reward_hacking keeps

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -210,7 +210,7 @@ func TestApplyVerdict_EscalateLeavesTaskRunning(t *testing.T) {
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "stall", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "stall", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "ambiguous environment churn",
 		Recommendation: "escalate",
@@ -241,7 +241,7 @@ func TestApplyVerdict_StopSetsReasonAndStopsAgent(t *testing.T) {
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "looping on toolchain setup",
 		Recommendation: "stop",
@@ -286,7 +286,7 @@ func TestApplyVerdict_StopWithBufferedResultRoutesThroughCompletion(t *testing.T
 	ag.AppendOutput(agent.StreamEvent{Type: "result", Content: `{"verdict":"PASS"}`})
 	ag.AppendOutput(agent.StreamEvent{Type: "assistant", Content: "lingering subagent chatter"})
 
-	w.applyVerdict(ag, "budget", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), ag, "budget", agent.InspectorVerdict{
 		Stuck:          false,
 		Reason:         "Agent completed verification successfully with PASS verdict; idle post-completion",
 		Recommendation: "stop",
@@ -328,7 +328,7 @@ func TestApplyVerdict_StopWithErrorResultStillEscalates(t *testing.T) {
 	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "headless"}
 	ag.AppendOutput(agent.StreamEvent{Type: "result", Subtype: "error_during_execution"})
 
-	w.applyVerdict(ag, "budget", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), ag, "budget", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "stuck after an error",
 		Recommendation: "stop",
@@ -356,7 +356,7 @@ func TestApplyVerdict_StallStopMarksRetryableHang(t *testing.T) {
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "stall", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "stall", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "no stream activity",
 		Recommendation: "stop",
@@ -392,7 +392,7 @@ func TestApplyVerdict_LoopStopWithGenericStallMarksRetryableHang(t *testing.T) {
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "repeating identical investigation commands",
 		Recommendation: "stop",
@@ -429,7 +429,7 @@ func TestApplyVerdict_LoopStopWithRewardHackingEscalates(t *testing.T) {
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "repeating the same failing fix with fabricated progress",
 		Recommendation: "stop",
@@ -451,6 +451,130 @@ func TestApplyVerdict_LoopStopWithRewardHackingEscalates(t *testing.T) {
 	}
 }
 
+// TestApplyVerdict_LoopStopWithEmptyReasonKindVerifiesFirst covers #2147/#2155:
+// an unclassified ("") loop stop is exactly the ambiguous case the judge's own
+// prompt steers toward when reward-hacking is merely possible — re-run verify
+// before trusting it rather than escalating on a potentially stale/wrong call.
+func TestApplyVerdict_LoopStopWithEmptyReasonKindVerifiesFirst(t *testing.T) {
+	tests := []struct {
+		name           string
+		verifyNow      func(ctx context.Context, taskID string) (verified, passed bool, failedCmd, output string, err error)
+		wantStatus     task.Status
+		wantReasonHas  string
+		wantVerifyCall bool
+	}{
+		{
+			name: "verify passes — false positive, retryable",
+			verifyNow: func(context.Context, string) (bool, bool, string, string, error) {
+				return true, true, "", "", nil
+			},
+			wantStatus:     task.StatusInProgress,
+			wantReasonHas:  "verify suite passed",
+			wantVerifyCall: true,
+		},
+		{
+			name: "verify still fails — escalate with fresh evidence",
+			verifyNow: func(context.Context, string) (bool, bool, string, string, error) {
+				return true, false, "go test ./...", "--- FAIL: TestFoo", nil
+			},
+			wantStatus:     task.StatusHumanRequired,
+			wantReasonHas:  "go test ./...",
+			wantVerifyCall: true,
+		},
+		{
+			name: "nothing to verify — falls back to judge reason",
+			verifyNow: func(context.Context, string) (bool, bool, string, string, error) {
+				return false, false, "", "", nil
+			},
+			wantStatus:     task.StatusHumanRequired,
+			wantReasonHas:  "watchdog: agent stuck, unclear why",
+			wantVerifyCall: true,
+		},
+		{
+			name:           "no verifyNow dependency wired — falls back to judge reason",
+			verifyNow:      nil,
+			wantStatus:     task.StatusHumanRequired,
+			wantReasonHas:  "watchdog: agent stuck, unclear why",
+			wantVerifyCall: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+
+			called := false
+			var verifyNow func(context.Context, string) (bool, bool, string, string, error)
+			if tc.verifyNow != nil {
+				verifyNow = func(ctx context.Context, taskID string) (bool, bool, string, string, error) {
+					called = true
+					return tc.verifyNow(ctx, taskID)
+				}
+			}
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				stopAgent: func(string) error { return nil },
+				verifyNow: verifyNow,
+			}
+
+			w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+				Stuck:          true,
+				Reason:         "agent stuck, unclear why",
+				Recommendation: "stop",
+				ReasonKind:     "",
+			})
+
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if !strings.Contains(got.StatusReason, tc.wantReasonHas) {
+				t.Fatalf("status_reason = %q, want it to contain %q", got.StatusReason, tc.wantReasonHas)
+			}
+			if called != tc.wantVerifyCall {
+				t.Fatalf("verifyNow called = %v, want %v", called, tc.wantVerifyCall)
+			}
+		})
+	}
+}
+
+// TestApplyVerdict_GenericStallAndRewardHackingSkipVerify pins that only an
+// unclassified ("") ReasonKind triggers the verify re-check — generic_stall
+// keeps its existing unconditional-retry treatment and reward_hacking keeps
+// its existing unconditional escalation, both untouched by #2155.
+func TestApplyVerdict_GenericStallAndRewardHackingSkipVerify(t *testing.T) {
+	for _, reasonKind := range []string{"generic_stall", "reward_hacking"} {
+		t.Run(reasonKind, func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+
+			called := false
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				stopAgent: func(string) error { return nil },
+				verifyNow: func(context.Context, string) (bool, bool, string, string, error) {
+					called = true
+					return true, true, "", "", nil
+				},
+			}
+
+			w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+				Stuck:          true,
+				Reason:         "some reason",
+				Recommendation: "stop",
+				ReasonKind:     reasonKind,
+			})
+
+			if called {
+				t.Fatalf("verifyNow must not be called for ReasonKind %q", reasonKind)
+			}
+		})
+	}
+}
+
 // TestApplyVerdict_BudgetStopWithGenericStallMarksRetryableHang covers the
 // gap left by #1456: a "stop" verdict on the "budget" trigger whose
 // ReasonKind is "generic_stall" (e.g. an agent legitimately polling
@@ -467,7 +591,7 @@ func TestApplyVerdict_BudgetStopWithGenericStallMarksRetryableHang(t *testing.T)
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "polling for backgrounded verify command to complete",
 		Recommendation: "stop",
@@ -505,7 +629,7 @@ func TestApplyVerdict_BudgetStopWithoutGenericStallEscalates(t *testing.T) {
 				stopAgent: func(string) error { stopped = true; return nil },
 			}
 
-			w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
+			w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
 				Stuck:          true,
 				Reason:         "burned through budget with no forward progress",
 				Recommendation: "stop",
@@ -553,7 +677,7 @@ func TestApplyVerdict_RateLimitStopReschedulesInsteadOfEscalating(t *testing.T) 
 			}
 
 			ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Provider: "claude"}
-			w.applyVerdict(ag, trigger, agent.InspectorVerdict{
+			w.applyVerdict(t.Context(), ag, trigger, agent.InspectorVerdict{
 				Stuck:          true,
 				Reason:         "org-level rate limit exhausted",
 				Recommendation: "stop",
@@ -603,7 +727,7 @@ func TestApplyVerdict_RateLimitStopWithoutTaskStillSignalsAndStops(t *testing.T)
 	}
 
 	ag := &agent.Agent{ID: "a1", Provider: "claude"}
-	w.applyVerdict(ag, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), ag, "loop", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "org-level rate limit exhausted",
 		Recommendation: "stop",
@@ -1001,7 +1125,7 @@ func TestApplyVerdict_NudgeLiveTransportDeliversInPlace(t *testing.T) {
 		nudgeAgent: func(_, text string) error { nudged = text; return nil },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
 		Recommendation: "nudge",
 		Reason:         "drifting",
 		Nudge:          "fix the root cause first",
@@ -1037,7 +1161,7 @@ func TestApplyVerdict_NudgeHeadlessPersistsSteerAndStops(t *testing.T) {
 		nudgeAgent: func(_, _ string) error { return errors.New("no active transport") },
 	}
 
-	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
 		Recommendation: "nudge",
 		Reason:         "drifting",
 		Nudge:          "stop retrying the failing command",
@@ -1072,7 +1196,7 @@ func TestApplyVerdict_NudgeWithoutExplicitSteerUsesLoopEvidence(t *testing.T) {
 	ag.NoteToolAction("check:mise run verify", "check:mise run verify")
 	ag.NoteToolAction("read:verify.log", "read:verify.log")
 
-	w.applyVerdict(ag, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), ag, "loop", agent.InspectorVerdict{
 		Recommendation: "nudge",
 	})
 

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/provider"
@@ -556,7 +557,7 @@ func TestApplyVerdict_EmptyReasonKindWaitsForKillBeforeVerify(t *testing.T) {
 		tasks:     tasks,
 		logger:    slog.New(slog.DiscardHandler),
 		stopAgent: func(string) error { stopAgentCalled = true; return nil },
-		killAgentsForTask: func(taskID string, timeout time.Duration) {
+		killAgentsForTask: func(taskID string, timeout time.Duration) bool {
 			order = append(order, "kill")
 			if taskID != tk.ID {
 				t.Errorf("killAgentsForTask taskID = %q, want %q", taskID, tk.ID)
@@ -571,6 +572,7 @@ func TestApplyVerdict_EmptyReasonKindWaitsForKillBeforeVerify(t *testing.T) {
 			if got.Status != task.StatusInProgress || !strings.Contains(got.StatusReason, "verifying before deciding") {
 				t.Errorf("status before kill returns = %q/%q, want an interim in-progress hang reason already written", got.Status, got.StatusReason)
 			}
+			return true
 		},
 		verifyNow: func(context.Context, string) (bool, bool, string, string, error) {
 			order = append(order, "verify")
@@ -591,6 +593,67 @@ func TestApplyVerdict_EmptyReasonKindWaitsForKillBeforeVerify(t *testing.T) {
 	want := []string{"kill", "verify"}
 	if len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
 		t.Fatalf("call order = %v, want %v", order, want)
+	}
+}
+
+// TestApplyVerdict_EmptyReasonKindSkipsVerifyWhenKillTimesOut covers a gap
+// found in review of #2155: killAgentsForTask returning false means the
+// deadline hit before every agent process confirmed exit, so it may still be
+// alive and touching the worktree — running verify then would risk the exact
+// race stopAndVerifyAmbiguousLoop exists to close. Must escalate directly on
+// the judge's own reason instead, and never call verifyNow.
+func TestApplyVerdict_EmptyReasonKindSkipsVerifyWhenKillTimesOut(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	verifyCalled := false
+	w := &Watchdog{
+		tasks:             tasks,
+		logger:            slog.New(slog.DiscardHandler),
+		stopAgent:         func(string) error { return nil },
+		killAgentsForTask: func(string, time.Duration) bool { return false },
+		verifyNow: func(context.Context, string) (bool, bool, string, string, error) {
+			verifyCalled = true
+			return true, true, "", "", nil
+		},
+	}
+
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "agent stuck, unclear why",
+		Recommendation: "stop",
+		ReasonKind:     "",
+	})
+
+	if verifyCalled {
+		t.Fatal("verifyNow must not be called when killAgentsForTask times out")
+	}
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+	if !strings.Contains(got.StatusReason, "could not confirm agent stopped") {
+		t.Fatalf("status_reason = %q, want it to explain the unconfirmed stop", got.StatusReason)
+	}
+}
+
+func TestTrimTail(t *testing.T) {
+	if got := trimTail("go test ./...", "", 10); got != "go test ./..." {
+		t.Fatalf("trimTail with empty output = %q, want just failedCmd", got)
+	}
+	if got := trimTail("cmd", "short", 10); got != "cmd\nshort" {
+		t.Fatalf("trimTail under the limit = %q, want the full output appended", got)
+	}
+	// "€" is a 3-byte rune; a naive byte-offset cut here splits it in half.
+	output := "€234567890"
+	got := trimTail("cmd", output, 8)
+	if !utf8.ValidString(got) {
+		t.Fatalf("trimTail produced invalid UTF-8: %q", got)
+	}
+	if strings.Contains(got, "�") {
+		t.Fatalf("trimTail = %q, want the split rune dropped rather than replaced with U+FFFD", got)
 	}
 }
 

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -197,6 +197,35 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, wfExec *Execution, 
 	return stepDone(step, "clean")
 }
 
+// VerifyTaskNow re-runs a task's configured verify commands against its
+// current worktree state on demand, outside the normal verify_checks step —
+// used by internal/watchdog to distinguish a genuine implementation defect
+// from a stale/false-positive loop-stop verdict before escalating to
+// human-required (#2155). verified is false whenever nothing could actually
+// be checked (no CheckConfigGetter/WorktreeGetter wired, no verify commands
+// configured, or no worktree yet); callers must treat that the same as
+// "could not verify" and fall back to their own default behavior rather than
+// treat it as a pass.
+func (e *Engine) VerifyTaskNow(ctx context.Context, taskID string) (verified, passed bool, failedCmd, output string, err error) {
+	if e.checks == nil || e.worktrees == nil {
+		return false, false, "", "", nil
+	}
+	cmds := e.checks.VerifyCommands(ctx, taskID)
+	if len(cmds) == 0 {
+		return false, false, "", "", nil
+	}
+	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	if !ok {
+		return false, false, "", "", nil
+	}
+	maybeMiseTrust(ctx, wtPath)
+	failedCmd, output, err = e.runVerifyCommands(ctx, taskID, wtPath, cmds)
+	if err != nil {
+		return true, false, failedCmd, output, err
+	}
+	return true, failedCmd == "", failedCmd, output, nil
+}
+
 // flagVerifyChecks flips the task to human-required. A failed status write
 // returns an error so the workflow stalls instead of advancing past the gate —
 // the YAML transition keys off task.status, so a silently-failed write would

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -147,7 +147,7 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, wfExec *Execution, 
 		e.logger.Warn("workflow.verify-checks.node-modules-repair-unresolved", "task_id", taskID)
 		return stepDone(step, "skipped: node_modules repair failed — broken toolchain state, not a product failure")
 	}
-	e.repairTornNodeModules(taskID, wtPath)
+	e.repairTornNodeModules(e.ctx, taskID, wtPath)
 
 	failedCmd, output, runErr := e.runVerifySuiteWithRetry(taskID, wtPath, cmds, timeout, step.ID)
 
@@ -218,6 +218,13 @@ func (e *Engine) VerifyTaskNow(ctx context.Context, taskID string) (verified, pa
 	if !ok {
 		return false, false, "", "", nil
 	}
+	if e.repairCorruptedNodeModules(ctx, taskID, wtPath) {
+		// Same as execVerifyChecks: an unrepairable corrupt install would
+		// deterministically fail verify and misattribute a toolchain problem
+		// to the diff — nothing was actually verified either way.
+		return false, false, "", "", nil
+	}
+	e.repairTornNodeModules(ctx, taskID, wtPath)
 	maybeMiseTrust(ctx, wtPath)
 	failedCmd, output, err = e.runVerifyCommands(ctx, taskID, wtPath, cmds)
 	if err != nil {
@@ -370,8 +377,8 @@ const repairTornNodeModulesTimeout = 3 * time.Minute
 // never completed or was gutted mid-run), or npm's own
 // node_modules/.package-lock.json stamp missing/older than package-lock.json
 // (an install that was interrupted before npm finished writing its stamp).
-func (e *Engine) repairTornNodeModules(taskID, wtPath string) {
-	e.repairTornNodeModulesInDir(taskID, wtPath, ".")
+func (e *Engine) repairTornNodeModules(ctx context.Context, taskID, wtPath string) {
+	e.repairTornNodeModulesInDir(ctx, taskID, wtPath, ".")
 	entries, err := os.ReadDir(wtPath)
 	if err != nil {
 		return
@@ -381,11 +388,11 @@ func (e *Engine) repairTornNodeModules(taskID, wtPath string) {
 			continue
 		}
 		dir := filepath.Join(wtPath, entry.Name())
-		e.repairTornNodeModulesInDir(taskID, dir, entry.Name())
+		e.repairTornNodeModulesInDir(ctx, taskID, dir, entry.Name())
 	}
 }
 
-func (e *Engine) repairTornNodeModulesInDir(taskID, dir, label string) {
+func (e *Engine) repairTornNodeModulesInDir(ctx context.Context, taskID, dir, label string) {
 	if _, err := os.Stat(filepath.Join(dir, "package.json")); err != nil {
 		return
 	}
@@ -402,9 +409,9 @@ func (e *Engine) repairTornNodeModulesInDir(taskID, dir, label string) {
 	}
 
 	e.logger.Warn("workflow.verify-checks.npm-repair", "task_id", taskID, "dir", label)
-	ctx, cancel := context.WithTimeout(e.ctx, repairTornNodeModulesTimeout)
+	rctx, cancel := context.WithTimeout(ctx, repairTornNodeModulesTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "npm", "ci", "--ignore-scripts")
+	cmd := exec.CommandContext(rctx, "npm", "ci", "--ignore-scripts")
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
 		e.logger.Warn("workflow.verify-checks.npm-repair-failed", "task_id", taskID, "dir", label, "err", err)

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -145,6 +145,40 @@ func TestVerifyTaskNow_CommandFails(t *testing.T) {
 	}
 }
 
+func TestVerifyTaskNow_RepairsTornNodeModulesBeforeRunning(t *testing.T) {
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	frontend := filepath.Join(wt, "frontend")
+	nm := filepath.Join(frontend, "node_modules")
+	if err := os.MkdirAll(filepath.Join(nm, "vite"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(frontend, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(frontend, "package-lock.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	npmScript := "#!/bin/sh\nmkdir -p node_modules/.bin\ntouch node_modules/.package-lock.json\n"
+	if err := os.WriteFile(filepath.Join(binDir, "npm"), []byte(npmScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := "test -d frontend/node_modules/.bin"
+	engine, _ := newVerifyChecksEngine(t, wt, []string{cmd})
+
+	verified, passed, failedCmd, output, err := engine.VerifyTaskNow(t.Context(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verified || !passed {
+		t.Fatalf("verified=%v passed=%v failedCmd=%q output=%q, want both true (repair should have fixed node_modules first)",
+			verified, passed, failedCmd, output)
+	}
+}
+
 func TestExecVerifyChecks_PassIsClean(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
@@ -1054,7 +1088,7 @@ func TestRepairTornNodeModules_RepairsWhenTorn(t *testing.T) {
 	fakeNpmOnPath(t, marker)
 
 	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.repairTornNodeModules("t1", wt)
+	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	out, err := os.ReadFile(marker)
 	if err != nil {
@@ -1082,7 +1116,7 @@ func TestRepairTornNodeModules_RepairsRootProject(t *testing.T) {
 	fakeNpmOnPath(t, marker)
 
 	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.repairTornNodeModules("t1", wt)
+	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	out, err := os.ReadFile(marker)
 	if err != nil {
@@ -1107,7 +1141,7 @@ func TestRepairTornNodeModules_SkipsWithoutLockfile(t *testing.T) {
 	fakeNpmOnPath(t, marker)
 
 	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.repairTornNodeModules("t1", wt)
+	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected npm ci to be skipped without lockfile, got err=%v", err)
@@ -1138,7 +1172,7 @@ func TestRepairTornNodeModules_LogsRepairFailure(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
 	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), logger)
-	engine.repairTornNodeModules("t1", wt)
+	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if !strings.Contains(logBuf.String(), "workflow.verify-checks.npm-repair-failed") {
 		t.Fatalf("expected failed npm repair to be logged, got %q", logBuf.String())
@@ -1180,7 +1214,7 @@ esac
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.repairTornNodeModules("t1", wt)
+	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if _, err := os.Stat(lifecycleMarker); !os.IsNotExist(err) {
 		t.Fatalf("repair ran package lifecycle script marker; err = %v", err)
@@ -1208,7 +1242,7 @@ func TestRepairTornNodeModules_SkipsWhenHealthy(t *testing.T) {
 	fakeNpmOnPath(t, marker)
 
 	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.repairTornNodeModules("t1", wt)
+	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Errorf("expected npm ci NOT to run for a healthy install (no lockfile to compare), marker err = %v", err)

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -66,6 +66,85 @@ func TestExecVerifyChecks_NoCommandsSkips(t *testing.T) {
 	}
 }
 
+func TestVerifyTaskNow_NoGetterNotVerified(t *testing.T) {
+	t.Parallel()
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
+
+	verified, passed, _, _, err := engine.VerifyTaskNow(t.Context(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verified || passed {
+		t.Fatalf("verified=%v passed=%v, want both false with no CheckConfigGetter", verified, passed)
+	}
+}
+
+func TestVerifyTaskNow_NoCommandsNotVerified(t *testing.T) {
+	t.Parallel()
+	engine, _ := newVerifyChecksEngine(t, t.TempDir(), nil)
+
+	verified, passed, _, _, err := engine.VerifyTaskNow(t.Context(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verified || passed {
+		t.Fatalf("verified=%v passed=%v, want both false with no configured commands", verified, passed)
+	}
+}
+
+func TestVerifyTaskNow_NoWorktreeNotVerified(t *testing.T) {
+	t.Parallel()
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
+	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: []string{"true"}})
+
+	verified, passed, _, _, err := engine.VerifyTaskNow(t.Context(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verified || passed {
+		t.Fatalf("verified=%v passed=%v, want both false with no worktree", verified, passed)
+	}
+}
+
+func TestVerifyTaskNow_CommandsPass(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, _ := newVerifyChecksEngine(t, wt, []string{"true", "echo ok"})
+
+	verified, passed, failedCmd, _, err := engine.VerifyTaskNow(t.Context(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verified || !passed {
+		t.Fatalf("verified=%v passed=%v, want both true", verified, passed)
+	}
+	if failedCmd != "" {
+		t.Errorf("failedCmd = %q, want empty", failedCmd)
+	}
+}
+
+func TestVerifyTaskNow_CommandFails(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, _ := newVerifyChecksEngine(t, wt, []string{"true", "false"})
+
+	verified, passed, failedCmd, output, err := engine.VerifyTaskNow(t.Context(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !verified || passed {
+		t.Fatalf("verified=%v passed=%v, want verified=true passed=false", verified, passed)
+	}
+	if failedCmd != "false" {
+		t.Errorf("failedCmd = %q, want %q", failedCmd, "false")
+	}
+	if !strings.Contains(output, "false") {
+		t.Errorf("output = %q, want it to contain the failing command", output)
+	}
+}
+
 func TestExecVerifyChecks_PassIsClean(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})


### PR DESCRIPTION
## Motivation

Umbrella #2004's children `8fa93c76`, `6656dc57`, `2d6793b6`, `d0f6ff89` were escalated to `human-required` with reasons like `watchdog: Agent re-running failing test \`go test ./cmd/sybra-cli\`...` — the cheap-model judge's free-text classification of a loop, taken at face value. Re-running the exact cited command manually succeeded; there was no real blocker (#2147). The judge's own prompt biases it toward leaving `ReasonKind` empty (`""`) whenever reward-hacking is merely possible rather than confidently pick `generic_stall` — so an unclassified verdict is exactly the ambiguous case a stale/wrong stop lands in, and today it escalates straight to `human-required` alongside confident `reward_hacking` verdicts, with zero re-verification of anything the judge cites.

## Implementation information

Exports `Engine.VerifyTaskNow` (`internal/workflow`) to re-run a task's configured verify commands on demand, wired into the watchdog via a new dependency-injected `verifyNow` func on `Watchdog` (same pattern as the existing `stopAgent`/`nudgeAgent` deps). `applyVerdict`'s "stop" branch now checks: `ReasonKind == ""` on a loop/budget trigger → re-verify before deciding. `generic_stall` and `reward_hacking` behavior is completely unchanged — this only touches the genuinely ambiguous case.

- Verify passes → retryable "watchdog hang" instead of `human-required` (same treatment as a `generic_stall` false alarm).
- Verify still fails → escalate to `human-required`, but with the fresh failing command + output instead of the judge's stale free-text reason.
- Nothing to verify (no worktree, no configured verify commands, dependency not wired) → falls through to today's unconditional escalation.

**Two blockers surfaced by adversarial pre-PR review, both fixed in a second commit:**
1. The verify re-run raced the still-alive agent process in the same worktree — the original code wrote status and started verify before the agent was actually stopped (`stopAgent` is a fire-and-forget signal, not a wait). Fixed by extracting `stopAndVerifyAmbiguousLoop`, which writes an interim status, then stops-and-waits via a new `killAgentsForTask` dependency (`agent.Manager.KillAgentsForTask`, blocks until the process exits or a 10s timeout) before running verify.
2. `VerifyTaskNow` skipped the node_modules repair `execVerifyChecks` already does before running verify — which would have reintroduced the exact false-positive class this fix targets (a torn/corrupt npm install failing verify for toolchain reasons, misread as a real defect). Fixed by threading `ctx` through `repairTornNodeModules`/`repairTornNodeModulesInDir` (previously only used the engine's own long-lived context) and adding both repair calls to `VerifyTaskNow`, matching `execVerifyChecks`'s order.

Independently re-verified both fixes hold under real (non-instant, non-mocked) conditions before opening this PR: a real OS subprocess trapping SIGINT and a real `agent.Manager.KillAgentsForTask` correctly rode out the actual SIGINT-grace window before the verify re-run started, and a real git worktree with a torn `node_modules` was correctly repaired end-to-end through `Watchdog.applyVerdict` rather than falsely escalating.

## Open questions

`verifyNowTimeout` (5 min) is a fixed constant, shorter than the project's own configurable verify budget (10 min default, higher via `SetVerifyTimeout`). A legitimately slow-but-healthy verify suite could hit this internal timeout and fall back to the original stale judge reason with no indication a timeout — not real project state — caused it. Didn't wire this to `config.WatchdogConfig` to keep this PR's scope to the incident it fixes; flagging in case a follow-up wants it configurable.

Closes #2155

> Changelog: fix(watchdog): verify before escalating loop stops