### PR TITLE
fix(skills): avoid self-pkill in test teardown

### DIFF
--- a/internal/skills/data/sybra-test.md
+++ b/internal/skills/data/sybra-test.md
@@ -86,6 +86,7 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
    - Bind **only ephemeral/dynamic ports** (`:0` or a high random port). Never a fixed well-known port — other test agents run in parallel on this machine.
    - Namespace anything global by the task id.
    - **Tear down** every process/container/cluster you start before exiting (trap/defer). Leaks starve the next agent.
+   - **Never `pkill`/`pgrep` by command-line pattern to stop a server you started.** Your own invocation's full prompt text is part of your process's command line, so a pattern that matches the server you meant to kill (e.g. a path or command fragment quoted in the task/manual_test text) can also match your own ancestor process and kill your own run instead. Capture the PID when you start the process (`cmd & pid=$!`) and tear it down with that exact PID (`kill "$pid"`).
 
    **`SYBRA_HOME` is always set to your per-task sandbox** — every task-scoped agent gets one automatically now (sybra#1577), not just Sybra-testing-Sybra. Test servers, e2e suites, and scratch data all belong there by default; that's where `go run ./cmd/sybra-server`, ad-hoc scripts, and anything else you start will land unless told otherwise.
 

--- a/internal/skills/data/sybra-test.md
+++ b/internal/skills/data/sybra-test.md
@@ -86,7 +86,7 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
    - Bind **only ephemeral/dynamic ports** (`:0` or a high random port). Never a fixed well-known port — other test agents run in parallel on this machine.
    - Namespace anything global by the task id.
    - **Tear down** every process/container/cluster you start before exiting (trap/defer). Leaks starve the next agent.
-   - **Never `pkill`/`pgrep` by command-line pattern to stop a server you started.** Your own invocation's full prompt text is part of your process's command line, so a pattern that matches the server you meant to kill (e.g. a path or command fragment quoted in the task/manual_test text) can also match your own ancestor process and kill your own run instead. Capture the PID when you start the process (`cmd & pid=$!`) and tear it down with that exact PID (`kill "$pid"`).
+   - **Never `pkill`/`pgrep` by command-line pattern to stop a server you started.** A broad pattern can match more than you intend — including, on some invocations, your own ancestor process (your prompt or task text can itself contain the same path/command fragment you're matching on), killing your own run instead of the server. Capture the PID when you start the process (`cmd & pid=$!`) and tear it down with that exact PID (`kill "$pid"`).
 
    **`SYBRA_HOME` is always set to your per-task sandbox** — every task-scoped agent gets one automatically now (sybra#1577), not just Sybra-testing-Sybra. Test servers, e2e suites, and scratch data all belong there by default; that's where `go run ./cmd/sybra-server`, ad-hoc scripts, and anything else you start will land unless told otherwise.
 


### PR DESCRIPTION
## Motivation

> Changelog: fix(skills): avoid self-pkill in test teardown

Task 0871ec54 crash-looped test-runner (#2574 fixed the sandbox cross-process
angle but the loop continued after that fix deployed — same
`agent.completion.stall` signature, `exit status 143`).

Root cause, confirmed from the live run's own transcript on the home-nas
server: every headless test-runner's rendered prompt is passed as a literal
CLI argument to `claude -p`, so it lands in the process's own
`/proc/PID/cmdline`. Agent run `1f928e56` ran this teardown before
restarting a dev server on a new port:

```
pkill -f "cmd/sybra-server" 2>/dev/null; pkill -f "go-build.*sybra-server" 2>/dev/null
```

`"cmd/sybra-server"` is also a substring of that same agent's own prompt
text (from the project's `.sybra.yaml` `manual_test.command`), so `pkill -f`
matched its own ancestor — the `claude` CLI process itself — and killed it.
Filed the deeper architectural fix (stop passing the prompt via argv at all)
separately as #2575, since it touches headless stdin plumbing with a
documented deadlock history (#1825) and needs its own careful review.

This PR ships the immediate, low-risk mitigation: tell the `/sybra-test`
skill to never `pkill`/`pgrep` by command-line pattern against a server it
started — capture the PID at start time and kill by that PID instead.

## Implementation information

One line added to `internal/skills/data/sybra-test.md`'s teardown guidance,
next to the existing "tear down what you start" bullet.

## Supporting documentation

- #2575 — tracked follow-up for the argv-leak root cause
- `internal/skills/data/sybra-test.md`