### PR TITLE
fix(github): resolve bot identity without /user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,15 @@ jobs:
       - name: Check for ~/.sybra fallbacks outside internal/config
         run: bash scripts/check-no-home-fallback.sh
 
+  check-no-viewer-user-endpoint:
+    name: No /user Identity Lookups
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check for /user identity lookups outside viewerLoginE
+        run: bash scripts/check-no-viewer-user-endpoint.sh
+
   test-release-scripts:
     name: Release Scripts Tests
     runs-on: ubuntu-latest

--- a/internal/github/appauth.go
+++ b/internal/github/appauth.go
@@ -38,6 +38,7 @@ type appTokenSource struct {
 	mu      sync.RWMutex
 	token   string
 	expires time.Time
+	slug    string
 }
 
 const appTokenRenewBefore = 5 * time.Minute
@@ -73,6 +74,10 @@ func EnableAppAuth(creds AppCredentials) error {
 	appSourceMu.Lock()
 	appSource = src
 	appSourceMu.Unlock()
+	// The viewer identity is auth-mode-dependent (<slug>[bot] under App auth,
+	// the /user login otherwise), so a mode switch must not inherit the
+	// previous mode's cached login.
+	resetCachedViewer()
 	return nil
 }
 
@@ -82,6 +87,7 @@ func DisableAppAuth() {
 	appSourceMu.Lock()
 	appSource = nil
 	appSourceMu.Unlock()
+	resetCachedViewer()
 }
 
 func currentAppSource() *appTokenSource {
@@ -195,6 +201,65 @@ func (s *appTokenSource) mintInstallationToken(ctx context.Context, jwt string) 
 		expires = time.Now().Add(50 * time.Minute)
 	}
 	return body.Token, expires, nil
