### PR TITLE
fix(review): watch PRs past in-review status

### DIFF
--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -1648,6 +1648,24 @@ func (r *Handler) includeKnownTaskPRs(ctx context.Context, tasks []task.Task, mo
 // own re-entry lane and must not also become a pr-fix candidate.
 // Branch-only matching stays gated on in-review to avoid false positives
 // from tasks that pushed a WIP branch without opening a PR yet.
+//
+// ready-pr, ready-review, and testing joined for the same class of bug
+// (sybra#2645/#2646): a task whose own workflow already opened a PR can sit
+// in any of these three lanes — ready-pr when its implement workflow
+// completed without a further status transition, ready-review/testing while
+// a *later* local review or test cycle (e.g. a post-push pr-fix loop, or a
+// PR-fix-triggered re-review) runs against the same already-open PR. None of
+// these lanes has any other mechanism watching GitHub for a real ci_failure
+// or review comment on that PR, so a check like Nilaway failing on every push
+// went unaddressed indefinitely (confirmed live: PR #2646 failed the same
+// Nilaway gate across 4+ pushes with no fix agent ever targeting it, and PR
+// #2645 sat at ready-pr with its `simple-task-implement` workflow already
+// `completed` — nothing left to drive it and pr-fix wasn't watching either).
+// Eligibility here only makes the task visible to the poll; canDispatch
+// (hasBlockingAgentForTask) still refuses to start a pr-fix agent while the
+// task's own workflow has a live agent running, so this cannot race an
+// in-flight local review/test loop — it only picks up the slack once that
+// loop is idle and something on GitHub still needs fixing.
 func prMonitorEligible(t *task.Task) bool {
 	if slices.Contains(t.Tags, "review") {
 		// Review tasks are inbound (reviewing someone else's PR), not tasks
@@ -1657,7 +1675,7 @@ func prMonitorEligible(t *task.Task) bool {
 	switch t.Status {
 	case task.StatusInReview:
 		return t.PRNumber != 0 || t.Branch != ""
-	case task.StatusInProgress:
+	case task.StatusInProgress, task.StatusReadyPR, task.StatusReadyReview, task.StatusTesting:
 		// Only tasks that already have a PR — a branch alone isn't enough,
 		// still mid-implementation.
 		return t.PRNumber != 0

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -1676,8 +1676,10 @@ func prMonitorEligible(t *task.Task) bool {
 	case task.StatusInReview:
 		return t.PRNumber != 0 || t.Branch != ""
 	case task.StatusInProgress, task.StatusReadyPR, task.StatusReadyReview, task.StatusTesting:
-		// Only tasks that already have a PR — a branch alone isn't enough,
-		// still mid-implementation.
+		// A PR number is required in every one of these lanes — a branch
+		// alone stays ineligible even past in-progress, since ready-review
+		// and testing also cover a pre-PR local loop (see prMonitorEligible
+		// doc comment above).
 		return t.PRNumber != 0
 	case task.StatusTodo:
 		// A handoff-tagged task is exempted from skipTaskCreatedWorkflow's

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -503,6 +503,36 @@ func TestPRMonitorEligible(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "ready-pr with PR — eligible (sybra#2645: workflow completed at ready-pr, nothing else watches its PR)",
+			tk:   task.Task{Status: task.StatusReadyPR, PRNumber: 2645},
+			want: true,
+		},
+		{
+			name: "ready-pr with nothing — not eligible",
+			tk:   task.Task{Status: task.StatusReadyPR},
+			want: false,
+		},
+		{
+			name: "ready-review with PR — eligible (sybra#2646: local review loop is blind to real CI failures on the already-open PR)",
+			tk:   task.Task{Status: task.StatusReadyReview, PRNumber: 2646},
+			want: true,
+		},
+		{
+			name: "ready-review with branch only — not eligible (avoid WIP false positives)",
+			tk:   task.Task{Status: task.StatusReadyReview, Branch: "sybra/wip"},
+			want: false,
+		},
+		{
+			name: "testing with PR — eligible, same lane as ready-review",
+			tk:   task.Task{Status: task.StatusTesting, PRNumber: 2646},
+			want: true,
+		},
+		{
+			name: "testing with nothing — not eligible",
+			tk:   task.Task{Status: task.StatusTesting},
+			want: false,
+		},
+		{
 			name: "review tag excluded (inbound review task, not ours)",
 			tk:   task.Task{Status: task.StatusInReview, PRNumber: 42, Tags: []string{"review"}},
 			want: false,


### PR DESCRIPTION
## Motivation

> Changelog: fix(review): watch PRs past in-review status

`prMonitorEligible` (internal/sybra/review/handler.go) only made a task
visible to the PR-fix poller when its status was `in-review`,
`in-progress`, or `todo` (with a PR). A task that already opened a PR
but sits at `ready-pr`, `ready-review`, or `testing` had nothing
watching GitHub for CI failures or review comments on that PR.

Confirmed live against two real tasks: one task's PR failed the same
Nilaway check across 4+ pushes while its local review/fix loop kept
iterating on unrelated findings, never targeting the actual CI
blocker. Another task's implement workflow completed at `ready-pr`
with the PR opened — and then nothing else was watching it, so a
substantive Copilot review comment went unaddressed indefinitely.

## Implementation information

Extends the `prMonitorEligible` switch to also cover `ready-pr`,
`ready-review`, and `testing`, gated on the same "must already have a
PR number" guard used for `in-progress`/`todo` (a branch alone isn't
enough — the task could still be mid-implementation). `prClosedEligible`
picks this up automatically since it delegates to `prMonitorEligible`
first.

This only makes the task *visible* to the poll — `canDispatch`
(`hasBlockingAgentForTask`) still refuses to start a pr-fix agent
while the task's own workflow has a live agent running, so it cannot
race an in-flight local review/test loop. It only picks up the slack
once that loop goes idle and something on GitHub still needs fixing.

## Supporting documentation

- `internal/sybra/review/handler.go`: `prMonitorEligible`
- New table-driven cases in `internal/sybra/review/unit_test.go`
  covering ready-pr/ready-review/testing, with and without a PR