### PR TITLE
fix(workflow): surface PR preflight failures

### DIFF
--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -372,6 +372,7 @@ func looksLikeAuthFailure(output string) bool {
 		"gh_token is invalid",
 		"github_token is invalid",
 		"token has expired",
+		"could not read username for 'https://github.com'",
 		"401 unauthorized",
 	}
 	for _, p := range patterns {

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -438,12 +438,15 @@ func prRetryReason(base, detail string) string {
 }
 
 func truncateMiddle(s string, limit int) string {
-	if limit <= 0 || len(s) <= limit {
+	if limit <= 0 {
+		return ""
+	}
+	if len(s) <= limit {
 		return s
 	}
 	marker := "\n... (truncated) ...\n"
 	if limit <= len(marker)+2 {
-		return truncate(s, limit)
+		return s[:limit]
 	}
 	keep := limit - len(marker)
 	head := keep / 2

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -416,17 +416,39 @@ func (e *Engine) classifyPRGitError(taskID string, step *Step, wfExec *Execution
 		attempts := parseWorkflowInt(wfExec.Variables[prCreateAuthAttemptsVar])
 		if attempts < maxPRCreateAuthRetries {
 			wfExec.SetVar(prCreateAuthAttemptsVar, strconv.Itoa(attempts+1))
-			return e.parkStepForRetry(taskID, wfExec, t, step.ID, prCreateAuthRetryReason, "workflow.pr-tail.auth-retry", "attempt", attempts+1, "max", maxPRCreateAuthRetries)
+			return e.parkStepForRetry(taskID, wfExec, t, step.ID, prRetryReason(prCreateAuthRetryReason, msg), "workflow.pr-tail.auth-retry", "attempt", attempts+1, "max", maxPRCreateAuthRetries, "phase", phase)
 		}
 		return e.humanRequiredPR(taskID, step, fmt.Sprintf("%s failing due to invalid or expired GitHub credentials after %d retries: %s", phase, attempts, msg))
 	default:
 		attempts := parseWorkflowInt(wfExec.Variables[prPushAttemptsVar])
 		if attempts < maxPRPushRetries {
 			wfExec.SetVar(prPushAttemptsVar, strconv.Itoa(attempts+1))
-			return e.parkStepForRetry(taskID, wfExec, t, step.ID, prPushRetryStatusReason, "workflow.pr-tail.push-retry", "phase", phase, "attempt", attempts+1, "max", maxPRPushRetries)
+			return e.parkStepForRetry(taskID, wfExec, t, step.ID, prRetryReason(prPushRetryStatusReason, msg), "workflow.pr-tail.push-retry", "phase", phase, "attempt", attempts+1, "max", maxPRPushRetries)
 		}
 		return e.humanRequiredPR(taskID, step, fmt.Sprintf("%s failed after %d retries: %s", phase, attempts, msg))
 	}
+}
+
+func prRetryReason(base, detail string) string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return base
+	}
+	return base + ": " + truncateMiddle(detail, 240)
+}
+
+func truncateMiddle(s string, limit int) string {
+	if limit <= 0 || len(s) <= limit {
+		return s
+	}
+	marker := "\n... (truncated) ...\n"
+	if limit <= len(marker)+2 {
+		return truncate(s, limit)
+	}
+	keep := limit - len(marker)
+	head := keep / 2
+	tail := keep - head
+	return s[:head] + marker + s[len(s)-tail:]
 }
 
 // findExistingPRForBranch checks for a PR already open on branch, mirroring

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -219,8 +219,8 @@ func TestExecPushBranch_PreflightAuthFailureParksBeforePush(t *testing.T) {
 	if ti.Status != "ready-pr" {
 		t.Fatalf("status = %q, want ready-pr", ti.Status)
 	}
-	if ti.StatusReason != prCreateAuthRetryReason {
-		t.Fatalf("status reason = %q, want %q", ti.StatusReason, prCreateAuthRetryReason)
+	if !strings.HasPrefix(ti.StatusReason, prCreateAuthRetryReason+": ") || !strings.Contains(ti.StatusReason, "Bad credentials") {
+		t.Fatalf("status reason = %q, want auth retry reason with diagnostic detail", ti.StatusReason)
 	}
 	if wfExec.Variables[prCreateAuthAttemptsVar] != "1" {
 		t.Fatalf("%s = %q, want 1", prCreateAuthAttemptsVar, wfExec.Variables[prCreateAuthAttemptsVar])
@@ -956,6 +956,49 @@ func TestClassifyPRGitError_AuthFailureEscalatesAfterMaxRetries(t *testing.T) {
 	}
 }
 
+func TestClassifyPRGitError_GitHTTPSUsernamePromptIsAuthFailure(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	step := newCreatePRStep()
+	task := TaskInfo{ID: "t1", Status: "ready-pr"}
+	wfExec := &Execution{Variables: map[string]string{}}
+	authErr := errors.New("github push credential preflight failed: git push --dry-run origin HEAD:refs/heads/sybra-preflight/abc: ambient env: fatal: could not read Username for 'https://github.com': No such device or address")
+
+	_, err := engine.classifyPRGitError("t1", step, wfExec, task, authErr, "push credential preflight")
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if !strings.HasPrefix(ti.StatusReason, prCreateAuthRetryReason+": ") {
+		t.Fatalf("status reason = %q, want auth retry reason with diagnostic detail", ti.StatusReason)
+	}
+	if !strings.Contains(ti.StatusReason, "could not read Username") {
+		t.Fatalf("status reason = %q, want git auth diagnostic", ti.StatusReason)
+	}
+	if wfExec.Variables[prCreateAuthAttemptsVar] != "1" {
+		t.Fatalf("%s = %q, want 1", prCreateAuthAttemptsVar, wfExec.Variables[prCreateAuthAttemptsVar])
+	}
+	if wfExec.Variables[prPushAttemptsVar] != "" {
+		t.Fatalf("%s = %q, want empty because auth retry counter should be used", prPushAttemptsVar, wfExec.Variables[prPushAttemptsVar])
+	}
+}
+
+func TestPRRetryReasonPreservesTailForLongHookOutput(t *testing.T) {
+	detail := strings.Repeat("ok github.com/Automaat/sybra/internal/pkg\n", 20) + "FAIL github.com/Automaat/sybra/internal/workflow\n"
+	got := prRetryReason(prPushRetryStatusReason, detail)
+
+	if !strings.HasPrefix(got, prPushRetryStatusReason+": ") {
+		t.Fatalf("reason = %q, want base prefix", got)
+	}
+	if !strings.Contains(got, "... (truncated) ...") {
+		t.Fatalf("reason = %q, want truncation marker", got)
+	}
+	if !strings.Contains(got, "FAIL github.com/Automaat/sybra/internal/workflow") {
+		t.Fatalf("reason = %q, want failing tail preserved", got)
+	}
+}
+
 // TestClassifyPRGitError_UnclassifiedFailureParksOnceThenEscalates covers a
 // push rejected by a project's own pre-push hook (e.g. `go test ./...`
 // failing under concurrent-agent CPU contention) — output that matches none
@@ -979,6 +1022,9 @@ func TestClassifyPRGitError_UnclassifiedFailureParksOnceThenEscalates(t *testing
 	ti, _ := tasks.GetTask("t1")
 	if ti.Status == "human-required" {
 		t.Fatalf("status = %q after %d retries, want unchanged (still parked)", ti.Status, maxPRPushRetries)
+	}
+	if !strings.HasPrefix(ti.StatusReason, prPushRetryStatusReason+": ") || !strings.Contains(ti.StatusReason, "FAIL internal/sybra") {
+		t.Fatalf("status reason = %q, want push retry reason with hook detail", ti.StatusReason)
 	}
 	if _, err := engine.classifyPRGitError("t1", step, wfExec, task, hookErr, "git push"); err != nil {
 		t.Fatalf("final attempt: unexpected error %v", err)

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -999,6 +999,15 @@ func TestPRRetryReasonPreservesTailForLongHookOutput(t *testing.T) {
 	}
 }
 
+func TestTruncateMiddleHonorsSmallLimit(t *testing.T) {
+	for _, limit := range []int{-1, 0, 1, 5, 20} {
+		got := truncateMiddle("abcdefghijklmnopqrstuvwxyz", limit)
+		if len(got) > max(0, limit) {
+			t.Fatalf("limit %d: len(%q) = %d, want <= %d", limit, got, len(got), max(0, limit))
+		}
+	}
+}
+
 // TestClassifyPRGitError_UnclassifiedFailureParksOnceThenEscalates covers a
 // push rejected by a project's own pre-push hook (e.g. `go test ./...`
 // failing under concurrent-agent CPU contention) — output that matches none

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -8798,6 +8798,7 @@ func TestLooksLikeAuthFailure(t *testing.T) {
 		{"auth failed", "authentication failed for repository", true},
 		{"github app token invalid", "X Failed to log in to github.com using token (GH_TOKEN)\n- The token in GH_TOKEN is invalid.", true},
 		{"expired token", "fatal: token has expired", true},
+		{"git https username prompt", "fatal: could not read Username for 'https://github.com': No such device or address", true},
 		{"gh auth hint", "run gh auth login to authenticate", true},
 		{"401", "401 Unauthorized", true},
 		{"unrelated failure", "PR title does not follow conventional commit format", false},


### PR DESCRIPTION
## Summary
- classify Git HTTPS username prompts from PR-tail push preflight as GitHub auth failures
- include truncated diagnostic details in PR-tail retry reasons
- preserve the tail of long hook output so the actual failing package remains visible

## Verification
- GOCACHE=/private/tmp/sybra-go-build-cache go test ./internal/workflow -run 'TestExecPushBranch_PreflightAuthFailureParksBeforePush|TestClassifyPRGitError_GitHTTPSUsernamePromptIsAuthFailure|TestPRRetryReasonPreservesTailForLongHookOutput|TestClassifyPRGitError_UnclassifiedFailureParksOnceThenEscalates|TestLooksLikeAuthFailure'
- SYBRA_HOME=/private/tmp/sybra-test-home/.sybra GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false GOCACHE=/private/tmp/sybra-go-build-cache go test ./internal/workflow