### PR TITLE
fix(workflow): provision envtest assets before repo-scoped Go test gates

### DIFF
--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -805,7 +805,7 @@ func goPackageAffectedByChanges(
 	}
 	cmd := exec.CommandContext(ctx, "go", "list", "-deps", target)
 	cmd.Dir = wtPath
-	env, err := verifyCommandEnv(parentCtx, taskID, wtPath, "go list -deps "+target)
+	env, err := verifyCommandEnv(ctx, taskID, wtPath)
 	if err != nil {
 		return false, err
 	}

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/Automaat/sybra/internal/buildcache"
 )
 
 // verifyChecksDefaultTimeout bounds the whole verify run (every command). A test
@@ -807,7 +805,7 @@ func goPackageAffectedByChanges(
 	}
 	cmd := exec.CommandContext(ctx, "go", "list", "-deps", target)
 	cmd.Dir = wtPath
-	env, err := verifyCommandEnv(taskID)
+	env, err := verifyCommandEnv(parentCtx, taskID, wtPath, "go list -deps "+target)
 	if err != nil {
 		return false, err
 	}
@@ -1227,7 +1225,7 @@ func ownedByNpm(dir string) bool {
 // of stdout/stderr cannot exhaust memory.
 func (e *Engine) runVerifyCommands(ctx context.Context, taskID, wtPath string, cmds []string) (failedCmd, output string, err error) {
 	tail := &boundedTail{max: verifyChecksMaxOutput}
-	cmdEnv, err := verifyCommandEnv(taskID)
+	cmdEnv, err := verifyCommandEnv(ctx, taskID, wtPath, cmds...)
 	if err != nil {
 		return "", tail.String(), err
 	}
@@ -1265,10 +1263,6 @@ func (e *Engine) runVerifyCommands(ctx context.Context, taskID, wtPath string, c
 		}
 	}
 	return "", tail.String(), nil
-}
-
-func verifyCommandEnv(taskID string) ([]string, error) {
-	return buildcache.PrepareGoEnv(taskID, os.Environ())
 }
 
 // boundedTail is a concurrency-safe io.Writer that retains only the last `max`

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -836,6 +836,41 @@ import "sigs.k8s.io/controller-runtime/pkg/envtest"
 	}
 }
 
+func TestVerifyCommandEnv_InjectsEnvtestAssetsForGoListCommands(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	wt := t.TempDir()
+	writeTestFile(t, filepath.Join(wt, "go.mod"), `module example.com/operator
+
+go 1.26
+
+require (
+	k8s.io/api v0.32.4
+	sigs.k8s.io/controller-runtime v0.20.3
+)
+`)
+	writeTestFile(t, filepath.Join(wt, "internal", "controller", "suite_test.go"), `package controller
+
+import "sigs.k8s.io/controller-runtime/pkg/envtest"
+`)
+
+	assetsDir := filepath.Join(t.TempDir(), "kubebuilder", "bin")
+	argsLog := fakeSetupEnvtest(t, assetsDir)
+	env, err := verifyCommandEnv(context.Background(), "t1", wt, "go list -deps ./internal/controller")
+	if err != nil {
+		t.Fatalf("verifyCommandEnv: %v", err)
+	}
+	if got := envValue(env, "KUBEBUILDER_ASSETS"); got != assetsDir {
+		t.Fatalf("KUBEBUILDER_ASSETS = %q, want %q", got, assetsDir)
+	}
+	args, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read args log: %v", err)
+	}
+	if got := strings.TrimSpace(string(args)); got != "use -p path 1.32.x!" {
+		t.Fatalf("setup-envtest args = %q, want %q", got, "use -p path 1.32.x!")
+	}
+}
+
 func TestVerifyCommandEnv_SkipsEnvtestForNonGoCommands(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	wt := t.TempDir()

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -841,6 +841,37 @@ func TestUnit(t *testing.T) {}
 	}
 }
 
