### PR TITLE
feat(k8s): publish and pin versioned images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          # Same build, same digest, pushed under two repository names: the
+          # `-server` alias is what deploy/k8s-poc production docs pin, since
+          # the k8s runner deploys this exact image (ENTRYPOINT sybra-server).
+          images: |
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-server
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,9 +49,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          # Same build, same digest, pushed under two repository names: the
-          # `-server` alias is what deploy/k8s-poc production docs pin, since
-          # the k8s runner deploys this exact image (ENTRYPOINT sybra-server).
+          # Same build, same digest, pushed under two repository names. The
+          # `-server` alias is what deploy/k8s-poc/README.md's "Versioned
+          # production images" section documents pinning manually — no
+          # in-repo manifest/overlay wires it in yet (tracked by #2110).
           images: |
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}-server

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -375,6 +375,23 @@ version=vX.Y.Z`, or leave `version` empty to auto-bump the minor via
 a deliberate, CI-run action, not something that fires on every merge to
 `main`.
 
+The first push under a new GHCR repository name defaults to **private** —
+`ghcr.io/automaat/sybra-server` will not exist as a package until
+`docker-publish.yml` runs once, and after that first run it is only pullable
+by an authenticated, authorized principal until someone flips its visibility
+in the package's GHCR settings (Package → Package settings → Danger Zone →
+Change visibility). Decide deliberately rather than by default:
+
+- **Public** — simplest; an unauthenticated `docker pull` (as shown below)
+  and a plain Kubernetes image reference both just work, no cluster-side
+  credential needed.
+- **Private** — safer default for a production image, but then the cluster
+  needs an `imagePullSecrets` entry: `kubectl create secret docker-registry
+  ghcr-pull --docker-server=ghcr.io --docker-username=<user>
+  --docker-password=<a token with read:packages>`, referenced from the
+  Deployment's `spec.template.spec.imagePullSecrets` (or the ServiceAccount,
+  so every pod using it inherits the credential without repeating the field).
+
 For a production deploy, pin by digest rather than a mutable tag — a tag can
 be re-pointed (accidentally or via `docker-publish.yml` re-running the same
 version), a digest cannot:

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -352,6 +352,56 @@ pairs a given ConfigMap declares). None of the three tools are wired into
 this PoC's kustomization — pick one and add its manifests/controller to your
 own deployment overlay.
 
+## Versioned production images
+
+`docker build -t sybra-server:poc .` + `k3d image import` above is a local
+dev/smoke loop only — the resulting image never leaves the machine that built
+it, which is fine for a throwaway k3d cluster but not reproducible or
+immutable enough to run in production.
+
+`.github/workflows/docker-publish.yml` builds the same root `Dockerfile` (its
+`ENTRYPOINT` is `sybra-server`) and pushes it to GHCR under two repository
+names sharing one digest per build: `ghcr.io/automaat/sybra` and
+`ghcr.io/automaat/sybra-server`. Each push is tagged three ways:
+
+- `vX.Y.Z` — the exact released version
+- `X.Y` — floating latest-patch alias for that minor
+- `sha-<short-sha>` — the commit it was built from, for bisecting a bad
+  deploy back to source independent of the version bump
+
+It runs on `workflow_dispatch` (`gh workflow run docker-publish.yml -f
+version=vX.Y.Z`, or leave `version` empty to auto-bump the minor via
+`scripts/resolve-release-version.sh`) — publishing a new production image is
+a deliberate, CI-run action, not something that fires on every merge to
+`main`.
+
+For a production deploy, pin by digest rather than a mutable tag — a tag can
+be re-pointed (accidentally or via `docker-publish.yml` re-running the same
+version), a digest cannot:
+
+```bash
+docker pull ghcr.io/automaat/sybra-server:vX.Y.Z
+docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/automaat/sybra-server:vX.Y.Z
+# ghcr.io/automaat/sybra-server@sha256:<digest>
+```
+
+Point a deployment at it without ever building locally — either patch the
+image directly:
+
+```bash
+kubectl -n sybra-poc set image deployment/sybra-server \
+  sybra-server=ghcr.io/automaat/sybra-server@sha256:<digest>
+```
+
+or, in a kustomize overlay (see issue #2110 for splitting the PoC base from a
+real production overlay), add an `images:` transformer instead of hand-editing
+`deployment.yaml`:
+
+```bash
+cd your-production-overlay
+kustomize edit set image sybra-server:poc=ghcr.io/automaat/sybra-server@sha256:<digest>
+```
+
 ## Real OpenCode testbed e2e
 
 This is the end-to-end path used to prove the PoC with a real model. It uses

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -394,9 +394,12 @@ Change visibility). Decide deliberately rather than by default:
 
 For a production deploy, pin by digest rather than a mutable tag — a tag can
 be re-pointed (accidentally or via `docker-publish.yml` re-running the same
-version), a digest cannot:
+version), a digest cannot. If the package is still private, log in first
+(a token with `read:packages` is enough — no need for `write:packages` just
+to pull):
 
 ```bash
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <user> --password-stdin
 docker pull ghcr.io/automaat/sybra-server:vX.Y.Z
 docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/automaat/sybra-server:vX.Y.Z
 # ghcr.io/automaat/sybra-server@sha256:<digest>


