### PR TITLE
fix(agent): say when allowed_tools is not enforced

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -529,7 +529,7 @@ export class StepConfig {
     "model": string;
 
     /**
-     * "", "claude", "codex", "copilot", "cross"
+     * "", "claude", "codex", "copilot", "opencode", "cross", "ab"
      */
     "provider": string;
     "prompt": string;
@@ -542,7 +542,7 @@ export class StepConfig {
      * unenforced on the copilot spawn beside it — dispatch logs
      * agent.run.allowed_tools.unenforced whenever that happens. For containment
      * that binds every provider, rely on the OS-level sandbox instead (see
-     * internal/agent/procsandbox_darwin.go).
+     * internal/agent/procsandbox_*.go).
      */
     "allowedTools": string[];
     "needsWorktree": boolean;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -533,6 +533,17 @@ export class StepConfig {
      */
     "provider": string;
     "prompt": string;
+
+    /**
+     * AllowedTools is advisory, not a capability boundary. Only claude enforces
+     * it (as --allowedTools); codex has no per-tool allowlist at all, and
+     * copilot spawns with --allow-all-tools. Since provider: ab / cross pick the
+     * provider at dispatch, the same step is enforced on a claude spawn and
+     * unenforced on the copilot spawn beside it — dispatch logs
+     * agent.run.allowed_tools.unenforced whenever that happens. For containment
+     * that binds every provider, rely on the OS-level sandbox instead (see
+     * internal/agent/procsandbox_darwin.go).
+     */
     "allowedTools": string[];
     "needsWorktree": boolean;
 

--- a/internal/agent/allowed_tools_test.go
+++ b/internal/agent/allowed_tools_test.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// restrictedTools is the plan step's real list — the one #2179 narrowed
+// specifically so the council could not be reconvened by an unprompted Skill
+// call, which is what turned this from a convenience into a containment claim.
+var restrictedTools = []string{"Bash", "Read", "Grep", "Glob", "Write"}
+
+// TestHonorsAllowedTools_MatchesTheSpawnedArgv is the invariant: a provider may
+// claim to honour allowed_tools only if its argv actually carries the list.
+//
+// The claim and the argv are what drift apart — a provider gaining a per-tool
+// flag without flipping the capability keeps warning about containment it now
+// has, and one flipping the capability without wiring the flag reports a fence
+// that isn't there. The second direction is the dangerous one.
+func TestHonorsAllowedTools_MatchesTheSpawnedArgv(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"claude", "codex", "copilot", "opencode"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			prov := providerByName(name)
+			if prov == nil {
+				t.Skipf("provider %s not registered", name)
+			}
+			a := &Agent{ID: "a1", Provider: name}
+			inv, err := prov.BuildHeadlessInvocation(a, RunConfig{
+				Prompt:       "plan it",
+				AllowedTools: restrictedTools,
+			})
+			if err != nil {
+				t.Fatalf("BuildHeadlessInvocation: %v", err)
+			}
+			argv := strings.Join(inv.args, " ")
+			carriesList := strings.Contains(argv, strings.Join(restrictedTools, ","))
+
+			if got := prov.HonorsAllowedTools(); got != carriesList {
+				t.Errorf("HonorsAllowedTools() = %v but argv carries the list = %v\nargv: %s",
+					got, carriesList, argv)
+			}
+		})
+	}
+}
+
+// A provider that does not honour the list must not be quietly handed it: the
+// same step is enforced on a claude spawn and unenforced on the copilot spawn
+// beside it, since ab/cross pick the provider at dispatch.
+func TestPrepareRunConfig_WarnsWhenProviderIgnoresAllowedTools(t *testing.T) {
+	var buf bytes.Buffer
+	m, _ := newTestManagerWithLogger(t, slog.New(slog.NewTextHandler(&buf, nil)))
+
+	for _, tc := range []struct {
+		provider  string
+		wantWarn  bool
+		wantInLog string
+	}{
+		{provider: "claude", wantWarn: false},
+		{provider: "codex", wantWarn: true, wantInLog: "codex"},
+		{provider: "copilot", wantWarn: true, wantInLog: "copilot"},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			buf.Reset()
+			prov := providerByName(tc.provider)
+			if prov == nil {
+				t.Skipf("provider %s not registered", tc.provider)
+			}
+			m.warnUnenforceableAllowedTools(RunConfig{
+				TaskID:       "t1",
+				Name:         "plan:t1",
+				AllowedTools: restrictedTools,
+			}, prov)
+
+			logged := strings.Contains(buf.String(), "allowed_tools.unenforced")
+			if logged != tc.wantWarn {
+				t.Errorf("warned = %v, want %v (log: %s)", logged, tc.wantWarn, buf.String())
+			}
+			if tc.wantWarn && !strings.Contains(buf.String(), tc.wantInLog) {
+				t.Errorf("log must name the provider that ignored the list, got: %s", buf.String())
+			}
+			if tc.wantWarn && !strings.Contains(buf.String(), "Bash,Read,Grep,Glob,Write") {
+				t.Errorf("log must name the list that is not enforced, got: %s", buf.String())
+			}
+		})
+	}
+}
+
+// No list, nothing to warn about — every step that never declared one must stay
+// silent, or the signal drowns.
+func TestPrepareRunConfig_SilentWithoutAllowedTools(t *testing.T) {
+	var buf bytes.Buffer
+	m, _ := newTestManagerWithLogger(t, slog.New(slog.NewTextHandler(&buf, nil)))
+
+	m.warnUnenforceableAllowedTools(RunConfig{TaskID: "t1", Name: "plan:t1"}, providerByName("codex"))
+
+	if strings.Contains(buf.String(), "allowed_tools") {
+		t.Errorf("warned with no allowed_tools set: %s", buf.String())
+	}
+}

