### PR TITLE
fix(workflow): loop verify auto-fix before human

### DIFF
--- a/internal/workflow/engine_steps_focused_checks.go
+++ b/internal/workflow/engine_steps_focused_checks.go
@@ -389,18 +389,20 @@ func (e *Engine) reaskFocusedChecks(taskID string, step *Step, wfExec *Execution
 		reason += " for " + surfaces
 	}
 	reason += ": " + trimDiffLine(failedCmd)
-	if wfExec == nil {
+	if wfExec == nil || wfExec.CountStep(verifyChecksImplStepID) == 0 {
 		return e.flagFocusedChecks(taskID, step, reason, failedCmd)
 	}
 	key := "step." + step.ID + ".auto_fix"
 	attempts := parseWorkflowInt(wfExec.Variables[key])
-	if attempts >= verifyChecksAutoFixCap || wfExec.CountStep(verifyChecksImplStepID) == 0 {
-		return e.flagFocusedChecks(taskID, step, reason, failedCmd)
+	if attempts >= verifyChecksAutoFixCeiling {
+		exhausted := fmt.Sprintf("%s — escalating after %d auto-fix attempts without passing",
+			reason, verifyChecksAutoFixCeiling)
+		return e.flagFocusedChecks(taskID, step, exhausted, "auto-fix-exhausted")
 	}
 
 	wfExec.SetVar(key, strconv.Itoa(attempts+1))
 	wfExec.SetVar(focusedChecksReaskNoteVar, buildFocusedChecksReaskNote(selected, changedFiles, failedCmd, output))
-	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(verifyChecksAutoFixBackoff).Format(time.RFC3339))
+	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(autoFixBackoff(attempts)).Format(time.RFC3339))
 	wfExec.ClearStepRecords(verifyChecksImplStepID)
 	wfExec.CurrentStep = verifyChecksImplStepID
 	wfExec.State = ExecWaiting
