### PR TITLE
fix(agent): expire stale dispatch claims consistently

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -384,7 +384,7 @@ func (m *Manager) dispatchClaimHeld(taskID string, now time.Time) bool {
 	return m.dispatchClaimHeldLocked(taskID, now)
 }
 
-func (m *Manager) dispatchClaimHeldReadLocked(taskID string, now time.Time) (held bool, stale bool) {
+func (m *Manager) dispatchClaimHeldReadLocked(taskID string, now time.Time) (held, stale bool) {
 	claimedAt, held := m.dispatchClaims[taskID]
 	if !held {
 		return false, false

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -319,15 +319,8 @@ const staleDispatchClaimAge = 15 * time.Minute
 func (m *Manager) ClaimTaskDispatch(taskID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if claimedAt, held := m.dispatchClaims[taskID]; held {
-		if time.Since(claimedAt) >= staleDispatchClaimAge {
-			if m.logger != nil {
-				m.logger.Warn("agent.dispatch-claim.stale-release", "task_id", taskID, "age", time.Since(claimedAt))
-			}
-			delete(m.dispatchClaims, taskID)
-		} else {
-			return false
-		}
+	if m.dispatchClaimHeldLocked(taskID, time.Now()) {
+		return false
 	}
 	if m.dispatchClaims == nil {
 		m.dispatchClaims = make(map[string]time.Time)
@@ -374,15 +367,27 @@ func (m *Manager) ReleaseTaskDispatch(taskID string) {
 func (m *Manager) IsDispatching(taskID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	return m.dispatchClaimHeldLocked(taskID, time.Now())
+}
+
+// dispatchClaimHeldLocked reports whether taskID has a non-stale dispatch
+// claim. Stale claims are deleted as a side effect so every caller that treats
+// dispatchClaims as liveness uses the same self-healing semantics.
+// Callers must hold m.mu for writing.
+func (m *Manager) dispatchClaimHeldLocked(taskID string, now time.Time) bool {
 	claimedAt, held := m.dispatchClaims[taskID]
-	if held && time.Since(claimedAt) >= staleDispatchClaimAge {
+	if !held {
+		return false
+	}
+	age := now.Sub(claimedAt)
+	if age >= staleDispatchClaimAge {
 		if m.logger != nil {
-			m.logger.Warn("agent.dispatch-claim.stale-release", "task_id", taskID, "age", time.Since(claimedAt))
+			m.logger.Warn("agent.dispatch-claim.stale-release", "task_id", taskID, "age", age)
 		}
 		delete(m.dispatchClaims, taskID)
 		return false
 	}
-	return held
+	return true
 }
 
 // DispatchClaim is a held per-task dispatch claim returned by

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -281,13 +281,13 @@ func (m *Manager) ActiveLogPaths() map[string]bool {
 // the goroutine finishes — avoiding a race where the worktree is cleaned up while the
 // agent process is still using it.
 func (m *Manager) HasRunningAgentForTask(taskID string) bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	// An in-flight dispatch counts as "running": the agent is mid-start and
 	// not yet in the map, but a second dispatcher must not treat the task as
 	// idle. Lets recovery / ResumeStalled / pr-fix pollers skip during the
 	// worktree-prep window instead of racing the dispatch.
-	if _, held := m.dispatchClaims[taskID]; held {
+	if m.dispatchClaimHeldLocked(taskID, time.Now()) {
 		return true
 	}
 	return m.hasLiveRegisteredAgent(taskID)
@@ -364,9 +364,9 @@ func (m *Manager) hasLiveRegisteredAgent(taskID string) bool {
 // after onComplete returns (see runner_headless), so it would otherwise still
 // read as running.
 func (m *Manager) HasOtherRunningAgentForTask(taskID, exceptAgentID string) bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if _, held := m.dispatchClaims[taskID]; held {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dispatchClaimHeldLocked(taskID, time.Now()) {
 		return true
 	}
 	for _, a := range m.agents {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -699,6 +699,21 @@ func TestClaimTaskDispatch(t *testing.T) {
 	m.ReleaseTaskDispatch("never-claimed")
 }
 
+func TestHasRunningAgentForTask_ExpiresStaleDispatchClaim(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	m.mu.Lock()
+	m.dispatchClaims["t1"] = time.Now().Add(-staleDispatchClaimAge - time.Minute)
+	m.mu.Unlock()
+
+	if m.HasRunningAgentForTask("t1") {
+		t.Fatal("stale dispatch claim with no agent should not report running")
+	}
+	if m.IsDispatching("t1") {
+		t.Fatal("stale dispatch claim should be removed")
+	}
+}
+
 // TestIsDispatching verifies the read-only peek other coordinators (e.g.
 // internal/workflow.Engine's DispatchEvent/ResumeStalled) consult as the
 // single ground truth for "does some dispatcher already own this task's next
@@ -861,6 +876,23 @@ func TestHasOtherRunningAgentForTask(t *testing.T) {
 	m.ClaimTaskDispatch("t1")
 	if !m.HasOtherRunningAgentForTask("t1", "a1") {
 		t.Error("a held dispatch claim should count as another running agent")
+	}
+}
+
+func TestHasOtherRunningAgentForTask_ExpiresStaleDispatchClaim(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	running := &Agent{ID: "a1", TaskID: "t1", State: StateRunning, cancel: func() {}}
+	m.mu.Lock()
+	m.agents["a1"] = running
+	m.dispatchClaims["t1"] = time.Now().Add(-staleDispatchClaimAge - time.Minute)
+	m.mu.Unlock()
+
+	if m.HasOtherRunningAgentForTask("t1", "a1") {
+		t.Fatal("stale dispatch claim should not count as another running agent")
+	}
+	if m.IsDispatching("t1") {
+		t.Fatal("stale dispatch claim should be removed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- make running-agent checks expire stale dispatch claims instead of treating raw map entries as active forever
- centralize dispatch-claim staleness cleanup behind the same locked helper
- add regression tests for stale claims in task liveness checks

## Tests
- go test ./internal/agent -run 'Test(ClaimTaskDispatch|IsDispatching|HasRunningAgentForTask_ExpiresStaleDispatchClaim|HasOtherRunningAgentForTask|HasOtherRunningAgentForTask_ExpiresStaleDispatchClaim)$'
- go test ./internal/agent