### PR TITLE
fix(sybra): retry crashed human-review agent

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1287,6 +1287,20 @@ func (a *Agent) TerminalResultIdle(grace time.Duration) bool {
 	return time.Since(a.LastEventAt) >= grace
 }
 
+// HadTerminalError reports whether the headless stream buffer contains a
+// terminal result event that ended in an error (e.g. a CLI-level
+// error_during_execution, distinct from a provider rate-limit/auth signal
+// classified via SetError/GetErrorKind). Callers use this to tell "the agent
+// crashed before producing any usable output" apart from "the agent finished
+// and returned text that just didn't parse the way we expected" — the two
+// need different recovery treatment.
+func (a *Agent) HadTerminalError() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	found, isError := bufferedResultEvent(a.outputBuffer)
+	return found && isError
+}
+
 // bufferedResultEvent scans the full event slice for the last "result" event,
 // regardless of whether it is the final element — unlike
 // lastHeadlessResultEvent, which requires the result to be strictly last.

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -927,11 +927,8 @@ func (h *humanReviewHandler) allowSpawnForTaskLocked(taskID string) bool {
 // further attempt fits within the window before maybeSpawn's own budget
 // checks start rejecting further spawns.
 //
-// Returns maybeSpawn's own report of whether a review agent was actually
-// dispatched — not merely whether this method decided to try. maybeSpawn can
-// still decline (global fleet-wide rate limit, a race on the per-task budget,
-// or the spawn call itself failing) after this method's own pre-check passes,
-// and the caller needs to know that happened rather than assume success.
+// This method has no budget check of its own; maybeSpawn's bool return is
+// the only source of truth on whether a retry actually dispatched.
 //
 // Called from onComplete before its own `defer delete(h.inflight, taskID)`
 // runs, so the crashed run's own slot must be freed here first — otherwise

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -147,29 +147,31 @@ func (a *App) initHumanReview() {
 // maybeSpawn is called from the status hook when a task lands in
 // human-required. Returns immediately if the feature is disabled, the task
 // already has an in-flight review, or the rolling rate limit is exceeded.
-func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
+// The bool return reports whether a review agent was actually dispatched —
+// retryAfterCrash relies on it to tell a real retry apart from a silent skip.
+func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) bool {
 	if h == nil {
-		return
+		return false
 	}
 	// Don't loop when an unblock flow flips blocked → todo → human-required.
 	if prevStatus == string(task.StatusBlocked) {
 		h.skip(taskID, "prev_status_blocked")
-		return
+		return false
 	}
 	t, err := h.tasks.Get(taskID)
 	if err != nil {
 		h.logger.Error("human-review.task.get", "task_id", taskID, "err", err)
-		return
+		return false
 	}
 	// Idempotency gate: a prior run already produced a verdict — re-spawning
 	// on app restart or repeated status hooks would just duplicate the diagnosis.
 	if verdictAlreadyRendered(t) {
 		h.skip(taskID, "verdict_rendered")
-		return
+		return false
 	}
 	if strings.TrimSpace(t.ProjectID) == "" {
 		h.skip(taskID, "no_project")
-		return
+		return false
 	}
 	// Work-Data Confidentiality: if the task's project is work-typed, the
 	// review still runs (we want the diagnosis) but the prompt is augmented
@@ -184,17 +186,17 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 	if _, busy := h.inflight[taskID]; busy {
 		h.mu.Unlock()
 		h.skip(taskID, "in_flight")
-		return
+		return false
 	}
 	if !h.allowSpawnLocked() {
 		h.mu.Unlock()
 		h.skip(taskID, "rate_limited")
-		return
+		return false
 	}
 	if !h.allowSpawnForTaskLocked(taskID) {
 		h.mu.Unlock()
 		h.skip(taskID, "task_rate_limited")
-		return
+		return false
 	}
 	// Reserve the slot before spawning so a racing second flip is rejected.
 	h.inflight[taskID] = ""
@@ -223,7 +225,7 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		h.mu.Unlock()
 		h.logger.Error("human-review.spawn", "task_id", taskID, "err", err)
 		h.logAudit(audit.EventHumanReviewSkipped, taskID, "", map[string]any{"reason": "spawn_failed", "err": err.Error()})
-		return
+		return false
 	}
 	h.mu.Lock()
 	h.inflight[taskID] = ag.ID
@@ -243,6 +245,7 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 	h.logAudit(audit.EventHumanReviewSpawned, taskID, ag.ID, map[string]any{
 		"prev_status": prevStatus, "model": h.cfg.HumanReviewModel(),
 	})
+	return true
 }
 
 // onComplete is the routing target inside App.onAgentComplete for runs whose