### PR DESCRIPTION
## Motivation

The k8s PoC only ever runs `docker build -t sybra-server:poc .` + `k3d image import` — the image never leaves the machine that built it, which is fine for a throwaway cluster but not reproducible or immutable enough for production.

Closes #2101. Parent: #2094.

> Changelog: feat(k8s): publish and pin versioned images

## Implementation information

- `.github/workflows/docker-publish.yml` already built the root Dockerfile (its `ENTRYPOINT` is `sybra-server`) and pushed `ghcr.io/automaat/sybra` tagged by semver + commit SHA via `workflow_dispatch`. This PR adds a second `images:` line to the same `docker/metadata-action` step so the identical build/digest is also pushed as `ghcr.io/automaat/sybra-server` — no new build step, no new job, same `docker/build-push-action` call.
- New "Versioned production images" section in `deploy/k8s-poc/README.md` documents: the local `k3d image import` flow is dev-only; how to resolve and pin a digest (`docker pull` + `docker inspect`); two ways to point a deployment at a pinned digest without building locally (`kubectl set image`, or `kustomize edit set image` in an operator's own overlay — no in-repo production overlay exists yet, tracked by #2110); and that a newly-published GHCR package defaults to **private** on first publish, with the operator's two options laid out (flip to public, or wire an `imagePullSecrets` entry).
- `deploy/k8s-poc/deployment.yaml` and every other PoC manifest are deliberately untouched — this issue is about the publish/pin mechanism, not restructuring the PoC's own default image (that's #2110's job).

## Supporting documentation

Adversarial review found the initial version's workflow comment overstated that some existing "k8s runner" already deploys the `-server` alias (it doesn't — only the new docs describe a manual pinning procedure) — reworded to be accurate and point at #2110. It also found the docs never addressed GHCR's private-by-default first-publish behavior, which would otherwise make the documented `docker pull`/deploy flow fail on first use — added the visibility/`imagePullSecrets` guidance above.

Adversarial manual testing (this is a docs/CI-config-only change with no runnable server surface, so verified with the strongest available static evidence per this repo's testing conventions, deliberately without triggering a real `docker-publish.yml` run — that would cut a real, permanently-visible release/package on the actual project, out of scope for automated verification):

- `actionlint` on the changed workflow: clean.
- Verified `docker/metadata-action`'s multi-line `images:` input at the source level (`src/meta.ts`): confirms a genuine tag-set cross-product per image name, not "last image wins."
- Built the real Dockerfile (`docker build -t test-sybra-server-publish:local .`): succeeds, `ENTRYPOINT` is `sybra-server` as documented. Cleaned up afterward.
- Ran the documented `kustomize edit set image sybra-server:poc=ghcr.io/automaat/sybra-server@sha256:...` against a scratch copy of `deploy/k8s-poc/` with the project's pinned kustomize: correctly rewrites the manifest and `kustomize build` renders the pinned digest.
- Cross-checked the GHCR private-by-default claim against GitHub's own documentation.
- Confirmed `deployment.yaml` and every other workflow file are genuinely untouched.