### PR TITLE
fix(recovery): keep stale restarts out of PR creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ deploy/k8s-poc/.env
 # Stray secondary git-dirs from sandboxed/isolated tool invocations
 # (see AutoCommitUncommitted's embedded-git-dir guard in internal/project/git.go)
 .git-local/
+
+# Local Codex/sandbox artifacts
+.codex-go-cache/
+.codex-golangci-cache/
+.codex-test-home/
+internal/sybra/zz_probe_release_test.go

--- a/internal/recovery/reconcile.go
+++ b/internal/recovery/reconcile.go
@@ -72,7 +72,9 @@ func (r *Recovery) reconcileBackfillPR(t *task.Task, prNumber int) {
 }
 
 func reconcileLostPREligible(t *task.Task) bool {
-	if t.Status != task.StatusInReview {
+	switch t.Status {
+	case task.StatusInReview, task.StatusReadyReview, task.StatusReadyPR:
+	default:
 		return false
 	}
 	if t.PRNumber != 0 || t.Branch == "" || t.ProjectID == "" {

--- a/internal/recovery/reconcile_test.go
+++ b/internal/recovery/reconcile_test.go
@@ -25,7 +25,7 @@ func (f *fakePRResolver) ResolvePRForTask(context.Context, string, string, strin
 	return f.ref, f.err
 }
 
-func newInReviewOrphan(t *testing.T, tasks *task.Manager, mutate func(*task.Update)) string {
+func newLostPROrphan(t *testing.T, tasks *task.Manager, mutate func(*task.Update)) string {
 	t.Helper()
 	created, err := tasks.Create("lost pr number", "", "headless")
 	if err != nil {
@@ -75,6 +75,7 @@ func newReconcileRecovery(t *testing.T, tasks *task.Manager, resolver recovery.P
 func TestReconcileLostPRNumber(t *testing.T) {
 	cases := []struct {
 		name            string
+		mutate          func(*task.Update)
 		ref             recovery.PRRef
 		resolveErr      error
 		wantStatus      task.Status
@@ -93,6 +94,25 @@ func TestReconcileLostPRNumber(t *testing.T) {
 			ref:        recovery.PRRef{Number: 42, State: "OPEN"},
 			wantStatus: task.StatusInReview,
 			wantPR:     42,
+		},
+		{
+			name: "ready-review merged PR advances to done and clears workflow",
+			mutate: func(u *task.Update) {
+				u.Status = task.Ptr(task.StatusReadyReview)
+			},
+			ref:             recovery.PRRef{Number: 2469, State: "MERGED"},
+			wantStatus:      task.StatusDone,
+			wantPR:          2469,
+			wantWorkflowNil: true,
+		},
+		{
+			name: "ready-pr open PR backfills pr_number and preserves status",
+			mutate: func(u *task.Update) {
+				u.Status = task.Ptr(task.StatusReadyPR)
+			},
+			ref:        recovery.PRRef{Number: 2470, State: "OPEN"},
+			wantStatus: task.StatusReadyPR,
+			wantPR:     2470,
 		},
 		{
 			name:       "no matching PR leaves the task unchanged",
@@ -115,7 +135,7 @@ func TestReconcileLostPRNumber(t *testing.T) {
 				t.Fatal(err)
 			}
 			tasks := task.NewManager(store, nil)
-			id := newInReviewOrphan(t, tasks, nil)
+			id := newLostPROrphan(t, tasks, tc.mutate)
 
 			resolver := &fakePRResolver{ref: tc.ref, err: tc.resolveErr}
 			r, wg := newReconcileRecovery(t, tasks, resolver)
@@ -174,7 +194,7 @@ func TestReconcileLostPRNumberSkipsIneligible(t *testing.T) {
 				t.Fatal(err)
 			}
 			tasks := task.NewManager(store, nil)
-			newInReviewOrphan(t, tasks, tc.mutate)
+			newLostPROrphan(t, tasks, tc.mutate)
 
 			resolver := &fakePRResolver{ref: recovery.PRRef{Number: 1, State: "MERGED"}}
 			r, wg := newReconcileRecovery(t, tasks, resolver)
@@ -194,7 +214,7 @@ func TestReconcileLostPRNumberNilResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 	tasks := task.NewManager(store, nil)
-	id := newInReviewOrphan(t, tasks, nil)
+	id := newLostPROrphan(t, tasks, nil)
 
 	r, wg := newReconcileRecovery(t, tasks, nil)
 	r.ReconcileLostPRNumber(context.Background())

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -774,6 +774,7 @@ func TestRestartStaleInteractiveOneShotRestartsAsOneShot(t *testing.T) {
 	if !stub.lastOneShot {
 		t.Fatal("interactive one-shot stale restart must preserve oneShot=true")
 	}
+	assertStaleRecoveryPromptDefersPR(t, stub.lastPrompt)
 }
 
 func TestRestartStaleInteractiveNoRunRedispatchesWhenProjectAssigned(t *testing.T) {
@@ -830,6 +831,7 @@ func TestRestartStaleInteractiveNoRunRedispatchesWhenProjectAssigned(t *testing.
 	if stub.lastOneShot {
 		t.Fatal("zero-run stale restart must not force oneShot")
 	}
+	assertStaleRecoveryPromptDefersPR(t, stub.lastPrompt)
 }
 
 func TestRestartStaleInteractiveNoWorkflowRedispatches(t *testing.T) {
@@ -894,6 +896,7 @@ func TestRestartStaleInteractiveNoWorkflowRedispatches(t *testing.T) {
 	if stub.lastOneShot {
 		t.Fatal("interactive stale redispatch without workflow must not force oneShot")
 	}
+	assertStaleRecoveryPromptDefersPR(t, stub.lastPrompt)
 }
 
 // TestRestartStaleInteractiveModeMismatchRedispatches covers the Copilot
@@ -963,6 +966,20 @@ func TestRestartStaleInteractiveModeMismatchRedispatches(t *testing.T) {
 	}
 	if stub.lastOneShot {
 		t.Fatal("mode-mismatch stale restart must not force oneShot")
+	}
+	assertStaleRecoveryPromptDefersPR(t, stub.lastPrompt)
+}
+
+func assertStaleRecoveryPromptDefersPR(t *testing.T, prompt string) {
+	t.Helper()
+	if !strings.Contains(prompt, "push the branch to origin") {
+		t.Fatalf("prompt = %q, want branch push instruction", prompt)
+	}
+	if !strings.Contains(prompt, "Do NOT create a PR") {
+		t.Fatalf("prompt = %q, want explicit PR creation ban", prompt)
+	}
+	if strings.Contains(prompt, "gh pr create") {
+		t.Fatalf("prompt = %q, must not tell stale recovery to create a PR", prompt)
 	}
 }
 

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -162,7 +162,7 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 	// the single dispatch choke point this path and the workflow resume path
 	// both funnel through — so it is delivered exactly once regardless of
 	// which loop re-dispatches the task.
-	prompt := "Continue implementing this task. When done, commit your work and push the branch to origin. Do NOT create a PR; Sybra's workflow will create, link, and stamp the PR after review and testing pass."
+	prompt := "Continue implementing this task. When done, commit your work and push the branch to origin. Do NOT create a PR; Sybra's workflow will create, link, and stamp the PR after review and testing have passed."
 	currentStatus := t.Status
 	r.WG.Go(func() {
 		_, err := r.Orchestrator.StartAgent(taskID, mode, prompt, false, oneShot)

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/metrics"
-	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 )
@@ -158,16 +157,12 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 		return
 	}
 	mode := t.AgentMode
-	prFlag := " --draft"
-	if proj, pErr := r.Projects.Get(t.ProjectID); pErr == nil && proj.Type == project.ProjectTypePet {
-		prFlag = ""
-	}
 	// A pending supervisor steer (set by the watchdog's headless nudge) is
 	// consumed and prepended to the prompt inside agentorch.Orchestrator.StartAgent,
 	// the single dispatch choke point this path and the workflow resume path
 	// both funnel through — so it is delivered exactly once regardless of
 	// which loop re-dispatches the task.
-	prompt := "Continue implementing this task. When done, create a PR with `gh pr create" + prFlag + "`."
+	prompt := "Continue implementing this task. When done, commit your work and push the branch to origin. Do NOT create a PR; Sybra's workflow will create, link, and stamp the PR after review and testing pass."
 	currentStatus := t.Status
 	r.WG.Go(func() {
 		_, err := r.Orchestrator.StartAgent(taskID, mode, prompt, false, oneShot)


### PR DESCRIPTION
## Summary

- keep stale recovery restarts from instructing agents to create PRs directly
- let lost-PR reconciliation repair ready-review/ready-pr task orphans, not only in-review tasks
- ignore local Codex cache/probe artifacts

## Verification

- GOCACHE=/Users/marcin.skalski/orca/workspaces/synapse/ship-bug/.codex-go-cache go test ./internal/recovery
- GOCACHE=/Users/marcin.skalski/orca/workspaces/synapse/ship-bug/.codex-go-cache GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./internal/workflow -run 'TestExecEnsurePRClosesIssue|TestExecLinkPRAndReview'
- GOCACHE=/Users/marcin.skalski/orca/workspaces/synapse/ship-bug/.codex-go-cache go test ./internal/sybra/review

Note: full ./internal/workflow still fails an unrelated existing TestExecVerifyChecks_UnrelatedGoPackageFailureBlocks assertion in this worktree.