+}
+
+// appLogin returns the App's bot login as it appears on GitHub artifacts —
+// "<slug>[bot]", e.g. "sybra-app[bot]". This is the App-auth answer to "who am
+// I?": /user (see ViewerLogin) is a user-to-server endpoint and always 403s for
+// installation tokens, so it can never identify an App. GET /app is JWT-authed
+// and returns the slug, which is immutable for the lifetime of the App and so
+// is cached indefinitely.
+func (s *appTokenSource) appLogin(ctx context.Context) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("app login: app auth is disabled")
+	}
+	s.mu.RLock()
+	slug := s.slug
+	s.mu.RUnlock()
+	if slug != "" {
+		return slug + "[bot]", nil
+	}
+
+	jwt, err := s.signJWT(time.Now())
+	if err != nil {
+		return "", err
+	}
+	slug, err = s.fetchAppSlug(ctx, jwt)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	s.slug = slug
+	s.mu.Unlock()
+	return slug + "[bot]", nil
+}
+
+func (s *appTokenSource) fetchAppSlug(ctx context.Context, jwt string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, appAPIBaseURL+"/app", http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch app slug: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var body struct {
+		Slug    string `json:"slug"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode app slug: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK || body.Slug == "" {
+		return "", fmt.Errorf("fetch app slug: HTTP %d: %s", resp.StatusCode, body.Message)
+	}
+	return body.Slug, nil
 }
 
 func loadPrivateKey(path string) (*rsa.PrivateKey, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // execer abstracts command execution for testing.
@@ -78,26 +79,68 @@ var (
 	cachedViewer string
 )
 
-func viewerLogin(e execer) string {
+// resetCachedViewer drops the memoized viewer login. Called when the auth mode
+// changes, since the identity is resolved differently per mode.
+func resetCachedViewer() {
+	viewerMu.Lock()
+	cachedViewer = ""
+	viewerMu.Unlock()
+}
+
+func viewerLogin(ctx context.Context, e execer) string {
+	login, err := viewerLoginE(ctx, e)
+	if err != nil {
+		return ""
+	}
+	return login
+}
+
+// viewerLoginE resolves the login this process acts as, returning the cause on
+// failure so callers can report *why* attribution is impossible rather than a
+// bare "unknown".
+//
+// Auth-mode-dependent by necessity: under GitHub App auth the identity is
+// "<slug>[bot]" and must come from GET /app, because /user is a user-to-server
+// endpoint that always 403s for installation tokens (the same trap #2032 hit in
+// Authenticated() — see the comment there). Silently returning "" from a failed
+// /user call is what froze review_phase and drove the 112-review loop in #2164.
+func viewerLoginE(ctx context.Context, e execer) (string, error) {
 	viewerMu.RLock()
 	cached := cachedViewer
 	viewerMu.RUnlock()
 	if cached != "" {
-		return cached
+		return cached, nil
 	}
-	out, err := e.run("api", "user", "-q", ".login")
-	if err != nil {
-		return ""
+
+	var login string
+	if src := currentAppSource(); src != nil {
+		reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		resolved, err := src.appLogin(reqCtx)
+		if err != nil {
+			return "", err
+		}
+		login = resolved
+	} else {
+		out, err := runE(ctx, e, "api", "user", "-q", ".login")
+		if err != nil {
+			return "", fmt.Errorf("gh api user: %w", err)
+		}
+		login = strings.TrimSpace(string(out))
+		if login == "" {
+			return "", fmt.Errorf("gh api user: empty login")
+		}
 	}
+
 	viewerMu.Lock()
 	// Double-checked: another goroutine may have populated the cache
 	// between RUnlock and Lock; keep whichever value is set.
 	if cachedViewer == "" {
-		cachedViewer = strings.TrimSpace(string(out))
+		cachedViewer = login
 	}
 	result := cachedViewer
 	viewerMu.Unlock()
-	return result
+	return result, nil
 }
 
 // sanitizeGHOutput trims the `gh` CLI's combined output for use in error
@@ -502,9 +545,15 @@ func ParseIssueURL(rawURL string) (repo string, number int) {
 	return parseGitHubResourceURL(rawURL, "issues")
 }
 
-// ViewerLogin returns the authenticated GitHub user's login.
+// ViewerLogin returns the login this process acts as — the authenticated user,
+// or "<slug>[bot]" under GitHub App auth. Returns "" if it cannot be resolved.
 func ViewerLogin() string {
-	return viewerLogin(defaultExecer)
+	return ViewerLoginCtx(context.Background())
+}
+
+// ViewerLoginCtx is ViewerLogin bound to a caller's context.
+func ViewerLoginCtx(ctx context.Context) string {
+	return viewerLogin(ctx, defaultExecer)
 }
 
 // IsTransientError reports whether err is a transient GitHub API failure

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -146,8 +146,15 @@ func viewerLoginE(ctx context.Context, e execer) (string, error) {
 	if viewerGen != gen {
 		// The auth mode changed while we were resolving, so `login` describes
 		// the old mode. Writing it back would defeat resetCachedViewer() and
-		// pin a wrong-but-plausible identity forever. Fail instead: the caller
+		// pin a wrong-but-plausible identity forever.
+		//
+		// A non-empty cache here was necessarily written after the reset that
+		// bumped the generation (the reset empties it), so it already reflects
+		// the current mode and is safe to return. Otherwise fail: the caller
 		// leaves state untouched and the next call resolves under the new mode.
+		if cachedViewer != "" {
+			return cachedViewer, nil
+		}
 		return "", fmt.Errorf("resolve viewer login: auth mode changed during resolution")
 	}
 	// Double-checked: another goroutine may have populated the cache

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -77,6 +77,13 @@ var defaultExecer execer = ghExecer{}
 var (
 	viewerMu     sync.RWMutex
 	cachedViewer string
+	// viewerGen invalidates in-flight resolutions across an auth-mode switch.
+	// The identity is mode-dependent, and resolving it is slow (a gh subprocess
+	// or an HTTPS round-trip), so a resolution that started under the old mode
+	// can finish after resetCachedViewer() and write a now-wrong login back
+	// into an empty cache. That poisoned value looks like success, so nothing
+	// downstream fails closed — see the write-back guard below.
+	viewerGen uint64
 )
 
 // resetCachedViewer drops the memoized viewer login. Called when the auth mode
@@ -84,6 +91,7 @@ var (
 func resetCachedViewer() {
 	viewerMu.Lock()
 	cachedViewer = ""
+	viewerGen++
 	viewerMu.Unlock()
 }
 
@@ -107,6 +115,7 @@ func viewerLogin(ctx context.Context, e execer) string {
 func viewerLoginE(ctx context.Context, e execer) (string, error) {
 	viewerMu.RLock()
 	cached := cachedViewer
+	gen := viewerGen
 	viewerMu.RUnlock()
 	if cached != "" {
 		return cached, nil
@@ -133,14 +142,20 @@ func viewerLoginE(ctx context.Context, e execer) (string, error) {
 	}
 
 	viewerMu.Lock()
+	defer viewerMu.Unlock()
+	if viewerGen != gen {
+		// The auth mode changed while we were resolving, so `login` describes
+		// the old mode. Writing it back would defeat resetCachedViewer() and
+		// pin a wrong-but-plausible identity forever. Fail instead: the caller
+		// leaves state untouched and the next call resolves under the new mode.
+		return "", fmt.Errorf("resolve viewer login: auth mode changed during resolution")
+	}
 	// Double-checked: another goroutine may have populated the cache
 	// between RUnlock and Lock; keep whichever value is set.
 	if cachedViewer == "" {
 		cachedViewer = login
 	}
-	result := cachedViewer
-	viewerMu.Unlock()
-	return result, nil
+	return cachedViewer, nil
 }
 
 // sanitizeGHOutput trims the `gh` CLI's combined output for use in error

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -690,13 +691,13 @@ func fetchMyReviewStateWith(e execer, repo string, number int) (MyReviewState, e
 		return MyReviewState{}, err
 	}
 
-	me := viewerLogin(e)
-	if me == "" {
+	me, err := viewerLoginE(context.Background(), e)
+	if err != nil {
 		// Without the viewer's login we cannot attribute submitted reviews, and
-		// guessing would misclassify the phase. Surface a (transient) error so
-		// the caller leaves the task's phase untouched this cycle rather than
-		// flapping it to "manual".
-		return MyReviewState{}, fmt.Errorf("resolve viewer login for %s#%d", repo, number)
+		// guessing would misclassify the phase. Surface the underlying cause so
+		// a persistent auth-mode failure is diagnosable from the log line rather
+		// than looking like a transient blip (#2164).
+		return MyReviewState{}, fmt.Errorf("resolve viewer login for %s#%d: %w", repo, number, err)
 	}
 
 	var st MyReviewState

--- a/internal/github/viewer_login_test.go
+++ b/internal/github/viewer_login_test.go
@@ -192,6 +192,52 @@ func TestViewerLogin_AuthModeSwitchDoesNotPoisonCache(t *testing.T) {
 	}
 }
 
+// A generation mismatch means the stale resolution must be discarded — but if
+// another goroutine already resolved under the *new* mode, that value is
+// current (resetCachedViewer empties the cache, so anything non-empty was
+// written after the bump) and should be returned rather than failing the caller
+// for no reason.
+func TestViewerLogin_StaleResolutionYieldsToFreshCache(t *testing.T) {
+	clearViewerCache(t)
+	DisableAppAuth()
+
+	release := make(chan struct{})
+	slow := &blockingExecer{output: []byte("Automaat"), release: release, entered: make(chan struct{})}
+
+	done := make(chan string, 1)
+	go func() {
+		login, err := viewerLoginE(context.Background(), slow)
+		if err != nil {
+			done <- "ERR:" + err.Error()
+			return
+		}
+		done <- login
+	}()
+	<-slow.entered
+
+	path, _ := writeTestKey(t, false)
+	appSlugServer(t, "sybra-app")
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	// Another caller resolves under the new mode before the stale one lands.
+	if _, err := viewerLoginE(context.Background(), &recordingExecer{}); err != nil {
+		t.Fatalf("fresh resolve: %v", err)
+	}
+
+	close(release)
+	if got := <-done; got != "sybra-app[bot]" {
+		t.Errorf("stale resolution returned %q, want the fresh cache value sybra-app[bot]", got)
+	}
+
+	viewerMu.RLock()
+	defer viewerMu.RUnlock()
+	if cachedViewer != "sybra-app[bot]" {
+		t.Errorf("cachedViewer = %q, want sybra-app[bot]", cachedViewer)
+	}
+}
+
 // Without App auth the /user path is correct and must be preserved.
 func TestViewerLogin_UserAuthUsesUserEndpoint(t *testing.T) {
 	clearViewerCache(t)

--- a/internal/github/viewer_login_test.go
+++ b/internal/github/viewer_login_test.go
@@ -7,8 +7,25 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
+
+// blockingExecer holds a /user resolution open until released, so a test can
+// interleave an auth-mode switch with an in-flight identity lookup.
+type blockingExecer struct {
+	output    []byte
+	release   chan struct{}
+	entered   chan struct{}
+	enterOnce sync.Once
+}
+
+func (b *blockingExecer) run(_ ...string) ([]byte, error) {
+	b.enterOnce.Do(func() { close(b.entered) })
+	<-b.release
+	return b.output, nil
+}
 
 // emptyLoginExecer answers the reviews call with valid JSON but yields an empty
 // /user login, isolating identity failure from reviews-fetch failure.
@@ -81,13 +98,16 @@ func TestViewerLogin_AppAuthResolvesSlugAndNeverCallsUser(t *testing.T) {
 	}
 }
 
-// The App slug is immutable, so it is fetched once and memoized.
-func TestViewerLogin_AppAuthCachesSlug(t *testing.T) {
+// The App slug is immutable, so appLogin fetches it once and memoizes it on the
+// token source. Driven through appLogin directly: viewerLoginE's own
+// cachedViewer memo would short-circuit calls 2..n and make this pass whether
+// or not the slug is cached at all.
+func TestAppLogin_CachesSlug(t *testing.T) {
 	clearViewerCache(t)
 	path, _ := writeTestKey(t, false)
-	var hits int
+	var hits atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		hits++
+		hits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"slug":"sybra-app"}`))
 	}))
