### PR TITLE
fix(agent): close gh shim approval bypasses

### DIFF
--- a/internal/agent/ghshim.go
+++ b/internal/agent/ghshim.go
@@ -51,15 +51,19 @@ if [ "$1" = "api" ]; then
 			exit 1
 			;;
 		esac
-		# A body read from stdin or a file is invisible to argv, so an approval
-		# can be posted with no matching arg at all.
+		# A payload read from stdin or a file is invisible to argv, so an approval
+		# can be posted with no matching arg at all. --input carries a whole
+		# body; -F/--field key=@path pulls a single value the same way, which is
+		# enough to hide a whole GraphQL mutation.
 		case "$arg" in
-		--input | --input=*)
+		--input | --input=* | *=@*)
 			sawinput=1
 			;;
 		esac
+		# graphql counts as review-capable: addPullRequestReview reaches the same
+		# place as POST /pulls/N/reviews.
 		case "$arg" in
-		*[Pp][Uu][Ll][Ll][Ss]/*/[Rr][Ee][Vv][Ii][Ee][Ww][Ss]* | */[Rr][Ee][Vv][Ii][Ee][Ww][Ss])
+		[Gg][Rr][Aa][Pp][Hh][Qq][Ll] | *[Pp][Uu][Ll][Ll][Ss]/*/[Rr][Ee][Vv][Ii][Ee][Ww][Ss]* | */[Rr][Ee][Vv][Ii][Ee][Ww][Ss])
 			sawreviews=1
 			;;
 		esac

--- a/internal/agent/ghshim.go
+++ b/internal/agent/ghshim.go
@@ -35,14 +35,37 @@ if [ "$1" = "pr" ] && [ "$2" = "review" ]; then
 	done
 fi
 if [ "$1" = "api" ]; then
+	sawinput=0
+	sawreviews=0
 	for arg in "$@"; do
 		case "$arg" in
 		*[Ee][Vv][Ee][Nn][Tt]*[Aa][Pp][Pp][Rr][Oo][Vv][Ee]*)
 			printf '%%s\n' '%[1]s' >&2
 			exit 1
 			;;
+		# The review mutation can carry its event in a GraphQL variable, so argv
+		# never sees APPROVE beside EVENT. Nothing legitimate needs the mutation:
+		# gh pr review --comment/--request-changes covers every sanctioned review.
+		*[Aa][Dd][Dd][Pp][Uu][Ll][Ll][Rr][Ee][Qq][Uu][Ee][Ss][Tt][Rr][Ee][Vv][Ii][Ee][Ww]*)
+			printf '%%s\n' '%[1]s' >&2
+			exit 1
+			;;
+		esac
+		# A body read from stdin or a file is invisible to argv, so an approval
+		# can be posted with no matching arg at all.
+		case "$arg" in
+		--input | --input=*)
+			sawinput=1
+			;;
+		esac
+		case "$arg" in
+		*[Pp][Uu][Ll][Ll][Ss]/*/[Rr][Ee][Vv][Ii][Ee][Ww][Ss]* | */[Rr][Ee][Vv][Ii][Ee][Ww][Ss])
+			sawreviews=1
+			;;
 		esac
 	done
