### PR TITLE
fix(review): park branch-conflict on rate limit

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1628,6 +1628,19 @@ func isTransientBranchConflictDispatchFailure(err error) bool {
 	return ue.RateLimited || ue.Reason == provider.RateLimitReason || !ue.Until.IsZero()
 }
 
+// dispatchFailureIsRateLimited reports whether a branch-conflict dispatch
+// failure is specifically a provider rate limit (as opposed to an ambiguous
+// cooldown). A rate limit always recovers, so this class parks indefinitely
+// instead of consuming the escalation budget — see
+// parkOrEscalateBranchConflictDispatchFailure.
+func dispatchFailureIsRateLimited(err error) bool {
+	var ue *provider.UnhealthyError
+	if !errors.As(err, &ue) {
+		return false
+	}
+	return ue.RateLimited || ue.Reason == provider.RateLimitReason
+}
+
 // parkOrEscalateBranchConflictDispatchFailure handles a transient
 // provider-unhealthy/rate-limit error starting the branch-conflict-fix
 // workflow — distinct from a genuine unresolved rebase conflict, which the
@@ -1641,6 +1654,17 @@ func isTransientBranchConflictDispatchFailure(err error) bool {
 // convention MarkRebaseBlocked relies on to avoid overwriting a specific
 // reason with its generic one.
 func (r *Handler) parkOrEscalateBranchConflictDispatchFailure(taskID string, dispatchErr error) bool {
+	if dispatchFailureIsRateLimited(dispatchErr) {
+		// A rate limit always recovers on its own, so park and retry each poll
+		// until a provider is healthy rather than consuming the escalation
+		// budget: a human cannot un-rate-limit a provider, and 5 rapid retries
+		// inside a multi-minute cooldown otherwise exhaust the budget before
+		// recovery (2026-07-24 kuma 5be87222). Mirrors sybra#1585's reschedule
+		// park-don't-burn policy.
+		r.logger.Info("pr-monitor.branch-conflict.dispatch-parked-cooldown",
+			"task_id", taskID, "err", dispatchErr)
+		return true
+	}
 	attempts := r.recordDispatchFailure(taskID)
 	if attempts < branchConflictDispatchFailureLimit {
 		r.logger.Info("pr-monitor.branch-conflict.dispatch-parked-retry",

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -1179,26 +1179,59 @@ func newDispatchFailureHandler(t *testing.T, launchErr error) (*Handler, task.Ta
 	return r, tk
 }
 
-// TestDispatchBranchConflictRecovery_TransientProviderUnhealthyParksForRetry
-// verifies that a provider-unhealthy/rate-limit failure starting the
-// branch-conflict-fix workflow itself is parked for a bounded number of
-// retries (restoring the task's prior status/workflow each time) instead of
-// escalating to human-required on the very first transient hit — the bug
-// this test guards against.
-func TestDispatchBranchConflictRecovery_TransientProviderUnhealthyParksForRetry(t *testing.T) {
+// TestDispatchBranchConflictRecovery_RateLimitedParksIndefinitely verifies that
+// a provider *rate-limit* failure starting the branch-conflict-fix workflow
+// parks and retries every poll without ever escalating or consuming the
+// dispatch budget. A rate limit always recovers, so escalating to a human (who
+// cannot un-rate-limit a provider) is wrong — 2026-07-24, 5 rapid retries
+// inside a multi-minute codex cooldown exhausted the cap and stranded kuma
+// task 5be87222. Mirrors sybra#1585's reschedule park-don't-burn policy.
+func TestDispatchBranchConflictRecovery_RateLimitedParksIndefinitely(t *testing.T) {
 	launchErr := &provider.UnhealthyError{Provider: "codex", Reason: provider.RateLimitReason, RateLimited: true}
 	r, tk := newDispatchFailureHandler(t, launchErr)
 	resume := r.captureBranchConflictResumeState(tk)
 
-	// Each call mirrors recoverBranchConflictNoPR's real sequence: cancel the
-	// active workflow (dispatchBranchConflictRecovery restores it on failure,
-	// same as the production caller does) immediately before dispatching.
+	// Well past the dispatch-failure limit: every attempt must park, restore the
+	// prior status/workflow, and never escalate or increment the budget.
+	for i := range branchConflictDispatchFailureLimit + 3 {
+		if _, err := r.WorkflowEngine.CancelWorkflow(tk.ID, "test: branch conflict recovery"); err != nil {
+			t.Fatalf("attempt %d: cancel prior workflow: %v", i+1, err)
+		}
+		if !r.dispatchBranchConflictRecovery(context.Background(), tk.ID, "/tmp/does-not-matter", branchConflictPrompt(context.Background(), tk, "main"), tk, "deadbeef", resume, false, branchConflictRetryKind) {
+			t.Fatalf("attempt %d: want true (parked) on rate-limited dispatch failure", i+1)
+		}
+		got, err := r.tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == task.StatusHumanRequired {
+			t.Fatalf("attempt %d: escalated to human-required on a rate limit", i+1)
+		}
+		if got.Status != task.StatusTesting || got.Workflow == nil || got.Workflow.WorkflowID != resume.workflowID {
+			t.Fatalf("attempt %d: prior status/workflow not restored: status=%q workflow=%+v", i+1, got.Status, got.Workflow)
+		}
+	}
+	if n := r.dispatchFailures[tk.ID]; n != 0 {
+		t.Fatalf("dispatchFailures[%s] = %d, want 0 (a rate limit must not consume the budget)", tk.ID, n)
+	}
+}
+
+// TestDispatchBranchConflictRecovery_NonRateLimitCooldownParksThenEscalates
+// verifies the conservative backstop: a transient cooldown that carries an
+// explicit Until deadline but is NOT a rate limit still parks for a bounded
+// number of retries, then escalates — so a future non-rate-limit cooldown
+// cannot park forever.
+func TestDispatchBranchConflictRecovery_NonRateLimitCooldownParksThenEscalates(t *testing.T) {
+	launchErr := &provider.UnhealthyError{Provider: "codex", Reason: "warming", Until: time.Now().Add(time.Minute)}
+	r, tk := newDispatchFailureHandler(t, launchErr)
+	resume := r.captureBranchConflictResumeState(tk)
+
 	for i := range branchConflictDispatchFailureLimit - 1 {
 		if _, err := r.WorkflowEngine.CancelWorkflow(tk.ID, "test: branch conflict recovery"); err != nil {
 			t.Fatalf("attempt %d: cancel prior workflow: %v", i+1, err)
 		}
 		if !r.dispatchBranchConflictRecovery(context.Background(), tk.ID, "/tmp/does-not-matter", branchConflictPrompt(context.Background(), tk, "main"), tk, "deadbeef", resume, false, branchConflictRetryKind) {
-			t.Fatalf("attempt %d: want true (parked for retry) on transient provider-unhealthy dispatch failure", i+1)
+			t.Fatalf("attempt %d: want true (parked for retry) on transient cooldown dispatch failure", i+1)
 		}
 		got, err := r.tasks.Get(tk.ID)
 		if err != nil {
@@ -1206,9 +1239,6 @@ func TestDispatchBranchConflictRecovery_TransientProviderUnhealthyParksForRetry(
 		}
 		if got.Status == task.StatusHumanRequired {
 			t.Fatalf("attempt %d: escalated to human-required too early", i+1)
-		}
-		if got.Status != task.StatusTesting || got.Workflow == nil || got.Workflow.WorkflowID != resume.workflowID {
-			t.Fatalf("attempt %d: prior status/workflow not restored: status=%q workflow=%+v", i+1, got.Status, got.Workflow)
 		}
 	}
 
@@ -1227,9 +1257,6 @@ func TestDispatchBranchConflictRecovery_TransientProviderUnhealthyParksForRetry(
 	}
 	if !strings.Contains(got.StatusReason, "branch-conflict-fix dispatch failed") {
 		t.Fatalf("status_reason = %q, want it to mention the exhausted dispatch retries", got.StatusReason)
-	}
-	if n := r.dispatchFailures[tk.ID]; n != 0 {
-		t.Fatalf("dispatchFailures[%s] = %d after escalation, want reset to 0", tk.ID, n)
 	}
 }
 


### PR DESCRIPTION
## Motivation

When a monitored PR's branch conflicts, the `branch-conflict-fix` dispatch
(`internal/sybra/review/fix.go`) counts every provider **rate-limit** failure
toward a 5-attempt escalation budget. Five rapid retries fired inside a
multi-minute provider cooldown exhaust the budget before the provider recovers,
stranding the task in `human-required` over a purely transient outage.

Observed 2026-07-24: kuma task `5be87222`'s branch-conflict auto-fix hit
`codex unhealthy (rate limit reached)` during a `claude→codex` failover; 5
attempts exhausted at 08:27 → `human-required`, even though both providers were
healthy again by 08:40. A human cannot un-rate-limit a provider, so the
escalation was pure noise. (Same *class* as the watchdog deadlock fixed in
#2554, on a different code path.)

> Changelog: fix(review): park branch-conflict on rate limit

## Implementation information

`parkOrEscalateBranchConflictDispatchFailure` now treats a provider **rate
limit** (`UnhealthyError.RateLimited` or `Reason == RateLimitReason`) as a
park-and-retry condition that does **not** consume the escalation budget: it
logs `pr-monitor.branch-conflict.dispatch-parked-cooldown` and returns handled,
so the pr-monitor re-dispatches each poll until a provider is healthy. This
mirrors sybra#1585's reschedule "park, don't burn" policy.

The only real `UnhealthyError` construction (`newProviderUnhealthy`) sets
`RateLimited`/`Reason` but never `Until`, so in practice every transient
dispatch failure is a rate limit and now parks indefinitely. The existing
5-attempt cap is retained as a conservative backstop for a hypothetical
non-rate-limit cooldown that carries an explicit `Until` deadline, so such a
future case still can't park forever.

Tests (`internal/sybra/review/rebase_recover_test.go`):
- `..._RateLimitedParksIndefinitely` — rewritten from the old test: a rate-limit
  failure parks past the limit + 3, never escalates, budget stays 0.
- `..._NonRateLimitCooldownParksThenEscalates` — new: an `Until`-bearing
  non-rate-limit cooldown keeps the bounded park-then-escalate backstop.

## Supporting documentation

- sybra#1585 (reschedule park-don't-burn on provider cooldown — same policy)
- #2554 (watchdog poisoned-resume recovery — same failure class, different path)
