### PR TITLE
fix(workflow): breaker ignores shutdown cancel

### DIFF
--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -1111,6 +1111,83 @@ func TestRestartStalePRFixRebaseFailedFlipsToHumanRequired(t *testing.T) {
 	}
 }
 
+// TestRestartStaleShutdownCancellationSuppressed is a regression guard for
+// sybra#2291's own reproduction: the incident's log line was literally
+// "restart-stale.failed", emitted by this package's StartAgent dispatch on
+// this exact code path. A graceful server shutdown cancels the context this
+// sweep runs under mid-dispatch, so StartAgent returns a context.Canceled
+// error for a task that has nothing wrong with it. Recovery.surfaceStartFailure
+// must recognize that shape (via workflow.IsShutdownCancellation) and leave
+// the task alone — no StatusReason overwrite, no status change — rather than
+// writing a misleading "agent start failed: ...context canceled..." reason on
+// every stale-restart sweep tick until the new instance resumes dispatching.
+func TestRestartStaleShutdownCancellationSuppressed(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agentsCtx, cancelAgents := context.WithCancel(t.Context())
+	t.Cleanup(cancelAgents)
+	agents := newTestAgentManager(t, agentsCtx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("shutdown-cancelled stale restart", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	if _, err := tasks.Update(created.ID, task.Update{Status: &inProg, ProjectID: &projID}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{
+		startErr: fmt.Errorf("worktree required for project task: %w",
+			fmt.Errorf("fetch origin: git fetch origin +refs/heads/*:refs/remotes/origin/*: %w", context.Canceled)),
+	}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Projects:     stubProjects{},
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+
+	// The sweep's own context is already cancelled — simulating the exact
+	// moment a graceful shutdown fires mid-sweep.
+	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
+	cancelShutdown()
+	r.RestartStaleInProgress(shutdownCtx)
+	wg.Wait()
+
+	if stub.startCalls != 1 {
+		t.Fatalf("StartAgent calls = %d, want 1", stub.startCalls)
+	}
+	updated, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusInProgress {
+		t.Errorf("status = %s, want unchanged %s", updated.Status, task.StatusInProgress)
+	}
+	if updated.StatusReason != "" {
+		t.Errorf("status reason = %q, want empty (shutdown cancellation must not surface a reason)", updated.StatusReason)
+	}
+}
+
 // stubWorkflowEngine implements recovery.WorkflowRestarter for tests that need
 // a non-nil engine without a real workflow store.
 type stubWorkflowEngine struct {

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -138,7 +138,7 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 		// file-backed Tasks.Update never blocks the fleet-wide sweep.
 		taskID, currentStatus := t.ID, t.Status
 		r.WG.Go(func() {
-			r.surfaceStartFailure(taskID, currentStatus, err)
+			r.surfaceStartFailure(ctx, taskID, currentStatus, err)
 		})
 		return
 	}
@@ -152,7 +152,7 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 			metrics.OrchestratorStaleRestart(ctx, err == nil)
 			r.Throttle.Log(r.Logger, "restart.pr-fix.failed", "pr-fix:"+taskID, err, "task_id", taskID)
 			if err != nil {
-				r.surfaceStartFailure(taskID, currentStatus, err)
+				r.surfaceStartFailure(ctx, taskID, currentStatus, err)
 			}
 		})
 		return
@@ -174,7 +174,7 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 		metrics.OrchestratorStaleRestart(ctx, err == nil)
 		r.Throttle.Log(r.Logger, "restart-stale.failed", "stale:"+taskID, err, "task_id", taskID)
 		if err != nil {
-			r.surfaceStartFailure(taskID, currentStatus, err)
+			r.surfaceStartFailure(ctx, taskID, currentStatus, err)
 		}
 	})
 }
