### PR TITLE
fix(project): skip pre-push hook in preflight

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1465,7 +1465,8 @@ func SetPushAuthFailureHook(f func(err error)) {
 // anonymous `git ls-remote` succeed while rejecting the real `git push`. Use a
 // dry-run push to a synthetic ref instead — it exercises the same credential
 // helper path without mutating remote state or depending on the live task branch
-// being fast-forwardable.
+// being fast-forwardable. The dry-run runs --no-verify so the project's pre-push
+// hook (tests, lint) never fires on this credential-only probe.
 func PreflightPushCredentials(ctx context.Context, worktreePath string) error {
 	remote := PushRemote(ctx, worktreePath)
 	pushURL, err := executil.Output(ctx, worktreePath, "git", "remote", "get-url", "--push", remote)
@@ -1534,7 +1535,12 @@ func pushPreflightRefspec(ctx context.Context, worktreePath string) (string, err
 }
 
 func gitPushDryRunAuthMessage(ctx context.Context, worktreePath, remote, refspec string, env []string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "push", "--dry-run", remote, refspec)
+	// --no-verify skips the project's pre-push hook. The hook (e.g. `go test
+	// ./...` + frontend check) has nothing to do with the credential path this
+	// probe validates; without this it runs the whole test suite per attempt —
+	// up to len(pushPreflightRetryBackoffs)+1 times — defeating the "cheap
+	// credential check" contract and burying the real error under hook output.
+	cmd := exec.CommandContext(ctx, "git", "push", "--dry-run", "--no-verify", remote, refspec)
 	cmd.Dir = worktreePath
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -3815,6 +3815,50 @@ func TestPreflightPushCredentials_DoesNotFalsePassOnReadOnlyProbe(t *testing.T) 
 	}
 }
 
+// TestPreflightPushCredentials_SkipsPrePushHook proves the credential probe
+// passes --no-verify, so a project's pre-push hook (go test, lint) never runs on
+// this synthetic dry-run. Without it the probe re-ran the whole test suite per
+// attempt and its output buried the real (often transient-network) push error.
+func TestPreflightPushCredentials_SkipsPrePushHook(t *testing.T) {
+	_, wtPath := initWorktree(t)
+	setGitHubOriginPushURL(t, wtPath)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath(git): %v", err)
+	}
+	dir := t.TempDir()
+	argsLog := filepath.Join(dir, "git-push-args-log")
+	if err := os.WriteFile(argsLog, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "push" ]; then
+  printf '%%s\n' "$*" >> %s
+  exit 0
+fi
+exec %q "$@"
+`, argsLog, realGit)
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	stubPushPreflightRetry(t)
+
+	if err := PreflightPushCredentials(context.Background(), wtPath); err != nil {
+		t.Fatalf("PreflightPushCredentials error = %v, want nil", err)
+	}
+	lines := readLogLines(t, argsLog)
+	if len(lines) == 0 {
+		t.Fatalf("git push args log = %v, want at least one probe", lines)
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, "--no-verify") {
+			t.Fatalf("git push args = %q, want --no-verify to skip the pre-push hook", line)
+		}
+	}
+}
+
 // pushAuthFailureHookCalls records invocations of a stubbed pushAuthFailureHook.
 type pushAuthFailureHookCalls struct {
 	count   int

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -3832,9 +3832,16 @@ func TestPreflightPushCredentials_SkipsPrePushHook(t *testing.T) {
 	if err := os.WriteFile(argsLog, nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	// Fail any non-dry-run push so a regression away from the dry-run probe is
+	// caught here instead of silently passing. Log path quoted for TMPDIRs with
+	// spaces.
 	script := fmt.Sprintf(`#!/bin/sh
 if [ "$1" = "push" ]; then
-  printf '%%s\n' "$*" >> %s
+  if [ "$2" != "--dry-run" ]; then
+    echo "unexpected non-dry-run push: $*" >&2
+    exit 1
+  fi
+  printf '%%s\n' "$*" >> "%s"
   exit 0
 fi
 exec %q "$@"


### PR DESCRIPTION
## Motivation

Server-node tasks repeatedly failed to push with unreadable errors. Two layers:

1. **Real cause (infra, out of scope here):** intermittent github.com connectivity from the deploy host — pushes hit `Couldn't connect to server` / `connection refused` / `RPC failed; curl 7`.
2. **Amplifier (this PR):** `PreflightPushCredentials` probes with `git push --dry-run`, which also fires the project's `pre-push` hook (`go test ./...` + frontend check). So a "cheap credential check" ran the entire test suite up to `len(pushPreflightRetryBackoffs)+1` times per preflight, and the hook's stdout was captured into the error string — burying the one real failure line under hundreds of lines of `ok  github.com/...`.

> Changelog: fix(project): skip pre-push hook in push preflight

## Implementation information

- Add `--no-verify` to the preflight `git push --dry-run` in `gitPushDryRunAuthMessage` so the pre-push hook never fires on this credential-only probe. The real push still runs the hook.
- Update the `PreflightPushCredentials` docstring to reflect that the probe skips local hooks.
- Add `TestPreflightPushCredentials_SkipsPrePushHook` asserting the probe passes `--no-verify`.

The hook has nothing to do with the credential path being validated, so skipping it does not weaken the check — it only makes the probe cheap (as its docstring already promised) and its error output readable.

## Supporting documentation

- `git push --dry-run` fires the `pre-push` hook; `--no-verify` bypasses it.
