### PR TITLE
refactor(workflow): plan without the council skill

### DIFF
--- a/.claude/skills/plan-critic/SKILL.md
+++ b/.claude/skills/plan-critic/SKILL.md
@@ -18,11 +18,12 @@ Critique an implementation plan **before** any code is written. The cost of revi
 
 **Core principle:** A plan that names files generically has not been read. A plan that references `verify_jwt_token` at `auth/middleware.go:42` has been read. The job of this skill is to tell those apart and force the second.
 
-**Sybra contract rule:** Sybra stores research/council evidence separately from
-the canonical plan. Treat the canonical plan as a compact execution contract:
-approve it when it names the decision, scope, files, ordered steps,
-verification, and stop conditions. Do not require council synthesis, critique
-history, persona names, or long rationale inside the execution contract.
+**Sybra contract rule:** Sybra stores research evidence — including the
+planner's scrutiny answers — separately from the canonical plan. Treat the
+canonical plan as a compact execution contract: approve it when it names the
+decision, scope, files, ordered steps, verification, and stop conditions. Do
+not require scrutiny answers, critique history, or long rationale inside the
+execution contract; flag them as bloat when they appear there.
 
 ## Arguments
 
@@ -132,7 +133,7 @@ After synthesis, act on the verdict before producing output. This is a hard requ
 
 **1. Auto-apply (only on REFINE verdict):**
 
-- If the plan was given as a **file path** → use `Edit` to modify the plan file in place. Apply each refinement directly: add missing steps, correct file/symbol references using the Grounding Brief, insert verification criteria, update caller lists. Preserve the plan's original compact execution-contract structure and voice. Do not paste the review's forensic evidence, critique history, or council rationale into the plan.
+- If the plan was given as a **file path** → use `Edit` to modify the plan file in place. Apply each refinement directly: add missing steps, correct file/symbol references using the Grounding Brief, insert verification criteria, update caller lists. Preserve the plan's original compact execution-contract structure and voice. Do not paste the review's forensic evidence, critique history, or scrutiny answers into the plan.
 - If the plan was **inline** or **`--from-conversation`** → output the refined plan as a fenced markdown block in the final report under a `## Refined Plan` section. The user can copy it into wherever they manage plans.
 - On **APPROVE** → nothing to apply.
 - On **REJECT** → nothing to apply (plan needs re-doing from scratch). Do not attempt to fix a rejected plan.

--- a/internal/skills/data/plan-critic.md
+++ b/internal/skills/data/plan-critic.md
@@ -10,11 +10,12 @@ allowed-tools: Read, Grep, Bash, Write, Edit, Agent
 
 Review an implementation plan before code is written. Reject plans that are vague, ungrounded, risky, or missing verification.
 
-Sybra planning stores research/council evidence separately from the canonical
-plan. Treat the canonical plan as an execution contract: compact is good when it
-names the decision, scope, files, ordered steps, verification, and stop
-conditions. Do not require council synthesis, critique history, persona names,
-or long rationale inside the execution contract.
+Sybra planning stores research evidence — including the planner's scrutiny
+answers — separately from the canonical plan. Treat the canonical plan as an
+execution contract: compact is good when it names the decision, scope, files,
+ordered steps, verification, and stop conditions. Do not require scrutiny
+answers, critique history, or long rationale inside the execution contract;
+flag them as bloat when they appear there.
 
 ## Inputs
 

