### PR TITLE
fix(agent): avoid blocking state views on stdin writes

### DIFF
--- a/internal/agent/convo_io.go
+++ b/internal/agent/convo_io.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 )
 
 // convoIO owns the conversational agent transport plus the existing
@@ -11,6 +12,7 @@ import (
 type convoIO struct {
 	stdinPipe io.WriteCloser
 	stdinMu   sync.Mutex
+	hasPipe   atomic.Bool
 
 	// stdinPath is the FIFO backing a detached conversational agent's stdin,
 	// reopened on reattach so follow-up messages survive a restart. Empty for
@@ -36,6 +38,7 @@ func (c *convoIO) installStdinPipe(pipe io.WriteCloser) error {
 		return fmt.Errorf("stdin pipe already installed")
 	}
 	c.stdinPipe = pipe
+	c.hasPipe.Store(pipe != nil)
 	return nil
 }
 
@@ -45,6 +48,7 @@ func (c *convoIO) replaceStdinPipe(pipe io.WriteCloser) {
 		_ = c.stdinPipe.Close()
 	}
 	c.stdinPipe = pipe
+	c.hasPipe.Store(pipe != nil)
 	c.stdinMu.Unlock()
 }
 
@@ -68,12 +72,11 @@ func (c *convoIO) closeStdinPipe() {
 	if c.stdinPipe != nil {
 		_ = c.stdinPipe.Close()
 		c.stdinPipe = nil
+		c.hasPipe.Store(false)
 	}
 	c.stdinMu.Unlock()
 }
 
 func (c *convoIO) hasStdinPipe() bool {
-	c.stdinMu.Lock()
-	defer c.stdinMu.Unlock()
-	return c.stdinPipe != nil
+	return c.hasPipe.Load()
 }

--- a/internal/agent/convo_io_test.go
+++ b/internal/agent/convo_io_test.go
@@ -95,7 +95,7 @@ func TestConvoIOHasStdinPipeDoesNotBlockBehindWrite(t *testing.T) {
 		if !got {
 			t.Fatal("hasStdinPipe = false, want true")
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("hasStdinPipe blocked behind writeStdin")
 	}
 

--- a/internal/agent/convo_io_test.go
+++ b/internal/agent/convo_io_test.go
@@ -2,7 +2,9 @@ package agent
 
 import (
 	"bytes"
+	"errors"
 	"testing"
+	"time"
 )
 
 type recordingWriteCloser struct {
@@ -54,4 +56,49 @@ func TestConvoIOReplaceStdinPipeClosesPrevious(t *testing.T) {
 	if got := second.String(); got != "next" {
 		t.Fatalf("second pipe got %q, want next", got)
 	}
+}
+
+type blockingWriteCloser struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (w *blockingWriteCloser) Write(_ []byte) (int, error) {
+	close(w.started)
+	<-w.release
+	return 0, errors.New("released")
+}
+
+func (w *blockingWriteCloser) Close() error { return nil }
+
+func TestConvoIOHasStdinPipeDoesNotBlockBehindWrite(t *testing.T) {
+	c := convoIO{}
+	w := &blockingWriteCloser{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	c.replaceStdinPipe(w)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- c.writeStdin([]byte("blocked"))
+	}()
+	<-w.started
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- c.hasStdinPipe()
+	}()
+
+	select {
+	case got := <-result:
+		if !got {
+			t.Fatal("hasStdinPipe = false, want true")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("hasStdinPipe blocked behind writeStdin")
+	}
+
+	close(w.release)
+	<-done
 }


### PR DESCRIPTION
## Summary
- make stdin transport presence readable without taking the stdin write mutex
- prevent agent state serialization/UI event emission from blocking behind a stuck provider stdin write
- add regression coverage for non-blocking hasStdinPipe behavior

## Verification
- env SYBRA_HOME=/private/tmp/sybra-leak-test GOCACHE=/private/tmp/sybra-go-build GOTMPDIR=/private/tmp GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test -run 'TestConvoIO|TestStopAgent|TestStopCompletedAgent|TestStopHeadlessDoesNotCallOnComplete|TestShutdown|TestGuardrails_CostHardStop_CompletedTurnIsNotAFailure|TestHeadlessUnsteeredClosesAndCompletes|TestTerminalResultIdle' ./internal/agent
- env SYBRA_HOME=/private/tmp/sybra-leak-test-workflow GOCACHE=/private/tmp/sybra-go-build GOTMPDIR=/private/tmp GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./internal/confighot ./internal/watcher ./internal/loopagent ./internal/workflow
- git diff --check

Note: full internal/agent and internal/sse package runs are blocked in this sandbox by localhost listener restrictions in approval/httptest tests.