### PR TITLE
fix(umbrella): stop silent progress stalls

### DIFF
--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"reflect"
 )
 
@@ -195,9 +196,23 @@ func stripErrorResult(out []reflect.Value, w http.ResponseWriter, logger *slog.L
 	}
 	callErr, _ := last.Interface().(error)
 	var ce ClientError
-	if errors.As(callErr, &ce) {
+	switch {
+	case errors.As(callErr, &ce):
 		respondError(w, logger, ce.HTTPStatus(), codeForStatus(ce.HTTPStatus()), ce.Error())
-	} else {
+	case errors.Is(callErr, os.ErrNotExist):
+		// A missing-file error (e.g. task.Store.Get on a trashed/deleted task)
+		// is a normal, expected outcome for callers like the cluster mirror's
+		// reconcileMissing, which needs to tell "the follower confirms this
+		// task is gone" apart from "the follower is unreachable" to reconcile
+		// its own stale copy instead of leaving it dangling forever. Surfacing
+		// it as 404 lets those callers branch on http.StatusNotFound instead of
+		// treating every GetTask failure as an opaque, non-retryable 500. The
+		// raw error is logged server-side only — like the default 500 case
+		// below, it wraps an *fs.PathError carrying the store's absolute
+		// filesystem path, which must never reach an HTTP client.
+		logger.Info("httpapi.call.not_found", "service", svcName, "method", methodName, "err", callErr)
+		respondError(w, logger, http.StatusNotFound, ErrCodeNotFound, "not found")
+	default:
 		logger.Warn("httpapi.call.error", "service", svcName, "method", methodName, "err", callErr)
 		respondError(w, logger, http.StatusInternalServerError, ErrCodeInternal, "internal error")
 	}

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -3,10 +3,12 @@ package httpapi_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -24,6 +26,13 @@ func (s *testSvc) Multi() (msg string, ok bool, err error) {
 func (s *testSvc) Void()           {}
 func (s *testSvc) Fail() error     { return nil }
 func (s *testSvc) FailWith() error { return &testError{"boom"} }
+
+// FailWithNotExist mirrors how internal/task.Store.read wraps a missing-file
+// read: fmt.Errorf("...: %w", os.ErrNotExist), so errors.Is finds it through
+// the same %w chain stripErrorResult walks in production.
+func (s *testSvc) FailWithNotExist() error {
+	return fmt.Errorf("task nope not found: %w", os.ErrNotExist)
+}
 func (s *testSvc) ReturnAndFail(v string) (string, error) {
 	return "", &testError{v}
 }
@@ -62,7 +71,7 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *bytes.Buffer) {
 	mux := http.NewServeMux()
 	httpapi.Mount(mux, map[string]httpapi.Service{
 		"TestSvc": httpapi.NewService(&testSvc{},
-			"Echo", "Add", "Multi", "Void", "Fail", "FailWith", "ReturnAndFail", "ObjIn",
+			"Echo", "Add", "Multi", "Void", "Fail", "FailWith", "FailWithNotExist", "ReturnAndFail", "ObjIn",
 			"ClientFail400", "ClientFail409",
 			// AdminOnly is intentionally absent from the allowlist.
 		),
@@ -209,6 +218,37 @@ func TestHandler_ErrorReturn(t *testing.T) {
 	}
 	if !strings.Contains(logs, "boom") {
 		t.Fatalf("expected raw error 'boom' in logs; got: %s", logs)
+	}
+}
+
+func TestHandler_NotExistMapsTo404(t *testing.T) {
+	_, srv, logBuf := setup(t)
+	resp := post(t, srv, "TestSvc", "FailWithNotExist")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+	msg, code := decodeErr(t, resp)
+	if code != string(httpapi.ErrCodeNotFound) {
+		t.Fatalf("expected code %q, got %q", httpapi.ErrCodeNotFound, code)
+	}
+	// Callers like the cluster mirror's reconcileMissing branch purely on the
+	// HTTP status (404), never the message, so the client-visible message
+	// must be sanitized the same way the generic 500 path is — the raw error
+	// wraps an *fs.PathError carrying the store's absolute filesystem path,
+	// which must never reach an HTTP client.
+	if msg != "not found" {
+		t.Fatalf("expected a sanitized not-found message, got %q", msg)
+	}
+	if strings.Contains(msg, "os.ErrNotExist") || strings.Contains(msg, "/") {
+		t.Fatalf("client-visible message must not leak the raw error or a filesystem path, got %q", msg)
+	}
+	if strings.Contains(logBuf.String(), "httpapi.call.error") {
+		t.Fatal("a confirmed not-found must not be logged as an internal error")
+	}
+	if !strings.Contains(logBuf.String(), "task nope not found") {
+		t.Fatal("the raw error must still be logged server-side for debugging")
 	}
 }
 

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -27,17 +27,16 @@ const umbrellaSettleDelay = 2 * time.Minute
 
 // umbrellaState aggregates one umbrella's tracker and children for a gate tick.
 type umbrellaState struct {
-	tracker      *task.Task
-	cap          int // max children running at once
-	total        int // child task count
-	doneCount    int
-	active       int // children occupying a parallelism slot
-	anyHR        bool
-	anyCancelled bool
-	anyBlocked   bool // non-gated child stuck in `blocked` (e.g. human-review flip)
-	expanding    bool
-	released     int // children released so far this tick (counts toward the cap)
-	children     []umbrellaProgressChild
+	tracker    *task.Task
+	cap        int // max children running at once
+	total      int // child task count
+	doneCount  int
+	active     int // children occupying a parallelism slot
+	anyHR      bool
+	anyBlocked bool // non-gated child stuck in `blocked` (e.g. human-review flip)
+	expanding  bool
+	released   int // children released so far this tick (counts toward the cap)
+	children   []umbrellaProgressChild
 }
 
 type umbrellaProgressChild struct {
@@ -170,10 +169,11 @@ func accumulateChild(st *umbrellaState, t *task.Task) {
 	case task.StatusDone:
 		st.doneCount++
 	case task.StatusCancelled:
-		// A cancelled prerequisite is a deliberate abandonment — surface it for
-		// a human rather than silently completing the umbrella or proceeding on
-		// the cancelled work (its dependents stay held; see depsSatisfied).
-		st.anyCancelled = true
+		// No side effect here: whether a cancelled child blocks rollup depends
+		// on whether a sibling still covers its issue (a cancelled duplicate
+		// from an umbrella-expansion race vs. a genuine abandonment), which
+		// needs the full child set — see unresolvedCancellation, called from
+		// trackerRollup once every child has been folded in.
 	case task.StatusHumanRequired:
 		if watchdogreason.IsRetryableStop(t.StatusReason) {
 			st.active++
@@ -458,21 +458,65 @@ func umbrellaProgressIssueSuffix(ref string) string {
 	return " (" + ref + ")"
 }
 
+// resolveCancellations classifies every cancelled child in children against
+// its siblings. An umbrella-expansion race can materialize the same sub-issue
+// as two tasks; cleanup cancels the loser in favor of its live twin (see
+// releaseUnblockedChildren's dedup path and #2294's post-mortem). That
+// cancellation is not an abandonment — the issue is still covered — and must
+// not permanently gate the umbrella to human-required. Only a cancellation
+// with no live (non-cancelled) sibling for its issue is a genuine deliberate
+// abandonment worth surfacing (dependents on that issue would otherwise stall
+// forever with no escalation; see depsSatisfied): unresolved reports whether
+// any such abandonment exists. resolved counts the opposite case — a
+// cancelled duplicate whose issue is covered by a live sibling — which the
+// caller must exclude from a total/doneCount completion check, or an umbrella
+// with a resolved duplicate could never satisfy doneCount == total (a
+// cancelled task never becomes done) and would sit at in-progress forever
+// with no signal at all once it stops being surfaced as human-required.
+func resolveCancellations(children []umbrellaProgressChild) (unresolved bool, resolved int) {
+	liveIssue := make(map[string]bool, len(children))
+	for _, c := range children {
+		if c.status == task.StatusCancelled {
+			continue
+		}
+		if key := umbrella.NormalizeIssueRef(c.issue); key != "" {
+			liveIssue[key] = true
+		}
+	}
+	for _, c := range children {
+		if c.status != task.StatusCancelled {
+			continue
+		}
+		key := umbrella.NormalizeIssueRef(c.issue)
+		if key == "" || !liveIssue[key] {
+			unresolved = true
+			continue
+		}
+		resolved++
+	}
+	return unresolved, resolved
+}
+
 // trackerRollup decides an umbrella tracker's status from its children. A
-// cycle, a stuck (human-required) child, a non-gated blocked child, or a
-// cancelled child surfaces as human-required (halting only that chain);
-// all-done closes the umbrella. A
-// tracker with no children (every sub-issue was already closed at expansion)
-// is vacuously complete, but only once `settled` (so a tracker observed while
-// its children are still being materialized is not closed prematurely) and
-// only when expansion isn't currently failing — a tracker carrying
-// umbrella.ExpandFailTagPrefix (see internal/umbrella.recordExpandFailure)
-// never had a chance to materialize its children in the first place, and
-// closing it would silently drop the umbrella issue while sub-issues remain
-// open on GitHub (#1570).
+// cycle, a stuck (human-required) child, a non-gated blocked child, or an
+// unresolved cancellation (see resolveCancellations) surfaces as
+// human-required (halting only that chain); all-done closes the umbrella. A
+// resolved cancellation (a cancelled duplicate whose issue has a live
+// sibling) counts against neither total nor doneCount, so it can never block
+// completion the way a cancelled child that never reaches Done otherwise
+// would. A tracker with no children (every sub-issue was already closed at
+// expansion) is vacuously complete, but only once `settled` (so a tracker
+// observed while its children are still being materialized is not closed
+// prematurely) and only when expansion isn't currently failing — a tracker
+// carrying umbrella.ExpandFailTagPrefix (see
+// internal/umbrella.recordExpandFailure) never had a chance to materialize
+// its children in the first place, and closing it would silently drop the
+// umbrella issue while sub-issues remain open on GitHub (#1570).
 func trackerRollup(st *umbrellaState, cyclic, settled bool) (status task.Status, reason string, doClose bool) {
 	expandFailing := st.tracker != nil && umbrella.ParseExpandFailCount(st.tracker.Tags) > 0
 	expandActive := st.tracker != nil && umbrella.HasActiveExpandPhase(st.tracker.Tags)
+	unresolvedCancellation, resolvedCancellations := resolveCancellations(st.children)
+	effectiveTotal := st.total - resolvedCancellations
 	switch {
 	case cyclic:
 		return task.StatusHumanRequired, "umbrella dependency cycle detected", false
@@ -480,7 +524,7 @@ func trackerRollup(st *umbrellaState, cyclic, settled bool) (status task.Status,
 		return task.StatusHumanRequired, "umbrella child needs attention", false
 	case st.anyBlocked:
 		return task.StatusHumanRequired, "umbrella child is blocked", false
-	case st.anyCancelled:
+	case unresolvedCancellation:
 		return task.StatusHumanRequired, "umbrella child was cancelled", false
 	case expandFailing:
 		// Defer entirely to internal/umbrella.recordExpandFailure, which owns
@@ -488,9 +532,9 @@ func trackerRollup(st *umbrellaState, cyclic, settled bool) (status task.Status,
 		// must not overwrite that state just because the tracker already has
 		// children or all currently-materialized children happen to be done.
 		return st.tracker.Status, st.tracker.StatusReason, false
-	case st.total > 0 && st.doneCount == st.total:
+	case effectiveTotal > 0 && st.doneCount == effectiveTotal:
 		return task.StatusDone, "all umbrella children complete", true
-	case st.total == 0 && settled && !expandActive:
+	case effectiveTotal == 0 && settled && !expandActive:
 		return task.StatusDone, "umbrella has no open sub-issues", true
 	default:
 		return task.StatusInProgress, "umbrella in progress", false

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -338,7 +338,36 @@ func TestTrackerRollup(t *testing.T) {
 		{"cycle", umbrellaState{total: 2}, true, true, task.StatusHumanRequired, false},
 		{"stuck child", umbrellaState{total: 2, anyHR: true}, false, true, task.StatusHumanRequired, false},
 		{"blocked child", umbrellaState{total: 2, anyBlocked: true}, false, true, task.StatusHumanRequired, false},
-		{"cancelled child", umbrellaState{total: 2, anyCancelled: true}, false, true, task.StatusHumanRequired, false},
+		{
+			"cancelled child with no live sibling",
+			umbrellaState{total: 2, children: []umbrellaProgressChild{
+				{id: "a", issue: "Automaat/sybra#1", status: task.StatusCancelled},
+				{id: "b", issue: "Automaat/sybra#2", status: task.StatusDone},
+			}},
+			false, true, task.StatusHumanRequired, false,
+		},
+		{
+			// A cancelled task can never reach Done, so it must not count
+			// against total — otherwise doneCount == total is impossible
+			// forever, and the umbrella sits at in-progress with no signal.
+			"cancelled duplicate with a live sibling on the same issue completes",
+			umbrellaState{total: 2, doneCount: 1, children: []umbrellaProgressChild{
+				{id: "a", issue: "Automaat/sybra#1", status: task.StatusCancelled},
+				{id: "b", issue: "Automaat/sybra#1", status: task.StatusDone},
+			}},
+			false, true, task.StatusDone, true,
+		},
+		{
+			// Excluding the resolved duplicate from total must not mask a
+			// genuinely unfinished sibling under the same umbrella.
+			"cancelled duplicate does not mask other still-running work",
+			umbrellaState{total: 3, doneCount: 1, children: []umbrellaProgressChild{
+				{id: "a", issue: "Automaat/sybra#1", status: task.StatusCancelled},
+				{id: "b", issue: "Automaat/sybra#1", status: task.StatusDone},
+				{id: "c", issue: "Automaat/sybra#2", status: task.StatusInProgress},
+			}},
+			false, true, task.StatusInProgress, false,
+		},
 		{"all done", umbrellaState{total: 2, doneCount: 2}, false, true, task.StatusDone, true},
 		{"in progress", umbrellaState{total: 2, doneCount: 1}, false, true, task.StatusInProgress, false},
 		{"zero children settled completes", umbrellaState{total: 0}, false, true, task.StatusDone, true},

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -839,6 +839,53 @@ func TestMirrorReconcileMissingSurvivesReassignRace(t *testing.T) {
 	}
 }
 
+// TestMirrorReconcileMissingResetsStreakOnDirectHit covers a Copilot-review
+// finding on this PR: a direct GetTask hit (the follower has the task even
+// though this tick's ListTasksForNode snapshot omitted it) must clear any
+// in-progress confirmed-404 streak, or a later, unrelated absence inherits
+// the stale count and can trash the canonical copy before
+// missingConfirmThreshold truly fresh confirmations have accumulated.
+func TestMirrorReconcileMissingResetsStreakOnDirectHit(t *testing.T) {
+	stub := &followerStub{live: map[string]task.Task{}}
+	srv := stub.server(t)
+
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "flaky-listing", Status: task.StatusInProgress, AssignedNode: "pet-box",
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mirror := NewMirror(cfg, mgr, roster, slog.New(slog.DiscardHandler), time.Second)
+	var consecutiveFailures int
+	mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+
+	stub.mu.Lock()
+	stub.live["flaky-listing"] = task.Task{
+		ID: "flaky-listing", Status: task.StatusInProgress, AssignedNode: "pet-box",
+		UpdatedAt: time.Now().Add(time.Minute),
+	}
+	stub.mu.Unlock()
+	mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+
+	stub.mu.Lock()
+	delete(stub.live, "flaky-listing")
+	stub.mu.Unlock()
+	for range missingConfirmThreshold - 1 {
+		mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+	}
+
+	if _, err := mgr.Get("flaky-listing"); err != nil {
+		t.Fatalf("canonical copy trashed on a stale pre-reset streak: %v", err)
+	}
+}
+
 // TestMirrorReconcileMissingLeavesCanonicalOnTransientError is the negative
 // case for TestMirrorReconcileMissingTrashesConfirmedGoneTask: a GetTask
 // failure that is not a confirmed 404 (follower down, network blip) must

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -748,6 +748,148 @@ func TestMirrorReconcileEscalatesLogLevelOnRepeatedFailure(t *testing.T) {
 	}
 }
 
+// TestMirrorReconcileMissingTrashesConfirmedGoneTask covers the mirror gap
+// from #2294's umbrella-expansion-race post-mortem: a task the leader still
+// holds as non-terminal but the follower's ListTasks snapshot omits used to
+// stay stuck forever, because reconcileMissing treated every GetTask error —
+// including a 404 confirming the task is genuinely gone (e.g. trashed as a
+// duplicate cleanup) — the same as a transient failure and never touched the
+// canonical copy. That left a ghost task that kept poisoning rollup logic
+// scanning all of an umbrella's children, like trackerRollup's
+// cancelled-child check. Once the follower confirms the task is gone across
+// missingConfirmThreshold consecutive ticks, the leader must trash its own
+// stale copy instead.
+func TestMirrorReconcileMissingTrashesConfirmedGoneTask(t *testing.T) {
+	stub := &followerStub{} // empty tasks/live — GetTask 404s for anything
+	srv := stub.server(t)
+
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "ghost-dup", Status: task.StatusTodo, AssignedNode: "pet-box",
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mirror := NewMirror(cfg, mgr, roster, slog.New(slog.DiscardHandler), time.Second)
+	var consecutiveFailures int
+	for i := 1; i < missingConfirmThreshold; i++ {
+		mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+		if _, err := mgr.Get("ghost-dup"); err != nil {
+			t.Fatalf("trashed after only %d confirmation(s), before missingConfirmThreshold (%d)", i, missingConfirmThreshold)
+		}
+	}
+	mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+
+	if _, err := mgr.Get("ghost-dup"); err == nil {
+		t.Fatalf("expected the leader's stale copy to be trashed after %d confirmed-404 ticks", missingConfirmThreshold)
+	}
+}
+
+// TestMirrorReconcileMissingSurvivesReassignRace covers the exact scenario
+// missingConfirmThreshold exists for: Assigner.Reassign stamps
+// canonical.AssignedNode to the new node *before* pushing the task there
+// (reassign.go's stampNode doc comment — deliberate, so a revived dead
+// follower cannot clobber a task that moved), so for at least one reconcile
+// tick after a reassignment the new follower legitimately 404s on a task the
+// leader now considers assigned to it. A single (or double) 404 must not
+// trash the canonical copy; only sustained absence across the full threshold
+// may.
+func TestMirrorReconcileMissingSurvivesReassignRace(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "just-reassigned", Status: task.StatusInProgress, AssignedNode: "pet-box",
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mirror := NewMirror(cfg, mgr, roster, slog.New(slog.DiscardHandler), time.Second)
+	var consecutiveFailures int
+	for range missingConfirmThreshold - 1 {
+		mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+	}
+	if _, err := mgr.Get("just-reassigned"); err != nil {
+		t.Fatalf("canonical copy trashed before the push had a chance to land: %v", err)
+	}
+
+	stub.mu.Lock()
+	stub.tasks = []task.Task{{
+		ID: "just-reassigned", Status: task.StatusInProgress, AssignedNode: "pet-box",
+		UpdatedAt: time.Now().Add(time.Minute),
+	}}
+	stub.mu.Unlock()
+	mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+
+	if _, err := mgr.Get("just-reassigned"); err != nil {
+		t.Fatalf("canonical copy must survive once the follower catches up: %v", err)
+	}
+}
+
+// TestMirrorReconcileMissingLeavesCanonicalOnTransientError is the negative
+// case for TestMirrorReconcileMissingTrashesConfirmedGoneTask: a GetTask
+// failure that is not a confirmed 404 (follower down, network blip) must
+// leave the canonical copy untouched so the next reconcile tick can retry —
+// trashing on an ambiguous error would be the #1576 board-wipe failure mode
+// recurring in the mirror instead of the local store.
+func TestMirrorReconcileMissingLeavesCanonicalOnTransientError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/TaskService/ListTasks":
+			_ = json.NewEncoder(w).Encode([]task.Task{})
+		case "/api/TaskService/GetTask":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":"boom","code":"internal_error"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, err := NewRoster(cfg, nil)
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	mgr := newManager(t)
+	if _, _, err := mgr.Put(task.Task{
+		ID: "maybe-still-there", Status: task.StatusTodo, AssignedNode: "pet-box",
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mirror := NewMirror(cfg, mgr, roster, slog.New(slog.DiscardHandler), time.Second)
+	var consecutiveFailures int
+	mirror.reconcileNode(context.Background(), "pet-box", &consecutiveFailures)
+
+	got, err := mgr.Get("maybe-still-there")
+	if err != nil {
+		t.Fatalf("canonical copy must survive a transient GetTask error: %v", err)
+	}
+	if got.Status != task.StatusTodo {
+		t.Errorf("status changed on a transient error: %v", got.Status)
+	}
+}
+
 type syncBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -2,7 +2,9 @@ package clusterlead
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"net/http"
 	"slices"
 	"sync"
 	"time"
@@ -36,6 +38,23 @@ const DefaultReconcileInterval = 30 * time.Second
 // still exceeds the response cap, network loss) becomes impossible to miss.
 const reconcileFailureEscalateThreshold = 5
 
+// missingConfirmThreshold is how many consecutive reconcile ticks a task must
+// 404 on its assigned node before reconcileMissing trusts that as "the
+// follower confirms this task is gone" and trashes the leader's canonical
+// copy. Assigner.Reassign stamps canonical.AssignedNode to the new node
+// *before* pushing the task there (reassign.go's stampNode doc comment: this
+// ordering is deliberate, so a revived dead follower cannot clobber a task
+// that has moved) — so a single 404 on a freshly assigned node is exactly as
+// consistent with "not pushed yet" as with "genuinely deleted," and a
+// follower client call can legitimately take up to defaultCallTimeout (30s)
+// before even failing. Requiring the same node to 404 across
+// missingConfirmThreshold ticks (each spaced by the reconcile interval)
+// gives a slow AssignTask/attachment-transfer push comfortably longer than
+// one RPC timeout to land before the leader trusts the absence and trashes
+// its own copy — while a genuinely deleted task, which will 404 forever,
+// still gets cleaned up in bounded time instead of staying a ghost.
+const missingConfirmThreshold = 3
+
 // Mirror keeps the leader's canonical store in sync with follower execution
 // state via a reconcile ticker, applying every update through one authority
 // merge: execution fields are follower-authoritative, identity/assignment
@@ -51,6 +70,11 @@ type Mirror struct {
 
 	attachments *attachment.Store
 	anomalySink monitor.IssueSink
+
+	// missingMu guards missingStreak, written from each node's independent
+	// reconcileLoop goroutine.
+	missingMu     sync.Mutex
+	missingStreak map[string]int // "node|taskID" -> consecutive confirmed-404 ticks
 }
 
 // NewMirror constructs a Mirror. A nil logger falls back to slog.Default(); a
@@ -62,7 +86,10 @@ func NewMirror(cfg *config.Config, tasks *task.Manager, roster *cluster.Roster, 
 	if interval <= 0 {
 		interval = DefaultReconcileInterval
 	}
-	return &Mirror{cfg: cfg, tasks: tasks, roster: roster, logger: logger, interval: interval}
+	return &Mirror{
+		cfg: cfg, tasks: tasks, roster: roster, logger: logger, interval: interval,
+		missingStreak: make(map[string]int),
+	}
 }
 
 // SetAttachments supplies the leader-local blob store used to mirror follower
@@ -132,20 +159,38 @@ func (m *Mirror) reconcileNode(ctx context.Context, node string, consecutiveFail
 	m.reconcileMissing(ctx, node, client, tasks)
 }
 
-// reconcileMissing closes the gap ListTasksForNode's staleness filter opens:
-// a task the leader still considers live and assigned to node, but that this
-// node's response omitted. That only happens when the follower closed it
-// more than mirrorStaleTerminalWindow ago while the leader could not reach
-// this node at all (an outage or restart spanning the entire window) -- the
-// closing update never got a chance to apply, and the follower will never
-// offer that task again, so without this the canonical copy would stay stuck
-// at its last non-terminal state permanently. Fetches only the handful of
-// affected tasks directly (GetTask) instead of falling back to a full list.
+// reconcileMissing closes the gap ListTasksForNode's staleness filter opens: a
+// non-terminal task the leader still considers live and assigned to node, but
+// that this node's response omitted. Fetches only the handful of affected
+// tasks directly (GetTask) instead of falling back to a full list, and
+// branches on the result:
+//   - The follower 404s (os.ErrNotExist surfaced as http.StatusNotFound — see
+//     httpapi.stripErrorResult) on missingConfirmThreshold consecutive ticks:
+//     the follower closed the task more than mirrorStaleTerminalWindow ago
+//     while unreachable (an outage or restart spanning the whole window, so
+//     the closing update never applied), or it was trashed outright (e.g. a
+//     duplicate cleanup, #2294's post-mortem). Either way the follower will
+//     never offer it again, so the leader trashes its own stale copy instead
+//     of leaving it stuck at its last non-terminal state permanently — which
+//     would otherwise keep poisoning downstream rollup logic that scans all
+//     children, like trackerRollup's cancelled-child check, forever. A
+//     single 404 is not enough on its own — see missingConfirmThreshold's
+//     doc comment for why a freshly reassigned task looks identical for one
+//     tick.
+//   - Any other error (network failure, follower down): leave the canonical
+//     copy untouched and retry next tick — the follower may still have it.
 func (m *Mirror) reconcileMissing(ctx context.Context, node string, client *cluster.Client, tasks []task.Task) {
 	seen := make(map[string]struct{}, len(tasks))
 	for i := range tasks {
 		seen[tasks[i].ID] = struct{}{}
 	}
+	// A task the follower's snapshot accounts for is not missing this tick,
+	// whatever it was on a prior tick — drop any confirmed-404 streak so a
+	// task that legitimately reappeared (e.g. a slow Reassign push that
+	// finally landed) starts from zero if it ever goes missing again, rather
+	// than resuming a stale count left over from an unrelated earlier gap.
+	m.clearMissingStreaks(node, tasks)
+
 	canonical, err := m.tasks.List()
 	if err != nil {
 		m.logger.Warn("cluster.mirror.reconcile_missing.list_failed", "node", node, "err", err)
@@ -161,10 +206,67 @@ func (m *Mirror) reconcileMissing(ctx context.Context, node string, client *clus
 		}
 		follower, gerr := client.GetTask(ctx, t.ID)
 		if gerr != nil {
+			var apiErr *cluster.APIError
+			if errors.As(gerr, &apiErr) && apiErr.Status == http.StatusNotFound {
+				streak := m.bumpMissingStreak(node, t.ID)
+				if streak < missingConfirmThreshold {
+					m.logger.Info("cluster.mirror.reconcile_missing.confirming",
+						"node", node, "task", t.ID, "streak", streak, "threshold", missingConfirmThreshold)
+					continue
+				}
+				// The follower has confirmed this task gone across
+				// missingConfirmThreshold consecutive ticks (e.g. trashed as
+				// a duplicate cleanup, see #2294's post-mortem) — long enough
+				// to rule out a task freshly reassigned to node whose push
+				// just hasn't landed yet (Assigner.Reassign stamps
+				// AssignedNode before pushing; see missingConfirmThreshold's
+				// doc comment). Trash the leader's stale mirror so it stops
+				// permanently gating downstream rollup logic (like
+				// trackerRollup's cancelled-child check) on a ghost task the
+				// follower will never offer again.
+				if derr := m.tasks.Delete(t.ID); derr != nil {
+					m.logger.Warn("cluster.mirror.reconcile_missing.trash_failed", "node", node, "task", t.ID, "err", derr)
+					continue
+				}
+				m.clearMissingStreak(node, t.ID)
+				m.logger.Info("cluster.mirror.reconcile_missing.trashed", "node", node, "task", t.ID, "confirmations", streak)
+				continue
+			}
 			m.logger.Debug("cluster.mirror.reconcile_missing.failed", "node", node, "task", t.ID, "err", gerr)
 			continue
 		}
 		m.applyFollowerTaskWithContext(ctx, node, follower)
+	}
+}
+
+func missingStreakKey(node, taskID string) string { return node + "|" + taskID }
+
+// bumpMissingStreak increments and returns node/taskID's consecutive
+// confirmed-404 count.
+func (m *Mirror) bumpMissingStreak(node, taskID string) int {
+	m.missingMu.Lock()
+	defer m.missingMu.Unlock()
+	key := missingStreakKey(node, taskID)
+	m.missingStreak[key]++
+	return m.missingStreak[key]
+}
+
+func (m *Mirror) clearMissingStreak(node, taskID string) {
+	m.missingMu.Lock()
+	defer m.missingMu.Unlock()
+	delete(m.missingStreak, missingStreakKey(node, taskID))
+}
+
+// clearMissingStreaks drops the confirmed-404 streak for every task node's
+// fresh ListTasks snapshot accounts for.
+func (m *Mirror) clearMissingStreaks(node string, tasks []task.Task) {
+	if len(tasks) == 0 {
+		return
+	}
+	m.missingMu.Lock()
+	defer m.missingMu.Unlock()
+	for i := range tasks {
+		delete(m.missingStreak, missingStreakKey(node, tasks[i].ID))
 	}
 }
 

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -235,6 +235,9 @@ func (m *Mirror) reconcileMissing(ctx context.Context, node string, client *clus
 			m.logger.Debug("cluster.mirror.reconcile_missing.failed", "node", node, "task", t.ID, "err", gerr)
 			continue
 		}
+		// Found despite this tick's snapshot omitting it — a later absence
+		// is unrelated and must not inherit a stale streak.
+		m.clearMissingStreak(node, t.ID)
 		m.applyFollowerTaskWithContext(ctx, node, follower)
 	}
 }


### PR DESCRIPTION
## Motivation

> Changelog: fix(umbrella): stop silent progress stalls

Two of the board's umbrella trackers stopped making visible progress
tonight. Investigating both surfaced two separate bugs, not one:

1. `trackerRollup` treats any cancelled child as a permanent
   human-required block. An umbrella-expansion race had materialized
   the same sub-issue as two tasks; cleanup correctly cancelled the
   duplicate in favor of its live twin, but the gate kept flipping
   the umbrella back to human-required anyway, even after the real
   work landed.
2. The leader's cluster mirror has no way to learn that a follower
   trashed a task. Cleaning up the duplicates above left several
   stale, non-terminal ghost copies on the leader that will never
   sync away on their own, quietly poisoning the same rollup logic.

## Implementation information

- `internal/sybra/app_umbrella_gate.go`: a cancelled child only
  blocks rollup now if its issue has no live (non-cancelled)
  sibling. A resolved cancellation is also excluded from the
  total/doneCount completion check, so the umbrella can still reach
  done instead of sitting at in-progress with no signal.
- `internal/httpapi/handler.go`: a service error wrapping
  `os.ErrNotExist` now maps to HTTP 404 instead of a generic 500, so
  callers can tell "confirmed gone" apart from "server broke." The
  client-visible message is sanitized to avoid leaking the store's
  filesystem path; the raw error still lands in the server log.
- `internal/sybra/clusterlead/mirror.go`: `reconcileMissing` trashes
  its own stale copy of a task the follower confirms is gone,
  guarded by a `missingConfirmThreshold` of consecutive ticks. The
  threshold exists because `Assigner.Reassign` stamps a task's new
  node before pushing it there, so a freshly reassigned task can
  legitimately 404 on its new node for a tick before the push lands
  — a single 404 is not enough to trust as a real deletion.

Every fix has direct test coverage, including a regression test for
the reassign race the debounce guards against
(`TestMirrorReconcileMissingSurvivesReassignRace`).

## Supporting documentation

Both bugs found and root-caused live, on the production cluster
board, while chasing why two umbrellas looked stuck despite real
work landing underneath them. An adversarial review pass on the fix
itself caught two further regressions before they shipped: the
completion-accounting gap above, and a filesystem-path leak in the
new 404 response.