--- a/internal/skills/plan_critic_vocabulary_test.go
+++ b/internal/skills/plan_critic_vocabulary_test.go
@@ -1,0 +1,62 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// planCriticSources lists every on-disk copy of the plan-critic skill that can
+// reach a running agent.
+//
+// There are two, and the embedded one loses. skillsync writes the embedded
+// bundle first, then syncs repoDir/.claude/skills over the top of it whenever
+// repoDir/go.mod exists — true for the server's own checkout — so the repo copy
+// is what agents actually read. Editing only data/plan-critic.md changes
+// nothing at runtime, which is exactly how the council vocabulary below
+// survived a prompt change that had supposedly removed it.
+func planCriticSources(t *testing.T) map[string]string {
+	t.Helper()
+
+	embedded, err := FS.ReadFile("data/plan-critic.md")
+	if err != nil {
+		t.Fatalf("read embedded plan-critic skill: %v", err)
+	}
+	repoPath := filepath.Join("..", "..", ".claude", "skills", "plan-critic", "SKILL.md")
+	repo, err := os.ReadFile(repoPath)
+	if err != nil {
+		t.Fatalf("read repo plan-critic skill (%s): %v", repoPath, err)
+	}
+	return map[string]string{
+		"data/plan-critic.md":                 string(embedded),
+		".claude/skills/plan-critic/SKILL.md": string(repo),
+	}
+}
+
+// TestPlanCritic_NoCouncilVocabulary keeps both copies of the skill in step
+// with the plan prompt.
+//
+// The plan step no longer convenes a council, so a critic still told not to
+// require "council synthesis" or "persona names" is policing a vocabulary that
+// no longer exists — and, worse, is not told to flag the scrutiny answers that
+// replaced it. Both copies must agree; asserting only the embedded one would
+// pass while the runtime-effective copy drifts.
+func TestPlanCritic_NoCouncilVocabulary(t *testing.T) {
+	t.Parallel()
+
+	for name, text := range planCriticSources(t) {
+		// These are prose files: a phrase can wrap across a line break at any
+		// time, so match against whitespace-collapsed text rather than pinning
+		// the current wrapping.
+		flat := strings.ToLower(strings.Join(strings.Fields(text), " "))
+		for _, banned := range []string{"council", "persona names"} {
+			if strings.Contains(flat, banned) {
+				t.Errorf("%s references %q — the plan step no longer convenes a council", name, banned)
+			}
+		}
+		if !strings.Contains(flat, "scrutiny answers") {
+			t.Errorf("%s does not name the scrutiny answers that replaced the council evidence", name)
+		}
+	}
+}

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -83,10 +83,16 @@ steps:
     next:
       - goto: ""
 
-  # Single plan step: one opus agent does the research/council work, but writes
+  # Single plan step: one opus agent does the research and scrutiny, but writes
   # separate artifacts. The canonical plan sidecar is now a compact execution
   # contract only; research, decisions, and human-review brief stay separate so
-  # implementation agents do not ingest council/critique history.
+  # implementation agents do not ingest scrutiny/critique history.
+  #
+  # The scrutiny questions are stated inline rather than delegated to a review
+  # skill. The prior prompt told the agent to convene `/council core-eng` with
+  # an "if unavailable, plan directly" opt-out that nothing could check, and 69
+  # of 79 traced runs took it silently while still writing council-shaped prose
+  # into the research artifact.
   - id: plan
     name: Plan
     type: run_agent
@@ -118,18 +124,40 @@ steps:
           1. Run: sybra-cli --json get {{.Task.ID}}
           2. Read the relevant source files so the plan is grounded in the
              real code (name files and symbols you will touch).
-          3. Convene the council on the implementation approach: run
-             `/council core-eng` and pass it a concise task summary plus the
-             approach options you are weighing, grounded in the files you read.
-             The personas will debate tradeoffs and surface risks from opposed
-             engineering lenses. If /council is unavailable in this
-             environment, plan directly using the same multi-lens scrutiny.
+          3. Before committing to an approach, answer every question below
+             about it and record the answers in the research artifact. These
+             are requirements on your output, not lenses to role-play — an
+             answer of "N/A" is only acceptable with a stated reason.
+               - Simplicity: what is the smallest change that satisfies the
+                 task? If your approach is bigger, name what the extra
+                 complexity buys.
+               - Reuse: name the existing code this duplicates or should
+                 route through. A new abstraction for one call site is not
+                 justified.
+               - Deletability: if this turns out to be wrong, what does
+                 reverting cost? Prefer a design that is cheap to delete
+                 over one that is cheap to extend.
+               - Failure modes: name how this breaks in the real system —
+                 partial write, concurrent run, restart mid-flight, missing
+                 dependency, in-flight work at deploy — and what the plan
+                 does about each.
+               - Second-order effects: name what else reads or writes the
+                 thing you are changing, and what breaks when this ships.
+               - Cost: what does this cost at the sizes it actually runs at
+                 — name the hot path, the extra I/O, or the added agent
+                 spend, or say why none exists.
+               - Worth: what does NOT doing this cost? If the answer is
+                 "little", say so — that is a valid finding, not a failure.
+               - Verification: name the command or observation that proves
+                 it works. If no mechanical signal exists, say so outright.
+             Name at least one alternative you rejected, and why.
           4. Write these FIVE files:
 
              A. .sybra-plan-research-{{.Task.ID}}.md
