### PR TITLE
fix(review): arm auto-merge when direct merge is blocked

### DIFF
--- a/internal/sybra/review/automerge_test.go
+++ b/internal/sybra/review/automerge_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -447,6 +448,132 @@ func TestHandleAutoMerge_ArmsNative(t *testing.T) {
 				t.Errorf("merged=%v (repo=%q num=%d), want merged=%v", merged, mergedRepo, mergedNum, tt.wantMerged)
 			}
 		})
+	}
+}
+
+func TestHandleAutoMerge_FallsBackToNativeWhenDirectMergeBlockedByPolicy(t *testing.T) {
+	projDir := t.TempDir()
+	projStore, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mustWriteProjectYAML(t, projDir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+	taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatalf("task NewStore: %v", err)
+	}
+	tasks := task.NewManager(taskStore, nil)
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		PRNumber:  task.Ptr(2385),
+		ProjectID: task.Ptr("pet-owner/pet-repo"),
+		Reviewed:  task.Ptr(true),
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	tracker := github.NewIssueTracker(time.Minute)
+	var mergeCalled bool
+	var armedRepo string
+	var armedNum int
+	r := &Handler{
+		logger:    slog.New(slog.DiscardHandler),
+		tasks:     tasks,
+		projects:  projStore,
+		prTracker: tracker,
+		mergePR: func(repo string, number int) error {
+			mergeCalled = true
+			return fmt.Errorf("gh pr merge %d: X Pull request owner/repo#%d is not mergeable: the base branch policy prohibits the merge.\nTo have the pull request merged after all the requirements have been met, add the `--auto` flag.: exit status 1", number, number)
+		},
+		enableAutoMergeFn: func(repo string, number int) error {
+			armedRepo, armedNum = repo, number
+			return nil
+		},
+	}
+
+	r.handleAutoMerge(github.PRIssue{
+		Kind:   github.PRIssueReadyToMerge,
+		TaskID: created.ID,
+		PR: github.PullRequest{
+			Repository: "pet-owner/pet-repo",
+			Number:     2385,
+			HeadSHA:    "sha2385",
+			Mergeable:  "MERGEABLE",
+			CIStatus:   "SUCCESS",
+		},
+	})
+
+	if !mergeCalled {
+		t.Fatal("direct merge was not attempted before fallback")
+	}
+	if armedRepo != "pet-owner/pet-repo" || armedNum != 2385 {
+		t.Fatalf("armed native auto-merge for %s#%d, want pet-owner/pet-repo#2385", armedRepo, armedNum)
+	}
+	if got := tracker.Retries(created.ID, github.PRIssueReadyToMerge); got != 1 {
+		t.Fatalf("ready_to_merge retries = %d, want 1 after native handoff", got)
+	}
+}
+
+func TestHandleAutoMerge_DirectMergeOrdinaryFailureDoesNotArmNative(t *testing.T) {
+	projDir := t.TempDir()
+	projStore, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mustWriteProjectYAML(t, projDir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+	taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatalf("task NewStore: %v", err)
+	}
+	tasks := task.NewManager(taskStore, nil)
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		PRNumber:  task.Ptr(42),
+		ProjectID: task.Ptr("pet-owner/pet-repo"),
+		Reviewed:  task.Ptr(true),
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	var armed bool
+	r := &Handler{
+		logger:    slog.New(slog.DiscardHandler),
+		tasks:     tasks,
+		projects:  projStore,
+		prTracker: github.NewIssueTracker(time.Minute),
+		mergePR: func(repo string, number int) error {
+			return fmt.Errorf("gh pr merge %d: transient network failure: exit status 1", number)
+		},
+		enableAutoMergeFn: func(repo string, number int) error {
+			armed = true
+			return nil
+		},
+	}
+
+	r.handleAutoMerge(github.PRIssue{
+		Kind:   github.PRIssueReadyToMerge,
+		TaskID: created.ID,
+		PR: github.PullRequest{
+			Repository: "pet-owner/pet-repo",
+			Number:     42,
+			HeadSHA:    "sha42",
+			Mergeable:  "MERGEABLE",
+			CIStatus:   "SUCCESS",
+		},
+	})
+
+	if armed {
+		t.Fatal("ordinary direct merge failure armed native auto-merge")
 	}
 }
 

