### PR TITLE
feat(workflow): flag plan-critic verdict at review

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -819,6 +819,17 @@ export enum StepType {
     StepTriageReview = "triage_review",
 
     /**
+     * StepFlagPlanCritique reads the plan-critic verdict (# Plan Review:
+     * APPROVE|REFINE|REJECT, the /plan-critic skill's required first line)
+     * and, on REFINE/REJECT, appends a prominent note to the task body so the
+     * verdict is impossible to miss at the review_plan human-approval gate.
+     * Never blocks progression itself — a human still approves/rejects every
+     * time regardless of verdict; this only ensures they can't miss that the
+     * critic asked for changes without opening the full critique sidecar.
+     */
+    StepFlagPlanCritique = "flag_plan_critique",
+
+    /**
      * StepDetectTampering inspects the worktree diff for reward-hacking /
      * test-tampering signals (deleted assertions, added skip/xfail markers,
      * deleted test files, neutered CI). A high-severity finding flips the task

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -480,6 +480,13 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - goto: flag_plan_critique_verdict
+
+  # Non-blocking by design — see StepFlagPlanCritique's doc comment for why.
+  - id: flag_plan_critique_verdict
+    name: Flag Plan Critique Verdict
+    type: flag_plan_critique
+    next:
       - goto: review_plan
 
   - id: review_plan

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -118,6 +118,66 @@ func TestBuiltinSimpleTask_MissingCritiqueSkipsToHumanReview(t *testing.T) {
 	}
 }
 
+// TestBuiltinSimpleTask_PresentCritiqueRoutesThroughFlagStep pins that a
+// present (non-skipped) plan critique routes through flag_plan_critique_verdict
+// before review_plan, not directly to review_plan. A regression that
+// re-points require_plan_critique's default transition straight at
+// review_plan would silently disable the whole REFINE/REJECT-visibility
+// feature (issue #2222) while still passing every unit test against
+// execFlagPlanCritique itself, since those call it directly without going
+// through this wiring.
+func TestBuiltinSimpleTask_PresentCritiqueRoutesThroughFlagStep(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-plan" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-plan builtin definition not found")
+		return
+	}
+
+	require := simple.StepByID("require_plan_critique")
+	if require == nil {
+		t.Fatal("require_plan_critique step not found in simple-task-plan")
+		return
+	}
+	got, err := ResolveTransition(require.Next, map[string]string{
+		"vars.step.require_plan_critique.output": "plan critique present",
+		"task.status":                            "planning",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTransition: %v", err)
+	}
+	if got != "flag_plan_critique_verdict" {
+		t.Fatalf("present critique next = %q, want flag_plan_critique_verdict", got)
+	}
+
+	flag := simple.StepByID("flag_plan_critique_verdict")
+	if flag == nil {
+		t.Fatal("flag_plan_critique_verdict step not found in simple-task-plan")
+		return
+	}
+	if flag.Type != StepFlagPlanCritique {
+		t.Fatalf("flag_plan_critique_verdict type = %q, want %q", flag.Type, StepFlagPlanCritique)
+	}
+	got, err = ResolveTransition(flag.Next, map[string]string{})
+	if err != nil {
+		t.Fatalf("ResolveTransition: %v", err)
+	}
+	if got != "review_plan" {
+		t.Fatalf("flag_plan_critique_verdict next = %q, want review_plan", got)
+	}
+}
+
 // TestBuiltinSimpleTask_ReplanCapEscalatesAfterThreeRejects locks the replan
 // iteration cap: task.replan_count is start_replan's own step-history count
 // as of the current reject, so 0/1/2 still have budget for another full

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -587,6 +587,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execValidatePlanContract(taskID, step, t)
 	case StepTriageReview:
 		return e.execTriageReview(taskID, step, t)
+	case StepFlagPlanCritique:
+		return e.execFlagPlanCritique(taskID, step, t)
 	case StepDetectTampering:
 		return e.execDetectTampering(taskID, step, t)
 	case StepVerifyChecks:

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -497,7 +497,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return comp, err
 		case StepWaitHuman:
 			return nil, wrapDispatchErr(step.ID, e.execWaitHuman(taskID, step, wfExec))
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepDetectTampering, StepVerifyChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch, StepCreatePR, StepClassifyTask:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepFlagPlanCritique, StepDetectTampering, StepVerifyChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch, StepCreatePR, StepClassifyTask:
 			// handled below as sync steps
 		default:
 			return nil, fmt.Errorf("unknown step type %q", step.Type)

--- a/internal/workflow/engine_steps_plancritique.go
+++ b/internal/workflow/engine_steps_plancritique.go
@@ -31,18 +31,38 @@ func (e *Engine) execFlagPlanCritique(taskID string, step *Step, t TaskInfo) (St
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "verdict: " + verdict + " — flagged"}, nil
 }
 
-// verdictWordRe matches a whole-word APPROVE/REFINE/REJECT, so prose like
-// "rejected previously" or "refine the error message" (a finding's own
-// wording, not a verdict) can't false-match.
-var verdictWordRe = regexp.MustCompile(`(?i)\b(APPROVE|REFINE|REJECT)\b`)
+// verdictWordRe matches a whole word inflected from APPROVE/REFINE/REJECT
+// (APPROVED, REJECTS, REFINING, ...), so prose like "rejected previously" or
+// "refine the error message" (a finding's own wording, not a verdict) can't
+// false-match, while a critic phrasing the verdict in a full sentence
+// ("this plan is rejected") still resolves to the base verdict.
+var verdictWordRe = regexp.MustCompile(`(?i)\b(APPROV(?:E|ES|ED|ING)|REFIN(?:E|ES|ED|ING)|REJECT(?:S|ED|ING)?)\b`)
 
 // planReviewTitleRe matches the /plan-critic skill's required title line,
 // "# Plan Review: <VERDICT>", within the first few lines of the sidecar.
-var planReviewTitleRe = regexp.MustCompile(`(?im)^#\s*Plan Review:?\s*([A-Z]*)`)
+// Tolerates 1-6 leading `#`s (a critic that titles at ## instead of #).
+var planReviewTitleRe = regexp.MustCompile(`(?im)^#{1,6}\s*Plan Review:?\s*([A-Z]*)`)
 
 // verdictSectionRe isolates the skill's "## Verdict" section (its prose
 // body, up to the next heading or end of content) as a fallback location.
-var verdictSectionRe = regexp.MustCompile(`(?is)##\s*Verdict\s*\n(.*?)(\n##|\z)`)
+// Tolerates 1-6 leading `#`s, same as planReviewTitleRe.
+var verdictSectionRe = regexp.MustCompile(`(?is)#{1,6}\s*Verdict\s*\n(.*?)(\n#{1,6}\s|\z)`)
+
+// canonicalVerdict maps a matched inflected verdict word (APPROVED,
+// REJECTS, REFINING, ...) back to its base APPROVE/REFINE/REJECT form.
+func canonicalVerdict(word string) string {
+	upper := strings.ToUpper(word)
+	switch {
+	case strings.HasPrefix(upper, "APPROV"):
+		return "APPROVE"
+	case strings.HasPrefix(upper, "REFIN"):
+		return "REFINE"
+	case strings.HasPrefix(upper, "REJECT"):
+		return "REJECT"
+	default:
+		return ""
+	}
+}
 
 // parsePlanCritiqueVerdict extracts the verdict word from a plan-critique
 // sidecar. The /plan-critic skill's output contract states the verdict twice
@@ -58,13 +78,13 @@ var verdictSectionRe = regexp.MustCompile(`(?is)##\s*Verdict\s*\n(.*?)(\n##|\z)`
 // is fine" behavior for critics that don't follow the contract at all.
 func parsePlanCritiqueVerdict(content string) string {
 	if m := planReviewTitleRe.FindStringSubmatch(content); m != nil {
-		if v := verdictWordRe.FindString(m[1]); v != "" {
-			return strings.ToUpper(v)
+		if v := canonicalVerdict(verdictWordRe.FindString(m[1])); v != "" {
+			return v
 		}
 	}
 	if m := verdictSectionRe.FindStringSubmatch(content); m != nil {
-		if v := verdictWordRe.FindString(m[1]); v != "" {
-			return strings.ToUpper(v)
+		if v := canonicalVerdict(verdictWordRe.FindString(m[1])); v != "" {
+			return v
 		}
 	}
 	return ""

--- a/internal/workflow/engine_steps_plancritique.go
+++ b/internal/workflow/engine_steps_plancritique.go
@@ -1,0 +1,56 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// execFlagPlanCritique appends a prominent note to the task body when the
+// plan-critic's own verdict is REFINE or REJECT. It never blocks progression
+// itself — review_plan's wait_human step already requires an explicit human
+// action every time regardless of verdict — this only makes sure "the critic
+// asked for changes" is visible right where that decision gets made, instead
+// of requiring the human to open and read the full critique sidecar. An
+// empty or unrecognized verdict (including a critic that didn't follow the
+// skill's output contract) is treated the same as APPROVE: no note, no
+// change in behavior from before this step existed.
+func (e *Engine) execFlagPlanCritique(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	verdict := parsePlanCritiqueVerdict(t.PlanCritique)
+	if verdict != "REFINE" && verdict != "REJECT" {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "verdict: " + verdict}, nil
+	}
+	note := fmt.Sprintf(
+		"## ⚠️ Plan Critic Verdict: %s\n\nThe plan critic did not approve this plan as written — review the findings in the critique sidecar before approving.",
+		verdict,
+	)
+	if err := e.tasks.AppendTaskBody(taskID, note); err != nil {
+		e.logger.Error("workflow.flag-plan-critique.append", "task_id", taskID, "err", err)
+		return StepOutput{}, err
+	}
+	return StepOutput{StepID: step.ID, Status: "completed", Output: "verdict: " + verdict + " — flagged"}, nil
+}
+
+// parsePlanCritiqueVerdict extracts the verdict word from a plan-critique
+// sidecar. The /plan-critic skill's output contract fixes the verdict to a
+// "# Plan Review: <APPROVE|REFINE|REJECT>" heading, but scans only the first
+// few lines for a "PLAN REVIEW:" marker rather than requiring it as literally
+// line one (tolerating a leading blank line or code fence) — and stops well
+// short of scanning the whole document, since the word REFINE/REJECT can
+// legitimately appear in later findings prose without being the verdict.
+func parsePlanCritiqueVerdict(content string) string {
+	const marker = "PLAN REVIEW:"
+	lines := strings.SplitN(content, "\n", 6)
+	for _, line := range lines {
+		upper := strings.ToUpper(line)
+		_, rest, found := strings.Cut(upper, marker)
+		if !found {
+			continue
+		}
+		for _, v := range []string{"APPROVE", "REFINE", "REJECT"} {
+			if strings.Contains(rest, v) {
+				return v
+			}
+		}
+	}
+	return ""
+}

--- a/internal/workflow/engine_steps_plancritique.go
+++ b/internal/workflow/engine_steps_plancritique.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -30,26 +31,40 @@ func (e *Engine) execFlagPlanCritique(taskID string, step *Step, t TaskInfo) (St
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "verdict: " + verdict + " — flagged"}, nil
 }
 
+// verdictWordRe matches a whole-word APPROVE/REFINE/REJECT, so prose like
+// "rejected previously" or "refine the error message" (a finding's own
+// wording, not a verdict) can't false-match.
+var verdictWordRe = regexp.MustCompile(`(?i)\b(APPROVE|REFINE|REJECT)\b`)
+
+// planReviewTitleRe matches the /plan-critic skill's required title line,
+// "# Plan Review: <VERDICT>", within the first few lines of the sidecar.
+var planReviewTitleRe = regexp.MustCompile(`(?im)^#\s*Plan Review:?\s*([A-Z]*)`)
+
+// verdictSectionRe isolates the skill's "## Verdict" section (its prose
+// body, up to the next heading or end of content) as a fallback location.
+var verdictSectionRe = regexp.MustCompile(`(?is)##\s*Verdict\s*\n(.*?)(\n##|\z)`)
+
 // parsePlanCritiqueVerdict extracts the verdict word from a plan-critique
-// sidecar. The /plan-critic skill's output contract fixes the verdict to a
-// "# Plan Review: <APPROVE|REFINE|REJECT>" heading, but scans only the first
-// few lines for a "PLAN REVIEW:" marker rather than requiring it as literally
-// line one (tolerating a leading blank line or code fence) — and stops well
-// short of scanning the whole document, since the word REFINE/REJECT can
-// legitimately appear in later findings prose without being the verdict.
+// sidecar. The /plan-critic skill's output contract states the verdict twice
+// — the "# Plan Review: <VERDICT>" title line, and again in prose inside the
+// "## Verdict" section — so this checks the title line first (the more
+// precise, contract-exact location) and falls back to the Verdict section
+// when a critic drifts from the exact title format (e.g. a bare "# Plan
+// Review" heading with the actual verdict stated only in the section below).
+// Deliberately does not scan the rest of the document (findings, required
+// changes, etc.), where REFINE/REJECT can appear in unrelated prose. Returns
+// "" — treated identically to APPROVE by the caller — when neither location
+// yields a recognizable verdict, preserving today's "any non-empty sidecar
+// is fine" behavior for critics that don't follow the contract at all.
 func parsePlanCritiqueVerdict(content string) string {
-	const marker = "PLAN REVIEW:"
-	lines := strings.SplitN(content, "\n", 6)
-	for _, line := range lines {
-		upper := strings.ToUpper(line)
-		_, rest, found := strings.Cut(upper, marker)
-		if !found {
-			continue
+	if m := planReviewTitleRe.FindStringSubmatch(content); m != nil {
+		if v := verdictWordRe.FindString(m[1]); v != "" {
+			return strings.ToUpper(v)
 		}
-		for _, v := range []string{"APPROVE", "REFINE", "REJECT"} {
-			if strings.Contains(rest, v) {
-				return v
-			}
+	}
+	if m := verdictSectionRe.FindStringSubmatch(content); m != nil {
+		if v := verdictWordRe.FindString(m[1]); v != "" {
+			return strings.ToUpper(v)
 		}
 	}
 	return ""

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7273,6 +7273,105 @@ func TestExecRequireSidecar_EmptySidecarConfigErrors(t *testing.T) {
 	}
 }
 
+// --- flag_plan_critique step ---
+
+func newFlagPlanCritiqueStep() *Step {
+	return &Step{ID: "flag_plan_critique_verdict", Type: StepFlagPlanCritique}
+}
+
+func TestParsePlanCritiqueVerdict(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"approve", "# Plan Review: APPROVE\n\n## Verdict\n\nLooks good.", "APPROVE"},
+		{"refine", "# Plan Review: REFINE\n\n## Findings\n\n- missing file", "REFINE"},
+		{"reject", "# Plan Review: REJECT\n\nToo vague.", "REJECT"},
+		{"lowercase verdict word", "# plan review: refine\n", "REFINE"},
+		{"leading blank line", "\n# Plan Review: REFINE\n", "REFINE"},
+		{"mention in prose is not the verdict line", "# Plan Review: APPROVE\n\nNo REFINE needed here.", "APPROVE"},
+		{"no marker at all", "Looks fine to me.", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parsePlanCritiqueVerdict(tt.content); got != tt.want {
+				t.Errorf("parsePlanCritiqueVerdict(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecFlagPlanCritique_ApproveDoesNotAppendNote(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", PlanCritique: "# Plan Review: APPROVE\n\nLooks good."})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execFlagPlanCritique("t1", newFlagPlanCritiqueStep(), TaskInfo{ID: "t1", PlanCritique: "# Plan Review: APPROVE\n\nLooks good."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if strings.Contains(ti.Body, "Plan Critic Verdict") {
+		t.Errorf("APPROVE should not append a verdict note; body = %q", ti.Body)
+	}
+}
+
+func TestExecFlagPlanCritique_RefineAppendsDistinguishableNote(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", PlanCritique: "# Plan Review: REFINE\n\n## Findings\n\n- [high] missing file"})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execFlagPlanCritique("t1", newFlagPlanCritiqueStep(), TaskInfo{ID: "t1", PlanCritique: "# Plan Review: REFINE\n\n## Findings\n\n- [high] missing file"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Output, "REFINE") {
+		t.Errorf("Output = %q, want it to report the REFINE verdict", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if !strings.Contains(ti.Body, "Plan Critic Verdict: REFINE") {
+		t.Errorf("expected a distinguishable REFINE note in body; got:\n%s", ti.Body)
+	}
+	if ti.Status == "human-required" {
+		t.Error("flag_plan_critique must not block progression by itself")
+	}
+}
+
+func TestExecFlagPlanCritique_RejectAppendsDistinguishableNote(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", PlanCritique: "# Plan Review: REJECT\n\nToo vague."})
+	engine := newEngineForEval(t, tasks)
+
+	_, err := engine.execFlagPlanCritique("t1", newFlagPlanCritiqueStep(), TaskInfo{ID: "t1", PlanCritique: "# Plan Review: REJECT\n\nToo vague."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if !strings.Contains(ti.Body, "Plan Critic Verdict: REJECT") {
+		t.Errorf("expected a distinguishable REJECT note in body; got:\n%s", ti.Body)
+	}
+}
+
+func TestExecFlagPlanCritique_UnparseableVerdictDoesNotAppendNote(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", PlanCritique: "Some free-form text with no verdict marker."})
+	engine := newEngineForEval(t, tasks)
+
+	_, err := engine.execFlagPlanCritique("t1", newFlagPlanCritiqueStep(), TaskInfo{ID: "t1", PlanCritique: "Some free-form text with no verdict marker."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if strings.Contains(ti.Body, "Plan Critic Verdict") {
+		t.Errorf("an unparseable verdict should behave like APPROVE (no note); body = %q", ti.Body)
+	}
+}
+
 // --- evaluate step ---
 
 func newEvaluateStep() *Step {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7293,6 +7293,21 @@ func TestParsePlanCritiqueVerdict(t *testing.T) {
 		{"mention in prose is not the verdict line", "# Plan Review: APPROVE\n\nNo REFINE needed here.", "APPROVE"},
 		{"no marker at all", "Looks fine to me.", ""},
 		{"empty", "", ""},
+		{
+			"bare title falls back to Verdict section prose",
+			"# Plan Review\n\n## Verdict\n\nThis plan needs REFINE — the rollback step is missing and the test command doesn't match the project.",
+			"REFINE",
+		},
+		{
+			"verdict section fallback is bounded to that section",
+			"# Plan Review\n\n## Verdict\n\nSound overall.\n\n## Findings\n\n- [nit] refine the error message wording",
+			"",
+		},
+		{
+			"whole-word match rejects a substring hit",
+			"# Plan Review\n\n## Verdict\n\nThis was rejected previously but is now fine.",
+			"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7304,8 +7304,18 @@ func TestParsePlanCritiqueVerdict(t *testing.T) {
 			"",
 		},
 		{
-			"whole-word match rejects a substring hit",
-			"# Plan Review\n\n## Verdict\n\nThis was rejected previously but is now fine.",
+			"inflected verdict word still resolves to its base form",
+			"# Plan Review: REJECTED\n\n## Verdict\n\nThis plan is rejected due to missing rollback safety verification steps.",
+			"REJECT",
+		},
+		{
+			"heading-level drift on the title line still matches",
+			"## Plan Review: REFINE\n\n## Verdict\n\nSeveral steps need adjustment.",
+			"REFINE",
+		},
+		{
+			"a longer unrelated word is not a boundary-crossing false match",
+			"# Plan Review\n\n## Verdict\n\nNo concerns; this is not a rejectionist take, just a sanity check.",
 			"",
 		},
 	}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -90,6 +90,14 @@ const (
 	StepValidatePlan         StepType = "validate_plan"
 	StepValidatePlanContract StepType = "validate_plan_contract"
 	StepTriageReview         StepType = "triage_review"
+	// StepFlagPlanCritique reads the plan-critic verdict (# Plan Review:
+	// APPROVE|REFINE|REJECT, the /plan-critic skill's required first line)
+	// and, on REFINE/REJECT, appends a prominent note to the task body so the
+	// verdict is impossible to miss at the review_plan human-approval gate.
+	// Never blocks progression itself — a human still approves/rejects every
+	// time regardless of verdict; this only ensures they can't miss that the
+	// critic asked for changes without opening the full critique sidecar.
+	StepFlagPlanCritique StepType = "flag_plan_critique"
 	// StepDetectTampering inspects the worktree diff for reward-hacking /
 	// test-tampering signals (deleted assertions, added skip/xfail markers,
 	// deleted test files, neutered CI). A high-severity finding flips the task


### PR DESCRIPTION
## Motivation

`plan-critic` can return `APPROVE`/`REFINE`/`REJECT` naming specific gaps in
an execution contract, but nothing in the workflow engine looked at that
verdict — `require_plan_critique` only checked the critique sidecar was
non-empty, and a human at the `review_plan` approval gate could easily click
through a `REFINE`/`REJECT` verdict without registering it, since nothing
distinguished it from a clean `APPROVE`.

Closes #2222

## Implementation information

- New synchronous step type `flag_plan_critique` (`StepFlagPlanCritique`,
  `internal/workflow/model.go`), wired into `simple-task-plan.yaml` as
  `flag_plan_critique_verdict` between `require_plan_critique` and
  `review_plan`.
- `parsePlanCritiqueVerdict` (`internal/workflow/engine_steps_plancritique.go`)
  extracts the verdict from the plan-critic sidecar, checking the skill's
  required `# Plan Review: <VERDICT>` title line first, falling back to the
  `## Verdict` section's prose when a critic drifts from the exact title
  format. Matches inflected forms (`REJECTED`, `REFINING`, ...) and tolerates
  heading-level drift (`##` vs `#`), while staying whole-word-bounded so
  `REFINE`/`REJECT` mentioned in unrelated findings prose can't false-match.
- On `REFINE`/`REJECT`, `execFlagPlanCritique` appends a
  `## ⚠️ Plan Critic Verdict: <VERDICT>` note to the task body. On `APPROVE`
  or an unparseable verdict, it's a no-op — byte-identical to behavior before
  this change.
- **Deliberately non-blocking**: `review_plan`'s `wait_human` step already
  requires an explicit human approve/reject action every time, regardless of
  verdict. This only makes the verdict impossible to miss at that gate,
  instead of requiring the human to open the full critique sidecar.
- New workflow-wiring test (`TestBuiltinSimpleTask_PresentCritiqueRoutesThroughFlagStep`)
  asserts `require_plan_critique`'s default transition actually routes through
  `flag_plan_critique_verdict` before `review_plan` — not just that
  `execFlagPlanCritique` behaves correctly in isolation, which wouldn't catch
  a regression that silently re-points the YAML `goto` straight at
  `review_plan`.

Went through two rounds of adversarial review before opening this PR:
- **Code review** found the initial parser only checked the title line, so a
  critic that titled bare (`# Plan Review` with no verdict) and stated the
  verdict only in the `## Verdict` section's prose would silently parse as
  `""` (treated like `APPROVE`) — fixed by adding the section fallback.
- **Manual testing** (running the real functions against constructed
  adversarial inputs) found two more gaps in that same parser: inflected
  verdict words (`REJECTED`, `REFINING`, ...) didn't match the strict
  whole-word regex, and a critic titling at `##` instead of `#` skipped the
  title-line path entirely. Both fixed; regression tests added for each.

### Open questions

A replan cycle producing a second `REFINE` critique for the same task
appends a second, stacked note rather than replacing the first — noted by
the manual tester but out of this issue's stated scope (visibility, not
deduplication), and consistent with how other body-appending steps in this
workflow already behave (e.g. the spec-decision section on repeated test
attempts). Flagging in case a future issue wants dedup.

> Changelog: feat(workflow): flag plan-critic verdict at review
