### PR TITLE
fix(agent): dismiss unauthorized bot self-approvals on gh shim

### DIFF
--- a/frontend/src/lib/review-phase.ts
+++ b/frontend/src/lib/review-phase.ts
@@ -12,6 +12,7 @@ export type ReviewPhase =
   | 'needs-approval'
   | 'approved'
   | 'conflict'
+  | 'self-approval-blocked'
 
 /** Icon keys, resolved to lucide components at the call site. */
 export type ReviewPhaseIcon = 'loader' | 'eye' | 'pen' | 'hourglass' | 'shield' | 'check' | 'conflict'
@@ -64,12 +65,22 @@ export const REVIEW_PHASE_META: Record<ReviewPhase, ReviewPhaseMeta> = {
     icon: 'conflict',
     classes: 'bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200',
   },
+  // Our own bot identity submitted an approval on its own review task — always
+  // an anomaly (see internal/sybra/review/review_phase.go). The approval is
+  // dismissed server-side; error-toned and needs-you since a human must
+  // actually review the PR.
+  'self-approval-blocked': {
+    label: 'Self-approval blocked',
+    icon: 'conflict',
+    classes: 'bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200',
+  },
 }
 
 // Lane sort: the user's pending actions first, then waiting, then done, and
 // conflicting PRs last — they're blocked on the author, so they sink to the
 // bottom of the lane.
 const REVIEW_PHASE_ORDER: ReviewPhase[] = [
+  'self-approval-blocked',
   'needs-approval',
   'drafted',
   'manual',
@@ -129,6 +140,7 @@ const REVIEW_PHASE_NEEDS_YOU: ReadonlySet<ReviewPhase> = new Set<ReviewPhase>([
   'manual',
   'drafted',
   'needs-approval',
+  'self-approval-blocked',
 ])
 
 /** True when an inbound PR review task awaits the user's review action. */

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -69,22 +69,27 @@ const (
 	// failing at or above the configured success-rate threshold. Logged
 	// instead of dispatching a fix agent or escalating to human-required.
 	// Data carries pr, repo, and the flaky check names — never agent output.
-	EventPRCIFlakeDetected         = "pr_monitor.ci_flake_detected"
-	EventReviewStarted             = "review.agent_started"
-	EventFixReviewStarted          = "fix_review.agent_started"
-	EventReviewPublished           = "review.published"
-	EventRenovateCIFix             = "renovate.ci_fix_started"
-	EventHealthReport              = "health.report"
-	EventAgentStartFailed          = "agent.start_failed"
-	EventProviderGateBlocked       = "provider.gate_blocked"
-	EventProviderModelIncompatible = "provider.model_incompatible"
-	EventHumanReviewSpawned        = "human_review.spawned"
-	EventHumanReviewVerdict        = "human_review.verdict"
-	EventHumanReviewIssue          = "human_review.issue_filed"
-	EventHumanReviewSkipped        = "human_review.skipped"
-	EventExperienceRecorded        = "experience.recorded"
-	EventExperienceSkipped         = "experience.skipped"
-	EventExperienceInjected        = "experience.injected"
+	EventPRCIFlakeDetected = "pr_monitor.ci_flake_detected"
+	EventReviewStarted     = "review.agent_started"
+	EventFixReviewStarted  = "fix_review.agent_started"
+	EventReviewPublished   = "review.published"
+	// EventReviewSelfApprovalDismissed records that our own bot identity's
+	// approval on an inbound review task's PR was detected and dismissed —
+	// the outcome-based backstop under the gh shim (#2198). Data carries pr
+	// and repo, never agent output.
+	EventReviewSelfApprovalDismissed = "review.self_approval_dismissed"
+	EventRenovateCIFix               = "renovate.ci_fix_started"
+	EventHealthReport                = "health.report"
+	EventAgentStartFailed            = "agent.start_failed"
+	EventProviderGateBlocked         = "provider.gate_blocked"
+	EventProviderModelIncompatible   = "provider.model_incompatible"
+	EventHumanReviewSpawned          = "human_review.spawned"
+	EventHumanReviewVerdict          = "human_review.verdict"
+	EventHumanReviewIssue            = "human_review.issue_filed"
+	EventHumanReviewSkipped          = "human_review.skipped"
+	EventExperienceRecorded          = "experience.recorded"
+	EventExperienceSkipped           = "experience.skipped"
+	EventExperienceInjected          = "experience.injected"
 
 	// EventTaskLanded records a task's terminal outcome (merged/closed) with
 	// queue-inclusive and work-based timing for the evaluation scorecard.

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -600,6 +600,7 @@ func approvedOnly(prs []PullRequest) []PullRequest {
 // fetchMyReviewStateWith, and the REST auto-merge approval gate
 // (restApproval) so all three parse the same /pulls/{n}/reviews shape once.
 type restReview struct {
+	ID          int64  `json:"id"`
 	State       string `json:"state"`
 	CommitID    string `json:"commit_id"`
 	SubmittedAt string `json:"submitted_at"`
@@ -714,6 +715,7 @@ type MyReviewState struct {
 	Submitted   bool   // a submitted (non-draft) review exists
 	Approved    bool   // the latest submitted review is an approval
 	ReviewedSHA string // commit_id of the latest submitted review ("" if none)
+	ReviewID    int64  // id of the review carrying the latest verdict (0 if none) — needed to dismiss it
 }
 
 // FetchMyReviewState reports the authenticated user's review state on a PR.
@@ -779,6 +781,7 @@ func fetchMyReviewStateWith(e execer, repo string, number int) (MyReviewState, e
 			if r.SubmittedAt >= latestVerdict {
 				latestVerdict = r.SubmittedAt
 				st.Approved = r.State == "APPROVED"
+				st.ReviewID = r.ID
 			}
 		}
 	}
@@ -799,6 +802,30 @@ func approvePRWith(e execer, repo string, number int) error {
 		strconv.Itoa(number), "-R", repo)
 	if err != nil {
 		return fmt.Errorf("gh pr review --approve %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	if runtimeCacheEnabled(e) {
+		invalidatePRCaches(repo, number)
+	}
+	return nil
+}
+
+// DismissReview dismisses a previously-submitted review, reverting its
+// verdict (e.g. an APPROVED that should never have counted). GitHub has no
+// `gh pr review` dismiss subcommand, so this goes through the REST
+// dismissals endpoint directly; it requires the numeric review ID (see
+// MyReviewState.ReviewID) and a message explaining why the verdict no
+// longer stands.
+func DismissReview(repo string, number int, reviewID int64, message string) error {
+	return dismissReviewWith(defaultExecer, repo, number, reviewID, message)
+}
+
+func dismissReviewWith(e execer, repo string, number int, reviewID int64, message string) error {
+	out, err := e.run("api", "--method", "PUT",
+		fmt.Sprintf("repos/%s/pulls/%d/reviews/%d/dismissals", repo, number, reviewID),
+		"-f", "message="+message,
+		"-f", "event=DISMISS")
+	if err != nil {
+		return fmt.Errorf("dismiss review %d on %s#%d: %s: %w", reviewID, repo, number, strings.TrimSpace(string(out)), err)
 	}
 	if runtimeCacheEnabled(e) {
 		invalidatePRCaches(repo, number)

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -154,6 +154,10 @@ type Handler struct {
 	// signal that decides whether a review task still needs an agent.
 	// Overridable in tests; nil falls back to github.FetchMyReviewState.
 	fetchMyReviewStateFn func(repo string, number int) (github.MyReviewState, error)
+	// dismissReviewFn reverses a review our own bot identity submitted on a PR
+	// it is reviewing (self-approval — see dismissSelfApproval). Overridable in
+	// tests; nil falls back to github.DismissReview.
+	dismissReviewFn func(repo string, number int, reviewID int64, message string) error
 	// viewerLoginFn returns the authenticated GitHub login (the identity the fix
 	// agent posts as), used to tell the agent's own thread replies from a human
 	// collaborator's. Overridable in tests; nil falls back to github.ViewerLogin.

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -503,6 +503,11 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 	}
 	r.clearReconcileFailure(t)
 
+	selfApproved := myState.Approved || inApproved
+	if selfApproved {
+		r.dismissSelfApproval(t, myState)
+	}
+
 	submitted := myState.Submitted || inApproved
 	headSHA := ""
 	baseOnlyMergeFromReviewed := false
@@ -545,7 +550,7 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 	r.applyReviewPhase(t, computeReviewPhase(reviewSignals{
 		CostGuardrailStopped:      latestReviewRunStoppedByCostGuardrail(t),
 		HasDraft:                  myState.Pending,
-		ViewerApproved:            myState.Approved || inApproved,
+		SelfApproved:              selfApproved,
 		Submitted:                 submitted,
 		ReRequested:               inReq,
 		HeadSHA:                   headSHA,
@@ -553,6 +558,38 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 		HeadLineageUnknown:        headLineageUnknown,
 		BaseOnlyMergeFromReviewed: baseOnlyMergeFromReviewed,
 	}))
+}
+
+// selfApprovalDismissMessage is left on GitHub's audit trail explaining why
+// an approval was reversed the moment it was detected.
+const selfApprovalDismissMessage = "Dismissed automatically by Sybra: our own bot identity approved its own review task, which can never stand in for a human review."
+
+// dismissSelfApproval reverses an approval our own bot identity submitted on
+// a PR it is reviewing. This is never a legitimate green light — it means an
+// approval escaped the gh shim's PreToolUse-adjacent floor (internal/agent's
+// ghshim.go) or was otherwise submitted under the bot's own credentials
+// rather than a human's — so the outcome, not just the attempt, is caught and
+// reversed here (#2198).
+//
+// Best-effort: myState is only populated with a review ID when the REST
+// fetch itself observed the approval (myState.Approved), so an inApproved-only
+// detection (stale search-leg signal, REST already shows something else) has
+// nothing to dismiss yet — computeReviewPhase still keeps the task out of the
+// "approved" phase regardless. A dismissal failure is logged, never fatal:
+// escalating the task to human-required does not depend on it succeeding.
+func (r *Handler) dismissSelfApproval(t *task.Task, myState github.MyReviewState) {
+	if !myState.Approved || myState.ReviewID == 0 {
+		return
+	}
+	dismissFn := github.DismissReview
+	if r.dismissReviewFn != nil {
+		dismissFn = r.dismissReviewFn
+	}
+	if err := dismissFn(t.ProjectID, t.PRNumber, myState.ReviewID, selfApprovalDismissMessage); err != nil {
+		r.logger.Error("review.self-approval.dismiss-failed", "task_id", t.ID, "pr", t.PRNumber, "err", err)
+		return
+	}
+	r.logAudit(audit.EventReviewSelfApprovalDismissed, t.ID, "", map[string]any{"pr": t.PRNumber})
 }
 
 func latestReviewRunStoppedByCostGuardrail(t *task.Task) bool {

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -451,6 +451,10 @@ func (r *Handler) reconcileReviewPhases(tasks []task.Task, summary github.Review
 
 // reconcileReviewTask computes and applies the phase for a single review task.
 func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[string]github.PullRequest) {
+	key := reviewPRKey(t.ProjectID, t.PRNumber)
+	reqPR, inReq := requested[key]
+	apPR, inApproved := approved[key]
+
 	// An agent owning the PR short-circuits: surface "reviewing" without the
 	// extra GitHub round-trips.
 	if r.agents.HasRunningAgentForTask(t.ID) {
@@ -458,13 +462,13 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 		// stale. Without clearing here the count never decays and a single fresh
 		// failure hours later can trip a circuit meant to catch a persistent one.
 		r.clearReconcileFailure(t)
+		// A running (possibly stuck/looping) review agent that already submitted a
+		// bogus approval would otherwise leave it live on GitHub for the whole run,
+		// since this branch skips the full self-approval path below (#2198).
+		r.reverseLiveSelfApproval(t, inApproved)
 		r.applyReviewPhase(t, computeReviewPhase(reviewSignals{AgentRunning: true}))
 		return
 	}
-
-	key := reviewPRKey(t.ProjectID, t.PRNumber)
-	reqPR, inReq := requested[key]
-	apPR, inApproved := approved[key]
 
 	// A conflicting PR is blocked on the author rebasing — surface "conflict" and
 	// sink it to the bottom of the lane, whatever the viewer's review state (the
@@ -488,6 +492,11 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 	}
 	if res, decided := stickyConflictPhase(mergeable, t.ReviewPhase); decided {
 		r.clearReconcileFailure(t)
+		// The conflict phase outranks review state, but a self-approval is still a
+		// live green light on GitHub that native auto-merge would count the moment
+		// the conflict clears — reverse it now rather than waiting for the one poll
+		// where mergeability flips back and this branch stops short-circuiting.
+		r.reverseLiveSelfApproval(t, inApproved)
 		r.applyReviewPhase(t, res)
 		return
 	}
@@ -563,6 +572,32 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 // selfApprovalDismissMessage is left on GitHub's audit trail explaining why
 // an approval was reversed the moment it was detected.
 const selfApprovalDismissMessage = "Dismissed automatically by Sybra: our own bot identity approved its own review task, which can never stand in for a human review."
+
+// reverseLiveSelfApproval dismisses a live bot self-approval before the
+// agent-running and conflict short-circuits in reconcileReviewTask return,
+// which would otherwise skip the full self-approval path and leave a bogus
+// APPROVED review standing on GitHub for the whole agent run / conflict window.
+//
+// The REST round-trip is spent only when the cheap approvals-only summary leg
+// (inApproved) already flags an approval, so the common no-approval path keeps
+// the short-circuit's zero-round-trip cost. Escalation to human-required is not
+// attempted here — the short-circuit phases (reviewing/conflict) stand; the
+// full self-approval escalation runs on the next fall-through poll.
+func (r *Handler) reverseLiveSelfApproval(t *task.Task, inApproved bool) {
+	if !inApproved {
+		return
+	}
+	myStateFn := github.FetchMyReviewState
+	if r.fetchMyReviewStateFn != nil {
+		myStateFn = r.fetchMyReviewStateFn
+	}
+	myState, err := myStateFn(t.ProjectID, t.PRNumber)
+	if err != nil {
+		r.logger.Warn("review.self-approval.probe", "task_id", t.ID, "pr", t.PRNumber, "err", err)
+		return
+	}
+	r.dismissSelfApproval(t, myState)
+}
 
 // dismissSelfApproval reverses an approval our own bot identity submitted on
 // a PR it is reviewing. This is never a legitimate green light — it means an

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -624,7 +624,7 @@ func (r *Handler) dismissSelfApproval(t *task.Task, myState github.MyReviewState
 		r.logger.Error("review.self-approval.dismiss-failed", "task_id", t.ID, "pr", t.PRNumber, "err", err)
 		return
 	}
-	r.logAudit(audit.EventReviewSelfApprovalDismissed, t.ID, "", map[string]any{"pr": t.PRNumber})
+	r.logAudit(audit.EventReviewSelfApprovalDismissed, t.ID, "", map[string]any{"pr": t.PRNumber, "repo": t.ProjectID})
 }
 
 func latestReviewRunStoppedByCostGuardrail(t *task.Task) bool {

--- a/internal/sybra/review/review_phase.go
+++ b/internal/sybra/review/review_phase.go
@@ -116,8 +116,10 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 
 	// Our own bot identity approving its own review task is backwards — it is
 	// never a legitimate green light, so it must not surface as "approved".
-	// The caller (reconcileReviewTask) has already dismissed the approval on
-	// GitHub by the time this runs; this only decides the resulting phase.
+	// The caller (reconcileReviewTask) has already made a best-effort attempt
+	// to dismiss the approval on GitHub by the time this runs (it can
+	// legitimately skip — e.g. no review ID, or search-leg-only detection);
+	// this only decides the resulting phase, regardless of dismissal outcome.
 	if s.SelfApproved {
 		return reviewPhaseResult{
 			Phase:  ReviewPhaseSelfApprovalBlocked,

--- a/internal/sybra/review/review_phase.go
+++ b/internal/sybra/review/review_phase.go
@@ -27,6 +27,11 @@ const (
 	ReviewPhaseNeedsApproval = "needs-approval"
 	// ReviewPhaseApproved: the human approved; the PR is waiting to merge.
 	ReviewPhaseApproved = "approved"
+	// ReviewPhaseSelfApprovalBlocked: our own bot identity submitted the
+	// approval on a PR it is reviewing — a self-approval, which must never be
+	// treated as a legitimate green light. The approval is dismissed and the
+	// task is escalated for a human to actually review the PR.
+	ReviewPhaseSelfApprovalBlocked = "self-approval-blocked"
 )
 
 // reviewSignals are the live GitHub facts about a review task's PR, gathered
@@ -35,7 +40,7 @@ type reviewSignals struct {
 	AgentRunning              bool   // a review agent is running for this task
 	CostGuardrailStopped      bool   // a review agent was cost-stopped before producing a draft/submission
 	HasDraft                  bool   // viewer has a PENDING (unsubmitted) review
-	ViewerApproved            bool   // viewer's latest submitted review is an approval
+	SelfApproved              bool   // our own bot identity's latest submitted review is an approval — always an anomaly, never a legitimate green light
 	Submitted                 bool   // viewer has a submitted (non-draft) review
 	ReRequested               bool   // PR is back in viewer's review-requested list
 	HeadSHA                   string // current PR head commit ("" if unknown)
@@ -109,11 +114,15 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 		}
 	}
 
-	if s.ViewerApproved {
+	// Our own bot identity approving its own review task is backwards — it is
+	// never a legitimate green light, so it must not surface as "approved".
+	// The caller (reconcileReviewTask) has already dismissed the approval on
+	// GitHub by the time this runs; this only decides the resulting phase.
+	if s.SelfApproved {
 		return reviewPhaseResult{
-			Phase:  ReviewPhaseApproved,
-			Status: task.StatusInReview,
-			Reason: "Approved — awaiting merge",
+			Phase:  ReviewPhaseSelfApprovalBlocked,
+			Status: task.StatusHumanRequired,
+			Reason: "Bot self-approved its own review task — approval dismissed; needs an actual human review",
 		}
 	}
 

--- a/internal/sybra/review/review_phase_test.go
+++ b/internal/sybra/review/review_phase_test.go
@@ -29,7 +29,7 @@ func TestComputeReviewPhase(t *testing.T) {
 		},
 		{
 			name: "conflict outranks a pending draft / submitted review",
-			sig:  reviewSignals{Mergeable: "CONFLICTING", HasDraft: true, Submitted: true, ViewerApproved: true},
+			sig:  reviewSignals{Mergeable: "CONFLICTING", HasDraft: true, Submitted: true, SelfApproved: true},
 			want: reviewPhaseResult{Phase: ReviewPhaseConflict, Status: task.StatusInReview, Reason: "PR has merge conflicts — author must rebase"},
 		},
 		{
@@ -38,9 +38,9 @@ func TestComputeReviewPhase(t *testing.T) {
 			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},
 		},
 		{
-			name: "approved waits for merge",
-			sig:  reviewSignals{ViewerApproved: true, Submitted: true, HeadSHA: "abc"},
-			want: reviewPhaseResult{Phase: ReviewPhaseApproved, Status: task.StatusInReview, Reason: "Approved — awaiting merge"},
+			name: "self-approval is blocked, dismissed, and escalated — never treated as approved",
+			sig:  reviewSignals{SelfApproved: true, Submitted: true, HeadSHA: "abc"},
+			want: reviewPhaseResult{Phase: ReviewPhaseSelfApprovalBlocked, Status: task.StatusHumanRequired, Reason: "Bot self-approved its own review task — approval dismissed; needs an actual human review"},
 		},
 		{
 			name: "pending draft → drafted, needs human to post",

--- a/internal/sybra/review/selfapproval_test.go
+++ b/internal/sybra/review/selfapproval_test.go
@@ -82,6 +82,79 @@ func TestReconcileReviewTask_DismissFailureStillEscalates(t *testing.T) {
 	}
 }
 
+// A running (possibly stuck/looping) review agent short-circuits the phase
+// computation to "reviewing", but a bogus approval it already submitted must
+// still be reversed on GitHub rather than left live for the whole run (#2198).
+func TestReconcileReviewTask_RunningAgentStillDismissesSelfApproval(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "reviewing")
+
+	claim, ok := r.agents.TryClaimDispatch(tk.ID)
+	if !ok {
+		t.Fatal("claim dispatch")
+	}
+	defer claim.Release()
+	if !r.agents.HasRunningAgentForTask(tk.ID) {
+		t.Fatal("test setup: task should read as running")
+	}
+
+	var dismissedReviewID int64
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 777}, nil
+	}
+	r.dismissReviewFn = func(_ string, _ int, reviewID int64, _ string) error {
+		dismissedReviewID = reviewID
+		return nil
+	}
+
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	approved := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE"},
+	}
+
+	got := mustGet(t, tasks, tk.ID)
+	r.reconcileReviewTask(&got, map[string]github.PullRequest{}, approved)
+
+	if dismissedReviewID != 777 {
+		t.Fatalf("dismiss review ID = %d, want 777 — a running agent's stale approval was left live", dismissedReviewID)
+	}
+	if final := mustGet(t, tasks, tk.ID); final.ReviewPhase != ReviewPhaseReviewing {
+		t.Errorf("review_phase = %q, want %q — the running-agent short-circuit still applies", final.ReviewPhase, ReviewPhaseReviewing)
+	}
+}
+
+// A conflicting PR short-circuits to the conflict phase, but a self-approval is
+// still a live green light that native auto-merge would count once the conflict
+// clears — it must be reversed now, not on the poll where mergeability flips.
+func TestReconcileReviewTask_ConflictStillDismissesSelfApproval(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "conflict")
+
+	var dismissedReviewID int64
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 888}, nil
+	}
+	r.dismissReviewFn = func(_ string, _ int, reviewID int64, _ string) error {
+		dismissedReviewID = reviewID
+		return nil
+	}
+
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	approved := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "CONFLICTING"},
+	}
+
+	got := mustGet(t, tasks, tk.ID)
+	r.reconcileReviewTask(&got, map[string]github.PullRequest{}, approved)
+
+	if dismissedReviewID != 888 {
+		t.Fatalf("dismiss review ID = %d, want 888 — a conflicting PR's self-approval was left live", dismissedReviewID)
+	}
+	if final := mustGet(t, tasks, tk.ID); final.ReviewPhase != ReviewPhaseConflict {
+		t.Errorf("review_phase = %q, want %q — the conflict short-circuit still applies", final.ReviewPhase, ReviewPhaseConflict)
+	}
+}
+
 // The reviewed-by:@me search leg (inApproved) is the only signal in some
 // polls — e.g. right after the REST fetch already observed a later verdict.
 // Without a REST-fetched review ID there is nothing to dismiss yet, but the

