### PR TITLE
fix(human-review): stop filing low-signal issues

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -386,19 +386,18 @@ HumanReviewConfig controls the in-process automation that spawns a
 headless review agent every time a task transitions to human-required.
 The agent inspects the task, its agent runs, recent logs and the Sybra
 source tree, decides whether the transition is genuine or a Sybra bug,
-and (on bug) files a deduplicated GitHub issue + flips the task to
-blocked. Per-machine toggle: enable on the laptop with the source
-checkout, leave disabled on the server.
+and records the diagnosis on the task. Per-machine toggle: enable on the
+laptop with the source checkout, leave disabled on the server.
 
 | YAML key | Type | Default | Unit | Env override | Legacy aliases | Secret | Reload | Constraints | Description |
 |---|---|---|---|---|---|---|---|---|---|
 | `supervision.human_review.enabled` | `bool` | `false` |  |  | `human_review.enabled` | `false` | `hot` |  |  |
 | `supervision.human_review.sybra_repo_dir` | `string` | `""` |  |  | `human_review.sybra_repo_dir` | `false` | `hot` |  | SybraRepoDir is the fallback working directory used only when a task has no worktree of its own (e.g. project-less, or the recorded worktree was cleaned up) — see humanReviewDispatchDir. It must be a dedicated checkout, distinct from auto_update.repo_dir: the review agent is dispatched with RunConfig.ReadOnlyDir=true in that fallback case, so the OS process sandbox denies writes to it under enforce regardless, but pointing it at the live deploy/build checkout is still wrong on principle — this diagnostic agent has no business sharing a directory that autoupdate concurrently ff-merges and builds from. |
-| `supervision.human_review.repo` | `string` | `""` |  |  | `human_review.repo` | `false` | `hot` |  | Repo is the owner/name where bug issues are filed. Defaults to "Automaat/sybra" when empty. |
+| `supervision.human_review.repo` | `string` | `""` |  |  | `human_review.repo` | `false` | `hot` |  | Repo is the owner/name project_id assigned to local sybra-bug tasks. Defaults to "Automaat/sybra" when empty. |
 | `supervision.human_review.model` | `string` | `""` |  |  | `human_review.model` | `false` | `hot` |  | Model is the Claude model name or alias (e.g. "sonnet", "claude-haiku-4-5-20251001"). Defaults to "claude-haiku-4-5-20251001" when empty — diagnosis, not authoring. |
 | `supervision.human_review.max_per_hour` | `int` | `0` |  |  | `human_review.max_per_hour` | `false` | `hot` |  | MaxPerHour caps how many review agents may be spawned in any rolling 60-minute window across all tasks on this machine. Zero falls back to DefaultHumanReviewMaxPerHour. |