@@ -383,7 +383,19 @@ func (r *Recovery) recoverCancelledPRFix(t *task.Task) bool {
 // recovery path: write a UI-visible reason on every retry, and flip to
 // human-required when the error is permanent (e.g. project not registered)
 // so the periodic resume loop stops hammering it.
-func (r *Recovery) surfaceStartFailure(taskID string, currentStatus task.Status, err error) {
+//
+// ctx is the same context RestartStaleInProgress/RestartTaskIfStale received
+// (ultimately the app's root context) — checked via
+// workflow.IsShutdownCancellation before writing anything, so a graceful
+// restart's mass context.Canceled burst across every stale in-progress task
+// (sybra#2291's own "restart-stale.failed" log line) never overwrites
+// StatusReason with a misleading "agent start failed: ...context canceled..."
+// message during the shutdown window.
+func (r *Recovery) surfaceStartFailure(ctx context.Context, taskID string, currentStatus task.Status, err error) {
+	if workflow.IsShutdownCancellation(ctx, err) {
+		r.Logger.Info("restart-stale.shutdown-cancellation.suppress", "task_id", taskID)
+		return
+	}
 	reason, permanent := workflow.ClassifyAgentStartError(err)
 	if reason == "" {
 		return

--- a/internal/sybra/services_wire_tasks.go
+++ b/internal/sybra/services_wire_tasks.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (a *App) wireTaskService() {
+	a.taskSvc.ctx = a.ctx
 	a.taskSvc.tasks = a.tasks
 	a.taskSvc.agents = a.agents
 	a.taskSvc.workflowEngine = a.workflowEngine

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -32,16 +32,21 @@ import (
 
 // TaskService exposes task CRUD operations as Wails-bound methods.
 type TaskService struct {
-	tasks               *task.Manager
-	agents              *agent.Manager
-	workflowEngine      *workflow.Engine
-	worktrees           *worktree.Manager
-	sandboxes           *sandbox.Manager
-	artifacts           *artifact.Store
-	wg                  *sync.WaitGroup
-	logger              *slog.Logger
-	audit               *audit.Logger
-	cfg                 *config.Config
+	tasks          *task.Manager
+	agents         *agent.Manager
+	workflowEngine *workflow.Engine
+	worktrees      *worktree.Manager
+	sandboxes      *sandbox.Manager
+	artifacts      *artifact.Store
+	wg             *sync.WaitGroup
+	logger         *slog.Logger
+	audit          *audit.Logger
+	cfg            *config.Config
+	// ctx is the app's root context (wireTaskService sets it from a.ctx), used
+	// only where a Wails-bound method has no request-scoped context of its own
+	// to thread through — see RecoverLostAgent. nil in tests that construct
+	// TaskService directly; recoveryCtx falls back to context.Background().
+	ctx                 context.Context
 	recoverLostAgent    func(context.Context, string) error
 	fetchPR             func(repo string, number int) (github.PullRequest, error)
 	fetchIssue          func(repo string, number int) (github.Issue, error)
@@ -561,7 +566,24 @@ func (s *TaskService) RecoverLostAgent(taskID string) error {
 			break
 		}
 	}
-	return s.recoverLostAgent(context.Background(), taskID)
+	return s.recoverLostAgent(s.recoveryCtx(), taskID)
+}
+
+// recoveryCtx is the context RecoverLostAgent hands to recovery.
+// RecoverLostAgent is a Wails-bound method with no request-scoped context of
+// its own — s.ctx (the app's root context, set once by wireTaskService) lets
+// a follower's shutdown-cancellation reach the same
+// workflow.IsShutdownCancellation check Recovery.surfaceStartFailure applies
+// on the local maintenance-sweep path (sybra#2291): without this, an
+// in-flight leader→follower RecoverLostAgent RPC racing a follower's
+// graceful shutdown would fall back to context.Background() (never done),
+// so the check could never recognize the cancellation as shutdown-induced
+// and would still surface a misleading status_reason / feed the breaker.
+func (s *TaskService) recoveryCtx() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return context.Background()
 }
 
 func assignedTaskNoOp(current, pushed task.Task) bool {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -1,6 +1,7 @@
 package sybra
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -60,6 +61,47 @@ func TestTaskService_WithEstimatedAgentRunCosts(t *testing.T) {
 	}
 	if got.AgentRuns[3].CostUSD != 0.42 {
 		t.Fatalf("reported cost = %g, want 0.42", got.AgentRuns[3].CostUSD)
+	}
+}
+
+// TestTaskService_RecoverLostAgent_ForwardsAppContext is a regression guard
+// for sybra#2291: RecoverLostAgent is a Wails-bound method with no
+// request-scoped context of its own, so it used to hand recoverLostAgent a
+// bare context.Background() — permanently invisible to
+// workflow.IsShutdownCancellation (ctx.Err() is always nil on
+// context.Background()). A leader→follower RecoverLostAgent RPC racing a
+// follower's graceful shutdown would then never have its resulting
+// context.Canceled recognized as shutdown-induced, reproducing the same
+// mass-status-reason-overwrite symptom the primary fix targets, just through
+// this one call site. s.ctx (wired from the app's root context) must be what
+// actually reaches recoverLostAgent.
+func TestTaskService_RecoverLostAgent_ForwardsAppContext(t *testing.T) {
+	t.Parallel()
+	svc, _ := setupTaskService(t)
+
+	created, err := svc.tasks.Create("lost agent recover", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type ctxKey struct{}
+	marker := context.WithValue(context.Background(), ctxKey{}, "app-root-ctx")
+	svc.ctx = marker
+
+	// Extract the marker value inside the closure rather than storing the raw
+	// ctx in an outer variable, since a stashed-away context.Context is a
+	// footgun the fatcontext linter rightly flags even in test code.
+	var gotMarker any
+	svc.recoverLostAgent = func(ctx context.Context, _ string) error {
+		gotMarker = ctx.Value(ctxKey{})
+		return nil
+	}
+
+	if err := svc.RecoverLostAgent(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if gotMarker != "app-root-ctx" {
+		t.Fatalf("recoverLostAgent received ctx marker %v, want svc.ctx (marked app-root context)", gotMarker)
 	}
 }
 

--- a/internal/workflow/engine_bestofn_test.go
+++ b/internal/workflow/engine_bestofn_test.go
@@ -1,7 +1,9 @@
 package workflow
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -411,6 +413,41 @@ func TestBestOfN_AllAttemptsFail_HumanRequiredDistinctReason(t *testing.T) {
 	}
 	if got := attemptWt.cleanupCalls[len(attemptWt.cleanupCalls)-1]; len(got) != 2 {
 		t.Fatalf("cleanup ids = %v, want both attempts", got)
+	}
+}
+
+// TestBestOfN_ShutdownCancellationDuringSpawnDoesNotEscalate is a regression
+// guard for a gap an adversarial manual test found in sybra#2291's fix: the
+// best-of-n fan-out loop (execBestOfN in engine_steps_bestofn.go) only routed
+// a spawn-time error through surfaceStartFailure's shutdown-cancellation gate
+// when transientAgentStartError(err) recognized it — a fixed sentinel list
+// that does NOT include a bare context.Canceled. A shutdown-cancelled
+// PrepareAttempt (the exact shape logged in the production incident:
+// "worktree required for project task: fetch origin: ...: context canceled")
+// used to fall straight to the non-transient branch, marking every attempt
+// permanently "failed" and letting finalizeBestOfNParent escalate the whole
+// task to human-required — reproducing the issue's mass-park symptom via a
+// path the primary fix's surfaceStartFailure gate never even ran on.
+func TestBestOfN_ShutdownCancellationDuringSpawnDoesNotEscalate(t *testing.T) {
+	engine, tasks, _, attemptWt, _ := newBestOfNTestEngine(t, 2)
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the app context already cancelled by graceful shutdown
+	engine.SetContext(shutdownCtx)
+
+	shutdownErr := fmt.Errorf("worktree required for project task: fetch origin: git fetch origin +refs/heads/*:refs/remotes/origin/*: %w", context.Canceled)
+	attemptWt.prepareErr[bestOfNAttemptID(1)] = shutdownErr
+	attemptWt.prepareErr[bestOfNAttemptID(2)] = shutdownErr
+
+	if err := engine.StartWorkflow("t1", "bestofn-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	ti := mustTaskInfo(t, tasks, "t1")
+	if ti.Status == "human-required" {
+		t.Fatalf("shutdown-cancelled spawn escalated task to human-required: reason=%q", ti.StatusReason)
+	}
+	if ti.StatusReason != "" {
+		t.Fatalf("shutdown-cancelled spawn wrote status_reason %q, want none", ti.StatusReason)
 	}
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1515,6 +1515,31 @@ func workflowRetryAfter(wf *Execution) (time.Time, bool) {
 	return t, err == nil
 }
 
+// isShutdownCancellationGate short-circuits surfaceStartFailure ahead of the
+// rebase-conflict-recovery branch further down: a context cancellation
+// tracing back to the engine's own shutdown context (e.ctx) is not a
+// task-attributable failure — one graceful restart cancels every in-flight
+// git/agent operation across every concurrently-dispatching task at once.
+// Placement matters: a shutdown-cancelled fetch inside reconcileAndRebase's
+// ReconcileWithRemote step wraps ErrRebaseFailed rather than
+// ErrTransientFetch (project.IsTransientNetworkError doesn't recognize
+// "context canceled" as a transient network blip), so a check placed only in
+// surfaceStartFailureClassified would still let this case fall into the
+// conflict-recovery branch below and dispatch real branch-conflict-fix
+// agents — doomed to be cancelled by that same shutdown — on top of
+// mass-tripping the circuit breaker this fix primarily targets. Suppressed
+// exactly like the other benign dispatch-plumbing sentinels
+// surfaceStartFailureClassified handles below (ErrDispatchInFlight et al.):
+// no status write, no breaker increment, no recovery dispatch (sybra#2291).
+func (e *Engine) isShutdownCancellationGate(taskID, stepID string, err error) bool {
+	if !e.isShutdownCancellation(err) {
+		return false
+	}
+	e.logger.Info("workflow.start-failure.shutdown-cancellation.suppress",
+		"task_id", taskID, "step", stepID)
+	return true
+}
+
 // surfaceStartFailure writes a human-readable reason to task.StatusReason
 // when ResumeStalled fails to (re-)dispatch a step's agent. Permanent errors
 // (e.g. project missing) also flip the task to human-required so the resume
@@ -1529,6 +1554,9 @@ func workflowRetryAfter(wf *Execution) (time.Time, bool) {
 // tracked. Either may be zero-valued (nil wf, empty stepID) for callers that
 // don't have them handy — the breaker simply stays inactive for that call.
 func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error, wf *Execution, stepID string) {
+	if e.isShutdownCancellationGate(taskID, stepID, err) {
+		return
+	}
 	// A pre-agent-start rebase failure is the same "task branch conflicts
 	// with base" condition push_branch/create_pr hit further down the
 	// pipeline (see pushTaskBranch's project.ErrDivergedNeedsResolve branch) —
@@ -1555,22 +1583,6 @@ func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error, wf
 }
 
 func (e *Engine) surfaceStartFailureClassified(taskID, currentStatus string, err error, wf *Execution, stepID string) {
-	// A context cancellation that traces back to the engine's own shutdown
-	// context (e.ctx, bound via SetContext from the app's root context) is
-	// not a task-attributable dispatch failure — a single graceful restart
-	// cancels every in-flight git/agent operation across every
-	// concurrently-dispatching task at once. Counting it toward the circuit
-	// breaker lets one restart mass-trip an unbounded number of breakers and
-	// park otherwise-healthy tasks to human-required for routine deploy
-	// churn that self-heals the moment the new instance resumes dispatching
-	// (sybra#2291). Suppressed exactly like the other benign dispatch-plumbing
-	// sentinels below (ErrDispatchInFlight et al.): no status write, no
-	// breaker increment.
-	if e.isShutdownCancellation(err) {
-		e.logger.Info("workflow.start-failure.shutdown-cancellation.suppress",
-			"task_id", taskID, "step", stepID)
-		return
-	}
 	reason, permanent := ClassifyAgentStartError(err)
 	if reason == "" {
 		return
@@ -1628,13 +1640,22 @@ func (e *Engine) surfaceStartFailureClassified(taskID, currentStatus string, err
 // unrelated per-call cancellation. e.ctx is bound exactly once, from the
 // app's root context (App.Startup -> Engine.SetContext), and is the same
 // context object agentorch.Orchestrator uses to cancel worktree/git
-// operations on shutdown — so e.ctx.Err() != nil at the moment a dispatch
-// error is classified is a reliable signal that this particular
-// context.Canceled came from that shutdown, not from an unrelated timeout or
-// a different context in the chain (which would surface as
-// context.DeadlineExceeded or a non-context error instead).
+// operations on shutdown.
 func (e *Engine) isShutdownCancellation(err error) bool {
-	return e.ctx != nil && e.ctx.Err() != nil && errors.Is(err, context.Canceled)
+	return IsShutdownCancellation(e.ctx, err)
+}
+
+// IsShutdownCancellation reports whether err is a context.Canceled that
+// traces back to ctx being done rather than some unrelated per-call
+// cancellation (a different, unrelated context's timeout would surface as
+// context.DeadlineExceeded or a non-context error instead). Exported so
+// internal/recovery's independent stale-task restart path — which surfaces
+// dispatch failures through its own Recovery.surfaceStartFailure rather than
+// going through Engine — can apply the identical shutdown-vs-genuine-failure
+// heuristic to the "restart-stale.failed" log line named in sybra#2291,
+// rather than maintaining a second, drifting copy of this logic.
+func IsShutdownCancellation(ctx context.Context, err error) bool {
+	return ctx != nil && ctx.Err() != nil && errors.Is(err, context.Canceled)
 }
 
 func circuitBreakerFailureKey(stepID string) string { return circuitBreakerFailureVarPrefix + stepID }

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1658,6 +1658,19 @@ func IsShutdownCancellation(ctx context.Context, err error) bool {
 	return ctx != nil && ctx.Err() != nil && errors.Is(err, context.Canceled)
 }
 
+// transientOrShutdownStartError reports whether a fan-out attempt/child spawn
+// error (best-of-n, parallel) should park the attempt as retryable ("pending")
+// rather than permanently "failed". transientAgentStartError alone doesn't
+// recognize context.Canceled, so a shutdown-cancelled spawn used to fall
+// straight to a hard "failed" that finalizeBestOfNParent/finalizeParallelParent
+// would then escalate the whole task to human-required for — the exact
+// mass-park symptom sybra#2291 targets, reached through a code path the
+// primary surfaceStartFailure fix doesn't gate on its own, since these two
+// call sites only invoke surfaceStartFailure inside the transient branch.
+func (e *Engine) transientOrShutdownStartError(err error) bool {
+	return transientAgentStartError(err) || e.isShutdownCancellation(err)
+}
+
 func circuitBreakerFailureKey(stepID string) string { return circuitBreakerFailureVarPrefix + stepID }
 func circuitBreakerFirstKey(stepID string) string   { return circuitBreakerFirstVarPrefix + stepID }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"cmp"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -1554,6 +1555,22 @@ func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error, wf
 }
 
 func (e *Engine) surfaceStartFailureClassified(taskID, currentStatus string, err error, wf *Execution, stepID string) {
+	// A context cancellation that traces back to the engine's own shutdown
+	// context (e.ctx, bound via SetContext from the app's root context) is
+	// not a task-attributable dispatch failure — a single graceful restart
+	// cancels every in-flight git/agent operation across every
+	// concurrently-dispatching task at once. Counting it toward the circuit
+	// breaker lets one restart mass-trip an unbounded number of breakers and
+	// park otherwise-healthy tasks to human-required for routine deploy
+	// churn that self-heals the moment the new instance resumes dispatching
+	// (sybra#2291). Suppressed exactly like the other benign dispatch-plumbing
+	// sentinels below (ErrDispatchInFlight et al.): no status write, no
+	// breaker increment.
+	if e.isShutdownCancellation(err) {
+		e.logger.Info("workflow.start-failure.shutdown-cancellation.suppress",
+			"task_id", taskID, "step", stepID)
+		return
+	}
 	reason, permanent := ClassifyAgentStartError(err)
 	if reason == "" {
 		return
@@ -1604,6 +1621,20 @@ func (e *Engine) surfaceStartFailureClassified(taskID, currentStatus string, err
 	if uErr := e.tasks.UpdateTaskStatus(taskID, target, reason); uErr != nil {
 		e.logger.Error("workflow.resume-stalled.surface", "task_id", taskID, "err", uErr)
 	}
+}
+
+// isShutdownCancellation reports whether err is a context.Canceled that
+// traces back to the engine's own shutdown context rather than some
+// unrelated per-call cancellation. e.ctx is bound exactly once, from the
+// app's root context (App.Startup -> Engine.SetContext), and is the same
+// context object agentorch.Orchestrator uses to cancel worktree/git
+// operations on shutdown — so e.ctx.Err() != nil at the moment a dispatch
+// error is classified is a reliable signal that this particular
+// context.Canceled came from that shutdown, not from an unrelated timeout or
+// a different context in the chain (which would surface as
+// context.DeadlineExceeded or a non-context error instead).
+func (e *Engine) isShutdownCancellation(err error) bool {
+	return e.ctx != nil && e.ctx.Err() != nil && errors.Is(err, context.Canceled)
 }
 
 func circuitBreakerFailureKey(stepID string) string { return circuitBreakerFailureVarPrefix + stepID }

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1635,9 +1635,9 @@ func (e *Engine) surfaceStartFailureClassified(taskID, currentStatus string, err
 	}
 }
 
-// isShutdownCancellation reports whether err is a context.Canceled that
-// traces back to the engine's own shutdown context rather than some
-// unrelated per-call cancellation. e.ctx is bound exactly once, from the
+// isShutdownCancellation applies IsShutdownCancellation's correlation
+// heuristic against e.ctx: err wraps context.Canceled while the engine's own
+// shutdown context is currently done. e.ctx is bound exactly once, from the
 // app's root context (App.Startup -> Engine.SetContext), and is the same
 // context object agentorch.Orchestrator uses to cancel worktree/git
 // operations on shutdown.
@@ -1645,15 +1645,19 @@ func (e *Engine) isShutdownCancellation(err error) bool {
 	return IsShutdownCancellation(e.ctx, err)
 }
 
-// IsShutdownCancellation reports whether err is a context.Canceled that
-// traces back to ctx being done rather than some unrelated per-call
-// cancellation (a different, unrelated context's timeout would surface as
-// context.DeadlineExceeded or a non-context error instead). Exported so
-// internal/recovery's independent stale-task restart path — which surfaces
-// dispatch failures through its own Recovery.surfaceStartFailure rather than
-// going through Engine — can apply the identical shutdown-vs-genuine-failure
-// heuristic to the "restart-stale.failed" log line named in sybra#2291,
-// rather than maintaining a second, drifting copy of this logic.
+// IsShutdownCancellation is a correlation heuristic, not causality proof: it
+// reports whether ctx is currently done AND err wraps context.Canceled. It
+// cannot verify err's cancellation actually originated from ctx specifically
+// (vs. some other cancelled context in the same call chain) — but a
+// different, unrelated context's own timeout would surface as
+// context.DeadlineExceeded or a non-context error instead, so in practice
+// this reliably distinguishes "we are shutting down" from a genuine failure.
+// Exported so internal/recovery's independent stale-task restart path —
+// which surfaces dispatch failures through its own
+// Recovery.surfaceStartFailure rather than going through Engine — can apply
+// the identical shutdown-vs-genuine-failure heuristic to the
+// "restart-stale.failed" log line named in sybra#2291, rather than
+// maintaining a second, drifting copy of this logic.
 func IsShutdownCancellation(ctx context.Context, err error) bool {
 	return ctx != nil && ctx.Err() != nil && errors.Is(err, context.Canceled)
 }

--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -1,7 +1,9 @@
 package workflow
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -477,6 +479,46 @@ func TestParallel_AllSpawnsFail_AdvancesParent(t *testing.T) {
 	}
 	if got := agents.CallCount(); got != 0 {
 		t.Errorf("recorded successful StartAgent calls = %d, want 0 (spawn was armed to fail)", got)
+	}
+}
+
+// TestParallel_ShutdownCancellationDuringSpawnDoesNotFailParent is the
+// parallel-step sibling of the best-of-n regression guard for sybra#2291's
+// fix: spawnParallelChild's error branch (engine_steps_parallel.go) only
+// routes through surfaceStartFailure's shutdown-cancellation gate when
+// transientAgentStartError(err) recognizes the error — a fixed sentinel list
+// that does not include a bare context.Canceled. A shutdown-cancelled child
+// spawn used to mark every child permanently "failed" and let
+// finalizeParallelParent fail the whole parent step, escalating the task —
+// the same mass-park symptom the primary fix targets, reached via a spawn
+// path outside surfaceStartFailure's direct control.
+func TestParallel_ShutdownCancellationDuringSpawnDoesNotFailParent(t *testing.T) {
+	store := newTestStoreWith(t, "test-parallel-terminal.yaml")
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
+
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the app context already cancelled by graceful shutdown
+	engine.SetContext(shutdownCtx)
+
+	agents.SetFailSpawn(fmt.Errorf("worktree required for project task: fetch origin: git fetch origin +refs/heads/*:refs/remotes/origin/*: %w", context.Canceled))
+
+	if err := engine.StartWorkflow("t1", "test-parallel-terminal"); err != nil {
+		t.Fatalf("StartWorkflow returned err = %v", err)
+	}
+
+	ti := mustTaskInfo(t, tasks, "t1")
+	if ti.Status == "human-required" {
+		t.Fatalf("shutdown-cancelled spawn escalated task to human-required: reason=%q", ti.StatusReason)
+	}
+	if ti.StatusReason != "" {
+		t.Fatalf("shutdown-cancelled spawn wrote status_reason %q, want none", ti.StatusReason)
+	}
+	wf := mustWorkflow(t, tasks, "t1")
+	if rec := findStepRecord(wf, "plan"); rec != nil && rec.Status == "failed" {
+		t.Errorf("parent step marked failed for a shutdown-cancelled spawn, want left pending/retryable")
 	}
 }
 

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -135,7 +135,7 @@ func (e *Engine) execBestOfN(taskID string, def *Definition, step *Step, wfExec 
 		}
 		if err := e.spawnBestOfNAttempt(taskID, step, wfExec, ctx, id, status); err != nil {
 			e.logger.Error("workflow.best-of-n.spawn", "task_id", taskID, "parent", step.ID, "attempt", id, "err", err)
-			if transientAgentStartError(err) {
+			if e.transientOrShutdownStartError(err) {
 				status.Status = "pending"
 				status.Output = "spawn blocked: " + err.Error()
 				e.surfaceStartFailure(taskID, ctx.Task.Status, err, wfExec, bestOfNAttemptStepKey(step.ID, id))

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -74,7 +74,7 @@ func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec
 		}
 		if err := e.spawnParallelChild(taskID, step, child, wfExec, ctx, dir, status); err != nil {
 			e.logger.Error("workflow.parallel.spawn", "task_id", taskID, "parent", step.ID, "child", child.ID, "err", err)
-			if transientAgentStartError(err) {
+			if e.transientOrShutdownStartError(err) {
 				status.Status = "pending"
 				status.Output = "spawn blocked: " + err.Error()
 				e.surfaceStartFailure(taskID, ctx.Task.Status, err, wfExec, child.ID)

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -646,6 +646,51 @@ func TestSurfaceStartFailure_ShutdownCancellationDoesNotTripBreaker(t *testing.T
 	}
 }
 
+// TestSurfaceStartFailure_ShutdownCancellationSkipsConflictRecoveryToo is a
+// regression guard for a gap an adversarial review found in the initial fix
+// for sybra#2291: reconcileAndRebase's ReconcileWithRemote step wraps a
+// shutdown-cancelled fetch in ErrRebaseFailed rather than ErrTransientFetch
+// (project.IsTransientNetworkError doesn't recognize "context canceled" as a
+// transient network blip). A shutdown-cancellation check placed only inside
+// surfaceStartFailureClassified would miss this shape entirely: the
+// ErrRebaseFailed match in surfaceStartFailure fires FIRST and dispatches a
+// real autonomous branch-conflict-recovery agent for a branch that has no
+// actual conflict — work that is itself guaranteed to be cancelled by the
+// same shutdown, on top of the circuit-breaker mass-trip the primary fix
+// targets. The shutdown-cancellation gate must run ahead of the
+// conflict-recovery branch so this shape is suppressed too.
+func TestSurfaceStartFailure_ShutdownCancellationSkipsConflictRecoveryToo(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the app context already cancelled by graceful shutdown
+	engine.SetContext(shutdownCtx)
+
+	var recoveryCalled bool
+	engine.SetConflictRecovery(func(string) bool {
+		recoveryCalled = true
+		return true
+	})
+
+	// Same wrapping shape reconcileAndRebase produces when ReconcileWithRemote
+	// hits a shutdown-cancelled fetch: ErrRebaseFailed wrapping context.Canceled,
+	// not ErrTransientFetch.
+	wrapped := fmt.Errorf("%w: reconcile branch with remote: %w", worktreeerr.ErrRebaseFailed, context.Canceled)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "implement")
+
+	if recoveryCalled {
+		t.Fatal("shutdown cancellation wrapped in ErrRebaseFailed triggered branch-conflict recovery")
+	}
+	got, _ := tasks.GetTask("t1")
+	if got.Status == "human-required" {
+		t.Fatal("shutdown cancellation wrapped in ErrRebaseFailed escalated task to human-required")
+	}
+	if reason := tasks.Reason("t1"); reason != "" {
+		t.Errorf("shutdown cancellation wrote status_reason %q, want none", reason)
+	}
+}
+
 // TestSurfaceStartFailure_ContextCanceledStillTripsBreakerWhenNotShuttingDown
 // guards the flip side of the shutdown-cancellation suppression above: a
 // context.Canceled error must still feed the circuit breaker normally when

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -601,6 +602,80 @@ func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 	}
 	if got := wf.Variables[circuitBreakerFailureKey("run_test")]; got != "1" {
 		t.Errorf("failure count = %q, want reset to 1", got)
+	}
+}
+
+// TestSurfaceStartFailure_ShutdownCancellationDoesNotTripBreaker is a
+// regression guard for sybra#2291: a graceful server shutdown cancels every
+// in-flight git/agent operation across every concurrently-dispatching task at
+// once, so a naive circuit breaker sees a burst of simultaneous "failures"
+// and mass-escalates unrelated, perfectly healthy tasks to human-required. A
+// context.Canceled error that traces back to the engine's own shutdown
+// context (bound via SetContext, mirroring App.Startup -> Engine.SetContext
+// -> agentorch.Orchestrator.SetContext all sharing one root context) must
+// never feed the breaker or touch the task, no matter how many times it
+// repeats — simulating several concurrently-dispatching tasks all hitting the
+// same shutdown-induced cancellation within the same circuit-breaker window.
+func TestSurfaceStartFailure_ShutdownCancellationDoesNotTripBreaker(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the app context already cancelled by graceful shutdown
+	engine.SetContext(shutdownCtx)
+
+	wrapped := fmt.Errorf("worktree required for project task: %w",
+		fmt.Errorf("fetch origin: git fetch origin +refs/heads/*:refs/remotes/origin/*: %w", context.Canceled))
+	wf := &Execution{CurrentStep: "implement", State: ExecRunning, Variables: map[string]string{}}
+
+	for i := range maxCircuitBreakerFailures + 5 {
+		engine.surfaceStartFailure("t1", "in-progress", wrapped, wf, "implement")
+		if wf.State == ExecFailed {
+			t.Fatalf("shutdown cancellation tripped the breaker on attempt %d", i+1)
+		}
+	}
+	if _, recorded := wf.Variables[circuitBreakerFailureKey("implement")]; recorded {
+		t.Fatalf("shutdown cancellation recorded a breaker failure: %v", wf.Variables)
+	}
+	got, _ := tasks.GetTask("t1")
+	if got.Status == "human-required" {
+		t.Fatal("shutdown cancellation escalated task to human-required")
+	}
+	if reason := tasks.Reason("t1"); reason != "" {
+		t.Errorf("shutdown cancellation wrote status_reason %q, want none", reason)
+	}
+}
+
+// TestSurfaceStartFailure_ContextCanceledStillTripsBreakerWhenNotShuttingDown
+// guards the flip side of the shutdown-cancellation suppression above: a
+// context.Canceled error must still feed the circuit breaker normally when
+// the engine's own context is healthy (not shutting down) — e.g. a per-call
+// timeout or an unrelated cancellation elsewhere in the chain. The
+// suppression is scoped to an actual shutdown, not to context.Canceled in
+// general.
+func TestSurfaceStartFailure_ContextCanceledStillTripsBreakerWhenNotShuttingDown(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine.SetContext(context.Background()) // healthy, not cancelled
+
+	wrapped := fmt.Errorf("fetch origin: %w", context.Canceled)
+	wf := &Execution{CurrentStep: "implement", State: ExecRunning, Variables: map[string]string{}}
+
+	for i := range maxCircuitBreakerFailures - 1 {
+		engine.surfaceStartFailure("t1", "todo", wrapped, wf, "implement")
+		if wf.State == ExecFailed {
+			t.Fatalf("breaker tripped early on attempt %d, want after %d", i+1, maxCircuitBreakerFailures)
+		}
+	}
+	engine.surfaceStartFailure("t1", "todo", wrapped, wf, "implement")
+
+	if wf.State != ExecFailed {
+		t.Errorf("wf.State = %q, want ExecFailed after %d failures", wf.State, maxCircuitBreakerFailures)
+	}
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", got.Status)
 	}
 }
 


### PR DESCRIPTION
## Motivation

A graceful server restart cancels every in-flight git/agent operation across every concurrently-dispatching task at once. The workflow circuit breaker counted that shutdown-induced `context canceled` the same as a genuine per-task dispatch failure, so one restart could mass-trip an unbounded number of breakers and park many healthy tasks to `human-required` simultaneously (confirmed live: 17 tasks in one second, self-recovering ~15 minutes later with zero real issues).

> Changelog: fix(workflow): breaker ignores shutdown cancel

## Implementation information

- `internal/workflow`: added `Engine.isShutdownCancellationGate`, checked at the top of `surfaceStartFailure` — ahead of both the circuit-breaker classification *and* the rebase-conflict-recovery branch, since a shutdown-cancelled fetch inside `reconcileAndRebase` wraps `ErrRebaseFailed` (not `ErrTransientFetch` — `IsTransientNetworkError` doesn't recognize "context canceled"), which would otherwise dispatch a real autonomous branch-conflict-fix agent doomed to be cancelled by the same shutdown.
- Exported `workflow.IsShutdownCancellation(ctx, err)` so `internal/recovery`'s independent stale-restart path (the exact `restart-stale.failed` log line from the incident) applies the same check instead of maintaining a second, drifting copy.
- `internal/sybra`: `TaskService.RecoverLostAgent` (the leader→follower lost-agent RPC) had no request-scoped context to forward and fell back to `context.Background()`, which is permanently invisible to the shutdown check. Wired the app's root context onto `TaskService` so a follower shutting down mid-RPC gets the same suppression.
- `internal/workflow`: the best-of-n and parallel fan-out spawn loops only routed a spawn error through `surfaceStartFailure` when `transientAgentStartError` recognized it — a fixed sentinel list that doesn't include `context.Canceled` — so a shutdown-cancelled attempt/child spawn fell straight to a hard "failed" and let the parent finalize step escalate the whole task. Added `Engine.transientOrShutdownStartError` to close that gap too.

Two rounds of adversarial review (code + a subagent that actually ran the test suite and wrote independent reproductions) found and closed three real gaps beyond the initial fix: the rebase-conflict-recovery bypass, the `RecoverLostAgent` RPC path, and the fan-out spawn paths. Every fix has a regression test that was verified to fail against the pre-fix code and pass against the current code.

## Supporting documentation

Closes #2291