### PR TITLE
fix(workflow): fence poisoned resumes, umbrella re-release

### DIFF
--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
@@ -114,15 +115,19 @@ func (a *App) releaseUnblockedChildren(ctx context.Context) {
 			// Gate-marked todo children (current model) and legacy
 			// blocked+gated children (tasks created before this change)
 			// are both eligible for release. Never release a task that is
-			// blocked without the gating tag (contained Sybra bug). A child
-			// whose umbrella is currently mid-recovery is held regardless —
+			// blocked without the gating tag (contained Sybra bug), or one
+			// that already ran an implementation agent — a watchdog-exhausted
+			// blocked status must never be mistaken for dependency-gating
+			// (sybra#2538). A child whose umbrella is currently mid-recovery
+			// is held regardless —
 			// RecoverDegraded may be mutating this same umbrella's children
 			// concurrently, so this tick must not release from a partial graph.
 			Awaiting: t.UmbrellaIssue != "" &&
 				!inFlight[umbrella.NormalizeIssueRef(t.UmbrellaIssue)] &&
 				!expanding &&
 				(t.Status == task.StatusTodo || t.Status == task.StatusBlocked) &&
-				slices.Contains(t.Tags, umbrellaGatedTag),
+				slices.Contains(t.Tags, umbrellaGatedTag) &&
+				!hasStartedImplementation(t),
 		}
 	}
 
