### PR TITLE
fix(review): pr-fix eligible for todo+PR tasks

### DIFF
--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -1462,7 +1462,17 @@ func (r *Handler) includeKnownTaskPRs(tasks []task.Task, monitoredPRs []github.P
 // agent that opened a PR outside of any workflow). Those tasks would render
 // a red ✗ in the kanban UI forever and never get picked up for pr-fix.
 //
-// Now we also include in-progress tasks that carry an explicit PR number.
+// Now we also include in-progress and todo tasks that carry an explicit PR
+// number. todo joined for the identical reason: skipTaskCreatedWorkflow
+// (workflow_dispatch.go) deliberately skips a fresh task.created dispatch for
+// any todo task with a PRNumber (starting a brand-new implementation
+// workflow would be wrong), on the assumption that "status-specific lanes"
+// resume it instead — but this was the only such lane, and it excluded todo,
+// so a task recovered to todo with its PR still open (e.g. a human-review
+// unblock, or an operator requeue) had no dispatch path at all and sat there
+// indefinitely even with a live, fixable (e.g. conflicting) PR. handoff-tagged
+// todo tasks are excluded (see the todo case below): they already have their
+// own re-entry lane and must not also become a pr-fix candidate.
 // Branch-only matching stays gated on in-review to avoid false positives
 // from tasks that pushed a WIP branch without opening a PR yet.
 func prMonitorEligible(t *task.Task) bool {
@@ -1479,10 +1489,18 @@ func prMonitorEligible(t *task.Task) bool {
 	case task.StatusInReview:
 		return t.PRNumber != 0 || t.Branch != ""
 	case task.StatusInProgress:
-		// Only in-progress tasks that already have a PR — a branch alone
-		// isn't enough, we don't want to treat mid-implementation tasks
-		// as candidates for pr-fix dispatch.
+		// Only tasks that already have a PR — a branch alone isn't enough,
+		// still mid-implementation.
 		return t.PRNumber != 0
+	case task.StatusTodo:
+		// A handoff-tagged task is exempted from skipTaskCreatedWorkflow's
+		// skip (allowsTaskCreatedWorkflowWithPR, workflow_dispatch.go) so its
+		// own task.created lane can re-fire regardless of PRNumber — pr-fix
+		// must stay out of that lane's way, the same way it stays out of an
+		// inbound review task's, or the two could pick a conflicting action
+		// (reimplement from scratch vs. patch the existing PR) for the same
+		// task on the same tick.
+		return t.PRNumber != 0 && !slices.Contains(t.Tags, "handoff")
 	default:
 		return false
 	}

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -501,8 +501,28 @@ func TestPRMonitorEligible(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "todo with PR — not eligible, not in monitored states",
+			name: "todo with PR — eligible; skipTaskCreatedWorkflow skips the fresh-implementation lane for this exact shape and pr-fix is the only other path",
 			tk:   task.Task{Status: task.StatusTodo, PRNumber: 42},
+			want: true,
+		},
+		{
+			name: "todo with branch only — not eligible (avoid WIP false positives, same as in-progress)",
+			tk:   task.Task{Status: task.StatusTodo, Branch: "sybra/wip"},
+			want: false,
+		},
+		{
+			name: "todo with nothing — not eligible, a normal fresh-dispatch candidate",
+			tk:   task.Task{Status: task.StatusTodo},
+			want: false,
+		},
+		{
+			name: "todo with PR and review tag — excluded (inbound review task, not ours)",
+			tk:   task.Task{Status: task.StatusTodo, PRNumber: 42, Tags: []string{"review"}},
+			want: false,
+		},
+		{
+			name: "todo with PR and handoff tag — excluded (handoff owns its own re-entry lane)",
+			tk:   task.Task{Status: task.StatusTodo, PRNumber: 42, Tags: []string{"handoff", "handoff-ready-pr"}},
 			want: false,
 		},
 		{
@@ -563,9 +583,9 @@ func TestPrClosedEligible(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "todo with PR — not eligible",
+			name: "todo with PR — eligible (via prMonitorEligible)",
 			tk:   task.Task{Status: task.StatusTodo, PRNumber: 42},
-			want: false,
+			want: true,
 		},
 		{
 			name: "done with PR — not eligible (terminal)",


### PR DESCRIPTION
## Motivation

Tasks recovered from human-required back to todo that still carry a
PRNumber from an earlier cycle had no dispatch path at all —
skipTaskCreatedWorkflow correctly skips a fresh implementation for
them, but prMonitorEligible never covered todo, so pr-fix never picked
them up either. Two real tasks sat idle for 4-7+ hours with open,
conflicting PRs while other todo tasks dispatched normally.

> Changelog: fix(review): pr-fix eligible for todo+PR tasks

Closes #2345

## Implementation information

- `prMonitorEligible` (`internal/sybra/review/handler.go`) now treats
  `StatusTodo` the same way as the pre-existing `StatusInProgress` case:
  eligible only with `PRNumber != 0`.
- Excludes `handoff`-tagged tasks: they're exempted from
  `skipTaskCreatedWorkflow`'s skip unconditionally (their own
  `task.created` lane must keep firing regardless of PRNumber), so
  making them pr-fix-eligible too would let two lanes pick conflicting
  actions for the same task on the same tick — caught and confirmed via
  adversarial review before this PR.
- `TestPRMonitorEligible`/`TestPrClosedEligible` extended: todo+PR now
  eligible, todo+branch-only/nothing still not, todo+PR+review-tag and
  todo+PR+handoff-tag still excluded.

## Supporting documentation

`go build ./...`, `golangci-lint run ./internal/sybra/review/...` (0
issues), and `go test ./internal/sybra/review/...` all pass. Adversarial
review (independent code-adversary + findings-adversary passes) found
one real issue (missing handoff-tag exclusion), fixed and re-verified
before opening this PR.