### PR TITLE
fix(agent): don't hold stdinMu across blocking stdin write

### DIFF
--- a/internal/agent/convo_io.go
+++ b/internal/agent/convo_io.go
@@ -139,16 +139,20 @@ func (c *convoIO) writeStdinTimeout(data []byte, timeout time.Duration) error {
 // forceClosePipe closes pipe and clears it from convoIO's bookkeeping, but
 // only if it is still the active stdin handle. A concurrent
 // replaceStdinPipe/closeStdinPipe call may already have moved convoIO on to
-// a different (or no) pipe by the time a wedged write's timeout fires, in
-// which case this is a no-op so a stale timeout cannot clobber a newer pipe.
+// a different (or no) pipe by the time a wedged write's timeout fires — in
+// which case that call already closed pipe itself, so this is a no-op
+// entirely: no bookkeeping to clobber and nothing left to close.
 func (c *convoIO) forceClosePipe(pipe io.WriteCloser) {
 	c.stdinMu.Lock()
-	if c.stdinPipe == pipe {
+	active := c.stdinPipe == pipe
+	if active {
 		c.stdinPipe = nil
 		c.hasPipe.Store(false)
 	}
 	c.stdinMu.Unlock()
-	_ = pipe.Close()
+	if active {
+		_ = pipe.Close()
+	}
 }
 
 func (c *convoIO) closeStdinPipe() {

--- a/internal/agent/convo_io.go
+++ b/internal/agent/convo_io.go
@@ -6,14 +6,34 @@ import (
 	"io"
 	"sync"
 	"sync/atomic"
+	"time"
 )
+
+// stdinWriteTimeout bounds how long a single writeStdin call may block on a
+// wedged child process. Kept well under the watchdog's smallest per-role
+// stall ceiling (10m, see internal/watchdog.stallLimit) so a stuck write
+// self-recovers long before the watchdog would notice the resulting
+// inactivity and try to stop the agent through the same pipe.
+const stdinWriteTimeout = 30 * time.Second
 
 // convoIO owns the conversational agent transport plus the existing
 // prompt/restart bookkeeping mechanically extracted from Agent.
 type convoIO struct {
+	// stdinPipe/hasPipe are the current stdin handle. stdinMu guards only
+	// handle bookkeeping (install/replace/close, plus the pointer snapshot
+	// writeStdin takes before writing) — it is never held across the
+	// blocking OS write itself, so a wedged write can never block
+	// installStdinPipe/replaceStdinPipe/closeStdinPipe. Those callers
+	// (StopAgent, markAgentDone, the watchdog's stall-recovery path) must
+	// always be able to make progress even while a write is stuck.
 	stdinPipe io.WriteCloser
 	stdinMu   sync.Mutex
 	hasPipe   atomic.Bool
+
+	// writeMu serializes the stdin writes themselves so concurrent callers
+	// cannot interleave partial writes into the child's stream-json input.
+	// Deliberately a separate lock from stdinMu — see the comment above.
+	writeMu sync.Mutex
 
 	// stdinPath is the FIFO backing a detached conversational agent's stdin,
 	// reopened on reattach so follow-up messages survive a restart. Empty for
@@ -49,18 +69,54 @@ func (c *convoIO) replaceStdinPipe(pipe io.WriteCloser) {
 }
 
 func (c *convoIO) writeStdin(data []byte) error {
-	c.stdinMu.Lock()
-	defer c.stdinMu.Unlock()
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 
-	if c.stdinPipe == nil {
+	c.stdinMu.Lock()
+	pipe := c.stdinPipe
+	c.stdinMu.Unlock()
+
+	if pipe == nil {
 		return fmt.Errorf("stdin pipe closed")
 	}
-	// A write larger than the pipe buffer can block under stdinMu until the
-	// child drains stdin; keep stdinPipe ownership here so callers cannot race.
-	if _, err := c.stdinPipe.Write(data); err != nil {
-		return fmt.Errorf("write stdin: %w", err)
+
+	// A write larger than the pipe buffer can block until the child drains
+	// stdin. Run it off a timer instead of inline so a wedged child cannot
+	// hold this call forever; on timeout, force-close the pipe so the
+	// blocked OS write unblocks (Close interrupts a pending Read/Write on
+	// the same *os.File) and any following write/close call proceeds
+	// against a clean pipe instead of piling up behind this one.
+	done := make(chan error, 1)
+	go func() {
+		_, err := pipe.Write(data)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("write stdin: %w", err)
+		}
+		return nil
+	case <-time.After(stdinWriteTimeout):
+		c.forceClosePipe(pipe)
+		return fmt.Errorf("write stdin: timed out after %s, pipe closed", stdinWriteTimeout)
 	}
-	return nil
+}
+
+// forceClosePipe closes pipe and clears it from convoIO's bookkeeping, but
+// only if it is still the active stdin handle. A concurrent
+// replaceStdinPipe/closeStdinPipe call may already have moved convoIO on to
+// a different (or no) pipe by the time a wedged write's timeout fires, in
+// which case this is a no-op so a stale timeout cannot clobber a newer pipe.
+func (c *convoIO) forceClosePipe(pipe io.WriteCloser) {
+	c.stdinMu.Lock()
+	if c.stdinPipe == pipe {
+		c.stdinPipe = nil
+		c.hasPipe.Store(false)
+	}
+	c.stdinMu.Unlock()
+	_ = pipe.Close()
 }
 
 func (c *convoIO) closeStdinPipe() {

--- a/internal/agent/convo_io.go
+++ b/internal/agent/convo_io.go
@@ -16,6 +16,16 @@ import (
 // inactivity and try to stop the agent through the same pipe.
 const stdinWriteTimeout = 30 * time.Second
 
+// stdinInitialWriteTimeout gives the first prompt delivery a longer grace
+// period than a steer message. The initial payload can exceed the OS pipe
+// buffer (~64KB on Linux) once a task body is combined with NOTES.md seeding,
+// so the write blocks until the child drains stdin — and a freshly-started
+// child may not be reading yet. Reusing the 30s steer ceiling would let a
+// merely slow-to-start child false-positive as wedged, silently stranding the
+// run. Still bounded (well under the watchdog's 10m stall ceiling) so a
+// genuinely wedged child self-recovers.
+const stdinInitialWriteTimeout = 2 * time.Minute
+
 // convoIO owns the conversational agent transport plus the existing
 // prompt/restart bookkeeping mechanically extracted from Agent.
 type convoIO struct {
@@ -34,6 +44,12 @@ type convoIO struct {
 	// cannot interleave partial writes into the child's stream-json input.
 	// Deliberately a separate lock from stdinMu — see the comment above.
 	writeMu sync.Mutex
+
+	// writeTimeout, when non-zero, overrides the per-call stdin write timeout.
+	// Injection seam for tests to drive writeStdin's self-timeout branch on a
+	// short duration instead of a real 30s/2m sleep. Zero = use the caller's
+	// timeout argument.
+	writeTimeout time.Duration
 
 	// stdinPath is the FIFO backing a detached conversational agent's stdin,
 	// reopened on reattach so follow-up messages survive a restart. Empty for
@@ -68,9 +84,20 @@ func (c *convoIO) replaceStdinPipe(pipe io.WriteCloser) {
 	c.stdinMu.Unlock()
 }
 
+// writeStdin writes data with the default steer-message timeout. Callers
+// delivering an oversized first prompt use writeStdinTimeout with
+// stdinInitialWriteTimeout instead.
 func (c *convoIO) writeStdin(data []byte) error {
+	return c.writeStdinTimeout(data, stdinWriteTimeout)
+}
+
+func (c *convoIO) writeStdinTimeout(data []byte, timeout time.Duration) error {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
+
+	if c.writeTimeout > 0 {
+		timeout = c.writeTimeout
+	}
 
 	c.stdinMu.Lock()
 	pipe := c.stdinPipe
@@ -92,15 +119,20 @@ func (c *convoIO) writeStdin(data []byte) error {
 		done <- err
 	}()
 
+	// Stoppable timer so the success path (the common case) releases the
+	// runtime timer immediately instead of leaving it armed until it fires.
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
 	select {
 	case err := <-done:
 		if err != nil {
 			return fmt.Errorf("write stdin: %w", err)
 		}
 		return nil
-	case <-time.After(stdinWriteTimeout):
+	case <-timer.C:
 		c.forceClosePipe(pipe)
-		return fmt.Errorf("write stdin: timed out after %s, pipe closed", stdinWriteTimeout)
+		return fmt.Errorf("write stdin: timed out after %s, pipe closed", timeout)
 	}
 }
 
@@ -152,10 +184,17 @@ func encodeUserMessage(text string) ([]byte, error) {
 
 // writeUserMessage writes a user message to the agent's stdin in stream-json format.
 func (m *Manager) writeUserMessage(a *Agent, text string) error {
+	return m.writeUserMessageTimeout(a, text, stdinWriteTimeout)
+}
+
+// writeUserMessageTimeout is writeUserMessage with an explicit write ceiling,
+// used by the initial-prompt path to grant the oversized first payload a
+// longer grace period than a steer message.
+func (m *Manager) writeUserMessageTimeout(a *Agent, text string, timeout time.Duration) error {
 	data, err := encodeUserMessage(text)
 	if err != nil {
 		return err
 	}
 
-	return a.convo.writeStdin(data)
+	return a.convo.writeStdinTimeout(data, timeout)
 }

--- a/internal/agent/convo_io_test.go
+++ b/internal/agent/convo_io_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 )
@@ -101,4 +102,95 @@ func TestConvoIOHasStdinPipeDoesNotBlockBehindWrite(t *testing.T) {
 
 	close(w.release)
 	<-done
+}
+
+// unblockOnCloseWriteCloser models a real *os.File: a blocked Write only
+// returns once Close is called on the same handle, mirroring how closing a
+// pipe/FIFO fd interrupts a pending write on it.
+type unblockOnCloseWriteCloser struct {
+	started   chan struct{}
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func (w *unblockOnCloseWriteCloser) Write(_ []byte) (int, error) {
+	close(w.started)
+	<-w.closed
+	return 0, errors.New("write on closed pipe")
+}
+
+func (w *unblockOnCloseWriteCloser) Close() error {
+	w.closeOnce.Do(func() { close(w.closed) })
+	return nil
+}
+
+// TestConvoIOCloseStdinPipeDoesNotBlockBehindWrite reproduces the deadlock
+// chain from #2546: a wedged writeStdin call used to hold stdinMu for the
+// entire blocking OS write, so closeStdinPipe (called by StopAgent /
+// markAgentDone / the watchdog's stall recovery) blocked on the same mutex
+// forever. closeStdinPipe must always be able to force the pipe closed even
+// while a write is stuck on it.
+func TestConvoIOCloseStdinPipeDoesNotBlockBehindWrite(t *testing.T) {
+	c := convoIO{}
+	w := &unblockOnCloseWriteCloser{
+		started: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+	c.replaceStdinPipe(w)
+
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- c.writeStdin([]byte("blocked"))
+	}()
+	<-w.started
+
+	closeDone := make(chan struct{})
+	go func() {
+		c.closeStdinPipe()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("closeStdinPipe blocked behind writeStdin")
+	}
+
+	select {
+	case err := <-writeDone:
+		if err == nil {
+			t.Fatal("writeStdin succeeded, want error once its pipe was force-closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("writeStdin did not unblock after closeStdinPipe")
+	}
+
+	if c.hasStdinPipe() {
+		t.Fatal("hasStdinPipe = true after closeStdinPipe")
+	}
+}
+
+// TestConvoIOForceClosePipeIgnoresStalePipe verifies the pointer-identity
+// guard in forceClosePipe: a wedged write's timeout can fire after the pipe
+// it was writing to has already been superseded by a newer
+// replaceStdinPipe/closeStdinPipe call. It must not clobber the newer pipe.
+func TestConvoIOForceClosePipeIgnoresStalePipe(t *testing.T) {
+	c := convoIO{}
+	old := &recordingWriteCloser{}
+	newer := &recordingWriteCloser{}
+
+	c.replaceStdinPipe(old)
+	c.replaceStdinPipe(newer)
+
+	c.forceClosePipe(old)
+
+	if !c.hasStdinPipe() {
+		t.Fatal("forceClosePipe on a stale pipe cleared the active pipe")
+	}
+	if err := c.writeStdin([]byte("still works")); err != nil {
+		t.Fatalf("writeStdin after stale forceClosePipe: %v", err)
+	}
+	if got := newer.String(); got != "still works" {
+		t.Fatalf("newer pipe got %q, want %q", got, "still works")
+	}
 }

--- a/internal/agent/convo_io_test.go
+++ b/internal/agent/convo_io_test.go
@@ -11,11 +11,13 @@ import (
 
 type recordingWriteCloser struct {
 	bytes.Buffer
-	closed bool
+	closed     bool
+	closeCount int
 }
 
 func (w *recordingWriteCloser) Close() error {
 	w.closed = true
+	w.closeCount++
 	return nil
 }
 
@@ -223,6 +225,9 @@ func TestConvoIOForceClosePipeIgnoresStalePipe(t *testing.T) {
 
 	if !c.hasStdinPipe() {
 		t.Fatal("forceClosePipe on a stale pipe cleared the active pipe")
+	}
+	if old.closeCount != 1 {
+		t.Fatalf("old pipe closeCount = %d, want 1 (forceClosePipe must not double-close a pipe replaceStdinPipe already closed)", old.closeCount)
 	}
 	if err := c.writeStdin([]byte("still works")); err != nil {
 		t.Fatalf("writeStdin after stale forceClosePipe: %v", err)

--- a/internal/agent/convo_io_test.go
+++ b/internal/agent/convo_io_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -167,6 +168,42 @@ func TestConvoIOCloseStdinPipeDoesNotBlockBehindWrite(t *testing.T) {
 
 	if c.hasStdinPipe() {
 		t.Fatal("hasStdinPipe = true after closeStdinPipe")
+	}
+}
+
+// TestConvoIOWriteStdinSelfTimeout drives writeStdin's own timer branch: with
+// no external closer, a wedged write must self-recover once writeTimeout
+// elapses — force-closing its pipe and returning the "timed out" error. The
+// injectable writeTimeout lets this exercise the real branch without a 30s
+// sleep.
+func TestConvoIOWriteStdinSelfTimeout(t *testing.T) {
+	c := convoIO{writeTimeout: 20 * time.Millisecond}
+	w := &unblockOnCloseWriteCloser{
+		started: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+	c.replaceStdinPipe(w)
+
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- c.writeStdin([]byte("wedged"))
+	}()
+	<-w.started
+
+	select {
+	case err := <-writeDone:
+		if err == nil {
+			t.Fatal("writeStdin succeeded, want timeout error")
+		}
+		if !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("writeStdin err = %v, want timed out", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("writeStdin did not self-timeout")
+	}
+
+	if c.hasStdinPipe() {
+		t.Fatal("hasStdinPipe = true after self-timeout, want pipe force-closed")
 	}
 }
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -313,8 +313,18 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 	// has it. Non-steerable stdin-prompt: always resent on every attempt,
 	// matching what the old positional-argv delivery did unconditionally.
 	if steerable && cfg.Prompt != "" && a.GetSessionID() == "" {
-		if writeErr := m.writeUserMessage(a, cfg.Prompt); writeErr != nil {
+		// Unlike a steer message, the initial prompt is the run's only chance to
+		// reach the child — on failure the child gets EOF having never seen the
+		// task, so a log-and-continue would silently strand the run. Fail the
+		// attempt instead of pressing on as if delivery succeeded.
+		if writeErr := m.writeUserMessageTimeout(a, cfg.Prompt, stdinInitialWriteTimeout); writeErr != nil {
 			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
+			a.convo.closeStdinPipe()
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			_ = cmd.Wait()
+			return false, fmt.Errorf("deliver initial prompt: %w", writeErr)
 		}
 	} else if promptStdin != nil {
 		m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt)
@@ -497,8 +507,17 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 	// attempt, matching what the old positional-argv delivery did
 	// unconditionally.
 	if steerable && cfg.Prompt != "" && a.GetSessionID() == "" {
-		if writeErr := m.writeUserMessage(a, cfg.Prompt); writeErr != nil {
+		// Unlike a steer message, the initial prompt is the run's only chance to
+		// reach the child — on failure the child gets EOF having never seen the
+		// task, so a log-and-continue would silently strand the detached run.
+		// Fail the attempt instead of pressing on as if delivery succeeded.
+		if writeErr := m.writeUserMessageTimeout(a, cfg.Prompt, stdinInitialWriteTimeout); writeErr != nil {
 			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
+			a.convo.closeStdinPipe()
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			return nil, fmt.Errorf("deliver initial prompt: %w", writeErr)
 		}
 	} else if promptStdin != nil {
 		m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -516,6 +516,11 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 			a.convo.closeStdinPipe()
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
+				// This process is the killed child's real OS parent, and the
+				// caller only starts its cmd.Wait() reaper after a successful
+				// start — so reap here to avoid leaking a zombie, mirroring the
+				// pipe variant's kill path.
+				_ = cmd.Wait()
 			}
 			return nil, fmt.Errorf("deliver initial prompt: %w", writeErr)
 		}


### PR DESCRIPTION
## Motivation

A wedged stdin write could hold stdinMu for the OS write's full duration, deadlocking the watchdog's stall recovery and the stopped-agent release path, silently starving the review/PR-fix pipeline.

## Implementation information

writeStdin no longer holds stdinMu across the blocking OS write; the lock is only held for pipe-handle bookkeeping, with a bounded timeout mirroring the watchdog's zero-output stall timeout so closeStdinPipe can always make progress.

> Changelog: fix(agent): don't hold stdinMu across blocking stdin write

Closes https://github.com/Automaat/sybra/issues/2546

_Generated by Sybra harness_