### PR TITLE
feat(cluster): detect and repair task mirror drift

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/monitor/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/monitor/models.ts
@@ -69,6 +69,15 @@ export enum AnomalyKind {
     KindLostAgent = "lost_agent",
     KindFailureSpike = "failure_spike",
     KindBottleneck = "bottleneck",
+
+    /**
+     * KindClusterDrift is filed by clusterlead.Mirror, not Detect — a leader
+     * canonical task's Tags/DependsOn disagree with what its home follower
+     * reports, meaning a leader-side write never reached the node that
+     * actually owns the task. Always RequiresLLM: false; Mirror repairs it
+     * deterministically and files this purely as an audit trail.
+     */
+    KindClusterDrift = "cluster_drift",
 };
 
 /**

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -250,6 +250,8 @@ func suggestedInvestigation(a Anomaly) string {
 		return "- Confirm the agent process actually exited; workflow recovery should resume the in-progress task.\n"
 	case KindUntriaged:
 		return "- Run `/sybra-triage` against the affected task to fill `agent_mode` and `tags`.\n"
+	case KindClusterDrift:
+		return "- Mirror already repaired this by re-pushing the leader's Tags/DependsOn to the follower — filed as an audit trail. If it recurs for the same task, the write path that edits it is failing to reach the follower; check that node's connectivity and cluster.mirror.drift_repair.failed logs.\n"
 	case KindStuckHumanBlocked:
 		hint := "- Review the task file and `status_reason`, then provide the required human input to unblock progress.\n"
 		if reason, _ := a.Evidence["status_reason"].(string); reason != "" {

--- a/internal/monitor/report.go
+++ b/internal/monitor/report.go
@@ -27,6 +27,12 @@ const (
 	KindLostAgent         AnomalyKind = "lost_agent"
 	KindFailureSpike      AnomalyKind = "failure_spike"
 	KindBottleneck        AnomalyKind = "bottleneck"
+	// KindClusterDrift is filed by clusterlead.Mirror, not Detect — a leader
+	// canonical task's Tags/DependsOn disagree with what its home follower
+	// reports, meaning a leader-side write never reached the node that
+	// actually owns the task. Always RequiresLLM: false; Mirror repairs it
+	// deterministically and files this purely as an audit trail.
+	KindClusterDrift AnomalyKind = "cluster_drift"
 )
 
 // AllAnomalyKinds returns every kind in declaration order. Useful for tests
@@ -40,6 +46,7 @@ func AllAnomalyKinds() []AnomalyKind {
 		KindLostAgent,
 		KindFailureSpike,
 		KindBottleneck,
+		KindClusterDrift,
 	}
 }
 

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -24,6 +24,9 @@ type followerStub struct {
 	mu       sync.Mutex
 	assigned []task.Task
 	tasks    []task.Task
+	// live overrides GetTask, letting a test make it disagree with tasks
+	// (the ListTasks snapshot) to simulate a follower that moved on.
+	live map[string]task.Task
 }
 
 func (f *followerStub) server(t *testing.T) *httptest.Server {
@@ -48,6 +51,26 @@ func (f *followerStub) server(t *testing.T) *httptest.Server {
 			f.mu.Lock()
 			_ = json.NewEncoder(w).Encode(f.tasks)
 			f.mu.Unlock()
+		case "/api/TaskService/GetTask":
+			var args []string
+			_ = json.Unmarshal(body, &args)
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			if len(args) != 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if t, ok := f.live[args[0]]; ok {
+				_ = json.NewEncoder(w).Encode(t)
+				return
+			}
+			for i := range f.tasks {
+				if f.tasks[i].ID == args[0] {
+					_ = json.NewEncoder(w).Encode(f.tasks[i])
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -399,6 +422,10 @@ func TestMirrorDetectsAndRepairsTagsAndDependsOnDrift(t *testing.T) {
 		DependsOn:    nil,
 		UpdatedAt:    t0.Add(time.Hour),
 	}
+	// repairDrift re-fetches via GetTask rather than trusting this tick's
+	// ListTasks snapshot; seed both to the same value here since this test
+	// covers ordinary (non-racing) repair.
+	stub.tasks = []task.Task{stale}
 	if !mirror.applyFollowerTask("pet-box", stale) {
 		t.Fatal("apply follower report")
 	}
@@ -434,6 +461,77 @@ func TestMirrorDetectsAndRepairsTagsAndDependsOnDrift(t *testing.T) {
 	// drift detection doesn't block the ordinary merge.
 	if leaderCopy, err := mgr.Get("task-pet"); err != nil || leaderCopy.Status != task.StatusInProgress {
 		t.Errorf("leader canonical status = %+v, err=%v, want in-progress merged normally", leaderCopy, err)
+	}
+}
+
+// TestMirrorDriftRepairUsesLiveFollowerStateNotStaleSnapshot covers an
+// adversarial-review finding: this reconcile tick's ListTasks response (the
+// `follower` value Merge/detectAndRepairDrift work from) can already be
+// behind the follower's actual current state by the time repairDrift's
+// AssignTask lands — earlier tasks in the same batch, under the same
+// applyMu lock, each take time first. Patching that stale snapshot's
+// Tags/DependsOn and pushing it verbatim would silently roll back whatever
+// the follower did since. The follower stub here answers ListTasks and
+// GetTask differently — GetTask (live, queried at repair time) reports a
+// status advance and a fresh AgentRuns entry ListTasks (the snapshot) never
+// saw — and asserts the repair preserves the live state, not the snapshot.
+func TestMirrorDriftRepairUsesLiveFollowerStateNotStaleSnapshot(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	canonical := task.Task{
+		ID:           "task-pet",
+		Status:       task.StatusTodo,
+		AssignedNode: "pet-box",
+		Tags:         []string{"backend", "umbrella-gated"},
+		UpdatedAt:    t0,
+	}
+	if _, _, err := mgr.Put(canonical); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := task.Task{
+		ID:           "task-pet",
+		Status:       task.StatusTodo,
+		AssignedNode: "pet-box",
+		Tags:         []string{"backend"},
+		UpdatedAt:    t0.Add(time.Hour),
+	}
+	moved := task.Task{
+		ID:           "task-pet",
+		Status:       task.StatusInProgress,
+		AssignedNode: "pet-box",
+		Tags:         []string{"backend"},
+		AgentRuns:    []task.AgentRun{{AgentID: "started-after-the-snapshot"}},
+		UpdatedAt:    t0.Add(2 * time.Hour),
+	}
+	stub.tasks = []task.Task{snapshot}
+	stub.live = map[string]task.Task{"task-pet": moved}
+
+	if !mirror.applyFollowerTask("pet-box", snapshot) {
+		t.Fatal("apply follower report")
+	}
+
+	got, ok := stub.lastAssigned()
+	if !ok {
+		t.Fatal("follower did not receive a repair push")
+	}
+	if !slices.Equal(got.Tags, canonical.Tags) {
+		t.Errorf("repaired tags = %v, want %v", got.Tags, canonical.Tags)
+	}
+	if got.Status != moved.Status {
+		t.Errorf("repair overwrote live status %q with the stale snapshot's %q — rolled back follower progress", moved.Status, got.Status)
+	}
+	if len(got.AgentRuns) != 1 || got.AgentRuns[0].AgentID != "started-after-the-snapshot" {
+		t.Errorf("repair dropped the follower's live AgentRuns, got %+v — rolled back follower progress", got.AgentRuns)
 	}
 }
 

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -60,8 +60,8 @@ func (f *followerStub) server(t *testing.T) *httptest.Server {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
-			if t, ok := f.live[args[0]]; ok {
-				_ = json.NewEncoder(w).Encode(t)
+			if liveTask, ok := f.live[args[0]]; ok {
+				_ = json.NewEncoder(w).Encode(liveTask)
 				return
 			}
 			for i := range f.tasks {

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -326,6 +328,154 @@ func TestMirrorMirrorsPlanningSidecars(t *testing.T) {
 		got.PlanBrief != "" ||
 		got.CodeReview != "" {
 		t.Fatalf("cleared follower sidecars should clear leader sidecars: %+v", got)
+	}
+}
+
+// fakeAnomalySink is a monitor.IssueSink test double that records every
+// submitted anomaly so tests can assert alerting fired without depending on
+// GitHub/local-task-routing machinery.
+type fakeAnomalySink struct {
+	mu    sync.Mutex
+	calls []monitor.Anomaly
+}
+
+func (s *fakeAnomalySink) Submit(_ context.Context, a monitor.Anomaly, _ string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, a)
+	return true, nil
+}
+
+func (s *fakeAnomalySink) submitted() []monitor.Anomaly {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.calls)
+}
+
+// TestMirrorDetectsAndRepairsTagsAndDependsOnDrift covers issue #2350: Tags
+// and DependsOn are leader-authoritative fields Merge never pulls from the
+// follower (see Merge's field list — only execution fields like Status flow
+// follower-authoritative). If a leader-side write to either one never
+// reached the follower, nothing in the ordinary reconcile loop would ever
+// notice. This seeds a follower report that disagrees with the canonical
+// copy on both fields and asserts the sweep detects it, alerts through the
+// anomaly sink, and repairs the follower within the same reconcile pass —
+// without touching the follower's own Status/PR fields (never a stale
+// full-task overwrite).
+func TestMirrorDetectsAndRepairsTagsAndDependsOnDrift(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+	sink := &fakeAnomalySink{}
+	mirror.SetAnomalySink(sink)
+
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	canonical := task.Task{
+		ID:           "task-pet",
+		Status:       task.StatusTodo,
+		AssignedNode: "pet-box",
+		Tags:         []string{"backend", "umbrella-gated"},
+		DependsOn:    []string{"https://github.com/o/r/issues/1"},
+		UpdatedAt:    t0,
+	}
+	if _, _, err := mgr.Put(canonical); err != nil {
+		t.Fatal(err)
+	}
+
+	// The follower reports real progress (a status advance the leader hasn't
+	// pulled yet — expected and fine) but still carries the stale Tags/
+	// DependsOn from before the leader's edit never reached it.
+	stale := task.Task{
+		ID:           "task-pet",
+		Status:       task.StatusInProgress,
+		AssignedNode: "pet-box",
+		Tags:         []string{"backend"},
+		DependsOn:    nil,
+		UpdatedAt:    t0.Add(time.Hour),
+	}
+	if !mirror.applyFollowerTask("pet-box", stale) {
+		t.Fatal("apply follower report")
+	}
+
+	// Detected + alerted.
+	calls := sink.submitted()
+	if len(calls) != 1 {
+		t.Fatalf("anomaly sink got %d submissions, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].Kind != monitor.KindClusterDrift || calls[0].TaskID != "task-pet" {
+		t.Fatalf("submitted anomaly = %+v, want KindClusterDrift for task-pet", calls[0])
+	}
+
+	// Repaired: the follower stub received an AssignTask carrying the
+	// canonical Tags/DependsOn...
+	got, ok := stub.lastAssigned()
+	if !ok {
+		t.Fatal("follower did not receive a repair push")
+	}
+	if !slices.Equal(got.Tags, canonical.Tags) {
+		t.Errorf("repaired tags = %v, want %v", got.Tags, canonical.Tags)
+	}
+	if !slices.Equal(got.DependsOn, canonical.DependsOn) {
+		t.Errorf("repaired depends_on = %v, want %v", got.DependsOn, canonical.DependsOn)
+	}
+	// ...but the follower's own execution state (Status) was left as its
+	// current report, not rolled back to the leader's stale canonical copy.
+	if got.Status != task.StatusInProgress {
+		t.Errorf("repair push overwrote follower status: got %q, want %q (must not roll back execution state)", got.Status, task.StatusInProgress)
+	}
+
+	// Applying normally still landed the follower's Status on the leader —
+	// drift detection doesn't block the ordinary merge.
+	if leaderCopy, err := mgr.Get("task-pet"); err != nil || leaderCopy.Status != task.StatusInProgress {
+		t.Errorf("leader canonical status = %+v, err=%v, want in-progress merged normally", leaderCopy, err)
+	}
+}
+
+// TestMirrorNoAlertOnOrdinaryStatusDisagreement asserts that Status differing
+// between the leader and follower — the normal, expected, self-healing case
+// Merge exists for — never fires the drift alert/repair path. Only
+// Tags/DependsOn (fields Merge doesn't carry) are drift-worthy; alerting on
+// every ordinary status lag would make the signal useless.
+func TestMirrorNoAlertOnOrdinaryStatusDisagreement(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+	sink := &fakeAnomalySink{}
+	mirror.SetAnomalySink(sink)
+
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "task-pet", Status: task.StatusTodo, AssignedNode: "pet-box",
+		Tags: []string{"backend"}, UpdatedAt: t0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	advanced := task.Task{
+		ID: "task-pet", Status: task.StatusPlanReview, AssignedNode: "pet-box",
+		Tags: []string{"backend"}, UpdatedAt: t0.Add(time.Hour),
+	}
+	if !mirror.applyFollowerTask("pet-box", advanced) {
+		t.Fatal("apply follower report")
+	}
+
+	if calls := sink.submitted(); len(calls) != 0 {
+		t.Fatalf("anomaly sink got %d submissions for an ordinary status advance, want 0: %+v", len(calls), calls)
+	}
+	if _, ok := stub.lastAssigned(); ok {
+		t.Error("follower received an unnecessary repair push for a matching Tags/DependsOn task")
 	}
 }
 

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -233,7 +233,7 @@ func (m *Mirror) detectAndRepairDrift(ctx context.Context, node string, canonica
 		"canonical_tags", canonical.Tags, "follower_tags", follower.Tags,
 		"canonical_depends_on", canonical.DependsOn, "follower_depends_on", follower.DependsOn)
 	m.alertDrift(ctx, node, canonical, tagsDrift, depsDrift)
-	m.repairDrift(ctx, node, canonical, follower)
+	m.repairDrift(ctx, node, canonical)
 }
 
 func (m *Mirror) alertDrift(ctx context.Context, node string, canonical task.Task, tagsDrift, depsDrift bool) {
@@ -261,22 +261,39 @@ func (m *Mirror) alertDrift(ctx context.Context, node string, canonical task.Tas
 	}
 }
 
+// driftRepairTimeout bounds repairDrift's two follower round trips (a
+// re-fetch plus the repair push) so one unreachable follower can't hold
+// applyMu — shared across every node's reconcile goroutine — for the full
+// 30s cluster client default per drifted task.
+const driftRepairTimeout = 5 * time.Second
+
 // repairDrift pushes only the drifted fields onto the follower's own current
 // task state (not the leader's canonical copy verbatim) — the follower's
 // Status/Workflow/AgentRuns/etc. may be more current than what the leader
 // last pulled, and overwriting those would roll back real execution
-// progress, exactly the split-brain risk PushUpdate exists to avoid.
-func (m *Mirror) repairDrift(ctx context.Context, node string, canonical, follower task.Task) {
+// progress, exactly the split-brain risk PushUpdate exists to avoid. It
+// re-fetches via GetTask rather than reusing this tick's ListTasks snapshot,
+// which can already be stale by the time this repair runs — earlier tasks in
+// the same batch, under the same applyMu lock, each take up to
+// driftRepairTimeout first.
+func (m *Mirror) repairDrift(ctx context.Context, node string, canonical task.Task) {
 	client, ok := m.roster.Client(node)
 	if !ok || client == nil {
 		m.logger.Warn("cluster.mirror.drift_repair.no_client", "task", canonical.ID, "node", node)
 		return
 	}
-	repaired := follower
+	repairCtx, cancel := context.WithTimeout(ctx, driftRepairTimeout)
+	defer cancel()
+	live, err := client.GetTask(repairCtx, canonical.ID)
+	if err != nil {
+		m.logger.Warn("cluster.mirror.drift_repair.refetch_failed", "task", canonical.ID, "node", node, "err", err)
+		return
+	}
+	repaired := live
 	repaired.Tags = canonical.Tags
 	repaired.DependsOn = canonical.DependsOn
 	repaired.AssignedNode = node
-	if err := client.AssignTask(ctx, repaired); err != nil {
+	if err := client.AssignTask(repairCtx, repaired); err != nil {
 		m.logger.Warn("cluster.mirror.drift_repair.failed", "task", canonical.ID, "node", node, "err", err)
 		return
 	}

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -3,12 +3,14 @@ package clusterlead
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/attachment"
 	"github.com/Automaat/sybra/internal/cluster"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -48,6 +50,7 @@ type Mirror struct {
 	applyMu  sync.Mutex
 
 	attachments *attachment.Store
+	anomalySink monitor.IssueSink
 }
 
 // NewMirror constructs a Mirror. A nil logger falls back to slog.Default(); a
@@ -66,6 +69,15 @@ func NewMirror(cfg *config.Config, tasks *task.Manager, roster *cluster.Roster, 
 // attachment uploads back into the canonical task view.
 func (m *Mirror) SetAttachments(store *attachment.Store) {
 	m.attachments = store
+}
+
+// SetAnomalySink supplies the sink drift detection reports through — the same
+// routing sink monitor.Service uses, so a cluster-drift finding gets the
+// existing dedup, work-project scrubbing, and durable GitHub-issue-outbox
+// behavior for free. A nil sink (monitor disabled, or not yet wired at
+// construction time) disables alerting only; detection and repair still run.
+func (m *Mirror) SetAnomalySink(sink monitor.IssueSink) {
+	m.anomalySink = sink
 }
 
 // Run starts, per follower, a reconcile ticker, and blocks until ctx is
@@ -171,6 +183,7 @@ func (m *Mirror) applyFollowerTaskWithContext(ctx context.Context, node string, 
 	if canonical.AssignedNode != node {
 		return false
 	}
+	m.detectAndRepairDrift(ctx, node, canonical, follower)
 	follower, ok := m.localizeFollowerAttachments(ctx, node, canonical, follower)
 	if !ok {
 		return false
@@ -189,6 +202,93 @@ func (m *Mirror) applyFollowerTaskWithContext(ctx context.Context, node string, 
 	}
 	m.logger.Debug("cluster.mirror.applied", "node", node, "task", follower.ID, "status", string(merged.Status), "rev", merged.MirrorRev)
 	return true
+}
+
+// detectAndRepairDrift compares the two leader-authoritative fields Merge
+// never touches — Tags and DependsOn — between the leader's canonical copy
+// and what the follower actually reports. Every other field either flows
+// follower-authoritative through Merge every reconcile tick (Status,
+// Workflow, AgentRuns, ...) or is immutable identity (ID, ProjectID,
+// CreatedAt), so an ordinary disagreement there is expected and self-heals
+// on its own — alerting on it would just be noise. Tags/DependsOn only ever
+// change on the leader (umbrella-gate release, a manual sybra-cli edit, ...);
+// if a leader-side write to one of them never reached the follower — the
+// #2349 class of bug, from any cause, not just the one fixed there — nothing
+// else in the reconcile loop will ever notice, because Merge doesn't carry
+// them and Assigner only pushes a task to its follower once, at first
+// assignment. This is the backstop: detected within one reconcile interval,
+// logged, alerted through the same anomaly sink as everything else, and
+// repaired by pushing just the drifted fields onto the follower's own
+// current state (never a stale full-task overwrite that could roll back
+// follower-side execution progress).
+func (m *Mirror) detectAndRepairDrift(ctx context.Context, node string, canonical, follower task.Task) {
+	tagsDrift := !slices.Equal(sortedCopy(canonical.Tags), sortedCopy(follower.Tags))
+	depsDrift := !slices.Equal(sortedCopy(canonical.DependsOn), sortedCopy(follower.DependsOn))
+	if !tagsDrift && !depsDrift {
+		return
+	}
+	m.logger.Error("cluster.mirror.drift_detected",
+		"task", canonical.ID, "node", node,
+		"tags_drift", tagsDrift, "deps_drift", depsDrift,
+		"canonical_tags", canonical.Tags, "follower_tags", follower.Tags,
+		"canonical_depends_on", canonical.DependsOn, "follower_depends_on", follower.DependsOn)
+	m.alertDrift(ctx, node, canonical, tagsDrift, depsDrift)
+	m.repairDrift(ctx, node, canonical, follower)
+}
+
+func (m *Mirror) alertDrift(ctx context.Context, node string, canonical task.Task, tagsDrift, depsDrift bool) {
+	if m.anomalySink == nil {
+		return
+	}
+	ev := map[string]any{
+		"node":       node,
+		"tags_drift": tagsDrift,
+		"deps_drift": depsDrift,
+		"tags":       canonical.Tags,
+		"depends_on": canonical.DependsOn,
+	}
+	a := monitor.Anomaly{
+		Kind:        monitor.KindClusterDrift,
+		TaskID:      canonical.ID,
+		Severity:    monitor.SeverityError,
+		RequiresLLM: false,
+		Fingerprint: monitor.Fingerprint(monitor.KindClusterDrift, canonical.ID, ev),
+		Evidence:    ev,
+		DetectedAt:  time.Now().UTC(),
+	}
+	if _, err := m.anomalySink.Submit(ctx, a, monitor.DeterministicIssueBody(a)); err != nil {
+		m.logger.Warn("cluster.mirror.drift_alert.failed", "task", canonical.ID, "node", node, "err", err)
+	}
+}
+
+// repairDrift pushes only the drifted fields onto the follower's own current
+// task state (not the leader's canonical copy verbatim) — the follower's
+// Status/Workflow/AgentRuns/etc. may be more current than what the leader
+// last pulled, and overwriting those would roll back real execution
+// progress, exactly the split-brain risk PushUpdate exists to avoid.
+func (m *Mirror) repairDrift(ctx context.Context, node string, canonical, follower task.Task) {
+	client, ok := m.roster.Client(node)
+	if !ok || client == nil {
+		m.logger.Warn("cluster.mirror.drift_repair.no_client", "task", canonical.ID, "node", node)
+		return
+	}
+	repaired := follower
+	repaired.Tags = canonical.Tags
+	repaired.DependsOn = canonical.DependsOn
+	repaired.AssignedNode = node
+	if err := client.AssignTask(ctx, repaired); err != nil {
+		m.logger.Warn("cluster.mirror.drift_repair.failed", "task", canonical.ID, "node", node, "err", err)
+		return
+	}
+	m.logger.Info("cluster.mirror.drift_repaired", "task", canonical.ID, "node", node)
+}
+
+// sortedCopy returns a sorted copy of ss so set-like fields (Tags,
+// DependsOn) compare equal regardless of element order.
+func sortedCopy(ss []string) []string {
+	out := slices.Clone(ss)
+	slices.Sort(out)
+	return out
 }
 
 func (m *Mirror) localizeFollowerAttachments(ctx context.Context, node string, canonical, follower task.Task) (task.Task, bool) {

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -532,6 +532,9 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			}
 		})
 	}, a.logger)
+	if a.mirror != nil {
+		a.mirror.SetAnomalySink(routingSink)
+	}
 	svc := monitor.NewService(monitor.Deps{
 		Cfg:          a.cfg.Monitor,
 		Tasks:        a.tasks,


### PR DESCRIPTION
## Motivation

Tasks homed on a non-local node are mirrored across the cluster, but nothing
periodically verifies the mirrors agree. When a cross-node write silently
fails to reach the authoritative node (see #2349), the divergence is
invisible until someone manually diffs the on-disk copies on both nodes —
exactly what happened in the incident #2349 fixed.

This is the backstop: a mirror-vs-authoritative drift sweep that catches
divergence regardless of which write path caused it, including future
regressions #2349's fix doesn't cover.

> Changelog: feat(cluster): detect and repair task mirror drift

## Implementation information

`Mirror`'s existing 30s reconcile tick already fetches both the leader's
canonical copy and the follower's reported copy of every task — the natural
place to compare them. `detectAndRepairDrift` checks `Tags` and `DependsOn`
specifically: `Merge()` already treats Status/Workflow/AgentRuns/etc. as
follower-authoritative and reconciles them silently every tick (expected,
self-healing — alerting on an ordinary status lag would be noise), but it
never touches Tags/DependsOn at all. Those only ever change on the leader
(umbrella-gate release, a manual edit, ...); if a leader-side write to either
never reaches the follower, nothing else in the reconcile loop will ever
notice.

On drift: log an ERROR line, submit a `monitor.Anomaly` (new `AnomalyKind`:
`cluster_drift`) through the same routing sink used elsewhere in the codebase
— reusing dedup, work-project scrubbing, and the durable GitHub-issue outbox
for free — and repair by re-fetching the follower's *live* current state
(`client.GetTask`, not the reconcile tick's possibly-stale `ListTasks`
snapshot) and pushing only the drifted fields onto it, never a stale
full-task overwrite that could roll back real follower execution progress.

Two adversarial-review rounds found and fixed a real defect: the first
implementation patched the tick's `ListTasks` snapshot directly and pushed it
verbatim, which could roll back follower progress if the follower advanced
between the snapshot and the repair push (a real, if narrow, race — the
snapshot ages behind every earlier task's processing in the same reconcile
batch, all serialized under one lock). Fixed by re-fetching via `GetTask`
immediately before the repair push, with a bounded 5s timeout on both
round trips combined so one unreachable follower can't stall the shared
reconcile lock for the cluster client's full 30s default.

`AllAnomalyKinds()`, `suggestedInvestigation`, and the generated Wails
frontend bindings (`wails3 generate bindings`) are all updated for the new
`cluster_drift` kind.

## Open questions

- The `GetTask`→`AssignTask` re-fetch narrows the staleness window to a
  single bounded round trip but doesn't make it airtight: a same-`Status`
  execution-field change (e.g. a new `AgentRuns` entry with no status
  transition) landing on the follower inside that window would still be
  silently overwritten, because the follower's only existing staleness guard
  (`Store.Put`'s status-change check) doesn't cover that case. Closing this
  fully needs either a dedicated partial-update RPC or extending that guard
  to reject execution-field regressions independent of status — a bigger
  change than this issue's scope. Filed as a known, narrow residual; the
  precondition (drift already present *and* a same-status follower write
  inside a sub-5s window) makes it materially rarer than the bug this PR
  fixes.
- The parallelism concern raised in review (repair's network calls run
  inside `Mirror`'s single cluster-wide `applyMu`, so a slow follower can
  delay other nodes' reconciliation) is mitigated by the bounded timeout but
  not eliminated by a per-node lock — that's a pre-existing architectural
  trait of `Mirror` (the same lock already guards the pre-existing attachment
  sync path), not something this PR introduces from scratch.