### PR TITLE
fix(deploy): build sybra-cli alongside server

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -69,11 +69,13 @@ Layout on the box:
 /data/sybra/home  →  HOME=/home/sybra/.sybra  (config, tasks, worktrees, agent registry)
 ```
 
-`sybra-build.sh` builds `sybra-cli` from the same checkout, in the same
-atomic swap, as `sybra-server` — the two binaries can never drift apart the
-way they used to when only `sybra-server` was rebuilt (#2619: `sybra-cli`
-could hard-fail on a config-schema key the running server already
-understood). It also symlinks the built CLI to `$HOME/.local/bin/sybra-cli`
+`sybra-build.sh` builds `sybra-cli` from the same checkout as `sybra-server`
+and swaps both binaries into place as a pair — if either swap fails, the
+other is rolled back too, so a successful rebuild always keeps them in sync
+and a failed one falls back to the previous matched pair rather than a
+half-applied mix (#2619: `sybra-cli` could hard-fail on a config-schema key
+the running server already understood, because only `sybra-server` was
+rebuilt). It also symlinks the built CLI to `$HOME/.local/bin/sybra-cli`
 (`/home/sybra/.local/bin/sybra-cli`), which is already on `PATH` per
 `sybra.env.example`, so `sybra-cli` resolves as a bare command for the
 `sybra` user without a separate manual install step.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -54,7 +54,7 @@ validate it (below) before trusting the deploy.**
 |------|--------------|---------|
 | `systemd/sybra.service` | `/etc/systemd/system/sybra.service` | The unit (KillMode=process, exit-42 restart, ExecStartPre build). |
 | `systemd/sybra.env.example` | `/etc/sybra/sybra.env` | Runtime env (listen port, local CLI server target, static dir, `PATH` with mise shims + npm globals). |
-| `bin/sybra-build.sh` | `/opt/sybra/bin/sybra-build.sh` | `ExecStartPre`: build web + binary from `/opt/sybra/src`, atomic swap, keep last-good on failure. |
+| `bin/sybra-build.sh` | `/opt/sybra/bin/sybra-build.sh` | `ExecStartPre`: build web + server + CLI from `/opt/sybra/src`, atomic swap, keep last-good on failure. |
 | `bin/sybra-run.sh` | `/opt/sybra/bin/sybra-run.sh` | `ExecStart`: activate mise toolchain, `exec` the built binary. |
 
 Layout on the box:
@@ -64,10 +64,19 @@ Layout on the box:
   src/         git checkout of Automaat/sybra on main   (autoupdate RepoDir)
   review-src/  second, independent checkout for human-review's fallback dir
   bin/         sybra-build.sh, sybra-run.sh
-  build/       sybra-server (running binary) + web/ (static bundle)
+  build/       sybra-server (running binary) + sybra-cli + web/ (static bundle)
 /etc/sybra/sybra.env
 /data/sybra/home  →  HOME=/home/sybra/.sybra  (config, tasks, worktrees, agent registry)
 ```
