### PR TITLE
fix(agent): exclude hard-quota providers from A/B

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -706,17 +706,29 @@ func (m *Manager) ProviderRateLimited(name string) bool {
 }
 
 // ProviderHealthy reports whether the named provider is currently usable —
-// false for a probe-detected outage (health gate) or a config-disabled
-// provider (providers.<name>.enabled=false, via limitPolicy.ProviderEnabled).
-// The config-disabled check is independent of the health gate so it still
-// holds when providers.health_check.enabled=false and the gate is nil (checks
-// disabled, tests) — otherwise ProviderHealthy would report true for a
-// provider the admin explicitly disabled. Empty name resolves to the default
-// provider. A/B variant selection consults this so a disabled or unhealthy
-// provider is never picked as an eligible weighted variant.
+// false for a probe-detected outage (health gate), a config-disabled
+// provider (providers.<name>.enabled=false, via limitPolicy.ProviderEnabled),
+// or a hard quota exhaustion (limitGate, e.g. a real "resets Jul 28" usage
+// cap, not a soft threshold). The limitGate check matters here specifically
+// because it's a different signal than the probe-based health gate: g's
+// rate-limit cooldown defaults to 15 minutes (nowhere near a real multi-day
+// quota reset), so without also consulting limitGate, A/B selection kept
+// treating a hard-exhausted provider as eligible, re-picking it every retry
+// only for resolveProviderDecision's own limitGate check to reject it at
+// dispatch — burning a full worktree rebuild per cycle with
+// DisableProviderFailover set (A/B-attributed runs) preventing the
+// in-dispatch fallback that would otherwise mask it. The config-disabled and
+// quota checks are independent of the health gate so they still hold when
+// providers.health_check.enabled=false and g is nil (checks disabled,
+// tests) — otherwise ProviderHealthy would report true for a provider the
+// admin explicitly disabled or that is verifiably out of quota. Empty name
+// resolves to the default provider. A/B variant selection consults this so a
+// disabled, quota-exhausted, or unhealthy provider is never picked as an
+// eligible weighted variant.
 func (m *Manager) ProviderHealthy(name string) bool {
 	m.mu.RLock()
 	g := m.gate
+	lg := m.limitGate
 	lp := m.limitPolicy
 	if name == "" {
 		name = m.defaultProv
@@ -724,6 +736,20 @@ func (m *Manager) ProviderHealthy(name string) bool {
 	m.mu.RUnlock()
 	if enabled, ok := lp.ProviderEnabled[name]; ok && !enabled {
 		return false
+	}
+	if lg != nil {
+		if ok, reason := lg.ProviderAvailable(name, lp); !ok && !limits.IsSoftThresholdReason(reason) {
+			// ProviderAvailable reports unavailable for soft session/weekly
+			// thresholds too, not just a hard block — deliberately, so
+			// resolveProviderDecision's softLimitLastResort can redirect to a
+			// healthier peer without stranding a task on a provider that
+			// still has real budget when no peer exists. ProviderHealthy
+			// must only exclude on the hard reasons (rate-limit-reached,
+			// provider-disabled), or a soft-thresholded provider would be
+			// wrongly removed from A/B eligibility entirely instead of just
+			// de-prioritized at dispatch time.
+			return false
+		}
 	}
 	if g == nil {
 		return true

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -662,6 +662,48 @@ func TestProviderHealthy_ConfigDisabledWithNilGate(t *testing.T) {
 	if m.ProviderHealthy("copilot") {
 		t.Error("config-disabled provider should report unhealthy even with nil health gate")
 	}
+}
+
+// TestProviderHealthy_HardQuotaExhaustion covers the busy-loop this fix
+// closes: a hard quota block (e.g. a real multi-day rate-limit-reached, not
+// the probe-based health gate's 15-minute cooldown) must also report
+// unhealthy, so A/B eligibility excludes it up front instead of re-selecting
+// it every retry only for resolveProviderDecision's own limitGate check to
+// reject it at dispatch — burning a full worktree rebuild per cycle.
+func TestProviderHealthy_HardQuotaExhaustion(t *testing.T) {
+	m, _ := newTestManager(t, ManagerConfig{
+		Runtime: ManagerRuntimeConfig{
+			LimitGate: &fakeLimitGate{
+				available: map[string]bool{"codex": false},
+				reasons:   map[string]string{"codex": "provider reports rate limit reached"},
+			},
+		},
+	})
+
+	if m.ProviderHealthy("codex") {
+		t.Error("hard quota-exhausted provider should report unhealthy")
+	}
+}
+
+// TestProviderHealthy_SoftThresholdStillHealthy is the negative case: a soft
+// session/weekly threshold must not exclude a provider from A/B eligibility
+// entirely — resolveProviderDecision's softLimitLastResort already handles
+// redirecting to a healthier peer for soft thresholds. ProviderHealthy
+// treating it the same as a hard block would strand the provider out of
+// rotation even though it still has real budget.
+func TestProviderHealthy_SoftThresholdStillHealthy(t *testing.T) {
+	m, _ := newTestManager(t, ManagerConfig{
+		Runtime: ManagerRuntimeConfig{
+			LimitGate: &fakeLimitGate{
+				available: map[string]bool{"codex": false},
+				reasons:   map[string]string{"codex": "session limit near threshold"},
+			},
+		},
+	})
+
+	if !m.ProviderHealthy("codex") {
+		t.Error("soft-threshold provider should still report healthy for A/B eligibility")
+	}
 	if !m.ProviderHealthy("claude") {
 		t.Error("config-enabled provider should report healthy with nil health gate")
 	}


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): exclude hard-quota providers from A/B

Diagnosed live tonight: home-nas fans audibly spinning up, load average
~3.5, `npm ci` pegged at 330% CPU. Root cause: at least two tasks stuck in
a busy-loop — full worktree rebuild (mise install + npm ci + npm run
build:desktop, ~8-30s) firing every retry cycle, immediately hitting
`agent.start.gated: provider codex unhealthy (provider reports rate limit
reached)`, then restarting the cycle. Codex had hit a real account usage
limit ("try again at Jul 28th, 2026") — not a transient rate limit, a
multi-day outage — so this would have burned CPU continuously for days.

Root cause in code: `Manager.ProviderHealthy` — consulted by the A/B
experiment router for eligibility — only checked a config-disabled flag
and the probe-based health gate (15-minute rate-limit cooldown). It never
consulted `limitGate`, the quota-store-backed signal that actually knows
about the real multi-day exhaustion. So the router kept treating codex as
eligible and re-selecting it every retry, only for the *separate*
dispatch-time gate (`resolveProviderDecision`, which already does consult
`limitGate`) to reject it a few seconds later — after the worktree was
already rebuilt.

## Implementation information

- `internal/agent/manager.go`: `ProviderHealthy` now also calls
  `limitGate.ProviderAvailable(name, limitPolicy)`, filtered through
  `limits.IsSoftThresholdReason` so only *hard* reasons (rate-limit-reached,
  provider-disabled) count as unhealthy. A soft session/weekly threshold
  stays eligible — `resolveProviderDecision`'s existing
  `softLimitLastResort`/`ChooseSoftLimitedPeer` logic already handles
  redirecting those to a healthier peer at dispatch time, and treating a
  soft threshold as a hard exclusion here would strand a provider with real
  remaining budget out of rotation entirely.
- Two new tests: `TestProviderHealthy_HardQuotaExhaustion` (the fix) and
  `TestProviderHealthy_SoftThresholdStillHealthy` (the negative case, so a
  future change can't accidentally widen this to soft thresholds).
- Verified the new test fails without the fix and passes with it.

## Supporting documentation

Adversarial review (Code Adversary subagent) attacked lock/race safety
(confirmed with `go test -race`), a typed-nil-interface trap on
`LimitGate`, whether the broader "healthy" definition could kill an
in-flight agent (it can't — only consulted at selection time), an
all-providers-ineligible deadlock scenario (existing code already handles
a total A/B shutout gracefully), and `quotaReasonProviderDisabled`
redundancy with the existing config-disabled check (confirmed harmless —
unreachable divergence given every production `Policy` constructor
populates all provider entries). Verdict: CLEAN, no findings.