@@ -411,14 +413,16 @@ func (e *Engine) reaskFocusedChecks(taskID string, step *Step, wfExec *Execution
 		return StepOutput{}, err
 	}
 	e.logger.Info("workflow.focused-checks.reask",
-		"task_id", taskID, "attempt", attempts+1, "cap", verifyChecksAutoFixCap, "cmd", trimDiffLine(failedCmd))
+		"task_id", taskID, "attempt", attempts+1, "cmd", trimDiffLine(failedCmd))
 	return StepOutput{}, errStepParked
 }
 
 func buildFocusedChecksReaskNote(selected []selectedFocusedCheck, changedFiles []string, failedCmd, output string) string {
 	var b strings.Builder
 	b.WriteString("A prior implementation FAILED Sybra's focused checks. Fix the ROOT CAUSE so the failing command passes on a clean run")
-	b.WriteString(" — do NOT weaken, skip, or edit the check to make it pass.\n\n")
+	b.WriteString(" — do NOT weaken, skip, or edit the check to make it pass. Then COMMIT and push your fix: the check runs against your")
+	b.WriteString(" branch HEAD in a freshly prepared worktree, so an uncommitted change is not picked up and the same failure recurs;")
+	b.WriteString(" some projects also enforce a clean working tree (e.g. a `git diff --exit-code` / generated-file gate) that fails outright on uncommitted changes.\n\n")
 	if surfaces := focusedSurfaceSummary(selected); surfaces != "" {
 		b.WriteString("## Focused surface\n\n")
 		b.WriteString(surfaces)

--- a/internal/workflow/engine_steps_focused_checks.go
+++ b/internal/workflow/engine_steps_focused_checks.go
@@ -397,7 +397,7 @@ func (e *Engine) reaskFocusedChecks(taskID string, step *Step, wfExec *Execution
 	if attempts >= verifyChecksAutoFixCeiling {
 		exhausted := fmt.Sprintf("%s — escalating after %d auto-fix attempts without passing",
 			reason, verifyChecksAutoFixCeiling)
-		return e.flagFocusedChecks(taskID, step, exhausted, "auto-fix-exhausted")
+		return e.flagFocusedChecks(taskID, step, exhausted, "auto-fix-exhausted: "+trimDiffLine(failedCmd))
 	}
 
 	wfExec.SetVar(key, strconv.Itoa(attempts+1))

--- a/internal/workflow/engine_steps_focused_checks_test.go
+++ b/internal/workflow/engine_steps_focused_checks_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -289,7 +290,7 @@ func TestExecFocusedChecks_FailureReasksImplement(t *testing.T) {
 	}
 }
 
-func TestExecFocusedChecks_FailureCapEscalates(t *testing.T) {
+func TestExecFocusedChecks_FailureKeepsReaskingNeverEscalates(t *testing.T) {
 	t.Parallel()
 
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
@@ -304,8 +305,46 @@ func TestExecFocusedChecks_FailureCapEscalates(t *testing.T) {
 	}}, nil)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
+	// A code-fixable focused-check failure is re-asked until it passes, never
+	// exhausted into human-required.
 	wf := implementedExec()
-	wf.Variables["step.focused_checks.auto_fix"] = "2"
+	wf.Variables["step.focused_checks.auto_fix"] = "9"
+	out, err := engine.execFocusedChecks("t1", newFocusedChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked (keep re-asking, never escalate)", err)
+	}
+	if out != (StepOutput{}) {
+		t.Fatalf("parked output should be zero, got %+v", out)
+	}
+	if wf.CurrentStep != verifyChecksImplStepID || wf.State != ExecWaiting {
+		t.Fatalf("workflow after rewind = %+v, want implement/ExecWaiting", wf)
+	}
+	if got := wf.Variables["step.focused_checks.auto_fix"]; got != "10" {
+		t.Fatalf("auto_fix counter = %q, want 10", got)
+	}
+	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress (never escalated to human)", ti.Status)
+	}
+}
+
+func TestExecFocusedChecks_FailureCeilingEscalates(t *testing.T) {
+	t.Parallel()
+
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	writeRepoFile(t, wt, "internal/workflow/model.go", "package workflow\n")
+	gitRun(t, wt, "add", ".")
+	gitRun(t, wt, "commit", "-m", "feat: touch workflow")
+
+	engine, tasks, _ := newFocusedChecksEngine(t, wt, []project.FocusedCheck{{
+		Name:     "workflow",
+		Paths:    []string{"internal/workflow/**"},
+		Commands: []string{"exit 1"},
+	}}, nil)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	// At the ceiling an unfixable focused-check failure escalates to a human.
+	wf := implementedExec()
+	wf.Variables["step.focused_checks.auto_fix"] = strconv.Itoa(verifyChecksAutoFixCeiling)
 	out, err := engine.execFocusedChecks("t1", newFocusedChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -314,9 +353,9 @@ func TestExecFocusedChecks_FailureCapEscalates(t *testing.T) {
 		t.Fatalf("Output = %q, want flagged", out.Output)
 	}
 	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "human-required" {
-		t.Fatalf("status = %q, want human-required after cap", ti.Status)
+		t.Fatalf("status = %q, want human-required at ceiling", ti.Status)
 	}
-	if reason := tasks.Reason("t1"); !strings.Contains(reason, "focused checks failed for workflow") {
-		t.Fatalf("reason = %q, want focused surface", reason)
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "escalating after") {
+		t.Fatalf("reason = %q, want exhaustion note", reason)
 	}
 }

--- a/internal/workflow/engine_steps_focused_checks_test.go
+++ b/internal/workflow/engine_steps_focused_checks_test.go
@@ -290,7 +290,7 @@ func TestExecFocusedChecks_FailureReasksImplement(t *testing.T) {
 	}
 }
 
-func TestExecFocusedChecks_FailureKeepsReaskingNeverEscalates(t *testing.T) {
+func TestExecFocusedChecks_FailureReasksPastOldCap(t *testing.T) {
 	t.Parallel()
 
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
@@ -305,8 +305,8 @@ func TestExecFocusedChecks_FailureKeepsReaskingNeverEscalates(t *testing.T) {
 	}}, nil)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	// A code-fixable focused-check failure is re-asked until it passes, never
