### PR TITLE
fix(watchdog): spare in-status agent dispatch

### DIFF
--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -469,7 +469,7 @@ func (w *Watchdog) reapTaskAgentForStatus(ag *agent.Agent) bool {
 	if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
 		return false
 	}
-	if !shouldReleaseTaskAgentForStatus(t.Status) {
+	if !shouldReleaseTaskAgentForStatus(t.Status) || !agentPredatesStatus(ag, t) {
 		return false
 	}
 	w.logger.Warn("agent.watchdog.status_release",
@@ -491,7 +491,7 @@ func (w *Watchdog) reapIdleInteractive(ag *agent.Agent, now time.Time) {
 	if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
 		return
 	}
-	if shouldReleaseTaskAgentForStatus(t.Status) {
+	if shouldReleaseTaskAgentForStatus(t.Status) && agentPredatesStatus(ag, t) {
 		w.logger.Warn("agent.watchdog.status_release",
 			"id", ag.ID, "task_id", ag.TaskID, "status", t.Status)
 		if err := w.stopForRelease(ag); err != nil {
@@ -508,6 +508,21 @@ func (w *Watchdog) reapIdleInteractive(ag *agent.Agent, now time.Time) {
 
 func shouldReleaseTaskAgentForStatus(status task.Status) bool {
 	return status == task.StatusHumanRequired || task.IsTerminalStatus(status)
+}
+
+// agentPredatesStatus reports whether ag was already running before the
+// task's current status took effect, as opposed to one freshly dispatched
+// specifically to act on that status — most notably the human-review agent
+// (internal/sybra/app_human_review.go), which app.go launches the moment a
+// task transitions to human-required. Only a leftover from a prior status is
+// safe for the release reapers above to stop; a same-status dispatch needs to
+// be left alone to do its job, and if it gets stuck, caught by the normal
+// stall/budget/loop triggers instead. StatusChangedAt is only ever zero for
+// legacy task files, which Store.List backfills on read (see
+// internal/task/store.go), so treating a zero value as "predates" preserves
+// the reapers' original behavior for that edge case.
+func agentPredatesStatus(ag *agent.Agent, t task.Task) bool {
+	return t.StatusChangedAt.IsZero() || ag.StartedAt.Before(t.StatusChangedAt)
 }
 
 func (w *Watchdog) stopForRelease(ag *agent.Agent) error {

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -469,7 +469,7 @@ func (w *Watchdog) reapTaskAgentForStatus(ag *agent.Agent) bool {
 	if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
 		return false
 	}
-	if !shouldReleaseTaskAgentForStatus(t.Status) || !agentPredatesStatus(ag, t) {
+	if !shouldReleaseTaskAgentForStatus(t.Status) || isHumanReviewAgent(ag) {
 		return false
 	}
 	w.logger.Warn("agent.watchdog.status_release",
@@ -491,7 +491,7 @@ func (w *Watchdog) reapIdleInteractive(ag *agent.Agent, now time.Time) {
 	if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
 		return
 	}
-	if shouldReleaseTaskAgentForStatus(t.Status) && agentPredatesStatus(ag, t) {
+	if shouldReleaseTaskAgentForStatus(t.Status) && !isHumanReviewAgent(ag) {
 		w.logger.Warn("agent.watchdog.status_release",
 			"id", ag.ID, "task_id", ag.TaskID, "status", t.Status)
 		if err := w.stopForRelease(ag); err != nil {
@@ -510,19 +510,19 @@ func shouldReleaseTaskAgentForStatus(status task.Status) bool {
 	return status == task.StatusHumanRequired || task.IsTerminalStatus(status)
 }
 
-// agentPredatesStatus reports whether ag was already running before the
-// task's current status took effect, as opposed to one freshly dispatched
-// specifically to act on that status — most notably the human-review agent
-// (internal/sybra/app_human_review.go), which app.go launches the moment a
-// task transitions to human-required. Only a leftover from a prior status is
-// safe for the release reapers above to stop; a same-status dispatch needs to
-// be left alone to do its job, and if it gets stuck, caught by the normal
-// stall/budget/loop triggers instead. StatusChangedAt is only ever zero for
-// legacy task files, which Store.List backfills on read (see
-// internal/task/store.go), so treating a zero value as "predates" preserves
-// the reapers' original behavior for that edge case.
-func agentPredatesStatus(ag *agent.Agent, t task.Task) bool {
-	return t.StatusChangedAt.IsZero() || ag.StartedAt.Before(t.StatusChangedAt)
+// isHumanReviewAgent reports whether ag is the human-review agent
+// (internal/sybra/app_human_review.go), which app.go dispatches the moment a
+// task transitions to human-required specifically to diagnose and unblock
+// it. The status-release reapers above must not kill it just because the
+// task's status is — by design — human-required; if it gets stuck itself,
+// the normal stall/budget/loop triggers in inspectHeadless still apply. This
+// mirrors the same exclusion App.releaseTaskAgents already applies at the
+// point of the status transition (internal/sybra/app_init.go) — a role-based
+// check, not a timing-based one, so it can't be widened by a future status
+// change to spare an unrelated agent that raced onto an already-terminal
+// task, which is unconditionally an orphan under this reaper's contract.
+func isHumanReviewAgent(ag *agent.Agent) bool {
+	return agent.RoleFromName(ag.Name) == agent.RoleHumanReview
 }
 
 func (w *Watchdog) stopForRelease(ag *agent.Agent) error {

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1181,13 +1181,7 @@ func TestCheckCompletedHang_LiveBackgroundTaskExtendsGrace(t *testing.T) {
 
 func TestReapIdleInteractive_ReleasesHumanRequiredTaskAgent(t *testing.T) {
 	tasks, tk := newTestTasks(t)
-	// The agent predates the human-required transition — a genuine leftover
-	// from before the status flipped (e.g. the task was in-progress with a
-	// live interactive session, then got parked externally) — so it is safe
-	// for the reaper to release.
-	before := time.Now()
-	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
-	if err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
 		t.Fatalf("set human-required: %v", err)
 	}
 
@@ -1198,25 +1192,21 @@ func TestReapIdleInteractive_ReleasesHumanRequiredTaskAgent(t *testing.T) {
 		stopAgent: func(id string) error { stopped = id; return nil },
 	}
 
-	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: before, LastEventAt: before}
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: time.Now(), LastEventAt: time.Now()}
 	w.reapIdleInteractive(ag, time.Now())
 
 	if stopped != "a1" {
 		t.Fatalf("stopAgent called with %q, want a1", stopped)
 	}
-	if !got.StatusChangedAt.After(before) {
-		t.Fatalf("test setup invalid: StatusChangedAt %v not after agent StartedAt %v", got.StatusChangedAt, before)
-	}
 }
 
-// TestReapIdleInteractive_SparesAgentDispatchedForCurrentStatus guards
-// against #2221: a human-review (or any other) agent freshly dispatched
-// specifically to act on a just-set human-required status must not be killed
-// by the same-tick status-release reaper before it can do its job.
-func TestReapIdleInteractive_SparesAgentDispatchedForCurrentStatus(t *testing.T) {
+// TestReapIdleInteractive_SparesHumanReviewAgent guards against #2221: the
+// human-review agent app_human_review.go dispatches the moment a task
+// becomes human-required, specifically to act on that status, must not be
+// killed by the same-tick status-release reaper before it can do its job.
+func TestReapIdleInteractive_SparesHumanReviewAgent(t *testing.T) {
 	tasks, tk := newTestTasks(t)
-	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
-	if err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
 		t.Fatalf("set human-required: %v", err)
 	}
 
@@ -1227,12 +1217,15 @@ func TestReapIdleInteractive_SparesAgentDispatchedForCurrentStatus(t *testing.T)
 		stopAgent: func(id string) error { stopped = id; return nil },
 	}
 
-	startedAt := got.StatusChangedAt.Add(time.Millisecond)
-	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: startedAt, LastEventAt: startedAt}
-	w.reapIdleInteractive(ag, startedAt.Add(time.Second))
+	ag := &agent.Agent{
+		ID: "a1", TaskID: tk.ID, Mode: "interactive",
+		Name:      agent.RoleHumanReview.AgentName(tk.Title),
+		StartedAt: time.Now(), LastEventAt: time.Now(),
+	}
+	w.reapIdleInteractive(ag, time.Now())
 
 	if stopped != "" {
-		t.Fatalf("stopAgent called with %q, want agent left running", stopped)
+		t.Fatalf("stopAgent called with %q, want the human-review agent left running", stopped)
 	}
 }
 
@@ -1264,13 +1257,8 @@ func TestReapIdleInteractive_HardStopsHungTaskAgent(t *testing.T) {
 
 func TestReapTaskAgentForStatus_ReleasesOrphanedHeadlessAgent(t *testing.T) {
 	tasks, tk := newTestTasks(t)
-	before := time.Now()
-	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
-	if err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
 		t.Fatalf("set human-required: %v", err)
-	}
-	if !got.StatusChangedAt.After(before) {
-		t.Fatalf("test setup invalid: StatusChangedAt %v not after agent StartedAt %v", got.StatusChangedAt, before)
 	}
 
 	stopped := ""
@@ -1280,27 +1268,60 @@ func TestReapTaskAgentForStatus_ReleasesOrphanedHeadlessAgent(t *testing.T) {
 		stopAgent: func(id string) error { stopped = id; return nil },
 	}
 
-	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "headless", StartedAt: before, LastEventAt: before}
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "headless", StartedAt: time.Now(), LastEventAt: time.Now()}
 	if !w.reapTaskAgentForStatus(ag) {
-		t.Fatal("reapTaskAgentForStatus = false, want true for a pre-existing agent")
+		t.Fatal("reapTaskAgentForStatus = false, want true for a non-human-review agent")
 	}
 	if stopped != "a1" {
 		t.Fatalf("stopAgent called with %q, want a1", stopped)
 	}
 }
 
-// TestReapTaskAgentForStatus_SparesAgentDispatchedForCurrentStatus is the
-// regression guard for the human-review self-defeat bug: the human-review
-// agent (internal/sybra/app_human_review.go) is dispatched the moment a task
-// becomes human-required specifically to diagnose and unblock it. Before this
-// fix, the very next watchdog tick treated it as an orphan of the status it
-// was launched to handle and killed it seconds in — both e153081f and
-// 27dd0478 landed here with an empty verdict because of this race.
-func TestReapTaskAgentForStatus_SparesAgentDispatchedForCurrentStatus(t *testing.T) {
+// TestReapTaskAgentForStatus_SparesHumanReviewAgent is the regression guard
+// for the human-review self-defeat bug: the human-review agent
+// (internal/sybra/app_human_review.go) is dispatched the moment a task
+// becomes human-required specifically to diagnose and unblock it. Before
+// this fix, the very next watchdog tick treated it as an orphan of the
+// status it was launched to handle and killed it seconds in — both
+// e153081f and 27dd0478 landed here with an empty verdict because of this
+// race.
+func TestReapTaskAgentForStatus_SparesHumanReviewAgent(t *testing.T) {
 	tasks, tk := newTestTasks(t)
-	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
-	if err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
 		t.Fatalf("set human-required: %v", err)
+	}
+
+	stopped := ""
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	ag := &agent.Agent{
+		ID: "a1", TaskID: tk.ID, Mode: "headless",
+		Name:      agent.RoleHumanReview.AgentName(tk.Title),
+		StartedAt: time.Now(), LastEventAt: time.Now(),
+	}
+	if w.reapTaskAgentForStatus(ag) {
+		t.Fatal("reapTaskAgentForStatus = true, want false for the human-review agent")
+	}
+	if stopped != "" {
+		t.Fatalf("stopAgent called with %q, want the human-review agent left running", stopped)
+	}
+}
+
+// TestReapTaskAgentForStatus_ReleasesAnyAgentOnTerminalStatus guards the
+// original, broader contract this reaper exists for (#1877): once a task is
+// terminal, any non-human-review agent still attached to it is an orphan
+// regardless of when it started relative to the transition — there is no
+// legitimate path that dispatches a fresh agent to act on an
+// already-closed task the way human-review does for human-required.
+func TestReapTaskAgentForStatus_ReleasesAnyAgentOnTerminalStatus(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusDone)})
+	if err != nil {
+		t.Fatalf("set done: %v", err)
 	}
 
 	stopped := ""
@@ -1312,11 +1333,11 @@ func TestReapTaskAgentForStatus_SparesAgentDispatchedForCurrentStatus(t *testing
 
 	startedAt := got.StatusChangedAt.Add(time.Millisecond)
 	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "headless", StartedAt: startedAt, LastEventAt: startedAt}
-	if w.reapTaskAgentForStatus(ag) {
-		t.Fatal("reapTaskAgentForStatus = true, want false for an agent dispatched after the status change")
+	if !w.reapTaskAgentForStatus(ag) {
+		t.Fatal("reapTaskAgentForStatus = false, want true: any live agent on a terminal task is an orphan")
 	}
-	if stopped != "" {
-		t.Fatalf("stopAgent called with %q, want agent left running", stopped)
+	if stopped != "a1" {
+		t.Fatalf("stopAgent called with %q, want a1", stopped)
 	}
 }
 

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1181,7 +1181,13 @@ func TestCheckCompletedHang_LiveBackgroundTaskExtendsGrace(t *testing.T) {
 
 func TestReapIdleInteractive_ReleasesHumanRequiredTaskAgent(t *testing.T) {
 	tasks, tk := newTestTasks(t)
-	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+	// The agent predates the human-required transition — a genuine leftover
+	// from before the status flipped (e.g. the task was in-progress with a
+	// live interactive session, then got parked externally) — so it is safe
+	// for the reaper to release.
+	before := time.Now()
+	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
+	if err != nil {
 		t.Fatalf("set human-required: %v", err)
 	}
 
@@ -1192,11 +1198,41 @@ func TestReapIdleInteractive_ReleasesHumanRequiredTaskAgent(t *testing.T) {
 		stopAgent: func(id string) error { stopped = id; return nil },
 	}
 
-	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: time.Now(), LastEventAt: time.Now()}
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: before, LastEventAt: before}
 	w.reapIdleInteractive(ag, time.Now())
 
 	if stopped != "a1" {
 		t.Fatalf("stopAgent called with %q, want a1", stopped)
+	}
+	if !got.StatusChangedAt.After(before) {
+		t.Fatalf("test setup invalid: StatusChangedAt %v not after agent StartedAt %v", got.StatusChangedAt, before)
+	}
+}
+
+// TestReapIdleInteractive_SparesAgentDispatchedForCurrentStatus guards
+// against #2221: a human-review (or any other) agent freshly dispatched
+// specifically to act on a just-set human-required status must not be killed
+// by the same-tick status-release reaper before it can do its job.
+func TestReapIdleInteractive_SparesAgentDispatchedForCurrentStatus(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
+	if err != nil {
+		t.Fatalf("set human-required: %v", err)
+	}
+
+	stopped := ""
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	startedAt := got.StatusChangedAt.Add(time.Millisecond)
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "interactive", StartedAt: startedAt, LastEventAt: startedAt}
+	w.reapIdleInteractive(ag, startedAt.Add(time.Second))
+
+	if stopped != "" {
+		t.Fatalf("stopAgent called with %q, want agent left running", stopped)
 	}
 }
 
@@ -1223,6 +1259,64 @@ func TestReapIdleInteractive_HardStopsHungTaskAgent(t *testing.T) {
 	}
 	if stopped != "a1" {
 		t.Fatalf("stopAgent called with %q, want a1", stopped)
+	}
+}
+
+func TestReapTaskAgentForStatus_ReleasesOrphanedHeadlessAgent(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	before := time.Now()
+	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
+	if err != nil {
+		t.Fatalf("set human-required: %v", err)
+	}
+	if !got.StatusChangedAt.After(before) {
+		t.Fatalf("test setup invalid: StatusChangedAt %v not after agent StartedAt %v", got.StatusChangedAt, before)
+	}
+
+	stopped := ""
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "headless", StartedAt: before, LastEventAt: before}
+	if !w.reapTaskAgentForStatus(ag) {
+		t.Fatal("reapTaskAgentForStatus = false, want true for a pre-existing agent")
+	}
+	if stopped != "a1" {
+		t.Fatalf("stopAgent called with %q, want a1", stopped)
+	}
+}
+
+// TestReapTaskAgentForStatus_SparesAgentDispatchedForCurrentStatus is the
+// regression guard for the human-review self-defeat bug: the human-review
+// agent (internal/sybra/app_human_review.go) is dispatched the moment a task
+// becomes human-required specifically to diagnose and unblock it. Before this
+// fix, the very next watchdog tick treated it as an orphan of the status it
+// was launched to handle and killed it seconds in — both e153081f and
+// 27dd0478 landed here with an empty verdict because of this race.
+func TestReapTaskAgentForStatus_SparesAgentDispatchedForCurrentStatus(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	got, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)})
+	if err != nil {
+		t.Fatalf("set human-required: %v", err)
+	}
+
+	stopped := ""
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(id string) error { stopped = id; return nil },
+	}
+
+	startedAt := got.StatusChangedAt.Add(time.Millisecond)
+	ag := &agent.Agent{ID: "a1", TaskID: tk.ID, Mode: "headless", StartedAt: startedAt, LastEventAt: startedAt}
+	if w.reapTaskAgentForStatus(ag) {
+		t.Fatal("reapTaskAgentForStatus = true, want false for an agent dispatched after the status change")
+	}
+	if stopped != "" {
+		t.Fatalf("stopAgent called with %q, want agent left running", stopped)
 	}
 }
 


