### PR TITLE
feat(k8s): Job TTL and retention policy

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -2604,6 +2604,7 @@ func cmdConfigDoctor(cfg *config.Config, jsonOut bool) int {
 	}
 
 	addK8sSecretEnvFindings(cfg, add)
+	addK8sFailedTTLFindings(cfg, add)
 
 	if len(findings) == 0 {
 		add("ok", "no issues found")
@@ -2658,6 +2659,23 @@ func addK8sSecretEnvFindings(cfg *config.Config, add func(severity, format strin
 		if len(missing) > 0 {
 			add("error", "agent.k8s_jobs.secret_env[%d]: missing %s", i, strings.Join(missing, ", "))
 		}
+	}
+}
+
+// addK8sFailedTTLFindings warns when ttl_seconds_after_finished is set low
+// enough to undermine failed_ttl_seconds_after_finished: the runner extends a
+// failed Job's TTL by PATCHing it after the fact
+// (internal/agent/k8s_job_runner.go), but per Kubernetes' own
+// ttlSecondsAfterFinished docs a late-extended TTL is not guaranteed to be
+// honored once the original, shorter window has elapsed.
+func addK8sFailedTTLFindings(cfg *config.Config, add func(severity, format string, a ...any)) {
+	if !cfg.Agent.K8sJobs.Enabled {
+		return
+	}
+	ttl := cfg.Agent.K8sJobs.TTL
+	failedTTL := cfg.Agent.K8sJobs.FailedTTL
+	if ttl > 0 && ttl < 30 && failedTTL != ttl {
+		add("warning", "agent.k8s_jobs.ttl_seconds_after_finished is %ds — Kubernetes does not guarantee honoring the failed_ttl_seconds_after_finished extension once such a short window has already elapsed", ttl)
 	}
 }
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -690,6 +690,54 @@ func TestConfigDoctorJSONValidatesK8sSecretEnvRegardlessOfMode(t *testing.T) {
 	}
 }
 