--- a/internal/sybra/review/automerge_test.go
+++ b/internal/sybra/review/automerge_test.go
@@ -486,9 +486,16 @@ func TestHandleAutoMerge_FallsBackToNativeWhenDirectMergeBlockedByPolicy(t *test
 		tasks:     tasks,
 		projects:  projStore,
 		prTracker: tracker,
+		cfg:       &config.Config{GitHub: config.GitHubConfig{NativeAutoMerge: true}},
 		mergePR: func(repo string, number int) error {
 			mergeCalled = true
 			return fmt.Errorf("gh pr merge %d: X Pull request owner/repo#%d is not mergeable: the base branch policy prohibits the merge.\nTo have the pull request merged after all the requirements have been met, add the `--auto` flag.: exit status 1", number, number)
+		},
+		supportsAutoMergeFn: func(repo, baseBranch string) (bool, error) {
+			if baseBranch != "main" {
+				t.Errorf("supportsAutoMergeFn called with baseBranch = %q, want %q", baseBranch, "main")
+			}
+			return true, nil
 		},
 		enableAutoMergeFn: func(repo string, number int) error {
 			armedRepo, armedNum = repo, number
@@ -500,11 +507,12 @@ func TestHandleAutoMerge_FallsBackToNativeWhenDirectMergeBlockedByPolicy(t *test
 		Kind:   github.PRIssueReadyToMerge,
 		TaskID: created.ID,
 		PR: github.PullRequest{
-			Repository: "pet-owner/pet-repo",
-			Number:     2385,
-			HeadSHA:    "sha2385",
-			Mergeable:  "MERGEABLE",
-			CIStatus:   "SUCCESS",
+			Repository:  "pet-owner/pet-repo",
+			Number:      2385,
+			BaseRefName: "main",
+			HeadSHA:     "sha2385",
+			Mergeable:   "MERGEABLE",
+			CIStatus:    "SUCCESS",
 		},
 	})
 
@@ -516,6 +524,83 @@ func TestHandleAutoMerge_FallsBackToNativeWhenDirectMergeBlockedByPolicy(t *test
 	}
 	if got := tracker.Retries(created.ID, github.PRIssueReadyToMerge); got != 1 {
 		t.Fatalf("ready_to_merge retries = %d, want 1 after native handoff", got)
+	}
+}
+
+func TestHandleAutoMerge_DirectMergePolicyBlockedHonorsNativeKillSwitch(t *testing.T) {
+	projDir := t.TempDir()
+	projStore, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mustWriteProjectYAML(t, projDir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+	taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatalf("task NewStore: %v", err)
+	}
+	tasks := task.NewManager(taskStore, nil)
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		PRNumber:  task.Ptr(2385),
+		ProjectID: task.Ptr("pet-owner/pet-repo"),
+		Reviewed:  task.Ptr(true),
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	tracker := github.NewIssueTracker(time.Minute)
+	var mergeCalled bool
+	var supportChecked bool
+	var armed bool
+	r := &Handler{
+		logger:    slog.New(slog.DiscardHandler),
+		tasks:     tasks,
+		projects:  projStore,
+		prTracker: tracker,
+		cfg:       &config.Config{GitHub: config.GitHubConfig{NativeAutoMerge: false}},
+		mergePR: func(repo string, number int) error {
+			mergeCalled = true
+			return fmt.Errorf("gh pr merge %d: X Pull request owner/repo#%d is not mergeable: the base branch policy prohibits the merge.\nTo have the pull request merged after all the requirements have been met, add the `--auto` flag.: exit status 1", number, number)
+		},
+		supportsAutoMergeFn: func(repo, baseBranch string) (bool, error) {
+			supportChecked = true
+			return true, nil
+		},
+		enableAutoMergeFn: func(repo string, number int) error {
+			armed = true
+			return nil
+		},
+	}
+
+	r.handleAutoMerge(github.PRIssue{
+		Kind:   github.PRIssueReadyToMerge,
+		TaskID: created.ID,
+		PR: github.PullRequest{
+			Repository:  "pet-owner/pet-repo",
+			Number:      2385,
+			BaseRefName: "main",
+			HeadSHA:     "sha2385",
+			Mergeable:   "MERGEABLE",
+			CIStatus:    "SUCCESS",
+		},
+	})
+
+	if !mergeCalled {
+		t.Fatal("direct merge was not attempted")
+	}
+	if supportChecked {
+		t.Fatal("native auto-merge support was checked while kill-switch was disabled")
+	}
+	if armed {
+		t.Fatal("native auto-merge was armed while kill-switch was disabled")
+	}
+	if got := tracker.Retries(created.ID, github.PRIssueReadyToMerge); got != 0 {
+		t.Fatalf("ready_to_merge retries = %d, want 0 when native auto-merge is disabled", got)
 	}
 }
 
