### PR TITLE
chore(githooks): drop lint/tests from git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -47,12 +47,6 @@ if [ -n "$staged_go" ]; then
   fi
 fi
 
-# 3. golangci-lint on changed lines only — fast feedback, no full repo scan.
-if [ -n "$staged_go" ] && command -v golangci-lint >/dev/null 2>&1; then
-  # --new-from-rev compares against the merge-base with main so the hook
-  # only flags newly introduced issues, never pre-existing ones.
-  if ! golangci-lint run --new-from-rev=origin/main --timeout 2m ./... 2>&1 | tail -50; then
-    echo "ERROR: golangci-lint flagged new issues on changed lines."
-    exit 1
-  fi
-fi
+# golangci-lint is intentionally not run here — CI's lint-go job covers it,
+# and running it per-commit across parallel agent worktrees overloads the
+# local machine.

--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -43,13 +43,14 @@ manual_test:
 # otherwise the hook fails with "tool not found" at commit time, which was
 # the aa9ba123 failure mode (see CLAUDE.md Server Deployment section).
 checks:
+  # golangci-lint and go test are intentionally NOT run here — CI's
+  # lint-go/test-go jobs already cover them on every push, and running the
+  # full-repo lint/test suite per-commit across parallel agent worktrees
+  # overloads the local machine. gofmt/goimports-equivalent formatting is
+  # cheap enough to keep local via oxlint/hadolint below.
   pre_commit:
-    - 'GOLANGCI_LINT_CACHE="${TMPDIR:-/tmp}/golangci-lint-$(basename "$(pwd)")" mise exec -- golangci-lint run ./...'
     - (cd frontend && npx oxlint .)
     - mise exec -- hadolint Dockerfile
-  pre_push:
-    - mise exec -- go test ./...
-    - (cd frontend && npm run check)
   # Mutation pass run by the codegen_gate workflow step before tamper/verify/
   # review/testing so generated files, goimports, and go.mod drift are fixed
   # in the worktree and committed before downstream validation.


### PR DESCRIPTION
## Motivation

> Changelog: chore(githooks): drop lint/tests from git hooks

Per-commit golangci-lint (and per-push go test) across parallel agent worktrees was overloading the local machine. CI's `lint-go`/`test-go` jobs already cover both on every push, so running them locally was redundant and expensive.

## Implementation information

Two separate mechanisms both needed the fix:

- `.githooks/pre-commit` — the manual `mise run hooks:install` dev hook. Dropped the `--new-from-rev` golangci-lint step; gofmt/goimports and the frontend pin/lockfile check are unchanged.
- `.sybra.yaml` `checks.pre_commit`/`checks.pre_push` — the actual source Sybra's `InstallHooks` reads to write hooks into every agent worktree, independent of `.githooks/`. Dropped golangci-lint from `pre_commit` (oxlint + hadolint stay, they're cheap) and removed `pre_push` entirely (was `go test ./...` + `npm run check`).

Already-provisioned bare clones (laptop's `~/.sybra/clones` + main dev clone, and the home-nas server's clone) were patched directly over SSH/locally so the fix takes effect immediately, since `InstallHooks` only re-writes hooks on new worktree creation, not for existing ones.

## Supporting documentation

n/a