### PR TITLE
fix(review): make recordSystemAgentStart fail closed on AddRun error

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -1178,10 +1178,10 @@ func (a *agentAdapter) recordSystemAgentStart(taskID, role, mode string, cfg age
 		// AgentRuns to bound the automated review loop, so a silently dropped
 		// write here under-counts that durable budget for this task, same as
 		// #2199 named. Fail closed like StartReviewAgent (review/inbound.go):
-		// stop the agent that already started before surfacing the error, so
-		// a workflow-level retry never races a live, unrecorded process —
-		// it always redispatches into a clean slate instead of piling a
-		// second agent on top of one still running.
+		// signal the agent that already started before surfacing the error
+		// (best-effort — does not block for exit), so a workflow-level retry
+		// targets an agent Sybra no longer considers live instead of piling a
+		// second one on top of an unrecorded process still running.
 		slog.Error("agent-adapter.add-run", "task_id", taskID, "agent_id", ag.ID, "err", addErr)
 		if stopErr := a.agents.StopAgent(ag.ID); stopErr != nil {
 			return fmt.Errorf("record agent run: %w; stop started agent %s: %w", addErr, ag.ID, stopErr)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -876,7 +876,9 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		return "", "", "", translatePoolBusy(err)
 	}
 
-	a.recordSystemAgentStart(taskID, role, mode, cfg, ag)
+	if recErr := a.recordSystemAgentStart(taskID, role, mode, cfg, ag); recErr != nil {
+		return "", "", "", recErr
+	}
 
 	return ag.ID, cfg.Dir, baselineRef, nil
 }
@@ -1138,7 +1140,7 @@ func (a *agentAdapter) resetWorktreeForRetry(t task.Task, dir, ref string) (bool
 	return true, nil
 }
 
