### PR TITLE
feat(triage): enforce executable task admission contracts

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -12,7 +12,7 @@ Regenerate with `go generate ./internal/config/...` after changing a struct tag 
 |---|---|---|
 | `instance` | Machine role, local routing, and operator-scoped UX defaults. | `instance`, `instance.project_types` |
 | `execution` | How Sybra launches and routes agent work across providers and local backends. | `execution.agent`, `execution.providers` |
-| `workflow` | Task-stage policy, planning/testing orchestration, and board-driven automation. | `workflow.orchestrator`, `workflow.testing`, `workflow.triage`, `workflow.umbrella` |
+| `workflow` | Task-stage policy, planning/testing orchestration, and board-driven automation. | `workflow.orchestrator`, `workflow.testing`, `workflow.triage`, `workflow.umbrella`, `workflow.admission` |
 | `integrations` | External systems Sybra talks to on the operator's behalf. | `integrations.notification`, `integrations.github`, `integrations.renovate`, `integrations.browser` |
 | `supervision` | Health checks, review escalation, and autonomous oversight loops. | `supervision.human_review`, `supervision.monitor`, `supervision.watchdog`, `supervision.self_monitor`, `supervision.evaluation`, `supervision.learning_digest`, `supervision.harness_evolution`, `supervision.prompt_lab` |
 | `storage` | Filesystem-backed retention and path layout under SYBRA_HOME. | `storage.attachments`, `storage.trash`, `storage.sandboxes`, `storage.task_snapshot`, `storage.paths` |
@@ -296,6 +296,21 @@ atomically applies the verdict (title, tags, size/type, mode, project).
 | `workflow.triage.enabled` | `bool` | `false` |  |  | `triage.enabled` | `false` | `hot` |  |  |
 | `workflow.triage.poll` | `int` | `60` | `seconds` |  | `triage.poll_seconds`, `triage.poll` | `false` | `hot` |  |  |
 | `workflow.triage.model` | `string` | `""` |  |  | `triage.model` | `false` | `hot` |  |  |
