### PR TITLE
fix(worktree): skip reaping sandboxes with unpushed commits

### DIFF
--- a/cmd/sybra-cli/doctor_test.go
+++ b/cmd/sybra-cli/doctor_test.go
@@ -13,7 +13,11 @@ import (
 )
 
 // makeDoctorWorktree creates a real git repo at path with one committed
-// file; dirty additionally leaves an uncommitted change.
+// file, pushed to a throwaway bare "origin" so it looks fully delivered
+// (matching production, where every Sybra-managed worktree tracks the
+// project's bare clone as origin) — i.e. it holds no unpushed commits unless
+// a caller commits further without pushing. dirty additionally leaves an
+// uncommitted change.
 func makeDoctorWorktree(t *testing.T, path string, dirty bool) {
 	t.Helper()
 	t.Setenv("GIT_AUTHOR_NAME", "test")
@@ -29,6 +33,12 @@ func makeDoctorWorktree(t *testing.T, path string, dirty bool) {
 	}
 	runGit(t, path, "add", "-A")
 	runGit(t, path, "commit", "-m", "init")
+
+	origin := t.TempDir()
+	runGit(t, origin, "init", "--bare")
+	runGit(t, path, "remote", "add", "origin", origin)
+	runGit(t, path, "push", "-u", "origin", "HEAD:refs/heads/main")
+
 	if dirty {
 		if err := os.WriteFile(filepath.Join(path, "f.txt"), []byte("b"), 0o644); err != nil {
 			t.Fatalf("dirty file: %v", err)

--- a/internal/agent/k8s_job_runner.go
+++ b/internal/agent/k8s_job_runner.go
@@ -542,24 +542,13 @@ func pushK8sGitWorkspace(ctx context.Context, dir string, workspace k8sGitWorksp
 	if workspace.Remote == "" || workspace.Branch == "" {
 		return nil
 	}
-	if !hasUnpushedCommits(ctx, dir) {
+	if !project.HasUnpushedCommits(ctx, dir) {
 		return nil
 	}
 	if _, err := gitOutput(ctx, dir, "push", "-u", "origin", "HEAD:"+workspace.Branch); err != nil {
 		return fmt.Errorf("push k8s workspace branch: %w", err)
 	}
 	return nil
-}
-
-// hasUnpushedCommits reports whether HEAD holds commits that no remote branch
-// contains. Errs toward true: if the count cannot be read, push and let a real
-// failure surface rather than silently dropping work.
-func hasUnpushedCommits(ctx context.Context, dir string) bool {
-	out, err := gitOutput(ctx, dir, "rev-list", "--count", "HEAD", "--not", "--remotes")
-	if err != nil {
-		return true
-	}
-	return strings.TrimSpace(out) != "0"
 }
 
 func syncK8sGitWorkspace(ctx context.Context, dir string) error {

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Automaat/sybra/internal/buildcache"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -310,6 +311,17 @@ func gitStatusClean(path string) bool {
 	return len(bytes.TrimSpace(out)) == 0
 }
 
+// hasUnpushedCommits reports whether the worktree at path holds commits not
+// on any remote. Unlike gitStatusClean this is never bypassed by --force: a
+// clean-but-unpushed worktree holds finished work with no other copy, which
+// --force exists to blow past for merely-dirty (in-progress, discardable)
+// state, not completed-but-undelivered commits (#2593).
+func hasUnpushedCommits(path string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return project.HasUnpushedCommits(ctx, path)
+}
+
 // resolveBucketNames returns the bucket names Scan/Apply should consider:
 // opts.Only when set (already validated by the caller), otherwise every
 // known bucket name (still subject to each bucket's own gate check).
@@ -565,6 +577,9 @@ func (s *Scanner) scanWorktrees(snap snapshot, opts Options) Bucket {
 		if ok, _ := eligible(snap, taskID, p, retention, disabled, s.now()); !ok {
 			continue
 		}
+		if hasUnpushedCommits(p) {
+			continue
+		}
 		if !opts.Force && !gitStatusClean(p) {
 			continue
 		}
@@ -719,6 +734,9 @@ func (s *Scanner) revalidate(bucketName, path string, snap snapshot, opts Option
 		taskID := taskIDFromWorktreeDir(filepath.Base(path))
 		if ok, reason := eligible(snap, taskID, path, retention, disabled, s.now()); !ok {
 			return false, reason
+		}
+		if hasUnpushedCommits(path) {
+			return false, "worktree has commits not pushed to any remote"
 		}
 		if !opts.Force && !gitStatusClean(path) {
 			return false, "worktree has uncommitted changes"

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -336,15 +336,45 @@ func (s *Scanner) sandboxWorktreeHasUnpushedCommits(snap snapshot, taskID string
 	if taskID == "" || taskID == unknownTaskID {
 		return false
 	}
-	t, exists := snap.byID[taskID]
-	if !exists || t.ProjectID == "" || t.WorktreeDir != "" {
-		return false
-	}
-	wtPath := filepath.Join(s.cfg.WorktreesDir, t.DirName())
-	if _, err := os.Stat(wtPath); err != nil {
+	wtPath, ok := s.sandboxWorktreePath(snap, taskID)
+	if !ok {
 		return false
 	}
 	return hasUnpushedCommits(wtPath)
+}
+
+// sandboxWorktreePath resolves the Sybra-managed worktree path for taskID. For
+// a live task it uses DirName(); for a deleted task (record gone from snap) it
+// falls back to scanning the worktrees dir for a directory whose embedded task
+// ID matches — the deleted-task case is exactly the one the unpushed-commits
+// guard must protect, yet a live record no longer exists to compute DirName()
+// from (#2593). Externally-adopted worktrees (WorktreeDir set) are never
+// resolved: they live outside WorktreesDir, so the directory scan never
+// surfaces them either.
+func (s *Scanner) sandboxWorktreePath(snap snapshot, taskID string) (string, bool) {
+	if t, exists := snap.byID[taskID]; exists {
+		if t.ProjectID == "" || t.WorktreeDir != "" {
+			return "", false
+		}
+		wtPath := filepath.Join(s.cfg.WorktreesDir, t.DirName())
+		if _, err := os.Stat(wtPath); err != nil {
+			return "", false
+		}
+		return wtPath, true
+	}
+	entries, err := os.ReadDir(s.cfg.WorktreesDir)
+	if err != nil {
+		return "", false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if taskIDFromWorktreeDir(e.Name()) == taskID {
+			return filepath.Join(s.cfg.WorktreesDir, e.Name()), true
+		}
+	}
+	return "", false
 }
 
 // resolveBucketNames returns the bucket names Scan/Apply should consider:

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -322,6 +322,31 @@ func hasUnpushedCommits(path string) bool {
 	return project.HasUnpushedCommits(ctx, path)
 }
 
+// sandboxWorktreeHasUnpushedCommits reports whether the sandbox dir's owning
+// task has a git worktree still holding commits not on any remote. A sandbox
+// (~/.sybra/sandboxes/<taskID>) is a separate per-task data dir from the git
+// worktree, so this resolves the task's worktree path and defers to the same
+// git check scanWorktrees uses — an unattended diskreclaim pass must never
+// reap a sandbox tied to completed-but-unpushed work (#2593). Mirrors
+// worktree.Manager.HasUnpushedCommits. Returns false — nothing to protect —
+// when the task, its project, or worktree cannot be resolved, or when the
+// worktree is externally adopted (owned by the tool that created it, so its
+// git state is not Sybra's to protect).
+func (s *Scanner) sandboxWorktreeHasUnpushedCommits(snap snapshot, taskID string) bool {
+	if taskID == "" || taskID == unknownTaskID {
+		return false
+	}
+	t, exists := snap.byID[taskID]
+	if !exists || t.ProjectID == "" || t.WorktreeDir != "" {
+		return false
+	}
+	wtPath := filepath.Join(s.cfg.WorktreesDir, t.DirName())
+	if _, err := os.Stat(wtPath); err != nil {
+		return false
+	}
+	return hasUnpushedCommits(wtPath)
+}
+
 // resolveBucketNames returns the bucket names Scan/Apply should consider:
 // opts.Only when set (already validated by the caller), otherwise every
 // known bucket name (still subject to each bucket's own gate check).
@@ -513,7 +538,11 @@ func (s *Scanner) scanSandboxes(snap snapshot) Bucket {
 		if isSymlink(p) {
 			continue
 		}
-		if ok, _ := eligible(snap, sandboxTaskIDFromDir(e.Name()), p, retention, disabled, s.now()); !ok {
+		taskID := sandboxTaskIDFromDir(e.Name())
+		if ok, _ := eligible(snap, taskID, p, retention, disabled, s.now()); !ok {
+			continue
+		}
+		if s.sandboxWorktreeHasUnpushedCommits(snap, taskID) {
 			continue
 		}
 		size, err := dirSize(p)
@@ -728,7 +757,13 @@ func (s *Scanner) revalidate(bucketName, path string, snap snapshot, opts Option
 		if bucketName == BucketSandboxes {
 			taskID = sandboxTaskIDFromDir(taskID)
 		}
-		return eligible(snap, taskID, path, retention, disabled, s.now())
+		if ok, reason := eligible(snap, taskID, path, retention, disabled, s.now()); !ok {
+			return false, reason
+		}
+		if bucketName == BucketSandboxes && s.sandboxWorktreeHasUnpushedCommits(snap, taskID) {
+			return false, "owning task worktree has commits not pushed to any remote"
+		}
+		return true, "eligible"
 	case BucketWorktrees:
 		retention, disabled := s.sandboxRetention()
 		taskID := taskIDFromWorktreeDir(filepath.Base(path))

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -397,6 +397,36 @@ func TestScanSandboxesSkipsActiveOrphanAndTerminal(t *testing.T) {
 	}
 }
 
+// TestScanSandboxesSkipsDeletedTaskUnpushedWorktree proves a sandbox whose
+// owning task was DELETED is still preserved when that task's git worktree
+// survives on disk holding commits never pushed to origin. The task record is
+// gone, so the guard must resolve the worktree by directory name rather than a
+// live record — the exact deleted-task gap #2593 must protect.
+func TestScanSandboxesSkipsDeletedTaskUnpushedWorktree(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Sandbox.RetentionHours = 1
+	now := time.Now()
+
+	// Sandbox dir is named by the bare task ID; its owning task is absent
+	// from the store (deleted).
+	taskID := "deadface"
+	sb := filepath.Join(sandboxesDir(), taskID)
+	writeFileAt(t, filepath.Join(sb, "f"), 9, now)
+
+	// The deleted task's worktree survives under a slug-prefixed dir name and
+	// still holds an unpushed commit.
+	makeGitWorktreeUnpushed(t, filepath.Join(cfg.WorktreesDir, "feat-"+taskID))
+
+	s := NewScanner(cfg, &fakeLister{}) // no tasks: the sandbox is an orphan
+	res, err := s.Scan(Options{Only: []string{BucketSandboxes}})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.Buckets[0].Items != 0 {
+		t.Fatalf("deleted task's sandbox must be preserved while its worktree holds unpushed commits, got %+v", res.Buckets[0])
+	}
+}
+
 func TestScanGoBuildCacheOrphanEligible(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Sandbox.RetentionHours = 1

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -68,7 +68,11 @@ func runGit(t *testing.T, dir string, args ...string) {
 }
 
 // makeGitWorktree creates a real, initialized git repo at path with one
-// committed file. dirty additionally leaves an uncommitted modification.
+// committed file, pushed to a throwaway bare "origin" so the worktree looks
+// fully delivered (matching production, where every Sybra-managed worktree
+// tracks the project's bare clone as origin) — i.e. HasUnpushedCommits is
+// false unless a caller commits further without pushing. dirty additionally
+// leaves an uncommitted modification.
 func makeGitWorktree(t *testing.T, path string, dirty bool) {
 	t.Helper()
 	mustMkdir(t, path)
@@ -78,11 +82,29 @@ func makeGitWorktree(t *testing.T, path string, dirty bool) {
 	}
 	runGit(t, path, "add", "-A")
 	runGit(t, path, "commit", "-q", "-m", "init")
+
+	originDir := t.TempDir()
+	runGit(t, originDir, "init", "-q", "--bare")
+	runGit(t, path, "remote", "add", "origin", originDir)
+	runGit(t, path, "push", "-q", "-u", "origin", "HEAD:refs/heads/main")
+
 	if dirty {
 		if err := os.WriteFile(filepath.Join(path, "f.txt"), []byte("b"), 0o644); err != nil {
 			t.Fatalf("dirty file: %v", err)
 		}
 	}
+}
+
+// makeGitWorktreeUnpushed is like makeGitWorktree but leaves an extra
+// committed change that was never pushed to origin — the scenario
+// HasUnpushedCommits must refuse to reap (#2593).
+func makeGitWorktreeUnpushed(t *testing.T, path string) {
+	t.Helper()
+	makeGitWorktree(t, path, false)
+	if err := os.WriteFile(filepath.Join(path, "f.txt"), []byte("c"), 0o644); err != nil {
+		t.Fatalf("unpushed file: %v", err)
+	}
+	runGit(t, path, "commit", "-q", "-am", "unpushed work")
 }
 
 func doneTask(id string, statusChangedAt time.Time) task.Task {
@@ -448,6 +470,61 @@ func TestScanWorktreesDirtySkippedWithoutForce(t *testing.T) {
 	}
 	if res.Buckets[0].Items != 1 {
 		t.Fatalf("dirty worktree must be reported eligible with --force, got %+v", res.Buckets[0])
+	}
+}
+
+// TestScanWorktreesUnpushedSkippedEvenWithForce proves a worktree holding
+// commits that never reached origin is never reported eligible — not even
+// with --force, which only bypasses the uncommitted-changes check. Without
+// this guard a task bounced through human-required (e.g. a push failure) and
+// later reaped by a status/retention-only sweep would silently lose a
+// completed diff (#2593).
+func TestScanWorktreesUnpushedSkippedEvenWithForce(t *testing.T) {
+	cfg := testConfig(t)
+	now := time.Now()
+	unpushedPath := filepath.Join(cfg.WorktreesDir, "beefdead")
+	makeGitWorktreeUnpushed(t, unpushedPath)
+
+	lister := &fakeLister{tasks: []task.Task{doneTask("beefdead", now.Add(-100*time.Hour))}}
+	s := NewScanner(cfg, lister)
+
+	for _, opts := range []Options{
+		{Only: []string{BucketWorktrees}, Worktrees: true},
+		{Only: []string{BucketWorktrees}, Worktrees: true, Force: true},
+	} {
+		res, err := s.Scan(opts)
+		if err != nil {
+			t.Fatalf("scan (force=%v): %v", opts.Force, err)
+		}
+		if res.Buckets[0].Items != 0 {
+			t.Fatalf("worktree with unpushed commits must never be eligible (force=%v), got %+v", opts.Force, res.Buckets[0])
+		}
+	}
+}
+
+// TestApplyWorktreesRevalidatesUnpushedCommits proves Apply's revalidation
+// step also refuses a worktree with unpushed commits, even when a stale
+// Bucket (as if produced before the guard existed, or by a racing Scan)
+// claims it is eligible.
+func TestApplyWorktreesRevalidatesUnpushedCommits(t *testing.T) {
+	cfg := testConfig(t)
+	now := time.Now()
+	unpushedPath := filepath.Join(cfg.WorktreesDir, "cafebabe")
+	makeGitWorktreeUnpushed(t, unpushedPath)
+
+	lister := &fakeLister{tasks: []task.Task{doneTask("cafebabe", now.Add(-100*time.Hour))}}
+	s := NewScanner(cfg, lister)
+
+	staleBucket := Bucket{Name: BucketWorktrees, Paths: []string{unpushedPath}}
+	res, err := s.Apply([]Bucket{staleBucket}, Options{Worktrees: true, Force: true})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(res.Buckets) != 1 || res.Buckets[0].Removed != 0 {
+		t.Fatalf("worktree with unpushed commits must not be removed, got %+v", res.Buckets)
+	}
+	if _, err := os.Stat(unpushedPath); err != nil {
+		t.Fatalf("worktree with unpushed commits must survive apply: %v", err)
 	}
 }
 

--- a/internal/diskreclaim/reclaimer_test.go
+++ b/internal/diskreclaim/reclaimer_test.go
@@ -82,8 +82,11 @@ func runGit(t *testing.T, dir string, args ...string) {
 	}
 }
 
-// makeCleanGitWorktree creates a real, initialized, clean git repo at path
-// so it passes cleanup's dirty-worktree safety check.
+// makeCleanGitWorktree creates a real, initialized, clean git repo at path,
+// pushed to a throwaway bare "origin" so it passes both cleanup's
+// dirty-worktree and unpushed-commits safety checks — matching production,
+// where every Sybra-managed worktree tracks the project's bare clone as
+// origin.
 func makeCleanGitWorktree(t *testing.T, path string) {
 	t.Helper()
 	mustMkdir(t, path)
@@ -93,6 +96,11 @@ func makeCleanGitWorktree(t *testing.T, path string) {
 	}
 	runGit(t, path, "add", "-A")
 	runGit(t, path, "commit", "-q", "-m", "init")
+
+	origin := t.TempDir()
+	runGit(t, origin, "init", "-q", "--bare")
+	runGit(t, path, "remote", "add", "origin", origin)
+	runGit(t, path, "push", "-q", "-u", "origin", "HEAD:refs/heads/main")
 }
 
 func TestReclaimerRunReclaimsSafeBucketsOnly(t *testing.T) {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1130,6 +1130,20 @@ func IsWorktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
 	return worktreeDirty(ctx, worktreePath)
 }
 
+// HasUnpushedCommits reports whether HEAD in worktreePath holds commits that
+// no remote-tracking ref locally knows about. Errs toward true: if the count
+// cannot be determined (not a git repo, missing dir, git failure), callers
+// deciding whether a worktree/sandbox is safe to reap must treat it as unsafe
+// rather than silently destroying possibly-unpushed work (see #2593, where a
+// completed implementation was lost this way).
+func HasUnpushedCommits(ctx context.Context, worktreePath string) bool {
+	out, err := executil.Output(ctx, worktreePath, "git", "rev-list", "--count", "HEAD", "--not", "--remotes")
+	if err != nil {
+		return true
+	}
+	return out != "0"
+}
+
 // HardResetWorktree resets a worktree's index and working tree to ref (a
 // branch name or commit SHA) via `git reset --hard`. Used by best-of-N
 // promotion to materialize the canonical worktree at the winning attempt's

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -202,5 +202,11 @@ func (r *Recovery) cleanupOrphanedSandboxes(ctx context.Context) {
 	if r.Agents != nil {
 		hasAgent = r.Agents.HasRunningAgentForTask
 	}
-	r.Sandboxes.CleanupOrphaned(ctx, tasks, hasAgent)
+	var hasUnpushedCommits func(string) bool
+	if r.Worktrees != nil {
+		hasUnpushedCommits = func(taskID string) bool {
+			return r.Worktrees.HasUnpushedCommits(ctx, taskID)
+		}
+	}
+	r.Sandboxes.CleanupOrphaned(ctx, tasks, hasAgent, hasUnpushedCommits)
 }

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -330,8 +330,13 @@ func cleanupEligible(s task.Status) bool {
 // they have been eligible for at least the configured retention window (see
 // SetRetentionWindow). Non-eligible tasks (active, in-review, etc.) always
 // keep their dirs. When hasAgent reports a live task agent, the dir is
-// preserved so cleanup never races an active run.
-func (m *Manager) CleanupOrphaned(ctx context.Context, tasks []task.Task, hasAgent func(string) bool) {
+// preserved so cleanup never races an active run. When hasUnpushedCommits
+// reports the task's git worktree still holds commits not on origin, the dir
+// is preserved regardless of status/age/deletion — status alone (e.g. a task
+// bounced to human-required by a failed push, then reset) is not proof the
+// work is safely recoverable elsewhere (#2593). hasUnpushedCommits may be nil,
+// in which case this signal is skipped (matches hasAgent's nil handling).
+func (m *Manager) CleanupOrphaned(ctx context.Context, tasks []task.Task, hasAgent, hasUnpushedCommits func(string) bool) {
 	entries, err := os.ReadDir(m.dataDir)
 	if err != nil {
 		return
@@ -361,6 +366,9 @@ func (m *Manager) CleanupOrphaned(ctx context.Context, tasks []task.Task, hasAge
 			// including a task record that's gone missing — an orphaned
 			// dir with a running agent is not orphaned, it's just
 			// unlinked from the (possibly stale) task list.
+			continue
+		case hasUnpushedCommits != nil && hasUnpushedCommits(taskID):
+			m.logger.Warn("sandbox.cleanup.unpushed-commits", "task_id", taskID)
 			continue
 		case !exists:
 			// Deleted task — remove regardless of age, and regardless of any

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -474,7 +474,7 @@ func TestManager_CleanupOrphaned(t *testing.T) {
 	}
 	m.CleanupOrphaned(context.Background(), tasks, func(taskID string) bool {
 		return taskID == "task-live-terminal"
-	})
+	}, nil)
 
 	if _, err := os.Stat(filepath.Dir(keepDir)); err != nil {
 		t.Fatalf("active task dir removed unexpectedly: %v", err)
@@ -487,6 +487,40 @@ func TestManager_CleanupOrphaned(t *testing.T) {
 	}
 	if _, err := os.Stat(missingRoot); !os.IsNotExist(err) {
 		t.Fatalf("missing-task dir still exists after cleanup: %v", err)
+	}
+}
+
+// TestManager_CleanupOrphaned_PreservesUnpushedCommits proves the
+// hasUnpushedCommits resolver takes precedence over every other signal —
+// terminal status, deletion, retention age — exactly like hasAgent does for
+// live agents. A task's sandbox is a separate data dir from its git
+// worktree, so this is sandbox cleanup's own defense against reaping a task
+// whose worktree still holds completed-but-unpushed work (#2593).
+func TestManager_CleanupOrphaned_PreservesUnpushedCommits(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t)
+
+	doneDir, err := m.SybraHomeDir("task-done-unpushed")
+	if err != nil {
+		t.Fatalf("SybraHomeDir(done-unpushed): %v", err)
+	}
+	deletedDir, err := m.SybraHomeDir("task-deleted-unpushed")
+	if err != nil {
+		t.Fatalf("SybraHomeDir(deleted-unpushed): %v", err)
+	}
+
+	tasks := []task.Task{
+		{ID: "task-done-unpushed", Status: task.StatusDone},
+	}
+	m.CleanupOrphaned(context.Background(), tasks, nil, func(taskID string) bool {
+		return taskID == "task-done-unpushed" || taskID == "task-deleted-unpushed"
+	})
+
+	if _, err := os.Stat(filepath.Dir(doneDir)); err != nil {
+		t.Fatalf("done task's sandbox removed despite unpushed commits: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(deletedDir)); err != nil {
+		t.Fatalf("deleted task's sandbox removed despite unpushed commits: %v", err)
 	}
 }
 
@@ -525,7 +559,7 @@ func TestManager_CleanupOrphaned_Retention(t *testing.T) {
 		{ID: "task-recent-blocked", Status: task.StatusBlocked, StatusChangedAt: now},
 		{ID: "task-in-review", Status: task.StatusInReview, StatusChangedAt: now.Add(-2 * time.Hour)},
 	}
-	m.CleanupOrphaned(context.Background(), tasks, nil)
+	m.CleanupOrphaned(context.Background(), tasks, nil, nil)
 
 	for _, dir := range []string{agedDoneDir, agedCancelledDir, agedBlockedDir} {
 		if _, err := os.Stat(filepath.Dir(dir)); !os.IsNotExist(err) {
@@ -552,7 +586,7 @@ func TestManager_CleanupOrphaned_RetentionDisabled(t *testing.T) {
 	tasks := []task.Task{
 		{ID: "task-aged-done", Status: task.StatusDone, StatusChangedAt: time.Now().Add(-1000 * time.Hour)},
 	}
-	m.CleanupOrphaned(context.Background(), tasks, nil)
+	m.CleanupOrphaned(context.Background(), tasks, nil, nil)
 
 	if _, err := os.Stat(filepath.Dir(dir)); err != nil {
 		t.Fatalf("eligible dir removed despite disabled retention: %v", err)
@@ -824,7 +858,7 @@ func TestManager_CleanupOrphaned_SkipsAlreadyQuarantined(t *testing.T) {
 	}
 
 	tasks := []task.Task{{ID: "task-q", Status: task.StatusDone}}
-	m.CleanupOrphaned(context.Background(), tasks, nil)
+	m.CleanupOrphaned(context.Background(), tasks, nil, nil)
 	if calls != 1 {
 		t.Fatalf("removeAll calls after first tick = %d, want 1", calls)
 	}
@@ -838,7 +872,7 @@ func TestManager_CleanupOrphaned_SkipsAlreadyQuarantined(t *testing.T) {
 		calls++
 		return nil
 	}
-	m.CleanupOrphaned(context.Background(), tasks, nil)
+	m.CleanupOrphaned(context.Background(), tasks, nil, nil)
 	if calls != 1 {
 		t.Errorf("removeAll calls after second tick = %d, want still 1 (quarantined task skipped)", calls)
 	}
@@ -865,7 +899,7 @@ func TestManager_CleanupOrphaned_PreservesOrphanedActiveAgent(t *testing.T) {
 
 	m.CleanupOrphaned(context.Background(), nil, func(taskID string) bool {
 		return taskID == "task-live-orphan"
-	})
+	}, nil)
 
 	if _, err := os.Stat(taskDir); err != nil {
 		t.Fatalf("orphaned dir with live agent removed unexpectedly: %v", err)

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -152,7 +152,13 @@ func (a *App) maintenancePass(ctx context.Context) {
 			if a.agents != nil {
 				hasAgent = a.agents.HasRunningAgentForTask
 			}
-			a.sandboxes.CleanupOrphaned(ctx, tasks, hasAgent)
+			var hasUnpushedCommits func(string) bool
+			if a.worktrees != nil {
+				hasUnpushedCommits = func(taskID string) bool {
+					return a.worktrees.HasUnpushedCommits(ctx, taskID)
+				}
+			}
+			a.sandboxes.CleanupOrphaned(ctx, tasks, hasAgent, hasUnpushedCommits)
 		}
 	}
 }

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -312,7 +312,7 @@ func TestInitSandboxes_AppliesRetentionWindow(t *testing.T) {
 		ID:              "task-done",
 		Status:          task.StatusDone,
 		StatusChangedAt: time.Now(),
-	}}, nil)
+	}}, nil, nil)
 
 	if _, err := os.Stat(filepath.Dir(dir)); err != nil {
 		t.Fatalf("recent done sandbox removed despite positive retention: %v", err)

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -5,10 +5,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+var (
+	bareTaskIDRe   = regexp.MustCompile(`^[0-9a-f]{8}$`)
+	suffixTaskIDRe = regexp.MustCompile(`-([0-9a-f]{8})$`)
+)
+
+// taskIDFromWorktreeDir extracts the owning task ID from a worktree directory
+// name: task.Task.DirName() is either the bare 8-hex-char ID (no slug yet) or
+// "<slug>-<8hex-id>". Anything else returns "" (no match).
+func taskIDFromWorktreeDir(name string) string {
+	if bareTaskIDRe.MatchString(name) {
+		return name
+	}
+	if m := suffixTaskIDRe.FindStringSubmatch(name); m != nil {
+		return m[1]
+	}
+	return ""
+}
 
 // Remove cleans up the worktree for a task via git worktree remove.
 func (m *Manager) Remove(ctx context.Context, taskID string) {
@@ -126,19 +145,48 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 // on origin. Used by sandbox cleanup (a separate per-task data dir from the
 // git worktree) so it never reaps a sandbox tied to a task whose worktree
 // still holds completed-but-unpushed work (#2593). Returns false — nothing to
-// protect — when the task, its worktree, or its project cannot be resolved,
-// or when the worktree is externally adopted (owned by the tool that created
-// it, not Sybra).
+// protect — when the worktree cannot be resolved, or when it is externally
+// adopted (owned by the tool that created it, not Sybra).
 func (m *Manager) HasUnpushedCommits(ctx context.Context, taskID string) bool {
-	t, err := m.tasks.Get(taskID)
-	if err != nil || t.ProjectID == "" || t.WorktreeDir != "" {
-		return false
-	}
-	wtPath := filepath.Join(m.dir, t.DirName())
-	if _, err := os.Stat(wtPath); err != nil {
+	wtPath, ok := m.resolveWorktreePath(taskID)
+	if !ok {
 		return false
 	}
 	return project.HasUnpushedCommits(ctx, wtPath)
+}
+
+// resolveWorktreePath returns the Sybra-managed worktree path for taskID. For
+// a live task it uses DirName(); for a deleted task (record gone) it falls
+// back to scanning the worktrees dir for a directory whose embedded task ID
+// matches — the deleted-task case is exactly what the unpushed-commits guard
+// must protect, and a live record no longer exists to compute DirName() from
+// (#2593). Externally-adopted worktrees (WorktreeDir set) are never resolved:
+// their lifecycle is owned by the tool that created them, and they live
+// outside m.dir so the directory scan never surfaces them either.
+func (m *Manager) resolveWorktreePath(taskID string) (string, bool) {
+	if t, err := m.tasks.Get(taskID); err == nil {
+		if t.ProjectID == "" || t.WorktreeDir != "" {
+			return "", false
+		}
+		wtPath := filepath.Join(m.dir, t.DirName())
+		if _, err := os.Stat(wtPath); err != nil {
+			return "", false
+		}
+		return wtPath, true
+	}
+	entries, err := os.ReadDir(m.dir)
+	if err != nil {
+		return "", false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if taskIDFromWorktreeDir(e.Name()) == taskID {
+			return filepath.Join(m.dir, e.Name()), true
+		}
+	}
+	return "", false
 }
 
 // List returns all git worktrees for the given project.

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -71,6 +71,11 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 			continue
 		}
 
+		if project.HasUnpushedCommits(ctx, wtPath) {
+			m.logger.Warn("worktree.orphan-cleanup.unpushed-commits", "path", wtPath)
+			continue
+		}
+
 		removed := false
 		if exists && t.ProjectID != "" {
 			if proj, perr := m.projects.Get(t.ProjectID); perr == nil {
@@ -104,6 +109,25 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 			m.logger.Warn("worktree.prune", "project", projects[i].ID, "err", err)
 		}
 	}
+}
+
+// HasUnpushedCommits reports whether taskID's own worktree holds commits not
+// on origin. Used by sandbox cleanup (a separate per-task data dir from the
+// git worktree) so it never reaps a sandbox tied to a task whose worktree
+// still holds completed-but-unpushed work (#2593). Returns false — nothing to
+// protect — when the task, its worktree, or its project cannot be resolved,
+// or when the worktree is externally adopted (owned by the tool that created
+// it, not Sybra).
+func (m *Manager) HasUnpushedCommits(ctx context.Context, taskID string) bool {
+	t, err := m.tasks.Get(taskID)
+	if err != nil || t.ProjectID == "" || t.WorktreeDir != "" {
+		return false
+	}
+	wtPath := filepath.Join(m.dir, t.DirName())
+	if _, err := os.Stat(wtPath); err != nil {
+		return false
+	}
+	return project.HasUnpushedCommits(ctx, wtPath)
 }
 
 // List returns all git worktrees for the given project.

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -26,6 +26,17 @@ func (m *Manager) Remove(ctx context.Context, taskID string) {
 	if _, err := os.Stat(wtPath); err != nil {
 		return
 	}
+	// Never reap a worktree whose completed work never reached origin — a task
+	// bounced to a terminal status (done/cancelled) after a failed push would
+	// otherwise lose its finished-but-unpushed diff right here, before the
+	// periodic orphan sweep's identical guard ever runs (#2593). This is the
+	// per-task chokepoint fired on task completion (completion.OnComplete),
+	// manual terminal transitions (UpdateTask), and explicit deletes
+	// (DeleteTask); consistent with doctor cleanup, even those never bypass it.
+	if project.HasUnpushedCommits(ctx, wtPath) {
+		m.logger.Warn("worktree.cleanup.unpushed-commits", "path", wtPath)
+		return
+	}
 	proj, err := m.projects.Get(t.ProjectID)
 	if err != nil {
 		return

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -461,6 +461,44 @@ func TestCleanupOrphaned_PreservesUnpushedCommits(t *testing.T) {
 	}
 }
 
+// TestRemove_PreservesUnpushedCommits proves the per-task cleanup chokepoint
+// (fired on task completion, manual terminal transitions, and explicit
+// deletes) refuses to delete a worktree whose completed work never reached
+// origin — the #2593 scenario where a terminal-status task's finished-but-
+// unpushed diff would otherwise be destroyed before the periodic orphan sweep
+// with its identical guard ever runs.
+func TestRemove_PreservesUnpushedCommits(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+	m := New(Config{WorktreesDir: dir, Tasks: taskMgr, Logger: discardLogger()})
+
+	tk, err := store.Create("unpushed task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Update(tk.ID, task.Update{ProjectID: task.Ptr("owner/repo")}); err != nil {
+		t.Fatal(err)
+	}
+	wtDir := filepath.Join(dir, tk.DirName())
+	makePushedGitDir(t, wtDir)
+	if err := os.WriteFile(filepath.Join(wtDir, "f.txt"), []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, wtDir, "git", "commit", "-q", "-am", "unpushed work")
+
+	m.Remove(context.Background(), tk.ID)
+
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Errorf("worktree with unpushed commits removed unexpectedly: %v", err)
+	}
+}
+
 // TestRunSetup_EmptyIsNoOp — backwards compat: projects without
 // SetupCommands must skip the hook entirely without creating log files
 // or calling into the filesystem.

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -425,6 +425,20 @@ func TestManager_HasUnpushedCommits(t *testing.T) {
 	if got := m.HasUnpushedCommits(ctx, "no-such-task"); got {
 		t.Error("missing task must report false (nothing to protect)")
 	}
+
+	// A deleted task's record is gone, but its worktree dir survives on disk
+	// still holding unpushed work — the exact case the guard must protect
+	// (#2593). Resolve it by directory name, not a live record.
+	deletedID := "aabbccdd"
+	deletedDir := filepath.Join(dir, "deleted-task-"+deletedID)
+	makePushedGitDir(t, deletedDir)
+	if err := os.WriteFile(filepath.Join(deletedDir, "f.txt"), []byte("c"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, deletedDir, "git", "commit", "-q", "-am", "unpushed work")
+	if got := m.HasUnpushedCommits(ctx, deletedID); !got {
+		t.Error("deleted task's worktree with an unpushed commit must be protected")
+	}
 }
 
 // TestCleanupOrphaned_PreservesUnpushedCommits proves an orphaned worktree

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -300,6 +300,29 @@ func TestPathFor_TraversalSlugWouldEscape(t *testing.T) {
 	}
 }
 
+// makePushedGitDir creates a real git repo at dir with one committed file,
+// pushed to a throwaway bare "origin" — HasUnpushedCommits reports false for
+// it, matching a normal Sybra-managed worktree that has landed its work.
+func makePushedGitDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, dir, "git", "init", "-q")
+	mustRunInDir(t, dir, "git", "config", "user.email", "test@test.com")
+	mustRunInDir(t, dir, "git", "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, dir, "git", "add", "-A")
+	mustRunInDir(t, dir, "git", "commit", "-q", "-m", "init")
+
+	origin := t.TempDir()
+	mustRunInDir(t, origin, "git", "init", "-q", "--bare")
+	mustRunInDir(t, dir, "git", "remote", "add", "origin", origin)
+	mustRunInDir(t, dir, "git", "push", "-q", "-u", "origin", "HEAD:refs/heads/main")
+}
+
 func TestCleanupOrphaned(t *testing.T) {
 	dir := t.TempDir()
 	tasksDir := t.TempDir()
@@ -315,14 +338,11 @@ func TestCleanupOrphaned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create worktree dirs: one matching task (not done), one orphaned
-	if err := os.MkdirAll(filepath.Join(dir, tk.DirName()), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	// Create worktree dirs: one matching task (not done), one orphaned —
+	// both fully pushed, so the unpushed-commits guard does not interfere.
+	makePushedGitDir(t, filepath.Join(dir, tk.DirName()))
 	orphanDir := filepath.Join(dir, "orphan-12345678")
-	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	makePushedGitDir(t, orphanDir)
 
 	m := New(Config{
 		WorktreesDir: dir,
@@ -339,6 +359,105 @@ func TestCleanupOrphaned(t *testing.T) {
 	// Active task's dir should remain
 	if _, err := os.Stat(filepath.Join(dir, tk.DirName())); err != nil {
 		t.Error("active task dir should remain")
+	}
+}
+
+// TestManager_HasUnpushedCommits proves the resolver sandbox cleanup relies
+// on (#2593): it locates taskID's own worktree by ID and reports whether it
+// holds commits not on origin, and fails safe (false — nothing to protect)
+// when the task, its worktree, or an external adoption makes that check
+// inapplicable.
+func TestManager_HasUnpushedCommits(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+	m := New(Config{WorktreesDir: dir, Tasks: taskMgr, Logger: discardLogger()})
+
+	pushedTask, err := store.Create("pushed task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Update(pushedTask.ID, task.Update{ProjectID: task.Ptr("owner/repo")}); err != nil {
+		t.Fatal(err)
+	}
+	makePushedGitDir(t, filepath.Join(dir, pushedTask.DirName()))
+
+	unpushedTask, err := store.Create("unpushed task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Update(unpushedTask.ID, task.Update{ProjectID: task.Ptr("owner/repo")}); err != nil {
+		t.Fatal(err)
+	}
+	unpushedDir := filepath.Join(dir, unpushedTask.DirName())
+	makePushedGitDir(t, unpushedDir)
+	if err := os.WriteFile(filepath.Join(unpushedDir, "f.txt"), []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, unpushedDir, "git", "commit", "-q", "-am", "unpushed work")
+
+	adoptedTask, err := store.Create("adopted task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Update(adoptedTask.ID, task.Update{
+		ProjectID:   task.Ptr("owner/repo"),
+		WorktreeDir: task.Ptr("/some/externally/owned/checkout"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	if got := m.HasUnpushedCommits(ctx, pushedTask.ID); got {
+		t.Error("fully pushed worktree reported as having unpushed commits")
+	}
+	if got := m.HasUnpushedCommits(ctx, unpushedTask.ID); !got {
+		t.Error("worktree with an unpushed commit reported as clean")
+	}
+	if got := m.HasUnpushedCommits(ctx, adoptedTask.ID); got {
+		t.Error("externally-adopted worktree must never be inspected")
+	}
+	if got := m.HasUnpushedCommits(ctx, "no-such-task"); got {
+		t.Error("missing task must report false (nothing to protect)")
+	}
+}
+
+// TestCleanupOrphaned_PreservesUnpushedCommits proves an orphaned worktree
+// holding commits that never reached origin survives the sweep — the
+// guard added for #2593 must block deletion/reuse regardless of the
+// existing status/no-live-agent eligibility check.
+func TestCleanupOrphaned_PreservesUnpushedCommits(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+
+	orphanDir := filepath.Join(dir, "orphan-deadbeef")
+	makePushedGitDir(t, orphanDir)
+	if err := os.WriteFile(filepath.Join(orphanDir, "f.txt"), []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, orphanDir, "git", "commit", "-q", "-am", "unpushed work")
+
+	m := New(Config{
+		WorktreesDir: dir,
+		Tasks:        taskMgr,
+		Logger:       discardLogger(),
+	})
+
+	m.CleanupOrphaned(context.Background())
+
+	if _, err := os.Stat(orphanDir); err != nil {
+		t.Errorf("orphaned worktree with unpushed commits removed unexpectedly: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Sandbox, worktree, and doctor-cleanup reap paths gated purely on task status/retention, never on git ahead/behind vs origin. A task bounced through human-required by a failed push, then reset, could have its finished-but-unpushed worktree/sandbox destroyed before an operator noticed (#2593).

## Implementation information

Adds `project.HasUnpushedCommits`, a generalized form of the k8s job runner's existing helper, and consults it in all three reap paths before deleting. `--force` in doctor cleanup still bypasses the uncommitted-changes check but never this one. Also fixes doctor/diskreclaim fixture worktrees to push to a throwaway bare origin so they aren't spuriously flagged as unpushed.

## Supporting documentation

Closes #2593

_Generated by Sybra harness_