-	// exhausted into human-required.
+	// Past the old cap of 2, a code-fixable focused-check failure keeps being
+	// re-asked; it escalates only at verifyChecksAutoFixCeiling.
 	wf := implementedExec()
 	wf.Variables["step.focused_checks.auto_fix"] = "9"
 	out, err := engine.execFocusedChecks("t1", newFocusedChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -857,7 +857,7 @@ func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Ex
 	if attempts >= verifyChecksAutoFixCeiling {
 		exhausted := fmt.Sprintf("%s — escalating after %d auto-fix attempts without passing",
 			reason, verifyChecksAutoFixCeiling)
-		return e.flagVerifyChecks(taskID, step, exhausted, "auto-fix-exhausted")
+		return e.flagVerifyChecks(taskID, step, exhausted, "auto-fix-exhausted: "+trimDiffLine(failedCmd))
 	}
 
 	wfExec.SetVar(key, strconv.Itoa(attempts+1))

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -35,10 +35,21 @@ const verifyChecksOutputTail = 8000
 const verifyBlessedTag = "verify-blessed"
 
 const (
-	verifyChecksImplStepID     = "implement"
-	verifyReaskNoteVar         = "verify_reask_note"
-	verifyChecksAutoFixCap     = 2
+	verifyChecksImplStepID = "implement"
+	verifyReaskNoteVar     = "verify_reask_note"
+	// verifyChecksAutoFixBackoff is the base re-dispatch delay before the next
+	// auto-fix attempt; autoFixBackoff grows it with the attempt count up to
+	// autoFixBackoffMax. The auto-fix loop never gives up on a code-fixable
+	// failure of its own accord — it re-asks the implementation agent to fix
+	// the root cause until the suite passes, so a broken implementation can
+	// never reach review by exhausting a retry budget. The per-task cost
+	// ceiling (agent.max_task_cost_usd, checked before every dispatch) is the
+	// backstop that ultimately bounds a genuinely unfixable loop.
 	verifyChecksAutoFixBackoff = 90 * time.Second
+	autoFixBackoffMax          = 15 * time.Minute
+	// verifyChecksAutoFixCeiling bounds auto-fix re-asks so a deterministic
+	// failure no agent can fix reaches a human instead of looping forever.
+	verifyChecksAutoFixCeiling = 20
 	// Full verify suites are CPU-heavy and already serialized by workflow
 	// retries; a single local slot prevents one saturated host from piling
 	// multiple suites on top of each other and timing them all out.
@@ -823,18 +834,39 @@ func goPackageAffectedByChanges(
 	return false, nil
 }
 
+// autoFixBackoff is the re-dispatch delay before the next verify/focused
+// auto-fix attempt. It grows linearly with the attempt count so a genuinely
+// stuck fix loop paces itself down instead of hammering the fleet, capped at
+// autoFixBackoffMax so a long-running loop still makes steady progress.
+func autoFixBackoff(attempts int) time.Duration {
+	backoff := verifyChecksAutoFixBackoff * time.Duration(attempts+1)
+	if backoff > autoFixBackoffMax {
+		return autoFixBackoffMax
+	}
+	return backoff
+}
+
+// autoFixOrFlagVerifyChecks rewinds the workflow to the implementation step and
+// re-asks the agent to fix a code-fixable verify failure at its root cause,
+// looping instead of escalating an ordinary lint/test failure the agent can fix
+// itself. It stays in that loop up to verifyChecksAutoFixCeiling re-asks; only a
+// deterministic failure that survives that many attempts, or the structural case
+// with no implementation step to rewind into (wfExec nil, or the step never
+// ran), escalates to human-required.
 func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Execution, t TaskInfo, reason, failedCmd, output string) (StepOutput, error) {
-	if wfExec == nil {
+	if wfExec == nil || wfExec.CountStep(verifyChecksImplStepID) == 0 {
 		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
 	}
 	key := "step." + step.ID + ".auto_fix"
 	attempts := parseWorkflowInt(wfExec.Variables[key])
-	if attempts >= verifyChecksAutoFixCap || wfExec.CountStep(verifyChecksImplStepID) == 0 {
-		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
+	if attempts >= verifyChecksAutoFixCeiling {
+		exhausted := fmt.Sprintf("%s — escalating after %d auto-fix attempts without passing",
+			reason, verifyChecksAutoFixCeiling)
+		return e.flagVerifyChecks(taskID, step, exhausted, "auto-fix-exhausted")
 	}
 
 	wfExec.SetVar(key, strconv.Itoa(attempts+1))
-	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(verifyChecksAutoFixBackoff).Format(time.RFC3339))
+	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(autoFixBackoff(attempts)).Format(time.RFC3339))
 	wfExec.SetVar(verifyReaskNoteVar, buildVerifyReaskNote(failedCmd, output))
 	wfExec.ClearStepRecords(verifyChecksImplStepID)
 	wfExec.CurrentStep = verifyChecksImplStepID
@@ -842,13 +874,13 @@ func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Ex
 	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
 		return StepOutput{}, fmt.Errorf("verify-checks: rewind to implement: %w", err)
 	}
-	retryReason := fmt.Sprintf("auto-fixing failed verify check (attempt %d/%d): %s",
-		attempts+1, verifyChecksAutoFixCap, trimDiffLine(failedCmd))
+	retryReason := fmt.Sprintf("auto-fixing failed verify check (attempt %d): %s",
+		attempts+1, trimDiffLine(failedCmd))
 	if err := e.tasks.UpdateTaskStatus(taskID, t.Status, retryReason); err != nil {
 		return StepOutput{}, err
 	}
 	e.logger.Info("workflow.verify-checks.auto-fix",
-		"task_id", taskID, "attempt", attempts+1, "cap", verifyChecksAutoFixCap, "cmd", trimDiffLine(failedCmd))
+		"task_id", taskID, "attempt", attempts+1, "cmd", trimDiffLine(failedCmd))
 	return StepOutput{}, errStepParked
 }
 
