### PR TITLE
fix(workflow): keep human-review recovery autonomous

### DIFF
--- a/internal/poll/triage.go
+++ b/internal/poll/triage.go
@@ -33,6 +33,7 @@ type TriageHandler struct {
 	gate       provider.HealthGate
 	factory    classifierFactory
 	perTaskTTL time.Duration
+	applyOpts  triage.ApplyOptions
 }
 
 // NewTriageHandler constructs a TriageHandler.
@@ -60,6 +61,12 @@ func (h *TriageHandler) Name() string { return "triage" }
 // to be rate-limited or logged out.
 func (h *TriageHandler) SetProviderGate(g provider.HealthGate) {
 	h.gate = g
+}
+
+// SetSybraBugProjectID configures the local tracking project used when
+// re-routing sybra-bug tasks during triage.
+func (h *TriageHandler) SetSybraBugProjectID(id string) {
+	h.applyOpts.SybraBugProjectID = id
 }
 
 // Poll implements poll.Fetcher. Returns the next poll interval.
@@ -121,7 +128,7 @@ func (h *TriageHandler) classifyOne(
 	ctx, cancel := context.WithTimeout(parent, h.perTaskTTL)
 	defer cancel()
 
-	if _, _, err := triage.ClassifyAndApply(ctx, classifier, h.tasks, h.audit, t, projects); err != nil {
+	if _, _, err := triage.ClassifyAndApplyWithOptions(ctx, classifier, h.tasks, h.audit, t, projects, h.applyOpts); err != nil {
 		h.logger.Warn("triage.classify", "task", t.ID, "err", err)
 	}
 }

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -740,6 +740,67 @@ func TestOnComplete_UnblockedVerdict_ReadyPRWithoutPRStaysReadyPR(t *testing.T) 
 	}
 }
 
+func TestOnComplete_UnblockedVerdict_DoneActionClosesTask(t *testing.T) {
+	t.Parallel()
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	const agentID = "agent-unblocked-done"
+	tk, err := tasks.Create("Already merged task", "Original body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		ProjectID: task.Ptr("Automaat/sybra"),
+		PRNumber:  task.Ptr(2417),
+	}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: agentID,
+		Role:    string(agent.RoleHumanReview),
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	var dispatchedTarget string
+	h.dispatchFromHumanRequired = func(id, target, reason, _ string) (task.Task, error) {
+		dispatchedTarget = target
+		return tasks.Update(id, task.Update{
+			Status:       task.Ptr(task.Status(target)),
+			StatusReason: task.Ptr(reason),
+		})
+	}
+
+	ag := &agent.Agent{ID: agentID, TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type:    "assistant",
+		Content: `{"decision":"unblocked","reason":"merged through PR #2417","recoverable_action":"done","confidence":"high","issue_title":null,"issue_body":null,"issue_labels":null}`,
+	})
+	h.inflight[tk.ID] = agentID
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if dispatchedTarget != string(task.StatusDone) {
+		t.Fatalf("dispatch target = %q, want %q", dispatchedTarget, task.StatusDone)
+	}
+	if got.Status != task.StatusDone {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusDone)
+	}
+	if !strings.Contains(got.Body, "Auto-review: unblocked") {
+		t.Fatalf("expected unblocked note in body; got:\n%s", got.Body)
+	}
+	if len(got.AgentRuns) != 1 || !got.AgentRuns[0].VerdictRendered {
+		t.Fatalf("agent runs = %+v, want rendered verdict", got.AgentRuns)
+	}
+}
+
 func TestOnComplete_UnblockedVerdict_TamperRerouteAddsBlessTag(t *testing.T) {
 	t.Parallel()
 	h, tasks, cleanup := newReviewTestEnv(t)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1170,10 +1170,11 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetPRAnyStateFinder(prFinderAdapter{})
 	a.workflowEngine.SetPRContentGenerator(prContentGeneratorAdapter{gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}})
 	a.workflowEngine.SetTaskClassifier(&taskClassifierAdapter{
-		tasks:      a.tasks,
-		projects:   a.projects,
-		classifier: &triage.FallbackClassifier{Model: a.cfg.Triage.Model, Logger: a.logger, Gate: a.providerHealth},
-		audit:      a.audit,
+		tasks:             a.tasks,
+		projects:          a.projects,
+		classifier:        &triage.FallbackClassifier{Model: a.cfg.Triage.Model, Logger: a.logger, Gate: a.providerHealth},
+		audit:             a.audit,
+		sybraBugProjectID: a.cfg.HumanReviewRepo(),
 	})
 	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -40,7 +40,6 @@ import (
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/task"
-	"github.com/Automaat/sybra/internal/triage"
 	"github.com/Automaat/sybra/internal/umbrella"
 	"github.com/Automaat/sybra/internal/watcher"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -1169,13 +1168,7 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetPRFinder(prFinderAdapter{})
 	a.workflowEngine.SetPRAnyStateFinder(prFinderAdapter{})
 	a.workflowEngine.SetPRContentGenerator(prContentGeneratorAdapter{gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}})