-                Raw research/evidence. Put file/symbol notes, council synthesis,
-                rejected alternatives, assumptions, and detailed rationale here.
-                This can be long. It is for audit/debug, not implementation.
+                Raw research/evidence. Put file/symbol notes, your answers to
+                the step-3 scrutiny questions, rejected alternatives,
+                assumptions, and detailed rationale here. This can be long.
+                It is for audit/debug, not implementation.
 
              B. .sybra-plan-decisions-{{.Task.ID}}.md
                 Human decision brief. Keep it short. Use this exact shape for
@@ -182,9 +210,10 @@ steps:
                 ## Stop Conditions
                 - Stop/replan if ...
 
-                Do NOT include council synthesis, plan-critic history,
-                persona names, disagreement logs, acceptance traceability tables,
-                or long risk matrices in this file.
+                Do NOT include your scrutiny answers, plan-critic history,
+                disagreement logs, acceptance traceability tables, or long
+                risk matrices in this file — those belong in the research
+                artifact.
 
              D. .sybra-plan-brief-{{.Task.ID}}.md
                 Human approval brief. Keep it under ~40 lines. Summarize final
@@ -230,14 +259,23 @@ steps:
         Do NOT call sybra-cli update — Sybra will ingest your file as the
         task sidecars after you exit. Do NOT modify task fields directly.
         Do NOT change the task status.
+      # No Skill/Agent: the prompt names neither a skill nor a subagent, so
+      # granting them only left the council one unprompted Skill call away —
+      # the plugin cache is discoverable — at 3.44x the cost of a plain plan
+      # and 7 cap breaches in 10. agent.max_cost_usd cannot pre-empt that,
+      # since providers report spend only on their terminal event and the
+      # ceiling fires once the money is already gone.
+      #
+      # Enforced on claude only, where len(allowed_tools) > 0 maps to
+      # --allowedTools. provider_claude.go is the sole reader; codex and
+      # copilot ignore it (copilot hardcodes --allow-all-tools), so on those
+      # paths the prompt naming no skill is the whole defence.
       allowed_tools:
         - Bash
         - Read
         - Grep
         - Glob
         - Write
-        - Skill
-        - Agent
       import_sidecars:
         - kind: plan_research
           from: '{{getvar .Vars "_dir"}}/.sybra-plan-research-{{.Task.ID}}.md'
@@ -254,7 +292,7 @@ steps:
       - goto: require_plan
 
   # Guard: the plan agent can exit cleanly without producing a plan (e.g. the
-  # council/plan flow failed or the agent skipped the write). Mirrors
+  # research flow failed or the agent skipped the write). Mirrors
   # require_plan_critique below: flips to human-required so the failure is
   # visible instead of silently advancing into critique_plan with an empty plan.
   - id: require_plan

