### PR TITLE
fix(agent): spend soft-limited budget on turns

### DIFF
--- a/internal/agent/regate.go
+++ b/internal/agent/regate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"maps"
 
+	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/providerid"
 )
 
@@ -30,6 +31,12 @@ import (
 // set to "rate_limit" so the existing isRateLimitedRun /
 // RescheduleRateLimitedAgent reschedule-and-park behavior stays reachable,
 // exactly as it would for an in-flight run that hit the same cap.
+//
+// That error must stay strictly narrower than what dispatch admits. Refusing a
+// turn on a reason gateProvider tolerates does not park the task — the
+// reschedule hands it straight back to dispatch, which starts it again — so a
+// divergence here is a spin loop, not a safety net (see the soft-threshold last
+// resort below).
 //
 // logWriter, if non-nil, receives the convoProviderMarker line for a switch
 // before the registry is persisted (saveRegistry below) — writing the
@@ -121,14 +128,33 @@ func (m *Manager) regate(ctx context.Context, a *Agent, cfg RunConfig, logWriter
 		}
 	}
 	if alt == "" {
+		gateUnhealthy := g != nil && !g.IsHealthy(current)
 		reason := "no healthy per-turn-capable provider peer available"
 		switch {
-		case g != nil && !g.IsHealthy(current):
+		case gateUnhealthy:
 			reason = g.Reason(current)
 		case lg != nil:
 			if ok, r := lg.ProviderAvailable(current, lp); !ok && r != "" {
 				reason = r
 			}
+		}
+		// Mirror gateProvider's softLimitLastResort. A soft reserve threshold
+		// means current still has budget, so with no peer to redirect to,
+		// spend it rather than strand the turn — the invariant
+		// limits.IsSoftThresholdReason documents. Refusing the turn on a
+		// reason that dispatch admits closes a loop instead: the turn is
+		// recorded rate-limited, rescheduled, re-admitted, and refused again
+		// ~20s later, forever, doing no work. It ran 1847 times on one task
+		// before this check existed (#2150).
+		//
+		// Only budget leniency is mirrored: a hard block (rate limit actually
+		// reached, provider disabled), an unhealthy gate, or a full in-flight
+		// cap are not soft reasons and still gate the turn.
+		if !gateUnhealthy && underCap(current) && (!currentMustBePerTurn || perTurnCapable(current)) &&
+			limits.IsSoftThresholdReason(reason) {
+			m.logger.Warn("agent.convo.regate.soft_limit_last_resort",
+				"id", a.ID, "task", cfg.TaskID, "provider", current, "reason", reason)
+			return cfg, false, nil
 		}
 		a.SetError("rate_limit", reason)
 		return cfg, false, fmt.Errorf("agent regate: %s capped, no per-turn-capable peer available: %s", current, reason)

--- a/internal/agent/regate.go
+++ b/internal/agent/regate.go
@@ -138,21 +138,29 @@ func (m *Manager) regate(ctx context.Context, a *Agent, cfg RunConfig, logWriter
 				reason = r
 			}
 		}
-		// Mirror gateProvider's softLimitLastResort. A soft reserve threshold
-		// means current still has budget, so with no peer to redirect to,
-		// spend it rather than strand the turn — the invariant
-		// limits.IsSoftThresholdReason documents. Refusing the turn on a
-		// reason that dispatch admits closes a loop instead: the turn is
-		// recorded rate-limited, rescheduled, re-admitted, and refused again
-		// ~20s later, forever, doing no work. It ran 1847 times on one task
-		// before this check existed (#2150).
+		// Redirect failed, so mirror what dispatch does when it cannot
+		// redirect either: keep the turn on current unless the reason is one
+		// gateProvider itself fails closed on. Refusing anything dispatch
+		// admits closes a loop rather than parking the task — recorded
+		// rate-limited, rescheduled, re-admitted, refused again ~20s later,
+		// forever, doing no work. It ran 1847 times on one task (#2150).
 		//
