### PR TITLE
fix(worktree): merge base into pushed branches

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1205,6 +1205,18 @@ func remoteTrackingRef(ctx context.Context, worktreePath, remote, branch string)
 	return sha, err == nil
 }
 
+// BranchPushed reports whether branch exists on the worktree's push remote —
+// i.e. it has been pushed at least once (an open PR). Reads the remote-tracking
+// ref, so callers must ReconcileWithRemote (or otherwise fetch the branch)
+// first; a first-push branch has no tracking ref and reports false. A pushed
+// branch must never be rebased: rewriting its SHAs diverges it from the remote,
+// and Sybra never force-pushes, so the divergence loops through conflict
+// recovery forever.
+func BranchPushed(ctx context.Context, worktreePath, branch string) bool {
+	_, ok := remoteTrackingRef(ctx, worktreePath, PushRemote(ctx, worktreePath), branch)
+	return ok
+}
+
 func refreshTrackingRef(ctx context.Context, worktreePath, remote, branch string) error {
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
 	fetchErr := withNetworkRetry(ctx, func() error {

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -351,7 +351,7 @@ func (m *Manager) reconcileAndRebase(ctx context.Context, wtPath, wtBranch, base
 		m.logger.Info("worktree.pushed-branch-merged-base", "branch", wtBranch, "base", baseRef)
 		return nil
 	}
-	callPhase(onPhase, "Rebasing onto origin…")
+	callPhase(onPhase, fmt.Sprintf("Rebasing onto %s…", baseRef))
 	if rebaseErr := project.RebaseOnto(ctx, wtPath, baseRef); rebaseErr != nil {
 		// A rebase failure on an unpushed branch is usually base moving under
 		// concurrent agents, not a content conflict. Try an additive merge

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -338,16 +338,24 @@ func (m *Manager) reconcileAndRebase(ctx context.Context, wtPath, wtBranch, base
 		}
 		return fmt.Errorf("%w: reconcile %s with remote: %w", ErrRebaseFailed, wtBranch, err)
 	}
+	// Rebasing rewrites SHAs, so rebasing an already-pushed branch diverges it
+	// from the remote; Sybra never force-pushes, so that loops through conflict
+	// recovery forever (the recurring "branch diverged from remote" that stalls
+	// autonomy). Merge base into a pushed branch instead — it keeps the pushed
+	// SHAs and stays fast-forwardable; only a genuine conflict escalates.
+	if project.BranchPushed(ctx, wtPath, wtBranch) {
+		callPhase(onPhase, "Merging base into pushed branch…")
+		if mergeErr := project.MergeOnto(ctx, wtPath, baseRef); mergeErr != nil {
+			return fmt.Errorf("%w: merge %s into pushed branch %s: %w", ErrRebaseFailed, baseRef, wtBranch, mergeErr)
+		}
+		m.logger.Info("worktree.pushed-branch-merged-base", "branch", wtBranch, "base", baseRef)
+		return nil
+	}
 	callPhase(onPhase, "Rebasing onto origin…")
 	if rebaseErr := project.RebaseOnto(ctx, wtPath, baseRef); rebaseErr != nil {
-		// A rebase failure here is very often not a genuine content conflict —
-		// under concurrent agents, base moves quickly and the branch's own
-		// history is otherwise clean. Try an additive merge before giving up:
-		// unlike rebase, it never rewrites existing commits, so recovery never
-		// needs a force-push (see MergeOnto). Only when the merge also fails
-		// (a real conflict) does this still surface ErrRebaseFailed for the
-		// caller to escalate — ordinarily to human-required, or to the PR-fix
-		// conflict-recovery agent when a PR is already open.
+		// A rebase failure on an unpushed branch is usually base moving under
+		// concurrent agents, not a content conflict. Try an additive merge
+		// before giving up; only a real conflict surfaces ErrRebaseFailed.
 		callPhase(onPhase, "Rebase failed, trying merge…")
 		if mergeErr := project.MergeOnto(ctx, wtPath, baseRef); mergeErr != nil {
 			return fmt.Errorf("%w: rebase %s onto %s: %w (merge fallback also failed: %w)",

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -10,8 +10,103 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/notes"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+// TestReconcileAndRebase_PushedBranchMergesNotRebases is the regression guard
+// for the recurring "branch diverged from remote": a branch that already exists
+// on its push remote (open PR) must be integrated with base via merge, never
+// rebase. Rebasing rewrites the pushed commits' SHAs, and since Sybra never
+// force-pushes, the local head then diverges from the remote and loops through
+// conflict recovery forever. An unpushed branch is still rebased.
+func TestReconcileAndRebase_PushedBranchMergesNotRebases(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		push           bool
+		wantOrigPreset bool
+	}{
+		{name: "pushed branch merges (SHAs preserved, no divergence)", push: true, wantOrigPreset: true},
+		{name: "unpushed branch rebases (linear history)", push: false, wantOrigPreset: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			root := t.TempDir()
+			remote := filepath.Join(root, "remote.git")
+			wt := filepath.Join(root, "wt")
+
+			git := func(dir string, args ...string) string {
+				t.Helper()
+				out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+				if err != nil {
+					t.Fatalf("git %v: %v: %s", args, err, out)
+				}
+				return strings.TrimSpace(string(out))
+			}
+			mustRun := func(name string, args ...string) {
+				t.Helper()
+				if out, err := exec.Command(name, args...).CombinedOutput(); err != nil {
+					t.Fatalf("%s %v: %v: %s", name, args, err, out)
+				}
+			}
+
+			mustRun("git", "init", "--bare", "-b", "main", remote)
+			mustRun("git", "clone", remote, wt)
+			git(wt, "config", "user.email", "t@t")
+			git(wt, "config", "user.name", "t")
+
+			write := func(name, body string) {
+				if err := os.WriteFile(filepath.Join(wt, name), []byte(body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write("main.txt", "base")
+			git(wt, "add", ".")
+			git(wt, "commit", "-m", "init main")
+			git(wt, "push", "origin", "main")
+
+			// Feature branch with a commit; push it only in the "pushed" case.
+			git(wt, "checkout", "-b", "feat")
+			write("feat.txt", "work")
+			git(wt, "add", ".")
+			git(wt, "commit", "-m", "feat work")
+			featSHA := git(wt, "rev-parse", "HEAD")
+			if tc.push {
+				git(wt, "push", "-u", "origin", "feat")
+			}
+
+			// Base advances on a different file (no conflict), pushed to remote.
+			git(wt, "checkout", "main")
+			write("base2.txt", "more base")
+			git(wt, "add", ".")
+			git(wt, "commit", "-m", "advance main")
+			baseSHA := git(wt, "rev-parse", "HEAD")
+			git(wt, "push", "origin", "main")
+			git(wt, "checkout", "feat")
+
+			m := New(Config{Logger: discardLogger()})
+			if err := m.reconcileAndRebase(ctx, wt, "feat", "origin/main", nil); err != nil {
+				t.Fatalf("reconcileAndRebase: %v", err)
+			}
+			head := git(wt, "rev-parse", "HEAD")
+
+			isAncestor := func(a, b string) bool {
+				return exec.Command("git", "-C", wt, "merge-base", "--is-ancestor", a, b).Run() == nil
+			}
+			if !isAncestor(baseSHA, head) {
+				t.Fatalf("base %s not integrated into feat HEAD %s", baseSHA, head)
+			}
+			if got := isAncestor(featSHA, head); got != tc.wantOrigPreset {
+				t.Fatalf("pre-reconcile commit %s ancestor-of-HEAD = %v, want %v (pushed=%v)", featSHA, got, tc.wantOrigPreset, tc.push)
+			}
+			if tc.push {
+				if err := project.PushSync(ctx, wt, "feat"); errors.Is(err, project.ErrDivergedNeedsResolve) {
+					t.Fatalf("PushSync reported divergence after merging a pushed branch: %v", err)
+				}
+			}
+		})
+	}
+}
 
 // TestPrepareForBranchFix_ExistingBranch verifies the happy path: a task
 // whose branch already exists (locally or on origin) gets a worktree checked

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -100,8 +100,11 @@ func TestReconcileAndRebase_PushedBranchMergesNotRebases(t *testing.T) {
 				t.Fatalf("pre-reconcile commit %s ancestor-of-HEAD = %v, want %v (pushed=%v)", featSHA, got, tc.wantOrigPreset, tc.push)
 			}
 			if tc.push {
-				if err := project.PushSync(ctx, wt, "feat"); errors.Is(err, project.ErrDivergedNeedsResolve) {
-					t.Fatalf("PushSync reported divergence after merging a pushed branch: %v", err)
+				// The local bare remote makes the post-merge push deterministic:
+				// a clean fast-forward returns nil. Any error (divergence or
+				// otherwise) is a regression.
+				if err := project.PushSync(ctx, wt, "feat"); err != nil {
+					t.Fatalf("PushSync after merging a pushed branch = %v, want nil (clean fast-forward)", err)
 				}
 			}
 		})


### PR DESCRIPTION
## Motivation

The recurring "branch diverged from remote" that repeatedly stalled autonomy
(kuma `369f5aeb`/`5be87222`, sybra `de7ca59f`) traces to **rebase-after-push**.

`reconcileAndRebase` runs on *every* worktree reuse (review, fix, testing,
branch-conflict recovery, restart recovery). It reconciled with the remote and
then **unconditionally rebased the branch onto `main`** — rewriting the SHAs of
commits already pushed to the open PR. Sybra never force-pushes, so the
rewritten local head can't reconcile with the pushed remote → the branch is
`ahead N / behind M` → conflict recovery fires → resolves → next reuse rebases
again → re-diverges. A self-perpetuating loop. (Checkpoint/`wip:` commits made
it more frequent by adding more commits to rewrite.)

> Changelog: fix(worktree): merge base into pushed branches

## Implementation information

**Rebase before push, merge after push** — never rewrite a branch that's live
on an open PR:

- New `project.BranchPushed(ctx, wtPath, branch)` — whether the branch exists on
  the push remote (reads `refs/remotes/<PushRemote>/<branch>`; callers must
  `ReconcileWithRemote` first, which `reconcileAndRebase` already does).
- In `reconcileAndRebase`, after reconcile: **pushed branch → `MergeOnto(base)`**
  (additive; preserves pushed SHAs; stays fast-forwardable → no divergence).
  **Unpushed branch → rebase** as before (clean linear history for the eventual
  PR). A genuine merge conflict still surfaces `ErrRebaseFailed` for in-place
  conflict recovery — "only escalate on a real conflict."

Test (`prepare_branch_fix_test.go`): pushed branch → merge (original SHA stays an
ancestor, `PushSync` reports no divergence); unpushed → rebase (SHA rewritten).
Full worktree + project suites pass (one pre-existing, credential-environment
failure on `main`, unrelated). Adversarially reviewed — no blocker.

## Supporting documentation

Known low-severity edge cases (from adversarial review, non-blocking):
- If a `fork` remote is configured **mid-task** after a first push to `origin`,
  `PushRemote` flips and `BranchPushed` can read the wrong remote → rebase a
  pushed branch. Fork config is normally fixed at project creation, so this is
  unlikely in practice.
- A pushed branch now integrates an advanced base with a **merge commit on the
  open PR** (vs the old rebase failing at push). This is the intended cost — with
  no force-push there is no rewrite-free way to advance base — and may
  re-trigger review on that PR.