+
+`sybra-build.sh` builds `sybra-cli` from the same checkout, in the same
+atomic swap, as `sybra-server` — the two binaries can never drift apart the
+way they used to when only `sybra-server` was rebuilt (#2619: `sybra-cli`
+could hard-fail on a config-schema key the running server already
+understood). It also symlinks the built CLI to `$HOME/.local/bin/sybra-cli`
+(`/home/sybra/.local/bin/sybra-cli`), which is already on `PATH` per
+`sybra.env.example`, so `sybra-cli` resolves as a bare command for the
+`sybra` user without a separate manual install step.
 
 `review-src/` exists so `human_review.sybra_repo_dir` never resolves to the
 same directory `auto_update.repo_dir` builds and ff-merges from (#1925) —

--- a/deploy/bin/sybra-build.sh
+++ b/deploy/bin/sybra-build.sh
@@ -64,12 +64,21 @@ rm -rf "$WEB"
 if ! mv "$WEB.new" "$WEB"; then
   keep_last_good_or_fail "swap web bundle"
 fi
+[[ -x "$BIN" ]] && mv -f "$BIN" "$BIN.prev"
 if ! mv -f "$BIN.new" "$BIN"; then
+  [[ -f "$BIN.prev" ]] && mv -f "$BIN.prev" "$BIN"
   keep_last_good_or_fail "swap server binary"
 fi
+[[ -x "$CLI_BIN" ]] && mv -f "$CLI_BIN" "$CLI_BIN.prev"
 if ! mv -f "$CLI_BIN.new" "$CLI_BIN"; then
+  # Roll the server swap back too, so a partial failure here can never
+  # leave a new server paired with a stale CLI (the drift this build step
+  # exists to prevent, #2619).
+  [[ -f "$CLI_BIN.prev" ]] && mv -f "$CLI_BIN.prev" "$CLI_BIN"
+  mv -f "$BIN.prev" "$BIN"
   keep_last_good_or_fail "swap sybra-cli binary"
 fi
+rm -f "$BIN.prev" "$CLI_BIN.prev"
 
 if ! (mkdir -p "$CLI_LINK_DIR" && ln -sf "$CLI_BIN" "$CLI_LINK_DIR/sybra-cli"); then
   log "warning: failed to symlink sybra-cli into $CLI_LINK_DIR; binary is still at $CLI_BIN"

--- a/deploy/bin/sybra-build.sh
+++ b/deploy/bin/sybra-build.sh
@@ -4,7 +4,9 @@ set -uo pipefail
 SRC="${SYBRA_SRC_DIR:-/opt/sybra/src}"
 OUT="${SYBRA_BUILD_DIR:-/opt/sybra/build}"
 BIN="$OUT/sybra-server"
+CLI_BIN="$OUT/sybra-cli"
 WEB="$OUT/web"
+CLI_LINK_DIR="${HOME:-/home/sybra}/.local/bin"
 
 log() { echo "[sybra-build] $*"; }
 
@@ -36,17 +38,26 @@ if ! CGO_ENABLED=0 mise exec -- go build -trimpath -o "$BIN.new" ./cmd/sybra-ser
   keep_last_good_or_fail "go build"
 fi
 
+# Built alongside sybra-server, from the same source checkout, in the same
+# atomic swap below — this is what keeps the CLI's config-schema handling
+# from drifting out of sync with the running server (#2619).
+log "building sybra-cli binary"
+if ! CGO_ENABLED=0 mise exec -- go build -trimpath -o "$CLI_BIN.new" ./cmd/sybra-cli; then
+  rm -f "$BIN.new" "$CLI_BIN.new"
+  keep_last_good_or_fail "go build sybra-cli"
+fi
+
 if command -v bwrap >/dev/null 2>&1; then
   log "running linked-worktree sandbox smoke"
   if ! mise exec -- go test ./internal/agent -run '^TestSandboxEnforce_LinkedWorktreeGitOps$' -count=1; then
-    rm -f "$BIN.new"
+    rm -f "$BIN.new" "$CLI_BIN.new"
     keep_last_good_or_fail "linux sandbox git smoke"
   fi
 fi
 
 rm -rf "$WEB.new"
 if ! cp -a frontend/dist-web "$WEB.new"; then
-  rm -f "$BIN.new"
+  rm -f "$BIN.new" "$CLI_BIN.new"
   keep_last_good_or_fail "stage web bundle"
 fi
 rm -rf "$WEB"
@@ -55,6 +66,13 @@ if ! mv "$WEB.new" "$WEB"; then
 fi
 if ! mv -f "$BIN.new" "$BIN"; then
   keep_last_good_or_fail "swap server binary"
+fi
+if ! mv -f "$CLI_BIN.new" "$CLI_BIN"; then
+  keep_last_good_or_fail "swap sybra-cli binary"
+fi
+
+if ! (mkdir -p "$CLI_LINK_DIR" && ln -sf "$CLI_BIN" "$CLI_LINK_DIR/sybra-cli"); then
+  log "warning: failed to symlink sybra-cli into $CLI_LINK_DIR; binary is still at $CLI_BIN"
 fi
 
 log "build complete: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"


### PR DESCRIPTION
## Motivation

sybra-build.sh only built sybra-server and the web bundle, so config-schema-affecting changes could leave a stale sybra-cli binary drifted from the running server's schema.

## Implementation information

sybra-build.sh now builds sybra-cli alongside sybra-server so both stay in sync on every deploy.

> Changelog: fix(deploy): build sybra-cli alongside server

Closes https://github.com/Automaat/sybra/issues/2619