@@ -857,7 +889,11 @@ func buildVerifyReaskNote(failedCmd, output string) string {
 	excerpt := highestSignalVerifyFailureExcerpt(failedCmd, output)
 	b.WriteString("A prior implementation FAILED the project verify suite. Fix the ROOT CAUSE ")
 	b.WriteString("so the failing command passes on a clean run — do NOT weaken, skip, or edit ")
-	b.WriteString("the check to make it pass.\n\n## Failing verify command\n\n`")
+	b.WriteString("the check to make it pass. Then COMMIT and push your fix: the suite runs ")
+	b.WriteString("against your branch HEAD in a freshly prepared worktree, so an uncommitted ")
+	b.WriteString("change is not picked up and the same failure recurs; some projects also ")
+	b.WriteString("enforce a clean working tree (e.g. a `git diff --exit-code` / generated-file ")
+	b.WriteString("gate) that fails outright on uncommitted changes.\n\n## Failing verify command\n\n`")
 	b.WriteString(failedCmd)
 	b.WriteString("`")
 	if excerpt != "" {

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -39,12 +39,7 @@ const (
 	verifyReaskNoteVar     = "verify_reask_note"
 	// verifyChecksAutoFixBackoff is the base re-dispatch delay before the next
 	// auto-fix attempt; autoFixBackoff grows it with the attempt count up to
-	// autoFixBackoffMax. The auto-fix loop never gives up on a code-fixable
-	// failure of its own accord — it re-asks the implementation agent to fix
-	// the root cause until the suite passes, so a broken implementation can
-	// never reach review by exhausting a retry budget. The per-task cost
-	// ceiling (agent.max_task_cost_usd, checked before every dispatch) is the
-	// backstop that ultimately bounds a genuinely unfixable loop.
+	// autoFixBackoffMax.
 	verifyChecksAutoFixBackoff = 90 * time.Second
 	autoFixBackoffMax          = 15 * time.Minute
 	// verifyChecksAutoFixCeiling bounds auto-fix re-asks so a deterministic

--- a/internal/workflow/engine_steps_verify_checks_autofix_test.go
+++ b/internal/workflow/engine_steps_verify_checks_autofix_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -136,14 +137,45 @@ func TestExecVerifyChecks_AutoFixRewindsToImplement(t *testing.T) {
 	}
 }
 
-func TestExecVerifyChecks_AutoFixCapEscalates(t *testing.T) {
+func TestExecVerifyChecks_AutoFixKeepsReaskingNeverEscalates(t *testing.T) {
 	t.Parallel()
 	wt := makeLintVerifyRepo(t)
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{lintVerifyCommand("internal/foo/foo.go")})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
+	// Many prior attempts must not exhaust into human-required — a code-fixable
+	// lint failure is re-asked until it passes, bounded only by the per-task
+	// cost ceiling, not a retry cap.
 	wf := implementedExec()
-	wf.Variables["step.verify_checks.auto_fix"] = "2"
+	wf.Variables["step.verify_checks.auto_fix"] = "9"
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked (keep re-asking, never escalate)", err)
+	}
+	if out != (StepOutput{}) {
+		t.Fatalf("parked output should be zero, got %+v", out)
+	}
+	if wf.CurrentStep != verifyChecksImplStepID || wf.State != ExecWaiting {
+		t.Fatalf("workflow after rewind = %+v, want implement/ExecWaiting", wf)
+	}
+	if got := wf.Variables["step.verify_checks.auto_fix"]; got != "10" {
+		t.Errorf("auto_fix counter = %q, want 10", got)
+	}
+	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress (never escalated to human)", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_AutoFixCeilingEscalates(t *testing.T) {
+	t.Parallel()
+	wt := makeLintVerifyRepo(t)
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{lintVerifyCommand("internal/foo/foo.go")})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	// A deterministic failure that survives the ceiling finally escalates so a
+	// human is paged instead of the loop running forever.
+	wf := implementedExec()
+	wf.Variables["step.verify_checks.auto_fix"] = strconv.Itoa(verifyChecksAutoFixCeiling)
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -151,8 +183,12 @@ func TestExecVerifyChecks_AutoFixCapEscalates(t *testing.T) {
 	if out.Output != "flagged" {
 		t.Errorf("Output = %q, want flagged", out.Output)
 	}
-	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "human-required" {
-		t.Errorf("status = %q, want human-required after cap", ti.Status)
+	ti := mustGetTaskInfo(t, tasks, "t1")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required at ceiling", ti.Status)
+	}
+	if !strings.Contains(ti.StatusReason, "escalating after") {
+		t.Errorf("reason = %q, want exhaustion note", ti.StatusReason)
 	}
 }
 
@@ -331,7 +367,7 @@ func TestExecVerifyChecks_DeterministicFrontendFailureRewindsToImplement(t *test
 	}
 }
 