-	a.workflowEngine.SetTaskClassifier(&taskClassifierAdapter{
-		tasks:             a.tasks,
-		projects:          a.projects,
-		classifier:        &triage.FallbackClassifier{Model: a.cfg.Triage.Model, Logger: a.logger, Gate: a.providerHealth},
-		audit:             a.audit,
-		sybraBugProjectID: a.cfg.HumanReviewRepo(),
-	})
+	a.workflowEngine.SetTaskClassifier(a.newTaskClassifierAdapter())
 	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
 	a.workflowEngine.SetAttemptNoteAppender(&attemptNoteAppenderAdapter{})

--- a/internal/sybra/app_triage.go
+++ b/internal/sybra/app_triage.go
@@ -47,6 +47,7 @@ func (c *triageCoordinator) init() {
 	}
 	c.handler = poll.NewTriageHandler(c.tasks, c.projects, c.auditLog, c.logger, &c.cfg.Triage)
 	c.handler.SetProviderGate(c.providerHealth)
+	c.handler.SetSybraBugProjectID(c.cfg.HumanReviewRepo())
 	c.logger.Info("triage.enabled", "poll_seconds", c.cfg.Triage.PollSeconds, "model", c.cfg.Triage.Model)
 }
 

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -255,6 +255,16 @@ type taskClassifierAdapter struct {
 	sybraBugProjectID string
 }
 
+func (a *App) newTaskClassifierAdapter() *taskClassifierAdapter {
+	return &taskClassifierAdapter{
+		tasks:             a.tasks,
+		projects:          a.projects,
+		classifier:        &triage.FallbackClassifier{Model: a.cfg.Triage.Model, Logger: a.logger, Gate: a.providerHealth},
+		audit:             a.audit,
+		sybraBugProjectID: a.cfg.HumanReviewRepo(),
+	}
+}
+
 func (a *taskClassifierAdapter) ClassifyTask(ctx context.Context, taskID string) error {
 	t, err := a.tasks.Get(taskID)
 	if err != nil {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -248,10 +248,11 @@ func (a *taskAdapter) WriteSidecar(id, kind, content string) error {
 // poll-based auto-triage handler (internal/poll.TriageHandler), so the
 // workflow step no longer needs a full agent session to reach it.
 type taskClassifierAdapter struct {
-	tasks      *task.Manager
-	projects   *project.Store
-	classifier triage.Classifier
-	audit      *audit.Logger
+	tasks             *task.Manager
+	projects          *project.Store
+	classifier        triage.Classifier
+	audit             *audit.Logger
+	sybraBugProjectID string
 }
 
 func (a *taskClassifierAdapter) ClassifyTask(ctx context.Context, taskID string) error {
@@ -266,7 +267,9 @@ func (a *taskClassifierAdapter) ClassifyTask(ctx context.Context, taskID string)
 			return err
 		}
 	}
-	_, _, err = triage.ClassifyAndApply(ctx, a.classifier, a.tasks, a.audit, t, projects)
+	_, _, err = triage.ClassifyAndApplyWithOptions(ctx, a.classifier, a.tasks, a.audit, t, projects, triage.ApplyOptions{
+		SybraBugProjectID: a.sybraBugProjectID,
+	})
 	return err
 }
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -936,8 +936,8 @@ func (s *TaskService) redispatchStatusChanged(id, status string) (string, error)
 	)
 }
 
