### PR TITLE
test(limits): stop hardcoding a drifting clock

### DIFF
--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -85,7 +85,7 @@ func TestStoreProviderAvailableAndChooseProvider(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	s.now = func() time.Time { return now }
 	policy := DefaultPolicy()
 
@@ -185,7 +185,7 @@ func TestStoreProviderAvailable_IgnoresExpiredQuotaCycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	s.now = func() time.Time { return now }
 	if err := s.UpdateSnapshot(Snapshot{
 		Provider:   ProviderCodex,
@@ -221,7 +221,7 @@ func TestChooseProvider_SkipsPolicyDisabledCandidates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	s.now = func() time.Time { return now }
 	if err := s.UpdateSnapshot(Snapshot{
 		Provider:   ProviderClaude,
@@ -322,7 +322,7 @@ func TestSummary_PrefersSessionFileUsageCountersButKeepsRunSpend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	s.now = func() time.Time { return now }
 
 	if err := s.RecordUsage(UsageEvent{
@@ -380,7 +380,13 @@ func TestStoreImport_DedupesAndPersistsBatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	// A fixed historical date here would drift out of sync with the real
+	// clock reopened's own NewStore->reloadLocked uses below (it has no way
+	// to inherit s.now), silently filtering the fixture events out once
+	// eventMaxAge (21d) of real time passed since the date was hardcoded —
+	// this test failed for exactly that reason. time.Now() keeps both
+	// clocks aligned regardless of when the test actually runs.
+	now := time.Now().UTC()
 	s.now = func() time.Time { return now }
 
 	if err := s.Import(
@@ -457,7 +463,7 @@ func TestRecordUsageCrossProcessSimulatesConcurrentWriters(t *testing.T) {
 }
 
 func TestSessionImport_DedupesEventsAndKeepsLatestSnapshot(t *testing.T) {
-	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	batch := newSessionImport()
 
 	batch.addEvent(UsageEvent{ID: "event-1", Provider: ProviderClaude, Source: SourceSessionFiles, InputTokens: 1})

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -380,12 +380,12 @@ func TestStoreImport_DedupesAndPersistsBatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A fixed historical date here would drift out of sync with the real
-	// clock reopened's own NewStore->reloadLocked uses below (it has no way
-	// to inherit s.now), silently filtering the fixture events out once
-	// eventMaxAge (21d) of real time passed since the date was hardcoded —
-	// this test failed for exactly that reason. time.Now() keeps both
-	// clocks aligned regardless of when the test actually runs.
+	// reopened below (see NewStore) has no way to inherit s.now, so its own
+	// reloadLocked always uses the real clock. A fixed historical date here
+	// would drift more than eventMaxAge (21d) past that real clock over
+	// time, silently filtering the fixture events out as stale — this test
+	// failed for exactly that reason. time.Now() keeps both clocks aligned
+	// no matter when the test runs.
 	now := time.Now().UTC()
 	s.now = func() time.Time { return now }
 


### PR DESCRIPTION
## Motivation

`TestStoreImport_DedupesAndPersistsBatch` (and five sibling tests in the same
file) hardcoded `now := time.Date(2026, 6, 27, ...)` as the mocked clock for
a `Store`. The test reopens a second `*Store` over the same path to verify
persistence (`reopened, err := NewStore(path)`), but `NewStore` has no way to
inherit the first store's mocked `now` — its own internal `reloadLocked()`
call runs with the real wall clock before the function even returns. Once
real time drifted more than `eventMaxAge` (21 days) past the hardcoded date,
`reloadLocked` started filtering the fixture's events out as stale on every
run, and the persistence check failed with `persisted events = 0, want 2`.
This is currently blocking CI on `main` for every PR — confirmed by running
this exact test against a clean `origin/main` checkout in a separate
worktree, and confirmed it's unrelated to any of the PRs I have open right
now (none touch `internal/limits`).

## Implementation information

Replaced the hardcoded date with `time.Now().UTC()` in all six occurrences
in `internal/limits/collect_test.go` — this keeps the mocked clock and any
reopened store's real clock aligned regardless of when the test actually
runs, removing the drift entirely rather than just resetting the clock to
buy another 21 days. Verified: `go test ./internal/limits/... -v -count=1`
— all 25 tests pass.

> Changelog: test(limits): stop hardcoding a drifting clock