### PR DESCRIPTION
## Motivation

`reapTaskAgentForStatus`/`reapIdleInteractive` (internal/watchdog/agent.go) force-stop any live agent once a task's status hits human-required/terminal — meant to clean up leftovers from before a status flip. They never excluded the human-review agent app_human_review.go dispatches specifically *because* a task just became human-required, so the watchdog killed its own remediation agent within one 30s tick, before it could ever read logs or produce a verdict. Confirmed live against two real tasks (kept abstract per repo confidentiality rules — one on a work-typed project): both landed with an empty verdict, `verdict: empty input`, 14-24s after the human-review agent started.

## Implementation information

Both reapers now spare only the human-review agent by name (`agent.RoleFromName(ag.Name) == agent.RoleHumanReview`), mirroring the exclusion `App.releaseTaskAgents` already applies at the point of the status transition itself (internal/sybra/app_init.go). Any other agent is still reaped on any status, including already-terminal ones — an earlier timing-based approach (agent StartedAt vs. task StatusChangedAt) was rejected in adversarial review because it also spared late-started agents on terminal tasks, weakening that original safety net with no fallback supervision.

Added regression tests: sparing the human-review agent on human-required (headless + interactive), still reaping a non-human-review agent on human-required, and still reaping any agent on a terminal status. Verified live against a real running sybra-server (isolated sandbox, fake provider CLI): a human-review-named agent survived a human-required transition while a same-status control agent was correctly reaped.

Closes #2221

> Changelog: fix(watchdog): spare in-status agent dispatch