### PR TITLE
fix(monitor): keep review tasks moving autonomously

### DIFF
--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -63,6 +64,10 @@ type Deps struct {
 	// recovery path so the monitor detection immediately hands the
 	// in-progress task back to workflow/agent recovery on the assigned node.
 	RecoverLostAgent func(context.Context, string)
+	// FetchPRState checks linked PR terminal state. Production uses GitHub REST
+	// so human-required tasks whose PR landed outside the normal review poll
+	// loop do not wait for an LLM stuck-task investigation.
+	FetchPRState func(repo string, number int) (github.PRState, error)
 }
 
 // Service runs the monitor loop. It is constructed once at app startup and
@@ -80,6 +85,7 @@ type Service struct {
 	now                 func() time.Time
 	allowsProject       func(string) bool
 	downgradeLLMForTask func(taskID string) bool
+	fetchPRState        func(repo string, number int) (github.PRState, error)
 	state               *runState
 	rem                 *remediator
 }
@@ -106,6 +112,9 @@ func NewService(d Deps) *Service {
 	if d.Emit == nil {
 		d.Emit = func(string, any) {}
 	}
+	if d.FetchPRState == nil {
+		d.FetchPRState = github.FetchPRStateViaREST
+	}
 	return &Service{
 		cfg:                 d.Cfg,
 		tasks:               d.Tasks,
@@ -119,6 +128,7 @@ func NewService(d Deps) *Service {
 		now:                 d.Now,
 		allowsProject:       d.AllowsProject,
 		downgradeLLMForTask: d.DowngradeLLMForTask,
+		fetchPRState:        d.FetchPRState,
 		state:               newRunState(),
 		rem:                 newRemediator(d.Tasks, d.RecoverLostAgent),
 	}
@@ -178,6 +188,16 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
+	preRemediated := []string(nil)
+	if !s.observerOnly {
+		preRemediated = s.closeMergedHumanRequiredPRs(ctx, tasks)
+		if len(preRemediated) > 0 {
+			tasks, err = s.tasks.List()
+			if err != nil {
+				return Report{}, err
+			}
+		}
+	}
 	since15 := now.Add(-15 * time.Minute)
 	events15, _ := s.audit.Read(audit.Query{Since: since15, Until: now})
 	since1h := now.Add(-1 * time.Hour)
@@ -200,7 +220,7 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 
 	if !s.observerOnly {
 		rem := s.applyRemediations(ctx, report.Anomalies)
-		report.Remediated = rem.labels
+		report.Remediated = append(preRemediated, rem.labels...)
 		report.Dispatched = s.dispatchLLMAnomalies(ctx, now, report.Anomalies)
 		opened, updated := s.fileIssues(ctx, now, report.Anomalies, rem.skipIssueForFP)
 		report.IssuesOpened = opened
@@ -214,6 +234,46 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 		metrics.MonitorAnomaly(ctx, string(report.Anomalies[i].Kind))
 	}
 	return report, nil
+}
+
+func (s *Service) closeMergedHumanRequiredPRs(ctx context.Context, tasks []task.Task) []string {
+	_ = ctx
+	if s.fetchPRState == nil {
+		return nil
+	}
+	var labels []string
+	for i := range tasks {
+		t := &tasks[i]
+		if t.Status != task.StatusHumanRequired || t.ProjectID == "" || t.PRNumber == 0 {
+			continue
+		}
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
+		if !projectAllowed(s.allowsProject, t.ProjectID) {
+			continue
+		}
+		state, err := s.fetchPRState(t.ProjectID, t.PRNumber)
+		if err != nil {
+			s.logger.Debug("monitor.human-required-pr-state.failed", "task_id", t.ID, "pr", t.PRNumber, "err", err)
+			continue
+		}
+		if state.State != "MERGED" {
+			continue
+		}
+		if _, err := s.tasks.Update(t.ID, task.Update{
+			Status:       task.Ptr(task.StatusDone),
+			StatusReason: task.Ptr("monitor: linked PR already merged"),
+			Outcome:      task.Ptr("merged"),
+		}); err != nil {
+			s.logger.Warn("monitor.human-required-pr-merged.update_failed", "task_id", t.ID, "pr", t.PRNumber, "err", err)
+			continue
+		}
+		label := "linked_pr_merged:" + t.ID
+		labels = append(labels, label)
+		s.logger.Info("monitor.human-required-pr-merged", "task_id", t.ID, "pr", t.PRNumber)
+	}
+	return labels
 }
 
 func (s *Service) logPRGapGraceSuppressions(tasks []task.Task, now time.Time) {

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -220,7 +220,9 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 
 	if !s.observerOnly {
 		rem := s.applyRemediations(ctx, report.Anomalies)
-		report.Remediated = append(preRemediated, rem.labels...)
+		report.Remediated = make([]string, 0, len(preRemediated)+len(rem.labels))
+		report.Remediated = append(report.Remediated, preRemediated...)
+		report.Remediated = append(report.Remediated, rem.labels...)
 		report.Dispatched = s.dispatchLLMAnomalies(ctx, now, report.Anomalies)
 		opened, updated := s.fileIssues(ctx, now, report.Anomalies, rem.skipIssueForFP)
 		report.IssuesOpened = opened

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -62,6 +63,9 @@ func (f *fakeTasks) Update(id string, u task.Update) (task.Task, error) {
 		}
 		if u.StatusReason != nil {
 			f.tasks[i].StatusReason = *u.StatusReason
+		}
+		if u.Outcome != nil {
+			f.tasks[i].Outcome = *u.Outcome
 		}
 		return f.tasks[i], nil
 	}
@@ -243,6 +247,55 @@ func TestServiceTickEndToEnd(t *testing.T) {
 	}
 	if report.IssuesOpened != 1 || report.IssuesUpdated != 0 {
 		t.Errorf("want issuesOpened=1 issuesUpdated=0, got %d/%d", report.IssuesOpened, report.IssuesUpdated)
+	}
+}
+
+func TestServiceTickClosesHumanRequiredTaskWithMergedPR(t *testing.T) {
+	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+	tasks := &fakeTasks{tasks: []task.Task{
+		mkTask("merged", task.StatusHumanRequired, func(t *task.Task) {
+			t.ProjectID = "owner/repo"
+			t.PRNumber = 42
+			t.UpdatedAt = now.Add(-time.Minute)
+		}),
+	}}
+	var fetched int
+	svc := NewService(Deps{
+		Cfg:    cfg,
+		Tasks:  tasks,
+		Audit:  fakeAudit{},
+		Agents: nilAgentLister{},
+		Now:    func() time.Time { return now },
+		Logger: slog.New(slog.DiscardHandler),
+		FetchPRState: func(repo string, number int) (github.PRState, error) {
+			fetched++
+			if repo != "owner/repo" || number != 42 {
+				t.Fatalf("FetchPRState(%q, %d), want owner/repo#42", repo, number)
+			}
+			return github.PRState{State: "MERGED"}, nil
+		},
+	})
+
+	report, err := svc.tick(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetched != 1 {
+		t.Fatalf("FetchPRState calls = %d, want 1", fetched)
+	}
+	got, err := tasks.Get("merged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusDone {
+		t.Fatalf("status = %q, want done", got.Status)
+	}
+	if got.Outcome != "merged" {
+		t.Fatalf("outcome = %q, want merged", got.Outcome)
+	}
+	if len(report.Remediated) != 1 || report.Remediated[0] != "linked_pr_merged:merged" {
+		t.Fatalf("remediated = %v, want [linked_pr_merged:merged]", report.Remediated)
 	}
 }
 

--- a/internal/poll/poller.go
+++ b/internal/poll/poller.go
@@ -36,7 +36,7 @@ func (p *Poller) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			next := p.fetcher.Poll(ctx)
+			next := p.pollOnce(ctx)
 			if next <= 0 {
 				next = time.Minute
 			}
@@ -44,6 +44,16 @@ func (p *Poller) Run(ctx context.Context) {
 			timer.Reset(next)
 		}
 	}
+}
+
+func (p *Poller) pollOnce(ctx context.Context) (next time.Duration) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			p.logger.Error("poll.panic", "name", p.fetcher.Name(), "panic", rec)
+			next = time.Minute
+		}
+	}()
+	return p.fetcher.Poll(ctx)
 }
 
 // Hub owns a set of Fetchers and starts them together.

