### PR TITLE
fix(provider): random healthy-only failover

### DIFF
--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -1151,20 +1151,25 @@ func newProviderUnhealthy(prov, reason string) *provider.UnhealthyError {
 	}
 }
 
-// firstHealthyProvider returns the first candidate (other than exclude) for
-// which healthy reports true, or "" if none qualify. Used for the in-flight
-// cap redirect, which must pick deterministically without consulting the
-// limits store's quota-pressure heuristics.
+// firstHealthyProvider returns a uniformly random candidate (other than
+// exclude) for which healthy reports true, or "" if none qualify. Used for
+// the in-flight cap redirect, which picks without consulting the limits
+// store's quota-pressure heuristics — but must still not always land on the
+// same peer, so no single provider is systematically favored or starved.
 func firstHealthyProvider(exclude string, candidates []string, healthy func(string) bool) string {
+	eligible := make([]string, 0, len(candidates))
 	for _, p := range candidates {
 		if p == exclude {
 			continue
 		}
 		if healthy(p) {
-			return p
+			eligible = append(eligible, p)
 		}
 	}
-	return ""
+	if len(eligible) == 0 {
+		return ""
+	}
+	return eligible[rand.IntN(len(eligible))]
 }
 
 func (m *Manager) providerForRun(name string) (string, error) {

--- a/internal/agent/manager_run_test.go
+++ b/internal/agent/manager_run_test.go
@@ -511,3 +511,33 @@ func TestTryReserveSlot_RegisterNoDoubleCount(t *testing.T) {
 	}
 	assertAccountingInvariant(t, m)
 }
+
+// TestFirstHealthyProvider_DistributesAcrossEligiblePeers guards against
+// re-introducing a fixed-order pick: with several equally-eligible
+// candidates, firstHealthyProvider must not always land on the same one.
+func TestFirstHealthyProvider_DistributesAcrossEligiblePeers(t *testing.T) {
+	candidates := []string{"claude", "codex", "copilot"}
+	healthy := func(string) bool { return true }
+
+	seen := map[string]bool{}
+	for range 200 {
+		seen[firstHealthyProvider("opencode", candidates, healthy)] = true
+	}
+	for _, want := range candidates {
+		if !seen[want] {
+			t.Errorf("firstHealthyProvider never picked %q across 200 trials: %v", want, seen)
+		}
+	}
+}
+
+func TestFirstHealthyProvider_ExcludesAndFiltersUnhealthy(t *testing.T) {
+	candidates := []string{"claude", "codex", "copilot"}
+	healthy := func(p string) bool { return p == "codex" }
+
+	if got := firstHealthyProvider("claude", candidates, healthy); got != "codex" {
+		t.Errorf("got %q, want codex (only healthy candidate)", got)
+	}
+	if got := firstHealthyProvider("codex", candidates, healthy); got != "" {
+		t.Errorf("got %q, want none (only healthy candidate is excluded)", got)
+	}
+}

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -257,6 +257,43 @@ func TestChooseProvider_NoDataDoesNotStealRequested(t *testing.T) {
 	}
 }
 
