### PR TITLE
feat(agent): default new tasks to headless mode

### DIFF
--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -204,7 +204,7 @@ test.describe('Create Task', () => {
     await page.getByPlaceholder('Task title...').fill('E2E Test Task')
     await page.getByPlaceholder('Task description (markdown)...').fill('Created by Playwright e2e test')
 
-    // Interactive is the default mode (headless is opt-in checkbox)
+    // Headless is the default mode (checkbox defaults on)
 
     // Submit
     await page.getByRole('button', { name: 'Create' }).click()
@@ -213,9 +213,9 @@ test.describe('Create Task', () => {
     await expect(page.locator('h1', { hasText: 'E2E Test Task' })).toBeVisible({ timeout: 5_000 })
     await expect(page.getByText('Created by Playwright e2e test')).toBeVisible()
 
-    // Agent mode should show interactive in the detail metadata (Mode row)
+    // Agent mode should show headless in the detail metadata (Mode row)
     const main = page.getByRole('main')
-    await expect(main.getByText('Mode', { exact: true }).locator('..').getByText('interactive')).toBeVisible()
+    await expect(main.getByText('Mode', { exact: true }).locator('..').getByText('headless')).toBeVisible()
 
     // Go back — new task should appear in list
     await page.getByText('Back to tasks').click()

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -16,7 +16,7 @@
 
   let title = $state('')
   let body = $state('')
-  let headless = $state(false)
+  let headless = $state(true)
   let reasoningEffort = $state('')
   let taskType = $state('normal')
   let selectedProject = $state('')
@@ -59,7 +59,7 @@
   function reset() {
     title = ''
     body = ''
-    headless = false
+    headless = true
     reasoningEffort = ''
     taskType = 'normal'
     selectedProject = ''

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -454,12 +454,12 @@ func (s *Store) safePath(id string) (string, error) {
 }
 
 // Create writes a new task file with a fresh 8-char ID, status "todo", and
-// type "normal". mode defaults to AgentModeInteractive when empty and is
+// type "normal". mode defaults to AgentModeHeadless when empty and is
 // validated via ValidateAgentMode. Use CreateFull to set additional fields
 // (tags, project, priority, ...) atomically at creation time.
 func (s *Store) Create(title, body, mode string) (Task, error) {
 	if mode == "" {
-		mode = AgentModeInteractive
+		mode = AgentModeHeadless
 	}
 	if _, err := ValidateAgentMode(mode); err != nil {
 		return Task{}, err
@@ -501,7 +501,7 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 // Update applies.
 func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) {
 	if mode == "" {
-		mode = AgentModeInteractive
+		mode = AgentModeHeadless
 	}
 	if _, err := ValidateAgentMode(mode); err != nil {
 		return Task{}, err

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1293,8 +1293,8 @@ func TestStoreCreateDefaultMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if created.AgentMode != "interactive" {
-		t.Errorf("AgentMode = %q, want %q", created.AgentMode, "interactive")
+	if created.AgentMode != "headless" {
+		t.Errorf("AgentMode = %q, want %q", created.AgentMode, "headless")
 	}
 }
 

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -427,7 +427,7 @@ func TestApplyMediumFeatureGoesToPlanning(t *testing.T) {
 	}
 }
 
-func TestApplyWorkProjectForcesInteractiveAndPlanning(t *testing.T) {
+func TestApplyWorkProjectPlanningKeepsMode(t *testing.T) {
 	mgr := newTestManager(t)
 	created, err := mgr.Create("refactor ingestion", "https://github.com/example-org/example-repo/issues/1", task.AgentModeHeadless)
 	if err != nil {
@@ -447,8 +447,9 @@ func TestApplyWorkProjectForcesInteractiveAndPlanning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if updated.AgentMode != task.AgentModeInteractive {
-		t.Errorf("mode: got %q, want interactive", updated.AgentMode)
+	// Work projects no longer force interactive; the classifier's pick stands.
+	if updated.AgentMode != task.AgentModeHeadless {
+		t.Errorf("mode: got %q, want headless", updated.AgentMode)
 	}
 	if updated.Status != task.StatusPlanning {
 		t.Errorf("status: got %s, want planning", updated.Status)
@@ -485,8 +486,8 @@ func TestApplyUsesExistingProjectWhenTaskHasNoRepoURL(t *testing.T) {
 	if updated.ProjectID != "example-org/example-repo" {
 		t.Errorf("project_id: got %q, want example-org/example-repo", updated.ProjectID)
 	}
-	if updated.AgentMode != task.AgentModeInteractive {
-		t.Errorf("mode: got %q, want interactive", updated.AgentMode)
+	if updated.AgentMode != task.AgentModeHeadless {
+		t.Errorf("mode: got %q, want headless", updated.AgentMode)
 	}
 	if updated.Status != task.StatusPlanning {
 		t.Errorf("status: got %s, want planning", updated.Status)
@@ -589,9 +590,10 @@ func TestApplyStaleProjectIDReResolvesFromIssueURL(t *testing.T) {
 	if updated.ProjectID != "example-org/example-repo" {
 		t.Errorf("project_id: got %q, want example-org/example-repo (stale ID must re-resolve)", updated.ProjectID)
 	}
-	// Re-resolution must recover the work project type so its forced routing applies.
-	if updated.AgentMode != task.AgentModeInteractive {
-		t.Errorf("mode: got %q, want interactive (work-typed routing must apply after re-resolve)", updated.AgentMode)
+	// Re-resolution recovers the work project type; mode is no longer forced,
+	// so the classifier's headless pick stands.
+	if updated.AgentMode != task.AgentModeHeadless {
+		t.Errorf("mode: got %q, want headless (classifier pick stands after re-resolve)", updated.AgentMode)
 	}
 	if updated.Status != task.StatusPlanning {
 		t.Errorf("status: got %s, want planning", updated.Status)

--- a/internal/triage/routing.go
+++ b/internal/triage/routing.go
@@ -25,11 +25,12 @@ func RouteStatus(size, taskType, projectType string) task.Status {
 	return task.StatusTodo
 }
 
-// RouteMode optionally overrides the LLM's mode pick based on project type.
-// Work projects get forced to interactive unless the task is a PR review.
+// RouteMode returns the mode to persist for a triaged task. The LLM's pick is
+// currently passed through unchanged; headless is the preferred execution mode
+// (see the interactive-removal umbrella), so no project type is forced to
+// interactive.
 func RouteMode(llmMode, taskType, projectType string) string {
-	if projectType == "work" && taskType != "review" {
-		return task.AgentModeInteractive
-	}
+	_ = taskType
+	_ = projectType
 	return llmMode
 }

--- a/internal/triage/routing.go
+++ b/internal/triage/routing.go
@@ -28,9 +28,8 @@ func RouteStatus(size, taskType, projectType string) task.Status {
 // RouteMode returns the mode to persist for a triaged task. The LLM's pick is
 // currently passed through unchanged; headless is the preferred execution mode
 // (see the interactive-removal umbrella), so no project type is forced to
-// interactive.
+// interactive. taskType/projectType are retained in the signature for callers
+// and future routing.
 func RouteMode(llmMode, taskType, projectType string) string {
-	_ = taskType
-	_ = projectType
 	return llmMode
 }

--- a/internal/triage/routing_test.go
+++ b/internal/triage/routing_test.go
@@ -43,7 +43,7 @@ func TestRouteMode(t *testing.T) {
 	}{
 		{"pet keeps headless", "headless", "feature", "pet", "headless"},
 		{"pet keeps interactive", "interactive", "feature", "pet", "interactive"},
-		{"work feature forced interactive", "headless", "feature", "work", "interactive"},
+		{"work feature no longer forced", "headless", "feature", "work", "headless"},
 		{"work review stays headless", "headless", "review", "work", "headless"},
 		{"empty project type", "headless", "feature", "", "headless"},
 	}


### PR DESCRIPTION
## Motivation

Interactive agent mode is effectively unused — everything runs through headless (`claude -p`) agents. This flips the base default so new tasks are headless unless a mode is explicitly chosen, and stops triage from forcing work projects onto interactive.

> Changelog: feat(agent): default new tasks to headless mode

Full removal of interactive mode + the chat feature is tracked in #2294.

## Implementation information

- `internal/task/store.go` — `Store.Create` / `Store.CreateFull`: empty `agent_mode` now defaults to `AgentModeHeadless` (was interactive). Doc comment updated.
- `internal/triage/routing.go` — `RouteMode` no longer force-overrides work projects to interactive; the classifier's pick passes through.
- `frontend/src/components/CreateTaskDialog.svelte` — the headless checkbox defaults on (and resets on).
- Tests updated to match the new default: `store_test.go`, `routing_test.go`, `apply_test.go` (the work-project routing test renamed — it now asserts the classifier pick stands).

`AgentModeInteractive` stays a valid, load-accepted value so existing on-disk task files carrying `agent_mode: interactive` still parse. No data migration.

## Supporting documentation

Blast-radius analysis on this branch confirmed the mint sites and the back-compat constraint. Remaining interactive-minting sites (`selfmonitor`, `TaskTypeDebug` forcing, classifier prompt bias) are intentionally left for the removal umbrella #2294 to keep this a minimal, reversible default-flip.
