### PR TITLE
fix(agent): unshare pid ns in enforce sandbox

### DIFF
--- a/internal/agent/procsandbox_linux.go
+++ b/internal/agent/procsandbox_linux.go
@@ -50,6 +50,15 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		return name, args
 	}
 	wrapped := []string{
+		// Without this, --proc /proc still reflects the host's real process
+		// table: a sandboxed agent's own `pkill -f <pattern>` can see and
+		// signal arbitrary host processes it doesn't own the tree of — e.g. a
+		// test-runner's dev-server teardown reaping an unrelated sibling
+		// sybra-server on the shared host, self-inflicting the very
+		// completion-stall it was supposed to avoid. bwrap reaps zombies for
+		// the new namespace's pid 1 automatically (see bwrap(1)), so no
+		// additional init flag is needed.
+		"--unshare-pid",
 		"--ro-bind", "/", "/",
 		"--dev", "/dev",
 		"--proc", "/proc",

--- a/internal/agent/procsandbox_linux_integration_test.go
+++ b/internal/agent/procsandbox_linux_integration_test.go
@@ -42,7 +42,10 @@ func TestSandboxEnforce_UnsharePidHidesHostProcesses(t *testing.T) {
 	if err := victim.Start(); err != nil {
 		t.Fatalf("start victim: %v", err)
 	}
-	t.Cleanup(func() { _ = victim.Process.Kill() })
+	t.Cleanup(func() {
+		_ = victim.Process.Kill()
+		_ = victim.Wait()
+	})
 
 	script := "kill -0 " + strconv.Itoa(victim.Process.Pid) + " 2>&1 && echo CAN_SIGNAL_HOST || echo CANNOT_SIGNAL_HOST"
 	cmd := newProviderCmd(context.Background(), cfg, false, "sh", "-c", script)

--- a/internal/agent/procsandbox_linux_integration_test.go
+++ b/internal/agent/procsandbox_linux_integration_test.go
@@ -7,11 +7,51 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/project"
 )
+
+// TestSandboxEnforce_UnsharePidHidesHostProcesses pins the fix for task
+// 0871ec54's test-runner crash loop: without --unshare-pid, --proc /proc
+// still reflects the host's real process table, so a sandboxed agent's own
+// `pkill -f <pattern>` (e.g. dev-server teardown) can see and signal
+// unrelated live processes on a shared multi-agent host — including a
+// sibling sybra-server — self-inflicting the completion-stall it was
+// supposed to avoid. The victim here stands in for that sibling process: it
+// runs entirely outside the sandboxed command's process tree.
+func TestSandboxEnforce_UnsharePidHidesHostProcesses(t *testing.T) {
+	if !sandboxExecAvailable() {
+		t.Skip("bwrap not installed; enforce path unexercised on this host")
+	}
+	wt, err := canonicalizeRoot(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &RunConfig{sandbox: sandboxSpec{
+		mode:        "enforce",
+		worktree:    wt,
+		sandboxHome: wt,
+		tmp:         wt,
+		sharedCache: wt,
+	}}
+
+	victim := exec.Command("sleep", "9999")
+	if err := victim.Start(); err != nil {
+		t.Fatalf("start victim: %v", err)
+	}
+	t.Cleanup(func() { _ = victim.Process.Kill() })
+
+	script := "kill -0 " + strconv.Itoa(victim.Process.Pid) + " 2>&1 && echo CAN_SIGNAL_HOST || echo CANNOT_SIGNAL_HOST"
+	cmd := newProviderCmd(context.Background(), cfg, false, "sh", "-c", script)
+	out, runErr := cmd.CombinedOutput()
+	got := string(out)
+	if strings.Contains(got, "CAN_SIGNAL_HOST") || !strings.Contains(got, "CANNOT_SIGNAL_HOST") {
+		t.Errorf("sandboxed process could see/signal a host process outside its own pid namespace (err=%v): %q", runErr, got)
+	}
+}
 
 func TestSandboxEnforce_FencesWritesToAllowlist(t *testing.T) {
 	if !sandboxExecAvailable() {

--- a/internal/agent/procsandbox_linux_test.go
+++ b/internal/agent/procsandbox_linux_test.go
@@ -48,8 +48,8 @@ func TestWrapInvocation_Linux_EnforceBindsOnlyWriteRoots(t *testing.T) {
 	}
 
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "--ro-bind / / --dev /dev --proc /proc") {
-		t.Fatalf("expected read-only root + fresh dev/proc bwrap args, got: %s", joined)
+	if !strings.Contains(joined, "--unshare-pid --ro-bind / / --dev /dev --proc /proc") {
+		t.Fatalf("expected pid-namespace isolation + read-only root + fresh dev/proc bwrap args, got: %s", joined)
 	}
 	for _, root := range []string{
 		"/data/wt",


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): unshare pid ns in enforce sandbox

Task 0871ec54 was stuck cycling test-runner agents indefinitely — six
dispatches in a row, each killed by a signal 2-5 minutes in, never
producing a PASS/FAIL verdict, so the workflow could never advance past
`run_test`.

Root cause, confirmed live on the home-nas server: the enforce-mode
bwrap sandbox (`wrapInvocation`, `internal/agent/procsandbox_linux.go`)
bind-mounts a fresh `/proc` but never unshares the pid namespace, so
that `/proc` still reflects the host's real, shared process table. A
sandboxed test-runner's own dev-server teardown (`pkill -f
"sybra-server$" -o`) is unscoped and picks the oldest host-wide match —
on a shared multi-agent host that can be an unrelated sibling
`sybra-server`, not its own child. Killing that sibling is what
produced the observed self-inflicted signal kill, misclassified as an
infra stall and retried from scratch every cycle.

Verified directly on the server (not just from docs): with a same-uid
host process running outside the sandbox's own process tree, `kill -0
<pid>` from inside the sandbox succeeds today (visible + signalable)
and fails with "No such process" once `--unshare-pid` is added — the
host pid doesn't even exist in the sandboxed `/proc`.

## Implementation information

Add `--unshare-pid` to the bwrap invocation. bwrap reaps zombies for
the new namespace's pid 1 automatically, so no extra init flag is
needed.

Added `TestSandboxEnforce_UnsharePidHidesHostProcesses`, an integration
test that starts a host-side victim process outside the sandboxed
command's tree and asserts it's unreachable via `kill -0` from inside.
Confirmed the test fails without the fix and passes with it (both runs
executed live against `bwrap` on the home-nas server, since these
`//go:build linux` tests don't run on darwin).

## Supporting documentation

- `internal/agent/procsandbox_linux.go` — the fix
- `internal/agent/procsandbox_linux_integration_test.go` — new
  regression test
- `internal/agent/procsandbox_linux_test.go` — updated argv assertion