-// dispatchTargetSpec describes one status an operator can dispatch a
-// human-required task to.
+// dispatchTargetSpec describes one status an operator or human-review recovery
+// can move a human-required task to.
 type dispatchTargetSpec struct {
 	// requiresPR gates the target on the task already having a linked PR
 	// (only in-review needs this — dispatching in-review without a PR would
@@ -946,7 +946,13 @@ type dispatchTargetSpec struct {
 	// dispatches selects whether redispatchStatusChanged runs after the
 	// status write. in-review has no task.status_changed trigger — it is a
 	// plain PR-guarded status flip into the existing PR-monitoring state.
+	// done is also non-dispatching: it is a terminal close-out for an already
+	// completed/merged task that human-review proved should not be retried.
 	dispatches bool
+	// clearWorkflow removes a stale terminal workflow when the target status
+	// itself is the complete recovery. Without this, a task can be closed while
+	// still displaying the failed workflow that caused the human-required park.
+	clearWorkflow bool
 }
 
 var dispatchTargets = map[string]dispatchTargetSpec{
@@ -955,6 +961,7 @@ var dispatchTargets = map[string]dispatchTargetSpec{
 	string(task.StatusTesting):     {dispatches: true},
 	string(task.StatusReadyPR):     {dispatches: true},
 	string(task.StatusInReview):    {requiresPR: true, dispatches: false},
+	string(task.StatusDone):        {dispatches: false, clearWorkflow: true},
 }
 
 func readyPRNoWorkflowAllowed(role, target string) bool {
@@ -1040,10 +1047,14 @@ func (s *TaskService) dispatchFromHumanRequiredLockedAllowingAgent(id, target, r
 			cur.Workflow.WorkflowID, cur.Workflow.State))
 	}
 
-	if _, err := s.tasks.UpdateMap(id, map[string]any{
+	updates := map[string]any{
 		"status":        target,
 		"status_reason": reason,
-	}); err != nil {
+	}
+	if spec.clearWorkflow {
+		updates["workflow"] = (*workflow.Execution)(nil)
+	}
+	if _, err := s.tasks.UpdateMap(id, updates); err != nil {
 		return task.Task{}, err
 	}
 

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -368,6 +368,40 @@ func TestDispatchFromHumanRequired_ReadyPRAllowsNoMatchForReviewOnlyRoles(t *tes
 	}
 }
 
+func TestDispatchFromHumanRequired_DoneClosesWithoutWorkflow(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+	a.initStatusHook()
+	tk := newHumanRequiredTask(t, a, 2417)
+	stale := &workflow.Execution{
+		WorkflowID:  "simple-task-implement",
+		CurrentStep: "implement",
+		State:       workflow.ExecFailed,
+		Variables:   map[string]string{},
+	}
+	if _, err := a.tasks.Update(tk.ID, task.Update{Workflow: &stale}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := svc.DispatchFromHumanRequired(tk.ID, "done", "already merged")
+	if err != nil {
+		t.Fatalf("DispatchFromHumanRequired: %v", err)
+	}
+	if got.Status != task.StatusDone {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusDone)
+	}
+	if got.StatusReason != "already merged" {
+		t.Fatalf("status_reason = %q, want operator reason preserved", got.StatusReason)
+	}
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want nil for terminal close-out", got.Workflow)
+	}
+	if launcher.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0 for terminal close-out", launcher.startCalls)
+	}
+}
+
 // TestApp_StatusHook_SkipsAgentDispatchForUmbrellaTracker reproduces the
 // production bug (task 33aa3f62 / issue #2004): app_umbrella_gate.go's
 // rollupTrackers rolls an umbrella tracker back to in-progress (e.g. after a
