### PR TITLE
fix(github): fall through to real push on preflight failure

### DIFF
--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -222,8 +222,15 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
 	if preflightErr := e.preflightPushCredentials(ctx, wtPath); preflightErr != nil {
-		out, err = e.classifyPRGitError(taskID, step, wfExec, t, preflightErr, "push credential preflight")
-		return out, err, false
+		// The dry-run probe can false-positive on a momentarily stale
+		// credential (e.g. an app-token rotation window landing mid-check,
+		// #2160) even though the real push would succeed (#2386). Don't park
+		// on the probe alone — fall through and attempt the actual push;
+		// only classify/escalate below if that also fails. PreflightPushCredentials
+		// already recorded the audit finding (pushAuthFailureHook) before
+		// returning, so the signal isn't lost even though it no longer blocks.
+		e.logger.Warn("workflow.pr-tail.preflight-failed-attempting-push",
+			"task_id", taskID, "step", step.ID, "err", preflightErr)
 	}
 	pushErr := project.PushSync(ctx, wtPath, branch)
 	if pushErr == nil {

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -232,7 +232,13 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 		e.logger.Warn("workflow.pr-tail.preflight-failed-attempting-push",
 			"task_id", taskID, "step", step.ID, "err", preflightErr)
 	}
-	pushErr := project.PushSync(ctx, wtPath, branch)
+	// Preflight's mandated retry backoffs and dry-run subprocesses can consume
+	// a large slice of the shared budget; give the real push its own fresh
+	// timeout so it isn't killed on stale budget and misclassified into the
+	// non-auth retry bucket (#2160/#2386).
+	pushCtx, pushCancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer pushCancel()
+	pushErr := project.PushSync(pushCtx, wtPath, branch)
 	if pushErr == nil {
 		return StepOutput{}, nil, true
 	}

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -197,8 +197,9 @@ func TestExecPushBranch_Success(t *testing.T) {
 // stale app-token cache) even though the real push would succeed. The step
 // must attempt the real push instead of parking on the probe alone.
 func TestExecPushBranch_PreflightFailureFallsThroughToSuccessfulPush(t *testing.T) {
-	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+	bare, wtPath := newPRWorktree(t, "feat/existing-pr")
 	commitFile(t, wtPath, "change.txt", "feat: task work")
+	local := headSHA(t, wtPath)
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
@@ -227,6 +228,11 @@ func TestExecPushBranch_PreflightFailureFallsThroughToSuccessfulPush(t *testing.
 	}
 	if ti.Status != "ready-pr" {
 		t.Fatalf("status = %q, want unchanged ready-pr (push succeeded despite the failed probe)", ti.Status)
+	}
+	// The real push must actually land on the remote — a silent no-op
+	// fallthrough would leave the bare repo without the branch head.
+	if got := strings.TrimSpace(runGitAt(t, bare, "rev-parse", "feat/existing-pr")); got != local {
+		t.Fatalf("bare remote head = %q, want %q (real push did not land)", got, local)
 	}
 }
 

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -192,8 +192,52 @@ func TestExecPushBranch_Success(t *testing.T) {
 	}
 }
 