@@ -99,14 +119,76 @@ func TestViewerLogin_AppAuthCachesSlug(t *testing.T) {
 	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
 		t.Fatalf("enable: %v", err)
 	}
+	src := currentAppSource()
 
 	for range 3 {
-		if _, err := viewerLoginE(context.Background(), &recordingExecer{}); err != nil {
-			t.Fatalf("viewerLoginE: %v", err)
+		got, err := src.appLogin(context.Background())
+		if err != nil {
+			t.Fatalf("appLogin: %v", err)
+		}
+		if got != "sybra-app[bot]" {
+			t.Fatalf("appLogin = %q, want sybra-app[bot]", got)
 		}
 	}
-	if hits != 1 {
-		t.Errorf("GET /app called %d times, want 1 (slug is immutable)", hits)
+	if n := hits.Load(); n != 1 {
+		t.Errorf("GET /app called %d times, want 1 (slug is immutable)", n)
+	}
+}
+
+// A resolution that started under the previous auth mode must not write its
+// now-stale login back into the freshly-invalidated cache. Sybra's startup hits
+// this window for real: orchestratorLoop (lifecycle.go:100) can call
+// ViewerLogin() under ambient PAT auth while startAppAuthLoop (lifecycle.go:107)
+// switches to App auth seven lines later, and a gh subprocess always loses that
+// race to a PEM read. Poisoning cachedViewer with the PAT login would look like
+// success — the bot would silently stop recognising its own reviews and every
+// in-review task would be flipped to manual/human-required.
+func TestViewerLogin_AuthModeSwitchDoesNotPoisonCache(t *testing.T) {
+	clearViewerCache(t)
+	DisableAppAuth()
+
+	release := make(chan struct{})
+	slow := &blockingExecer{output: []byte("Automaat"), release: release, entered: make(chan struct{})}
+
+	type result struct {
+		login string
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		login, err := viewerLoginE(context.Background(), slow)
+		done <- result{login, err}
+	}()
+
+	<-slow.entered // the /user resolution is in flight under PAT auth
+
+	path, _ := writeTestKey(t, false)
+	appSlugServer(t, "sybra-app")
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	close(release) // let the stale PAT resolution finish and try to write back
+	got := <-done
+	if got.err == nil {
+		t.Errorf("stale resolution returned %q with no error; it must not be trusted across a mode switch", got.login)
+	}
+
+	viewerMu.RLock()
+	poisoned := cachedViewer
+	viewerMu.RUnlock()
+	if poisoned != "" {
+		t.Fatalf("cachedViewer poisoned with %q after the switch to App auth", poisoned)
+	}
+
+	// The next resolution must produce the App identity, not the PAT one.
+	login, err := viewerLoginE(context.Background(), &recordingExecer{output: []byte("Automaat")})
+	if err != nil {
+		t.Fatalf("viewerLoginE after switch: %v", err)
+	}
+	if login != "sybra-app[bot]" {
+		t.Errorf("login = %q, want sybra-app[bot]", login)
 	}
 }
 

--- a/internal/github/viewer_login_test.go
+++ b/internal/github/viewer_login_test.go
@@ -1,0 +1,231 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// emptyLoginExecer answers the reviews call with valid JSON but yields an empty
+// /user login, isolating identity failure from reviews-fetch failure.
+type emptyLoginExecer struct{}
+
+func (e *emptyLoginExecer) run(args ...string) ([]byte, error) {
+	if slices.Contains(args, "user") {
+		return []byte(""), nil
+	}
+	return []byte(`[]`), nil
+}
+
+// clearViewerCache isolates a test from the package-global viewer memo.
+func clearViewerCache(t *testing.T) {
+	t.Helper()
+	viewerMu.Lock()
+	prev := cachedViewer
+	cachedViewer = ""
+	viewerMu.Unlock()
+	t.Cleanup(func() {
+		viewerMu.Lock()
+		cachedViewer = prev
+		viewerMu.Unlock()
+	})
+}
+
+// appSlugServer stands in for GitHub's JWT-authed GET /app.
+func appSlugServer(t *testing.T, slug string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app" {
+			t.Errorf("unexpected path %q, want /app", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("GET /app must be JWT-authed")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"slug":"` + slug + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+	orig := appAPIBaseURL
+	appAPIBaseURL = srv.URL
+	t.Cleanup(func() { appAPIBaseURL = orig })
+}
+
+// Under App auth the identity must come from GET /app, never /user: /user is a
+// user-to-server endpoint that always 403s for installation tokens, which is
+// the root cause of the #2164 review loop.
+func TestViewerLogin_AppAuthResolvesSlugAndNeverCallsUser(t *testing.T) {
+	clearViewerCache(t)
+	path, _ := writeTestKey(t, false)
+	appSlugServer(t, "sybra-app")
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	// A 403 from /user, exactly as GitHub answers an installation token.
+	fe := &recordingExecer{err: errors.New("gh: HTTP 403: Resource not accessible by integration")}
+
+	got, err := viewerLoginE(context.Background(), fe)
+	if err != nil {
+		t.Fatalf("viewerLoginE: %v", err)
+	}
+	if got != "sybra-app[bot]" {
+		t.Errorf("login = %q, want sybra-app[bot]", got)
+	}
+	if fe.calls != 0 {
+		t.Errorf("gh was called %d times; /user must not be reached under App auth", fe.calls)
+	}
+}
+
+// The App slug is immutable, so it is fetched once and memoized.
+func TestViewerLogin_AppAuthCachesSlug(t *testing.T) {
+	clearViewerCache(t)
+	path, _ := writeTestKey(t, false)
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"slug":"sybra-app"}`))
+	}))
+	defer srv.Close()
+	orig := appAPIBaseURL
+	appAPIBaseURL = srv.URL
+	t.Cleanup(func() { appAPIBaseURL = orig })
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	for range 3 {
+		if _, err := viewerLoginE(context.Background(), &recordingExecer{}); err != nil {
+			t.Fatalf("viewerLoginE: %v", err)
+		}
+	}
+	if hits != 1 {
+		t.Errorf("GET /app called %d times, want 1 (slug is immutable)", hits)
+	}
+}
+
+// Without App auth the /user path is correct and must be preserved.
+func TestViewerLogin_UserAuthUsesUserEndpoint(t *testing.T) {
+	clearViewerCache(t)
+	DisableAppAuth()
+
+	fe := &recordingExecer{output: []byte("octocat\n")}
+	got, err := viewerLoginE(context.Background(), fe)
+	if err != nil {
+		t.Fatalf("viewerLoginE: %v", err)
+	}
+	if got != "octocat" {
+		t.Errorf("login = %q, want octocat", got)
+	}
+	if !slices.Contains(fe.lastArgs, "user") {
+		t.Errorf("user auth must resolve identity via /user; got args %v", fe.lastArgs)
+	}
+}
+
+// The bare "" return swallowed the reason for 23 hours during #2164. The cause
+// must reach the caller.
+func TestViewerLoginE_SurfacesCause(t *testing.T) {
+	clearViewerCache(t)
+	DisableAppAuth()
+
+	fe := &recordingExecer{err: errors.New("HTTP 403: Resource not accessible by integration")}
+	_, err := viewerLoginE(context.Background(), fe)
+	if err == nil {
+		t.Fatal("expected an error when identity cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error %q must carry the underlying cause", err)
+	}
+
+	// The legacy string-only wrapper still degrades to "" for its callers.
+	if got := viewerLogin(context.Background(), fe); got != "" {
+		t.Errorf("viewerLogin = %q, want empty on failure", got)
+	}
+}
+
+// An empty login is a failure, not a valid identity — attributing reviews to ""
+// would silently match nothing.
+func TestViewerLoginE_EmptyLoginIsAnError(t *testing.T) {
+	clearViewerCache(t)
+	DisableAppAuth()
+
+	if _, err := viewerLoginE(context.Background(), &recordingExecer{output: []byte("  \n")}); err == nil {
+		t.Fatal("expected an error for an empty /user login")
+	}
+}
+
+// The regression test for #2164: under App auth, the bot's own review must be
+// attributed to the viewer. This is what reconcileReviewPhases needs to see in
+// order to leave needs-approval, and its failure drove 112 reviews on one PR.
+func TestFetchMyReviewState_AttributesAppBotReview(t *testing.T) {
+	clearViewerCache(t)
+	path, _ := writeTestKey(t, false)
+	appSlugServer(t, "sybra-app")
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	body := `[{"state":"CHANGES_REQUESTED","user":{"login":"sybra-app[bot]"},` +
+		`"commit_id":"e57e4b5","submitted_at":"2026-07-15T18:48:08Z"}]`
+	got, err := fetchMyReviewStateWith(&recordingExecer{output: []byte(body)}, "o/r", 151)
+	if err != nil {
+		t.Fatalf("fetchMyReviewState: %v", err)
+	}
+	want := MyReviewState{Submitted: true, Approved: false, ReviewedSHA: "e57e4b5"}
+	if got != want {
+		t.Errorf("got %+v, want %+v — the bot must recognise its own review", got, want)
+	}
+}
+
+// FetchMyReviewState's error must name the cause, so a persistent auth failure
+// is not mistaken for a transient blip.
+func TestFetchMyReviewState_ErrorCarriesViewerCause(t *testing.T) {
+	clearViewerCache(t)
+	DisableAppAuth()
+
+	_, err := fetchMyReviewStateWith(&emptyLoginExecer{}, "o/r", 151)
+	if err == nil {
+		t.Fatal("expected an error when the viewer cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "resolve viewer login") {
+		t.Errorf("error %q should name the failing operation", err)
+	}
+}
+
+// Switching auth mode must not inherit the previous mode's identity.
+func TestAppAuthToggle_ResetsCachedViewer(t *testing.T) {
+	clearViewerCache(t)
+	DisableAppAuth()
+
+	if _, err := viewerLoginE(context.Background(), &recordingExecer{output: []byte("octocat")}); err != nil {
+		t.Fatalf("seed viewer: %v", err)
+	}
+	viewerMu.RLock()
+	seeded := cachedViewer
+	viewerMu.RUnlock()
+	if seeded != "octocat" {
+		t.Fatalf("cachedViewer = %q, want octocat", seeded)
+	}
+
+	path, _ := writeTestKey(t, false)
+	appSlugServer(t, "sybra-app")
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	got, err := viewerLoginE(context.Background(), &recordingExecer{output: []byte("octocat")})
+	if err != nil {
+		t.Fatalf("viewerLoginE: %v", err)
+	}
+	if got != "sybra-app[bot]" {
+		t.Errorf("login = %q, want sybra-app[bot] — the user-auth identity must not survive the switch", got)
+	}
+}

--- a/internal/sybra/review/automerge_test.go
+++ b/internal/sybra/review/automerge_test.go
@@ -821,7 +821,7 @@ func TestResolveAddressedCopilotThreads(t *testing.T) {
 		Number: 21, Repository: "pet-owner/pet-repo", HeadRefName: "feat",
 		Mergeable: "MERGEABLE", CIStatus: "SUCCESS", CopilotReviewed: true, UnresolvedCount: 3,
 	}}
-	r.resolveAddressedCopilotThreads(all, prs)
+	r.resolveAddressedCopilotThreads(context.Background(), all, prs)
 
 	if len(resolvedIDs) != 2 || resolvedIDs[0] != "T1" || resolvedIDs[1] != "T5" {
 		t.Fatalf("resolvedIDs = %v, want [T1 T5]", resolvedIDs)

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -177,11 +177,11 @@ type Handler struct {
 }
 
 // agentLogin returns the GitHub login the fix agent posts as.
-func (r *Handler) agentLogin() string {
+func (r *Handler) agentLogin(ctx context.Context) string {
 	if r.viewerLoginFn != nil {
 		return r.viewerLoginFn()
 	}
-	return github.ViewerLogin()
+	return github.ViewerLoginCtx(ctx)
 }
 
 // pollFast/pollSlow resolve the review poll cadence from config (github.*),
@@ -331,7 +331,7 @@ func (r *Handler) pollKnownTaskPRs(ctx context.Context) time.Duration {
 	}
 
 	r.scanForReverts(ctx, tasks)
-	r.resolveAddressedCopilotThreads(tasks, monitoredPRs)
+	r.resolveAddressedCopilotThreads(ctx, tasks, monitoredPRs)
 	r.reconcilePRPhases(tasks, monitoredPRs)
 	r.reconcileHumanRequiredBlockers(tasks, monitoredPRs)
 	r.closeFinishedReviewTasks(tasks, nil)
@@ -453,7 +453,7 @@ func (r *Handler) pollAndMonitorPRs(ctx context.Context) time.Duration {
 	}
 
 	r.scanForReverts(ctx, tasks)
-	r.resolveAddressedCopilotThreads(tasks, monitoredPRs)
+	r.resolveAddressedCopilotThreads(ctx, tasks, monitoredPRs)
 	r.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
 	// reconcileReviewTask's gh calls (FetchMyReviewState, FetchPRState,
 	// FetchPRHeadSHA) use the package's legacy ctx-less runGHAPIWith path,

--- a/internal/sybra/review/threads.go
+++ b/internal/sybra/review/threads.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"context"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/audit"
@@ -20,7 +21,7 @@ import (
 // detected via isOutdated (the anchored code changed since the comment). Human-
 // authored threads and still-live (non-outdated) Copilot threads are never
 // touched, so genuinely-unaddressed feedback still blocks the merge.
-func (r *Handler) resolveAddressedCopilotThreads(tasks []task.Task, prs []github.PullRequest) {
+func (r *Handler) resolveAddressedCopilotThreads(ctx context.Context, tasks []task.Task, prs []github.PullRequest) {
 	byNumber := make(map[int]string, len(tasks))
 	byBranch := make(map[string]string, len(tasks))
 	for i := range tasks {
@@ -63,7 +64,7 @@ func (r *Handler) resolveAddressedCopilotThreads(tasks []task.Task, prs []github
 		if r.WorkflowEngine != nil && r.WorkflowEngine.HasActiveWorkflow(taskID) {
 			continue
 		}
-		r.resolveCopilotThreadsForPR(taskID, *pr, r.agentLogin())
+		r.resolveCopilotThreadsForPR(taskID, *pr, r.agentLogin(ctx))
 	}
 }
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -967,6 +967,13 @@ func (s *TaskService) enrichFromPR(taskID, repo string, number int) {
 		return
 	}
 	viewer := s.viewerLoginFunc()()
+	if viewer == "" {
+		// Guessing "not mine" is irreversible: it points a review agent at our
+		// own PR and, via u.Tags, drops the enrich-pending marker reconcile
+		// retries on. Bail before any Update so the retry survives.
+		s.logger.Warn("enrich-pr.no-viewer", "task_id", taskID, "repo", repo, "number", number)
+		return
+	}
 
 	slug := task.Slugify(pr.Title)
 	u := task.Update{
@@ -985,7 +992,7 @@ func (s *TaskService) enrichFromPR(taskID, repo string, number int) {
 	labels := pr.Labels
 	u.Tags = &labels
 
-	isMyPR := viewer != "" && strings.EqualFold(pr.Author, viewer)
+	isMyPR := strings.EqualFold(pr.Author, viewer)
 	if isMyPR {
 		u.Status = task.Ptr(task.StatusInReview)
 		if _, err := s.tasks.Update(taskID, u); err != nil {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -1428,3 +1428,46 @@ func TestTaskService_ReconcilePendingEnrichment_SkipsNonStubs(t *testing.T) {
 		t.Fatal("reconcile fetched GitHub for a non-URL / unmarked task")
 	}
 }
+
+// An unresolvable viewer identity must not be guessed into "not my PR": that
+// branch spawns a /staff-code-review agent against what may be our own PR and,
+// by writing u.Tags, drops the enrich-pending marker
+// ReconcilePendingEnrichment retries on — permanently misrouting the task.
+// Reachable whenever the startup GET /app has not resolved yet (2165).
+func TestTaskService_EnrichFromPR_UnknownViewerDefersInsteadOfMisrouting(t *testing.T) {
+	svc, _ := setupTaskService(t)
+	var fetched atomic.Bool
+	svc.fetchPR = func(string, int) (github.PullRequest, error) {
+		fetched.Store(true)
+		return github.PullRequest{
+			Number:      151,
+			Title:       "fix(plugin): recover from stale connection",
+			HeadRefName: "fix/windows-stale-connection",
+			Author:      "sybra-app[bot]",
+			Labels:      []string{"bug"},
+		}, nil
+	}
+	svc.viewerLogin = func() string { return "" }
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/pull/151", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	if !fetched.Load() {
+		t.Fatal("fetchPR was never called; test does not exercise enrichFromPR")
+	}
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The marker is what ReconcilePendingEnrichment retries on. Any Update in
+	// enrichFromPR replaces Tags and would drop it.
+	if !slices.Contains(got.Tags, enrichPendingTag) {
+		t.Errorf("tags = %v, want %q retained so reconcile retries once identity resolves", got.Tags, enrichPendingTag)
+	}
+	if slices.Contains(got.Tags, "review") {
+		t.Error("task was tagged for review on an unidentified PR; it may be our own")
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -77,6 +77,7 @@ run = [
   "cd frontend && node scripts/check-pin-strategy.mjs",
   "bash scripts/check-api-shim-sync.sh",
   "bash scripts/check-no-home-fallback.sh",
+  "bash scripts/check-no-viewer-user-endpoint.sh",
   "bash scripts/resolve-release-version.test.sh",
   "bash scripts/generate-release-notes.test.sh",
   "command -v wails3 >/dev/null 2>&1 || (echo 'wails3 not found — install with: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.87 (see .github/workflows/ci.yml for the full workaround)' && exit 1)",

--- a/scripts/check-no-viewer-user-endpoint.sh
+++ b/scripts/check-no-viewer-user-endpoint.sh
@@ -62,7 +62,11 @@ fail=0
 #   gh api user            -> e.run("api", "user", ...)
 #   gh api /user           -> exec.Command("gh", "api", "/user")
 #   "api", "user"          -> arg-slice form
-PATTERN='"api",[[:space:]]*"/?user"|gh[[:space:]]+api[[:space:]]+/?user\b|"/user"'
+#
+# The trailing boundary is spelled as an explicit character class rather than
+# \b: \b is a GNU/BSD extension undefined in POSIX ERE, and a guard that
+# silently stops matching is worse than no guard at all.
+PATTERN='"api",[[:space:]]*"/?user"|gh[[:space:]]+api[[:space:]]+/?user([^[:alnum:]_-]|$)|"/user"'
 
 files=()
 while IFS= read -r -d '' file; do

--- a/scripts/check-no-viewer-user-endpoint.sh
+++ b/scripts/check-no-viewer-user-endpoint.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Ban new code that resolves the bot's own GitHub identity via `gh api user`
+# (or the REST /user endpoint) outside internal/github's single resolution
+# point (viewerLoginE).
+#
+# /user is a user-to-server endpoint that ALWAYS 403s for GitHub App
+# installation tokens, even when they are fully functional for everything
+# else. The server authenticates as a GitHub App, so any /user-based identity
+# lookup silently resolves to "" there.
+#
+# This has now bitten twice:
+#   - #2032: Authenticated() preflighted with `gh api user` and false-negatived
+#     on exactly the credential type it existed to support. Fixed by probing
+#     /rate_limit instead.
+#   - #2164: viewerLogin() resolved the review-attribution identity with
+#     `gh api user`, returned "", froze review_phase at needs-approval, and
+#     drove 112 duplicate reviews onto an external contributor's PR over 23h.
+#
+# Both times the fix was applied to one call site while its twin kept the bug.
+# This check exists so the third occurrence fails in CI instead of on someone
+# else's pull request.
+#
+# This is a literal-string grep, not an AST/data-flow check: it flags source
+# that spells out the /user identity lookup. It cannot prove a given lookup is
+# actually used for identity, so it narrows the risk rather than closing it.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Files allowed to reference the /user endpoint:
+#   - internal/github/client.go: viewerLoginE(), the canonical resolution
+#     point. It calls /user ONLY when App auth is disabled, where /user is
+#     correct; under App auth it resolves <slug>[bot] from GET /app instead.
+#   - internal/github/appauth.go: the comment on Authenticated() documenting
+#     why /user must not be used (the #2032 fix).
+#   - internal/github/viewer_login_test.go: asserts both branches, including
+#     that /user is NOT called under App auth.
+#   - internal/github/appauth_test.go: prose in the #2032 regression test
+#     naming the banned call, not a lookup.
+#   - scripts/check-no-viewer-user-endpoint.sh (this file): the patterns
+#     below are grep targets, not a lookup.
+ALLOWLIST=(
+  "internal/github/client.go"
+  "internal/github/appauth.go"
+  "internal/github/viewer_login_test.go"
+  "internal/github/appauth_test.go"
+  "scripts/check-no-viewer-user-endpoint.sh"
+)
+
+is_allowlisted() {
+  local f="$1"
+  for allowed in "${ALLOWLIST[@]}"; do
+    [[ "${f}" == "${allowed}" ]] && return 0
+  done
+  return 1
+}
+
+fail=0
+
+# Matches the identity lookup in the shapes it actually appears in:
+#   gh api user            -> e.run("api", "user", ...)
+#   gh api /user           -> exec.Command("gh", "api", "/user")
+#   "api", "user"          -> arg-slice form
+PATTERN='"api",[[:space:]]*"/?user"|gh[[:space:]]+api[[:space:]]+/?user\b|"/user"'
+
+files=()
+while IFS= read -r -d '' file; do
+  case "${file}" in
+    *.go | *.sh | *.ts)
+      files+=("${file}")
+      ;;
+  esac
+done < <(git ls-files -z --cached --others --exclude-standard)
+
+if ((${#files[@]} > 0)); then
+  while IFS= read -r hit; do
+    [[ -z "${hit}" ]] && continue
+    f="${hit%%:*}"
+    if is_allowlisted "${f}"; then
+      continue
+    fi
+    if ((fail == 0)); then
+      echo "ERROR: /user identity lookup outside internal/github's viewerLoginE()." >&2
+      echo "/user always 403s for GitHub App installation tokens (#2032, #2164)." >&2
+      echo "Call github.ViewerLogin()/viewerLoginE(), which is App-auth-aware, instead." >&2
+      echo >&2
+    fi
+    fail=1
+    echo "  ${hit}" >&2
+  done < <(grep -nHE "${PATTERN}" "${files[@]}" 2>/dev/null | sed 's#^\./##' || true)
+fi
+
+if ((fail != 0)); then
+  exit 1
+fi
+
+echo "check-no-viewer-user-endpoint: ok"


### PR DESCRIPTION
## Motivation

`viewerLogin()` resolved this process's own GitHub identity with `gh api user`. `/user` is a user-to-server endpoint that **always 403s for GitHub App installation tokens**, and the server authenticates as a GitHub App — so it returned `""` on every call, with the error swallowed.

Downstream, `FetchMyReviewState` cannot attribute reviews without a login, so it failed; `reconcileReviewPhases` logged `review.my-state` and returned early, freezing `review_phase` at `needs-approval`; and `inboundReviewNeedsAgent` treats `needs-approval` as dispatchable once the 10-minute cooldown elapses. The result was a self-sustaining loop: **112 reviews and 57 inline comments over 23 hours on an external contributor's PR** (`Automaat/lightroom-mcp#151`), every one against the same unchanged commit, verdicts flapping between APPROVED and CHANGES_REQUESTED because each run was a fresh model with no memory of the last. It stopped only when the task was manually set to `blocked`.

We already knew this. #2032 hit the identical trap and fixed `Authenticated()` to probe `/rate_limit` instead; the comment at `internal/github/appauth.go` spells the rule out. The lesson was applied to one call site and not its twin.

Closes #2165. Part of #2164.

> Changelog: fix(github): resolve bot identity without /user under App auth

## Implementation information

**Identity resolution is now auth-mode-aware.** Under App auth the identity is `<slug>[bot]`, resolved from the JWT-authed `GET /app` and memoized (the slug is immutable). `/user` is kept only for user/PAT auth, where it is correct. Verified against production: the real reviews on PR #151 carry login `sybra-app[bot]` and the App's slug is `sybra-app`, so `slug + "[bot]"` matches byte-for-byte.

**Failures now carry their cause.** `viewerLoginE` returns the underlying error instead of a bare `""`, so a persistent auth-mode failure is diagnosable from the log line rather than looking like a transient blip for 23 hours. The string-only `viewerLogin` wrapper is retained for existing callers.

**A generation-versioned cache** (`0048770f`). The first cut of this PR introduced a worse bug than the one it fixed: `resetCachedViewer()` invalidated the memo on an auth-mode switch, but the write-back didn't respect it. Startup hits this window for real — `orchestratorLoop` (`lifecycle.go:100`) can call `ViewerLogin()` under ambient PAT auth while `startAppAuthLoop` (`:107`) switches to App auth seven lines later, and a `gh` subprocess reliably loses that race to a PEM read. The stale login would land after the invalidation and pin `"Automaat"` as the identity permanently. That *looks like success*, so nothing fails closed: the bot silently stops recognising its own reviews and every in-review task gets flipped to manual/human-required. The cache is now versioned; a resolution whose generation no longer matches is rejected rather than written back, so the caller leaves state untouched and the next call resolves under the current mode.

**Unknown identity no longer misroutes a task** (`86294af4`). `enrichFromPR` treated an unresolvable viewer as "not my PR" — spawning a `/staff-code-review` agent against what may be our own PR and, by writing `u.Tags`, dropping the `enrich-pending` marker that `ReconcilePendingEnrichment` retries on. The misroute was permanent. Reachable without any race, since the login memoizes only on success: any failure of the startup lookup yields `""` for every caller until the first success, and the maintenance tick runs `enrichFromPR` in exactly that window. It now bails before any `Update`, mirroring the fetch-failure path directly above, so the retry survives.

**A drift check** (`scripts/check-no-viewer-user-endpoint.sh`), wired into `mise run verify` and CI, following `check-no-home-fallback.sh`. This trap has now bitten twice, both times because a fix landed on one call site while its twin kept the bug. The check exists so the third occurrence fails CI instead of landing on someone else's pull request. It is a literal-string grep, not a data-flow analysis — its header documents what it cannot catch.

### Testing

Nine tests in `internal/github/viewer_login_test.go` plus one in `internal/sybra`. Each new guard is **mutation-verified** — I confirmed the test fails against the pre-fix code and passes after:

- Neutralize the App-auth branch → `TestFetchMyReviewState_AttributesAppBotReview` fails with `Submitted:false`, reproducing the exact freeze from the incident.
- Neutralize the generation guard → `TestViewerLogin_AuthModeSwitchDoesNotPoisonCache` fails with `cachedViewer poisoned with "Automaat"`.
- Delete the slug memo → `TestAppLogin_CachesSlug` fails (3 `GET /app` calls vs 1).
- Restore the `viewer != ""` guard → the enrich test fails.

`FetchMyReviewState` was also driven against the real 115-review PR #151 payload, returning `{Submitted:true, ReviewedSHA:e57e4b5...}` with zero `/user` calls. Package globals meant test isolation needed attention: `-race -count=2 -shuffle=on` is clean.

Note that `go vet` and `golangci-lint` both report **0 issues** against a neutralized `if false && viewerGen != gen`. The tests are the only thing holding that line.

## Open questions

**Non-atomic generation bump.** `EnableAppAuth` swaps `appSource` and bumps `viewerGen` in separate critical sections, so a resolution finishing in the gap can *return* a stale login to its caller (the cache is not poisoned — `resetCachedViewer()` clears it immediately after). Closing it means bumping the generation inside the `appSourceMu` critical section, which nests `appSourceMu` → `viewerMu`. I judged that lock-ordering risk worse than the window it closes: reaching it requires a ~200ms `gh` subprocess to land inside a ~100ns gap, once per process. Flagging rather than silently leaving it.

**`appLogin` is not single-flight.** N concurrent cold callers each fire a `GET /app` (observed: 33 hits from 64 goroutines before converging to 1). Idempotent and self-limiting via the memo, so correctness is unaffected — noting it rather than adding a `singleflight` dependency for a once-per-process path.

## Supporting documentation

- Incident PR: https://github.com/Automaat/lightroom-mcp/pull/151
- Public post-mortem + apology to the contributor: https://github.com/Automaat/lightroom-mcp/pull/151#issuecomment-4996227984
- #2032 — the same trap, previously fixed in `Authenticated()` only
- Sybra task `7fb000c5` is `blocked` to hold the loop down; #2166 and #2167 are the layers that make unblocking it safe