-func TestExecVerifyChecks_DeterministicFrontendFailureCapEscalates(t *testing.T) {
+func TestExecVerifyChecks_DeterministicFrontendFailureKeepsReasking(t *testing.T) {
 	t.Parallel()
 	wt := makeFrontendVerifyRepo(t)
 	binDir := writeFrontendVerifyMise(t)
@@ -340,20 +376,20 @@ func TestExecVerifyChecks_DeterministicFrontendFailureCapEscalates(t *testing.T)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
 	wf := implementedExec()
-	wf.Variables["step.verify_checks.auto_fix"] = "2"
+	wf.Variables["step.verify_checks.auto_fix"] = "9"
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked (keep re-asking, never escalate)", err)
 	}
-	if out.Output != "flagged" {
-		t.Fatalf("Output = %q, want flagged", out.Output)
+	if out != (StepOutput{}) {
+		t.Fatalf("parked output should be zero, got %+v", out)
+	}
+	if wf.CurrentStep != verifyChecksImplStepID || wf.State != ExecWaiting {
+		t.Fatalf("workflow after rewind = %+v, want implement/ExecWaiting", wf)
 	}
 	ti := mustGetTaskInfo(t, tasks, "t1")
-	if ti.Status != "human-required" {
-		t.Fatalf("status = %q, want human-required", ti.Status)
-	}
-	if !strings.Contains(ti.StatusReason, "deterministic frontend check") {
-		t.Fatalf("reason = %q, want deterministic frontend classification", ti.StatusReason)
+	if ti.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress (never escalated to human)", ti.Status)
 	}
 }
 

--- a/internal/workflow/engine_steps_verify_checks_autofix_test.go
+++ b/internal/workflow/engine_steps_verify_checks_autofix_test.go
@@ -137,15 +137,14 @@ func TestExecVerifyChecks_AutoFixRewindsToImplement(t *testing.T) {
 	}
 }
 
