### PR TITLE
ci(actions): use a PAT for bindings-sync push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,14 +181,20 @@ jobs:
 
       - name: Commit and push regenerated bindings and shims
         # Restricted to same-repo PRs — a fork PR's GITHUB_TOKEN is read-only
-        # and falls through to the drift gate. A GITHUB_TOKEN push never
-        # re-triggers workflows, so no loop; the generated files ride into the
-        # squash-merge.
+        # and falls through to the drift gate.
+        #
+        # BINDINGS_SYNC_PAT, when set, avoids a GitHub anti-recursion guard:
+        # a GITHUB_TOKEN-authored commit leaves the required "CI"/"Wails
+        # Bindings Sync" checks permanently `action_required` on this new
+        # HEAD instead of running them, so the PR gets stuck until a human
+        # clicks "Re-run". Falls back to GITHUB_TOKEN, with that drawback,
+        # until the secret exists.
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         env:
           HEAD_REF: ${{ github.head_ref }}
+          PUSH_TOKEN: ${{ secrets.BINDINGS_SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |
           if git diff --quiet -- frontend/bindings/ frontend/src/lib/api.ts frontend/src/lib/api-http.ts; then
             echo "bindings and api shims already in sync"
@@ -198,7 +204,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add frontend/bindings/ frontend/src/lib/api.ts frontend/src/lib/api-http.ts
           git commit -s -m "chore(bindings): regenerate wails bindings and api shims"
-          git push origin HEAD:"$HEAD_REF"
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:"$HEAD_REF"
 
       - name: Check for drift
         # Fork PRs and push/tag events cannot auto-commit, so the hard gate


### PR DESCRIPTION
## Motivation

> Changelog: ci(actions): use a PAT for bindings-sync push

Every open PR that hit a bindings drift was stuck waiting on CI forever.
`check-wailsjs` auto-commits regenerated bindings and pushes with the
default `GITHUB_TOKEN`. GitHub exempts `GITHUB_TOKEN`-authored pushes
from re-triggering workflow runs — but instead of skipping cleanly, it
still records a `pull_request` event and leaves it `action_required`
with zero jobs. Branch protection requires the `CI` and `Wails Bindings
Sync` checks to pass on the latest commit, but that commit's checks can
never run without a human manually clicking "Re-run" in the Actions UI.

Confirmed by inspecting the four PRs open on this repo today: every one
that had a bindings-regen commit had a matching `action_required` run
with 0 jobs, immediately after the bot's push.

## Implementation information

- `check-wailsjs`'s push step now pushes with `BINDINGS_SYNC_PAT` when
  the secret is set, embedding it directly in the push URL instead of
  relying on the checkout step's persisted credentials. A PAT-authored
  push isn't subject to the GITHUB_TOKEN re-trigger guard, so CI runs
  normally against the regenerated commit.
- Falls back to `GITHUB_TOKEN` (same stuck-check drawback as before)
  until the secret exists, so this doesn't regress anything on its own —
  provisioning `BINDINGS_SYNC_PAT` is a follow-up:
  1. Create a fine-grained PAT scoped to `Automaat/sybra` only, with
     `Contents: Read and write` permission.
  2. `gh secret set BINDINGS_SYNC_PAT --repo Automaat/sybra`

I manually re-ran the stuck `action_required` runs on the four affected
open PRs to unblock them today; two (the ones with real content left)
have already auto-merged since.

## Supporting documentation

N/A