### PR TITLE
fix(clusterlead): stop cluster_drift GH issues

### DIFF
--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
-	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -411,27 +410,6 @@ func TestMirrorMirrorsPlanningSidecars(t *testing.T) {
 	}
 }
 
-// fakeAnomalySink is a monitor.IssueSink test double that records every
-// submitted anomaly so tests can assert alerting fired without depending on
-// GitHub/local-task-routing machinery.
-type fakeAnomalySink struct {
-	mu    sync.Mutex
-	calls []monitor.Anomaly
-}
-
-func (s *fakeAnomalySink) Submit(_ context.Context, a monitor.Anomaly, _ string) (bool, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.calls = append(s.calls, a)
-	return true, nil
-}
-
-func (s *fakeAnomalySink) submitted() []monitor.Anomaly {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return slices.Clone(s.calls)
-}
-
 // TestMirrorDetectsAndRepairsTagsAndDependsOnDrift covers issue #2350: Tags
 // and DependsOn are leader-authoritative fields Merge never pulls from the
 // follower (see Merge's field list — only execution fields like Status flow
@@ -440,9 +418,7 @@ func (s *fakeAnomalySink) submitted() []monitor.Anomaly {
 // notice. This seeds a follower report that disagrees with the canonical
 // copy on both fields and asserts the sweep detects it and repairs the
 // follower within the same reconcile pass — without touching the follower's
-// own Status/PR fields (never a stale full-task overwrite) — and, per #2495,
-// does NOT alert: a single drift that repairs cleanly is the backstop
-// working as designed, not something a human needs to see.
+// own Status/PR fields (never a stale full-task overwrite).
 func TestMirrorDetectsAndRepairsTagsAndDependsOnDrift(t *testing.T) {
 	stub := &followerStub{}
 	srv := stub.server(t)
@@ -453,8 +429,6 @@ func TestMirrorDetectsAndRepairsTagsAndDependsOnDrift(t *testing.T) {
 	}
 	mgr := newManager(t)
 	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
-	sink := &fakeAnomalySink{}
-	mirror.SetAnomalySink(sink)
 
 	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
 	canonical := task.Task{
@@ -486,12 +460,6 @@ func TestMirrorDetectsAndRepairsTagsAndDependsOnDrift(t *testing.T) {
 	stub.tasks = []task.Task{stale}
 	if !mirror.applyFollowerTask("pet-box", stale) {
 		t.Fatal("apply follower report")
-	}
-
-	// Detected and repaired, but not alerted — a lone drift that repairs
-	// cleanly on the first try is exactly the case #2495 stopped alerting on.
-	if calls := sink.submitted(); len(calls) != 0 {
-		t.Fatalf("anomaly sink got %d submissions, want 0 (a single clean repair must not alert): %+v", len(calls), calls)
 	}
 
 	// Repaired: the follower stub received an AssignTask carrying the
@@ -590,64 +558,11 @@ func TestMirrorDriftRepairUsesLiveFollowerStateNotStaleSnapshot(t *testing.T) {
 	}
 }
 
-// TestMirrorAlertsWhenDriftRepairFails covers #2495's other alert-worthy
-// case: the backstop detects drift but the repair push itself never reaches
-// the follower (e.g. the follower is down). Unlike a drift that repairs
-// cleanly (TestMirrorDetectsAndRepairsTagsAndDependsOnDrift, which must NOT
-// alert), a repair failure means the backstop couldn't self-heal — that is
-// exactly when a human needs to know.
-func TestMirrorAlertsWhenDriftRepairFails(t *testing.T) {
-	stub := &followerStub{failAssign: true}
-	srv := stub.server(t)
-	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
-	roster, err := NewRoster(cfg, nil)
-	if err != nil || roster == nil {
-		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
-	}
-	mgr := newManager(t)
-	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
-	sink := &fakeAnomalySink{}
-	mirror.SetAnomalySink(sink)
-
-	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
-	canonical := task.Task{
-		ID:           "task-pet",
-		Status:       task.StatusTodo,
-		AssignedNode: "pet-box",
-		Tags:         []string{"backend", "umbrella-gated"},
-		UpdatedAt:    t0,
-	}
-	if _, _, err := mgr.Put(canonical); err != nil {
-		t.Fatal(err)
-	}
-
-	stale := task.Task{
-		ID:           "task-pet",
-		Status:       task.StatusInProgress,
-		AssignedNode: "pet-box",
-		Tags:         []string{"backend"},
-		UpdatedAt:    t0.Add(time.Hour),
-	}
-	stub.tasks = []task.Task{stale}
-	if !mirror.applyFollowerTask("pet-box", stale) {
-		t.Fatal("apply follower report")
-	}
-
-	calls := sink.submitted()
-	if len(calls) != 1 {
-		t.Fatalf("anomaly sink got %d submissions, want 1 (repair failed, backstop couldn't self-heal): %+v", len(calls), calls)
-	}
-	if calls[0].Kind != monitor.KindClusterDrift || calls[0].TaskID != "task-pet" {
-		t.Fatalf("submitted anomaly = %+v, want KindClusterDrift for task-pet", calls[0])
-	}
-}
-
-// TestMirrorAlertsOnRepeatedDriftWithinWindow covers #2495's third
-// alert-worthy case: even when each individual repair succeeds, the same
-// task drifting again shortly after signals the write-time push isn't
-// sticking for it — worth a human's attention even though the backstop keeps
-// self-healing it.
-func TestMirrorAlertsOnRepeatedDriftWithinWindow(t *testing.T) {
+// TestMirrorNoRepairOnOrdinaryStatusDisagreement asserts that Status
+// differing between the leader and follower — the normal, expected,
+// self-healing case Merge exists for — never fires the drift repair path.
+// Only Tags/DependsOn (fields Merge doesn't carry) are drift-worthy.
+func TestMirrorNoRepairOnOrdinaryStatusDisagreement(t *testing.T) {
 	stub := &followerStub{}
 	srv := stub.server(t)
 	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
@@ -657,71 +572,6 @@ func TestMirrorAlertsOnRepeatedDriftWithinWindow(t *testing.T) {
 	}
 	mgr := newManager(t)
 	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
-	sink := &fakeAnomalySink{}
-	mirror.SetAnomalySink(sink)
-
-	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
-	canonical := task.Task{
-		ID:           "task-pet",
-		Status:       task.StatusTodo,
-		AssignedNode: "pet-box",
-		Tags:         []string{"backend", "umbrella-gated"},
-		UpdatedAt:    t0,
-	}
-	if _, _, err := mgr.Put(canonical); err != nil {
-		t.Fatal(err)
-	}
-
-	firstDrift := task.Task{
-		ID: "task-pet", Status: task.StatusInProgress, AssignedNode: "pet-box",
-		Tags: []string{"backend"}, UpdatedAt: t0.Add(time.Hour),
-	}
-	stub.tasks = []task.Task{firstDrift}
-	if !mirror.applyFollowerTask("pet-box", firstDrift) {
-		t.Fatal("apply first follower report")
-	}
-	if calls := sink.submitted(); len(calls) != 0 {
-		t.Fatalf("first (clean) repair alerted, want 0 submissions: %+v", calls)
-	}
-
-	// The follower re-reports the same stale Tags shortly after the first
-	// repair — as if whatever originally broke the write-time push for this
-	// task is still broken.
-	secondDrift := task.Task{
-		ID: "task-pet", Status: task.StatusInProgress, AssignedNode: "pet-box",
-		Tags: []string{"backend"}, UpdatedAt: t0.Add(2 * time.Hour),
-	}
-	stub.tasks = []task.Task{secondDrift}
-	if !mirror.applyFollowerTask("pet-box", secondDrift) {
-		t.Fatal("apply second follower report")
-	}
-
-	calls := sink.submitted()
-	if len(calls) != 1 {
-		t.Fatalf("anomaly sink got %d submissions, want 1 (re-drift within window must alert): %+v", len(calls), calls)
-	}
-	if calls[0].Kind != monitor.KindClusterDrift || calls[0].TaskID != "task-pet" {
-		t.Fatalf("submitted anomaly = %+v, want KindClusterDrift for task-pet", calls[0])
-	}
-}
-
-// TestMirrorNoAlertOnOrdinaryStatusDisagreement asserts that Status differing
-// between the leader and follower — the normal, expected, self-healing case
-// Merge exists for — never fires the drift alert/repair path. Only
-// Tags/DependsOn (fields Merge doesn't carry) are drift-worthy; alerting on
-// every ordinary status lag would make the signal useless.
-func TestMirrorNoAlertOnOrdinaryStatusDisagreement(t *testing.T) {
-	stub := &followerStub{}
-	srv := stub.server(t)
-	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
-	roster, err := NewRoster(cfg, nil)
-	if err != nil || roster == nil {
-		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
-	}
-	mgr := newManager(t)
-	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
-	sink := &fakeAnomalySink{}
-	mirror.SetAnomalySink(sink)
 
 	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
 	if _, _, err := mgr.Put(task.Task{
@@ -739,9 +589,6 @@ func TestMirrorNoAlertOnOrdinaryStatusDisagreement(t *testing.T) {
 		t.Fatal("apply follower report")
 	}
 
-	if calls := sink.submitted(); len(calls) != 0 {
-		t.Fatalf("anomaly sink got %d submissions for an ordinary status advance, want 0: %+v", len(calls), calls)
-	}
 	if _, ok := stub.lastAssigned(); ok {
 		t.Error("follower received an unnecessary repair push for a matching Tags/DependsOn task")
 	}

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Automaat/sybra/internal/attachment"
 	"github.com/Automaat/sybra/internal/cluster"
 	"github.com/Automaat/sybra/internal/config"
-	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -70,17 +69,11 @@ type Mirror struct {
 	applyMu  sync.Mutex
 
 	attachments *attachment.Store
-	anomalySink monitor.IssueSink
 
 	// missingMu guards missingStreak, written from each node's independent
 	// reconcileLoop goroutine.
 	missingMu     sync.Mutex
 	missingStreak map[string]int // "node|taskID" -> consecutive confirmed-404 ticks
-
-	// driftMu guards driftLastSeen, written from each node's independent
-	// reconcileLoop goroutine.
-	driftMu       sync.Mutex
-	driftLastSeen map[string]time.Time // "node|taskID" -> time of the last detected drift
 }
 
 // NewMirror constructs a Mirror. A nil logger falls back to slog.Default(); a
@@ -95,7 +88,6 @@ func NewMirror(cfg *config.Config, tasks *task.Manager, roster *cluster.Roster, 
 	return &Mirror{
 		cfg: cfg, tasks: tasks, roster: roster, logger: logger, interval: interval,
 		missingStreak: make(map[string]int),
-		driftLastSeen: make(map[string]time.Time),
 	}
 }
 
@@ -103,15 +95,6 @@ func NewMirror(cfg *config.Config, tasks *task.Manager, roster *cluster.Roster, 
 // attachment uploads back into the canonical task view.
 func (m *Mirror) SetAttachments(store *attachment.Store) {
 	m.attachments = store
-}
-
-// SetAnomalySink supplies the sink drift detection reports through — the same
-// routing sink monitor.Service uses, so a cluster-drift finding gets the
-// existing dedup, work-project scrubbing, and durable GitHub-issue-outbox
-// behavior for free. A nil sink (monitor disabled, or not yet wired at
-// construction time) disables alerting only; detection and repair still run.
-func (m *Mirror) SetAnomalySink(sink monitor.IssueSink) {
-	m.anomalySink = sink
 }
 
 // Run starts, per follower, a reconcile ticker, and blocks until ctx is
@@ -362,45 +345,33 @@ func (m *Mirror) adoptFollowerTask(ctx context.Context, node string, follower ta
 	return true
 }
 
-// driftAlertWindow bounds how soon a second drift on the same task after a
-// previously detected one is treated as a re-drift worth alerting on. Now
-// that Assigner pushes Tags/DependsOn edits to the follower at write time
-// (see PushFieldUpdate and its TaskService.UpdateTask caller), this backstop
-// firing at all should be rare; a repair that holds for longer than this
-// before the task drifts again is presumed unrelated (e.g. two independent
-// manual edits), not a repair that failed to stick.
-const driftAlertWindow = time.Hour
-
 // detectAndRepairDrift compares the two leader-authoritative fields Merge
 // never touches — Tags and DependsOn — between the leader's canonical copy
 // and what the follower actually reports. Every other field either flows
 // follower-authoritative through Merge every reconcile tick (Status,
 // Workflow, AgentRuns, ...) or is immutable identity (ID, ProjectID,
 // CreatedAt), so an ordinary disagreement there is expected and self-heals
-// on its own — alerting on it would just be noise. Tags/DependsOn only ever
-// change on the leader (umbrella-gate release, a manual sybra-cli edit, ...);
-// if a leader-side write to one of them never reached the follower — the
-// #2349 class of bug, from any cause, not just the one fixed there — nothing
-// else in the reconcile loop will ever notice, because Merge doesn't carry
-// them. This is the backstop: detected within one reconcile interval, logged,
-// and repaired by pushing just the drifted fields onto the follower's own
-// current state (never a stale full-task overwrite that could roll back
-// follower-side execution progress).
+// on its own. Tags/DependsOn only ever change on the leader (umbrella-gate
+// release, a manual sybra-cli edit, ...); if a leader-side write to one of
+// them never reached the follower — the #2349 class of bug, from any cause,
+// not just the one fixed there — nothing else in the reconcile loop will
+// ever notice, because Merge doesn't carry them. This is the backstop:
+// detected within one reconcile interval, logged, and repaired by pushing
+// just the drifted fields onto the follower's own current state (never a
+// stale full-task overwrite that could roll back follower-side execution
+// progress).
 //
-// Alerting is deliberately narrower than detection: a single drift that
-// repairs cleanly is exactly the write-time push path missing a beat (a
-// follower restart mid-push, a transient network blip, ...) — the sort of
-// thing the 42 `cluster_drift` issues/2 weeks were filed for despite the
-// backstop already having fixed it within one tick. Only alert when the
-// repair itself fails (the backstop couldn't self-heal, so a human needs to
-// know) or when the same task drifted again within driftAlertWindow of the
-// last time (the backstop keeps working, but something keeps re-breaking the
-// write-time push for this task, which is worth investigating).
+// Purely self-healing, no alerting: every case this backstop hits — a
+// follower restart mid-push, a transient network blip, a repair that fails
+// outright — either fixes itself within one tick or keeps retrying every
+// tick after, so there is nothing here a human needs paged for. (#2495
+// narrowed alerting to repair-failure/re-drift only, and it still produced
+// 42 `cluster_drift` issues in 2 weeks for cases the backstop had already
+// fixed — not worth a GitHub issue at any threshold.)
 func (m *Mirror) detectAndRepairDrift(ctx context.Context, node string, canonical, follower task.Task) {
 	tagsDrift := !slices.Equal(sortedCopy(canonical.Tags), sortedCopy(follower.Tags))
 	depsDrift := !slices.Equal(sortedCopy(canonical.DependsOn), sortedCopy(follower.DependsOn))
 	if !tagsDrift && !depsDrift {
-		m.clearDriftLastSeen(node, canonical.ID)
 		return
 	}
 	m.logger.Error("cluster.mirror.drift_detected",
@@ -408,64 +379,7 @@ func (m *Mirror) detectAndRepairDrift(ctx context.Context, node string, canonica
 		"tags_drift", tagsDrift, "deps_drift", depsDrift,
 		"canonical_tags", canonical.Tags, "follower_tags", follower.Tags,
 		"canonical_depends_on", canonical.DependsOn, "follower_depends_on", follower.DependsOn)
-
-	redrift := m.recentDrift(node, canonical.ID)
-	m.recordDriftSeen(node, canonical.ID)
-	repaired := m.repairDrift(ctx, node, canonical)
-	if !repaired || redrift {
-		m.alertDrift(ctx, node, canonical, tagsDrift, depsDrift)
-	}
-}
-
-func driftSeenKey(node, taskID string) string { return missingStreakKey(node, taskID) }
-
-// recentDrift reports whether node/taskID last drifted within
-// driftAlertWindow.
-func (m *Mirror) recentDrift(node, taskID string) bool {
-	m.driftMu.Lock()
-	defer m.driftMu.Unlock()
-	last, ok := m.driftLastSeen[driftSeenKey(node, taskID)]
-	return ok && time.Since(last) < driftAlertWindow
-}
-
-func (m *Mirror) recordDriftSeen(node, taskID string) {
-	m.driftMu.Lock()
-	defer m.driftMu.Unlock()
-	m.driftLastSeen[driftSeenKey(node, taskID)] = time.Now()
-}
-
-// clearDriftLastSeen drops node/taskID's drift history once a reconcile tick
-// finds it no longer drifting, so a later, unrelated drift starts fresh
-// instead of inheriting a stale streak (mirrors clearMissingStreak).
-func (m *Mirror) clearDriftLastSeen(node, taskID string) {
-	m.driftMu.Lock()
-	defer m.driftMu.Unlock()
-	delete(m.driftLastSeen, driftSeenKey(node, taskID))
-}
-
-func (m *Mirror) alertDrift(ctx context.Context, node string, canonical task.Task, tagsDrift, depsDrift bool) {
-	if m.anomalySink == nil {
-		return
-	}
-	ev := map[string]any{
-		"node":       node,
-		"tags_drift": tagsDrift,
-		"deps_drift": depsDrift,
-		"tags":       canonical.Tags,
-		"depends_on": canonical.DependsOn,
-	}
-	a := monitor.Anomaly{
-		Kind:        monitor.KindClusterDrift,
-		TaskID:      canonical.ID,
-		Severity:    monitor.SeverityError,
-		RequiresLLM: false,
-		Fingerprint: monitor.Fingerprint(monitor.KindClusterDrift, canonical.ID, ev),
-		Evidence:    ev,
-		DetectedAt:  time.Now().UTC(),
-	}
-	if _, err := m.anomalySink.Submit(ctx, a, monitor.DeterministicIssueBody(a)); err != nil {
-		m.logger.Warn("cluster.mirror.drift_alert.failed", "task", canonical.ID, "node", node, "err", err)
-	}
+	m.repairDrift(ctx, node, canonical)
 }
 
 // driftRepairTimeout bounds repairDrift's two follower round trips (a
@@ -482,21 +396,20 @@ const driftRepairTimeout = 5 * time.Second
 // re-fetches via GetTask rather than reusing this tick's ListTasks snapshot,
 // which can already be stale by the time this repair runs — earlier tasks in
 // the same batch, under the same applyMu lock, each take up to
-// driftRepairTimeout first. Returns whether the repair reached the follower —
-// detectAndRepairDrift alerts when it doesn't, since that's the one case the
-// backstop itself can't self-heal.
-func (m *Mirror) repairDrift(ctx context.Context, node string, canonical task.Task) bool {
+// driftRepairTimeout first. Every failure path logs its own Warn; a failed
+// repair simply retries on the next reconcile tick.
+func (m *Mirror) repairDrift(ctx context.Context, node string, canonical task.Task) {
 	client, ok := m.roster.Client(node)
 	if !ok || client == nil {
 		m.logger.Warn("cluster.mirror.drift_repair.no_client", "task", canonical.ID, "node", node)
-		return false
+		return
 	}
 	repairCtx, cancel := context.WithTimeout(ctx, driftRepairTimeout)
 	defer cancel()
 	live, err := client.GetTask(repairCtx, canonical.ID)
 	if err != nil {
 		m.logger.Warn("cluster.mirror.drift_repair.refetch_failed", "task", canonical.ID, "node", node, "err", err)
-		return false
+		return
 	}
 	repaired := live
 	repaired.Tags = canonical.Tags
@@ -504,10 +417,9 @@ func (m *Mirror) repairDrift(ctx context.Context, node string, canonical task.Ta
 	repaired.AssignedNode = node
 	if err := client.AssignTask(repairCtx, repaired); err != nil {
 		m.logger.Warn("cluster.mirror.drift_repair.failed", "task", canonical.ID, "node", node, "err", err)
-		return false
+		return
 	}
 	m.logger.Info("cluster.mirror.drift_repaired", "task", canonical.ID, "node", node)
-	return true
 }
 
 // sortedCopy returns a sorted copy of ss so set-like fields (Tags,

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -629,9 +629,6 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			}
 		})
 	}, a.logger)
-	if a.mirror != nil {
-		a.mirror.SetAnomalySink(routingSink)
-	}
 	svc := monitor.NewService(monitor.Deps{
 		Cfg:          a.cfg.Monitor,
 		Tasks:        a.tasks,


### PR DESCRIPTION
## Motivation

> Changelog: fix(clusterlead): stop cluster_drift GH issues

Tags/DependsOn drift between the leader and a follower always self-heals
via the existing repair push in `Mirror.detectAndRepairDrift`, which
retries every reconcile tick on failure. Alerting for this had already
been narrowed once (repair-failure or re-drift-within-1h only), but that
narrower rule still produced 42 `[monitor] cluster_drift: <id>` issues in
2 weeks — for cases the backstop had already fixed on its own. The signal
never earned its keep; every single one of the ~20 currently-open issues
of this kind is noise, not something that needed a human.

## Implementation information

- `Mirror.detectAndRepairDrift` (`internal/sybra/clusterlead/mirror.go`)
  no longer submits an anomaly to the monitor sink. Detection (Tags/
  DependsOn comparison), the `cluster.mirror.drift_detected` error log,
  and the repair push are unchanged.
- Removed the now-dead alerting machinery: `alertDrift`, `SetAnomalySink`,
  the `anomalySink` field, the redrift-within-window bookkeeping
  (`driftLastSeen`, `recentDrift`, `recordDriftSeen`, `clearDriftLastSeen`,
  `driftAlertWindow`).
- Dropped the `SetAnomalySink` wiring call in `internal/sybra/lifecycle.go`.
- Updated `internal/sybra/clusterlead/clusterlead_test.go` to drop the two
  alert-specific tests and the `fakeAnomalySink` test double; the repair
  behavior tests are unchanged apart from no longer asserting on alerting.

## Supporting documentation

None.