+// TestChooseProvider_DistributesAcrossEligiblePeers guards against
+// re-introducing a fixed-priority pick: with PreferUnderused off and no
+// quantitative reason to prefer one equally-eligible peer over another,
+// ChooseProvider must not always land on the same candidate.
+func TestChooseProvider_DistributesAcrossEligiblePeers(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	if err := s.UpdateSnapshot(Snapshot{
+		Provider:             ProviderClaude,
+		Source:               SourceStream,
+		Confidence:           ConfidenceExact,
+		CapturedAt:           now,
+		RateLimitReachedType: "rate_limit_reached",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	policy := DefaultPolicy()
+	policy.PreferUnderused = false
+
+	seen := map[string]bool{}
+	for range 200 {
+		alt, _ := s.ChooseProvider(ProviderClaude, []string{ProviderClaude, ProviderCodex, ProviderCopilot}, func(string) bool {
+			return true
+		}, policy)
+		seen[alt] = true
+	}
+	for _, want := range []string{ProviderCodex, ProviderCopilot} {
+		if !seen[want] {
+			t.Errorf("ChooseProvider never picked %q across 200 trials: %v", want, seen)
+		}
+	}
+}
+
 // TestChooseSoftLimitedPeer_PicksPeerOnlySoftLimited verifies the last-resort
 // failover for task c61f327a: a peer whose only issue is its own soft
 // session/weekly threshold is still eligible when the requested provider is
@@ -314,6 +351,41 @@ func TestChooseSoftLimitedPeer_SkipsHardBlockedPeer(t *testing.T) {
 	}, DefaultPolicy())
 	if alt != "" {
 		t.Fatalf("alt = %q, want none (claude is hard blocked, not soft-limited)", alt)
+	}
+}
+
+// TestChooseSoftLimitedPeer_DistributesAcrossEligiblePeers guards against a
+// fixed-priority pick among multiple equally-eligible soft-limited peers.
+func TestChooseSoftLimitedPeer_DistributesAcrossEligiblePeers(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	for _, p := range []string{ProviderCodex, ProviderCopilot} {
+		if err := s.UpdateSnapshot(Snapshot{
+			Provider:   p,
+			Source:     SourceStream,
+			Confidence: ConfidenceExact,
+			CapturedAt: now,
+			Primary:    &CycleSnapshot{UsedPercent: 90, WindowMinutes: 300, ResetsAt: now.Add(time.Hour)},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	seen := map[string]bool{}
+	for range 200 {
+		alt, _ := s.ChooseSoftLimitedPeer(ProviderClaude, []string{ProviderClaude, ProviderCodex, ProviderCopilot}, func(string) bool {
+			return true
+		}, DefaultPolicy())
+		seen[alt] = true
+	}
+	for _, want := range []string{ProviderCodex, ProviderCopilot} {
+		if !seen[want] {
+			t.Errorf("ChooseSoftLimitedPeer never picked %q across 200 trials: %v", want, seen)
+		}
 	}
 }
 

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -3,6 +3,7 @@ package limits
 import (
 	"cmp"
 	"encoding/json"
+	"math/rand/v2"
 	"os"
 	"slices"
 	"strings"
@@ -381,6 +382,15 @@ func (s *Store) ChooseProvider(requested string, candidates []string, healthy fu
 			}
 			return cmp.Compare(a.WeeklySpendUSD, b.WeeklySpendUSD)
 		})
+	} else {
+		// available[0] below picks the winner. Without PreferUnderused there is
+		// no quantitative signal to rank by, so shuffle first — otherwise
+		// available[0] always lands on whichever candidate sorts first in the
+		// caller-supplied order (typically providerid.All()'s fixed order),
+		// systematically favoring the same peer every time.
+		rand.Shuffle(len(available), func(i, j int) {
+			available[i], available[j] = available[j], available[i]
+		})
 	}
 	if !requestedLimited {
 		// Do not route away from the requested/default provider just because
@@ -417,6 +427,7 @@ func (s *Store) ChooseSoftLimitedPeer(requested string, candidates []string, hea
 		p := &summary.Providers[i]
 		byProvider[p.Provider] = p
 	}
+	eligible := make([]*ProviderSummary, 0, len(candidates))
 	for _, p := range candidates {
 		if p == requested || !providerEnabled(policy, p) || !healthy(p) {
 			continue
@@ -428,10 +439,17 @@ func (s *Store) ChooseSoftLimitedPeer(requested string, candidates []string, hea
 			continue
 		}
 		if IsSoftThresholdReason(ps.QuotaReason) {
-			return p, ps.QuotaReason
+			eligible = append(eligible, ps)
 		}
 	}
-	return "", ""
+	if len(eligible) == 0 {
+		return "", ""
+	}
+	// No quantitative ranking among last-resort soft-limited peers, so pick
+	// uniformly at random instead of always the first match in candidates'
+	// (typically fixed provider) order.
+	pick := eligible[rand.IntN(len(eligible))]
+	return pick.Provider, pick.QuotaReason
 }
 
 func (s *Store) flushLocked() error {

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -38,9 +39,10 @@ type Config struct {
 	ProbeErrorThreshold int
 }
 
-// failoverPriority is the order auto-failover prefers healthy peers in.
-// Copilot is last: it is never chosen over claude/codex, but can be a
-// fallback target when both are unhealthy, and can itself fail over to them.
+// failoverPriority is the universe of providers auto-failover considers.
+// Despite the name it imposes no preference order: failoverLocked picks
+// uniformly at random among whichever of these are enabled and healthy, so
+// no single peer (e.g. copilot) is systematically favored or starved.
 var failoverPriority = providerid.All()
 
 const defaultProbeErrorThreshold = 2
@@ -135,10 +137,17 @@ func New(cfg Config, emit func(string, any), logger *slog.Logger) *Checker {
 		now:           time.Now,
 	}
 	// Seed defaults so Snapshot returns something meaningful before first probe.
-	c.statuses["claude"] = &Status{Provider: "claude", Healthy: cfg.ClaudeEnabled, Reason: initialReason(cfg.ClaudeEnabled)}
-	c.statuses["codex"] = &Status{Provider: "codex", Healthy: cfg.CodexEnabled, Reason: initialReason(cfg.CodexEnabled)}
-	c.statuses["copilot"] = &Status{Provider: "copilot", Healthy: cfg.CopilotEnabled, Reason: initialReason(cfg.CopilotEnabled)}
-	c.statuses["opencode"] = &Status{Provider: "opencode", Healthy: cfg.OpenCodeEnabled, Reason: initialReason(cfg.OpenCodeEnabled)}
+	// Healthy is always seeded false, even for an enabled provider: "enabled"
+	// only means the operator turned it on, not that its CLI is installed,
+	// authenticated, or working. A provider whose binary is missing (e.g.
+	// copilot not on PATH) must not be eligible as a failover target until a
+	// real probe confirms it — see the incident that motivated this: a
+	// pre-probe seed of Healthy=true let quota-based failover route runs to
+	// an uninstalled copilot CLI, crashing every one of them.
+	c.statuses["claude"] = &Status{Provider: "claude", Healthy: false, Reason: initialReason(cfg.ClaudeEnabled)}
+	c.statuses["codex"] = &Status{Provider: "codex", Healthy: false, Reason: initialReason(cfg.CodexEnabled)}
+	c.statuses["copilot"] = &Status{Provider: "copilot", Healthy: false, Reason: initialReason(cfg.CopilotEnabled)}
+	c.statuses["opencode"] = &Status{Provider: "opencode", Healthy: false, Reason: initialReason(cfg.OpenCodeEnabled)}
 	return c
 }
 
@@ -486,9 +495,9 @@ func (c *Checker) Reason(provider string) string {
 	return ""
 }
 
-// Failover picks a healthy peer when auto-failover is enabled, walking
-// failoverPriority in order (claude > codex > copilot). Returns empty string
-// if auto-failover is disabled or no enabled peer is currently healthy.
+// Failover picks a uniformly random healthy peer when auto-failover is
+// enabled. Returns empty string if auto-failover is disabled or no enabled
+// peer is currently healthy.
 func (c *Checker) Failover(unhealthy string) string {
 	if c == nil {
 		return ""
@@ -502,15 +511,19 @@ func (c *Checker) failoverLocked(unhealthy string) string {
 	if !c.cfg.AutoFailover {
 		return ""
 	}
+	candidates := make([]string, 0, len(failoverPriority))
 	for _, peer := range failoverPriority {
 		if peer == unhealthy || !c.providerEnabledLocked(peer) {
 			continue
 		}
 		if s, ok := c.statuses[peer]; ok && s.Healthy {
-			return peer
+			candidates = append(candidates, peer)
 		}
 	}
-	return ""
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[rand.IntN(len(candidates))]
 }
 
 // providerEnabledLocked reports whether a provider participates in probing and

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -158,6 +158,21 @@ func initialReason(enabled bool) string {
 	return "disabled"
 }
 
+// ProbeOnce runs a single synchronous probe pass across all enabled
+// providers, replacing their seeded Healthy=false with a real result before
+// returning. Callers that wire a Checker into a gate other goroutines will
+// immediately start consulting (e.g. Manager.SetHealthGate) must call this
+// first — otherwise every provider reads unhealthy until Run's background
+// goroutine gets scheduled and completes its own first pass, which can fail
+// every dispatch attempted in that window closed. Bounded by probeTimeout
+// (10s) regardless of provider count, since checkAll probes concurrently.
+func (c *Checker) ProbeOnce(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.checkAll(ctx)
+}
+
 // Run performs an immediate probe and then probes on a ticker until ctx is
 // cancelled. Safe to call once from a goroutine.
 func (c *Checker) Run(ctx context.Context) {

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -299,6 +299,33 @@ func (f *fakeEmitter) snapshot() []HealthEvent {
 	return out
 }
 
+// TestNew_SeedsUnhealthyUntilProbed guards against re-introducing the
+// incident where an enabled-but-never-probed provider (copilot with no CLI
+// on PATH) was seeded Healthy=true and picked as a failover target before
+// any probe had run.
+func TestNew_SeedsUnhealthyUntilProbed(t *testing.T) {
+	fe := &fakeEmitter{}
+	c := New(Config{
+		ClaudeEnabled:  true,
+		CodexEnabled:   true,
+		CopilotEnabled: true,
+	}, fe.emit, nil)
+	for _, p := range []string{"claude", "codex", "copilot"} {
+		if c.IsHealthy(p) {
+			t.Errorf("%s: seeded healthy before any probe ran", p)
+		}
+		if got := c.Reason(p); got != "unknown" {
+			t.Errorf("%s: seeded reason = %q, want %q", p, got, "unknown")
+		}
+	}
+	if c.IsHealthy("opencode") {
+		t.Error("opencode: disabled provider seeded healthy")
+	}
+	if got := c.Reason("opencode"); got != "disabled" {
+		t.Errorf("opencode: seeded reason = %q, want %q", got, "disabled")
+	}
+}
+
 func newTestChecker(t *testing.T) (*Checker, *fakeEmitter, *fakeClock) {
 	t.Helper()
 	fe := &fakeEmitter{}
@@ -534,7 +561,12 @@ func TestFailover_PicksHealthyPeer(t *testing.T) {
 	}
 }
 
-func TestFailover_PriorityChainCopilotLast(t *testing.T) {
+// TestFailover_NoFixedPriority verifies that with multiple healthy peers
+// available, Failover distributes across all of them instead of always
+// preferring the same one — copilot in particular must be picked sometimes,
+// not systematically last. A single-eligible-candidate case must still
+// return deterministically.
+func TestFailover_NoFixedPriority(t *testing.T) {
 	fe := &fakeEmitter{}
 	c := New(Config{
 		Interval:       time.Minute,
@@ -549,37 +581,26 @@ func TestFailover_PriorityChainCopilotLast(t *testing.T) {
 	healthy("codex")
 	healthy("copilot")
 
-	// Copilot is never preferred while a higher-priority peer is healthy.
-	if got := c.Failover("codex"); got != "claude" {
-		t.Errorf("codex down, claude healthy → want claude, got %q", got)
+	seen := map[string]bool{}
+	for range 200 {
+		seen[c.Failover("opencode")] = true
 	}
-	if got := c.Failover("copilot"); got != "claude" {
-		t.Errorf("copilot down → want claude (highest), got %q", got)
+	for _, want := range []string{"claude", "codex", "copilot"} {
+		if !seen[want] {
+			t.Errorf("Failover never picked %q across 200 trials with all peers healthy: %v", want, seen)
+		}
 	}
 
-	// claude down → codex (next in priority), still not copilot.
 	down("claude")
-	if got := c.Failover("claude"); got != "codex" {
-		t.Errorf("claude down → want codex, got %q", got)
-	}
-
-	// claude + codex down → copilot is the only healthy peer left.
 	down("codex")
 	if got := c.Failover("claude"); got != "copilot" {
 		t.Errorf("claude+codex down → want copilot, got %q", got)
 	}
 
-	// copilot can itself fail over to a recovered higher-priority peer.
 	healthy("claude")
-	if got := c.Failover("copilot"); got != "claude" {
-		t.Errorf("copilot down, claude back → want claude, got %q", got)
-	}
-
-	// Disabled peers are skipped even when healthy.
 	c.SetProviderEnabled("claude", false)
-	down("codex")
-	if got := c.Failover("codex"); got != "copilot" {
-		t.Errorf("claude disabled, codex down → want copilot, got %q", got)
+	if got := c.Failover("claude"); got != "copilot" {
+		t.Errorf("claude disabled → want copilot, got %q", got)
 	}
 }
 

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -326,6 +326,32 @@ func TestNew_SeedsUnhealthyUntilProbed(t *testing.T) {
 	}
 }
 
+// TestProbeOnce_ClearsSeedBeforeGateWiring guards the fix for the window
+// TestNew_SeedsUnhealthyUntilProbed's seed change opened: a caller wiring
+// this Checker into a gate other goroutines immediately consult (see
+// app_init.go's initProviderHealth) must be able to get a real status
+// synchronously, without waiting for Run's background ticker to fire.
+func TestProbeOnce_ClearsSeedBeforeGateWiring(t *testing.T) {
+	fe := &fakeEmitter{}
+	c := New(Config{ClaudeEnabled: true, CodexEnabled: true}, fe.emit, nil)
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{Provider: "claude", Healthy: true, Reason: "ok"}, nil
+	}
+	c.probeCodex = func(context.Context) (Status, error) {
+		return Status{Provider: "codex", Healthy: false, Reason: "logged_out"}, nil
+	}
+	if c.IsHealthy("claude") {
+		t.Fatal("precondition: claude should read unhealthy before ProbeOnce")
+	}
+	c.ProbeOnce(context.Background())
+	if !c.IsHealthy("claude") {
+		t.Error("claude should be healthy after ProbeOnce resolves its probe true")
+	}
+	if c.IsHealthy("codex") {
+		t.Error("codex should stay unhealthy after ProbeOnce resolves its probe false")
+	}
+}
+
 func newTestChecker(t *testing.T) (*Checker, *fakeEmitter, *fakeClock) {
 	t.Helper()
 	fe := &fakeEmitter{}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1084,6 +1084,10 @@ func (a *App) initProviderHealth(ctx context.Context, emit func(string, any)) {
 		CopilotRLCooldown:  time.Duration(a.cfg.Providers.Copilot.RateLimitCooldownSeconds) * time.Second,
 		OpenCodeRLCooldown: time.Duration(a.cfg.Providers.OpenCode.RateLimitCooldownSeconds) * time.Second,
 	}, emit, a.logger)
+	// New seeds every provider Healthy=false until probed; probe once here,
+	// before the gate is live, so startLifecycle's dispatch never sees a
+	// window where every provider reads unhealthy and fails closed.
+	pc.ProbeOnce(ctx)
 	a.providerHealth = pc
 	a.agents.SetHealthGate(pc)
 	a.wg.Go(func() { pc.Run(ctx) })


### PR DESCRIPTION
## Motivation

Provider failover picked peers by walking a fixed claude > codex >
copilot order, and a provider only had to be *enabled* in config
(not actually probed) to be seeded healthy. Last night this routed
a run to copilot on a host where the copilot CLI isn't installed,
crashing every attempt, because copilot was seeded Healthy=true
before its first probe ever ran.

> Changelog: fix(provider): random healthy-only failover

## Implementation information

- `Checker.New()` now seeds every provider `Healthy: false` instead
  of mirroring its `enabled` config flag — unconfirmed is not
  healthy.
- `Checker.failoverLocked`, `firstHealthyProvider`,
  `Store.ChooseProvider`, and `Store.ChooseSoftLimitedPeer` now
  collect all eligible/healthy candidates and pick uniformly at
  random instead of returning the first match in a fixed order, so
  no single provider is systematically favored or starved.
- Follow-up fix in the second commit: the seed change opened a
  ~10s window on every server start/restart where every provider
  (including the primary) reads unhealthy before the health
  checker's first background probe pass completes, failing
  dispatch closed. Added `Checker.ProbeOnce` and made
  `initProviderHealth` call it synchronously before wiring the
  health gate, so the gate only ever sees real status. Found by an
  adversarial review pass on the first commit before this PR was
  opened.

## Supporting documentation

New/updated tests in `internal/provider/health_test.go`,
`internal/limits/collect_test.go`, and
`internal/agent/manager_run_test.go` cover: the unhealthy-until-
probed seed, `ProbeOnce` resolving it synchronously, and
statistical distribution checks (200 trials) that every eligible
peer gets picked instead of always the same one.

`go build ./...`, `go vet`, `golangci-lint run` (0 issues), and
`go test` for `internal/provider`, `internal/limits`,
`internal/agent`, and `internal/sybra` (+ subpackages) all pass.