--- a/internal/agent/allowed_tools_test.go
+++ b/internal/agent/allowed_tools_test.go
@@ -25,8 +25,8 @@ func TestHonorsAllowedTools_MatchesTheSpawnedArgv(t *testing.T) {
 	for _, name := range []string{"claude", "codex", "copilot", "opencode"} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			prov := providerByName(name)
-			if prov == nil {
+			prov, err := lookupProvider(name)
+			if err != nil {
 				t.Skipf("provider %s not registered", name)
 			}
 			a := &Agent{ID: "a1", Provider: name}
@@ -66,8 +66,8 @@ func TestPrepareRunConfig_WarnsWhenProviderIgnoresAllowedTools(t *testing.T) {
 	} {
 		t.Run(tc.provider, func(t *testing.T) {
 			buf.Reset()
-			prov := providerByName(tc.provider)
-			if prov == nil {
+			prov, err := lookupProvider(tc.provider)
+			if err != nil {
 				t.Skipf("provider %s not registered", tc.provider)
 			}
 			m.warnUnenforceableAllowedTools(RunConfig{

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -102,6 +102,31 @@ func (m *Manager) jitterDispatchContext(ctx context.Context) error {
 	}
 }
 
+// warnUnenforceableAllowedTools reports a step whose allowed_tools list the
+// resolved provider cannot enforce.
+//
+// The check lives here rather than in Definition.Validate because `ab` and
+// `cross` pick the provider at dispatch: the same step is enforced on a claude
+// spawn and unenforced on the copilot spawn beside it, so which guarantee you
+// get depends on where the run landed. Nothing surfaced that before.
+//
+// It warns rather than refusing or re-routing. Excluding providers that cannot
+// enforce would silently narrow failover and strand a step whenever claude is
+// capped — the stranding shape that produced #2150's spin loop — and refusing
+// outright would break every step that has always used the list as an allowance
+// rather than a fence. The OS-level process sandbox (procsandbox_*.go) is the
+// boundary that actually binds every provider; allowed_tools is advisory
+// wherever this warns.
+func (m *Manager) warnUnenforceableAllowedTools(cfg RunConfig, prov Provider) {
+	if len(cfg.AllowedTools) == 0 || prov.HonorsAllowedTools() {
+		return
+	}
+	m.logger.Warn("agent.run.allowed_tools.unenforced",
+		"task_id", cfg.TaskID, "name", cfg.Name, "provider", prov.Name(),
+		"allowed_tools", strings.Join(cfg.AllowedTools, ","),
+		"detail", "provider ignores allowed_tools; the agent runs with its default tool reach and only the prompt and the process sandbox constrain it")
+}
+
 func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	if err := validateRunDir(cfg.Dir); err != nil {
 		return cfg, nil, err
@@ -122,6 +147,7 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 		return cfg, nil, err
 	}
 	cfg.provider = prov
+	m.warnUnenforceableAllowedTools(cfg, prov)
 	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort)
 	if cfg.Mode == "headless" {
 		m.mu.RLock()

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -65,6 +65,15 @@ func newTestManager(t *testing.T, cfgs ...ManagerConfig) (mgr *Manager, emitted 
 	return m, emitted
 }
 
+// newTestManagerWithLogger is newTestManager for tests that assert on what the
+// manager logged rather than on what it did.
+func newTestManagerWithLogger(t *testing.T, logger *slog.Logger, cfgs ...ManagerConfig) (mgr *Manager, emitted *eventRecorder) {
+	t.Helper()
+	emitted = &eventRecorder{}
+	emit := func(event string, _ any) { emitted.add(event) }
+	return mustNewManager(t, t.Context(), emit, logger, t.TempDir(), cfgs...), emitted
+}
+
 // startTestAgent starts an agent in a fresh working directory, satisfying the
 // Run guard that requires a valid, existing working dir. Uses os.MkdirTemp
 // with a best-effort cleanup (not t.TempDir) because background goroutines

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1583,10 +1583,15 @@ func (a *Agent) Output() []StreamEvent {
 
 // RunConfig is the single entry point for starting any agent.
 type RunConfig struct {
-	TaskID             string
-	Name               string
-	Mode               string // "headless", "interactive", or "conversational"
-	Prompt             string
+	TaskID string
+	Name   string
+	Mode   string // "headless", "interactive", or "conversational"
+	Prompt string
+	// AllowedTools is honoured only by providers whose HonorsAllowedTools()
+	// reports true — claude alone today. Elsewhere it is silently ignored, and
+	// warnUnenforceableAllowedTools says so at dispatch, since ab/cross choose
+	// the provider long after the step declared its list. Treat it as advisory:
+	// only the OS-level sandbox binds a run on every provider.
 	AllowedTools       []string
 	Dir                string
 	Provider           string // "claude", "codex", or "copilot"

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -33,11 +33,23 @@ type Provider interface {
 	ParseConvoLine(line []byte) (ConvoEvent, error)
 	SessionFilePath(sessionID string) string
 	ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration)
+	// HonorsAllowedTools reports whether this provider actually enforces
+	// RunConfig.AllowedTools on the spawned CLI. False means the list is
+	// silently ignored and the agent runs with the provider's own default
+	// reach — see warnUnenforceableAllowedTools.
+	HonorsAllowedTools() bool
 }
 
 type baseProvider struct{}
 
 func (baseProvider) SandboxArgs(bool, bool) []string { return nil }
+
+// HonorsAllowedTools defaults to false so a provider only claims to enforce the
+// list by saying so. codex has no per-tool allowlist at all (only --sandbox,
+// which is filesystem-level), and copilot's --allow-tool vocabulary is
+// unrelated to claude's tool names — a guessed mapping would manufacture a
+// boundary that does not hold, which is worse than an honest gap.
+func (baseProvider) HonorsAllowedTools() bool { return false }
 
 func (baseProvider) OutputSchemaAsFile() bool { return false }
 

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -20,6 +20,10 @@ func init() {
 
 func (claudeProvider) Name() string { return "claude" }
 
+// HonorsAllowedTools is true here alone: claudePermissionArgs turns the list
+// into --allowedTools. Every other provider inherits the false default.
+func (claudeProvider) HonorsAllowedTools() bool { return true }
+
 func (claudeProvider) NormalizeModel(model string) string {
 	// [1m] is a Claude-Code-only context marker. Fable 5 ships a 1M context
 	// window by default, so CC 2.1.173 strips the redundant suffix; Sybra

--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -17,6 +17,11 @@ func init() {
 
 func (codexProvider) Name() string { return "codex" }
 
+// HonorsAllowedTools is false: the codex CLI has no per-tool allowlist. Its
+// only containment is -s/--sandbox, which is filesystem-level and unrelated to
+// which tools the model may call, so allowed_tools cannot be mapped onto it.
+func (codexProvider) HonorsAllowedTools() bool { return false }
+
 func (codexProvider) NormalizeModel(model string) string {
 	// Codex models come from `codex debug models` and never carry a [1m]
 	// suffix — a stray suffix stays untouched and is rejected by safeArgRe.

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -196,11 +196,19 @@ type Position struct {
 // Only fields relevant to the step type are populated.
 type StepConfig struct {
 	// run_agent
-	Role          string   `yaml:"role,omitempty" json:"role"`
-	Mode          string   `yaml:"mode,omitempty" json:"mode"`
-	Model         string   `yaml:"model,omitempty" json:"model"`
-	Provider      string   `yaml:"provider,omitempty" json:"provider"` // "", "claude", "codex", "copilot", "cross"
-	Prompt        string   `yaml:"prompt,omitempty" json:"prompt"`
+	Role     string `yaml:"role,omitempty" json:"role"`
+	Mode     string `yaml:"mode,omitempty" json:"mode"`
+	Model    string `yaml:"model,omitempty" json:"model"`
+	Provider string `yaml:"provider,omitempty" json:"provider"` // "", "claude", "codex", "copilot", "cross"
+	Prompt   string `yaml:"prompt,omitempty" json:"prompt"`
+	// AllowedTools is advisory, not a capability boundary. Only claude enforces
+	// it (as --allowedTools); codex has no per-tool allowlist at all, and
+	// copilot spawns with --allow-all-tools. Since provider: ab / cross pick the
+	// provider at dispatch, the same step is enforced on a claude spawn and
+	// unenforced on the copilot spawn beside it — dispatch logs
+	// agent.run.allowed_tools.unenforced whenever that happens. For containment
+	// that binds every provider, rely on the OS-level sandbox instead (see
+	// internal/agent/procsandbox_darwin.go).
 	AllowedTools  []string `yaml:"allowed_tools,omitempty" json:"allowedTools"`
 	NeedsWorktree bool     `yaml:"needs_worktree,omitempty" json:"needsWorktree"`
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -199,7 +199,7 @@ type StepConfig struct {
 	Role     string `yaml:"role,omitempty" json:"role"`
 	Mode     string `yaml:"mode,omitempty" json:"mode"`
 	Model    string `yaml:"model,omitempty" json:"model"`
-	Provider string `yaml:"provider,omitempty" json:"provider"` // "", "claude", "codex", "copilot", "cross"
+	Provider string `yaml:"provider,omitempty" json:"provider"` // "", "claude", "codex", "copilot", "opencode", "cross", "ab"
 	Prompt   string `yaml:"prompt,omitempty" json:"prompt"`
 	// AllowedTools is advisory, not a capability boundary. Only claude enforces
 	// it (as --allowedTools); codex has no per-tool allowlist at all, and
@@ -208,7 +208,7 @@ type StepConfig struct {
 	// unenforced on the copilot spawn beside it — dispatch logs
 	// agent.run.allowed_tools.unenforced whenever that happens. For containment
 	// that binds every provider, rely on the OS-level sandbox instead (see
-	// internal/agent/procsandbox_darwin.go).
+	// internal/agent/procsandbox_*.go).
 	AllowedTools  []string `yaml:"allowed_tools,omitempty" json:"allowedTools"`
 	NeedsWorktree bool     `yaml:"needs_worktree,omitempty" json:"needsWorktree"`
 


### PR DESCRIPTION
## Motivation

`allowed_tools` reads like a capability boundary. It is one on **claude alone**: `provider_claude.go` is the sole reader, codex ignores it entirely, and copilot hardcodes `--allow-all-tools`. Because `provider: ab` and `cross` route across families at dispatch, which guarantee a step gets depends on where the run landed — and nothing said so. Observed live on one plan step: claude took `--allowedTools Bash,Read,Grep,Glob,Write` while an A/B copilot spawn for the same step took `--allow-all-tools --no-ask-user`.

This matters more since #2179 removed `Skill` and `Agent` from the plan step specifically so the council could not be reconvened by an unprompted `Skill` call. That containment holds on claude and does not exist on codex/copilot, where the prompt naming no skill is the whole defence.

> Changelog: fix(agent): stop silently ignoring allowed_tools on codex and copilot

## Implementation information

The issue asks which of three options to take, and says the answer depends on whether `allowed_tools` is meant to be a boundary or a hint. I researched the CLIs rather than guessing, and the research settles it:

- **codex has no per-tool allowlist at all.** Its only containment is `-s/--sandbox`, which is filesystem-level and unrelated to which tools the model may call. There is nothing to map onto.
- **copilot has `--allow-tool`/`--deny-tool`**, but in a different vocabulary — `shell(git:*)`, `write`, MCP server names — not claude's `Bash`/`Read`/`Grep`. A guessed mapping would manufacture a boundary that does not actually hold, which is **worse than an honest gap**: it would invite exactly the reliance the issue warns against.

So option 2 ("honour it per provider") cannot be completed, which is the case the issue anticipated: *"in which case (1) plus documentation is the ceiling."*

**What this does.** Providers declare `HonorsAllowedTools()`, defaulting to `false` in `baseProvider` so a provider only claims enforcement by saying so; claude returns true. Dispatch (`prepareRunConfig`, after `gateProvider` — the point where `ab`/`cross` finally pick) logs `agent.run.allowed_tools.unenforced` naming the task, the provider, and the list that will not be enforced.

**What this deliberately does not do.** Option 3 (exclude non-enforcing providers from routing) silently narrows failover and strands a step whenever claude is capped — the exact stranding shape behind the codex spin loop just fixed in #2174. Refusing outright would break every step that has always used the list as an allowance rather than a fence. So: warn, and say plainly that the list is advisory.

Documented at both definition sites (`workflow.StepConfig.AllowedTools` and `agent.RunConfig.AllowedTools`) rather than in one workflow's comments, pointing at the OS-level process sandbox as the boundary that actually binds every provider.

## Supporting documentation

The test pins the invariant rather than a hardcoded list: **a provider may claim `HonorsAllowedTools()` only if its spawned argv really carries the list.** It builds a real headless invocation per provider and compares the claim against the argv, so the two cannot drift — a provider gaining a per-tool flag without flipping the capability keeps warning about containment it now has, and (the dangerous direction) one flipping the capability without wiring the flag would report a fence that isn't there. Today it confirms the issue's claim empirically: claude carries the list, codex/copilot/opencode do not.

Plus: the warning fires for codex and copilot and names both the provider and the list; it does not fire for claude; and it stays silent when a step declares no list at all, so the signal does not drown.

Closes #2190
