### PR TITLE
fix(agent): deny ScheduleWakeup headless

### DIFF
--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -943,22 +943,22 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "no model no tools",
 			cfg:     RunConfig{},
-			wantCmd: "claude --dangerously-skip-permissions --model sonnet",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model sonnet",
 		},
 		{
 			name:    "valid model",
 			cfg:     RunConfig{Model: "claude-opus-4-6"},
-			wantCmd: "claude --dangerously-skip-permissions --model claude-opus-4-6",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model claude-opus-4-6",
 		},
 		{
 			name:    "valid tools",
 			cfg:     RunConfig{AllowedTools: []string{"Read", "Write", "Bash"}},
-			wantCmd: "claude --allowedTools Read,Write,Bash --model sonnet",
+			wantCmd: "claude --allowedTools Read,Write,Bash --disallowedTools ScheduleWakeup --model sonnet",
 		},
 		{
 			name:    "valid model and tools",
 			cfg:     RunConfig{Model: "claude-sonnet-4-6", AllowedTools: []string{"Read"}},
-			wantCmd: "claude --allowedTools Read --model claude-sonnet-4-6",
+			wantCmd: "claude --allowedTools Read --disallowedTools ScheduleWakeup --model claude-sonnet-4-6",
 		},
 		{
 			name:    "model with shell metachar semicolon",
@@ -1003,7 +1003,7 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "valid model with slash and dot",
 			cfg:     RunConfig{Model: "anthropic/claude-3.5-sonnet"},
-			wantCmd: "claude --dangerously-skip-permissions --model anthropic/claude-3.5-sonnet",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model anthropic/claude-3.5-sonnet",
 		},
 		{
 			name:    "codex default model mapping",
@@ -1023,22 +1023,22 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "fable alias",
 			cfg:     RunConfig{Model: "fable"},
-			wantCmd: "claude --dangerously-skip-permissions --model fable",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model fable",
 		},
 		{
 			name:    "fable with 1m suffix stripped",
 			cfg:     RunConfig{Model: "fable[1m]"},
-			wantCmd: "claude --dangerously-skip-permissions --model fable",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model fable",
 		},
 		{
 			name:    "claude-fable-5 with 1m suffix stripped",
 			cfg:     RunConfig{Model: "claude-fable-5[1m]"},
-			wantCmd: "claude --dangerously-skip-permissions --model claude-fable-5",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model claude-fable-5",
 		},
 		{
 			name:    "sonnet with 1m suffix stripped",
 			cfg:     RunConfig{Model: "sonnet[1m]"},
-			wantCmd: "claude --dangerously-skip-permissions --model sonnet",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model sonnet",
 		},
 		{
 			name:    "codex fable passes through as explicit model",

--- a/internal/agent/permissions_test.go
+++ b/internal/agent/permissions_test.go
@@ -13,14 +13,14 @@ func TestClaudePermissionArgs(t *testing.T) {
 		mode         string
 		want         []string
 	}{
-		{"allowlist wins over bypass", []string{"Bash", "Read"}, false, "bypass", []string{"--allowedTools", "Bash,Read"}},
-		{"allowlist wins over auto", []string{"Bash"}, false, "auto", []string{"--allowedTools", "Bash"}},
-		{"allowlist wins over requirePerms", []string{"Read"}, true, "auto", []string{"--allowedTools", "Read"}},
-		{"requirePerms → nil", nil, true, "bypass", nil},
-		{"requirePerms with auto → nil", nil, true, "auto", nil},
-		{"auto mode", nil, false, "auto", []string{"--permission-mode", "auto"}},
-		{"bypass mode", nil, false, "bypass", []string{"--dangerously-skip-permissions"}},
-		{"empty mode → bypass", nil, false, "", []string{"--dangerously-skip-permissions"}},
+		{"allowlist wins over bypass", []string{"Bash", "Read"}, false, "bypass", []string{"--allowedTools", "Bash,Read", "--disallowedTools", "ScheduleWakeup"}},
+		{"allowlist wins over auto", []string{"Bash"}, false, "auto", []string{"--allowedTools", "Bash", "--disallowedTools", "ScheduleWakeup"}},
+		{"allowlist wins over requirePerms", []string{"Read"}, true, "auto", []string{"--allowedTools", "Read", "--disallowedTools", "ScheduleWakeup"}},
+		{"requirePerms → disallow only", nil, true, "bypass", []string{"--disallowedTools", "ScheduleWakeup"}},
+		{"requirePerms with auto → disallow only", nil, true, "auto", []string{"--disallowedTools", "ScheduleWakeup"}},
+		{"auto mode", nil, false, "auto", []string{"--permission-mode", "auto", "--disallowedTools", "ScheduleWakeup"}},
+		{"bypass mode", nil, false, "bypass", []string{"--dangerously-skip-permissions", "--disallowedTools", "ScheduleWakeup"}},
+		{"empty mode → bypass", nil, false, "", []string{"--dangerously-skip-permissions", "--disallowedTools", "ScheduleWakeup"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -164,7 +164,17 @@ func effortArgs(effort string) []string {
 //  2. requirePerms -> nil (approval-hook mode; no bypass or auto flag)
 //  3. mode=="auto" -> --permission-mode auto (auto-mode classifier)
 //  4. else -> --dangerously-skip-permissions (legacy bypass, default)
+//
+// ScheduleWakeup is always denied on top of whichever branch above fires: a
+// headless run is a single `claude -p` process that reads one NDJSON stream
+// and exits, so nothing ever re-invokes it later. A run that schedules a
+// wakeup and then ends its turn strands itself — zero commits, clean exit —
+// which verify_commits cannot tell apart from "nothing to do here" (#2296).
 func claudePermissionArgs(allowed []string, requirePerms bool, mode string) []string {
+	return append(claudePermissionModeArgs(allowed, requirePerms, mode), "--disallowedTools", "ScheduleWakeup")
+}
+
+func claudePermissionModeArgs(allowed []string, requirePerms bool, mode string) []string {
 	if len(allowed) > 0 {
 		return []string{"--allowedTools", strings.Join(allowed, ",")}
 	}

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -169,7 +169,7 @@ func effortArgs(effort string) []string {
 // headless run is a single `claude -p` process that reads one NDJSON stream
 // and exits, so nothing ever re-invokes it later. A run that schedules a
 // wakeup and then ends its turn strands itself — zero commits, clean exit —
-// which verify_commits cannot tell apart from "nothing to do here" (#2296).
+// which verify_commits cannot tell apart from a task with nothing to do.
 func claudePermissionArgs(allowed []string, requirePerms bool, mode string) []string {
 	return append(claudePermissionModeArgs(allowed, requirePerms, mode), "--disallowedTools", "ScheduleWakeup")
 }


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): deny ScheduleWakeup on headless claude runs

A headless `claude -p` process is single-shot: it reads one NDJSON stream and exits, so nothing ever fires a scheduled wakeup. An implement-step agent called `ScheduleWakeup` twice, deferred to a background subagent, and ended its turn with zero commits and a clean exit. `verify_commits` couldn't tell that apart from "already merged elsewhere" and marked the task done, which auto-closed the linked GitHub issue with no actual work landed.

Closes #2296

## Implementation information

- `claudePermissionArgs` now always appends `--disallowedTools ScheduleWakeup` regardless of which permission branch fires, since the tool can never be honored by a one-shot headless run.
- Renamed the old branching logic to `claudePermissionModeArgs` and wrapped it.
- Updated `permissions_test.go` and `manager_test.go` expectations for the new flag.

## Supporting documentation

`internal/agent` test suite passes.