### PR TITLE
fix(agent): unblock file-sourced review body

### DIFF
--- a/internal/agent/ghshim.go
+++ b/internal/agent/ghshim.go
@@ -20,7 +20,7 @@ if [ "$1" = "pr" ] && [ "$2" = "review" ]; then
 	exit 1
 fi
 if [ "$1" = "api" ]; then
-	sawinput=0
+	sawhidden=0
 	sawreviews=0
 	for arg in "$@"; do
 		case "$arg" in
@@ -38,13 +38,17 @@ if [ "$1" = "api" ]; then
 			exit 1
 			;;
 		esac
-		# A payload read from stdin or a file is invisible to argv, so an approval
-		# can be posted with no matching arg at all. --input carries a whole
-		# body; -F/--field key=@path pulls a single value the same way, which is
-		# enough to hide a whole GraphQL mutation.
+		# --input (or --input=path) swaps the whole request body for a file/stdin
+		# stream gh never parses, so an event field could ride along with nothing
+		# in argv to catch it. event=@path and, for graphql, query=@path are the
+		# same hole one field wide: gh api scopes a file value to exactly the
+		# named field, so body=@path or comments[][body]=@path can only ever
+		# become that field's string content — it cannot inject a sibling "event"
+		# key — but event=@path hides the submission verb itself, and query=@path
+		# hides a mutation that might embed one.
 		case "$arg" in
-		--input | --input=* | *=@*)
-			sawinput=1
+		--input | --input=* | [Ee][Vv][Ee][Nn][Tt]=@* | [Qq][Uu][Ee][Rr][Yy]=@*)
+			sawhidden=1
 			;;
 		esac
 		# graphql counts as review-capable: addPullRequestReview reaches the same
@@ -56,7 +60,7 @@ if [ "$1" = "api" ]; then
 		esac
 	done
 	# Refuse a review payload we cannot inspect rather than assume it is benign.
-	[ "$sawinput$sawreviews" = "11" ] && printf '%%s\n' '%[1]s' >&2 && exit 1
+	[ "$sawhidden$sawreviews" = "11" ] && printf '%%s\n' '%[1]s' >&2 && exit 1
 fi
 exec '%[2]s' "$@"
 `

--- a/internal/agent/ghshim_test.go
+++ b/internal/agent/ghshim_test.go
@@ -118,6 +118,22 @@ func TestGhShim_AllowsPendingDraftReviews(t *testing.T) {
 		{"pending review with inline comment", []string{"api", "-X", "POST", "repos/owner/repo/pulls/1/reviews", "-f", "body=needs work", "-f", "comments[][path]=main.go", "-f", "comments[][line]=12", "-f", "comments[][side]=RIGHT", "-f", "comments[][body]=fix this"}},
 		{"pending review path contains event comment", []string{"api", "-X", "POST", "repos/owner/repo/pulls/1/reviews", "-f", "body=summary", "-f", "comments[][path]=internal/event/comment.go", "-f", "comments[][line]=12", "-f", "comments[][side]=RIGHT", "-f", "comments[][body]=fix this"}},
 		{"body mentions approve event", []string{"api", "-X", "POST", "repos/owner/repo/pulls/1/reviews", "-f", "body=event: APPROVED is banned"}},
+		{
+			// A multi-paragraph markdown body with a footer is impractical to
+			// pass inline (quoting), so gh api's own docs recommend @file for it.
+			// gh api scopes a file value to exactly the named field, so this
+			// cannot smuggle a sibling "event" key the way --input/query=@ can.
+			name: "pending review with file-sourced body",
+			args: []string{"api", "-X", "POST", "repos/owner/repo/pulls/1/reviews", "-f", "commit_id=abc123", "-F", "body=@review_body.txt"},
+		},
+		{
+			name: "pending review with file-sourced inline comment bodies",
+			args: []string{
+				"api", "-X", "POST", "repos/owner/repo/pulls/1/reviews",
+				"-f", "commit_id=abc123", "-F", "body=@review_body.txt",
+				"-f", "comments[][path]=main.go", "-F", "comments[][line]=12", "-f", "comments[][side]=RIGHT", "-F", "comments[][body]=@c1.txt",
+			},
+		},
 		{"reading reviews", []string{"pr", "view", "1", "--json", "reviews"}},
 		{"listing approved reviews", []string{"api", "graphql", "-f", `query=query { reviews(states: APPROVED) { id } }`}},
 		{"merge is gated elsewhere", []string{"pr", "merge", "1", "--squash"}},


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): unblock file-sourced review body

The `gh` shim (`internal/agent/ghshim.go`) blocked posting a pending PR
review draft whenever the body or comment text came from a file
(`-F body=@file.txt`), even with no `event` field anywhere in the
command. This is the sanctioned way to pass multi-paragraph markdown
findings without fighting shell quoting, so every review substantial
enough to need it silently failed to post and fell back to
`human-required` — confirmed against a real run (task `10592e48`, PR
kumahq/kuma#17605) where the agent's `gh api .../reviews -F
body=@review_body.txt -F 'comments[][body]=@c1.txt'` was rejected by
the shim despite carrying no submission event.

## Implementation information

`gh api`'s `-f`/`-F` flags scope a file's contents to exactly the
named field — a `body=@file` or `comments[][body]=@file` can only ever
become that field's string value, it cannot inject a sibling `event`
key. The only fields that can actually hide a submission are
`event=@path` (hides the verb itself) and, for GraphQL, `query=@path`
(hides a mutation that might embed one). Narrowed the "payload we
can't inspect" check from any `key=@path` to just those two field
names; `--input`/`--input=*` (whole payload swapped for an unparsed
stream) is still always blocked.

Added test cases mirroring the exact blocked production command
(`commit_id` + `body=@file` + `comments[][body]=@file`) to
`TestGhShim_AllowsPendingDraftReviews`; all existing block cases
(`event=@path`, GraphQL `query=@path`, `--input`, literal event
values, GraphQL mutation names) are unchanged and still pass.

## Supporting documentation

- `internal/agent/ghshim.go`, `internal/agent/ghshim_test.go`