-		// Only budget leniency is mirrored: a hard block (rate limit actually
-		// reached, provider disabled), an unhealthy gate, or a full in-flight
-		// cap are not soft reasons and still gate the turn.
-		if !gateUnhealthy && underCap(current) && (!currentMustBePerTurn || perTurnCapable(current)) &&
-			limits.IsSoftThresholdReason(reason) {
-			m.logger.Warn("agent.convo.regate.soft_limit_last_resort",
+		// Two reasons dispatch tolerates, so this must too. A soft reserve
+		// threshold leaves budget, and stranding a task on it is exactly what
+		// limits.IsSoftThresholdReason forbids (softLimitLastResort). A full
+		// in-flight cap only ever redirects a *new* dispatch (see
+		// MaxInFlightPerProvider), and gateProvider admits an at-cap provider
+		// once no peer is free; refusing here could not reduce concurrency
+		// anyway, since this agent already holds the slot it would
+		// re-dispatch into — the count is self-count-aware, so an exceeded cap
+		// means someone else's slot.
+		//
+		// A hard block (rate limit actually reached, provider disabled) and an
+		// unhealthy health gate are what dispatch does fail closed on, so they
+		// still gate the turn.
+		if !gateUnhealthy && (!currentMustBePerTurn || perTurnCapable(current)) &&
+			(limitAvailable(current) || limits.IsSoftThresholdReason(reason)) {
+			m.logger.Info("agent.convo.regate.last_resort",
 				"id", a.ID, "task", cfg.TaskID, "provider", current, "reason", reason)
 			return cfg, false, nil
 		}

--- a/internal/agent/regate_claude_test.go
+++ b/internal/agent/regate_claude_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/limits"
 )
 
 // TestRegateBeforeClaudeTurn_HealthyClaudeNoOp verifies that when Claude
@@ -105,6 +107,43 @@ func TestRegateBeforeClaudeTurn_NoPeerRejected(t *testing.T) {
 	}
 	if a.GetErrorKind() != "rate_limit" {
 		t.Errorf("expected rate_limit error kind, got %q", a.GetErrorKind())
+	}
+}
+
+// TestRegateBeforeClaudeTurn_SoftThresholdLastResort pins that the soft-
+// threshold last resort does not require the current provider to be per-turn-
+// capable. Claude never is (UsesPerTurnConvo() is false), so a check written
+// against the per-turn caller alone would strand every soft-capped claude
+// session — the same stranding the per-turn path suffered (#2150), just
+// arriving through regateBeforeClaudeTurn instead.
+func TestRegateBeforeClaudeTurn_SoftThresholdLastResort(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "claude",
+		LimitGate: &fakeLimitGate{
+			available:  map[string]bool{"claude": false},
+			reasons:    map[string]string{"claude": "session limit near threshold"},
+			chooseNone: true,
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Agent{ID: "cn4", Provider: "claude"}
+	got, switched, err := m.regateBeforeClaudeTurn(t.Context(), a, RunConfig{Provider: "claude", TaskID: "tcn4"})
+	if err != nil {
+		t.Fatalf("soft threshold with no peer must not block claude's turn: %v", err)
+	}
+	if switched {
+		t.Error("switched = true, want false: there is no peer to switch to")
+	}
+	if got.Provider != "claude" {
+		t.Errorf("cfg.Provider = %q, want claude (spend the remaining budget)", got.Provider)
+	}
+	if a.GetErrorKind() != "" {
+		t.Errorf("error kind = %q, want empty: a soft threshold is not a rate-limit failure", a.GetErrorKind())
 	}
 }
 

--- a/internal/agent/regate_test.go
+++ b/internal/agent/regate_test.go
@@ -211,31 +211,66 @@ func TestRegateForTurn_HardLimitStillBlocksWithNoPeer(t *testing.T) {
 	}
 }
 