-func TestExecPushBranch_PreflightAuthFailureParksBeforePush(t *testing.T) {
-	wtPath := t.TempDir()
+// TestExecPushBranch_PreflightFailureFallsThroughToSuccessfulPush covers the
+// #2386 false-block: the dry-run preflight probe can fail transiently (e.g. a
+// stale app-token cache) even though the real push would succeed. The step
+// must attempt the real push instead of parking on the probe alone.
+func TestExecPushBranch_PreflightFailureFallsThroughToSuccessfulPush(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	preflight := &fakePushPreflighter{err: errors.New("github push credential preflight failed: gh auth status: Bad credentials")}
+	engine.SetPushCredentialPreflighter(preflight)
+
+	wfExec := &Execution{Variables: map[string]string{}}
+	out, err := engine.execPushBranch("t1", newPushBranchStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
+	if err != nil {
+		t.Fatalf("execPushBranch: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, want completed", out.Status)
+	}
+	if preflight.calls != 1 {
+		t.Fatalf("preflight calls = %d, want 1", preflight.calls)
+	}
+	if got := preflight.paths[0]; got != wtPath {
+		t.Fatalf("preflight path = %q, want %q", got, wtPath)
+	}
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Status != "ready-pr" {
+		t.Fatalf("status = %q, want unchanged ready-pr (push succeeded despite the failed probe)", ti.Status)
+	}
+}
+
+// TestExecPushBranch_PreflightAndPushBothFailParksForRetry covers the other
+// half of #2386: a preflight failure must not be the last word either — it's
+// only the real push's outcome that decides retry/escalation.
+func TestExecPushBranch_PreflightAndPushBothFailParksForRetry(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+	runGit(t, wtPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "does-not-exist.git"))
+
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
 	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
@@ -209,21 +253,21 @@ func TestExecPushBranch_PreflightAuthFailureParksBeforePush(t *testing.T) {
 	if preflight.calls != 1 {
 		t.Fatalf("preflight calls = %d, want 1", preflight.calls)
 	}
-	if got := preflight.paths[0]; got != wtPath {
-		t.Fatalf("preflight path = %q, want %q", got, wtPath)
-	}
 	ti, err := tasks.GetTask("t1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ti.Status != "ready-pr" {
-		t.Fatalf("status = %q, want ready-pr", ti.Status)
+		t.Fatalf("status = %q, want ready-pr (parked)", ti.Status)
 	}
-	if !strings.HasPrefix(ti.StatusReason, prCreateAuthRetryReason+": ") || !strings.Contains(ti.StatusReason, "Bad credentials") {
-		t.Fatalf("status reason = %q, want auth retry reason with diagnostic detail", ti.StatusReason)
+	// Classification must be driven by the real push's error, not the
+	// preflight probe's — the push-retry counter increments, not the
+	// preflight-specific auth-retry counter.
+	if wfExec.Variables[prPushAttemptsVar] != "1" {
+		t.Fatalf("%s = %q, want 1", prPushAttemptsVar, wfExec.Variables[prPushAttemptsVar])
 	}
-	if wfExec.Variables[prCreateAuthAttemptsVar] != "1" {
-		t.Fatalf("%s = %q, want 1", prCreateAuthAttemptsVar, wfExec.Variables[prCreateAuthAttemptsVar])
+	if wfExec.Variables[prCreateAuthAttemptsVar] != "" {
+		t.Fatalf("%s = %q, want empty (classification came from the push error)", prCreateAuthAttemptsVar, wfExec.Variables[prCreateAuthAttemptsVar])
 	}
 }
 

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -421,8 +421,14 @@ func TestExecRoutePRFixResult_RecoversResolvedButUnstagedConflict(t *testing.T) 
 func TestExecRoutePRFixResult_ResolvedMergePushRetryKeepsCheckpointContext(t *testing.T) {
 	t.Parallel()
 
-	_, wtPath := newResolvedUnmergedPRFixWorktree(t, "feat/conflict-retry")
+	bare, wtPath := newResolvedUnmergedPRFixWorktree(t, "feat/conflict-retry")
 	runGitAt(t, wtPath, "add", filepath.Join("internal", "workflow", "engine_advance.go"))
+
+	// A preflight-only failure now falls through to a real push attempt
+	// (#2386) instead of parking, so this must drive the retry with a real
+	// push failure: break the remote for the first attempt, restore it
+	// before the resumed attempt.
+	runGitAt(t, wtPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "does-not-exist.git"))
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
@@ -433,7 +439,7 @@ func TestExecRoutePRFixResult_ResolvedMergePushRetryKeepsCheckpointContext(t *te
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
 	}}})
-	preflight := &fakePushPreflighter{errs: []error{errors.New("i/o timeout")}}
+	preflight := &fakePushPreflighter{}
 	engine.SetPushCredentialPreflighter(preflight)
 
 	wf := &Execution{
@@ -475,6 +481,8 @@ func TestExecRoutePRFixResult_ResolvedMergePushRetryKeepsCheckpointContext(t *te
 	if len(resolved) != 0 {
 		t.Fatalf("resolved paths after checkpoint = %v, want none", resolved)
 	}
+
+	runGitAt(t, wtPath, "remote", "set-url", "origin", bare)
 
 	resumedTask, err := tasks.GetTask("t1")
 	if err != nil {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7757,7 +7757,7 @@ func runGitAt(t *testing.T, dir string, args ...string) string {
 }
 
 func gitCombinedAt(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	return string(out), err


### PR DESCRIPTION
## Motivation

Push credential preflight is a dry-run probe and can false-positive on a momentarily stale credential (app-token rotation window) even though the real push would succeed, parking tasks unnecessarily.

## Implementation information

`pushTaskBranch` now logs the preflight failure and falls through to the actual push instead of parking on the probe alone; only the real push's outcome drives retry/escalation.

## Supporting documentation

Closes #2386

_Generated by Sybra harness_