### PR TITLE
fix(workflow): route existing-PR fix to in-review

### DIFF
--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -211,6 +211,11 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - when:
+          field: task.pr_number
+          operator: not_equals
+          value: ""
+        goto: set_ready_pr_existing
       - goto: set_ready_review
 
   # Terminal hand-off to simple-task-review: flip status to ready-review
@@ -221,5 +226,14 @@ steps:
     type: set_status
     config:
       status: ready-review
+    next:
+      - goto: ""
+
+  # simple-task-review skips pr_number != "", so this avoids orphaning a re-fix cycle at an undispatched status. The fix cycle already verified itself; land straight on the PR's own review lane instead of re-running local review/testing.
+  - id: set_ready_pr_existing
+    name: Hand Off to In-Review (existing PR)
+    type: set_status
+    config:
+      status: in-review
     next:
       - goto: ""

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -462,6 +462,51 @@ func TestBuiltinSimpleTaskImplement_CodegenPrecedesValidation(t *testing.T) {
 	}
 }
 
+// TestBuiltinSimpleTaskImplement_ExistingPRSkipsReadyReview pins the fix for
+// a re-fix cycle orphaning at ready-review: simple-task-review's own trigger
+// refuses pr_number != "", so verify_checks must route a PR-having task to
+// in-review directly rather than a status nothing dispatches.
+func TestBuiltinSimpleTaskImplement_ExistingPRSkipsReadyReview(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var impl *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-implement" {
+			impl = &defs[i]
+			break
+		}
+	}
+	if impl == nil {
+		t.Fatal("simple-task-implement builtin definition not found")
+	}
+	verifyChecks := impl.StepByID("verify_checks")
+	if verifyChecks == nil {
+		t.Fatal("verify_checks step not found in simple-task-implement")
+	}
+
+	if got, err := ResolveTransition(verifyChecks.Next, map[string]string{"task.status": "in-progress"}); err != nil || got != "set_ready_review" {
+		t.Fatalf("verify_checks no-PR goto = %q, err=%v; want set_ready_review", got, err)
+	}
+	if got, err := ResolveTransition(verifyChecks.Next, map[string]string{"task.status": "in-progress", "task.pr_number": "17478"}); err != nil || got != "set_ready_pr_existing" {
+		t.Fatalf("verify_checks existing-PR goto = %q, err=%v; want set_ready_pr_existing", got, err)
+	}
+	if got, err := ResolveTransition(verifyChecks.Next, map[string]string{"task.status": "human-required", "task.pr_number": "17478"}); err != nil || got != "" {
+		t.Fatalf("verify_checks human-required goto = %q, err=%v; want end (wins over PR routing)", got, err)
+	}
+
+	existingPR := impl.StepByID("set_ready_pr_existing")
+	if existingPR == nil {
+		t.Fatal("set_ready_pr_existing step not found in simple-task-implement")
+	}
+	if existingPR.Type != StepSetStatus || existingPR.Config.Status != "in-review" {
+		t.Fatalf("set_ready_pr_existing = type %q status %q; want set_status in-review", existingPR.Type, existingPR.Config.Status)
+	}
+}
+
 // TestBuiltinSimpleTask_TriageNoplanRouting locks the noplan escape hatch in
 // the triage step's transition table: a noplan tag routes straight to
 // implement (winning over a planning status), terminal statuses still win over


### PR DESCRIPTION
## Motivation

> Changelog: fix(workflow): route existing-PR fix to in-review

`simple-task-implement`'s terminal step unconditionally sets status to `ready-review`, but `simple-task-review`'s own trigger explicitly refuses to fire when `task.pr_number` is already set (by design — a linked PR is the PR monitor's job, not another local diff review). A re-implementation cycle on a task that already has a PR — e.g. a test-runner or watchdog-triggered fix loop sending it back to `in-progress` — lands back on `ready-review` with nothing watching it, and orphans there.

Confirmed live: task `3effdc78` (kumahq/kuma) sat idle at `ready-review` for hours, twice in a row, each time right after a fresh implementation agent finished fixing a test-runner-reported bug on a branch with PR #17478 already open.

## Implementation information

`verify_checks`'s transition table now checks `task.pr_number` before deciding where to hand off: unset → `set_ready_review` (unchanged first-time path), set → a new `set_ready_pr_existing` step that sets status to `in-review` directly. The fix cycle that got here already verified itself (implementation + its own checks), so there's no need to re-run local review or testing before landing on the PR's own review lane — this matches how the codebase already treats a PR as "owned by the PR monitor" once it exists.

Added `TestBuiltinSimpleTaskImplement_ExistingPRSkipsReadyReview` pinning both branches of `verify_checks`'s routing and the new step's target status.

## Supporting documentation

n/a — reproduced and diagnosed live via task audit trail + workflow definition inspection, not from an external report.