-func (a *agentAdapter) recordSystemAgentStart(taskID, role, mode string, cfg agent.RunConfig, ag *agent.Agent) {
+func (a *agentAdapter) recordSystemAgentStart(taskID, role, mode string, cfg agent.RunConfig, ag *agent.Agent) error {
 	var nextStatus *task.Status
 	if cur, rerr := a.tasks.Get(taskID); rerr == nil && cur.Status == task.StatusHumanRequired {
 		nextStatus = task.Ptr(task.StatusInProgress)
@@ -1170,17 +1172,23 @@ func (a *agentAdapter) recordSystemAgentStart(taskID, role, mode string, cfg age
 			// (delete/cleanup/terminal teardown) after StartAgent succeeded but
 			// before the AgentRun write. Treat that as a silent no-op: the
 			// workflow already no longer owns a task file to update.
-			return
+			return nil
 		}
 		// Not just lost history: reviewbudget.Budget (#2499) counts Role=="review"
 		// AgentRuns to bound the automated review loop, so a silently dropped
 		// write here under-counts that durable budget for this task, same as
-		// #2199 named. Logged at Error rather than escalated to human-required
-		// directly — ag is already a live, running process, and flipping every
-		// role's dispatch to a hard failure here risks a duplicate dispatch on
-		// retry, which is worse than an undercounted budget.
+		// #2199 named. Fail closed like StartReviewAgent (review/inbound.go):
+		// stop the agent that already started before surfacing the error, so
+		// a workflow-level retry never races a live, unrecorded process —
+		// it always redispatches into a clean slate instead of piling a
+		// second agent on top of one still running.
 		slog.Error("agent-adapter.add-run", "task_id", taskID, "agent_id", ag.ID, "err", addErr)
+		if stopErr := a.agents.StopAgent(ag.ID); stopErr != nil {
+			return fmt.Errorf("record agent run: %w; stop started agent %s: %w", addErr, ag.ID, stopErr)
+		}
+		return fmt.Errorf("record agent run: %w", addErr)
 	}
+	return nil
 }
 
 func (a *agentAdapter) withExperiencePrompt(cfg *agent.RunConfig, role agent.Role, t task.Task) {

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -1076,10 +1076,99 @@ func TestRecordSystemAgentStartIgnoresMissingTask(t *testing.T) {
 	}
 
 	adapter := &agentAdapter{tasks: mgr}
-	adapter.recordSystemAgentStart(created.ID, string(agent.RolePlan), "headless", agent.RunConfig{Prompt: "prompt"}, &agent.Agent{
+	if err := adapter.recordSystemAgentStart(created.ID, string(agent.RolePlan), "headless", agent.RunConfig{Prompt: "prompt"}, &agent.Agent{
 		ID:        "agent-1",
 		Provider:  "claude",
 		Model:     "sonnet",
 		StartedAt: time.Now().UTC(),
-	})
+	}); err != nil {
+		t.Fatalf("recordSystemAgentStart() err = %v, want nil: a task the workflow no longer owns is a silent no-op, not a failure", err)
+	}
+}
+
+// TestAgentAdapterStartAgentFailsClosedOnDroppedRunRecord pins #2199's
+// remaining gap: recordSystemAgentStart must not log-and-continue when
+// AddRunWithStatus fails for a reason other than the task having disappeared
+// (os.ErrNotExist, covered above). A dropped write here silently un-counts
+// reviewbudget.Budget's Role=="review" rate cap, so the already-started agent
+// must be stopped and the failure surfaced rather than left to run unrecorded.
+func TestAgentAdapterStartAgentFailsClosedOnDroppedRunRecord(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses the write-permission block this test relies on")
+	}
+
+	fakebin := t.TempDir()
+	fakeClaude := filepath.Join(fakebin, "claude")
+	// Short-lived (well under the goleak check at process exit) but long
+	// enough to still be alive when recordSystemAgentStart's StopAgent call
+	// runs, so the state assertion below exercises a genuinely live process
+	// rather than one that raced to completion on its own.
+	if err := os.WriteFile(fakeClaude, []byte("#!/usr/bin/env bash\n"+
+		"printf '{\"type\":\"system\",\"session_id\":\"fake-session\"}\\n'\n"+
+		"sleep 0.2\n"),
+		0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", fakebin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	tmp := t.TempDir()
+	tasksDir := filepath.Join(tmp, "tasks")
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr := task.NewManager(store, nil)
+	created, err := mgr.Create("drop run record", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, filepath.Join(tmp, "logs"))
+	t.Cleanup(func() { agents.ShutdownWithGrace(2 * time.Second) })
+
+	adapter := &agentAdapter{
+		agents:    agents,
+		tasks:     mgr,
+		agentOrch: agentorch.New(nil, nil, nil, nil, logger, nil, nil),
+	}
+
+	// Block writes to the tasks dir so AddRunWithStatus fails with something
+	// other than os.ErrNotExist once the agent below has already started.
+	if err := os.Chmod(tasksDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(tasksDir, 0o755) })
+
+	agentID, _, _, startErr := adapter.StartAgent(created.ID, string(agent.RoleReview), "headless", "sonnet", "claude", "prompt", t.TempDir(), nil, false, false, "", "", workflow.AgentAssignment{})
+	if startErr == nil {
+		t.Fatal("StartAgent() err = nil, want an error when the run-record write fails")
+	}
+	if agentID != "" {
+		t.Fatalf("StartAgent() agentID = %q, want empty on a failed dispatch", agentID)
+	}
+
+	var started *agent.Agent
+	for _, a := range agents.ListAgents() {
+		if a.TaskID == created.ID {
+			started = a
+		}
+	}
+	if started == nil {
+		t.Fatal("no agent registered for the task despite agents.Run succeeding before the failed write")
+	}
+	if got := started.GetState(); got != agent.StateStopped {
+		t.Fatalf("started agent state = %v, want Stopped: a dropped run-record write must not leave an unrecorded agent running", got)
+	}
+
+	if err := os.Chmod(tasksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := mgr.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.AgentRuns) != 0 {
+		t.Fatalf("AgentRuns = %+v, want none — a dropped run-record write must not silently grant free review-round budget", reloaded.AgentRuns)
+	}
 }


### PR DESCRIPTION
## Motivation

A dropped `AddRunWithStatus` write in `recordSystemAgentStart` left a posted review with no AgentRun on the task, silently un-counting spent review-round budget (`reviewRoundsSpent` reads that list for the rate cap).

> Changelog: fix(review): make recordSystemAgentStart fail closed on AddRun error

## Implementation information

- `recordSystemAgentStart` now stops the already-started agent on an `AddRunWithStatus` error, matching `StartReviewAgent`'s existing fail-closed behavior, instead of logging and continuing.
- Added a test pinning that a dropped run-record write does not grant free review-round budget.

Closes #2199

## Supporting documentation

N/A