### PR TITLE
fix(ci): let bindings sync push with PAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,10 @@ jobs:
           # empty ref and use the default checkout — a fork branch name would
           # not resolve in this repo, and a fork cannot be pushed to.
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
-          persist-credentials: true
+          # The push step supplies BINDINGS_SYNC_PAT explicitly. If checkout
+          # persists its GITHUB_TOKEN extraheader, Git uses that instead and
+          # the follow-up PR checks are left action_required by anti-recursion.
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 


### PR DESCRIPTION
## Summary
- stop actions/checkout from persisting the default GITHUB_TOKEN credentials in the Wails bindings sync job
- let the explicit BINDINGS_SYNC_PAT push URL control the generated bindings commit author/token path
- document why this avoids action_required follow-up PR checks

## Validation
- actionlint .github/workflows/ci.yml
- git diff --check