+
+### AdmissionConfig (`workflow.admission`)
+
+AdmissionConfig gates the workflow engine's admission_preflight step (see
+internal/workflow/engine_steps_admission.go), a deterministic pre-dispatch
+check that rejects a task's plan contract for missing admission facts
+(objective, unrecognized required_capabilities), oversized scope, or a
+failing push-credential preflight — before any code-author agent is
+dispatched.
+
+| YAML key | Type | Default | Unit | Env override | Legacy aliases | Secret | Reload | Constraints | Description |
+|---|---|---|---|---|---|---|---|---|---|
+| `workflow.admission.enabled` | `bool` | `true` |  |  | `admission.enabled` | `false` | `restart` |  | Enabled turns the admission_preflight step's checks on. Defaults true (see applyAdmissionDefaults) — safe because a contract with no schema_version (every contract generated before this feature shipped) validates exactly as it did before this migration, and the size limits below default to 0 (disabled), so enabling this does not retroactively block any in-flight task. |
+| `workflow.admission.max_acceptance_criteria` | `int` | `0` |  |  | `admission.max_acceptance_criteria` | `false` | `restart` |  | MaxAcceptanceCriteria caps a plan contract's acceptance_criteria count before admission_preflight flags the task as oversized (an operator_decision human-required, not an automatic split — auto-split is deferred, see #2466 Fix point 5). Zero disables the limit. |
+| `workflow.admission.max_change_surface_files` | `int` | `0` |  |  | `admission.max_change_surface_files` | `false` | `restart` |  | MaxChangeSurfaceFiles caps a plan contract's files count the same way. Zero disables the limit. |
 
 ## Integrations
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -996,6 +996,19 @@ export enum StepType {
      * agent invoking the /sybra-triage skill around this same classifier.
      */
     StepClassifyTask = "classify_task",
+
+    /**
+     * StepAdmissionPreflight runs deterministic pre-dispatch admission checks
+     * (plan contract schema/capability validation, oversize scope limits,
+     * push credential readiness) before any code-author agent is dispatched —
+     * see execAdmissionPreflight (engine_steps_admission.go). Recoverable
+     * environment failures (missing push credentials) route through a
+     * blocker.KindCredentialRequired; scope/content problems (missing
+     * objective, unknown capability, oversize scope) route through
+     * blocker.KindOperatorDecision — both terminal (no automatic
+     * re-attempts), matching blocker.AllowsHumanRequired.
+     */
+    StepAdmissionPreflight = "admission_preflight",
 };
 
 /**

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -1006,7 +1006,10 @@ export enum StepType {
      * blocker.KindCredentialRequired; scope/content problems (missing
      * objective, unknown capability, oversize scope) route through
      * blocker.KindOperatorDecision — both terminal (no automatic
-     * re-attempts), matching blocker.AllowsHumanRequired.
+     * re-attempts), matching blocker.AllowsHumanRequired. Listed in
+     * isResumableStepType (like StepClassifyTask): it is deterministic and
+     * side-effect-free until it decides, so re-running it after a crash
+     * between persisting CurrentStep and executing it is safe.
      */
     StepAdmissionPreflight = "admission_preflight",
 };

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -1001,15 +1001,17 @@ export enum StepType {
      * StepAdmissionPreflight runs deterministic pre-dispatch admission checks
      * (plan contract schema/capability validation, oversize scope limits,
      * push credential readiness) before any code-author agent is dispatched —
-     * see execAdmissionPreflight (engine_steps_admission.go). Recoverable
-     * environment failures (missing push credentials) route through a
-     * blocker.KindCredentialRequired; scope/content problems (missing
-     * objective, unknown capability, oversize scope) route through
-     * blocker.KindOperatorDecision — both terminal (no automatic
-     * re-attempts), matching blocker.AllowsHumanRequired. Listed in
-     * isResumableStepType (like StepClassifyTask): it is deterministic and
-     * side-effect-free until it decides, so re-running it after a crash
-     * between persisting CurrentStep and executing it is safe.
+     * see execAdmissionPreflight (engine_steps_admission.go). Scope/content
+     * problems (missing objective, unknown capability, oversize scope) and a
+     * non-transient credential failure both route through human-required —
+     * the former always blocker.KindOperatorDecision, the latter
+     * blocker.KindCredentialRequired — as terminal (no automatic re-attempts),
+     * matching blocker.AllowsHumanRequired. A transient/rate-limited
+     * credential-preflight error is NOT terminal: classifyAdmissionCredentialError
+     * parks the step for a bounded retry instead, mirroring push_branch/
+     * create_pr's identical classification of the same error. Resumable —
+     * see isResumableStepType — so a crash between persisting CurrentStep and
+     * executing it does not strand the task.
      */
     StepAdmissionPreflight = "admission_preflight",
 };

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -21,10 +21,17 @@ const (
 	EventPlanApproved         = "plan.approved"
 	EventPlanRejected         = "plan.rejected"
 	EventEvalCompleted        = "eval.completed"
-	EventOrchestratorStart    = "orchestrator.started"
-	EventOrchestratorStop     = "orchestrator.stopped"
-	EventPRConflictDetected   = "pr_monitor.conflict_detected"
-	EventPRCIFailureDetected  = "pr_monitor.ci_failure_detected"
+	// EventAdmissionDecided records the workflow engine's admission_preflight
+	// step outcome (internal/workflow/engine_steps_admission.go) — "admitted"
+	// or "blocked" — plus the task's declared risk_tier/permission_tier and,
+	// on a block, the blocker.Kind and reason. Recorded on every dispatch,
+	// not just blocks, so evaluation can correlate predicted risk/clarity
+	// against actual task outcome.
+	EventAdmissionDecided    = "admission.decided"
+	EventOrchestratorStart   = "orchestrator.started"
+	EventOrchestratorStop    = "orchestrator.stopped"
+	EventPRConflictDetected  = "pr_monitor.conflict_detected"
+	EventPRCIFailureDetected = "pr_monitor.ci_failure_detected"
 	// EventPRCIFlakyDetected records that a ci_failure issue's failing check
 	// names all also show a passing outcome for the same head commit (see
 	// github.flakyOnlyFailure) — noise, not a deterministic regression. The

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Triage         TriageConfig         `yaml:"triage" json:"triage"`
 	HumanReview    HumanReviewConfig    `yaml:"human_review" json:"humanReview"`
 	ReviewHold     ReviewHoldConfig     `yaml:"review_hold" json:"reviewHold"`
+	Admission      AdmissionConfig      `yaml:"admission" json:"admission"`
 	Monitor        MonitorConfig        `yaml:"monitor" json:"monitor"`
 	Watchdog       WatchdogConfig       `yaml:"watchdog" json:"watchdog"`
 	SelfMonitor    SelfMonitorConfig    `yaml:"self_monitor" json:"selfMonitor"`

--- a/internal/config/config_admission.go
+++ b/internal/config/config_admission.go
@@ -1,0 +1,25 @@
+package config
+
+// AdmissionConfig gates the workflow engine's admission_preflight step (see
+// internal/workflow/engine_steps_admission.go), a deterministic pre-dispatch
+// check that rejects a task's plan contract for missing admission facts
+// (objective, unrecognized required_capabilities), oversized scope, or a
+// failing push-credential preflight — before any code-author agent is
+// dispatched.
+type AdmissionConfig struct {
+	// Enabled turns the admission_preflight step's checks on. Defaults true
+	// (see applyAdmissionDefaults) — safe because a contract with no
+	// schema_version (every contract generated before this feature shipped)
+	// validates exactly as it did before this migration, and the size limits
+	// below default to 0 (disabled), so enabling this does not retroactively
+	// block any in-flight task.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// MaxAcceptanceCriteria caps a plan contract's acceptance_criteria count
+	// before admission_preflight flags the task as oversized (an
+	// operator_decision human-required, not an automatic split — auto-split
+	// is deferred, see #2466 Fix point 5). Zero disables the limit.
+	MaxAcceptanceCriteria int `yaml:"max_acceptance_criteria" json:"maxAcceptanceCriteria"`
+	// MaxChangeSurfaceFiles caps a plan contract's files count the same way.
+	// Zero disables the limit.
+	MaxChangeSurfaceFiles int `yaml:"max_change_surface_files" json:"maxChangeSurfaceFiles"`
+}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -1086,6 +1086,39 @@ func (c *Config) ReviewHoldNitMaxLines() int {
 	return c.ReviewHold.NitMaxLines
 }
 
+// Admission size limits default to 0 (disabled) — auto-splitting an
+// oversized task into a gated DAG is deferred (#2466 Fix point 5), so these
+// only ever flag a task for a human, never reshape it.
+const (
+	DefaultAdmissionMaxAcceptanceCriteria = 0
+	DefaultAdmissionMaxChangeSurfaceFiles = 0
+)
+
+// applyAdmissionDefaults defaults Enabled to true unless the file explicitly
+// disabled it — using file.Has (not the zero value) so an operator who
+// explicitly set `admission.enabled: false` is never silently re-enabled on
+// the next resolve, mirroring applySelfMonitorDefaults' DryRun handling.
+// True-by-default is safe here: a plan contract with no schema_version (every
+// contract generated before this feature shipped) validates unchanged, and
+// the size limits below stay off unless explicitly configured.
+func applyAdmissionDefaults(cfg *Config, file *FileConfig) {
+	if file == nil || !file.Has("admission", "enabled") {
+		cfg.Admission.Enabled = true
+	}
+	if cfg.Admission.MaxAcceptanceCriteria < 0 {
+		cfg.Admission.MaxAcceptanceCriteria = DefaultAdmissionMaxAcceptanceCriteria
+	}
+	if cfg.Admission.MaxChangeSurfaceFiles < 0 {
+		cfg.Admission.MaxChangeSurfaceFiles = DefaultAdmissionMaxChangeSurfaceFiles
+	}
+}
+
+// AdmissionEnabled reports whether admission_preflight's checks are active.
+// Nil-safe for test construction.
+func (c *Config) AdmissionEnabled() bool {
+	return c != nil && c.Admission.Enabled
+}
+
 func applyExperienceDefaults(cfg *Config) {
 	if cfg.Experience.MaxRecords <= 0 {
 		cfg.Experience.MaxRecords = 5

--- a/internal/config/config_migration.go
+++ b/internal/config/config_migration.go
@@ -20,7 +20,7 @@ type V2NamespaceDoc struct {
 var v2NamespaceDocs = []V2NamespaceDoc{
 	{Name: "instance", OwnershipRule: "Machine role, local routing, and operator-scoped UX defaults.", Paths: []string{"instance", "instance.project_types"}},
 	{Name: "execution", OwnershipRule: "How Sybra launches and routes agent work across providers and local backends.", Paths: []string{"execution.agent", "execution.providers"}},
-	{Name: "workflow", OwnershipRule: "Task-stage policy, planning/testing orchestration, and board-driven automation.", Paths: []string{"workflow.orchestrator", "workflow.testing", "workflow.triage", "workflow.umbrella"}},
+	{Name: "workflow", OwnershipRule: "Task-stage policy, planning/testing orchestration, and board-driven automation.", Paths: []string{"workflow.orchestrator", "workflow.testing", "workflow.triage", "workflow.umbrella", "workflow.admission"}},
 	{Name: "integrations", OwnershipRule: "External systems Sybra talks to on the operator's behalf.", Paths: []string{"integrations.notification", "integrations.github", "integrations.renovate", "integrations.browser"}},
 	{Name: "supervision", OwnershipRule: "Health checks, review escalation, and autonomous oversight loops.", Paths: []string{"supervision.human_review", "supervision.monitor", "supervision.watchdog", "supervision.self_monitor", "supervision.evaluation", "supervision.learning_digest", "supervision.harness_evolution", "supervision.prompt_lab"}},
 	{Name: "storage", OwnershipRule: "Filesystem-backed retention and path layout under SYBRA_HOME.", Paths: []string{"storage.attachments", "storage.trash", "storage.sandboxes", "storage.task_snapshot", "storage.paths"}},
@@ -62,6 +62,7 @@ var topLevelNamespaceRules = []topLevelNamespaceRule{
 	{legacyKey: "orchestrator", canonical: []string{"workflow", "orchestrator"}, deprecated: "workflow.orchestrator", namespace: "workflow"},
 	{legacyKey: "triage", canonical: []string{"workflow", "triage"}, deprecated: "workflow.triage", namespace: "workflow"},
 	{legacyKey: "umbrella", canonical: []string{"workflow", "umbrella"}, deprecated: "workflow.umbrella", namespace: "workflow"},
+	{legacyKey: "admission", canonical: []string{"workflow", "admission"}, deprecated: "workflow.admission", namespace: "workflow"},
 	{legacyKey: "notification", canonical: []string{"integrations", "notification"}, deprecated: "integrations.notification", namespace: "integrations"},
 	{legacyKey: "github", canonical: []string{"integrations", "github"}, deprecated: "integrations.github", namespace: "integrations"},
 	{legacyKey: "review_hold", canonical: []string{"integrations", "github", "review_hold"}, deprecated: "integrations.github.review_hold", namespace: "integrations"},
@@ -167,6 +168,7 @@ func NormalizeV2Document(root *yaml.Node) (*yaml.Node, []string, error) {
 				"testing":      "testing",
 				"triage":       "triage",
 				"umbrella":     "umbrella",
+				"admission":    "admission",
 			}, "workflow"); err != nil {
 				return nil, nil, err
 			}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -199,4 +199,5 @@ func applyResolvedDefaults(cfg *ResolvedConfig, file *FileConfig) {
 	applyAutoUpdateDefaults(cfg)
 	applyGitHubPollingCompat(cfg, file)
 	applyReviewHoldDefaults(cfg)
+	applyAdmissionDefaults(cfg, file)
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1265,6 +1265,7 @@ func (a *App) configureWorkflowPolicies() {
 	a.workflowEngine.SetMaxCheckpoints(a.cfg.MaxCheckpoints())
 	a.workflowEngine.SetABTestingConfig(a.abTestingConfig())
 	a.configurePlanAutoApproval()
+	a.configureAdmissionPolicy()
 }
 
 func (a *App) configurePlanAutoApproval() {
@@ -1273,6 +1274,22 @@ func (a *App) configurePlanAutoApproval() {
 		a.logAudit(audit.EventPlanApproved, t.ID, "", map[string]any{
 			"auto":   true,
 			"reason": reason,
+		})
+	})
+}
+
+// configureAdmissionPolicy wires the admission_preflight step's config and
+// its audit hook. The hook writes admission.decided without making
+// internal/workflow import internal/audit — mirrors configurePlanAutoApproval.
+func (a *App) configureAdmissionPolicy() {
+	a.workflowEngine.SetAdmissionConfig(a.cfg.Admission)
+	a.workflowEngine.SetAdmissionDecisionHook(func(t workflow.TaskInfo, d workflow.AdmissionDecision) {
+		a.logAudit(audit.EventAdmissionDecided, t.ID, "", map[string]any{
+			"outcome":         d.Outcome,
+			"risk_tier":       d.RiskTier,
+			"permission_tier": d.PermissionTier,
+			"blocker_kind":    d.BlockerKind,
+			"reason":          d.Reason,
 		})
 	})
 }

--- a/internal/sybra/config_registry.go
+++ b/internal/sybra/config_registry.go
@@ -73,6 +73,12 @@ var configRegistry = []configRegistryEntry{
 	{Path: "github", Policy: configPolicyRestart, Visibility: configVisibilityUI},
 	{Path: "umbrella", Policy: configPolicyRestart, Visibility: configVisibilityUI},
 	{Path: "triage", Policy: configPolicyHot, Visibility: configVisibilityUI},
+	// restart, not hot: the workflow engine caches this via
+	// SetAdmissionConfig (configureAdmissionPolicy, called once from
+	// initWorkflowEngine) into an unexported Engine field, mirroring
+	// orchestrator/monitor/self_monitor's read-once-at-startup tickers below
+	// — there is no live re-arm point that would pick up a config hot-swap.
+	{Path: "admission", Policy: configPolicyRestart, Visibility: configVisibilityUI},
 	{Path: "human_review", Policy: configPolicyHot, Visibility: configVisibilityRaw},
 	{Path: "review_hold", Policy: configPolicyHot, Visibility: configVisibilityRaw},
 	{Path: "monitor", Policy: configPolicyRestart, Visibility: configVisibilityUI},

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -19,6 +19,25 @@ trigger:
       operator: not_contains
       value: prompt-lab-proposal
 steps:
+  # Mechanical check (no LLM): deterministic pre-dispatch admission checks —
+  # plan contract validity (including v2 admission-facts fields), oversize
+  # scope, and push credential readiness — before any code-author agent is
+  # dispatched. Covers both the planned path (already checked once by
+  # simple-task-plan's validate_plan_contract) and the noplan/handoff paths
+  # that reach in-progress without ever running that step. A failure flips
+  # the task to human-required with a terminal credential_required or
+  # operator_decision blocker; see execAdmissionPreflight.
+  - id: admission_preflight
+    name: Admission Preflight
+    type: admission_preflight
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: implement
+
   - id: implement
     name: Implement
     type: run_agent

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -226,6 +226,8 @@ steps:
 
                 {
                   "task_id": "{{.Task.ID}}",
+                  "schema_version": "2",
+                  "objective": "one-line statement of what 'done' means for this task",
                   "branch": "<current branch>",
                   "worktree": "<current working directory>",
                   "files": [
@@ -236,6 +238,8 @@ steps:
                     "internal/foo/legacy_test.go",
                     "testdata/*.golden"
                   ],
+                  "dependencies": ["other-task-id-or-external-resource-this-depends-on"],
+                  "required_capabilities": ["repo_write"],
                   "verification": [
                     {"command": "go test ./...", "expected": "tests pass"},
                     {"manual": "manual inspection or smoke test", "expected": "observable result"}
@@ -262,6 +266,14 @@ steps:
                 source criterion out of scope; if a source criterion needs a
                 human scope decision, record that in .sybra-plan-decisions and
                 keep it in the contract.
+
+                Always set schema_version to "2" and objective is required.
+                `dependencies` is optional: omit it or write `[]` when this
+                task has none. `required_capabilities` must be a subset of
+                this closed set: `repo_write`, `network`, `provider`,
+                `git_push` — omit it or write `[]` when the task needs none
+                beyond ordinary repo edits; do not invent new capability
+                names, admission_preflight rejects anything outside this set.
 
         Do NOT call sybra-cli update — Sybra will ingest your file as the
         task sidecars after you exit. Do NOT modify task fields directly.

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Automaat/sybra/internal/abtest"
@@ -363,8 +364,11 @@ type Engine struct {
 	dispatchGate     func(TaskInfo) bool
 	// dispatchDisabled is stored negated so the zero value keeps a
 	// struct-literal Engine dispatching, matching its behavior before this
-	// gate existed.
-	dispatchDisabled bool
+	// gate existed. atomic.Bool because SetAutoDispatch (config/lifecycle
+	// goroutines) and the read sites (startWorkflowCore, DispatchEvent,
+	// HandleStatusChange, ResumeStalled — all called from agent/workflow
+	// goroutines) run concurrently with no shared lock between them.
+	dispatchDisabled atomic.Bool
 	logger           *slog.Logger
 	ctx              context.Context
 	mu               sync.Mutex
@@ -522,13 +526,13 @@ func (e *Engine) SetDispatchGate(gate func(TaskInfo) bool) { e.dispatchGate = ga
 // agent starts (App.StartAgent, sybra-cli) never touch the engine and keep
 // working. Set orchestrator.scheduler_enabled true to opt an agent-only
 // instance back into workflows.
-func (e *Engine) SetAutoDispatch(on bool) { e.dispatchDisabled = !on }
+func (e *Engine) SetAutoDispatch(on bool) { e.dispatchDisabled.Store(!on) }
 
 // AutoDispatchEnabled reports whether this instance dispatches workflows. The
 // gate in startWorkflowCore is what actually enforces it; this lets a caller
 // avoid announcing an auto-start that is about to be refused, and avoid
 // spawning a goroutine that would only no-op.
-func (e *Engine) AutoDispatchEnabled() bool { return !e.dispatchDisabled }
+func (e *Engine) AutoDispatchEnabled() bool { return !e.dispatchDisabled.Load() }
 
 // SetAutoApprovePlansWithoutDecisions enables automatic approval of validated
 // simple-task plans whose decision sidecar explicitly says there are no open

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -455,7 +455,11 @@ type AdmissionDecision struct {
 	// BlockerKind is the blocker.Kind string set on a "blocked" outcome
 	// (empty on "admitted").
 	BlockerKind string
-	Reason      string
+	// Reason is the full block reason on a "blocked" outcome, or one of
+	// "admitted" (checks ran and passed) / "disabled" (admission.Enabled is
+	// false, no checks ran) on an "admitted" outcome — never empty, so
+	// consumers can distinguish a real pass from a skipped check.
+	Reason string
 }
 
 // defaultTestAttempts is the generous absolute backstop for the testing →

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -430,6 +430,32 @@ type Engine struct {
 	queueReconciler                  func()
 	autoApprovePlansWithoutDecisions bool
 	planAutoApproveHook              func(TaskInfo, string)
+	// admission configures the admission_preflight step's oversize checks
+	// (zero-value MaxAcceptanceCriteria/MaxChangeSurfaceFiles disables them,
+	// matching config.AdmissionConfig's own default). SetAdmissionConfig's
+	// doc comment covers Enabled.
+	admission config.AdmissionConfig
+	// admissionDecisionHook observes every admission_preflight outcome. It is
+	// used by the app layer to write the admission.decided audit event
+	// without making workflow import the audit package — mirrors
+	// planAutoApproveHook.
+	admissionDecisionHook func(TaskInfo, AdmissionDecision)
+}
+
+// AdmissionDecision summarizes one admission_preflight step outcome, passed
+// to the hook installed via SetAdmissionDecisionHook.
+type AdmissionDecision struct {
+	// Outcome is "admitted" or "blocked".
+	Outcome string
+	// RiskTier/PermissionTier echo the task's plan contract fields (empty
+	// when no contract is present), so evaluation can correlate predicted
+	// risk/clarity against the actual admission and eventual task outcome.
+	RiskTier       string
+	PermissionTier string
+	// BlockerKind is the blocker.Kind string set on a "blocked" outcome
+	// (empty on "admitted").
+	BlockerKind string
+	Reason      string
 }
 
 // defaultTestAttempts is the generous absolute backstop for the testing →
@@ -512,6 +538,23 @@ func (e *Engine) SetAutoApprovePlansWithoutDecisions(enabled bool) {
 // the audit package.
 func (e *Engine) SetPlanAutoApproveHook(hook func(TaskInfo, string)) {
 	e.planAutoApproveHook = hook
+}
+
+// SetAdmissionConfig wires the admission_preflight step's oversize limits.
+// Enabled defaults false in a zero-value config (matching every other
+// Engine dependency's nil-safe default); the app layer resolves
+// config.AdmissionConfig's own default-true before calling this, so an
+// unwired Engine (e.g. in unit tests) safely runs the step as a no-op.
+func (e *Engine) SetAdmissionConfig(cfg config.AdmissionConfig) {
+	e.admission = cfg
+}
+
+// SetAdmissionDecisionHook installs an observer for every admission_preflight
+// outcome. It is used by the app layer to write the admission.decided audit
+// event without making workflow import the audit package — mirrors
+// SetPlanAutoApproveHook.
+func (e *Engine) SetAdmissionDecisionHook(hook func(TaskInfo, AdmissionDecision)) {
+	e.admissionDecisionHook = hook
 }
 
 // Defs returns the workflow definition store.

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -672,7 +672,7 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 	case StepClassifyTask:
 		return e.execClassifyTask(taskID, step, wfExec)
 	case StepAdmissionPreflight:
-		return e.execAdmissionPreflight(taskID, step, t)
+		return e.execAdmissionPreflight(taskID, step, wfExec, t)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -553,7 +553,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return comp, err
 		case StepWaitHuman:
 			return nil, wrapDispatchErr(step.ID, e.execWaitHuman(taskID, step, wfExec))
-		case StepClearPlanArtifacts, StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepFlagPlanCritique, StepDetectTampering, StepVerifyChecks, StepFocusedChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch, StepCreatePR, StepClassifyTask:
+		case StepClearPlanArtifacts, StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepFlagPlanCritique, StepDetectTampering, StepVerifyChecks, StepFocusedChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch, StepCreatePR, StepClassifyTask, StepAdmissionPreflight:
 			// handled below as sync steps
 		default:
 			return nil, fmt.Errorf("unknown step type %q", step.Type)
@@ -671,6 +671,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execCreatePR(taskID, step, wfExec, t)
 	case StepClassifyTask:
 		return e.execClassifyTask(taskID, step, wfExec)
+	case StepAdmissionPreflight:
+		return e.execAdmissionPreflight(taskID, step, t)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -85,7 +85,7 @@ func (e *Engine) startWorkflowCore(taskID, workflowID, startStepID string, vars 
 	// The gate lives here, not on the exported Start*/Replace* entries: every
 	// one of them funnels through this function, so a caller cannot start a
 	// workflow by reaching past it.
-	if e.dispatchDisabled {
+	if e.dispatchDisabled.Load() {
 		return nil, ErrAutoDispatchDisabled
 	}
 	// Guard against sequential duplicate starts: the starting map only prevents
@@ -236,7 +236,7 @@ func (e *Engine) matchWorkflow(t TaskInfo, event string, extra map[string]string
 // want to replace an active workflow should use ReplaceWorkflow or
 // ReplaceWorkflowForEvent.
 func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[string]string) (string, error) {
-	if e.dispatchDisabled {
+	if e.dispatchDisabled.Load() {
 		return "", ErrAutoDispatchDisabled
 	}
 	// Serialize event-driven workflow dispatch attempts per task. The shared

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1053,7 +1053,7 @@ func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
 
 func isResumableStepType(t StepType) bool {
 	switch t {
-	case StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepVerifyChecks, StepCreatePR, StepPushBranch, StepPromoteBestOfN:
+	case StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepVerifyChecks, StepCreatePR, StepPushBranch, StepPromoteBestOfN, StepAdmissionPreflight:
 		return true
 	default:
 		return false

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -226,7 +226,7 @@ func (e *Engine) advanceSatisfiedWaitForStatus(taskID string, t TaskInfo) (TaskI
 // Safe to call for any status change — no-ops when the current step does
 // not declare wait_for_status or when the status does not match.
 func (e *Engine) HandleStatusChange(taskID, newStatus string) {
-	if e.dispatchDisabled {
+	if e.dispatchDisabled.Load() {
 		return
 	}
 	t, err := e.tasks.GetTask(taskID)
@@ -1189,7 +1189,7 @@ func (e *Engine) handleMissingStep(t *TaskInfo) {
 }
 
 func (e *Engine) ResumeStalled() {
-	if e.dispatchDisabled {
+	if e.dispatchDisabled.Load() {
 		return
 	}
 	// Prune stale admission-queue items (missing/terminal/in-progress tasks)

--- a/internal/workflow/engine_reconcile.go
+++ b/internal/workflow/engine_reconcile.go
@@ -105,7 +105,7 @@ func (e *Engine) findReachableWaitHumanByStatus(def *Definition, current *Step, 
 			StepDetectTampering, StepVerifyChecks, StepFocusedChecks,
 			StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch,
 			StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch,
-			StepCreatePR, StepClassifyTask:
+			StepCreatePR, StepClassifyTask, StepAdmissionPreflight:
 			return nil, false, false, nil
 		}
 		nextID, err = ResolveTransition(step.Next, fields)

--- a/internal/workflow/engine_resume_pr_steps_test.go
+++ b/internal/workflow/engine_resume_pr_steps_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestIsResumableStepType(t *testing.T) {
-	resumable := []StepType{StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepVerifyChecks, StepCreatePR, StepPushBranch, StepPromoteBestOfN}
+	resumable := []StepType{StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepVerifyChecks, StepCreatePR, StepPushBranch, StepPromoteBestOfN, StepAdmissionPreflight}
 	for _, st := range resumable {
 		if !isResumableStepType(st) {
 			t.Errorf("isResumableStepType(%q) = false, want true", st)

--- a/internal/workflow/engine_resume_pr_steps_test.go
+++ b/internal/workflow/engine_resume_pr_steps_test.go
@@ -3,10 +3,12 @@ package workflow
 import (
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/config"
 )
 
 func TestIsResumableStepType(t *testing.T) {
-	resumable := []StepType{StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepVerifyChecks, StepCreatePR, StepPushBranch, StepPromoteBestOfN}
+	resumable := []StepType{StepRunAgent, StepParallel, StepBestOfN, StepClassifyTask, StepVerifyChecks, StepCreatePR, StepPushBranch, StepPromoteBestOfN, StepAdmissionPreflight}
 	for _, st := range resumable {
 		if !isResumableStepType(st) {
 			t.Errorf("isResumableStepType(%q) = false, want true", st)
@@ -148,5 +150,49 @@ func TestResumeStalled_ResumesParkedPushBranch(t *testing.T) {
 	if ti.Workflow.State != ExecCompleted || ti.Workflow.CurrentStep != "" {
 		t.Fatalf("workflow state = %v at step %q, want completed — parked push_existing_pr was not resumed (reason=%q)",
 			ti.Workflow.State, ti.Workflow.CurrentStep, tasks.Reason("t1"))
+	}
+}
+
+// TestResumeStalled_ResumesParkedAdmissionPreflight guards against the crash
+// window a stuck admission_preflight leaves behind: CurrentStep persisted but
+// the step never executed. Before admission_preflight was added to
+// isResumableStepType, ResumeStalled refused to touch this task and it stayed
+// stuck at in-progress indefinitely (see PR #2631 review).
+func TestResumeStalled_ResumesParkedAdmissionPreflight(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.Save(Definition{
+		ID:   "admission-wf",
+		Name: "admission wf",
+		Steps: []Step{
+			{ID: "admission_preflight", Name: "Admission Preflight", Type: StepAdmissionPreflight, Next: []Transition{{GoTo: ""}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "in-progress",
+		Workflow: &Execution{
+			WorkflowID:  "admission-wf",
+			CurrentStep: "admission_preflight",
+			State:       ExecRunning,
+			Variables:   map[string]string{},
+		},
+	})
+
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+
+	engine.ResumeStalled()
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow.State != ExecCompleted || ti.Workflow.CurrentStep != "" {
+		t.Fatalf("workflow state = %v at step %q, want completed — parked admission_preflight was not resumed (reason=%q)",
+			ti.Workflow.State, ti.Workflow.CurrentStep, tasks.Reason("t1"))
+	}
+	if ti.Status == "human-required" {
+		t.Fatalf("status = %q, want not human-required (no plan contract must admit)", ti.Status)
 	}
 }

--- a/internal/workflow/engine_steps_admission.go
+++ b/internal/workflow/engine_steps_admission.go
@@ -1,0 +1,194 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/blocker"
+)
+
+// admissionPreflightReasonPrefix marks a human-required status_reason as
+// having been written by admission_preflight, mirroring
+// TamperFlaggedReasonPrefix/verifyBlessedTag's pattern for other mechanical
+// gates — lets health checks and dashboards group admission blocks distinctly
+// from other human-required causes.
+const admissionPreflightReasonPrefix = "admission preflight blocked:"
+
+// execAdmissionPreflight runs deterministic pre-dispatch admission checks
+// before any code-author agent is dispatched: it is wired as the first step
+// of simple-task-implement, so it covers both the planned path (a plan
+// contract already validated once by validate_plan_contract during planning)
+// and the noplan/handoff paths (a task that reaches in-progress without ever
+// running that step — e.g. a simple task, or `sybra-cli handoff --stage
+// implement`).
+//
+// Checks, in order:
+//  1. Plan contract validity (schema + admission-facts fields under
+//     PlanContractSchemaV2) via the same ValidatePlanContractForTask the
+//     planning-time gate uses — a no-op for an absent contract (the
+//     markdown-only migration fallback, matching execValidatePlanContract).
+//  2. Oversize scope, when the app config sets a non-zero limit: the
+//     contract's acceptance_criteria/files counts against
+//     admission.MaxAcceptanceCriteria/MaxChangeSurfaceFiles. Zero (the
+//     default) disables both — auto-splitting an oversized task into a gated
+//     DAG is deferred (#2466 Fix point 5); this only flags it for a human.
+//  3. Push credential readiness via the same preflighter push_branch/
+//     create_pr already use (e.factory.pushPreflight, falling back to
+//     project.PreflightPushCredentials) — but ONLY when a worktree already
+//     exists for the task. A fresh task dispatched straight from planning (or
+//     a noplan task's very first run) has no worktree yet at this point —
+//     PrepareForTask creates it lazily inside the `implement` run_agent step
+//     itself — so a missing worktree here is not yet a failure; skipping it
+//     avoids flipping every ordinary task to human-required on its first
+//     pass (see the Stop Condition on mass-flipping in-flight tasks).
+//
+// A failure sets a terminal blocker.State (Exhausted: true — no automatic
+// re-attempts, matching KindTriageRetryExhausted's precedent) and flips the
+// task to human-required: blocker.KindCredentialRequired for the push-auth
+// probe, blocker.KindOperatorDecision for a contract/scope problem (a human
+// must fix the spec, not retry the same dispatch). Both are in
+// blocker.AllowsHumanRequired's allow-list.
+//
+// Disabled via admission.Enabled=false (SetAdmissionConfig) is a pure no-op —
+// the step always admits.
+func (e *Engine) execAdmissionPreflight(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	if !e.admission.Enabled {
+		return e.admitTask(step, t, "disabled")
+	}
+
+	raw := strings.TrimSpace(t.PlanContract)
+	if raw != "" {
+		if problems := ValidatePlanContractForTask(raw, taskID, t.Body); len(problems) > 0 {
+			reason := "plan contract invalid: " + strings.Join(problems, "; ")
+			return e.blockAdmission(taskID, step, t, blocker.KindOperatorDecision, reason)
+		}
+		if reason := e.checkAdmissionOversize(raw); reason != "" {
+			return e.blockAdmission(taskID, step, t, blocker.KindOperatorDecision, reason)
+		}
+	}
+
+	if reason := e.checkAdmissionCredentials(taskID); reason != "" {
+		return e.blockAdmission(taskID, step, t, blocker.KindCredentialRequired, reason)
+	}
+
+	return e.admitTask(step, t, "admitted")
+}
+
+// checkAdmissionOversize returns a non-empty reason when the plan contract's
+// acceptance-criteria or file count exceeds a configured (non-zero) limit.
+// raw has already round-tripped through ValidatePlanContractForTask
+// successfully, so the re-parse here cannot fail.
+func (e *Engine) checkAdmissionOversize(raw string) string {
+	if e.admission.MaxAcceptanceCriteria <= 0 && e.admission.MaxChangeSurfaceFiles <= 0 {
+		return ""
+	}
+	contract, err := parsePlanContract(raw)
+	if err != nil {
+		return ""
+	}
+	if limit := e.admission.MaxAcceptanceCriteria; limit > 0 && len(contract.AcceptanceCriteria) > limit {
+		return fmt.Sprintf(
+			"acceptance_criteria count %d exceeds configured limit %d — split into smaller tasks (auto-split is deferred, see #2466 Fix point 5) or raise admission.max_acceptance_criteria",
+			len(contract.AcceptanceCriteria), limit)
+	}
+	if limit := e.admission.MaxChangeSurfaceFiles; limit > 0 && len(contract.Files) > limit {
+		return fmt.Sprintf(
+			"files count %d exceeds configured change-surface limit %d — split into smaller tasks (auto-split is deferred, see #2466 Fix point 5) or raise admission.max_change_surface_files",
+			len(contract.Files), limit)
+	}
+	return ""
+}
+
+// checkAdmissionCredentials returns a non-empty reason when a worktree
+// already exists for the task and the push-auth preflight against it fails.
+// A not-yet-existing worktree is not a failure here — see the doc comment on
+// execAdmissionPreflight.
+func (e *Engine) checkAdmissionCredentials(taskID string) string {
+	if e.worktrees == nil {
+		return ""
+	}
+	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	if !ok {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+	if err := e.preflightPushCredentials(ctx, wtPath); err != nil {
+		return "push credential preflight failed: " + trimDiffLine(err.Error())
+	}
+	return ""
+}
+
+// blockAdmission flips the task to human-required with a terminal blocker
+// (Exhausted: true — no automatic re-attempts) and records the decision.
+func (e *Engine) blockAdmission(taskID string, step *Step, t TaskInfo, kind blocker.Kind, reason string) (StepOutput, error) {
+	full := admissionPreflightReasonPrefix + " " + reason
+	if err := e.tasks.UpdateTaskBlocker(taskID, "human-required", full, blocker.State{
+		Kind:      kind,
+		Actor:     blocker.ActorWorkflow,
+		Exhausted: true,
+	}); err != nil {
+		return StepOutput{}, fmt.Errorf("%s: set human-required: %w", step.ID, err)
+	}
+	e.recordAdmissionDecision(t, AdmissionDecision{
+		Outcome:        "blocked",
+		RiskTier:       planContractRiskTier(t.PlanContract),
+		PermissionTier: planContractPermissionTier(t.PlanContract),
+		BlockerKind:    string(kind),
+		Reason:         full,
+	})
+	e.logger.Warn("workflow.admission-preflight.blocked",
+		"task_id", taskID, "step", step.ID, "kind", kind, "reason", full)
+	return StepOutput{StepID: step.ID, Status: "completed", Output: full}, nil
+}
+
+// admitTask records a passing admission decision.
+func (e *Engine) admitTask(step *Step, t TaskInfo, output string) (StepOutput, error) {
+	e.recordAdmissionDecision(t, AdmissionDecision{
+		Outcome:        "admitted",
+		RiskTier:       planContractRiskTier(t.PlanContract),
+		PermissionTier: planContractPermissionTier(t.PlanContract),
+	})
+	return StepOutput{StepID: step.ID, Status: "completed", Output: output}, nil
+}
+
+func (e *Engine) recordAdmissionDecision(t TaskInfo, d AdmissionDecision) {
+	if e.admissionDecisionHook == nil {
+		return
+	}
+	e.admissionDecisionHook(t, d)
+}
+
+// planContractRiskTier/planContractPermissionTier best-effort extract the
+// contract's own risk/permission tier for the admission.decided audit event,
+// so evaluation can correlate predicted risk against the actual outcome. An
+// absent or malformed contract yields an empty string rather than an error —
+// these are advisory audit fields, not a second validation pass.
+func planContractRiskTier(raw string) string {
+	contract, ok := parsePlanContractQuiet(raw)
+	if !ok {
+		return ""
+	}
+	return contract.RiskTier
+}
+
+func planContractPermissionTier(raw string) string {
+	contract, ok := parsePlanContractQuiet(raw)
+	if !ok {
+		return ""
+	}
+	return contract.PermissionTier
+}
+
+func parsePlanContractQuiet(raw string) (PlanContract, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return PlanContract{}, false
+	}
+	contract, err := parsePlanContract(raw)
+	if err != nil {
+		return PlanContract{}, false
+	}
+	return contract, true
+}

--- a/internal/workflow/engine_steps_admission.go
+++ b/internal/workflow/engine_steps_admission.go
@@ -43,16 +43,22 @@ const admissionPreflightReasonPrefix = "admission preflight blocked:"
 //     avoids flipping every ordinary task to human-required on its first
 //     pass (see the Stop Condition on mass-flipping in-flight tasks).
 //
-// A failure sets a terminal blocker.State (Exhausted: true — no automatic
-// re-attempts, matching KindTriageRetryExhausted's precedent) and flips the
-// task to human-required: blocker.KindCredentialRequired for the push-auth
-// probe, blocker.KindOperatorDecision for a contract/scope problem (a human
-// must fix the spec, not retry the same dispatch). Both are in
-// blocker.AllowsHumanRequired's allow-list.
+// A contract/scope failure sets a terminal blocker.State (Exhausted: true — no
+// automatic re-attempts, matching KindTriageRetryExhausted's precedent) and
+// flips the task to human-required with blocker.KindOperatorDecision (a human
+// must fix the spec, not retry the same dispatch).
+//
+// A push-credential failure is NOT unconditionally terminal: it is classified
+// the same way push_branch/create_pr classify the identical preflight error
+// (classifyAdmissionCredentialError), so a rate-limit or transient GitHub blip
+// hit at this step self-heals via a bounded retry instead of permanently
+// stranding a re-dispatched task at human-required. Only a non-transient
+// credential failure escalates, as blocker.KindCredentialRequired. Both
+// blocker kinds are in blocker.AllowsHumanRequired's allow-list.
 //
 // Disabled via admission.Enabled=false (SetAdmissionConfig) is a pure no-op —
 // the step always admits.
-func (e *Engine) execAdmissionPreflight(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+func (e *Engine) execAdmissionPreflight(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
 	if !e.admission.Enabled {
 		return e.admitTask(step, t, "disabled")
 	}
@@ -68,11 +74,33 @@ func (e *Engine) execAdmissionPreflight(taskID string, step *Step, t TaskInfo) (
 		}
 	}
 
-	if reason := e.checkAdmissionCredentials(taskID); reason != "" {
-		return e.blockAdmission(taskID, step, t, blocker.KindCredentialRequired, reason)
+	if credErr := e.checkAdmissionCredentials(taskID); credErr != nil {
+		return e.classifyAdmissionCredentialError(taskID, step, wfExec, t, credErr)
 	}
 
 	return e.admitTask(step, t, "admitted")
+}
+
+// classifyAdmissionCredentialError mirrors classifyPRGitError's transient-vs-
+// permanent split for the push-credential preflight run at admission time: a
+// rate-limit or transient GitHub blip parks the step for a bounded retry (it
+// self-heals on a later pass, exactly as push_branch/create_pr would for the
+// identical error moments later in the same workflow), while a genuine auth
+// failure or otherwise unclassifiable credential problem escalates to a
+// terminal blocker.KindCredentialRequired — the same distinction
+// looksLikeAuthFailure draws (a broken token does not self-heal, a network
+// blip does).
+func (e *Engine) classifyAdmissionCredentialError(taskID string, step *Step, wfExec *Execution, t TaskInfo, err error) (StepOutput, error) {
+	msg := err.Error()
+	switch {
+	case looksLikeGitHubRateLimit(msg):
+		return e.parkStepForRetry(taskID, wfExec, t, step.ID, prCreateRetryStatusReason, "workflow.admission-preflight.rate-limit")
+	case looksLikeTransientGitHub(msg):
+		return e.parkStepForRetry(taskID, wfExec, t, step.ID, prCreateTransientStatusReason, "workflow.admission-preflight.transient")
+	default:
+		return e.blockAdmission(taskID, step, t, blocker.KindCredentialRequired,
+			"push credential preflight failed: "+trimDiffLine(msg))
+	}
 }
 
 // checkAdmissionOversize returns a non-empty reason when the plan contract's
@@ -100,24 +128,22 @@ func (e *Engine) checkAdmissionOversize(raw string) string {
 	return ""
 }
 
-// checkAdmissionCredentials returns a non-empty reason when a worktree
-// already exists for the task and the push-auth preflight against it fails.
-// A not-yet-existing worktree is not a failure here — see the doc comment on
-// execAdmissionPreflight.
-func (e *Engine) checkAdmissionCredentials(taskID string) string {
+// checkAdmissionCredentials returns a non-nil error when a worktree already
+// exists for the task and the push-auth preflight against it fails. The raw
+// error is returned (not a formatted reason) so the caller can classify it as
+// transient vs permanent. A not-yet-existing worktree is not a failure here —
+// see the doc comment on execAdmissionPreflight.
+func (e *Engine) checkAdmissionCredentials(taskID string) error {
 	if e.worktrees == nil {
-		return ""
+		return nil
 	}
 	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
 	if !ok {
-		return ""
+		return nil
 	}
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
-	if err := e.preflightPushCredentials(ctx, wtPath); err != nil {
-		return "push credential preflight failed: " + trimDiffLine(err.Error())
-	}
-	return ""
+	return e.preflightPushCredentials(ctx, wtPath)
 }
 
 // blockAdmission flips the task to human-required with a terminal blocker

--- a/internal/workflow/engine_steps_admission.go
+++ b/internal/workflow/engine_steps_admission.go
@@ -169,12 +169,17 @@ func (e *Engine) blockAdmission(taskID string, step *Step, t TaskInfo, kind bloc
 	return StepOutput{StepID: step.ID, Status: "completed", Output: full}, nil
 }
 
-// admitTask records a passing admission decision.
+// admitTask records a passing admission decision. output is either "disabled"
+// (admission.Enabled=false — checks were skipped, not evaluated) or
+// "admitted" (checks ran and passed); it is echoed into AdmissionDecision.Reason
+// so the admission.decided audit event can tell the two apart instead of
+// showing an empty reason for both.
 func (e *Engine) admitTask(step *Step, t TaskInfo, output string) (StepOutput, error) {
 	e.recordAdmissionDecision(t, AdmissionDecision{
 		Outcome:        "admitted",
 		RiskTier:       planContractRiskTier(t.PlanContract),
 		PermissionTier: planContractPermissionTier(t.PlanContract),
+		Reason:         output,
 	})
 	return StepOutput{StepID: step.ID, Status: "completed", Output: output}, nil
 }

--- a/internal/workflow/engine_steps_admission.go
+++ b/internal/workflow/engine_steps_admission.go
@@ -143,12 +143,17 @@ func (e *Engine) blockAdmission(taskID string, step *Step, t TaskInfo, kind bloc
 	return StepOutput{StepID: step.ID, Status: "completed", Output: full}, nil
 }
 
-// admitTask records a passing admission decision.
+// admitTask records a passing admission decision. output is either
+// "admitted" (checks ran and passed) or "disabled" (admission.Enabled=false,
+// no checks ran) — it doubles as AdmissionDecision.Reason so the
+// admission.decided audit event can distinguish the two instead of reporting
+// an empty reason for every admit.
 func (e *Engine) admitTask(step *Step, t TaskInfo, output string) (StepOutput, error) {
 	e.recordAdmissionDecision(t, AdmissionDecision{
 		Outcome:        "admitted",
 		RiskTier:       planContractRiskTier(t.PlanContract),
 		PermissionTier: planContractPermissionTier(t.PlanContract),
+		Reason:         output,
 	})
 	return StepOutput{StepID: step.ID, Status: "completed", Output: output}, nil
 }

--- a/internal/workflow/engine_steps_admission_test.go
+++ b/internal/workflow/engine_steps_admission_test.go
@@ -300,6 +300,30 @@ func TestExecAdmissionPreflight_TransientCredentialErrorParksForRetry(t *testing
 	}
 }
 
+// TestExecAdmissionPreflight_DisabledDecisionReasonDistinguishesSkip asserts
+// that a disabled-admission no-op and a checks-ran-and-passed admission both
+// report Outcome "admitted" but differ in Reason ("disabled" vs "admitted") —
+// without this, the admission.decided audit event can't tell "checks were
+// skipped" from "checks passed" (see PR #2631 review).
+func TestExecAdmissionPreflight_DisabledDecisionReasonDistinguishesSkip(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	// admission zero-value: Enabled defaults false.
+	var decisions []AdmissionDecision
+	engine.SetAdmissionDecisionHook(func(_ TaskInfo, d AdmissionDecision) {
+		decisions = append(decisions, d)
+	})
+
+	if _, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
+		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")}); err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 1 || decisions[0].Outcome != "admitted" || decisions[0].Reason != "disabled" {
+		t.Fatalf("decisions = %+v, want single admitted/disabled decision", decisions)
+	}
+}
+
 func TestExecAdmissionPreflight_RecordsAdmissionDecision(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
@@ -319,6 +343,9 @@ func TestExecAdmissionPreflight_RecordsAdmissionDecision(t *testing.T) {
 	}
 	if decisions[0].Outcome != "admitted" || decisions[0].RiskTier != "medium" || decisions[0].PermissionTier != "repo-write" {
 		t.Fatalf("decision = %+v, want admitted/medium/repo-write", decisions[0])
+	}
+	if decisions[0].Reason != "admitted" {
+		t.Fatalf("decision.Reason = %q, want %q — checks that actually ran must be distinguishable from a disabled no-op", decisions[0].Reason, "admitted")
 	}
 
 	invalid := strings.Replace(validPlanContract("fa6919fc"),

--- a/internal/workflow/engine_steps_admission_test.go
+++ b/internal/workflow/engine_steps_admission_test.go
@@ -13,6 +13,15 @@ func newAdmissionPreflightStep() *Step {
 	return &Step{ID: "admission_preflight", Type: StepAdmissionPreflight}
 }
 
+func newAdmissionExec() *Execution {
+	return &Execution{
+		WorkflowID:  "simple-task-implement",
+		CurrentStep: "admission_preflight",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+	}
+}
+
 func TestExecAdmissionPreflight_DisabledIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
@@ -20,7 +29,7 @@ func TestExecAdmissionPreflight_DisabledIsNoOp(t *testing.T) {
 	// admission zero-value: Enabled defaults false, matching every other
 	// Engine dependency's nil-safe default.
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: `{"schema_version": "2"}`})
 	if err != nil {
 		t.Fatal(err)
@@ -40,7 +49,7 @@ func TestExecAdmissionPreflight_AdmitsNoContract(t *testing.T) {
 	engine := newEngineForEval(t, tasks)
 	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc"})
 	if err != nil {
 		t.Fatal(err)
@@ -60,7 +69,7 @@ func TestExecAdmissionPreflight_AdmitsValidContract(t *testing.T) {
 	engine := newEngineForEval(t, tasks)
 	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
 	if err != nil {
 		t.Fatal(err)
@@ -87,7 +96,7 @@ func TestExecAdmissionPreflight_InvalidContractBlocksAsOperatorDecision(t *testi
 		`"task_id": "fa6919fc",
   "schema_version": "2",`, 1)
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: contract})
 	if err != nil {
 		t.Fatal(err)
@@ -122,7 +131,7 @@ func TestExecAdmissionPreflight_UnknownCapabilityBlocksAsOperatorDecision(t *tes
   "objective": "ship the thing",
   "required_capabilities": ["launch_missiles"],`, 1)
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: contract})
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +160,7 @@ func TestExecAdmissionPreflight_OversizeAcceptanceCriteriaBlocksAsOperatorDecisi
 		`"acceptance_criteria": ["implementation prompt includes the contract"]`,
 		`"acceptance_criteria": ["first criterion", "second criterion"]`, 1)
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: contract})
 	if err != nil {
 		t.Fatal(err)
@@ -185,7 +194,7 @@ func TestExecAdmissionPreflight_OversizeFilesBlocksAsOperatorDecision(t *testing
     {"path": "internal/workflow/engine_advance.go", "purpose": "edit"}
   ],`, 1)
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: contract})
 	if err != nil {
 		t.Fatal(err)
@@ -211,7 +220,7 @@ func TestExecAdmissionPreflight_NoWorktreeSkipsCredentialCheck(t *testing.T) {
 	preflight := &fakePushPreflighter{err: errors.New("should never be called")}
 	engine.SetPushCredentialPreflighter(preflight)
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
 	if err != nil {
 		t.Fatal(err)
@@ -233,7 +242,7 @@ func TestExecAdmissionPreflight_MissingCredentialsBlockAsCredentialRequired(t *t
 	preflight := &fakePushPreflighter{err: errors.New("gh auth status: Bad credentials")}
 	engine.SetPushCredentialPreflighter(preflight)
 
-	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
 	if err != nil {
 		t.Fatal(err)
@@ -259,6 +268,38 @@ func TestExecAdmissionPreflight_MissingCredentialsBlockAsCredentialRequired(t *t
 	}
 }
 
+func TestExecAdmissionPreflight_TransientCredentialErrorParksForRetry(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: "/tmp/wt", ok: true})
+	// A rate-limited/transient preflight hit must self-heal via a bounded
+	// retry, not permanently strand a re-dispatched task at human-required.
+	preflight := &fakePushPreflighter{err: errors.New("gh: API rate limit exceeded for GitHub")}
+	engine.SetPushCredentialPreflighter(preflight)
+
+	wfExec := newAdmissionExec()
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), wfExec,
+		TaskInfo{ID: "fa6919fc", Status: "in-progress", PlanContract: validPlanContract("fa6919fc")})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	if out.Status == "completed" {
+		t.Fatalf("out = %+v, want the step parked (not completed)", out)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status == "human-required" {
+		t.Fatalf("status = %q, want the task parked in-progress (transient error must not strand it)", ti.Status)
+	}
+	if ti.Blocker.Exhausted {
+		t.Error("blocker.Exhausted = true, want false (transient error is retriable)")
+	}
+	if wfExec.State != ExecWaiting {
+		t.Errorf("wfExec.State = %v, want ExecWaiting (parked for retry)", wfExec.State)
+	}
+}
+
 func TestExecAdmissionPreflight_RecordsAdmissionDecision(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
@@ -269,7 +310,7 @@ func TestExecAdmissionPreflight_RecordsAdmissionDecision(t *testing.T) {
 		decisions = append(decisions, d)
 	})
 
-	if _, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	if _, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")}); err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +325,7 @@ func TestExecAdmissionPreflight_RecordsAdmissionDecision(t *testing.T) {
 		`"task_id": "fa6919fc",`,
 		`"task_id": "fa6919fc",
   "schema_version": "2",`, 1)
-	if _, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+	if _, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: invalid}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/workflow/engine_steps_admission_test.go
+++ b/internal/workflow/engine_steps_admission_test.go
@@ -1,0 +1,297 @@
+package workflow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/config"
+)
+
+func newAdmissionPreflightStep() *Step {
+	return &Step{ID: "admission_preflight", Type: StepAdmissionPreflight}
+}
+
+func TestExecAdmissionPreflight_DisabledIsNoOp(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	// admission zero-value: Enabled defaults false, matching every other
+	// Engine dependency's nil-safe default.
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: `{"schema_version": "2"}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" || out.Output != "disabled" {
+		t.Fatalf("out = %+v, want completed/disabled", out)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status == "human-required" {
+		t.Errorf("disabled admission should never block: reason=%q", tasks.Reason("fa6919fc"))
+	}
+}
+
+func TestExecAdmissionPreflight_AdmitsNoContract(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" || out.Output != "admitted" {
+		t.Fatalf("out = %+v, want completed/admitted", out)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status == "human-required" {
+		t.Errorf("a noplan task must not be blocked: reason=%q", tasks.Reason("fa6919fc"))
+	}
+}
+
+func TestExecAdmissionPreflight_AdmitsValidContract(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" || out.Output != "admitted" {
+		t.Fatalf("out = %+v, want completed/admitted", out)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status == "human-required" {
+		t.Errorf("a valid contract must not be blocked: reason=%q", tasks.Reason("fa6919fc"))
+	}
+}
+
+func TestExecAdmissionPreflight_InvalidContractBlocksAsOperatorDecision(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+	// schema_version "2" with no objective — a missing machine-checkable
+	// admission fact, covering the noplan/handoff path where
+	// validate_plan_contract never ran during planning.
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "2",`, 1)
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: contract})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("out.Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if ti.Blocker.Kind != blocker.KindOperatorDecision {
+		t.Errorf("blocker kind = %q, want %q", ti.Blocker.Kind, blocker.KindOperatorDecision)
+	}
+	if !ti.Blocker.Exhausted {
+		t.Error("blocker.Exhausted = false, want true (terminal, no re-attempts)")
+	}
+	if reason := tasks.Reason("fa6919fc"); !strings.Contains(reason, "objective is required") {
+		t.Errorf("reason = %q, want missing objective", reason)
+	}
+}
+
+func TestExecAdmissionPreflight_UnknownCapabilityBlocksAsOperatorDecision(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "2",
+  "objective": "ship the thing",
+  "required_capabilities": ["launch_missiles"],`, 1)
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: contract})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("out.Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if ti.Blocker.Kind != blocker.KindOperatorDecision {
+		t.Errorf("blocker kind = %q, want %q", ti.Blocker.Kind, blocker.KindOperatorDecision)
+	}
+	if reason := tasks.Reason("fa6919fc"); !strings.Contains(reason, `unknown capability "launch_missiles"`) {
+		t.Errorf("reason = %q, want unknown capability", reason)
+	}
+}
+
+func TestExecAdmissionPreflight_OversizeAcceptanceCriteriaBlocksAsOperatorDecision(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true, MaxAcceptanceCriteria: 1})
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"acceptance_criteria": ["implementation prompt includes the contract"]`,
+		`"acceptance_criteria": ["first criterion", "second criterion"]`, 1)
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: contract})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("out.Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if ti.Blocker.Kind != blocker.KindOperatorDecision {
+		t.Errorf("blocker kind = %q, want %q", ti.Blocker.Kind, blocker.KindOperatorDecision)
+	}
+	if reason := tasks.Reason("fa6919fc"); !strings.Contains(reason, "acceptance_criteria count 2 exceeds configured limit 1") {
+		t.Errorf("reason = %q, want oversize acceptance_criteria", reason)
+	}
+}
+
+func TestExecAdmissionPreflight_OversizeFilesBlocksAsOperatorDecision(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true, MaxChangeSurfaceFiles: 1})
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"files": [
+    {"path": "internal/workflow/engine.go", "purpose": "edit", "symbols": ["Engine"]}
+  ],`,
+		`"files": [
+    {"path": "internal/workflow/engine.go", "purpose": "edit", "symbols": ["Engine"]},
+    {"path": "internal/workflow/engine_advance.go", "purpose": "edit"}
+  ],`, 1)
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: contract})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("out.Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("fa6919fc"); !strings.Contains(reason, "files count 2 exceeds configured change-surface limit 1") {
+		t.Errorf("reason = %q, want oversize files", reason)
+	}
+}
+
+func TestExecAdmissionPreflight_NoWorktreeSkipsCredentialCheck(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
+	preflight := &fakePushPreflighter{err: errors.New("should never be called")}
+	engine.SetPushCredentialPreflighter(preflight)
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "admitted" {
+		t.Fatalf("out.Output = %q, want admitted (a not-yet-existing worktree is not a failure)", out.Output)
+	}
+	if preflight.calls != 0 {
+		t.Errorf("preflight calls = %d, want 0", preflight.calls)
+	}
+}
+
+func TestExecAdmissionPreflight_MissingCredentialsBlockAsCredentialRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: "/tmp/wt", ok: true})
+	preflight := &fakePushPreflighter{err: errors.New("gh auth status: Bad credentials")}
+	engine.SetPushCredentialPreflighter(preflight)
+
+	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("out.Status = %q, want completed", out.Status)
+	}
+	if preflight.calls != 1 {
+		t.Fatalf("preflight calls = %d, want 1", preflight.calls)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if ti.Blocker.Kind != blocker.KindCredentialRequired {
+		t.Errorf("blocker kind = %q, want %q", ti.Blocker.Kind, blocker.KindCredentialRequired)
+	}
+	if !ti.Blocker.Exhausted {
+		t.Error("blocker.Exhausted = false, want true (terminal, no re-attempts)")
+	}
+	if reason := tasks.Reason("fa6919fc"); !strings.Contains(reason, "Bad credentials") {
+		t.Errorf("reason = %q, want push credential failure detail", reason)
+	}
+}
+
+func TestExecAdmissionPreflight_RecordsAdmissionDecision(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
+	var decisions []AdmissionDecision
+	engine.SetAdmissionDecisionHook(func(_ TaskInfo, d AdmissionDecision) {
+		decisions = append(decisions, d)
+	})
+
+	if _, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")}); err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 1 {
+		t.Fatalf("decisions = %v, want exactly one", decisions)
+	}
+	if decisions[0].Outcome != "admitted" || decisions[0].RiskTier != "medium" || decisions[0].PermissionTier != "repo-write" {
+		t.Fatalf("decision = %+v, want admitted/medium/repo-write", decisions[0])
+	}
+
+	invalid := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "2",`, 1)
+	if _, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(),
+		TaskInfo{ID: "fa6919fc", PlanContract: invalid}); err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 2 {
+		t.Fatalf("decisions = %v, want exactly two", decisions)
+	}
+	if decisions[1].Outcome != "blocked" || decisions[1].BlockerKind != string(blocker.KindOperatorDecision) {
+		t.Fatalf("decision = %+v, want blocked/operator_decision", decisions[1])
+	}
+}

--- a/internal/workflow/engine_validate_plan_contract.go
+++ b/internal/workflow/engine_validate_plan_contract.go
@@ -12,6 +12,27 @@ import (
 
 const maxPlanContractBytes = 64 * 1024
 
+// PlanContractSchemaV2 opts a plan contract into the admission-facts
+// extension (Objective, RequiredCapabilities). An absent SchemaVersion (or
+// explicit "1") validates under the original v1 rules only — existing
+// contracts and in-flight tasks are unaffected by this migration, so
+// deploying the extension never mass-flips them to human-required. See
+// ValidatePlanContractForTask and execAdmissionPreflight
+// (engine_steps_admission.go).
+const PlanContractSchemaV2 = "2"
+
+// planContractCapabilities is the closed registry of capability names a v2
+// plan contract's RequiredCapabilities may declare. Deliberately closed (not
+// free text): an unrecognized capability is a validation problem rather than
+// a silent pass, so admission_preflight cannot be bypassed by inventing a new
+// capability name the engine has no probe for.
+var planContractCapabilities = map[string]bool{
+	"repo_write": true,
+	"network":    true,
+	"provider":   true,
+	"git_push":   true,
+}
+
 type PlanContract struct {
 	TaskID             string                     `json:"task_id"`
 	Branch             string                     `json:"branch"`
@@ -24,6 +45,22 @@ type PlanContract struct {
 	RiskTier           string                     `json:"risk_tier"`
 	PermissionTier     string                     `json:"permission_tier"`
 	Rollback           string                     `json:"rollback"`
+	// SchemaVersion gates the admission-facts fields below. Empty and "1" are
+	// equivalent (the original schema); PlanContractSchemaV2 requires
+	// Objective and validates RequiredCapabilities against a closed registry.
+	// Any other value is an unsupported-schema-version validation problem.
+	SchemaVersion string `json:"schema_version,omitempty"`
+	// Objective is a one-line statement of what "done" means for this task,
+	// required under PlanContractSchemaV2 — a machine-checkable admission
+	// fact distinct from the free-form Steps/AcceptanceCriteria prose.
+	Objective string `json:"objective,omitempty"`
+	// Dependencies names other task IDs or external resources this task's
+	// admission depends on. Advisory only (no validation beyond being a plain
+	// string list) — scheduling on it is deferred, see #2466 Fix point 5.
+	Dependencies []string `json:"dependencies,omitempty"`
+	// RequiredCapabilities declares which planContractCapabilities entries
+	// this task's implementation needs. Validated under PlanContractSchemaV2.
+	RequiredCapabilities []string `json:"required_capabilities,omitempty"`
 }
 
 type PlanContractFile struct {
@@ -130,7 +167,46 @@ func ValidatePlanContractForTask(raw, taskID, taskBody string) []string {
 	for _, id := range collectForeignTaskIDs(raw, taskID) {
 		problems = append(problems, "references foreign task ID "+id)
 	}
+	problems = append(problems, validateSchemaVersion(contract)...)
 	sort.Strings(problems)
+	return problems
+}
+
+// validateSchemaVersion applies the admission-facts rules gated by
+// PlanContract.SchemaVersion. Absent and "1" are the original schema — no
+// additional fields are required, so pre-existing contracts (and any
+// generated without the extension) keep validating exactly as before this
+// migration. PlanContractSchemaV2 requires Objective and validates
+// RequiredCapabilities against the closed planContractCapabilities registry.
+// Any other value is rejected outright rather than silently treated as v1,
+// so a typo'd or future schema_version cannot skip the extension's checks.
+func validateSchemaVersion(contract PlanContract) []string {
+	switch contract.SchemaVersion {
+	case "", "1":
+		return nil
+	case PlanContractSchemaV2:
+		var problems []string
+		if strings.TrimSpace(contract.Objective) == "" {
+			problems = append(problems, "objective is required for schema_version \"2\"")
+		}
+		problems = append(problems, validateRequiredCapabilities(contract.RequiredCapabilities)...)
+		return problems
+	default:
+		return []string{fmt.Sprintf("unsupported schema_version %q", contract.SchemaVersion)}
+	}
+}
+
+// validateRequiredCapabilities checks each declared capability against the
+// closed planContractCapabilities registry. An unrecognized name is a
+// validation problem, never a silent pass — see planContractCapabilities.
+func validateRequiredCapabilities(capabilities []string) []string {
+	var problems []string
+	for _, c := range capabilities {
+		name := strings.TrimSpace(c)
+		if !planContractCapabilities[name] {
+			problems = append(problems, fmt.Sprintf("required_capabilities: unknown capability %q", c))
+		}
+	}
 	return problems
 }
 

--- a/internal/workflow/engine_validate_plan_contract_test.go
+++ b/internal/workflow/engine_validate_plan_contract_test.go
@@ -373,6 +373,84 @@ func TestExecValidatePlanContract_RejectsMalformedExpectedDeletions(t *testing.T
 	}
 }
 
+func TestValidatePlanContract_SchemaV2Migration(t *testing.T) {
+	// A contract with no schema_version at all — the shape every contract
+	// generated before this admission-facts extension shipped — must
+	// validate exactly as before: zero new problems, even without
+	// objective/required_capabilities. This is the backward-compat
+	// guarantee that keeps deploying the extension from mass-flipping
+	// in-flight tasks to human-required.
+	if problems := ValidatePlanContract(validPlanContract("fa6919fc"), "fa6919fc"); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none for a contract with no schema_version", problems)
+	}
+
+	// Explicit schema_version "1" is equivalent to absent.
+	v1 := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "1",`, 1)
+	if problems := ValidatePlanContract(v1, "fa6919fc"); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none for schema_version \"1\"", problems)
+	}
+}
+
+func TestValidatePlanContract_SchemaV2RequiresObjective(t *testing.T) {
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "2",`, 1)
+
+	problems := ValidatePlanContract(contract, "fa6919fc")
+	joined := strings.Join(problems, "\n")
+	if !strings.Contains(joined, `objective is required for schema_version "2"`) {
+		t.Fatalf("problems = %v, want missing objective", problems)
+	}
+}
+
+func TestValidatePlanContract_SchemaV2AcceptsObjectiveAndKnownCapabilities(t *testing.T) {
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "2",
+  "objective": "ship the thing",
+  "dependencies": ["other-task-id"],
+  "required_capabilities": ["repo_write", "git_push"],`, 1)
+
+	if problems := ValidatePlanContract(contract, "fa6919fc"); len(problems) != 0 {
+		t.Fatalf("problems = %v, want none", problems)
+	}
+}
+
+func TestValidatePlanContract_SchemaV2RejectsUnknownCapability(t *testing.T) {
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "2",
+  "objective": "ship the thing",
+  "required_capabilities": ["repo_write", "launch_missiles"],`, 1)
+
+	problems := ValidatePlanContract(contract, "fa6919fc")
+	joined := strings.Join(problems, "\n")
+	if !strings.Contains(joined, `unknown capability "launch_missiles"`) {
+		t.Fatalf("problems = %v, want unknown capability", problems)
+	}
+	if strings.Contains(joined, `"repo_write"`) {
+		t.Fatalf("problems = %v, want the known capability left unflagged", problems)
+	}
+}
+
+func TestValidatePlanContract_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	contract := strings.Replace(validPlanContract("fa6919fc"),
+		`"task_id": "fa6919fc",`,
+		`"task_id": "fa6919fc",
+  "schema_version": "99",`, 1)
+
+	problems := ValidatePlanContract(contract, "fa6919fc")
+	if len(problems) != 1 || !strings.Contains(problems[0], `unsupported schema_version "99"`) {
+		t.Fatalf("problems = %v, want unsupported schema_version", problems)
+	}
+}
+
 func TestExecValidatePlanContract_RejectsForeignWorktreeOrBranch(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -182,6 +182,16 @@ const (
 	// session involved. Replaces a run_agent step that wrapped a full Sonnet
 	// agent invoking the /sybra-triage skill around this same classifier.
 	StepClassifyTask StepType = "classify_task"
+	// StepAdmissionPreflight runs deterministic pre-dispatch admission checks
+	// (plan contract schema/capability validation, oversize scope limits,
+	// push credential readiness) before any code-author agent is dispatched —
+	// see execAdmissionPreflight (engine_steps_admission.go). Recoverable
+	// environment failures (missing push credentials) route through a
+	// blocker.KindCredentialRequired; scope/content problems (missing
+	// objective, unknown capability, oversize scope) route through
+	// blocker.KindOperatorDecision — both terminal (no automatic
+	// re-attempts), matching blocker.AllowsHumanRequired.
+	StepAdmissionPreflight StepType = "admission_preflight"
 )
 
 // Best-of-N attempt count bounds enforced by Definition.Validate. A floor of

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -185,12 +185,17 @@ const (
 	// StepAdmissionPreflight runs deterministic pre-dispatch admission checks
 	// (plan contract schema/capability validation, oversize scope limits,
 	// push credential readiness) before any code-author agent is dispatched —
-	// see execAdmissionPreflight (engine_steps_admission.go). Recoverable
-	// environment failures (missing push credentials) route through a
-	// blocker.KindCredentialRequired; scope/content problems (missing
-	// objective, unknown capability, oversize scope) route through
-	// blocker.KindOperatorDecision — both terminal (no automatic
-	// re-attempts), matching blocker.AllowsHumanRequired.
+	// see execAdmissionPreflight (engine_steps_admission.go). Scope/content
+	// problems (missing objective, unknown capability, oversize scope) and a
+	// non-transient credential failure both route through human-required —
+	// the former always blocker.KindOperatorDecision, the latter
+	// blocker.KindCredentialRequired — as terminal (no automatic re-attempts),
+	// matching blocker.AllowsHumanRequired. A transient/rate-limited
+	// credential-preflight error is NOT terminal: classifyAdmissionCredentialError
+	// parks the step for a bounded retry instead, mirroring push_branch/
+	// create_pr's identical classification of the same error. Resumable —
+	// see isResumableStepType — so a crash between persisting CurrentStep and
+	// executing it does not strand the task.
 	StepAdmissionPreflight StepType = "admission_preflight"
 )
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -190,7 +190,10 @@ const (
 	// blocker.KindCredentialRequired; scope/content problems (missing
 	// objective, unknown capability, oversize scope) route through
 	// blocker.KindOperatorDecision — both terminal (no automatic
-	// re-attempts), matching blocker.AllowsHumanRequired.
+	// re-attempts), matching blocker.AllowsHumanRequired. Listed in
+	// isResumableStepType (like StepClassifyTask): it is deterministic and
+	// side-effect-free until it decides, so re-running it after a crash
+	// between persisting CurrentStep and executing it is safe.
 	StepAdmissionPreflight StepType = "admission_preflight"
 )
 


### PR DESCRIPTION
## Motivation

Sybra could spend agents on tasks before proving they were sufficiently scoped, runnable, verifiable, and authorized in the current project environment.

## Implementation information

Introduces `admission_preflight`, a deterministic gate that runs before any code-author agent is dispatched. It enforces: plan contract schema/capability validity (objective and required_capabilities under schema_version "2"), oversize change-surface limits (acceptance_criteria/files counts against configurable caps), and push credential readiness. acceptance_criteria and verification-command presence are enforced by the existing plan-contract schema validator this step reuses, not new in this PR.

`dependencies` is a new advisory-only contract field (no validation yet — scheduling on it is deferred, see #2466 Fix point 5). Setup health is not yet checked by this gate.

> Changelog: feat(triage): enforce executable task admission contracts


Closes https://github.com/Automaat/sybra/issues/2466