### PR TITLE
fix(workflow): stop false-closing empty impls

### DIFF
--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -4856,13 +4856,12 @@ func TestE2E_ProviderCrossUnavailable_FallsBackToDefault(t *testing.T) {
 	}
 }
 
-// TestE2E_VerifyCommits_BranchAtBaseMarksDone covers verify_commits when the
-// worktree HEAD matches origin/main (rebased branch with no commits ahead).
-// The implementation is already on origin from a prior merge, so the step
-// marks the task done and ends the workflow instead of routing to
-// set_ready_review (which would otherwise loop forever via the auto-restart
-// in svc_tasks.UpdateTask).
-func TestE2E_VerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
+// TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired covers verify_commits
+// when the worktree HEAD matches origin/main (branch has no commits ahead). The
+// workflow must surface this as human-required instead of silently marking the
+// task done: this git state is indistinguishable from an implementation agent
+// that reported success without committing anything.
+func TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired(t *testing.T) {
 	// triage is a deterministic classify_task step now — no scenario slot —
 	// so only "success" (implement) remains in the queue. The default
 	// classifier verdict (env.classifier) already routes to status=todo,
@@ -4897,17 +4896,17 @@ func TestE2E_VerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
 	})
 
 	tk, _ := env.tasks.Get(created.ID)
-	if tk.Status != task.StatusDone {
-		t.Fatalf("status = %q, want done", tk.Status)
+	if tk.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", tk.Status)
 	}
-	if !strings.Contains(tk.StatusReason, "already merged into base") {
+	if !strings.Contains(tk.StatusReason, "no commits") {
 		var verifyOut string
 		for i := range tk.Workflow.StepHistory {
 			if tk.Workflow.StepHistory[i].StepID == "verify_commits" {
 				verifyOut = tk.Workflow.StepHistory[i].Output
 			}
 		}
-		t.Fatalf("status_reason = %q, want 'already merged into base' (verify_commits output=%q)", tk.StatusReason, verifyOut)
+		t.Fatalf("status_reason = %q, want 'no commits' (verify_commits output=%q)", tk.StatusReason, verifyOut)
 	}
 	stepIDs := stepIDsFromHistory(tk.Workflow)
 	if !slices.Contains(stepIDs, "verify_commits") {

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -441,14 +441,21 @@ func (e *Engine) verifyCommitsHandleEmptyOutput(taskID string, step *Step, wfExe
 		e.recordEvidence(taskID, step.ID, evidenceCriterionVerifyCommits, evidence.ProofDeterministicCheck, 1, "", reason)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "agent failed before commit: flipped to human-required"}
 	}
-	if branchMergedIntoBase(e.ctx, wtPath) {
-		reason := "branch already merged into base — implementation already on origin"
-		if statusErr := e.tasks.UpdateTaskStatus(taskID, "done", reason); statusErr != nil {
-			e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
-		}
-		e.logger.Info("workflow.verify-commits.branch-merged", "task_id", taskID)
-		return StepOutput{StepID: step.ID, Status: "completed", Output: "branch merged into base: marked done"}
-	}
+	// branchMergedIntoBase(e.ctx, wtPath) used to gate a "done" verdict here,
+	// on the theory that HEAD == base could mean the fix already landed via a
+	// different branch. That check is unreachable-false in this exact spot:
+	// the caller only reaches verifyCommitsHandleEmptyOutput when
+	// gitLogAheadOfBase (baseRef..HEAD) already came back empty, and
+	// "baseRef..HEAD has no commits" and "HEAD is an ancestor of baseRef" are
+	// the same git fact stated two ways — merge-base --is-ancestor can never
+	// disagree with an empty log range. So this branch was true unconditionally
+	// on every call, silently marking done any task whose implementation agent
+	// reported success but committed nothing. Confirmed live: two foundational
+	// tasks under the durable-effects umbrella (issues #2658, #2659) landed
+	// `done` with prNumber 0 and a branch byte-identical to origin/main —
+	// zero code, zero diff. Always escalate instead, matching the sibling
+	// agent-failed case above: a human must see and explain "the agent
+	// reported success but committed nothing," never have it silently closed.
 	reason := "no commits pushed to branch"
 	if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
 		e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -8403,12 +8403,17 @@ func TestExecVerifyCommits_FetchesMissingLocalHeadObject(t *testing.T) {
 	}
 }
 
