### PR TITLE
fix(provider): make a nil health gate absent

### DIFF
--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/provider"
 )
 
 func TestRunJSONFallsBackOnRateLimit(t *testing.T) {
@@ -363,5 +365,36 @@ func writeExe(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestRunJSONWithNilHealthChecker is the regression test for the config
+// docs/manual-testing.md recommends: providers.health_check.enabled=false.
+//
+// App.initProviderHealth leaves the checker nil there and callers box it into
+// Options.Gate, so `opts.Gate != nil` below is TRUE for a nil *Checker and the
+// IsHealthy call went straight into a nil dereference — crashing planning,
+// triage, PR content, umbrella expansion, and the digest, all of which reach
+// RunJSON through this line.
+func TestRunJSONWithNilHealthChecker(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "claude"), `#!/bin/sh
+printf '%s\n' '{"type":"result","subtype":"success","result":"{\"ok\":true}","total_cost_usd":0.01}'
+`)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Exactly what the disabled-health-check path hands callers: a nil
+	// *provider.Checker in a non-nil provider.HealthGate interface.
+	var gate provider.HealthGate = (*provider.Checker)(nil)
+
+	res, err := RunJSON(context.Background(), "hi", Options{Provider: "claude", Gate: gate})
+	if err != nil {
+		t.Fatalf("RunJSON with health checks disabled: %v", err)
+	}
+	if res.Provider != "claude" {
+		t.Errorf("Provider = %q, want claude: an absent gate must block nothing", res.Provider)
+	}
+	if !strings.Contains(res.Text, `"ok"`) {
+		t.Errorf("Text = %q, want the provider's payload", res.Text)
 	}
 }

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/provider"
 )
 
 type testOut struct {
@@ -285,5 +286,31 @@ func stubRunner(fn runnerFunc) func() {
 	runJSON = fn
 	return func() {
 		runJSON = prev
+	}
+}
+
+// TestAvoidingGate_TypedNilBaseIsAbsentNotFatal covers the wrapper's own nil
+// guard, which cannot catch the case that actually reaches it.
+//
+// `g.base == nil` is false when base holds a nil *provider.Checker — the shape
+// the disabled-health-check config hands every gate consumer — so the wrapper
+// delegates straight through, and only the base's nil-receiver contract keeps
+// that from panicking (see provider.Checker's HealthGate section).
+func TestAvoidingGate_TypedNilBaseIsAbsentNotFatal(t *testing.T) {
+	t.Parallel()
+
+	g := avoidingGate{base: (*provider.Checker)(nil), avoid: "codex"}
+
+	if !g.IsHealthy("claude") {
+		t.Error("IsHealthy(claude) = false; an absent base gate blocks nothing")
+	}
+	if g.IsHealthy("codex") {
+		t.Error("IsHealthy(codex) = true; the avoided provider must still be refused")
+	}
+	if got := g.Reason("claude"); got != "" {
+		t.Errorf("Reason(claude) = %q, want empty", got)
+	}
+	if got := g.Reason("codex"); got != "avoided for independence" {
+		t.Errorf("Reason(codex) = %q, want the avoid reason", got)
 	}
 }

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -427,9 +427,25 @@ func (c *Checker) failoverActiveLocked(unhealthy string) bool {
 }
 
 // --- HealthGate implementation ---
+//
+// Every method in this section is nil-receiver safe, and must stay that way.
+//
+// With providers.health_check.enabled=false the checker is never constructed
+// (App.initProviderHealth), which the config documents as "no gate, no
+// blocking". Callers box that nil *Checker into a HealthGate, and an interface
+// holding a nil pointer is itself not nil — so their `if gate != nil` guards
+// all pass and call straight through to here. Answering as an absent gate is
+// what makes the documented config actually work; panicking made it crash
+// planning, triage, PR content, umbrella expansion, and the learning digest.
+//
+// A new method on this interface that dereferences c unguarded reopens that
+// crash for every one of those callers at once.
 
 // IsHealthy reports whether the named provider can currently be used.
 func (c *Checker) IsHealthy(provider string) bool {
+	if c == nil {
+		return true
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	s, ok := c.statuses[provider]
@@ -445,6 +461,9 @@ func (c *Checker) IsHealthy(provider string) bool {
 // that's the distinction recovery uses to wait-and-retry rate limits while
 // letting auth failures take the human-required path.
 func (c *Checker) RateLimited(provider string) bool {
+	if c == nil {
+		return false
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	s, ok := c.statuses[provider]
@@ -456,6 +475,9 @@ func (c *Checker) RateLimited(provider string) bool {
 
 // Reason returns the current reason string for a provider, or empty if unknown.
 func (c *Checker) Reason(provider string) string {
+	if c == nil {
+		return ""
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if s, ok := c.statuses[provider]; ok {
@@ -468,6 +490,9 @@ func (c *Checker) Reason(provider string) string {
 // failoverPriority in order (claude > codex > copilot). Returns empty string
 // if auto-failover is disabled or no enabled peer is currently healthy.
 func (c *Checker) Failover(unhealthy string) string {
+	if c == nil {
+		return ""
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.failoverLocked(unhealthy)
@@ -508,7 +533,12 @@ func (c *Checker) providerEnabledLocked(provider string) bool {
 // ReportAuthFailure marks a provider as logged-out from a passive runner signal.
 // Only cleared by a successful active probe.
 func (c *Checker) ReportAuthFailure(provider, reason string) {
+	// The metric records a provider event, not gate state, so it stays truthful
+	// with no checker; only the status write needs one.
 	metrics.ProviderAuthFailure(provider)
+	if c == nil {
+		return
+	}
 	if reason == "" {
 		reason = "logged_out"
 	}
@@ -523,7 +553,12 @@ func (c *Checker) ReportAuthFailure(provider, reason string) {
 // ReportRateLimit marks a provider as rate-limited. retryAfter zero falls back
 // to the per-provider configured cooldown.
 func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, reason string) {
+	// See ReportAuthFailure: the metric is a provider event and survives a nil
+	// checker; the cooldown it would record has nowhere to live without one.
 	metrics.ProviderRateLimit(provider)
+	if c == nil {
+		return
+	}
 	cooldown := retryAfter
 	if cooldown <= 0 {
 		c.mu.RLock()

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -772,16 +772,3 @@ func TestNilChecker_IsAnAbsentGateNotAPanic(t *testing.T) {
 	gate.ReportAuthFailure("codex", "logged_out")
 	gate.ReportRateLimit("codex", time.Minute, "429")
 }
-
-// TestNilChecker_SurvivesAWrappedGate covers the wrappers that delegate to a
-// base gate (learning's claude-only gate, llmjob's avoiding gate). Their own
-// `base == nil` guards miss a typed nil for the same reason, so they only hold
-// up because the base is safe.
-func TestNilChecker_SurvivesAWrappedGate(t *testing.T) {
-	t.Parallel()
-
-	var base HealthGate = (*Checker)(nil)
-	if !base.IsHealthy("claude") || base.Reason("claude") != "" {
-		t.Error("a wrapper delegating to a nil base must see absent-gate answers, not a panic")
-	}
-}

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -739,3 +739,49 @@ func TestFailover_BothUnhealthySymmetric(t *testing.T) {
 		t.Errorf("Failover(claude) after codex recovery = %q, want codex", peer)
 	}
 }
+
+// TestNilChecker_IsAnAbsentGateNotAPanic pins the nil-receiver contract of the
+// HealthGate surface.
+//
+// providers.health_check.enabled=false leaves App.providerHealth nil, and every
+// caller boxes it into a provider.HealthGate. An interface holding a nil
+// pointer is not itself nil, so the callers' `if gate != nil` guards cannot
+// catch it — these methods are reached with c == nil and must answer as the
+// absent gate the disabled config promises. Before this, they panicked and took
+// planning, triage, PR content, umbrella expansion, and the digest with them.
+func TestNilChecker_IsAnAbsentGateNotAPanic(t *testing.T) {
+	t.Parallel()
+
+	// govet's nilness proves `gate == nil` is impossible here, which is the
+	// whole trap in one line: a caller's nil check cannot save it either, and
+	// the compiler will not warn them across a function boundary.
+	var gate HealthGate = (*Checker)(nil)
+
+	if !gate.IsHealthy("codex") {
+		t.Error("IsHealthy = false; an absent gate blocks nothing")
+	}
+	if gate.RateLimited("codex") {
+		t.Error("RateLimited = true; an absent gate knows of no cooldown")
+	}
+	if got := gate.Reason("codex"); got != "" {
+		t.Errorf("Reason = %q, want empty", got)
+	}
+	if got := gate.Failover("codex"); got != "" {
+		t.Errorf("Failover = %q, want empty: an absent gate has no view to fail over with", got)
+	}
+	gate.ReportAuthFailure("codex", "logged_out")
+	gate.ReportRateLimit("codex", time.Minute, "429")
+}
+
+// TestNilChecker_SurvivesAWrappedGate covers the wrappers that delegate to a
+// base gate (learning's claude-only gate, llmjob's avoiding gate). Their own
+// `base == nil` guards miss a typed nil for the same reason, so they only hold
+// up because the base is safe.
+func TestNilChecker_SurvivesAWrappedGate(t *testing.T) {
+	t.Parallel()
+
+	var base HealthGate = (*Checker)(nil)
+	if !base.IsHealthy("claude") || base.Reason("claude") != "" {
+		t.Error("a wrapper delegating to a nil base must see absent-gate answers, not a panic")
+	}
+}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -614,13 +614,7 @@ func (lm *LifecycleManager) startLearningDigestService(ctx context.Context, emit
 	if a.stats != nil {
 		deps.Stats = a.stats
 	}
-	// a.providerHealth is a typed *provider.Checker that stays nil when
-	// health-checking is disabled; assigning a nil pointer straight into the
-	// Gate interface field would produce a non-nil interface wrapping a nil
-	// receiver, and Checker's methods are not nil-receiver-safe.
-	if a.providerHealth != nil {
-		deps.Gate = a.providerHealth
-	}
+	deps.Gate = a.providerHealth
 	svc := learning.NewService(deps)
 	a.learningDigestSvc = svc
 	a.wg.Go(func() { svc.Run(ctx) })


### PR DESCRIPTION
## Motivation

With `providers.health_check.enabled: false` — the config `docs/manual-testing.md` itself recommends — `initProviderHealth` returns early and leaves `a.providerHealth` nil. Its doc calls that supported: *"the checker is skipped entirely and the manager runs with a nil gate (no blocking)"*.

That promise held only for `internal/agent`, which compares the gate against nil correctly. Everywhere else it crashed: `provider.(*Checker).IsHealthy` dereferenced a nil receiver at `health.go:433`, taking planning, triage, PR-content generation, umbrella expansion, the learning digest, and the self-monitor's rate-limit feedback with it. Found when `PlanningService.PlanTask` panicked during manual testing of an unrelated branch; reproduces on `main`.

The cause is the typed-nil-in-interface trap. `a.providerHealth` is a `*provider.Checker`; boxed into a `provider.HealthGate`, the interface is **not** nil — it holds a non-nil type with a nil value. So every downstream guard passes and calls straight through:

```go
// internal/llmexec/llmexec.go:77 — this guard is true for a typed nil
if opts.Gate != nil && !opts.Gate.IsHealthy(p) {
```

It hides well: the sites that *look* like they prove the pattern is safe — `lifecycle.go:379`, `svc_provider_health.go` — compare the concrete `*Checker`, where `!= nil` works. Only the interface assignments are broken.

> Changelog: fix(provider): make a nil health gate absent rather than fatal

## Implementation information

The six `HealthGate` methods on `*Checker` now answer as the absent gate the disabled config documents: `IsHealthy`→true, `RateLimited`→false, `Reason`→"", `Failover`→"", and the two `Report*` become no-ops. A 12-line contract block records why, so a future method that dereferences `c` unguarded doesn't quietly reopen the crash for all of them at once.

**One place, not eight.** The alternative was to guard each site that boxes the nil. The issue listed six; there are **eight** — `lifecycle.go:571` (self-monitor's `ProviderGate`, dereferenced at `selfmonitor/service.go:313` behind a nil check a typed nil walks through) and `services_wire_tasks.go:37` (a second `umbrella.FallbackPlannerRunner`) were missed, and both were live panic sites on `main`. That miscount is the argument: the per-site approach depends on enumerating sites correctly, and the person who filed the issue — me — could not. A `nilness`-style lint can't enforce it either; it reasons within a function and cannot see `deps.Gate = a.providerHealth` in one file reach `c.mu.RLock()` in another. That is precisely why this survived to production.

Nil-receiver methods are a documented Go idiom (`(*tls.Config).Clone`, `(*sync.Map)`); the contract block is what makes it one here rather than a surprise.

**A stale workaround removed.** The learning-digest wiring carried its own nil guard whose comment read *"Checker's methods are not nil-receiver-safe"* — the trap was known at that one site and worked around locally instead of fixed. That comment is now the inverse of the contract and would have taught the next reader either to copy the ceremony or to delete the guards it justifies. Dropped, which also removes an asymmetry: the digest was the only consumer handed a nil *interface* while the other seven got a typed nil.

**The report metrics still fire without a checker.** They record a provider event, not gate state, so disabling health checks shouldn't silently disable them. (Not a behaviour change: both already fired before the deref.)

## Supporting documentation

Reverting `internal/provider/health.go` alone makes the new tests fail with the exact panic from the issue:

```
panic: runtime error: invalid memory address or nil pointer dereference
	internal/provider/health.go:433 +0x28   (*Checker).IsHealthy
```

Coverage:
- `internal/provider` — the six methods answer as an absent gate through a `HealthGate` holding a typed nil. (govet's `nilness` proves `gate == nil` is statically impossible there, which is the trap in one line: a caller's nil check can't save it either.)
- `internal/llmexec` — `RunJSON` with a typed-nil gate completes instead of panicking; this is the line the crash came through.
- `internal/llmjob` — `avoidingGate` with a typed-nil base: its own `base == nil` guard is false for the value it actually receives, so it delegates straight through and only the base's contract saves it.

On the acceptance criterion's App-level test: `PlanTask` reaches the gate several layers down (`StartWorkflow` → classifier → `llmexec.RunJSON`) and would need a real provider CLI, so an App-level test would mostly exercise the workflow engine. The `llmexec` test pins the actual defect — boxing → deref — directly. Manual testing covers the App-level path end to end instead.

Closes #2175
