### PR TITLE
fix(agent): track task-agent release in App.wg

### DIFF
--- a/internal/sybra/app_agent_release_lifecycle_test.go
+++ b/internal/sybra/app_agent_release_lifecycle_test.go
@@ -1,0 +1,147 @@
+package sybra
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/sybra/agentorch"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+// newFakeInteractiveClaudeApp builds a real *App (unmocked taskAgentReleaser)
+// backed by a real agent.Manager with restart-survival enabled, and installs
+// a fake `claude` binary on PATH that blocks reading its never-EOF FIFO
+// stdin — the same shape a live, idle (StatePaused) interactive session has
+// in production.
+func newFakeInteractiveClaudeApp(t *testing.T) *App {
+	t.Helper()
+
+	fakebin := t.TempDir()
+	fakeClaude := filepath.Join(fakebin, "claude")
+	// exec replaces the shell with `cat`, which blocks reading the detached
+	// FIFO stdin forever — the "waiting for a turn that never arrives" shape
+	// from #2290.
+	if err := os.WriteFile(fakeClaude, []byte("#!/usr/bin/env bash\nexec cat >/dev/null\n"), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", fakebin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dir, err := os.MkdirTemp("", "sybra-test-tasks-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+
+	logger := discardLogger()
+	mgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir(), agent.ManagerConfig{
+		Runtime:           agent.ManagerRuntimeConfig{DefaultProvider: "claude"},
+		SurviveRestartDir: t.TempDir(),
+		SandboxHome:       func(string) (string, error) { return t.TempDir(), nil },
+	})
+	t.Cleanup(func() { mgr.ShutdownWithGrace(2 * time.Second) })
+
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        taskMgr,
+		Logger:       logger,
+		AgentChecker: mgr.HasRunningAgentForTask,
+	})
+	agentOrch := agentorch.New(taskMgr, nil, mgr, nil, logger, wm, nil)
+
+	a := &App{
+		tasks:     taskMgr,
+		agents:    mgr,
+		tasksDir:  dir,
+		logger:    logger,
+		worktrees: wm,
+		agentOrch: agentOrch,
+	}
+	a.initStatusHook()
+	return a
+}
+
+// startIdleInteractiveAgent runs a detached interactive "claude" session for
+// taskID and waits for it to settle into StatePaused (idle, awaiting the
+// next turn — a live process holding an agent.max_concurrent slot). Returns
+// the agent and its OS pid.
+func startIdleInteractiveAgent(t *testing.T, a *App, taskID string) (ag *agent.Agent, pid int) {
+	t.Helper()
+	ag, err := a.agents.Run(agent.RunConfig{
+		TaskID:   taskID,
+		Name:     "implementation",
+		Mode:     "interactive",
+		Provider: "claude",
+		Dir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && ag.GetState() != agent.StatePaused {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if ag.GetState() != agent.StatePaused {
+		t.Fatalf("agent did not settle into paused state, got %s", ag.GetState())
+	}
+	pid = ag.GetPID()
+	if pid <= 0 {
+		t.Fatalf("agent has no pid")
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("fake claude process not alive right after start: %v", err)
+	}
+	// Detached agents are exempt from Manager.Shutdown's own cleanup by
+	// design (restart survival), so a failed assertion before the release
+	// path runs would otherwise leave this process orphaned.
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	return ag, pid
+}
+
+func processAliveForTest(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+// TestApp_TaskTerminal_AsksLiveInteractiveAgentToExit is the regression test
+// for #2290: an interactive-mode agent process has no lifecycle tie-back to
+// its owning task, so it survives task completion indefinitely, permanently
+// holding an agent.max_concurrent slot. It reproduces the exact production
+// shape — a detached (restart-surviving) interactive claude session idling
+// on a never-EOF stdin FIFO — and asserts that moving the owning task to a
+// terminal status asks the real OS process to exit within a bounded time.
+func TestApp_TaskTerminal_AsksLiveInteractiveAgentToExit(t *testing.T) {
+	for _, target := range []task.Status{task.StatusDone, task.StatusCancelled} {
+		t.Run(string(target), func(t *testing.T) {
+			a := newFakeInteractiveClaudeApp(t)
+
+			created, err := a.tasks.Create("interactive session outlives task", "", "interactive")
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, pid := startIdleInteractiveAgent(t, a, created.ID)
+
+			if _, err := a.tasks.Update(created.ID, task.Update{Status: task.Ptr(target)}); err != nil {
+				t.Fatal(err)
+			}
+
+			deadline := time.Now().Add(5 * time.Second)
+			for time.Now().Before(deadline) {
+				if !processAliveForTest(pid) {
+					return
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+			t.Fatalf("interactive agent process (pid %d) still alive 5s after task reached %s", pid, target)
+		})
+	}
+}

--- a/internal/sybra/app_agent_release_lifecycle_test.go
+++ b/internal/sybra/app_agent_release_lifecycle_test.go
@@ -103,8 +103,14 @@ func startIdleInteractiveAgent(t *testing.T, a *App, taskID string) (ag *agent.A
 	}
 	// Detached agents are exempt from Manager.Shutdown's own cleanup by
 	// design (restart survival), so a failed assertion before the release
-	// path runs would otherwise leave this process orphaned.
-	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	// path runs would otherwise leave this process orphaned. Guard on
+	// liveness first — the pid may already be gone (and reused by an
+	// unrelated process) by the time cleanup runs on a passing test.
+	t.Cleanup(func() {
+		if processAliveForTest(pid) {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	})
 	return ag, pid
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -746,8 +746,19 @@ func (a *App) releaseTaskAgents(taskID string) {
 	if len(filtered) == 0 {
 		return
 	}
-	go func(agentsToStop []*agent.Agent) {
-		for _, ag := range agentsToStop {
+	// Tracked by a.wg (not a bare `go func`): App.Shutdown waits on a.wg
+	// before calling agents.Shutdown, which explicitly skips detached agents
+	// so they survive a restart. A task landing (e.g. its own PR merging)
+	// commonly races the very redeploy that lands it, so an untracked
+	// goroutine here can be starved of scheduler time entirely — the process
+	// exits before ever sending the stop signal, and a detached interactive
+	// agent (a never-EOF stdin FIFO) then idles forever holding a
+	// concurrency slot until happenstance reaps it on some later restart.
+	// Tracking it here only needs to guarantee the signal is sent — once
+	// StopAgent's SIGINT/SIGKILL reaches the OS, delivery no longer depends
+	// on this process staying alive.
+	a.wg.Go(func() {
+		for _, ag := range filtered {
 			var err error
 			if ag.Mode == "headless" && ag.CompletedSuccessfully() {
 				err = a.agents.StopCompletedAgent(ag.ID)
@@ -758,7 +769,7 @@ func (a *App) releaseTaskAgents(taskID string) {
 				a.logger.Warn("task.status.release-agent", "task_id", taskID, "agent_id", ag.ID, "err", err)
 			}
 		}
-	}(filtered)
+	})
 }
 
 func (a *App) runsTaskLocally(t task.Task) bool {


### PR DESCRIPTION
## Motivation

Interactive-mode Claude agent processes are spawned detached (restart-survival) with a live, never-EOF stdin FIFO so they can outlive an app restart. Production confirmed processes still running hours to days after their owning task reached done/cancelled, each permanently holding an `agent.max_concurrent` slot.

Sybra already has a mechanism for this: `App.initStatusHook` fires `releaseTaskAgents` on every transition into a terminal (or human-required) status, which stops all of a task's live agents. That mechanism does work end-to-end in a live app — verified directly. The gap is narrower: `releaseTaskAgents` spawned its stop loop as a bare, untracked `go func(){}()`, unlike every other background op in that file, which uses `a.wg.Go(...)`. `App.Shutdown()` waits on `a.wg` before calling `agents.Shutdown()` (which by design skips detached agents so they survive a restart). Since a task landing (its own PR merging, for this self-hosted-on-its-own-repo deployment) commonly races the redeploy it triggers, the untracked goroutine could be starved of scheduler time by process exit before ever sending the stop signal — leaking the detached process until a later restart happens to reap it via the stale-reattach sweep, which itself only runs when a new commit triggers the next redeploy.

## Implementation information

- `internal/sybra/app_init.go`: `releaseTaskAgents`'s stop loop now runs via `a.wg.Go(...)` instead of a bare goroutine, so `App.Shutdown` genuinely waits for the stop signal to be sent before the process can exit. No other behavior change.
- `internal/sybra/app_agent_release_lifecycle_test.go`: new test `TestApp_TaskTerminal_AsksLiveInteractiveAgentToExit` builds a real App + agent.Manager (restart-survival on) with a fake `claude` binary that blocks reading a never-EOF FIFO stdin exactly like a real idle interactive session, starts a detached interactive session for a task, transitions the task to done/cancelled via the real (unmocked) status-hook path, and asserts the OS process exits within a bounded time — this is the regression test the issue itself asks for.

### Open questions

The specific "untracked vs `a.wg.Go`" mechanism is only observable via a real process-exit race, and I could not find a way to unit-test it deterministically: an in-process check (no process exit) can't distinguish tracked from untracked, since a live process's untracked goroutine still runs to completion "by luck" regardless of scheduling; a subprocess/`os.Exit` trick that does exit the process gives a false negative under `-race` (confirmed empirically — reverting the fix and running the trick 15/15 times under `-race` all passed, i.e. failed to catch the regression, while it caught it reliably 10/10 without `-race`). I verified the fix manually during development this way rather than shipping a misleading always-green test. The shipped test instead covers the functional promise the issue asks for (task terminal → live interactive agent asked to exit), which is real regression coverage even though it doesn't isolate this specific mechanism.

> Changelog: fix(agent): track task-agent release in App.wg

Closes #2290