### PR TITLE
feat(workflow): canonical desired/observed state + pure reducer

### DIFF
--- a/internal/workflow/state_reducer.go
+++ b/internal/workflow/state_reducer.go
@@ -207,6 +207,9 @@ func reduceCurrentStep(desired DesiredState, observed ObservedState, exec *Execu
 			effects = append(effects, newWorkflowEffect(kind, completeExecution(exec, workflowStateForKind(kind), observed.Now)))
 			return cloneEffects(effects), nil
 		}
+		if next == nil {
+			return nil, fmt.Errorf("next step missing after unresolved transition from %s", current.ID)
+		}
 		exec.CurrentStep = next.ID
 		exec.State = ExecRunning
 		current = next
@@ -225,6 +228,9 @@ func continueFromStep(desired DesiredState, observed ObservedState, exec *Execut
 			kind = EffectFailWorkflow
 		}
 		return append(cloneEffects(effects), newWorkflowEffect(kind, completeExecution(exec, workflowStateForKind(kind), observed.Now))), nil
+	}
+	if next == nil {
+		return nil, fmt.Errorf("next step missing after unresolved transition from %s", current.ID)
 	}
 	exec.CurrentStep = next.ID
 	exec.State = ExecRunning
@@ -334,9 +340,15 @@ func reducerAsyncBoundaryComplete(exec *Execution, step *Step) bool {
 	}
 	switch step.Type {
 	case StepParallel:
-		return exec.ParallelInflight[step.ID].AllChildrenDone()
+		if p := exec.ParallelInflight[step.ID]; p != nil {
+			return p.AllChildrenDone()
+		}
+		return false
 	case StepBestOfN:
-		return exec.BestOfNInflight[step.ID].AllAttemptsDone()
+		if b := exec.BestOfNInflight[step.ID]; b != nil {
+			return b.AllAttemptsDone()
+		}
+		return false
 	default:
 		return true
 	}

--- a/internal/workflow/state_reducer.go
+++ b/internal/workflow/state_reducer.go
@@ -274,6 +274,9 @@ func previewWaitHumanByStatus(desired DesiredState, observed ObservedState, exec
 				return nil, false, nil
 			}
 			reconciled := exec.Clone()
