### PR TITLE
fix(task): guard Put against a frozen UpdatedAt

### DIFF
--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -208,7 +208,13 @@ func Merge(canonical, follower task.Task) (task.Task, bool) {
 	out.MirrorRev = canonical.MirrorRev + 1
 	followerUpdated := follower.UpdatedAt
 	out.MirrorUpdatedAt = &followerUpdated
-	out.UpdatedAt = follower.UpdatedAt
+	// UpdatedAt is the leader-local write clock every other Store writer
+	// (UpdateWithPrev) stamps with time.Now() — borrowing the follower's
+	// clock here instead let an unrelated leader-side edit's fresher
+	// UpdatedAt outrun a genuinely newer, already-validated (via
+	// MirrorUpdatedAt above) follower update, tripping Put's #2203 stale
+	// guard on legitimate mirror traffic.
+	out.UpdatedAt = time.Now().UTC()
 	return out, true
 }
 

--- a/internal/sybra/clusterlead/mirror_leader_edit_race_test.go
+++ b/internal/sybra/clusterlead/mirror_leader_edit_race_test.go
@@ -1,0 +1,98 @@
+package clusterlead
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestMirrorApplyRejectsLegitimateFollowerUpdateAfterLeaderLocalEdit probes
+// #2203's acceptance criterion #4 — "The cluster mirror's own Merge→Put path
+// is unaffected for legitimate follower updates (still trusts a genuinely
+// newer follower timestamp verbatim)" — against a scenario the criterion
+// does not anticipate: Merge's own staleness guard compares the follower's
+// UpdatedAt against canonical.MirrorUpdatedAt (a separate leader-local
+// bookkeeping clock, last set by Merge itself), not against the on-disk
+// canonical.UpdatedAt that Store.Put's new #2203 guard actually checks.
+// Those two clocks can diverge: any ordinary leader-side edit through the
+// normal Manager.Update path (title, tags, anything) bumps canonical.UpdatedAt
+// to wall-clock now() without touching MirrorUpdatedAt at all. If a
+// genuinely-newer follower status update (newer than MirrorUpdatedAt, so
+// Merge accepts it) arrives with an UpdatedAt that is nonetheless older than
+// the leader's freshly-bumped canonical.UpdatedAt, Store.Put's guard rejects
+// it and silently keeps the stale status — reproducing the exact class of
+// bug #2203 exists to fix, through the fix's own new code path.
+func TestMirrorApplyRejectsLegitimateFollowerUpdateAfterLeaderLocalEdit(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "task-pet", Title: "leader title", Status: task.StatusTodo,
+		ProjectID: "owner/pet", AssignedNode: "pet-box", CreatedAt: t0, UpdatedAt: t0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 1: a first mirror apply, exactly like TestMirrorApplyConvergesAndDropsStale.
+	// This sets both canonical.UpdatedAt and canonical.MirrorUpdatedAt to t0+1h,
+	// so the two clocks start in sync.
+	firstFollowerUpdate := t0.Add(time.Hour)
+	first := task.Task{
+		ID: "task-pet", Title: "follower title", Status: task.StatusBlocked,
+		ProjectID: "attacker/x", AssignedNode: "elsewhere", UpdatedAt: firstFollowerUpdate,
+	}
+	if !mirror.applyFollowerTask("pet-box", first) {
+		t.Fatal("first follower apply must succeed")
+	}
+	got, _ := mgr.Get("task-pet")
+	if got.Status != task.StatusBlocked {
+		t.Fatalf("setup: status = %q, want blocked", got.Status)
+	}
+	if got.MirrorUpdatedAt == nil || !got.MirrorUpdatedAt.Equal(firstFollowerUpdate) {
+		t.Fatalf("setup: MirrorUpdatedAt = %v, want %v", got.MirrorUpdatedAt, firstFollowerUpdate)
+	}
+
+	// Step 2: an ordinary LEADER-side edit through the normal Update path
+	// (nothing to do with the mirror) bumps canonical.UpdatedAt to real
+	// wall-clock now() — which, since t0 is fixed in 2026-07-01, is always
+	// far later than any t0-relative timestamp used below. MirrorUpdatedAt
+	// is untouched by Update: it is a Merge-only field.
+	newTitle := "leader renamed it locally"
+	if _, err := mgr.Update("task-pet", task.Update{Title: &newTitle}); err != nil {
+		t.Fatal(err)
+	}
+	afterEdit, _ := mgr.Get("task-pet")
+	if afterEdit.Title != newTitle {
+		t.Fatalf("setup: leader edit did not apply, title = %q", afterEdit.Title)
+	}
+	if !afterEdit.UpdatedAt.After(firstFollowerUpdate) {
+		t.Fatalf("setup: leader edit did not bump UpdatedAt past %v, got %v", firstFollowerUpdate, afterEdit.UpdatedAt)
+	}
+
+	// Step 3: the follower reports genuine forward progress — its own
+	// UpdatedAt (t0+90m) is newer than MirrorUpdatedAt (t0+1h), so Merge's
+	// own staleness guard says this is a legitimate, non-stale update that
+	// must apply.
+	genuineFollowerUpdate := t0.Add(90 * time.Minute)
+	if !genuineFollowerUpdate.After(firstFollowerUpdate) {
+		t.Fatal("test setup invariant broken: genuine follower update must be after MirrorUpdatedAt")
+	}
+	progressed := task.Task{
+		ID: "task-pet", Title: "follower title", Status: task.StatusInProgress,
+		ProjectID: "attacker/x", AssignedNode: "elsewhere", UpdatedAt: genuineFollowerUpdate,
+	}
+	applied := mirror.applyFollowerTask("pet-box", progressed)
+
+	got, _ = mgr.Get("task-pet")
+	if !applied || got.Status != task.StatusInProgress {
+		t.Fatalf("Merge accepted a genuinely-newer-than-MirrorUpdatedAt follower status change (in-progress), "+
+			"but Store.Put's #2203 guard rejected it because canonical.UpdatedAt (bumped by an unrelated leader edit) "+
+			"outran canonical.MirrorUpdatedAt — applied=%v, got status=%q (want in-progress). "+
+			"This reproduces the #2203 symptom (stale status silently frozen on the leader) through the fix's own new code path.",
+			applied, got.Status)
+	}
+}

