### PR TITLE
fix(workflow): avoid duplicate PRs after squash merge

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1167,6 +1167,7 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetPRCreator(prCreatorAdapter{})
 	a.workflowEngine.SetPRCloser(prCloserAdapter{})
 	a.workflowEngine.SetPRFinder(prFinderAdapter{})
+	a.workflowEngine.SetPRAnyStateFinder(prFinderAdapter{})
 	a.workflowEngine.SetPRContentGenerator(prContentGeneratorAdapter{gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}})
 	a.workflowEngine.SetTaskClassifier(&taskClassifierAdapter{
 		tasks:      a.tasks,

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -403,6 +403,10 @@ func (prFinderAdapter) FindPRForBranch(ctx context.Context, repo, head string) (
 	return github.FindPRForBranch(ctx, repo, head)
 }
 
+func (prFinderAdapter) FindPRForBranchAnyState(ctx context.Context, repo, head string) (number int, state string, found bool, err error) {
+	return github.FindPRForBranchAnyState(ctx, repo, head)
+}
+
 // prContentGeneratorAdapter wires the workflow engine's PRContentGenerator
 // interface to internal/prcontent's LLM-backed drafter.
 type prContentGeneratorAdapter struct {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -248,6 +248,14 @@ type PRFinder interface {
 	FindPRForBranch(ctx context.Context, repo, head string) (number int, found bool, err error)
 }
 
+// PRAnyStateFinder resolves a PR for a head branch across open and merged
+// states. Used as a stronger duplicate guard before create_pr opens a new PR:
+// a previously squash-merged PR can leave the branch tip non-ancestor of base
+// while the tree diff is already present on base.
+type PRAnyStateFinder interface {
+	FindPRForBranchAnyState(ctx context.Context, repo, head string) (number int, state string, found bool, err error)
+}
+
 // PRCreateRequest describes a new pull request to open for an
 // already-pushed branch.
 type PRCreateRequest struct {
@@ -324,6 +332,7 @@ type Engine struct {
 	prCreator        PRCreator
 	prCloser         PRCloser
 	prFinder         PRFinder
+	prAnyStateFinder PRAnyStateFinder
 	prContentGen     PRContentGenerator
 	worktrees        WorktreeGetter
 	attemptNotes     AttemptNoteAppender
@@ -527,6 +536,10 @@ func (e *Engine) SetPRCloser(c PRCloser) { e.prCloser = c }
 // SetPRFinder wires the open-PR-by-branch lookup used by create_pr's
 // idempotency guard. Leaving it unset skips the guard.
 func (e *Engine) SetPRFinder(f PRFinder) { e.prFinder = f }
+
+// SetPRAnyStateFinder wires the all-state branch lookup used by create_pr's
+// squash-merge duplicate guard. Leaving it unset skips the guard.
+func (e *Engine) SetPRAnyStateFinder(f PRAnyStateFinder) { e.prAnyStateFinder = f }
 
 // SetPRContentGenerator wires the LLM-backed title/body drafter used by the
 // `create_pr` step. Leaving it unset falls back to a templated title/body.

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -1,12 +1,10 @@
 package workflow
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -469,12 +467,8 @@ func (e *Engine) handleExistingAnyStatePRForBranch(taskID string, step *Step, wt
 			return StepOutput{}, false
 		}
 		reason := fmt.Sprintf("branch already landed via merged PR #%d and has no remaining diff against base", num)
-		if err := e.tasks.UpdateTaskStatus(taskID, "done", reason); err != nil {
-			e.logger.Warn("workflow.create-pr.merged-branch-status", "task_id", taskID, "pr", num, "err", err)
-			return StepOutput{}, false
-		}
 		e.logger.Info("workflow.create-pr.merged-branch-done", "task_id", taskID, "pr", num)
-		out, _ := stepDone(step, reason)
+		out := StepOutput{StepID: step.ID, Status: "completed", Output: reason, TerminalStatus: "done", TerminalReason: reason}
 		return out, true
 	default:
 		return StepOutput{}, false
@@ -509,23 +503,25 @@ func branchPatchAlreadyAppliedToBase(ctx context.Context, wtPath string) (bool, 
 		return false, fmt.Errorf("create temp base tree: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
+	baseTreeDir := filepath.Join(tmpDir, "base")
 
-	archiveCmd := exec.CommandContext(ctx, "git", "archive", "--format=tar", baseRef)
-	archiveCmd.Dir = wtPath
-	archiveOut, err := archiveCmd.Output()
+	addCmd := exec.CommandContext(ctx, "git", "worktree", "add", "--detach", baseTreeDir, baseRef)
+	addCmd.Dir = wtPath
+	addOut, err := addCmd.CombinedOutput()
 	if err != nil {
-		return false, fmt.Errorf("git archive %s: %w", baseRef, err)
+		return false, fmt.Errorf("git worktree add %s: %w: %s", baseRef, err, strings.TrimSpace(string(addOut)))
 	}
-	if err := extractTar(archiveOut, tmpDir); err != nil {
-		return false, err
-	}
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), shellTimeout)
+		defer cleanupCancel()
+		rmCmd := exec.CommandContext(cleanupCtx, "git", "worktree", "remove", "--force", baseTreeDir)
+		rmCmd.Dir = wtPath
+		_ = rmCmd.Run()
+	}()
 
-	patchPath := filepath.Join(tmpDir, ".sybra-branch.patch")
-	if err := os.WriteFile(patchPath, patch, 0o600); err != nil {
-		return false, fmt.Errorf("write branch patch: %w", err)
-	}
-	cmd := exec.CommandContext(ctx, "git", "apply", "--check", "--reverse", "--whitespace=nowarn", patchPath)
-	cmd.Dir = tmpDir
+	cmd := exec.CommandContext(ctx, "git", "apply", "--check", "--reverse", "--whitespace=nowarn", "-")
+	cmd.Dir = baseTreeDir
+	cmd.Stdin = bytes.NewReader(patch)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		return true, nil
@@ -539,54 +535,6 @@ func branchPatchAlreadyAppliedToBase(ctx context.Context, wtPath string) (bool, 
 		return false, fmt.Errorf("git apply --reverse --check: %w", err)
 	}
 	return false, fmt.Errorf("git apply --reverse --check: %w: %s", err, detail)
-}
-
-func extractTar(data []byte, dest string) error {
-	tr := tar.NewReader(bytes.NewReader(data))
-	for {
-		hdr, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("read base archive: %w", err)
-		}
-		target := filepath.Join(dest, hdr.Name)
-		cleanDest := filepath.Clean(dest) + string(os.PathSeparator)
-		cleanTarget := filepath.Clean(target)
-		if cleanTarget != filepath.Clean(dest) && !strings.HasPrefix(cleanTarget, cleanDest) {
-			return fmt.Errorf("archive path escapes destination: %s", hdr.Name)
-		}
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
-				return fmt.Errorf("create archive dir %s: %w", hdr.Name, err)
-			}
-		case tar.TypeReg, tar.TypeRegA:
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-				return fmt.Errorf("create archive parent %s: %w", hdr.Name, err)
-			}
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
-			if err != nil {
-				return fmt.Errorf("create archive file %s: %w", hdr.Name, err)
-			}
-			_, copyErr := io.Copy(f, tr)
-			closeErr := f.Close()
-			if copyErr != nil {
-				return fmt.Errorf("write archive file %s: %w", hdr.Name, copyErr)
-			}
-			if closeErr != nil {
-				return fmt.Errorf("close archive file %s: %w", hdr.Name, closeErr)
-			}
-		case tar.TypeSymlink:
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-				return fmt.Errorf("create archive parent %s: %w", hdr.Name, err)
-			}
-			if err := os.Symlink(hdr.Linkname, target); err != nil {
-				return fmt.Errorf("create archive symlink %s: %w", hdr.Name, err)
-			}
-		}
-	}
 }
 
 // verifyPushedHead best-effort verifies the PR head now matches local HEAD

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -1,10 +1,15 @@
 package workflow
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -70,6 +75,9 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 			return StepOutput{}, fmt.Errorf("create_pr: link existing pr: %w", err)
 		}
 		return stepDone(step, fmt.Sprintf("pr #%d already exists for branch", existing))