@@ -551,8 +636,12 @@ func TestHandleAutoMerge_DirectMergeOrdinaryFailureDoesNotArmNative(t *testing.T
 		tasks:     tasks,
 		projects:  projStore,
 		prTracker: github.NewIssueTracker(time.Minute),
+		cfg:       &config.Config{GitHub: config.GitHubConfig{NativeAutoMerge: true}},
 		mergePR: func(repo string, number int) error {
 			return fmt.Errorf("gh pr merge %d: transient network failure: exit status 1", number)
+		},
+		supportsAutoMergeFn: func(repo, baseBranch string) (bool, error) {
+			return true, nil
 		},
 		enableAutoMergeFn: func(repo string, number int) error {
 			armed = true
@@ -564,11 +653,12 @@ func TestHandleAutoMerge_DirectMergeOrdinaryFailureDoesNotArmNative(t *testing.T
 		Kind:   github.PRIssueReadyToMerge,
 		TaskID: created.ID,
 		PR: github.PullRequest{
-			Repository: "pet-owner/pet-repo",
-			Number:     42,
-			HeadSHA:    "sha42",
-			Mergeable:  "MERGEABLE",
-			CIStatus:   "SUCCESS",
+			Repository:  "pet-owner/pet-repo",
+			Number:      42,
+			BaseRefName: "main",
+			HeadSHA:     "sha42",
+			Mergeable:   "MERGEABLE",
+			CIStatus:    "SUCCESS",
 		},
 	})
 

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -276,6 +276,23 @@ func (r *Handler) handleAutoMerge(issue github.PRIssue) {
 	}
 	r.evictReadyPRCache(issue.PR.Repository, issue.PR.Number)
 	if mergeErr != nil {
+		if !issue.PR.SourcedViaREST && requiresNativeAutoMerge(mergeErr) {
+			enableFn := r.enableAutoMergeFn
+			if enableFn == nil {
+				enableFn = github.EnableAutoMerge
+			}
+			if aerr := enableFn(issue.PR.Repository, issue.PR.Number); aerr != nil {
+				r.logger.Error("auto-merge.native-arm-failed", "task_id", t.ID, "pr", issue.PR.Number, "err", aerr)
+			} else {
+				r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
+				r.logAudit(audit.EventAutoMergeEnabled, t.ID, "", map[string]any{
+					"pr": issue.PR.Number, "repo": issue.PR.Repository,
+					"fallback": "direct_merge_rejected",
+				})
+				r.logger.Info("auto-merge.native-armed", "task_id", t.ID, "pr", issue.PR.Number, "fallback", "direct_merge_rejected")
+				return
+			}
+		}
 		r.logger.Error("auto-merge.failed", "task_id", t.ID, "pr", issue.PR.Number, "err", mergeErr)
 		return
 	}
@@ -294,6 +311,15 @@ func (r *Handler) handleAutoMerge(issue github.PRIssue) {
 	if r.onAutoMergeApplied != nil {
 		r.onAutoMergeApplied()
 	}
+}
+
+func requiresNativeAutoMerge(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "base branch policy prohibits the merge") &&
+		strings.Contains(msg, "--auto")
 }
 
 // escalateExhaustedFix parks a task whose pr-fix retry budget is spent. Trying

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -199,31 +199,10 @@ func (r *Handler) handleAutoMerge(issue github.PRIssue) {
 	// poll on GitHub's side) than Sybra's GraphQL merge-gate polling. Only
 	// tried once the CI-green-gated legacy path would otherwise fire, so this
 	// never delays a merge; it just lets GitHub finish the last mile.
-	if r.cfg != nil && r.cfg.GitHub.NativeAutoMerge && readyToArmNativeAutoMerge(issue.PR) {
-		supportsFn := r.supportsAutoMergeFn
-		if supportsFn == nil {
-			supportsFn = github.SupportsNativeAutoMerge
-		}
-		ok, serr := supportsFn(issue.PR.Repository, issue.PR.BaseRefName)
-		if serr != nil {
-			r.logger.Error("auto-merge.native-support-check-failed", "task_id", t.ID, "pr", issue.PR.Number, "err", serr)
-		}
-		if serr == nil && ok {
-			enableFn := r.enableAutoMergeFn
-			if enableFn == nil {
-				enableFn = github.EnableAutoMerge
-			}
-			if aerr := enableFn(issue.PR.Repository, issue.PR.Number); aerr != nil {
-				r.logger.Error("auto-merge.native-arm-failed", "task_id", t.ID, "pr", issue.PR.Number, "err", aerr)
-			} else {
-				r.evictReadyPRCache(issue.PR.Repository, issue.PR.Number)
-				r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
-				r.logAudit(audit.EventAutoMergeEnabled, t.ID, "", map[string]any{
-					"pr": issue.PR.Number, "repo": issue.PR.Repository,
-				})
-				r.logger.Info("auto-merge.native-armed", "task_id", t.ID, "pr", issue.PR.Number)
-				return
-			}
+	if r.nativeAutoMergeEnabled() && readyToArmNativeAutoMerge(issue.PR) {
+		if r.tryArmNativeAutoMerge(t, issue, "") {
+			r.evictReadyPRCache(issue.PR.Repository, issue.PR.Number)
+			return
 		}
 	}
 
@@ -276,20 +255,8 @@ func (r *Handler) handleAutoMerge(issue github.PRIssue) {
 	}
 	r.evictReadyPRCache(issue.PR.Repository, issue.PR.Number)
 	if mergeErr != nil {
-		if !issue.PR.SourcedViaREST && requiresNativeAutoMerge(mergeErr) {
-			enableFn := r.enableAutoMergeFn
-			if enableFn == nil {
-				enableFn = github.EnableAutoMerge
-			}
-			if aerr := enableFn(issue.PR.Repository, issue.PR.Number); aerr != nil {
-				r.logger.Error("auto-merge.native-arm-failed", "task_id", t.ID, "pr", issue.PR.Number, "err", aerr)
-			} else {
-				r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
-				r.logAudit(audit.EventAutoMergeEnabled, t.ID, "", map[string]any{
-					"pr": issue.PR.Number, "repo": issue.PR.Repository,
-					"fallback": "direct_merge_rejected",
-				})
-				r.logger.Info("auto-merge.native-armed", "task_id", t.ID, "pr", issue.PR.Number, "fallback", "direct_merge_rejected")
+		if r.nativeAutoMergeEnabled() && !issue.PR.SourcedViaREST && requiresNativeAutoMerge(mergeErr) {
+			if r.tryArmNativeAutoMerge(t, issue, "direct_merge_rejected") {
 				return
 			}
 		}
@@ -311,6 +278,47 @@ func (r *Handler) handleAutoMerge(issue github.PRIssue) {
 	if r.onAutoMergeApplied != nil {
 		r.onAutoMergeApplied()
 	}
+}
+
+func (r *Handler) nativeAutoMergeEnabled() bool {
+	return r.cfg != nil && r.cfg.GitHub.NativeAutoMerge
+}
+
+func (r *Handler) tryArmNativeAutoMerge(t task.Task, issue github.PRIssue, fallback string) bool {
+	supportsFn := r.supportsAutoMergeFn
+	if supportsFn == nil {
+		supportsFn = github.SupportsNativeAutoMerge
+	}
+	ok, serr := supportsFn(issue.PR.Repository, issue.PR.BaseRefName)
+	if serr != nil {
+		r.logger.Error("auto-merge.native-support-check-failed", "task_id", t.ID, "pr", issue.PR.Number, "err", serr)
+		return false
+	}
+	if !ok {
+		return false
+	}
+
+	enableFn := r.enableAutoMergeFn
+	if enableFn == nil {
+		enableFn = github.EnableAutoMerge
+	}
+	if aerr := enableFn(issue.PR.Repository, issue.PR.Number); aerr != nil {
+		r.logger.Error("auto-merge.native-arm-failed", "task_id", t.ID, "pr", issue.PR.Number, "err", aerr)
+		return false
+	}
+
+	r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
+	auditData := map[string]any{"pr": issue.PR.Number, "repo": issue.PR.Repository}
+	if fallback != "" {
+		auditData["fallback"] = fallback
+	}
+	r.logAudit(audit.EventAutoMergeEnabled, t.ID, "", auditData)
+	if fallback != "" {
+		r.logger.Info("auto-merge.native-armed", "task_id", t.ID, "pr", issue.PR.Number, "fallback", fallback)
+	} else {
+		r.logger.Info("auto-merge.native-armed", "task_id", t.ID, "pr", issue.PR.Number)
+	}
+	return true
 }
 
 func requiresNativeAutoMerge(err error) bool {


### PR DESCRIPTION
## Summary
- detect GitHub's protected-branch rejection that tells callers to use --auto
- arm native auto-merge as a fallback after Sybra's normal merge gate has already approved the PR
- mark the ready_to_merge issue handled after the native handoff so Sybra does not retry direct merge every poll

## Verification
- go test ./internal/sybra/review
- go test ./internal/workflow ./internal/github ./internal/sybra/review