### PR TITLE
ci(actions): retry e2e module download on stall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
         # transient stall costs seconds, not the whole job.
         run: |
           for i in 1 2 3 4 5; do
-            timeout 120 go mod download && exit 0
-            echo "go mod download attempt $i timed out or failed; retrying" >&2
+            timeout --kill-after=10 120 go mod download && exit 0
+            echo "go mod download attempt $i exited $?; retrying" >&2
           done
           echo "go mod download failed after 5 attempts" >&2
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Build frontend (needed for go:embed)
         run: cd frontend && npm ci && npm run build:desktop
 
+      - name: Pre-fetch Go modules (retried, bounded)
+        # go test's own -timeout only bounds test execution, not module
+        # download — a proxy/network stall during `go mod download` is only
+        # caught by this job's outer 20m timeout-minutes, burning the whole
+        # budget on one bad fetch. Bound each attempt short and retry so a
+        # transient stall costs seconds, not the whole job.
+        run: |
+          for i in 1 2 3 4 5; do
+            timeout 120 go mod download && exit 0
+            echo "go mod download attempt $i timed out or failed; retrying" >&2
+          done
+          echo "go mod download failed after 5 attempts" >&2
+          exit 1
+
       - name: Run Go e2e tests
         run: go test -race -tags e2e -p 1 -timeout 20m ./internal/sybra/...
 


### PR DESCRIPTION
## Motivation

> Changelog: ci(actions): retry e2e module download on stall

PR #2577's `Go E2E Tests` job hung 7 times in a row, always at the same
spot (`go: downloading go.yaml.in/yaml/v2 v2.4.4`), for the full 20-minute
job timeout each time — even across a since-resolved unrelated GitHub
platform incident, and on a completely fresh workflow run (different run
ID, fresh runner), ruling out anything specific to that one commit or run.

Root cause of *why it burns the entire budget*: `go test -timeout 20m`
only bounds test execution — it does nothing during module
download/compilation, which is where the hang actually happens, before a
single test runs. The only thing bounding a stall there is the job's outer
`timeout-minutes: 20`, which is why it always dies at exactly the 20-minute
mark with a hard cancel rather than a clean, informative timeout.

## Implementation information

Add a "Pre-fetch Go modules" step before the test run: `go mod download`
wrapped in a loop with a short (120s) per-attempt timeout, retried up to 5
times. `go mod download` (no args) fetches every module in `go.sum`
regardless of build tags, so it covers everything the `e2e`-tagged test
run needs. Once modules are cached locally, the actual `go test` step
never touches the network for dependencies, so its full 20-minute budget
is available for what it's actually meant to bound: test execution.

Validated: `actionlint` clean, retry-loop logic sanity-tested locally for
both the success and repeated-timeout paths, `go mod download` itself
runs correctly against this repo's `go.sum`.

## Supporting documentation

- `.github/workflows/ci.yml` `test-go-e2e` job