+	}
+	if out, done := e.handleExistingAnyStatePRForBranch(taskID, step, wtPath, t, headArg); done {
+		return out, nil
 	}
 
 	if out, err, ok := e.pushTaskBranch(taskID, step, wfExec, t, wtPath, branch); !ok {
@@ -426,6 +434,159 @@ func (e *Engine) findExistingPRForBranch(repo, branch string) (number int, ok bo
 		return 0, false
 	}
 	return num, found
+}
+
+func (e *Engine) handleExistingAnyStatePRForBranch(taskID string, step *Step, wtPath string, t TaskInfo, headArg string) (StepOutput, bool) {
+	if e.prAnyStateFinder == nil {
+		return StepOutput{}, false
+	}
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+	num, state, found, err := e.prAnyStateFinder.FindPRForBranchAnyState(ctx, t.ProjectID, headArg)
+	if err != nil {
+		e.logger.Warn("workflow.create-pr.find-any-state", "task_id", taskID, "repo", t.ProjectID, "head", headArg, "err", err)
+		return StepOutput{}, false
+	}
+	if !found {
+		return StepOutput{}, false
+	}
+	switch state {
+	case "OPEN":
+		if err := e.linkTaskPR(taskID, t, num); err != nil {
+			e.logger.Warn("workflow.create-pr.link-any-state-open", "task_id", taskID, "pr", num, "err", err)
+			return StepOutput{}, false
+		}
+		out, _ := stepDone(step, fmt.Sprintf("pr #%d already exists for branch", num))
+		return out, true
+	case "MERGED":
+		clean, cleanErr := branchPatchAlreadyAppliedToBase(ctx, wtPath)
+		if cleanErr != nil {
+			e.logger.Warn("workflow.create-pr.merged-branch-diff", "task_id", taskID, "pr", num, "err", cleanErr)
+			return StepOutput{}, false
+		}
+		if !clean {
+			e.logger.Info("workflow.create-pr.merged-branch-has-diff", "task_id", taskID, "pr", num)
+			return StepOutput{}, false
+		}
+		reason := fmt.Sprintf("branch already landed via merged PR #%d and has no remaining diff against base", num)
+		if err := e.tasks.UpdateTaskStatus(taskID, "done", reason); err != nil {
+			e.logger.Warn("workflow.create-pr.merged-branch-status", "task_id", taskID, "pr", num, "err", err)
+			return StepOutput{}, false
+		}
+		e.logger.Info("workflow.create-pr.merged-branch-done", "task_id", taskID, "pr", num)
+		out, _ := stepDone(step, reason)
+		return out, true
+	default:
+		return StepOutput{}, false
+	}
+}
+
+func branchPatchAlreadyAppliedToBase(ctx context.Context, wtPath string) (bool, error) {
+	baseRef := resolveOriginBase(ctx, wtPath)
+	mergeBaseCmd := exec.CommandContext(ctx, "git", "merge-base", baseRef, "HEAD")
+	mergeBaseCmd.Dir = wtPath
+	mergeBaseOut, err := mergeBaseCmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git merge-base %s HEAD: %w", baseRef, err)
+	}
+	mergeBase := strings.TrimSpace(string(mergeBaseOut))
+	if mergeBase == "" {
+		return false, fmt.Errorf("git merge-base %s HEAD: empty output", baseRef)
+	}
+
+	diffCmd := exec.CommandContext(ctx, "git", "diff", "--binary", mergeBase+"..HEAD", "--")
+	diffCmd.Dir = wtPath
+	patch, err := diffCmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git diff %s..HEAD: %w", mergeBase, err)
+	}
+	if len(bytes.TrimSpace(patch)) == 0 {
+		return true, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "sybra-branch-base-*")
+	if err != nil {
+		return false, fmt.Errorf("create temp base tree: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	archiveCmd := exec.CommandContext(ctx, "git", "archive", "--format=tar", baseRef)
+	archiveCmd.Dir = wtPath
+	archiveOut, err := archiveCmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git archive %s: %w", baseRef, err)
+	}
+	if err := extractTar(archiveOut, tmpDir); err != nil {
+		return false, err
+	}
+
+	patchPath := filepath.Join(tmpDir, ".sybra-branch.patch")
+	if err := os.WriteFile(patchPath, patch, 0o600); err != nil {
+		return false, fmt.Errorf("write branch patch: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "git", "apply", "--check", "--reverse", "--whitespace=nowarn", patchPath)
+	cmd.Dir = tmpDir
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	detail := strings.TrimSpace(string(out))
+	if detail == "" {
+		return false, fmt.Errorf("git apply --reverse --check: %w", err)
+	}
+	return false, fmt.Errorf("git apply --reverse --check: %w: %s", err, detail)
+}
+
+func extractTar(data []byte, dest string) error {
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read base archive: %w", err)
+		}
+		target := filepath.Join(dest, hdr.Name)
+		cleanDest := filepath.Clean(dest) + string(os.PathSeparator)
+		cleanTarget := filepath.Clean(target)
+		if cleanTarget != filepath.Clean(dest) && !strings.HasPrefix(cleanTarget, cleanDest) {
+			return fmt.Errorf("archive path escapes destination: %s", hdr.Name)
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+				return fmt.Errorf("create archive dir %s: %w", hdr.Name, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create archive parent %s: %w", hdr.Name, err)
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
+			if err != nil {
+				return fmt.Errorf("create archive file %s: %w", hdr.Name, err)
+			}
+			_, copyErr := io.Copy(f, tr)
+			closeErr := f.Close()
+			if copyErr != nil {
+				return fmt.Errorf("write archive file %s: %w", hdr.Name, copyErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close archive file %s: %w", hdr.Name, closeErr)
+			}
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create archive parent %s: %w", hdr.Name, err)
+			}
+			if err := os.Symlink(hdr.Linkname, target); err != nil {
+				return fmt.Errorf("create archive symlink %s: %w", hdr.Name, err)
+			}
+		}
+	}
 }
 
 // verifyPushedHead best-effort verifies the PR head now matches local HEAD

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -114,6 +114,19 @@ func (f *fakePRFinder) FindPRForBranch(context.Context, string, string) (number 
 	return f.number, f.found, f.err
 }
 
+type fakePRAnyStateFinder struct {
+	number int
+	state  string
+	found  bool
+	err    error
+	calls  int
+}
+
+func (f *fakePRAnyStateFinder) FindPRForBranchAnyState(context.Context, string, string) (number int, state string, found bool, err error) {
+	f.calls++
+	return f.number, f.state, f.found, f.err
+}
+
 type fakePRCloser struct {
 	err      error
 	calls    int
@@ -663,6 +676,89 @@ func TestExecCreatePR_ExistingPRShortCircuitsWithoutCreating(t *testing.T) {
 	}
 	if ti.Status == "human-required" {
 		t.Errorf("task should not be human-required: %s", tasks.Reason("t1"))
+	}
+}
+
+func TestExecCreatePR_MergedSameBranchWithAppliedPatchMarksDoneWithoutCreating(t *testing.T) {
+	bare, wtPath := newPRWorktree(t, "feat/my-branch")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+
+	upstream := filepath.Join(t.TempDir(), "upstream")
+	runGit(t, t.TempDir(), "clone", bare, upstream)
+	runGit(t, upstream, "config", "user.email", "test@test.com")
+	runGit(t, upstream, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(upstream, "change.txt"), []byte("feat: task work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(upstream, "unrelated.txt"), []byte("newer main work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, upstream, "add", "change.txt", "unrelated.txt")
+	runGit(t, upstream, "commit", "-m", "squash equivalent plus unrelated")
+	runGit(t, upstream, "push", "origin", "main")
+	runGit(t, wtPath, "fetch", bare, "main:refs/remotes/origin/main")
+
+	tasks := newMemTasks()
+	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
+	tasks.Put(task)
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	anyState := &fakePRAnyStateFinder{number: 77, state: "MERGED", found: true}
+	engine.SetPRAnyStateFinder(anyState)
+	creator := &fakePRCreator{number: 999, headSHA: headSHA(t, wtPath)}
+	engine.SetPRCreator(creator)
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execCreatePR: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, output = %q", out.Status, out.Output)
+	}
+	if anyState.calls != 1 {
+		t.Fatalf("any-state finder calls = %d, want 1", anyState.calls)
+	}
+	if creator.gotReq.Repo != "" {
+		t.Fatal("CreatePR must not be called when the branch patch already landed via a merged PR")
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "done" {
+		t.Fatalf("status = %q, want done", ti.Status)
+	}
+	if !strings.Contains(ti.StatusReason, "merged PR #77") {
+		t.Fatalf("status reason = %q, want merged PR reference", ti.StatusReason)
+	}
+}
+
+func TestExecCreatePR_MergedSameBranchWithRemainingPatchStillCreates(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/my-branch")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+
+	tasks := newMemTasks()
+	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
+	tasks.Put(task)
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetPRAnyStateFinder(&fakePRAnyStateFinder{number: 77, state: "MERGED", found: true})
+	creator := &fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)}
+	engine.SetPRCreator(creator)
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execCreatePR: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, output = %q", out.Status, out.Output)
+	}
+	if creator.gotReq.Repo == "" {
+		t.Fatal("CreatePR must be called when the branch still contributes a patch")
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status == "done" {
+		t.Fatal("task must not be marked done while the branch still has unapplied work")
+	}
+	if ti.PRNumber != 42 {
+		t.Fatalf("PRNumber = %d, want 42", ti.PRNumber)
 	}
 }
 

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -721,12 +721,15 @@ func TestExecCreatePR_MergedSameBranchWithAppliedPatchMarksDoneWithoutCreating(t
 	if creator.gotReq.Repo != "" {
 		t.Fatal("CreatePR must not be called when the branch patch already landed via a merged PR")
 	}
-	ti, _ := tasks.GetTask("t1")
-	if ti.Status != "done" {
-		t.Fatalf("status = %q, want done", ti.Status)
+	if out.TerminalStatus != "done" {
+		t.Fatalf("TerminalStatus = %q, want done", out.TerminalStatus)
 	}
-	if !strings.Contains(ti.StatusReason, "merged PR #77") {
-		t.Fatalf("status reason = %q, want merged PR reference", ti.StatusReason)
+	if !strings.Contains(out.TerminalReason, "merged PR #77") {
+		t.Fatalf("TerminalReason = %q, want merged PR reference", out.TerminalReason)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "ready-pr" {
+		t.Fatalf("status = %q, want unchanged ready-pr before AdvanceStep handles terminal output", ti.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

- check same-branch PRs across all states before create_pr opens a new PR
- mark the task done when the branch already landed through a merged PR and its patch is present on the current base
- keep creating a PR when the branch still contributes unapplied work

## Verification

- go test ./internal/workflow -run 'TestExecCreatePR_MergedSameBranchWithAppliedPatchMarksDoneWithoutCreating|TestExecCreatePR_MergedSameBranchWithRemainingPatchStillCreates'
- go test ./internal/workflow -run 'TestExecCreatePR_(ExistingPRShortCircuitsWithoutCreating|MergedSameBranchWithAppliedPatchMarksDoneWithoutCreating|MergedSameBranchWithRemainingPatchStillCreates|FinderErrorFallsThroughToCreate|AdoptsExistingPROnAlreadyExistsConflict)'
- go test ./internal/sybra

Note: a broader go test ./internal/workflow ./internal/sybra run had unrelated existing failures in workflow timeout-scaling tests.