### PR TITLE
fix(stats): stop counting stalls as failures

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -380,7 +380,7 @@ func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {
 	fmt.Printf("evaluation (%dd window): landed=%d merged=%d merged_with_edits=%d closed=%d\n",
 		int(o.WindowDays), o.TasksLanded, o.Merged, o.MergedWithEdits, o.Closed)
 	fmt.Printf("  autonomy=%.0f%%  ci-first-pass=%.0f%%  failure=%.0f%% (%d/%d resolved runs)  change-failure=%.0f%% (%d reverted)  rework_tasks=%d\n",
-		o.AutonomyRate*100, o.CIFirstPassRate*100, o.FailureRate*100, o.AgentFailures, o.AgentRuns-o.AgentStalls,
+		o.AutonomyRate*100, o.CIFirstPassRate*100, o.FailureRate*100, o.AgentFailures, o.AgentResolvedRuns,
 		o.ChangeFailureRate*100, o.Reverted, o.ReworkTasks)
 	fmt.Printf("  runs=%d  stalled=%d (retried, excluded from failure rate)\n", o.AgentRuns, o.AgentStalls)
 	fmt.Printf("  lead p50/p90=%.1f/%.1fh  cycle p50/p90=%.1f/%.1fh\n",

--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -379,8 +379,10 @@ func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {
 	o := report.Overall
 	fmt.Printf("evaluation (%dd window): landed=%d merged=%d merged_with_edits=%d closed=%d\n",
 		int(o.WindowDays), o.TasksLanded, o.Merged, o.MergedWithEdits, o.Closed)
-	fmt.Printf("  autonomy=%.0f%%  ci-first-pass=%.0f%%  failure=%.0f%%  change-failure=%.0f%% (%d reverted)  rework_tasks=%d\n",
-		o.AutonomyRate*100, o.CIFirstPassRate*100, o.FailureRate*100, o.ChangeFailureRate*100, o.Reverted, o.ReworkTasks)
+	fmt.Printf("  autonomy=%.0f%%  ci-first-pass=%.0f%%  failure=%.0f%% (%d/%d resolved runs)  change-failure=%.0f%% (%d reverted)  rework_tasks=%d\n",
+		o.AutonomyRate*100, o.CIFirstPassRate*100, o.FailureRate*100, o.AgentFailures, o.AgentRuns-o.AgentStalls,
+		o.ChangeFailureRate*100, o.Reverted, o.ReworkTasks)
+	fmt.Printf("  runs=%d  stalled=%d (retried, excluded from failure rate)\n", o.AgentRuns, o.AgentStalls)
 	fmt.Printf("  lead p50/p90=%.1f/%.1fh  cycle p50/p90=%.1f/%.1fh\n",
 		o.LeadTimeP50H, o.LeadTimeP90H, o.CycleTimeP50H, o.CycleTimeP90H)
 	fmt.Printf("  cost=$%.2f ($%.2f/landed)  turns/landed=%.1f  tools/landed=%.1f\n",

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -14,11 +14,15 @@ import * as abtest$0 from "../abtest/models.js";
  * reliability metrics derivable from stats run records. Landing-derived metrics
  * (autonomy, throughput) are not broken down because task.landed events don't
  * carry provider/role/project yet — see Report.Notes.
+ * Runs counts every run in the group (stalls included — they burn real
+ * wall-clock and spend). Stalled counts the retried subset, and FailureRate
+ * divides by Runs-Stalled so a stall-prone provider cannot look reliable.
  */
 export class Breakdown {
     "key": string;
     "runs": number;
     "failures": number;
+    "stalled": number;
     "failureRate": number;
     "totalCostUsd": number;
     "turns": number;
@@ -34,6 +38,9 @@ export class Breakdown {
         }
         if (!("failures" in $$source)) {
             this["failures"] = 0;
+        }
+        if (!("stalled" in $$source)) {
+            this["stalled"] = 0;
         }
         if (!("failureRate" in $$source)) {
             this["failureRate"] = 0;
@@ -73,6 +80,7 @@ export class ComparisonBreakdown {
     "subject"?: abtest$0.Subject | null;
     "runs": number;
     "failures": number;
+    "stalled": number;
     "failureRate": number;
     "failureEstimate": RateEstimate;
     "landed": number;
@@ -119,6 +127,9 @@ export class ComparisonBreakdown {
         }
         if (!("failures" in $$source)) {
             this["failures"] = 0;
+        }
+        if (!("stalled" in $$source)) {
+            this["stalled"] = 0;
         }
         if (!("failureRate" in $$source)) {
             this["failureRate"] = 0;
@@ -213,41 +224,41 @@ export class ComparisonBreakdown {
      */
     static createFrom($$source: any = {}): ComparisonBreakdown {
         const $$createField9_0 = $$createType1;
-        const $$createField13_0 = $$createType2;
-        const $$createField15_0 = $$createType2;
-        const $$createField24_0 = $$createType2;
+        const $$createField14_0 = $$createType2;
+        const $$createField16_0 = $$createType2;
         const $$createField25_0 = $$createType2;
         const $$createField26_0 = $$createType2;
         const $$createField27_0 = $$createType2;
         const $$createField28_0 = $$createType2;
-        const $$createField43_0 = $$createType4;
+        const $$createField29_0 = $$createType2;
+        const $$createField44_0 = $$createType4;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("subject" in $$parsedSource) {
             $$parsedSource["subject"] = $$createField9_0($$parsedSource["subject"]);
         }
         if ("failureEstimate" in $$parsedSource) {
-            $$parsedSource["failureEstimate"] = $$createField13_0($$parsedSource["failureEstimate"]);
+            $$parsedSource["failureEstimate"] = $$createField14_0($$parsedSource["failureEstimate"]);
         }
         if ("landedEstimate" in $$parsedSource) {
-            $$parsedSource["landedEstimate"] = $$createField15_0($$parsedSource["landedEstimate"]);
+            $$parsedSource["landedEstimate"] = $$createField16_0($$parsedSource["landedEstimate"]);
         }
         if ("mergeEstimate" in $$parsedSource) {
-            $$parsedSource["mergeEstimate"] = $$createField24_0($$parsedSource["mergeEstimate"]);
+            $$parsedSource["mergeEstimate"] = $$createField25_0($$parsedSource["mergeEstimate"]);
         }
         if ("ciFirstPassEstimate" in $$parsedSource) {
-            $$parsedSource["ciFirstPassEstimate"] = $$createField25_0($$parsedSource["ciFirstPassEstimate"]);
+            $$parsedSource["ciFirstPassEstimate"] = $$createField26_0($$parsedSource["ciFirstPassEstimate"]);
         }
         if ("mergedWithEditsEstimate" in $$parsedSource) {
-            $$parsedSource["mergedWithEditsEstimate"] = $$createField26_0($$parsedSource["mergedWithEditsEstimate"]);
+            $$parsedSource["mergedWithEditsEstimate"] = $$createField27_0($$parsedSource["mergedWithEditsEstimate"]);
         }
         if ("reworkEstimate" in $$parsedSource) {
-            $$parsedSource["reworkEstimate"] = $$createField27_0($$parsedSource["reworkEstimate"]);
+            $$parsedSource["reworkEstimate"] = $$createField28_0($$parsedSource["reworkEstimate"]);
         }
         if ("revertEstimate" in $$parsedSource) {
-            $$parsedSource["revertEstimate"] = $$createField28_0($$parsedSource["revertEstimate"]);
+            $$parsedSource["revertEstimate"] = $$createField29_0($$parsedSource["revertEstimate"]);
         }
         if ("roleBreakdowns" in $$parsedSource) {
-            $$parsedSource["roleBreakdowns"] = $$createField43_0($$parsedSource["roleBreakdowns"]);
+            $$parsedSource["roleBreakdowns"] = $$createField44_0($$parsedSource["roleBreakdowns"]);
         }
         return new ComparisonBreakdown($$parsedSource as Partial<ComparisonBreakdown>);
     }
@@ -674,10 +685,14 @@ export class Scorecard {
     "autonomyRate": number;
 
     /**
-     * Reliability (from stats run outcomes).
+     * Reliability (from stats run outcomes). AgentStalls counts runs that were
+     * retried rather than resolved (stats.OutcomeStalled); they are excluded
+     * from FailureRate's numerator and denominator alike, so the rate is
+     * failures over runs that actually reached a result.
      */
     "agentRuns": number;
     "agentFailures": number;
+    "agentStalls": number;
     "failureRate": number;
 
     /**
@@ -754,6 +769,9 @@ export class Scorecard {
         }
         if (!("agentFailures" in $$source)) {
             this["agentFailures"] = 0;
+        }
+        if (!("agentStalls" in $$source)) {
+            this["agentStalls"] = 0;
         }
         if (!("failureRate" in $$source)) {
             this["failureRate"] = 0;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -14,15 +14,22 @@ import * as abtest$0 from "../abtest/models.js";
  * reliability metrics derivable from stats run records. Landing-derived metrics
  * (autonomy, throughput) are not broken down because task.landed events don't
  * carry provider/role/project yet — see Report.Notes.
- * Runs counts every run in the group (stalls included — they burn real
- * wall-clock and spend). Stalled counts the retried subset, and FailureRate
- * divides by ResolvedRuns so a stall-prone provider cannot look reliable.
+ * 
+ * Every dispatch counts toward Runs, stalls included, since they burn real
+ * wall-clock and spend. FailureRate divides by ResolvedRuns instead — the only
+ * honest denominator, and the only honest sample count for gating on it: a
+ * stall carries no signal about the subject's quality, so 29 stalls and 1
+ * failure is a sample of one, not 30. Anything that rates or gates on failures
+ * must agree on that population, or a rate and its own sufficiency check end up
+ * measuring different things. Resolved runs are counted rather than derived by
+ * subtracting stalls, so a run with an unknown outcome lands in neither.
  */
 export class Breakdown {
     "key": string;
     "runs": number;
     "failures": number;
     "stalled": number;
+    "resolvedRuns": number;
     "failureRate": number;
     "totalCostUsd": number;
     "turns": number;
@@ -41,6 +48,9 @@ export class Breakdown {
         }
         if (!("stalled" in $$source)) {
             this["stalled"] = 0;
+        }
+        if (!("resolvedRuns" in $$source)) {
+            this["resolvedRuns"] = 0;
         }
         if (!("failureRate" in $$source)) {
             this["failureRate"] = 0;
@@ -81,6 +91,7 @@ export class ComparisonBreakdown {
     "runs": number;
     "failures": number;
     "stalled": number;
+    "resolvedRuns": number;
     "failureRate": number;
     "failureEstimate": RateEstimate;
     "landed": number;
@@ -130,6 +141,9 @@ export class ComparisonBreakdown {
         }
         if (!("stalled" in $$source)) {
             this["stalled"] = 0;
+        }
+        if (!("resolvedRuns" in $$source)) {
+            this["resolvedRuns"] = 0;
         }
         if (!("failureRate" in $$source)) {
             this["failureRate"] = 0;
@@ -224,41 +238,41 @@ export class ComparisonBreakdown {
      */
     static createFrom($$source: any = {}): ComparisonBreakdown {
         const $$createField9_0 = $$createType1;
-        const $$createField14_0 = $$createType2;
-        const $$createField16_0 = $$createType2;
-        const $$createField25_0 = $$createType2;
+        const $$createField15_0 = $$createType2;
+        const $$createField17_0 = $$createType2;
         const $$createField26_0 = $$createType2;
         const $$createField27_0 = $$createType2;
         const $$createField28_0 = $$createType2;
         const $$createField29_0 = $$createType2;
-        const $$createField44_0 = $$createType4;
+        const $$createField30_0 = $$createType2;
+        const $$createField45_0 = $$createType4;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("subject" in $$parsedSource) {
             $$parsedSource["subject"] = $$createField9_0($$parsedSource["subject"]);
         }
         if ("failureEstimate" in $$parsedSource) {
-            $$parsedSource["failureEstimate"] = $$createField14_0($$parsedSource["failureEstimate"]);
+            $$parsedSource["failureEstimate"] = $$createField15_0($$parsedSource["failureEstimate"]);
         }
         if ("landedEstimate" in $$parsedSource) {
-            $$parsedSource["landedEstimate"] = $$createField16_0($$parsedSource["landedEstimate"]);
+            $$parsedSource["landedEstimate"] = $$createField17_0($$parsedSource["landedEstimate"]);
         }
         if ("mergeEstimate" in $$parsedSource) {
-            $$parsedSource["mergeEstimate"] = $$createField25_0($$parsedSource["mergeEstimate"]);
+            $$parsedSource["mergeEstimate"] = $$createField26_0($$parsedSource["mergeEstimate"]);
         }
         if ("ciFirstPassEstimate" in $$parsedSource) {
-            $$parsedSource["ciFirstPassEstimate"] = $$createField26_0($$parsedSource["ciFirstPassEstimate"]);
+            $$parsedSource["ciFirstPassEstimate"] = $$createField27_0($$parsedSource["ciFirstPassEstimate"]);
         }
         if ("mergedWithEditsEstimate" in $$parsedSource) {
-            $$parsedSource["mergedWithEditsEstimate"] = $$createField27_0($$parsedSource["mergedWithEditsEstimate"]);
+            $$parsedSource["mergedWithEditsEstimate"] = $$createField28_0($$parsedSource["mergedWithEditsEstimate"]);
         }
         if ("reworkEstimate" in $$parsedSource) {
-            $$parsedSource["reworkEstimate"] = $$createField28_0($$parsedSource["reworkEstimate"]);
+            $$parsedSource["reworkEstimate"] = $$createField29_0($$parsedSource["reworkEstimate"]);
         }
         if ("revertEstimate" in $$parsedSource) {
-            $$parsedSource["revertEstimate"] = $$createField29_0($$parsedSource["revertEstimate"]);
+            $$parsedSource["revertEstimate"] = $$createField30_0($$parsedSource["revertEstimate"]);
         }
         if ("roleBreakdowns" in $$parsedSource) {
-            $$parsedSource["roleBreakdowns"] = $$createField44_0($$parsedSource["roleBreakdowns"]);
+            $$parsedSource["roleBreakdowns"] = $$createField45_0($$parsedSource["roleBreakdowns"]);
         }
         return new ComparisonBreakdown($$parsedSource as Partial<ComparisonBreakdown>);
     }
@@ -689,14 +703,16 @@ export class Scorecard {
     "autonomyRate": number;
 
     /**
-     * Reliability (from stats run outcomes). AgentStalls counts runs that were
-     * retried rather than resolved (stats.OutcomeStalled); they are excluded
-     * from FailureRate's numerator and denominator alike, so the rate is
-     * failures over runs that actually reached a result.
+     * Reliability (from stats run outcomes). AgentRuns counts every run;
+     * AgentStalls the retried subset (stats.OutcomeStalled); AgentResolvedRuns
+     * those that reached a definitive result, which is FailureRate's
+     * denominator. The three are counted independently, so runs with an unknown
+     * outcome are in AgentRuns alone and never reach a rate.
      */
     "agentRuns": number;
     "agentFailures": number;
     "agentStalls": number;
+    "agentResolvedRuns": number;
     "failureRate": number;
 
     /**
@@ -776,6 +792,9 @@ export class Scorecard {
         }
         if (!("agentStalls" in $$source)) {
             this["agentStalls"] = 0;
+        }
+        if (!("agentResolvedRuns" in $$source)) {
+            this["agentResolvedRuns"] = 0;
         }
         if (!("failureRate" in $$source)) {
             this["failureRate"] = 0;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -360,6 +360,7 @@ export class ExperimentSampleStatus {
     "variants": VariantSampleStatus[];
     "readyVariants": number;
     "totalRuns": number;
+    "totalResolvedRuns": number;
     "status": string;
 
     /** Creates a new ExperimentSampleStatus instance. */
@@ -384,6 +385,9 @@ export class ExperimentSampleStatus {
         }
         if (!("totalRuns" in $$source)) {
             this["totalRuns"] = 0;
+        }
+        if (!("totalResolvedRuns" in $$source)) {
+            this["totalResolvedRuns"] = 0;
         }
         if (!("status" in $$source)) {
             this["status"] = "";
@@ -853,10 +857,16 @@ export class TaskPhases {
 /**
  * VariantSampleStatus describes whether one configured or observed A/B variant
  * has enough samples for the configured minimum.
+ * 
+ * Runs counts dispatches, matching Breakdown.Runs — "runs" means the same
+ * population in every struct in this package. ResolvedRuns is what Ready gates
+ * on, so a variant that stalled away most of its dispatches reads as
+ * observed-but-not-ready rather than as never dispatched.
  */
 export class VariantSampleStatus {
     "variantId": string;
     "runs": number;
+    "resolvedRuns": number;
     "ready": boolean;
     "configured": boolean;
     "observed": boolean;
@@ -869,6 +879,9 @@ export class VariantSampleStatus {
         }
         if (!("runs" in $$source)) {
             this["runs"] = 0;
+        }
+        if (!("resolvedRuns" in $$source)) {
+            this["resolvedRuns"] = 0;
         }
         if (!("ready" in $$source)) {
             this["ready"] = false;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -16,7 +16,7 @@ import * as abtest$0 from "../abtest/models.js";
  * carry provider/role/project yet — see Report.Notes.
  * Runs counts every run in the group (stalls included — they burn real
  * wall-clock and spend). Stalled counts the retried subset, and FailureRate
- * divides by Runs-Stalled so a stall-prone provider cannot look reliable.
+ * divides by ResolvedRuns so a stall-prone provider cannot look reliable.
  */
 export class Breakdown {
     "key": string;

--- a/frontend/src/components/ExperimentGroup.svelte
+++ b/frontend/src/components/ExperimentGroup.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { interpretExperiment } from '$lib/evaluation-interpretation.js'
   import {
+    estimateBasis,
     guardrailClasses,
     num,
     rateCell,
@@ -138,6 +139,9 @@
                     <td class="py-1.5 text-xs font-medium">All roles</td>
                     <td class="py-1.5 text-right">
                       {row.runs}
+                      {#if row.stalled > 0}
+                        <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700" title="retried, excluded from the failure rate">{row.stalled} stalled</span>
+                      {/if}
                       {#if rowState(row)}
                         <span class="ml-1 rounded px-1 text-[10px] {sampleClasses(row.sampleStatus)} {isDominantSample(row) ? 'experiment-caveat--dominant' : ''}">{rowState(row)}</span>
                       {:else if row.insufficientData}
@@ -154,7 +158,7 @@
                         {row.landed} · {rateCell(row, 'landedEstimate', undefined, true)}
                       {/if}
                     </td>
-                    <td class="py-1.5 text-right text-xs">{rateCell(row, 'failureEstimate', row.failureRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs" title={estimateBasis(row, 'failureEstimate')}>{rateCell(row, 'failureEstimate', row.failureRate, true)}</td>
                     <td class="py-1.5 text-right text-xs">{rateCell(row, 'mergeEstimate', row.mergeRate, true)}</td>
                     <td class="py-1.5 text-right text-xs">{rateCell(row, 'ciFirstPassEstimate', row.ciFirstPassRate, true)}</td>
                     <td class="py-1.5 text-right text-xs">{rateCell(row, 'mergedWithEditsEstimate', row.mergedWithEditsRate, true)}</td>
@@ -194,6 +198,9 @@
                       <td class="py-1.5 text-xs">{child.role || '—'}</td>
                       <td class="py-1.5 text-right">
                         {child.runs}
+                        {#if child.stalled > 0}
+                          <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700" title="retried, excluded from the failure rate">{child.stalled} stalled</span>
+                        {/if}
                         {#if rowState(child)}
                           <span class="ml-1 rounded px-1 text-[10px] {sampleClasses(child.sampleStatus)} {isDominantSample(child) ? 'experiment-caveat--dominant' : ''}">{rowState(child)}</span>
                         {:else if child.insufficientData}
@@ -210,7 +217,7 @@
                           {child.landed} · {rateCell(child, 'landedEstimate', undefined, true)}
                         {/if}
                       </td>
-                      <td class="py-1.5 text-right text-xs">{rateCell(child, 'failureEstimate', child.failureRate, true)}</td>
+                      <td class="py-1.5 text-right text-xs" title={estimateBasis(child, 'failureEstimate')}>{rateCell(child, 'failureEstimate', child.failureRate, true)}</td>
                       <td class="py-1.5 text-right text-xs">{rateCell(child, 'mergeEstimate', child.mergeRate, true)}</td>
                       <td class="py-1.5 text-right text-xs">{rateCell(child, 'ciFirstPassEstimate', child.ciFirstPassRate, true)}</td>
                       <td class="py-1.5 text-right text-xs">{rateCell(child, 'mergedWithEditsEstimate', child.mergedWithEditsRate, true)}</td>

--- a/frontend/src/lib/agent-run.test.ts
+++ b/frontend/src/lib/agent-run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { runStateClasses, runRoleLabel, runRoleClasses } from './agent-run.js'
+import { runStateClasses, runOutcomeClasses, runRoleLabel, runRoleClasses } from './agent-run.js'
 
 describe('runStateClasses', () => {
   // The actual persisted terminal state for finished runs — must be neutral,
@@ -31,6 +31,24 @@ describe('runStateClasses', () => {
   it('falls back to neutral grey for unknown states', () => {
     expect(runStateClasses('mystery')).toMatch(/surface/)
     expect(runStateClasses('mystery')).not.toMatch(/primary/)
+  })
+})
+
+describe('runOutcomeClasses', () => {
+  it('renders a completed run green', () => {
+    expect(runOutcomeClasses('completed')).toMatch(/success/)
+  })
+
+  // A stall was retried, not failed (#2149) — dressing it in the failure colour
+  // is the UI half of the same miscount that broke the failure rate.
+  it('renders a stalled run neutral, never the failure colour', () => {
+    const cls = runOutcomeClasses('stalled')
+    expect(cls).toMatch(/surface/)
+    expect(cls).not.toMatch(/error/)
+  })
+
+  it('renders a failed run coral', () => {
+    expect(runOutcomeClasses('failed')).toMatch(/error/)
   })
 })
 

--- a/frontend/src/lib/agent-run.ts
+++ b/frontend/src/lib/agent-run.ts
@@ -22,6 +22,22 @@ export function runStateClasses(state: string): string {
   }
 }
 
+// Treatment for a stats run record's outcome pill.
+//
+// "stalled" is neither a success nor a failure — the run never produced a
+// result and Sybra retried it — so it reads neutral grey rather than the error
+// coral it wore while stalls were miscounted as failures.
+export function runOutcomeClasses(outcome: string): string {
+  switch (outcome) {
+    case 'completed':
+      return 'bg-success-200 text-success-800 dark:bg-success-800 dark:text-success-200'
+    case 'stalled':
+      return 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-300'
+    default:
+      return 'bg-error-200 text-error-800 dark:bg-error-800 dark:text-error-200'
+  }
+}
+
 // Human-readable label for an agent run's pipeline role (AgentRun.role). Roles
 // are the lowercase technical values the backend persists (see
 // internal/agent/role.go and lib/agent-name.ts). An empty/absent role carries

--- a/frontend/src/lib/evaluation-format.ts
+++ b/frontend/src/lib/evaluation-format.ts
@@ -3,6 +3,8 @@
 // exact same rate/percent/duration formatting without drifting.
 
 export type RateEstimateLike = {
+  numerator?: number
+  denominator?: number
   point?: number
   wilsonLower?: number
   wilsonUpper?: number
@@ -79,6 +81,15 @@ export function rateCell(row: ComparisonRowLike, key: EstimateKey, fallback: num
   const interval = estimateInterval(row, key)
   const delta = showDelta ? estimateDelta(row, key) : ''
   return [estimatePct(row, key, fallback), interval ? `CI ${interval}` : '', delta].filter(Boolean).join(' · ')
+}
+
+// Spells out the population a rate was actually computed over. A failure rate
+// is rated over resolved runs, which is smaller than the Runs column whenever a
+// variant stalled — without this the two numbers read as a contradiction.
+export function estimateBasis(row: ComparisonRowLike, key: EstimateKey): string {
+  const est = estimate(row, key)
+  if (!est?.hasData) return ''
+  return `${est.numerator ?? 0}/${est.denominator ?? 0} resolved runs`
 }
 
 export function verdictClasses(verdict: string): string {

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -124,7 +124,7 @@
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Failure rate</span>
         <p class="mt-1 text-2xl font-bold {goodScale(1 - o.failureRate)}">{pct(o.failureRate)}</p>
-        <p class="mt-0.5 text-xs text-surface-400">{o.agentFailures}/{o.agentRuns} runs · {o.reverted} reverted ({pct(o.changeFailureRate)})</p>
+        <p class="mt-0.5 text-xs text-surface-400">{o.agentFailures}/{o.agentRuns - o.agentStalls} resolved runs · {o.agentStalls} stalled · {o.reverted} reverted ({pct(o.changeFailureRate)})</p>
       </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Cost / landed</span>
@@ -272,6 +272,7 @@
                 <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
                   <th class="pb-2">Name</th>
                   <th class="pb-2 text-right">Runs</th>
+                  <th class="pb-2 text-right">Stalled</th>
                   <th class="pb-2 text-right">Fail %</th>
                   <th class="pb-2 text-right">Cost</th>
                   <th class="pb-2 text-right">Turns</th>
@@ -283,7 +284,8 @@
                   <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
                     <td class="py-1.5 font-mono text-xs">{row.key}</td>
                     <td class="py-1.5 text-right">{row.runs}</td>
-                    <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
+                    <td class="py-1.5 text-right text-surface-400">{row.stalled}</td>
+                    <td class="py-1.5 text-right" title="{row.failures}/{row.runs - row.stalled} resolved runs">{pct(row.failureRate)}</td>
                     <td class="py-1.5 text-right">${row.totalCostUsd.toFixed(2)}</td>
                     <td class="py-1.5 text-right text-surface-400">{row.turns}</td>
                     <td class="py-1.5 text-right text-surface-400">{row.tools}</td>

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -124,7 +124,7 @@
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Failure rate</span>
         <p class="mt-1 text-2xl font-bold {goodScale(1 - o.failureRate)}">{pct(o.failureRate)}</p>
-        <p class="mt-0.5 text-xs text-surface-400">{o.agentFailures}/{o.agentRuns - o.agentStalls} resolved runs · {o.agentStalls} stalled · {o.reverted} reverted ({pct(o.changeFailureRate)})</p>
+        <p class="mt-0.5 text-xs text-surface-400">{o.agentFailures}/{o.agentResolvedRuns} resolved runs · {o.agentStalls} stalled · {o.reverted} reverted ({pct(o.changeFailureRate)})</p>
       </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Cost / landed</span>
@@ -285,7 +285,7 @@
                     <td class="py-1.5 font-mono text-xs">{row.key}</td>
                     <td class="py-1.5 text-right">{row.runs}</td>
                     <td class="py-1.5 text-right text-surface-400">{row.stalled}</td>
-                    <td class="py-1.5 text-right" title="{row.failures}/{row.runs - row.stalled} resolved runs">{pct(row.failureRate)}</td>
+                    <td class="py-1.5 text-right" title="{row.failures}/{row.resolvedRuns} resolved runs">{pct(row.failureRate)}</td>
                     <td class="py-1.5 text-right">${row.totalCostUsd.toFixed(2)}</td>
                     <td class="py-1.5 text-right text-surface-400">{row.turns}</td>
                     <td class="py-1.5 text-right text-surface-400">{row.tools}</td>

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -7,6 +7,7 @@
     closedTasksSeries,
     type StatsPeriod,
   } from '$lib/stats-charts.js'
+  import { runOutcomeClasses } from '$lib/agent-run.js'
   import StatsLineChart from '../components/stats/StatsLineChart.svelte'
   import StatsBarChart from '../components/stats/StatsBarChart.svelte'
 
@@ -358,9 +359,7 @@
                   <td class="py-1.5 text-right text-xs">{formatDuration(run.durationS)}</td>
                   <td class="py-1.5 text-right text-xs text-surface-400">{run.reasoningTokens ? formatTokens(run.reasoningTokens) : '—'}</td>
                   <td class="py-1.5">
-                    <span class="rounded px-1.5 py-0.5 text-xs {run.outcome === 'completed'
-                      ? 'bg-success-200 text-success-800 dark:bg-success-800 dark:text-success-200'
-                      : 'bg-error-200 text-error-800 dark:bg-error-800 dark:text-error-200'}">
+                    <span class="rounded px-1.5 py-0.5 text-xs {runOutcomeClasses(run.outcome)}">
                       {run.outcome}
                     </span>
                   </td>

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -67,7 +67,7 @@ type Scorecard struct {
 // carry provider/role/project yet — see Report.Notes.
 // Runs counts every run in the group (stalls included — they burn real
 // wall-clock and spend). Stalled counts the retried subset, and FailureRate
-// divides by Runs-Stalled so a stall-prone provider cannot look reliable.
+// divides by ResolvedRuns so a stall-prone provider cannot look reliable.
 type Breakdown struct {
 	Key          string  `json:"key"`
 	Runs         int     `json:"runs"`
@@ -78,6 +78,15 @@ type Breakdown struct {
 	Turns        int     `json:"turns"`
 	Tools        int     `json:"tools"`
 }
+
+// ResolvedRuns counts runs that reached a definitive outcome.
+//
+// It is both the only honest denominator for a failure rate and the only
+// honest sample count for gating on one: a stall carries no signal about the
+// subject's quality, so 29 stalls and 1 failure is a sample of one, not 30.
+// Anything that rates or gates on failures must use this rather than Runs, or
+// the rate and its sufficiency check end up measuring different populations.
+func (b Breakdown) ResolvedRuns() int { return b.Runs - b.Stalled }
 
 // ComparisonBreakdown compares agent/model or experiment variants on the
 // speed, quality, and cost signals Sybra already records.
@@ -135,6 +144,11 @@ type ComparisonBreakdown struct {
 	MinSamplesPerVariant      int                   `json:"minSamplesPerVariant,omitempty"`
 	RoleBreakdowns            []ComparisonBreakdown `json:"roleBreakdowns,omitempty"`
 }
+
+// ResolvedRuns counts runs that reached a definitive outcome — see
+// Breakdown.ResolvedRuns for why failure rating and sample gating must agree
+// on this denominator rather than Runs.
+func (c ComparisonBreakdown) ResolvedRuns() int { return c.Runs - c.Stalled }
 
 // RateEstimate is a binomial rate with fixed 95% Wilson uncertainty and an
 // optional effect delta relative to an A/B baseline row.
@@ -477,7 +491,7 @@ func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(sta
 	out := make([]Breakdown, 0, len(groups))
 	for k, a := range groups {
 		b := Breakdown{Key: k, Runs: a.runs, Failures: a.fails, Stalled: a.stalls, TotalCostUSD: a.cost, Turns: a.turns, Tools: a.tools}
-		if resolved := a.runs - a.stalls; resolved > 0 {
+		if resolved := b.ResolvedRuns(); resolved > 0 {
 			b.FailureRate = float64(a.fails) / float64(resolved)
 		}
 		out = append(out, b)
@@ -891,7 +905,7 @@ func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []Comparis
 		row := a.row
 		// Landing stays rated over all runs (a stall still consumed a dispatch
 		// of this variant); only the failure rate drops the retried ones.
-		row.FailureEstimate = wilson95(row.Failures, row.Runs-row.Stalled)
+		row.FailureEstimate = wilson95(row.Failures, row.ResolvedRuns())
 		row.LandedEstimate = wilson95(row.Landed, row.Runs)
 		row.MergeEstimate = wilson95(row.Merged, row.Landed)
 		row.MergedWithEditsEstimate = wilson95(row.MergedWithEdits, row.Landed)
@@ -924,7 +938,9 @@ func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []Comparis
 		}
 		row.DurationP50S = percentile(a.durations, 50)
 		row.DurationP90S = percentile(a.durations, 90)
-		row.InsufficientData = minSamples > 0 && row.Runs < minSamples
+		// Gate on resolved runs, or a variant with 29 stalls and 1 failure —
+		// one data point — is declared trustworthy at a 100% failure rate.
+		row.InsufficientData = minSamples > 0 && row.ResolvedRuns() < minSamples
 		row.QualityAttributionLimited = row.Landed == 0 && row.Runs > 0
 		out = append(out, row)
 	}
@@ -1002,7 +1018,7 @@ func applyVariantSemantics(rows []ComparisonBreakdown, opts CompareOptions) []Ex
 			}
 			row.MinSamplesPerVariant = opts.MinSamples
 			row.BaselineVariantID = cfg.baselineVariantID
-			if opts.MinSamples > 0 && row.Runs < opts.MinSamples {
+			if opts.MinSamples > 0 && row.ResolvedRuns() < opts.MinSamples {
 				row.SampleStatus = "low-sample"
 			} else {
 				row.SampleStatus = "actionable"
@@ -1138,10 +1154,12 @@ func experimentSampleStatus(key string, cfg experimentRoleConfig, rows map[strin
 	}
 	for _, id := range variantIDs {
 		row := rows[id]
+		// Readiness is about decidable evidence, so it counts resolved runs —
+		// matching the row-level SampleStatus above rather than contradicting it.
 		runs := 0
 		observed := false
 		if row != nil {
-			runs = row.Runs
+			runs = row.ResolvedRuns()
 			observed = true
 		}
 		ready := minSamples <= 0 || runs >= minSamples

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -41,9 +41,13 @@ type Scorecard struct {
 	HumanTouchedLandings int     `json:"humanTouchedLandings"`
 	AutonomyRate         float64 `json:"autonomyRate"` // autonomous / landed
 
-	// Reliability (from stats run outcomes).
+	// Reliability (from stats run outcomes). AgentStalls counts runs that were
+	// retried rather than resolved (stats.OutcomeStalled); they are excluded
+	// from FailureRate's numerator and denominator alike, so the rate is
+	// failures over runs that actually reached a result.
 	AgentRuns         int     `json:"agentRuns"`
 	AgentFailures     int     `json:"agentFailures"`
+	AgentStalls       int     `json:"agentStalls"`
 	FailureRate       float64 `json:"failureRate"`
 	CIFirstPassRate   float64 `json:"ciFirstPassRate"`   // landed without a CI-fix / landed
 	Reverted          int     `json:"reverted"`          // merged landings later reverted on the default branch
@@ -61,10 +65,14 @@ type Scorecard struct {
 // reliability metrics derivable from stats run records. Landing-derived metrics
 // (autonomy, throughput) are not broken down because task.landed events don't
 // carry provider/role/project yet — see Report.Notes.
+// Runs counts every run in the group (stalls included — they burn real
+// wall-clock and spend). Stalled counts the retried subset, and FailureRate
+// divides by Runs-Stalled so a stall-prone provider cannot look reliable.
 type Breakdown struct {
 	Key          string  `json:"key"`
 	Runs         int     `json:"runs"`
 	Failures     int     `json:"failures"`
+	Stalled      int     `json:"stalled"`
 	FailureRate  float64 `json:"failureRate"`
 	TotalCostUSD float64 `json:"totalCostUsd"`
 	Turns        int     `json:"turns"`
@@ -93,6 +101,7 @@ type ComparisonBreakdown struct {
 	Subject                   *abtest.Subject       `json:"subject,omitempty"`
 	Runs                      int                   `json:"runs"`
 	Failures                  int                   `json:"failures"`
+	Stalled                   int                   `json:"stalled"`
 	FailureRate               float64               `json:"failureRate"`
 	FailureEstimate           RateEstimate          `json:"failureEstimate"`
 	Landed                    int                   `json:"landed"`
@@ -235,12 +244,12 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 
 	lg := scanLandings(events, win)
 	sigs := scanTaskSignals(events) // not window-bound: capture full task history
-	runs, fails := scanReliability(records, win)
+	runs, fails, stalls := scanReliability(records, win)
 	cost, turns, tools := scanEfficiency(records, win)
 
 	sc.TasksLanded, sc.Merged, sc.Closed = lg.count, lg.merged, lg.closed
 	sc.MergedWithEdits = lg.mergedWithEdits
-	sc.AgentRuns, sc.AgentFailures = runs, fails
+	sc.AgentRuns, sc.AgentFailures, sc.AgentStalls = runs, fails, stalls
 	sc.Reverted = countReverts(events, win, lg.tasks)
 	sc.TotalCostUSD = cost
 	autonomous, humanTouched, ciClean := classifyLanded(lg.tasks, lg.edited, sigs)
@@ -255,8 +264,8 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 		sc.TurnsPerLanded = float64(turns) / n
 		sc.ToolsPerLanded = float64(tools) / n
 	}
-	if sc.AgentRuns > 0 {
-		sc.FailureRate = float64(sc.AgentFailures) / float64(sc.AgentRuns)
+	if resolved := sc.AgentRuns - sc.AgentStalls; resolved > 0 {
+		sc.FailureRate = float64(sc.AgentFailures) / float64(resolved)
 	}
 	if mergedLandings := sc.Merged + sc.MergedWithEdits; mergedLandings > 0 {
 		sc.ChangeFailureRate = float64(sc.Reverted) / float64(mergedLandings)
@@ -361,18 +370,21 @@ func countReverts(events []audit.Event, win func(time.Time) bool, landed map[str
 	return n
 }
 
-func scanReliability(records []stats.RunRecord, win func(time.Time) bool) (runs, failures int) {
+func scanReliability(records []stats.RunRecord, win func(time.Time) bool) (runs, failures, stalls int) {
 	for i := range records {
 		r := records[i]
 		if !win(r.Timestamp) {
 			continue
 		}
 		runs++
-		if r.Outcome == "failed" {
+		switch {
+		case !stats.IsTerminalOutcome(r.Outcome):
+			stalls++
+		case r.Outcome == stats.OutcomeFailed:
 			failures++
 		}
 	}
-	return runs, failures
+	return runs, failures, stalls
 }
 
 func scanEfficiency(records []stats.RunRecord, win func(time.Time) bool) (cost float64, turns, tools int) {
@@ -433,8 +445,8 @@ func countRework(sigs map[string]*taskSignals, landed map[string]bool) int {
 // reliability per group, sorted by key. Records with an empty key are skipped.
 func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(stats.RunRecord) string) []Breakdown {
 	type acc struct {
-		runs, fails, turns, tools int
-		cost                      float64
+		runs, fails, stalls, turns, tools int
+		cost                              float64
 	}
 	groups := map[string]*acc{}
 	for i := range records {
@@ -452,7 +464,10 @@ func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(sta
 			groups[k] = a
 		}
 		a.runs++
-		if r.Outcome == "failed" {
+		switch {
+		case !stats.IsTerminalOutcome(r.Outcome):
+			a.stalls++
+		case r.Outcome == stats.OutcomeFailed:
 			a.fails++
 		}
 		a.cost += r.CostUSD
@@ -461,9 +476,9 @@ func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(sta
 	}
 	out := make([]Breakdown, 0, len(groups))
 	for k, a := range groups {
-		b := Breakdown{Key: k, Runs: a.runs, Failures: a.fails, TotalCostUSD: a.cost, Turns: a.turns, Tools: a.tools}
-		if a.runs > 0 {
-			b.FailureRate = float64(a.fails) / float64(a.runs)
+		b := Breakdown{Key: k, Runs: a.runs, Failures: a.fails, Stalled: a.stalls, TotalCostUSD: a.cost, Turns: a.turns, Tools: a.tools}
+		if resolved := a.runs - a.stalls; resolved > 0 {
+			b.FailureRate = float64(a.fails) / float64(resolved)
 		}
 		out = append(out, b)
 	}
@@ -538,7 +553,10 @@ func compareByAttribution(records []stats.RunRecord, events []audit.Event, since
 		}
 		a := ensure(r, k)
 		a.row.Runs++
-		if r.Outcome == "failed" {
+		switch {
+		case !stats.IsTerminalOutcome(r.Outcome):
+			a.row.Stalled++
+		case r.Outcome == stats.OutcomeFailed:
 			a.row.Failures++
 		}
 		a.row.TotalCostUSD += r.CostUSD
@@ -871,7 +889,9 @@ func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []Comparis
 	out := make([]ComparisonBreakdown, 0, len(groups))
 	for _, a := range groups {
 		row := a.row
-		row.FailureEstimate = wilson95(row.Failures, row.Runs)
+		// Landing stays rated over all runs (a stall still consumed a dispatch
+		// of this variant); only the failure rate drops the retried ones.
+		row.FailureEstimate = wilson95(row.Failures, row.Runs-row.Stalled)
 		row.LandedEstimate = wilson95(row.Landed, row.Runs)
 		row.MergeEstimate = wilson95(row.Merged, row.Landed)
 		row.MergedWithEditsEstimate = wilson95(row.MergedWithEdits, row.Landed)

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -43,13 +43,15 @@ type Scorecard struct {
 	HumanTouchedLandings int     `json:"humanTouchedLandings"`
 	AutonomyRate         float64 `json:"autonomyRate"` // autonomous / landed
 
-	// Reliability (from stats run outcomes). AgentStalls counts runs that were
-	// retried rather than resolved (stats.OutcomeStalled); they are excluded
-	// from FailureRate's numerator and denominator alike, so the rate is
-	// failures over runs that actually reached a result.
+	// Reliability (from stats run outcomes). AgentRuns counts every run;
+	// AgentStalls the retried subset (stats.OutcomeStalled); AgentResolvedRuns
+	// those that reached a definitive result, which is FailureRate's
+	// denominator. The three are counted independently, so runs with an unknown
+	// outcome are in AgentRuns alone and never reach a rate.
 	AgentRuns         int     `json:"agentRuns"`
 	AgentFailures     int     `json:"agentFailures"`
 	AgentStalls       int     `json:"agentStalls"`
+	AgentResolvedRuns int     `json:"agentResolvedRuns"`
 	FailureRate       float64 `json:"failureRate"`
 	CIFirstPassRate   float64 `json:"ciFirstPassRate"`   // landed without a CI-fix / landed
 	Reverted          int     `json:"reverted"`          // merged landings later reverted on the default branch
@@ -67,28 +69,26 @@ type Scorecard struct {
 // reliability metrics derivable from stats run records. Landing-derived metrics
 // (autonomy, throughput) are not broken down because task.landed events don't
 // carry provider/role/project yet — see Report.Notes.
-// Runs counts every run in the group (stalls included — they burn real
-// wall-clock and spend). Stalled counts the retried subset, and FailureRate
-// divides by ResolvedRuns so a stall-prone provider cannot look reliable.
+//
+// Every dispatch counts toward Runs, stalls included, since they burn real
+// wall-clock and spend. FailureRate divides by ResolvedRuns instead — the only
+// honest denominator, and the only honest sample count for gating on it: a
+// stall carries no signal about the subject's quality, so 29 stalls and 1
+// failure is a sample of one, not 30. Anything that rates or gates on failures
+// must agree on that population, or a rate and its own sufficiency check end up
+// measuring different things. Resolved runs are counted rather than derived by
+// subtracting stalls, so a run with an unknown outcome lands in neither.
 type Breakdown struct {
 	Key          string  `json:"key"`
 	Runs         int     `json:"runs"`
 	Failures     int     `json:"failures"`
 	Stalled      int     `json:"stalled"`
+	ResolvedRuns int     `json:"resolvedRuns"`
 	FailureRate  float64 `json:"failureRate"`
 	TotalCostUSD float64 `json:"totalCostUsd"`
 	Turns        int     `json:"turns"`
 	Tools        int     `json:"tools"`
 }
-
-// ResolvedRuns counts runs that reached a definitive outcome.
-//
-// It is both the only honest denominator for a failure rate and the only
-// honest sample count for gating on one: a stall carries no signal about the
-// subject's quality, so 29 stalls and 1 failure is a sample of one, not 30.
-// Anything that rates or gates on failures must use this rather than Runs, or
-// the rate and its sufficiency check end up measuring different populations.
-func (b Breakdown) ResolvedRuns() int { return b.Runs - b.Stalled }
 
 // ComparisonBreakdown compares agent/model or experiment variants on the
 // speed, quality, and cost signals Sybra already records.
@@ -113,6 +113,7 @@ type ComparisonBreakdown struct {
 	Runs                      int                   `json:"runs"`
 	Failures                  int                   `json:"failures"`
 	Stalled                   int                   `json:"stalled"`
+	ResolvedRuns              int                   `json:"resolvedRuns"`
 	FailureRate               float64               `json:"failureRate"`
 	FailureEstimate           RateEstimate          `json:"failureEstimate"`
 	Landed                    int                   `json:"landed"`
@@ -146,11 +147,6 @@ type ComparisonBreakdown struct {
 	MinSamplesPerVariant      int                   `json:"minSamplesPerVariant,omitempty"`
 	RoleBreakdowns            []ComparisonBreakdown `json:"roleBreakdowns,omitempty"`
 }
-
-// ResolvedRuns counts runs that reached a definitive outcome — see
-// Breakdown.ResolvedRuns for why failure rating and sample gating must agree
-// on this denominator rather than Runs.
-func (c ComparisonBreakdown) ResolvedRuns() int { return c.Runs - c.Stalled }
 
 // RateEstimate is a binomial rate with fixed 95% Wilson uncertainty and an
 // optional effect delta relative to an A/B baseline row.
@@ -308,12 +304,12 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 
 	lg := scanLandings(events, win)
 	sigs := scanTaskSignals(events) // not window-bound: capture full task history
-	runs, fails, stalls := scanReliability(records, win)
+	runs, fails, stalls, resolved := scanReliability(records, win)
 	cost, turns, tools := scanEfficiency(records, win)
 
 	sc.TasksLanded, sc.Merged, sc.Closed = lg.count, lg.merged, lg.closed
 	sc.MergedWithEdits = lg.mergedWithEdits
-	sc.AgentRuns, sc.AgentFailures, sc.AgentStalls = runs, fails, stalls
+	sc.AgentRuns, sc.AgentFailures, sc.AgentStalls, sc.AgentResolvedRuns = runs, fails, stalls, resolved
 	sc.Reverted = countReverts(events, win, lg.tasks)
 	sc.TotalCostUSD = cost
 	autonomous, humanTouched, ciClean := classifyLanded(lg.tasks, lg.edited, sigs)
@@ -328,8 +324,8 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 		sc.TurnsPerLanded = float64(turns) / n
 		sc.ToolsPerLanded = float64(tools) / n
 	}
-	if resolved := sc.AgentRuns - sc.AgentStalls; resolved > 0 {
-		sc.FailureRate = float64(sc.AgentFailures) / float64(resolved)
+	if sc.AgentResolvedRuns > 0 {
+		sc.FailureRate = float64(sc.AgentFailures) / float64(sc.AgentResolvedRuns)
 	}
 	if mergedLandings := sc.Merged + sc.MergedWithEdits; mergedLandings > 0 {
 		sc.ChangeFailureRate = float64(sc.Reverted) / float64(mergedLandings)
@@ -434,21 +430,28 @@ func countReverts(events []audit.Event, win func(time.Time) bool, landed map[str
 	return n
 }
 
-func scanReliability(records []stats.RunRecord, win func(time.Time) bool) (runs, failures, stalls int) {
+// scanReliability counts each state rather than deriving one by subtraction:
+// resolved is not "everything that didn't stall", since an unknown outcome is
+// neither, and calling it either would put a run with no known result into a
+// rate or mislabel it a stall.
+func scanReliability(records []stats.RunRecord, win func(time.Time) bool) (runs, failures, stalls, resolved int) {
 	for i := range records {
 		r := records[i]
 		if !win(r.Timestamp) {
 			continue
 		}
 		runs++
-		switch {
-		case !stats.IsTerminalOutcome(r.Outcome):
+		if r.Outcome == stats.OutcomeStalled {
 			stalls++
-		case r.Outcome == stats.OutcomeFailed:
+		}
+		if stats.IsTerminalOutcome(r.Outcome) {
+			resolved++
+		}
+		if r.Outcome == stats.OutcomeFailed {
 			failures++
 		}
 	}
-	return runs, failures, stalls
+	return runs, failures, stalls, resolved
 }
 
 func scanEfficiency(records []stats.RunRecord, win func(time.Time) bool) (cost float64, turns, tools int) {
@@ -509,8 +512,8 @@ func countRework(sigs map[string]*taskSignals, landed map[string]bool) int {
 // reliability per group, sorted by key. Records with an empty key are skipped.
 func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(stats.RunRecord) string) []Breakdown {
 	type acc struct {
-		runs, fails, stalls, turns, tools int
-		cost                              float64
+		runs, fails, stalls, resolved, turns, tools int
+		cost                                        float64
 	}
 	groups := map[string]*acc{}
 	for i := range records {
@@ -528,10 +531,13 @@ func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(sta
 			groups[k] = a
 		}
 		a.runs++
-		switch {
-		case !stats.IsTerminalOutcome(r.Outcome):
+		if r.Outcome == stats.OutcomeStalled {
 			a.stalls++
-		case r.Outcome == stats.OutcomeFailed:
+		}
+		if stats.IsTerminalOutcome(r.Outcome) {
+			a.resolved++
+		}
+		if r.Outcome == stats.OutcomeFailed {
 			a.fails++
 		}
 		a.cost += r.CostUSD
@@ -540,9 +546,10 @@ func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(sta
 	}
 	out := make([]Breakdown, 0, len(groups))
 	for k, a := range groups {
-		b := Breakdown{Key: k, Runs: a.runs, Failures: a.fails, Stalled: a.stalls, TotalCostUSD: a.cost, Turns: a.turns, Tools: a.tools}
-		if resolved := b.ResolvedRuns(); resolved > 0 {
-			b.FailureRate = float64(a.fails) / float64(resolved)
+		b := Breakdown{Key: k, Runs: a.runs, Failures: a.fails, Stalled: a.stalls, ResolvedRuns: a.resolved,
+			TotalCostUSD: a.cost, Turns: a.turns, Tools: a.tools}
+		if b.ResolvedRuns > 0 {
+			b.FailureRate = float64(a.fails) / float64(b.ResolvedRuns)
 		}
 		out = append(out, b)
 	}
@@ -617,10 +624,13 @@ func compareByAttribution(records []stats.RunRecord, events []audit.Event, since
 		}
 		a := ensure(r, k)
 		a.row.Runs++
-		switch {
-		case !stats.IsTerminalOutcome(r.Outcome):
+		if r.Outcome == stats.OutcomeStalled {
 			a.row.Stalled++
-		case r.Outcome == stats.OutcomeFailed:
+		}
+		if stats.IsTerminalOutcome(r.Outcome) {
+			a.row.ResolvedRuns++
+		}
+		if r.Outcome == stats.OutcomeFailed {
 			a.row.Failures++
 		}
 		a.row.TotalCostUSD += r.CostUSD
@@ -955,7 +965,7 @@ func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []Comparis
 		row := a.row
 		// Landing stays rated over all runs (a stall still consumed a dispatch
 		// of this variant); only the failure rate drops the retried ones.
-		row.FailureEstimate = wilson95(row.Failures, row.ResolvedRuns())
+		row.FailureEstimate = wilson95(row.Failures, row.ResolvedRuns)
 		row.LandedEstimate = wilson95(row.Landed, row.Runs)
 		row.MergeEstimate = wilson95(row.Merged, row.Landed)
 		row.MergedWithEditsEstimate = wilson95(row.MergedWithEdits, row.Landed)
@@ -990,7 +1000,7 @@ func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []Comparis
 		row.DurationP90S = percentile(a.durations, 90)
 		// Gate on resolved runs, or a variant with 29 stalls and 1 failure —
 		// one data point — is declared trustworthy at a 100% failure rate.
-		row.InsufficientData = minSamples > 0 && row.ResolvedRuns() < minSamples
+		row.InsufficientData = minSamples > 0 && row.ResolvedRuns < minSamples
 		row.QualityAttributionLimited = row.Landed == 0 && row.Runs > 0
 		out = append(out, row)
 	}
@@ -1068,7 +1078,7 @@ func applyVariantSemantics(rows []ComparisonBreakdown, opts CompareOptions) []Ex
 			}
 			row.MinSamplesPerVariant = opts.MinSamples
 			row.BaselineVariantID = cfg.baselineVariantID
-			if opts.MinSamples > 0 && row.ResolvedRuns() < opts.MinSamples {
+			if opts.MinSamples > 0 && row.ResolvedRuns < opts.MinSamples {
 				row.SampleStatus = "low-sample"
 			} else {
 				row.SampleStatus = "actionable"
@@ -1210,7 +1220,7 @@ func experimentSampleStatus(key string, cfg experimentRoleConfig, rows map[strin
 		runs, resolved := 0, 0
 		observed := false
 		if row != nil {
-			runs, resolved = row.Runs, row.ResolvedRuns()
+			runs, resolved = row.Runs, row.ResolvedRuns
 			observed = true
 		}
 		ready := minSamples <= 0 || resolved >= minSamples

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -7,7 +7,9 @@ package evaluation
 
 import (
 	"encoding/base64"
+	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -165,9 +167,15 @@ type RateEstimate struct {
 
 // VariantSampleStatus describes whether one configured or observed A/B variant
 // has enough samples for the configured minimum.
+//
+// Runs counts dispatches, matching Breakdown.Runs — "runs" means the same
+// population in every struct in this package. ResolvedRuns is what Ready gates
+// on, so a variant that stalled away most of its dispatches reads as
+// observed-but-not-ready rather than as never dispatched.
 type VariantSampleStatus struct {
 	VariantID    string `json:"variantId"`
 	Runs         int    `json:"runs"`
+	ResolvedRuns int    `json:"resolvedRuns"`
 	Ready        bool   `json:"ready"`
 	Configured   bool   `json:"configured"`
 	Observed     bool   `json:"observed"`
@@ -184,6 +192,7 @@ type ExperimentSampleStatus struct {
 	Variants             []VariantSampleStatus `json:"variants"`
 	ReadyVariants        int                   `json:"readyVariants"`
 	TotalRuns            int                   `json:"totalRuns"`
+	TotalResolvedRuns    int                   `json:"totalResolvedRuns"`
 	Status               string                `json:"status"`
 }
 
@@ -230,6 +239,47 @@ type ExperimentGroup struct {
 
 // experimentKindOrder is the stable rendering order for ExperimentKindBreakdown groups.
 var experimentKindOrder = []string{"model", "prompt", "skill", "unknown"}
+
+// unaccountedFailureNote flags failed runs that recorded no cost and no tokens.
+//
+// Stall records only exist going forward: before the stall fix a retried stall
+// was recorded as a failure, and a stall's terminal usage event never arrives,
+// so those runs are on disk as failures costing nothing. Until the window rolls
+// past the upgrade the scorecard therefore overstates failure_rate while
+// reporting few or no stalls, which reads exactly like the fix never landed.
+// There is no signal that can tell an old stall from a genuinely instant
+// failure (an auth error also costs $0), so this reports the ambiguity rather
+// than guessing: it is diagnostic only and never adjusts a metric.
+func unaccountedFailureNote(records []stats.RunRecord, since, until time.Time) string {
+	failures, unaccounted := 0, 0
+	for i := range records {
+		r := records[i]
+		if r.Timestamp.Before(since) || r.Timestamp.After(until) || r.Outcome != stats.OutcomeFailed {
+			continue
+		}
+		failures++
+		if r.CostUSD == 0 && r.PremiumRequests == 0 && r.InputTokens == 0 && r.OutputTokens == 0 &&
+			r.CacheCreationInputTokens == 0 && r.CacheReadInputTokens == 0 && r.ReasoningTokens == 0 {
+			unaccounted++
+		}
+	}
+	if unaccounted == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%d of %d failed runs recorded zero cost and zero tokens — runs from before the stall fix recorded retried stalls as failures, so a window straddling that upgrade overstates failure_rate and understates stalls",
+		unaccounted, failures)
+}
+
+// reportNotes pairs the static deferred-metric notes with any note that depends
+// on what is actually in the window.
+func reportNotes(records []stats.RunRecord, since, until time.Time) []string {
+	notes := slices.Clone(deferredNotes)
+	if n := unaccountedFailureNote(records, since, until); n != "" {
+		notes = append(notes, n)
+	}
+	return notes
+}
 
 // deferredNotes documents metrics that need signals not yet captured, so the
 // report never silently presents a partial picture as complete.
@@ -1154,19 +1204,21 @@ func experimentSampleStatus(key string, cfg experimentRoleConfig, rows map[strin
 	}
 	for _, id := range variantIDs {
 		row := rows[id]
-		// Readiness is about decidable evidence, so it counts resolved runs —
-		// matching the row-level SampleStatus above rather than contradicting it.
-		runs := 0
+		// Readiness gates on resolved runs to match the row-level SampleStatus
+		// above rather than contradict it, while Runs stays the dispatch count
+		// so "never ran" stays distinguishable from "every dispatch stalled".
+		runs, resolved := 0, 0
 		observed := false
 		if row != nil {
-			runs = row.ResolvedRuns()
+			runs, resolved = row.Runs, row.ResolvedRuns()
 			observed = true
 		}
-		ready := minSamples <= 0 || runs >= minSamples
+		ready := minSamples <= 0 || resolved >= minSamples
 		if ready {
 			status.ReadyVariants++
 		}
 		status.TotalRuns += runs
+		status.TotalResolvedRuns += resolved
 		sampleStatus := "low-sample"
 		if ready {
 			sampleStatus = "actionable"
@@ -1174,6 +1226,7 @@ func experimentSampleStatus(key string, cfg experimentRoleConfig, rows map[strin
 		status.Variants = append(status.Variants, VariantSampleStatus{
 			VariantID:    id,
 			Runs:         runs,
+			ResolvedRuns: resolved,
 			Ready:        ready,
 			Configured:   configured[id],
 			Observed:     observed,

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -91,6 +91,96 @@ func TestCompute(t *testing.T) {
 	}
 }
 
+// #2149: a stalled run is retried, not resolved, so it must stay out of both
+// sides of every failure rate. Codex stalls on ~96% of implementation runs, so
+// leaving stalls in the denominator would rank the stall-prone provider as the
+// most reliable one — the same corrupted evidence Prompt Lab gates on.
+func TestComputeExcludesStallsFromFailureRate(t *testing.T) {
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -30)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A", CostUSD: 1.0, Outcome: stats.OutcomeCompleted, Timestamp: in},
+		{TaskID: "A", CostUSD: 1.0, Outcome: stats.OutcomeFailed, Timestamp: in},
+		{TaskID: "A", CostUSD: 0, Outcome: stats.OutcomeStalled, Timestamp: in},
+		{TaskID: "A", CostUSD: 0, Outcome: stats.OutcomeStalled, Timestamp: in},
+		{TaskID: "A", CostUSD: 0, Outcome: stats.OutcomeStalled, Timestamp: in},
+	}
+
+	got := Compute(records, nil, since, base)
+
+	if got.AgentRuns != 5 {
+		t.Errorf("AgentRuns = %d, want 5 (stalls burn real wall-clock, so they stay counted)", got.AgentRuns)
+	}
+	if got.AgentStalls != 3 {
+		t.Errorf("AgentStalls = %d, want 3", got.AgentStalls)
+	}
+	if got.AgentFailures != 1 {
+		t.Errorf("AgentFailures = %d, want 1", got.AgentFailures)
+	}
+	if got.FailureRate != 0.5 {
+		t.Errorf("FailureRate = %v, want 0.5 (1 failure over 2 resolved runs, not 5 dispatched)", got.FailureRate)
+	}
+}
+
+func TestBreakdownByExcludesStallsFromFailureRate(t *testing.T) {
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		// codex: stalls constantly, and every run that resolved failed.
+		{Provider: "codex", Outcome: stats.OutcomeStalled, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeStalled, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeStalled, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeFailed, Timestamp: in},
+		// claude: never stalls, resolves half its runs into failures.
+		{Provider: "claude", Outcome: stats.OutcomeCompleted, Timestamp: in},
+		{Provider: "claude", Outcome: stats.OutcomeFailed, Timestamp: in},
+	}
+
+	got := BreakdownBy(records, since, base, func(r stats.RunRecord) string { return r.Provider })
+	if len(got) != 2 {
+		t.Fatalf("got %d groups, want 2: %+v", len(got), got)
+	}
+	cl, cx := got[0], got[1]
+	if cl.Key != "claude" || cl.Stalled != 0 || cl.FailureRate != 0.5 {
+		t.Errorf("claude breakdown = %+v, want stalled=0 failureRate=0.5", cl)
+	}
+	if cx.Key != "codex" || cx.Runs != 4 || cx.Stalled != 3 || cx.Failures != 1 {
+		t.Errorf("codex breakdown = %+v, want runs=4 stalled=3 failures=1", cx)
+	}
+	if cx.FailureRate != 1.0 {
+		t.Errorf("codex FailureRate = %v, want 1.0: its one resolved run failed. Counting the 3 stalls in the denominator would report 0.25 and rank the stall-prone provider above claude", cx.FailureRate)
+	}
+}
+
+func TestCompareByExcludesStallsFromFailureEstimate(t *testing.T) {
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{Provider: "codex", Outcome: stats.OutcomeStalled, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeStalled, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeFailed, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeCompleted, Timestamp: in},
+	}
+
+	rows := CompareByLatestAuthor(records, nil, since, base, 0, func(r stats.RunRecord) string { return r.Provider })
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.Runs != 4 || row.Stalled != 2 {
+		t.Errorf("row = %+v, want runs=4 stalled=2", row)
+	}
+	if row.FailureEstimate.Denominator != 2 {
+		t.Errorf("FailureEstimate.Denominator = %d, want 2 (resolved runs only)", row.FailureEstimate.Denominator)
+	}
+	if row.FailureRate != 0.5 {
+		t.Errorf("FailureRate = %v, want 0.5", row.FailureRate)
+	}
+}
+
 func TestBreakdownBy(t *testing.T) {
 	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	since := base.AddDate(0, 0, -7)

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -201,6 +202,58 @@ func TestCompareByGatesSamplesOnResolvedRuns(t *testing.T) {
 	if !rows[0].InsufficientData {
 		t.Errorf("InsufficientData = false for a row with 1 resolved run against minSamples=30 (runs=%d stalled=%d failureRate=%v)",
 			rows[0].Runs, rows[0].Stalled, rows[0].FailureRate)
+	}
+}
+
+// Stall records only exist going forward, so a window straddling the upgrade
+// shows an inflated failure rate next to a stall count of ~0 — which reads as
+// if the fix never landed. The report has to say so itself; the operator
+// looking at the dashboard is the one who needs to know.
+func TestReportNotesFlagsPreFixStallsRecordedAsFailures(t *testing.T) {
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -30)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		// Pre-fix stalls: recorded as failures, and a stall's usage event never
+		// arrived, so they cost nothing and produced nothing.
+		{Outcome: stats.OutcomeFailed, Timestamp: in},
+		{Outcome: stats.OutcomeFailed, Timestamp: in},
+		// A genuine failure that actually did work.
+		{Outcome: stats.OutcomeFailed, CostUSD: 0.76, OutputTokens: 900, Timestamp: in},
+		{Outcome: stats.OutcomeCompleted, CostUSD: 1.2, OutputTokens: 500, Timestamp: in},
+	}
+
+	notes := reportNotes(records, since, base)
+	found := ""
+	for _, n := range notes {
+		if strings.Contains(n, "zero cost and zero tokens") {
+			found = n
+		}
+	}
+	if found == "" {
+		t.Fatalf("reportNotes = %v, want a note about failed runs that recorded no cost or tokens", notes)
+	}
+	if !strings.Contains(found, "2 of 3") {
+		t.Errorf("note = %q, want it to count 2 of 3 failed runs", found)
+	}
+}
+
+// Once the window is clear of pre-fix records the note must disappear, or it
+// becomes permanent furniture that no one reads.
+func TestReportNotesOmitsStallCaveatWhenFailuresAreAccounted(t *testing.T) {
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -30)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{Outcome: stats.OutcomeFailed, CostUSD: 0.76, OutputTokens: 900, Timestamp: in},
+		{Outcome: stats.OutcomeStalled, Timestamp: in},
+		{Outcome: stats.OutcomeCompleted, CostUSD: 1.2, OutputTokens: 500, Timestamp: in},
+	}
+
+	for _, n := range reportNotes(records, since, base) {
+		if strings.Contains(n, "zero cost and zero tokens") {
+			t.Errorf("note %q present, but the only failure is fully accounted and the stall is recorded as a stall", n)
+		}
 	}
 }
 

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -181,6 +181,29 @@ func TestCompareByExcludesStallsFromFailureEstimate(t *testing.T) {
 	}
 }
 
+// The failure rate and the check on whether it has enough samples must count
+// the same population. Gating on dispatches while rating over resolved runs
+// lets a row declare itself actionable at a 100% failure rate off n=1.
+func TestCompareByGatesSamplesOnResolvedRuns(t *testing.T) {
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := make([]stats.RunRecord, 0, 30)
+	for range 29 {
+		records = append(records, stats.RunRecord{Provider: "codex", Outcome: stats.OutcomeStalled, Timestamp: in})
+	}
+	records = append(records, stats.RunRecord{Provider: "codex", Outcome: stats.OutcomeFailed, Timestamp: in})
+
+	rows := CompareByLatestAuthor(records, nil, since, base, 30, func(r stats.RunRecord) string { return r.Provider })
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if !rows[0].InsufficientData {
+		t.Errorf("InsufficientData = false for a row with 1 resolved run against minSamples=30 (runs=%d stalled=%d failureRate=%v)",
+			rows[0].Runs, rows[0].Stalled, rows[0].FailureRate)
+	}
+}
+
 func TestBreakdownBy(t *testing.T) {
 	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	since := base.AddDate(0, 0, -7)

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -257,6 +257,41 @@ func TestReportNotesOmitsStallCaveatWhenFailuresAreAccounted(t *testing.T) {
 	}
 }
 
+// An outcome nothing can currently produce must still be handled: it is not a
+// definitive result, so it belongs in no rate — and it is not a stall either,
+// so it must not be counted as one. Runs, Stalled and ResolvedRuns are counted
+// independently precisely so an unknown value lands in Runs alone.
+func TestUnknownOutcomeCountsAsNeitherResolvedNorStalled(t *testing.T) {
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{Provider: "codex", Outcome: stats.OutcomeFailed, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeCompleted, Timestamp: in},
+		{Provider: "codex", Outcome: stats.OutcomeStalled, Timestamp: in},
+		{Provider: "codex", Outcome: "", Timestamp: in},
+		{Provider: "codex", Outcome: "some-future-outcome", Timestamp: in},
+	}
+
+	got := BreakdownBy(records, since, base, func(r stats.RunRecord) string { return r.Provider })
+	if len(got) != 1 {
+		t.Fatalf("got %d groups, want 1", len(got))
+	}
+	b := got[0]
+	if b.Runs != 5 || b.Stalled != 1 || b.ResolvedRuns != 2 || b.Failures != 1 {
+		t.Errorf("breakdown = %+v, want runs=5 stalled=1 resolvedRuns=2 failures=1", b)
+	}
+	if b.FailureRate != 0.5 {
+		t.Errorf("FailureRate = %v, want 0.5 (1 of 2 definitive results; the unknown pair must not dilute it)", b.FailureRate)
+	}
+
+	sc := Compute(records, nil, since, base)
+	if sc.AgentRuns != 5 || sc.AgentStalls != 1 || sc.AgentResolvedRuns != 2 || sc.FailureRate != 0.5 {
+		t.Errorf("scorecard = runs:%d stalls:%d resolved:%d rate:%v, want 5/1/2/0.5",
+			sc.AgentRuns, sc.AgentStalls, sc.AgentResolvedRuns, sc.FailureRate)
+	}
+}
+
 func TestBreakdownBy(t *testing.T) {
 	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	since := base.AddDate(0, 0, -7)

--- a/internal/evaluation/service.go
+++ b/internal/evaluation/service.go
@@ -178,7 +178,7 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 			return r.Provider + ":" + r.Model + ":" + r.ReasoningEffort + ":" + normalizedRole(r.Role)
 		}),
 		ByExperimentKind: GroupByKind(byVariant, byVariantContribution, s.abTesting.Experiments),
-		Notes:            deferredNotes,
+		Notes:            reportNotes(recs, since, now),
 	}
 	rep.Weaknesses = Weaknesses(rep)
 	return rep, nil

--- a/internal/evaluation/weakness.go
+++ b/internal/evaluation/weakness.go
@@ -60,7 +60,7 @@ func Weaknesses(r Report) []Weakness {
 		}
 	}
 
-	if o.AgentRuns-o.AgentStalls >= minRunsForSignal && o.FailureRate > 0.2 {
+	if o.AgentResolvedRuns >= minRunsForSignal && o.FailureRate > 0.2 {
 		out = append(out, Weakness{
 			Severity:   "warn",
 			Metric:     "failure_rate",
@@ -97,7 +97,7 @@ func outlierWeaknesses(groups []Breakdown, overallFailure float64, dimension str
 	var out []Weakness
 	for i := range groups {
 		b := groups[i]
-		if b.ResolvedRuns() < minRunsForSignal || b.FailureRate <= overallFailure+outlierMargin {
+		if b.ResolvedRuns < minRunsForSignal || b.FailureRate <= overallFailure+outlierMargin {
 			continue
 		}
 		out = append(out, Weakness{

--- a/internal/evaluation/weakness.go
+++ b/internal/evaluation/weakness.go
@@ -15,7 +15,9 @@ type Weakness struct {
 }
 
 // Signal gates: don't emit weaknesses from a near-empty window, where a single
-// task or run swings every ratio.
+// task or run swings every ratio. Run gates count resolved runs, never
+// dispatches — a window of stalls carries no evidence about prompts or
+// guardrails, which is what these weaknesses tell the operator to go fix.
 const (
 	minLandedForSignal = 3
 	minRunsForSignal   = 5
@@ -58,11 +60,11 @@ func Weaknesses(r Report) []Weakness {
 		}
 	}
 
-	if o.AgentRuns >= minRunsForSignal && o.FailureRate > 0.2 {
+	if o.AgentRuns-o.AgentStalls >= minRunsForSignal && o.FailureRate > 0.2 {
 		out = append(out, Weakness{
 			Severity:   "warn",
 			Metric:     "failure_rate",
-			Detail:     fmt.Sprintf("%.0f%% of agent runs failed", o.FailureRate*100),
+			Detail:     fmt.Sprintf("%.0f%% of resolved agent runs failed", o.FailureRate*100),
 			Suggestion: "investigate the failing roles/providers below; check guardrails and prompts",
 		})
 	}
@@ -95,7 +97,7 @@ func outlierWeaknesses(groups []Breakdown, overallFailure float64, dimension str
 	var out []Weakness
 	for i := range groups {
 		b := groups[i]
-		if b.Runs < minRunsForSignal || b.FailureRate <= overallFailure+outlierMargin {
+		if b.ResolvedRuns() < minRunsForSignal || b.FailureRate <= overallFailure+outlierMargin {
 			continue
 		}
 		out = append(out, Weakness{

--- a/internal/evaluation/weakness_test.go
+++ b/internal/evaluation/weakness_test.go
@@ -21,12 +21,15 @@ func TestWeaknesses_FlagsShortfalls(t *testing.T) {
 			AutonomyRate:    0.4, // < 0.7 → autonomy
 			CIFirstPassRate: 0.5, // < 0.6 → ci_first_pass
 			ReworkTasks:     5,   // 5/10 = 0.5 > 0.3 → rework
-			AgentRuns:       20,
-			FailureRate:     0.3, // > 0.2 → failure_rate
+			// Rates read over resolved runs, so a fixture must say how many of
+			// its dispatches resolved — the gate no longer infers it.
+			AgentRuns:         20,
+			AgentResolvedRuns: 20,
+			FailureRate:       0.3, // > 0.2 → failure_rate
 		},
 		ByProvider: []Breakdown{
-			{Key: "codex", Runs: 10, FailureRate: 0.6}, // 0.6 > 0.3+0.15 → outlier
-			{Key: "claude", Runs: 10, FailureRate: 0.3},
+			{Key: "codex", Runs: 10, ResolvedRuns: 10, FailureRate: 0.6}, // 0.6 > 0.3+0.15 → outlier
+			{Key: "claude", Runs: 10, ResolvedRuns: 10, FailureRate: 0.3},
 		},
 	}
 	ws := Weaknesses(r)
@@ -53,7 +56,7 @@ func TestWeaknesses_HealthyAndLowData(t *testing.T) {
 	// Healthy fleet with enough data → no weaknesses.
 	healthy := Report{Overall: Scorecard{
 		TasksLanded: 10, AutonomyRate: 0.95, CIFirstPassRate: 0.9, ReworkTasks: 0,
-		AgentRuns: 20, FailureRate: 0.05,
+		AgentRuns: 20, AgentResolvedRuns: 20, FailureRate: 0.05,
 	}}
 	if ws := Weaknesses(healthy); len(ws) != 0 {
 		t.Errorf("healthy fleet flagged: %+v", ws)
@@ -62,7 +65,7 @@ func TestWeaknesses_HealthyAndLowData(t *testing.T) {
 	// Too little data → gates suppress everything despite bad ratios.
 	sparse := Report{Overall: Scorecard{
 		TasksLanded: 1, AutonomyRate: 0, CIFirstPassRate: 0, ReworkTasks: 1,
-		AgentRuns: 1, FailureRate: 1,
+		AgentRuns: 1, AgentResolvedRuns: 1, FailureRate: 1,
 	}}
 	if ws := Weaknesses(sparse); len(ws) != 0 {
 		t.Errorf("sparse window flagged (should be gated): %+v", ws)
@@ -77,11 +80,11 @@ func TestWeaknesses_GateCountsResolvedRunsNotStalls(t *testing.T) {
 	r := Report{
 		Overall: Scorecard{
 			// 20 dispatches but only 4 resolved: below minRunsForSignal.
-			AgentRuns: 20, AgentStalls: 16, FailureRate: 1,
+			AgentRuns: 20, AgentStalls: 16, AgentResolvedRuns: 4, FailureRate: 1,
 		},
 		ByProvider: []Breakdown{
 			// 10 dispatches, 1 resolved, and it failed: a sample of one.
-			{Key: "codex", Runs: 10, Stalled: 9, Failures: 1, FailureRate: 1},
+			{Key: "codex", Runs: 10, Stalled: 9, ResolvedRuns: 1, Failures: 1, FailureRate: 1},
 		},
 	}
 	if ws := Weaknesses(r); len(ws) != 0 {
@@ -93,9 +96,9 @@ func TestWeaknesses_GateCountsResolvedRunsNotStalls(t *testing.T) {
 // nor change the rate the weakness narrates.
 func TestWeaknesses_StallsDoNotBlockAGenuineSignal(t *testing.T) {
 	r := Report{
-		Overall: Scorecard{AgentRuns: 40, AgentStalls: 20, AgentFailures: 6, FailureRate: 0.3},
+		Overall: Scorecard{AgentRuns: 40, AgentStalls: 20, AgentResolvedRuns: 20, AgentFailures: 6, FailureRate: 0.3},
 		ByProvider: []Breakdown{
-			{Key: "codex", Runs: 20, Stalled: 10, Failures: 6, FailureRate: 0.6},
+			{Key: "codex", Runs: 20, Stalled: 10, ResolvedRuns: 10, Failures: 6, FailureRate: 0.6},
 		},
 	}
 	ws := Weaknesses(r)

--- a/internal/evaluation/weakness_test.go
+++ b/internal/evaluation/weakness_test.go
@@ -69,6 +69,46 @@ func TestWeaknesses_HealthyAndLowData(t *testing.T) {
 	}
 }
 
+// Weaknesses tell the operator to go fix a prompt or route work away from a
+// provider. A window of stalls is no evidence for either, so a role/provider
+// whose runs mostly stalled must not clear the signal gate on the strength of
+// its dispatch count (#2149).
+func TestWeaknesses_GateCountsResolvedRunsNotStalls(t *testing.T) {
+	r := Report{
+		Overall: Scorecard{
+			// 20 dispatches but only 4 resolved: below minRunsForSignal.
+			AgentRuns: 20, AgentStalls: 16, FailureRate: 1,
+		},
+		ByProvider: []Breakdown{
+			// 10 dispatches, 1 resolved, and it failed: a sample of one.
+			{Key: "codex", Runs: 10, Stalled: 9, Failures: 1, FailureRate: 1},
+		},
+	}
+	if ws := Weaknesses(r); len(ws) != 0 {
+		t.Errorf("Weaknesses = %+v, want none: 4 resolved fleet runs and 1 resolved codex run are below the signal gate", ws)
+	}
+}
+
+// Stalls alongside a sufficient number of resolved runs neither block the gate
+// nor change the rate the weakness narrates.
+func TestWeaknesses_StallsDoNotBlockAGenuineSignal(t *testing.T) {
+	r := Report{
+		Overall: Scorecard{AgentRuns: 40, AgentStalls: 20, AgentFailures: 6, FailureRate: 0.3},
+		ByProvider: []Breakdown{
+			{Key: "codex", Runs: 20, Stalled: 10, Failures: 6, FailureRate: 0.6},
+		},
+	}
+	ws := Weaknesses(r)
+	if !hasMetric(ws, "failure_rate") || !hasMetric(ws, "provider:codex") {
+		t.Errorf("Weaknesses = %+v, want failure_rate and provider:codex flagged", ws)
+	}
+	for _, w := range ws {
+		if w.Metric == "failure_rate" && !strings.Contains(w.Detail, "resolved") {
+			t.Errorf("failure_rate detail = %q, want it to name the resolved-run basis", w.Detail)
+		}
+	}
+}
+
 func TestWeaknesses_SuggestionsPresent(t *testing.T) {
 	r := Report{Overall: Scorecard{TasksLanded: 10, AutonomyRate: 0.1, CIFirstPassRate: 1, AgentRuns: 10}}
 	ws := Weaknesses(r)

--- a/internal/learning/input.go
+++ b/internal/learning/input.go
@@ -25,6 +25,7 @@ type ExperimentSignal struct {
 	Provider             string  `json:"provider,omitempty"`
 	Model                string  `json:"model,omitempty"`
 	Runs                 int     `json:"runs"`
+	Stalled              int     `json:"stalled,omitempty"`
 	MergeRate            float64 `json:"mergeRate"`
 	FailureRate          float64 `json:"failureRate"`
 	InsufficientData     bool    `json:"insufficientData"`
@@ -130,6 +131,7 @@ func buildPacket(recs []stats.RunRecord, evts []audit.Event, abTesting abtest.Co
 			Provider:             rows[i].Provider,
 			Model:                rows[i].Model,
 			Runs:                 rows[i].Runs,
+			Stalled:              rows[i].Stalled,
 			MergeRate:            rows[i].MergeRate,
 			FailureRate:          rows[i].FailureRate,
 			InsufficientData:     rows[i].InsufficientData,

--- a/internal/learning/input.go
+++ b/internal/learning/input.go
@@ -26,6 +26,7 @@ type ExperimentSignal struct {
 	Model                string  `json:"model,omitempty"`
 	Runs                 int     `json:"runs"`
 	Stalled              int     `json:"stalled,omitempty"`
+	ResolvedRuns         int     `json:"resolvedRuns"`
 	MergeRate            float64 `json:"mergeRate"`
 	FailureRate          float64 `json:"failureRate"`
 	InsufficientData     bool    `json:"insufficientData"`
@@ -132,6 +133,7 @@ func buildPacket(recs []stats.RunRecord, evts []audit.Event, abTesting abtest.Co
 			Model:                rows[i].Model,
 			Runs:                 rows[i].Runs,
 			Stalled:              rows[i].Stalled,
+			ResolvedRuns:         rows[i].ResolvedRuns,
 			MergeRate:            rows[i].MergeRate,
 			FailureRate:          rows[i].FailureRate,
 			InsufficientData:     rows[i].InsufficientData,

--- a/internal/promptlab/collect.go
+++ b/internal/promptlab/collect.go
@@ -40,7 +40,7 @@ func CollectWeakSubjects(records []stats.RunRecord, minSamples int, minEffectSiz
 		// resolved runs only, so gating on b.Runs would let a role whose runs
 		// mostly stalled clear MinSamples on a rate derived from one run —
 		// exactly the single unlucky run this is supposed to exclude.
-		resolved := b.ResolvedRuns()
+		resolved := b.ResolvedRuns
 		if resolved < minSamples {
 			continue
 		}

--- a/internal/promptlab/collect.go
+++ b/internal/promptlab/collect.go
@@ -24,7 +24,7 @@ var (
 // filtered evidence backs both the gating metrics (samples, failure rate,
 // effect size vs the fleet baseline) and the representative project/task
 // attribution. A role is only surfaced when it clears BOTH gates —
-// MinSamples (enough runs to trust the number) and MinEffectSize (the
+// MinSamples (enough resolved runs to trust the number) and MinEffectSize (the
 // failure rate is actually worse than the fleet baseline, not noise) — so a
 // single unlucky run never triggers a proposal. Results are sorted by effect
 // size, worst first.
@@ -36,7 +36,12 @@ func CollectWeakSubjects(records []stats.RunRecord, minSamples int, minEffectSiz
 
 	var out []WeakSubject
 	for _, b := range byRole {
-		if b.Runs < minSamples {
+		// Gate on resolved runs, not dispatches: b.FailureRate is rated over
+		// resolved runs only, so gating on b.Runs would let a role whose runs
+		// mostly stalled clear MinSamples on a rate derived from one run —
+		// exactly the single unlucky run this is supposed to exclude.
+		resolved := b.ResolvedRuns()
+		if resolved < minSamples {
 			continue
 		}
 		effect := b.FailureRate - overall.FailureRate
@@ -46,9 +51,9 @@ func CollectWeakSubjects(records []stats.RunRecord, minSamples int, minEffectSiz
 		out = append(out, WeakSubject{
 			Subject: Subject{Role: b.Key},
 			Metric:  "failure_rate",
-			Detail: fmt.Sprintf("role %s fails %.0f%% vs %.0f%% overall over %d runs",
-				b.Key, b.FailureRate*100, overall.FailureRate*100, b.Runs),
-			Samples:    b.Runs,
+			Detail: fmt.Sprintf("role %s fails %.0f%% vs %.0f%% overall over %d resolved runs (%d stalled)",
+				b.Key, b.FailureRate*100, overall.FailureRate*100, resolved, b.Stalled),
+			Samples:    resolved,
 			EffectSize: effect,
 			ProjectIDs: projectIDsForRole(records, b.Key),
 			TaskIDs:    taskIDsForRole(records, b.Key, 5),

--- a/internal/promptlab/collect_test.go
+++ b/internal/promptlab/collect_test.go
@@ -54,6 +54,41 @@ func TestCollectWeakSubjectsGates(t *testing.T) {
 	}
 }
 
+// A role whose runs mostly stalled has almost no evidence about its prompt.
+// Gating on dispatches instead of resolved runs would let one resolved run
+// clear MinSamples and — with PromptLab.AutoApprove defaulting to true —
+// autonomously rewrite a prompt over what is really a provider stall (#2149).
+func TestCollectWeakSubjectsGatesOnResolvedRunsNotStalls(t *testing.T) {
+	var records []stats.RunRecord
+	// review: 5 dispatches, but only 1 resolved (a failure). Samples of one.
+	records = append(records, repeatRecords(4, "review", stats.OutcomeStalled, "p1", "review-stall-")...)
+	records = append(records, repeatRecords(1, "review", stats.OutcomeFailed, "p1", "review-fail-")...)
+	// docs: 20 clean runs, holding the fleet baseline near zero so review's
+	// effect size clears MinEffectSize easily if the sample gate lets it past.
+	records = append(records, repeatRecords(20, "docs", stats.OutcomeCompleted, "p1", "docs-")...)
+
+	if got := CollectWeakSubjects(records, 5, 0.15); len(got) != 0 {
+		t.Fatalf("CollectWeakSubjects = %+v, want none: review has 1 resolved run against minSamples=5", got)
+	}
+}
+
+// Once a role has enough resolved runs, stalls alongside them neither block it
+// nor inflate the reported sample count.
+func TestCollectWeakSubjectsReportsResolvedSampleCount(t *testing.T) {
+	var records []stats.RunRecord
+	records = append(records, repeatRecords(5, "implementation", stats.OutcomeFailed, "p1", "impl-fail-")...)
+	records = append(records, repeatRecords(3, "implementation", stats.OutcomeStalled, "p1", "impl-stall-")...)
+	records = append(records, repeatRecords(20, "docs", stats.OutcomeCompleted, "p1", "docs-")...)
+
+	got := CollectWeakSubjects(records, 5, 0.15)
+	if len(got) != 1 || got[0].Role != "implementation" {
+		t.Fatalf("CollectWeakSubjects = %+v, want implementation", got)
+	}
+	if got[0].Samples != 5 {
+		t.Errorf("Samples = %d, want 5 (resolved runs, not the 8 dispatched)", got[0].Samples)
+	}
+}
+
 func TestCollectWeakSubjectsNoRecords(t *testing.T) {
 	got := CollectWeakSubjects(nil, 5, 0.15)
 	if len(got) != 0 {

--- a/internal/promptlab/collect_test.go
+++ b/internal/promptlab/collect_test.go
@@ -25,15 +25,15 @@ func repeatRecords(n int, role, outcome, projectID, taskIDPrefix string) []stats
 func TestCollectWeakSubjectsGates(t *testing.T) {
 	var records []stats.RunRecord
 	// implementation: 10 runs, 5 failed -> 0.50 failure rate, clears both gates.
-	records = append(records, repeatRecords(5, "implementation", "failed", "p1", "impl-fail-")...)
-	records = append(records, repeatRecords(5, "implementation", "ok", "p2", "impl-ok-")...)
+	records = append(records, repeatRecords(5, "implementation", stats.OutcomeFailed, "p1", "impl-fail-")...)
+	records = append(records, repeatRecords(5, "implementation", stats.OutcomeCompleted, "p2", "impl-ok-")...)
 	// review: 10 runs, 1 failed -> 0.10 failure rate, below min effect size.
-	records = append(records, repeatRecords(1, "review", "failed", "p1", "review-fail-")...)
-	records = append(records, repeatRecords(9, "review", "ok", "p1", "review-ok-")...)
+	records = append(records, repeatRecords(1, "review", stats.OutcomeFailed, "p1", "review-fail-")...)
+	records = append(records, repeatRecords(9, "review", stats.OutcomeCompleted, "p1", "review-ok-")...)
 	// fix-review: 2 runs, both failed -> below min samples despite high rate.
-	records = append(records, repeatRecords(2, "fix-review", "failed", "p1", "fix-review-")...)
+	records = append(records, repeatRecords(2, "fix-review", stats.OutcomeFailed, "p1", "fix-review-")...)
 	// docs: 10 runs, all passing -> dilutes the fleet baseline to 0.25.
-	records = append(records, repeatRecords(10, "docs", "ok", "p1", "docs-")...)
+	records = append(records, repeatRecords(10, "docs", stats.OutcomeCompleted, "p1", "docs-")...)
 
 	got := CollectWeakSubjects(records, 5, 0.15)
 	if len(got) != 1 {

--- a/internal/promptlab/service_test.go
+++ b/internal/promptlab/service_test.go
@@ -94,9 +94,9 @@ func TestRunCapsProposalsAndLogs(t *testing.T) {
 func weakRoleRecords(role string, fails, runs int) []stats.RunRecord {
 	out := make([]stats.RunRecord, runs)
 	for i := range out {
-		outcome := "ok"
+		outcome := stats.OutcomeCompleted
 		if i < fails {
-			outcome = "failed"
+			outcome = stats.OutcomeFailed
 		}
 		out[i] = stats.RunRecord{Role: role, Outcome: outcome, TaskID: role + string(rune('a'+i))}
 	}

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -71,9 +71,9 @@ func (s *Store) Backfill(auditDir string) error {
 			r.DurationS = v
 		}
 		if run.Failed {
-			r.Outcome = "failed"
+			r.Outcome = OutcomeFailed
 		} else {
-			r.Outcome = "completed"
+			r.Outcome = OutcomeCompleted
 		}
 		if v, ok := run.TerminalEvent.Data["provider"].(string); ok {
 			r.Provider = v

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -6,6 +6,27 @@ import (
 	"github.com/Automaat/sybra/internal/limits"
 )
 
+// Outcome values recorded on RunRecord.Outcome.
+//
+// OutcomeStalled marks a run that never produced a definitive result — a signal
+// kill, a stop before the terminal event, a provider rate limit, or a malformed
+// tool call (see completion.classifyStall). Sybra retries those runs, so a stall
+// is neither a success nor a failure: it must stay out of both the numerator and
+// the denominator of any failure rate, or a provider that stalls often reads as
+// more reliable than one that stalls rarely. Use IsTerminalOutcome to gate a
+// record into an outcome-derived rate.
+const (
+	OutcomeCompleted = "completed"
+	OutcomeFailed    = "failed"
+	OutcomeStalled   = "stalled"
+)
+
+// IsTerminalOutcome reports whether an outcome represents a definitive result
+// and therefore belongs in a failure-rate denominator.
+func IsTerminalOutcome(outcome string) bool {
+	return outcome != OutcomeStalled
+}
+
 // RunRecord captures a single agent execution for analytics.
 //
 // Cache token fields are recorded so the stats UI can show actual API

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -23,8 +23,14 @@ const (
 
 // IsTerminalOutcome reports whether an outcome represents a definitive result
 // and therefore belongs in a failure-rate denominator.
+//
+// Deliberately an allowlist. A denylist ("anything but stalled") would quietly
+// count an empty, corrupt, or newly-added outcome as a resolved non-failure —
+// the same false dichotomy that caused this bug, where runOutcome assumed any
+// non-nil exit error meant failure. Anything not known to be definitive is not
+// definitive.
 func IsTerminalOutcome(outcome string) bool {
-	return outcome != OutcomeStalled
+	return outcome == OutcomeCompleted || outcome == OutcomeFailed
 }
 
 // RunRecord captures a single agent execution for analytics.

--- a/internal/stats/model_test.go
+++ b/internal/stats/model_test.go
@@ -1,0 +1,29 @@
+package stats
+
+import "testing"
+
+// IsTerminalOutcome is an allowlist on purpose: a denylist ("anything but
+// stalled") would count an empty, corrupt, or newly-added outcome as a resolved
+// non-failure and quietly skew every failure-rate denominator that reads it.
+func TestIsTerminalOutcome(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		outcome string
+		want    bool
+	}{
+		{OutcomeCompleted, true},
+		{OutcomeFailed, true},
+		{OutcomeStalled, false},
+		{"", false},
+		{"some-future-outcome", false},
+		{"COMPLETED", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.outcome, func(t *testing.T) {
+			t.Parallel()
+			if got := IsTerminalOutcome(tc.outcome); got != tc.want {
+				t.Errorf("IsTerminalOutcome(%q) = %v, want %v", tc.outcome, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -673,25 +673,35 @@ func (h *Handler) captureHeadSHA(taskID string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// runOutcome derives the stats.RunRecord outcome ("completed"/"failed") for a
-// terminal agent run. Test-runner is special-cased: its exitErr reflects
+// runOutcome derives the stats.RunRecord outcome for a completed agent run.
+//
+// The stall check comes first and mirrors runTerminalOutcome so the stats
+// dataset and the persisted AgentRun.Outcome cannot disagree about the same
+// run: a stall is retried (notifyWorkflowEngine re-drives the step), so it is
+// not a result at all and is recorded as stats.OutcomeStalled — never as a
+// failure. Recording it as "failed" is what put implementation at a reported
+// 92.3% failure rate over runs that were merely retried (#2149).
+//
+// Test-runner is special-cased for the non-stall case: its exitErr reflects
 // whether the *process* exited clean, not whether it correctly did its job
 // (proving or failing to disprove the implementation). A test-runner that
 // produced a protocol-valid PASS/FAIL verdict succeeded at its job even if a
 // benign post-result glitch (e.g. a trailing stream hiccup) left exitErr
-// non-nil, so it is recorded as "completed" rather than inflating the role's
-// failure_rate with a run that was never actually a failure. Other roles are
-// unaffected: their exitErr already reflects whether they completed the task.
-func runOutcome(role agent.Role, exitErr error, resultContent string) string {
+// non-nil, so it is recorded as completed rather than inflating the role's
+// failure_rate with a run that was never actually a failure.
+func runOutcome(ag *agent.Agent, role agent.Role, exitErr error, resultContent string) string {
+	if stalled, _, _, _, _ := classifyStall(ag, exitErr); stalled {
+		return stats.OutcomeStalled
+	}
 	if exitErr == nil {
-		return "completed"
+		return stats.OutcomeCompleted
 	}
 	if role == agent.RoleTestRunner {
 		if v := workflow.ExtractTestVerdict(resultContent); v == "PASS" || v == "FAIL" {
-			return "completed"
+			return stats.OutcomeCompleted
 		}
 	}
-	return "failed"
+	return stats.OutcomeFailed
 }
 
 func (h *Handler) roleForAgentName(name string) agent.Role {
@@ -717,7 +727,7 @@ func (h *Handler) recordRunStats(ag *agent.Agent, role agent.Role, cost, duratio
 	cacheRead := ag.GetCacheReadInputTokens()
 	reasoning := ag.GetReasoningTokens()
 	agCost := estimatedRunCost(ag, cost, ag.GetPremiumRequests())
-	outcome := runOutcome(role, exitErr, resultContent)
+	outcome := runOutcome(ag, role, exitErr, resultContent)
 	var projectID string
 	if ag.TaskID != "" {
 		if t, err := h.tasks.Get(ag.TaskID); err == nil {

--- a/internal/sybra/completion/completion_test.go
+++ b/internal/sybra/completion/completion_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/Automaat/sybra/internal/worktree"
 )
 
+// sigkillErr SIGKILLs a live process and returns its Wait error, so tests can
+// exercise the real signal-kill shape (WaitStatus.Signaled) rather than a
+// hand-made error that isSignalKill would classify differently.
+func sigkillErr(t *testing.T) error {
+	t.Helper()
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+	return cmd.Wait()
+}
+
 func TestRunOutcome(t *testing.T) {
 	t.Parallel()
 	errBoom := errors.New("boom")
@@ -23,12 +39,13 @@ func TestRunOutcome(t *testing.T) {
 	cases := []struct {
 		name          string
 		role          agent.Role
+		agent         func() *agent.Agent
 		exitErr       error
 		resultContent string
 		want          string
 	}{
-		{"clean_exit_any_role", agent.RoleImplementation, nil, "", "completed"},
-		{"non_test_runner_errors_are_failed", agent.RoleImplementation, errBoom, "TEST_VERDICT: PASS", "failed"},
+		{name: "clean_exit_any_role", role: agent.RoleImplementation, want: "completed"},
+		{name: "non_test_runner_errors_are_failed", role: agent.RoleImplementation, exitErr: errBoom, resultContent: "TEST_VERDICT: PASS", want: "failed"},
 		{
 			name:          "test_runner_genuine_pass_survives_trailing_process_error",
 			role:          agent.RoleTestRunner,
@@ -54,12 +71,70 @@ func TestRunOutcome(t *testing.T) {
 			resultContent: "crashed before concluding anything",
 			want:          "failed",
 		},
+		{
+			// #2149: the ~96% codex stall case. The workflow engine retries
+			// this run, so recording it as "failed" is what drove the reported
+			// 92.3% implementation failure rate over runs that never resolved.
+			name:    "signal_killed_run_is_a_stall_not_a_failure",
+			role:    agent.RoleImplementation,
+			exitErr: sigkillErr(t),
+			want:    "stalled",
+		},
+		{
+			name: "stopped_before_result_is_a_stall",
+			role: agent.RoleImplementation,
+			agent: func() *agent.Agent {
+				ag := &agent.Agent{}
+				ag.MarkStopped()
+				return ag
+			},
+			want: "stalled",
+		},
+		{
+			name: "rate_limited_run_is_a_stall",
+			role: agent.RoleImplementation,
+			agent: func() *agent.Agent {
+				ag := &agent.Agent{}
+				ag.SetError("rate_limit", "rate_limited")
+				return ag
+			},
+			exitErr: errBoom,
+			want:    "stalled",
+		},
+		{
+			name: "malformed_tool_call_is_a_stall",
+			role: agent.RoleImplementation,
+			agent: func() *agent.Agent {
+				ag := &agent.Agent{}
+				ag.SetError("malformed_tool_call", "tool rejected malformed input")
+				return ag
+			},
+			want: "stalled",
+		},
+		{
+			// A budget breach is a deliberate hard-stop, not an infra stall —
+			// it must stay countable as a real failure (classifyStall).
+			name: "cost_guardrail_stop_stays_a_failure",
+			role: agent.RoleImplementation,
+			agent: func() *agent.Agent {
+				ag := &agent.Agent{}
+				ag.MarkStopped()
+				ag.SetEscalationReason(agent.EscalationReasonCost)
+				return ag
+			},
+			exitErr: errBoom,
+			want:    "failed",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := runOutcome(tc.role, tc.exitErr, tc.resultContent); got != tc.want {
+			ag := &agent.Agent{}
+			if tc.agent != nil {
+				ag = tc.agent()
+			}
+			if got := runOutcome(ag, tc.role, tc.exitErr, tc.resultContent); got != tc.want {
 				t.Errorf("runOutcome(%v, %v, %q) = %q, want %q", tc.role, tc.exitErr, tc.resultContent, got, tc.want)
 			}
 		})
@@ -111,20 +186,6 @@ func TestIsSignalKill(t *testing.T) {
 			t.Fatalf("exit code mismatch: got %d want %d", ee.ExitCode(), code)
 		}
 		return err
-	}
-
-	// Helper: send SIGKILL to a running process and return the Wait error.
-	sigkillErr := func(t *testing.T) error {
-		t.Helper()
-		cmd := exec.Command("sleep", "60")
-		if err := cmd.Start(); err != nil {
-			t.Fatalf("start sleep: %v", err)
-		}
-		time.Sleep(20 * time.Millisecond)
-		if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
-			t.Fatalf("signal: %v", err)
-		}
-		return cmd.Wait()
 	}
 
 	tests := []struct {


### PR DESCRIPTION
## Motivation

`runOutcome` recorded a stalled agent run as `outcome: "failed"` in `stats.RunRecord`, while its sibling `runTerminalOutcome` correctly recorded the same run as indeterminate in `task.AgentRun`. Stalls are retried by the workflow engine, so they are not a definitive result — but `stats.RunRecord.Outcome` is the only dataset the Evaluation scorecard and Prompt Lab read, so both worked from corrupted evidence. On the live server that reported implementation at 92.3% failure over 2204 runs, of which 99.4% cost $0 and produced nothing.

That number is one gate away from acting on its own: Prompt Lab had implementation at effect +0.149 against a `min_effect_size` of 0.15, and its first autonomous act would have been to rewrite the implementation prompt to fix what is really a codex stall. Missing by 0.001 was luck.

> Changelog: fix(stats): stop counting retried stalls as failures

## Implementation information

`runOutcome` now consults `classifyStall` first, mirroring `runTerminalOutcome`, and records a third outcome value `stats.OutcomeStalled`. The two functions can no longer disagree about the same run.

**The denominator decision the issue asked to make explicitly.** A stall is excluded from the failure numerator *and* the denominator. Leaving it in the denominator would rank the stall-prone provider as the most reliable one — codex stalls ~96% of the time (#2150), so its failure rate would read ~25× better than claude's on identical underlying quality. Stalls stay counted as runs, since they burn real wall-clock and spend, and now carry their own count.

Every failure rating and every sample-sufficiency gate reads `ResolvedRuns`. Rating over resolved runs while gating on dispatches is its own bug: a role with 4 stalls and 1 failure would clear `min_samples=5` on a rate derived from a single run, and `prompt_lab.auto_approve` defaults to `true` — reintroducing the exact harm this fix exists to prevent, through the back door. Covered at all four gates: Prompt Lab `MinSamples`, evaluation `InsufficientData` / `SampleStatus`, experiment readiness, and `weakness.go`'s signal gate.

`stats.IsTerminalOutcome` is an allowlist (`completed`/`failed`), not `!= stalled`. A denylist would count an empty, corrupt, or newly-added outcome as a resolved non-failure — the same false dichotomy as the bug itself, where `runOutcome` assumed any non-nil exit error meant failure. Consequently `Runs`, `Stalled` and `ResolvedRuns` are each counted rather than one being derived by subtraction, so an unknown outcome is excluded from every rate without being mislabelled a stall. This changes no current number: the live store holds 764 `completed` and 2218 `failed` and nothing else, and no production path can emit a non-canonical value. It is a guard against the next outcome value — which #2150 may well add. The allowlist also caught two Prompt Lab fixtures asserting on a made-up `"ok"` outcome that the denylist had been silently counting as a success.

`Runs` keeps meaning dispatches in every struct in the package, so "never dispatched" stays distinguishable from "every dispatch stalled" — the latter now reads as observed-but-not-ready rather than `no-data`. Stall counts are surfaced wherever a failure rate is shown: CLI, the Evaluation cards and breakdown table, the experiment tables, and the learning digest packet.

**Known transition state — deliberate.** The fix is forward-only. Stall records only exist going forward, so for up to `evaluation.window_days` (default 30) the scorecard keeps reading pre-fix stalls as failures while reporting ~0 stalls, which reads exactly like the fix never landed. No repair is possible: `agent.completion.stall` is an slog line, not an audit event, so `audit.Read` cannot see it; `AgentRun.Outcome == ""` is ambiguous (the field only landed six days ago, so ~80% of the window predates it — repairing on it would convert every genuine older failure into a stall); and `cost==0 && tokens==0` is a heuristic that would launder real instant failures (an auth error also costs $0). Rather than guess, `Report.Notes` now says so when the window holds failed runs that cost nothing and produced nothing, and the note clears itself as the window rolls.

Alternatives considered: skipping `stats.Record` for stalls entirely (rejected — it would hide the stall waste #2150 needs to measure, and make cost accounting less honest, not more).

Closes #2149

## Supporting documentation

- Adversarial review found the gate/rate split described above and a missed sibling site in `weakness.go`; both fixed, each with a regression test verified to fail against the pre-fix source.
- Regression coverage: stalled/rate-limited/malformed-tool/signal-kill runs record `stalled`; cost-guardrail stops stay `failed`; stalls leave the numerator and denominator in `Compute`, `BreakdownBy`, and `CompareBy`; all four sample gates count resolved runs; the transition note appears and clears.