@@ -152,6 +157,21 @@ func (a *App) releaseUnblockedChildren(ctx context.Context) {
 	// snapshot RecoverDegraded may be mutating underneath. Unrelated
 	// umbrellas continue rolling up normally.
 	a.rollupTrackers(states, cyclic)
+}
+
+// hasStartedImplementation reports whether t has ever run an implementation
+// agent. A dependency-gated child that never left blocked-awaiting-deps has
+// none; the umbrella gate must never release one that does, since a blocked
+// status on a child that already ran implementation means a watchdog
+// exhaustion, not an unmet dependency (sybra#2538).
+func hasStartedImplementation(t *task.Task) bool {
+	for i := range t.AgentRuns {
+		role := t.AgentRuns[i].Role
+		if role == "" || role == string(agent.RoleImplementation) {
+			return true
+		}
+	}
+	return false
 }
 
 // accumulateChild folds one child task's status into its umbrella's tally.

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -165,7 +165,7 @@ func (a *App) releaseUnblockedChildren(ctx context.Context) {
 // status on a child that already ran implementation means a watchdog
 // exhaustion, not an unmet dependency (sybra#2538).
 func hasStartedImplementation(t *task.Task) bool {
-	for i := range t.AgentRuns {
+	for i := range slices.Backward(t.AgentRuns) {
 		role := t.AgentRuns[i].Role
 		if role == "" || role == string(agent.RoleImplementation) {
 			return true

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
@@ -190,6 +191,40 @@ func TestReleaseUnblockedChildren_NonGatedBlockedChildEscalates(t *testing.T) {
 	}
 	if got := mustStatus(t, m, dependent.ID); got != task.StatusBlocked {
 		t.Fatalf("dependent child = %q, want to stay held (dep never reached done)", got)
+	}
+}
+
+// TestReleaseUnblockedChildren_WatchdogBlockedChildWithImplementationHistoryNotReleased
+// is the regression guard for sybra#2538: a child that already ran an
+// implementation agent and later hit `blocked` via watchdog exhaustion must
+// never be re-released as though it were still awaiting its dependencies,
+// even if it still (or once again) carries the gating tag.
+func TestReleaseUnblockedChildren_WatchdogBlockedChildWithImplementationHistoryNotReleased(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	mkTracker(t, m, umb, 5)
+
+	started := mkChild(t, m, "started", "Automaat/sybra#1", umb, nil, task.StatusBlocked)
+	if err := m.AddRun(started.ID, task.AgentRun{
+		AgentID: "a1",
+		Role:    string(agent.RoleImplementation),
+	}); err != nil {
+		t.Fatalf("add implementation run: %v", err)
+	}
+	neverStarted := mkChild(t, m, "never-started", "Automaat/sybra#2", umb, nil, task.StatusBlocked)
+
+	app.releaseUnblockedChildren(context.Background())
+
+	startedTask := mustTask(t, m, started.ID)
+	if startedTask.Status != task.StatusBlocked || !slices.Contains(startedTask.Tags, umbrellaGatedTag) {
+		t.Fatalf("started child = %q tags=%v, want to stay blocked+gated (already implemented, not dependency-gated)",
+			startedTask.Status, startedTask.Tags)
+	}
+	neverStartedTask := mustTask(t, m, neverStarted.ID)
+	if neverStartedTask.Status != task.StatusTodo || slices.Contains(neverStartedTask.Tags, umbrellaGatedTag) {
+		t.Fatalf("never-started child = %q tags=%v, want released to todo (dependency-gated with no history)",
+			neverStartedTask.Status, neverStartedTask.Tags)
 	}
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1662,6 +1662,11 @@ func (e *Engine) handleWatchdogRateLimitRetry(t *TaskInfo, step *Step) bool {
 	if attempts >= maxWatchdogRateLimitRetries {
 		targetStatus, reason, terminalState := watchdogRateLimitExhaustionResolution(*t, step, attempts)
 		t.Workflow.State = terminalState
+		if watchdogreason.IsZeroOutputRateLimit(t.StatusReason) {
+			// Bump past PickImplementationResumeSession's StartedAt fence so the
+			// next dispatch stops resuming this poisoned session. See sybra#2542.
+			t.Workflow.StartedAt = time.Now().UTC()
+		}
 		if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
 			e.logger.Error("workflow.watchdog-rate-limit.persist", "task_id", t.ID, "step", step.ID, "err", err)
 		}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3229,13 +3229,15 @@ func TestRescheduleRateLimitedAgent_WatchdogRetriesThenEscalates(t *testing.T) {
 }
 
 func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
+	oldStartedAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name       string
-		retries    string
-		wantStarts int
-		wantStatus string
-		wantReason string
-		wantRetry  string
+		name             string
+		retries          string
+		wantStarts       int
+		wantStatus       string
+		wantReason       string
+		wantRetry        string
+		wantSessionFence bool
 	}{
 		{
 			name:       "resume consumes persisted retry and reruns",
@@ -3246,12 +3248,13 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			wantRetry:  "2",
 		},
 		{
-			name:       "third identical zero-output attempt blocks",
-			retries:    strconv.Itoa(maxWatchdogRateLimitRetries),
-			wantStarts: 0,
-			wantStatus: "blocked",
-			wantReason: "watchdog: zero-output startup retry budget exhausted after 3 identical attempts",
-			wantRetry:  strconv.Itoa(maxWatchdogRateLimitRetries),
+			name:             "third identical zero-output attempt blocks and fences off the poisoned session",
+			retries:          strconv.Itoa(maxWatchdogRateLimitRetries),
+			wantStarts:       0,
+			wantStatus:       "blocked",
+			wantReason:       "watchdog: zero-output startup retry budget exhausted after 3 identical attempts",
+			wantRetry:        strconv.Itoa(maxWatchdogRateLimitRetries),
+			wantSessionFence: true,
 		},
 	}
 	for _, tc := range tests {
@@ -3275,6 +3278,7 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 					CurrentStep: "implement",
 					State:       ExecWaiting,
 					Variables:   vars,
+					StartedAt:   oldStartedAt,
 				},
 			})
 
@@ -3295,6 +3299,17 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			}
 			if got.Workflow.Variables[watchdogRateLimitRetryKey("implement")] != tc.wantRetry {
 				t.Fatalf("rate-limit retry var = %q, want %q", got.Workflow.Variables[watchdogRateLimitRetryKey("implement")], tc.wantRetry)
+			}
+			// sybra#2542: exhausting the zero-output-stall budget must bump
+			// Workflow.StartedAt past every prior agent run, so
+			// PickImplementationResumeSession's StartedAt fence rejects the
+			// poisoned session and the next dispatch starts fresh instead of
+			// resuming the same session that just hung.
+			if tc.wantSessionFence && !got.Workflow.StartedAt.After(oldStartedAt) {
+				t.Fatalf("workflow.started_at = %v, want it bumped past %v to fence off the poisoned resume session", got.Workflow.StartedAt, oldStartedAt)
+			}
+			if !tc.wantSessionFence && !got.Workflow.StartedAt.Equal(oldStartedAt) {
+				t.Fatalf("workflow.started_at = %v, want unchanged %v", got.Workflow.StartedAt, oldStartedAt)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

Two related reliability bugs found while live-debugging today's fleet outage on `de7ca59f`/`384174e7`:

1. A `--resume`'d session that hangs with zero output on startup repeats the exact same hang on every future resume, forever — the watchdog's rate-limit-retry budget exhausts, the task lands in `blocked`, and nothing distinguishes "this session is poisoned" from "the provider is transiently rate-limited."
2. The umbrella gate's `Awaiting` check only required the gating tag + a `blocked` status to treat a child as dependency-gated and release it. A child that had already run a real implementation agent and later hit `blocked` via watchdog exhaustion could be mistaken for a never-started child and released again, silently discarding its in-flight `simple-task-implement` workflow state.

> Changelog: fix(workflow): fence poisoned resumes and stop umbrella re-release

Closes #2542, closes #2538.

## Implementation information

- `internal/workflow/engine_events.go`: when the zero-output-rate-limit exhaustion path fires, bump `Workflow.StartedAt` to now. `PickImplementationResumeSession` (`internal/sybra/agentorch/agentorch.go`) already filters candidate resume sessions by `run.StartedAt.Before(workflowStart)`, so this makes the next dispatch reject every prior run and start a fresh session instead of repeating the doomed resume.
- `internal/sybra/app_umbrella_gate.go`: added `hasStartedImplementation`, which checks whether a task has ever recorded an implementation-role (or legacy empty-role) agent run. `Awaiting` now also requires `!hasStartedImplementation(t)`, so a child that's already been implementing cannot be re-released regardless of its current tags/status.
- Both fixes are unit-tested: `TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget` asserts `StartedAt` is bumped only on the exhaustion path, and `TestReleaseUnblockedChildren_WatchdogBlockedChildWithImplementationHistoryNotReleased` asserts a child with implementation history stays held while a genuinely never-started sibling still releases normally.

## Supporting documentation

Root-cause evidence (log excerpts, live process inspection, reproduction) is in #2542 and #2538.