### PR TITLE
fix(cluster): push umbrella release to home node

### DIFF
--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -63,7 +63,7 @@ func (a *App) dispatchPass(ctx context.Context) {
 	if !a.runsScheduler() {
 		return
 	}
-	a.releaseUnblockedChildren()
+	a.releaseUnblockedChildren(ctx)
 	a.reconcileRunnableBoardTasks(ctx)
 	if a.assigner != nil {
 		a.assigner.Tick(ctx)

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -56,7 +56,7 @@ const (
 // umbrella's max-parallel cap — and rolls each umbrella tracker's status up
 // from its children (cycle or a stuck child → human-required; all done →
 // done + close the umbrella issue). No-op when no umbrella tasks exist.
-func (a *App) releaseUnblockedChildren() {
+func (a *App) releaseUnblockedChildren(ctx context.Context) {
 	a.recoverDegradedUmbrellas()
 
 	tasks, err := a.tasks.List()
@@ -124,7 +124,7 @@ func (a *App) releaseUnblockedChildren() {
 
 	// A blocked tracker pauses only tracker rollup/issue close; dependency-ready
 	// children still release so independent work under the umbrella can proceed.
-	a.releaseCapped(g.ReadyToRelease(), byID, states)
+	a.releaseCapped(ctx, g.ReadyToRelease(), byID, states)
 
 	// An in-flight recovery run owns this umbrella's tracker/children this
 	// tick; skip its rollup entirely rather than computing status from a
@@ -196,7 +196,7 @@ func isRunningChild(s task.Status) bool {
 // releaseCapped releases ready children to `todo`, but no more than each
 // umbrella's remaining parallelism budget (cap - active). Strips the gating
 // marker on release so a later re-block cannot retrigger it.
-func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states map[string]*umbrellaState) {
+func (a *App) releaseCapped(ctx context.Context, ready []string, byID map[string]*task.Task, states map[string]*umbrellaState) {
 	for _, id := range ready {
 		t, ok := byID[id]
 		if !ok || t == nil {
@@ -206,6 +206,7 @@ func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states m
 		if st == nil || st.active+st.released >= st.cap {
 			continue // at the umbrella's parallelism cap for this tick
 		}
+		prevTags, prevStatus, prevReason := t.Tags, t.Status, t.StatusReason
 		newTags := slices.DeleteFunc(slices.Clone(t.Tags), func(s string) bool {
 			return s == umbrellaGatedTag
 		})
@@ -218,12 +219,33 @@ func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states m
 			a.logger.Error("umbrella.release.failed", "task_id", id, "err", err)
 			continue
 		}
-		a.pushReleaseToHomeNode(updated)
+		if err := a.pushReleaseToHomeNode(ctx, updated); err != nil {
+			a.logger.Error("umbrella.release.push_failed", "task_id", id, "err", err)
+			// The follower never saw the release, so it must not look released
+			// here either — restore the pre-release state so ReadyToRelease
+			// picks this child up again next tick instead of leaving the
+			// leader's board silently diverged from the follower forever.
+			if _, rerr := a.tasks.Update(id, task.Update{
+				Status:       task.Ptr(prevStatus),
+				Tags:         &prevTags,
+				StatusReason: task.Ptr(prevReason),
+			}); rerr != nil {
+				a.logger.Error("umbrella.release.rollback_failed", "task_id", id, "err", rerr)
+			}
+			continue
+		}
 		st.setChildStatus(id, updated.Status)
 		st.released++
 		a.logger.Info("umbrella.child.released", "task_id", id)
 	}
 }
+
+// pushReleaseTimeout bounds pushReleaseToHomeNode's remote call well under the
+// cluster client's own 30s default so one unreachable follower can delay the
+// single-threaded dispatch tick — and every other umbrella's local-only
+// releases queued behind it in the same releaseCapped loop — by at most this
+// long rather than up to 30s per stuck release.
+const pushReleaseTimeout = 5 * time.Second
 
 // pushReleaseToHomeNode forwards a just-released child's new state to its
 // home follower when the task isn't homed locally. The local a.tasks.Update
@@ -235,18 +257,22 @@ func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states m
 // the node that actually dispatches it — stays stuck on its pre-release copy.
 // Released children are always still-gated/todo, so pushing them verbatim can
 // never roll back a follower's in-progress execution state (see
-// Assigner.PushUpdate).
-func (a *App) pushReleaseToHomeNode(t task.Task) {
+// Assigner.PushUpdate). Returns nil when the task is homed locally (nothing
+// to push) or the assigner/config aren't wired up (test doubles).
+func (a *App) pushReleaseToHomeNode(ctx context.Context, t task.Task) error {
 	if a.assigner == nil || a.cfg == nil {
-		return
+		return nil
 	}
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local {
-		return
+		return nil
 	}
-	if _, err := a.assigner.PushUpdate(a.ctx, t); err != nil {
-		a.logger.Error("umbrella.release.push_failed", "task_id", t.ID, "node", home.Name, "err", err)
+	pushCtx, cancel := context.WithTimeout(ctx, pushReleaseTimeout)
+	defer cancel()
+	if _, err := a.assigner.PushUpdate(pushCtx, t); err != nil {
+		return fmt.Errorf("push release to %q: %w", home.Name, err)
 	}
+	return nil
 }
 
 func (st *umbrellaState) setChildStatus(id string, status task.Status) {

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -219,7 +219,8 @@ func (a *App) releaseCapped(ctx context.Context, ready []string, byID map[string
 			a.logger.Error("umbrella.release.failed", "task_id", id, "err", err)
 			continue
 		}
-		if err := a.pushReleaseToHomeNode(ctx, updated); err != nil {
+		pushed, err := a.pushReleaseToHomeNode(ctx, updated)
+		if err != nil {
 			a.logger.Error("umbrella.release.push_failed", "task_id", id, "err", err)
 			// The follower never saw the release, so it must not look released
 			// here either — restore the pre-release state so ReadyToRelease
@@ -232,6 +233,19 @@ func (a *App) releaseCapped(ctx context.Context, ready []string, byID map[string
 			}); rerr != nil {
 				a.logger.Error("umbrella.release.rollback_failed", "task_id", id, "err", rerr)
 			}
+			continue
+		}
+		if !pushed {
+			// No transport error, but the release did not reach the follower
+			// and, unlike a failed push, retrying it would not help — e.g.
+			// Assigner declined for confidentiality and has already moved the
+			// task to its own terminal blocked state with an operator-facing
+			// reason (clusterlead.blockForConfidentiality). Rolling back here
+			// would stomp that reason with a generic "gated" state and retry
+			// forever against a follower that will never accept the push.
+			// Leave whatever state the push path already applied alone and
+			// just decline to report a release that never happened.
+			a.logger.Warn("umbrella.release.not_pushed", "task_id", id)
 			continue
 		}
 		st.setChildStatus(id, updated.Status)
@@ -257,22 +271,32 @@ const pushReleaseTimeout = 5 * time.Second
 // the node that actually dispatches it — stays stuck on its pre-release copy.
 // Released children are always still-gated/todo, so pushing them verbatim can
 // never roll back a follower's in-progress execution state (see
-// Assigner.PushUpdate). Returns nil when the task is homed locally (nothing
-// to push) or the assigner/config aren't wired up (test doubles).
-func (a *App) pushReleaseToHomeNode(ctx context.Context, t task.Task) error {
+// Assigner.PushUpdate).
+//
+// Returns pushed=true, err=nil when the task is homed locally (nothing to
+// push), the assigner/config aren't wired up (test doubles), or the push
+// reached the follower. Returns pushed=false, err=nil when PushUpdate
+// declined to push without a transport error — currently only the
+// confidentiality gate (clusterlead.blockForConfidentiality), which already
+// moves the task to its own terminal blocked state — so the caller must not
+// treat that as either a release or a transient failure to retry. A non-nil
+// err means the push itself failed (network/timeout/remote error) and the
+// caller should roll back and let the next tick retry.
+func (a *App) pushReleaseToHomeNode(ctx context.Context, t task.Task) (pushed bool, err error) {
 	if a.assigner == nil || a.cfg == nil {
-		return nil
+		return true, nil
 	}
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local {
-		return nil
+		return true, nil
 	}
 	pushCtx, cancel := context.WithTimeout(ctx, pushReleaseTimeout)
 	defer cancel()
-	if _, err := a.assigner.PushUpdate(pushCtx, t); err != nil {
-		return fmt.Errorf("push release to %q: %w", home.Name, err)
+	ok, err := a.assigner.PushUpdate(pushCtx, t)
+	if err != nil {
+		return false, fmt.Errorf("push release to %q: %w", home.Name, err)
 	}
-	return nil
+	return ok, nil
 }
 
 func (st *umbrellaState) setChildStatus(id string, status task.Status) {

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -275,13 +275,23 @@ const pushReleaseTimeout = 5 * time.Second
 //
 // Returns pushed=true, err=nil when the task is homed locally (nothing to
 // push), the assigner/config aren't wired up (test doubles), or the push
-// reached the follower. Returns pushed=false, err=nil when PushUpdate
-// declined to push without a transport error — currently only the
-// confidentiality gate (clusterlead.blockForConfidentiality), which already
-// moves the task to its own terminal blocked state — so the caller must not
-// treat that as either a release or a transient failure to retry. A non-nil
-// err means the push itself failed (network/timeout/remote error) and the
-// caller should roll back and let the next tick retry.
+// reached the follower — PushUpdate's own routed/pushed return is the
+// authority on that even when it also reports an error: AssignTask lands
+// before PushUpdate's trailing local bookkeeping write (re-stamping
+// AssignedNode, already-correct here), so a failure in that last step must
+// not be read as "the follower never got it" — the caller must not roll back
+// a release the follower already holds, or leader and follower go split
+// brain (leader thinks gated, follower thinks released).
+//
+// Returns pushed=false, err=nil when PushUpdate declined to push without any
+// transport error — currently only the confidentiality gate
+// (clusterlead.blockForConfidentiality), which already moves the task to its
+// own terminal blocked state — so the caller must not treat that as either a
+// release or a transient failure to retry.
+//
+// Returns pushed=false, err!=nil only when the push itself never reached the
+// follower (network/timeout/remote error); the caller should roll back and
+// let the next tick retry.
 func (a *App) pushReleaseToHomeNode(ctx context.Context, t task.Task) (pushed bool, err error) {
 	if a.assigner == nil || a.cfg == nil {
 		return true, nil
@@ -293,10 +303,16 @@ func (a *App) pushReleaseToHomeNode(ctx context.Context, t task.Task) (pushed bo
 	pushCtx, cancel := context.WithTimeout(ctx, pushReleaseTimeout)
 	defer cancel()
 	ok, err := a.assigner.PushUpdate(pushCtx, t)
+	if ok {
+		if err != nil {
+			a.logger.Warn("umbrella.release.push_bookkeeping_failed", "task_id", t.ID, "node", home.Name, "err", err)
+		}
+		return true, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("push release to %q: %w", home.Name, err)
 	}
-	return ok, nil
+	return false, nil
 }
 
 func (st *umbrellaState) setChildStatus(id string, status task.Status) {

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -218,9 +218,34 @@ func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states m
 			a.logger.Error("umbrella.release.failed", "task_id", id, "err", err)
 			continue
 		}
+		a.pushReleaseToHomeNode(updated)
 		st.setChildStatus(id, updated.Status)
 		st.released++
 		a.logger.Info("umbrella.child.released", "task_id", id)
+	}
+}
+
+// pushReleaseToHomeNode forwards a just-released child's new state to its
+// home follower when the task isn't homed locally. The local a.tasks.Update
+// above only ever touches this leader's own canonical copy; Mirror only pulls
+// follower state up to the leader; and the assigner's normal Route/Tick push
+// a task to its follower once, at first assignment, then never again. Without
+// this forward, a follower-homed task released by this leader's umbrella gate
+// would carry the release in the leader's mirror forever while the follower —
+// the node that actually dispatches it — stays stuck on its pre-release copy.
+// Released children are always still-gated/todo, so pushing them verbatim can
+// never roll back a follower's in-progress execution state (see
+// Assigner.PushUpdate).
+func (a *App) pushReleaseToHomeNode(t task.Task) {
+	if a.assigner == nil || a.cfg == nil {
+		return
+	}
+	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
+	if home.Local {
+		return
+	}
+	if _, err := a.assigner.PushUpdate(a.ctx, t); err != nil {
+		a.logger.Error("umbrella.release.push_failed", "task_id", t.ID, "node", home.Name, "err", err)
 	}
 }
 

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -781,6 +781,106 @@ func TestReleaseUnblockedChildren_RollsBackReleaseOnPushFailure(t *testing.T) {
 	}
 }
 
+// TestReleaseUnblockedChildren_ConfidentialityDeclineDoesNotConsumeCap covers
+// an adversarial-review finding: PushUpdate can decline to push (pushed=false)
+// with no error at all — Assigner's confidentiality gate refuses to send a
+// work-typed task to an untrusted/unencrypted follower and moves the task to
+// its own Blocked+reason state instead. If releaseCapped read that nil-error
+// as "released" (ignoring the pushed=false signal), it would count a task
+// that never reached any follower against the umbrella's parallelism cap,
+// starving a sibling that was genuinely ready. Cap=1 with a declined remote
+// child and a releasable local child makes that starvation observable: the
+// local child must still get the slot.
+func TestReleaseUnblockedChildren_ConfidentialityDeclineDoesNotConsumeCap(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux) // plain HTTP: Encrypted() is false, same as an unconfigured follower
+	t.Cleanup(srv.Close)
+
+	cfg := &config.Config{Cluster: config.ClusterConfig{
+		Role: config.ClusterRoleLeader,
+		Followers: []config.Follower{{
+			Name:      "home-nas",
+			Endpoints: []string{srv.URL},
+			Homes:     []string{"Automaat/sybra"},
+			// Trusted defaults to false.
+		}},
+	}}
+	roster, err := clusterlead.NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+
+	app, m := newUmbrellaGateApp(t)
+	app.cfg = cfg
+	app.ctx = context.Background()
+	app.assigner = clusterlead.NewAssigner(cfg, m, roster, func(string) bool { return true }, nil, nil)
+
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	mkTracker(t, m, umb, 1) // cap=1: only one real release should fit this tick
+
+	// IDs are ordered so os.ReadDir's lexical sort (Store.List's iteration
+	// order, and thus ReadyToRelease's) puts the declined task first — the
+	// scenario that actually exercises the cap-consumption bug. If the local
+	// task were processed first it would legitimately take the cap=1 slot
+	// before the declined task is even reached, masking the defect.
+	declined, _, err := m.Put(task.Task{
+		ID:            "task-a-declined",
+		Title:         "remote child",
+		Status:        task.StatusBlocked,
+		ProjectID:     "Automaat/sybra", // homes to the untrusted follower above
+		Issue:         "Automaat/sybra#1",
+		UmbrellaIssue: umb,
+		Tags:          []string{umbrellaGatedTag},
+		AssignedNode:  "home-nas",
+	})
+	if err != nil {
+		t.Fatalf("Put(declined): %v", err)
+	}
+	// Not in any follower's Homes list, so HomeNodeFor resolves it Local —
+	// genuinely releasable this tick if the cap isn't wrongly consumed above.
+	local, _, err := m.Put(task.Task{
+		ID:            "task-b-local",
+		Title:         "local child",
+		Status:        task.StatusTodo,
+		ProjectID:     "Automaat/other",
+		Issue:         "Automaat/sybra#2",
+		UmbrellaIssue: umb,
+		Tags:          []string{umbrellaGatedTag},
+	})
+	if err != nil {
+		t.Fatalf("Put(local): %v", err)
+	}
+
+	app.releaseUnblockedChildren(context.Background())
+
+	if attempts.Load() != 0 {
+		t.Fatalf("follower endpoint was hit %d times, want 0 — a work task must never reach an untrusted follower", attempts.Load())
+	}
+	gotDeclined, err := m.Get(declined.ID)
+	if err != nil {
+		t.Fatalf("Get(declined): %v", err)
+	}
+	if gotDeclined.Status != task.StatusBlocked {
+		t.Fatalf("declined child status = %q, want %q (confidentiality-blocked, not released)", gotDeclined.Status, task.StatusBlocked)
+	}
+	if !strings.Contains(gotDeclined.StatusReason, "withheld") {
+		t.Fatalf("declined child status reason = %q, want the confidentiality block's own reason", gotDeclined.StatusReason)
+	}
+	gotLocal, err := m.Get(local.ID)
+	if err != nil {
+		t.Fatalf("Get(local): %v", err)
+	}
+	if gotLocal.Status != task.StatusTodo || slices.Contains(gotLocal.Tags, umbrellaGatedTag) {
+		t.Fatalf("local child = status=%q tags=%v, want released — the confidentiality decline must not have consumed cap=1's only slot", gotLocal.Status, gotLocal.Tags)
+	}
+}
+
 func TestReleaseUnblockedChildren_IgnoresSybraBugBlock(t *testing.T) {
 	t.Parallel()
 	app, m := newUmbrellaGateApp(t)

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -1,6 +1,7 @@
 package sybra
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -878,6 +879,105 @@ func TestReleaseUnblockedChildren_ConfidentialityDeclineDoesNotConsumeCap(t *tes
 	}
 	if gotLocal.Status != task.StatusTodo || slices.Contains(gotLocal.Tags, umbrellaGatedTag) {
 		t.Fatalf("local child = status=%q tags=%v, want released — the confidentiality decline must not have consumed cap=1's only slot", gotLocal.Status, gotLocal.Tags)
+	}
+}
+
+// TestReleaseUnblockedChildren_SurvivesPostPushBookkeepingFailure covers a
+// second adversarial-review finding: Assigner.route's local bookkeeping write
+// after a successful AssignTask (re-stamping AssignedNode) can itself fail,
+// in which case PushUpdate reports routed=true *and* a non-nil error. If
+// releaseCapped read any non-nil error as "the follower never got it" and
+// rolled back, the leader's local copy would revert to gated while the
+// follower already holds the release — a split brain, and the exact silent
+// divergence #2349 exists to close. The follower's AssignTask handler here
+// deletes the task's on-disk file the instant it receives the push (after
+// already recording receipt), deterministically forcing route()'s trailing
+// a.tasks.Get to fail without relying on OS-specific permission semantics.
+func TestReleaseUnblockedChildren_SurvivesPostPushBookkeepingFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(store, task.EmitterFunc(func(string, any) {}))
+	var logBuf bytes.Buffer
+	app := &App{tasks: tasks, logger: slog.New(slog.NewTextHandler(&logBuf, nil)), umbrellaRecoveryInFlight: make(map[string]bool)}
+
+	const childID = "task-remote"
+	var received atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/TaskService/AssignTask" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		received.Add(1)
+		// Simulate the push having already landed on the follower, then a
+		// local-store fault on the leader before it finishes stamping
+		// AssignedNode — the exact fault window route() documents handling.
+		if err := os.Remove(filepath.Join(dir, childID+".md")); err != nil {
+			t.Errorf("remove task file to force post-push bookkeeping failure: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := &config.Config{Cluster: config.ClusterConfig{
+		Role: config.ClusterRoleLeader,
+		Followers: []config.Follower{{
+			Name:      "home-nas",
+			Endpoints: []string{srv.URL},
+			Homes:     []string{"Automaat/sybra"},
+		}},
+	}}
+	roster, err := clusterlead.NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	app.cfg = cfg
+	app.ctx = context.Background()
+	app.assigner = clusterlead.NewAssigner(cfg, tasks, roster, func(string) bool { return false }, nil, nil)
+
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	if _, _, err := tasks.Put(task.Task{
+		ID:            childID,
+		Title:         "remote child",
+		Status:        task.StatusBlocked,
+		ProjectID:     "Automaat/sybra",
+		Issue:         "Automaat/sybra#1",
+		UmbrellaIssue: umb,
+		Tags:          []string{umbrellaGatedTag},
+		AssignedNode:  "home-nas",
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	app.releaseUnblockedChildren(context.Background())
+
+	if received.Load() != 1 {
+		t.Fatalf("follower received %d pushes, want 1", received.Load())
+	}
+	// The handler deletes the task file the instant it receives the push, so
+	// route()'s trailing a.tasks.Get is guaranteed to fail — confirming the
+	// fault actually fired before asserting on how releaseCapped handled it.
+	if _, err := os.Stat(filepath.Join(dir, childID+".md")); err == nil {
+		t.Fatalf("task file unexpectedly still present — fault injection did not fire as intended")
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "umbrella.child.released") {
+		t.Errorf("logs missing umbrella.child.released — a follower-acknowledged push must still count as a real release:\n%s", logs)
+	}
+	if !strings.Contains(logs, "umbrella.release.push_bookkeeping_failed") {
+		t.Errorf("logs missing umbrella.release.push_bookkeeping_failed — the trailing local-write error must still be surfaced:\n%s", logs)
+	}
+	if strings.Contains(logs, "umbrella.release.push_failed") {
+		t.Errorf("logs contain umbrella.release.push_failed — a push the follower already acknowledged must not be reported as a transport failure:\n%s", logs)
+	}
+	if strings.Contains(logs, "umbrella.release.rollback_failed") || strings.Contains(logs, "umbrella.release.rollback") {
+		t.Errorf("logs show a rollback attempt — rolling back a release the follower already holds would split-brain leader and follower:\n%s", logs)
 	}
 }
 

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -2,18 +2,24 @@ package sybra
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -593,6 +599,88 @@ func TestReleaseUnblockedChildren_ReleasesRootWithNoDeps(t *testing.T) {
 	// retrigger a release.
 	if slices.Contains(released.Tags, umbrellaGatedTag) {
 		t.Fatalf("gating tag not stripped on release: tags=%v", released.Tags)
+	}
+}
+
+// TestReleaseUnblockedChildren_PushesReleaseToRemoteHomeNode reproduces the
+// 2026-07-19 incident: a child already stamped AssignedNode by a prior
+// Assigner.Tick (i.e. routed once, same as every real gated child) gets
+// released locally by the umbrella gate, but without pushReleaseToHomeNode
+// that release only ever lands in the leader's own canonical copy — the
+// follower that actually dispatches the task never sees it.
+func TestReleaseUnblockedChildren_PushesReleaseToRemoteHomeNode(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	var assigned []task.Task
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/TaskService/AssignTask" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var args []task.Task
+		_ = json.Unmarshal(body, &args)
+		if len(args) == 1 {
+			mu.Lock()
+			assigned = append(assigned, args[0])
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := &config.Config{Cluster: config.ClusterConfig{
+		Role: config.ClusterRoleLeader,
+		Followers: []config.Follower{{
+			Name:      "home-nas",
+			Endpoints: []string{srv.URL},
+			Homes:     []string{"Automaat/sybra"},
+		}},
+	}}
+	roster, err := clusterlead.NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+
+	app, m := newUmbrellaGateApp(t)
+	app.cfg = cfg
+	app.ctx = context.Background()
+	app.assigner = clusterlead.NewAssigner(cfg, m, roster, func(string) bool { return false }, nil, nil)
+
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	child, _, err := m.Put(task.Task{
+		ID:            "task-remote",
+		Title:         "remote child",
+		Status:        task.StatusTodo,
+		ProjectID:     "Automaat/sybra",
+		Issue:         "Automaat/sybra#1",
+		UmbrellaIssue: umb,
+		Tags:          []string{umbrellaGatedTag},
+		AssignedNode:  "home-nas",
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	app.releaseUnblockedChildren()
+
+	released, err := m.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if slices.Contains(released.Tags, umbrellaGatedTag) {
+		t.Fatalf("gating tag not stripped locally: tags=%v", released.Tags)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(assigned) != 1 {
+		t.Fatalf("follower received %d pushes, want 1 — the release must reach the remote home node", len(assigned))
+	}
+	if assigned[0].Status != task.StatusTodo || slices.Contains(assigned[0].Tags, umbrellaGatedTag) {
+		t.Errorf("pushed task = %+v, want released (todo, gate tag stripped)", assigned[0])
 	}
 }
 

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ func TestReleaseUnblockedChildren_RespectsMaxParallel(t *testing.T) {
 	c2 := mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusTodo)
 	c3 := mkChild(t, m, "c3", "Automaat/sybra#3", umb, nil, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	released, held := 0, 0
 	for _, id := range []string{c1.ID, c2.ID, c3.ID} {
@@ -80,7 +81,7 @@ func TestReleaseUnblockedChildren_HaltChainFlagsTracker(t *testing.T) {
 	stuck := mkChild(t, m, "stuck", "Automaat/sybra#1", umb, nil, task.StatusHumanRequired)
 	indep := mkChild(t, m, "indep", "Automaat/sybra#2", umb, nil, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
 		t.Fatalf("tracker = %q, want human-required on stuck child", got)
@@ -110,7 +111,7 @@ func TestReleaseUnblockedChildren_StuckChildDoesNotConsumeParallelSlot(t *testin
 	}
 	ready := mkChild(t, m, "ready", "Automaat/sybra#2", umb, nil, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
 		t.Fatalf("tracker = %q, want human-required on stuck child", got)
@@ -141,7 +142,7 @@ func TestReleaseUnblockedChildren_RetryableWatchdogStopKeepsTrackerInProgress(t 
 	}
 	ready := mkChild(t, m, "ready", "Automaat/sybra#2", umb, nil, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusInProgress {
 		t.Fatalf("tracker = %q, want in-progress while watchdog-stopped child is still recoverable", got)
@@ -178,7 +179,7 @@ func TestReleaseUnblockedChildren_NonGatedBlockedChildEscalates(t *testing.T) {
 	}
 	dependent := mkChild(t, m, "dependent", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusBlocked)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
 		t.Fatalf("tracker = %q, want human-required on non-gated blocked child", got)
@@ -205,7 +206,7 @@ func TestReleaseUnblockedChildren_RollupClosesUmbrella(t *testing.T) {
 	mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusDone)
 	mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusDone)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusDone {
 		t.Fatalf("tracker = %q, want done when all children done", got)
@@ -226,7 +227,7 @@ func TestReleaseUnblockedChildren_UpdatesTrackerProgressChecklist(t *testing.T) 
 	mkChild(t, m, "done child", "Automaat/sybra#1", umb, nil, task.StatusDone)
 	mkChild(t, m, "blocked child", "Automaat/sybra#2", umb, nil, task.StatusHumanRequired)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	body := mustTask(t, m, tracker.ID).Body
 	for _, want := range []string{
@@ -390,7 +391,7 @@ func TestReleaseUnblockedChildren_ExpandFailingTrackerNeverAutoCloses(t *testing
 		t.Fatalf("create failure tracker: %v", err)
 	}
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
 		t.Fatalf("tracker = %q, want to stay human-required (never auto-closed)", got)
@@ -409,7 +410,7 @@ func TestReleaseUnblockedChildren_EmptyTrackerHeldUntilSettled(t *testing.T) {
 	// Tracker with no children, created just now → not yet settled.
 	tracker := mkTracker(t, m, umb, 5)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	// A freshly-created childless tracker must not be closed — its children may
 	// still be materializing in the same expansion.
@@ -431,7 +432,7 @@ func TestReleaseUnblockedChildren_CancelledChildSurfaces(t *testing.T) {
 	mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusDone)
 	mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusCancelled)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	// A cancelled child must surface for a human, never silently complete/close.
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
@@ -468,7 +469,7 @@ func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
 			}
 			mkChild(t, m, "child", "Automaat/sybra#1", umb, nil, tt.childStatus)
 
-			app.releaseUnblockedChildren()
+			app.releaseUnblockedChildren(context.Background())
 
 			got := mustTask(t, m, tracker.ID)
 			if got.Status != task.StatusBlocked {
@@ -498,7 +499,7 @@ func TestReleaseUnblockedChildren_BlockedTrackerStillReleasesReadyChildren(t *te
 	}
 	child := mkChild(t, m, "ready", "Automaat/sybra#1", umb, nil, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	gotTracker := mustTask(t, m, tracker.ID)
 	if gotTracker.Status != task.StatusBlocked {
@@ -527,7 +528,7 @@ func TestReleaseUnblockedChildren_CloseFailureDefersDone(t *testing.T) {
 	tracker := mkTracker(t, m, umb, 5)
 	mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusDone)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	// Close failed transiently → tracker must NOT flip to done (so the close
 	// retries next tick rather than orphaning the open issue).
@@ -586,7 +587,7 @@ func TestReleaseUnblockedChildren_ReleasesRootWithNoDeps(t *testing.T) {
 
 	root := mkChild(t, m, "root", "Automaat/sybra#1", umb, nil, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	released, err := m.Get(root.ID)
 	if err != nil {
@@ -664,7 +665,7 @@ func TestReleaseUnblockedChildren_PushesReleaseToRemoteHomeNode(t *testing.T) {
 		t.Fatalf("Put: %v", err)
 	}
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	released, err := m.Get(child.ID)
 	if err != nil {
@@ -681,6 +682,102 @@ func TestReleaseUnblockedChildren_PushesReleaseToRemoteHomeNode(t *testing.T) {
 	}
 	if assigned[0].Status != task.StatusTodo || slices.Contains(assigned[0].Tags, umbrellaGatedTag) {
 		t.Errorf("pushed task = %+v, want released (todo, gate tag stripped)", assigned[0])
+	}
+}
+
+// TestReleaseUnblockedChildren_RollsBackReleaseOnPushFailure covers the
+// adversarial-review blocker on the fix above: if the remote push fails, the
+// leader must not report the child as released while the follower — the node
+// that actually dispatches it — never saw the change. Without the rollback,
+// the gating tag/status only ever get stripped once, so a failed push
+// permanently strands the follower with no way for the next tick to retry.
+func TestReleaseUnblockedChildren_RollsBackReleaseOnPushFailure(t *testing.T) {
+	t.Parallel()
+	var failing atomic.Bool
+	failing.Store(true)
+	var attempts atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/TaskService/AssignTask" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		attempts.Add(1)
+		if failing.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := &config.Config{Cluster: config.ClusterConfig{
+		Role: config.ClusterRoleLeader,
+		Followers: []config.Follower{{
+			Name:      "home-nas",
+			Endpoints: []string{srv.URL},
+			Homes:     []string{"Automaat/sybra"},
+		}},
+	}}
+	roster, err := clusterlead.NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+
+	app, m := newUmbrellaGateApp(t)
+	app.cfg = cfg
+	app.ctx = context.Background()
+	app.assigner = clusterlead.NewAssigner(cfg, m, roster, func(string) bool { return false }, nil, nil)
+
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	child, _, err := m.Put(task.Task{
+		ID:            "task-remote",
+		Title:         "remote child",
+		Status:        task.StatusBlocked,
+		ProjectID:     "Automaat/sybra",
+		Issue:         "Automaat/sybra#1",
+		UmbrellaIssue: umb,
+		Tags:          []string{umbrellaGatedTag},
+		AssignedNode:  "home-nas",
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	app.releaseUnblockedChildren(context.Background())
+
+	if attempts.Load() != 1 {
+		t.Fatalf("push attempts = %d, want 1", attempts.Load())
+	}
+	afterFailedPush, err := m.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !slices.Contains(afterFailedPush.Tags, umbrellaGatedTag) {
+		t.Fatalf("gating tag stripped despite failed push: tags=%v", afterFailedPush.Tags)
+	}
+	if afterFailedPush.Status != task.StatusBlocked {
+		t.Fatalf("status = %q after failed push, want rolled back to %q", afterFailedPush.Status, task.StatusBlocked)
+	}
+
+	// Next tick, the follower is healthy again — the rolled-back state must
+	// still be eligible for release rather than permanently stranded.
+	failing.Store(false)
+	app.releaseUnblockedChildren(context.Background())
+
+	if attempts.Load() != 2 {
+		t.Fatalf("push attempts after recovery = %d, want 2", attempts.Load())
+	}
+	afterRetry, err := m.Get(child.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if slices.Contains(afterRetry.Tags, umbrellaGatedTag) {
+		t.Fatalf("gating tag still present after a successful retry: tags=%v", afterRetry.Tags)
+	}
+	if afterRetry.Status != task.StatusTodo {
+		t.Fatalf("status = %q after successful retry, want %q", afterRetry.Status, task.StatusTodo)
 	}
 }
 
@@ -705,7 +802,7 @@ func TestReleaseUnblockedChildren_IgnoresSybraBugBlock(t *testing.T) {
 		t.Fatalf("create buggy: %v", err)
 	}
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, bug.ID); got != task.StatusBlocked {
 		t.Fatalf("sybra-bug-blocked child was released to %q, want blocked", got)
@@ -721,7 +818,7 @@ func TestReleaseUnblockedChildren_HoldsThenReleasesChain(t *testing.T) {
 	dep := mkChild(t, m, "dep", "Automaat/sybra#1", umb, nil, task.StatusInProgress)
 	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 	childTask := mustTask(t, m, child.ID)
 	if childTask.Status != task.StatusTodo || !slices.Contains(childTask.Tags, umbrellaGatedTag) {
 		t.Fatalf("child released early: status = %q tags = %v, want todo+%s", childTask.Status, childTask.Tags, umbrellaGatedTag)
@@ -731,7 +828,7 @@ func TestReleaseUnblockedChildren_HoldsThenReleasesChain(t *testing.T) {
 	if _, err := m.Update(dep.ID, task.Update{Status: task.Ptr(task.StatusDone)}); err != nil {
 		t.Fatalf("finish dep: %v", err)
 	}
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 	if got := mustStatus(t, m, child.ID); got != task.StatusTodo {
 		t.Fatalf("child status = %q, want %q after dep done", got, task.StatusTodo)
 	}
@@ -746,7 +843,7 @@ func TestReleaseUnblockedChildren_CrossFormDependencyResolves(t *testing.T) {
 	mkChild(t, m, "dep", "https://github.com/Automaat/sybra/issues/1", umb, nil, task.StatusDone)
 	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 	if got := mustStatus(t, m, child.ID); got != task.StatusTodo {
 		t.Fatalf("child status = %q, want %q (cross-form dep should resolve)", got, task.StatusTodo)
 	}
@@ -771,7 +868,7 @@ func TestReleaseUnblockedChildren_CycleFlagsTracker(t *testing.T) {
 	x := mkChild(t, m, "x", "Automaat/sybra#1", umb, []string{"Automaat/sybra#2"}, task.StatusTodo)
 	y := mkChild(t, m, "y", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
 		t.Fatalf("tracker status = %q, want %q on cycle", got, task.StatusHumanRequired)
@@ -798,7 +895,7 @@ func TestReleaseUnblockedChildren_NoUmbrellaNoOp(t *testing.T) {
 		t.Fatalf("create plain: %v", err)
 	}
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 	if got := mustStatus(t, m, tk.ID); got != task.StatusBlocked {
 		t.Fatalf("plain blocked task changed to %q, want blocked", got)
 	}
@@ -904,7 +1001,7 @@ func TestReleaseUnblockedChildren_InFlightUmbrellaSkipsReleaseAndRollup(t *testi
 
 	app.umbrellaRecoveryInFlight[umbrella.NormalizeIssueRef(umb)] = true
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	got := mustTask(t, m, child.ID)
 	if got.Status != task.StatusTodo || !slices.Contains(got.Tags, umbrellaGatedTag) {
@@ -931,7 +1028,7 @@ func TestReleaseUnblockedChildren_InFlightUmbrellaDoesNotBlockUnrelated(t *testi
 
 	app.umbrellaRecoveryInFlight[umbrella.NormalizeIssueRef(umbA)] = true
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	gotA := mustTask(t, m, childA.ID)
 	if gotA.Status != task.StatusTodo || !slices.Contains(gotA.Tags, umbrellaGatedTag) {
@@ -974,7 +1071,7 @@ func TestReleaseUnblockedChildren_AsyncRecoveryDoesNotBlockUnrelatedRelease(t *t
 	mkTracker(t, tasks, umbB, 5)
 	childB := mkChild(t, tasks, "b", "Automaat/sybra#1", umbB, nil, task.StatusTodo)
 
-	app.releaseUnblockedChildren()
+	app.releaseUnblockedChildren(context.Background())
 
 	if !app.umbrellaRecoveryInFlightSnapshot()[umbrella.NormalizeIssueRef(umbA)] {
 		t.Fatal("degraded umbrella ref not marked in-flight")

--- a/internal/sybra/clusterlead/assigner.go
+++ b/internal/sybra/clusterlead/assigner.go
@@ -96,11 +96,31 @@ func (a *Assigner) Tick(ctx context.Context) {
 // idempotent: the follower's AssignTask upserts by id, so a repeated push is
 // harmless.
 func (a *Assigner) Route(ctx context.Context, t task.Task) (routed bool, err error) {
+	return a.route(ctx, t, false)
+}
+
+// PushUpdate re-pushes a task that is already assigned to its home follower,
+// forwarding a leader-side canonical edit (e.g. the umbrella gate clearing a
+// dependency block) that would otherwise never reach the follower: Mirror
+// only pulls follower state up to the leader (internal/sybra/clusterlead/mirror.go),
+// it never pushes leader edits back down, and Route/Tick push only once, at
+// first assignment.
+//
+// Callers must only use this for a task that has not started executing
+// anywhere (e.g. still gated/todo) — AssignTask writes the pushed copy
+// verbatim on the follower, so pushing a stale leader-side snapshot over a
+// follower's own in-progress execution state (AgentRuns, Workflow, ...) would
+// roll it back.
+func (a *Assigner) PushUpdate(ctx context.Context, t task.Task) (pushed bool, err error) {
+	return a.route(ctx, t, true)
+}
+
+func (a *Assigner) route(ctx context.Context, t task.Task, force bool) (routed bool, err error) {
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local {
 		return false, nil
 	}
-	if t.AssignedNode == home.Name {
+	if !force && t.AssignedNode == home.Name {
 		return false, nil
 	}
 	if a.isWorkProject(t.ProjectID) && (!home.Trusted || !home.Encrypted) {

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -147,6 +147,50 @@ func TestAssignerRouteIsIdempotentOnceStamped(t *testing.T) {
 	}
 }
 
+func TestAssignerPushUpdateReSyncsAlreadyStampedTask(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	assigner := NewAssigner(cfg, mgr, roster, func(string) bool { return false }, nil, nil)
+
+	if _, _, err := mgr.Put(task.Task{ID: "task-pet", Title: "t", Status: task.StatusTodo, ProjectID: "owner/pet"}); err != nil {
+		t.Fatal(err)
+	}
+	cur, _ := mgr.Get("task-pet")
+	if routed, err := assigner.Route(context.Background(), cur); err != nil || !routed {
+		t.Fatalf("first Route: routed=%v err=%v", routed, err)
+	}
+
+	// Simulate a leader-side edit after the initial push (e.g. the umbrella
+	// gate clearing a dependency block) — Route alone would never re-push
+	// this since AssignedNode already matches home.
+	stamped, _ := mgr.Get("task-pet")
+	stamped.StatusReason = "umbrella dependencies satisfied"
+	edited, _, err := mgr.Put(stamped)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pushed, err := assigner.PushUpdate(context.Background(), edited)
+	if err != nil || !pushed {
+		t.Fatalf("PushUpdate: pushed=%v err=%v", pushed, err)
+	}
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.assigned) != 2 {
+		t.Fatalf("follower received %d pushes, want 2 (initial Route + PushUpdate)", len(stub.assigned))
+	}
+	if got := stub.assigned[1]; got.StatusReason != "umbrella dependencies satisfied" {
+		t.Errorf("second push StatusReason = %q, want the edited value", got.StatusReason)
+	}
+}
+
 func TestAssignerLeavesLocalTaskAlone(t *testing.T) {
 	stub := &followerStub{}
 	srv := stub.server(t)


### PR DESCRIPTION
## Motivation

In a leader/follower Sybra cluster, a leader-side edit to a task already
homed on a follower never reaches the follower's own authoritative copy.
`Assigner.Route`/`Tick` only ever push a task to its home follower once, at
first assignment; `Mirror` only pulls follower state up to the leader, never
pushes leader edits down. When the umbrella gate releases a gated child on
the leader (clearing a dependency block), that release lands only in the
leader's own canonical copy.

Real incident: two `Automaat/sybra` tasks sat in `todo` with dependencies
satisfied on the leader's mirror, but the follower — the node that actually
dispatches work — never budged. Silently stuck for days with no error
anywhere.

> Changelog: fix(cluster): push umbrella release to home node

## Implementation information

`Assigner.PushUpdate` re-pushes an already-assigned task on demand (`route()`
gains a `force` bool; the existing `Route`/`Tick` call site is unaffected).
`releaseCapped` calls it via `pushReleaseToHomeNode` right after releasing a
child that isn't homed locally, bounded to a 5s timeout so one unreachable
follower can't stall the whole dispatch tick.

Three adversarial-review rounds surfaced and fixed real defects beyond the
initial push:
- A failed push was logged but not rolled back, permanently stranding the
  child (its gating tag was already stripped, so nothing would ever retry
  it). Fixed: roll back the local release on a genuine push failure so the
  next tick retries.
- `Assigner`'s confidentiality gate declining a work-typed push to an
  untrusted follower (`pushed=false, err=nil` — an intentional decline, not a
  transport failure) was being misread as a successful release, falsely
  consuming the umbrella's parallelism cap and starving a genuinely-ready
  sibling. Fixed: a three-way branch on `(pushed, err)` instead of
  error-only.
- When the remote `AssignTask` call succeeds but the trailing local
  bookkeeping write (re-stamping `AssignedNode`) fails, `PushUpdate` returns
  `(pushed=true, err!=nil)`. The push-succeeded signal was being discarded in
  favor of the trailing error, rolling back a release the follower already
  holds — a leader/follower split-brain. Fixed: the `pushed` bool takes
  precedence over a trailing error.

Each fix has a dedicated regression test in `app_umbrella_gate_test.go` /
`clusterlead_test.go`; every one was verified to fail on the pre-fix code and
pass after (including a deterministic fault-injection test for the
post-push-bookkeeping-failure case, no timing races).

## Open questions

If the push itself fails (network/timeout) *and* the compensating local
rollback also fails (a coincident local-store fault), the task is left
inconsistent with nothing to auto-recover it. This double-fault case is
accepted as out of scope here — issue #2350 (a general leader/follower drift
reconciliation sweep) is designed as the backstop for exactly this class of
residual divergence, independent of which write path caused it.