+			if reconciled == nil {
+				return nil, false, fmt.Errorf("execution clone is nil")
+			}
 			reconciled.CurrentStep = step.ID
 			reconciled.State = ExecWaiting
 			return []Effect{
@@ -367,6 +370,9 @@ func reducerStartStep(desired DesiredState) (*Step, error) {
 
 func completeExecution(exec *Execution, state ExecState, now time.Time) *Execution {
 	completed := exec.Clone()
+	if completed == nil {
+		return nil
+	}
 	completed.CurrentStep = ""
 	completed.State = state
 	completedAt := now

--- a/internal/workflow/state_reducer.go
+++ b/internal/workflow/state_reducer.go
@@ -1,0 +1,455 @@
+package workflow
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DesiredState is the reducer's intended workflow definition/config snapshot.
+type DesiredState struct {
+	Definition       Definition
+	WorkflowID       string
+	StartStep        string
+	DesiredVars      map[string]string
+	ReviewUntilClean bool
+	TransitionExtras map[string]string
+}
+
+// ObservedState is the reducer's caller-supplied runtime snapshot.
+type ObservedState struct {
+	Task                 TaskInfo
+	Execution            *Execution
+	CompletedOutput      *StepOutput
+	Now                  time.Time
+	ReviewBudgetExceeded bool
+}
+
+type EffectKind string
+
+const (
+	EffectSetWorkflowState EffectKind = "set_workflow_state"
+	EffectSetTaskStatus    EffectKind = "set_task_status"
+	EffectRecordStep       EffectKind = "record_step"
+	EffectDispatchStep     EffectKind = "dispatch_step"
+	EffectWaitHuman        EffectKind = "wait_human"
+	EffectCompleteWorkflow EffectKind = "complete_workflow"
+	EffectFailWorkflow     EffectKind = "fail_workflow"
+)
+
+// Effect is a plain-data reducer output.
+type Effect struct {
+	Kind         EffectKind
+	Workflow     *Execution
+	Status       string
+	StatusReason string
+	Record       *StepRecord
+	Step         *Step
+	HumanActions []string
+}
+
+// Reduce converts desired/observed workflow state into plain-data effects.
+func Reduce(desired DesiredState, observed ObservedState) ([]Effect, error) {
+	workflowID, err := reducerWorkflowID(desired)
+	if err != nil {
+		return nil, err
+	}
+	if observed.Now.IsZero() {
+		return nil, fmt.Errorf("malformed reducer input: observed time is required")
+	}
+	if observed.Execution == nil {
+		if observed.CompletedOutput != nil {
+			return nil, fmt.Errorf("malformed reducer input: completed output requires an execution")
+		}
+		start, err := reducerStartStep(desired)
+		if err != nil {
+			return nil, err
+		}
+		exec := &Execution{
+			WorkflowID:  workflowID,
+			CurrentStep: start.ID,
+			State:       ExecRunning,
+			Variables:   maps.Clone(desired.DesiredVars),
+			StartedAt:   observed.Now,
+		}
+		if reducerParksExistingExecution(start) {
+			return reduceCurrentStep(desired, observed, exec, start, []Effect{newWorkflowEffect(EffectSetWorkflowState, exec)})
+		}
+		return []Effect{
+			newWorkflowEffect(EffectSetWorkflowState, exec),
+			{Kind: EffectDispatchStep, Step: cloneStep(start)},
+		}, nil
+	}
+
+	exec := observed.Execution.Clone()
+	if exec == nil {
+		return nil, fmt.Errorf("malformed reducer input: execution clone is nil")
+	}
+	if exec.WorkflowID != "" && exec.WorkflowID != workflowID {
+		return nil, fmt.Errorf("malformed reducer input: execution workflow %q does not match desired workflow %q", exec.WorkflowID, workflowID)
+	}
+	if exec.WorkflowID == "" {
+		exec.WorkflowID = workflowID
+	}
+	if strings.TrimSpace(exec.CurrentStep) == "" {
+		return nil, fmt.Errorf("missing current step for workflow %s", workflowID)
+	}
+	current := desired.Definition.StepByID(exec.CurrentStep)
+	if current == nil {
+		return nil, fmt.Errorf("missing current step %s in workflow %s", exec.CurrentStep, workflowID)
+	}
+
+	if observed.CompletedOutput != nil {
+		return reduceCompletedStep(desired, observed, exec, current)
+	}
+
+	if effects, ok, err := previewWaitHumanByStatus(desired, observed, exec, current); ok || err != nil {
+		return effects, err
+	}
+	return reduceCurrentStep(desired, observed, exec, current, nil)
+}
+
+func reduceCompletedStep(desired DesiredState, observed ObservedState, exec *Execution, current *Step) ([]Effect, error) {
+	output := *observed.CompletedOutput
+	if strings.TrimSpace(output.StepID) == "" {
+		return nil, fmt.Errorf("malformed reducer input: completed output step id is required")
+	}
+	if output.StepID != current.ID {
+		return nil, fmt.Errorf("malformed reducer input: completed output step %q does not match current step %q", output.StepID, current.ID)
+	}
+
+	record := StepRecord{
+		StepID:    output.StepID,
+		Status:    output.Status,
+		Output:    output.Output,
+		AgentID:   output.AgentID,
+		Provider:  output.Provider,
+		StartedAt: observed.Now,
+		EndedAt:   observed.Now,
+	}
+	exec.RecordStep(record)
+	if output.Output != "" {
+		exec.SetVar("step."+output.StepID+".output", output.Output)
+	}
+	effects := []Effect{newRecordEffect(record)}
+	if output.TerminalStatus != "" {
+		effects = append(effects, Effect{
+			Kind:         EffectSetTaskStatus,
+			Status:       output.TerminalStatus,
+			StatusReason: output.TerminalReason,
+		})
+		return append(effects, newWorkflowEffect(EffectCompleteWorkflow, completeExecution(exec, ExecCompleted, observed.Now))), nil
+	}
+	return continueFromStep(desired, observed, exec, current, effects)
+}
+
+func reduceCurrentStep(desired DesiredState, observed ObservedState, exec *Execution, current *Step, effects []Effect) ([]Effect, error) {
+	visited := make(map[string]int)
+	for i := range maxSyncSteps {
+		if firstAt, seen := visited[current.ID]; seen {
+			return nil, &CycleError{StepID: current.ID, At: i, FirstAt: firstAt}
+		}
+		visited[current.ID] = i
+
+		switch current.Type {
+		case StepWaitHuman:
+			if exec.State == ExecWaiting && (current.Config.Status == "" || observed.Task.Status == current.Config.Status) {
+				return cloneEffects(effects), nil
+			}
+			if current.Config.Status != "" {
+				effects = append(effects, Effect{Kind: EffectSetTaskStatus, Status: current.Config.Status, StatusReason: current.Config.StatusReason})
+			}
+			exec.CurrentStep = current.ID
+			exec.State = ExecWaiting
+			effects = append(effects,
+				newWorkflowEffect(EffectSetWorkflowState, exec),
+				Effect{Kind: EffectWaitHuman, Step: cloneStep(current), HumanActions: slices.Clone(current.Config.HumanActions)},
+			)
+			return cloneEffects(effects), nil
+		case StepSetStatus:
+			if current.Config.Status != "" {
+				effects = append(effects, Effect{Kind: EffectSetTaskStatus, Status: current.Config.Status, StatusReason: current.Config.StatusReason})
+				observed.Task.Status = current.Config.Status
+				observed.Task.StatusReason = current.Config.StatusReason
+			}
+			record := StepRecord{StepID: current.ID, Status: "completed", StartedAt: observed.Now, EndedAt: observed.Now}
+			exec.RecordStep(record)
+			effects = append(effects, newRecordEffect(record))
+		case StepCondition:
+			record := StepRecord{StepID: current.ID, Status: "completed", StartedAt: observed.Now, EndedAt: observed.Now}
+			exec.RecordStep(record)
+			effects = append(effects, newRecordEffect(record))
+		default:
+			if len(effects) > 0 || observed.Execution == nil {
+				exec.CurrentStep = current.ID
+				exec.State = ExecRunning
+				effects = append(effects,
+					newWorkflowEffect(EffectSetWorkflowState, exec),
+					Effect{Kind: EffectDispatchStep, Step: cloneStep(current)},
+				)
+				return cloneEffects(effects), nil
+			}
+			return nil, nil
+		}
+
+		next, complete, err := reducerNextStep(desired, observed, exec, current)
+		if err != nil {
+			return nil, err
+		}
+		if complete {
+			kind := EffectCompleteWorkflow
+			if last := exec.LastRecord(); last != nil && last.Status == "failed" {
+				kind = EffectFailWorkflow
+			}
+			effects = append(effects, newWorkflowEffect(kind, completeExecution(exec, workflowStateForKind(kind), observed.Now)))
+			return cloneEffects(effects), nil
+		}
+		exec.CurrentStep = next.ID
+		exec.State = ExecRunning
+		current = next
+	}
+	return nil, fmt.Errorf("workflow exceeded max sync step depth (%d)", maxSyncSteps)
+}
+
+func continueFromStep(desired DesiredState, observed ObservedState, exec *Execution, current *Step, effects []Effect) ([]Effect, error) {
+	next, complete, err := reducerNextStep(desired, observed, exec, current)
+	if err != nil {
+		return nil, err
+	}
+	if complete {
+		kind := EffectCompleteWorkflow
+		if observed.CompletedOutput != nil && observed.CompletedOutput.Status == "failed" {
+			kind = EffectFailWorkflow
+		}
+		return append(cloneEffects(effects), newWorkflowEffect(kind, completeExecution(exec, workflowStateForKind(kind), observed.Now))), nil
+	}
+	exec.CurrentStep = next.ID
+	exec.State = ExecRunning
+	return reduceCurrentStep(desired, observed, exec, next, effects)
+}
+
+func reducerNextStep(desired DesiredState, observed ObservedState, exec *Execution, current *Step) (*Step, bool, error) {
+	fields := reducerTransitionFields(desired, observed, exec)
+	nextID, err := ResolveTransition(current.Next, fields)
+	if err != nil {
+		return nil, false, err
+	}
+	if nextID == "" {
+		return nil, true, nil
+	}
+	next := desired.Definition.StepByID(nextID)
+	if next == nil {
+		return nil, false, fmt.Errorf("next step %s not found in workflow %s", nextID, exec.WorkflowID)
+	}
+	return next, false, nil
+}
+
+func previewWaitHumanByStatus(desired DesiredState, observed ObservedState, exec *Execution, current *Step) ([]Effect, bool, error) {
+	status := observed.Task.Status
+	if status == "" {
+		return nil, false, nil
+	}
+	if current.Type != StepParallel && current.Type != StepBestOfN {
+		return nil, false, nil
+	}
+	if !reducerAsyncBoundaryComplete(exec, current) {
+		return nil, false, nil
+	}
+	fields := reducerTransitionFields(desired, observed, exec)
+	nextID, err := ResolveTransition(current.Next, fields)
+	if err != nil || nextID == "" {
+		return nil, false, err
+	}
+	for range maxSyncSteps {
+		step := desired.Definition.StepByID(nextID)
+		if step == nil {
+			return nil, false, fmt.Errorf("next step %s not found in workflow %s", nextID, exec.WorkflowID)
+		}
+		switch step.Type {
+		case StepWaitHuman:
+			if step.Config.Status != status {
+				return nil, false, nil
+			}
+			reconciled := exec.Clone()
+			reconciled.CurrentStep = step.ID
+			reconciled.State = ExecWaiting
+			return []Effect{
+				newWorkflowEffect(EffectSetWorkflowState, reconciled),
+				{Kind: EffectWaitHuman, Step: cloneStep(step), HumanActions: slices.Clone(step.Config.HumanActions)},
+			}, true, nil
+		case StepSetStatus:
+			if step.Config.Status != "" {
+				fields["task.status"] = step.Config.Status
+			}
+		case StepCondition:
+			// Keep walking.
+		default:
+			return nil, false, nil
+		}
+		nextID, err = ResolveTransition(step.Next, fields)
+		if err != nil || nextID == "" {
+			return nil, false, err
+		}
+	}
+	return nil, false, fmt.Errorf("workflow exceeded max sync step depth (%d)", maxSyncSteps)
+}
+
+func reducerParksExistingExecution(step *Step) bool {
+	if step == nil {
+		return false
+	}
+	switch step.Type {
+	case StepWaitHuman, StepSetStatus, StepCondition:
+		return true
+	default:
+		return false
+	}
+}
+
+func reducerTransitionFields(desired DesiredState, observed ObservedState, exec *Execution) map[string]string {
+	task := observed.Task
+	task.Workflow = exec
+	fields := taskFields(task)
+	for k, v := range exec.Variables {
+		fields["vars."+k] = v
+	}
+	if exec.Recovered {
+		fields["vars.recovered"] = "true"
+	}
+	fields["config.review_until_clean"] = strconv.FormatBool(desired.ReviewUntilClean)
+	fields["task.review_budget_exceeded"] = strconv.FormatBool(observed.ReviewBudgetExceeded)
+	for k, v := range desired.TransitionExtras {
+		fields[k] = v
+	}
+	return fields
+}
+
+func reducerAsyncBoundaryComplete(exec *Execution, step *Step) bool {
+	if exec == nil || step == nil {
+		return true
+	}
+	switch step.Type {
+	case StepParallel:
+		return exec.ParallelInflight[step.ID].AllChildrenDone()
+	case StepBestOfN:
+		return exec.BestOfNInflight[step.ID].AllAttemptsDone()
+	default:
+		return true
+	}
+}
+
+func reducerWorkflowID(desired DesiredState) (string, error) {
+	workflowID := strings.TrimSpace(desired.WorkflowID)
+	if workflowID == "" {
+		workflowID = strings.TrimSpace(desired.Definition.ID)
+	}
+	if workflowID == "" {
+		return "", fmt.Errorf("malformed reducer input: workflow id is required")
+	}
+	return workflowID, nil
+}
+
+func reducerStartStep(desired DesiredState) (*Step, error) {
+	if startID := strings.TrimSpace(desired.StartStep); startID != "" {
+		start := desired.Definition.StepByID(startID)
+		if start == nil {
+			return nil, fmt.Errorf("workflow %s step %s not found", desired.Definition.ID, startID)
+		}
+		return start, nil
+	}
+	start := desired.Definition.FirstStep()
+	if start == nil {
+		return nil, fmt.Errorf("workflow %s has no steps", desired.Definition.ID)
+	}
+	return start, nil
+}
+
+func completeExecution(exec *Execution, state ExecState, now time.Time) *Execution {
+	completed := exec.Clone()
+	completed.CurrentStep = ""
+	completed.State = state
+	completedAt := now
+	completed.CompletedAt = &completedAt
+	return completed
+}
+
+func workflowStateForKind(kind EffectKind) ExecState {
+	if kind == EffectFailWorkflow {
+		return ExecFailed
+	}
+	return ExecCompleted
+}
+
+func newWorkflowEffect(kind EffectKind, exec *Execution) Effect {
+	return Effect{Kind: kind, Workflow: exec.Clone()}
+}
+
+func newRecordEffect(record StepRecord) Effect {
+	rec := record
+	return Effect{Kind: EffectRecordStep, Record: &rec}
+}
+
+func cloneEffects(in []Effect) []Effect {
+	out := make([]Effect, len(in))
+	for i := range in {
+		out[i] = Effect{
+			Kind:         in[i].Kind,
+			Workflow:     in[i].Workflow.Clone(),
+			Status:       in[i].Status,
+			StatusReason: in[i].StatusReason,
+			Step:         cloneStep(in[i].Step),
+			HumanActions: slices.Clone(in[i].HumanActions),
+		}
+		if in[i].Record != nil {
+			record := *in[i].Record
+			out[i].Record = &record
+		}
+	}
+	return out
+}
+
+func cloneStep(step *Step) *Step {
+	if step == nil {
+		return nil
+	}
+	cloned := *step
+	cloned.Config.AllowedTools = slices.Clone(step.Config.AllowedTools)
+	cloned.Config.HumanActions = slices.Clone(step.Config.HumanActions)
+	cloned.Config.ClearSidecars = slices.Clone(step.Config.ClearSidecars)
+	cloned.Config.ClearWorktreeGlobs = slices.Clone(step.Config.ClearWorktreeGlobs)
+	cloned.Config.AttemptProviders = slices.Clone(step.Config.AttemptProviders)
+	cloned.Parallel = cloneSteps(step.Parallel)
+	if step.Config.Check != nil {
+		check := *step.Config.Check
+		cloned.Config.Check = &check
+	}
+	if step.Position != nil {
+		pos := *step.Position
+		cloned.Position = &pos
+	}
+	if step.Next != nil {
+		cloned.Next = make([]Transition, len(step.Next))
+		for i := range step.Next {
+			cloned.Next[i] = step.Next[i]
+			if step.Next[i].When != nil {
+				when := *step.Next[i].When
+				cloned.Next[i].When = &when
+			}
+		}
+	}
+	return &cloned
+}
+
+func cloneSteps(steps []Step) []Step {
+	if steps == nil {
+		return nil
+	}
+	out := make([]Step, len(steps))
+	for i := range steps {
+		out[i] = *cloneStep(&steps[i])
+	}
+	return out
+}

--- a/internal/workflow/state_reducer.go
+++ b/internal/workflow/state_reducer.go
@@ -321,9 +321,7 @@ func reducerTransitionFields(desired DesiredState, observed ObservedState, exec 
 	}
 	fields["config.review_until_clean"] = strconv.FormatBool(desired.ReviewUntilClean)
 	fields["task.review_budget_exceeded"] = strconv.FormatBool(observed.ReviewBudgetExceeded)
-	for k, v := range desired.TransitionExtras {
-		fields[k] = v
-	}
+	maps.Copy(fields, desired.TransitionExtras)
 	return fields
 }
 

--- a/internal/workflow/state_reducer_test.go
+++ b/internal/workflow/state_reducer_test.go
@@ -1,0 +1,428 @@
+package workflow
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReduce(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		desired  DesiredState
+		observed ObservedState
+		check    func(t *testing.T, effects []Effect)
+		wantErr  string
+	}{
+		{
+			name: "workflow start dispatches first step",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{{ID: "start", Type: StepRunAgent}}},
+				WorkflowID: "wf",
+				DesiredVars: map[string]string{
+					"seed": "value",
+				},
+			},
+			observed: ObservedState{Now: now},
+			check: func(t *testing.T, effects []Effect) {
+				requireKinds(t, effects, EffectSetWorkflowState, EffectDispatchStep)
+				wf := effects[0].Workflow
+				if wf == nil {
+					t.Fatal("set-workflow effect missing workflow")
+				}
+				if wf.WorkflowID != "wf" || wf.CurrentStep != "start" || wf.State != ExecRunning {
+					t.Fatalf("workflow = %#v", wf)
+				}
+				if !wf.StartedAt.Equal(now) {
+					t.Fatalf("StartedAt = %s, want %s", wf.StartedAt, now)
+				}
+				if got := wf.Variables["seed"]; got != "value" {
+					t.Fatalf("Variables[seed] = %q, want value", got)
+				}
+				if effects[1].Step == nil || effects[1].Step.ID != "start" {
+					t.Fatalf("dispatch step = %#v, want start", effects[1].Step)
+				}
+			},
+		},
+		{
+			name: "advance to next step after completion",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{
+					{ID: "build", Type: StepRunAgent, Next: []Transition{{GoTo: "review"}}},
+					{ID: "review", Type: StepRunAgent},
+				}},
+				WorkflowID: "wf",
+			},
+			observed: ObservedState{
+				Now: now,
+				Execution: &Execution{
+					WorkflowID:  "wf",
+					CurrentStep: "build",
+					State:       ExecRunning,
+					Variables:   map[string]string{"keep": "me"},
+					StartedAt:   now.Add(-time.Hour),
+				},
+				CompletedOutput: &StepOutput{StepID: "build", Status: "completed", Output: "ok"},
+			},
+			check: func(t *testing.T, effects []Effect) {
+				requireKinds(t, effects, EffectRecordStep, EffectSetWorkflowState, EffectDispatchStep)
+				if effects[0].Record == nil || effects[0].Record.StepID != "build" || effects[0].Record.Status != "completed" {
+					t.Fatalf("record = %#v", effects[0].Record)
+				}
+				wf := effects[1].Workflow
+				if wf == nil || wf.CurrentStep != "review" || wf.State != ExecRunning {
+					t.Fatalf("workflow = %#v, want running review", wf)
+				}
+				if got := wf.Variables["step.build.output"]; got != "ok" {
+					t.Fatalf("step output var = %q, want ok", got)
+				}
+				if effects[2].Step == nil || effects[2].Step.ID != "review" {
+					t.Fatalf("dispatch step = %#v, want review", effects[2].Step)
+				}
+			},
+		},
+		{
+			name: "end transition completes workflow",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{{ID: "done", Type: StepRunAgent, Next: []Transition{{GoTo: ""}}}}},
+				WorkflowID: "wf",
+			},
+			observed: ObservedState{
+				Now:             now,
+				Execution:       &Execution{WorkflowID: "wf", CurrentStep: "done", State: ExecRunning, StartedAt: now.Add(-time.Minute)},
+				CompletedOutput: &StepOutput{StepID: "done", Status: "completed"},
+			},
+			check: func(t *testing.T, effects []Effect) {
+				requireKinds(t, effects, EffectRecordStep, EffectCompleteWorkflow)
+				wf := effects[1].Workflow
+				if wf == nil || wf.State != ExecCompleted || wf.CurrentStep != "" || wf.CompletedAt == nil || !wf.CompletedAt.Equal(now) {
+					t.Fatalf("workflow = %#v", wf)
+				}
+			},
+		},
+		{
+			name: "terminal step output completes workflow immediately",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{{ID: "link-pr", Type: StepRunAgent, Next: []Transition{{GoTo: "next"}}}, {ID: "next", Type: StepRunAgent}}},
+				WorkflowID: "wf",
+			},
+			observed: ObservedState{
+				Now:             now,
+				Execution:       &Execution{WorkflowID: "wf", CurrentStep: "link-pr", State: ExecRunning, StartedAt: now.Add(-time.Minute)},
+				CompletedOutput: &StepOutput{StepID: "link-pr", Status: "completed", TerminalStatus: "done", TerminalReason: "already merged"},
+			},
+			check: func(t *testing.T, effects []Effect) {
+				requireKinds(t, effects, EffectRecordStep, EffectSetTaskStatus, EffectCompleteWorkflow)
+				if effects[1].Status != "done" || effects[1].StatusReason != "already merged" {
+					t.Fatalf("status effect = %#v", effects[1])
+				}
+				wf := effects[2].Workflow
+				if wf == nil || wf.State != ExecCompleted || wf.CurrentStep != "" {
+					t.Fatalf("workflow = %#v", wf)
+				}
+			},
+		},
+		{
+			name: "step set status emits task-status effect",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{
+					{ID: "mark-review", Type: StepSetStatus, Config: StepConfig{Status: "in-review", StatusReason: "ready"}, Next: []Transition{{GoTo: "await"}}},
+					{ID: "await", Type: StepWaitHuman, Config: StepConfig{Status: "plan-review", HumanActions: []string{"approve"}}},
+				}},
+				WorkflowID: "wf",
+			},
+			observed: ObservedState{
+				Now:       now,
+				Task:      TaskInfo{ID: "t1", Status: "todo"},
+				Execution: &Execution{WorkflowID: "wf", CurrentStep: "mark-review", State: ExecRunning, StartedAt: now.Add(-time.Minute)},
+			},
+			check: func(t *testing.T, effects []Effect) {
+				requireKinds(t, effects, EffectSetTaskStatus, EffectRecordStep, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
+				if effects[0].Status != "in-review" {
+					t.Fatalf("first status = %q, want in-review", effects[0].Status)
+				}
+				if effects[4].Step == nil || effects[4].Step.ID != "await" {
+					t.Fatalf("wait effect = %#v", effects[4].Step)
+				}
+			},
+		},
+		{
+			name: "step wait human emits wait-human effect",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{{ID: "review", Type: StepWaitHuman, Config: StepConfig{Status: "plan-review", HumanActions: []string{"approve", "reject"}}}}},
+				WorkflowID: "wf",
+			},
+			observed: ObservedState{
+				Now:       now,
+				Task:      TaskInfo{ID: "t1", Status: "todo"},
+				Execution: &Execution{WorkflowID: "wf", CurrentStep: "review", State: ExecRunning, StartedAt: now.Add(-time.Minute)},
+			},
+			check: func(t *testing.T, effects []Effect) {
+				requireKinds(t, effects, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
+				if effects[2].Step == nil || effects[2].Step.ID != "review" {
+					t.Fatalf("wait step = %#v", effects[2].Step)
+				}
+				if got := effects[2].HumanActions; !reflect.DeepEqual(got, []string{"approve", "reject"}) {
+					t.Fatalf("human actions = %#v", got)
+				}
+			},
+		},
+		{
+			name: "transition error returns error",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{{
+					ID:   "gate",
+					Type: StepRunAgent,
+					Next: []Transition{{When: &Condition{Field: "task.reviewed", Operator: "equals", Value: "true"}, GoTo: "next"}},
+				}, {ID: "next", Type: StepRunAgent}}},
+				WorkflowID: "wf",
+			},
+			observed: ObservedState{
+				Now:             now,
+				Task:            TaskInfo{ID: "t1", Reviewed: false},
+				Execution:       &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning},
+				CompletedOutput: &StepOutput{StepID: "gate", Status: "completed"},
+			},
+			wantErr: "no matching transition found",
+		},
+		{
+			name: "missing next step returns error",
+			desired: DesiredState{
+				Definition: Definition{ID: "wf", Steps: []Step{{ID: "gate", Type: StepRunAgent, Next: []Transition{{GoTo: "missing"}}}}},
+				WorkflowID: "wf",
+			},
+			observed: ObservedState{
+				Now:             now,
+				Execution:       &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning},
+				CompletedOutput: &StepOutput{StepID: "gate", Status: "completed"},
+			},
+			wantErr: "next step missing not found",
+		},
+		{
+			name: "returned effects do not alias inputs",
+			desired: DesiredState{
+				Definition:  Definition{ID: "wf", Steps: []Step{{ID: "review", Type: StepWaitHuman, Config: StepConfig{Status: "plan-review", HumanActions: []string{"approve", "reject"}}}}},
+				WorkflowID:  "wf",
+				DesiredVars: map[string]string{"seed": "value"},
+			},
+			observed: ObservedState{Now: now},
+			check: func(t *testing.T, effects []Effect) {
+				requireKinds(t, effects, EffectSetWorkflowState, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
+				effects[0].Workflow.Variables["seed"] = "mutated"
+				effects[3].HumanActions[0] = "mutated"
+				effects[3].Step.Config.HumanActions[0] = "mutated-step"
+				if got := effects[0].Workflow.Variables["seed"]; got != "mutated" {
+					t.Fatalf("mutation failed, got %q", got)
+				}
+				if got := effects[3].Step.Config.HumanActions[0]; got != "mutated-step" {
+					t.Fatalf("step mutation failed, got %q", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			effects, err := Reduce(tc.desired, tc.observed)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr && !contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.check != nil {
+				tc.check(t, effects)
+			}
+		})
+	}
+
+	t.Run("input immutability source objects stay unchanged", func(t *testing.T) {
+		t.Parallel()
+		desired := DesiredState{
+			Definition:  Definition{ID: "wf", Steps: []Step{{ID: "review", Type: StepWaitHuman, Config: StepConfig{Status: "plan-review", HumanActions: []string{"approve", "reject"}}}}},
+			WorkflowID:  "wf",
+			DesiredVars: map[string]string{"seed": "value"},
+		}
+		observed := ObservedState{Now: now}
+		_, err := Reduce(desired, observed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := desired.DesiredVars["seed"]; got != "value" {
+			t.Fatalf("DesiredVars mutated to %q", got)
+		}
+		if got := desired.Definition.Steps[0].Config.HumanActions[0]; got != "approve" {
+			t.Fatalf("definition mutated to %q", got)
+		}
+	})
+}
+
+func TestReduceTransitionFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	makeDesired := func(cond Condition) DesiredState {
+		return DesiredState{
+			Definition: Definition{ID: "wf", Steps: []Step{
+				{ID: "gate", Type: StepCondition, Next: []Transition{{When: &cond, GoTo: "wait"}, {GoTo: ""}}},
+				{ID: "wait", Type: StepWaitHuman, Config: StepConfig{Status: "plan-review", HumanActions: []string{"approve"}}},
+			}},
+			WorkflowID:       "wf",
+			ReviewUntilClean: true,
+		}
+	}
+	makeObserved := func(task TaskInfo, exec *Execution, exceeded bool) ObservedState {
+		return ObservedState{
+			Now:                  now,
+			Task:                 task,
+			Execution:            exec,
+			ReviewBudgetExceeded: exceeded,
+		}
+	}
+
+	cases := []struct {
+		name      string
+		condition Condition
+		observed  ObservedState
+	}{
+		{
+			name:      "task plan critique",
+			condition: Condition{Field: "task.plan_critique", Operator: "equals", Value: "approve"},
+			observed:  makeObserved(TaskInfo{ID: "t1", PlanCritique: "approve"}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning}, false),
+		},
+		{
+			name:      "task reviewed",
+			condition: Condition{Field: "task.reviewed", Operator: "equals", Value: "true"},
+			observed:  makeObserved(TaskInfo{ID: "t1", Reviewed: true}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning}, false),
+		},
+		{
+			name:      "task pr number",
+			condition: Condition{Field: "task.pr_number", Operator: "equals", Value: "42"},
+			observed:  makeObserved(TaskInfo{ID: "t1", PRNumber: 42}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning}, false),
+		},
+		{
+			name:      "task code review",
+			condition: Condition{Field: "task.code_review", Operator: "equals", Value: "clean"},
+			observed:  makeObserved(TaskInfo{ID: "t1", CodeReview: "clean"}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning}, false),
+		},
+		{
+			name:      "review budget exceeded",
+			condition: Condition{Field: "task.review_budget_exceeded", Operator: "equals", Value: "true"},
+			observed:  makeObserved(TaskInfo{ID: "t1"}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning}, true),
+		},
+		{
+			name:      "workflow vars",
+			condition: Condition{Field: "vars.choice", Operator: "equals", Value: "ship"},
+			observed:  makeObserved(TaskInfo{ID: "t1"}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning, Variables: map[string]string{"choice": "ship"}}, false),
+		},
+		{
+			name:      "vars recovered",
+			condition: Condition{Field: "vars.recovered", Operator: "equals", Value: "true"},
+			observed:  makeObserved(TaskInfo{ID: "t1"}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning, Recovered: true}, false),
+		},
+		{
+			name:      "review until clean config",
+			condition: Condition{Field: "config.review_until_clean", Operator: "equals", Value: "true"},
+			observed:  makeObserved(TaskInfo{ID: "t1"}, &Execution{WorkflowID: "wf", CurrentStep: "gate", State: ExecRunning}, false),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			effects, err := Reduce(makeDesired(tc.condition), tc.observed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			requireKinds(t, effects, EffectRecordStep, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
+			if effects[3].Step == nil || effects[3].Step.ID != "wait" {
+				t.Fatalf("wait effect = %#v, want wait", effects[3].Step)
+			}
+		})
+	}
+}
+
+func TestReduceAsyncBoundaryCompatibility(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	desired := DesiredState{
+		Definition: Definition{ID: "wf", Steps: []Step{
+			{ID: "fan_out", Type: StepParallel, Next: []Transition{{GoTo: "review"}}},
+			{ID: "best", Type: StepBestOfN, Next: []Transition{{GoTo: "review"}}},
+			{ID: "review", Type: StepWaitHuman, Config: StepConfig{Status: "plan-review", HumanActions: []string{"approve"}}},
+		}},
+		WorkflowID: "wf",
+	}
+
+	cases := []struct {
+		name string
+		exec *Execution
+	}{
+		{
+			name: "parallel boundary still incomplete",
+			exec: &Execution{
+				WorkflowID:  "wf",
+				CurrentStep: "fan_out",
+				State:       ExecWaiting,
+				ParallelInflight: map[string]*ParallelChildren{
+					"fan_out": {
+						ParentStepID: "fan_out",
+						Children: map[string]*ChildStatus{
+							"child_a": {Status: "completed"},
+							"child_b": {Status: "pending"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "best of n boundary not yet spawned still blocks",
+			exec: &Execution{WorkflowID: "wf", CurrentStep: "best", State: ExecWaiting},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			effects, err := Reduce(desired, ObservedState{
+				Now:       now,
+				Task:      TaskInfo{ID: "t1", Status: "plan-review"},
+				Execution: tc.exec,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(effects) != 0 {
+				t.Fatalf("effects = %#v, want no status-preview skip across incomplete async boundary", effects)
+			}
+		})
+	}
+}
+
+func requireKinds(t *testing.T, effects []Effect, want ...EffectKind) {
+	t.Helper()
+	got := make([]EffectKind, len(effects))
+	for i := range effects {
+		got[i] = effects[i].Kind
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("effect kinds = %#v, want %#v", got, want)
+	}
+}
+
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/internal/workflow/state_reducer_test.go
+++ b/internal/workflow/state_reducer_test.go
@@ -30,6 +30,7 @@ func TestReduce(t *testing.T) {
 			},
 			observed: ObservedState{Now: now},
 			check: func(t *testing.T, effects []Effect) {
+				t.Helper()
 				requireKinds(t, effects, EffectSetWorkflowState, EffectDispatchStep)
 				wf := effects[0].Workflow
 				if wf == nil {
@@ -70,6 +71,7 @@ func TestReduce(t *testing.T) {
 				CompletedOutput: &StepOutput{StepID: "build", Status: "completed", Output: "ok"},
 			},
 			check: func(t *testing.T, effects []Effect) {
+				t.Helper()
 				requireKinds(t, effects, EffectRecordStep, EffectSetWorkflowState, EffectDispatchStep)
 				if effects[0].Record == nil || effects[0].Record.StepID != "build" || effects[0].Record.Status != "completed" {
 					t.Fatalf("record = %#v", effects[0].Record)
@@ -98,6 +100,7 @@ func TestReduce(t *testing.T) {
 				CompletedOutput: &StepOutput{StepID: "done", Status: "completed"},
 			},
 			check: func(t *testing.T, effects []Effect) {
+				t.Helper()
 				requireKinds(t, effects, EffectRecordStep, EffectCompleteWorkflow)
 				wf := effects[1].Workflow
 				if wf == nil || wf.State != ExecCompleted || wf.CurrentStep != "" || wf.CompletedAt == nil || !wf.CompletedAt.Equal(now) {
@@ -117,6 +120,7 @@ func TestReduce(t *testing.T) {
 				CompletedOutput: &StepOutput{StepID: "link-pr", Status: "completed", TerminalStatus: "done", TerminalReason: "already merged"},
 			},
 			check: func(t *testing.T, effects []Effect) {
+				t.Helper()
 				requireKinds(t, effects, EffectRecordStep, EffectSetTaskStatus, EffectCompleteWorkflow)
 				if effects[1].Status != "done" || effects[1].StatusReason != "already merged" {
 					t.Fatalf("status effect = %#v", effects[1])
@@ -142,6 +146,7 @@ func TestReduce(t *testing.T) {
 				Execution: &Execution{WorkflowID: "wf", CurrentStep: "mark-review", State: ExecRunning, StartedAt: now.Add(-time.Minute)},
 			},
 			check: func(t *testing.T, effects []Effect) {
+				t.Helper()
 				requireKinds(t, effects, EffectSetTaskStatus, EffectRecordStep, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
 				if effects[0].Status != "in-review" {
 					t.Fatalf("first status = %q, want in-review", effects[0].Status)
@@ -163,6 +168,7 @@ func TestReduce(t *testing.T) {
 				Execution: &Execution{WorkflowID: "wf", CurrentStep: "review", State: ExecRunning, StartedAt: now.Add(-time.Minute)},
 			},
 			check: func(t *testing.T, effects []Effect) {
+				t.Helper()
 				requireKinds(t, effects, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
 				if effects[2].Step == nil || effects[2].Step.ID != "review" {
 					t.Fatalf("wait step = %#v", effects[2].Step)
@@ -212,6 +218,7 @@ func TestReduce(t *testing.T) {
 			},
 			observed: ObservedState{Now: now},
 			check: func(t *testing.T, effects []Effect) {
+				t.Helper()
 				requireKinds(t, effects, EffectSetWorkflowState, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
 				effects[0].Workflow.Variables["seed"] = "mutated"
 				effects[3].HumanActions[0] = "mutated"
@@ -227,7 +234,6 @@ func TestReduce(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			effects, err := Reduce(tc.desired, tc.observed)
@@ -338,7 +344,6 @@ func TestReduceTransitionFields(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			effects, err := Reduce(makeDesired(tc.condition), tc.observed)
@@ -394,7 +399,6 @@ func TestReduceAsyncBoundaryCompatibility(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			effects, err := Reduce(desired, ObservedState{

--- a/internal/workflow/state_reducer_test.go
+++ b/internal/workflow/state_reducer_test.go
@@ -376,6 +376,10 @@ func TestReduceAsyncBoundaryCompatibility(t *testing.T) {
 		exec *Execution
 	}{
 		{
+			name: "parallel boundary not yet spawned still blocks",
+			exec: &Execution{WorkflowID: "wf", CurrentStep: "fan_out", State: ExecWaiting},
+		},
+		{
 			name: "parallel boundary still incomplete",
 			exec: &Execution{
 				WorkflowID:  "wf",


### PR DESCRIPTION
## Motivation

Add an isolated canonical workflow state/reducer primitive as the foundation for #2464. Today, correctness depends on timing because multiple pollers/recovery paths interpret ad-hoc snapshots and mutate status directly — there is no single, pure function that says "given this desired state and this observed state, here is the next effect."

## Implementation information

- New `DesiredState` and `ObservedState` types in `internal/workflow`
- New `EffectKind` constants and plain-data `Effect` struct
- Pure `Reduce(desired DesiredState, observed ObservedState) ([]Effect, error)` with zero I/O, no hidden clock, no goroutines
- Uses `ResolveTransition` for transition selection; builds transition-field map compatible with existing `taskFields`/`resolveNext`
- Table-driven unit tests covering: workflow start, advance, completion, failure, set_status, wait_human, transition errors, input immutability, transition-field compatibility, and async-boundary no-skip invariant
- No production engine wiring — behaviorally inert outside unit tests

Closes #2658

> Changelog: feat(workflow): canonical desired/observed state + pure reducer