+	# Refuse a review payload we cannot inspect rather than assume it is benign.
+	[ "$sawinput$sawreviews" = "11" ] && printf '%%s\n' '%[1]s' >&2 && exit 1
 fi
 exec '%[2]s' "$@"
 `

--- a/internal/agent/ghshim_test.go
+++ b/internal/agent/ghshim_test.go
@@ -276,6 +276,20 @@ func TestGhShim_BlocksApprovalsInvisibleToArgv(t *testing.T) {
 				"-f", "query=mutation{addPullRequestReview(input:{pullRequestId:\"x\",event:APPROVE}){clientMutationId}}",
 			},
 		},
+		{
+			// -F key=@path reads the value from a file, so the whole mutation
+			// stays out of argv — the same hole as --input, one field wide.
+			name: "graphql query read from a file",
+			args: []string{"api", "graphql", "-F", "query=@/tmp/mutation.graphql"},
+		},
+		{
+			name: "graphql query read from stdin",
+			args: []string{"api", "graphql", "-F", "query=@-"},
+		},
+		{
+			name: "review event read from a file",
+			args: []string{"api", "repos/o/r/pulls/151/reviews", "-F", "event=@/tmp/event.txt"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -312,6 +326,19 @@ func TestGhShim_AllowsInspectableAndUnrelatedCalls(t *testing.T) {
 			args: []string{"api", "repos/o/r/issues/1/comments", "--method", "POST", "--input", "-"},
 		},
 		{"unrelated graphql", []string{"api", "graphql", "-f", "query=query{viewer{login}}"}},
+		{
+			// Variables are fine; it is a file-sourced *value* that hides intent.
+			name: "graphql read query with variables",
+			args: []string{
+				"api", "graphql",
+				"-f", "query=query($n:Int!){repository(owner:\"o\",name:\"r\"){pullRequest(number:$n){id}}}",
+				"-F", "n=151",
+			},
+		},
+		{
+			name: "file-sourced body on a non-review endpoint",
+			args: []string{"api", "repos/o/r/issues/1/comments", "-F", "body=@/tmp/note.md"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/agent/ghshim_test.go
+++ b/internal/agent/ghshim_test.go
@@ -233,3 +233,92 @@ func TestPrependPATH(t *testing.T) {
 		t.Fatalf("prependPATH left %d PATH entries: %v", pathCount, got)
 	}
 }
+
+// The bypasses that let 28 approvals onto Automaat/lightroom-mcp#151 while the
+// shim was on PATH for every run (agent.gh-shim.ready, never unguarded).
+//
+// Both defeat argv scanning the same way — they move APPROVE somewhere argv
+// cannot see it. The shim cannot read a request body, so a payload it cannot
+// inspect on a reviews endpoint is refused rather than assumed benign.
+func TestGhShim_BlocksApprovalsInvisibleToArgv(t *testing.T) {
+	shim := newShim(t)
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			// The body never appears in argv at all.
+			name: "review body piped on stdin",
+			args: []string{"api", "repos/o/r/pulls/151/reviews", "--method", "POST", "--input", "-"},
+		},
+		{
+			name: "review body read from a file",
+			args: []string{"api", "repos/o/r/pulls/151/reviews", "--method", "POST", "--input", "/tmp/body.json"},
+		},
+		{
+			name: "review body via --input=",
+			args: []string{"api", "repos/o/r/pulls/151/reviews", "--input=/tmp/body.json"},
+		},
+		{
+			// EVENT and APPROVE land in different argv elements, so the
+			// event=APPROVE glob never matches either one.
+			name: "graphql mutation with the event in a variable",
+			args: []string{
+				"api", "graphql",
+				"-f", "query=mutation($e:PullRequestReviewEvent!){addPullRequestReview(input:{event:$e}){clientMutationId}}",
+				"-F", "e=APPROVE",
+			},
+		},
+		{
+			name: "graphql mutation with the event inline",
+			args: []string{
+				"api", "graphql",
+				"-f", "query=mutation{addPullRequestReview(input:{pullRequestId:\"x\",event:APPROVE}){clientMutationId}}",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, stderr, code := runShim(t, shim, tt.args...)
+			if code == 0 {
+				t.Fatalf("shim allowed an approval it could not inspect: %v", tt.args)
+			}
+			if !strings.Contains(stderr, GhShimReason) {
+				t.Errorf("stderr = %q, want the shim's refusal reason", stderr)
+			}
+		})
+	}
+}
+
+// The tightening must not cost the agent the reviews it is supposed to post.
+// A guard that blocks legitimate work gets routed around by the next person.
+func TestGhShim_AllowsInspectableAndUnrelatedCalls(t *testing.T) {
+	shim := newShim(t)
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"comment review", []string{"pr", "review", "151", "--comment", "-b", "looks good"}},
+		{"request changes", []string{"pr", "review", "151", "--request-changes", "-b", "fix this"}},
+		{
+			// The body is prose; "approve" and "event" in it mean nothing.
+			name: "body that merely mentions approving an event",
+			args: []string{"pr", "review", "151", "--comment", "-b", "I approve of this event handler"},
+		},
+		{"reading reviews", []string{"api", "repos/o/r/pulls/151/reviews"}},
+		{
+			// --input is only suspicious when the target is a reviews endpoint.
+			name: "input body on a non-review endpoint",
+			args: []string{"api", "repos/o/r/issues/1/comments", "--method", "POST", "--input", "-"},
+		},
+		{"unrelated graphql", []string{"api", "graphql", "-f", "query=query{viewer{login}}"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, stderr, _ := runShim(t, shim, tt.args...)
+			if strings.Contains(stderr, GhShimReason) {
+				t.Fatalf("shim blocked a legitimate call: %v", tt.args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

**28 of the 112 reviews #2164 posted were approvals.** Agents are supposed to be structurally incapable of approving a PR — that is the entire purpose of `internal/agent/ghshim.go`, whose refusal message states it plainly:

> Blocked by Sybra: agents have no PR-approval authority. […] approval is a human decision.

This is a **permission boundary that failed silently**, which is more serious than the loop itself: the loop was noisy and got noticed, this did not.

**The shim was active.** The server logged `agent.gh-shim.ready` 21 times and `agent.gh-shim.unguarded` zero times, so "the shim wasn't on PATH" is refuted — it was there, and it was routed around.

Closes #2169. Part of #2164.

> Changelog: fix(agent): close the gh shim PR-approval bypasses

## Implementation information

I reproduced the bypasses against the real shim rather than reasoning about them. Two work, and they defeat it the same way: **they move `APPROVE` somewhere argv cannot see it.**

| invocation | before |
|---|---|
| `gh pr review --approve` / `-a` | blocked |
| `gh api … -f/-F/--field event=APPROVE` | blocked |
| `gh api …/pulls/N/reviews --input -` | **bypass** — the body never enters argv |
| `gh api …/pulls/N/reviews --input body.json` | **bypass** |
| `gh api graphql -f query=…event:$e… -F e=APPROVE` | **bypass** — `EVENT` and `APPROVE` land in different argv elements, so the `event=APPROVE` glob matches neither |
| `gh api graphql -F query=@mutation.graphql` | **bypass** — `-F key=@path` reads the value from a file, so the whole mutation stays out of argv |
| `gh api graphql -F query=@-` | **bypass** — same, from stdin |
| `gh api …/pulls/N/reviews -F event=@e.txt` | **bypass** |

The last three were found by Copilot during review of this PR — a third instance of the same class, which is itself the argument in Open Questions below. Three narrow rules close them:

- **A payload we cannot inspect is refused, not assumed benign.** `--input`/`--input=` against a reviews endpoint is blocked, because the shim can never read a request body. `--input` on any other endpoint is untouched.
- **The `addPullRequestReview` mutation is refused outright.** Nothing legitimate needs it: `gh pr review --comment/--request-changes` covers every sanctioned review, and the one sanctioned approval path (`github.ApprovePR`, Renovate/auto-merge) runs in the **server** process, not under the agent's shim — so tightening here costs it nothing.
- **A file-sourced value (`key=@path`, `key=@-`) on a review-capable endpoint is refused**, for the same reason as `--input`: `-F/--field` reads the value from a file, which is enough to hide an entire mutation. `graphql` counts as review-capable, since `addPullRequestReview` reaches the same place as `POST /pulls/N/reviews`.

### Testing

`TestGhShim_BlocksApprovalsInvisibleToArgv` covers all eight bypass shapes, and every guard is **mutation-verified**:

| Mutation | Caught by |
|---|---|
| drop the `--input` refusal | the three body cases |
| drop the `addPullRequestReview` refusal | the GraphQL cases |
| drop `=@` detection | the three file-sourced cases |
| drop `graphql` from review-capable | the two GraphQL file cases |

`TestGhShim_AllowsInspectableAndUnrelatedCalls` guards the other direction, which matters just as much — a guard that blocks legitimate work gets routed around by the next person. It pins comment reviews, request-changes, reads of `/reviews`, `--input` on a non-review endpoint, unrelated GraphQL, **GraphQL with variables** (`-F n=151`), **a file-sourced body on a non-review endpoint** (`-F body=@note.md`), and a review body that literally reads *"I approve of this event handler"*. It is a file-sourced value on a *review-capable* endpoint that is refused, not `@` generally.

## Open questions

**This is still a denylist over an unbounded input space, and it cannot be otherwise.** The shim only sees `gh`. It does not see:

- `curl -H "Authorization: token $GH_TOKEN" …/reviews -d '{"event":"APPROVE"}'`
- a GitHub MCP server
- any language runtime with an HTTP client and the token in env

**Copilot found the third bypass during review of this very PR**, which is the point better than any argument I can make: I closed two, and a reviewer immediately found a third in the same class. So this PR makes the known routes fail; it does not make the claim in `GhShimReason` true. That needs enforcement at a layer the agent cannot address — filed as **#2198**, whose most promising option is to stop trying to prevent and start *undoing*: an approval by our own identity on an inbound review task is agent-authored by definition, and the reviewer already computes `MyReviewState.Approved`. Acting on the outcome catches curl and MCP too.

I have not claimed the 28 approvals came through any one of these specific routes — the reviews record their result, not the command that produced them. What I can say is that every route listed above worked against the shim as shipped, and all of them are now closed.

## Supporting documentation

- Incident: https://github.com/Automaat/lightroom-mcp/pull/151 — 28 APPROVED reviews from `sybra-app[bot]` (now dismissed; states preserved in the timeline)
- `internal/agent/ghshim.go` — the shim and `GhShimReason`
- #2198 — enforce the no-approval rule below the shim
