### PR TITLE
fix(workflow): recover poisoned resume sessions

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -29,6 +29,14 @@ const (
 	watchdogRateLimitStatusPrefix   = "watchdog: rate limit"
 	watchdogRateLimitRetryVarPrefix = "watchdog.rate_limit_retry."
 	maxWatchdogRateLimitRetries     = 2
+	// watchdogZeroOutputFreshRetryVarPrefix records that a zero-output stall was
+	// already granted its one fresh-session round. A zero-output stall is a
+	// poisoned resume, not a real rate limit; sybra#2542's StartedAt fence makes
+	// a fresh dispatch succeed, but parking straight to blocked meant that fresh
+	// retry never ran and a transient stall latched a permanent deadlock
+	// (2026-07-23 board freeze). We fence, reset the budget, retry fresh once,
+	// and only park blocked if the fresh round also exhausts.
+	watchdogZeroOutputFreshRetryVarPrefix = "watchdog.rate_limit_fresh_retry."
 	// watchdogRewardHackingStatusPrefix must stay in sync with
 	// internal/watchdog/agent.go's rewardHackingRetryStatusReason — the
 	// watchdog writes this exact status-reason prefix when it retries a
@@ -1660,6 +1668,26 @@ func (e *Engine) handleWatchdogRateLimitRetry(t *TaskInfo, step *Step) bool {
 	retryKey := watchdogRateLimitRetryKey(step.ID)
 	attempts := parseWorkflowInt(t.Workflow.Variables[retryKey])
 	if attempts >= maxWatchdogRateLimitRetries {
+		freshKey := watchdogZeroOutputFreshRetryKey(step.ID)
+		if watchdogreason.IsZeroOutputRateLimit(t.StatusReason) &&
+			parseWorkflowInt(t.Workflow.Variables[freshKey]) == 0 {
+			// Resume-attempt budget exhausted on a poisoned session. Fence it
+			// (fresh dispatch next time), reset the budget, and retry once fresh
+			// rather than parking blocked — see watchdogZeroOutputFreshRetryVarPrefix.
+			t.Workflow.StartedAt = time.Now().UTC()
+			t.Workflow.SetVar(freshKey, "1")
+			t.Workflow.SetVar(retryKey, "0")
+			if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
+				e.logger.Error("workflow.watchdog-rate-limit.persist", "task_id", t.ID, "step", step.ID, "err", err)
+				return true
+			}
+			e.logger.Warn("workflow.watchdog-rate-limit.fresh-session-recovery",
+				"task_id", t.ID, "step", step.ID, "resume_attempts", attempts+1)
+			// Consume this tick: the reset budget + fence are now persisted, so the
+			// next ResumeStalled dispatches a clean session from stored state
+			// rather than resuming the poisoned one via the in-flight copy.
+			return true
+		}
 		targetStatus, reason, terminalState := watchdogRateLimitExhaustionResolution(*t, step, attempts)
 		t.Workflow.State = terminalState
 		if watchdogreason.IsZeroOutputRateLimit(t.StatusReason) {
@@ -1920,6 +1948,10 @@ func watchdogHangCleanRetryKey(stepID string) string {
 
 func watchdogRateLimitRetryKey(stepID string) string {
 	return watchdogRateLimitRetryVarPrefix + stepID
+}
+
+func watchdogZeroOutputFreshRetryKey(stepID string) string {
+	return watchdogZeroOutputFreshRetryVarPrefix + stepID
 }
 
 func worktreeRepairRetryKey(stepID string) string {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3233,10 +3233,12 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 	tests := []struct {
 		name             string
 		retries          string
+		freshUsed        bool
 		wantStarts       int
 		wantStatus       string
 		wantReason       string
 		wantRetry        string
+		wantFresh        string
 		wantSessionFence bool
 	}{
 		{
@@ -3248,12 +3250,28 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			wantRetry:  "2",
 		},
 		{
-			name:             "third identical zero-output attempt blocks and fences off the poisoned session",
+			// Exhausting the *resume* budget is not terminal: the poisoned
+			// session is fenced with a reset budget so the next tick dispatches a
+			// clean session, instead of latching a permanent blocked deadlock
+			// (2026-07-23). This tick is consumed (no dispatch yet).
+			name:             "resume budget exhausted grants one fresh-session round",
 			retries:          strconv.Itoa(maxWatchdogRateLimitRetries),
+			wantStarts:       0,
+			wantStatus:       "in-progress",
+			wantReason:       watchdogreason.RateLimit(watchdogreason.ZeroOutputBeforeStartup),
+			wantRetry:        "0",
+			wantFresh:        "1",
+			wantSessionFence: true,
+		},
+		{
+			name:             "fresh round also exhausts, blocks and fences off the poisoned session",
+			retries:          strconv.Itoa(maxWatchdogRateLimitRetries),
+			freshUsed:        true,
 			wantStarts:       0,
 			wantStatus:       "blocked",
 			wantReason:       "watchdog: zero-output startup retry budget exhausted after 3 identical attempts",
 			wantRetry:        strconv.Itoa(maxWatchdogRateLimitRetries),
+			wantFresh:        "1",
 			wantSessionFence: true,
 		},
 	}
@@ -3267,6 +3285,9 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			vars := map[string]string{}
 			if tc.retries != "" {
 				vars[watchdogRateLimitRetryKey("implement")] = tc.retries
+			}
+			if tc.freshUsed {
+				vars[watchdogZeroOutputFreshRetryKey("implement")] = "1"
 			}
 			tasks.Put(TaskInfo{
 				ID:           "t1",
@@ -3300,6 +3321,9 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			if got.Workflow.Variables[watchdogRateLimitRetryKey("implement")] != tc.wantRetry {
 				t.Fatalf("rate-limit retry var = %q, want %q", got.Workflow.Variables[watchdogRateLimitRetryKey("implement")], tc.wantRetry)
 			}
+			if got.Workflow.Variables[watchdogZeroOutputFreshRetryKey("implement")] != tc.wantFresh {
+				t.Fatalf("fresh-retry var = %q, want %q", got.Workflow.Variables[watchdogZeroOutputFreshRetryKey("implement")], tc.wantFresh)
+			}
 			// sybra#2542: exhausting the zero-output-stall budget must bump
 			// Workflow.StartedAt past every prior agent run, so
 			// PickImplementationResumeSession's StartedAt fence rejects the
@@ -3312,6 +3336,62 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 				t.Fatalf("workflow.started_at = %v, want unchanged %v", got.Workflow.StartedAt, oldStartedAt)
 			}
 		})
+	}
+}
+
+// TestResumeStalled_WatchdogZeroOutputFreshRoundDispatches proves the deadlock
+// break end-to-end: a poisoned resume that has exhausted its resume budget is
+// granted a fresh round (tick 1 consumed, fenced) and then actually
+// re-dispatches a clean session on the next tick — rather than latching a
+// permanent blocked state as it did during the 2026-07-23 board freeze.
+func TestResumeStalled_WatchdogZeroOutputFreshRoundDispatches(t *testing.T) {
+	oldStartedAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: watchdogreason.RateLimit(watchdogreason.ZeroOutputBeforeStartup),
+		AgentMode:    "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{watchdogRateLimitRetryKey("implement"): strconv.Itoa(maxWatchdogRateLimitRetries)},
+			StartedAt:   oldStartedAt,
+		},
+	})
+
+	// Tick 1: resume budget already exhausted -> fence + reset, no dispatch yet.
+	engine.ResumeStalled()
+	if got := agents.CallCount(); got != 0 {
+		t.Fatalf("tick 1 dispatched %d agents, want 0 (fence-and-wait)", got)
+	}
+	afterFence, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if afterFence.Status != "in-progress" {
+		t.Fatalf("tick 1 status = %q, want in-progress (not blocked)", afterFence.Status)
+	}
+	if !afterFence.Workflow.StartedAt.After(oldStartedAt) {
+		t.Fatalf("tick 1 did not fence the poisoned session (started_at %v)", afterFence.Workflow.StartedAt)
+	}
+
+	// Tick 2: fenced clean session actually dispatches.
+	engine.ResumeStalled()
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("tick 2 dispatched %d agents total, want 1 (fresh session ran)", got)
+	}
+	final, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if final.Status == "blocked" {
+		t.Fatalf("task latched blocked despite a fresh-session recovery being available")
 	}
 }
 


