### PR TITLE
fix(workflow): request Copilot review for Sybra PRs

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -164,7 +164,7 @@ type Manager struct {
 	// it intentionally does NOT inspect running agents, so a step transition
 	// dispatching its next agent inside the prior agent's onComplete (whose
 	// `done` channel is not yet closed) is never blocked.
-	dispatchClaims map[string]struct{}
+	dispatchClaims map[string]time.Time
 
 	// queueNudge is a buffer-1 coalescing signal mirroring App.dispatchNudge:
 	// at most one pending nudge is retained, so a burst of completions that
@@ -259,7 +259,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 	}
 	m := &Manager{
 		agents:                 make(map[string]*Agent),
-		dispatchClaims:         make(map[string]struct{}),
+		dispatchClaims:         make(map[string]time.Time),
 		queueNudge:             make(chan struct{}, 1),
 		liveByProvider:         make(map[string]int),
 		ctx:                    ctx,
@@ -314,16 +314,44 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 // once dispatch finishes (success or failure) on a true return. This closes the
 // window between dispatch start and agent registration where a concurrent
 // dispatcher would otherwise see no running agent and start a duplicate.
+const staleDispatchClaimAge = 15 * time.Minute
+
 func (m *Manager) ClaimTaskDispatch(taskID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, held := m.dispatchClaims[taskID]; held {
-		return false
+	if claimedAt, held := m.dispatchClaims[taskID]; held {
+		if time.Since(claimedAt) >= staleDispatchClaimAge {
+			if m.logger != nil {
+				m.logger.Warn("agent.dispatch-claim.stale-release", "task_id", taskID, "age", time.Since(claimedAt))
+			}
+			delete(m.dispatchClaims, taskID)
+		} else {
+			return false
+		}
 	}
 	if m.dispatchClaims == nil {
-		m.dispatchClaims = make(map[string]struct{})
+		m.dispatchClaims = make(map[string]time.Time)
 	}
-	m.dispatchClaims[taskID] = struct{}{}
+	m.dispatchClaims[taskID] = time.Now()
+	return true
+}
+
+// ReleaseStaleTaskDispatch releases an in-flight dispatch claim only when it
+// has exceeded age. It returns true when a claim was removed.
+func (m *Manager) ReleaseStaleTaskDispatch(taskID string, age time.Duration) bool {
+	if age <= 0 {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	claimedAt, held := m.dispatchClaims[taskID]
+	if !held || time.Since(claimedAt) < age {
+		return false
+	}
+	if m.logger != nil {
+		m.logger.Warn("agent.dispatch-claim.stale-release", "task_id", taskID, "age", time.Since(claimedAt))
+	}
+	delete(m.dispatchClaims, taskID)
 	return true
 }
 
@@ -346,7 +374,14 @@ func (m *Manager) ReleaseTaskDispatch(taskID string) {
 func (m *Manager) IsDispatching(taskID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	_, held := m.dispatchClaims[taskID]
+	claimedAt, held := m.dispatchClaims[taskID]
+	if held && time.Since(claimedAt) >= staleDispatchClaimAge {
+		if m.logger != nil {
+			m.logger.Warn("agent.dispatch-claim.stale-release", "task_id", taskID, "age", time.Since(claimedAt))
+		}
+		delete(m.dispatchClaims, taskID)
+		return false
+	}
 	return held
 }
 

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -88,6 +89,41 @@ func (m *Manager) FindAllRunningAgentsForTask(taskID string, role Role) []*Agent
 		result = append(result, a)
 	}
 	return result
+}
+
+// ReleaseStaleStoppedAgentsForTask releases manager liveness for agents that
+// are already marked stopped but whose runner goroutine never closed its done
+// channel. It does not stop running/paused agents. The caller supplies grace so
+// short StopAgent races still keep protecting the worktree and dispatch path.
+func (m *Manager) ReleaseStaleStoppedAgentsForTask(ctx context.Context, taskID string, grace time.Duration) int {
+	if grace <= 0 {
+		return 0
+	}
+	cutoff := time.Now().Add(-grace)
+	var stale []*Agent
+	m.mu.RLock()
+	for _, a := range m.agents {
+		if a.TaskID != taskID || a.done == nil || a.GetState() != StateStopped {
+			continue
+		}
+		if last := a.GetLastEventAt(); !last.IsZero() && last.After(cutoff) {
+			continue
+		}
+		select {
+		case <-a.done:
+		default:
+			stale = append(stale, a)
+		}
+	}
+	m.mu.RUnlock()
+
+	for _, a := range stale {
+		if m.logger != nil {
+			m.logger.Warn("agent.stale-stopped.release", "agent_id", a.ID, "task_id", taskID, "last_event_at", a.GetLastEventAt())
+		}
+		m.markAgentDone(ctx, a)
+	}
+	return len(stale)
 }
 
 // StopAgents stops the provided agents without waiting for their goroutines to

--- a/internal/agent/manager_run_test.go
+++ b/internal/agent/manager_run_test.go
@@ -60,6 +60,75 @@ func TestRegisterMarkAgentDone_ProviderAccountingInvariant(t *testing.T) {
 	}
 }
 
+func TestReleaseStaleStoppedAgentsForTask_ReleasesDoneGate(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.deadAgentRetention = 0
+	stale := &Agent{
+		ID:          "stale-stopped",
+		TaskID:      "task-1",
+		Provider:    "claude",
+		State:       StateStopped,
+		LastEventAt: time.Now().Add(-30 * time.Minute),
+		done:        make(chan struct{}),
+	}
+	if err := m.registerRunningAgent(stale, RunConfig{}, func() {}); err != nil {
+		t.Fatalf("registerRunningAgent: %v", err)
+	}
+	if !m.HasRunningAgentForTask("task-1") {
+		t.Fatal("precondition: stopped agent with open done channel should still gate liveness")
+	}
+
+	if got := m.ReleaseStaleStoppedAgentsForTask(context.Background(), "task-1", 15*time.Minute); got != 1 {
+		t.Fatalf("released = %d, want 1", got)
+	}
+	if m.HasRunningAgentForTask("task-1") {
+		t.Fatal("stale stopped agent should no longer gate dispatch")
+	}
+}
+
+func TestReleaseStaleStoppedAgentsForTask_KeepsFreshStopRace(t *testing.T) {
+	m, _ := newTestManager(t)
+	fresh := &Agent{
+		ID:          "fresh-stopped",
+		TaskID:      "task-1",
+		Provider:    "claude",
+		State:       StateStopped,
+		LastEventAt: time.Now().Add(-30 * time.Minute),
+		done:        make(chan struct{}),
+	}
+	fresh.MarkStopped()
+	if err := m.registerRunningAgent(fresh, RunConfig{}, func() {}); err != nil {
+		t.Fatalf("registerRunningAgent: %v", err)
+	}
+	t.Cleanup(func() { m.markAgentDone(context.Background(), fresh) })
+
+	if got := m.ReleaseStaleStoppedAgentsForTask(context.Background(), "task-1", 15*time.Minute); got != 0 {
+		t.Fatalf("released = %d, want 0", got)
+	}
+	if !m.HasRunningAgentForTask("task-1") {
+		t.Fatal("fresh stopped agent should still gate until its runner exits")
+	}
+}
+
+func TestClaimTaskDispatch_ExpiresLeakedClaim(t *testing.T) {
+	m, _ := newTestManager(t)
+	if !m.ClaimTaskDispatch("task-1") {
+		t.Fatal("initial claim failed")
+	}
+	if m.ClaimTaskDispatch("task-1") {
+		t.Fatal("fresh duplicate claim should be rejected")
+	}
+
+	m.mu.Lock()
+	m.dispatchClaims["task-1"] = time.Now().Add(-staleDispatchClaimAge - time.Minute)
+	m.mu.Unlock()
+
+	if !m.ClaimTaskDispatch("task-1") {
+		t.Fatal("stale leaked claim should be released and reacquired")
+	}
+	m.ReleaseTaskDispatch("task-1")
+}
+
 // TestMarkAgentDone_EvictsFromRegistry locks in that a finished agent is
 // eventually removed from m.agents once its terminal path runs, so a
 // long-lived server does not accumulate output buffers and prompts forever

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -569,6 +569,7 @@ func (a *Agent) GetState() State {
 func (a *Agent) MarkStopped() {
 	a.mu.Lock()
 	a.stopped = true
+	a.LastEventAt = time.Now().UTC()
 	a.mu.Unlock()
 }
 

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -997,15 +997,24 @@ func editPRBodyWith(e execer, repo string, number int, body string) error {
 
 // RequestReviewers requests a review from the given GitHub user logins.
 func RequestReviewers(repo string, number int, reviewers []string) error {
-	return requestReviewersWith(defaultExecer, repo, number, reviewers)
+	return requestReviewersCtxWith(context.Background(), defaultExecer, repo, number, reviewers)
 }
 
 // RequestCopilotReview requests GitHub Copilot code review for a pull request.
 func RequestCopilotReview(repo string, number int) error {
-	return RequestReviewers(repo, number, []string{"copilot-pull-request-reviewer[bot]"})
+	return RequestCopilotReviewCtx(context.Background(), repo, number)
+}
+
+// RequestCopilotReviewCtx requests GitHub Copilot code review under ctx.
+func RequestCopilotReviewCtx(ctx context.Context, repo string, number int) error {
+	return requestReviewersCtxWith(ctx, defaultExecer, repo, number, []string{"copilot-pull-request-reviewer[bot]"})
 }
 
 func requestReviewersWith(e execer, repo string, number int, reviewers []string) error {
+	return requestReviewersCtxWith(context.Background(), e, repo, number, reviewers)
+}
+
+func requestReviewersCtxWith(ctx context.Context, e execer, repo string, number int, reviewers []string) error {
 	if len(reviewers) == 0 {
 		return nil
 	}
@@ -1022,7 +1031,7 @@ func requestReviewersWith(e execer, repo string, number int, reviewers []string)
 	if len(args) == 3 {
 		return nil
 	}
-	resp, err := runGHAPIWith(e, "", args...)
+	resp, err := runGHAPICtxWith(ctx, e, "", args...)
 	if err != nil {
 		return fmt.Errorf("gh request reviewers %d: %s: %w", number, sanitizeGHOutput(resp.body), err)
 	}

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -1000,6 +1000,11 @@ func RequestReviewers(repo string, number int, reviewers []string) error {
 	return requestReviewersWith(defaultExecer, repo, number, reviewers)
 }
 
+// RequestCopilotReview requests GitHub Copilot code review for a pull request.
+func RequestCopilotReview(repo string, number int) error {
+	return RequestReviewers(repo, number, []string{"copilot-pull-request-reviewer[bot]"})
+}
+
 func requestReviewersWith(e execer, repo string, number int, reviewers []string) error {
 	if len(reviewers) == 0 {
 		return nil

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -446,6 +446,30 @@ func TestRequestReviewersWith_passesArgs(t *testing.T) {
 	}
 }
 
+func TestRequestCopilotReview_RequestsCopilotBot(t *testing.T) {
+	orig := defaultExecer
+	fe := &recordingExecer{output: []byte("HTTP/2.0 201 Created\n\n{}")}
+	defaultExecer = fe
+	t.Cleanup(func() { defaultExecer = orig })
+
+	if err := RequestCopilotReview("owner/repo", 42); err != nil {
+		t.Fatalf("RequestCopilotReview: %v", err)
+	}
+	want := []string{
+		"api", "--include", "--method", "POST",
+		"repos/owner/repo/pulls/42/requested_reviewers",
+		"-f", "reviewers[]=copilot-pull-request-reviewer[bot]",
+	}
+	if len(fe.lastArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", fe.lastArgs, want)
+	}
+	for i, a := range fe.lastArgs {
+		if a != want[i] {
+			t.Errorf("arg[%d] = %q, want %q", i, a, want[i])
+		}
+	}
+}
+
 func TestRequestReviewersWith_emptySkips(t *testing.T) {
 	t.Parallel()
 	fe := &recordingExecer{}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -299,6 +299,9 @@ func (a *App) startLifecycle(ctx context.Context, emit func(string, any)) {
 
 	issuesFetcher := a.initAutomations(emit)
 	a.wireServices(emit)
+	if a.humanReview != nil {
+		a.wg.Go(a.humanReview.recoverRenderedUnblockedTasks)
+	}
 
 	// syncSkillsBundle's deep diagnostic logging uses context.Background()
 	// intentionally (see skillsync.Syncer.log) — not a cancellation bug.

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -443,6 +443,9 @@ func (h *humanReviewHandler) prepareRecoveryDispatch(current task.Task, status t
 	if target == task.StatusReadyPR && current.PRNumber == 0 && workflow.IsTamperFlaggedReason(current.StatusReason) {
 		target = task.StatusInProgress
 	}
+	if target == task.StatusInReview && current.PRNumber == 0 {
+		target = task.StatusReadyReview
+	}
 	if target == task.StatusReadyReview && current.PRNumber != 0 {
 		target = task.StatusInReview
 	}
@@ -452,6 +455,71 @@ func (h *humanReviewHandler) prepareRecoveryDispatch(current task.Task, status t
 		}
 	}
 	return target, nil
+}
+
+func (h *humanReviewHandler) recoverRenderedUnblockedTasks() {
+	if h == nil || h.tasks == nil || h.dispatchFromHumanRequired == nil {
+		return
+	}
+	tasks, err := h.tasks.List()
+	if err != nil {
+		h.logger.Warn("human-review.recover-rendered.list", "err", err)
+		return
+	}
+	for i := range tasks {
+		t := tasks[i]
+		if !missingCachedWorktreeCircuitBreaker(t) {
+			continue
+		}
+		agentID, v, ok := latestHumanReviewUnblockedVerdict(t)
+		if !ok {
+			continue
+		}
+		status, ok := safeHumanReviewRecoveryStatus(v.RecoverableAction)
+		if !ok {
+			continue
+		}
+		target, prepErr := h.prepareRecoveryDispatch(t, status)
+		if prepErr != nil {
+			h.logger.Warn("human-review.recover-rendered.prepare",
+				"task_id", t.ID, "agent_id", agentID, "target", status, "err", prepErr)
+			continue
+		}
+		reason := "auto-review recovery retry: " + strings.TrimSpace(v.Summary)
+		if _, err := h.dispatchFromHumanRequired(t.ID, string(target), reason, agentID); err != nil {
+			h.logger.Warn("human-review.recover-rendered.dispatch",
+				"task_id", t.ID, "agent_id", agentID, "target", target, "err", err)
+			continue
+		}
+		h.logger.Info("human-review.recover-rendered.dispatched",
+			"task_id", t.ID, "agent_id", agentID, "target", target)
+	}
+}
+
+func missingCachedWorktreeCircuitBreaker(t task.Task) bool {
+	if t.Status != task.StatusHumanRequired {
+		return false
+	}
+	reason := strings.ToLower(t.StatusReason)
+	return strings.Contains(reason, "circuit breaker: agent start failed") &&
+		strings.Contains(reason, "dir ") &&
+		strings.Contains(reason, "not accessible") &&
+		strings.Contains(reason, "/worktrees/")
+}
+
+func latestHumanReviewUnblockedVerdict(t task.Task) (agentID string, v verdictDecision, ok bool) {
+	for i := range slices.Backward(t.AgentRuns) {
+		run := &t.AgentRuns[i]
+		if run.Role != string(agent.RoleHumanReview) || !run.VerdictRendered || strings.TrimSpace(run.Result) == "" {
+			continue
+		}
+		parsed, _, err := verdict.Parse(run.Result)
+		if err != nil || parsed.Decision != "unblocked" {
+			continue
+		}
+		return run.AgentID, parsed, true
+	}
+	return "", verdictDecision{}, false
 }
 
 func recoveryNeedsTamperBless(current task.Task, target task.Status) bool {

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -550,6 +550,131 @@ func TestOnComplete_UnblockedVerdict_AppliesRecoverableAction(t *testing.T) {
 	}
 }
 
+func TestPrepareRecoveryDispatch_InReviewWithoutPRFallsBackToReadyReview(t *testing.T) {
+	t.Parallel()
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Recover pre-PR review", "body", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = tasks.Update(tk.ID, task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		ProjectID: task.Ptr("Automaat/sybra"),
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	got, err := h.prepareRecoveryDispatch(tk, task.StatusInReview)
+	if err != nil {
+		t.Fatalf("prepareRecoveryDispatch: %v", err)
+	}
+	if got != task.StatusReadyReview {
+		t.Fatalf("target = %q, want %q", got, task.StatusReadyReview)
+	}
+}
+
+func TestRecoverRenderedUnblockedTasks_DispatchesMissingWorktreeCircuitBreaker(t *testing.T) {
+	t.Parallel()
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Recover old missing worktree park", "body", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	reason := `circuit breaker: agent start failed: start agent: agent.Run: Dir "/tmp/sybra/worktrees/task-1" not accessible: stat /tmp/sybra/worktrees/task-1: no such file or directory (tripped after 3 dispatch failures for step "fix_review" within 15m0s)`
+	tk, err = tasks.Update(tk.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(reason),
+		ProjectID:    task.Ptr("Automaat/sybra"),
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID:         "hr-rendered",
+		Role:            string(agent.RoleHumanReview),
+		Mode:            "headless",
+		State:           "stopped",
+		Outcome:         "success",
+		VerdictRendered: true,
+		Result:          `{"decision":"unblocked","reason":"worktree has been recreated; resume review","recoverable_action":"in-review","confidence":"high","issue_title":null,"issue_body":null,"issue_labels":null}`,
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	var dispatchedTarget string
+	h.dispatchFromHumanRequired = func(id, target, dispatchReason, _ string) (task.Task, error) {
+		dispatchedTarget = target
+		return tasks.Update(id, task.Update{
+			Status:       task.Ptr(task.StatusReadyReview),
+			StatusReason: task.Ptr(dispatchReason),
+		})
+	}
+
+	h.recoverRenderedUnblockedTasks()
+
+	if dispatchedTarget != string(task.StatusReadyReview) {
+		t.Fatalf("dispatch target = %q, want %q", dispatchedTarget, task.StatusReadyReview)
+	}
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusReadyReview {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusReadyReview)
+	}
+}
+
+func TestRecoverRenderedUnblockedTasks_IgnoresUnrenderedVerdict(t *testing.T) {
+	t.Parallel()
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Recover old missing worktree park", "body", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	reason := `circuit breaker: agent start failed: start agent: agent.Run: Dir "/tmp/sybra/worktrees/task-1" not accessible: stat /tmp/sybra/worktrees/task-1: no such file or directory`
+	tk, err = tasks.Update(tk.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(reason),
+		ProjectID:    task.Ptr("Automaat/sybra"),
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID:         "hr-unrendered",
+		Role:            string(agent.RoleHumanReview),
+		Mode:            "headless",
+		State:           "stopped",
+		Outcome:         "success",
+		VerdictRendered: false,
+		Result:          `{"decision":"unblocked","reason":"worktree has been recreated; resume review","recoverable_action":"in-review","confidence":"high","issue_title":null,"issue_body":null,"issue_labels":null}`,
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	h.dispatchFromHumanRequired = func(id, target, dispatchReason, agentID string) (task.Task, error) {
+		t.Fatalf("dispatchFromHumanRequired called unexpectedly with id=%q target=%q reason=%q agent=%q", id, target, dispatchReason, agentID)
+		return task.Task{}, nil
+	}
+
+	h.recoverRenderedUnblockedTasks()
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+}
+
 func TestOnComplete_UnblockedVerdict_ReadyReviewWithPRResumesInReview(t *testing.T) {
 	t.Parallel()
 	h, tasks, cleanup := newReviewTestEnv(t)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -471,8 +471,8 @@ func (prReviewRequesterAdapter) RerequestReview(repo string, prNumber int) ([]st
 	return reviewers, nil
 }
 
-func (prReviewRequesterAdapter) RequestCopilotReview(repo string, prNumber int) error {
-	return github.RequestCopilotReview(repo, prNumber)
+func (prReviewRequesterAdapter) RequestCopilotReview(ctx context.Context, repo string, prNumber int) error {
+	return github.RequestCopilotReviewCtx(ctx, repo, prNumber)
 }
 
 func eligibleRerequestReviewer(login, viewer, prAuthor string) bool {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -471,6 +471,10 @@ func (prReviewRequesterAdapter) RerequestReview(repo string, prNumber int) ([]st
 	return reviewers, nil
 }
 
+func (prReviewRequesterAdapter) RequestCopilotReview(repo string, prNumber int) error {
+	return github.RequestCopilotReview(repo, prNumber)
+}
+
 func eligibleRerequestReviewer(login, viewer, prAuthor string) bool {
 	if login == "" {
 		return false

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -30,6 +30,8 @@ import (
 
 const TransientFetchWarnThreshold = 3
 
+const stalePRDispatchGateAge = 15 * time.Minute
+
 // readyPRState is a cached "confirmed ready to merge" snapshot for a task's
 // linked PR, keyed by "repo#number". fetchKnownTaskPRs reuses it across poll
 // cycles instead of re-running the full per-PR fetch (reviews, threads,
@@ -379,7 +381,7 @@ func (r *Handler) pollKnownTaskPRs(ctx context.Context) time.Duration {
 		return r.nextInterval(false, false)
 	}
 
-	selection := r.selectKnownPRPoll(tasks)
+	selection := r.selectKnownPRPoll(ctx, tasks)
 	r.logger.Info("reviews.poll.bounded",
 		"selected", selection.selectedPRs,
 		"deferred", selection.deferredPRs,
@@ -435,9 +437,9 @@ func (r *Handler) pollKnownTaskPRs(ctx context.Context) time.Duration {
 
 	r.scanForReverts(ctx, tasks)
 	r.resolveAddressedCopilotThreads(ctx, tasks, monitoredPRs)
-	r.reconcilePRPhases(tasks, monitoredPRs)
+	r.reconcilePRPhases(ctx, tasks, monitoredPRs)
 	reconciledReady := r.reconcileHumanRequiredBlockers(tasks, monitoredPRs)
-	issues = r.mergeReconciledReady(reconciledReady, issues)
+	issues = r.mergeReconciledReady(ctx, reconciledReady, issues)
 	r.closeFinishedReviewTasks(tasks, nil)
 	r.maybeArmNativeAutoMerge(tasks, monitoredPRs, issues)
 
@@ -456,13 +458,13 @@ func (r *Handler) pollKnownTaskPRs(ctx context.Context) time.Duration {
 // dispatch (e.g. a second poller instance) could already have a workflow or
 // agent live against it by the time this runs — merging out from under that
 // would race the in-flight run.
-func (r *Handler) mergeReconciledReady(reconciledReady, issues []github.PRIssue) []github.PRIssue {
+func (r *Handler) mergeReconciledReady(ctx context.Context, reconciledReady, issues []github.PRIssue) []github.PRIssue {
 	if r.projects == nil {
 		return issues
 	}
 	for i := range reconciledReady {
 		issue := reconciledReady[i]
-		if r.agents.HasRunningAgentForTask(issue.TaskID) {
+		if r.hasBlockingAgentForTask(ctx, issue.TaskID) {
 			r.logger.Info("reviews.dispatch.gate", "task_id", issue.TaskID, "gate", "running_agent", "kind", issue.Kind)
 			continue
 		}
@@ -609,7 +611,7 @@ func (r *Handler) handleTransientReviewFetchError(ctx context.Context, tasks []t
 
 func (r *Handler) processSybraPRPoll(ctx context.Context, tasks []task.Task, summary github.ReviewSummary) bool {
 	monitoredPRs := r.monitoredPRs(summary)
-	monitoredPRs = r.includeKnownTaskPRs(tasks, monitoredPRs)
+	monitoredPRs = r.includeKnownTaskPRs(ctx, tasks, monitoredPRs)
 
 	// Recover PRs orphaned by a workflow that exited before linking — e.g. a
 	// task stranded in human-required while a late-finishing agent opened the
@@ -629,12 +631,12 @@ func (r *Handler) processSybraPRPoll(ctx context.Context, tasks []task.Task, sum
 
 	r.scanForReverts(ctx, tasks)
 	r.resolveAddressedCopilotThreads(ctx, tasks, monitoredPRs)
-	r.reconcilePRPhases(tasks, monitoredPRs)
+	r.reconcilePRPhases(ctx, tasks, monitoredPRs)
 	// monitoredPRs here is the author:@me search result (r.monitoredPRs), which
 	// already spans every open PR the user authored regardless of task status —
 	// no separate fetch is needed to reach a human-required task's own PR.
 	reconciledReady := r.reconcileHumanRequiredBlockers(tasks, monitoredPRs)
-	issues = r.mergeReconciledReady(reconciledReady, issues)
+	issues = r.mergeReconciledReady(ctx, reconciledReady, issues)
 	r.maybeArmNativeAutoMerge(tasks, monitoredPRs, issues)
 
 	return prNeedsAttention(monitoredPRs)
@@ -685,7 +687,7 @@ func buildOutboundMatchers(tasks []task.Task) (matchers, closedMatchers []github
 // gates a SourcedViaREST PR on the strict REST readiness check
 // (readyForRESTAutoMerge) rather than the Copilot/thread-based gate.
 func (r *Handler) handleKnownPRConflictsViaREST(ctx context.Context, tasks []task.Task) {
-	selection := r.selectKnownPRPoll(tasks)
+	selection := r.selectKnownPRPoll(ctx, tasks)
 	r.logger.Info("reviews.poll.bounded",
 		"selected", selection.selectedPRs,
 		"deferred", selection.deferredPRs,
@@ -733,7 +735,7 @@ func (r *Handler) handleKnownPRConflictsViaREST(ctx context.Context, tasks []tas
 		}
 		r.handleMatchedPRIssues(ctx, handled)
 	}
-	r.cancelSettledImplementationWorkflows(tasks, monitoredPRs)
+	r.cancelSettledImplementationWorkflows(ctx, tasks, monitoredPRs)
 	if len(closedMatchers) > 0 {
 		fetchState := github.FetchPRStateViaREST
 		if r.fetchPRStateFn != nil {
@@ -753,7 +755,7 @@ func (r *Handler) handleMatchedOwnPRs(ctx context.Context, tasks []task.Task, mo
 		r.cancelResolvedPRFixWorkflows(tasks, issues, github.MatchTaskPRIndex(monitoredPRs, matchers))
 		r.handleMatchedPRIssues(ctx, issues)
 	}
-	r.cancelSettledImplementationWorkflows(tasks, monitoredPRs)
+	r.cancelSettledImplementationWorkflows(ctx, tasks, monitoredPRs)
 	return issues
 }
 
@@ -794,7 +796,7 @@ func (r *Handler) handleTaskPRIssues(ctx context.Context, taskID string, issues 
 		kinds = append(kinds, string(issues[i].Kind))
 	}
 	r.logger.Info("reviews.task-issues", "task_id", taskID, "kinds", kinds)
-	if r.agents.HasRunningAgentForTask(taskID) {
+	if r.hasBlockingAgentForTask(ctx, taskID) {
 		r.logger.Info("reviews.dispatch.gate", "task_id", taskID, "gate", "running_agent")
 		return
 	}
@@ -1044,7 +1046,7 @@ func (r *Handler) AdvanceClosedTaskPR(ctx context.Context, taskID string, prNumb
 }
 
 func (r *Handler) advanceClosedTaskPR(ctx context.Context, c github.ClosedPR) error {
-	if r.agents.HasRunningAgentForTask(c.TaskID) {
+	if r.hasBlockingAgentForTask(ctx, c.TaskID) {
 		r.logger.Info("pr-monitor.closed-stop-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
 		r.agents.KillAgentsForTask(c.TaskID, 10*time.Second)
 	}
@@ -1579,8 +1581,8 @@ func (r *Handler) monitoredPRs(summary github.ReviewSummary) []github.PullReques
 // result. FetchReviews is intentionally search-based and can miss PRs created
 // by another machine/account in the cluster; linked task metadata is the
 // canonical fallback for those outbound PRs.
-func (r *Handler) includeKnownTaskPRs(tasks []task.Task, monitoredPRs []github.PullRequest) []github.PullRequest {
-	selection := r.selectKnownPRPoll(tasks)
+func (r *Handler) includeKnownTaskPRs(ctx context.Context, tasks []task.Task, monitoredPRs []github.PullRequest) []github.PullRequest {
+	selection := r.selectKnownPRPoll(ctx, tasks)
 	if r.logger != nil {
 		r.logger.Info("reviews.poll.bounded",
 			"selected", selection.selectedPRs,

--- a/internal/sybra/review/outbound.go
+++ b/internal/sybra/review/outbound.go
@@ -26,7 +26,7 @@ const reconciledLatchTag = "monitor:reconciled"
 // task (status in-review/ready-review, not tag `review`) from the live
 // monitored PRs and persists any delta. The phase is a pure overlay on the In
 // Review column — it never changes task.Status.
-func (r *Handler) reconcilePRPhases(tasks []task.Task, monitoredPRs []github.PullRequest) {
+func (r *Handler) reconcilePRPhases(ctx context.Context, tasks []task.Task, monitoredPRs []github.PullRequest) {
 	byNumber, byBranch := indexMonitoredPRs(monitoredPRs)
 
 	for i := range tasks {
@@ -53,7 +53,7 @@ func (r *Handler) reconcilePRPhases(tasks []task.Task, monitoredPRs []github.Pul
 		}
 
 		r.applyPRPhase(t, computePRPhase(prSignals{
-			AgentRunning:     r.agents.HasRunningAgentForTask(t.ID),
+			AgentRunning:     r.hasBlockingAgentForTask(ctx, t.ID),
 			IsDraft:          pr.IsDraft,
 			CIStatus:         pr.CIStatus,
 			HasPendingChecks: pr.HasPendingChecks,
@@ -73,7 +73,7 @@ func (r *Handler) reconcilePRPhases(tasks []task.Task, monitoredPRs []github.Pul
 // Intentionally scoped to the implement step itself. A workflow parked on later
 // deterministic gates (verify_checks, etc.) still owns meaningful work and must
 // not be short-circuited just because an older PR snapshot looks green.
-func (r *Handler) cancelSettledImplementationWorkflows(tasks []task.Task, monitoredPRs []github.PullRequest) {
+func (r *Handler) cancelSettledImplementationWorkflows(ctx context.Context, tasks []task.Task, monitoredPRs []github.PullRequest) {
 	if r.WorkflowEngine == nil {
 		return
 	}
@@ -84,7 +84,7 @@ func (r *Handler) cancelSettledImplementationWorkflows(tasks []task.Task, monito
 		if !staleImplementationWorkflowEligible(t) {
 			continue
 		}
-		if r.hasRunningAgentForTask(t.ID) {
+		if r.hasRunningAgentForTask(ctx, t.ID) {
 			continue
 		}
 		pr := matchingPR(t, byNumber, byBranch)
@@ -122,7 +122,7 @@ func (r *Handler) settledImplementationFetchMatchers(ctx context.Context, tasks 
 		if !staleImplementationWorkflowEligible(t) || t.ProjectID == "" {
 			continue
 		}
-		if r.hasRunningAgentForTask(t.ID) {
+		if r.hasRunningAgentForTask(ctx, t.ID) {
 			continue
 		}
 		m := github.TaskMatcher{
@@ -188,8 +188,27 @@ func (r *Handler) findOpenPRForBranch(ctx context.Context, repo, branch string) 
 	return github.FindPRForBranch(ctx, repo, branch)
 }
 
-func (r *Handler) hasRunningAgentForTask(taskID string) bool {
-	return r != nil && r.agents != nil && r.agents.HasRunningAgentForTask(taskID)
+func (r *Handler) hasRunningAgentForTask(ctx context.Context, taskID string) bool {
+	return r.hasBlockingAgentForTask(ctx, taskID)
+}
+
+func (r *Handler) hasBlockingAgentForTask(ctx context.Context, taskID string) bool {
+	if r == nil || r.agents == nil {
+		return false
+	}
+	if !r.agents.HasRunningAgentForTask(taskID) {
+		return false
+	}
+	releasedAgents := r.agents.ReleaseStaleStoppedAgentsForTask(ctx, taskID, stalePRDispatchGateAge)
+	releasedClaim := r.agents.ReleaseStaleTaskDispatch(taskID, stalePRDispatchGateAge)
+	if releasedAgents > 0 || releasedClaim {
+		if r.logger != nil {
+			r.logger.Warn("reviews.dispatch.gate.stale-released",
+				"task_id", taskID, "agents", releasedAgents, "dispatch_claim", releasedClaim)
+		}
+		return r.agents.HasRunningAgentForTask(taskID)
+	}
+	return true
 }
 
 // indexMonitoredPRs builds the by-number and by-branch lookup maps shared by

--- a/internal/sybra/review/outbound_test.go
+++ b/internal/sybra/review/outbound_test.go
@@ -125,7 +125,7 @@ func TestCancelSettledImplementationWorkflows(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		r.cancelSettledImplementationWorkflows(all, []github.PullRequest{{
+		r.cancelSettledImplementationWorkflows(context.Background(), all, []github.PullRequest{{
 			Number:      42,
 			Repository:  "Automaat/sybra",
 			HeadRefName: "feat/watchdog-pr",
@@ -173,7 +173,7 @@ func TestCancelSettledImplementationWorkflows(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		r.cancelSettledImplementationWorkflows(all, []github.PullRequest{{
+		r.cancelSettledImplementationWorkflows(context.Background(), all, []github.PullRequest{{
 			Number:      77,
 			Repository:  "Automaat/sybra",
 			HeadRefName: "feat/branch-only",
@@ -233,7 +233,7 @@ func TestCancelSettledImplementationWorkflows(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		r.cancelSettledImplementationWorkflows(all, []github.PullRequest{{
+		r.cancelSettledImplementationWorkflows(context.Background(), all, []github.PullRequest{{
 			Number:      42,
 			Repository:  "Automaat/sybra",
 			HeadRefName: "feat/watchdog-pr",
@@ -284,7 +284,7 @@ func TestCancelSettledImplementationWorkflows(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		r.cancelSettledImplementationWorkflows(all, []github.PullRequest{{
+		r.cancelSettledImplementationWorkflows(context.Background(), all, []github.PullRequest{{
 			Number:           55,
 			Repository:       "Automaat/sybra",
 			HeadRefName:      "feat/not-green",
@@ -336,7 +336,7 @@ func TestCancelSettledImplementationWorkflows(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		r.cancelSettledImplementationWorkflows(all, []github.PullRequest{{
+		r.cancelSettledImplementationWorkflows(context.Background(), all, []github.PullRequest{{
 			Number:         66,
 			Repository:     "Automaat/sybra",
 			HeadRefName:    "feat/rest-ci-unknown",
@@ -569,7 +569,7 @@ func TestReconcilePRPhases(t *testing.T) {
 		{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"},
 		{Number: 7, ReviewDecision: "CHANGES_REQUESTED"},
 	}
-	r.reconcilePRPhases(all, prs)
+	r.reconcilePRPhases(context.Background(), all, prs)
 
 	got, err := tasks.Get(own.ID)
 	if err != nil {
@@ -614,7 +614,7 @@ func TestReconcilePRPhasesClearsStaleWhenIneligible(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, CIStatus: "SUCCESS"}})
+	r.reconcilePRPhases(context.Background(), all, []github.PullRequest{{Number: 42, CIStatus: "SUCCESS"}})
 
 	got, err := tasks.Get(created.ID)
 	if err != nil {
@@ -666,7 +666,7 @@ func TestReconcilePRPhasesDoesNotReactivateFreshManualHumanRequired(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
+	r.reconcilePRPhases(context.Background(), all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
 
 	got, err := tasks.Get(created.ID)
 	if err != nil {
@@ -700,7 +700,7 @@ func TestReconcilePRPhasesDoesNotReactivateReasonedHumanRequired(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
+	r.reconcilePRPhases(context.Background(), all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
 
 	got, err := tasks.Get(created.ID)
 	if err != nil {
@@ -736,7 +736,7 @@ func TestReconcilePRPhasesDoesNotReactivateLaterManualHumanRequired(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
+	r.reconcilePRPhases(context.Background(), all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
 
 	got, err := tasks.Get(created.ID)
 	if err != nil {
@@ -769,7 +769,7 @@ func TestReconcilePRPhasesDoesNotReactivateWithoutLivePR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.reconcilePRPhases(all, nil)
+	r.reconcilePRPhases(context.Background(), all, nil)
 
 	got, err := tasks.Get(created.ID)
 	if err != nil {
@@ -1014,7 +1014,7 @@ func TestReconcileHumanRequiredBlockersNoDoubleMoveWithReactivateLinkedOwnPR(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
+	r.reconcilePRPhases(context.Background(), all, []github.PullRequest{{Number: 42, Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
 	afterPhases, err := tasks.Get(parked.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -1406,7 +1406,7 @@ func TestMergeReconciledReady_SkipsTaskWithRunningAgent(t *testing.T) {
 		Kind: github.PRIssueReadyToMerge, TaskID: created.ID,
 		PR: github.PullRequest{Number: 42, Repository: "pet-owner/pet-repo", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"},
 	}
-	got := r.mergeReconciledReady([]github.PRIssue{issue}, nil)
+	got := r.mergeReconciledReady(context.Background(), []github.PRIssue{issue}, nil)
 
 	if merged {
 		t.Fatal("handleAutoMerge ran while an agent is live for the task")
@@ -1446,7 +1446,7 @@ func TestMergeReconciledReady_SkipsTaskWithActiveWorkflow(t *testing.T) {
 		Kind: github.PRIssueReadyToMerge, TaskID: created.ID,
 		PR: github.PullRequest{Number: 42, Repository: "Automaat/sybra", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"},
 	}
-	got := r.mergeReconciledReady([]github.PRIssue{issue}, nil)
+	got := r.mergeReconciledReady(context.Background(), []github.PRIssue{issue}, nil)
 
 	if merged {
 		t.Fatal("handleAutoMerge ran while the task's workflow is still active")

--- a/internal/sybra/review/pr_poll_sched.go
+++ b/internal/sybra/review/pr_poll_sched.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"cmp"
+	"context"
 	"slices"
 
 	"github.com/Automaat/sybra/internal/config"
@@ -37,7 +38,7 @@ func expBackoff(streak, maxTicks int) int {
 	return skip
 }
 
-func (r *Handler) selectKnownPRPoll(tasks []task.Task) knownPRPollSelection {
+func (r *Handler) selectKnownPRPoll(ctx context.Context, tasks []task.Task) knownPRPollSelection {
 	if r.prPollState == nil {
 		r.prPollState = make(map[string]prPollEntry)
 	}
@@ -50,7 +51,7 @@ func (r *Handler) selectKnownPRPoll(tasks []task.Task) knownPRPollSelection {
 
 	for i := range tasks {
 		tk := tasks[i]
-		if r.agents != nil && r.agents.HasRunningAgentForTask(tk.ID) {
+		if r.hasBlockingAgentForTask(ctx, tk.ID) {
 			active = append(active, tk)
 			if knownPRPollEligible(&tk) {
 				activePRs++

--- a/internal/sybra/review/pr_poll_sched_test.go
+++ b/internal/sybra/review/pr_poll_sched_test.go
@@ -70,7 +70,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 			},
 		}
 
-		sel := r.selectKnownPRPoll([]task.Task{
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{
 			newTask("older", 3, base.Add(-2*time.Hour)),
 			newTask("active", 1, base.Add(-4*time.Hour)),
 			newTask("newest", 2, base),
@@ -93,7 +93,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 			},
 		}
 
-		sel := r.selectKnownPRPoll([]task.Task{
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{
 			newTask("mid", 2, base.Add(-time.Minute)),
 			newTask("old", 3, base.Add(-2*time.Minute)),
 			newTask("new", 1, base),
@@ -123,7 +123,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 		reviewTask := newTask("review-task", 3, base.Add(-2*time.Second))
 		reviewTask.Tags = []string{"review"}
 
-		sel := r.selectKnownPRPoll([]task.Task{
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{
 			done,
 			chat,
 			reviewTask,
@@ -151,7 +151,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 		tk := newTask("deferred", 7, base)
 
 		for i, wantSkip := range []int{1, 0} {
-			sel := r.selectKnownPRPoll([]task.Task{tk})
+			sel := r.selectKnownPRPoll(context.Background(), []task.Task{tk})
 			if len(sel.tasks) != 0 {
 				t.Fatalf("poll %d selected ids = %v, want none while deferred", i+1, taskIDs(sel.tasks))
 			}
@@ -163,7 +163,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 			}
 		}
 
-		sel := r.selectKnownPRPoll([]task.Task{tk})
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{tk})
 		if got := taskIDs(sel.tasks); len(got) != 1 || got[0] != "deferred" {
 			t.Fatalf("selected ids = %v, want [deferred] after countdown", got)
 		}
@@ -190,7 +190,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 			},
 		}
 
-		sel := r.selectKnownPRPoll([]task.Task{tk})
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{tk})
 		if got := taskIDs(sel.tasks); len(got) != 1 || got[0] != "reviewed" {
 			t.Fatalf("selected ids = %v, want [reviewed] when updatedAt changes", got)
 		}
@@ -220,7 +220,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 			},
 		}
 
-		sel := r.selectKnownPRPoll([]task.Task{tk})
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{tk})
 		if got := taskIDs(sel.tasks); len(got) != 0 {
 			t.Fatalf("selected ids = %v, want none while probe error preserves backoff", got)
 		}
@@ -284,7 +284,7 @@ func TestSelectKnownPRPoll(t *testing.T) {
 		}
 		tasks[0].ID = "active-1"
 
-		sel := r.selectKnownPRPoll(tasks)
+		sel := r.selectKnownPRPoll(context.Background(), tasks)
 		if sel.selectedPRs != 25 {
 			t.Fatalf("selectedPRs = %d, want 25", sel.selectedPRs)
 		}

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -1514,7 +1514,7 @@ func TestIncludeKnownTaskPRsAddsLinkedPRsMissingFromSearch(t *testing.T) {
 		},
 	}
 
-	got := r.includeKnownTaskPRs([]task.Task{
+	got := r.includeKnownTaskPRs(context.Background(), []task.Task{
 		{
 			ID:        "already-search",
 			Status:    task.StatusInReview,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -196,7 +196,7 @@ type PRLinker interface {
 // workflow fixes review comments and pushes updated commits.
 type PRReviewRequester interface {
 	RerequestReview(repo string, prNumber int) (reviewers []string, err error)
-	RequestCopilotReview(repo string, prNumber int) error
+	RequestCopilotReview(ctx context.Context, repo string, prNumber int) error
 }
 
 // PRStateFetcher fetches the live state of a GitHub pull request. Used by

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -196,6 +196,7 @@ type PRLinker interface {
 // workflow fixes review comments and pushes updated commits.
 type PRReviewRequester interface {
 	RerequestReview(repo string, prNumber int) (reviewers []string, err error)
+	RequestCopilotReview(repo string, prNumber int) error
 }
 
 // PRStateFetcher fetches the live state of a GitHub pull request. Used by

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -120,7 +120,9 @@ func (e *Engine) requestCopilotReview(taskID, repo string, prNumber int) {
 	if repo == "" || prNumber <= 0 || e.prReviewers == nil {
 		return
 	}
-	if err := e.prReviewers.RequestCopilotReview(repo, prNumber); err != nil {
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+	if err := e.prReviewers.RequestCopilotReview(ctx, repo, prNumber); err != nil {
 		e.logger.Warn("workflow.create-pr.copilot-review.failed", "task_id", taskID, "repo", repo, "pr", prNumber, "err", err)
 		return
 	}

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -72,6 +72,7 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 		if err := e.linkTaskPR(taskID, t, existing); err != nil {
 			return StepOutput{}, fmt.Errorf("create_pr: link existing pr: %w", err)
 		}
+		e.requestCopilotReview(taskID, t.ProjectID, existing)
 		return stepDone(step, fmt.Sprintf("pr #%d already exists for branch", existing))
 	}
 	if out, done := e.handleExistingAnyStatePRForBranch(taskID, step, wtPath, t, headArg); done {
@@ -107,11 +108,23 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 	if err := e.linkTaskPR(taskID, t, number); err != nil {
 		return StepOutput{}, fmt.Errorf("create_pr: link pr: %w", err)
 	}
+	e.requestCopilotReview(taskID, t.ProjectID, number)
 	if localSHA, lErr := project.CurrentCommit(ctx, wtPath); lErr == nil && headSHA != "" && localSHA != headSHA {
 		e.logger.Warn("workflow.create-pr.head-mismatch", "task_id", taskID, "pr", number, "local", localSHA, "remote", headSHA)
 	}
 	e.logger.Info("workflow.create-pr.created", "task_id", taskID, "pr", number)
 	return stepDone(step, fmt.Sprintf("created pr #%d", number))
+}
+
+func (e *Engine) requestCopilotReview(taskID, repo string, prNumber int) {
+	if repo == "" || prNumber <= 0 || e.prReviewers == nil {
+		return
+	}
+	if err := e.prReviewers.RequestCopilotReview(repo, prNumber); err != nil {
+		e.logger.Warn("workflow.create-pr.copilot-review.failed", "task_id", taskID, "repo", repo, "pr", prNumber, "err", err)
+		return
+	}
+	e.logger.Info("workflow.create-pr.copilot-review.requested", "task_id", taskID, "repo", repo, "pr", prNumber)
 }
 
 func (e *Engine) adoptExistingPROnConflict(taskID, repo, headArg string, createErr error) (int, bool) {
@@ -132,6 +145,7 @@ func (e *Engine) adoptExistingPROnConflict(taskID, repo, headArg string, createE
 		return 0, false
 	}
 	e.logger.Info("workflow.create-pr.adopt-existing", "task_id", taskID, "pr", existing)
+	e.requestCopilotReview(taskID, repo, existing)
 	return existing, true
 }
 

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -533,6 +533,8 @@ func TestExecCreatePR_Success(t *testing.T) {
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	creator := &fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)}
 	engine.SetPRCreator(creator)
+	reviewer := &fakePRReviewRequester{}
+	engine.SetPRReviewRequester(reviewer)
 	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
@@ -560,6 +562,37 @@ func TestExecCreatePR_Success(t *testing.T) {
 	}
 	if creator.gotReq.Title != "feat(x): y" {
 		t.Errorf("CreatePR title = %q", creator.gotReq.Title)
+	}
+	if reviewer.copilotCalls != 1 || reviewer.copilotRepo != "acme/widgets" || reviewer.copilotPRNumber != 42 {
+		t.Fatalf("Copilot request = calls:%d repo:%q pr:%d", reviewer.copilotCalls, reviewer.copilotRepo, reviewer.copilotPRNumber)
+	}
+}
+
+func TestExecCreatePR_CopilotReviewFailureDoesNotBlockPR(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/my-branch")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+
+	tasks := newMemTasks()
+	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
+	tasks.Put(task)
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetPRCreator(&fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)})
+	engine.SetPRReviewRequester(&fakePRReviewRequester{copilotErr: errors.New("copilot unavailable")})
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execCreatePR: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, output = %q", out.Status, out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42", ti.PRNumber)
+	}
+	if ti.Status == "human-required" {
+		t.Errorf("task should not be human-required: %s", tasks.Reason("t1"))
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6240,11 +6240,15 @@ func newEnsurePRStep() *Step {
 }
 
 type fakePRReviewRequester struct {
-	reviewers []string
-	err       error
-	calls     int
-	repo      string
-	prNumber  int
+	reviewers       []string
+	err             error
+	copilotErr      error
+	calls           int
+	copilotCalls    int
+	repo            string
+	prNumber        int
+	copilotRepo     string
+	copilotPRNumber int
 }
 
 func (f *fakePRReviewRequester) RerequestReview(repo string, prNumber int) ([]string, error) {
@@ -6252,6 +6256,13 @@ func (f *fakePRReviewRequester) RerequestReview(repo string, prNumber int) ([]st
 	f.repo = repo
 	f.prNumber = prNumber
 	return f.reviewers, f.err
+}
+
+func (f *fakePRReviewRequester) RequestCopilotReview(repo string, prNumber int) error {
+	f.copilotCalls++
+	f.copilotRepo = repo
+	f.copilotPRNumber = prNumber
+	return f.copilotErr
 }
 
 func newRerequestReviewStep() *Step {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6258,7 +6258,7 @@ func (f *fakePRReviewRequester) RerequestReview(repo string, prNumber int) ([]st
 	return f.reviewers, f.err
 }
 
-func (f *fakePRReviewRequester) RequestCopilotReview(repo string, prNumber int) error {
+func (f *fakePRReviewRequester) RequestCopilotReview(_ context.Context, repo string, prNumber int) error {
 	f.copilotCalls++
 	f.copilotRepo = repo
 	f.copilotPRNumber = prNumber


### PR DESCRIPTION
## Summary
- recover stale autonomy gates by expiring stale dispatch claims and releasing stopped-but-not-done agents that block review polling
- add startup recovery for human-review-rendered unblocked tasks in specific circuit-breaker cases
- request GitHub Copilot review after Sybra opens, adopts, or relinks a PR, with a bounded best-effort timeout so PR creation cannot wedge

## Tests
- go test ./internal/github
- go test ./internal/workflow
- go test ./internal/sybra -run TestNonExistent