### PR TITLE
feat(workflow): monotonic effect identity

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -581,6 +581,7 @@ export class Task {
     "statusChangedAt": string;
     "assignedNode"?: string;
     "nodeOverride"?: string;
+    "generation"?: number;
     "mirrorRev"?: number;
     "mirrorUpdatedAt"?: string | null;
     "body": string;
@@ -705,7 +706,7 @@ export class Task {
         const $$createField41_0 = $$createType5;
         const $$createField42_0 = $$createType7;
         const $$createField43_0 = $$createType9;
-        const $$createField59_0 = $$createType10;
+        const $$createField60_0 = $$createType10;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -732,7 +733,7 @@ export class Task {
             $$parsedSource["workflow"] = $$createField43_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField59_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField60_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -325,7 +325,7 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 	return workflow.TaskInfo{
 		ID:                    t.ID,
 		Title:                 t.Title,
-		Generation:            t.MirrorRev,
+		Generation:            t.Generation,
 		Status:                string(t.Status),
 		StatusReason:          t.StatusReason,
 		Blocker:               t.Blocker,

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -325,6 +325,7 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 	return workflow.TaskInfo{
 		ID:                    t.ID,
 		Title:                 t.Title,
+		Generation:            t.MirrorRev,
 		Status:                string(t.Status),
 		StatusReason:          t.StatusReason,
 		Blocker:               t.Blocker,

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -161,6 +161,7 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 	return workflow.TaskInfo{
 		ID:                    t.ID,
 		Title:                 t.Title,
+		Generation:            t.MirrorRev,
 		Status:                string(t.Status),
 		StatusReason:          t.StatusReason,
 		Role:                  t.RunRole,

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -161,7 +161,7 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 	return workflow.TaskInfo{
 		ID:                    t.ID,
 		Title:                 t.Title,
-		Generation:            t.MirrorRev,
+		Generation:            t.Generation,
 		Status:                string(t.Status),
 		StatusReason:          t.StatusReason,
 		Role:                  t.RunRole,

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -504,6 +504,7 @@ type Task struct {
 
 	AssignedNode    string     `json:"assignedNode,omitempty"`
 	NodeOverride    string     `json:"nodeOverride,omitempty"`
+	Generation      int64      `json:"generation,omitempty"`
 	MirrorRev       int64      `json:"mirrorRev,omitempty"`
 	MirrorUpdatedAt *time.Time `json:"mirrorUpdatedAt,omitempty"`
 

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -65,6 +65,7 @@ type taskFrontmatter struct {
 	StatusChangedAt        time.Time           `yaml:"status_changed_at,omitempty"`
 	AssignedNode           string              `yaml:"assigned_node,omitempty"`
 	NodeOverride           string              `yaml:"node_override,omitempty"`
+	Generation             int64               `yaml:"generation,omitempty"`
 	MirrorRev              int64               `yaml:"mirror_rev,omitempty"`
 	MirrorUpdatedAt        *time.Time          `yaml:"mirror_updated_at,omitempty"`
 }
@@ -160,6 +161,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		StatusChangedAt:        fm.StatusChangedAt,
 		AssignedNode:           fm.AssignedNode,
 		NodeOverride:           fm.NodeOverride,
+		Generation:             fm.Generation,
 		MirrorRev:              fm.MirrorRev,
 		MirrorUpdatedAt:        fm.MirrorUpdatedAt,
 		Body:                   body,
@@ -233,6 +235,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		StatusChangedAt:        t.StatusChangedAt,
 		AssignedNode:           t.AssignedNode,
 		NodeOverride:           t.NodeOverride,
+		Generation:             t.Generation,
 		MirrorRev:              t.MirrorRev,
 		MirrorUpdatedAt:        t.MirrorUpdatedAt,
 	}

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -113,6 +113,7 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		UpdatedAt:       now,
 		AssignedNode:    "pet-box",
 		NodeOverride:    "gpu-box",
+		Generation:      2,
 		MirrorRev:       7,
 		MirrorUpdatedAt: &completedAt,
 		Body:            "body",
@@ -360,6 +361,8 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.AssignedNode = "pet-box"
 	case "NodeOverride":
 		task.NodeOverride = "gpu-box"
+	case "Generation":
+		task.Generation = 2
 	case "MirrorRev":
 		task.MirrorRev = 7
 	case "MirrorUpdatedAt":

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -441,6 +441,7 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 		Slug:            Slugify(title),
 		Title:           title,
 		Status:          StatusTodo,
+		Generation:      1,
 		AgentMode:       mode,
 		Attachments:     []Attachment{},
 		CreatedAt:       now,
@@ -483,6 +484,7 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 		Slug:            Slugify(title),
 		Title:           title,
 		Status:          StatusTodo,
+		Generation:      1,
 		AgentMode:       mode,
 		Attachments:     []Attachment{},
 		CreatedAt:       now,
@@ -923,6 +925,7 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 		t.TestingCycleStartedAt = &now
 	}
 	statusChangedBackfill := statusChangedAtBackfill(t, now)
+	t.Generation++
 	t.UpdatedAt = now
 	if t.Status != prevStatus {
 		t.StatusChangedAt = now

--- a/internal/workflow/effect_id.go
+++ b/internal/workflow/effect_id.go
@@ -47,12 +47,17 @@ func (id EffectID) Compare(other EffectID) int {
 		return -1
 	case id.StepSeq > other.StepSeq:
 		return 1
+	}
+	if cmp := strings.Compare(id.StepID, other.StepID); cmp != 0 {
+		return cmp
+	}
+	switch {
 	case id.Pos < other.Pos:
 		return -1
 	case id.Pos > other.Pos:
 		return 1
 	}
-	return strings.Compare(id.StepID, other.StepID)
+	return 0
 }
 
 func (id EffectID) String() string {
@@ -67,6 +72,7 @@ func assignEffectIDs(desired DesiredState, observed ObservedState, effects []Eff
 		return effects
 	}
 	currentStepID, currentSeq := initialEffectCursor(desired, observed)
+	pos := 0
 	for i := range effects {
 		stepID := effectAnchorStepID(effects, i, currentStepID)
 		switch {
@@ -77,13 +83,15 @@ func assignEffectIDs(desired DesiredState, observed ObservedState, effects []Eff
 		case stepID != currentStepID:
 			currentSeq++
 			currentStepID = stepID
+			pos = 0
 		}
 		effects[i].ID = EffectID{
 			Generation: observed.Task.Generation,
 			StepSeq:    currentSeq,
 			StepID:     stepID,
-			Pos:        i,
+			Pos:        pos,
 		}
+		pos++
 	}
 	return effects
 }

--- a/internal/workflow/effect_id.go
+++ b/internal/workflow/effect_id.go
@@ -141,8 +141,10 @@ func effectAnchorStepID(effects []Effect, idx int, fallback string) string {
 				if next.Step != nil {
 					return next.Step.ID
 				}
+			case EffectSetTaskStatus, EffectCompleteWorkflow, EffectFailWorkflow:
 			}
 		}
+	case EffectCompleteWorkflow, EffectFailWorkflow:
 	}
 	return fallback
 }

--- a/internal/workflow/effect_id.go
+++ b/internal/workflow/effect_id.go
@@ -1,0 +1,174 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EffectID identifies one reducer-emitted effect within a task generation.
+// Generation scopes ids across retries/resets, StepSeq orders steps within that
+// generation, StepID anchors the originating workflow step, and Pos
+// distinguishes sibling effects from the same reducer decision.
+type EffectID struct {
+	Generation int64
+	StepSeq    int
+	StepID     string
+	Pos        int
+}
+
+// IsZero reports whether the id has not been assigned yet.
+func (id EffectID) IsZero() bool {
+	return id.Generation == 0 && id.StepSeq == 0 && id.StepID == "" && id.Pos == 0
+}
+
+// Equal reports whether two ids name the same logical effect.
+func (id EffectID) Equal(other EffectID) bool {
+	return id == other
+}
+
+// Less reports whether id sorts before other in monotonic execution order.
+func (id EffectID) Less(other EffectID) bool {
+	return id.Compare(other) < 0
+}
+
+// Before is an alias for Less.
+func (id EffectID) Before(other EffectID) bool {
+	return id.Less(other)
+}
+
+// Compare returns -1, 0, or 1 using the reducer's monotonic ordering.
+func (id EffectID) Compare(other EffectID) int {
+	switch {
+	case id.Generation < other.Generation:
+		return -1
+	case id.Generation > other.Generation:
+		return 1
+	case id.StepSeq < other.StepSeq:
+		return -1
+	case id.StepSeq > other.StepSeq:
+		return 1
+	case id.Pos < other.Pos:
+		return -1
+	case id.Pos > other.Pos:
+		return 1
+	}
+	return strings.Compare(id.StepID, other.StepID)
+}
+
+func (id EffectID) String() string {
+	if id.IsZero() {
+		return "effect:zero"
+	}
+	return fmt.Sprintf("g%d:s%d:%s:%d", id.Generation, id.StepSeq, id.StepID, id.Pos)
+}
+
+func assignEffectIDs(desired DesiredState, observed ObservedState, effects []Effect) []Effect {
+	if len(effects) == 0 {
+		return effects
+	}
+	currentStepID, currentSeq := initialEffectCursor(desired, observed)
+	for i := range effects {
+		stepID := effectAnchorStepID(effects, i, currentStepID)
+		switch {
+		case stepID == "":
+			stepID = currentStepID
+		case currentStepID == "":
+			currentStepID = stepID
+		case stepID != currentStepID:
+			currentSeq++
+			currentStepID = stepID
+		}
+		effects[i].ID = EffectID{
+			Generation: observed.Task.Generation,
+			StepSeq:    currentSeq,
+			StepID:     stepID,
+			Pos:        i,
+		}
+	}
+	return effects
+}
+
+func initialEffectCursor(desired DesiredState, observed ObservedState) (stepID string, stepSeq int) {
+	stepSeq = executionStepSeq(observed.Execution)
+	if observed.Execution == nil {
+		start, err := reducerStartStep(desired)
+		if err != nil || start == nil {
+			return "", stepSeq
+		}
+		return start.ID, stepSeq
+	}
+	stepID = observed.Execution.CurrentStep
+	if stepID == "" {
+		return "", stepSeq
+	}
+	current := desired.Definition.StepByID(stepID)
+	if current == nil {
+		return stepID, stepSeq
+	}
+	if observed.CompletedOutput == nil && !workflowBoundaryOpen(current, observed.Execution) {
+		return "", stepSeq
+	}
+	return stepID, stepSeq
+}
+
+func effectAnchorStepID(effects []Effect, idx int, fallback string) string {
+	effect := effects[idx]
+	switch effect.Kind {
+	case EffectRecordStep:
+		if effect.Record != nil {
+			return effect.Record.StepID
+		}
+	case EffectDispatchStep, EffectWaitHuman:
+		if effect.Step != nil {
+			return effect.Step.ID
+		}
+	case EffectSetWorkflowState:
+		if effect.Workflow != nil && effect.Workflow.CurrentStep != "" {
+			return effect.Workflow.CurrentStep
+		}
+	case EffectSetTaskStatus:
+		if idx+1 < len(effects) {
+			switch next := effects[idx+1]; next.Kind {
+			case EffectRecordStep:
+				if next.Record != nil {
+					return next.Record.StepID
+				}
+			case EffectSetWorkflowState:
+				if next.Workflow != nil && next.Workflow.CurrentStep != "" {
+					return next.Workflow.CurrentStep
+				}
+			case EffectDispatchStep, EffectWaitHuman:
+				if next.Step != nil {
+					return next.Step.ID
+				}
+			}
+		}
+	}
+	return fallback
+}
+
+func executionStepSeq(exec *Execution) int {
+	if exec == nil {
+		return 0
+	}
+	if len(exec.StepCounts) == 0 {
+		return len(exec.StepHistory)
+	}
+	total := 0
+	for _, count := range exec.StepCounts {
+		total += count
+	}
+	return total
+}
+
+func workflowBoundaryOpen(step *Step, exec *Execution) bool {
+	if step == nil || exec == nil {
+		return true
+	}
+	switch step.Type {
+	case StepParallel, StepBestOfN:
+		return !reducerAsyncBoundaryComplete(exec, step)
+	default:
+		return true
+	}
+}

--- a/internal/workflow/effect_id_test.go
+++ b/internal/workflow/effect_id_test.go
@@ -26,7 +26,8 @@ func TestEffectIDComparison(t *testing.T) {
 	if first.String() != "g2:s3:plan:0" {
 		t.Fatalf("first.String() = %q, want g2:s3:plan:0", first.String())
 	}
-	if !first.Equal(first) {
+	firstCopy := first
+	if !first.Equal(firstCopy) {
 		t.Fatal("Equal must match identical ids")
 	}
 	if first.Equal(second) {
@@ -41,7 +42,8 @@ func TestEffectIDComparison(t *testing.T) {
 	if !laterStep.Less(nextGen) {
 		t.Fatal("next generation must sort after prior generation")
 	}
-	if got := nextGen.Compare(nextGen); got != 0 {
+	nextGenCopy := nextGen
+	if got := nextGen.Compare(nextGenCopy); got != 0 {
 		t.Fatalf("Compare(self) = %d, want 0", got)
 	}
 }

--- a/internal/workflow/effect_id_test.go
+++ b/internal/workflow/effect_id_test.go
@@ -1,0 +1,124 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEffectIDComparison(t *testing.T) {
+	t.Parallel()
+
+	zero := EffectID{}
+	first := EffectID{Generation: 2, StepSeq: 3, StepID: "plan", Pos: 0}
+	second := EffectID{Generation: 2, StepSeq: 3, StepID: "plan", Pos: 1}
+	laterStep := EffectID{Generation: 2, StepSeq: 4, StepID: "review", Pos: 0}
+	nextGen := EffectID{Generation: 3, StepSeq: 0, StepID: "start", Pos: 0}
+
+	if !zero.IsZero() {
+		t.Fatal("zero EffectID must report IsZero")
+	}
+	if first.IsZero() {
+		t.Fatal("assigned EffectID reported zero")
+	}
+	if zero.String() != "effect:zero" {
+		t.Fatalf("zero.String() = %q, want effect:zero", zero.String())
+	}
+	if first.String() != "g2:s3:plan:0" {
+		t.Fatalf("first.String() = %q, want g2:s3:plan:0", first.String())
+	}
+	if !first.Equal(first) {
+		t.Fatal("Equal must match identical ids")
+	}
+	if first.Equal(second) {
+		t.Fatal("Equal matched distinct ids")
+	}
+	if !first.Less(second) || !first.Before(second) {
+		t.Fatal("position must order sibling effects")
+	}
+	if !second.Less(laterStep) {
+		t.Fatal("later step must sort after earlier sibling")
+	}
+	if !laterStep.Less(nextGen) {
+		t.Fatal("next generation must sort after prior generation")
+	}
+	if got := nextGen.Compare(nextGen); got != 0 {
+		t.Fatalf("Compare(self) = %d, want 0", got)
+	}
+}
+
+func TestReduceAssignsDistinctEffectIDs(t *testing.T) {
+	t.Parallel()
+
+	effects, err := Reduce(
+		DesiredState{
+			Definition: Definition{ID: "wf", Steps: []Step{{ID: "start", Type: StepRunAgent}}},
+			WorkflowID: "wf",
+		},
+		ObservedState{
+			Task: TaskInfo{ID: "t1", Generation: 7},
+			Now:  time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(effects) != 2 {
+		t.Fatalf("len(effects) = %d, want 2", len(effects))
+	}
+	if effects[0].ID.IsZero() || effects[1].ID.IsZero() {
+		t.Fatalf("assigned ids must be non-zero: %#v", effects)
+	}
+	if effects[0].ID.Equal(effects[1].ID) {
+		t.Fatalf("effects share id %v", effects[0].ID)
+	}
+	if !effects[0].ID.Less(effects[1].ID) {
+		t.Fatalf("ids not ordered: %v !< %v", effects[0].ID, effects[1].ID)
+	}
+	if effects[0].ID.Generation != 7 || effects[1].ID.Generation != 7 {
+		t.Fatalf("generation = %d/%d, want 7/7", effects[0].ID.Generation, effects[1].ID.Generation)
+	}
+	if effects[0].ID.StepID != "start" || effects[1].ID.StepID != "start" {
+		t.Fatalf("step ids = %q/%q, want start/start", effects[0].ID.StepID, effects[1].ID.StepID)
+	}
+}
+
+func TestReduceOrdersEffectIDsAcrossSteps(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	effects, err := Reduce(
+		DesiredState{
+			Definition: Definition{ID: "wf", Steps: []Step{
+				{ID: "mark-review", Type: StepSetStatus, Config: StepConfig{Status: "in-review", StatusReason: "ready"}, Next: []Transition{{GoTo: "await"}}},
+				{ID: "await", Type: StepWaitHuman, Config: StepConfig{Status: "plan-review", HumanActions: []string{"approve"}}},
+			}},
+			WorkflowID: "wf",
+		},
+		ObservedState{
+			Task: TaskInfo{ID: "t1", Generation: 3, Status: "todo"},
+			Now:  now,
+			Execution: &Execution{
+				WorkflowID:  "wf",
+				CurrentStep: "mark-review",
+				State:       ExecRunning,
+				StartedAt:   now.Add(-time.Minute),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireKinds(t, effects, EffectSetTaskStatus, EffectRecordStep, EffectSetTaskStatus, EffectSetWorkflowState, EffectWaitHuman)
+	if got := effects[1].ID.StepID; got != "mark-review" {
+		t.Fatalf("record step id = %q, want mark-review", got)
+	}
+	if got := effects[4].ID.StepID; got != "await" {
+		t.Fatalf("wait step id = %q, want await", got)
+	}
+	if !effects[1].ID.Less(effects[4].ID) {
+		t.Fatalf("earlier step id %v must sort before later step id %v", effects[1].ID, effects[4].ID)
+	}
+	if effects[1].ID.StepSeq >= effects[4].ID.StepSeq {
+		t.Fatalf("step seq = %d/%d, want earlier < later", effects[1].ID.StepSeq, effects[4].ID.StepSeq)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -25,8 +25,11 @@ const (
 
 // TaskInfo is the subset of task data the engine needs.
 type TaskInfo struct {
-	ID           string
-	Title        string
+	ID    string
+	Title string
+	// Generation is the reducer-visible monotonic task version the effect-id
+	// scheme keys on until a dedicated persisted task-generation counter lands.
+	Generation   int64
 	Status       string
 	StatusReason string
 	Blocker      blocker.State

--- a/internal/workflow/state_reducer.go
+++ b/internal/workflow/state_reducer.go
@@ -201,7 +201,7 @@ func reduceCurrentStep(desired DesiredState, observed ObservedState, exec *Execu
 				)
 				return cloneEffects(effects), nil
 			}
-			return nil, nil
+			return cloneEffects(effects), nil
 		}
 
 		next, complete, err := reducerNextStep(desired, observed, exec, current)

--- a/internal/workflow/state_reducer.go
+++ b/internal/workflow/state_reducer.go
@@ -42,6 +42,7 @@ const (
 
 // Effect is a plain-data reducer output.
 type Effect struct {
+	ID           EffectID
 	Kind         EffectKind
 	Workflow     *Execution
 	Status       string
@@ -53,6 +54,14 @@ type Effect struct {
 
 // Reduce converts desired/observed workflow state into plain-data effects.
 func Reduce(desired DesiredState, observed ObservedState) ([]Effect, error) {
+	effects, err := reduceEffects(desired, observed)
+	if err != nil {
+		return nil, err
+	}
+	return assignEffectIDs(desired, observed, effects), nil
+}
+
+func reduceEffects(desired DesiredState, observed ObservedState) ([]Effect, error) {
 	workflowID, err := reducerWorkflowID(desired)
 	if err != nil {
 		return nil, err
@@ -412,6 +421,7 @@ func cloneEffects(in []Effect) []Effect {
 	out := make([]Effect, len(in))
 	for i := range in {
 		out[i] = Effect{
+			ID:           in[i].ID,
 			Kind:         in[i].Kind,
 			Workflow:     in[i].Workflow.Clone(),
 			Status:       in[i].Status,


### PR DESCRIPTION
## Motivation

Gives every Effect produced by Reduce() a monotonic identity (generation + step + position), enabling comparison and ordering without wall-clock timing. Foundation step for #2464.

## Implementation information

- New `EffectID` type in `internal/workflow/effect_id.go` with monotonic ordering, equality, and string representation
- `Effect` struct gains an `ID EffectID` field; `Reduce()` assigns IDs at construction time
- Unit tests verify uniqueness, ordering, and zero-value distinguishability

Closes #2659