+func TestDiscoverEnvtestPlan_SkipsOversizeFiles(t *testing.T) {
+	wt := t.TempDir()
+	writeTestFile(t, filepath.Join(wt, "go.mod"), `module example.com/operator
+
+go 1.26
+
+require (
+	k8s.io/api v0.32.4
+	sigs.k8s.io/controller-runtime v0.20.3
+)
+`)
+	writeTestFile(t, filepath.Join(wt, "internal", "controller", "suite_test.go"), `package controller
+
+import "sigs.k8s.io/controller-runtime/pkg/envtest"
+`)
+	writeTestFile(t, filepath.Join(wt, "hack", "envtest.sh"), "ENVTEST_K8S_VERSION=1.31\n")
+	oversize := strings.Repeat("# filler\n", maxEnvtestInspectFileSize/8+1)
+	writeTestFile(t, filepath.Join(wt, ".github", "workflows", "generated.yml"), oversize+"ENVTEST_K8S_VERSION=1.99\n")
+
+	plan, err := discoverEnvtestPlan(wt)
+	if err != nil {
+		t.Fatalf("discoverEnvtestPlan: %v", err)
+	}
+	if !plan.Needed {
+		t.Fatal("Needed = false, want true")
+	}
+	if got, want := plan.VersionSpec, "1.31"; got != want {
+		t.Fatalf("VersionSpec = %q, want %q", got, want)
+	}
+}
+
 func TestVerifyCommandEnv_InjectsEnvtestAssetsForGoCommands(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	wt := t.TempDir()
@@ -873,6 +904,38 @@ import "sigs.k8s.io/controller-runtime/pkg/envtest"
 	}
 	if got := strings.TrimSpace(string(args)); got != "use -p path 1.32.x!" {
 		t.Fatalf("setup-envtest args = %q, want %q", got, "use -p path 1.32.x!")
+	}
+}
+
+func TestGoPackageAffectedByChanges_SkipsEnvtestProvisionForGoList(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	wt := t.TempDir()
+	writeTestFile(t, filepath.Join(wt, "go.mod"), `module example.com/operator
+
+go 1.26
+
+require (
+	k8s.io/api v0.32.4
+	sigs.k8s.io/controller-runtime v0.20.3
+)
+`)
+	writeTestFile(t, filepath.Join(wt, "internal", "controller", "suite_test.go"), `package controller
+
+import "sigs.k8s.io/controller-runtime/pkg/envtest"
+`)
+	argsLog := fakeSetupEnvtest(t, filepath.Join(t.TempDir(), "kubebuilder", "bin"))
+
+	affected, err := goPackageAffectedByChanges(context.Background(), "t1", wt, "internal/controller", map[string]bool{
+		"internal/other": true,
+	}, "example.com/operator")
+	if err != nil {
+		t.Fatalf("goPackageAffectedByChanges: %v", err)
+	}
+	if affected {
+		t.Fatal("affected = true, want false")
+	}
+	if _, err := os.Stat(argsLog); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("setup-envtest should not run, stat err = %v", err)
 	}
 }
 

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -801,6 +801,46 @@ import "sigs.k8s.io/controller-runtime/pkg/envtest"
 	}
 }
 
+func TestDiscoverEnvtestPlan_IgnoresToolingMentionsWithoutEnvtestImport(t *testing.T) {
+	wt := t.TempDir()
+	writeTestFile(t, filepath.Join(wt, "go.mod"), `module example.com/operator
+
+go 1.26
+
+require (
+	k8s.io/api v0.32.4
+	sigs.k8s.io/controller-runtime v0.20.3
+)
+`)
+	writeTestFile(t, filepath.Join(wt, ".github", "workflows", "ci.yml"), `name: ci
+jobs:
+  test:
+    steps:
+      - run: echo KUBEBUILDER_ASSETS setup-envtest
+`)
+	writeTestFile(t, filepath.Join(wt, "hack", "envtest.sh"), `#!/bin/sh
+echo "setup-envtest use 1.31"
+`)
+	writeTestFile(t, filepath.Join(wt, "internal", "controller", "suite_test.go"), `package controller
+
+func TestUnit(t *testing.T) {}
+`)
+
+	plan, err := discoverEnvtestPlan(wt)
+	if err != nil {
+		t.Fatalf("discoverEnvtestPlan: %v", err)
+	}
+	if plan.Needed {
+		t.Fatal("Needed = true, want false")
+	}
+	if got, want := plan.VersionSpec, "1.31"; got != want {
+		t.Fatalf("VersionSpec = %q, want %q", got, want)
+	}
+	if got, want := plan.SetupEnvtestRef, "release-0.20"; got != want {
+		t.Fatalf("SetupEnvtestRef = %q, want %q", got, want)
+	}
+}
+
 func TestVerifyCommandEnv_InjectsEnvtestAssetsForGoCommands(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	wt := t.TempDir()

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -769,6 +769,103 @@ func TestRunVerifyCommands_GOCACHEIsPerTaskWhileGOMODCACHEStaysShared(t *testing
 	}
 }
 
