### PR TITLE
fix(review): bound automated re-review per head

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -347,13 +347,11 @@ export class Task {
     "reviewPhase"?: string;
 
     /**
-     * ReviewedHeadSHA is the PR head an automated review was last dispatched
-     * against; the dispatcher refuses to re-review it. Durable backstop against
-     * a re-dispatch loop (#2164 posted 112 reviews on one unchanged commit).
-     * Stamped at dispatch, not completion, so a crashing run cannot re-review
-     * forever — a real push moves the head and re-opens review.
+     * Bounds automated re-review per PR commit: the durable backstop against a
+     * re-dispatch loop (#2164 spent 112 reviews on one unchanged commit).
      */
     "reviewedHeadSha"?: string;
+    "reviewedHeadAttempts"?: number;
 
     /**
      * PRPhase tracks where an outbound own-PR task (status in-review/ready-review,
@@ -569,9 +567,9 @@ export class Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
         const $$createField18_0 = $$createType0;
-        const $$createField38_0 = $$createType2;
-        const $$createField39_0 = $$createType4;
-        const $$createField55_0 = $$createType5;
+        const $$createField39_0 = $$createType2;
+        const $$createField40_0 = $$createType4;
+        const $$createField56_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -583,13 +581,13 @@ export class Task {
             $$parsedSource["dependsOn"] = $$createField18_0($$parsedSource["dependsOn"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField38_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField39_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField39_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField40_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField55_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField56_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }
@@ -653,6 +651,7 @@ export class Update {
     "SupervisorSteer": string | null;
     "ReviewPhase": string | null;
     "ReviewedHeadSHA": string | null;
+    "ReviewedHeadAttempts": number | null;
     "PRPhase": string | null;
     "TodoistID": string | null;
     "Priority": Priority | null;
@@ -744,6 +743,9 @@ export class Update {
         if (!("ReviewedHeadSHA" in $$source)) {
             this["ReviewedHeadSHA"] = null;
         }
+        if (!("ReviewedHeadAttempts" in $$source)) {
+            this["ReviewedHeadAttempts"] = null;
+        }
         if (!("PRPhase" in $$source)) {
             this["PRPhase"] = null;
         }
@@ -811,7 +813,7 @@ export class Update {
     static createFrom($$source: any = {}): Update {
         const $$createField6_0 = $$createType6;
         const $$createField10_0 = $$createType6;
-        const $$createField27_0 = $$createType7;
+        const $$createField28_0 = $$createType7;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("DependsOn" in $$parsedSource) {
             $$parsedSource["DependsOn"] = $$createField6_0($$parsedSource["DependsOn"]);
@@ -820,7 +822,7 @@ export class Update {
             $$parsedSource["Tags"] = $$createField10_0($$parsedSource["Tags"]);
         }
         if ("Workflow" in $$parsedSource) {
-            $$parsedSource["Workflow"] = $$createField27_0($$parsedSource["Workflow"]);
+            $$parsedSource["Workflow"] = $$createField28_0($$parsedSource["Workflow"]);
         }
         return new Update($$parsedSource as Partial<Update>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -347,6 +347,15 @@ export class Task {
     "reviewPhase"?: string;
 
     /**
+     * ReviewedHeadSHA is the PR head an automated review was last dispatched
+     * against; the dispatcher refuses to re-review it. Durable backstop against
+     * a re-dispatch loop (#2164 posted 112 reviews on one unchanged commit).
+     * Stamped at dispatch, not completion, so a crashing run cannot re-review
+     * forever — a real push moves the head and re-opens review.
+     */
+    "reviewedHeadSha"?: string;
+
+    /**
      * PRPhase tracks where an outbound own-PR task (status in-review/ready-review,
      * not tag `review`) sits in its lifecycle: draft → building → fixing →
      * changes-requested → awaiting-approval → approved. Computed by the PR poller;
@@ -560,9 +569,9 @@ export class Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
         const $$createField18_0 = $$createType0;
-        const $$createField37_0 = $$createType2;
-        const $$createField38_0 = $$createType4;
-        const $$createField54_0 = $$createType5;
+        const $$createField38_0 = $$createType2;
+        const $$createField39_0 = $$createType4;
+        const $$createField55_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -574,13 +583,13 @@ export class Task {
             $$parsedSource["dependsOn"] = $$createField18_0($$parsedSource["dependsOn"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField37_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField38_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField38_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField39_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField54_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField55_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }
@@ -643,6 +652,7 @@ export class Update {
     "RunRole": string | null;
     "SupervisorSteer": string | null;
     "ReviewPhase": string | null;
+    "ReviewedHeadSHA": string | null;
     "PRPhase": string | null;
     "TodoistID": string | null;
     "Priority": Priority | null;
@@ -731,6 +741,9 @@ export class Update {
         if (!("ReviewPhase" in $$source)) {
             this["ReviewPhase"] = null;
         }
+        if (!("ReviewedHeadSHA" in $$source)) {
+            this["ReviewedHeadSHA"] = null;
+        }
         if (!("PRPhase" in $$source)) {
             this["PRPhase"] = null;
         }
@@ -798,7 +811,7 @@ export class Update {
     static createFrom($$source: any = {}): Update {
         const $$createField6_0 = $$createType6;
         const $$createField10_0 = $$createType6;
-        const $$createField26_0 = $$createType7;
+        const $$createField27_0 = $$createType7;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("DependsOn" in $$parsedSource) {
             $$parsedSource["DependsOn"] = $$createField6_0($$parsedSource["DependsOn"]);
@@ -807,7 +820,7 @@ export class Update {
             $$parsedSource["Tags"] = $$createField10_0($$parsedSource["Tags"]);
         }
         if ("Workflow" in $$parsedSource) {
-            $$parsedSource["Workflow"] = $$createField26_0($$parsedSource["Workflow"]);
+            $$parsedSource["Workflow"] = $$createField27_0($$parsedSource["Workflow"]);
         }
         return new Update($$parsedSource as Partial<Update>);
     }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -61,9 +61,11 @@ import (
 )
 
 type App struct {
-	ctx               context.Context
-	cancel            context.CancelFunc
-	wg                sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	// fetchPRHeadSHA overrides the PR-head lookup in tests; nil uses GitHub.
+	fetchPRHeadSHA    func(repo string, number int) (string, error)
 	tasks             *task.Manager
 	projects          *project.Store
 	loopAgents        *loopagent.Store

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -65,7 +65,7 @@ type App struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	// fetchPRHeadSHA overrides the PR-head lookup in tests; nil uses GitHub.
-	fetchPRHeadSHA    func(repo string, number int) (string, error)
+	fetchPRHeadSHA    func(ctx context.Context, repo string, number int) (string, error)
 	tasks             *task.Manager
 	projects          *project.Store
 	loopAgents        *loopagent.Store

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -62,7 +62,7 @@ func (a *App) dispatchPass(ctx context.Context) {
 		return
 	}
 	a.releaseUnblockedChildren()
-	a.reconcileRunnableBoardTasks()
+	a.reconcileRunnableBoardTasks(ctx)
 	if a.assigner != nil {
 		a.assigner.Tick(ctx)
 	}
@@ -163,7 +163,7 @@ func (a *App) queueDrainPass(ctx context.Context) {
 	if !a.runsScheduler() {
 		return
 	}
-	a.reconcileRunnableBoardTasks()
+	a.reconcileRunnableBoardTasks(ctx)
 	if a.workflowEngine != nil {
 		// workflow.Engine derives its shell-step context from its own e.ctx
 		// field (Engine.SetContext, bound once from App's root ctx), not an
@@ -172,7 +172,7 @@ func (a *App) queueDrainPass(ctx context.Context) {
 	}
 }
 
-func (a *App) reconcileRunnableBoardTasks() {
+func (a *App) reconcileRunnableBoardTasks(ctx context.Context) {
 	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
 		return
 	}
@@ -205,7 +205,7 @@ func (a *App) reconcileRunnableBoardTasks() {
 			a.dispatchPlanningWorkflow(t.ID)
 		case task.StatusInReview:
 			if isInboundReviewTask(t) {
-				a.dispatchInboundReviewWorkflow(t.ID)
+				a.dispatchInboundReviewWorkflow(ctx, t.ID)
 				continue
 			}
 		case task.StatusInProgress, task.StatusReadyReview, task.StatusTesting, task.StatusReadyPR:
@@ -219,25 +219,46 @@ func isInboundReviewTask(t task.Task) bool {
 	return slices.Contains(t.Tags, "review") && t.ProjectID != "" && t.PRNumber != 0
 }
 
-// reviewCoversHead reports whether an automated review was already dispatched
-// against head. An unknown head ("") is treated as covered: the caller could
-// not establish what to review, and declining is the safe direction.
+// maxReviewAttemptsPerHead bounds automated review runs against one PR commit.
+// Above 1 so a transient provider failure gets a retry: refusing after a single
+// dispatch would trade #2164's re-review loop for a PR nobody ever reviews
+// again, which is the worse outcome for a contributor.
+const maxReviewAttemptsPerHead = 2
+
+// reviewCoversHead reports whether head's review budget is spent. An unknown
+// head ("") counts as covered: we cannot tell a new push from the commit we
+// just reviewed, and declining is the safe direction.
 func reviewCoversHead(t task.Task, head string) bool {
 	if head == "" {
 		return true
 	}
-	return t.ReviewedHeadSHA == head
+	if t.ReviewedHeadSHA != head {
+		return false
+	}
+	return t.ReviewedHeadAttempts >= maxReviewAttemptsPerHead
 }
 
-// fetchPRHeadSHAFunc returns the PR-head lookup, overridable in tests.
-func (a *App) fetchPRHeadSHAFunc() func(repo string, number int) (string, error) {
+// nextReviewAttempt returns the attempt number head is about to consume. A new
+// head restarts the budget, so a real push always re-opens review.
+func nextReviewAttempt(t task.Task, head string) int {
+	if t.ReviewedHeadSHA != head {
+		return 1
+	}
+	return t.ReviewedHeadAttempts + 1
+}
+
+// fetchPRHeadSHAFunc returns the PR-head lookup, overridable in tests. The
+// context-aware form is mandatory here: this runs inline on the orchestrator
+// loop, and gh's global request gate is held across the whole subprocess, so an
+// uncancellable call would stall every other dispatch behind it.
+func (a *App) fetchPRHeadSHAFunc() func(ctx context.Context, repo string, number int) (string, error) {
 	if a.fetchPRHeadSHA != nil {
 		return a.fetchPRHeadSHA
 	}
-	return github.FetchPRHeadSHA
+	return github.FetchPRHeadSHAContext
 }
 
-func (a *App) dispatchInboundReviewWorkflow(taskID string) {
+func (a *App) dispatchInboundReviewWorkflow(ctx context.Context, taskID string) {
 	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
 		return
 	}
@@ -261,12 +282,14 @@ func (a *App) dispatchInboundReviewWorkflow(taskID string) {
 		return
 	}
 
-	// Everything above is a function of local state, so a stale or frozen phase
-	// re-opens the gate every cooldown. Ask GitHub what the head actually is and
-	// refuse to review a commit we already reviewed — the durable backstop that
-	// #2164 lacked. The lookup is TTL-cached and only runs once the cheap gates
-	// pass, so it costs at most one call per cooldown per task.
-	head, err := a.fetchPRHeadSHAFunc()(t.ProjectID, t.PRNumber)
+	// Every gate above is a function of local state, so a stale or frozen phase
+	// re-opens them every cooldown — that is how #2164 spent 112 reviews on one
+	// commit. Ask GitHub for the real head and spend a bounded budget per
+	// commit. Cached 30s (github.prHeadSHACache), so a task whose gates are
+	// stuck open costs ~2 lookups/min, not one per tick.
+	headCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	head, err := a.fetchPRHeadSHAFunc()(headCtx, t.ProjectID, t.PRNumber)
 	if err != nil {
 		// Fail closed: without the head we cannot tell a new push from the
 		// commit we already reviewed, and guessing is what produced 112 reviews.
@@ -276,16 +299,23 @@ func (a *App) dispatchInboundReviewWorkflow(taskID string) {
 	if reviewCoversHead(t, head) {
 		return
 	}
-	// Stamp before dispatching: a run that crashes or loops must not be able to
-	// re-review the same commit on the next tick.
-	if _, err := a.tasks.Update(taskID, task.Update{ReviewedHeadSHA: task.Ptr(head)}); err != nil {
-		a.logger.Error("workflow.dispatch.inbound-review.stamp", "task_id", taskID, "err", err)
+
+	if err := a.workflowEngine.StartWorkflow(taskID, "pr-review"); err != nil {
+		if !errors.Is(err, workflow.ErrWorkflowAlreadyActive) &&
+			!errors.Is(err, workflow.ErrAutoDispatchDisabled) {
+			a.logger.Error("workflow.dispatch.inbound-review", "task_id", taskID, "err", err)
+		}
+		// Nothing ran, so nothing is charged; the next tick stays free to retry.
 		return
 	}
-	if err := a.workflowEngine.StartWorkflow(taskID, "pr-review"); err != nil &&
-		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) &&
-		!errors.Is(err, workflow.ErrAutoDispatchDisabled) {
-		a.logger.Error("workflow.dispatch.inbound-review", "task_id", taskID, "err", err)
+	// Charge only once a run is underway. A run that then crashes or loops still
+	// burns its attempt, which is what bounds the loop.
+	attempt := nextReviewAttempt(t, head)
+	if _, err := a.tasks.Update(taskID, task.Update{
+		ReviewedHeadSHA:      task.Ptr(head),
+		ReviewedHeadAttempts: task.Ptr(attempt),
+	}); err != nil {
+		a.logger.Error("workflow.dispatch.inbound-review.stamp", "task_id", taskID, "err", err)
 	}
 }
 

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -296,6 +296,14 @@ func (a *App) dispatchInboundReviewWorkflow(ctx context.Context, taskID string) 
 		a.logger.Warn("workflow.dispatch.inbound-review.head", "task_id", taskID, "err", err)
 		return
 	}
+	if head == "" {
+		// Declining is right, but silence is not: an empty SHA with no error means
+		// gh returned something we don't understand, and a PR that is quietly
+		// never reviewed again is exactly what #2164 was hard to diagnose about.
+		a.logger.Warn("workflow.dispatch.inbound-review.head-empty",
+			"task_id", taskID, "repo", t.ProjectID, "pr", t.PRNumber)
+		return
+	}
 	if reviewCoversHead(t, head) {
 		return
 	}

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/agentqueue"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -218,6 +219,24 @@ func isInboundReviewTask(t task.Task) bool {
 	return slices.Contains(t.Tags, "review") && t.ProjectID != "" && t.PRNumber != 0
 }
 
+// reviewCoversHead reports whether an automated review was already dispatched
+// against head. An unknown head ("") is treated as covered: the caller could
+// not establish what to review, and declining is the safe direction.
+func reviewCoversHead(t task.Task, head string) bool {
+	if head == "" {
+		return true
+	}
+	return t.ReviewedHeadSHA == head
+}
+
+// fetchPRHeadSHAFunc returns the PR-head lookup, overridable in tests.
+func (a *App) fetchPRHeadSHAFunc() func(repo string, number int) (string, error) {
+	if a.fetchPRHeadSHA != nil {
+		return a.fetchPRHeadSHA
+	}
+	return github.FetchPRHeadSHA
+}
+
 func (a *App) dispatchInboundReviewWorkflow(taskID string) {
 	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
 		return
@@ -239,6 +258,28 @@ func (a *App) dispatchInboundReviewWorkflow(taskID string) {
 		return
 	}
 	if a.agents.HasRunningAgentForTask(taskID) {
+		return
+	}
+
+	// Everything above is a function of local state, so a stale or frozen phase
+	// re-opens the gate every cooldown. Ask GitHub what the head actually is and
+	// refuse to review a commit we already reviewed — the durable backstop that
+	// #2164 lacked. The lookup is TTL-cached and only runs once the cheap gates
+	// pass, so it costs at most one call per cooldown per task.
+	head, err := a.fetchPRHeadSHAFunc()(t.ProjectID, t.PRNumber)
+	if err != nil {
+		// Fail closed: without the head we cannot tell a new push from the
+		// commit we already reviewed, and guessing is what produced 112 reviews.
+		a.logger.Warn("workflow.dispatch.inbound-review.head", "task_id", taskID, "err", err)
+		return
+	}
+	if reviewCoversHead(t, head) {
+		return
+	}
+	// Stamp before dispatching: a run that crashes or loops must not be able to
+	// re-review the same commit on the next tick.
+	if _, err := a.tasks.Update(taskID, task.Update{ReviewedHeadSHA: task.Ptr(head)}); err != nil {
+		a.logger.Error("workflow.dispatch.inbound-review.stamp", "task_id", taskID, "err", err)
 		return
 	}
 	if err := a.workflowEngine.StartWorkflow(taskID, "pr-review"); err != nil &&

--- a/internal/sybra/app_orchestrator_review_test.go
+++ b/internal/sybra/app_orchestrator_review_test.go
@@ -113,7 +113,7 @@ func TestReconcileRunnableBoardTasks_ConvergedInboundReviewIsNoOp(t *testing.T) 
 		t.Fatalf("test precondition failed: status_changed_at=%s must be after workflow completed_at=%s", got.StatusChangedAt, completedAt)
 	}
 
-	a.reconcileRunnableBoardTasks()
+	a.reconcileRunnableBoardTasks(t.Context())
 	a.wg.Wait()
 	afterFirst, err := a.tasks.Get(got.ID)
 	if err != nil {
@@ -129,7 +129,7 @@ func TestReconcileRunnableBoardTasks_ConvergedInboundReviewIsNoOp(t *testing.T) 
 		t.Fatalf("first maintenance tick status = %q, want %q", afterFirst.Status, task.StatusInReview)
 	}
 
-	a.reconcileRunnableBoardTasks()
+	a.reconcileRunnableBoardTasks(t.Context())
 	a.wg.Wait()
 	afterSecond, err := a.tasks.Get(got.ID)
 	if err != nil {

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -66,6 +66,12 @@ func setupApp(t *testing.T) *App {
 		logger:    logger,
 		worktrees: wm,
 		agentOrch: agentOrch,
+		// Default the PR-head lookup to a stub so no test can reach GitHub. A
+		// distinct per-PR SHA keeps the review dispatcher's already-reviewed
+		// guard inert unless a test opts in by stamping reviewed_head_sha.
+		fetchPRHeadSHA: func(_ string, number int) (string, error) {
+			return fmt.Sprintf("head-sha-pr-%d", number), nil
+		},
 	}
 }
 

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -69,7 +69,7 @@ func setupApp(t *testing.T) *App {
 		// Default the PR-head lookup to a stub so no test can reach GitHub. A
 		// distinct per-PR SHA keeps the review dispatcher's already-reviewed
 		// guard inert unless a test opts in by stamping reviewed_head_sha.
-		fetchPRHeadSHA: func(_ string, number int) (string, error) {
+		fetchPRHeadSHA: func(_ context.Context, _ string, number int) (string, error) {
 			return fmt.Sprintf("head-sha-pr-%d", number), nil
 		},
 	}

--- a/internal/sybra/clusterlead/merge_test.go
+++ b/internal/sybra/clusterlead/merge_test.go
@@ -140,3 +140,38 @@ func TestTaskIDFromEvent(t *testing.T) {
 		}
 	}
 }
+
+// The re-review backstop (#2166) lives on the follower that runs the review, so
+// the leader's canonical copy must carry it. If Merge drops it, a Reassign or a
+// home-node change writes the canonical copy back verbatim, resetting the guard
+// and re-reviewing a commit that was already reviewed — the #2164 loop, via the
+// cluster.
+func TestMergeCarriesReviewGuard(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	canonical := task.Task{
+		ID: "task-1", AssignedNode: "pet-box", Status: task.StatusTodo,
+		CreatedAt: t0, UpdatedAt: t0, MirrorRev: 1,
+	}
+	follower := task.Task{
+		ID:                   "task-1",
+		Status:               task.StatusInReview,
+		ReviewPhase:          "needs-approval",
+		Reviewed:             true,
+		ReviewedHeadSHA:      "e57e4b5db72c55ba7610140631a80946a7edddf0",
+		ReviewedHeadAttempts: 2,
+		UpdatedAt:            t0.Add(time.Hour),
+	}
+
+	out, ok := Merge(canonical, follower)
+	if !ok {
+		t.Fatal("Merge rejected a newer follower revision")
+	}
+	if out.ReviewedHeadSHA != follower.ReviewedHeadSHA {
+		t.Errorf("ReviewedHeadSHA = %q, want %q — the leader would re-review an already-reviewed commit",
+			out.ReviewedHeadSHA, follower.ReviewedHeadSHA)
+	}
+	if out.ReviewedHeadAttempts != follower.ReviewedHeadAttempts {
+		t.Errorf("ReviewedHeadAttempts = %d, want %d — the review budget would reset on reassign",
+			out.ReviewedHeadAttempts, follower.ReviewedHeadAttempts)
+	}
+}

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -212,6 +212,8 @@ func Merge(canonical, follower task.Task) (task.Task, bool) {
 	out.PRNumber = follower.PRNumber
 	out.PRPhase = follower.PRPhase
 	out.ReviewPhase = follower.ReviewPhase
+	out.ReviewedHeadSHA = follower.ReviewedHeadSHA
+	out.ReviewedHeadAttempts = follower.ReviewedHeadAttempts
 	out.Reviewed = follower.Reviewed
 	out.RunRole = follower.RunRole
 	out.Outcome = follower.Outcome

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -1,8 +1,10 @@
 package sybra
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1047,4 +1049,27 @@ func newInboundReviewTask(t *testing.T, a *App, prNumber int, phase string) task
 		t.Fatal(err)
 	}
 	return updated
+}
+
+// An empty SHA with no error means gh returned something we don't understand.
+// Declining is right, but it must be visible: a PR quietly never reviewed again
+// is precisely what made #2164 hard to diagnose.
+func TestDispatchInboundReview_EmptyHeadIsLoggedNotSilent(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+
+	var buf bytes.Buffer
+	a.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	a.fetchPRHeadSHA = func(context.Context, string, int) (string, error) { return "", nil }
+
+	tk := newInboundReviewTask(t, a, 151, "needs-approval")
+	a.dispatchInboundReviewWorkflow(t.Context(), tk.ID)
+
+	if launcher.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0 — an unknown head must not dispatch", launcher.startCalls)
+	}
+	if !strings.Contains(buf.String(), "head-empty") {
+		t.Errorf("declined silently; logs = %q", buf.String())
+	}
 }

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -523,7 +523,7 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 		t.Fatal(err)
 	}
 
-	a.reconcileRunnableBoardTasks()
+	a.reconcileRunnableBoardTasks(t.Context())
 	a.wg.Wait()
 
 	assertWorkflow := func(id, want string) {
@@ -809,18 +809,21 @@ func TestDispatchInboundReview_SkipsAlreadyReviewedHead(t *testing.T) {
 
 	const head = "e57e4b5db72c55ba7610140631a80946a7edddf0"
 	var headCalls atomic.Int64
-	a.fetchPRHeadSHA = func(string, int) (string, error) {
+	a.fetchPRHeadSHA = func(context.Context, string, int) (string, error) {
 		headCalls.Add(1)
 		return head, nil
 	}
 
 	tk := newInboundReviewTask(t, a, 151, "needs-approval")
-	// Already reviewed this exact commit.
-	if _, err := a.tasks.Update(tk.ID, task.Update{ReviewedHeadSHA: task.Ptr(head)}); err != nil {
+	// This commit's review budget is already spent.
+	if _, err := a.tasks.Update(tk.ID, task.Update{
+		ReviewedHeadSHA:      task.Ptr(head),
+		ReviewedHeadAttempts: task.Ptr(maxReviewAttemptsPerHead),
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	a.dispatchInboundReviewWorkflow(tk.ID)
+	a.dispatchInboundReviewWorkflow(t.Context(), tk.ID)
 
 	got, err := a.tasks.Get(tk.ID)
 	if err != nil {
@@ -844,14 +847,17 @@ func TestDispatchInboundReview_NewHeadIsReviewed(t *testing.T) {
 	svc, a := setupDispatchTestService(t, launcher)
 	a.workflowEngine = svc.workflowEngine
 
-	a.fetchPRHeadSHA = func(string, int) (string, error) { return "new-head-sha", nil }
+	a.fetchPRHeadSHA = func(context.Context, string, int) (string, error) { return "new-head-sha", nil }
 
 	tk := newInboundReviewTask(t, a, 151, "needs-approval")
-	if _, err := a.tasks.Update(tk.ID, task.Update{ReviewedHeadSHA: task.Ptr("old-head-sha")}); err != nil {
+	if _, err := a.tasks.Update(tk.ID, task.Update{
+		ReviewedHeadSHA:      task.Ptr("old-head-sha"),
+		ReviewedHeadAttempts: task.Ptr(maxReviewAttemptsPerHead),
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	a.dispatchInboundReviewWorkflow(tk.ID)
+	a.dispatchInboundReviewWorkflow(t.Context(), tk.ID)
 
 	got, err := a.tasks.Get(tk.ID)
 	if err != nil {
@@ -872,12 +878,14 @@ func TestDispatchInboundReview_HeadLookupFailureDefers(t *testing.T) {
 	svc, a := setupDispatchTestService(t, launcher)
 	a.workflowEngine = svc.workflowEngine
 
-	a.fetchPRHeadSHA = func(string, int) (string, error) {
-		return "", errors.New("gh: HTTP 502")
+	// A non-empty SHA alongside the error: with "" the fail-closed branch in
+	// reviewCoversHead would mask a deleted error check, making this tautological.
+	a.fetchPRHeadSHA = func(context.Context, string, int) (string, error) {
+		return "unreviewed-head-sha", errors.New("gh: HTTP 502")
 	}
 
 	tk := newInboundReviewTask(t, a, 151, "needs-approval")
-	a.dispatchInboundReviewWorkflow(tk.ID)
+	a.dispatchInboundReviewWorkflow(t.Context(), tk.ID)
 
 	got, err := a.tasks.Get(tk.ID)
 	if err != nil {
@@ -904,12 +912,13 @@ func TestDispatchInboundReview_CooldownOpenButHeadUnchanged(t *testing.T) {
 	a.workflowEngine = svc.workflowEngine
 
 	const head = "e57e4b5db72c55ba7610140631a80946a7edddf0"
-	a.fetchPRHeadSHA = func(string, int) (string, error) { return head, nil }
+	a.fetchPRHeadSHA = func(context.Context, string, int) (string, error) { return head, nil }
 
 	tk := newInboundReviewTask(t, a, 151, "needs-approval")
 	completedAt := time.Now().Add(-inboundReviewRedispatchCooldown - time.Minute)
 	if _, err := a.tasks.UpdateMap(tk.ID, map[string]any{
-		"reviewed_head_sha": head,
+		"reviewed_head_sha":      head,
+		"reviewed_head_attempts": maxReviewAttemptsPerHead,
 		"workflow": &workflow.Execution{
 			WorkflowID: "pr-review", State: workflow.ExecCompleted,
 			CompletedAt: &completedAt, Variables: map[string]string{},
@@ -926,7 +935,7 @@ func TestDispatchInboundReview_CooldownOpenButHeadUnchanged(t *testing.T) {
 		t.Fatal("precondition: the phase/cooldown gates must be open for this test to exercise the SHA guard")
 	}
 
-	a.dispatchInboundReviewWorkflow(tk.ID)
+	a.dispatchInboundReviewWorkflow(t.Context(), tk.ID)
 
 	if launcher.startCalls != 0 {
 		t.Fatalf("startCalls = %d, want 0 — re-reviewed an unchanged head with the cooldown open (the #2164 loop)", launcher.startCalls)
@@ -938,23 +947,86 @@ func TestReviewCoversHead(t *testing.T) {
 	tests := []struct {
 		name     string
 		reviewed string
+		attempts int
 		head     string
 		want     bool
 	}{
-		{"same head is covered", "abc", "abc", true},
-		{"new head is not covered", "abc", "def", false},
-		{"never reviewed is not covered", "", "abc", false},
-		{"unknown head is covered (fail closed)", "abc", "", true},
-		{"unknown head with no prior review still fails closed", "", "", true},
+		{"never reviewed", "", 0, "abc", false},
+		{"same head, budget left", "abc", 1, "abc", false},
+		{"same head, budget spent", "abc", maxReviewAttemptsPerHead, "abc", true},
+		{"same head, over budget", "abc", maxReviewAttemptsPerHead + 5, "abc", true},
+		{"new head resets the budget", "abc", maxReviewAttemptsPerHead, "def", false},
+		{"unknown head fails closed", "abc", 0, "", true},
+		{"unknown head with no prior review fails closed", "", 0, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := reviewCoversHead(task.Task{ReviewedHeadSHA: tt.reviewed}, tt.head)
-			if got != tt.want {
-				t.Errorf("reviewCoversHead(%q, %q) = %v, want %v", tt.reviewed, tt.head, got, tt.want)
+			tk := task.Task{ReviewedHeadSHA: tt.reviewed, ReviewedHeadAttempts: tt.attempts}
+			if got := reviewCoversHead(tk, tt.head); got != tt.want {
+				t.Errorf("reviewCoversHead(sha=%q attempts=%d, head=%q) = %v, want %v",
+					tt.reviewed, tt.attempts, tt.head, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNextReviewAttempt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		reviewed string
+		attempts int
+		head     string
+		want     int
+	}{
+		{"first ever review", "", 0, "abc", 1},
+		{"retry on the same head", "abc", 1, "abc", 2},
+		{"a new push restarts the budget", "abc", 9, "def", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tk := task.Task{ReviewedHeadSHA: tt.reviewed, ReviewedHeadAttempts: tt.attempts}
+			if got := nextReviewAttempt(tk, tt.head); got != tt.want {
+				t.Errorf("nextReviewAttempt = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// The blocking regression the adversary found in the first cut: stamping at
+// dispatch and refusing forever turned any transient provider failure into a PR
+// that is never reviewed again. A run that fails to start must not spend budget.
+func TestDispatchInboundReview_FailedStartDoesNotSpendBudget(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+	a.fetchPRHeadSHA = func(context.Context, string, int) (string, error) { return "head-1", nil }
+
+	tk := newInboundReviewTask(t, a, 151, "needs-approval")
+	// Auto-dispatch off models StartWorkflow refusing before anything runs.
+	a.workflowEngine.SetAutoDispatch(false)
+	a.dispatchInboundReviewWorkflow(t.Context(), tk.ID)
+
+	got, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReviewedHeadSHA != "" || got.ReviewedHeadAttempts != 0 {
+		t.Fatalf("charged the head (sha=%q attempts=%d) for a review that never started — "+
+			"the PR would never be reviewed again", got.ReviewedHeadSHA, got.ReviewedHeadAttempts)
+	}
+
+	// With dispatch re-enabled the review must still happen.
+	a.workflowEngine.SetAutoDispatch(true)
+	a.dispatchInboundReviewWorkflow(t.Context(), tk.ID)
+	got, err = a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReviewedHeadAttempts != 1 {
+		t.Errorf("attempts = %d, want 1 once a run actually started", got.ReviewedHeadAttempts)
 	}
 }
 

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -793,4 +794,185 @@ func TestDispatchFromHumanRequired_FailsClosedOnDispatchError(t *testing.T) {
 	if !strings.Contains(got.StatusReason, "retry please") {
 		t.Fatalf("status_reason = %q, want it to preserve the operator's reason", got.StatusReason)
 	}
+}
+
+// The durable backstop from #2164: a review must never be dispatched twice
+// against the same PR head. The phase/cooldown gates above this are all
+// functions of local state, so a frozen or wrong review_phase re-opens them
+// every cooldown — which is exactly how one unchanged commit collected 112
+// reviews. Asking GitHub for the head and refusing a commit we already
+// reviewed is what holds when those gates are wrong.
+func TestDispatchInboundReview_SkipsAlreadyReviewedHead(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+
+	const head = "e57e4b5db72c55ba7610140631a80946a7edddf0"
+	var headCalls atomic.Int64
+	a.fetchPRHeadSHA = func(string, int) (string, error) {
+		headCalls.Add(1)
+		return head, nil
+	}
+
+	tk := newInboundReviewTask(t, a, 151, "needs-approval")
+	// Already reviewed this exact commit.
+	if _, err := a.tasks.Update(tk.ID, task.Update{ReviewedHeadSHA: task.Ptr(head)}); err != nil {
+		t.Fatal(err)
+	}
+
+	a.dispatchInboundReviewWorkflow(tk.ID)
+
+	got, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil && got.Workflow.WorkflowID == "pr-review" && got.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("dispatched a pr-review for an already-reviewed head %s", head)
+	}
+	if launcher.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0 — the head was already reviewed", launcher.startCalls)
+	}
+	if headCalls.Load() == 0 {
+		t.Fatal("never asked GitHub for the head; the guard cannot be honest about local state alone")
+	}
+}
+
+// A genuine new push must still be reviewed — the guard is per-SHA, not a
+// blanket reviewed-once flag.
+func TestDispatchInboundReview_NewHeadIsReviewed(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+
+	a.fetchPRHeadSHA = func(string, int) (string, error) { return "new-head-sha", nil }
+
+	tk := newInboundReviewTask(t, a, 151, "needs-approval")
+	if _, err := a.tasks.Update(tk.ID, task.Update{ReviewedHeadSHA: task.Ptr("old-head-sha")}); err != nil {
+		t.Fatal(err)
+	}
+
+	a.dispatchInboundReviewWorkflow(tk.ID)
+
+	got, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil || got.Workflow.WorkflowID != "pr-review" {
+		t.Fatalf("workflow = %+v, want pr-review — a new push must be reviewed", got.Workflow)
+	}
+	if got.ReviewedHeadSHA != "new-head-sha" {
+		t.Errorf("reviewed_head_sha = %q, want new-head-sha stamped at dispatch", got.ReviewedHeadSHA)
+	}
+}
+
+// Without the head we cannot tell a new push from the commit we already
+// reviewed. Guessing is what produced the incident, so fail closed.
+func TestDispatchInboundReview_HeadLookupFailureDefers(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+
+	a.fetchPRHeadSHA = func(string, int) (string, error) {
+		return "", errors.New("gh: HTTP 502")
+	}
+
+	tk := newInboundReviewTask(t, a, 151, "needs-approval")
+	a.dispatchInboundReviewWorkflow(tk.ID)
+
+	got, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil && got.Workflow.WorkflowID == "pr-review" {
+		t.Fatalf("dispatched despite an unknown head: %+v", got.Workflow)
+	}
+	if launcher.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0 — an unknown head must not dispatch", launcher.startCalls)
+	}
+	if got.ReviewedHeadSHA != "" {
+		t.Errorf("reviewed_head_sha = %q, want empty — nothing was reviewed", got.ReviewedHeadSHA)
+	}
+}
+
+// The incident itself, reduced: review_phase frozen at needs-approval and the
+// 10-minute cooldown long expired, so every local gate re-opens — exactly the
+// state that re-fired 112 times. The head is unchanged, so the SHA guard is the
+// only thing left that can say no.
+func TestDispatchInboundReview_CooldownOpenButHeadUnchanged(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+
+	const head = "e57e4b5db72c55ba7610140631a80946a7edddf0"
+	a.fetchPRHeadSHA = func(string, int) (string, error) { return head, nil }
+
+	tk := newInboundReviewTask(t, a, 151, "needs-approval")
+	completedAt := time.Now().Add(-inboundReviewRedispatchCooldown - time.Minute)
+	if _, err := a.tasks.UpdateMap(tk.ID, map[string]any{
+		"reviewed_head_sha": head,
+		"workflow": &workflow.Execution{
+			WorkflowID: "pr-review", State: workflow.ExecCompleted,
+			CompletedAt: &completedAt, Variables: map[string]string{},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// The local gates must genuinely be open, or this test proves nothing.
+	stale, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inboundReviewNeedsAgent(stale) {
+		t.Fatal("precondition: the phase/cooldown gates must be open for this test to exercise the SHA guard")
+	}
+
+	a.dispatchInboundReviewWorkflow(tk.ID)
+
+	if launcher.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0 — re-reviewed an unchanged head with the cooldown open (the #2164 loop)", launcher.startCalls)
+	}
+}
+
+func TestReviewCoversHead(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		reviewed string
+		head     string
+		want     bool
+	}{
+		{"same head is covered", "abc", "abc", true},
+		{"new head is not covered", "abc", "def", false},
+		{"never reviewed is not covered", "", "abc", false},
+		{"unknown head is covered (fail closed)", "abc", "", true},
+		{"unknown head with no prior review still fails closed", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := reviewCoversHead(task.Task{ReviewedHeadSHA: tt.reviewed}, tt.head)
+			if got != tt.want {
+				t.Errorf("reviewCoversHead(%q, %q) = %v, want %v", tt.reviewed, tt.head, got, tt.want)
+			}
+		})
+	}
+}
+
+func newInboundReviewTask(t *testing.T, a *App, prNumber int, phase string) task.Task {
+	t.Helper()
+	tk, err := a.tasks.Create("Review: external PR", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := a.tasks.UpdateMap(tk.ID, map[string]any{
+		"status":       string(task.StatusInReview),
+		"tags":         []string{"review"},
+		"project_id":   "Automaat/lightroom-mcp",
+		"pr_number":    prNumber,
+		"review_phase": phase,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return updated
 }

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -339,12 +339,10 @@ type Task struct {
 	// human). Computed by the PR poller; drives the board's PR Reviews lane.
 	// Empty for non-review tasks.
 	ReviewPhase string `json:"reviewPhase,omitempty"`
-	// ReviewedHeadSHA is the PR head an automated review was last dispatched
-	// against; the dispatcher refuses to re-review it. Durable backstop against
-	// a re-dispatch loop (#2164 posted 112 reviews on one unchanged commit).
-	// Stamped at dispatch, not completion, so a crashing run cannot re-review
-	// forever — a real push moves the head and re-opens review.
-	ReviewedHeadSHA string `json:"reviewedHeadSha,omitempty"`
+	// Bounds automated re-review per PR commit: the durable backstop against a
+	// re-dispatch loop (#2164 spent 112 reviews on one unchanged commit).
+	ReviewedHeadSHA      string `json:"reviewedHeadSha,omitempty"`
+	ReviewedHeadAttempts int    `json:"reviewedHeadAttempts,omitempty"`
 	// PRPhase tracks where an outbound own-PR task (status in-review/ready-review,
 	// not tag `review`) sits in its lifecycle: draft → building → fixing →
 	// changes-requested → awaiting-approval → approved. Computed by the PR poller;

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -339,6 +339,12 @@ type Task struct {
 	// human). Computed by the PR poller; drives the board's PR Reviews lane.
 	// Empty for non-review tasks.
 	ReviewPhase string `json:"reviewPhase,omitempty"`
+	// ReviewedHeadSHA is the PR head an automated review was last dispatched
+	// against; the dispatcher refuses to re-review it. Durable backstop against
+	// a re-dispatch loop (#2164 posted 112 reviews on one unchanged commit).
+	// Stamped at dispatch, not completion, so a crashing run cannot re-review
+	// forever — a real push moves the head and re-opens review.
+	ReviewedHeadSHA string `json:"reviewedHeadSha,omitempty"`
 	// PRPhase tracks where an outbound own-PR task (status in-review/ready-review,
 	// not tag `review`) sits in its lifecycle: draft → building → fixing →
 	// changes-requested → awaiting-approval → approved. Computed by the PR poller;

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -34,6 +34,7 @@ type taskFrontmatter struct {
 	SupervisorSteer        string              `yaml:"supervisor_steer,omitempty"`
 	ReviewPhase            string              `yaml:"review_phase,omitempty"`
 	ReviewedHeadSHA        string              `yaml:"reviewed_head_sha,omitempty"`
+	ReviewedHeadAttempts   int                 `yaml:"reviewed_head_attempts,omitempty"`
 	PRPhase                string              `yaml:"pr_phase,omitempty"`
 	TodoistID              string              `yaml:"todoist_id,omitempty"`
 	Priority               Priority            `yaml:"priority,omitempty"`
@@ -118,6 +119,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		SupervisorSteer:        fm.SupervisorSteer,
 		ReviewPhase:            fm.ReviewPhase,
 		ReviewedHeadSHA:        fm.ReviewedHeadSHA,
+		ReviewedHeadAttempts:   fm.ReviewedHeadAttempts,
 		PRPhase:                fm.PRPhase,
 		TodoistID:              fm.TodoistID,
 		Priority:               fm.Priority,
@@ -179,6 +181,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		SupervisorSteer:        t.SupervisorSteer,
 		ReviewPhase:            t.ReviewPhase,
 		ReviewedHeadSHA:        t.ReviewedHeadSHA,
+		ReviewedHeadAttempts:   t.ReviewedHeadAttempts,
 		PRPhase:                t.PRPhase,
 		TodoistID:              t.TodoistID,
 		Priority:               t.Priority,

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -33,6 +33,7 @@ type taskFrontmatter struct {
 	RunRole                string              `yaml:"run_role,omitempty"`
 	SupervisorSteer        string              `yaml:"supervisor_steer,omitempty"`
 	ReviewPhase            string              `yaml:"review_phase,omitempty"`
+	ReviewedHeadSHA        string              `yaml:"reviewed_head_sha,omitempty"`
 	PRPhase                string              `yaml:"pr_phase,omitempty"`
 	TodoistID              string              `yaml:"todoist_id,omitempty"`
 	Priority               Priority            `yaml:"priority,omitempty"`
@@ -116,6 +117,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		RunRole:                fm.RunRole,
 		SupervisorSteer:        fm.SupervisorSteer,
 		ReviewPhase:            fm.ReviewPhase,
+		ReviewedHeadSHA:        fm.ReviewedHeadSHA,
 		PRPhase:                fm.PRPhase,
 		TodoistID:              fm.TodoistID,
 		Priority:               fm.Priority,
@@ -176,6 +178,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		RunRole:                t.RunRole,
 		SupervisorSteer:        t.SupervisorSteer,
 		ReviewPhase:            t.ReviewPhase,
+		ReviewedHeadSHA:        t.ReviewedHeadSHA,
 		PRPhase:                t.PRPhase,
 		TodoistID:              t.TodoistID,
 		Priority:               t.Priority,

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -42,6 +42,7 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		SupervisorSteer:        "read the failure",
 		ReviewPhase:            "awaiting-author",
 		ReviewedHeadSHA:        "e57e4b5db72c55ba7610140631a80946a7edddf0",
+		ReviewedHeadAttempts:   2,
 		PRPhase:                "fixing",
 		TodoistID:              "todoist-1",
 		Priority:               PriorityHigh,
@@ -241,6 +242,8 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.ReviewPhase = "awaiting-author"
 	case "ReviewedHeadSHA":
 		task.ReviewedHeadSHA = "e57e4b5db72c55ba7610140631a80946a7edddf0"
+	case "ReviewedHeadAttempts":
+		task.ReviewedHeadAttempts = 2
 	case "PRPhase":
 		task.PRPhase = "fixing"
 	case "TodoistID":

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -41,6 +41,7 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		RunRole:                "pr-fix",
 		SupervisorSteer:        "read the failure",
 		ReviewPhase:            "awaiting-author",
+		ReviewedHeadSHA:        "e57e4b5db72c55ba7610140631a80946a7edddf0",
 		PRPhase:                "fixing",
 		TodoistID:              "todoist-1",
 		Priority:               PriorityHigh,
@@ -238,6 +239,8 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.SupervisorSteer = "read the failure"
 	case "ReviewPhase":
 		task.ReviewPhase = "awaiting-author"
+	case "ReviewedHeadSHA":
+		task.ReviewedHeadSHA = "e57e4b5db72c55ba7610140631a80946a7edddf0"
 	case "PRPhase":
 		task.PRPhase = "fixing"
 	case "TodoistID":

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1183,6 +1183,9 @@ func applyReviewFields(t *Task, u Update) {
 	if u.ReviewPhase != nil {
 		t.ReviewPhase = *u.ReviewPhase
 	}
+	if u.ReviewedHeadSHA != nil {
+		t.ReviewedHeadSHA = *u.ReviewedHeadSHA
+	}
 	if u.PRPhase != nil {
 		t.PRPhase = *u.PRPhase
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1186,6 +1186,9 @@ func applyReviewFields(t *Task, u Update) {
 	if u.ReviewedHeadSHA != nil {
 		t.ReviewedHeadSHA = *u.ReviewedHeadSHA
 	}
+	if u.ReviewedHeadAttempts != nil {
+		t.ReviewedHeadAttempts = *u.ReviewedHeadAttempts
+	}
 	if u.PRPhase != nil {
 		t.PRPhase = *u.PRPhase
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -34,6 +34,7 @@ type Update struct {
 	RunRole               *string
 	SupervisorSteer       *string
 	ReviewPhase           *string
+	ReviewedHeadSHA       *string
 	PRPhase               *string
 	TodoistID             *string
 	Priority              *Priority
@@ -90,7 +91,7 @@ func applyMapField(u *Update, k string, v any) error {
 	case "title", "slug", "status_reason", "blocked_by_issue", "umbrella_issue", "body",
 		"project_id", "branch", "worktree_dir", "issue", "ref_issue", "run_role", "todoist_id", "plan", "plan_critique",
 		"plan_contract", "plan_research", "plan_decisions", "plan_brief", "code_review",
-		"review_phase", "pr_phase", "outcome", "merge_commit", "supervisor_steer":
+		"review_phase", "reviewed_head_sha", "pr_phase", "outcome", "merge_commit", "supervisor_steer":
 		return applyPlainStringField(u, k, v)
 	case "depends_on":
 		return applyDependsOnField(u, k, v)
@@ -202,6 +203,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.CodeReview = &s
 	case "review_phase":
 		u.ReviewPhase = &s
+	case "reviewed_head_sha":
+		u.ReviewedHeadSHA = &s
 	case "pr_phase":
 		u.PRPhase = &s
 	case "outcome":

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -35,6 +35,7 @@ type Update struct {
 	SupervisorSteer       *string
 	ReviewPhase           *string
 	ReviewedHeadSHA       *string
+	ReviewedHeadAttempts  *int
 	PRPhase               *string
 	TodoistID             *string
 	Priority              *Priority
@@ -109,6 +110,8 @@ func applyMapField(u *Update, k string, v any) error {
 		return applyTagsField(u, k, v)
 	case "pr_number":
 		return applyPRNumberField(u, k, v)
+	case "reviewed_head_attempts":
+		return applyReviewedHeadAttemptsField(u, k, v)
 	case "max_turns":
 		return applyMaxTurnsField(u, v)
 	case "fork_subagent":
@@ -335,6 +338,19 @@ func applyDependsOnField(u *Update, k string, v any) error {
 		u.DependsOn = &parts
 	default:
 		return fmt.Errorf("field %q: want []string or string, got %T", k, v)
+	}
+	return nil
+}
+
+func applyReviewedHeadAttemptsField(u *Update, k string, v any) error {
+	switch n := v.(type) {
+	case int:
+		u.ReviewedHeadAttempts = &n
+	case float64:
+		i := int(n)
+		u.ReviewedHeadAttempts = &i
+	default:
+		return fmt.Errorf("field %q: want int or float64, got %T", k, v)
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Every gate on the inbound-review dispatch path is a function of *local* state — `review_phase`, a workflow's terminal status, a 10-minute cooldown. So when the phase froze at `needs-approval` during #2164, those gates re-opened every cooldown and nothing else said no: **112 reviews on one unchanged commit over 23 hours**.

`reviewAgentAlreadyRan` exists and is a good guard, but it only gates `StartReviewAgent`. `dispatchInboundReviewWorkflow` starts the `pr-review` workflow directly and never consults it, so the poller path had no idempotency at all.

#2165 fixed the trigger (the `/user` identity lookup) and is verified in production — `review.my-state` warnings went to zero and task `7fb000c5` self-corrected to `awaiting-author`. **This PR is the independent backstop**: even if the phase machine breaks again for some other reason, never re-review the same commit without bound.

Closes #2166. Part of #2164.

> Changelog: fix(review): bound automated re-review per PR head

## Implementation information

Ask GitHub what the head actually is (the one fact local state cannot fake) once the cheap gates pass, and spend a **bounded budget per commit**:

- `reviewed_head_sha` + `reviewed_head_attempts` on the task, durable in frontmatter, so the guard survives a restart.
- `maxReviewAttemptsPerHead = 2`. A new head resets the budget, so a real push always re-opens review.
- The lookup is cached 30s, so a task whose gates are stuck open costs ~2 lookups/min rather than one per tick.

**Why a budget and not a one-shot flag — this PR's first cut had it wrong.** I originally stamped the head at dispatch and refused forever after. Adversarial review constructed the consequence and it is worse than the bug being fixed: a single transient provider failure stamps the head, nothing ever un-stamps it, and **that PR is never reviewed again, silently, for the life of the commit**. A never-reviewed external contribution is precisely the failure this automation exists to prevent. A count keeps the loop bounded (2, not 112) while leaving a transient blip a retry.

**Charge only after `StartWorkflow` returns.** A dispatch that never started must not spend budget — that closes the same never-reviewed hole reached via `ErrWorkflowAlreadyActive`. A run that starts and *then* crashes still burns its attempt, which is what bounds the loop.

**Fails closed on an unknown head.** Without it we cannot distinguish a new push from the commit we just reviewed, and guessing is what produced the incident.

### Also found by adversarial review

- **`clusterlead.Merge` dropped both new fields.** It is an explicit allowlist and copies `ReviewPhase`/`Reviewed` but skipped these, so a `Reassign` or a home-node change writes the leader's canonical copy back verbatim, resets the guard, and re-reviews an already-reviewed commit — the same loop, via the cluster. Proven by executing `Merge`; now covered by `TestMergeCarriesReviewGuard`.
- **The head lookup was uncancellable.** `github.FetchPRHeadSHA` uses `context.TODO()`, and this runs inline on the orchestrator loop while gh's process-global request gate is held across the whole subprocess — a stalled call would block every other dispatch (planning, in-progress, ready-pr) behind it. Now threads the loop's ctx through `reconcileRunnableBoardTasks` → `dispatchInboundReviewWorkflow` and uses `FetchPRHeadSHAContext`, which exists for exactly this reason.

### Testing

Every guard is **mutation-verified** — each test was confirmed to fail against the code without its guard:

| Mutation | Caught by |
|---|---|
| remove the SHA guard | `SkipsAlreadyReviewedHead`, `CooldownOpenButHeadUnchanged` |
| budget never spends | both of the above + `TestReviewCoversHead` |
| delete the head-error return | `HeadLookupFailureDefers` |
| revert the `Merge` allowlist | `TestMergeCarriesReviewGuard` |

`CooldownOpenButHeadUnchanged` is the incident reduced to a unit test: phase frozen at `needs-approval`, cooldown expired, head unchanged — it asserts the preconditions leave every local gate open, so it genuinely exercises the SHA guard and nothing else. Without the guard it fails with `startCalls = 1, want 0`.

Two tautological tests were caught and rewritten rather than kept:
- `StampsHeadBeforeDispatch` passed with the guard deleted (the first dispatch left a running agent, so `HasRunningAgentForTask` blocked the second, not my guard). Replaced with the cooldown-open repro above.
- `HeadLookupFailureDefers` passed with its error branch deleted, because the real fetcher returns `""` on error and `reviewCoversHead`'s fail-closed branch already declined. It now returns a non-empty SHA alongside the error, so only the error branch can save it.

The `setupApp` PR-head stub is defaulted for every test, so no test can reach GitHub.

## Open questions

**Two side doors stamp nothing**, so `reviewed_head_sha` is an invariant of "the poller dispatched", not "a review ran". `pr-review.yaml`'s `on: task.created` trigger dispatches the first-ever review of every inbound PR, and `recovery.convergeReviewOnPlanWorkflow` starts the workflow directly. Neither records what it reviewed, so the budget can be spent twice on one commit in the worst case — bounded and far from 112, but not the intended one. Closing it properly means stamping inside the `pr-review` workflow so every route that reviews records it; I left that out of scope here rather than reshape the workflow engine in a backstop PR. Worth a follow-up.

**`ErrAutoDispatchDisabled` may be unreachable here** — `runsScheduler()` gates `reconcileRunnableBoardTasks` and is set from the same value as `SetAutoDispatch`, so the branch looks dead. It is kept as defence-in-depth and is harmless either way (it now returns without charging).

## Supporting documentation

- Incident: https://github.com/Automaat/lightroom-mcp/pull/151
- #2165 (merged) — the trigger, verified fixed in production
- #2167 — the fail-safe direction; #2168 — the global blast-radius cap
