### PR TITLE
ci(actions): remove the rollout restart race

### DIFF
--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -79,7 +79,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-for bin in docker k3d kubectl jq; do
+# python3 filters the default ConfigMap out of the kustomize output below.
+for bin in docker k3d kubectl jq python3; do
   command -v "$bin" >/dev/null 2>&1 || fail "$bin is required but not on PATH"
 done
 

--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -52,6 +52,10 @@ in_pod() { kc exec deploy/sybra-server -- "$@"; }
 dump_diagnostics() {
   printf '\n===== DIAGNOSTICS =====\n' >&2
   kc get pods,jobs -o wide 2>&1 | head -30 >&2 || true
+  # A Pending pod says nothing about why; the events do (PVC binding, taints,
+  # insufficient memory). Cheap, and the first thing wanted on a CI failure.
+  printf '\n--- recent events ---\n' >&2
+  kc get events --sort-by=.lastTimestamp 2>&1 | tail -15 >&2 || true
   # Sybra's slog handler writes to a rotating file, not stdout, so `kubectl logs`
   # on the server shows almost nothing — the real sink is on the PVC.
   in_pod tail -100 /home/sybra/.sybra/logs/sybra.log 2>&1 | tail -60 >&2 || true
@@ -98,27 +102,44 @@ k3d kubeconfig get "$CLUSTER" > "$KUBECONFIG"
 log "Importing $IMAGE"
 k3d image import "$IMAGE" -c "$CLUSTER"
 
-log "Applying manifests ($PROVIDER)"
-kubectl --context "k3d-$CLUSTER" apply -k "$REPO_ROOT/deploy/k8s-poc"
-
+# Resolve the config BEFORE anything is applied. The old order applied the
+# kustomization (starting a pod on the default config), swapped the ConfigMap,
+# then rollout-restarted — needed because the config is a subPath mount, which
+# never updates in place. That restart raced itself: strategy Recreate plus a
+# ReadWriteOnce PVC means the new pod cannot schedule until the old one releases
+# the volume, and the old one was still coming up, so the rollout hung Pending
+# until it timed out. Giving the pod the right config at birth removes the
+# restart, and with it the race.
 case "$PROVIDER" in
   fake) CONFIG=config-fake-repo.yaml ;;
   opencode)
     CONFIG=config-provider-example.yaml
     [ -n "${OPENROUTER_API_KEY:-}" ] || fail "SMOKE_PROVIDER=opencode needs OPENROUTER_API_KEY"
-    kc create secret generic sybra-provider-api-keys \
-      --from-literal=openrouter_api_key="$OPENROUTER_API_KEY" \
-      --from-literal=github_token="${GITHUB_TOKEN:-}" \
-      --dry-run=client -o yaml | kubectl --context "k3d-$CLUSTER" apply -f -
     ;;
   *) fail "unknown SMOKE_PROVIDER '$PROVIDER' (want: fake, opencode)" ;;
 esac
 
-# These configs declare the same ConfigMap name, so this swaps sybra-config
-# wholesale. The mount is a subPath, which never receives ConfigMap updates, so
-# the restart below is mandatory rather than cosmetic.
+log "Applying manifests ($PROVIDER, config=$CONFIG)"
+kubectl --context "k3d-$CLUSTER" apply -f "$REPO_ROOT/deploy/k8s-poc/namespace.yaml"
+
+if [ "$PROVIDER" = "opencode" ]; then
+  kc create secret generic sybra-provider-api-keys \
+    --from-literal=openrouter_api_key="$OPENROUTER_API_KEY" \
+    --from-literal=github_token="${GITHUB_TOKEN:-}" \
+    --dry-run=client -o yaml | kubectl --context "k3d-$CLUSTER" apply -f -
+fi
+
+# The chosen ConfigMap goes in first, then everything else except the default
+# one it would otherwise be clobbered by (both declare the same name).
 kubectl --context "k3d-$CLUSTER" apply -f "$REPO_ROOT/deploy/k8s-poc/$CONFIG"
-kc rollout restart deployment/sybra-server
+kubectl kustomize "$REPO_ROOT/deploy/k8s-poc" \
+  | python3 -c '
+import sys
+docs = sys.stdin.read().split("\n---\n")
+kept = [d for d in docs if not ("kind: ConfigMap" in d and "name: sybra-config" in d)]
+sys.stdout.write("\n---\n".join(kept))
+' | kubectl --context "k3d-$CLUSTER" apply -f -
+
 kc rollout status deployment/sybra-server --timeout=180s
 
 log "Seeding fake repo project"


### PR DESCRIPTION
## Motivation

The `k3d Job Runner Smoke` job added in #2156 has a race that fails the run with no explanation in the log. It is a gate on every PR, so a flaky one is worse than none — and it is about to become the harness the rest of #2094 is verified against.

Observed locally:

```
deployment.apps/sybra-server created      <- pod A starts, binds the RWO PVC
configmap/sybra-config configured         <- the config is swapped
deployment.apps/sybra-server restarted    <- pod B must wait for A to release the volume
Waiting for deployment "sybra-server" rollout to finish: 0 of 1 updated replicas are available...
```

The pod then sat `Pending` until the rollout timed out, and the diagnostics dumped a pod with no host assigned and nothing about why.

> Changelog: ci(actions): remove the rollout restart race

## Implementation information

The restart existed only because the config is a **subPath mount**, which never receives ConfigMap updates — so the smoke applied the kustomization (starting a pod on the *default* config), swapped `sybra-config`, then restarted to pick it up.

That restart races itself: `strategy: Recreate` plus a `ReadWriteOnce` PVC means the new pod cannot schedule until the old one releases the volume, and the old one was still coming up.

The fix removes the need for a restart rather than trying to time it: resolve the config **first**, apply it before the Deployment exists, and filter the default ConfigMap out of the kustomize output so it cannot clobber the chosen one (all three config files declare the same `sybra-config` name). The pod now gets the right config at birth — no restart, no volume handoff, no race.

Also dumps recent events on failure. A `Pending` pod says nothing about why; the events name the cause (PVC binding, taints, memory), which is exactly what was missing while diagnosing this.

## Supporting documentation

Verified on a real k3d cluster — **two consecutive clean runs**, since a flake fix proven by one pass is not proven:

```
fix1  assertions=8 restarts=0  === PASS — k3d agent-Job smoke green
fix2  assertions=8 restarts=0  === PASS — k3d agent-Job smoke green
```

`restarts=0` is the load-bearing number: the `rollout restart` is gone entirely, so the handoff that hung `Pending` cannot occur.

The filter keeps every resource except the one it should drop:

```
kept: Namespace, ServiceAccount, Role, RoleBinding, Service, PersistentVolumeClaim, Deployment
dropped: 1 doc (the default sybra-config ConfigMap)
```

Scope note: this is deliberately split out of the #2099 branch, which carries unverified feature work. This is the main-stability half and stands alone.

Separately, one failure seen while diagnosing was **not** a code flake and is not addressed here: `k3d cluster create` died with `runc init error(s): nsexec-0: failed to sync with child` — a Docker daemon-level exec failure on a machine that had been building multi-GB images and cycling clusters for hours. It cleared on its own.