+func TestDiscoverEnvtestPlan_UsesExplicitVersionAndControllerRuntimeRelease(t *testing.T) {
+	wt := t.TempDir()
+	writeTestFile(t, filepath.Join(wt, "go.mod"), `module example.com/operator
+
+go 1.26
+
+require (
+	k8s.io/api v0.32.4
+	sigs.k8s.io/controller-runtime v0.20.3
+)
+`)
+	writeTestFile(t, filepath.Join(wt, "Makefile"), "ENVTEST_K8S_VERSION ?= 1.31\n")
+	writeTestFile(t, filepath.Join(wt, "internal", "controller", "suite_test.go"), `package controller
+
+import "sigs.k8s.io/controller-runtime/pkg/envtest"
+`)
+
+	plan, err := discoverEnvtestPlan(wt)
+	if err != nil {
+		t.Fatalf("discoverEnvtestPlan: %v", err)
+	}
+	if !plan.Needed {
+		t.Fatal("Needed = false, want true")
+	}
+	if got, want := plan.VersionSpec, "1.31"; got != want {
+		t.Fatalf("VersionSpec = %q, want %q", got, want)
+	}
+	if got, want := plan.SetupEnvtestRef, "release-0.20"; got != want {
+		t.Fatalf("SetupEnvtestRef = %q, want %q", got, want)
+	}
+}
+
+func TestVerifyCommandEnv_InjectsEnvtestAssetsForGoCommands(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	wt := t.TempDir()
+	writeTestFile(t, filepath.Join(wt, "go.mod"), `module example.com/operator
+
+go 1.26
+
+require (
+	k8s.io/api v0.32.4
+	sigs.k8s.io/controller-runtime v0.20.3
+)
+`)
+	writeTestFile(t, filepath.Join(wt, "internal", "controller", "suite_test.go"), `package controller
+
+import "sigs.k8s.io/controller-runtime/pkg/envtest"
+`)
+
+	assetsDir := filepath.Join(t.TempDir(), "kubebuilder", "bin")
+	argsLog := fakeSetupEnvtest(t, assetsDir)
+	env, err := verifyCommandEnv(context.Background(), "t1", wt, "mise exec -- go test ./...")
+	if err != nil {
+		t.Fatalf("verifyCommandEnv: %v", err)
+	}
+	if got := envValue(env, "KUBEBUILDER_ASSETS"); got != assetsDir {
+		t.Fatalf("KUBEBUILDER_ASSETS = %q, want %q", got, assetsDir)
+	}
+	args, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read args log: %v", err)
+	}
+	if got := strings.TrimSpace(string(args)); got != "use -p path 1.32.x!" {
+		t.Fatalf("setup-envtest args = %q, want %q", got, "use -p path 1.32.x!")
+	}
+}
+
+func TestVerifyCommandEnv_SkipsEnvtestForNonGoCommands(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	wt := t.TempDir()
+	writeTestFile(t, filepath.Join(wt, "go.mod"), `module example.com/operator
+
+go 1.26
+
+require (
+	k8s.io/api v0.32.4
+	sigs.k8s.io/controller-runtime v0.20.3
+)
+`)
+	writeTestFile(t, filepath.Join(wt, "internal", "controller", "suite_test.go"), `package controller
+
+import "sigs.k8s.io/controller-runtime/pkg/envtest"
+`)
+
+	argsLog := fakeSetupEnvtest(t, filepath.Join(t.TempDir(), "kubebuilder", "bin"))
+	env, err := verifyCommandEnv(context.Background(), "t1", wt, "(cd frontend && npm run check)")
+	if err != nil {
+		t.Fatalf("verifyCommandEnv: %v", err)
+	}
+	if got := envValue(env, "KUBEBUILDER_ASSETS"); got != "" {
+		t.Fatalf("KUBEBUILDER_ASSETS = %q, want empty", got)
+	}
+	if _, err := os.Stat(argsLog); err == nil {
+		t.Fatal("setup-envtest should not run for non-Go commands")
+	}
+}
+
 func TestEnsureNodeToolchain_RepairsCorruptBin(t *testing.T) {
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "package.json"), "{}")
@@ -975,8 +1072,23 @@ func fakeNPM(t *testing.T, markerName string) {
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
+func fakeSetupEnvtest(t *testing.T, assetsDir string) string {
+	t.Helper()
+	fakeBin := t.TempDir()
+	argsLog := filepath.Join(t.TempDir(), "setup-envtest.args")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' \"$*\" > %q\nprintf '%%s\\n' %q\n", argsLog, assetsDir)
+	if err := os.WriteFile(filepath.Join(fakeBin, "setup-envtest"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsLog
+}
+
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/workflow/envtest_assets.go
+++ b/internal/workflow/envtest_assets.go
@@ -64,21 +64,27 @@ func discoverEnvtestPlan(wtPath string) (envtestPlan, error) {
 	if plan.SetupEnvtestRef == "" {
 		plan.SetupEnvtestRef = "latest"
 	}
-	err = filepath.WalkDir(wtPath, func(path string, d fs.DirEntry, walkErr error) error {
+	root, err := os.OpenRoot(wtPath)
+	if err != nil {
+		return envtestPlan{}, err
+	}
+	defer func() { _ = root.Close() }()
+	err = fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
+		name := d.Name()
 		if d.IsDir() {
-			switch d.Name() {
+			switch name {
 			case ".git", "node_modules", "vendor":
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		if !shouldInspectEnvtestFile(path, d.Name()) {
+		if !shouldInspectEnvtestFile(path, name) {
 			return nil
 		}
-		data, err := os.ReadFile(path)
+		data, err := fs.ReadFile(root.FS(), path)
 		if err != nil {
 			return err
 		}
@@ -239,8 +245,8 @@ func provisionEnvtestAssets(ctx context.Context, wtPath string, plan envtestPlan
 func envValue(env []string, key string) string {
 	prefix := key + "="
 	for _, kv := range env {
-		if strings.HasPrefix(kv, prefix) {
-			return strings.TrimPrefix(kv, prefix)
+		if value, ok := strings.CutPrefix(kv, prefix); ok {
+			return value
 		}
 	}
 	return ""

--- a/internal/workflow/envtest_assets.go
+++ b/internal/workflow/envtest_assets.go
@@ -177,24 +177,24 @@ func inferEnvtestVersionFromText(data []byte) string {
 }
 
 func cleanEnvtestVersionToken(raw string) string {
-	token := strings.TrimSpace(raw)
-	if fields := strings.Fields(token); len(fields) > 0 {
-		token = fields[0]
+	versionToken := strings.TrimSpace(raw)
+	if fields := strings.Fields(versionToken); len(fields) > 0 {
+		versionToken = fields[0]
 	}
-	token = strings.Trim(token, `"'()[]{};,`)
-	if token == "" {
+	versionToken = strings.Trim(versionToken, `"'()[]{};,`)
+	if versionToken == "" {
 		return ""
 	}
-	token = strings.TrimPrefix(token, "v")
-	if !strings.HasPrefix(token, "1.") {
+	versionToken = strings.TrimPrefix(versionToken, "v")
+	if !strings.HasPrefix(versionToken, "1.") {
 		return ""
 	}
-	for _, ch := range token {
+	for _, ch := range versionToken {
 		if (ch < '0' || ch > '9') && ch != '.' && ch != 'x' && ch != '!' {
 			return ""
 		}
 	}
-	return token
+	return versionToken
 }
 
 func inferEnvtestVersionFromGoMod(goMod []byte) string {

--- a/internal/workflow/envtest_assets.go
+++ b/internal/workflow/envtest_assets.go
@@ -1,13 +1,15 @@
 package workflow
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/buildcache"
@@ -91,9 +93,7 @@ func discoverEnvtestPlan(wtPath string) (envtestPlan, error) {
 		if explicit := inferEnvtestVersionFromText(data); explicit != "" {
 			plan.VersionSpec = explicit
 		}
-		if bytes.Contains(data, []byte("sigs.k8s.io/controller-runtime/pkg/envtest")) ||
-			bytes.Contains(data, []byte("KUBEBUILDER_ASSETS")) ||
-			bytes.Contains(data, []byte("setup-envtest")) {
+		if fileImportsEnvtest(path, data) {
 			plan.Needed = true
 		}
 		return nil
@@ -112,6 +112,26 @@ func shouldInspectEnvtestFile(path, name string) bool {
 	switch filepath.Ext(path) {
 	case ".go", ".mk", ".sh", ".bash", ".envrc", ".yaml", ".yml":
 		return true
+	}
+	return false
+}
+
+func fileImportsEnvtest(path string, data []byte) bool {
+	if filepath.Ext(path) != ".go" {
+		return false
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), path, data, parser.ImportsOnly)
+	if err != nil {
+		return false
+	}
+	for _, imp := range file.Imports {
+		importPath, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		if importPath == "sigs.k8s.io/controller-runtime/pkg/envtest" {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/workflow/envtest_assets.go
+++ b/internal/workflow/envtest_assets.go
@@ -1,0 +1,267 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/buildcache"
+)
+
+type envtestPlan struct {
+	Needed          bool
+	VersionSpec     string
+	SetupEnvtestRef string
+}
+
+func verifyCommandEnv(ctx context.Context, taskID, wtPath string, rawCmds ...string) ([]string, error) {
+	env, err := buildcache.PrepareGoEnv(taskID, os.Environ())
+	if err != nil {
+		return nil, err
+	}
+	if envValue(env, "KUBEBUILDER_ASSETS") != "" || !commandsNeedEnvtest(rawCmds) {
+		return env, nil
+	}
+	plan, err := discoverEnvtestPlan(wtPath)
+	if err != nil || !plan.Needed {
+		return env, err
+	}
+	assets, err := provisionEnvtestAssets(ctx, wtPath, plan, env)
+	if err != nil {
+		return nil, err
+	}
+	env = stripEnvKeysLocal(env, "KUBEBUILDER_ASSETS")
+	return append(env, "KUBEBUILDER_ASSETS="+assets), nil
+}
+
+func commandsNeedEnvtest(rawCmds []string) bool {
+	for _, raw := range rawCmds {
+		if strings.Contains(raw, "go test") || strings.Contains(raw, "go list") {
+			return true
+		}
+	}
+	return false
+}
+
+func discoverEnvtestPlan(wtPath string) (envtestPlan, error) {
+	goModPath := filepath.Join(wtPath, "go.mod")
+	goMod, err := os.ReadFile(goModPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return envtestPlan{}, nil
+		}
+		return envtestPlan{}, err
+	}
+	plan := envtestPlan{
+		VersionSpec:     inferEnvtestVersionFromGoMod(goMod),
+		SetupEnvtestRef: inferSetupEnvtestRef(goMod),
+	}
+	if plan.SetupEnvtestRef == "" {
+		plan.SetupEnvtestRef = "latest"
+	}
+	err = filepath.WalkDir(wtPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !shouldInspectEnvtestFile(path, d.Name()) {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if explicit := inferEnvtestVersionFromText(data); explicit != "" {
+			plan.VersionSpec = explicit
+		}
+		if bytes.Contains(data, []byte("sigs.k8s.io/controller-runtime/pkg/envtest")) ||
+			bytes.Contains(data, []byte("KUBEBUILDER_ASSETS")) ||
+			bytes.Contains(data, []byte("setup-envtest")) {
+			plan.Needed = true
+		}
+		return nil
+	})
+	if err != nil {
+		return envtestPlan{}, err
+	}
+	return plan, nil
+}
+
+func shouldInspectEnvtestFile(path, name string) bool {
+	switch name {
+	case "Makefile", "makefile", "GNUmakefile", "go.mod":
+		return true
+	}
+	switch filepath.Ext(path) {
+	case ".go", ".mk", ".sh", ".bash", ".envrc", ".yaml", ".yml":
+		return true
+	}
+	return false
+}
+
+func inferEnvtestVersionFromText(data []byte) string {
+	for raw := range strings.SplitSeq(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if key, val, ok := strings.Cut(line, "="); ok && strings.Contains(key, "ENVTEST_K8S_VERSION") {
+			if v := cleanEnvtestVersionToken(val); v != "" {
+				return v
+			}
+		}
+		if idx := strings.Index(line, "setup-envtest"); idx >= 0 {
+			fields := strings.Fields(line[idx:])
+			for i, field := range fields {
+				if field != "use" {
+					continue
+				}
+				for _, token := range fields[i+1:] {
+					if strings.HasPrefix(token, "-") {
+						continue
+					}
+					if v := cleanEnvtestVersionToken(token); v != "" {
+						return v
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func cleanEnvtestVersionToken(raw string) string {
+	token := strings.TrimSpace(raw)
+	if fields := strings.Fields(token); len(fields) > 0 {
+		token = fields[0]
+	}
+	token = strings.Trim(token, `"'()[]{};,`)
+	if token == "" {
+		return ""
+	}
+	token = strings.TrimPrefix(token, "v")
+	if !strings.HasPrefix(token, "1.") {
+		return ""
+	}
+	for _, ch := range token {
+		if (ch < '0' || ch > '9') && ch != '.' && ch != 'x' && ch != '!' {
+			return ""
+		}
+	}
+	return token
+}
+
+func inferEnvtestVersionFromGoMod(goMod []byte) string {
+	for raw := range strings.SplitSeq(string(goMod), "\n") {
+		fields := strings.Fields(strings.TrimSpace(raw))
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] == "k8s.io/api" || fields[0] == "k8s.io/apimachinery" || fields[0] == "k8s.io/client-go" {
+			if version := k8sVersionSpecFromModule(fields[1]); version != "" {
+				return version
+			}
+		}
+	}
+	return ""
+}
+
+func inferSetupEnvtestRef(goMod []byte) string {
+	for raw := range strings.SplitSeq(string(goMod), "\n") {
+		fields := strings.Fields(strings.TrimSpace(raw))
+		if len(fields) < 2 || fields[0] != "sigs.k8s.io/controller-runtime" {
+			continue
+		}
+		version := strings.TrimPrefix(strings.TrimPrefix(fields[1], "v"), "0.")
+		minor, _, ok := strings.Cut(version, ".")
+		if !ok || minor == "" {
+			return ""
+		}
+		return "release-0." + minor
+	}
+	return ""
+}
+
+func k8sVersionSpecFromModule(raw string) string {
+	version := strings.TrimPrefix(strings.TrimSpace(raw), "v")
+	if !strings.HasPrefix(version, "0.") {
+		return ""
+	}
+	version = strings.TrimPrefix(version, "0.")
+	minor, _, ok := strings.Cut(version, ".")
+	if !ok || minor == "" {
+		return ""
+	}
+	return "1." + minor + ".x!"
+}
+
+func provisionEnvtestAssets(ctx context.Context, wtPath string, plan envtestPlan, env []string) (string, error) {
+	args := []string{"use", "-p", "path"}
+	if plan.VersionSpec != "" {
+		args = append(args, plan.VersionSpec)
+	}
+	var cmd *exec.Cmd
+	if bin, err := exec.LookPath("setup-envtest"); err == nil {
+		cmd = exec.CommandContext(ctx, bin, args...)
+	} else {
+		goArgs := []string{"run", "sigs.k8s.io/controller-runtime/tools/setup-envtest@" + plan.SetupEnvtestRef}
+		goArgs = append(goArgs, args...)
+		cmd = exec.CommandContext(ctx, "go", goArgs...)
+	}
+	cmd.Dir = wtPath
+	cmd.Env = append(stripEnvKeysLocal(env, "XDG_DATA_HOME"), "XDG_DATA_HOME="+buildcache.SharedRoot())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail == "" {
+			return "", fmt.Errorf("provision envtest assets: %w", err)
+		}
+		return "", fmt.Errorf("provision envtest assets: %w: %s", err, trimDiffLine(detail))
+	}
+	assets := strings.TrimSpace(string(out))
+	if assets == "" {
+		return "", fmt.Errorf("provision envtest assets: empty path")
+	}
+	return assets, nil
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return strings.TrimPrefix(kv, prefix)
+		}
+	}
+	return ""
+}
+
+func stripEnvKeysLocal(env []string, keys ...string) []string {
+	if len(env) == 0 {
+		return env
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		drop := false
+		for _, key := range keys {
+			if strings.HasPrefix(kv, key+"=") {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/internal/workflow/envtest_assets.go
+++ b/internal/workflow/envtest_assets.go
@@ -21,6 +21,8 @@ type envtestPlan struct {
 	SetupEnvtestRef string
 }
 
+const maxEnvtestInspectFileSize = 1 * 1024 * 1024 // 1 MiB
+
 func verifyCommandEnv(ctx context.Context, taskID, wtPath string, rawCmds ...string) ([]string, error) {
 	env, err := buildcache.PrepareGoEnv(taskID, os.Environ())
 	if err != nil {
@@ -84,6 +86,13 @@ func discoverEnvtestPlan(wtPath string) (envtestPlan, error) {
 			return nil
 		}
 		if !shouldInspectEnvtestFile(path, name) {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() > maxEnvtestInspectFileSize {
 			return nil
 		}
 		data, err := fs.ReadFile(root.FS(), path)


### PR DESCRIPTION
## Summary
- provision Kubernetes envtest assets for repo-scoped Go verification gates that need controller-runtime envtest
- avoid treating missing local envtest setup as a terminal human-required timeout
- include focused workflow coverage for the envtest go test/go list paths

## Tests
- go test ./internal/workflow -run 'Test(DiscoverEnvtestPlan|VerifyCommandEnv)'
- go test ./internal/workflow

_Generated by Sybra harness_