-// TestRegateForTurn_SoftThresholdAtInFlightCapStillBlocks guards that the last
-// resort only forgives budget. A full in-flight cap is a concurrency limit, not
-// spare quota, so it must keep gating even when the reason is soft.
-func TestRegateForTurn_SoftThresholdAtInFlightCapStillBlocks(t *testing.T) {
-	m, _ := newTestManager(t)
-	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
-	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
-		DefaultProvider:        "codex",
-		MaxInFlightPerProvider: 1,
-		LimitGate: &fakeLimitGate{
-			available:  map[string]bool{"codex": false},
-			reasons:    map[string]string{"codex": "session limit near threshold"},
-			chooseNone: true,
+// TestRegateForTurn_AtInFlightCapWithNoPeerProceeds pins that an exceeded
+// in-flight cap does not refuse a turn.
+//
+// The cap only ever redirects a new dispatch: gateProvider admits an at-cap
+// provider once no peer is free (MaxInFlightPerProvider). Refusing here would
+// diverge from that and reopen #2150's loop under `max_in_flight_per_provider`
+// — and it could not reduce concurrency regardless, because this agent already
+// holds the slot it would re-dispatch into.
+//
+// Both sub-cases matter: a quota signal that is soft, and no quota signal at
+// all (where `reason` stays the default string and never looks "soft").
+func TestRegateForTurn_AtInFlightCapWithNoPeerProceeds(t *testing.T) {
+	cases := []struct {
+		name string
+		gate *fakeLimitGate
+	}{
+		{
+			name: "soft quota signal",
+			gate: &fakeLimitGate{
+				available:  map[string]bool{"codex": false},
+				reasons:    map[string]string{"codex": "session limit near threshold"},
+				chooseNone: true,
+			},
 		},
-		LimitPolicy: limits.Policy{},
-	}); err != nil {
-		t.Fatal(err)
+		{
+			name: "no quota signal at all",
+			gate: &fakeLimitGate{chooseNone: true},
+		},
 	}
-	m.mu.Lock()
-	m.liveByProvider["codex"] = 2 // this agent's own slot, plus another agent's
-	m.mu.Unlock()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestManager(t)
+			m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
+			if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+				DefaultProvider:        "codex",
+				MaxInFlightPerProvider: 1,
+				LimitGate:              tc.gate,
+				LimitPolicy:            limits.Policy{},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			m.mu.Lock()
+			m.liveByProvider["codex"] = 2 // this agent's own slot, plus another agent's
+			m.mu.Unlock()
 
-	a := &Agent{ID: "cap1", Provider: "codex"}
-	if _, _, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t-cap"}, nil); err == nil {
-		t.Fatal("a full in-flight cap is not spare budget; the turn must still be rejected")
+			a := &Agent{ID: "cap1", Provider: "codex"}
+			got, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t-cap"}, nil)
+			if err != nil {
+				t.Fatalf("an at-cap provider must keep its turn when no peer is free, as dispatch admits it: %v", err)
+			}
+			if switched {
+				t.Error("switched = true, want false: there is no peer to switch to")
+			}
+			if got.Provider != "codex" {
+				t.Errorf("cfg.Provider = %q, want codex", got.Provider)
+			}
+			if a.GetErrorKind() != "" {
+				t.Errorf("error kind = %q, want empty: marking this rate-limited is what fed the reschedule loop", a.GetErrorKind())
+			}
+		})
 	}
 }
 

--- a/internal/agent/regate_test.go
+++ b/internal/agent/regate_test.go
@@ -130,6 +130,115 @@ func TestRegateForTurn_NoPerTurnPeerRejected(t *testing.T) {
 	}
 }
 
