### PR TITLE
fix(frontend): use in-app task delete confirmation

### DIFF
--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -7,6 +7,7 @@
   import { StartReview, StartFixReview } from '$lib/api'
   import { statusOptionsFor, STATUS_MAP, coreStatus } from '../../lib/statuses.js'
   import { isTamperFlaggedTask } from '$lib/tamper.js'
+  import MobileSheet from '../shell/MobileSheet.svelte'
 
   interface Props {
     task: Task
@@ -31,6 +32,7 @@
   let fixReviewLoading = $state(false)
   let error = $state('')
   let menuOpen = $state(false)
+  let deleteConfirmOpen = $state(false)
 
   function closeMenu() {
     menuOpen = false
@@ -107,7 +109,7 @@
       copyBranch()
     }
     function onDeleteEv() {
-      deleteTask()
+      openDeleteConfirm()
     }
     window.addEventListener('task-detail:edit-title', onEditTitle)
     window.addEventListener('task-detail:focus-status', onFocusStatus)
@@ -214,11 +216,18 @@
     }
   }
 
-  async function deleteTask() {
-    if (!window.confirm(`Delete task "${task.title}"? This cannot be undone.`)) return
+  function openDeleteConfirm() {
+    if (deleting) return
+    error = ''
+    deleteConfirmOpen = true
+  }
+
+  async function confirmDeleteTask() {
     deleting = true
     try {
       await taskStore.remove(task.id)
+      deleteConfirmOpen = false
+      deleting = false
       ondelete()
     } catch (e) {
       error = String(e)
@@ -378,7 +387,7 @@
             type="button"
             role="menuitem"
             class="flex w-full items-center px-3 py-1.5 text-left text-xs text-error-600 hover:bg-error-50 disabled:opacity-50 dark:text-error-400 dark:hover:bg-error-950"
-            onclick={() => { closeMenu(); deleteTask() }}
+            onclick={() => { closeMenu(); openDeleteConfirm() }}
             disabled={deleting}
           >
             {deleting ? 'Deleting...' : 'Delete task'}
@@ -388,3 +397,35 @@
     </div>
   </div>
 </div>
+
+<MobileSheet
+  open={deleteConfirmOpen}
+  onOpenChange={(open) => { if (!deleting) deleteConfirmOpen = open }}
+  variant="center"
+  title="Delete task"
+>
+  <div class="flex flex-col gap-4 px-5 pb-5 md:px-6 md:pb-6">
+    <p class="text-sm text-surface-700 dark:text-surface-300">
+      Delete "{task.title}"? This cannot be undone.
+    </p>
+
+    <div class="flex justify-end gap-2">
+      <button
+        type="button"
+        class="tap rounded-lg bg-surface-200 px-4 py-2.5 text-sm font-medium active:bg-surface-300 dark:bg-surface-700 dark:active:bg-surface-600"
+        onclick={() => (deleteConfirmOpen = false)}
+        disabled={deleting}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="tap rounded-lg bg-error-600 px-4 py-2.5 text-sm font-medium text-white active:bg-error-700 disabled:opacity-50"
+        onclick={confirmDeleteTask}
+        disabled={deleting}
+      >
+        {deleting ? 'Deleting...' : 'Delete'}
+      </button>
+    </div>
+  </div>
+</MobileSheet>

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
@@ -57,7 +57,6 @@ describe('TaskHeaderBar', () => {
     mockStartFixReview.mockReset()
     mockUpdate.mockResolvedValue(baseTask)
     mockRemove.mockResolvedValue(undefined)
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
   afterEach(() => {
     cleanup()
@@ -119,26 +118,37 @@ describe('TaskHeaderBar', () => {
     expect(screen.getByText('Run Review')).toBeDefined()
   })
 
-  it('calls remove and ondelete on Delete from the overflow menu', async () => {
+  it('opens an in-app confirmation before deleting from the overflow menu', async () => {
     const ondelete = vi.fn()
     render(TaskHeaderBar, { props: { task: baseTask as never, ondelete } })
     await fireEvent.click(screen.getByLabelText('More actions'))
-    await fireEvent.click(screen.getByText('Delete task'))
+    await fireEvent.click(screen.getByRole('menuitem', { name: 'Delete task' }))
+    expect(screen.getByText('Delete "Test Task"? This cannot be undone.')).toBeDefined()
+    expect(mockRemove).not.toHaveBeenCalled()
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     await waitFor(() => {
-      expect(window.confirm).toHaveBeenCalledWith('Delete task "Test Task"? This cannot be undone.')
       expect(mockRemove).toHaveBeenCalledWith('t1')
       expect(ondelete).toHaveBeenCalled()
     })
   })
 
-  it('does not delete when confirmation is cancelled', async () => {
-    vi.mocked(window.confirm).mockReturnValue(false)
+  it('does not delete when the in-app confirmation is cancelled', async () => {
     const ondelete = vi.fn()
     render(TaskHeaderBar, { props: { task: baseTask as never, ondelete } })
     await fireEvent.click(screen.getByLabelText('More actions'))
-    await fireEvent.click(screen.getByText('Delete task'))
+    await fireEvent.click(screen.getByRole('menuitem', { name: 'Delete task' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(mockRemove).not.toHaveBeenCalled()
     expect(ondelete).not.toHaveBeenCalled()
+    expect(screen.queryByText('Delete "Test Task"? This cannot be undone.')).toBeNull()
+  })
+
+  it('opens the in-app delete confirmation from the window delete event', async () => {
+    render(TaskHeaderBar, { props: { task: baseTask as never, ondelete: vi.fn() } })
+    window.dispatchEvent(new CustomEvent('task-detail:delete'))
+    await waitFor(() => {
+      expect(screen.getByText('Delete "Test Task"? This cannot be undone.')).toBeDefined()
+    })
   })
 
   it('responds to task-detail:edit-title window event', async () => {

--- a/frontend/src/pages/TaskDetail.svelte.test.ts
+++ b/frontend/src/pages/TaskDetail.svelte.test.ts
@@ -98,16 +98,20 @@ vi.mock('$lib/api', () => ({
   GetAttachmentURL: (...args: unknown[]) => mockGetAttachmentURL(...args),
 }))
 
-vi.mock('@skeletonlabs/skeleton-svelte', () => ({
-  SegmentedControl: Object.assign(() => {}, {
-    Control: () => {},
-    Indicator: () => {},
-    Item: Object.assign(() => {}, {
-      ItemText: () => {},
-      ItemHiddenInput: () => {},
+vi.mock('@skeletonlabs/skeleton-svelte', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@skeletonlabs/skeleton-svelte')>()
+  return {
+    ...actual,
+    SegmentedControl: Object.assign(() => {}, {
+      Control: () => {},
+      Indicator: () => {},
+      Item: Object.assign(() => {}, {
+        ItemText: () => {},
+        ItemHiddenInput: () => {},
+      }),
     }),
-  }),
-}))
+  }
+})
 
 vi.mock('../components/StreamOutput.svelte', () => ({ default: () => {} }))
 vi.mock('../components/StatusBadge.svelte', () => ({ default: () => {} }))
@@ -217,7 +221,11 @@ describe('TaskDetail', () => {
     await vi.waitFor(() => {
       expect(screen.getByText('Delete task')).toBeDefined()
     })
-    screen.getByText('Delete task').click()
+    await fireEvent.click(screen.getByText('Delete task'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('Delete "Test Task"? This cannot be undone.')).toBeDefined()
+    })
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     await vi.waitFor(() => {
       expect(mockRemove).toHaveBeenCalledWith('task-1')
       expect(ondelete).toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- replace the task delete window.confirm path with an app-rendered MobileSheet confirmation
- route overflow-menu delete and task-detail:delete keyboard command through the same confirmation
- update TaskHeaderBar tests to assert the in-app confirmation behavior instead of mocking window.confirm

## Tests
- cd frontend && npm test -- TaskHeaderBar.svelte.test.ts
- cd frontend && npm run check