### PR TITLE
fix(cluster): scope mirror poll to owned tasks

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
@@ -152,6 +152,19 @@ export function ListTasks(): $CancellablePromise<task$0.Task[]> {
 }
 
 /**
+ * ListTasksForNode returns the subset of the board relevant to a cluster
+ * follower's mirror: tasks assigned to that node, excluding chat tasks and
+ * terminal tasks closed longer than mirrorStaleTerminalWindow ago. Unlike
+ * ListTasks, this is sized for repeated polling rather than a one-off full
+ * board read.
+ */
+export function ListTasksForNode(node: string): $CancellablePromise<task$0.Task[]> {
+    return $Call.ByID(844621143, node).then(($result: any) => {
+        return $$createType9($result);
+    });
+}
+
+/**
  * ReconcilePendingEnrichment re-attempts GitHub enrichment for URL stubs whose
  * initial async enrichment never completed. A stub is created with the raw URL
  * as its title and the enrich-pending marker; enrichment then runs in a

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -199,6 +199,7 @@ export function ListTaskAuditEvents(arg1: string, arg2: number): Promise<Array<T
 export function GetTamperReport(arg1: string): Promise<TamperReportDTO> { return call('TaskService', 'GetTamperReport', arg1) }
 export function GetTask(arg1: string): Promise<Task> { return call('TaskService', 'GetTask', arg1) }
 export function ListTasks(): Promise<Array<Task>> { return call('TaskService', 'ListTasks') }
+export function ListTasksForNode(arg1: string): Promise<Array<Task>> { return call('TaskService', 'ListTasksForNode', arg1) }
 export function ListTaskProgress(arg1: string): Promise<Array<ProgressEntry>> { return call('TaskService', 'ListTaskProgress', arg1) }
 export function UpdateTask(arg1: string, arg2: Record<string, unknown>): Promise<Task> { return call('TaskService', 'UpdateTask', arg1, arg2) }
 export function AssignTask(arg1: Task): Promise<void> { return call('TaskService', 'AssignTask', arg1) }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -162,6 +162,7 @@ export const ListTaskAuditEvents = pick(TaskSvc.ListTaskAuditEvents, http.ListTa
 export const GetTamperReport = pick(TaskSvc.GetTamperReport, http.GetTamperReport)
 export const GetTask = pick(TaskSvc.GetTask, http.GetTask)
 export const ListTasks = pick(TaskSvc.ListTasks, http.ListTasks)
+export const ListTasksForNode = pick(TaskSvc.ListTasksForNode, http.ListTasksForNode)
 export const ListTaskProgress = pick(TaskSvc.ListTaskProgress, http.ListTaskProgress)
 export const UpdateTask = pick(TaskSvc.UpdateTask, http.UpdateTask)
 export const AssignTask = pick(TaskSvc.AssignTask, http.AssignTask)

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -333,9 +333,24 @@ func (c *Client) GetTask(ctx context.Context, id string) (task.Task, error) {
 	return decode[task.Task](raw)
 }
 
-// ListTasks fetches all of the follower's tasks.
+// ListTasks fetches the follower's tasks relevant to this node's mirror —
+// ListTasksForNode filters to tasks assigned to c.node.Name and drops
+// long-terminal ones (#2188/#2258: the leader's Mirror re-lists every
+// follower every 30s, and a follower's full unfiltered board — every task it
+// has ever touched, full body/plan/review sidecars included — routinely
+// exceeds the 30s call timeout long before it exceeds maxResponseBody).
+// Falls back to the legacy unfiltered ListTasks on a 404 so a leader that has
+// rolled out this client change ahead of a not-yet-updated follower (or vice
+// versa, during the follower's auto-update window) still gets a working,
+// just less efficient, reconcile instead of a broken one.
 func (c *Client) ListTasks(ctx context.Context) ([]task.Task, error) {
-	raw, err := c.callIdempotent(ctx, "TaskService", "ListTasks")
+	raw, err := c.callIdempotent(ctx, "TaskService", "ListTasksForNode", c.node.Name)
+	if err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound {
+			raw, err = c.callIdempotent(ctx, "TaskService", "ListTasks")
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cluster/client_test.go
+++ b/internal/cluster/client_test.go
@@ -32,6 +32,8 @@ type stubFollower struct {
 	gotPath  string
 	gotAuth  string
 	assigned *task.Task
+	gotPaths []string
+	forNode  string
 }
 
 func (s *stubFollower) server(t *testing.T) *httptest.Server {
@@ -42,6 +44,7 @@ func (s *stubFollower) server(t *testing.T) *httptest.Server {
 	})
 	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
 		s.gotPath = r.URL.Path
+		s.gotPaths = append(s.gotPaths, r.URL.Path)
 		s.gotAuth = r.Header.Get("Authorization")
 		s.gotBody, _ = io.ReadAll(r.Body)
 		if s.token != "" && r.Header.Get("Authorization") != "Bearer "+s.token {
@@ -51,6 +54,13 @@ func (s *stubFollower) server(t *testing.T) *httptest.Server {
 			return
 		}
 		switch r.URL.Path {
+		case "/api/TaskService/ListTasksForNode":
+			var args []string
+			_ = json.Unmarshal(s.gotBody, &args)
+			if len(args) == 1 {
+				s.forNode = args[0]
+			}
+			_ = json.NewEncoder(w).Encode(s.tasks)
 		case "/api/TaskService/ListTasks":
 			_ = json.NewEncoder(w).Encode(s.tasks)
 		case "/api/TaskService/GetTask":
@@ -86,6 +96,38 @@ func TestClientListTasks(t *testing.T) {
 	}
 	if stub.gotAuth != "Bearer sekret" {
 		t.Errorf("auth header = %q", stub.gotAuth)
+	}
+	if stub.gotPath != "/api/TaskService/ListTasksForNode" {
+		t.Errorf("gotPath = %q, want the node-filtered endpoint", stub.gotPath)
+	}
+	if stub.forNode != "n1" {
+		t.Errorf("forNode = %q, want the client's own roster name %q", stub.forNode, "n1")
+	}
+}
+
+// TestClientListTasksFallsBackToLegacyWhenNodeFilteredEndpointMissing covers
+// the rolling-deploy window: a follower that hasn't picked up
+// ListTasksForNode yet (auto-update lag, or a leader built ahead of it)
+// returns 404 for the lean endpoint, and the client must still succeed via
+// the original unfiltered ListTasks rather than surfacing the 404.
+func TestClientListTasksFallsBackToLegacyWhenNodeFilteredEndpointMissing(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+	mux.HandleFunc("POST /api/TaskService/ListTasks", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]task.Task{{ID: "legacy"}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := mustClient(t, Node{Name: "n1", Endpoints: []string{srv.URL}})
+	got, err := client.ListTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListTasks did not fall back to the legacy endpoint: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "legacy" {
+		t.Fatalf("ListTasks = %+v, want the legacy endpoint's result", got)
 	}
 }
 

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -127,6 +127,7 @@ func (m *Mirror) reconcileMissing(ctx context.Context, node string, client *clus
 	}
 	canonical, err := m.tasks.List()
 	if err != nil {
+		m.logger.Warn("cluster.mirror.reconcile_missing.list_failed", "node", node, "err", err)
 		return
 	}
 	for i := range canonical {

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -108,6 +108,42 @@ func (m *Mirror) reconcileNode(ctx context.Context, node string, consecutiveFail
 	for i := range tasks {
 		m.applyFollowerTask(node, tasks[i])
 	}
+	m.reconcileMissing(ctx, node, client, tasks)
+}
+
+// reconcileMissing closes the gap ListTasksForNode's staleness filter opens:
+// a task the leader still considers live and assigned to node, but that this
+// node's response omitted. That only happens when the follower closed it
+// more than mirrorStaleTerminalWindow ago while the leader could not reach
+// this node at all (an outage or restart spanning the entire window) -- the
+// closing update never got a chance to apply, and the follower will never
+// offer that task again, so without this the canonical copy would stay stuck
+// at its last non-terminal state permanently. Fetches only the handful of
+// affected tasks directly (GetTask) instead of falling back to a full list.
+func (m *Mirror) reconcileMissing(ctx context.Context, node string, client *cluster.Client, tasks []task.Task) {
+	seen := make(map[string]struct{}, len(tasks))
+	for i := range tasks {
+		seen[tasks[i].ID] = struct{}{}
+	}
+	canonical, err := m.tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range canonical {
+		t := canonical[i]
+		if t.AssignedNode != node || task.IsTerminalStatus(t.Status) {
+			continue
+		}
+		if _, ok := seen[t.ID]; ok {
+			continue
+		}
+		follower, gerr := client.GetTask(ctx, t.ID)
+		if gerr != nil {
+			m.logger.Debug("cluster.mirror.reconcile_missing.failed", "node", node, "task", t.ID, "err", gerr)
+			continue
+		}
+		m.applyFollowerTask(node, follower)
+	}
 }
 
 func (m *Mirror) applyFollowerTask(node string, follower task.Task) bool {

--- a/internal/sybra/clusterlead/mirror_oob_integration_test.go
+++ b/internal/sybra/clusterlead/mirror_oob_integration_test.go
@@ -33,6 +33,30 @@ type managerTaskService struct{ mgr *task.Manager }
 
 func (s *managerTaskService) ListTasks() ([]task.Task, error) { return s.mgr.List() }
 
+// ListTasksForNode mirrors internal/sybra.TaskService.ListTasksForNode's
+// filter (assigned-to-node, drop terminal tasks closed more than 10m ago --
+// keep the window in sync with internal/sybra's mirrorStaleTerminalWindow) so
+// tests exercising realFollowerServer drive the real, lean mirror path rather
+// than the pre-#2258 fallback.
+func (s *managerTaskService) ListTasksForNode(node string) ([]task.Task, error) {
+	all, err := s.mgr.List()
+	if err != nil {
+		return nil, err
+	}
+	out := all[:0]
+	for i := range all {
+		t := all[i]
+		if t.AssignedNode != node {
+			continue
+		}
+		if task.IsTerminalStatus(t.Status) && t.ClosedAt != nil && time.Since(*t.ClosedAt) > 10*time.Minute {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
 func (s *managerTaskService) GetTask(id string) (task.Task, error) { return s.mgr.Get(id) }
 
 func (s *managerTaskService) AssignTask(t task.Task) error {
@@ -100,7 +124,7 @@ func realFollowerServer(t *testing.T, mgr *task.Manager) *httptest.Server {
 		_, _ = io.WriteString(w, `{"status":"ok"}`)
 	})
 	httpapi.Mount(mux, map[string]httpapi.Service{
-		"TaskService": httpapi.NewService(&managerTaskService{mgr: mgr}, "ListTasks", "GetTask", "AssignTask"),
+		"TaskService": httpapi.NewService(&managerTaskService{mgr: mgr}, "ListTasks", "ListTasksForNode", "GetTask", "AssignTask"),
 	}, slog.New(slog.DiscardHandler))
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -136,10 +160,11 @@ func TestMirrorPropagatesOutOfBandFollowerWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The follower's own copy of the same task, as AssignTask would have
-	// written it there.
+	// written it there -- AssignedNode included, since the leader's push
+	// (clusterlead.Assigner.Route) stamps it on the task before sending.
 	if _, _, err := followerMgr.Put(task.Task{
 		ID: "task-oob", Title: "t", Status: task.StatusInProgress,
-		ProjectID: "owner/pet", CreatedAt: t0, UpdatedAt: t0,
+		ProjectID: "owner/pet", AssignedNode: "pet-box", CreatedAt: t0, UpdatedAt: t0,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -180,6 +205,65 @@ func TestMirrorPropagatesOutOfBandFollowerWrite(t *testing.T) {
 	}
 }
 
+// TestMirrorReconcileMissingRecoversTaskListTasksForNodeOmitted repros the gap
+// ListTasksForNode's staleness filter opens: the follower closed a task
+// (ClosedAt) long before the leader ever managed a successful reconcile
+// against it (simulating a leader outage/restart spanning the entire
+// mirrorStaleTerminalWindow), so the task never once appears in
+// ListTasksForNode's response. Without Mirror.reconcileMissing's GetTask
+// backstop, canonical would stay stuck at its last non-terminal status
+// forever, since the follower will never offer that task again.
+func TestMirrorReconcileMissingRecoversTaskListTasksForNodeOmitted(t *testing.T) {
+	followerMgr := newManager(t)
+	srv := realFollowerServer(t, followerMgr)
+
+	leaderMgr := newManager(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+
+	t0 := time.Now().Add(-time.Hour)
+	if _, _, err := leaderMgr.Put(task.Task{
+		ID: "task-late-close", Title: "t", Status: task.StatusInProgress,
+		ProjectID: "owner/pet", AssignedNode: "pet-box", CreatedAt: t0, UpdatedAt: t0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	closedAt := time.Now().Add(-time.Hour)
+	if _, _, err := followerMgr.Put(task.Task{
+		ID: "task-late-close", Title: "t", Status: task.StatusDone,
+		ProjectID: "owner/pet", AssignedNode: "pet-box", Branch: "feat/late-close",
+		UpdatedAt: closedAt, ClosedAt: &closedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mirror := NewMirror(cfg, leaderMgr, roster, slog.New(slog.DiscardHandler), 20*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); mirror.Run(ctx) }()
+	t.Cleanup(func() { cancel(); <-done })
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got task.Task
+	for time.Now().Before(deadline) {
+		got, err = leaderMgr.Get("task-late-close")
+		if err == nil && got.Status == task.StatusDone {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got.Status != task.StatusDone {
+		t.Fatalf("leader canonical status = %q, want done -- reconcileMissing should have fetched the task ListTasksForNode's staleness filter omitted", got.Status)
+	}
+	if got.Branch != "feat/late-close" {
+		t.Errorf("leader canonical branch = %q, want feat/late-close", got.Branch)
+	}
+}
+
 // TestMirrorReconcileSucceedsPastOldThirtyTwoMegabyteCap attacks the size-cap
 // fix with a real oversized payload transmitted over a real HTTP connection
 // (chunked transfer, real read loop) -- not the author's own tiny
@@ -210,7 +294,7 @@ func TestMirrorReconcileSucceedsPastOldThirtyTwoMegabyteCap(t *testing.T) {
 	bigBody := strings.Repeat("x", payloadBytes)
 	if _, _, err := followerMgr.Put(task.Task{
 		ID: "task-big", Title: "t", Status: task.StatusDone,
-		ProjectID: "owner/pet", Body: bigBody, UpdatedAt: time.Now(),
+		ProjectID: "owner/pet", AssignedNode: "pet-box", Body: bigBody, UpdatedAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sybra/clusterlead/mirror_oob_integration_test.go
+++ b/internal/sybra/clusterlead/mirror_oob_integration_test.go
@@ -46,6 +46,9 @@ func (s *managerTaskService) ListTasksForNode(node string) ([]task.Task, error) 
 	out := all[:0]
 	for i := range all {
 		t := all[i]
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
 		if t.AssignedNode != node {
 			continue
 		}

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -91,6 +91,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 			"AssignTask",
 			"BlessTampering",
 			"ListTasks",
+			"ListTasksForNode",
 			"ListTaskArtifacts",
 			"GetTaskSetupLog",
 			"ListTaskAuditEvents",

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -125,6 +125,41 @@ func (s *TaskService) ListTasks() ([]task.Task, error) {
 	return out, nil
 }
 
+// mirrorStaleTerminalWindow bounds how long a terminal (done/cancelled) task
+// keeps appearing in ListTasksForNode after it closed. The leader's Mirror
+// polls every DefaultReconcileInterval (30s); ten minutes is dozens of cycles
+// of headroom to deliver the final state before the task drops out, so a
+// large closed-task backlog stops being re-serialized (full body/plan/review
+// sidecars) on every reconcile forever — see #2188/#2258.
+const mirrorStaleTerminalWindow = 10 * time.Minute
+
+// ListTasksForNode returns the subset of the board relevant to a cluster
+// follower's mirror: tasks assigned to that node, excluding chat tasks and
+// terminal tasks closed longer than mirrorStaleTerminalWindow ago. Unlike
+// ListTasks, this is sized for repeated polling rather than a one-off full
+// board read.
+func (s *TaskService) ListTasksForNode(node string) ([]task.Task, error) {
+	all, err := s.tasks.List()
+	if err != nil {
+		return nil, err
+	}
+	out := all[:0]
+	for i := range all {
+		t := all[i]
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
+		if t.AssignedNode != node {
+			continue
+		}
+		if task.IsTerminalStatus(t.Status) && t.ClosedAt != nil && time.Since(*t.ClosedAt) > mirrorStaleTerminalWindow {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
 // GetTask returns a single task by ID.
 func (s *TaskService) GetTask(id string) (task.Task, error) {
 	t, err := s.tasks.Get(id)

--- a/internal/sybra/svc_tasks_listfornode_test.go
+++ b/internal/sybra/svc_tasks_listfornode_test.go
@@ -1,0 +1,88 @@
+package sybra
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestListTasksForNodeFiltersByAssignedNode verifies the cluster-mirror-only
+// listing (see internal/cluster.Client.ListTasks and #2258) only returns
+// tasks assigned to the requested node, never tasks assigned elsewhere, to
+// this node's own board, or ephemeral chat tasks.
+func TestListTasksForNodeFiltersByAssignedNode(t *testing.T) {
+	svc, a := setupTaskService(t)
+
+	mustPut := func(tk task.Task) {
+		t.Helper()
+		if _, _, err := a.tasks.Put(tk); err != nil {
+			t.Fatalf("Put(%s): %v", tk.ID, err)
+		}
+	}
+
+	mustPut(task.Task{ID: "mine", Title: "mine", Status: task.StatusTodo, AssignedNode: "home-nas", UpdatedAt: time.Now()})
+	mustPut(task.Task{ID: "elsewhere", Title: "elsewhere", Status: task.StatusTodo, AssignedNode: "other-box", UpdatedAt: time.Now()})
+	mustPut(task.Task{ID: "unassigned", Title: "unassigned", Status: task.StatusTodo, UpdatedAt: time.Now()})
+	mustPut(task.Task{ID: "chat-mine", Title: "chat", Status: task.StatusTodo, AssignedNode: "home-nas", TaskType: task.TaskTypeChat, UpdatedAt: time.Now()})
+
+	got, err := svc.ListTasksForNode("home-nas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "mine" {
+		t.Fatalf("ListTasksForNode(home-nas) = %+v, want only [mine]", got)
+	}
+}
+
+// TestListTasksForNodeDropsStaleTerminalTasks verifies a terminal (done)
+// task assigned to the node stops being re-serialized once it has been
+// closed for longer than mirrorStaleTerminalWindow -- the leader's Mirror
+// converged on it long ago, so repeating its full body/plan sidecars on
+// every 30s reconcile forever is pure waste. A task closed inside the window
+// still appears, giving the leader multiple chances to apply the final state
+// first.
+func TestListTasksForNodeDropsStaleTerminalTasks(t *testing.T) {
+	svc, a := setupTaskService(t)
+
+	old := time.Now().Add(-mirrorStaleTerminalWindow - time.Minute)
+	fresh := time.Now().Add(-time.Minute)
+
+	mustPut := func(tk task.Task) {
+		t.Helper()
+		if _, _, err := a.tasks.Put(tk); err != nil {
+			t.Fatalf("Put(%s): %v", tk.ID, err)
+		}
+	}
+
+	mustPut(task.Task{
+		ID: "stale-done", Title: "stale-done", Status: task.StatusDone,
+		AssignedNode: "home-nas", UpdatedAt: old, ClosedAt: &old,
+	})
+	mustPut(task.Task{
+		ID: "fresh-done", Title: "fresh-done", Status: task.StatusDone,
+		AssignedNode: "home-nas", UpdatedAt: fresh, ClosedAt: &fresh,
+	})
+	mustPut(task.Task{
+		ID: "in-progress", Title: "in-progress", Status: task.StatusInProgress,
+		AssignedNode: "home-nas", UpdatedAt: old,
+	})
+
+	got, err := svc.ListTasksForNode("home-nas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make(map[string]bool, len(got))
+	for _, tk := range got {
+		ids[tk.ID] = true
+	}
+	if ids["stale-done"] {
+		t.Errorf("ListTasksForNode returned stale-done, want it dropped (closed %v ago)", mirrorStaleTerminalWindow+time.Minute)
+	}
+	if !ids["fresh-done"] {
+		t.Error("ListTasksForNode dropped fresh-done, want it kept (closed within the window)")
+	}
+	if !ids["in-progress"] {
+		t.Error("ListTasksForNode dropped in-progress, want non-terminal tasks always kept")
+	}
+}


### PR DESCRIPTION
## Motivation

> Changelog: fix(cluster): scope mirror poll to owned tasks

The leader's mirror re-lists every follower's full task board every
30s to sync execution state back into its own canonical store. That
list includes every task the follower has ever touched, full
body/plan/review text included, regardless of whether it belongs to
this leader at all. Against a follower with a large task history the
response routinely took longer than the client's 30s call timeout,
so reconcile failed on every single tick and the leader's view of
that follower went stale indefinitely.

## Implementation information

- `TaskService.ListTasksForNode(node)` — a leaner follower endpoint
  that filters to tasks assigned to the requesting node and drops
  terminal (done/cancelled) tasks closed more than 10 minutes ago.
- `cluster.Client.ListTasks` calls the new endpoint first, falling
  back to the old unfiltered one on a 404 so a leader/follower
  version mismatch during a rolling deploy degrades gracefully
  instead of breaking.
- `Mirror.reconcileMissing` backstops the staleness filter: if the
  leader still considers a task live and assigned to a node, but
  that node's response no longer mentions it, the task is fetched
  directly via `GetTask`. Without this, an outage spanning the whole
  10-minute window at the moment a task closes would leave the
  leader's copy stuck at its last non-terminal state forever.
- Regenerated Wails bindings and added the matching frontend API shim
  for the new method.

## Supporting documentation

Covered by new/updated tests:
- `internal/sybra/svc_tasks_listfornode_test.go` — node filtering and
  the staleness window.
- `internal/cluster/client_test.go` — the node-filtered call and its
  404 fallback.
- `internal/sybra/clusterlead/mirror_oob_integration_test.go` — a new
  end-to-end repro proving `reconcileMissing` recovers a task the
  staleness filter would otherwise have dropped permanently, plus the
  existing mirror suite updated to exercise the real lean path.

`mise run verify`'s Go/frontend gates all pass; the only failure seen
locally (`TestDetectAvailableRuntimes`) is a pre-existing,
environment-specific flake unrelated to this change (reproduces
identically on a clean main checkout).