--- a/internal/sybra/clusterlead/mirror_leader_edit_race_test.go
+++ b/internal/sybra/clusterlead/mirror_leader_edit_race_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
-// TestMirrorApplyRejectsLegitimateFollowerUpdateAfterLeaderLocalEdit probes
+// TestMirrorApplyAppliesLegitimateFollowerUpdateAfterLeaderLocalEdit probes
 // #2203's acceptance criterion #4 — "The cluster mirror's own Merge→Put path
 // is unaffected for legitimate follower updates (still trusts a genuinely
 // newer follower timestamp verbatim)" — against a scenario the criterion
@@ -23,7 +23,7 @@ import (
 // the leader's freshly-bumped canonical.UpdatedAt, Store.Put's guard rejects
 // it and silently keeps the stale status — reproducing the exact class of
 // bug #2203 exists to fix, through the fix's own new code path.
-func TestMirrorApplyRejectsLegitimateFollowerUpdateAfterLeaderLocalEdit(t *testing.T) {
+func TestMirrorApplyAppliesLegitimateFollowerUpdateAfterLeaderLocalEdit(t *testing.T) {
 	cfg := leaderConfig("http://unused", []string{"owner/pet"})
 	roster, _ := NewRoster(cfg, nil)
 	mgr := newManager(t)

--- a/internal/sybra/clusterlead/mirror_snapshot_gap_test.go
+++ b/internal/sybra/clusterlead/mirror_snapshot_gap_test.go
@@ -1,0 +1,53 @@
+package clusterlead
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestMergeSnapshotGapSurvivesInterveningLeaderEdit closes the gap the
+// leader-edit-race regression test doesn't cover: applyFollowerTask calls
+// Merge, then writeSidecars (several blocking file writes), then Put — an
+// unrelated local edit can land in that window, after Merge's own
+// time.Now() snapshot but before the write actually reaches Put's lock.
+// Store.Put's MirrorRev-based freshness check must still accept the
+// follower's status change in that case, since MirrorRev proves it
+// regardless of what happened to UpdatedAt in the interim.
+func TestMergeSnapshotGapSurvivesInterveningLeaderEdit(t *testing.T) {
+	mgr := newManager(t)
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "task-pet", Title: "leader title", Status: task.StatusTodo,
+		ProjectID: "owner/pet", AssignedNode: "pet-box", CreatedAt: t0, UpdatedAt: t0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	canonical, _ := mgr.Get("task-pet")
+
+	follower := task.Task{
+		ID: "task-pet", Title: "follower title", Status: task.StatusInProgress,
+		ProjectID: "attacker/x", AssignedNode: "elsewhere", UpdatedAt: t0.Add(90 * time.Minute),
+	}
+	merged, ok := Merge(canonical, follower)
+	if !ok {
+		t.Fatal("Merge should accept")
+	}
+
+	// Simulates the writeSidecars gap: an unrelated leader edit lands here,
+	// after Merge's snapshot but before the mirror's own Put reaches disk.
+	newTitle := "leader renamed it while mirror apply was in flight"
+	if _, err := mgr.Update("task-pet", task.Update{Title: &newTitle}); err != nil {
+		t.Fatal(err)
+	}
+
+	saved, _, err := mgr.Put(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.Status != task.StatusInProgress {
+		t.Fatalf("got status=%q title=%q, want status=in-progress title=%q",
+			saved.Status, saved.Title, follower.Title)
+	}
+}

--- a/internal/sybra/clusterlead/mirror_snapshot_gap_test.go
+++ b/internal/sybra/clusterlead/mirror_snapshot_gap_test.go
@@ -47,7 +47,6 @@ func TestMergeSnapshotGapSurvivesInterveningLeaderEdit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if saved.Status != task.StatusInProgress {
-		t.Fatalf("got status=%q title=%q, want status=in-progress title=%q",
-			saved.Status, saved.Title, follower.Title)
+		t.Fatalf("status = %q, want in-progress", saved.Status)
 	}
 }

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -509,6 +509,15 @@ func (s *TaskService) AssignTask(t task.Task) error {
 		s.logger.Debug("cluster.task.assign.noop", "task", current.ID, "assigned_node", current.AssignedNode, "status", string(current.Status))
 		return nil
 	}
+	// Leader-owned mirror bookkeeping (see normalizeAssignedTaskForCompare)
+	// must never reach the local store: Assigner.Route forwards the leader's
+	// canonical copy as-is, so a task re-routed after prior mirror cycles
+	// still carries a stale MirrorRev/MirrorUpdatedAt here. Store.Put reads
+	// those fields as proof this Put came through Merge; left untouched,
+	// this write would masquerade as mirror-authoritative and bypass its
+	// plain staleness guard.
+	t.MirrorRev = 0
+	t.MirrorUpdatedAt = nil
 	saved, created, err := s.tasks.Put(t)
 	if err != nil {
 		return fmt.Errorf("assign task: %w", err)

--- a/internal/sybra/svc_tasks_assign_test.go
+++ b/internal/sybra/svc_tasks_assign_test.go
@@ -42,6 +42,44 @@ func TestAssignTaskPersistsVerbatim(t *testing.T) {
 	}
 }
 
+// TestAssignTaskScrubsLeakedMirrorBookkeeping guards against a Route push
+// (internal/sybra/clusterlead/assigner.go) that forwards the leader's
+// canonical task copy as-is: a task re-routed to a follower after a prior
+// mirror cycle still carries a stale MirrorRev/MirrorUpdatedAt. Store.Put's
+// stale-status guard reads those fields as proof a write came through the
+// serialized clusterlead.Merge; left on the pushed task, an unrelated
+// assignment could masquerade as mirror-authoritative and silently clobber
+// a fresher local status with a stale one.
+func TestAssignTaskScrubsLeakedMirrorBookkeeping(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	recent := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	if err := svc.AssignTask(task.Task{
+		ID: "leader-mirror-leak", Title: "t", Status: task.StatusInProgress,
+		AgentMode: task.AgentModeHeadless, CreatedAt: recent, UpdatedAt: recent,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := recent.Add(-time.Hour)
+	leaked := stale
+	if err := svc.AssignTask(task.Task{
+		ID: "leader-mirror-leak", Title: "t", Status: task.StatusBlocked,
+		AgentMode: task.AgentModeHeadless, CreatedAt: recent, UpdatedAt: stale,
+		MirrorRev: 7, MirrorUpdatedAt: &leaked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := svc.GetTask("leader-mirror-leak")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want it to stay in-progress — a stale push carrying leaked mirror bookkeeping must not masquerade as mirror-authoritative", got.Status)
+	}
+}
+
 func TestAssignTaskUpsertsOnRepeatedPush(t *testing.T) {
 	svc, _ := setupTaskService(t)
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -596,6 +596,12 @@ func (s *Store) Put(t Task) (Task, error) {
 	if t.UpdatedAt.IsZero() {
 		t.UpdatedAt = now
 	}
+	// A status change with a non-advancing UpdatedAt defeats every consumer
+	// gating on strictly-newer to detect it (#2203) — correct that one field
+	// rather than trust every Put caller to have gotten it right.
+	if existing, err := s.read(t.ID); err == nil && existing.Status != t.Status && !t.UpdatedAt.After(existing.UpdatedAt) {
+		t.UpdatedAt = now
+	}
 	if t.StatusChangedAt.IsZero() {
 		t.StatusChangedAt = t.UpdatedAt
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -596,11 +596,19 @@ func (s *Store) Put(t Task) (Task, error) {
 	if t.UpdatedAt.IsZero() {
 		t.UpdatedAt = now
 	}
-	// A status change with a non-advancing UpdatedAt defeats every consumer
-	// gating on strictly-newer to detect it (#2203) — correct that one field
-	// rather than trust every Put caller to have gotten it right.
-	if existing, err := s.read(t.ID); err == nil && existing.Status != t.Status && !t.UpdatedAt.After(existing.UpdatedAt) {
-		t.UpdatedAt = now
+	// A status change whose UpdatedAt doesn't strictly advance past what's
+	// already on disk is a stale snapshot, not a real update (#2203).
+	// Fabricating a fresh timestamp on top of it would let the stale status
+	// masquerade as the latest legitimate state to a consumer like the
+	// cluster mirror's Merge — discard it instead and keep what's on disk.
+	if existing, err := s.read(t.ID); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			slog.Default().Warn("task.store.put.read_existing_failed", "id", t.ID, "err", err)
+		}
+	} else if existing.Status != t.Status && !t.UpdatedAt.After(existing.UpdatedAt) {
+		t.Status = existing.Status
+		t.UpdatedAt = existing.UpdatedAt
+		t.StatusChangedAt = existing.StatusChangedAt
 	}
 	if t.StatusChangedAt.IsZero() {
 		t.StatusChangedAt = t.UpdatedAt

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -612,14 +612,26 @@ func (s *Store) Put(t Task) (Task, error) {
 	// Fabricating a fresh timestamp on top of it would let the stale status
 	// masquerade as the latest legitimate state to a consumer like the
 	// cluster mirror's Merge — discard it instead and keep what's on disk.
+	//
+	// A mirror-applied task (MirrorUpdatedAt set, only by clusterlead.Merge)
+	// proves freshness via MirrorRev instead: Merge runs fully serialized,
+	// so an incoming MirrorRev past the on-disk value is race-free proof
+	// even if an unrelated edit bumped UpdatedAt in the gap between Merge's
+	// snapshot and this write reaching the lock above.
 	if existing, err := s.read(t.ID); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			slog.Default().Warn("task.store.put.read_existing_failed", "id", t.ID, "err", err)
 		}
-	} else if existing.Status != t.Status && !t.UpdatedAt.After(existing.UpdatedAt) {
-		t.Status = existing.Status
-		t.UpdatedAt = existing.UpdatedAt
-		t.StatusChangedAt = existing.StatusChangedAt
+	} else if existing.Status != t.Status {
+		if t.MirrorUpdatedAt != nil && t.MirrorRev > existing.MirrorRev {
+			if !t.UpdatedAt.After(existing.UpdatedAt) {
+				t.UpdatedAt = now
+			}
+		} else if !t.UpdatedAt.After(existing.UpdatedAt) {
+			t.Status = existing.Status
+			t.UpdatedAt = existing.UpdatedAt
+			t.StatusChangedAt = existing.StatusChangedAt
+		}
 	}
 	if t.StatusChangedAt.IsZero() {
 		t.StatusChangedAt = t.UpdatedAt

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -585,10 +585,21 @@ func applyCreateInit(t *Task, init Update, now time.Time) {
 // it here, and the follower's file watcher then dispatches it through the
 // normal workflow. Marshal persists frontmatter + body; sidecars are not
 // written by this path.
+// Put is a blind, verbatim upsert used by the cluster leader/follower mirror
+// — most fields are trusted from the caller with no merge logic. Its #2203
+// stale-status guard reads the existing on-disk task before deciding whether
+// to write, so concurrent Puts for the same ID need external serialization;
+// callers should go through Manager.Put, which holds a per-ID lock around
+// this call, rather than calling Store.Put directly.
 func (s *Store) Put(t Task) (Task, error) {
 	if err := ValidateID(t.ID); err != nil {
 		return Task{}, err
 	}
+	unlock, err := s.lockTask(t.ID)
+	if err != nil {
+		return Task{}, err
+	}
+	defer unlock()
 	now := time.Now().UTC()
 	if t.CreatedAt.IsZero() {
 		t.CreatedAt = now

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -587,10 +587,10 @@ func applyCreateInit(t *Task, init Update, now time.Time) {
 // written by this path.
 // Put is a blind, verbatim upsert used by the cluster leader/follower mirror
 // — most fields are trusted from the caller with no merge logic. Its #2203
-// stale-status guard reads the existing on-disk task before deciding whether
-// to write, so concurrent Puts for the same ID need external serialization;
-// callers should go through Manager.Put, which holds a per-ID lock around
-// this call, rather than calling Store.Put directly.
+// stale-status guard reads the existing on-disk task under s.lockTask, so
+// concurrent Puts for the same ID are race-safe on their own; go through
+// Manager.Put instead when the caller also needs Manager's lifecycle side
+// effects (status-change hooks, created/updated events).
 func (s *Store) Put(t Task) (Task, error) {
 	if err := ValidateID(t.ID); err != nil {
 		return Task{}, err
@@ -625,12 +625,25 @@ func (s *Store) Put(t Task) (Task, error) {
 	} else if existing.Status != t.Status {
 		if t.MirrorUpdatedAt != nil && t.MirrorRev > existing.MirrorRev {
 			if !t.UpdatedAt.After(existing.UpdatedAt) {
-				t.UpdatedAt = now
+				// now alone isn't guaranteed to advance past existing.UpdatedAt
+				// (a prior genuinely-advancing Put can carry a caller-supplied
+				// timestamp ahead of this process's wall clock) — fall back to
+				// one tick past it so this write is never itself non-monotonic.
+				t.UpdatedAt = existing.UpdatedAt.Add(time.Nanosecond)
+				if now.After(t.UpdatedAt) {
+					t.UpdatedAt = now
+				}
 			}
 		} else if !t.UpdatedAt.After(existing.UpdatedAt) {
 			t.Status = existing.Status
 			t.UpdatedAt = existing.UpdatedAt
 			t.StatusChangedAt = existing.StatusChangedAt
+			// A rejected write's MirrorRev/MirrorUpdatedAt must not reach
+			// disk either — otherwise a stale/duplicate push regresses the
+			// mirror bookkeeping this same guard relies on to judge freshness
+			// on the next mirror-authoritative Put for this task.
+			t.MirrorRev = existing.MirrorRev
+			t.MirrorUpdatedAt = existing.MirrorUpdatedAt
 		}
 	}
 	if t.StatusChangedAt.IsZero() {

--- a/internal/task/store_put_concurrency_test.go
+++ b/internal/task/store_put_concurrency_test.go
@@ -1,0 +1,286 @@
+package task
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAdversarialStorePutTOCTOU pins that Store.Put's #2203 stale-status
+// guard is safe for concurrent use within a process, per the Store type's
+// own doc comment. Put now locks via s.lockTask around its read-then-write
+// span — without it, two concurrent Puts for the same ID could interleave
+// and produce exactly the stale clobber the #2203 guard exists to prevent.
+//
+// Scenario: on disk starts at status=blocked/T0. Two concurrent Puts land:
+//   - B: a legitimate, genuinely-advancing update (status=inprogress, T5)
+//   - A: a stale re-push carrying the *original* T0 (status=todo, T0) — the
+//     exact #2203 shape that must be rejected once B's advance is visible.
+//
+// Under any serialized (locked) execution order, the final state is
+// deterministically inprogress/T5 (verified by hand: A-then-B ends at T5
+// because B genuinely advances past A's no-op; B-then-A ends at T5 because
+// A's guard triggers against the now-current inprogress/T5 disk state and
+// rejects the stale todo/T0). If the observed final state after concurrent,
+// unsynchronized execution is ever something else (e.g. blocked/T0 or
+// todo/T0), that proves the read-then-write span raced: A must have read
+// the pre-B state before B wrote, then written after B — the very stale
+// clobber the #2203 guard exists to prevent.
+func TestAdversarialStorePutTOCTOU(t *testing.T) {
+	t0 := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	t5 := t0.Add(5 * time.Minute)
+
+	const trials = 300
+	violations := 0
+	var samples []Task
+
+	for range trials {
+		store, err := NewStore(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Put(Task{
+			ID: "task-race", Title: "t", Status: StatusBlocked,
+			CreatedAt: t0, UpdatedAt: t0,
+		}); err != nil {
+			t.Fatalf("seed Put: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = store.Put(Task{
+				ID: "task-race", Title: "t", Status: StatusTodo,
+				CreatedAt: t0, UpdatedAt: t0, // stale: identical to original on-disk UpdatedAt
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = store.Put(Task{
+				ID: "task-race", Title: "t", Status: StatusInProgress,
+				CreatedAt: t0, UpdatedAt: t5, // genuinely advancing
+			})
+		}()
+		close(start)
+		wg.Wait()
+
+		got, err := store.Get("task-race")
+		if err != nil {
+			t.Fatalf("Get after race: %v", err)
+		}
+		if got.Status != StatusInProgress || !got.UpdatedAt.Equal(t5) {
+			violations++
+			if len(samples) < 5 {
+				samples = append(samples, got)
+			}
+		}
+	}
+
+	if violations > 0 {
+		t.Fatalf("TOCTOU violation: %d/%d trials did not converge to the only two valid serialized outcomes (status=in-progress, updated_at=%v); samples: %+v",
+			violations, trials, t5, samples)
+	}
+	t.Logf("0/%d trials violated serialized-outcome invariant", trials)
+}
+
+// TestAdversarialManagerPutSerializesSameID exercises the actual production
+// path (Manager.Put, which every real caller — TaskService.AssignTask,
+// clusterlead.Mirror, clusterlead.Assigner, clusterlead.Reassign — goes
+// through) with the same race shape as above, to confirm Manager's
+// per-ID in-process mutex (lockFor) does what Store.Put itself does not:
+// serialize the read-decide-write span.
+func TestAdversarialManagerPutSerializesSameID(t *testing.T) {
+	t0 := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	t5 := t0.Add(5 * time.Minute)
+
+	const trials = 300
+	violations := 0
+
+	for range trials {
+		store, err := NewStore(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		mgr := NewManager(store, NoopEmitter())
+		if _, err := store.Put(Task{
+			ID: "task-race", Title: "t", Status: StatusBlocked,
+			CreatedAt: t0, UpdatedAt: t0,
+		}); err != nil {
+			t.Fatalf("seed Put: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, _ = mgr.Put(Task{
+				ID: "task-race", Title: "t", Status: StatusTodo,
+				CreatedAt: t0, UpdatedAt: t0,
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, _ = mgr.Put(Task{
+				ID: "task-race", Title: "t", Status: StatusInProgress,
+				CreatedAt: t0, UpdatedAt: t5,
+			})
+		}()
+		close(start)
+		wg.Wait()
+
+		got, err := store.Get("task-race")
+		if err != nil {
+			t.Fatalf("Get after race: %v", err)
+		}
+		if got.Status != StatusInProgress || !got.UpdatedAt.Equal(t5) {
+			violations++
+		}
+	}
+
+	if violations > 0 {
+		t.Errorf("Manager.Put allowed %d/%d TOCTOU violations despite lockFor", violations, trials)
+	} else {
+		t.Logf("Manager.Put: 0/%d violations — lockFor serializes the race", trials)
+	}
+}
+
+// TestAdversarialPutFirstWritePassesThroughUntouched confirms the #2203
+// guard's s.read(t.ID) branch for a brand-new ID (os.ErrNotExist) does not
+// accidentally trip the guard and clobber a legitimate first-ever write.
+func TestAdversarialPutFirstWritePassesThroughUntouched(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	saved, err := store.Put(Task{
+		ID: "task-new", Title: "brand new", Status: StatusInProgress,
+		CreatedAt: ts, UpdatedAt: ts,
+	})
+	if err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if saved.Status != StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (first write must not be guarded)", saved.Status)
+	}
+	if !saved.UpdatedAt.Equal(ts) {
+		t.Fatalf("UpdatedAt = %v, want verbatim %v", saved.UpdatedAt, ts)
+	}
+}
+
+// TestAdversarialPutZeroOnDiskUpdatedAt probes whether !After is
+// well-defined when the existing on-disk UpdatedAt is a zero time.Time
+// (e.g. a legacy/hand-crafted record). A non-zero incoming UpdatedAt should
+// count as strictly advancing past zero, so the status change must go
+// through rather than being spuriously rejected.
+func TestAdversarialPutZeroOnDiskUpdatedAt(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Hand-write a task with a zero UpdatedAt directly, bypassing Put's
+	// zero-defaulting, to simulate a corrupted/legacy on-disk record.
+	raw := Task{ID: "task-zero", Title: "t", Status: StatusBlocked}
+	data, err := marshalTask(raw, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/task-zero.md", data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	newTS := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	saved, err := store.Put(Task{
+		ID: "task-zero", Title: "t", Status: StatusTodo,
+		CreatedAt: newTS, UpdatedAt: newTS,
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if saved.Status != StatusTodo {
+		t.Fatalf("status = %q, want todo — a non-zero UpdatedAt must count as advancing past a zero on-disk UpdatedAt", saved.Status)
+	}
+	if !saved.UpdatedAt.Equal(newTS) {
+		t.Fatalf("UpdatedAt = %v, want verbatim %v", saved.UpdatedAt, newTS)
+	}
+}
+
+// TestAdversarialFlappingMirrorConverges simulates a flapping mirror
+// re-pushing the same stale snapshot alongside genuine forward progress in
+// a tight sequential loop, and asserts the final state is the last
+// genuinely-advancing status rather than oscillating back to something stale.
+func TestAdversarialFlappingMirrorConverges(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	if _, err := store.Put(Task{ID: "task-flap", Title: "t", Status: StatusBlocked, CreatedAt: base, UpdatedAt: base}); err != nil {
+		t.Fatal(err)
+	}
+
+	toggle := func(s Status) Status {
+		if s == StatusBlocked {
+			return StatusInProgress
+		}
+		return StatusBlocked
+	}
+
+	advance := base
+	curStatus := StatusBlocked
+	for i := range 50 {
+		other := toggle(curStatus)
+
+		// Flapping stale re-push carrying the *other* status at the
+		// original base timestamp — must be rejected, whatever curStatus
+		// currently is.
+		if _, err := store.Put(Task{ID: "task-flap", Title: "t", Status: other, CreatedAt: base, UpdatedAt: base}); err != nil {
+			t.Fatalf("flap Put %d: %v", i, err)
+		}
+		got, err := store.Get("task-flap")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != curStatus || !got.UpdatedAt.Equal(advance) {
+			t.Fatalf("iter %d: status regressed to %q/%v from a stale re-push, want %q/%v", i, got.Status, got.UpdatedAt, curStatus, advance)
+		}
+
+		// Genuine forward progress: flip to the other status with an
+		// advancing timestamp.
+		advance = advance.Add(time.Minute)
+		if _, err := store.Put(Task{ID: "task-flap", Title: "t", Status: other, CreatedAt: base, UpdatedAt: advance}); err != nil {
+			t.Fatalf("advance Put %d: %v", i, err)
+		}
+		curStatus = other
+		got, err = store.Get("task-flap")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != curStatus || !got.UpdatedAt.Equal(advance) {
+			t.Fatalf("iter %d: expected %q/%v after genuine advance, got %q/%v", i, curStatus, advance, got.Status, got.UpdatedAt)
+		}
+
+		// Re-flap with the *original* base snapshot again, carrying the
+		// now-stale opposite status — must still be rejected now that disk
+		// is ahead at `advance`.
+		if _, err := store.Put(Task{ID: "task-flap", Title: "t", Status: toggle(curStatus), CreatedAt: base, UpdatedAt: base}); err != nil {
+			t.Fatalf("re-flap Put %d: %v", i, err)
+		}
+		got, err = store.Get("task-flap")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != curStatus || !got.UpdatedAt.Equal(advance) {
+			t.Fatalf("iter %d: stale re-flap corrupted state, got %q/%v want %q/%v", i, got.Status, got.UpdatedAt, curStatus, advance)
+		}
+	}
+}

--- a/internal/task/store_put_concurrency_test.go
+++ b/internal/task/store_put_concurrency_test.go
@@ -48,12 +48,13 @@ func TestAdversarialStorePutTOCTOU(t *testing.T) {
 		}
 
 		var wg sync.WaitGroup
+		var staleErr, advancingErr error
 		start := make(chan struct{})
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
 			<-start
-			_, _ = store.Put(Task{
+			_, staleErr = store.Put(Task{
 				ID: "task-race", Title: "t", Status: StatusTodo,
 				CreatedAt: t0, UpdatedAt: t0, // stale: identical to original on-disk UpdatedAt
 			})
@@ -61,13 +62,19 @@ func TestAdversarialStorePutTOCTOU(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			_, _ = store.Put(Task{
+			_, advancingErr = store.Put(Task{
 				ID: "task-race", Title: "t", Status: StatusInProgress,
 				CreatedAt: t0, UpdatedAt: t5, // genuinely advancing
 			})
 		}()
 		close(start)
 		wg.Wait()
+		if staleErr != nil {
+			t.Fatalf("stale Put: %v", staleErr)
+		}
+		if advancingErr != nil {
+			t.Fatalf("advancing Put: %v", advancingErr)
+		}
 
 		got, err := store.Get("task-race")
 		if err != nil {
@@ -115,12 +122,13 @@ func TestAdversarialManagerPutSerializesSameID(t *testing.T) {
 		}
 
 		var wg sync.WaitGroup
+		var staleErr, advancingErr error
 		start := make(chan struct{})
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
 			<-start
-			_, _, _ = mgr.Put(Task{
+			_, _, staleErr = mgr.Put(Task{
 				ID: "task-race", Title: "t", Status: StatusTodo,
 				CreatedAt: t0, UpdatedAt: t0,
 			})
@@ -128,13 +136,19 @@ func TestAdversarialManagerPutSerializesSameID(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			_, _, _ = mgr.Put(Task{
+			_, _, advancingErr = mgr.Put(Task{
 				ID: "task-race", Title: "t", Status: StatusInProgress,
 				CreatedAt: t0, UpdatedAt: t5,
 			})
 		}()
 		close(start)
 		wg.Wait()
+		if staleErr != nil {
+			t.Fatalf("stale Put: %v", staleErr)
+		}
+		if advancingErr != nil {
+			t.Fatalf("advancing Put: %v", advancingErr)
+		}
 
 		got, err := store.Get("task-race")
 		if err != nil {

--- a/internal/task/store_put_test.go
+++ b/internal/task/store_put_test.go
@@ -50,6 +50,7 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 	}
 
 	in.Status = StatusReadyPR
+	in.UpdatedAt = updated.Add(time.Minute)
 	if _, err := store.Put(in); err != nil {
 		t.Fatalf("second Put (upsert): %v", err)
 	}
@@ -69,13 +70,14 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 	}
 }
 
-// TestStorePutBumpsUpdatedAtWhenStatusChangesWithoutAdvancing covers #2203: a
+// TestStorePutRejectsStatusChangeWithoutAdvancingUpdatedAt covers #2203: a
 // Put that changes Status but carries forward a stale/unchanged UpdatedAt
-// (e.g. a push built from a snapshot captured before the change) silently
-// defeats any consumer gating on strictly-newer to detect the update — the
-// cluster mirror's own staleness guard among them. Put must correct the
-// timestamp rather than trust the caller in this one specific case.
-func TestStorePutBumpsUpdatedAtWhenStatusChangesWithoutAdvancing(t *testing.T) {
+// (e.g. a push built from a snapshot captured before the change, such as a
+// cluster-mirror re-push racing a real edit) is not distinguishable from a
+// stale clobber. Put must discard the incoming status/timestamp and keep
+// what's already on disk rather than let the stale value masquerade as a
+// fresh update to a consumer like the cluster mirror's Merge.
+func TestStorePutRejectsStatusChangeWithoutAdvancingUpdatedAt(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())
 	if err != nil {
@@ -90,8 +92,7 @@ func TestStorePutBumpsUpdatedAtWhenStatusChangesWithoutAdvancing(t *testing.T) {
 		t.Fatalf("first Put: %v", err)
 	}
 
-	// Same UpdatedAt as before, but Status changed — the exact bug: a caller
-	// that forgot to advance the timestamp on a real status change.
+	// The exact bug: same UpdatedAt as before, but Status changed.
 	if _, err := store.Put(Task{
 		ID: "task-x", Title: "t", Status: StatusTodo,
 		CreatedAt: stale, UpdatedAt: stale,
@@ -103,11 +104,50 @@ func TestStorePutBumpsUpdatedAtWhenStatusChangesWithoutAdvancing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Status != StatusTodo {
-		t.Fatalf("status = %q, want todo", got.Status)
+	if got.Status != StatusBlocked {
+		t.Fatalf("status = %q, want it to stay blocked — the stale status change must be discarded", got.Status)
 	}
-	if !got.UpdatedAt.After(stale) {
-		t.Fatalf("UpdatedAt = %v, want it bumped past the stale caller-supplied value %v", got.UpdatedAt, stale)
+	if !got.UpdatedAt.Equal(stale) {
+		t.Fatalf("UpdatedAt = %v, want it left unchanged at %v — no fabricated timestamp", got.UpdatedAt, stale)
+	}
+}
+
+// TestStorePutRejectsStatusChangeWithBackdatedUpdatedAt pins the boundary
+// below equal: a caller-supplied UpdatedAt strictly before what's on disk is
+// just as stale as an equal one and must be rejected the same way — guards
+// a narrower `!Equal` reformulation of the #2203 guard from slipping through.
+func TestStorePutRejectsStatusChangeWithBackdatedUpdatedAt(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	current := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	backdated := current.Add(-1 * time.Hour)
+	if _, err := store.Put(Task{
+		ID: "task-w", Title: "t", Status: StatusBlocked,
+		CreatedAt: current, UpdatedAt: current,
+	}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+
+	if _, err := store.Put(Task{
+		ID: "task-w", Title: "t", Status: StatusTodo,
+		CreatedAt: current, UpdatedAt: backdated,
+	}); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	got, err := store.Get("task-w")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != StatusBlocked {
+		t.Fatalf("status = %q, want it to stay blocked — a backdated status change must be discarded", got.Status)
+	}
+	if !got.UpdatedAt.Equal(current) {
+		t.Fatalf("UpdatedAt = %v, want it left unchanged at %v", got.UpdatedAt, current)
 	}
 }
 

--- a/internal/task/store_put_test.go
+++ b/internal/task/store_put_test.go
@@ -69,6 +69,116 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 	}
 }
 
+// TestStorePutBumpsUpdatedAtWhenStatusChangesWithoutAdvancing covers #2203: a
+// Put that changes Status but carries forward a stale/unchanged UpdatedAt
+// (e.g. a push built from a snapshot captured before the change) silently
+// defeats any consumer gating on strictly-newer to detect the update — the
+// cluster mirror's own staleness guard among them. Put must correct the
+// timestamp rather than trust the caller in this one specific case.
+func TestStorePutBumpsUpdatedAtWhenStatusChangesWithoutAdvancing(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	if _, err := store.Put(Task{
+		ID: "task-x", Title: "t", Status: StatusBlocked,
+		CreatedAt: stale, UpdatedAt: stale,
+	}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+
+	// Same UpdatedAt as before, but Status changed — the exact bug: a caller
+	// that forgot to advance the timestamp on a real status change.
+	if _, err := store.Put(Task{
+		ID: "task-x", Title: "t", Status: StatusTodo,
+		CreatedAt: stale, UpdatedAt: stale,
+	}); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	got, err := store.Get("task-x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != StatusTodo {
+		t.Fatalf("status = %q, want todo", got.Status)
+	}
+	if !got.UpdatedAt.After(stale) {
+		t.Fatalf("UpdatedAt = %v, want it bumped past the stale caller-supplied value %v", got.UpdatedAt, stale)
+	}
+}
+
+// TestStorePutKeepsVerbatimUpdatedAtWhenStatusUnchanged pins that the #2203
+// guard is scoped to an actual status change — a same-status Put (the common
+// idempotent-repush case) must still write UpdatedAt exactly as supplied.
+func TestStorePutKeepsVerbatimUpdatedAtWhenStatusUnchanged(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	if _, err := store.Put(Task{
+		ID: "task-y", Title: "t", Status: StatusTodo,
+		CreatedAt: stale, UpdatedAt: stale,
+	}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if _, err := store.Put(Task{
+		ID: "task-y", Title: "t retitled", Status: StatusTodo,
+		CreatedAt: stale, UpdatedAt: stale,
+	}); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	got, err := store.Get("task-y")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.UpdatedAt.Equal(stale) {
+		t.Fatalf("UpdatedAt = %v, want unchanged verbatim %v — status did not change, no bump should apply", got.UpdatedAt, stale)
+	}
+}
+
+// TestStorePutTrustsGenuinelyAdvancingUpdatedAt pins the normal, correct
+// case unaffected: a status change whose caller-supplied UpdatedAt already
+// advances past what's on disk (the cluster mirror applying a real, newer
+// follower update) is written verbatim, no defensive bump needed or applied.
+func TestStorePutTrustsGenuinelyAdvancingUpdatedAt(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	older := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	newer := time.Date(2026, 7, 16, 7, 3, 50, 0, time.UTC)
+	if _, err := store.Put(Task{
+		ID: "task-z", Title: "t", Status: StatusInProgress,
+		CreatedAt: older, UpdatedAt: older,
+	}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if _, err := store.Put(Task{
+		ID: "task-z", Title: "t", Status: StatusDone,
+		CreatedAt: older, UpdatedAt: newer,
+	}); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	got, err := store.Get("task-z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.UpdatedAt.Equal(newer) {
+		t.Fatalf("UpdatedAt = %v, want the caller-supplied, already-advancing %v preserved verbatim", got.UpdatedAt, newer)
+	}
+}
+
 func TestStorePutRejectsUnsafeID(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/task/store_put_test.go
+++ b/internal/task/store_put_test.go
@@ -219,6 +219,99 @@ func TestStorePutTrustsGenuinelyAdvancingUpdatedAt(t *testing.T) {
 	}
 }
 
+// TestStorePutRejectedWriteDoesNotRegressMirrorRev pins a Copilot review
+// finding on PR #2216: the reject branch restored Status/UpdatedAt but left
+// the caller's MirrorRev/MirrorUpdatedAt writing through untouched. A stale
+// or duplicate mirror push carrying a MirrorRev below what's on disk would
+// then regress the mirror bookkeeping itself, corrupting the very signal
+// the mirror-authoritative branch relies on to judge freshness on the next
+// legitimate Put for this task.
+func TestStorePutRejectedWriteDoesNotRegressMirrorRev(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	current := time.Date(2026, 7, 14, 19, 3, 4, 0, time.UTC)
+	currentMirror := current
+	if _, err := store.Put(Task{
+		ID: "task-mrev", Title: "t", Status: StatusInProgress,
+		CreatedAt: current, UpdatedAt: current,
+		MirrorRev: 5, MirrorUpdatedAt: &currentMirror,
+	}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+
+	stale := current.Add(-time.Hour)
+	staleMirror := stale
+	if _, err := store.Put(Task{
+		ID: "task-mrev", Title: "t", Status: StatusBlocked,
+		CreatedAt: current, UpdatedAt: stale,
+		MirrorRev: 2, MirrorUpdatedAt: &staleMirror,
+	}); err != nil {
+		t.Fatalf("second (rejected) Put: %v", err)
+	}
+
+	got, err := store.Get("task-mrev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != StatusInProgress {
+		t.Fatalf("status = %q, want it to stay in-progress", got.Status)
+	}
+	if got.MirrorRev != 5 {
+		t.Fatalf("MirrorRev = %d, want it to stay 5 — a rejected write must not regress mirror bookkeeping", got.MirrorRev)
+	}
+	if got.MirrorUpdatedAt == nil || !got.MirrorUpdatedAt.Equal(currentMirror) {
+		t.Fatalf("MirrorUpdatedAt = %v, want it to stay %v", got.MirrorUpdatedAt, currentMirror)
+	}
+}
+
+// TestStorePutMirrorAuthoritativeAlwaysAdvancesPastFutureExisting pins
+// another Copilot finding on PR #2216: stamping UpdatedAt with the
+// process's wall clock alone isn't guaranteed to advance past what's on
+// disk if a prior (trusted, non-guarded) Put wrote a caller-supplied
+// UpdatedAt ahead of real wall-clock time. The mirror-authoritative branch
+// must still leave the write strictly newer than existing in that case,
+// or it reintroduces the exact non-monotonic-UpdatedAt class #2203 exists
+// to fix, just one level removed.
+func TestStorePutMirrorAuthoritativeAlwaysAdvancesPastFutureExisting(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	future := time.Now().UTC().Add(24 * time.Hour)
+	if _, err := store.Put(Task{
+		ID: "task-future", Title: "t", Status: StatusBlocked,
+		CreatedAt: future, UpdatedAt: future,
+	}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+
+	mirrorTS := future.Add(-time.Hour)
+	if _, err := store.Put(Task{
+		ID: "task-future", Title: "t", Status: StatusInProgress,
+		CreatedAt: future, UpdatedAt: mirrorTS,
+		MirrorRev: 1, MirrorUpdatedAt: &mirrorTS,
+	}); err != nil {
+		t.Fatalf("mirror-authoritative Put: %v", err)
+	}
+
+	got, err := store.Get("task-future")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != StatusInProgress {
+		t.Fatalf("status = %q, want in-progress", got.Status)
+	}
+	if !got.UpdatedAt.After(future) {
+		t.Fatalf("UpdatedAt = %v, want it strictly after the prior on-disk value %v", got.UpdatedAt, future)
+	}
+}
+
 func TestStorePutRejectsUnsafeID(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Motivation

Production had 13 of 45 home-nas-owned tasks the leader mirrors showing a stale status, all with `mirrorUpdatedAt` identical to the microsecond to the follower's current `updated_at` despite a different status. `Store.Put` is a blind verbatim upsert — the leader-follower execution mirror's write path — and a status change whose `UpdatedAt` doesn't strictly advance past what's already on disk is structurally invisible to every consumer that gates on strictly-newer-wins, including the cluster mirror's own `Merge` staleness guard, regardless of transport.

> Changelog: fix(task): guard Put against a frozen UpdatedAt

## Implementation information

`Put` now reads the existing on-disk task before writing. If `Status` differs from what's on disk and the incoming write doesn't prove itself fresher, the stale write is discarded and the existing state is kept — rather than trusting the caller or fabricating a fresh timestamp on top of stale data (an earlier version of this fix did exactly that, and adversarial review caught that it lets a stale clobber masquerade as genuinely fresh, which is worse than the original bug).

Four rounds of adversarial code review and manual testing found and fixed three more issues introduced by the guard itself, each fixed in its own commit:

1. **`clusterlead.Merge` borrowed the wrong clock.** It stamped a mirrored task's `UpdatedAt` from the follower's own reported clock, while every other writer (`Store.UpdateWithPrev`) stamps the leader's wall clock. An unrelated local leader edit could bump the on-disk `UpdatedAt` past a genuinely newer follower update's clock, so the new guard rejected legitimate mirror traffic — reproducing the original symptom through the fix's own code path.
2. **The wall-clock fix only narrowed the race, it didn't close it.** `Mirror.applyFollowerTask` calls `Merge` (which snapshots the fix from #1), then runs several blocking sidecar writes, then calls `Store.Put` — a real, non-zero gap where an intervening edit could still win. The freshness decision now happens atomically inside `Store.Put`'s own lock instead of being pre-computed before it: a mirror-applied task (`MirrorUpdatedAt` set, only by `clusterlead.Merge`) proves freshness via `MirrorRev` instead of timestamps — `Merge` runs fully serialized process-wide, so an incoming `MirrorRev` past the on-disk value is race-free proof regardless of any intervening gap.
3. **The `MirrorRev` trust decision was gameable.** `Assigner.Route` forwards the leader's canonical task copy over RPC to a follower without clearing its `MirrorRev`/`MirrorUpdatedAt` fields. A task re-routed to a follower after a prior mirror cycle still carried stale mirror bookkeeping into an unrelated assignment push, which the follower's `AssignTask` handler wrote verbatim — masquerading as mirror-authoritative and bypassing the plain guard. `AssignTask` now scrubs both fields before writing (the existing `normalizeAssignedTaskForCompare` helper already zeroed them on a comparison-only copy, showing this was already understood as leader-owned bookkeeping that shouldn't cross an assignment push — that scrub just never reached the actual write).

`Store.Put`'s read-then-write span also had no lock, unlike every other `Store` mutator — closed by wrapping it in the existing `s.lockTask`, the same nested-locking pattern `Manager.UpdateFn` already uses around `Store.UpdateWithPrev`.

Each round's regression tests are kept as permanent tests: `store_put_test.go`, `store_put_concurrency_test.go` (a 300-trial concurrency stress test proving the lock closes a real TOCTOU), `mirror_leader_edit_race_test.go`, `mirror_snapshot_gap_test.go`, and `svc_tasks_assign_test.go`'s masquerade test.

An exhaustive audit of every `Manager.Put` call site (there are 6, `Store.Put` has exactly one caller, `Manager.Put`) confirmed no other path can inject caller-controlled `MirrorRev`/`MirrorUpdatedAt` into a status-changing write.

### Open questions

- `Store.Put` still writes all other fields (`AgentRuns`, `Workflow`, `Branch`, etc.) verbatim from the caller even when the `Status` guard fires and rejects the status/timestamp. A stale push could still clobber those other fields with old data even though `Status` itself is now protected. Left out of scope — the production incident was specifically about `Status`/`UpdatedAt`, and widening the guard to every field is a larger, separate design decision.
- `TestMirrorReconcileSucceedsPastOldThirtyTwoMegabyteCap` (pre-existing, from #2195, unrelated to this diff) flakes under `-race` + concurrent machine load — confirmed via repeated isolated reruns on both `main` and this branch. Already tracked as #2204; not a blocker here.