+// TestRegateForTurn_SoftThresholdLastResortUsesRemainingBudget is the turn-
+// boundary mirror of TestGateProvider_SoftThresholdLastResortUsesRemainingBudget.
+//
+// Dispatch admits a soft-threshold-limited provider when no peer exists (budget
+// remains). If regate refuses that same provider on that same reason, the
+// refusal does not park anything: the turn is recorded rate-limited, the
+// workflow reschedules it, dispatch admits it again, and regate refuses again —
+// a ~20s loop that did no work and ran 1847 times on one task (#2150).
+func TestRegateForTurn_SoftThresholdLastResortUsesRemainingBudget(t *testing.T) {
+	for _, reason := range []string{"weekly limit near threshold", "session limit near threshold"} {
+		t.Run(reason, func(t *testing.T) {
+			m, _ := newTestManager(t)
+			m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
+			if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+				DefaultProvider: "codex",
+				LimitGate: &fakeLimitGate{
+					available:  map[string]bool{"codex": false},
+					reasons:    map[string]string{"codex": reason},
+					chooseNone: true,
+				},
+				LimitPolicy: limits.Policy{},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			a := &Agent{ID: "soft1", Provider: "codex", Model: "gpt-5.5"}
+			a.SetSessionID("sess-keep")
+			cfg := RunConfig{Provider: "codex", TaskID: "t-soft"}
+
+			got, switched, err := m.regateForTurn(t.Context(), a, cfg, nil)
+			if err != nil {
+				t.Fatalf("soft threshold with no peer must not block the turn: %v", err)
+			}
+			if switched {
+				t.Error("switched = true, want false: there is no peer to switch to")
+			}
+			if got.Provider != "codex" {
+				t.Errorf("cfg.Provider = %q, want codex (spend the remaining budget)", got.Provider)
+			}
+			if a.GetErrorKind() != "" {
+				t.Errorf("error kind = %q, want empty: a soft threshold is not a rate-limit failure, and marking it one is what fed the reschedule loop", a.GetErrorKind())
+			}
+			if a.GetSessionID() != "sess-keep" {
+				t.Errorf("session id = %q, want it untouched when no switch happens", a.GetSessionID())
+			}
+		})
+	}
+}
+
+// TestRegateForTurn_HardLimitStillBlocksWithNoPeer guards the other side of the
+// last resort: a hard block (the cap is actually reached, not merely neared) has
+// no budget left to spend, so it must still reject the turn and stay reachable
+// for the rate-limit reschedule.
+func TestRegateForTurn_HardLimitStillBlocksWithNoPeer(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "codex",
+		LimitGate: &fakeLimitGate{
+			available:  map[string]bool{"codex": false},
+			reasons:    map[string]string{"codex": "provider reports rate limit reached"},
+			chooseNone: true,
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Agent{ID: "hard1", Provider: "codex"}
+	_, switched, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t-hard"}, nil)
+	if err == nil {
+		t.Fatal("a reached rate limit has no remaining budget; the turn must be rejected")
+	}
+	if switched {
+		t.Error("switched must be false on rejection")
+	}
+	if a.GetErrorKind() != "rate_limit" {
+		t.Errorf("error kind = %q, want rate_limit", a.GetErrorKind())
+	}
+}
+
+// TestRegateForTurn_SoftThresholdAtInFlightCapStillBlocks guards that the last
+// resort only forgives budget. A full in-flight cap is a concurrency limit, not
+// spare quota, so it must keep gating even when the reason is soft.
+func TestRegateForTurn_SoftThresholdAtInFlightCapStillBlocks(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider:        "codex",
+		MaxInFlightPerProvider: 1,
+		LimitGate: &fakeLimitGate{
+			available:  map[string]bool{"codex": false},
+			reasons:    map[string]string{"codex": "session limit near threshold"},
+			chooseNone: true,
+		},
+		LimitPolicy: limits.Policy{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	m.liveByProvider["codex"] = 2 // this agent's own slot, plus another agent's
+	m.mu.Unlock()
+
+	a := &Agent{ID: "cap1", Provider: "codex"}
+	if _, _, err := m.regateForTurn(t.Context(), a, RunConfig{Provider: "codex", TaskID: "t-cap"}, nil); err == nil {
+		t.Fatal("a full in-flight cap is not spare budget; the turn must still be rejected")
+	}
+}
+
 // TestRegateForTurn_SelfCountAware verifies that the agent's own in-flight
 // turn (already counted in its provider's live bucket) does not make its own
 // healthy provider look "at cap" to itself.


### PR DESCRIPTION
## Motivation

Issue #2150 reports codex implementation agents stalling on ~96% of runs and asks whether codex's terminal event fails to arrive, and whether the watchdog's `signal: killed` timeout is tuned for codex's turn latency. The live logs say the diagnosis is wrong, and the real cause is ours, not codex's.

Over all 1977 `agent.completion.stall` events in the current window:

| stall flags | count |
|---|---|
| `rate_limited=true` | 1935 |
| `signaled=true stopped=true` | 7 |
| `signaled=true` | 3 |
| other (stopped / checkpoint) | ~32 |

Signal kills — the mechanism the issue is built on — account for ten events. The run it sampled (`0fd27493`, killed mid-`apply_patch`) is a genuine outlier; the diagnosis was generalised from it.

1930 of the 1935 rate-limited stalls trace to a single line: `agent.convo.regate.blocked`, `err="agent regate: codex capped, no per-turn-capable peer available: session limit near threshold"`. All 1930 are `provider=codex`, spread over **3 tasks** (1847 on task `02909563` alone), ~20s apart for 9 hours. All 3 tasks are `agent_mode: interactive` — the only path that reaches the per-turn conversational runner.

**Two layers disagree about the identical condition.** When a provider sits at a *soft* reserve threshold — near its session cap, budget still remaining — and no peer is available:

- `gateProvider` at **dispatch** admits it (`softLimitLastResort`): spend the remaining budget. Live: `agent.run.soft_limit_last_resort` fires **1972** times.
- `regate` at the **turn boundary** refused it: `SetError("rate_limit")` + error. Live: **1930** refusals.

The refusal parks nothing. The turn is recorded rate-limited, `RescheduleRateLimitedAgent` re-queues it, dispatch admits it again, and regate refuses it again ~20 seconds later — forever, doing no work. That loop is the "96% stall rate": the denominator is mostly zero-work spins, not real attempts.

`regate` was breaking an invariant this codebase already documents on `limits.IsSoftThresholdReason`:

> A soft threshold should only redirect a run to a healthier peer; it must never strand a task on a provider that still has budget when no peer is available.

Dispatch has a named regression test for exactly this (`TestGateProvider_SoftThresholdLastResortUsesRemainingBudget`). The turn boundary never got the mirror.

This also answers the issue's "why codex more than claude?" with no speculation about parse gaps or watchdog tuning: `regate` guards the per-turn path, which is codex/copilot-only. Claude's reported 52% has a different cause and is not addressed here — all 1930 refusals carried `provider=codex`, and the persistent-claude path logs this line without a provider key, so none came from it.

The persistent-claude path does share `regate`'s core and was susceptible to the same stranding; it simply never triggered in production. Manual testing found that on `main` a soft-capped claude session fails `SendMessage` with an HTTP 500, and that this fix delivers the turn instead — so the repair lands there too, pinned by `TestRegateBeforeClaudeTurn_SoftThresholdLastResort`.

> Changelog: fix(agent): spend soft-limited budget on turns instead of looping

## Implementation information

Once the redirect has failed, `regate` now gates the turn on exactly what dispatch gates on, and nothing more: a hard block (`rate limit actually reached`, `provider disabled`) or an unhealthy health gate. Everything dispatch tolerates, the turn boundary now tolerates too — the current provider keeps its turn.

That covers two reasons, both pinned by tests:

- **A soft reserve threshold** — budget remains, and stranding a task on it is what `IsSoftThresholdReason` forbids (`softLimitLastResort`).
- **A full in-flight cap** — the cap only ever *redirects* a new dispatch (`MaxInFlightPerProvider`'s own doc says so), and `gateProvider` admits an at-cap provider once no peer is free. Refusing here could not reduce concurrency in any case: the live count is self-count-aware, so an exceeded cap means someone *else's* slot, and this agent already holds the one it would re-dispatch into.

The first cut of this fix forgave only the soft threshold and kept refusing at-cap turns. Adversarial review caught that this left the identical loop behind `max_in_flight_per_provider`, and proved it by running both deciders against the same manager state — dispatch admitted, regate refused. It also surfaced a pre-existing sibling the soft-only check would have missed: at-cap with *no* quota signal at all, where the reason never looks soft and the loop ran just the same.

The `regate` doc now states the invariant the bug violated: this error path must stay strictly narrower than what dispatch admits, because refusing a turn on a reason dispatch tolerates does not park the task — the reschedule hands it straight back — so any divergence is a spin loop rather than a safety net.

**Why nothing bounded 1847 retries.** All three existing guards are structurally unreachable from this path, which is worth recording:
- The **park guard** keys on `ProviderRateLimited`, which reads the *health gate*. regate's block only calls `a.SetError` and never reports to the gate, so the gate never learned codex was capped.
- The **watchdog retry budget** (`maxWatchdogRateLimitRetries = 2`) only applies when `StatusReason` carries the `watchdog: rate limit` prefix, which only `watchdog.stopForRateLimit` writes. The completion stall path never sets it.
- The **dispatch circuit breaker** is fed by start failures. regate refuses *after* a successful start, so the run reports as a completion, not a start failure.

### Scope calls

- **No `ChooseSoftLimitedPeer` in regate.** Dispatch tries a soft-limited *peer* when the current provider is hard-blocked. Adding that here would be a no-op: regate's `healthy` predicate folds in `limitAvailable`, which is false for every soft-limited peer, whereas dispatch's is only `IsHealthy && underCap`. Verified empirically against a real `limits.Store` with a peer at 99% session: dispatch's predicate returns that peer, regate's returns `""`. The hard-current + soft-peer case also converges after one reschedule (dispatch picks the soft peer, and this fix is what then lets the peer's own turns proceed), so it is not a loop. Left alone deliberately.
- **No `ReportProviderSignal` from regate.** Reporting a soft threshold to the health gate would mark the provider globally unhealthy and park tasks — the exact stranding the invariant forbids — and the hard-block case is already bounded at dispatch by the start-failure path.
- **Stalled-usage attribution (issue question 4) is moot for these runs.** The turn never starts, so $0 and zero tokens is the honest record. The spend the issue is chasing is the retry loop itself, which this removes.

## Supporting documentation

Reverting `regate.go` alone makes the new tests fail with the exact production string: `agent regate: codex capped, no per-turn-capable peer available: session limit near threshold`.

Manual testing drove the real turn boundary through `sybra-server` with fake provider CLIs in an isolated `SYBRA_HOME`, contrasting `origin/main` against this branch on the identical probe:

| signal | `origin/main` | this branch |
|---|---|---|
| `agent.convo.regate.blocked` | 43 | 0 |
| `agent.completion.stall` | 42 | 0 |
| `workflow.resume-stalled` | 41 | 0 |
| real provider turns executed | 0 | 2 |

On `main` a single `StartAgent` self-fed a storm that was still climbing when killed, every run $0 / 0 tokens. Also verified: a hard block, a disabled provider, and an unhealthy health gate each still refuse and burn **zero** turns; a healthy peer still wins both dispatch failover and mid-conversation hot-swap, so the last resort only fires when there is genuinely nowhere to go; ten sequential soft-capped turns proceed with no stalls, bounded by the hard block that does refuse.

Hard-block refusals stay bounded precisely *because* dispatch fails closed on them too — refusals are now a strict subset of what dispatch rejects, so they park instead of spin. That subset relationship is the property to preserve if this code changes again.

After this lands, the codex stall rate needs re-measuring before anyone tunes a watchdog: the current figure is an artifact of the loop. #2149 (merged) is what makes that measurement trustworthy.

Closes #2150
