### PR TITLE
fix(workflow): close superseded task PRs

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -743,6 +743,26 @@ func MergePR(repo string, number int) error {
 	return mergePRWith(defaultExecer, repo, number)
 }
 
+// ClosePR closes an open pull request with a short explanatory comment.
+func ClosePR(ctx context.Context, repo string, number int, comment string) error {
+	return closePRWith(ctx, defaultExecer, repo, number, comment)
+}
+
+func closePRWith(ctx context.Context, e execer, repo string, number int, comment string) error {
+	args := []string{"pr", "close", strconv.Itoa(number), "--repo", repo}
+	if strings.TrimSpace(comment) != "" {
+		args = append(args, "--comment", comment)
+	}
+	out, err := runE(ctx, e, args...)
+	if err != nil {
+		return fmt.Errorf("gh pr close %d: %s: %w", number, sanitizeGHOutput(out), err)
+	}
+	if runtimeCacheEnabled(e) {
+		invalidatePRCaches(repo, number)
+	}
+	return nil
+}
+
 func mergePRWith(e execer, repo string, number int) error {
 	var lastOut []byte
 	var lastErr error

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -646,6 +646,38 @@ func TestEnableAutoMerge(t *testing.T) {
 	})
 }
 
+func TestClosePRWith(t *testing.T) {
+	t.Parallel()
+	t.Run("success passes args with comment", func(t *testing.T) {
+		t.Parallel()
+		fe := &recordingExecer{}
+		if err := closePRWith(t.Context(), fe, "owner/repo", 42, "Superseded by #43."); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"pr", "close", "42", "--repo", "owner/repo", "--comment", "Superseded by #43."}
+		if len(fe.lastArgs) != len(want) {
+			t.Fatalf("args = %v, want %v", fe.lastArgs, want)
+		}
+		for i, a := range fe.lastArgs {
+			if a != want[i] {
+				t.Errorf("arg[%d] = %q, want %q", i, a, want[i])
+			}
+		}
+	})
+
+	t.Run("gh error passthrough", func(t *testing.T) {
+		t.Parallel()
+		fe := &fakeExecer{output: []byte("not authorized"), err: fmt.Errorf("exit 1")}
+		err := closePRWith(t.Context(), fe, "owner/repo", 42, "Superseded")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "gh pr close 42") {
+			t.Errorf("error = %v, want it to mention 'gh pr close 42'", err)
+		}
+	})
+}
+
 func TestSupportsNativeAutoMerge(t *testing.T) {
 	t.Parallel()
 	repoAllowed := `{"allow_auto_merge":true}`

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1162,6 +1162,7 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetPRStateFetcher(prStateFetcherAdapter{})
 	a.workflowEngine.SetPRHeadFetcher(prHeadFetcherAdapter{})
 	a.workflowEngine.SetPRCreator(prCreatorAdapter{})
+	a.workflowEngine.SetPRCloser(prCloserAdapter{})
 	a.workflowEngine.SetPRFinder(prFinderAdapter{})
 	a.workflowEngine.SetPRContentGenerator(prContentGeneratorAdapter{gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}})
 	a.workflowEngine.SetTaskClassifier(&taskClassifierAdapter{

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -39,6 +39,7 @@ var (
 	_ workflow.PRStateFetcher         = (*prStateFetcherAdapter)(nil)
 	_ workflow.PRHeadFetcher          = (*prHeadFetcherAdapter)(nil)
 	_ workflow.PRCreator              = (*prCreatorAdapter)(nil)
+	_ workflow.PRCloser               = (*prCloserAdapter)(nil)
 	_ workflow.PRFinder               = (*prFinderAdapter)(nil)
 	_ workflow.PRContentGenerator     = (*prContentGeneratorAdapter)(nil)
 	_ workflow.PRReviewRequester      = (*prReviewRequesterAdapter)(nil)
@@ -384,6 +385,14 @@ func (prCreatorAdapter) CreatePR(ctx context.Context, dir string, req workflow.P
 		Title: req.Title,
 		Body:  req.Body,
 	})
+}
+
+// prCloserAdapter wires the workflow engine's best-effort superseded-PR
+// cleanup to the github package.
+type prCloserAdapter struct{}
+
+func (prCloserAdapter) ClosePR(ctx context.Context, repo string, number int, comment string) error {
+	return github.ClosePR(ctx, repo, number, comment)
 }
 
 // prFinderAdapter wires the workflow engine's PRFinder interface to the github

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -233,6 +233,13 @@ type PRCreator interface {
 	CreatePR(ctx context.Context, dir string, req PRCreateRequest) (number int, headSHA string, err error)
 }
 
+// PRCloser closes an open pull request that has been superseded by a newer PR
+// for the same task. Engine treats this as best-effort cleanup: a close failure
+// must not roll back linking the replacement PR.
+type PRCloser interface {
+	ClosePR(ctx context.Context, repo string, number int, comment string) error
+}
+
 // PRFinder looks up an open PR by its head branch, backing the create_pr
 // idempotency guard (a prior run may have created the PR but crashed before
 // persisting pr_number). Engine operates with a nil finder — the guard is
@@ -315,6 +322,7 @@ type Engine struct {
 	prHeads          PRHeadFetcher
 	pushPreflight    PushCredentialPreflighter
 	prCreator        PRCreator
+	prCloser         PRCloser
 	prFinder         PRFinder
 	prContentGen     PRContentGenerator
 	worktrees        WorktreeGetter
@@ -511,6 +519,10 @@ func (e *Engine) SetPushCredentialPreflighter(p PushCredentialPreflighter) {
 // `create_pr` step. Leaving it unset flips the task to human-required when
 // create_pr is reached, since a PR cannot be opened without it.
 func (e *Engine) SetPRCreator(c PRCreator) { e.prCreator = c }
+
+// SetPRCloser wires best-effort cleanup for superseded PRs after a task is
+// relinked to a replacement PR.
+func (e *Engine) SetPRCloser(c PRCloser) { e.prCloser = c }
 
 // SetPRFinder wires the open-PR-by-branch lookup used by create_pr's
 // idempotency guard. Leaving it unset skips the guard.

--- a/internal/workflow/engine_pr_recovery.go
+++ b/internal/workflow/engine_pr_recovery.go
@@ -119,7 +119,7 @@ func (e *Engine) maybeRecoverHumanRequiredByOpeningPR(taskID string, currentStep
 	// simple-task-pr pushes the current HEAD before linking.
 	if remoteSHA == localSHA {
 		if existing, found := e.findExistingPRForBranch(t.ProjectID, headArg); found {
-			if err := e.tasks.UpdateTaskPR(taskID, existing); err != nil {
+			if err := e.linkTaskPR(taskID, t, existing); err != nil {
 				return nil, false, err
 			}
 			status = "in-review"

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -45,7 +45,7 @@ const (
 // the workflow to fall through to the LLM eval step.
 func (e *Engine) execLinkPRAndReview(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
 	setInReview := func(prNumber int, source string) (StepOutput, error) {
-		if err := e.tasks.UpdateTaskPR(taskID, prNumber); err != nil {
+		if err := e.linkTaskPR(taskID, t, prNumber); err != nil {
 			return StepOutput{}, fmt.Errorf("link pr: %w", err)
 		}
 		if err := e.tasks.UpdateTaskStatus(taskID, "in-review", ""); err != nil {
@@ -130,7 +130,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 			jsonErr := json.Unmarshal(out, &prs)
 			if jsonErr == nil && len(prs) == 1 {
 				prNum := prs[0].Number
-				if linkErr := e.tasks.UpdateTaskPR(taskID, prNum); linkErr != nil {
+				if linkErr := e.linkTaskPR(taskID, t, prNum); linkErr != nil {
 					return StepOutput{}, fmt.Errorf("evaluate: link pr: %w", linkErr)
 				}
 				if linkErr := e.tasks.UpdateTaskStatus(taskID, "in-review", ""); linkErr != nil {

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -66,7 +66,7 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 	// so a fork-hosted branch, which GitHub only matches as "owner:branch",
 	// is found too.
 	if existing, ok := e.findExistingPRForBranch(t.ProjectID, headArg); ok {
-		if err := e.tasks.UpdateTaskPR(taskID, existing); err != nil {
+		if err := e.linkTaskPR(taskID, t, existing); err != nil {
 			return StepOutput{}, fmt.Errorf("create_pr: link existing pr: %w", err)
 		}
 		return stepDone(step, fmt.Sprintf("pr #%d already exists for branch", existing))
@@ -98,7 +98,7 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 		return e.classifyPRGitError(taskID, step, wfExec, t, createErr, "create_pr")
 	}
 
-	if err := e.tasks.UpdateTaskPR(taskID, number); err != nil {
+	if err := e.linkTaskPR(taskID, t, number); err != nil {
 		return StepOutput{}, fmt.Errorf("create_pr: link pr: %w", err)
 	}
 	if localSHA, lErr := project.CurrentCommit(ctx, wtPath); lErr == nil && headSHA != "" && localSHA != headSHA {
@@ -116,12 +116,36 @@ func (e *Engine) adoptExistingPROnConflict(taskID, repo, headArg string, createE
 	if !ok {
 		return 0, false
 	}
-	if err := e.tasks.UpdateTaskPR(taskID, existing); err != nil {
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil {
+		e.logger.Warn("workflow.create-pr.adopt-existing.get-task", "task_id", taskID, "pr", existing, "err", err)
+		return 0, false
+	}
+	if err := e.linkTaskPR(taskID, t, existing); err != nil {
 		e.logger.Warn("workflow.create-pr.adopt-existing", "task_id", taskID, "pr", existing, "err", err)
 		return 0, false
 	}
 	e.logger.Info("workflow.create-pr.adopt-existing", "task_id", taskID, "pr", existing)
 	return existing, true
+}
+
+func (e *Engine) linkTaskPR(taskID string, t TaskInfo, newPR int) error {
+	oldPR := t.PRNumber
+	if err := e.tasks.UpdateTaskPR(taskID, newPR); err != nil {
+		return err
+	}
+	if oldPR == 0 || oldPR == newPR || t.ProjectID == "" || e.prCloser == nil {
+		return nil
+	}
+	comment := fmt.Sprintf("Superseded by #%d for Sybra task %s.", newPR, taskID)
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+	if err := e.prCloser.ClosePR(ctx, t.ProjectID, oldPR, comment); err != nil {
+		e.logger.Warn("workflow.pr.superseded-close", "task_id", taskID, "old_pr", oldPR, "new_pr", newPR, "err", err)
+		return nil
+	}
+	e.logger.Info("workflow.pr.superseded-close", "task_id", taskID, "old_pr", oldPR, "new_pr", newPR)
+	return nil
 }
 
 // prWorktreeAndBranch resolves the on-disk worktree and branch used by

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/project"
@@ -111,6 +112,22 @@ type fakePRFinder struct {
 func (f *fakePRFinder) FindPRForBranch(context.Context, string, string) (number int, found bool, err error) {
 	f.calls++
 	return f.number, f.found, f.err
+}
+
+type fakePRCloser struct {
+	err      error
+	calls    int
+	repo     string
+	number   int
+	comments []string
+}
+
+func (f *fakePRCloser) ClosePR(_ context.Context, repo string, number int, comment string) error {
+	f.calls++
+	f.repo = repo
+	f.number = number
+	f.comments = append(f.comments, comment)
+	return f.err
 }
 
 type fakePRContentGenerator struct {
@@ -530,6 +547,84 @@ func TestExecCreatePR_Success(t *testing.T) {
 	}
 	if creator.gotReq.Title != "feat(x): y" {
 		t.Errorf("CreatePR title = %q", creator.gotReq.Title)
+	}
+}
+
+func TestExecCreatePR_ClosesSupersededLinkedPR(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/my-branch-recovered")
+	commitFile(t, wtPath, "change.txt", "feat: recovered task work")
+
+	tasks := newMemTasks()
+	task := TaskInfo{
+		ID:          "t1",
+		Status:      "ready-pr",
+		Branch:      "feat/my-branch-recovered",
+		ProjectID:   "acme/widgets",
+		ProjectType: "pet",
+		PRNumber:    41,
+		Title:       "feat(x): y",
+		Body:        "body",
+	}
+	tasks.Put(task)
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetPRCreator(&fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)})
+	closer := &fakePRCloser{}
+	engine.SetPRCloser(closer)
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execCreatePR: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, output = %q", out.Status, out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42", ti.PRNumber)
+	}
+	if closer.calls != 1 {
+		t.Fatalf("ClosePR calls = %d, want 1", closer.calls)
+	}
+	if closer.repo != "acme/widgets" || closer.number != 41 {
+		t.Fatalf("ClosePR target = %s#%d, want acme/widgets#41", closer.repo, closer.number)
+	}
+	if len(closer.comments) != 1 || !strings.Contains(closer.comments[0], "#42") || !strings.Contains(closer.comments[0], "t1") {
+		t.Fatalf("ClosePR comment = %q, want superseded-by PR and task", closer.comments)
+	}
+}
+
+func TestExecCreatePR_SupersededCloseFailureDoesNotBlockRelink(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/my-branch-recovered")
+	commitFile(t, wtPath, "change.txt", "feat: recovered task work")
+
+	tasks := newMemTasks()
+	task := TaskInfo{
+		ID:          "t1",
+		Status:      "ready-pr",
+		Branch:      "feat/my-branch-recovered",
+		ProjectID:   "acme/widgets",
+		ProjectType: "pet",
+		PRNumber:    41,
+		Title:       "feat(x): y",
+		Body:        "body",
+	}
+	tasks.Put(task)
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetPRCreator(&fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)})
+	engine.SetPRCloser(&fakePRCloser{err: errors.New("github unavailable")})
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execCreatePR: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, output = %q", out.Status, out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42 even when superseded close fails", ti.PRNumber)
 	}
 }
 


### PR DESCRIPTION
## Summary
- close a task's previously linked PR when workflow relinks it to a replacement PR
- route PR linking/recovery paths through one helper so superseded cleanup is consistent
- add GitHub close helper and regression coverage

## Verification
- go test ./internal/workflow ./internal/github ./internal/sybra/review

Note: PR #2388 was manually closed as superseded by #2389 after this bug was diagnosed.