--- a/internal/workflow/builtin_plan_prompt_test.go
+++ b/internal/workflow/builtin_plan_prompt_test.go
@@ -1,0 +1,113 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// scrutinyBlock returns the plan prompt's step-3 scrutiny requirements, sliced
+// out of the surrounding prompt.
+//
+// Asserting against the whole prompt is not good enough: "Verification" also
+// appears as artifact C's `## Verification` template header and in the JSON
+// contract spec, and "rejected" appears in artifact A's spec — so a
+// whole-prompt Contains passes even with the scrutiny bullets deleted.
+func scrutinyBlock(t *testing.T, prompt string) string {
+	t.Helper()
+	const start = "3. Before committing to an approach"
+	const end = "4. Write these"
+	i := strings.Index(prompt, start)
+	if i < 0 {
+		t.Fatalf("plan prompt has no step-3 scrutiny block (looked for %q)", start)
+	}
+	j := strings.Index(prompt[i:], end)
+	if j < 0 {
+		t.Fatalf("plan prompt has no step-4 artifact block after scrutiny (looked for %q)", end)
+	}
+	return prompt[i : i+j]
+}
+
+// TestBuiltinSimpleTaskPlan_PromptStatesScrutinyInline locks the plan prompt
+// against re-delegating its scrutiny to a review skill.
+//
+// The prompt used to tell the agent to convene `/council core-eng`, with an
+// "if /council is unavailable in this environment, plan directly" opt-out that
+// nothing could verify. 69 of 79 traced plan runs took that opt-out silently
+// while still writing council-shaped prose into the research artifact, and no
+// Go code enforced, measured, or recorded whether the council ever convened —
+// so the regression was invisible for weeks. Any future escape hatch of this
+// shape must fail here instead.
+func TestBuiltinSimpleTaskPlan_PromptStatesScrutinyInline(t *testing.T) {
+	t.Parallel()
+
+	plan := mustBuiltinDefinition(t, "simple-task-plan")
+	step := plan.StepByID("plan")
+	if step == nil {
+		t.Fatal("plan step not found in simple-task-plan")
+		return
+	}
+	prompt := step.Config.Prompt
+
+	for _, banned := range []string{"council", "persona"} {
+		if strings.Contains(strings.ToLower(prompt), banned) {
+			t.Errorf("plan prompt references %q — scrutiny must be stated inline, not delegated to a skill", banned)
+		}
+	}
+	// An "if X is unavailable, do Y instead" opt-out is unfalsifiable from
+	// outside the agent: it reads as compliance whichever branch is taken.
+	if strings.Contains(strings.ToLower(prompt), "unavailable") {
+		t.Error("plan prompt offers an unverifiable availability escape hatch")
+	}
+
+	// Each lens the council supplied must survive as a labelled requirement in
+	// the scrutiny block itself. The trailing colon is what distinguishes a
+	// requirement from prose elsewhere in the prompt.
+	block := scrutinyBlock(t, prompt)
+	for _, required := range []string{
+		"- Simplicity:",
+		"- Reuse:",
+		"- Deletability:",
+		"- Failure modes:",
+		"- Second-order effects:",
+		"- Cost:",
+		"- Worth:",
+		"- Verification:",
+	} {
+		if !strings.Contains(block, required) {
+			t.Errorf("scrutiny block is missing the %q requirement", required)
+		}
+	}
+	if !strings.Contains(block, "alternative you rejected") {
+		t.Error("scrutiny block does not require naming a rejected alternative")
+	}
+}
+
+// TestBuiltinSimpleTaskPlan_PlanStepGrantsNoSkillOrAgent makes the council's
+// removal structural on the claude path rather than purely advisory.
+//
+// The plan prompt names neither a skill nor a subagent, so granting either
+// leaves the council one unprompted Skill call away (the plugin cache is
+// discoverable), at 3.44x the cost of a plain plan run. agent.max_cost_usd
+// cannot pre-empt that: providers report spend only on their terminal event,
+// so the ceiling fires after the money is gone.
+//
+// Only provider_claude.go reads AllowedTools — codex and copilot ignore it —
+// so this bounds the claude path and the empty prompt carries the rest.
+func TestBuiltinSimpleTaskPlan_PlanStepGrantsNoSkillOrAgent(t *testing.T) {
+	t.Parallel()
+
+	plan := mustBuiltinDefinition(t, "simple-task-plan")
+	step := plan.StepByID("plan")
+	if step == nil {
+		t.Fatal("plan step not found in simple-task-plan")
+		return
+	}
+	if len(step.Config.AllowedTools) == 0 {
+		t.Fatal("plan step has no allowed_tools — the permission precedence would fall through to a bypass mode")
+	}
+	for _, tool := range step.Config.AllowedTools {
+		if tool == "Skill" || tool == "Agent" {
+			t.Errorf("plan step grants %q, but its prompt invokes neither — that is the capability the council needs", tool)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

The plan prompt told the agent to convene `/council core-eng`, then handed it an escape hatch:

> If /council is unavailable in this environment, plan directly using the same multi-lens scrutiny.

**That opt-out was the default path.** Of 79 traced plan runs, **10** invoked the council; the other **69 never called the Skill tool once** — and wrote council-flavored prose anyway. One $2.00 run (`3becf187`) said "council" 62 times across 13 Bash + 5 Write calls and zero Skill/Task calls.

Nothing detected this. `grep -rn council internal/ | grep "\.go:"` returns only test fixtures — no enforcement, no telemetry, no role of its own (council cost is billed inside the parent plan run and isn't separable). So it is an unintentional A/B test with **n=69 and no observed quality regression**.

When it *did* run it cost **3.44x** ($6.23 vs $1.81 mean) and breached the $5 per-run cap in **7 of 10** runs. It also nested: `/council` spawns 6 personas and `/plan-critic` 3 more — a partial survival of the double-critique #887 set out to delete. And despite `SKILL.md:189` claiming personas run in parallel, traced runs show strict spawn→result interleaving.

### The evidence says the prompt is the lever, not the debate

Huang et al., Table 8 (CommonGen-Hard):

| | calls | score |
|---|---|---|
| Standard prompting | 1 | 44.0 |
| Self-correct | 7 | 67.0 |
| **Improved initial prompt** | **1** | **81.8** |
| …plus self-correct | 7 | 75.1 |

A better initial prompt beat the 7-call critique loop by **14.8 points at 1/7th the cost**, and bolting critique on top made it **worse**. Compute-matched debate also loses to plain self-consistency (83.2 vs 85.3 at 6 responses; 83.0 vs 88.2 at 9).

Closes #2154

> Changelog: refactor(workflow): plan directly instead of via the council skill

## Implementation information

- **Remove the `/council` invocation and the unverifiable escape hatch.** Scrutiny is now stated inline as checkable requirements on the output: simplicity, reuse, deletability, failure modes, second-order effects, cost, worth, verification — plus a named rejected alternative.
- **Cost and worth are deliberate.** `core-eng` is antirez-simplicity, tef-deletability, muratori-**perf**, hebert-resilience, meadows-systems, chin-**strategy**. An earlier draft mapped only 4 of 6 and dropped perf and strategy outright — and pinned the 6-item list in a test, cementing the gap. These two restore them.
- **Drop `Skill` and `Agent` from the plan step's `allowed_tools`.** The prompt names neither, and granting them left the council one unprompted Skill call away (the plugin cache is discoverable). This binds on **claude only** — `provider_claude.go` is the sole reader of `AllowedTools`; copilot hardcodes `--allow-all-tools`. `critique_plan` keeps both, since it genuinely invokes `/plan-critic`.
- **Update *both* copies of the plan-critic skill.** It still told the critic not to require "council synthesis … persona names" — policing a vocabulary the prompt had dropped, and not flagging the scrutiny answers that replaced it.

Not done here: `/plan-critic` still runs its own 3 personas. That's the critic's grounding pass, which #2152 kept deliberately; only the plan step's council is removed.

## Supporting documentation

**Verified against a real run** in an isolated `SYBRA_HOME` with fake provider CLIs. Captured argv for the plan spawn:

```
--allowedTools Bash,Read,Grep,Glob,Write
```

No `Skill`, no `Agent`, and no fallthrough to `--dangerously-skip-permissions` (precedence branch 1 held). The planner completed on the reduced set — read source, wrote all five artifacts, all five sidecars imported. Checked against the prompt **actually sent over stdin**, not the YAML: zero hits for `council|persona|unavailable`; all eight lenses present plus "alternative you rejected". Pipeline intact: plan→critique→plan-review, approve→implement, reject loop + 3-reject cap, `nocritic`, `noplan`, and both missing-artifact guards.

### Two findings from review worth recording

**The skill edit initially didn't ship.** `skillsync` writes the embedded bundle first, then syncs `repoDir/.claude/skills` **over the top** whenever `repoDir/go.mod` exists — true for the server's checkout — so `.claude/skills/plan-critic/SKILL.md` is what agents read and `internal/skills/data/plan-critic.md` is inert. Editing only the embedded copy changed nothing at runtime; the manual run caught it by grepping the *synced* file. `plan-fork` and `fix-review-auto` are dual-sourced the same way. `internal/skills/plan_critic_vocabulary_test.go` now asserts both copies, matching against whitespace-collapsed text so a reflowed paragraph can't defeat it.

**The prompt tests were tautological**, proven by mutation: `"Verification"` also matches artifact C's `## Verification` header and `"rejected"` matches artifact A's spec, so deleting either scrutiny bullet still passed. They now slice the step-3 block and assert labelled requirements within it — re-mutation-checked:

```
--- FAIL: TestBuiltinSimpleTaskPlan_PromptStatesScrutinyInline
    scrutiny block is missing the "- Verification:" requirement
    scrutiny block does not require naming a rejected alternative
```

Part of #2151, after #2152. Remaining: #2015 (collapse the five planning sidecars).