### PR DESCRIPTION
## Motivation

On 2026-07-23 the whole board froze for ~10h and cascaded two umbrellas to
human-required. Root cause: a "zero output before startup timeout" watchdog
stall is a **poisoned resume session** (the CLI resumed a session that produced
no output), not a real provider rate limit. After `maxWatchdogRateLimitRetries`
(2) resume attempts, the task was parked terminal `blocked`.

sybra#2542 already bumped `Workflow.StartedAt` to fence the poisoned session so
a fresh dispatch would start clean — but the task went straight to `blocked`, a
dead-end nothing re-dispatches, so **the fenced clean retry never ran**. A
transient stall thus latched a permanent deadlock, and because the blocked
children were workflow-owned, both parent umbrellas rolled up to
human-required, freezing every gated sibling.

> Changelog: fix(workflow): recover poisoned resume sessions

## Implementation information

`handleWatchdogRateLimitRetry` now gives a zero-output exhaustion **one
fresh-session round** before parking blocked:

- On resume-budget exhaustion, if it's a zero-output stall and the fresh round
  hasn't been used yet: fence (`StartedAt`), set a per-step
  `watchdog.rate_limit_fresh_retry.<step>` flag, reset the retry counter, and
  consume the tick. The next `ResumeStalled` dispatches a genuinely fresh
  session from persisted state (not the in-flight poisoned copy).
- Only if the **fresh round also exhausts** does it fall through to the
  original terminal `blocked` + `KindWatchdogRateLimitExhausted` resolution — at
  which point the task is genuinely stuck and the umbrella gate's escalation of
  a workflow-owned block is correct.

Bounded: 2 resume attempts → fence → 2 fresh attempts → blocked. The flag is
per-step and never cleared, so a later independent stall on the same step
degrades to the prior (visible) blocked behavior rather than looping.

Tests (`internal/workflow/engine_test.go`):
- `TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget` — updated: the
  exhausted-resume case now grants a fresh round (in-progress, fenced, budget
  reset); a new case asserts the fresh round also exhausting → blocked.
- `TestResumeStalled_WatchdogZeroOutputFreshRoundDispatches` — new end-to-end:
  tick 1 fences (no dispatch), tick 2 actually dispatches a clean session and
  never latches blocked.

Adversarially reviewed (infinite-loop, nil-deref, stuck-in-progress, and
double-fence scenarios all traced and refuted).

## Supporting documentation

- sybra#2542 (poisoned-resume StartedAt fence — this makes that fence effective)
- Incident: 2026-07-23 ~20:25–06:11 board freeze; the two blocked children were
  `fix(github): make auth outages self-healing` and `refactor(agent): remove
  interactive runners`, both parked with `watchdog_rate_limit_exhausted`.