@@ -718,7 +752,7 @@ func TestDispatchFromHumanRequired_RejectsUnknownTarget(t *testing.T) {
 	svc, a := setupDispatchTestService(t, launcher)
 	tk := newHumanRequiredTask(t, a, 0)
 
-	if _, err := svc.DispatchFromHumanRequired(tk.ID, "done", "reason"); err == nil {
+	if _, err := svc.DispatchFromHumanRequired(tk.ID, "cancelled", "reason"); err == nil {
 		t.Fatal("expected error dispatching to an unsupported target")
 	}
 }

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -15,7 +15,15 @@ import (
 // must survive a wholesale tag-replacement in Apply because dropping them
 // would silently break routing the task depends on: escape-hatch opt-outs
 // (see escapeHatchTags) and the umbrella dependency gate marker.
-var preservedTags = append(append([]string{}, escapeHatchTags...), umbrella.GatedTag)
+var preservedTags = append(append([]string{}, escapeHatchTags...),
+	umbrella.GatedTag,
+	"sybra-bug",
+	"scrubbed",
+	"local",
+	"issue-filing-failed",
+)
+
+const sybraProjectID = "Automaat/sybra"
 
 const umbrellaNormalTypeStatusReason = "☂️-titled task has task_type=normal, not umbrella — " +
 	"guard blocked dispatch to avoid a wasted implement run; " +
@@ -61,6 +69,9 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	stale := projectID != "" && !resolved
 	if !resolved {
 		projectID = MatchProjectFromIssue(t.Issue, projects)
+		if projectID == "" && isSybraBugTask(t, v) {
+			projectID = registeredProjectID(sybraProjectID, projects)
+		}
 		if projectID == "" {
 			guess := strings.TrimSpace(v.ProjectID)
 			if _, ok := projectTypeFor(guess, projects); ok {
@@ -149,6 +160,19 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 
 func isPRFixTask(t task.Task) bool {
 	return t.RunRole == "pr-fix" || t.PRNumber > 0
+}
+
+func isSybraBugTask(t task.Task, v Verdict) bool {
+	return slices.Contains(t.Tags, "sybra-bug") || slices.Contains(v.Tags, "sybra-bug")
+}
+
+func registeredProjectID(id string, projects []project.Project) string {
+	for i := range projects {
+		if projects[i].ID == id {
+			return projects[i].ID
+		}
+	}
+	return ""
 }
 
 // projectTypeFor returns the registered project type for id and whether id

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -14,7 +14,8 @@ import (
 // preservedTags are tags never emitted by the classifier vocabulary but that
 // must survive a wholesale tag-replacement in Apply because dropping them
 // would silently break routing the task depends on: escape-hatch opt-outs
-// (see escapeHatchTags) and the umbrella dependency gate marker.
+// (see escapeHatchTags), the umbrella dependency gate marker, and local
+// Sybra-bug tracker routing markers.
 var preservedTags = append(append([]string{}, escapeHatchTags...),
 	umbrella.GatedTag,
 	"sybra-bug",
@@ -23,7 +24,22 @@ var preservedTags = append(append([]string{}, escapeHatchTags...),
 	"issue-filing-failed",
 )
 
-const sybraProjectID = "Automaat/sybra"
+const defaultSybraBugProjectID = "Automaat/sybra"
+
+// ApplyOptions tunes deterministic routing decisions that come from app
+// configuration rather than classifier output.
+type ApplyOptions struct {
+	// SybraBugProjectID is the local tracking project for tasks tagged
+	// sybra-bug. Empty falls back to the package default.
+	SybraBugProjectID string
+}
+
+func (o ApplyOptions) sybraBugProjectID() string {
+	if id := strings.TrimSpace(o.SybraBugProjectID); id != "" {
+		return id
+	}
+	return defaultSybraBugProjectID
+}
 
 const umbrellaNormalTypeStatusReason = "☂️-titled task has task_type=normal, not umbrella — " +
 	"guard blocked dispatch to avoid a wasted implement run; " +
@@ -42,6 +58,12 @@ const umbrellaGuardOptOutTag = "notumbrella"
 // projects is used to look up the project type after ProjectID is matched,
 // which feeds into routing rules (work projects force interactive mode).
 func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project) (task.Task, error) {
+	return ApplyWithOptions(mgr, t, v, projects, ApplyOptions{})
+}
+
+// ApplyWithOptions writes the classifier verdict to the task with explicit
+// deterministic routing options supplied by the caller.
+func ApplyWithOptions(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project, opts ApplyOptions) (task.Task, error) {
 	updates := make(map[string]any, 8)
 
 	// A prompt-lab proposal is owned by PromptLabService, not triage. It may
@@ -70,7 +92,11 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	if !resolved {
 		projectID = MatchProjectFromIssue(t.Issue, projects)
 		if projectID == "" && isSybraBugTask(t, v) {
-			projectID = registeredProjectID(sybraProjectID, projects)
+			if id := opts.sybraBugProjectID(); id != "" {
+				if _, ok := projectTypeFor(id, projects); ok {
+					projectID = id
+				}
+			}
 		}
 		if projectID == "" {
 			guess := strings.TrimSpace(v.ProjectID)
@@ -164,15 +190,6 @@ func isPRFixTask(t task.Task) bool {
 
 func isSybraBugTask(t task.Task, v Verdict) bool {
 	return slices.Contains(t.Tags, "sybra-bug") || slices.Contains(v.Tags, "sybra-bug")
-}
-
-func registeredProjectID(id string, projects []project.Project) string {
-	for i := range projects {
-		if projects[i].ID == id {
-			return projects[i].ID
-		}
-	}
-	return ""
 }
 
 // projectTypeFor returns the registered project type for id and whether id

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -85,6 +85,32 @@ func TestApplyPreservesEscapeHatchTags(t *testing.T) {
 	}
 }
 
+func TestApplyPreservesSybraBugRoutingTags(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("fix(workflow): local tracker", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created.Tags = []string{"sybra-bug", "scrubbed"}
+
+	v := Verdict{
+		Title: "fix(workflow): local tracker",
+		Tags:  []string{"backend", "medium", "bug"},
+		Size:  "medium",
+		Type:  "bug",
+		Mode:  "headless",
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	for _, want := range []string{"sybra-bug", "scrubbed"} {
+		if !slices.Contains(updated.Tags, want) {
+			t.Fatalf("tags = %v, want preserved %q", updated.Tags, want)
+		}
+	}
+}
+
 func TestApplyPreservesHumanSetTrivialTag(t *testing.T) {
 	mgr := newTestManager(t)
 	created, err := mgr.Create("trivial typo fix", "", task.AgentModeHeadless)
@@ -624,6 +650,40 @@ func TestApplyRejectsUnregisteredClassifierGuess(t *testing.T) {
 	}
 	if updated.ProjectID != "" {
 		t.Errorf("project_id: got %q, want empty (unregistered classifier guess must not be persisted)", updated.ProjectID)
+	}
+}
+
+func TestApplySybraBugTaskDefaultsToSybraProjectBeforeBodyMatch(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create(
+		"fix(workflow): assign project before dispatching Sybra bug tasks",
+		"Local tracker for a Sybra bug seen while handling https://github.com/Automaat/synapse/issues/7.",
+		task.AgentModeHeadless,
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created.Tags = []string{"sybra-bug", "scrubbed"}
+	projects := []project.Project{
+		{ID: "Automaat/sybra", Owner: "Automaat", Repo: "sybra", Type: project.ProjectTypePet},
+		{ID: "Automaat/synapse", Owner: "Automaat", Repo: "synapse", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "fix(workflow): assign project before dispatching Sybra bug tasks",
+		Size:  "medium",
+		Type:  "bug",
+		Mode:  "headless",
+		Tags:  []string{"backend", "medium", "bug"},
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.ProjectID != "Automaat/sybra" {
+		t.Fatalf("project_id = %q, want Automaat/sybra", updated.ProjectID)
+	}
+	if !slices.Contains(updated.Tags, "sybra-bug") || !slices.Contains(updated.Tags, "scrubbed") {
+		t.Fatalf("tags = %v, want sybra-bug and scrubbed preserved", updated.Tags)
 	}
 }
 

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -687,6 +687,38 @@ func TestApplySybraBugTaskDefaultsToSybraProjectBeforeBodyMatch(t *testing.T) {
 	}
 }
 
+func TestApplySybraBugTaskUsesConfiguredProjectBeforeBodyMatch(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create(
+		"fix(workflow): assign project before dispatching Sybra bug tasks",
+		"Local tracker for a Sybra bug seen while handling https://github.com/Automaat/synapse/issues/7.",
+		task.AgentModeHeadless,
+	)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created.Tags = []string{"sybra-bug", "scrubbed"}
+	projects := []project.Project{
+		{ID: "fork/sybra", Owner: "fork", Repo: "sybra", Type: project.ProjectTypePet},
+		{ID: "Automaat/sybra", Owner: "Automaat", Repo: "sybra", Type: project.ProjectTypePet},
+		{ID: "Automaat/synapse", Owner: "Automaat", Repo: "synapse", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "fix(workflow): assign project before dispatching Sybra bug tasks",
+		Size:  "medium",
+		Type:  "bug",
+		Mode:  "headless",
+		Tags:  []string{"backend", "medium", "bug"},
+	}
+	updated, err := ApplyWithOptions(mgr, created, v, projects, ApplyOptions{SybraBugProjectID: "fork/sybra"})
+	if err != nil {
+		t.Fatalf("ApplyWithOptions: %v", err)
+	}
+	if updated.ProjectID != "fork/sybra" {
+		t.Fatalf("project_id = %q, want fork/sybra", updated.ProjectID)
+	}
+}
+
 func TestApplyClearsStaleProjectIDWhenReResolutionFails(t *testing.T) {
 	mgr := newTestManager(t)
 	created, err := mgr.Create("refactor ingestion", "", task.AgentModeHeadless)

--- a/internal/triage/classify.go
+++ b/internal/triage/classify.go
@@ -28,11 +28,25 @@ func ClassifyAndApply(
 	t task.Task,
 	projects []project.Project,
 ) (Verdict, task.Task, error) {
+	return ClassifyAndApplyWithOptions(ctx, classifier, mgr, al, t, projects, ApplyOptions{})
+}
+
+// ClassifyAndApplyWithOptions runs the classifier and applies the verdict with
+// explicit deterministic routing options.
+func ClassifyAndApplyWithOptions(
+	ctx context.Context,
+	classifier Classifier,
+	mgr *task.Manager,
+	al *audit.Logger,
+	t task.Task,
+	projects []project.Project,
+	opts ApplyOptions,
+) (Verdict, task.Task, error) {
 	v, err := classifier.Classify(ctx, t, projects)
 	if err != nil {
 		return Verdict{}, task.Task{}, err
 	}
-	updated, err := Apply(mgr, t, v, projects)
+	updated, err := ApplyWithOptions(mgr, t, v, projects, opts)
 	if err != nil {
 		return Verdict{}, task.Task{}, err
 	}


### PR DESCRIPTION
## Summary
- allow human-review recovery to close already-complete tasks with recoverable_action=done
- clear stale failed workflows when human-required recovery marks a task done
- preserve and route local sybra-bug tracker tasks to Automaat/sybra before title/body URL matching

## Tests
- git diff --check HEAD~1..HEAD
- GOCACHE=.codex-go-cache go test ./internal/triage
- GOCACHE=.codex-go-cache go test ./internal/sybra -run 'TestOnComplete_UnblockedVerdict_DoneActionClosesTask|TestDispatchFromHumanRequired_DoneClosesWithoutWorkflow|TestAgentAdapterStartAgentRepreparesMissingProvidedDirForReview|TestAgentAdapterStartAgentRepreparesMissingProvidedDirForPRFix|TestAgentAdapterStartAgentCleanRetryResetsRecreatedProvidedDir'