-func TestExecVerifyChecks_AutoFixKeepsReaskingNeverEscalates(t *testing.T) {
+func TestExecVerifyChecks_AutoFixReasksPastOldCap(t *testing.T) {
 	t.Parallel()
 	wt := makeLintVerifyRepo(t)
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{lintVerifyCommand("internal/foo/foo.go")})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	// Many prior attempts must not exhaust into human-required — a code-fixable
-	// lint failure is re-asked until it passes, bounded only by the per-task
-	// cost ceiling, not a retry cap.
+	// Past the old cap of 2, a code-fixable lint failure keeps being re-asked
+	// rather than escalating; it escalates only at verifyChecksAutoFixCeiling.
 	wf := implementedExec()
 	wf.Variables["step.verify_checks.auto_fix"] = "9"
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})


### PR DESCRIPTION
## Motivation

A failing `golangci-lint` / verify suite or focused-check re-asked the implementation agent only **twice** (`verifyChecksAutoFixCap = 2`) before flipping the task to `human-required`. An ordinary lint finding the agent could fix in a cycle or two stranded the task on a human — the exact `implementation does not pass the project verify suite: … golangci-lint …` escalation operators kept hand-fixing.

> Changelog: fix(workflow): loop verify auto-fix before human

## Implementation information

- **Keep re-asking instead of escalating early.** `autoFixOrFlagVerifyChecks` (verify_checks) and `reaskFocusedChecks` (focused_checks) no longer escalate at the old cap of 2. A code-fixable failure rewinds to `implement` and re-asks the agent to fix the root cause, looping until the suite passes.
- **Terminating backstop that always applies.** A high absolute ceiling (`verifyChecksAutoFixCeiling = 20`) escalates to `human-required` only when a deterministic failure is genuinely unfixable — 10× the old cap, so every realistic fix resolves well inside it. This replaces the misleading reliance on `agent.max_task_cost_usd`, which is off by default and cannot bound the loop on a stock install. The structural fallback (no `implement` step to rewind into) still escalates.
- **Escalating, capped backoff.** `autoFixBackoff` grows the re-dispatch delay linearly with the attempt count, capped at 15 min, so a stuck loop paces itself down instead of hammering the fleet.
- **Commit the fix.** Both re-ask notes now tell the agent to commit + push — the suite runs against branch HEAD in a freshly prepared worktree, and some projects enforce a clean tree (e.g. a `git diff --exit-code` / generated-file gate) that fails outright on uncommitted changes.

Ran through an adversarial review (find-bug + refute passes): the only surviving finding was the unbounded-loop / no-human-page risk on default config, addressed by the ceiling above.

## Supporting documentation

- Tests: `...KeepsReaskingNeverEscalates` (loops past the old cap of 2), new `...CeilingEscalates` (escalates at 20) for both verify and focused checks.
- Verified: `go build`, `go vet`, `golangci-lint run ./internal/workflow/` (0 issues), targeted workflow tests.