### PR TITLE
fix(workflow): retry no-pr remote outages

### DIFF
--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -17,6 +17,8 @@ var transientNetworkMarkers = []string{
 	"connection refused",
 	"connection reset",
 	"connection timed out",
+	"failed to connect",
+	"couldn't connect to server",
 	"could not resolve host",
 	"couldn't resolve host",
 	"network is unreachable",

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -122,6 +122,16 @@ func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Executi
 			return out, err
 		}
 	}
+	if !reviewHoldForced && prFixShouldResumeNoPRRecovery(t, reason) {
+		msg := "retryable no-PR remote outage; resuming original workflow: " + reason
+		workflowID := ""
+		if wfExec != nil {
+			workflowID = wfExec.WorkflowID
+		}
+		e.logger.Warn("workflow.pr-fix.no-pr-retryable-remote",
+			"task_id", taskID, "workflow", workflowID, "reason", reason)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
+	}
 	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 		return StepOutput{}, fmt.Errorf("route pr-fix result: set human-required: %w", err)
 	}
@@ -142,6 +152,25 @@ func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Executi
 		}
 	}
 	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+}
+
+func prFixShouldResumeNoPRRecovery(t TaskInfo, reason string) bool {
+	if t.PRNumber > 0 {
+		return false
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return false
+	}
+	lower := strings.ToLower(reason)
+	if strings.Contains(lower, "missing credential") || strings.Contains(lower, "authentication") || strings.Contains(lower, "permission denied") {
+		return false
+	}
+	if project.IsTransientNetworkError(errors.New(reason)) {
+		return true
+	}
+	return strings.Contains(lower, "remote unreachable") ||
+		(strings.Contains(lower, "transport") && strings.Contains(lower, "github"))
 }
 
 func prFixAllowsResolvedMergeRecovery(reason string) bool {

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -913,6 +913,53 @@ func TestExecRoutePRFixResult_HumanRequiredWithoutFailingTestsNoNote(t *testing.
 	}
 }
 
+func TestExecRoutePRFixResult_NoPRRemoteOutageResumesRecovery(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "branch-conflict-fix",
+		CurrentStep: "route_result",
+		State:       ExecRunning,
+		Variables: map[string]string{
+			resumeStatusVar:       "in-progress",
+			resumeStatusReasonVar: "",
+			resumeWorkflowIDVar:   "simple-task-implement",
+			resumeWorkflowStepVar: "implement",
+		},
+		StepHistory: []StepRecord{{
+			StepID: "fix",
+			Status: "completed",
+			Output: "Focused regression tests passed.\n" +
+				"SYBRA_PR_FIX_RESULT: human-required\n" +
+				"SYBRA_PR_FIX_REASON: GitHub remote unreachable from this environment; fetch/push blocked by HTTPS transport failure to github.com:443: Failed to connect to github.com port 443\n",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", ProjectID: "Automaat/sybra", PRNumber: 0, Workflow: wf})
+
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_result"}, wf, TaskInfo{ID: "t1", ProjectID: "Automaat/sybra"})
+	if err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	if !strings.Contains(out.Output, "retryable no-PR remote outage") {
+		t.Fatalf("output = %q, want retryable no-PR remote outage", out.Output)
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == "human-required" {
+		t.Fatalf("status = %q, want recovery to continue toward resume_original", got.Status)
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress", got.Status)
+	}
+}
+
 // A flake verdict must not park a human and must not reach verify_commits,
 // which would fail the task for the missing commit the honest answer implies.
 func TestExecRoutePRFixResult_FlakeRoutesToInReviewWithoutCommit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat no-PR pr-fix GitHub transport failures as retryable recovery instead of human-required
- Let branch-conflict recovery continue to resume_original so similar tasks start again after remote outages
- Expand transient git network markers for failed-to-connect variants

## Tests
- go test ./internal/workflow -run 'TestExecRoutePRFixResult' -count=1
- go test ./internal/project -run TestIsTransientNetworkError -count=1