### PR TITLE
fix(watchdog): unwrap codex -c wrapper

### DIFF
--- a/internal/agent/tool_loop_semantic.go
+++ b/internal/agent/tool_loop_semantic.go
@@ -100,6 +100,7 @@ func normalizeBashActionLabel(command string) string {
 	if cmd == "" {
 		return ""
 	}
+	cmd = unwrapShellDashC(cmd)
 	pipeline := splitShellPipeline(cmd)
 	for len(pipeline) > 1 && pipelineStageIsOutputFilter(pipeline[len(pipeline)-1]) {
 		pipeline = pipeline[:len(pipeline)-1]
@@ -227,6 +228,43 @@ func normalizePath(path string) string {
 		return ""
 	}
 	return filepath.Clean(path)
+}
+
+// unwrapShellDashC extracts the real command from a `<shell> -c "<cmd>"` /
+// `<shell> -lc "<cmd>"` wrapper. Codex's exec tool shells out every command
+// this way (e.g. `/bin/bash -lc "sed -n '1,50p' file.go"`), so without
+// unwrapping, the outer wrapper — not the inner command — is what gets
+// classified: every Codex bash call's first token is identically "/bin/bash",
+// collapsing every distinct command (reads of different files, greps, tests,
+// git operations) into the same loop-family signature regardless of what it
+// actually does. That defeats semantic-loop detection entirely for Codex
+// agents, firing the "loop" trigger (and downstream watchdog kill) on
+// perfectly normal, non-repetitive multi-step work. Bounded to a few
+// unwraps in case of nested wrapping; falls through unchanged for any shape
+// that isn't a plain `<shell> -c/-lc <command>` invocation.
+func unwrapShellDashC(command string) string {
+	for range 3 {
+		fields := shellFields(command)
+		if len(fields) < 3 {
+			return command
+		}
+		switch filepath.Base(fields[0]) {
+		case "bash", "sh", "zsh", "dash":
+		default:
+			return command
+		}
+		switch fields[1] {
+		case "-c", "-lc", "-ic", "-lic", "-cl", "-ci":
+		default:
+			return command
+		}
+		inner := strings.TrimSpace(fields[2])
+		if inner == "" || inner == command {
+			return command
+		}
+		command = inner
+	}
+	return command
 }
 
 func splitShellPipeline(command string) []string {

--- a/internal/agent/tool_loop_semantic_test.go
+++ b/internal/agent/tool_loop_semantic_test.go
@@ -67,6 +67,53 @@ func TestTruncateCommandFamily(t *testing.T) {
 	}
 }
 
+// TestNormalizeBashActionLabel_UnwrapsCodexShellDashC covers the false-positive
+// semantic-loop kills seen live on codex agents (#2217-adjacent): codex's exec
+// tool always shells out as `<shell> -c/-lc "<cmd>"`, and without unwrapping,
+// every such call's outer wrapper — not the real inner command — was what got
+// classified, collapsing distinct reads/greps/tests into one identical
+// "bash:/bin/bash" family regardless of what they actually did.
+func TestNormalizeBashActionLabel_UnwrapsCodexShellDashC(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{
+			name:    "bash -lc read of file A",
+			command: `/bin/bash -lc "sed -n '940,1085p' internal/sybra/app_human_review.go"`,
+			want:    "read:internal/sybra/app_human_review.go",
+		},
+		{
+			name:    "bash -lc read of file B — must differ from file A",
+			command: `/bin/bash -lc "sed -n '1,220p' internal/sybra/completion/completion.go"`,
+			want:    "read:internal/sybra/completion/completion.go",
+		},
+		{
+			name:    "bash -lc long-running check",
+			command: `/bin/bash -lc "go test ./internal/sybra -run TestFoo"`,
+			want:    "check:go test ./internal/sybra -run",
+		},
+		{
+			name:    "sh -c generic command",
+			command: `sh -c "git status --short"`,
+			want:    "bash:git",
+		},
+		{
+			name:    "no shell wrapper stays unaffected",
+			command: `sed -n '1,10p' foo.go`,
+			want:    "read:foo.go",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeBashActionLabel(tc.command); got != tc.want {
+				t.Fatalf("normalizeBashActionLabel(%q) = %q, want %q", tc.command, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeBashActionLabel_HeadTailWithoutFileStayGeneric(t *testing.T) {
 	for _, cmd := range []string{"tail -n 20", "head -n 20", "tail --lines 20", "head --bytes 20"} {
 		want := "bash:" + strings.Fields(cmd)[0]


### PR DESCRIPTION
## Motivation

> Changelog: fix(watchdog): unwrap codex -c wrapper

Six live tasks today (including the umbrella tracker itself, `33aa3f62`) were killed by the watchdog with `reason_kind: reward_hacking` and escalated straight to `human-required`, bypassing the verify-before-trust safety net (`stopAndVerifyAmbiguousLoop`) that only covers ambiguous (empty) `reason_kind`. Reading the raw agent transcripts, none of them were actually looping — they were doing normal, converging, non-repetitive investigation (reading different files, running different commands), several of which had already finished the underlying work (e.g. one had a CLEAN review with an open PR).

Root cause: all six were Codex-provider agents. Codex's exec tool always shells out as `<shell> -c/-lc "<cmd>"` (e.g. `/bin/bash -lc "sed -n '1,50p' file.go"`). The deterministic loop-family classifier (`normalizeBashActionLabel`) never unwraps this — it classifies the *outer* wrapper, whose first token is identically `/bin/bash` for every single Codex bash call, regardless of what the inner command actually does. This collapsed every distinct read/grep/test/git call into one loop-family signature, so `loop_streak` hit the 12-action detection window in well under a minute of completely normal work, firing the "loop" trigger on every Codex agent that ran more than ~12 tool calls. The LLM judge then rationalized a semantic-loop narrative to match.

## Implementation information

Added `unwrapShellDashC` to `internal/agent/tool_loop_semantic.go`: before classifying a Bash tool call, unwrap a `<bash|sh|zsh|dash> -c/-lc "<cmd>"` wrapper down to the real inner command, so the existing read/check/generic classification operates on what the agent actually ran. Claude-provider commands (which pass the raw command directly, no wrapper) are unaffected.

## Supporting documentation

Confirmed via live server logs (`/data/sybra/home/logs/sybra.log`) across all six affected tasks: every kill logged `trigger: "loop"` with `loop_streak` at or near the 12-action window within 27-53 seconds of agent start, and every raw NDJSON transcript showed non-repetitive, purposeful commands with no actual duplication.