--- a/internal/poll/poller_test.go
+++ b/internal/poll/poller_test.go
@@ -1,0 +1,25 @@
+package poll
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestPollerPollOnceRecoversPanic(t *testing.T) {
+	t.Parallel()
+
+	p := New(&panicFetcher{}, 0, slog.New(slog.DiscardHandler))
+	if got := p.pollOnce(context.Background()); got != time.Minute {
+		t.Fatalf("pollOnce() = %s, want %s after panic recovery", got, time.Minute)
+	}
+}
+
+type panicFetcher struct{}
+
+func (*panicFetcher) Name() string { return "panic" }
+
+func (*panicFetcher) Poll(context.Context) time.Duration {
+	panic("boom")
+}

--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -17,6 +17,8 @@ var transientNetworkMarkers = []string{
 	"connection refused",
 	"connection reset",
 	"connection timed out",
+	"failed to connect",
+	"couldn't connect to server",
 	"could not resolve host",
 	"couldn't resolve host",
 	"network is unreachable",

--- a/internal/sybra/review/pr_poll_sched.go
+++ b/internal/sybra/review/pr_poll_sched.go
@@ -65,10 +65,10 @@ func (r *Handler) selectKnownPRPoll(tasks []task.Task) knownPRPollSelection {
 		key := prRefCacheKey(tk.ProjectID, tk.PRNumber)
 		entry := r.prPollState[key]
 		if entry.skipTicks > 0 {
-			entry.skipTicks--
-			r.prPollState[key] = entry
-			deferred++
-			continue
+			if r.knownPRStillStableDuringBackoff(&tk, key, entry) {
+				deferred++
+				continue
+			}
 		}
 		candidates = append(candidates, tk)
 	}
@@ -104,6 +104,25 @@ func knownPRPollEligible(t *task.Task) bool {
 		return false
 	}
 	return prMonitorEligible(t) || prClosedEligible(t) || humanRequiredBlockerReconcileEligible(t)
+}
+
+func (r *Handler) knownPRStillStableDuringBackoff(t *task.Task, key string, entry prPollEntry) bool {
+	headStateFn := r.fetchHeadStateFn
+	if headStateFn == nil {
+		entry.skipTicks--
+		r.prPollState[key] = entry
+		return true
+	}
+	sha, open, updatedAt, err := headStateFn(t.ProjectID, t.PRNumber)
+	if err != nil || !open || sha == "" || sha != entry.lastHeadSHA || updatedAt != entry.lastUpdatedAt {
+		entry.skipTicks = 0
+		entry.stableStreak = 0
+		r.prPollState[key] = entry
+		return false
+	}
+	entry.skipTicks--
+	r.prPollState[key] = entry
+	return true
 }
 
 func (r *Handler) noteKnownPRResult(repo string, number int, pr github.PullRequest) {

--- a/internal/sybra/review/pr_poll_sched.go
+++ b/internal/sybra/review/pr_poll_sched.go
@@ -114,7 +114,12 @@ func (r *Handler) knownPRStillStableDuringBackoff(t *task.Task, key string, entr
 		return true
 	}
 	sha, open, updatedAt, err := headStateFn(t.ProjectID, t.PRNumber)
-	if err != nil || !open || sha == "" || sha != entry.lastHeadSHA || updatedAt != entry.lastUpdatedAt {
+	if err != nil {
+		entry.skipTicks--
+		r.prPollState[key] = entry
+		return true
+	}
+	if !open || sha == "" || sha != entry.lastHeadSHA || updatedAt != entry.lastUpdatedAt {
 		entry.skipTicks = 0
 		entry.stableStreak = 0
 		r.prPollState[key] = entry

--- a/internal/sybra/review/pr_poll_sched_test.go
+++ b/internal/sybra/review/pr_poll_sched_test.go
@@ -169,6 +169,39 @@ func TestSelectKnownPRPoll(t *testing.T) {
 		}
 	})
 
+	t.Run("updatedAt change breaks stable backoff", func(t *testing.T) {
+		t.Parallel()
+
+		tk := newTask("reviewed", 7, base)
+		r := &Handler{
+			prPollState: map[string]prPollEntry{
+				"owner/repo#7": {
+					lastHeadSHA:   "sha-1",
+					lastUpdatedAt: "2026-07-13T12:00:00Z",
+					stableStreak:  3,
+					skipTicks:     4,
+				},
+			},
+			fetchHeadStateFn: func(repo string, number int) (string, bool, string, error) {
+				if repo != "owner/repo" || number != 7 {
+					t.Fatalf("fetchHeadStateFn(%q, %d), want owner/repo#7", repo, number)
+				}
+				return "sha-1", true, "2026-07-13T12:05:00Z", nil
+			},
+		}
+
+		sel := r.selectKnownPRPoll([]task.Task{tk})
+		if got := taskIDs(sel.tasks); len(got) != 1 || got[0] != "reviewed" {
+			t.Fatalf("selected ids = %v, want [reviewed] when updatedAt changes", got)
+		}
+		if sel.deferredPRs != 0 {
+			t.Fatalf("deferredPRs = %d, want 0", sel.deferredPRs)
+		}
+		if got := r.prPollState["owner/repo#7"].skipTicks; got != 0 {
+			t.Fatalf("skipTicks = %d, want reset to 0", got)
+		}
+	})
+
 	t.Run("prunes unlinked PRs", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/sybra/review/pr_poll_sched_test.go
+++ b/internal/sybra/review/pr_poll_sched_test.go
@@ -202,6 +202,36 @@ func TestSelectKnownPRPoll(t *testing.T) {
 		}
 	})
 
