### PR TITLE
fix(monitor): guard detectStuckHumanBlocked against umbrella tasks

### DIFF
--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -127,7 +127,12 @@ func (r *remediator) remediateHumanRequiredStuck(ctx context.Context, a Anomaly)
 		return string(a.Kind) + ":merged:" + a.TaskID, nil
 	}
 	if known, _ := a.Evidence["known_lost_agent_investigation"].(bool); known {
-		if humanReviewVerdict(a) == "human" || workflow.IsTamperFlaggedReason(t.StatusReason) {
+		// Umbrella trackers run no agent of their own — their in-progress is a
+		// rollup of their children (app_umbrella_gate.go), not a dispatchable
+		// unit of work. Flipping one straight to in-progress here bypasses the
+		// only umbrella-guarded dispatch choke point (agentorch.startAgent) and
+		// re-triggers the exact bug #2610 fixed. Mirrors detectLostAgents.
+		if humanReviewVerdict(a) == "human" || workflow.IsTamperFlaggedReason(t.StatusReason) || t.TaskType == task.TaskTypeUmbrella {
 			return r.refreshHumanRequiredStuck(a)
 		}
 		return r.retryKnownLostAgentStuck(a, t)

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -336,6 +336,43 @@ func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_HumanVerdictDoesNotRet
 	}
 }
 
+func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_UmbrellaDoesNotRetry(t *testing.T) {
+	t.Parallel()
+	existing := mkTask("hr5", task.StatusHumanRequired, func(t *task.Task) {
+		t.StatusReason = "watchdog: stop"
+		t.Tags = []string{"medium"}
+		t.TaskType = task.TaskTypeUmbrella
+	})
+	ft := &fakeTasks{tasks: []task.Task{existing}}
+	rem := newRemediator(ft, nil, nil, nil)
+	a := Anomaly{
+		Kind:   KindStuckHumanBlocked,
+		TaskID: "hr5",
+		Evidence: map[string]any{
+			"status":                         "human-required",
+			"known_lost_agent_investigation": true,
+		},
+	}
+
+	label, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if label == "" {
+		t.Fatal("expected non-empty label")
+	}
+	if len(ft.updates) != 1 {
+		t.Fatalf("want 1 update, got %d", len(ft.updates))
+	}
+	u := ft.updates[0]
+	if u.u.Status != nil {
+		t.Fatalf("status must not change for umbrella tracker, got %v", u.u.Status)
+	}
+	if u.u.Tags != nil {
+		t.Fatalf("tags must not change for umbrella tracker, got %v", *u.u.Tags)
+	}
+}
+
 func TestRemediator_StuckHumanBlocked_KnownLostAgentCause_TamperFlagDoesNotRetry(t *testing.T) {
 	t.Parallel()
 	existing := mkTask("hr4", task.StatusHumanRequired, func(t *task.Task) {


### PR DESCRIPTION
## Motivation

detectStuckHumanBlocked had no TaskTypeUmbrella guard, unlike its sibling detectLostAgents, letting stale lost-agent investigations flip umbrella tasks back to in-progress without dispatching through agentorch's startAgent choke point.

## Implementation information

Adds the same TaskTypeUmbrella guard already present in detectLostAgents to the stuck-human-blocked remediation path.

> Changelog: fix(monitor): guard detectStuckHumanBlocked against umbrella tasks

Closes https://github.com/Automaat/sybra/issues/2617

_Generated by Sybra harness_