@@ -298,13 +301,11 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 			h.logAudit(audit.EventHumanReviewSkipped, taskID, ag.ID, map[string]any{"reason": "provider_rate_limited"})
 			return
 		}
-		// A crashed run (e.g. error_during_execution before any tool call)
-		// produces no usable final text, which would otherwise fall through
-		// to the generic "unparseable verdict" path below and get marked
-		// verdict_rendered — permanently disabling further autonomy attempts
-		// via the idempotency gate in maybeSpawn, even though the autonomy
-		// mandate never actually ran.
-		if ag.HadTerminalError() {
+		// Without the zero-tool-calls check, a run that did real diagnostic
+		// work and only errored at the very end would be treated the same as
+		// an instant crash and get retried/discarded instead of routing
+		// through the ordinary unparseable-verdict path below.
+		if ag.HadTerminalError() && ag.GetToolCalls() == 0 {
 			h.handleCrashedVerdict(taskID, ag)
 			return
 		}
@@ -350,11 +351,15 @@ func (h *humanReviewHandler) handleCrashedVerdict(taskID string, ag *agent.Agent
 		return
 	}
 	h.logger.Warn("human-review.verdict.crashed-exhausted", "task_id", taskID, "agent_id", ag.ID)
+	// Deliberately silent on retry count: retryAfterCrash's true/false only
+	// says whether maybeSpawn actually dispatched a retry, not how many were
+	// attempted, so this note must not assert a specific attempt count.
 	if h.appendNote(taskID, "Auto-review (crashed)",
-		"The autonomy-mandate agent crashed before producing a diagnosis, on repeated "+
-			"attempts. This is a genuine human-required case, but note the automated "+
-			"recovery attempt never actually ran to completion — it errored out before "+
-			"doing anything, so the failure itself has not been reviewed.") {
+		"The autonomy-mandate agent crashed before producing a diagnosis, and an "+
+			"automatic retry could not be dispatched (spawn budget exhausted, or the "+
+			"retry attempt itself failed to start). This is a genuine human-required "+
+			"case, but note the failure itself has not actually been reviewed — the "+
+			"automated recovery never completed a run.") {
 		h.markVerdictRendered(taskID, ag.ID)
 	}
 	h.logAudit(audit.EventHumanReviewVerdict, taskID, ag.ID, map[string]any{
@@ -919,9 +924,14 @@ func (h *humanReviewHandler) allowSpawnForTaskLocked(taskID string) bool {
 // existing per-task spawn budget (allowSpawnForTaskLocked,
 // humanReviewMaxPerTaskPerWindow) as the retry bound instead of adding a
 // second counter: the crashed run already consumed one slot, so at most one
-// further attempt fits within the window before allowSpawnForTaskLocked (and
-// maybeSpawn's own re-check) start rejecting further spawns. Returns true if
-// a retry was dispatched.
+// further attempt fits within the window before maybeSpawn's own budget
+// checks start rejecting further spawns.
+//
+// Returns maybeSpawn's own report of whether a review agent was actually
+// dispatched — not merely whether this method decided to try. maybeSpawn can
+// still decline (global fleet-wide rate limit, a race on the per-task budget,
+// or the spawn call itself failing) after this method's own pre-check passes,
+// and the caller needs to know that happened rather than assume success.
 //
 // Called from onComplete before its own `defer delete(h.inflight, taskID)`
 // runs, so the crashed run's own slot must be freed here first — otherwise
@@ -930,13 +940,8 @@ func (h *humanReviewHandler) allowSpawnForTaskLocked(taskID string) bool {
 func (h *humanReviewHandler) retryAfterCrash(taskID string) bool {
 	h.mu.Lock()
 	delete(h.inflight, taskID)
-	ok := h.allowSpawnForTaskLocked(taskID)
 	h.mu.Unlock()
-	if !ok {
-		return false
-	}
-	h.maybeSpawn(taskID, "human-required")
-	return true
+	return h.maybeSpawn(taskID, "human-required")
 }
 
 func (h *humanReviewHandler) logAudit(evt, taskID, agentID string, data map[string]any) {

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -254,7 +254,14 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 	taskID := ag.TaskID
 	defer func() {
 		h.mu.Lock()
-		delete(h.inflight, taskID)
+		// Only clear the slot if it still belongs to this completing agent.
+		// A crash-retry dispatched earlier in this same call (see
+		// retryAfterCrash) registers a new inflight agent for taskID before
+		// this defer runs; blindly deleting here would wipe that fresh
+		// registration and reopen the in_flight guard for the retry.
+		if h.inflight[taskID] == ag.ID {
+			delete(h.inflight, taskID)
+		}
 		h.mu.Unlock()
 	}()
 
@@ -291,6 +298,16 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 			h.logAudit(audit.EventHumanReviewSkipped, taskID, ag.ID, map[string]any{"reason": "provider_rate_limited"})
 			return
 		}
+		// A crashed run (e.g. error_during_execution before any tool call)
+		// produces no usable final text, which would otherwise fall through
+		// to the generic "unparseable verdict" path below and get marked
+		// verdict_rendered — permanently disabling further autonomy attempts
+		// via the idempotency gate in maybeSpawn, even though the autonomy
+		// mandate never actually ran.
+		if ag.HadTerminalError() {
+			h.handleCrashedVerdict(taskID, ag)
+			return
+		}
 		h.logger.Warn("human-review.verdict.parse", "task_id", taskID, "agent_id", ag.ID, "err", parseErr)
 		if h.appendNote(taskID, "Auto-review (unparseable verdict)", h.scrubForTask(current.ProjectID, final)) {
 			h.markVerdictRendered(taskID, ag.ID)
@@ -311,42 +328,74 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 			h.markVerdictRendered(taskID, ag.ID)
 		}
 	case "sybra_bug":
-		// Re-check work context at completion time so a project re-typed
-		// during the review run still routes correctly.
-		var wctx *WorkScrubContext
-		if h.workCtx != nil {
-			if t, err := h.tasks.Get(taskID); err == nil {
-				wctx = h.workCtx(t.ProjectID)
-			}
-		}
-		switch h.cfg.HumanReviewSybraBugAction() {
-		case config.HumanReviewSybraBugActionNoteOnly:
-			if wctx != nil {
-				v = scrubVerdict(v, wctx)
-			}
-			h.noteSybraBugOnly(taskID, ag.ID, v)
-		case config.HumanReviewSybraBugActionBlockOnly:
-			if wctx != nil {
-				v = scrubVerdict(v, wctx)
-			}
-			h.blockSybraBugOnly(taskID, ag.ID, v)
-		case config.HumanReviewSybraBugActionLocalTask:
-			if wctx != nil {
-				h.fileLocalScrubbed(taskID, ag.ID, v, wctx)
-			} else {
-				h.fileLocalConfigured(taskID, ag.ID, v)
-			}
-		default:
-			if wctx != nil {
-				h.fileLocalScrubbed(taskID, ag.ID, v, wctx)
-			} else {
-				h.fileIssue(taskID, ag.ID, v)
-			}
-		}
+		h.handleSybraBugVerdict(taskID, ag, v)
 	default:
 		h.logger.Warn("human-review.verdict.unknown", "task_id", taskID, "decision", v.Decision)
 		if h.appendNote(taskID, "Auto-review (unknown decision)", h.scrubForTask(current.ProjectID, final)) {
 			h.markVerdictRendered(taskID, ag.ID)
+		}
+	}
+}
+
+// handleCrashedVerdict is onComplete's branch for a review run that produced
+// no usable output because it crashed (HadTerminalError). It retries once via
+// the existing per-task spawn budget rather than falling through to the
+// generic unparseable-verdict path, which would mark verdict_rendered and
+// permanently disable further autonomy attempts for a run that never
+// actually diagnosed anything.
+func (h *humanReviewHandler) handleCrashedVerdict(taskID string, ag *agent.Agent) {
+	h.logger.Warn("human-review.verdict.crashed", "task_id", taskID, "agent_id", ag.ID)
+	h.logAudit(audit.EventHumanReviewSkipped, taskID, ag.ID, map[string]any{"reason": "crashed_before_output"})
+	if h.retryAfterCrash(taskID) {
+		return
+	}
+	h.logger.Warn("human-review.verdict.crashed-exhausted", "task_id", taskID, "agent_id", ag.ID)
+	if h.appendNote(taskID, "Auto-review (crashed)",
+		"The autonomy-mandate agent crashed before producing a diagnosis, on repeated "+
+			"attempts. This is a genuine human-required case, but note the automated "+
+			"recovery attempt never actually ran to completion — it errored out before "+
+			"doing anything, so the failure itself has not been reviewed.") {
+		h.markVerdictRendered(taskID, ag.ID)
+	}
+	h.logAudit(audit.EventHumanReviewVerdict, taskID, ag.ID, map[string]any{
+		"decision": "crashed_exhausted", "verdict_source": "unparseable",
+	})
+}
+
+// handleSybraBugVerdict is onComplete's branch for a "sybra_bug" verdict. It
+// re-checks the work context at completion time (rather than reusing the one
+// captured before the review agent ran) so a project re-typed work/pet during
+// the run still routes to the right sink, then dispatches per
+// HumanReviewSybraBugAction.
+func (h *humanReviewHandler) handleSybraBugVerdict(taskID string, ag *agent.Agent, v verdictDecision) {
+	var wctx *WorkScrubContext
+	if h.workCtx != nil {
+		if t, err := h.tasks.Get(taskID); err == nil {
+			wctx = h.workCtx(t.ProjectID)
+		}
+	}
+	switch h.cfg.HumanReviewSybraBugAction() {
+	case config.HumanReviewSybraBugActionNoteOnly:
+		if wctx != nil {
+			v = scrubVerdict(v, wctx)
+		}
+		h.noteSybraBugOnly(taskID, ag.ID, v)
+	case config.HumanReviewSybraBugActionBlockOnly:
+		if wctx != nil {
+			v = scrubVerdict(v, wctx)
+		}
+		h.blockSybraBugOnly(taskID, ag.ID, v)
+	case config.HumanReviewSybraBugActionLocalTask:
+		if wctx != nil {
+			h.fileLocalScrubbed(taskID, ag.ID, v, wctx)
+		} else {
+			h.fileLocalConfigured(taskID, ag.ID, v)
+		}
+	default:
+		if wctx != nil {
+			h.fileLocalScrubbed(taskID, ag.ID, v, wctx)
+		} else {
+			h.fileIssue(taskID, ag.ID, v)
 		}
 	}
 }
@@ -863,6 +912,31 @@ func (h *humanReviewHandler) allowSpawnForTaskLocked(taskID string) bool {
 		h.perTask[taskID] = kept
 	}
 	return len(kept) < humanReviewMaxPerTaskPerWindow
+}
+
+// retryAfterCrash re-spawns the autonomy-mandate agent once for a task whose
+// review run crashed before producing any output. It deliberately reuses the
+// existing per-task spawn budget (allowSpawnForTaskLocked,
+// humanReviewMaxPerTaskPerWindow) as the retry bound instead of adding a
+// second counter: the crashed run already consumed one slot, so at most one
+// further attempt fits within the window before allowSpawnForTaskLocked (and
+// maybeSpawn's own re-check) start rejecting further spawns. Returns true if
+// a retry was dispatched.
+//
+// Called from onComplete before its own `defer delete(h.inflight, taskID)`
+// runs, so the crashed run's own slot must be freed here first — otherwise
+// maybeSpawn's in_flight guard sees the (still-registered) crashed run and
+// silently skips the retry.
+func (h *humanReviewHandler) retryAfterCrash(taskID string) bool {
+	h.mu.Lock()
+	delete(h.inflight, taskID)
+	ok := h.allowSpawnForTaskLocked(taskID)
+	h.mu.Unlock()
+	if !ok {
+		return false
+	}
+	h.maybeSpawn(taskID, "human-required")
+	return true
 }
 
 func (h *humanReviewHandler) logAudit(evt, taskID, agentID string, data map[string]any) {

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -1509,12 +1509,11 @@ func TestOnComplete_CrashedVerdict_ExhaustedRetriesMarksDistinguishableNote(t *t
 }
 
 // TestOnComplete_CrashedVerdict_GlobalCapDeclinesRetrySilently pins that a
-// retry attempt maybeSpawn silently declines for a reason other than the
-// per-task budget (here: the fleet-wide global cap, allowSpawnLocked) still
-// lands on the distinguishable crashed-exhausted note rather than acting as
-// if a retry actually happened. retryAfterCrash's own pre-check only covers
-// the per-task budget, so this exercises the case where that pre-check would
-// have said "go ahead" but maybeSpawn's independent global check declines.
+// retry maybeSpawn declines for a reason retryAfterCrash never checks itself
+// (here: the fleet-wide global cap, allowSpawnLocked) still lands on the
+// distinguishable crashed-exhausted note rather than acting as if a retry
+// actually happened — retryAfterCrash trusts maybeSpawn's own bool return,
+// it has no budget logic of its own to get out of sync with.
 func TestOnComplete_CrashedVerdict_GlobalCapDeclinesRetrySilently(t *testing.T) {
 	t.Parallel()
 	h, tasks, _, cleanup := newReviewTestEnv(t)

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -261,7 +261,7 @@ func TestOnComplete_HumanVerdict_AppendsNote(t *testing.T) {
 		t.Fatalf("flip to human-required: %v", err)
 	}
 
-	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag := &agent.Agent{ID: "agent-1", TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
 	ag.AppendOutput(agent.StreamEvent{
 		Type: "assistant",
 		Content: "Verdict below.\n\n```sybra-verdict\n" +
@@ -357,7 +357,7 @@ func TestOnComplete_UnblockedVerdict_NotesAndDoesNotBlock(t *testing.T) {
 		t.Fatalf("advance to ready-pr: %v", err)
 	}
 
-	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag := &agent.Agent{ID: "agent-1", TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
 	ag.AppendOutput(agent.StreamEvent{
 		Type: "assistant",
 		Content: "```sybra-verdict\n" +
@@ -730,7 +730,7 @@ func TestOnComplete_StaleVerdictSkipsWhenTaskNoLongerHumanRequired(t *testing.T)
 		t.Fatalf("requeue task: %v", err)
 	}
 
-	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag := &agent.Agent{ID: "agent-stale", TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
 	ag.AppendOutput(agent.StreamEvent{
 		Type: "assistant",
 		Content: "Diagnosis.\n\n```sybra-verdict\n" + `{
@@ -1399,5 +1399,108 @@ func TestOnComplete_SetsVerdictRendered(t *testing.T) {
 	}
 	if !rendered {
 		t.Error("expected AgentRun.VerdictRendered=true after onComplete; idempotency gate will not block re-spawn")
+	}
+}
+
+// TestOnComplete_CrashedVerdict_RetriesOnce pins that a review run that
+// crashed before producing any output (e.g. error_during_execution) triggers
+// a retry spawn rather than being treated like a normal unparseable verdict.
+// h.agents is nil in newReviewTestEnv, so a genuine retry attempt panics
+// inside maybeSpawn — the same "panic proves a spawn was attempted" signal
+// TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered relies on.
+func TestOnComplete_CrashedVerdict_RetriesOnce(t *testing.T) {
+	t.Parallel()
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	const agentID = "agent-hr-crash-1"
+	tk, err := tasks.Create("Crashed review", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	// ProjectID must be non-empty: maybeSpawn's no_project gate would
+	// otherwise skip before the retry logic under test ever runs.
+	if _, err := tasks.Update(tk.ID, task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		ProjectID: task.Ptr("owner/repo"),
+	}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: agentID,
+		Role:    string(agent.RoleHumanReview),
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	ag := &agent.Agent{ID: agentID, TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Subtype: "error_during_execution"})
+	h.inflight[tk.ID] = agentID
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected a retry spawn attempt (nil h.agents panics inside maybeSpawn)")
+		}
+	}()
+	h.onComplete(ag)
+	t.Fatal("onComplete should have panicked via the retry spawn before reaching here")
+}
+
+// TestOnComplete_CrashedVerdict_ExhaustedRetriesMarksDistinguishableNote pins
+// that once the per-task spawn budget is exhausted (this crash would be the
+// second spawn within the window), onComplete stops retrying and leaves a
+// note that says the automated recovery crashed rather than reviewed the
+// task — not the generic "unparseable verdict" text, and not silence.
+func TestOnComplete_CrashedVerdict_ExhaustedRetriesMarksDistinguishableNote(t *testing.T) {
+	t.Parallel()
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	const agentID = "agent-hr-crash-2"
+	tk, err := tasks.Create("Crashed review, exhausted", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: agentID,
+		Role:    string(agent.RoleHumanReview),
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+	// Simulate the per-task window budget already spent (humanReviewMaxPerTaskPerWindow=2):
+	// this completion represents the second spawn, so no further retry fits.
+	h.perTask[tk.ID] = []time.Time{h.now(), h.now()}
+
+	ag := &agent.Agent{ID: agentID, TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Subtype: "error_during_execution"})
+	h.inflight[tk.ID] = agentID
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if !strings.Contains(got.Body, "crashed") {
+		t.Errorf("expected a distinguishable crash note in body; got:\n%s", got.Body)
+	}
+	if strings.Contains(got.Body, "unparseable verdict") {
+		t.Errorf("crash exhaustion should not read like a normal unparseable verdict; got:\n%s", got.Body)
+	}
+	var rendered bool
+	for i := range got.AgentRuns {
+		if got.AgentRuns[i].AgentID == agentID {
+			rendered = got.AgentRuns[i].VerdictRendered
+			break
+		}
+	}
+	if !rendered {
+		t.Error("expected VerdictRendered=true once retries are exhausted, so the task doesn't loop forever")
 	}
 }

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -1463,7 +1463,10 @@ func TestOnComplete_CrashedVerdict_ExhaustedRetriesMarksDistinguishableNote(t *t
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+	if _, err := tasks.Update(tk.ID, task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		ProjectID: task.Ptr("owner/repo"),
+	}); err != nil {
 		t.Fatalf("flip to human-required: %v", err)
 	}
 	if err := tasks.AddRun(tk.ID, task.AgentRun{
@@ -1502,5 +1505,119 @@ func TestOnComplete_CrashedVerdict_ExhaustedRetriesMarksDistinguishableNote(t *t
 	}
 	if !rendered {
 		t.Error("expected VerdictRendered=true once retries are exhausted, so the task doesn't loop forever")
+	}
+}
+
+// TestOnComplete_CrashedVerdict_GlobalCapDeclinesRetrySilently pins that a
+// retry attempt maybeSpawn silently declines for a reason other than the
+// per-task budget (here: the fleet-wide global cap, allowSpawnLocked) still
+// lands on the distinguishable crashed-exhausted note rather than acting as
+// if a retry actually happened. retryAfterCrash's own pre-check only covers
+// the per-task budget, so this exercises the case where that pre-check would
+// have said "go ahead" but maybeSpawn's independent global check declines.
+func TestOnComplete_CrashedVerdict_GlobalCapDeclinesRetrySilently(t *testing.T) {
+	t.Parallel()
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	h.cfg.HumanReview.MaxPerHour = 1
+	h.recent = []time.Time{h.now()}
+
+	const agentID = "agent-hr-crash-global"
+	tk, err := tasks.Create("Crashed review, global cap", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		ProjectID: task.Ptr("owner/repo"),
+	}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: agentID,
+		Role:    string(agent.RoleHumanReview),
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	ag := &agent.Agent{ID: agentID, TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Subtype: "error_during_execution"})
+	h.inflight[tk.ID] = agentID
+	// Must not panic: the global cap declines inside maybeSpawn before it
+	// ever reaches the nil h.agents call that TestOnComplete_CrashedVerdict_
+	// RetriesOnce relies on panicking.
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if !strings.Contains(got.Body, "crashed") {
+		t.Errorf("expected a distinguishable crash note in body; got:\n%s", got.Body)
+	}
+	var rendered bool
+	for i := range got.AgentRuns {
+		if got.AgentRuns[i].AgentID == agentID {
+			rendered = got.AgentRuns[i].VerdictRendered
+			break
+		}
+	}
+	if !rendered {
+		t.Error("expected VerdictRendered=true once the global cap silently declines the retry")
+	}
+}
+
+// TestOnComplete_TerminalErrorWithToolCalls_SkipsCrashPath pins that a run
+// which made real tool calls before hitting a terminal error is NOT treated
+// as "crashed before doing anything" — it must fall through to the ordinary
+// unparseable-verdict path so its (possibly substantive) output is preserved
+// instead of being discarded for a pointless retry.
+func TestOnComplete_TerminalErrorWithToolCalls_SkipsCrashPath(t *testing.T) {
+	t.Parallel()
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	const agentID = "agent-hr-worked-then-errored"
+	tk, err := tasks.Create("Errored after real work", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: agentID,
+		Role:    string(agent.RoleHumanReview),
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	ag := &agent.Agent{ID: agentID, TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{Type: "assistant", Content: "Investigated the failure at length."})
+	ag.AppendOutput(agent.StreamEvent{
+		Type:    "result",
+		Subtype: "error_during_execution",
+		Content: "Ran out of turns before finishing the investigation.",
+	})
+	ag.AddToolCalls(3)
+	h.inflight[tk.ID] = agentID
+	// h.agents is nil: if this went down the crash-retry path it would
+	// attempt a spawn and panic, which is this test's failure signal too.
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if strings.Contains(got.Body, "Auto-review (crashed)") {
+		t.Errorf("a run with tool calls should not use the crashed-run note; got:\n%s", got.Body)
+	}
+	if !strings.Contains(got.Body, "Auto-review (unparseable verdict)") {
+		t.Errorf("expected the ordinary unparseable-verdict path; got:\n%s", got.Body)
 	}
 }


### PR DESCRIPTION
## Motivation

Sybra's human-review autonomy-mandate agent (`internal/sybra/app_human_review.go`)
is meant to fix deterministic lint/test/build failures itself before ever
leaving a task for a human. In a real run, this agent crashed after 2 turns
(`error_during_execution`, zero tool calls) and did nothing. The old code
treated that identically to a normal "unparseable verdict" response and
permanently marked the run's verdict as rendered — disabling any further
automatic recovery attempt for the task, even though the recovery had never
actually run. The task sat in `human-required` looking indistinguishable from
a genuine human-reviewed case.

Closes #2221

## Implementation information

- `Agent.HadTerminalError()` (`internal/agent/model.go`) reports whether the
  headless stream buffer's terminal result was an error subtype, distinct
  from a provider rate-limit/auth signal (already handled separately) or a
  clean finish whose text just didn't parse as a verdict.
- `onComplete` treats a crash as "crashed before doing anything" only when
  `HadTerminalError() && GetToolCalls() == 0` — a run that did real
  diagnostic/fix work and only errored at the very end still goes through the
  ordinary unparseable-verdict path, so its output isn't discarded.
- `retryAfterCrash` re-dispatches once, reusing the existing per-task/global
  spawn-rate budgets (`humanReviewMaxPerTaskPerWindow`, `MaxPerHour`) as the
  retry bound instead of adding a second counter.
- `maybeSpawn` now returns a `bool` reporting whether it actually dispatched
  an agent (previously void) — `retryAfterCrash` relies on this real signal
  rather than guessing from its own budget pre-check, so a retry that's
  silently declined by an independent gate (the fleet-wide rate limit, a
  race) is correctly detected as "did not happen," not assumed to have
  succeeded.
- Once retries are exhausted, a distinguishable note is appended and the verdict
  is marked rendered so the task doesn't loop forever — the note deliberately
  avoids asserting how many retries were attempted, since that's not tracked.
- `onComplete`'s own inflight-clearing `defer` now only clears the slot if it
  still belongs to the completing agent — needed because a crash-retry
  dispatched earlier in the same call registers a new inflight agent for the
  same task before that defer runs.
- Extracted `handleSybraBugVerdict` out of `onComplete` for `funlen`; no
  behavior change there.

Went through one round of adversarial code review first: the initial version
had `retryAfterCrash` always return `true` whenever its own pre-check passed,
without checking whether `maybeSpawn` actually dispatched anything — meaning
a retry declined by the *global* rate limit (after the per-task pre-check
passed) would silently vanish with no note and no rendered verdict, and the
exhaustion note falsely claimed "repeated attempts" even when zero retries
ran. Fixed by making `maybeSpawn` report its real outcome.

### Open questions

Adversarial manual testing (real `agent.Manager` + fake crashing CLI, not
mocked structs) found one plausible-but-unconfirmed gap: `onComplete` has no
local idempotency check of its own against a duplicate completion callback
for an already-superseded crashed agent — it relies entirely on
`Agent.completedOnce` (`internal/agent/model.go`, a `sync.Once` guarding
`onComplete`/`recordCompletion` for that one agent object) to guarantee
at-most-once delivery. That guarantee is a pre-existing, system-wide
invariant every role handler already depends on (not something this diff
introduces or weakens), and the tester could not construct a reachable
production path where it fails. Flagging rather than adding a redundant local
guard against an invariant the whole completion-dispatch model already
relies on everywhere.

> Changelog: fix(sybra): retry crashed human-review agent