+	t.Run("head-state probe error preserves backoff", func(t *testing.T) {
+		t.Parallel()
+
+		tk := newTask("rate-limited", 7, base)
+		r := &Handler{
+			prPollState: map[string]prPollEntry{
+				"owner/repo#7": {
+					lastHeadSHA:   "sha-1",
+					lastUpdatedAt: "2026-07-13T12:00:00Z",
+					stableStreak:  3,
+					skipTicks:     4,
+				},
+			},
+			fetchHeadStateFn: func(string, int) (string, bool, string, error) {
+				return "", false, "", fmt.Errorf("rate limited")
+			},
+		}
+
+		sel := r.selectKnownPRPoll([]task.Task{tk})
+		if got := taskIDs(sel.tasks); len(got) != 0 {
+			t.Fatalf("selected ids = %v, want none while probe error preserves backoff", got)
+		}
+		if sel.deferredPRs != 1 {
+			t.Fatalf("deferredPRs = %d, want 1", sel.deferredPRs)
+		}
+		if got := r.prPollState["owner/repo#7"].skipTicks; got != 3 {
+			t.Fatalf("skipTicks = %d, want decremented to 3", got)
+		}
+	})
+
 	t.Run("prunes unlinked PRs", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -122,6 +122,16 @@ func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Executi
 			return out, err
 		}
 	}