-// TestExecVerifyCommits_BranchAtBaseMarksDone covers the case where the
-// agent committed nothing because the implementation was already on
-// origin/main (e.g. merged via a different branch). HEAD == origin/main, so
-// the task is marked done instead of human-required to avoid an infinite
-// auto-restart loop in svc_tasks.UpdateTask.
-func TestExecVerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
+// TestExecVerifyCommits_BranchAtBaseFlipsHumanRequired covers the case where
+// the agent reported success but committed nothing: HEAD == origin/main. This
+// used to mark the task done on the theory that the fix might already be on
+// origin/main via a different branch, but that check (branchMergedIntoBase)
+// can never actually distinguish "already merged elsewhere" from "nothing was
+// committed" at this call site — an empty baseRef..HEAD log range and "HEAD
+// is an ancestor of baseRef" are the same git fact, so it was true on every
+// call. Confirmed live: two foundational tasks landed `done` with prNumber 0
+// and a branch byte-identical to origin/main — zero code shipped. A human
+// must see this instead.
+func TestExecVerifyCommits_BranchAtBaseFlipsHumanRequired(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
@@ -8425,25 +8430,31 @@ func TestExecVerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
 	if out.Status != "completed" {
 		t.Errorf("Status = %q, want completed", out.Status)
 	}
-	if !strings.Contains(out.Output, "branch merged into base") {
-		t.Errorf("Output = %q, want 'branch merged into base'", out.Output)
+	if !strings.Contains(out.Output, "no commits") {
+		t.Errorf("Output = %q, want 'no commits'", out.Output)
 	}
 	ti, _ := tasks.GetTask("t1")
-	if ti.Status != "done" {
-		t.Errorf("task status = %q, want done", ti.Status)
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
 	}
-	if reason := tasks.Reason("t1"); !strings.Contains(reason, "already merged into base") {
-		t.Errorf("status reason = %q, want 'already merged into base'", reason)
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "no commits") {
+		t.Errorf("status reason = %q, want 'no commits'", reason)
 	}
 }
 
-// TestExecVerifyCommits_BranchAncestorOfBaseMarksDone covers the regression
-// from issue #670: HEAD is an ancestor of origin/main (branch tip equals an
-// older commit on main, with newer commits on top — typical of squash-merge
-// followed by additional PRs). `git log origin/main..HEAD` is empty AND
-// HEAD != base.tip, but the work is still on origin. Must flip to done, not
-// human-required.
-func TestExecVerifyCommits_BranchAncestorOfBaseMarksDone(t *testing.T) {
+// TestExecVerifyCommits_BranchAncestorOfBaseFlipsHumanRequired covers the
+// regression from issue #670: HEAD is an ancestor of origin/main (branch tip
+// equals an older commit on main, with newer commits on top — typical of
+// squash-merge followed by additional PRs). `git log origin/main..HEAD` is
+// empty AND HEAD != base.tip. #670 originally fixed this by marking the task
+// done outright (the theory: the work must already be on origin). That
+// theory cannot be verified from ancestry alone — "HEAD is an ancestor of
+// base because its own commits already landed" and "HEAD is an ancestor of
+// base because it never had any commits to begin with" are the same git
+// fact, indistinguishable by `merge-base --is-ancestor`. Silently marking
+// done was proven live to misfire on the second case (issues #2658, #2659
+// landed `done` with zero code). A human must confirm either way now.
+func TestExecVerifyCommits_BranchAncestorOfBaseFlipsHumanRequired(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
@@ -8460,12 +8471,12 @@ func TestExecVerifyCommits_BranchAncestorOfBaseMarksDone(t *testing.T) {
 	if out.Status != "completed" {
 		t.Errorf("Status = %q, want completed", out.Status)
 	}
-	if !strings.Contains(out.Output, "branch merged into base") {
-		t.Errorf("Output = %q, want 'branch merged into base'", out.Output)
+	if !strings.Contains(out.Output, "no commits") {
+		t.Errorf("Output = %q, want 'no commits'", out.Output)
 	}
 	ti, _ := tasks.GetTask("t1")
-	if ti.Status != "done" {
-		t.Errorf("task status = %q, want done", ti.Status)
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
 	}
 }
 
@@ -8482,8 +8493,8 @@ func TestExecVerifyCommits_AgentFailedFlipsHumanRequired(t *testing.T) {
 	agents := newMockAgents()
 	engine := NewEngine(store, tasks, agents, discardLogger())
 
-	// Same git state as TestExecVerifyCommits_BranchAtBaseMarksDone: HEAD ==
-	// origin/main, so branchMergedIntoBase would otherwise mark the task done.
+	// Same git state as TestExecVerifyCommits_BranchAtBaseFlipsHumanRequired:
+	// HEAD == origin/main.
 	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 


### PR DESCRIPTION
## Motivation

> Changelog: fix(workflow): stop false-closing empty implementations

Two foundational tasks under the durable-effects umbrella (issues
#2658, #2659) were marked `done` with `prNumber: 0` and a branch
byte-identical to `origin/main` — zero code ever committed by either
implementation agent, both reporting outcome "success" with an empty
result.

`verifyCommitsHandleEmptyOutput` is only reached after
`gitLogAheadOfBase` (`git log baseRef..HEAD`) already returned empty.
It then trusted `branchMergedIntoBase` — `git merge-base
--is-ancestor HEAD baseRef` — as evidence the fix already landed on
main via a different branch. But "`baseRef..HEAD` has no commits" and
"HEAD is an ancestor of baseRef" are the same git fact stated two
ways; the ancestor check can never disagree with the already-empty
log range that got us into this function. It returned `true`
unconditionally on every call from this site, marking `done` any time
an implementation agent completed without committing — regardless of
whether main genuinely already had the fix (rare) or the agent simply
produced nothing (the common failure mode, and what we hit twice
live).

The sibling case (agent explicitly recorded as failed) already had a
guard for this exact false-positive pattern
(`TestExecVerifyCommits_AgentFailedFlipsHumanRequired`'s doc comment
names it directly) — but that guard only checks
`wfExec.LastAgentStepFailed()`, which is false when the agent
self-reports success despite committing nothing.

The original "mark done" behavior was itself a deliberate tradeoff
(per the old `TestExecVerifyCommits_BranchAtBaseMarksDone` doc
comment: "to avoid an infinite auto-restart loop in
svc_tasks.UpdateTask"). Given the dispatch-gating and budget
safeguards shipped since, silently closing real work is the worse
failure mode now.

## Implementation information

- Removed the `branchMergedIntoBase` "done" branch from
  `verifyCommitsHandleEmptyOutput` entirely. Every zero-commit case
  now escalates to `human-required` with "no commits pushed to
  branch," matching the agent-failed sibling's safety philosophy.
- `branchMergedIntoBase` itself is untouched — still used by
  `branchAlreadySatisfiedOnMain` (`engine_pr_recovery.go`), where it's
  corroborated by independent textual signals (PR/issue comments)
  before being trusted, not used as a sole signal.
- Renamed and updated the two tests that encoded the old (buggy)
  expectation: `TestExecVerifyCommits_BranchAtBaseMarksDone` →
  `..._BranchAtBaseFlipsHumanRequired`, and
  `TestExecVerifyCommits_BranchAncestorOfBaseMarksDone` (the issue
  #670 regression test) → `..._BranchAncestorOfBaseFlipsHumanRequired`.

## Supporting documentation

- Filed as issue #2667, with recovery notes for the two affected
  tasks (`1370e822` / #2658, `52f0ba11` / #2659), which need to be
  reset and re-run now that this is fixed.
- `internal/workflow/engine_steps_verify.go`:
  `verifyCommitsHandleEmptyOutput`, `branchMergedIntoBase`