### PR TITLE
fix(watchdog): watch in-review for run-rate

### DIFF
--- a/internal/watchdog/runrate.go
+++ b/internal/watchdog/runrate.go
@@ -8,8 +8,8 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
-// checkRunRate escalates an in-progress task whose dispatch loop is
-// thrashing — many agent runs of the same role landing within a short
+// checkRunRate escalates an in-progress or in-review task whose dispatch loop
+// is thrashing — many agent runs of the same role landing within a short
 // trailing window — rather than waiting for the dwell budget (hours) to
 // notice. See #2134: a task accumulated 1204 implementation runs over ~29h,
 // each ~18-90s apart and all costUsd:0/instant-stopped, before dwell finally
@@ -28,7 +28,13 @@ func (w *Watchdog) checkRunRate(now time.Time) {
 		if t.TaskType == task.TaskTypeChat {
 			continue
 		}
-		if t.Status != task.StatusInProgress {
+		// in-review is watched alongside in-progress: pr-fix — one of the
+		// exact same-role thrash targets this check exists for — dispatches
+		// against StatusInReview tasks (see prMonitorEligible), not just
+		// StatusInProgress ones. A pr-fix loop against an in-review task was
+		// otherwise structurally invisible to this breaker (#2134's fix only
+		// ever covered in-progress).
+		if t.Status != task.StatusInProgress && t.Status != task.StatusInReview {
 			continue
 		}
 		// Same exemption as checkDwell: a live headless agent may itself be

--- a/internal/watchdog/runrate_test.go
+++ b/internal/watchdog/runrate_test.go
@@ -141,6 +141,47 @@ func TestCheckRunRate_SkipsNonInProgressTask(t *testing.T) {
 	}
 }
 
+// TestCheckRunRate_EscalatesBurstOnInReviewTask covers the gap behind
+// task 1e9f8878: pr-fix dispatches against in-review tasks (prMonitorEligible
+// allows StatusInReview whenever a branch or PR is set), so a same-role
+// thrash there must escalate exactly like an in-progress one — not sit
+// invisible to this breaker because it only ever checked in-progress.
+func TestCheckRunRate_EscalatesBurstOnInReviewTask(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+	tk, err := mgr.Create("in-review burst task", "## Description\nsome work", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = mgr.Update(tk.ID, task.Update{
+		Status:   task.Ptr(task.StatusInReview),
+		PRNumber: task.Ptr(2292),
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	now := time.Now()
+	addRuns(t, mgr, tk.ID, "pr-fix", 30, now.Add(-29*time.Minute), 18*time.Second)
+
+	w := &Watchdog{tasks: mgr, logger: slog.New(slog.DiscardHandler), maxRunsPerWindow: 30, runWindow: 30 * time.Minute}
+	w.checkRunRate(now)
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if !strings.Contains(got.StatusReason, "run_rate") || !strings.Contains(got.StatusReason, "pr-fix") {
+		t.Fatalf("status reason = %q, want it to mention run_rate and pr-fix", got.StatusReason)
+	}
+}
+
 func TestCheckRunRate_DoesNotSumAcrossRoles(t *testing.T) {
 	store, err := task.NewStore(t.TempDir())
 	if err != nil {

--- a/internal/watchdog/runrate_test.go
+++ b/internal/watchdog/runrate_test.go
@@ -137,7 +137,7 @@ func TestCheckRunRate_SkipsNonInProgressTask(t *testing.T) {
 		t.Fatalf("get task: %v", err)
 	}
 	if got.Status != task.StatusTodo {
-		t.Fatalf("status = %q, want todo (run-rate must only watch in-progress tasks)", got.Status)
+		t.Fatalf("status = %q, want todo (run-rate must only watch in-progress/in-review tasks)", got.Status)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Task 1e9f8878 dispatched 128 `pr-fix`-role agent runs over ~16h without
ever tripping the run-rate circuit breaker (#2148/#2134), because that
breaker only watches `StatusInProgress` tasks while `pr-fix` dispatches
mostly happen against `StatusInReview` ones (`prMonitorEligible`).

> Changelog: fix(watchdog): watch in-review for run-rate too

Closes #2342

## Implementation information

- `checkRunRate` (`internal/watchdog/runrate.go`) now escalates on
  `StatusInReview` in addition to `StatusInProgress`.
- Added `TestCheckRunRate_EscalatesBurstOnInReviewTask`, which reproduces
  the exact scenario (30 `pr-fix` runs on an in-review task with a PR
  number set) — confirmed it fails without the fix, passes with it.
- Existing `TestCheckRunRate_SkipsNonInProgressTask` (a `todo` task)
  still passes unchanged, confirming other non-eligible statuses remain
  excluded.

## Supporting documentation

`go build ./...`, `golangci-lint run ./internal/watchdog/...` (0 issues),
and `go test ./internal/watchdog/...` all pass.