+	if !reviewHoldForced && prFixShouldResumeNoPRRecovery(t, reason) {
+		msg := "retryable no-PR remote outage; resuming original workflow: " + reason
+		workflowID := ""
+		if wfExec != nil {
+			workflowID = wfExec.WorkflowID
+		}
+		e.logger.Warn("workflow.pr-fix.no-pr-retryable-remote",
+			"task_id", taskID, "workflow", workflowID, "reason", reason)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
+	}
 	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 		return StepOutput{}, fmt.Errorf("route pr-fix result: set human-required: %w", err)
 	}
@@ -142,6 +152,25 @@ func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Executi
 		}
 	}
 	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+}
+
+func prFixShouldResumeNoPRRecovery(t TaskInfo, reason string) bool {
+	if t.PRNumber > 0 {
+		return false
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return false
+	}
+	lower := strings.ToLower(reason)
+	if strings.Contains(lower, "missing credential") || strings.Contains(lower, "authentication") || strings.Contains(lower, "permission denied") {
+		return false
+	}
+	if project.IsTransientNetworkError(errors.New(reason)) {
+		return true
+	}
+	return strings.Contains(lower, "remote unreachable") ||
+		(strings.Contains(lower, "transport") && strings.Contains(lower, "github"))
 }
 
 func prFixAllowsResolvedMergeRecovery(reason string) bool {

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -913,6 +913,53 @@ func TestExecRoutePRFixResult_HumanRequiredWithoutFailingTestsNoNote(t *testing.
 	}
 }
 
+func TestExecRoutePRFixResult_NoPRRemoteOutageResumesRecovery(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "branch-conflict-fix",
+		CurrentStep: "route_result",
+		State:       ExecRunning,
+		Variables: map[string]string{
+			resumeStatusVar:       "in-progress",
+			resumeStatusReasonVar: "",
+			resumeWorkflowIDVar:   "simple-task-implement",
+			resumeWorkflowStepVar: "implement",
+		},
+		StepHistory: []StepRecord{{
+			StepID: "fix",
+			Status: "completed",
+			Output: "Focused regression tests passed.\n" +
+				"SYBRA_PR_FIX_RESULT: human-required\n" +
+				"SYBRA_PR_FIX_REASON: GitHub remote unreachable from this environment; fetch/push blocked by HTTPS transport failure to github.com:443: Failed to connect to github.com port 443\n",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", ProjectID: "Automaat/sybra", PRNumber: 0, Workflow: wf})
+
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_result"}, wf, TaskInfo{ID: "t1", ProjectID: "Automaat/sybra"})
+	if err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	if !strings.Contains(out.Output, "retryable no-PR remote outage") {
+		t.Fatalf("output = %q, want retryable no-PR remote outage", out.Output)
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == "human-required" {
+		t.Fatalf("status = %q, want recovery to continue toward resume_original", got.Status)
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress", got.Status)
+	}
+}
+
 // A flake verdict must not park a human and must not reach verify_commits,
 // which would fail the task for the missing commit the honest answer implies.
 func TestExecRoutePRFixResult_FlakeRoutesToInReviewWithoutCommit(t *testing.T) {


### PR DESCRIPTION
## Summary
- break known-PR polling backoff when GitHub reports a changed PR updatedAt, so same-head review comments are picked up promptly
- deterministically mark human-required tasks done when their linked PR is already merged
- recover poller panics per cycle so one bad poll cannot permanently stop review polling

## Tests
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/poll ./internal/monitor ./internal/sybra/review