-| `supervision.human_review.issue_label` | `string` | `""` |  |  | `human_review.issue_label` | `false` | `hot` |  | IssueLabel is the label applied to filed issues (in addition to "bug"). Defaults to "sybra-bug". |
-| `supervision.human_review.sybra_bug_action` | `string` | `""` |  |  | `human_review.sybra_bug_action` | `false` | `hot` |  | SybraBugAction controls the side-effect for sybra_bug verdicts: file_issue (default), local_task, block_only, or note_only. |
+| `supervision.human_review.issue_label` | `string` | `""` |  |  | `human_review.issue_label` | `false` | `hot` |  | IssueLabel is a legacy setting from the removed GitHub issue filing path. Defaults to "sybra-bug". |
+| `supervision.human_review.sybra_bug_action` | `string` | `""` |  |  | `human_review.sybra_bug_action` | `false` | `hot` |  | SybraBugAction controls the side-effect for sybra_bug verdicts: note_only (default), local_task, or block_only. The legacy file_issue value is accepted but treated as note_only. |
 
 ### MonitorConfig (`supervision.monitor`)
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -508,6 +508,9 @@ func secsOr(v, def int) time.Duration {
 const DefaultHumanReviewMaxPerHour = 6
 
 const (
+	// HumanReviewSybraBugActionFileIssue is a legacy config value. It is
+	// accepted for compatibility but maps to note_only so the human-review
+	// automation no longer opens low-signal GitHub issues.
 	HumanReviewSybraBugActionFileIssue = "file_issue"
 	HumanReviewSybraBugActionLocalTask = "local_task"
 	HumanReviewSybraBugActionBlockOnly = "block_only"
@@ -522,7 +525,8 @@ func (c *Config) HumanReviewMaxPerHour() int {
 	return DefaultHumanReviewMaxPerHour
 }
 
-// HumanReviewRepo returns the configured target repo or "Automaat/sybra".
+// HumanReviewRepo returns the configured local tracking project or
+// "Automaat/sybra".
 func (c *Config) HumanReviewRepo() string {
 	if c != nil && c.HumanReview.Repo != "" {
 		return c.HumanReview.Repo
@@ -541,7 +545,9 @@ func (c *Config) HumanReviewModel() string {
 	return "claude-haiku-4-5-20251001"
 }
 
-// HumanReviewIssueLabel returns the configured label or "sybra-bug".
+// HumanReviewIssueLabel returns the legacy configured label or "sybra-bug".
+// Human-review no longer files GitHub issues directly, but the accessor is
+// kept so old configs and generated docs remain stable.
 func (c *Config) HumanReviewIssueLabel() string {
 	if c != nil && c.HumanReview.IssueLabel != "" {
 		return c.HumanReview.IssueLabel
@@ -551,11 +557,11 @@ func (c *Config) HumanReviewIssueLabel() string {
 
 func (c *Config) HumanReviewSybraBugAction() string {
 	if c == nil {
-		return HumanReviewSybraBugActionFileIssue
+		return HumanReviewSybraBugActionNoteOnly
 	}
 	switch strings.ToLower(strings.TrimSpace(c.HumanReview.SybraBugAction)) {
 	case "", HumanReviewSybraBugActionFileIssue:
-		return HumanReviewSybraBugActionFileIssue
+		return HumanReviewSybraBugActionNoteOnly
 	case HumanReviewSybraBugActionLocalTask:
 		return HumanReviewSybraBugActionLocalTask
 	case HumanReviewSybraBugActionBlockOnly:
@@ -563,8 +569,8 @@ func (c *Config) HumanReviewSybraBugAction() string {
 	case HumanReviewSybraBugActionNoteOnly:
 		return HumanReviewSybraBugActionNoteOnly
 	default:
-		slog.Warn("config: invalid human_review.sybra_bug_action; falling back to file_issue", "value", c.HumanReview.SybraBugAction)
-		return HumanReviewSybraBugActionFileIssue
+		slog.Warn("config: invalid human_review.sybra_bug_action; falling back to note_only", "value", c.HumanReview.SybraBugAction)
+		return HumanReviewSybraBugActionNoteOnly
 	}
 }
 

--- a/internal/config/config_humanreview.go
+++ b/internal/config/config_humanreview.go
@@ -4,9 +4,8 @@ package config
 // headless review agent every time a task transitions to human-required.
 // The agent inspects the task, its agent runs, recent logs and the Sybra
 // source tree, decides whether the transition is genuine or a Sybra bug,
-// and (on bug) files a deduplicated GitHub issue + flips the task to
-// blocked. Per-machine toggle: enable on the laptop with the source
-// checkout, leave disabled on the server.
+// and records the diagnosis on the task. Per-machine toggle: enable on the
+// laptop with the source checkout, leave disabled on the server.
 type HumanReviewConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
 	// SybraRepoDir is the fallback working directory used only when a task
@@ -19,8 +18,8 @@ type HumanReviewConfig struct {
 	// wrong on principle — this diagnostic agent has no business sharing a
 	// directory that autoupdate concurrently ff-merges and builds from.
 	SybraRepoDir string `yaml:"sybra_repo_dir" json:"sybraRepoDir"`
-	// Repo is the owner/name where bug issues are filed. Defaults to
-	// "Automaat/sybra" when empty.
+	// Repo is the owner/name project_id assigned to local sybra-bug tasks.
+	// Defaults to "Automaat/sybra" when empty.
 	Repo string `yaml:"repo" json:"repo"`
 	// Model is the Claude model name or alias (e.g. "sonnet",
 	// "claude-haiku-4-5-20251001"). Defaults to
@@ -30,10 +29,11 @@ type HumanReviewConfig struct {
 	// 60-minute window across all tasks on this machine. Zero falls back
 	// to DefaultHumanReviewMaxPerHour.
 	MaxPerHour int `yaml:"max_per_hour" json:"maxPerHour"`
-	// IssueLabel is the label applied to filed issues (in addition to
-	// "bug"). Defaults to "sybra-bug".
+	// IssueLabel is a legacy setting from the removed GitHub issue filing
+	// path. Defaults to "sybra-bug".
 	IssueLabel string `yaml:"issue_label" json:"issueLabel"`
 	// SybraBugAction controls the side-effect for sybra_bug verdicts:
-	// file_issue (default), local_task, block_only, or note_only.
+	// note_only (default), local_task, or block_only. The legacy file_issue
+	// value is accepted but treated as note_only.
 	SybraBugAction string `yaml:"sybra_bug_action" json:"sybraBugAction"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -782,7 +782,8 @@ func TestHumanReviewSybraBugAction(t *testing.T) {
 		want    string
 		wantErr string
 	}{
-		{name: "empty defaults to file_issue", yaml: "human_review:\n  enabled: true\n", want: HumanReviewSybraBugActionFileIssue},
+		{name: "empty defaults to note_only", yaml: "human_review:\n  enabled: true\n", want: HumanReviewSybraBugActionNoteOnly},
+		{name: "legacy file_issue maps to note_only", yaml: "human_review:\n  sybra_bug_action: file_issue\n", want: HumanReviewSybraBugActionNoteOnly},
 		{name: "note only", yaml: "human_review:\n  sybra_bug_action: note_only\n", want: HumanReviewSybraBugActionNoteOnly},
 		{name: "block only", yaml: "human_review:\n  sybra_bug_action: block_only\n", want: HumanReviewSybraBugActionBlockOnly},
 		{name: "local task", yaml: "human_review:\n  sybra_bug_action: local_task\n", want: HumanReviewSybraBugActionLocalTask},

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -110,7 +110,7 @@ func ValidateResolvedConfig(cfg *ResolvedConfig) error {
 	switch action := strings.ToLower(strings.TrimSpace(cfg.HumanReview.SybraBugAction)); action {
 	case "", HumanReviewSybraBugActionFileIssue, HumanReviewSybraBugActionLocalTask, HumanReviewSybraBugActionBlockOnly, HumanReviewSybraBugActionNoteOnly:
 	default:
-		add("human_review.sybra_bug_action must be one of file_issue, local_task, block_only, note_only, got %q", cfg.HumanReview.SybraBugAction)
+		add("human_review.sybra_bug_action must be one of note_only, local_task, block_only, or legacy file_issue, got %q", cfg.HumanReview.SybraBugAction)
 	}
 	if cfg.ReviewHold.Enabled && !validReviewHoldMode(cfg.ReviewHold.Mode) {
 		add("review_hold.mode must be push, push_nits, or hold, got %q", cfg.ReviewHold.Mode)

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -15,8 +15,6 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
-	"github.com/Automaat/sybra/internal/github"
-	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/scrub"
 	"github.com/Automaat/sybra/internal/task"
@@ -42,13 +40,6 @@ const (
 	humanReviewMaxPerTaskPerWindow = 2
 )
 
-// humanReviewIssueFiler is the subset of monitor.GHIssueSink the handler
-// depends on. Stub-friendly for tests; production wiring uses
-// monitor.NewGHIssueSink.
-type humanReviewIssueFiler interface {
-	SubmitIssue(ctx context.Context, title, body string, extraLabels []string) (created bool, url string, err error)
-}
-
 type humanReviewAgentRunner interface {
 	ApplyABVariant(cfg agent.RunConfig, ab abtest.Config, taskID, role string) agent.RunConfig
 	Run(cfg agent.RunConfig) (*agent.Agent, error)
@@ -58,8 +49,8 @@ type humanReviewAgentRunner interface {
 // transitions into status=human-required. The agent inspects task state,
 // agent runs and Sybra logs/source, then emits a structured verdict
 // (verdict.Decision, enforced via --json-schema) which the handler turns
-// into a side-effect: genuine -> append a note; sybra_bug -> file a
-// deduplicated GitHub issue and flip the task to status=blocked.
+// into a side-effect. sybra_bug verdicts are retained as task notes by
+// default; richer issue filing is handled by the why-human workflow.
 type humanReviewHandler struct {
 	cfg       *config.Config
 	abTesting func() abtest.Config
@@ -67,7 +58,6 @@ type humanReviewHandler struct {
 	agents    humanReviewAgentRunner
 	audit     *audit.Logger
 	logger    *slog.Logger
-	sink      humanReviewIssueFiler
 	homeDir   string
 	logFile   string
 	now       func() time.Time
@@ -115,7 +105,6 @@ func newHumanReviewHandler(
 	agents humanReviewAgentRunner,
 	al *audit.Logger,
 	logger *slog.Logger,
-	sink humanReviewIssueFiler,
 	homeDir, logFile string,
 	workCtx func(projectID string) *WorkScrubContext,
 ) *humanReviewHandler {
@@ -125,7 +114,6 @@ func newHumanReviewHandler(
 		agents:   agents,
 		audit:    al,
 		logger:   logger,
-		sink:     sink,
 		homeDir:  homeDir,
 		logFile:  logFile,
 		now:      time.Now,
@@ -150,24 +138,8 @@ func (a *App) initHumanReview() {
 		a.logger.Warn("human-review.disabled", "reason", "sybra_repo_dir not a directory", "dir", dir, "err", err)
 		return
 	}
-	// Auth preflight: mirrors the monitor service's check (see
-	// LifecycleManager.startMonitorService) — human-review issue filing
-	// shares the same GHIssueSink/credential source, so surface the same
-	// loud, non-fatal startup signal rather than only discovering an
-	// unauthenticated `gh` after a review verdict silently fails to file.
-	if !github.Authenticated() {
-		a.logger.Error("human-review.issue_filing.auth_unavailable",
-			"hint", "configure github.app or run `gh auth login`; issue filing will queue and retry via the durable outbox once credentials are available")
-	}
-	ghSink := monitor.NewGHIssueSink(a.cfg.HumanReviewIssueLabel(), a.cfg.HumanReviewRepo())
-	var sink humanReviewIssueFiler = ghSink
-	if durableSink, err := monitor.NewDurableGHIssueSink(ghSink, filepath.Join(config.GHIssueOutboxDir(), "human-review"), "human-review", a.logger, a.audit); err != nil {
-		a.logger.Error("human-review.issue_outbox.init_failed", "err", err)
-	} else {
-		sink = durableSink
-	}
 	logFile := filepath.Join(a.logDir, "sybra.log")
-	a.humanReview = newHumanReviewHandler(a.cfg, a.tasks, a.agents, a.audit, a.logger, sink, config.HomeDir(), logFile, a.workScrubContextForTask)
+	a.humanReview = newHumanReviewHandler(a.cfg, a.tasks, a.agents, a.audit, a.logger, config.HomeDir(), logFile, a.workScrubContextForTask)
 	a.humanReview.abTesting = a.abTestingConfig
 	a.logger.Info("human-review.enabled", "dir", dir, "repo", a.cfg.HumanReviewRepo(), "model", a.cfg.HumanReviewModel())
 }
@@ -601,7 +573,6 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 
 	switch v.Decision {
 	case "human":
-		h.fileAutonomyIssue(taskID, current.ProjectID, ag.ID, v)
 		if h.appendNote(taskID, "Auto-review verdict: needs human", h.scrubForTask(current.ProjectID, v.Summary)) {
 			h.markVerdictRendered(taskID, ag.ID)
 		}
@@ -712,10 +683,9 @@ func (h *humanReviewHandler) handleSybraBugVerdict(taskID string, ag *agent.Agen
 		}
 	default:
 		if wctx != nil {
-			h.fileLocalScrubbed(taskID, ag.ID, v, wctx)
-		} else {
-			h.fileIssue(taskID, ag.ID, v)
+			v = scrubVerdict(v, wctx)
 		}
+		h.noteSybraBugOnly(taskID, ag.ID, v)
 	}
 }
 
@@ -901,7 +871,6 @@ func (h *humanReviewHandler) recordUnblocked(current task.Task, agentID string, 
 		"decision": v.Decision, "summary": v.Summary, "verdict_source": string(source),
 		"recoverable_action": v.RecoverableAction, "confidence": v.Confidence,
 	})
-	h.fileAutonomyIssue(current.ID, current.ProjectID, agentID, v)
 	h.applyUnblockedRecovery(current, agentID, v)
 }
 
@@ -910,137 +879,6 @@ func (h *humanReviewHandler) workCtxFor(projectID string) *WorkScrubContext {
 		return nil
 	}
 	return h.workCtx(projectID)
-}
-
-func (h *humanReviewHandler) fileAutonomyIssue(taskID, projectID, agentID string, v verdictDecision) {
-	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
-		return
-	}
-	if wctx := h.workCtxFor(projectID); wctx != nil {
-		sv := scrubVerdict(v, wctx)
-		if _, ok := h.findExistingLocalBugTask(sv.IssueTitle); ok {
-			return
-		}
-		tags := append([]string{"sybra-bug", "scrubbed", "autonomy"}, sv.IssueLabels...)
-		init := task.Update{Tags: &tags}
-		if repo := strings.TrimSpace(h.cfg.HumanReviewRepo()); repo != "" {
-			init.ProjectID = &repo
-		}
-		if _, err := h.tasks.CreateFull(sv.IssueTitle, sv.IssueBody, task.AgentModeHeadless, init); err != nil {
-			h.logger.Warn("human-review.autonomy.local.create", "task_id", taskID, "agent_id", agentID, "err", err)
-		}
-		return
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	created, url, err := h.sink.SubmitIssue(ctx, v.IssueTitle, v.IssueBody, v.IssueLabels)
-	if err != nil {
-		h.logger.Warn("human-review.autonomy.file", "task_id", taskID, "agent_id", agentID, "err", err)
-		// Record the failure in the audit trail too — an autonomy issue is
-		// best-effort (nothing downstream blocks on it, unlike fileIssue's
-		// sybra_bug path), but a silent Warn-only log meant a filing failure
-		// left no trace an operator could distinguish from "nothing to file".
-		// The sink itself (DurableGHIssueSink) already queues an
-		// auth-classified failure for retry — this event is purely the
-		// audit-visible record that the attempt did not succeed.
-		h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
-			"created": false, "url": "", "title": v.IssueTitle, "autonomy": true, "err": err.Error(),
-		})
-		return
-	}
-	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
-		"created": created, "url": url, "title": v.IssueTitle, "autonomy": true,
-	})
-}
-
-func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision) {
-	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
-		h.logger.Warn("human-review.issue.empty", "task_id", taskID, "agent_id", agentID)
-		if h.appendNote(taskID, "Auto-review verdict: sybra_bug (no issue payload)", v.Summary) {
-			h.markVerdictRendered(taskID, agentID)
-		}
-		return
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	created, url, err := h.sink.SubmitIssue(ctx, v.IssueTitle, v.IssueBody, v.IssueLabels)
-	if err != nil {
-		h.logger.Error("human-review.issue.submit", "task_id", taskID, "agent_id", agentID, "err", err)
-		// On rate limit or transient failure, keep the diagnosis actionable by
-		// falling back to a local Sybra bug task and blocking the origin on it.
-		if h.fileLocalIssueFallback(taskID, agentID, v, err) {
-			return
-		}
-		if h.appendNote(taskID, "Auto-review verdict: sybra_bug (issue submission failed)", v.Summary+"\n\nError: "+err.Error()) {
-			h.markVerdictRendered(taskID, agentID)
-		}
-		return
-	}
-	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
-		"created": created, "url": url, "title": v.IssueTitle,
-	})
-
-	body := fmt.Sprintf("**Linked Sybra bug:** %s\n\n%s", urlOrPlaceholder(url, v.IssueTitle), v.Summary)
-	header := "Auto-review verdict: blocked by Sybra bug"
-	if !created {
-		header = "Auto-review verdict: blocked by existing Sybra bug"
-	}
-	t, err := h.tasks.Get(taskID)
-	if err != nil {
-		h.logger.Error("human-review.task.get-after-submit", "task_id", taskID, "err", err)
-		return
-	}
-	newBody := appendSection(t.Body, header, body)
-	upd := task.Update{
-		Body:           &newBody,
-		Status:         task.Ptr(task.StatusBlocked),
-		StatusReason:   task.Ptr(fmt.Sprintf("auto-review: %s (%s)", v.Summary, urlOrPlaceholder(url, v.IssueTitle))),
-		BlockedByIssue: task.Ptr(url),
-	}
-	if _, err := h.tasks.Update(taskID, upd); err != nil {
-		h.logger.Error("human-review.task.update", "task_id", taskID, "err", err)
-		return
-	}
-	h.markVerdictRendered(taskID, agentID)
-}
-
-func (h *humanReviewHandler) fileLocalIssueFallback(taskID, agentID string, v verdictDecision, submitErr error) bool {
-	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
-		return false
-	}
-	if existing, ok := h.findExistingLocalBugTask(v.IssueTitle); ok {
-		h.linkExistingLocalBug(taskID, agentID, existing, v)
-		return true
-	}
-	body := strings.TrimSpace(v.IssueBody) + "\n\n## Filing failure\n\nGitHub issue filing failed, so Sybra created this local fallback task instead.\n\nError: " + submitErr.Error()
-	tags := append([]string{"sybra-bug", "issue-filing-failed"}, v.IssueLabels...)
-	init := task.Update{Tags: &tags}
-	if projectID := strings.TrimSpace(h.cfg.HumanReviewRepo()); projectID != "" {
-		init.ProjectID = &projectID
-	}
-	if existing := h.findExistingLocalBugTaskOnRoute(v.IssueTitle, "issue-filing-failed"); existing != nil {
-		h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
-			"created": false, "url": "", "title": v.IssueTitle, "local_task_id": existing.ID,
-			"fallback": true, "err": submitErr.Error(),
-		})
-		h.blockOriginOnLocalBug(taskID, agentID, "Auto-review verdict: blocked by existing Sybra bug (local fallback)", v.Summary, existing.ID, "GitHub issue filing failed: "+submitErr.Error())
-		return true
-	}
-	newTask, err := h.tasks.CreateFull(v.IssueTitle, body, task.AgentModeHeadless, init)
-	if err != nil {
-		h.logger.Error("human-review.issue.local-fallback.create", "task_id", taskID, "agent_id", agentID, "err", err)
-		return false
-	}
-	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
-		"created":       true,
-		"url":           "",
-		"title":         v.IssueTitle,
-		"local_task_id": newTask.ID,
-		"fallback":      true,
-		"err":           submitErr.Error(),
-	})
-
-	return h.blockOriginOnLocalBug(taskID, agentID, "Auto-review verdict: blocked by Sybra bug (local fallback)", v.Summary, newTask.ID, "GitHub issue filing failed: "+submitErr.Error())
 }
 
 func (h *humanReviewHandler) findExistingLocalBugTaskOnRoute(title, routeTag string) *task.Task {
@@ -1095,13 +933,10 @@ func (h *humanReviewHandler) blockOriginOnLocalBug(taskID, agentID, header, summ
 }
 
 // findExistingLocalBugTask returns an already-filed local sybra-bug task with
-// an exact title match, if one exists. This is the local-fallback-path
-// counterpart to GHIssueSink.findOpenIssue's title-based dedup on the public
-// path: without it, a task that cycles human-required -> blocked -> todo ->
-// human-required for the same root cause spawns a brand-new local fallback
-// task on every fallback filing instead of pointing back at the one already
-// filed (see task 2379fece's repro: task 3e61e464 accumulated multiple
-// bug/fallback links for one underlying failure).
+// an exact title match, if one exists. This dedupes the local_task and
+// work-scrubbed routes so a task that cycles human-required -> blocked ->
+// todo -> human-required for the same root cause points back at the one
+// already filed instead of creating duplicates.
 func (h *humanReviewHandler) findExistingLocalBugTask(title string) (task.Task, bool) {
 	title = strings.TrimSpace(title)
 	if title == "" {
@@ -1346,9 +1181,9 @@ func writeAutonomyMandate(b *strings.Builder) {
 	b.WriteString("   - Deterministic failures you can fix (lint/test/build): fix them in the task's worktree, re-run the exact check and SEE it pass, commit + push, then advance the task with sybra-cli (e.g. `sybra-cli update <id> --status ready-pr [--pr N]`) so it re-enters the pipeline.\n")
 	b.WriteString("   - Work is complete but stuck on a gate the harness genuinely cannot run: open or link a PR (`gh pr create` / `sybra-cli update <id> --pr N --status ready-pr`) and move it to review so CI + Copilot + a human reviewer verify it. Never fabricate or fake the verification you could not run.\n")
 	b.WriteString("   - If the task is parked on a pending GitHub review draft, pre-flight the draft before submitting anything: determine whether it is COMMENT, REQUEST_CHANGES, or APPROVE. COMMENT / REQUEST_CHANGES drafts may be submitted when that safely unblocks the task. APPROVE drafts must NEVER be auto-submitted: approval authority is human-only. If you cannot prove the draft is COMMENT or REQUEST_CHANGES, do not submit it.\n")
-	b.WriteString("   - A Sybra workflow bug: work around it to unblock the task if you safely can, and file an issue (phase 3).\n")
+	b.WriteString("   - A Sybra workflow bug: work around it to unblock the task if you safely can, then record the autonomy gap in your verdict (phase 3).\n")
 	b.WriteString("   HARD LIMITS: never fabricate results, never force-merge a PR, never push code whose checks you did not run and see pass. Only LEAVE the task at human-required when a human genuinely must decide — scope, creative direction, missing credentials, or an unreachable external system.\n\n")
-	b.WriteString("3. AUTONOMY — for anything that needed a human, OR that you had to do by hand here, ask: 'how should Sybra have handled this itself?' If there is a real gap, prepare an issue (issue_* fields) describing the gap and the fix so the next occurrence is automatic. Every human-required transition is a bug in Sybra's autonomy until proven otherwise; this issue is often your most valuable output. Do NOT run `gh issue create` yourself — return the payload so the host files it (and scrubs it for work-typed projects).\n\n")
+	b.WriteString("3. AUTONOMY — for anything that needed a human, OR that you had to do by hand here, ask: 'how should Sybra have handled this itself?' If there is a real gap, describe it in the issue_* fields so a follow-up workflow can turn it into a high-quality tracker. Every human-required transition is a bug in Sybra's autonomy until proven otherwise. Do NOT run `gh issue create` yourself.\n\n")
 }
 
 func (h *humanReviewHandler) writePromptTaskDetails(b *strings.Builder, t task.Task, dir string) {
@@ -1439,8 +1274,8 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, dir string, wctx *WorkScru
 
 	b.WriteString("## Investigation hints\n")
 	fmt.Fprintf(&b, "- Your working directory is %s. Use Grep/Read/Glob there directly; cd to the Sybra source tree path above (if listed) when a stack trace or error message points into Sybra's own internal/ instead of the task's repo.\n", dir)
-	fmt.Fprintf(&b, "- Audit events live under %s (newest file is today's). Run `gh issue list --repo %s --label %s` first to avoid duplicate filings.\n",
-		filepath.Join(h.homeDir, "audit"), h.cfg.HumanReviewRepo(), h.cfg.HumanReviewIssueLabel())
+	fmt.Fprintf(&b, "- Audit events live under %s (newest file is today's). Use them to understand prior human-review diagnoses before returning a verdict.\n",
+		filepath.Join(h.homeDir, "audit"))
 	b.WriteString("- Trust deterministic workflow signals before inferring from weak provider metadata: status history, exit state, parsed verdict, protocol_violation, test_outcome, failure fingerprint, task body delta, and log tail. Do NOT classify a Codex run as crashed solely because cost=0 or session is empty; confirm from log contents or exit failure.\n")
 	b.WriteString("- For test escalations, separate product_bug, test_protocol_violation, infra_failure, ambiguous_requirement, and missing_evidence. Only grounded product_bug failures should be described as implementation misses.\n")
 	b.WriteString("- A task parked with `Draft review ready — verify & submit on GitHub` needs extra care: before any submit attempt, inspect the pending review's intended verdict. APPROVE must stay human-required with explicit wording like `Review APPROVE verdict ready for human submission (approval authority required)`. Only COMMENT / REQUEST_CHANGES drafts are eligible for auto-submit. If a submit attempt is rejected by the approval hook or GitHub, surface that exact rejection and tell the human what to do next instead of leaving a vague dead-end.\n")
@@ -1454,13 +1289,13 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, dir string, wctx *WorkScru
 	b.WriteString("- `decision`: \"unblocked\" | \"human\" | \"sybra_bug\"\n")
 	b.WriteString("  - \"unblocked\": you moved the task forward yourself (fixed + pushed, opened/linked a PR, advanced its status) — it is no longer waiting on you.\n")
 	b.WriteString("  - \"human\": a human genuinely must act (scope, creative decision, missing credential, unreachable system); the task stays human-required.\n")
-	b.WriteString("  - \"sybra_bug\": you could not unblock it and the cause is a Sybra defect; the host files the issue and blocks the task pending the fix.\n")
+	b.WriteString("  - \"sybra_bug\": you could not unblock it and the cause is a Sybra defect; the host records the diagnosis on the task without opening a GitHub issue.\n")
 	b.WriteString("- `reason`: one sentence — what you did to unblock it, what a human must decide, or the diagnosis.\n")
 	b.WriteString("- `recoverable_action`: one of `none`, `todo`, `planning`, `plan-review`, `in-progress`, `ready-review`, `in-review`, `testing`, `ready-pr`, `done`.\n")
 	b.WriteString("  - Use `none` when you already moved the task yourself or when no safe host-side status change applies.\n")
 	b.WriteString("  - For `unblocked`, set this to the target workflow status when the host should move the task back into the pipeline for you.\n")
 	b.WriteString("- `confidence`: `low` | `medium` | `high`.\n")
-	b.WriteString("- `issue_title` / `issue_body` / `issue_labels`: the issue payload. REQUIRED for sybra_bug. For unblocked or human, fill these when there is a real Sybra autonomy gap worth tracking (the host files it) — leave null only when there is genuinely nothing to file. `issue_title` must be conventional-commit format (e.g. fix(workflow): ...); `issue_body` = \"## What happened\\n...\\n\\n## Repro\\n...\\n\\n## Suspected cause\\n...\\n\\n## Autonomy fix\\n...\".\n\n")
+	b.WriteString("- `issue_title` / `issue_body` / `issue_labels`: optional autonomy-gap tracker payload. Fill these only when there is a real Sybra gap worth tracking; otherwise set them to null. For sybra_bug, these fields are useful context but do not cause the host to open a GitHub issue. `issue_title` should be conventional-commit format (e.g. fix(workflow): ...); `issue_body` = \"## What happened\\n...\\n\\n## Repro\\n...\\n\\n## Suspected cause\\n...\\n\\n## Autonomy fix\\n...\".\n\n")
 	b.WriteString("Set unused issue_* fields to null (the schema requires the keys to be present).\n")
 	return b.String()
 }

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -874,13 +874,6 @@ func (h *humanReviewHandler) recordUnblocked(current task.Task, agentID string, 
 	h.applyUnblockedRecovery(current, agentID, v)
 }
 
-func (h *humanReviewHandler) workCtxFor(projectID string) *WorkScrubContext {
-	if h.workCtx == nil {
-		return nil
-	}
-	return h.workCtx(projectID)
-}
-
 func (h *humanReviewHandler) findExistingLocalBugTaskOnRoute(title, routeTag string) *task.Task {
 	title = strings.TrimSpace(title)
 	routeTag = strings.TrimSpace(routeTag)
@@ -1346,13 +1339,6 @@ func defaultStr(s, fallback string) string {
 		return fallback
 	}
 	return s
-}
-
-func urlOrPlaceholder(url, title string) string {
-	if url != "" {
-		return url
-	}
-	return "(issue: " + title + ")"
 }
 
 // verdictAlreadyRendered reports whether any completed human-review agent run

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -1,7 +1,6 @@
 package sybra
 
 import (
-	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -9,7 +8,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -54,28 +52,6 @@ func setupUnblockedRecoveryWorktree(t *testing.T, branch string) string {
 	return clone
 }
 
-type fakeIssueSink struct {
-	mu      sync.Mutex
-	calls   int
-	created bool
-	url     string
-	err     error
-
-	gotTitle  string
-	gotBody   string
-	gotLabels []string
-}
-
-func (f *fakeIssueSink) SubmitIssue(_ context.Context, title, body string, labels []string) (created bool, url string, err error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.calls++
-	f.gotTitle = title
-	f.gotBody = body
-	f.gotLabels = labels
-	return f.created, f.url, f.err
-}
-
 type fakeHumanReviewAgentRunner struct {
 	apply func(agent.RunConfig) agent.RunConfig
 	run   func(agent.RunConfig) (*agent.Agent, error)
@@ -95,7 +71,7 @@ func (f *fakeHumanReviewAgentRunner) Run(cfg agent.RunConfig) (*agent.Agent, err
 	return &agent.Agent{ID: "fake-human-review", TaskID: cfg.TaskID, StartedAt: time.Now().UTC()}, nil
 }
 
-func newReviewTestEnv(t *testing.T) (*humanReviewHandler, *task.Manager, *fakeIssueSink, func()) {
+func newReviewTestEnv(t *testing.T) (*humanReviewHandler, *task.Manager, func()) {
 	t.Helper()
 	dir := t.TempDir()
 	store, err := task.NewStore(dir)
@@ -107,10 +83,9 @@ func newReviewTestEnv(t *testing.T) (*humanReviewHandler, *task.Manager, *fakeIs
 	cfg.HumanReview.Enabled = true
 	cfg.HumanReview.SybraRepoDir = dir
 	cfg.HumanReview.MaxPerHour = 3
-	sink := &fakeIssueSink{created: true, url: "https://github.com/Automaat/sybra/issues/42"}
 	logger := slog.New(slog.DiscardHandler)
 	h := newHumanReviewHandler(cfg, tasks, nil, nil, logger, dir, filepath.Join(dir, "missing.log"), nil)
-	return h, tasks, sink, func() {}
+	return h, tasks, func() {}
 }
 
 // TestVerdictDecisionIsSharedParserType pins that this package's local
@@ -184,7 +159,7 @@ func TestHumanReviewDispatchDir_ReadOnlyFallback(t *testing.T) {
 // prompt just names the JSON fields to return.
 func TestBuildPrompt_NoFencedVerdictInstruction(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Some task", "body", "headless")
@@ -208,7 +183,7 @@ func TestBuildPrompt_NoFencedVerdictInstruction(t *testing.T) {
 // plausible causes alone.
 func TestBuildPrompt_RequiresVerificationBeforeTransient(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Some task", "body", "headless")
@@ -229,7 +204,7 @@ func TestBuildPrompt_RequiresVerificationBeforeTransient(t *testing.T) {
 // approval authority is human-only.
 func TestBuildPrompt_DraftApproveRequiresHumanSubmission(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Review draft task", "body", "headless")
@@ -269,7 +244,7 @@ func TestBuildPrompt_DraftApproveRequiresHumanSubmission(t *testing.T) {
 // human-required status_reason from a stale verdict.
 func TestBuildPrompt_RequiresRecheckingSupersededFailures(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Some task", "body", "headless")
@@ -298,7 +273,7 @@ func TestBuildPrompt_RequiresRecheckingSupersededFailures(t *testing.T) {
 
 func TestRateLimiter(t *testing.T) {
 	t.Parallel()
-	h, _, _, cleanup := newReviewTestEnv(t)
+	h, _, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	now := time.Now()
@@ -338,7 +313,7 @@ func TestRateLimiter(t *testing.T) {
 // this test env) and starve every other task's diagnosis.
 func TestPerTaskRateLimiter(t *testing.T) {
 	t.Parallel()
-	h, _, _, cleanup := newReviewTestEnv(t)
+	h, _, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	now := time.Now()
@@ -382,7 +357,7 @@ func TestPerTaskRateLimiter(t *testing.T) {
 
 func TestOnComplete_HumanVerdict_AppendsNote(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Refactor billing", "Original body.", "headless")
@@ -419,9 +394,6 @@ func TestOnComplete_HumanVerdict_AppendsNote(t *testing.T) {
 	if !strings.Contains(got.Body, "needs product input on scope") {
 		t.Errorf("expected summary in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called for human verdict; calls=%d", sink.calls)
-	}
 	if _, busy := h.inflight[tk.ID]; busy {
 		t.Errorf("inflight should be cleared after onComplete")
 	}
@@ -429,7 +401,7 @@ func TestOnComplete_HumanVerdict_AppendsNote(t *testing.T) {
 
 func TestOnComplete_StaleHumanVerdictMarksRendered(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Prompt Lab approval", "Original body.", "headless")
@@ -471,14 +443,11 @@ func TestOnComplete_StaleHumanVerdictMarksRendered(t *testing.T) {
 	if !verdictAlreadyRendered(got) {
 		t.Fatal("verdictAlreadyRendered should accept the stale run's rendered marker")
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called for stale human verdict; calls=%d", sink.calls)
-	}
 }
 
 func TestOnComplete_UnblockedVerdict_NotesAndDoesNotBlock(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Fix flaky test", "Original body.", "headless")
@@ -512,9 +481,6 @@ func TestOnComplete_UnblockedVerdict_NotesAndDoesNotBlock(t *testing.T) {
 	if !strings.Contains(got.Body, "Auto-review: unblocked") {
 		t.Errorf("expected unblocked note in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called without an issue payload; calls=%d", sink.calls)
-	}
 	if _, busy := h.inflight[tk.ID]; busy {
 		t.Errorf("inflight should be cleared after onComplete")
 	}
@@ -522,7 +488,7 @@ func TestOnComplete_UnblockedVerdict_NotesAndDoesNotBlock(t *testing.T) {
 
 func TestOnComplete_UnblockedVerdict_AppliesRecoverableAction(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-unblocked-action"
@@ -566,9 +532,6 @@ func TestOnComplete_UnblockedVerdict_AppliesRecoverableAction(t *testing.T) {
 	if !strings.Contains(got.Body, "Auto-review: unblocked") {
 		t.Fatalf("expected unblocked note in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Fatalf("sink calls = %d, want 0", sink.calls)
-	}
 	if len(got.AgentRuns) != 1 || !got.AgentRuns[0].VerdictRendered {
 		t.Fatalf("agent runs = %+v, want rendered verdict", got.AgentRuns)
 	}
@@ -580,7 +543,7 @@ func TestOnComplete_UnblockedVerdict_AppliesRecoverableAction(t *testing.T) {
 // and the status transition must still go through.
 func TestOnComplete_UnblockedVerdict_CleanPushedBranchTransitions(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-unblocked-clean"
@@ -617,9 +580,6 @@ func TestOnComplete_UnblockedVerdict_CleanPushedBranchTransitions(t *testing.T) 
 	if got.Status != task.StatusReadyPR {
 		t.Fatalf("status = %q, want %q (clean, pushed branch must be trusted)", got.Status, task.StatusReadyPR)
 	}
-	if sink.calls != 0 {
-		t.Fatalf("sink calls = %d, want 0", sink.calls)
-	}
 }
 
 // TestOnComplete_UnblockedVerdict_DirtyWorktreeDoesNotTransition is the
@@ -629,7 +589,7 @@ func TestOnComplete_UnblockedVerdict_CleanPushedBranchTransitions(t *testing.T) 
 // unverified claim.
 func TestOnComplete_UnblockedVerdict_DirtyWorktreeDoesNotTransition(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-unblocked-dirty"
@@ -676,9 +636,6 @@ func TestOnComplete_UnblockedVerdict_DirtyWorktreeDoesNotTransition(t *testing.T
 	if !strings.Contains(got.Body, "Auto-review: unblocked claim not verified") {
 		t.Fatalf("expected verification-failure note in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Fatalf("sink calls = %d, want 0", sink.calls)
-	}
 }
 
 // TestOnComplete_UnblockedVerdict_UnpushedBranchDoesNotTransition is the
@@ -687,7 +644,7 @@ func TestOnComplete_UnblockedVerdict_DirtyWorktreeDoesNotTransition(t *testing.T
 // dirty" symptom from the incident) must also not be trusted.
 func TestOnComplete_UnblockedVerdict_UnpushedBranchDoesNotTransition(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-unblocked-unpushed"
@@ -743,14 +700,11 @@ func TestOnComplete_UnblockedVerdict_UnpushedBranchDoesNotTransition(t *testing.
 	if !strings.Contains(got.Body, "Auto-review: unblocked claim not verified") {
 		t.Fatalf("expected verification-failure note in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Fatalf("sink calls = %d, want 0", sink.calls)
-	}
 }
 
 func TestBuildPrompt_IncludesUnblockAndAutonomyMandate(t *testing.T) {
 	t.Parallel()
-	h, _, _, cleanup := newReviewTestEnv(t)
+	h, _, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk := task.Task{
@@ -775,7 +729,7 @@ func TestBuildPrompt_IncludesUnblockAndAutonomyMandate(t *testing.T) {
 // by --json-schema enforcement, previously untested end-to-end.
 func TestOnComplete_BareJSONVerdict_HumanDecision(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Refactor billing", "Original body.", "headless")
@@ -807,9 +761,6 @@ func TestOnComplete_BareJSONVerdict_HumanDecision(t *testing.T) {
 	if !strings.Contains(got.Body, "needs product input on scope") {
 		t.Errorf("expected summary in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called for human verdict; calls=%d", sink.calls)
-	}
 }
 
 // TestOnComplete_BareJSONVerdict_SybraBug is the sybra_bug counterpart of
@@ -817,7 +768,7 @@ func TestOnComplete_BareJSONVerdict_HumanDecision(t *testing.T) {
 // no fence, driving the default non-filing note side effect.
 func TestOnComplete_BareJSONVerdict_SybraBug(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Workflow misfire", "Original body.", "headless")
@@ -842,10 +793,6 @@ func TestOnComplete_BareJSONVerdict_SybraBug(t *testing.T) {
 	h.inflight[tk.ID] = "agent-4"
 	h.onComplete(ag)
 
-	if sink.calls != 0 {
-		t.Fatalf("sink calls: got %d want 0", sink.calls)
-	}
-
 	got, err := tasks.Get(tk.ID)
 	if err != nil {
 		t.Fatalf("re-load: %v", err)
@@ -864,7 +811,7 @@ func TestOnComplete_BareJSONVerdict_SybraBug(t *testing.T) {
 
 func TestOnComplete_SybraBugVerdict_DefaultNotesWithoutFiling(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Workflow misfire", "Original body.", "headless")
@@ -889,10 +836,6 @@ func TestOnComplete_SybraBugVerdict_DefaultNotesWithoutFiling(t *testing.T) {
 	h.inflight[tk.ID] = "agent-2"
 	h.onComplete(ag)
 
-	if sink.calls != 0 {
-		t.Fatalf("sink calls: got %d want 0", sink.calls)
-	}
-
 	got, err := tasks.Get(tk.ID)
 	if err != nil {
 		t.Fatalf("re-load: %v", err)
@@ -911,7 +854,7 @@ func TestOnComplete_SybraBugVerdict_DefaultNotesWithoutFiling(t *testing.T) {
 
 func TestOnComplete_SybraBugVerdict_NoteOnly(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 	h.cfg.HumanReview.SybraBugAction = config.HumanReviewSybraBugActionNoteOnly
 
@@ -950,9 +893,6 @@ func TestOnComplete_SybraBugVerdict_NoteOnly(t *testing.T) {
 		!strings.Contains(got.Body, "fix(workflow): verify_commits race") {
 		t.Errorf("expected note-only diagnosis in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called in note_only mode; calls=%d", sink.calls)
-	}
 	all, err := tasks.List()
 	if err != nil {
 		t.Fatalf("list tasks: %v", err)
@@ -964,7 +904,7 @@ func TestOnComplete_SybraBugVerdict_NoteOnly(t *testing.T) {
 
 func TestOnComplete_SybraBugVerdict_BlockOnly(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 	h.cfg.HumanReview.SybraBugAction = config.HumanReviewSybraBugActionBlockOnly
 
@@ -1001,9 +941,6 @@ func TestOnComplete_SybraBugVerdict_BlockOnly(t *testing.T) {
 	if !strings.Contains(got.Body, "issue filing disabled") {
 		t.Errorf("expected block-only note in body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called in block_only mode; calls=%d", sink.calls)
-	}
 	all, err := tasks.List()
 	if err != nil {
 		t.Fatalf("list tasks: %v", err)
@@ -1015,7 +952,7 @@ func TestOnComplete_SybraBugVerdict_BlockOnly(t *testing.T) {
 
 func TestOnComplete_SybraBugVerdict_NoteOnlyScrubsWorkProject(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 	h.cfg.HumanReview.SybraBugAction = config.HumanReviewSybraBugActionNoteOnly
 
@@ -1060,14 +997,11 @@ func TestOnComplete_SybraBugVerdict_NoteOnlyScrubsWorkProject(t *testing.T) {
 			t.Fatalf("note_only body leaks %q:\n%s", leak, got.Body)
 		}
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called in note_only mode; calls=%d", sink.calls)
-	}
 }
 
 func TestOnComplete_StaleVerdictSkipsWhenTaskNoLongerHumanRequired(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Transient failure", "Original body.", "headless")
@@ -1104,9 +1038,6 @@ func TestOnComplete_StaleVerdictSkipsWhenTaskNoLongerHumanRequired(t *testing.T)
 	if got.Body != "Original body." {
 		t.Errorf("stale verdict should not mutate body; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Errorf("stale verdict should not file an issue; calls=%d", sink.calls)
-	}
 	if _, busy := h.inflight[tk.ID]; busy {
 		t.Errorf("inflight should be cleared after stale onComplete")
 	}
@@ -1114,7 +1045,7 @@ func TestOnComplete_StaleVerdictSkipsWhenTaskNoLongerHumanRequired(t *testing.T)
 
 func TestOnComplete_WorkProject_ConfiguredLocalTaskScrubbed(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 	h.cfg.HumanReview.SybraBugAction = config.HumanReviewSybraBugActionLocalTask
 
@@ -1156,10 +1087,6 @@ func TestOnComplete_WorkProject_ConfiguredLocalTaskScrubbed(t *testing.T) {
 	})
 	h.inflight[tk.ID] = "agent-work"
 	h.onComplete(ag)
-
-	if sink.calls != 0 {
-		t.Errorf("public sink must NOT be called for work-typed project; calls=%d", sink.calls)
-	}
 
 	// Original task: flipped to blocked with a pointer to the local task.
 	got, err := tasks.Get(tk.ID)
@@ -1212,7 +1139,7 @@ func TestOnComplete_WorkProject_ConfiguredLocalTaskScrubbed(t *testing.T) {
 
 func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Mystery", "Body.", "headless")
@@ -1237,14 +1164,11 @@ func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {
 	if !strings.Contains(got.Body, "unparseable verdict") {
 		t.Errorf("expected unparseable header; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called on malformed verdict; calls=%d", sink.calls)
-	}
 }
 
 func TestOnComplete_StructuredVerdictFailure_RetriesAlternateProvider(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const firstAgentID = "hr-structured-1"
@@ -1321,14 +1245,11 @@ func TestOnComplete_StructuredVerdictFailure_RetriesAlternateProvider(t *testing
 	if strings.Contains(got.Body, "unparseable verdict") {
 		t.Fatalf("fallback spawn should not append a terminal note yet; body:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Fatalf("sink calls = %d, want 0", sink.calls)
-	}
 }
 
 func TestOnComplete_StructuredVerdictFailure_SecondFailureRendersDurableNote(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const currentAgentID = "hr-structured-2"
@@ -1391,9 +1312,6 @@ func TestOnComplete_StructuredVerdictFailure_SecondFailureRendersDurableNote(t *
 	if !strings.Contains(got.Body, "did not return a usable structured verdict") {
 		t.Fatalf("expected durable structured-verdict note; got:\n%s", got.Body)
 	}
-	if sink.calls != 0 {
-		t.Fatalf("sink calls = %d, want 0", sink.calls)
-	}
 }
 
 // TestOnComplete_PlaceholderVerdict_RejectedNotFiled pins task 2379fece's
@@ -1403,7 +1321,7 @@ func TestOnComplete_StructuredVerdictFailure_SecondFailureRendersDurableNote(t *
 // onComplete treats it like any other unparseable verdict.
 func TestOnComplete_PlaceholderVerdict_RejectedNotFiled(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Some task", "Body.", "headless")
@@ -1421,9 +1339,6 @@ func TestOnComplete_PlaceholderVerdict_RejectedNotFiled(t *testing.T) {
 	})
 	h.onComplete(ag)
 
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called for placeholder verdict; calls=%d", sink.calls)
-	}
 	got, err := tasks.Get(tk.ID)
 	if err != nil {
 		t.Fatalf("re-load: %v", err)
@@ -1438,7 +1353,7 @@ func TestOnComplete_PlaceholderVerdict_RejectedNotFiled(t *testing.T) {
 
 func TestOnComplete_RateLimitedVerdictDoesNotRenderNoise(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Quota limited", "Body.", "headless")
@@ -1469,9 +1384,6 @@ func TestOnComplete_RateLimitedVerdictDoesNotRenderNoise(t *testing.T) {
 			t.Fatal("rate-limited human-review must not mark verdict_rendered")
 		}
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called on quota failure; calls=%d", sink.calls)
-	}
 }
 
 // TestOnComplete_ExecutionCrashRendersDiagnosis pins the no-dead-end contract
@@ -1487,7 +1399,7 @@ func TestOnComplete_RateLimitedVerdictDoesNotRenderNoise(t *testing.T) {
 // than deferring into a dead-end that strands it silently.
 func TestOnComplete_ExecutionCrashRendersDiagnosis(t *testing.T) {
 	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Crashed review", "Body.", "headless")
@@ -1539,16 +1451,13 @@ func TestOnComplete_ExecutionCrashRendersDiagnosis(t *testing.T) {
 	if got.Status != task.StatusHumanRequired {
 		t.Errorf("crashed review must leave task in human-required; got %s", got.Status)
 	}
-	if sink.calls != 0 {
-		t.Errorf("sink should not be called on execution crash; calls=%d", sink.calls)
-	}
 }
 
 func TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered(t *testing.T) {
 	t.Parallel()
 	// h.agents is nil in newReviewTestEnv — if maybeSpawn tries to spawn an
 	// agent past the gate it will panic, which is the test's failure signal.
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Stale task", "Body.", "headless")
@@ -1585,7 +1494,7 @@ func TestMaybeSpawn_SkipsWhenTaskNoLongerHumanRequired(t *testing.T) {
 	t.Parallel()
 	// h.agents is nil in newReviewTestEnv — a stale human-required hook must
 	// exit before attempting a real spawn.
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Stale hook task", "Body.", "headless")
@@ -1612,7 +1521,7 @@ func TestMaybeSpawn_SkipsWhenTaskNoLongerHumanRequired(t *testing.T) {
 func TestMaybeSpawn_RechecksStatusBeforeRun(t *testing.T) {
 	t.Parallel()
 
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Racey hook task", "Body.", "headless")
@@ -1676,7 +1585,7 @@ func TestMaybeSpawn_RechecksStatusBeforeRun(t *testing.T) {
 
 func TestMaybeSpawn_IdempotencyGate_IgnoresRenderedVerdictBeforeTestingCycle(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Re-tested task", "Body.", "headless")
@@ -1723,7 +1632,7 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenVerdictSetButNotRendered(t *testin
 	// but the process crashed before onComplete appended the "## Auto-review"
 	// section. The gate must allow a re-spawn so the task is not permanently
 	// stranded at human-required with no diagnosis.
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Crash-window task", "Body without auto-review section.", "headless")
@@ -1767,7 +1676,7 @@ func TestMaybeSpawn_IdempotencyGate_PreexistingAutoReviewTextDoesNotBlock(t *tes
 	// NOT satisfy the idempotency gate when onComplete has not run.
 	// The gate now checks AgentRun.VerdictRendered, not body text, so
 	// pre-existing headings never falsely block a re-spawn.
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	body := "Original task body.\n\n## Auto-review requirements\n\nThis task is about auto-review diagnostics, but no diagnostic has been rendered yet.\n"
@@ -1806,7 +1715,7 @@ func TestMaybeSpawn_IdempotencyGate_PreexistingAutoReviewTextDoesNotBlock(t *tes
 
 func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Fresh task", "Body.", "headless")
@@ -1845,7 +1754,7 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
 
 func TestMaybeSpawn_SkipsProjectlessTask(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Orphan smoke-test task", "queued", "headless")
@@ -1868,7 +1777,7 @@ func TestMaybeSpawn_SkipsProjectlessTask(t *testing.T) {
 
 func TestMaybeSpawn_SkipsStaleNonHumanRequiredTask(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	tk, err := tasks.Create("Already handled task", "queued", "headless")
@@ -1896,7 +1805,7 @@ func TestOnComplete_SetsVerdictRendered(t *testing.T) {
 	t.Parallel()
 	// Verifies that onComplete sets VerdictRendered on the matching AgentRun so
 	// verdictAlreadyRendered can use it as the durable rendered-marker on restart.
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-hr-1"
@@ -1950,7 +1859,7 @@ func TestOnComplete_SetsVerdictRendered(t *testing.T) {
 // TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered relies on.
 func TestOnComplete_CrashedVerdict_RetriesOnce(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-hr-crash-1"
@@ -1995,7 +1904,7 @@ func TestOnComplete_CrashedVerdict_RetriesOnce(t *testing.T) {
 // task — not the generic "unparseable verdict" text, and not silence.
 func TestOnComplete_CrashedVerdict_ExhaustedRetriesMarksDistinguishableNote(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-hr-crash-2"
@@ -2056,7 +1965,7 @@ func TestOnComplete_CrashedVerdict_ExhaustedRetriesMarksDistinguishableNote(t *t
 // it has no budget logic of its own to get out of sync with.
 func TestOnComplete_CrashedVerdict_GlobalCapDeclinesRetrySilently(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	h.cfg.HumanReview.MaxPerHour = 1
@@ -2116,7 +2025,7 @@ func TestOnComplete_CrashedVerdict_GlobalCapDeclinesRetrySilently(t *testing.T) 
 // instead of being discarded for a pointless retry.
 func TestOnComplete_TerminalErrorWithToolCalls_SkipsCrashPath(t *testing.T) {
 	t.Parallel()
-	h, tasks, _, cleanup := newReviewTestEnv(t)
+	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const agentID = "agent-hr-worked-then-errored"

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -109,7 +109,7 @@ func newReviewTestEnv(t *testing.T) (*humanReviewHandler, *task.Manager, *fakeIs
 	cfg.HumanReview.MaxPerHour = 3
 	sink := &fakeIssueSink{created: true, url: "https://github.com/Automaat/sybra/issues/42"}
 	logger := slog.New(slog.DiscardHandler)
-	h := newHumanReviewHandler(cfg, tasks, nil, nil, logger, sink, dir, filepath.Join(dir, "missing.log"), nil)
+	h := newHumanReviewHandler(cfg, tasks, nil, nil, logger, dir, filepath.Join(dir, "missing.log"), nil)
 	return h, tasks, sink, func() {}
 }
 
@@ -814,7 +814,7 @@ func TestOnComplete_BareJSONVerdict_HumanDecision(t *testing.T) {
 
 // TestOnComplete_BareJSONVerdict_SybraBug is the sybra_bug counterpart of
 // TestOnComplete_BareJSONVerdict_HumanDecision — bare JSON assistant output,
-// no fence, driving the issue-filing side effect.
+// no fence, driving the default non-filing note side effect.
 func TestOnComplete_BareJSONVerdict_SybraBug(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)
@@ -842,26 +842,27 @@ func TestOnComplete_BareJSONVerdict_SybraBug(t *testing.T) {
 	h.inflight[tk.ID] = "agent-4"
 	h.onComplete(ag)
 
-	if sink.calls != 1 {
-		t.Fatalf("sink calls: got %d want 1", sink.calls)
-	}
-	if sink.gotTitle != "fix(workflow): verify_commits race" {
-		t.Errorf("sink title: got %q", sink.gotTitle)
+	if sink.calls != 0 {
+		t.Fatalf("sink calls: got %d want 0", sink.calls)
 	}
 
 	got, err := tasks.Get(tk.ID)
 	if err != nil {
 		t.Fatalf("re-load: %v", err)
 	}
-	if got.Status != task.StatusBlocked {
-		t.Errorf("status: got %q want blocked", got.Status)
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status: got %q want human-required", got.Status)
 	}
-	if got.BlockedByIssue != sink.url {
-		t.Errorf("BlockedByIssue: got %q want %q", got.BlockedByIssue, sink.url)
+	if got.BlockedByIssue != "" {
+		t.Errorf("BlockedByIssue: got %q want empty", got.BlockedByIssue)
+	}
+	if !strings.Contains(got.Body, "Auto-review verdict: Sybra bug (note only)") ||
+		!strings.Contains(got.Body, "fix(workflow): verify_commits race") {
+		t.Errorf("expected non-filing note in body; got:\n%s", got.Body)
 	}
 }
 
-func TestOnComplete_SybraBugVerdict_FilesIssueAndBlocks(t *testing.T) {
+func TestOnComplete_SybraBugVerdict_DefaultNotesWithoutFiling(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)
 	defer cleanup()
@@ -888,34 +889,23 @@ func TestOnComplete_SybraBugVerdict_FilesIssueAndBlocks(t *testing.T) {
 	h.inflight[tk.ID] = "agent-2"
 	h.onComplete(ag)
 
-	if sink.calls != 1 {
-		t.Fatalf("sink calls: got %d want 1", sink.calls)
-	}
-	if sink.gotTitle != "fix(workflow): verify_commits race" {
-		t.Errorf("sink title: got %q", sink.gotTitle)
-	}
-	if !strings.Contains(sink.gotBody, "race condition") {
-		t.Errorf("sink body missing diagnosis: %q", sink.gotBody)
-	}
-	if len(sink.gotLabels) != 2 || sink.gotLabels[0] != "workflow" {
-		t.Errorf("sink labels: got %v", sink.gotLabels)
+	if sink.calls != 0 {
+		t.Fatalf("sink calls: got %d want 0", sink.calls)
 	}
 
 	got, err := tasks.Get(tk.ID)
 	if err != nil {
 		t.Fatalf("re-load: %v", err)
 	}
-	if got.Status != task.StatusBlocked {
-		t.Errorf("status: got %q want blocked", got.Status)
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status: got %q want human-required", got.Status)
 	}
-	if got.BlockedByIssue != sink.url {
-		t.Errorf("BlockedByIssue: got %q want %q", got.BlockedByIssue, sink.url)
+	if got.BlockedByIssue != "" {
+		t.Errorf("BlockedByIssue: got %q want empty", got.BlockedByIssue)
 	}
-	if !strings.Contains(got.Body, "Auto-review verdict: blocked by Sybra bug") {
-		t.Errorf("expected blocked-by-Sybra-bug header; got:\n%s", got.Body)
-	}
-	if !strings.Contains(got.Body, sink.url) {
-		t.Errorf("expected issue URL in body; got:\n%s", got.Body)
+	if !strings.Contains(got.Body, "Auto-review verdict: Sybra bug (note only)") ||
+		!strings.Contains(got.Body, "race condition") {
+		t.Errorf("expected non-filing diagnosis note; got:\n%s", got.Body)
 	}
 }
 
@@ -1122,166 +1112,11 @@ func TestOnComplete_StaleVerdictSkipsWhenTaskNoLongerHumanRequired(t *testing.T)
 	}
 }
 
-func TestOnComplete_SinkError_CreatesLocalFallback(t *testing.T) {
+func TestOnComplete_WorkProject_ConfiguredLocalTaskScrubbed(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)
 	defer cleanup()
-	sink.err = errors.New("rate limited")
-
-	tk, err := tasks.Create("Whatever", "Body.", "headless")
-	if err != nil {
-		t.Fatalf("create task: %v", err)
-	}
-	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
-		t.Fatalf("flip: %v", err)
-	}
-
-	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
-	ag.AppendOutput(agent.StreamEvent{
-		Type:    "assistant",
-		Content: "```sybra-verdict\n" + `{"decision":"sybra_bug","summary":"x","issue_title":"fix(x): y","issue_body":"z"}` + "\n```",
-	})
-	h.onComplete(ag)
-
-	got, err := tasks.Get(tk.ID)
-	if err != nil {
-		t.Fatalf("re-load: %v", err)
-	}
-	if got.Status != task.StatusBlocked {
-		t.Errorf("status: got %q want blocked (local fallback path)", got.Status)
-	}
-	if got.BlockedByIssue != "" {
-		t.Errorf("BlockedByIssue should be empty on sink error; got %q", got.BlockedByIssue)
-	}
-	if !strings.Contains(got.Body, "Auto-review verdict: blocked by Sybra bug (local fallback)") ||
-		!strings.Contains(got.Body, "GitHub issue filing failed: rate limited") {
-		t.Errorf("expected local fallback note in body; got:\n%s", got.Body)
-	}
-	if !strings.Contains(got.StatusReason, "issue filing failed") {
-		t.Errorf("status reason = %q, want issue filing failed context", got.StatusReason)
-	}
-	if !strings.Contains(got.StatusReason, "local task ") {
-		t.Errorf("status reason = %q, want local task pointer", got.StatusReason)
-	}
-}
-
-func TestOnComplete_SinkError_DedupesExistingLocalFallback(t *testing.T) {
-	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
-	defer cleanup()
-	sink.err = errors.New("rate limited")
-
-	tk, err := tasks.Create("Whatever", "Body.", "headless")
-	if err != nil {
-		t.Fatalf("create task: %v", err)
-	}
-	verdictContent := "```sybra-verdict\n" +
-		`{"decision":"sybra_bug","summary":"branch stale before agent start","issue_title":"fix(workflow): stale branch race","issue_body":"z"}` +
-		"\n```"
-
-	runOnce := func() {
-		if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
-			t.Fatalf("flip: %v", err)
-		}
-		ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
-		ag.AppendOutput(agent.StreamEvent{Type: "assistant", Content: verdictContent})
-		h.onComplete(ag)
-	}
-
-	runOnce()
-	runOnce()
-
-	all, err := tasks.List()
-	if err != nil {
-		t.Fatalf("list tasks: %v", err)
-	}
-	var localBugTasks []task.Task
-	for _, lt := range all {
-		if lt.ID == tk.ID {
-			continue
-		}
-		localBugTasks = append(localBugTasks, lt)
-	}
-	if len(localBugTasks) != 1 {
-		t.Fatalf("want exactly 1 local fallback task after two runs, got %d: %+v", len(localBugTasks), localBugTasks)
-	}
-
-	got, err := tasks.Get(tk.ID)
-	if err != nil {
-		t.Fatalf("re-load: %v", err)
-	}
-	if got.Status != task.StatusBlocked {
-		t.Errorf("status: got %q want blocked", got.Status)
-	}
-	if !strings.Contains(got.Body, "Auto-review verdict: blocked by Sybra bug (already filed)") {
-		t.Errorf("expected dedup note on second run; got:\n%s", got.Body)
-	}
-	if strings.Count(got.Body, "Linked local Sybra bug") > 1 {
-		t.Errorf("expected only one fresh-filing note, got body:\n%s", got.Body)
-	}
-}
-
-func TestOnComplete_SinkError_DoesNotDedupAgainstUnrelatedSybraBug(t *testing.T) {
-	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
-	defer cleanup()
-	sink.err = errors.New("rate limited")
-
-	if _, err := tasks.CreateFull("fix(workflow): stale branch race", "existing unrelated bug", task.AgentModeHeadless, task.Update{
-		Tags: task.Ptr([]string{"sybra-bug"}),
-	}); err != nil {
-		t.Fatalf("seed unrelated sybra-bug task: %v", err)
-	}
-	tk, err := tasks.Create("Whatever", "Body.", "headless")
-	if err != nil {
-		t.Fatalf("create task: %v", err)
-	}
-	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
-		t.Fatalf("flip: %v", err)
-	}
-
-	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
-	ag.AppendOutput(agent.StreamEvent{
-		Type: "assistant",
-		Content: "```sybra-verdict\n" +
-			`{"decision":"sybra_bug","summary":"branch stale before agent start","issue_title":"fix(workflow): stale branch race","issue_body":"z"}` +
-			"\n```",
-	})
-	h.onComplete(ag)
-
-	all, err := tasks.List()
-	if err != nil {
-		t.Fatalf("list tasks: %v", err)
-	}
-	localFallbackCount := 0
-	for _, got := range all {
-		if got.ID == tk.ID {
-			continue
-		}
-		if slices.Contains(got.Tags, "issue-filing-failed") {
-			localFallbackCount++
-		}
-	}
-	if localFallbackCount != 1 {
-		t.Fatalf("want exactly 1 new local fallback task, got %d", localFallbackCount)
-	}
-
-	got, err := tasks.Get(tk.ID)
-	if err != nil {
-		t.Fatalf("re-load: %v", err)
-	}
-	if !strings.Contains(got.Body, "blocked by Sybra bug (local fallback)") {
-		t.Errorf("expected fresh local fallback note, got:\n%s", got.Body)
-	}
-	if strings.Contains(got.Body, "already filed") {
-		t.Errorf("must not dedupe against unrelated sybra-bug task; got:\n%s", got.Body)
-	}
-}
-
-func TestOnComplete_WorkProject_LocalTaskScrubbed(t *testing.T) {
-	t.Parallel()
-	h, tasks, sink, cleanup := newReviewTestEnv(t)
-	defer cleanup()
+	h.cfg.HumanReview.SybraBugAction = config.HumanReviewSybraBugActionLocalTask
 
 	const workProject = "work-owner/work-repo"
 	h.workCtx = func(projectID string) *WorkScrubContext {
@@ -1306,7 +1141,8 @@ func TestOnComplete_WorkProject_LocalTaskScrubbed(t *testing.T) {
 	}
 
 	// Verdict body contains all three leak vectors: blocklist literal, GH
-	// URL, Jira key. After scrub, none must survive in the created task.
+	// URL, Jira key. With local_task explicitly configured, none may survive
+	// in the created task.
 	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
 	ag.AppendOutput(agent.StreamEvent{
 		Type: "assistant",

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -1209,7 +1209,7 @@ func TestE2E_HumanReview_StructuredFallbackUnblocksTask(t *testing.T) {
 	cfg.HumanReview.SybraRepoDir = env.agentDir
 	cfg.HumanReview.MaxPerHour = 3
 	sink := &fakeIssueSink{created: true, url: "https://github.com/Automaat/sybra/issues/42"}
-	h := newHumanReviewHandler(cfg, env.tasks, env.agents, nil, e2eLogger(t), sink, config.HomeDir(), "", nil)
+	h := newHumanReviewHandler(cfg, env.tasks, env.agents, nil, e2eLogger(t), config.HomeDir(), "", nil)
 	env.onAgentComplete = h.onComplete
 
 	created, err := env.tasks.Create("human review structured fallback", "", "headless")

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -1208,7 +1208,6 @@ func TestE2E_HumanReview_StructuredFallbackUnblocksTask(t *testing.T) {
 	cfg.HumanReview.Enabled = true
 	cfg.HumanReview.SybraRepoDir = env.agentDir
 	cfg.HumanReview.MaxPerHour = 3
-	sink := &fakeIssueSink{created: true, url: "https://github.com/Automaat/sybra/issues/42"}
 	h := newHumanReviewHandler(cfg, env.tasks, env.agents, nil, e2eLogger(t), config.HomeDir(), "", nil)
 	env.onAgentComplete = h.onComplete
 
@@ -1253,9 +1252,6 @@ func TestE2E_HumanReview_StructuredFallbackUnblocksTask(t *testing.T) {
 	}
 	if !strings.Contains(tk.StatusReason, "auto-review recovery") {
 		t.Fatalf("status_reason = %q, want auto-review recovery marker", tk.StatusReason)
-	}
-	if sink.calls != 0 {
-		t.Fatalf("sink calls = %d, want 0", sink.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove human-review GitHub issue sink wiring and direct filing paths
- make sybra_bug verdicts note-only by default, with legacy file_issue mapping to note_only
- keep explicit local_task/block_only behavior and update config docs/tests

## Tests
- env GOCACHE=/private/tmp/sybra-go-cache go generate ./internal/config/...
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/config
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra -run 'TestOnComplete_|TestHumanReviewDispatchDir|TestVerdictDecisionIsSharedParserType'
- git diff --check

Note: full `go test ./internal/config ./internal/sybra` was attempted but the sandbox cannot bind localhost ports for unrelated sybra tests.