### PR TITLE
feat(k8s): production secret management

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -2603,6 +2603,19 @@ func cmdConfigDoctor(cfg *config.Config, jsonOut bool) int {
 		add("error", "github.app.enabled is true but github.app.private_key_path is empty")
 	}
 
+	if cfg.Agent.K8sJobs.Enabled && cfg.Agent.K8sJobs.Mode == "provider" {
+		for i, e := range cfg.Agent.K8sJobs.SecretEnv {
+			switch {
+			case e.Name == "":
+				add("error", "agent.k8s_jobs.secret_env[%d]: name is empty", i)
+			case e.SecretName == "":
+				add("error", "agent.k8s_jobs.secret_env[%d] (%s): secret_name is empty", i, e.Name)
+			case e.SecretKey == "":
+				add("error", "agent.k8s_jobs.secret_env[%d] (%s): secret_key is empty", i, e.Name)
+			}
+		}
+	}
+
 	if len(findings) == 0 {
 		add("ok", "no issues found")
 	}

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -2646,13 +2646,13 @@ func addK8sSecretEnvFindings(cfg *config.Config, add func(severity, format strin
 	}
 	for i, e := range cfg.Agent.K8sJobs.SecretEnv {
 		var missing []string
-		if e.Name == "" {
+		if strings.TrimSpace(e.Name) == "" {
 			missing = append(missing, "name")
 		}
-		if e.SecretName == "" {
+		if strings.TrimSpace(e.SecretName) == "" {
 			missing = append(missing, "secret_name")
 		}
-		if e.SecretKey == "" {
+		if strings.TrimSpace(e.SecretKey) == "" {
 			missing = append(missing, "secret_key")
 		}
 		if len(missing) > 0 {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -2603,18 +2603,7 @@ func cmdConfigDoctor(cfg *config.Config, jsonOut bool) int {
 		add("error", "github.app.enabled is true but github.app.private_key_path is empty")
 	}
 
-	if cfg.Agent.K8sJobs.Enabled && cfg.Agent.K8sJobs.Mode == "provider" {
-		for i, e := range cfg.Agent.K8sJobs.SecretEnv {
-			switch {
-			case e.Name == "":
-				add("error", "agent.k8s_jobs.secret_env[%d]: name is empty", i)
-			case e.SecretName == "":
-				add("error", "agent.k8s_jobs.secret_env[%d] (%s): secret_name is empty", i, e.Name)
-			case e.SecretKey == "":
-				add("error", "agent.k8s_jobs.secret_env[%d] (%s): secret_key is empty", i, e.Name)
-			}
-		}
-	}
+	addK8sSecretEnvFindings(cfg, add)
 
 	if len(findings) == 0 {
 		add("ok", "no issues found")
@@ -2645,6 +2634,31 @@ func cmdConfigDoctor(cfg *config.Config, jsonOut bool) int {
 		return 1
 	}
 	return 0
+}
+
+// addK8sSecretEnvFindings validates agent.k8s_jobs.secret_env whenever k8s_jobs
+// is enabled at all: baseEnv (internal/agent/k8s_job_runner.go) injects these
+// entries into the Job container regardless of agent.k8s_jobs.mode, and an
+// incomplete entry is silently dropped there rather than erroring.
+func addK8sSecretEnvFindings(cfg *config.Config, add func(severity, format string, a ...any)) {
+	if !cfg.Agent.K8sJobs.Enabled {
+		return
+	}
+	for i, e := range cfg.Agent.K8sJobs.SecretEnv {
+		var missing []string
+		if e.Name == "" {
+			missing = append(missing, "name")
+		}
+		if e.SecretName == "" {
+			missing = append(missing, "secret_name")
+		}
+		if e.SecretKey == "" {
+			missing = append(missing, "secret_key")
+		}
+		if len(missing) > 0 {
+			add("error", "agent.k8s_jobs.secret_env[%d]: missing %s", i, strings.Join(missing, ", "))
+		}
+	}
 }
 
 func addConfigPermFindings(add func(severity, format string, a ...any)) {

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -605,9 +605,39 @@ func TestConfigDoctorJSONReportsIncompleteK8sSecretEnv(t *testing.T) {
 	var report configDoctorReport
 	mustUnmarshal(t, out, &report)
 	if !slices.ContainsFunc(report.Findings, func(f configDoctorFinding) bool {
-		return f.Severity == "error" && strings.Contains(f.Message, "secret_env[0]") && strings.Contains(f.Message, "secret_key is empty")
+		return f.Severity == "error" && strings.Contains(f.Message, "secret_env[0]") && strings.Contains(f.Message, "missing secret_key")
 	}) {
-		t.Fatalf("expected secret_env[0] secret_key error in report: %+v", report.Findings)
+		t.Fatalf("expected secret_env[0] missing secret_key error in report: %+v", report.Findings)
+	}
+}
+
+func TestConfigDoctorJSONReportsAllMissingK8sSecretEnvFields(t *testing.T) {
+	setupStore(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.K8sJobs.Enabled = true
+	cfg.Agent.K8sJobs.Mode = "provider"
+	cfg.Agent.K8sJobs.SecretEnv = []config.K8sJobSecretEnvVar{
+		{Name: "", SecretName: "", SecretKey: ""},
+	}
+
+	code, out := captureStdout(t, func() int {
+		return cmdConfigDoctor(cfg, true)
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for an empty secret_env entry, output:\n%s", out)
+	}
+
+	var report configDoctorReport
+	mustUnmarshal(t, out, &report)
+	if !slices.ContainsFunc(report.Findings, func(f configDoctorFinding) bool {
+		return f.Severity == "error" &&
+			strings.Contains(f.Message, "secret_env[0]") &&
+			strings.Contains(f.Message, "name") &&
+			strings.Contains(f.Message, "secret_name") &&
+			strings.Contains(f.Message, "secret_key")
+	}) {
+		t.Fatalf("expected a single secret_env[0] finding listing all three missing fields: %+v", report.Findings)
 	}
 }
 
@@ -637,7 +667,12 @@ func TestConfigDoctorJSONAcceptsCompleteK8sSecretEnv(t *testing.T) {
 	}
 }
 
-func TestConfigDoctorJSONIgnoresK8sSecretEnvWhenModeNotProvider(t *testing.T) {
+func TestConfigDoctorJSONValidatesK8sSecretEnvRegardlessOfMode(t *testing.T) {
+	// baseEnv (internal/agent/k8s_job_runner.go) injects secret_env into the
+	// Job container regardless of agent.k8s_jobs.mode, so an incomplete entry
+	// must be caught even outside mode: provider — a bare mode: fake config
+	// with a stray secret_env entry silently dropped the credential at
+	// runtime before this check existed.
 	setupStore(t)
 
 	cfg := config.DefaultConfig()
@@ -650,8 +685,8 @@ func TestConfigDoctorJSONIgnoresK8sSecretEnvWhenModeNotProvider(t *testing.T) {
 	code, out := captureStdout(t, func() int {
 		return cmdConfigDoctor(cfg, true)
 	})
-	if code != 0 {
-		t.Fatalf("expected fake mode to skip secret_env validation, got %d:\n%s", code, out)
+	if code == 0 {
+		t.Fatalf("expected mode: fake to still validate secret_env, output:\n%s", out)
 	}
 }
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -690,6 +690,32 @@ func TestConfigDoctorJSONValidatesK8sSecretEnvRegardlessOfMode(t *testing.T) {
 	}
 }
 
+func TestConfigDoctorJSONReportsWhitespaceOnlyK8sSecretEnvFields(t *testing.T) {
+	setupStore(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.K8sJobs.Enabled = true
+	cfg.Agent.K8sJobs.Mode = "provider"
+	cfg.Agent.K8sJobs.SecretEnv = []config.K8sJobSecretEnvVar{
+		{Name: "GITHUB_TOKEN", SecretName: "sybra-provider-api-keys", SecretKey: "  "},
+	}
+
+	code, out := captureStdout(t, func() int {
+		return cmdConfigDoctor(cfg, true)
+	})
+	if code == 0 {
+		t.Fatalf("expected a whitespace-only secret_key to be treated as missing, output:\n%s", out)
+	}
+
+	var report configDoctorReport
+	mustUnmarshal(t, out, &report)
+	if !slices.ContainsFunc(report.Findings, func(f configDoctorFinding) bool {
+		return f.Severity == "error" && strings.Contains(f.Message, "secret_env[0]") && strings.Contains(f.Message, "missing secret_key")
+	}) {
+		t.Fatalf("expected secret_env[0] missing secret_key error in report: %+v", report.Findings)
+	}
+}
+
 func TestConfigDoctorJSONAcceptsSupportedEnforceHosts(t *testing.T) {
 	setupStore(t)
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -585,6 +585,76 @@ func TestConfigDoctorJSONReportsSandboxModeErrors(t *testing.T) {
 	}
 }
 
+func TestConfigDoctorJSONReportsIncompleteK8sSecretEnv(t *testing.T) {
+	setupStore(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.K8sJobs.Enabled = true
+	cfg.Agent.K8sJobs.Mode = "provider"
+	cfg.Agent.K8sJobs.SecretEnv = []config.K8sJobSecretEnvVar{
+		{Name: "GITHUB_TOKEN", SecretName: "sybra-provider-api-keys", SecretKey: ""},
+	}
+
+	code, out := captureStdout(t, func() int {
+		return cmdConfigDoctor(cfg, true)
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for an incomplete secret_env entry, output:\n%s", out)
+	}
+
+	var report configDoctorReport
+	mustUnmarshal(t, out, &report)
+	if !slices.ContainsFunc(report.Findings, func(f configDoctorFinding) bool {
+		return f.Severity == "error" && strings.Contains(f.Message, "secret_env[0]") && strings.Contains(f.Message, "secret_key is empty")
+	}) {
+		t.Fatalf("expected secret_env[0] secret_key error in report: %+v", report.Findings)
+	}
+}
+
+func TestConfigDoctorJSONAcceptsCompleteK8sSecretEnv(t *testing.T) {
+	setupStore(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.K8sJobs.Enabled = true
+	cfg.Agent.K8sJobs.Mode = "provider"
+	cfg.Agent.K8sJobs.SecretEnv = []config.K8sJobSecretEnvVar{
+		{Name: "GITHUB_TOKEN", SecretName: "sybra-provider-api-keys", SecretKey: "github_token"},
+	}
+
+	code, out := captureStdout(t, func() int {
+		return cmdConfigDoctor(cfg, true)
+	})
+	if code != 0 {
+		t.Fatalf("expected a complete secret_env entry to stay non-fatal, got %d:\n%s", code, out)
+	}
+
+	var report configDoctorReport
+	mustUnmarshal(t, out, &report)
+	if slices.ContainsFunc(report.Findings, func(f configDoctorFinding) bool {
+		return strings.Contains(f.Message, "secret_env")
+	}) {
+		t.Fatalf("did not expect a secret_env finding: %+v", report.Findings)
+	}
+}
+
+func TestConfigDoctorJSONIgnoresK8sSecretEnvWhenModeNotProvider(t *testing.T) {
+	setupStore(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.K8sJobs.Enabled = true
+	cfg.Agent.K8sJobs.Mode = "fake"
+	cfg.Agent.K8sJobs.SecretEnv = []config.K8sJobSecretEnvVar{
+		{Name: "GITHUB_TOKEN", SecretName: "", SecretKey: ""},
+	}
+
+	code, out := captureStdout(t, func() int {
+		return cmdConfigDoctor(cfg, true)
+	})
+	if code != 0 {
+		t.Fatalf("expected fake mode to skip secret_env validation, got %d:\n%s", code, out)
+	}
+}
+
 func TestConfigDoctorJSONAcceptsSupportedEnforceHosts(t *testing.T) {
 	setupStore(t)
 

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -10,9 +10,19 @@ deployment.
 docker build -t sybra-server:poc .
 k3d cluster create sybra-poc --agents 1 --wait
 k3d image import sybra-server:poc -c sybra-poc
+kubectl apply -f deploy/k8s-poc/namespace.yaml
+kubectl -n sybra-poc create secret generic sybra-server-auth \
+  --from-literal=token=poc-token
 kubectl apply -k deploy/k8s-poc
 kubectl -n sybra-poc rollout status deployment/sybra-server --timeout=120s
 ```
+
+`sybra-server-auth` holds the bearer token the Deployment reads via
+`SYBRA_AUTH_TOKEN` (`deploy/k8s-poc/deployment.yaml`) — it is never a plain
+manifest value, so `kubectl apply -k` alone will not start the pod until this
+Secret exists. See [Production secret management](#production-secret-management)
+for how to handle it (and `sybra-provider-api-keys` below) outside a
+throwaway k3d cluster.
 
 Start a fake headless agent Job through Sybra:
 
@@ -289,6 +299,57 @@ After the Job completes, the local task worktree fast-forwards from `origin` so
 review/test stages see the pod's files. The `GITHUB_TOKEN` value is optional for
 public HTTPS remotes, but required for private GitHub HTTPS remotes and pushes.
 SSH remotes are not wired in this PoC.
+
+## Production secret management
+
+The PoC keeps two Secrets out of every manifest and out of git:
+
+- `sybra-server-auth` (`deploy/k8s-poc/server-auth-secret.example.yaml`) — the
+  Deployment's `SYBRA_AUTH_TOKEN`.
+- `sybra-provider-api-keys` (`deploy/k8s-poc/api-key-secret.example.yaml`) —
+  provider/GitHub credentials referenced by `agent.k8s_jobs.secret_env` and
+  injected straight into the agent Job's container as `valueFrom.secretKeyRef`
+  (`internal/agent/k8s_job_runner.go`). Kubernetes resolves the reference at
+  pod start; `sybra-server` never reads the secret value itself, so a
+  compromised server process cannot exfiltrate provider or GitHub credentials
+  it was never handed. `sybra-cli config doctor` catches a `secret_env` entry
+  with a missing `name`/`secret_name`/`secret_key` before it fails silently at
+  Job-creation time.
+
+The `.example.yaml` files are templates only (`replace-me` placeholders) and
+are not part of `kustomization.yaml` — nothing applies them automatically, and
+`kubectl create secret generic ... --from-literal=...` never writes a
+manifest to disk. That is enough for a throwaway k3d cluster. A real
+deployment needs the Secret's desired state to be reviewable and
+reproducible without ever putting plaintext credentials in git history. Pick
+one:
+
+- **SOPS** — encrypt a Secret manifest (or just the values) with `sops`,
+  commit the ciphertext, decrypt at deploy time and `kubectl apply` the
+  result (or `kubectl create secret --from-literal` from the decrypted
+  values, as `server-auth-secret.example.yaml` and
+  `api-key-secret.example.yaml` are shaped for). This is the option to
+  reach for if your deploy pipeline already runs `sops` for other
+  environments — the encrypted file lives next to the rest of the manifests
+  and needs no extra cluster component.
+- **Sealed Secrets** (bitnami-labs/sealed-secrets) — a cluster-side
+  controller decrypts a `SealedSecret` CRD that is safe to commit (encrypted
+  with the controller's public key) into a real `Secret`. Best fit when the
+  encryption key must stay cluster-local rather than shared with a CI
+  pipeline.
+- **External Secrets Operator** — a cluster-side controller syncs Secrets
+  from an external store (Vault, AWS/GCP/Azure secret managers, etc.) via an
+  `ExternalSecret` CRD; nothing encrypted ever touches git. Best fit when
+  provider/GitHub credentials are already centrally managed in one of those
+  stores.
+
+Whichever mechanism renders the final `Secret`, the object names/keys must
+match what `deployment.yaml` and `agent.k8s_jobs.secret_env` expect:
+`sybra-server-auth`/`token`, and `sybra-provider-api-keys`/
+`openrouter_api_key`+`github_token` (or whatever `secret_name`/`secret_key`
+pairs a given ConfigMap declares). None of the three tools are wired into
+this PoC's kustomization — pick one and add its manifests/controller to your
+own deployment overlay.
 
 ## Real OpenCode testbed e2e
 

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -12,7 +12,8 @@ k3d cluster create sybra-poc --agents 1 --wait
 k3d image import sybra-server:poc -c sybra-poc
 kubectl apply -f deploy/k8s-poc/namespace.yaml
 kubectl -n sybra-poc create secret generic sybra-server-auth \
-  --from-literal=token=poc-token
+  --from-literal=token=poc-token \
+  --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -k deploy/k8s-poc
 kubectl -n sybra-poc rollout status deployment/sybra-server --timeout=120s
 ```

--- a/deploy/k8s-poc/deployment.yaml
+++ b/deploy/k8s-poc/deployment.yaml
@@ -49,7 +49,10 @@ spec:
             - name: SYBRA_STATIC_DIR
               value: /app/web
             - name: SYBRA_AUTH_TOKEN
-              value: poc-token
+              valueFrom:
+                secretKeyRef:
+                  name: sybra-server-auth
+                  key: token
           volumeMounts:
             - name: sybra-home
               mountPath: /home/sybra/.sybra

--- a/deploy/k8s-poc/server-auth-secret.example.yaml
+++ b/deploy/k8s-poc/server-auth-secret.example.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sybra-server-auth
+  namespace: sybra-poc
+type: Opaque
+stringData:
+  token: replace-me

--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -137,6 +137,10 @@ fi
 log "Applying manifests ($PROVIDER, config=$CONFIG)"
 kubectl --context "k3d-$CLUSTER" apply -f "$REPO_ROOT/deploy/k8s-poc/namespace.yaml"
 
+kc create secret generic sybra-server-auth \
+  --from-literal=token=poc-token \
+  --dry-run=client -o yaml | kubectl --context "k3d-$CLUSTER" apply -f -
+
 if [ "$GITHUB_MODE" = "1" ] || [ "$PROVIDER" = "opencode" ]; then
   kc create secret generic sybra-provider-api-keys \
     --from-literal=openrouter_api_key="${OPENROUTER_API_KEY:-}" \


### PR DESCRIPTION
## Motivation

The PoC boots with `SYBRA_AUTH_TOKEN` hardcoded in `deployment.yaml` and only documents provider/GitHub credentials via imperative `kubectl create secret`. Production needs a real secret strategy: runtime secrets in Kubernetes Secrets only, a documented path to a deployable mechanism, and operator validation so a broken `secret_env` entry doesn't fail silently.

Closes #2100. Parent: #2094.

> Changelog: feat(k8s): production secret management

## Implementation information

- `deploy/k8s-poc/deployment.yaml` now sources `SYBRA_AUTH_TOKEN` from a new `sybra-server-auth` Secret (`token` key) instead of a plaintext env value. `deploy/k8s-poc/server-auth-secret.example.yaml` documents the shape, mirroring the existing `api-key-secret.example.yaml` pattern — neither is applied by `kustomization.yaml`.
- `scripts/smoke-k3d.sh` creates `sybra-server-auth` unconditionally before applying the kustomization (every provider mode needs it now), and `deploy/k8s-poc/README.md`'s quick-start does the same.
- `sybra-cli config doctor` (`cmd/sybra-cli/main.go`, `addK8sSecretEnvFindings`) now validates every `agent.k8s_jobs.secret_env` entry has a non-empty `name`/`secret_name`/`secret_key` whenever `agent.k8s_jobs.enabled` is true — `baseEnv` (`internal/agent/k8s_job_runner.go`) injects `secret_env` into the Job container regardless of `agent.k8s_jobs.mode`, so the check does not gate on mode either (an earlier version gated on `mode == "provider"`; adversarial review found that a `mode: Provider`/whitespace typo, or a `mode: fake` config with a stray broken entry, both bypassed it while the runtime still ran the affected path — fixed by dropping the mode gate entirely).
- New "Production secret management" section in `deploy/k8s-poc/README.md` documents SOPS, Sealed Secrets, and External Secrets Operator as options for rendering the final Secret objects outside git — documentation only, none are wired into this PoC's kustomization.

## Supporting documentation

Adversarial manual testing (real credentials, real cluster, real GitHub):

- **Negative case**: applying the kustomization without `sybra-server-auth` leaves the pod in `CreateContainerConfigError` (`secret "sybra-server-auth" not found`) — confirmed no fallback token exists.
- **Positive case**: the README quick-start followed verbatim (including the new secret-creation step) rolls out cleanly; `Bearer poc-token` curl examples still work.
- **`config doctor` live**: a `secret_env` entry missing `secret_key` is caught under both `mode: provider` and `mode: fake`; a control case with `k8s_jobs.enabled: false` correctly stays silent.
- **Real e2e**: ran a real `opencode`/OpenRouter agent against `Automaat/sybra-testbed` issue #9, credentials sourced from a `sybra-provider-api-keys` Secret via `secretKeyRef`. The Job committed a working `/version` endpoint and pushed a real branch to GitHub (real spend: ~$0.0007, not fake-claude). Branch deleted afterward as cleanup.
- **Leak sweep**: grepped the real API key/token values against the diff, pod specs, PVC logs, and docs — zero hits.
- **Edge cases**: a misspelled Secret key (`tokenn`) fails closed the same way a missing Secret does; re-applying the kustomization twice is idempotent and never touches the out-of-band Secret.

One side observation, not in scope here: the server-side task worktree didn't fast-forward after the Job pushed to the real GitHub remote (only the PVC-bare-clone path fast-forwards today) — the credential flow itself worked correctly, this is a pre-existing gap unrelated to secret sourcing.