+func TestConfigDoctorJSONWarnsOnLowTTLWithDifferingFailedTTL(t *testing.T) {
+	setupStore(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.K8sJobs.Enabled = true
+	cfg.Agent.K8sJobs.TTL = 5
+	cfg.Agent.K8sJobs.FailedTTL = 86400
+
+	code, out := captureStdout(t, func() int {
+		return cmdConfigDoctor(cfg, true)
+	})
+	if code != 0 {
+		t.Fatalf("expected a warning-only doctor to exit zero, got %d:\n%s", code, out)
+	}
+
+	var report configDoctorReport
+	mustUnmarshal(t, out, &report)
+	if !slices.ContainsFunc(report.Findings, func(f configDoctorFinding) bool {
+		return f.Severity == "warning" && strings.Contains(f.Message, "ttl_seconds_after_finished")
+	}) {
+		t.Fatalf("expected a low-ttl warning in report: %+v", report.Findings)
+	}
+}
+
+func TestConfigDoctorJSONAcceptsTypicalTTLDefaults(t *testing.T) {
+	setupStore(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.K8sJobs.Enabled = true
+	cfg.Agent.K8sJobs.TTL = 300
+	cfg.Agent.K8sJobs.FailedTTL = 86400
+
+	code, out := captureStdout(t, func() int {
+		return cmdConfigDoctor(cfg, true)
+	})
+	if code != 0 {
+		t.Fatalf("expected typical TTL defaults to stay clean, got %d:\n%s", code, out)
+	}
+
+	var report configDoctorReport
+	mustUnmarshal(t, out, &report)
+	if slices.ContainsFunc(report.Findings, func(f configDoctorFinding) bool {
+		return strings.Contains(f.Message, "ttl_seconds_after_finished is")
+	}) {
+		t.Fatalf("did not expect a TTL finding for the recommended defaults: %+v", report.Findings)
+	}
+}
+
 func TestConfigDoctorJSONReportsWhitespaceOnlyK8sSecretEnvFields(t *testing.T) {
 	setupStore(t)
 

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -474,16 +474,41 @@ kubectl -n sybra-poc describe pod -l sybra.agent/id=<agent-id>
 
 **Stale Jobs** — a Job that exists in the cluster but no longer maps to an
 agent Sybra is actively tracking, typically after a server crash/restart
-during a run. Every agent Job carries `app.kubernetes.io/name=sybra-agent`,
-`sybra.agent/id=<id>`, and `sybra.task/id=<id>` labels
-(`internal/agent/k8s_job_runner.go`), so today an operator can find candidates
-manually by listing Jobs with that selector and cross-referencing the ids
-against `ListAgents`/`sybra-cli list`:
+during a run.
+
+For the common case — the orphaned Job still finishes on its own — TTL
+already covers it: `ttlSecondsAfterFinished` deletes a Job once it reaches
+Complete/Failed regardless of whether anything in Sybra still tracks its
+`sybra.agent/id`, since Kubernetes' TTL controller only looks at the Job's
+own status, never at Sybra's registry. A restart doesn't stop the pod that's
+already running; it just orphans Sybra's reference to it, and the two TTLs
+above still reap it on the same schedule as a normally-tracked run.
+
+What TTL *cannot* reach is a Job that never finishes at all — stuck
+`Pending`/`Running` forever with no terminal condition to start either TTL's
+countdown. That's a timeout/liveness problem, not a retention-window problem,
+and it's tracked separately: #2106 (resource/timeout/concurrency controls)
+and #2109 (observability and stuck-Job alerts) own detecting and acting on a
+Job that's actually hung, rather than one that finished and is just waiting
+out its TTL.
+
+What's left for a human to do manually today is inspection, not cleanup: every
+agent Job carries `app.kubernetes.io/name=sybra-agent`, `sybra.agent/id=<id>`,
+and `sybra.task/id=<id>` labels (`internal/agent/k8s_job_runner.go`), so an
+operator can list Jobs with that selector and cross-reference the ids against
+`ListAgents`/`sybra-cli list` to see what's currently orphaned before its TTL
+elapses:
 
 ```bash
 kubectl -n sybra-poc get jobs -l app.kubernetes.io/name=sybra-agent \
   -o jsonpath='{range .items[*]}{.metadata.labels.sybra\.agent/id}{"\n"}{end}'
 ```
+
+Automating that lookup into a scheduled sweep (rather than an operator running
+it by hand), and extending the same garbage collection to branches and
+worktrees left behind by an orphaned run, is #2111. Reattaching Sybra's own
+tracking to a still-running Job after a restart — so it stops looking
+"orphaned" from Sybra's side in the first place — is #2112.
 
 Automatically *detecting and pruning* stale Jobs — not just finding them by
 hand — is out of scope here; it's tracked in #2111. Automatically

--- a/deploy/k8s-poc/README.md
+++ b/deploy/k8s-poc/README.md
@@ -422,6 +422,75 @@ cd your-production-overlay
 kustomize edit set image sybra-server:poc=ghcr.io/automaat/sybra-server@sha256:<digest>
 ```
 
+## Job cleanup and log retention
+
+Every agent Job runs with `backoffLimit: 0` and `restartPolicy: Never`
+(`deploy/k8s-poc/deployment.yaml` config, applied in
+`internal/agent/k8s_job_runner.go`), so it reaches a terminal Kubernetes Job
+condition — Complete or Failed — on its first pod exit, success or failure
+alike. Kubernetes' [TTL-after-finished
+controller](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
+then deletes the Job (and, via its pod's ownerReference, the Pod) once
+`spec.ttlSecondsAfterFinished` elapses from that terminal condition — deleting
+the Pod is also what makes `kubectl logs` on it stop working, so this number
+is really "how long do I have to pull a Job's logs before they're gone."
+
+**Two separate defaults, not one**, because a five-minute window is fine for
+a Job that worked but far too short to debug one that didn't:
+
+- `agent.k8s_jobs.ttl_seconds_after_finished` — applied at Job creation,
+  covers the **successful** case. Default **300s** if unset.
+- `agent.k8s_jobs.failed_ttl_seconds_after_finished` — Kubernetes has no
+  native way to set a different TTL for Failed vs Complete at creation time
+  (`ttlSecondsAfterFinished` is one scalar), so the runner instead PATCHes it
+  onto the Job the moment it observes `status.failed > 0`, before finalizing
+  the agent run. Default **86400s (24h)** if unset — long enough that an
+  operator investigating a page the next morning still has the evidence.
+  Requires the `patch` verb on `batch/jobs` in the Role bound to
+  `sybra-server`'s ServiceAccount (already granted in
+  `deploy/k8s-poc/rbac.yaml`); without it the patch attempt is logged as a
+  warning (`agent.k8s.failed_ttl_patch`) and the Job silently falls back to
+  the success TTL.
+
+Both are configurable per-deployment via the `agent.k8s_jobs` ConfigMap key —
+see `deploy/k8s-poc/config-provider-example.yaml` for the surrounding block.
+
+**Inspecting a failed run before it's cleaned up:**
+
+```bash
+# Sybra's own parsed view — cost, tokens, session id, exit state
+kubectl -n sybra-poc exec deploy/sybra-server -- \
+  curl -sS -X POST 'http://127.0.0.1:8080/api/AgentService/ListAgents' \
+    -H 'Authorization: Bearer poc-token' -H 'Content-Type: application/json' --data '[]' \
+  | jq '.[] | select(.taskId == "<task-id>")'
+
+# Raw provider stdout/stderr for the pod (works until failedTTL elapses)
+kubectl -n sybra-poc logs job/sybra-agent-<agent-id>
+
+# Why the pod itself failed (OOMKilled, image pull error, etc. — not just
+# a nonzero exit from the provider CLI)
+kubectl -n sybra-poc describe pod -l sybra.agent/id=<agent-id>
+```
+
+**Stale Jobs** — a Job that exists in the cluster but no longer maps to an
+agent Sybra is actively tracking, typically after a server crash/restart
+during a run. Every agent Job carries `app.kubernetes.io/name=sybra-agent`,
+`sybra.agent/id=<id>`, and `sybra.task/id=<id>` labels
+(`internal/agent/k8s_job_runner.go`), so today an operator can find candidates
+manually by listing Jobs with that selector and cross-referencing the ids
+against `ListAgents`/`sybra-cli list`:
+
+```bash
+kubectl -n sybra-poc get jobs -l app.kubernetes.io/name=sybra-agent \
+  -o jsonpath='{range .items[*]}{.metadata.labels.sybra\.agent/id}{"\n"}{end}'
+```
+
+Automatically *detecting and pruning* stale Jobs — not just finding them by
+hand — is out of scope here; it's tracked in #2111. Automatically
+*reattaching* to a Job that outlived a server restart, so it stops looking
+stale in the first place, is #2112. This section defines the retention
+policy and the manual inspection path; those two issues own the automation.
+
 ## Real OpenCode testbed e2e
 
 This is the end-to-end path used to prove the PoC with a real model. It uses

--- a/deploy/k8s-poc/config-provider-example.yaml
+++ b/deploy/k8s-poc/config-provider-example.yaml
@@ -20,6 +20,10 @@ data:
         namespace: sybra-poc
         image: sybra-server:poc
         ttl_seconds_after_finished: 300
+        # Longer TTL for a Failed Job, patched on by the runner once it
+        # observes the failure — see "Job cleanup and log retention" in
+        # README.md. Omit to fall back to the built-in 86400s default.
+        failed_ttl_seconds_after_finished: 86400
         secret_env:
           - name: OPENROUTER_API_KEY
             secret_name: sybra-provider-api-keys

--- a/deploy/k8s-poc/rbac.yaml
+++ b/deploy/k8s-poc/rbac.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create", "get", "list", "watch", "delete"]
+    verbs: ["create", "get", "list", "watch", "delete", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -166,6 +166,7 @@ in-cluster service account.
 | `agent.k8s_jobs.image` | `string` |  |  |
 | `agent.k8s_jobs.command` | `[]string` |  |  |
 | `agent.k8s_jobs.ttl_seconds_after_finished` | `int` |  |  |
+| `agent.k8s_jobs.failed_ttl_seconds_after_finished` | `int` |  | FailedTTL overrides TTL for a Job that finishes Failed rather than Succeeded, via a post-completion patch once the runner observes the failure — Kubernetes' own ttlSecondsAfterFinished is a single value that cannot vary by outcome at creation time. Defaults much longer than TTL's own default so a failed run's logs survive long enough for an operator to pull them before Kubernetes garbage-collects the Pod. |
 | `agent.k8s_jobs.mode` | `string` |  |  |
 | `agent.k8s_jobs.create_pr` | `bool` |  | CreatePR lets the agent Job open its own pull request once it has pushed its branch, instead of the server shelling gh in the task worktree. Only fires when the task's remote is a GitHub URL — a PVC-backed bare clone has no PR to open. Default false: the server-side create_pr workflow step still owns the normal path, and this would otherwise open a PR after every agent run rather than at the pr stage. |
 | `agent.k8s_jobs.env` | `[]K8sJobEnvVar` | _(see below)_ |  |

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -746,6 +746,16 @@ export class K8sJobsConfig {
     "image": string;
     "command": string[];
     "ttlSecondsAfterFinished": number;
+
+    /**
+     * FailedTTL overrides TTL for a Job that finishes Failed rather than
+     * Succeeded, via a post-completion patch once the runner observes the
+     * failure — Kubernetes' own ttlSecondsAfterFinished is a single value
+     * that cannot vary by outcome at creation time. Defaults much longer
+     * than TTL's own default so a failed run's logs survive long enough for
+     * an operator to pull them before Kubernetes garbage-collects the Pod.
+     */
+    "failedTtlSecondsAfterFinished": number;
     "mode": string;
 
     /**
@@ -778,6 +788,9 @@ export class K8sJobsConfig {
         if (!("ttlSecondsAfterFinished" in $$source)) {
             this["ttlSecondsAfterFinished"] = 0;
         }
+        if (!("failedTtlSecondsAfterFinished" in $$source)) {
+            this["failedTtlSecondsAfterFinished"] = 0;
+        }
         if (!("mode" in $$source)) {
             this["mode"] = "";
         }
@@ -802,21 +815,21 @@ export class K8sJobsConfig {
      */
     static createFrom($$source: any = {}): K8sJobsConfig {
         const $$createField3_0 = $$createType5;
-        const $$createField7_0 = $$createType7;
-        const $$createField8_0 = $$createType9;
-        const $$createField9_0 = $$createType11;
+        const $$createField8_0 = $$createType7;
+        const $$createField9_0 = $$createType9;
+        const $$createField10_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("command" in $$parsedSource) {
             $$parsedSource["command"] = $$createField3_0($$parsedSource["command"]);
         }
         if ("env" in $$parsedSource) {
-            $$parsedSource["env"] = $$createField7_0($$parsedSource["env"]);
+            $$parsedSource["env"] = $$createField8_0($$parsedSource["env"]);
         }
         if ("secretEnv" in $$parsedSource) {
-            $$parsedSource["secretEnv"] = $$createField8_0($$parsedSource["secretEnv"]);
+            $$parsedSource["secretEnv"] = $$createField9_0($$parsedSource["secretEnv"]);
         }
         if ("volumes" in $$parsedSource) {
-            $$parsedSource["volumes"] = $$createField9_0($$parsedSource["volumes"]);
+            $$parsedSource["volumes"] = $$createField10_0($$parsedSource["volumes"]);
         }
         return new K8sJobsConfig($$parsedSource as Partial<K8sJobsConfig>);
     }

--- a/internal/agent/k8s_job_runner.go
+++ b/internal/agent/k8s_job_runner.go
@@ -43,6 +43,7 @@ type K8sJobRunnerConfig struct {
 	Image     string
 	Command   []string
 	TTL       int
+	FailedTTL int
 	Mode      string
 	CreatePR  bool
 	Env       []K8sJobEnvVar
@@ -74,6 +75,7 @@ type k8sJobRunner struct {
 	image     string
 	command   []string
 	ttl       int
+	failedTTL int
 	mode      string
 	createPR  bool
 	env       []K8sJobEnvVar
@@ -104,12 +106,17 @@ func newK8sJobRunner(logger *slog.Logger, cfg K8sJobRunnerConfig) *k8sJobRunner 
 	if ttl == 0 {
 		ttl = 300
 	}
+	failedTTL := cfg.FailedTTL
+	if failedTTL == 0 {
+		failedTTL = 86400
+	}
 	return &k8sJobRunner{
 		logger:    logger,
 		namespace: ns,
 		image:     image,
 		command:   append([]string(nil), cfg.Command...),
 		ttl:       ttl,
+		failedTTL: failedTTL,
 		mode:      normalizeK8sRunnerMode(cfg.Mode),
 		createPR:  cfg.CreatePR,
 		env:       append([]K8sJobEnvVar(nil), cfg.Env...),
@@ -188,6 +195,11 @@ func (r *k8sJobRunner) Run(ctx context.Context, m *Manager, a *Agent, cfg RunCon
 		}
 		if failed {
 			a.SetExitErr(fmt.Errorf("kubernetes job %s failed", jobName))
+			if r.failedTTL != r.ttl {
+				if perr := r.patchJobTTL(ctx, jobName, r.failedTTL); perr != nil {
+					r.logger.Warn("agent.k8s.failed_ttl_patch", "job", jobName, "err", perr)
+				}
+			}
 		} else {
 			if err := syncK8sGitWorkspace(ctx, cfg.Dir); err != nil {
 				a.SetExitErr(err)
@@ -638,6 +650,34 @@ func (r *k8sJobRunner) jobDone(ctx context.Context, jobName string) (done, faile
 		return true, true, nil
 	}
 	return false, false, nil
+}
+
+// patchJobTTL overrides a Job's ttlSecondsAfterFinished after the fact. The
+// Kubernetes API only accepts a patch content type here (application/json on
+// a Job PATCH 415s), so this bypasses doJSON's fixed Content-Type rather than
+// complicating it for one caller.
+func (r *k8sJobRunner) patchJobTTL(ctx context.Context, jobName string, ttlSeconds int) error {
+	data, err := json.Marshal(map[string]any{"spec": map[string]any{"ttlSecondsAfterFinished": ttlSeconds}})
+	if err != nil {
+		return err
+	}
+	endpoint := "/apis/batch/v1/namespaces/" + url.PathEscape(r.namespace) + "/jobs/" + url.PathEscape(jobName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, r.apiURL+endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.token)
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("kubernetes PATCH %s: %s: %s", endpoint, resp.Status, strings.TrimSpace(string(b)))
+	}
+	return nil
 }
 
 func (r *k8sJobRunner) doJSON(ctx context.Context, method, endpoint string, body, out any) error {

--- a/internal/agent/k8s_job_runner.go
+++ b/internal/agent/k8s_job_runner.go
@@ -197,7 +197,9 @@ func (r *k8sJobRunner) Run(ctx context.Context, m *Manager, a *Agent, cfg RunCon
 			a.SetExitErr(fmt.Errorf("kubernetes job %s failed", jobName))
 			if r.failedTTL != r.ttl {
 				if perr := r.patchJobTTL(ctx, jobName, r.failedTTL); perr != nil {
-					r.logger.Warn("agent.k8s.failed_ttl_patch", "job", jobName, "err", perr)
+					r.logger.Warn("agent.k8s.failed_ttl_patch",
+						"job", jobName, "err", perr,
+						"hint", "failed-Job retention not extended past ttl_seconds_after_finished; check the patch verb on batch/jobs RBAC")
 				}
 			}
 		} else {

--- a/internal/agent/k8s_job_runner_test.go
+++ b/internal/agent/k8s_job_runner_test.go
@@ -287,6 +287,100 @@ func TestPatchJobTTLSendsMergePatch(t *testing.T) {
 	}
 }
 
+// TestK8sRunPatchesFailedJobTTL exercises Run() itself end-to-end against a
+// mocked Kubernetes API, not just patchJobTTL in isolation — a regression
+// that dropped the call, inverted the failedTTL!=ttl guard, or moved it into
+// the success branch would pass every other test in this file.
+func TestK8sRunPatchesFailedJobTTL(t *testing.T) {
+	var patchSeen bool
+	var patchTTL float64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/namespaces/sybra-poc/pods", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	})
+	mux.HandleFunc("/apis/batch/v1/namespaces/sybra-poc/jobs", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost {
+			t.Errorf("unexpected method on jobs collection: %s", req.Method)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	mux.HandleFunc("/apis/batch/v1/namespaces/sybra-poc/jobs/sybra-agent-test-agent", func(w http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": map[string]any{"failed": 1}})
+		case http.MethodPatch:
+			patchSeen = true
+			var body map[string]any
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			spec, _ := body["spec"].(map[string]any)
+			patchTTL, _ = spec["ttlSecondsAfterFinished"].(float64)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected method on job resource: %s", req.Method)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r := newK8sJobRunner(discardK8sLogger(), K8sJobRunnerConfig{Namespace: "sybra-poc", TTL: 300, FailedTTL: 86400})
+	r.apiURL = srv.URL
+	r.client = srv.Client()
+	r.token = "test-token"
+
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "test-agent", TaskID: "task-1", Provider: "claude"}
+
+	r.Run(t.Context(), m, a, RunConfig{})
+
+	if !patchSeen {
+		t.Fatal("expected a PATCH to extend TTL on the failed Job, saw none")
+	}
+	if patchTTL != 86400 {
+		t.Fatalf("patched ttlSecondsAfterFinished = %v, want 86400", patchTTL)
+	}
+	if a.GetExitErr() == nil {
+		t.Fatal("expected the agent to record an error for a failed Job")
+	}
+}
+
+// TestK8sRunSkipsPatchWhenFailedTTLMatchesTTL confirms the guard actually
+// saves the extra API call when there's nothing to extend.
+func TestK8sRunSkipsPatchWhenFailedTTLMatchesTTL(t *testing.T) {
+	var patchSeen bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/namespaces/sybra-poc/pods", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	})
+	mux.HandleFunc("/apis/batch/v1/namespaces/sybra-poc/jobs", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	mux.HandleFunc("/apis/batch/v1/namespaces/sybra-poc/jobs/sybra-agent-test-agent", func(w http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": map[string]any{"failed": 1}})
+		case http.MethodPatch:
+			patchSeen = true
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r := newK8sJobRunner(discardK8sLogger(), K8sJobRunnerConfig{Namespace: "sybra-poc", TTL: 300, FailedTTL: 300})
+	r.apiURL = srv.URL
+	r.client = srv.Client()
+	r.token = "test-token"
+
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "test-agent", TaskID: "task-1", Provider: "claude"}
+
+	r.Run(t.Context(), m, a, RunConfig{})
+
+	if patchSeen {
+		t.Fatal("expected no PATCH when failedTTL equals ttl — the Job already has that TTL from creation")
+	}
+}
+
 func TestPatchJobTTLReturnsErrorOnNonSuccessStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusUnsupportedMediaType)

--- a/internal/agent/k8s_job_runner_test.go
+++ b/internal/agent/k8s_job_runner_test.go
@@ -1,7 +1,11 @@
 package agent
 
 import (
+	"context"
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -232,4 +236,70 @@ func TestAppendK8sPRRepoEnv(t *testing.T) {
 
 func discardK8sLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
+}
+
+func TestK8sRunnerFailedTTLDefaultsWhenUnset(t *testing.T) {
+	r := newK8sJobRunner(nil, K8sJobRunnerConfig{})
+	if r.failedTTL != 86400 {
+		t.Fatalf("failedTTL = %d, want 86400", r.failedTTL)
+	}
+}
+
+func TestK8sRunnerFailedTTLHonorsConfiguredValue(t *testing.T) {
+	r := newK8sJobRunner(nil, K8sJobRunnerConfig{FailedTTL: 3600})
+	if r.failedTTL != 3600 {
+		t.Fatalf("failedTTL = %d, want 3600", r.failedTTL)
+	}
+}
+
+func TestPatchJobTTLSendsMergePatch(t *testing.T) {
+	var gotMethod, gotContentType, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotMethod = req.Method
+		gotContentType = req.Header.Get("Content-Type")
+		gotPath = req.URL.Path
+		_ = json.NewDecoder(req.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := newK8sJobRunner(discardK8sLogger(), K8sJobRunnerConfig{Namespace: "sybra-poc"})
+	r.apiURL = srv.URL
+	r.client = srv.Client()
+	r.token = "test-token"
+
+	if err := r.patchJobTTL(context.Background(), "sybra-agent-abc", 86400); err != nil {
+		t.Fatalf("patchJobTTL: %v", err)
+	}
+	if gotMethod != http.MethodPatch {
+		t.Fatalf("method = %s, want PATCH", gotMethod)
+	}
+	if gotContentType != "application/merge-patch+json" {
+		t.Fatalf("content-type = %s, want application/merge-patch+json", gotContentType)
+	}
+	if want := "/apis/batch/v1/namespaces/sybra-poc/jobs/sybra-agent-abc"; gotPath != want {
+		t.Fatalf("path = %s, want %s", gotPath, want)
+	}
+	spec, _ := gotBody["spec"].(map[string]any)
+	if got, want := spec["ttlSecondsAfterFinished"], float64(86400); got != want {
+		t.Fatalf("ttlSecondsAfterFinished = %v, want %v", got, want)
+	}
+}
+
+func TestPatchJobTTLReturnsErrorOnNonSuccessStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	r := newK8sJobRunner(discardK8sLogger(), K8sJobRunnerConfig{Namespace: "sybra-poc"})
+	r.apiURL = srv.URL
+	r.client = srv.Client()
+	r.token = "test-token"
+
+	if err := r.patchJobTTL(context.Background(), "sybra-agent-abc", 86400); err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
 }

--- a/internal/config/config_agent.go
+++ b/internal/config/config_agent.go
@@ -183,7 +183,14 @@ type K8sJobsConfig struct {
 	Image     string   `yaml:"image,omitempty" json:"image"`
 	Command   []string `yaml:"command,omitempty" json:"command"`
 	TTL       int      `yaml:"ttl_seconds_after_finished,omitempty" json:"ttlSecondsAfterFinished"`
-	Mode      string   `yaml:"mode,omitempty" json:"mode"`
+	// FailedTTL overrides TTL for a Job that finishes Failed rather than
+	// Succeeded, via a post-completion patch once the runner observes the
+	// failure — Kubernetes' own ttlSecondsAfterFinished is a single value
+	// that cannot vary by outcome at creation time. Defaults much longer
+	// than TTL's own default so a failed run's logs survive long enough for
+	// an operator to pull them before Kubernetes garbage-collects the Pod.
+	FailedTTL int    `yaml:"failed_ttl_seconds_after_finished,omitempty" json:"failedTtlSecondsAfterFinished"`
+	Mode      string `yaml:"mode,omitempty" json:"mode"`
 	// CreatePR lets the agent Job open its own pull request once it has pushed
 	// its branch, instead of the server shelling gh in the task worktree. Only
 	// fires when the task's remote is a GitHub URL — a PVC-backed bare clone

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -484,6 +484,7 @@ func k8sJobRunnerConfigFromConfig(cfg config.K8sJobsConfig) agent.K8sJobRunnerCo
 		Image:     cfg.Image,
 		Command:   cfg.Command,
 		TTL:       cfg.TTL,
+		FailedTTL: cfg.FailedTTL,
 		Mode:      cfg.Mode,
 		CreatePR:  cfg.CreatePR,
 	}


### PR DESCRIPTION
## Motivation

Every agent Job runs with `backoffLimit: 0`/`restartPolicy: Never`, so it hits a terminal Complete/Failed condition on its very first pod exit. The only cleanup path was a single `ttlSecondsAfterFinished` (default 300s) applied uniformly regardless of outcome — a failed run's logs had a five-minute window before `kubectl logs` stopped working, whether or not anyone was watching.

Closes #2102. Parent: #2094.

> Changelog: feat(k8s): Job TTL and retention policy

## Implementation information

- New `agent.k8s_jobs.failed_ttl_seconds_after_finished` config field (default 86400s). Kubernetes' `ttlSecondsAfterFinished` is a single scalar set at Job creation with no native way to vary it by outcome, so `k8sJobRunner.Run` instead PATCHes it onto the Job the moment it observes `status.failed > 0`, before finalizing the agent run — skipped when `failedTTL == ttl` (nothing to extend).
- `deploy/k8s-poc/rbac.yaml` gained the `patch` verb on `batch/jobs`, required for that PATCH against real (non-permissive-default) RBAC.
- `sybra-cli config doctor` warns when `ttl_seconds_after_finished` is set below 30s with a differing `failed_ttl_seconds_after_finished` — Kubernetes doesn't guarantee honoring a late TTL extension once a very short original window has already elapsed.
- New "Job cleanup and log retention" section in `deploy/k8s-poc/README.md`: both TTL knobs, how to inspect a failed run before cleanup (`kubectl logs`/`describe pod`/`ListAgents`), and the manual label-selector path for finding "stale" Jobs today — deliberately **not** implementing automatic stale-Job detection/pruning (#2111) or restart-time reconciliation (#2112), both already-open sibling issues in this umbrella that explicitly own that territory. This issue defines the retention policy; those two own the automation.

## Supporting documentation

Adversarial review raised four points; addressed the actionable three:
- No test exercised the actual `Run()` call site (guard, wiring to `jobDone`, position before `finalizeRun`) — added `TestK8sRunPatchesFailedJobTTL` and `TestK8sRunSkipsPatchWhenFailedTTLMatchesTTL`, driving `Run()` end-to-end against a mocked k8s API. Confirmed both catch the regression by temporarily inverting the guard and watching them fail.
- Extending TTL after the fact isn't Kubernetes-guaranteed if the original window already elapsed — added the `config doctor` low-TTL warning above.
- The RBAC-missing failure mode was a bare `Warn` log with no actionable text — the log line now names the fix (`check the patch verb on batch/jobs RBAC`).
- Not fixed: a single transient `jobDone` API error on the exact tick a Job goes Failed aborts the whole run-tracking loop before the patch can fire (pre-existing behavior of `Run()`'s error handling, not introduced here — fixing it means redesigning the polling loop's general resilience, disproportionate to this issue's scope and better suited to #2112's restart/reconciliation work).

Adversarial manual testing against a real k3d cluster (not just the unit tests):
- Forced two real Job failures via `FAKE_CLAUDE_SCENARIO=fail_exit`. Watched `spec.ttlSecondsAfterFinished` flip live from `300` to `86400` the instant `status.failed` became `1` (sub-second polling caught the transition).
- **Negative control**: removed the `patch` verb from the live Role, forced a third failure — got a real 403, the exact warning log with the new hint text, and confirmed the TTL correctly stayed at 300 (no false success). Restored RBAC afterward.
- Confirmed both Jobs still existed ~8 minutes post-failure, well past the original 300s window.
- Ran `sybra-cli config doctor` for real against both a triggering and a non-triggering TTL config.
- Ran all four `kubectl`/curl commands from the new README section verbatim — no typos.