### PR TITLE
fix(project): set explicit commit identity

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -317,10 +318,35 @@ func CloneBare(ctx context.Context, repoURL, destPath string) error {
 	if err := InstallSignoffHook(ctx, destPath); err != nil {
 		return fmt.Errorf("install signoff hook: %w", err)
 	}
+	if err := configureCommitIdentity(ctx, destPath); err != nil {
+		return fmt.Errorf("configure commit identity: %w", err)
+	}
 	// `git clone --bare` leaves remote.origin.fetch empty, so later `git fetch
 	// origin` becomes a no-op against refs/remotes/origin/*. Configure the
 	// standard refspec so fetches actually update tracking refs.
 	return runBare(ctx, destPath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+}
+
+// configureCommitIdentity sets an explicit git identity on the bare clone.
+// Headless/interactive agent commits are made by the agent's own bash tool
+// calls, not orchestrated Go code, so they inherit whatever identity is
+// already configured on the clone — an empty one fails every commit with
+// "empty ident name", and any stray local override (however it got there)
+// silently becomes the permanent author of every real commit. Setting it
+// explicitly at clone time means neither can happen by accident.
+// GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL let an operator brand commits (e.g. as
+// their own GitHub App bot); the default matches the identity
+// internal/agent/k8s_job_runner.go already falls back to.
+func configureCommitIdentity(ctx context.Context, barePath string) error {
+	name := cmp.Or(os.Getenv("GIT_AUTHOR_NAME"), "Sybra Agent")
+	email := cmp.Or(os.Getenv("GIT_AUTHOR_EMAIL"), "sybra-agent@example.invalid")
+	if err := runBare(ctx, barePath, "config", "user.name", name); err != nil {
+		return fmt.Errorf("set user.name: %w", err)
+	}
+	if err := runBare(ctx, barePath, "config", "user.email", email); err != nil {
+		return fmt.Errorf("set user.email: %w", err)
+	}
+	return nil
 }
 
 // DefaultBranch resolves barePath's HEAD symbolic ref (e.g.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -202,6 +202,58 @@ func TestCloneBareInvalidURL(t *testing.T) {
 	}
 }
 
+func TestCloneBare_SetsCommitIdentity(t *testing.T) {
+	t.Parallel()
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	name, err := outputBare(context.Background(), bare, "config", "user.name")
+	if err != nil {
+		t.Fatalf("read user.name: %v", err)
+	}
+	if got := strings.TrimSpace(name); got != "Sybra Agent" {
+		t.Errorf("user.name = %q, want %q", got, "Sybra Agent")
+	}
+
+	email, err := outputBare(context.Background(), bare, "config", "user.email")
+	if err != nil {
+		t.Fatalf("read user.email: %v", err)
+	}
+	if got := strings.TrimSpace(email); got != "sybra-agent@example.invalid" {
+		t.Errorf("user.email = %q, want %q", got, "sybra-agent@example.invalid")
+	}
+}
+
+func TestCloneBare_CommitIdentityRespectsEnvOverride(t *testing.T) {
+	t.Setenv("GIT_AUTHOR_NAME", "Custom Bot")
+	t.Setenv("GIT_AUTHOR_EMAIL", "custom-bot@example.com")
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	name, err := outputBare(context.Background(), bare, "config", "user.name")
+	if err != nil {
+		t.Fatalf("read user.name: %v", err)
+	}
+	if got := strings.TrimSpace(name); got != "Custom Bot" {
+		t.Errorf("user.name = %q, want %q", got, "Custom Bot")
+	}
+
+	email, err := outputBare(context.Background(), bare, "config", "user.email")
+	if err != nil {
+		t.Fatalf("read user.email: %v", err)
+	}
+	if got := strings.TrimSpace(email); got != "custom-bot@example.com" {
+		t.Errorf("user.email = %q, want %q", got, "custom-bot@example.com")
+	}
+}
+
 func TestDefaultBranch(t *testing.T) {
 	t.Parallel()
 	bare := initBareRepo(t)


### PR DESCRIPTION
## Motivation

> Changelog: fix(project): set explicit commit identity

Headless/interactive agent commits are made by the agent's own bash
tool calls, not orchestrated Go code, so they silently inherit
whatever git identity happens to be ambient on the host. The sybra
user's global git config has no identity configured at all, so every
real production agent commit on the home-nas bare clone depended on a
stray local override that turned out to be a manual-testing session's
throwaway "Smoke Test" identity, evidently applied to the production
clone by accident instead of an isolated test repo. It went unnoticed
because it made commits succeed, just under the wrong author — found
by noticing dozens of `Smoke Test`-authored commits across several
real, board-tracked PRs.

## Implementation information

- `CloneBare` (`internal/project/git.go`) now sets an explicit
  `user.name`/`user.email` on every bare clone right after cloning, so
  a fresh clone can never be identity-less or silently inherit an
  unrelated stray override again.
- `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` env vars let an operator brand
  commits (e.g. as their own GitHub App bot); the default
  (`Sybra Agent <sybra-agent@example.invalid>`) matches the fallback
  `internal/agent/k8s_job_runner.go` already uses.
- Out-of-band: fixed the home-nas bare clone's contaminated local git
  config directly (now `sybra-app[bot]`), and removed the also-broken
  ephemeral SSH signing config that came bundled with it (pointed at
  files outside any tracked/backed-up location; the commits it
  produced weren't even verifiable on GitHub — `reason: no_user`).

## Supporting documentation

N/A