### PR TITLE
fix(review): escalate a failing phase reconcile

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -579,7 +579,12 @@ func ViewerLoginCtx(ctx context.Context) string {
 }
 
 // IsTransientError reports whether err is a transient GitHub API failure
-// (HTTP 5xx or network timeout) that is expected to resolve on its own.
+// (HTTP 5xx, rate limiting, or a network blip) that is expected to resolve on
+// its own.
+//
+// Callers escalate on the non-transient side, and these errors arrive on every
+// in-flight request at once, so a gap here turns a ten-second network wobble
+// into a board-wide escalation storm.
 func IsTransientError(err error) bool {
 	if err == nil {
 		return false
@@ -594,9 +599,17 @@ func IsTransientError(err error) bool {
 	if strings.Contains(msg, "http 5") {
 		return true
 	}
+	// Rate limiting is backpressure, not a defect — GitHub is telling us to wait.
+	if isRateLimitedMessage(msg) {
+		return true
+	}
 	return strings.Contains(msg, "dial tcp") ||
 		strings.Contains(msg, "i/o timeout") ||
-		strings.Contains(msg, "context deadline exceeded")
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "tls handshake timeout") ||
+		strings.Contains(msg, "no route to host")
 }
 
 // IsAuthError reports whether err is a GitHub authentication failure — an

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -908,5 +909,42 @@ func TestSanitizeGHOutput(t *testing.T) {
 				t.Errorf("sanitizeGHOutput = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// IsTransientError decides whether a caller escalates. These errors hit every
+// in-flight request at once, so a gap here turns a brief network wobble into a
+// board-wide escalation storm (#2167).
+func TestIsTransientError_CoversRealNetworkAndRateLimitFailures(t *testing.T) {
+	t.Parallel()
+	transient := []string{
+		"gh: HTTP 502 Bad Gateway",
+		"gh: HTTP 503",
+		`Post "https://api.github.com/graphql": dial tcp 140.82.121.6:443: connect: no route to host`,
+		"read tcp 10.0.0.2:52134->140.82.121.6:443: read: connection reset by peer",
+		"dial tcp 140.82.121.6:443: connect: connection refused",
+		"net/http: TLS handshake timeout",
+		"i/o timeout",
+		"context deadline exceeded",
+		"You have exceeded a secondary rate limit (HTTP 403)",
+		"API rate limit exceeded for user ID 1 (HTTP 403)",
+	}
+	for _, msg := range transient {
+		if !IsTransientError(errors.New(msg)) {
+			t.Errorf("IsTransientError(%q) = false, want true — a caller would escalate on a blip", msg)
+		}
+	}
+
+	permanent := []string{
+		// A parse-level EOF is our decoder failing, not a network blip.
+		"parse graphql response: unexpected EOF",
+		"resolve viewer login for owner/repo#151: gh api user: HTTP 403: Resource not accessible by integration",
+		"gh: Not Found (HTTP 404)",
+		"gh: Bad credentials (HTTP 401)",
+	}
+	for _, msg := range permanent {
+		if IsTransientError(errors.New(msg)) {
+			t.Errorf("IsTransientError(%q) = true, want false — a real defect would never escalate", msg)
+		}
 	}
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -938,7 +938,7 @@ func TestIsTransientError_CoversRealNetworkAndRateLimitFailures(t *testing.T) {
 	permanent := []string{
 		// A parse-level EOF is our decoder failing, not a network blip.
 		"parse graphql response: unexpected EOF",
-		"resolve viewer login for owner/repo#151: gh api user: HTTP 403: Resource not accessible by integration",
+		"resolve viewer login for owner/repo#151: HTTP 403: Resource not accessible by integration",
 		"gh: Not Found (HTTP 404)",
 		"gh: Bad credentials (HTTP 401)",
 	}

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -76,6 +76,9 @@ type Handler struct {
 	// global-search fetch path (pollAndMonitorPRs) and backs off instead of
 	// retrying at pollFast cadence once tripped. See poll.AuthCircuit.
 	authCircuit *poll.AuthCircuit
+	// reconcileFailures tracks consecutive non-transient phase-reconcile
+	// failures per task ID, escalating at reconcileFailureLimit (#2164).
+	reconcileFailures map[string]int
 	// wtFailures tracks consecutive worktree-creation failures per task ID.
 	// Once a task hits wtFailureLimit, it is escalated to human-required.
 	wtFailures map[string]int
@@ -149,6 +152,10 @@ type Handler struct {
 	// fetchReviewsFn fetches the PR review summary. Overridable in tests; nil
 	// falls back to github.FetchReviews.
 	fetchReviewsFn func() (github.ReviewSummary, error)
+	// fetchMyReviewStateFn reads the viewer's own review state on a PR — the
+	// signal that decides whether a review task still needs an agent.
+	// Overridable in tests; nil falls back to github.FetchMyReviewState.
+	fetchMyReviewStateFn func(repo string, number int) (github.MyReviewState, error)
 	// viewerLoginFn returns the authenticated GitHub login (the identity the fix
 	// agent posts as), used to tell the agent's own thread replies from a human
 	// collaborator's. Overridable in tests; nil falls back to github.ViewerLogin.

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -312,8 +312,7 @@ func reviewPRKey(projectID string, prNumber int) string {
 // a stranger's PR 112 times. A warn-log is not an alarm.
 const reconcileFailureLimit = 5
 
-// reconcileEscalationReason prefixes the StatusReason this circuit writes, so a
-// re-escalation can recognise its own note and leave an operator's alone.
+// reconcileEscalationReason prefixes the StatusReason this circuit writes.
 const reconcileEscalationReason = "review reconcile failed"
 
 // recordReconcileFailure counts consecutive reconcile failures and escalates
@@ -332,6 +331,10 @@ func (r *Handler) recordReconcileFailure(t *task.Task, err error) {
 	// status alone, not on our own reason string: an operator who replaces the
 	// note must not thereby re-arm the clobber.
 	if t.Status == task.StatusHumanRequired {
+		// Drop the count too: it measures progress toward an escalation that has
+		// already happened, and keeping it would pin an entry for every parked
+		// task for the life of the process.
+		r.clearReconcileFailure(t.ID)
 		return
 	}
 

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -301,6 +301,58 @@ func reviewPRKey(projectID string, prNumber int) string {
 	return projectID + "#" + strconv.Itoa(prNumber)
 }
 
+// reconcileFailureLimit is how many consecutive non-transient reconcile
+// failures a review task tolerates before escalating to a human.
+//
+// The reconcile read decides whether a review task still needs an agent. The
+// old code logged a warning and left the phase untouched on failure, which
+// sounds conservative but is not: `needs-approval` is a *dispatchable* phase,
+// so a permanently-failing read parked the task in the one state that re-fires
+// every cooldown. #2164 warned every ~2 minutes for 23 hours while re-reviewing
+// a stranger's PR 112 times. A warn-log is not an alarm.
+const reconcileFailureLimit = 5
+
+// recordReconcileFailure counts consecutive reconcile failures and escalates
+// once they look permanent. Transient blips (5xx, timeouts, budget backoff) are
+// expected and never count; only a read that keeps failing is a defect.
+func (r *Handler) recordReconcileFailure(t *task.Task, err error) {
+	if github.IsTransientError(err) {
+		r.logger.Warn("review.my-state", "task_id", t.ID, "err", err, "transient", true)
+		return
+	}
+
+	r.failureMu.Lock()
+	if r.reconcileFailures == nil {
+		r.reconcileFailures = make(map[string]int)
+	}
+	r.reconcileFailures[t.ID]++
+	attempts := r.reconcileFailures[t.ID]
+	if attempts < reconcileFailureLimit {
+		r.failureMu.Unlock()
+		r.logger.Warn("review.my-state", "task_id", t.ID, "err", err, "attempts", attempts)
+		return
+	}
+	delete(r.reconcileFailures, t.ID)
+	r.failureMu.Unlock()
+
+	r.logger.Error("review.reconcile.circuit-open",
+		"task_id", t.ID, "failures", reconcileFailureLimit, "err", err)
+	// human-required is not dispatchable, so escalating both surfaces the defect
+	// and starves the re-review a frozen phase would keep feeding.
+	if _, uerr := r.tasks.Update(t.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(fmt.Sprintf("review reconcile failed %d times: %v", reconcileFailureLimit, err)),
+	}); uerr != nil {
+		r.logger.Error("review.reconcile.escalate", "task_id", t.ID, "err", uerr)
+	}
+}
+
+func (r *Handler) clearReconcileFailure(taskID string) {
+	r.failureMu.Lock()
+	defer r.failureMu.Unlock()
+	delete(r.reconcileFailures, taskID)
+}
+
 // reconcileReviewPhases recomputes the lifecycle phase of every inbound
 // PR-review task (tag `review`) from live GitHub signals and persists any
 // delta. It supersedes the old human-required→in-review "published" detector,
@@ -359,11 +411,16 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 		return
 	}
 
-	myState, err := github.FetchMyReviewState(t.ProjectID, t.PRNumber)
+	myStateFn := github.FetchMyReviewState
+	if r.fetchMyReviewStateFn != nil {
+		myStateFn = r.fetchMyReviewStateFn
+	}
+	myState, err := myStateFn(t.ProjectID, t.PRNumber)
 	if err != nil {
-		r.logger.Warn("review.my-state", "task_id", t.ID, "err", err)
+		r.recordReconcileFailure(t, err)
 		return
 	}
+	r.clearReconcileFailure(t.ID)
 
 	submitted := myState.Submitted || inApproved
 	headSHA := ""

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -312,12 +312,26 @@ func reviewPRKey(projectID string, prNumber int) string {
 // a stranger's PR 112 times. A warn-log is not an alarm.
 const reconcileFailureLimit = 5
 
+// reconcileEscalationReason prefixes the StatusReason this circuit writes, so a
+// re-escalation can recognise its own note and leave an operator's alone.
+const reconcileEscalationReason = "review reconcile failed"
+
 // recordReconcileFailure counts consecutive reconcile failures and escalates
 // once they look permanent. Transient blips (5xx, timeouts, budget backoff) are
 // expected and never count; only a read that keeps failing is a defect.
 func (r *Handler) recordReconcileFailure(t *task.Task, err error) {
 	if github.IsTransientError(err) {
 		r.logger.Warn("review.my-state", "task_id", t.ID, "err", err, "transient", true)
+		return
+	}
+
+	// Already parked on a human: escalating again achieves nothing and actively
+	// harms — human-required is not terminal, so the poller keeps feeding this
+	// task back, and each pass would overwrite the operator's own triage note
+	// and rewrite updated_at on work nobody is doing. Deliberately keyed on
+	// status alone, not on our own reason string: an operator who replaces the
+	// note must not thereby re-arm the clobber.
+	if t.Status == task.StatusHumanRequired {
 		return
 	}
 
@@ -332,7 +346,6 @@ func (r *Handler) recordReconcileFailure(t *task.Task, err error) {
 		r.logger.Warn("review.my-state", "task_id", t.ID, "err", err, "attempts", attempts)
 		return
 	}
-	delete(r.reconcileFailures, t.ID)
 	r.failureMu.Unlock()
 
 	r.logger.Error("review.reconcile.circuit-open",
@@ -341,7 +354,7 @@ func (r *Handler) recordReconcileFailure(t *task.Task, err error) {
 	// and starves the re-review a frozen phase would keep feeding.
 	if _, uerr := r.tasks.Update(t.ID, task.Update{
 		Status:       task.Ptr(task.StatusHumanRequired),
-		StatusReason: task.Ptr(fmt.Sprintf("review reconcile failed %d times: %v", reconcileFailureLimit, err)),
+		StatusReason: task.Ptr(fmt.Sprintf("%s %d times: %v", reconcileEscalationReason, reconcileFailureLimit, err)),
 	}); uerr != nil {
 		r.logger.Error("review.reconcile.escalate", "task_id", t.ID, "err", uerr)
 	}
@@ -378,6 +391,10 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 	// An agent owning the PR short-circuits: surface "reviewing" without the
 	// extra GitHub round-trips.
 	if r.agents.HasRunningAgentForTask(t.ID) {
+		// Reaching this proves the task is healthy, so any earlier failures are
+		// stale. Without clearing here the count never decays and a single fresh
+		// failure hours later can trip a circuit meant to catch a persistent one.
+		r.clearReconcileFailure(t.ID)
 		r.applyReviewPhase(t, computeReviewPhase(reviewSignals{AgentRunning: true}))
 		return
 	}
@@ -407,6 +424,7 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 		}
 	}
 	if res, decided := stickyConflictPhase(mergeable, t.ReviewPhase); decided {
+		r.clearReconcileFailure(t.ID)
 		r.applyReviewPhase(t, res)
 		return
 	}

--- a/internal/sybra/review/reconcile_failure_test.go
+++ b/internal/sybra/review/reconcile_failure_test.go
@@ -1,0 +1,245 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func newReconcileFailureHandler(t *testing.T) (*Handler, *task.Manager) {
+	t.Helper()
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	return &Handler{
+		logger: logger,
+		tasks:  tasks,
+		agents: agents,
+	}, tasks
+}
+
+func newReviewTaskInPhase(t *testing.T, tasks *task.Manager, phase string) task.Task {
+	t.Helper()
+	tk, err := tasks.Create("Review: external PR", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := tasks.UpdateMap(tk.ID, map[string]any{
+		"status":       string(task.StatusInReview),
+		"tags":         []string{"review"},
+		"project_id":   "Automaat/lightroom-mcp",
+		"pr_number":    151,
+		"review_phase": phase,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return updated
+}
+
+// The #2164 shape: a permanently-failing reconcile read left review_phase
+// frozen at needs-approval — a *dispatchable* phase — and only ever logged a
+// warning. It warned every ~2 minutes for 23 hours while re-reviewing a
+// stranger's PR 112 times. Past the limit the task must land somewhere a human
+// sees and the dispatcher will not fire on.
+func TestRecordReconcileFailure_EscalatesPersistentFailure(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	// The exact error from the incident.
+	err := errors.New("resolve viewer login for Automaat/lightroom-mcp#151: gh api user: HTTP 403")
+	for range reconcileFailureLimit {
+		got, gerr := tasks.Get(tk.ID)
+		if gerr != nil {
+			t.Fatal(gerr)
+		}
+		r.recordReconcileFailure(&got, err)
+	}
+
+	got, gerr := tasks.Get(tk.ID)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q after %d consecutive failures — a warn-log is not an alarm",
+			got.Status, task.StatusHumanRequired, reconcileFailureLimit)
+	}
+	if got.StatusReason == "" {
+		t.Error("StatusReason is empty; the operator cannot tell why this stopped")
+	}
+}
+
+// Below the limit the task is left alone: a couple of failed reads is not
+// evidence of a defect, and flipping a healthy task to human-required on the
+// first blip would be its own bug.
+func TestRecordReconcileFailure_ToleratesFailuresBelowLimit(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	err := errors.New("resolve viewer login: HTTP 403")
+	for range reconcileFailureLimit - 1 {
+		got, gerr := tasks.Get(tk.ID)
+		if gerr != nil {
+			t.Fatal(gerr)
+		}
+		r.recordReconcileFailure(&got, err)
+	}
+
+	got, gerr := tasks.Get(tk.ID)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if got.Status != task.StatusInReview {
+		t.Fatalf("status = %q, want %q — escalated before the limit", got.Status, task.StatusInReview)
+	}
+}
+
+// A 5xx or a timeout is expected weather, not a defect. Counting it would
+// escalate healthy tasks during a GitHub blip.
+func TestRecordReconcileFailure_TransientNeverEscalates(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	transient := fmt.Errorf("gh: HTTP 502 Bad Gateway")
+	for range reconcileFailureLimit * 3 {
+		got, gerr := tasks.Get(tk.ID)
+		if gerr != nil {
+			t.Fatal(gerr)
+		}
+		r.recordReconcileFailure(&got, transient)
+	}
+
+	got, gerr := tasks.Get(tk.ID)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if got.Status != task.StatusInReview {
+		t.Fatalf("status = %q, want %q — a transient blip must not escalate", got.Status, task.StatusInReview)
+	}
+	r.failureMu.Lock()
+	n := r.reconcileFailures[tk.ID]
+	r.failureMu.Unlock()
+	if n != 0 {
+		t.Errorf("transient failures counted %d toward the limit, want 0", n)
+	}
+}
+
+// The counter is consecutive: one good read means the defect is gone.
+func TestClearReconcileFailure_ResetsTheCount(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	err := errors.New("resolve viewer login: HTTP 403")
+	for range reconcileFailureLimit - 1 {
+		got, gerr := tasks.Get(tk.ID)
+		if gerr != nil {
+			t.Fatal(gerr)
+		}
+		r.recordReconcileFailure(&got, err)
+	}
+	r.clearReconcileFailure(tk.ID)
+
+	// A further failure starts from scratch, so this must not escalate.
+	got, gerr := tasks.Get(tk.ID)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	r.recordReconcileFailure(&got, err)
+
+	got, gerr = tasks.Get(tk.ID)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if got.Status != task.StatusInReview {
+		t.Fatalf("status = %q, want %q — the counter did not reset on a successful read",
+			got.Status, task.StatusInReview)
+	}
+}
+
+// The wiring, not just the helper: reconcileReviewTask must actually route a
+// failed read through the circuit. Without this the call site could be reverted
+// to the incident's warn-and-return and every other test here would still pass.
+func TestReconcileReviewTask_RoutesFailureThroughCircuit(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	// The exact failure from #2164, repeated until the circuit should trip.
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{}, errors.New("resolve viewer login for Automaat/lightroom-mcp#151: gh api user: HTTP 403")
+	}
+	// MERGEABLE keeps stickyConflictPhase from deciding early and avoids a live
+	// FetchPRState call, so the read under test is the one that fails.
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	requested := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	for range reconcileFailureLimit {
+		got, gerr := tasks.Get(tk.ID)
+		if gerr != nil {
+			t.Fatal(gerr)
+		}
+		r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
+	}
+
+	got, gerr := tasks.Get(tk.ID)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q — reconcileReviewTask swallowed a permanently failing read, "+
+			"leaving the task dispatchable (the #2164 loop)", got.Status, task.StatusHumanRequired)
+	}
+}
+
+// A healthy read must leave the task alone and clear any prior failures.
+func TestReconcileReviewTask_SuccessClearsTheCircuit(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	var fail bool
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		if fail {
+			return github.MyReviewState{}, errors.New("resolve viewer login: HTTP 403")
+		}
+		return github.MyReviewState{Submitted: true, ReviewedSHA: "e57e4b5"}, nil
+	}
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	requested := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	// Fail almost to the limit, then succeed — the counter must reset.
+	fail = true
+	for range reconcileFailureLimit - 1 {
+		got, _ := tasks.Get(tk.ID)
+		r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
+	}
+	fail = false
+	got, _ := tasks.Get(tk.ID)
+	r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
+
+	r.failureMu.Lock()
+	n := r.reconcileFailures[tk.ID]
+	r.failureMu.Unlock()
+	if n != 0 {
+		t.Errorf("failure count = %d after a successful read, want 0", n)
+	}
+
+	fail = true
+	got, _ = tasks.Get(tk.ID)
+	r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
+	got, _ = tasks.Get(tk.ID)
+	if got.Status == task.StatusHumanRequired {
+		t.Error("escalated on the first failure after a success; the counter did not reset")
+	}
+}

--- a/internal/sybra/review/reconcile_failure_test.go
+++ b/internal/sybra/review/reconcile_failure_test.go
@@ -27,6 +27,17 @@ func newReconcileFailureHandler(t *testing.T) (*Handler, *task.Manager) {
 	}, tasks
 }
 
+// mustGet reads a task or fails the test — nilaway (rightly) will not accept an
+// ignored error feeding a pointer into production code.
+func mustGet(t *testing.T, tasks *task.Manager, id string) task.Task {
+	t.Helper()
+	got, err := tasks.Get(id)
+	if err != nil {
+		t.Fatalf("get %s: %v", id, err)
+	}
+	return got
+}
+
 func newReviewTaskInPhase(t *testing.T, tasks *task.Manager, phase string) task.Task {
 	t.Helper()
 	tk, err := tasks.Create("Review: external PR", "", "headless")
@@ -56,7 +67,7 @@ func TestRecordReconcileFailure_EscalatesPersistentFailure(t *testing.T) {
 	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
 
 	// The exact error from the incident.
-	err := errors.New("resolve viewer login for Automaat/lightroom-mcp#151: gh api user: HTTP 403")
+	err := errors.New("resolve viewer login for Automaat/lightroom-mcp#151: HTTP 403: Resource not accessible by integration")
 	for range reconcileFailureLimit {
 		got, gerr := tasks.Get(tk.ID)
 		if gerr != nil {
@@ -174,7 +185,7 @@ func TestReconcileReviewTask_RoutesFailureThroughCircuit(t *testing.T) {
 
 	// The exact failure from #2164, repeated until the circuit should trip.
 	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
-		return github.MyReviewState{}, errors.New("resolve viewer login for Automaat/lightroom-mcp#151: gh api user: HTTP 403")
+		return github.MyReviewState{}, errors.New("resolve viewer login for Automaat/lightroom-mcp#151: HTTP 403: Resource not accessible by integration")
 	}
 	// MERGEABLE keeps stickyConflictPhase from deciding early and avoids a live
 	// FetchPRState call, so the read under test is the one that fails.
@@ -221,11 +232,11 @@ func TestReconcileReviewTask_SuccessClearsTheCircuit(t *testing.T) {
 	// Fail almost to the limit, then succeed — the counter must reset.
 	fail = true
 	for range reconcileFailureLimit - 1 {
-		got, _ := tasks.Get(tk.ID)
+		got := mustGet(t, tasks, tk.ID)
 		r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
 	}
 	fail = false
-	got, _ := tasks.Get(tk.ID)
+	got := mustGet(t, tasks, tk.ID)
 	r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
 
 	r.failureMu.Lock()
@@ -236,9 +247,9 @@ func TestReconcileReviewTask_SuccessClearsTheCircuit(t *testing.T) {
 	}
 
 	fail = true
-	got, _ = tasks.Get(tk.ID)
+	got = mustGet(t, tasks, tk.ID)
 	r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
-	got, _ = tasks.Get(tk.ID)
+	got = mustGet(t, tasks, tk.ID)
 	if got.Status == task.StatusHumanRequired {
 		t.Error("escalated on the first failure after a success; the counter did not reset")
 	}
@@ -254,10 +265,10 @@ func TestRecordReconcileFailure_DoesNotClobberOperatorNote(t *testing.T) {
 
 	err := errors.New("resolve viewer login: HTTP 403")
 	for range reconcileFailureLimit {
-		got, _ := tasks.Get(tk.ID)
+		got := mustGet(t, tasks, tk.ID)
 		r.recordReconcileFailure(&got, err)
 	}
-	escalated, _ := tasks.Get(tk.ID)
+	escalated := mustGet(t, tasks, tk.ID)
 	if escalated.Status != task.StatusHumanRequired {
 		t.Fatalf("precondition: want escalated, got %q", escalated.Status)
 	}
@@ -266,15 +277,15 @@ func TestRecordReconcileFailure_DoesNotClobberOperatorNote(t *testing.T) {
 	if _, uerr := tasks.Update(tk.ID, task.Update{StatusReason: task.Ptr(note)}); uerr != nil {
 		t.Fatal(uerr)
 	}
-	before, _ := tasks.Get(tk.ID)
+	before := mustGet(t, tasks, tk.ID)
 
 	// Keep polling with the same failing read.
 	for range reconcileFailureLimit * 2 {
-		got, _ := tasks.Get(tk.ID)
+		got := mustGet(t, tasks, tk.ID)
 		r.recordReconcileFailure(&got, err)
 	}
 
-	after, _ := tasks.Get(tk.ID)
+	after := mustGet(t, tasks, tk.ID)
 	if after.StatusReason != note {
 		t.Errorf("StatusReason = %q, want the operator's note %q — re-escalation clobbered it",
 			after.StatusReason, note)
@@ -303,7 +314,7 @@ func TestReconcileReviewTask_HealthyCycleClearsStaleFailures(t *testing.T) {
 
 	// Accumulate failures just short of the limit.
 	for range reconcileFailureLimit - 1 {
-		got, _ := tasks.Get(tk.ID)
+		got := mustGet(t, tasks, tk.ID)
 		r.reconcileReviewTask(&got, mergeableReq, map[string]github.PullRequest{})
 	}
 
@@ -312,7 +323,7 @@ func TestReconcileReviewTask_HealthyCycleClearsStaleFailures(t *testing.T) {
 	conflicting := map[string]github.PullRequest{
 		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "CONFLICTING", HeadSHA: "e57e4b5"},
 	}
-	got, _ := tasks.Get(tk.ID)
+	got := mustGet(t, tasks, tk.ID)
 	r.reconcileReviewTask(&got, conflicting, map[string]github.PullRequest{})
 
 	r.failureMu.Lock()
@@ -320,5 +331,34 @@ func TestReconcileReviewTask_HealthyCycleClearsStaleFailures(t *testing.T) {
 	r.failureMu.Unlock()
 	if n != 0 {
 		t.Fatalf("failure count = %d after a healthy cycle, want 0 — one later blip would escalate a healthy task", n)
+	}
+}
+
+// A parked task must not pin a counter entry for the life of the process: the
+// count measures progress toward an escalation that already happened.
+func TestRecordReconcileFailure_ParkedTaskLeavesNoStaleCounter(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	err := errors.New("resolve viewer login: HTTP 403: Resource not accessible by integration")
+	for range reconcileFailureLimit {
+		got := mustGet(t, tasks, tk.ID)
+		r.recordReconcileFailure(&got, err)
+	}
+	if mustGet(t, tasks, tk.ID).Status != task.StatusHumanRequired {
+		t.Fatal("precondition: want escalated")
+	}
+
+	// Further polls against the parked task must leave nothing behind.
+	for range 3 {
+		got := mustGet(t, tasks, tk.ID)
+		r.recordReconcileFailure(&got, err)
+	}
+
+	r.failureMu.Lock()
+	n, present := r.reconcileFailures[tk.ID]
+	r.failureMu.Unlock()
+	if present {
+		t.Errorf("parked task still holds a counter entry (%d); it leaks for the life of the process", n)
 	}
 }

--- a/internal/sybra/review/reconcile_failure_test.go
+++ b/internal/sybra/review/reconcile_failure_test.go
@@ -243,3 +243,82 @@ func TestReconcileReviewTask_SuccessClearsTheCircuit(t *testing.T) {
 		t.Error("escalated on the first failure after a success; the counter did not reset")
 	}
 }
+
+// Escalation must be idempotent. human-required is not terminal, so the poller
+// keeps feeding the escalated task back in — re-escalating would overwrite the
+// operator's own triage note and rewrite updated_at forever on a task nobody is
+// working on (also defeating any dwell detector keyed on it).
+func TestRecordReconcileFailure_DoesNotClobberOperatorNote(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	err := errors.New("resolve viewer login: HTTP 403")
+	for range reconcileFailureLimit {
+		got, _ := tasks.Get(tk.ID)
+		r.recordReconcileFailure(&got, err)
+	}
+	escalated, _ := tasks.Get(tk.ID)
+	if escalated.Status != task.StatusHumanRequired {
+		t.Fatalf("precondition: want escalated, got %q", escalated.Status)
+	}
+
+	const note = "OPERATOR: investigating, do not touch"
+	if _, uerr := tasks.Update(tk.ID, task.Update{StatusReason: task.Ptr(note)}); uerr != nil {
+		t.Fatal(uerr)
+	}
+	before, _ := tasks.Get(tk.ID)
+
+	// Keep polling with the same failing read.
+	for range reconcileFailureLimit * 2 {
+		got, _ := tasks.Get(tk.ID)
+		r.recordReconcileFailure(&got, err)
+	}
+
+	after, _ := tasks.Get(tk.ID)
+	if after.StatusReason != note {
+		t.Errorf("StatusReason = %q, want the operator's note %q — re-escalation clobbered it",
+			after.StatusReason, note)
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Errorf("updated_at was rewritten (%v -> %v) on an already-escalated task",
+			before.UpdatedAt, after.UpdatedAt)
+	}
+}
+
+// The count must decay when a cycle proves the task is healthy. Otherwise stale
+// failures accumulate across hours of a perfectly healthy PR and a single fresh
+// blip trips a circuit meant to catch a *persistent* failure.
+func TestReconcileReviewTask_HealthyCycleClearsStaleFailures(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	err := errors.New("resolve viewer login: HTTP 403")
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{}, err
+	}
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	mergeableReq := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	// Accumulate failures just short of the limit.
+	for range reconcileFailureLimit - 1 {
+		got, _ := tasks.Get(tk.ID)
+		r.reconcileReviewTask(&got, mergeableReq, map[string]github.PullRequest{})
+	}
+
+	// The PR goes CONFLICTING: a decided phase proves GitHub is readable, so the
+	// stale failures must not survive it.
+	conflicting := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "CONFLICTING", HeadSHA: "e57e4b5"},
+	}
+	got, _ := tasks.Get(tk.ID)
+	r.reconcileReviewTask(&got, conflicting, map[string]github.PullRequest{})
+
+	r.failureMu.Lock()
+	n := r.reconcileFailures[tk.ID]
+	r.failureMu.Unlock()
+	if n != 0 {
+		t.Fatalf("failure count = %d after a healthy cycle, want 0 — one later blip would escalate a healthy task", n)
+	}
+}


### PR DESCRIPTION
## Motivation

This is the general lesson from #2164, and it is uncomfortable: **the code that caused the incident was written to be conservative.**

```go
myState, err := github.FetchMyReviewState(t.ProjectID, t.PRNumber)
if err != nil {
    r.logger.Warn("review.my-state", "task_id", t.ID, "err", err)
    return
}
```

The comment at the error's origin even explained the intent — don't guess the phase on bad data, leave it alone. But `needs-approval` is a **dispatchable** phase. Leaving it alone parked the task in the one state that re-fires every cooldown. A fail-*closed* read that leaves state in a re-firing phase is fail-*open* in practice: it warned every ~2 minutes for 23 hours while re-reviewing an external contributor's PR 112 times, and nothing escalated. **A warn-log is not an alarm.**

Closes #2167. Part of #2164.

> Changelog: fix(review): escalate a persistently failing phase reconcile

## Implementation information

Count consecutive **non-transient** reconcile failures per task and escalate to `human-required` at `reconcileFailureLimit` (5), mirroring the existing `recordWorktreeFailure`/`wtFailureLimit` convention. `human-required` is not dispatchable, so escalating both surfaces the defect and starves the re-review a frozen phase would keep feeding.

Transient errors (5xx, timeouts, rate limits, network blips) are expected weather and never count — only a read that *keeps* failing is a defect.

### Corrections from adversarial review

The first cut had three real defects, all found by constructing the failure rather than speculating:

**Escalation clobbered the operator.** `human-required` is not terminal, so the poller keeps feeding an escalated task back through reconcile. Each pass rewrote `StatusReason` — destroying an operator's own triage note — and bumped `updated_at` forever on work nobody was doing, which also defeats any dwell/stale detector keyed on it. Now skipped when the task is already `human-required`, keyed on **status alone**: my first attempt keyed on recognising my own reason string, which meant an operator replacing the note re-armed the clobber.

**"Consecutive" was a misnomer.** `reconcileReviewTask` returns early when an agent owns the PR or a conflict phase is decided, and neither path counted *or* cleared. So four old failures could sit behind seventeen hours of a perfectly healthy conflicting PR, and one unlucky fresh read would then escalate a healthy task. Both early returns prove GitHub is readable, so both now clear.

**`IsTransientError` missed the common cases** — `connection reset`, `connection refused`, `TLS handshake timeout`, `no route to host`, and rate limiting (which is backpressure, not a defect). These arrive on *every* in-flight request at once, so the gap turned a ten-second network wobble into a board-wide escalation storm. Deliberately left non-transient: a parse-level `unexpected EOF`, which is our decoder failing rather than the network — an existing test pins that contract and it is correct.

### Testing

Eight tests, each **mutation-verified** — the guard was neutralized and the test confirmed to fail:

| Mutation | Caught by |
|---|---|
| revert the call site to `Warn(...); return` | `RoutesFailureThroughCircuit` |
| escalate to `in-review` instead | `EscalatesPersistentFailure` |
| delete the `IsTransientError` guard | `TransientNeverEscalates` |
| drop the already-escalated guard | `DoesNotClobberOperatorNote` |
| drop the conflict-path clear | `HealthyCycleClearsStaleFailures` |
| revert `IsTransientError` to the narrow set | `IsTransientError_CoversRealNetworkAndRateLimitFailures` |

A `fetchMyReviewStateFn` seam was added specifically so the **wiring** is covered, not just the helper. Without it I could revert the call site to the exact incident behaviour and the entire suite still passed — which is the same class of blind spot as the incident itself.

## Open questions

**The counter is in-memory, so a restart resets it.** On a quiet board the reconcile cadence is `pollSlow` (600s), so 5 failures ≈ 50 minutes to trip, and autoupdate restarts on any new `main` commit (~5 min poll). On an active merge day, restarts could keep the circuit from ever tripping. This is mitigated in practice — #2166 (merged) bounds re-review at 2 per head *durably*, independent of this counter — but the honest statement is that this layer alone is uptime-dependent. Making it durable means a first-failure timestamp on the task; worth a follow-up, and deliberately not bundled into this PR.

**Worst case is ~5 spurious reviews, not ~1**, since 50 minutes to escalate against a 10-minute redispatch cooldown lets several through. 112 → ≤5 is the win here, and #2166's per-head budget caps it at 2 regardless. Flagging rather than implying this layer alone gets to 1.

## Supporting documentation

- Incident: https://github.com/Automaat/lightroom-mcp/pull/151
- #2165 (merged, production-verified: `review.my-state` warnings went to zero and the task self-corrected to `awaiting-author`)
- #2166 (merged) — the durable per-head budget this layer complements
