### PR TITLE
fix(cluster): mirror unassigned follower tasks

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
@@ -172,6 +172,15 @@ export function ListTasks(): $CancellablePromise<task$0.Task[]> {
  * follower's mirror: tasks assigned to that node, excluding terminal tasks
  * closed longer than mirrorStaleTerminalWindow ago. Unlike ListTasks, this is
  * sized for repeated polling rather than a one-off full board read.
+ * 
+ * Also includes tasks with no AssignedNode at all. This service call always
+ * runs against this instance's own store (the leader polls each follower's
+ * HTTP API individually), so an unassigned task here unambiguously lives on
+ * this node — e.g. created by this follower's own local umbrella expansion
+ * or triage, never routed by a leader. AssignedNode is leader-only metadata
+ * (see Assigner.route/stampNode); a follower has no way to stamp its own
+ * name onto a task it created itself, so without this, such a task is
+ * permanently invisible to the leader's mirror — see cluster.mirror.adopted.
  */
 export function ListTasksForNode(node: string): $CancellablePromise<task$0.Task[]> {
     return $Call.ByID(844621143, node).then(($result: any) => {

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -621,7 +621,7 @@ func TestMirrorNoAlertOnOrdinaryStatusDisagreement(t *testing.T) {
 	}
 }
 
-func TestMirrorIgnoresUnownedTask(t *testing.T) {
+func TestMirrorIgnoresTaskOwnedByAnotherNode(t *testing.T) {
 	cfg := leaderConfig("http://unused", []string{"owner/pet"})
 	roster, _ := NewRoster(cfg, nil)
 	mgr := newManager(t)
@@ -632,11 +632,43 @@ func TestMirrorIgnoresUnownedTask(t *testing.T) {
 	}
 	follower := task.Task{ID: "task-x", Status: task.StatusDone, UpdatedAt: time.Unix(100, 0)}
 	if mirror.applyFollowerTask("pet-box", follower) {
-		t.Error("a task not assigned to this node must not be mirrored from it")
+		t.Error("a task the leader already has assigned to a different node must not be mirrored from this one")
 	}
+}
 
-	if mirror.applyFollowerTask("pet-box", task.Task{ID: "ghost", UpdatedAt: time.Unix(100, 0)}) {
-		t.Error("a task the leader does not own must be ignored")
+// TestMirrorAdoptsUnknownFollowerTask covers the mirror gap behind
+// c01cafd6's local-board investigation: a task with no prior canonical copy
+// (the leader has never heard of it) is not necessarily a stray to ignore —
+// it may be a follower's own self-originated work (umbrella expansion or
+// triage run directly on that node, with no leader routing involved, so
+// never assigned a node). Since ListTasksForNode only ever returns tasks
+// that genuinely live on the node being asked, the leader can safely adopt
+// any task it sees there for the first time.
+func TestMirrorAdoptsUnknownFollowerTask(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	follower := task.Task{
+		ID: "self-originated", Title: "made on pet-box", ProjectID: "owner/pet",
+		Status: task.StatusTodo, UpdatedAt: time.Unix(100, 0),
+	}
+	if !mirror.applyFollowerTask("pet-box", follower) {
+		t.Fatal("expected the leader to adopt a task it has never seen before")
+	}
+	got, err := mgr.Get("self-originated")
+	if err != nil {
+		t.Fatalf("adopted task not found in canonical store: %v", err)
+	}
+	if got.AssignedNode != "pet-box" {
+		t.Errorf("AssignedNode = %q, want pet-box", got.AssignedNode)
+	}
+	if got.Title != "made on pet-box" || got.ProjectID != "owner/pet" {
+		t.Errorf("adopted task lost identity fields: %+v", got)
+	}
+	if got.MirrorRev != 1 {
+		t.Errorf("MirrorRev = %d, want 1 on first adoption", got.MirrorRev)
 	}
 }
 

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -669,6 +671,35 @@ func TestMirrorAdoptsUnknownFollowerTask(t *testing.T) {
 	}
 	if got.MirrorRev != 1 {
 		t.Errorf("MirrorRev = %d, want 1 on first adoption", got.MirrorRev)
+	}
+}
+
+// TestMirrorApplyLogsGenuineLocalStoreFailure covers a Copilot-review finding
+// on this PR: a m.tasks.Get failure that is NOT "doesn't exist yet" (I/O
+// fault, corrupt frontmatter, ...) took the same silent `return false` as
+// every other case, and the caller discards the bool — so a real local-store
+// fault left zero trace anywhere that mirror convergence had stalled for
+// that task.
+func TestMirrorApplyLogsGenuineLocalStoreFailure(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+
+	corrupt := filepath.Join(mgr.Store().Dir(), "broken.md")
+	if err := os.WriteFile(corrupt, []byte("---\nstatus: [not, a, string]\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf syncBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	mirror := NewMirror(cfg, mgr, roster, logger, time.Second)
+
+	follower := task.Task{ID: "broken", Status: task.StatusDone, UpdatedAt: time.Unix(100, 0)}
+	if mirror.applyFollowerTask("pet-box", follower) {
+		t.Error("apply must not report success over an unreadable canonical file")
+	}
+	if !strings.Contains(buf.String(), "cluster.mirror.apply.get_failed") {
+		t.Errorf("expected a get_failed warn log for the genuine store fault, got:\n%s", buf.String())
 	}
 }
 

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -287,6 +287,10 @@ func (m *Mirror) applyFollowerTaskWithContext(ctx context.Context, node string, 
 		if errors.Is(err, os.ErrNotExist) {
 			return m.adoptFollowerTask(ctx, node, follower)
 		}
+		// A genuine local-store fault (I/O, corrupt frontmatter), not
+		// "doesn't exist yet" — the discarded bool at the call site leaves
+		// this as the only trace convergence stalled for this task.
+		m.logger.Warn("cluster.mirror.apply.get_failed", "node", node, "task", follower.ID, "err", err)
 		return false
 	}
 	if canonical.AssignedNode != node {

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -283,9 +284,20 @@ func (m *Mirror) applyFollowerTaskWithContext(ctx context.Context, node string, 
 
 	canonical, err := m.tasks.Get(follower.ID)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return m.adoptFollowerTask(ctx, node, follower)
+		}
 		return false
 	}
 	if canonical.AssignedNode != node {
+		// Silent before this diff too, but now reachable by a new class of
+		// cause: adoptFollowerTask assigns a never-seen ID to the first node
+		// whose reconcile tick claims it, so a same-ID collision between two
+		// followers' independently self-originated tasks (task IDs are only
+		// 32 bits of randomness, internal/task/store.go) would permanently
+		// strand the loser here with no prior trace at all. Whatever the
+		// cause, a canonical/reporting-node mismatch deserves a log line.
+		m.logger.Warn("cluster.mirror.apply.assigned_elsewhere", "node", node, "task", follower.ID, "assigned_node", canonical.AssignedNode)
 		return false
 	}
 	m.detectAndRepairDrift(ctx, node, canonical, follower)
@@ -306,6 +318,37 @@ func (m *Mirror) applyFollowerTaskWithContext(ctx context.Context, node string, 
 		return false
 	}
 	m.logger.Debug("cluster.mirror.applied", "node", node, "task", follower.ID, "status", string(merged.Status), "rev", merged.MirrorRev)
+	return true
+}
+
+// adoptFollowerTask creates the leader's first canonical record for a task
+// that exists only on node — e.g. a follower's own local umbrella expansion
+// or triage, created without leader involvement and so never assigned a
+// node (ListTasksForNode returns these to the node that actually holds
+// them; see its doc comment). There is no existing canonical copy to merge
+// against, so unlike applyFollowerTaskWithContext's steady-state path, this
+// takes follower's own fields as the whole record rather than preserving
+// leader-authoritative identity fields from a prior version — there is no
+// prior version.
+func (m *Mirror) adoptFollowerTask(ctx context.Context, node string, follower task.Task) bool {
+	adopted, ok := m.localizeFollowerAttachments(ctx, node, task.Task{}, follower)
+	if !ok {
+		return false
+	}
+	adopted.AssignedNode = node
+	adopted.MirrorRev = 1
+	followerUpdated := adopted.UpdatedAt
+	adopted.MirrorUpdatedAt = &followerUpdated
+	adopted.UpdatedAt = time.Now().UTC()
+	if err := m.writeSidecars(adopted); err != nil {
+		m.logger.Warn("cluster.mirror.adopt.sidecar_failed", "node", node, "task", adopted.ID, "err", err)
+		return false
+	}
+	if _, _, err := m.tasks.Put(adopted); err != nil {
+		m.logger.Warn("cluster.mirror.adopt.failed", "node", node, "task", adopted.ID, "err", err)
+		return false
+	}
+	m.logger.Info("cluster.mirror.adopted", "node", node, "task", adopted.ID, "status", string(adopted.Status))
 	return true
 }
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -133,6 +133,15 @@ const mirrorStaleTerminalWindow = 10 * time.Minute
 // follower's mirror: tasks assigned to that node, excluding terminal tasks
 // closed longer than mirrorStaleTerminalWindow ago. Unlike ListTasks, this is
 // sized for repeated polling rather than a one-off full board read.
+//
+// Also includes tasks with no AssignedNode at all. This service call always
+// runs against this instance's own store (the leader polls each follower's
+// HTTP API individually), so an unassigned task here unambiguously lives on
+// this node — e.g. created by this follower's own local umbrella expansion
+// or triage, never routed by a leader. AssignedNode is leader-only metadata
+// (see Assigner.route/stampNode); a follower has no way to stamp its own
+// name onto a task it created itself, so without this, such a task is
+// permanently invisible to the leader's mirror — see cluster.mirror.adopted.
 func (s *TaskService) ListTasksForNode(node string) ([]task.Task, error) {
 	all, err := s.tasks.List()
 	if err != nil {
@@ -141,7 +150,7 @@ func (s *TaskService) ListTasksForNode(node string) ([]task.Task, error) {
 	out := all[:0]
 	for i := range all {
 		t := all[i]
-		if t.AssignedNode != node {
+		if t.AssignedNode != node && t.AssignedNode != "" {
 			continue
 		}
 		if task.IsTerminalStatus(t.Status) && t.ClosedAt != nil && time.Since(*t.ClosedAt) > mirrorStaleTerminalWindow {

--- a/internal/sybra/svc_tasks_listfornode_test.go
+++ b/internal/sybra/svc_tasks_listfornode_test.go
@@ -8,9 +8,14 @@ import (
 )
 
 // TestListTasksForNodeFiltersByAssignedNode verifies the cluster-mirror-only
-// listing (see internal/cluster.Client.ListTasks and #2258) only returns
-// tasks assigned to the requested node, never tasks assigned elsewhere or
-// unassigned to this node's own board.
+// listing (see internal/cluster.Client.ListTasks and #2258) returns tasks
+// assigned to the requested node, never tasks assigned elsewhere — but does
+// include unassigned tasks, since this call always runs against the local
+// instance's own store: an unassigned task here can only be one this node
+// created itself (e.g. its own local umbrella expansion or triage), and
+// AssignedNode is leader-only metadata a follower has no way to stamp on
+// its own work. See ListTasksForNode's doc comment and
+// Mirror.adoptFollowerTask.
 func TestListTasksForNodeFiltersByAssignedNode(t *testing.T) {
 	svc, a := setupTaskService(t)
 
@@ -29,8 +34,21 @@ func TestListTasksForNodeFiltersByAssignedNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].ID != "mine" {
-		t.Fatalf("ListTasksForNode(home-nas) = %+v, want only [mine]", got)
+	ids := make(map[string]bool, len(got))
+	for _, tk := range got {
+		ids[tk.ID] = true
+	}
+	if !ids["mine"] {
+		t.Error("ListTasksForNode dropped a task explicitly assigned to this node")
+	}
+	if ids["elsewhere"] {
+		t.Error("ListTasksForNode returned a task assigned to a different node")
+	}
+	if !ids["unassigned"] {
+		t.Error("ListTasksForNode dropped an unassigned task — self-originated follower work would be permanently invisible to the leader's mirror")
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListTasksForNode(home-nas) = %+v, want [mine, unassigned]", got)
 	}
 }
 


### PR DESCRIPTION
## Motivation

> Changelog: fix(cluster): mirror unassigned follower tasks

While investigating why umbrella `c01cafd6`'s local board showed only
2 of 7 child tasks, found the 5 missing ones all had `AssignedNode`
completely empty on home-nas (the authoritative follower). They were
created there directly by local umbrella expansion, never routed by
the leader — and `AssignedNode` is leader-only routing metadata, so a
follower has no way to stamp its own name onto work it originates
itself. The leader's mirror polls `ListTasksForNode(node)`, which
filters strictly on `AssignedNode == node`, so these tasks were
permanently invisible to the leader — not a bug from tonight's
redeploy, a pre-existing structural gap.

## Implementation information

- `internal/sybra/svc_tasks.go`: `ListTasksForNode` now also returns
  tasks with `AssignedNode == ""`. Safe because this method call
  always runs against the local instance's own store (the leader
  polls each follower's HTTP API individually) — an unassigned task
  in the response can only be self-originated work living on that
  exact node, no cross-follower ambiguity possible.
- `internal/sybra/clusterlead/mirror.go`: `applyFollowerTaskWithContext`
  previously only updated an *existing* canonical record; on a
  not-found `Get`, it just gave up. It now calls a new
  `adoptFollowerTask`, which creates the leader's first canonical
  copy and stamps `AssignedNode` to the node it came from.
- Also added a `Warn` log on the previously-silent
  `canonical.AssignedNode != node` mismatch branch — an adversarial
  review pass flagged that a same-ID collision between two followers'
  independently self-originated tasks (task IDs are only 32 bits of
  randomness) could now strand the losing task with zero diagnostic
  trace; this doesn't prevent it (a pre-existing, extremely low-
  probability tail risk of the ID scheme, not something this PR
  introduces) but makes it observable if it ever happens.
- Updated one existing test (`TestMirrorIgnoresUnownedTask`) that
  explicitly asserted the old broken behavior — split into
  `TestMirrorIgnoresTaskOwnedByAnotherNode` (unchanged case: a task
  already assigned elsewhere must not be stolen) and
  `TestMirrorAdoptsUnknownFollowerTask` (new case: a never-seen task
  gets adopted with identity fields intact). Added
  `TestListTasksForNodeFiltersByAssignedNode` coverage for the new
  inclusion behavior.

## Supporting documentation

Both fixes (this PR and #2528, already merged and deployed) went
through the same adversarial-review pass before shipping — a Code
Adversary and an independent Findings Adversary subagent, run
separately so the second one has no memory of the first one's
reasoning. This PR's review caught one real gap (the silent
mismatch branch, now logged) and one non-blocking test-coverage
suggestion (the adopt path isn't exercised over the real wire/RPC
transport, only in-process) that's left as a known follow-up rather
than blocking this fix.