--- a/internal/sybra/review/selfapproval_test.go
+++ b/internal/sybra/review/selfapproval_test.go
@@ -1,0 +1,118 @@
+package review
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// A self-approval must never read as "approved and waiting to merge" — it is
+// always an anomaly (an escaped prompt, a bypassed gh shim, or manual gh use
+// under the bot's own credentials). reconcileReviewTask must dismiss it and
+// escalate to human-required, not park it as if a human had approved (#2198).
+func TestReconcileReviewTask_DismissesSelfApprovalAndEscalates(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "reviewing")
+
+	var dismissedRepo string
+	var dismissedNumber int
+	var dismissedReviewID int64
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 555, ReviewedSHA: "e57e4b5"}, nil
+	}
+	r.dismissReviewFn = func(repo string, number int, reviewID int64, message string) error {
+		dismissedRepo, dismissedNumber, dismissedReviewID = repo, number, reviewID
+		if message == "" {
+			t.Error("dismiss message is empty; the GitHub audit trail would carry no explanation")
+		}
+		return nil
+	}
+
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	requested := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	got := mustGet(t, tasks, tk.ID)
+	r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
+
+	if dismissedRepo != tk.ProjectID || dismissedNumber != tk.PRNumber || dismissedReviewID != 555 {
+		t.Fatalf("dismiss called with (%q, %d, %d), want (%q, %d, 555)",
+			dismissedRepo, dismissedNumber, dismissedReviewID, tk.ProjectID, tk.PRNumber)
+	}
+
+	final := mustGet(t, tasks, tk.ID)
+	if final.ReviewPhase != ReviewPhaseSelfApprovalBlocked {
+		t.Errorf("review_phase = %q, want %q", final.ReviewPhase, ReviewPhaseSelfApprovalBlocked)
+	}
+	if final.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want %q — a self-approval must not be treated as a legitimate approval",
+			final.Status, task.StatusHumanRequired)
+	}
+}
+
+// A dismissal failure (GitHub API error, permissions, etc.) must not stop the
+// task from escalating — the important invariant is that the task never
+// parks as "approved", whether or not the reversal on GitHub itself succeeds.
+func TestReconcileReviewTask_DismissFailureStillEscalates(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "reviewing")
+
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 555, ReviewedSHA: "e57e4b5"}, nil
+	}
+	r.dismissReviewFn = func(string, int, int64, string) error {
+		return errors.New("gh api: HTTP 403")
+	}
+
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	requested := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	got := mustGet(t, tasks, tk.ID)
+	r.reconcileReviewTask(&got, requested, map[string]github.PullRequest{})
+
+	final := mustGet(t, tasks, tk.ID)
+	if final.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want %q — a dismiss failure must not block escalation",
+			final.Status, task.StatusHumanRequired)
+	}
+}
+
+// The reviewed-by:@me search leg (inApproved) is the only signal in some
+// polls — e.g. right after the REST fetch already observed a later verdict.
+// Without a REST-fetched review ID there is nothing to dismiss yet, but the
+// task must still never read as "approved".
+func TestReconcileReviewTask_SelfApprovalFromSearchLegWithoutReviewID(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "reviewing")
+
+	dismissCalled := false
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{Submitted: true, ReviewedSHA: "e57e4b5"}, nil
+	}
+	r.dismissReviewFn = func(string, int, int64, string) error {
+		dismissCalled = true
+		return nil
+	}
+
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	approved := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	got := mustGet(t, tasks, tk.ID)
+	r.reconcileReviewTask(&got, map[string]github.PullRequest{}, approved)
+
+	if dismissCalled {
+		t.Error("dismiss called without a review ID to dismiss")
+	}
+	final := mustGet(t, tasks, tk.ID)
+	if final.ReviewPhase != ReviewPhaseSelfApprovalBlocked {
+		t.Errorf("review_phase = %q, want %q even without a dismissable review ID",
+			final.ReviewPhase, ReviewPhaseSelfApprovalBlocked)
+	}
+}


### PR DESCRIPTION
## Motivation

Own-bot review approvals on inbound PR reviews were being treated as legitimate signal instead of dismissed and escalated.

## Implementation information

Detects bot self-approval via MyReviewState/ViewerApproved and dismisses + escalates instead of treating it as "Approved — awaiting merge". Keeps existing ghshim.go denylist as defense in depth.

> Changelog: fix(agent): dismiss unauthorized bot self-approvals on gh shim

Closes https://github.com/Automaat/sybra/issues/2198

_Generated by Sybra harness_