### PR TITLE
test(workflow): add permutation contract harness

### DIFF
--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -592,6 +592,19 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			}
 			return nil, wrapDispatchErr(step.ID, execErr)
 		}
+		if step.Type == StepPromoteBestOfN {
+			// execPromoteBestOfN reloads and persists the freshest workflow state
+			// itself so it can preserve judge-step vars and the promoted canonical
+			// dir. Continue from that persisted copy rather than the stale pre-step
+			// wfExec passed into executeSteps.
+			fresh, err := e.tasks.GetTask(taskID)
+			if err != nil {
+				return nil, err
+			}
+			if fresh.Workflow != nil {
+				wfExec = fresh.Workflow
+			}
+		}
 
 		now := time.Now().UTC()
 		wfExec.RecordStep(StepRecord{

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -338,8 +338,17 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	// written, recreating the #2176 hang through a different pair of critical
 	// sections than the ones the first fix closed (an adversarial review's
 	// second pass). resolveCompletionRoute folds both checks into one.
-	spawnedStep, routeStatus := e.resolveCompletionRoute(taskID, t.Workflow.CurrentStep, c)
 	defs := completionDefinitionCache{engine: e, task: t}
+	spawnedStep, routeStatus, duplicatedTerminal := e.resolvePersistedParallelCompletion(t.Workflow, c.AgentID)
+	if !duplicatedTerminal && routeStatus != taskStepTracked {
+		spawnedStep, routeStatus = e.resolveCompletionRoute(taskID, t.Workflow.CurrentStep, c)
+	}
+	if duplicatedTerminal {
+		e.logger.Info("workflow.agent-complete.bail",
+			"task_id", taskID, "agent_id", c.AgentID, "reason", "parallel-child-terminal-duplicate", "current_step", t.Workflow.CurrentStep)
+		e.clearAgentStep(c.AgentID)
+		return
+	}
 	switch routeStatus {
 	case taskStepTracked:
 		// c.AgentID owns spawnedStep. Falls through to the advancement logic
@@ -363,6 +372,19 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 			"task_id", taskID, "agent_id", c.AgentID, "reason", "start-in-flight", "current_step", spawnedStep)
 		return
 	case taskStepFree:
+		if def, ok := defs.get(); ok {
+			if step := def.StepByID(spawnedStep); step == nil || step.Type != StepRunAgent {
+				e.logger.Info("workflow.agent-complete.bail",
+					"task_id", taskID, "agent_id", c.AgentID, "reason", "untracked-non-agent-step", "current_step", spawnedStep)
+				e.clearAgentStep(c.AgentID)
+				return
+			}
+		} else {
+			e.logger.Info("workflow.agent-complete.bail",
+				"task_id", taskID, "agent_id", c.AgentID, "reason", "workflow-definition-unavailable", "current_step", spawnedStep)
+			e.clearAgentStep(c.AgentID)
+			return
+		}
 		// Neither a route nor a pending start exists for this task+step, so
 		// the role match below is what decides.
 		if runRole := agentRunRole(t.AgentRuns, c.AgentID); runRole != "" {
@@ -585,6 +607,26 @@ func (e *Engine) resolveCompletionRoute(taskID, currentStep string, c AgentCompl
 	}
 	e.pendingCompletions[key] = append(e.pendingCompletions[key], c)
 	return spawnedStep, taskStepBuffered
+}
+
+func (e *Engine) resolvePersistedParallelCompletion(wf *Execution, agentID string) (spawnedStep string, status taskStepStatus, duplicatedTerminal bool) {
+	if wf == nil || agentID == "" || wf.CurrentStep == "" {
+		return "", taskStepFree, false
+	}
+	rec := wf.ParallelInflight[wf.CurrentStep]
+	if rec == nil {
+		return "", taskStepFree, false
+	}
+	for childID, child := range rec.Children {
+		if child == nil || child.AgentID != agentID {
+			continue
+		}
+		if child.Status == "completed" || child.Status == "failed" {
+			return childID, taskStepFree, true
+		}
+		return childID, taskStepTracked, false
+	}
+	return "", taskStepFree, false
 }
 
 func pendingStepStartKey(taskID, stepID string) string {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -338,17 +338,8 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	// written, recreating the #2176 hang through a different pair of critical
 	// sections than the ones the first fix closed (an adversarial review's
 	// second pass). resolveCompletionRoute folds both checks into one.
+	spawnedStep, routeStatus := e.resolveCompletionRoute(taskID, t.Workflow.CurrentStep, c)
 	defs := completionDefinitionCache{engine: e, task: t}
-	spawnedStep, routeStatus, duplicatedTerminal := e.resolvePersistedParallelCompletion(t.Workflow, c.AgentID)
-	if !duplicatedTerminal && routeStatus != taskStepTracked {
-		spawnedStep, routeStatus = e.resolveCompletionRoute(taskID, t.Workflow.CurrentStep, c)
-	}
-	if duplicatedTerminal {
-		e.logger.Info("workflow.agent-complete.bail",
-			"task_id", taskID, "agent_id", c.AgentID, "reason", "parallel-child-terminal-duplicate", "current_step", t.Workflow.CurrentStep)
-		e.clearAgentStep(c.AgentID)
-		return
-	}
 	switch routeStatus {
 	case taskStepTracked:
 		// c.AgentID owns spawnedStep. Falls through to the advancement logic
@@ -372,21 +363,16 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 			"task_id", taskID, "agent_id", c.AgentID, "reason", "start-in-flight", "current_step", spawnedStep)
 		return
 	case taskStepFree:
-		if def, ok := defs.get(); ok {
-			if step := def.StepByID(spawnedStep); step == nil || step.Type != StepRunAgent {
-				e.logger.Info("workflow.agent-complete.bail",
-					"task_id", taskID, "agent_id", c.AgentID, "reason", "untracked-non-agent-step", "current_step", spawnedStep)
-				e.clearAgentStep(c.AgentID)
-				return
-			}
-		} else {
-			e.logger.Info("workflow.agent-complete.bail",
-				"task_id", taskID, "agent_id", c.AgentID, "reason", "workflow-definition-unavailable", "current_step", spawnedStep)
-			e.clearAgentStep(c.AgentID)
-			return
-		}
 		// Neither a route nor a pending start exists for this task+step, so
 		// the role match below is what decides.
+		if def, ok := defs.get(); ok {
+			if current := def.StepByID(t.Workflow.CurrentStep); current != nil && current.Type == StepParallel {
+				if childStepID, ok := parallelChildStepByAgentID(t.Workflow, current.ID, c.AgentID); ok {
+					spawnedStep = childStepID
+					break
+				}
+			}
+		}
 		if runRole := agentRunRole(t.AgentRuns, c.AgentID); runRole != "" {
 			if def, ok := defs.get(); ok && !untrackedCompletionMatchesCurrentStep(def, spawnedStep, runRole) {
 				e.logger.Info("workflow.agent-complete.bail",
@@ -609,26 +595,6 @@ func (e *Engine) resolveCompletionRoute(taskID, currentStep string, c AgentCompl
 	return spawnedStep, taskStepBuffered
 }
 
-func (e *Engine) resolvePersistedParallelCompletion(wf *Execution, agentID string) (spawnedStep string, status taskStepStatus, duplicatedTerminal bool) {
-	if wf == nil || agentID == "" || wf.CurrentStep == "" {
-		return "", taskStepFree, false
-	}
-	rec := wf.ParallelInflight[wf.CurrentStep]
-	if rec == nil {
-		return "", taskStepFree, false
-	}
-	for childID, child := range rec.Children {
-		if child == nil || child.AgentID != agentID {
-			continue
-		}
-		if child.Status == "completed" || child.Status == "failed" {
-			return childID, taskStepFree, true
-		}
-		return childID, taskStepTracked, false
-	}
-	return "", taskStepFree, false
-}
-
 func pendingStepStartKey(taskID, stepID string) string {
 	return taskID + "|" + stepID
 }
@@ -675,6 +641,22 @@ func untrackedCompletionMatchesCurrentStep(def *Definition, stepID, runRole stri
 		return true
 	}
 	return step.Config.Role == runRole
+}
+
+func parallelChildStepByAgentID(wf *Execution, parentStepID, agentID string) (string, bool) {
+	if wf == nil || parentStepID == "" || agentID == "" {
+		return "", false
+	}
+	rec := wf.ParallelInflight[parentStepID]
+	if rec == nil {
+		return "", false
+	}
+	for childStepID, child := range rec.Children {
+		if child != nil && child.AgentID == agentID {
+			return childStepID, true
+		}
+	}
+	return "", false
 }
 
 // markStepStarting records that a run_agent step's agent-start sequence

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -936,8 +936,21 @@ func (e *Engine) rescheduleRunAgent(taskID, agentID string, step *Step, t TaskIn
 		e.surfaceStartFailure(taskID, t.Status, rErr, t.Workflow, step.ID)
 		return
 	}
-	e.clearCircuitBreakerOnSuccess(taskID, t.Workflow, step.ID)
-	e.clearWatchdogReaskNote(taskID, t.Workflow)
+	cleanupWorkflow := e.workflowForPostDispatchCleanup(taskID)
+	e.clearCircuitBreakerOnSuccess(taskID, cleanupWorkflow, step.ID)
+	e.clearWatchdogReaskNote(taskID, cleanupWorkflow)
+}
+
+func (e *Engine) workflowForPostDispatchCleanup(taskID string) *Execution {
+	if taskID == "" {
+		return nil
+	}
+	fresh, err := e.tasks.GetTask(taskID)
+	if err != nil {
+		e.logger.Error("workflow.post-dispatch-cleanup.get", "task_id", taskID, "err", err)
+		return nil
+	}
+	return fresh.Workflow
 }
 
 func (e *Engine) shouldRetryGhostPark(taskID, stepID string) bool {
@@ -1332,7 +1345,7 @@ func (e *Engine) resumeStalledTask(t *TaskInfo) {
 		return
 	}
 
-	e.finishResumeStalledStep(t.ID, &def, step, t.Workflow, fresh)
+	e.finishResumeStalledStep(t.ID, &def, step, fresh.Workflow, fresh)
 }
 
 // resolveFreshTaskForResume re-reads and reconciles the task's current step to guard
@@ -1400,9 +1413,10 @@ func (e *Engine) finishResumeStalledStep(taskID string, def *Definition, step *S
 		e.surfaceStartFailure(taskID, fresh.Status, rErr, fresh.Workflow, step.ID)
 		return
 	}
-	e.clearTransientFetchRetry(fresh.ID, fresh.Workflow, step.ID)
-	e.clearCircuitBreakerOnSuccess(fresh.ID, fresh.Workflow, step.ID)
-	e.clearWatchdogReaskNote(fresh.ID, fresh.Workflow)
+	cleanupWorkflow := e.workflowForPostDispatchCleanup(taskID)
+	e.clearTransientFetchRetry(fresh.ID, cleanupWorkflow, step.ID)
+	e.clearCircuitBreakerOnSuccess(fresh.ID, cleanupWorkflow, step.ID)
+	e.clearWatchdogReaskNote(fresh.ID, cleanupWorkflow)
 }
 
 // handleWatchdogRetries checks both bounded watchdog stop-retry paths — a

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -222,12 +222,8 @@ func (m *memTasks) GetTask(id string) (TaskInfo, error) {
 		m.onGet(id, t, m.gets[id])
 	}
 	cp := *t
-	// Shallow-copy the Execution struct so concurrent callers each get their
-	// own State field — mirroring the file-backed store which always
-	// deserializes a fresh object.
 	if t.Workflow != nil {
-		wf := *t.Workflow
-		cp.Workflow = &wf
+		cp.Workflow = t.Workflow.Clone()
 	}
 	return cp, nil
 }

--- a/internal/workflow/permutation_contract_test.go
+++ b/internal/workflow/permutation_contract_test.go
@@ -150,8 +150,9 @@ func (s *workflowPermutationScenario) statusChange(status string) {
 func (s *workflowPermutationScenario) restart() {
 	s.t.Helper()
 	clonedTasks := newMemTasks()
-	for _, task := range mustListTasks(s.t, s.tasks) {
-		clonedTasks.Put(cloneWorkflowPermutationTask(task))
+	tasks := mustListTasks(s.t, s.tasks)
+	for i := range tasks {
+		clonedTasks.Put(cloneWorkflowPermutationTask(tasks[i]))
 	}
 	clonedAgents := cloneWorkflowPermutationAgents(s.agents)
 	clonedEngine := NewEngine(s.store, clonedTasks, clonedAgents, discardLogger())
@@ -332,12 +333,13 @@ func workflowPermutationParallelChildren(wf *Execution) []string {
 	return out
 }
 
-func workflowPermutationEffects(calls []startCall) ([]string, []string) {
+func workflowPermutationEffects(calls []startCall) (effectSet, effectCounts []string) {
 	if len(calls) == 0 {
 		return nil, nil
 	}
 	counts := make(map[string]int)
-	for _, call := range calls {
+	for i := range calls {
+		call := &calls[i]
 		key := strings.Join([]string{workflowPermutationStepID(call.Prompt), call.Provider, call.Role}, "|")
 		counts[key]++
 	}
@@ -350,7 +352,9 @@ func workflowPermutationEffects(calls []startCall) ([]string, []string) {
 	for _, key := range keys {
 		countStrings = append(countStrings, fmt.Sprintf("%s=%d", key, counts[key]))
 	}
-	return keys, countStrings
+	effectSet = keys
+	effectCounts = countStrings
+	return effectSet, effectCounts
 }
 
 func workflowPermutationStepID(prompt string) string {

--- a/internal/workflow/permutation_contract_test.go
+++ b/internal/workflow/permutation_contract_test.go
@@ -221,18 +221,37 @@ func workflowPermutationEvents() []workflowPermutationEvent {
 }
 
 func sampleWorkflowPermutationOrders(events []workflowPermutationEvent, limit int, seed int64) [][]workflowPermutationEvent {
-	perms := permuteWorkflowPermutationEvents(events)
-	if len(perms) <= limit {
-		return perms
+	if permutationCountAtMost(len(events), limit) {
+		return permuteWorkflowPermutationEvents(events)
 	}
 	rng := rand.New(rand.NewSource(seed))
-	idxs := rng.Perm(len(perms))[:limit]
-	slices.Sort(idxs)
-	out := make([][]workflowPermutationEvent, 0, len(idxs))
-	for _, idx := range idxs {
-		out = append(out, perms[idx])
+	seen := make(map[string]bool, limit)
+	out := make([][]workflowPermutationEvent, 0, limit)
+	for len(out) < limit {
+		perm := slices.Clone(events)
+		rng.Shuffle(len(perm), func(i, j int) { perm[i], perm[j] = perm[j], perm[i] })
+		key := strings.Join(workflowPermutationEventNames(perm), ",")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, perm)
 	}
 	return out
+}
+
+// permutationCountAtMost reports whether len(events)! <= limit without
+// materializing every permutation just to count them — the factorial grows
+// fast enough that doing so would defeat the point of sampling.
+func permutationCountAtMost(n, limit int) bool {
+	count := 1
+	for i := 2; i <= n; i++ {
+		count *= i
+		if count > limit {
+			return false
+		}
+	}
+	return count <= limit
 }
 
 func permuteWorkflowPermutationEvents(events []workflowPermutationEvent) [][]workflowPermutationEvent {

--- a/internal/workflow/permutation_contract_test.go
+++ b/internal/workflow/permutation_contract_test.go
@@ -1,595 +1,425 @@
 package workflow
 
 import (
+	"fmt"
 	"maps"
+	"math/rand"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 )
 
-const (
-	workflowPermutationTaskID     = "t1"
-	workflowPermutationWorkflowID = "permutation-contract"
-	workflowPermutationParentStep = "fan_out"
-	workflowPermutationStatus     = "plan-review"
-	workflowPermutationReason     = "parallel plans ready"
-	workflowPermutationGateStep   = "review_gate"
-)
+const workflowPermutationContractYAML = `id: permutation-contract
+name: Permutation Contract
+trigger:
+  on: manual
+steps:
+  - id: plan
+    type: parallel
+    parallel:
+      - id: plan_a
+        type: run_agent
+        config:
+          role: plan
+          provider: claude
+          mode: headless
+          prompt: "Plan A {{.Task.ID}}"
+      - id: plan_b
+        type: run_agent
+        config:
+          role: plan
+          provider: codex
+          mode: headless
+          prompt: "Plan B {{.Task.ID}}"
+    next:
+      - goto: set_review
+  - id: set_review
+    type: set_status
+    config:
+      status: plan-review
+      status_reason: ready for review
+    next:
+      - goto: review_plan
+  - id: review_plan
+    type: wait_human
+    config:
+      status: plan-review
+      human_actions: [approve, reject]
+    next:
+      - goto: ""
+`
 
 type workflowPermutationScenario struct {
-	t           *testing.T
-	store       *Store
-	tasks       *memTasks
-	agents      *mockAgents
-	engine      *Engine
-	childRoutes map[string]workflowPermutationChildRoute
+	t      *testing.T
+	store  *Store
+	tasks  *memTasks
+	agents *mockAgents
+	engine *Engine
 }
 
 type workflowPermutationEvent struct {
-	name  string
-	apply func(*testing.T, *workflowPermutationScenario)
+	Name string
+	Fire func(*workflowPermutationScenario)
 }
 
 type workflowPermutationResult struct {
-	EffectCount int
-	Effects     []string
-	State       workflowPermutationState
-}
-
-type workflowPermutationState struct {
 	TaskStatus       string
-	TaskStatusReason string
+	TaskReason       string
 	WorkflowID       string
 	CurrentStep      string
 	ExecState        ExecState
-	StepHistory      []string
 	StepCounts       []string
 	Variables        []string
-	ParallelInflight []string
-	AgentRoutes      []string
-}
-
-type workflowPermutationChildRoute struct {
-	AgentID  string
-	Provider string
+	ParallelChildren []string
+	EffectSet        []string
+	EffectCounts     []string
 }
 
 func TestWorkflowPermutationContract(t *testing.T) {
 	prev := providerAvailable
 	providerAvailable = func(string) bool { return true }
-	t.Cleanup(func() { providerAvailable = prev })
+	defer func() { providerAvailable = prev }()
 
-	baseline := runWorkflowPermutationContract(t,
-		workflowPermutationComplete("child_a"),
-		workflowPermutationComplete("child_b"),
-	)
-	assertWorkflowPermutationSettled(t, baseline)
+	baseline := runWorkflowPermutationContract(t, workflowPermutationBaselineEvents())
+	withDuplicates := runWorkflowPermutationContract(t, workflowPermutationEvents())
+	assertWorkflowPermutationEqual(t, "duplicate-control", baseline, withDuplicates)
 
-	permutations := []struct {
-		name   string
-		events []workflowPermutationEvent
-	}{
-		{
-			name: "reverse_completion_order",
-			events: []workflowPermutationEvent{
-				workflowPermutationComplete("child_b"),
-				workflowPermutationComplete("child_a"),
-			},
-		},
-		{
-			name: "duplicate_before_boundary_completes",
-			events: []workflowPermutationEvent{
-				workflowPermutationComplete("child_a"),
-				workflowPermutationDuplicate("child_a"),
-				workflowPermutationComplete("child_b"),
-			},
-		},
-		{
-			name: "late_duplicate_after_parent_advance",
-			events: []workflowPermutationEvent{
-				workflowPermutationComplete("child_a"),
-				workflowPermutationComplete("child_b"),
-				workflowPermutationDuplicate("child_b"),
-			},
-		},
-		{
-			name: "restart_after_first_child",
-			events: []workflowPermutationEvent{
-				workflowPermutationComplete("child_a"),
-				workflowPermutationRestart(),
-				workflowPermutationComplete("child_b"),
-			},
-		},
-		{
-			name: "restart_after_first_child_reverse",
-			events: []workflowPermutationEvent{
-				workflowPermutationComplete("child_b"),
-				workflowPermutationRestart(),
-				workflowPermutationComplete("child_a"),
-			},
-		},
-		{
-			name: "concurrent_status_reconcile_while_parallel_incomplete",
-			events: []workflowPermutationEvent{
-				workflowPermutationComplete("child_a"),
-				workflowPermutationConcurrentStatusChange(8),
-				workflowPermutationComplete("child_b"),
-			},
-		},
-		{
-			name: "restart_then_status_reconcile_then_duplicate",
-			events: []workflowPermutationEvent{
-				workflowPermutationComplete("child_a"),
-				workflowPermutationRestart(),
-				workflowPermutationConcurrentStatusChange(8),
-				workflowPermutationComplete("child_b"),
-				workflowPermutationDuplicate("child_b"),
-			},
-		},
-	}
-
-	for _, tc := range permutations {
-		t.Run(tc.name, func(t *testing.T) {
-			got := runWorkflowPermutationContract(t, tc.events...)
-			if !reflect.DeepEqual(got, baseline) {
-				t.Fatalf("permutation result mismatch\n got: %#v\nwant: %#v", got, baseline)
-			}
+	perms := sampleWorkflowPermutationOrders(workflowPermutationEvents(), 32, 42)
+	for i, perm := range perms {
+		names := workflowPermutationEventNames(perm)
+		t.Run(fmt.Sprintf("perm-%02d/%s", i, strings.Join(names, ",")), func(t *testing.T) {
+			got := runWorkflowPermutationContract(t, perm)
+			assertWorkflowPermutationEqual(t, strings.Join(names, ","), baseline, got)
 		})
 	}
-}
 
-func runWorkflowPermutationContract(t *testing.T, events ...workflowPermutationEvent) workflowPermutationResult {
-	t.Helper()
-
-	scenario := newWorkflowPermutationScenario(t)
-	for _, event := range events {
-		event.apply(t, scenario)
-	}
-
-	return scenario.result()
+	t.Run("concurrent-reconciler", func(t *testing.T) {
+		for i := range 100 {
+			t.Run(fmt.Sprintf("iter-%03d", i), func(t *testing.T) {
+				s := newWorkflowPermutationScenario(t)
+				s.complete("agent-1", "claude", "plan a done")
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					s.statusChange("plan-review")
+				}()
+				go func() {
+					defer wg.Done()
+					s.complete("agent-2", "codex", "plan b done")
+				}()
+				wg.Wait()
+				assertWorkflowPermutationEqual(t, "concurrent", baseline, s.result())
+			})
+		}
+	})
 }
 
 func newWorkflowPermutationScenario(t *testing.T) *workflowPermutationScenario {
 	t.Helper()
-
-	store := newTestStore(t)
-	if err := store.Save(workflowPermutationDefinition()); err != nil {
-		t.Fatalf("save workflow: %v", err)
-	}
+	store := newInlineTestStore(t, "permutation-contract", workflowPermutationContractYAML)
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	engine := NewEngine(store, tasks, agents, discardLogger())
-	tasks.Put(TaskInfo{
-		ID:        workflowPermutationTaskID,
-		Status:    "todo",
-		AgentMode: "headless",
-	})
-	if err := engine.StartWorkflow(workflowPermutationTaskID, workflowPermutationWorkflowID); err != nil {
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	if err := engine.StartWorkflow("t1", "permutation-contract"); err != nil {
 		t.Fatalf("StartWorkflow: %v", err)
 	}
-
-	scenario := &workflowPermutationScenario{
-		t:           t,
-		store:       store,
-		tasks:       tasks,
-		agents:      agents,
-		engine:      engine,
-		childRoutes: make(map[string]workflowPermutationChildRoute),
-	}
-	scenario.assertParallelPending("initial start")
-	return scenario
+	return &workflowPermutationScenario{t: t, store: store, tasks: tasks, agents: agents, engine: engine}
 }
 
-func workflowPermutationDefinition() Definition {
-	return Definition{
-		ID:   workflowPermutationWorkflowID,
-		Name: "permutation contract",
-		Trigger: Trigger{
-			On: "manual",
-		},
-		Steps: []Step{
-			{
-				ID:   workflowPermutationParentStep,
-				Name: "Fan Out",
-				Type: StepParallel,
-				Parallel: []Step{
-					{
-						ID:   "child_a",
-						Name: "Child A",
-						Type: StepRunAgent,
-						Config: StepConfig{
-							Role:     "child_a",
-							Mode:     "headless",
-							Provider: "claude",
-							Prompt:   "plan a",
-						},
-					},
-					{
-						ID:   "child_b",
-						Name: "Child B",
-						Type: StepRunAgent,
-						Config: StepConfig{
-							Role:     "child_b",
-							Mode:     "headless",
-							Provider: "codex",
-							Prompt:   "plan b",
-						},
-					},
-				},
-				Next: []Transition{{GoTo: "set_review"}},
-			},
-			{
-				ID:   "set_review",
-				Name: "Set Review Status",
-				Type: StepSetStatus,
-				Config: StepConfig{
-					Status:       workflowPermutationStatus,
-					StatusReason: workflowPermutationReason,
-				},
-				Next: []Transition{{GoTo: workflowPermutationGateStep}},
-			},
-			{
-				ID:   workflowPermutationGateStep,
-				Name: "Review Gate",
-				Type: StepWaitHuman,
-				Config: StepConfig{
-					Status:       workflowPermutationStatus,
-					StatusReason: workflowPermutationReason,
-					HumanActions: []string{"approve", "reject"},
-				},
-				Next: []Transition{{GoTo: ""}},
-			},
-		},
-	}
-}
-
-func workflowPermutationComplete(childID string) workflowPermutationEvent {
-	return workflowPermutationEvent{
-		name: "complete_" + childID,
-		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
-			t.Helper()
-			scenario.completeChild(childID)
-		},
-	}
-}
-
-func workflowPermutationDuplicate(childID string) workflowPermutationEvent {
-	return workflowPermutationEvent{
-		name: "duplicate_" + childID,
-		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
-			t.Helper()
-			scenario.completeChild(childID)
-		},
-	}
-}
-
-func workflowPermutationRestart() workflowPermutationEvent {
-	return workflowPermutationEvent{
-		name: "restart",
-		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
-			t.Helper()
-			scenario.restart()
-		},
-	}
-}
-
-func workflowPermutationConcurrentStatusChange(workers int) workflowPermutationEvent {
-	return workflowPermutationEvent{
-		name: "concurrent_status_change",
-		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
-			t.Helper()
-			scenario.tasks.SetStatus(workflowPermutationTaskID, workflowPermutationStatus)
-
-			var wg sync.WaitGroup
-			for i := 0; i < workers; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					scenario.engine.HandleStatusChange(workflowPermutationTaskID, workflowPermutationStatus)
-				}()
-			}
-			wg.Wait()
-			scenario.assertParallelPending("concurrent status reconcile")
-		},
-	}
-}
-
-func (s *workflowPermutationScenario) completeChild(childID string) {
-	s.t.Helper()
-
-	agentID, provider := s.childRoute(childID)
-	s.engine.HandleAgentComplete(workflowPermutationTaskID, AgentCompletion{
+func (s *workflowPermutationScenario) complete(agentID, provider, result string) {
+	s.engine.HandleAgentComplete("t1", AgentCompletion{
 		AgentID:  agentID,
 		Provider: provider,
-		Result:   childID + " complete",
+		Result:   result,
 		Success:  true,
 	})
 }
 
-func (s *workflowPermutationScenario) childRoute(childID string) (string, string) {
-	s.t.Helper()
-
-	if route, ok := s.childRoutes[childID]; ok {
-		return route.AgentID, route.Provider
+func (s *workflowPermutationScenario) statusChange(status string) {
+	ti := mustTaskInfo(s.t, s.tasks, "t1")
+	if err := s.tasks.UpdateTaskStatus("t1", status, ti.StatusReason); err != nil {
+		s.t.Fatalf("UpdateTaskStatus: %v", err)
 	}
-	ti := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
-	if ti.Workflow == nil {
-		s.t.Fatalf("task %s has no workflow", workflowPermutationTaskID)
-	}
-	rec := ti.Workflow.ParallelInflight[workflowPermutationParentStep]
-	if rec == nil {
-		s.t.Fatalf("parallel record missing while resolving %s", childID)
-	}
-	status := rec.Children[childID]
-	if status == nil {
-		s.t.Fatalf("child %s missing from parallel record", childID)
-	}
-	if status.AgentID == "" {
-		s.t.Fatalf("child %s has no agent route", childID)
-	}
-	s.childRoutes[childID] = workflowPermutationChildRoute{
-		AgentID:  status.AgentID,
-		Provider: status.Provider,
-	}
-	return status.AgentID, status.Provider
+	s.engine.HandleStatusChange("t1", status)
 }
 
 func (s *workflowPermutationScenario) restart() {
 	s.t.Helper()
-
-	current := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
-	freshTasks := newMemTasks()
-	freshTasks.Put(cloneWorkflowTaskInfo(current))
-
-	s.tasks = freshTasks
-	s.engine = NewEngine(s.store, s.tasks, s.agents, discardLogger())
-	s.restoreRoutes()
-}
-
-func (s *workflowPermutationScenario) restoreRoutes() {
-	s.t.Helper()
-
-	ti := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
-	if ti.Workflow == nil {
-		return
+	clonedTasks := newMemTasks()
+	for _, task := range mustListTasks(s.t, s.tasks) {
+		clonedTasks.Put(cloneWorkflowPermutationTask(task))
 	}
-
-	s.engine.mu.Lock()
-	defer s.engine.mu.Unlock()
-	for _, rec := range ti.Workflow.ParallelInflight {
-		if rec == nil {
-			continue
-		}
-		for childID, child := range rec.Children {
-			if child == nil || child.AgentID == "" || child.Status != "pending" {
-				continue
-			}
-			s.engine.agentRoutes[child.AgentID] = agentRoute{
-				taskID: workflowPermutationTaskID,
-				stepID: childID,
-			}
-		}
-	}
-}
-
-func (s *workflowPermutationScenario) assertParallelPending(context string) {
-	s.t.Helper()
-
-	wf := mustWorkflow(s.t, s.tasks, workflowPermutationTaskID)
-	if wf.CurrentStep != workflowPermutationParentStep {
-		s.t.Fatalf("%s: current step = %q, want %q", context, wf.CurrentStep, workflowPermutationParentStep)
-	}
-	if wf.State != ExecWaiting {
-		s.t.Fatalf("%s: workflow state = %q, want %q", context, wf.State, ExecWaiting)
-	}
-	rec := wf.ParallelInflight[workflowPermutationParentStep]
-	if rec == nil {
-		s.t.Fatalf("%s: parallel record missing", context)
-	}
-	if rec.AllChildrenDone() {
-		s.t.Fatalf("%s: parallel record already terminal", context)
-	}
+	clonedAgents := cloneWorkflowPermutationAgents(s.agents)
+	clonedEngine := NewEngine(s.store, clonedTasks, clonedAgents, discardLogger())
+	rehydrateWorkflowPermutationRoutes(clonedEngine, clonedTasks)
+	s.tasks = clonedTasks
+	s.agents = clonedAgents
+	s.engine = clonedEngine
 }
 
 func (s *workflowPermutationScenario) result() workflowPermutationResult {
-	s.t.Helper()
-
-	ti := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
+	ti := mustTaskInfo(s.t, s.tasks, "t1")
+	result := workflowPermutationResult{TaskStatus: ti.Status, TaskReason: ti.StatusReason}
 	if ti.Workflow == nil {
-		s.t.Fatalf("task %s has no workflow", workflowPermutationTaskID)
+		return result
 	}
+	result.WorkflowID = ti.Workflow.WorkflowID
+	result.CurrentStep = ti.Workflow.CurrentStep
+	result.ExecState = ti.Workflow.State
+	result.StepCounts = workflowPermutationStepCounts(ti.Workflow)
+	result.Variables = workflowPermutationVars(ti.Workflow.Variables)
+	result.ParallelChildren = workflowPermutationParallelChildren(ti.Workflow)
+	result.EffectSet, result.EffectCounts = workflowPermutationEffects(s.agents.calls)
+	return result
+}
 
-	return workflowPermutationResult{
-		EffectCount: s.agents.CallCount(),
-		Effects:     workflowPermutationEffects(s.agents),
-		State:       workflowPermutationStateForTask(ti, s.engine),
+func runWorkflowPermutationContract(t *testing.T, events []workflowPermutationEvent) workflowPermutationResult {
+	t.Helper()
+	s := newWorkflowPermutationScenario(t)
+	for _, event := range events {
+		event.Fire(s)
+	}
+	return s.result()
+}
+
+func workflowPermutationBaselineEvents() []workflowPermutationEvent {
+	return []workflowPermutationEvent{
+		{Name: "status-change", Fire: func(s *workflowPermutationScenario) { s.statusChange("plan-review") }},
+		{Name: "child-a-complete", Fire: func(s *workflowPermutationScenario) { s.complete("agent-1", "claude", "plan a done") }},
+		{Name: "restart", Fire: func(s *workflowPermutationScenario) { s.restart() }},
+		{Name: "concurrent-status-child-b", Fire: func(s *workflowPermutationScenario) {
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				s.statusChange("plan-review")
+			}()
+			go func() {
+				defer wg.Done()
+				s.complete("agent-2", "codex", "plan b done")
+			}()
+			wg.Wait()
+		}},
 	}
 }
 
-func workflowPermutationEffects(agents *mockAgents) []string {
-	agents.mu.Lock()
-	defer agents.mu.Unlock()
-
-	seen := make(map[string]struct{}, len(agents.calls))
-	for _, call := range agents.calls {
-		identity := call.Role + "|" + call.Provider + "|" + call.Mode
-		seen[identity] = struct{}{}
+func workflowPermutationEvents() []workflowPermutationEvent {
+	events := workflowPermutationBaselineEvents()
+	return []workflowPermutationEvent{
+		events[0],
+		{Name: "status-change-dup", Fire: events[0].Fire},
+		events[1],
+		{Name: "child-a-complete-dup", Fire: events[1].Fire},
+		events[2],
+		events[3],
 	}
+}
 
-	out := make([]string, 0, len(seen))
-	for identity := range seen {
-		out = append(out, identity)
+func sampleWorkflowPermutationOrders(events []workflowPermutationEvent, limit int, seed int64) [][]workflowPermutationEvent {
+	perms := permuteWorkflowPermutationEvents(events)
+	if len(perms) <= limit {
+		return perms
 	}
-	slices.Sort(out)
+	rng := rand.New(rand.NewSource(seed))
+	idxs := rng.Perm(len(perms))[:limit]
+	slices.Sort(idxs)
+	out := make([][]workflowPermutationEvent, 0, len(idxs))
+	for _, idx := range idxs {
+		out = append(out, perms[idx])
+	}
 	return out
 }
 
-func workflowPermutationStateForTask(ti TaskInfo, engine *Engine) workflowPermutationState {
-	wf := ti.Workflow
-
-	state := workflowPermutationState{
-		TaskStatus:       ti.Status,
-		TaskStatusReason: ti.StatusReason,
-		WorkflowID:       wf.WorkflowID,
-		CurrentStep:      wf.CurrentStep,
-		ExecState:        wf.State,
-		StepHistory:      workflowPermutationStepHistory(wf),
-		StepCounts:       workflowPermutationStepCounts(wf),
-		Variables:        workflowPermutationVars(wf),
-		ParallelInflight: workflowPermutationParallelState(wf),
-		AgentRoutes:      workflowPermutationAgentRoutes(engine),
-	}
-
-	return state
-}
-
-func workflowPermutationStepHistory(wf *Execution) []string {
-	out := make([]string, 0, len(wf.StepHistory))
-	for _, record := range wf.StepHistory {
-		entry := record.StepID + "|" + record.Status
-		if record.Output != "" {
-			entry += "|" + record.Output
+func permuteWorkflowPermutationEvents(events []workflowPermutationEvent) [][]workflowPermutationEvent {
+	out := make([][]workflowPermutationEvent, 0)
+	cur := slices.Clone(events)
+	var walk func(int)
+	walk = func(i int) {
+		if i == len(cur) {
+			out = append(out, slices.Clone(cur))
+			return
 		}
-		out = append(out, entry)
+		for j := i; j < len(cur); j++ {
+			cur[i], cur[j] = cur[j], cur[i]
+			walk(i + 1)
+			cur[i], cur[j] = cur[j], cur[i]
+		}
 	}
+	walk(0)
 	return out
+}
+
+func workflowPermutationEventNames(events []workflowPermutationEvent) []string {
+	names := make([]string, 0, len(events))
+	for _, event := range events {
+		names = append(names, event.Name)
+	}
+	return names
+}
+
+func assertWorkflowPermutationEqual(t *testing.T, name string, want, got workflowPermutationResult) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s result mismatch\nwant: %+v\n got: %+v", name, want, got)
+	}
 }
 
 func workflowPermutationStepCounts(wf *Execution) []string {
-	if len(wf.StepCounts) == 0 {
+	if wf == nil || len(wf.StepCounts) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(wf.StepCounts))
-	for stepID, count := range wf.StepCounts {
-		out = append(out, stepID+"="+itoa(count))
+	keys := make([]string, 0, len(wf.StepCounts))
+	for key := range wf.StepCounts {
+		keys = append(keys, key)
 	}
-	slices.Sort(out)
+	slices.Sort(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, fmt.Sprintf("%s=%d", key, wf.StepCounts[key]))
+	}
 	return out
 }
 
-func workflowPermutationVars(wf *Execution) []string {
-	if len(wf.Variables) == 0 {
+func workflowPermutationVars(vars map[string]string) []string {
+	if len(vars) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(wf.Variables))
-	for key, value := range wf.Variables {
-		out = append(out, key+"="+value)
+	keys := make([]string, 0, len(vars))
+	for key := range vars {
+		keys = append(keys, key)
 	}
-	slices.Sort(out)
+	slices.Sort(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key+"="+vars[key])
+	}
 	return out
 }
 
-func workflowPermutationParallelState(wf *Execution) []string {
-	if len(wf.ParallelInflight) == 0 {
+func workflowPermutationParallelChildren(wf *Execution) []string {
+	if wf == nil || len(wf.ParallelInflight) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(wf.ParallelInflight))
-	for parentID, rec := range wf.ParallelInflight {
-		if rec == nil {
-			out = append(out, parentID+"=<nil>")
+	var out []string
+	parents := make([]string, 0, len(wf.ParallelInflight))
+	for parentID := range wf.ParallelInflight {
+		parents = append(parents, parentID)
+	}
+	slices.Sort(parents)
+	for _, parentID := range parents {
+		rec := wf.ParallelInflight[parentID]
+		if rec == nil || len(rec.Children) == 0 {
 			continue
 		}
-		children := make([]string, 0, len(rec.Children))
-		for childID, child := range rec.Children {
+		childIDs := make([]string, 0, len(rec.Children))
+		for childID := range rec.Children {
+			childIDs = append(childIDs, childID)
+		}
+		slices.Sort(childIDs)
+		for _, childID := range childIDs {
+			child := rec.Children[childID]
 			if child == nil {
-				children = append(children, childID+"=<nil>")
+				out = append(out, parentID+"/"+childID+"=<nil>")
 				continue
 			}
-			children = append(children, childID+"="+child.Status)
+			out = append(out, fmt.Sprintf("%s/%s=%s|%s|%s|%d", parentID, childID, child.Status, child.Provider, child.AgentID, child.Retries))
 		}
-		slices.Sort(children)
-		out = append(out, parentID+":"+join(children))
 	}
-	slices.Sort(out)
 	return out
 }
 
-func workflowPermutationAgentRoutes(engine *Engine) []string {
-	engine.mu.Lock()
-	defer engine.mu.Unlock()
-
-	if len(engine.agentRoutes) == 0 {
-		return nil
+func workflowPermutationEffects(calls []startCall) ([]string, []string) {
+	if len(calls) == 0 {
+		return nil, nil
 	}
-	out := make([]string, 0, len(engine.agentRoutes))
-	for agentID, route := range engine.agentRoutes {
-		out = append(out, agentID+"="+route.taskID+"/"+route.stepID)
+	counts := make(map[string]int)
+	for _, call := range calls {
+		key := strings.Join([]string{workflowPermutationStepID(call.Prompt), call.Provider, call.Role}, "|")
+		counts[key]++
 	}
-	slices.Sort(out)
-	return out
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	countStrings := make([]string, 0, len(keys))
+	for _, key := range keys {
+		countStrings = append(countStrings, fmt.Sprintf("%s=%d", key, counts[key]))
+	}
+	return keys, countStrings
 }
 
-func assertWorkflowPermutationSettled(t *testing.T, result workflowPermutationResult) {
-	t.Helper()
-
-	if result.EffectCount != 2 {
-		t.Fatalf("effect count = %d, want 2", result.EffectCount)
-	}
-	wantEffects := []string{"child_a|claude|headless", "child_b|codex|headless"}
-	if !reflect.DeepEqual(result.Effects, wantEffects) {
-		t.Fatalf("effects = %#v, want %#v", result.Effects, wantEffects)
-	}
-	if result.State.TaskStatus != workflowPermutationStatus {
-		t.Fatalf("task status = %q, want %q", result.State.TaskStatus, workflowPermutationStatus)
-	}
-	if result.State.TaskStatusReason != workflowPermutationReason {
-		t.Fatalf("task status reason = %q, want %q", result.State.TaskStatusReason, workflowPermutationReason)
-	}
-	if result.State.CurrentStep != workflowPermutationGateStep {
-		t.Fatalf("current step = %q, want %q", result.State.CurrentStep, workflowPermutationGateStep)
-	}
-	if result.State.ExecState != ExecWaiting {
-		t.Fatalf("exec state = %q, want %q", result.State.ExecState, ExecWaiting)
-	}
-	if result.State.ParallelInflight != nil {
-		t.Fatalf("parallel inflight = %#v, want nil", result.State.ParallelInflight)
-	}
-	if result.State.AgentRoutes != nil {
-		t.Fatalf("agent routes = %#v, want nil", result.State.AgentRoutes)
-	}
-	wantHistory := []string{
-		"fan_out|completed|child_a=completed, child_b=completed",
-		"set_review|completed",
-	}
-	if !reflect.DeepEqual(result.State.StepHistory, wantHistory) {
-		t.Fatalf("step history = %#v, want %#v", result.State.StepHistory, wantHistory)
+func workflowPermutationStepID(prompt string) string {
+	switch {
+	case strings.Contains(prompt, "Plan A"):
+		return "plan_a"
+	case strings.Contains(prompt, "Plan B"):
+		return "plan_b"
+	default:
+		return "unknown"
 	}
 }
 
-func cloneWorkflowTaskInfo(ti TaskInfo) TaskInfo {
-	cloned := ti
-	cloned.Tags = slices.Clone(ti.Tags)
-	cloned.Attachments = slices.Clone(ti.Attachments)
-	cloned.PlanDrafts = maps.Clone(ti.PlanDrafts)
-	cloned.AgentRuns = slices.Clone(ti.AgentRuns)
-	if ti.Workflow != nil {
-		cloned.Workflow = ti.Workflow.Clone()
-	}
+func cloneWorkflowPermutationTask(task TaskInfo) TaskInfo {
+	cloned := task
+	cloned.Tags = slices.Clone(task.Tags)
+	cloned.Attachments = slices.Clone(task.Attachments)
+	cloned.AgentRuns = slices.Clone(task.AgentRuns)
+	cloned.PlanDrafts = maps.Clone(task.PlanDrafts)
+	cloned.Workflow = task.Workflow.Clone()
 	return cloned
 }
 
-func join(parts []string) string {
-	if len(parts) == 0 {
-		return ""
+func cloneWorkflowPermutationAgents(src *mockAgents) *mockAgents {
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	return &mockAgents{
+		calls:             slices.Clone(src.calls),
+		prompts:           slices.Clone(src.prompts),
+		running:           maps.Clone(src.running),
+		roles:             maps.Clone(src.roles),
+		counter:           src.counter,
+		failSpawn:         src.failSpawn,
+		providerRateLimit: src.providerRateLimit,
+		providerFailover:  src.providerFailover,
+		rateLimited:       maps.Clone(src.rateLimited),
+		unhealthy:         maps.Clone(src.unhealthy),
+		dispatchClaimed:   maps.Clone(src.dispatchClaimed),
+		claimInsideStart:  src.claimInsideStart,
+		failSpawnOnce:     src.failSpawnOnce,
+		admitDenyReason:   src.admitDenyReason,
 	}
-	out := parts[0]
-	for i := 1; i < len(parts); i++ {
-		out += "," + parts[i]
-	}
-	return out
 }
 
-func itoa(v int) string {
-	if v == 0 {
-		return "0"
+func rehydrateWorkflowPermutationRoutes(engine *Engine, tasks *memTasks) {
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		return
 	}
-	var buf [20]byte
-	i := len(buf)
-	for v > 0 {
-		i--
-		buf[i] = byte('0' + v%10)
-		v /= 10
+	if ti.Workflow == nil || ti.Workflow.CurrentStep == "" {
+		return
 	}
-	return string(buf[i:])
+	rec := ti.Workflow.ParallelInflight[ti.Workflow.CurrentStep]
+	if rec == nil {
+		return
+	}
+	for childID, child := range rec.Children {
+		if child == nil || child.AgentID == "" || child.Status != "pending" {
+			continue
+		}
+		engine.agentRoutes[child.AgentID] = agentRoute{taskID: ti.ID, stepID: childID}
+	}
+}
+
+func mustListTasks(t *testing.T, tasks *memTasks) []TaskInfo {
+	t.Helper()
+	list, err := tasks.ListTasks()
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	return list
 }

--- a/internal/workflow/permutation_contract_test.go
+++ b/internal/workflow/permutation_contract_test.go
@@ -1,0 +1,595 @@
+package workflow
+
+import (
+	"maps"
+	"reflect"
+	"slices"
+	"sync"
+	"testing"
+)
+
+const (
+	workflowPermutationTaskID     = "t1"
+	workflowPermutationWorkflowID = "permutation-contract"
+	workflowPermutationParentStep = "fan_out"
+	workflowPermutationStatus     = "plan-review"
+	workflowPermutationReason     = "parallel plans ready"
+	workflowPermutationGateStep   = "review_gate"
+)
+
+type workflowPermutationScenario struct {
+	t           *testing.T
+	store       *Store
+	tasks       *memTasks
+	agents      *mockAgents
+	engine      *Engine
+	childRoutes map[string]workflowPermutationChildRoute
+}
+
+type workflowPermutationEvent struct {
+	name  string
+	apply func(*testing.T, *workflowPermutationScenario)
+}
+
+type workflowPermutationResult struct {
+	EffectCount int
+	Effects     []string
+	State       workflowPermutationState
+}
+
+type workflowPermutationState struct {
+	TaskStatus       string
+	TaskStatusReason string
+	WorkflowID       string
+	CurrentStep      string
+	ExecState        ExecState
+	StepHistory      []string
+	StepCounts       []string
+	Variables        []string
+	ParallelInflight []string
+	AgentRoutes      []string
+}
+
+type workflowPermutationChildRoute struct {
+	AgentID  string
+	Provider string
+}
+
+func TestWorkflowPermutationContract(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	baseline := runWorkflowPermutationContract(t,
+		workflowPermutationComplete("child_a"),
+		workflowPermutationComplete("child_b"),
+	)
+	assertWorkflowPermutationSettled(t, baseline)
+
+	permutations := []struct {
+		name   string
+		events []workflowPermutationEvent
+	}{
+		{
+			name: "reverse_completion_order",
+			events: []workflowPermutationEvent{
+				workflowPermutationComplete("child_b"),
+				workflowPermutationComplete("child_a"),
+			},
+		},
+		{
+			name: "duplicate_before_boundary_completes",
+			events: []workflowPermutationEvent{
+				workflowPermutationComplete("child_a"),
+				workflowPermutationDuplicate("child_a"),
+				workflowPermutationComplete("child_b"),
+			},
+		},
+		{
+			name: "late_duplicate_after_parent_advance",
+			events: []workflowPermutationEvent{
+				workflowPermutationComplete("child_a"),
+				workflowPermutationComplete("child_b"),
+				workflowPermutationDuplicate("child_b"),
+			},
+		},
+		{
+			name: "restart_after_first_child",
+			events: []workflowPermutationEvent{
+				workflowPermutationComplete("child_a"),
+				workflowPermutationRestart(),
+				workflowPermutationComplete("child_b"),
+			},
+		},
+		{
+			name: "restart_after_first_child_reverse",
+			events: []workflowPermutationEvent{
+				workflowPermutationComplete("child_b"),
+				workflowPermutationRestart(),
+				workflowPermutationComplete("child_a"),
+			},
+		},
+		{
+			name: "concurrent_status_reconcile_while_parallel_incomplete",
+			events: []workflowPermutationEvent{
+				workflowPermutationComplete("child_a"),
+				workflowPermutationConcurrentStatusChange(8),
+				workflowPermutationComplete("child_b"),
+			},
+		},
+		{
+			name: "restart_then_status_reconcile_then_duplicate",
+			events: []workflowPermutationEvent{
+				workflowPermutationComplete("child_a"),
+				workflowPermutationRestart(),
+				workflowPermutationConcurrentStatusChange(8),
+				workflowPermutationComplete("child_b"),
+				workflowPermutationDuplicate("child_b"),
+			},
+		},
+	}
+
+	for _, tc := range permutations {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runWorkflowPermutationContract(t, tc.events...)
+			if !reflect.DeepEqual(got, baseline) {
+				t.Fatalf("permutation result mismatch\n got: %#v\nwant: %#v", got, baseline)
+			}
+		})
+	}
+}
+
+func runWorkflowPermutationContract(t *testing.T, events ...workflowPermutationEvent) workflowPermutationResult {
+	t.Helper()
+
+	scenario := newWorkflowPermutationScenario(t)
+	for _, event := range events {
+		event.apply(t, scenario)
+	}
+
+	return scenario.result()
+}
+
+func newWorkflowPermutationScenario(t *testing.T) *workflowPermutationScenario {
+	t.Helper()
+
+	store := newTestStore(t)
+	if err := store.Save(workflowPermutationDefinition()); err != nil {
+		t.Fatalf("save workflow: %v", err)
+	}
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	tasks.Put(TaskInfo{
+		ID:        workflowPermutationTaskID,
+		Status:    "todo",
+		AgentMode: "headless",
+	})
+	if err := engine.StartWorkflow(workflowPermutationTaskID, workflowPermutationWorkflowID); err != nil {
+		t.Fatalf("StartWorkflow: %v", err)
+	}
+
+	scenario := &workflowPermutationScenario{
+		t:           t,
+		store:       store,
+		tasks:       tasks,
+		agents:      agents,
+		engine:      engine,
+		childRoutes: make(map[string]workflowPermutationChildRoute),
+	}
+	scenario.assertParallelPending("initial start")
+	return scenario
+}
+
+func workflowPermutationDefinition() Definition {
+	return Definition{
+		ID:   workflowPermutationWorkflowID,
+		Name: "permutation contract",
+		Trigger: Trigger{
+			On: "manual",
+		},
+		Steps: []Step{
+			{
+				ID:   workflowPermutationParentStep,
+				Name: "Fan Out",
+				Type: StepParallel,
+				Parallel: []Step{
+					{
+						ID:   "child_a",
+						Name: "Child A",
+						Type: StepRunAgent,
+						Config: StepConfig{
+							Role:     "child_a",
+							Mode:     "headless",
+							Provider: "claude",
+							Prompt:   "plan a",
+						},
+					},
+					{
+						ID:   "child_b",
+						Name: "Child B",
+						Type: StepRunAgent,
+						Config: StepConfig{
+							Role:     "child_b",
+							Mode:     "headless",
+							Provider: "codex",
+							Prompt:   "plan b",
+						},
+					},
+				},
+				Next: []Transition{{GoTo: "set_review"}},
+			},
+			{
+				ID:   "set_review",
+				Name: "Set Review Status",
+				Type: StepSetStatus,
+				Config: StepConfig{
+					Status:       workflowPermutationStatus,
+					StatusReason: workflowPermutationReason,
+				},
+				Next: []Transition{{GoTo: workflowPermutationGateStep}},
+			},
+			{
+				ID:   workflowPermutationGateStep,
+				Name: "Review Gate",
+				Type: StepWaitHuman,
+				Config: StepConfig{
+					Status:       workflowPermutationStatus,
+					StatusReason: workflowPermutationReason,
+					HumanActions: []string{"approve", "reject"},
+				},
+				Next: []Transition{{GoTo: ""}},
+			},
+		},
+	}
+}
+
+func workflowPermutationComplete(childID string) workflowPermutationEvent {
+	return workflowPermutationEvent{
+		name: "complete_" + childID,
+		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
+			t.Helper()
+			scenario.completeChild(childID)
+		},
+	}
+}
+
+func workflowPermutationDuplicate(childID string) workflowPermutationEvent {
+	return workflowPermutationEvent{
+		name: "duplicate_" + childID,
+		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
+			t.Helper()
+			scenario.completeChild(childID)
+		},
+	}
+}
+
+func workflowPermutationRestart() workflowPermutationEvent {
+	return workflowPermutationEvent{
+		name: "restart",
+		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
+			t.Helper()
+			scenario.restart()
+		},
+	}
+}
+
+func workflowPermutationConcurrentStatusChange(workers int) workflowPermutationEvent {
+	return workflowPermutationEvent{
+		name: "concurrent_status_change",
+		apply: func(t *testing.T, scenario *workflowPermutationScenario) {
+			t.Helper()
+			scenario.tasks.SetStatus(workflowPermutationTaskID, workflowPermutationStatus)
+
+			var wg sync.WaitGroup
+			for i := 0; i < workers; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					scenario.engine.HandleStatusChange(workflowPermutationTaskID, workflowPermutationStatus)
+				}()
+			}
+			wg.Wait()
+			scenario.assertParallelPending("concurrent status reconcile")
+		},
+	}
+}
+
+func (s *workflowPermutationScenario) completeChild(childID string) {
+	s.t.Helper()
+
+	agentID, provider := s.childRoute(childID)
+	s.engine.HandleAgentComplete(workflowPermutationTaskID, AgentCompletion{
+		AgentID:  agentID,
+		Provider: provider,
+		Result:   childID + " complete",
+		Success:  true,
+	})
+}
+
+func (s *workflowPermutationScenario) childRoute(childID string) (string, string) {
+	s.t.Helper()
+
+	if route, ok := s.childRoutes[childID]; ok {
+		return route.AgentID, route.Provider
+	}
+	ti := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
+	if ti.Workflow == nil {
+		s.t.Fatalf("task %s has no workflow", workflowPermutationTaskID)
+	}
+	rec := ti.Workflow.ParallelInflight[workflowPermutationParentStep]
+	if rec == nil {
+		s.t.Fatalf("parallel record missing while resolving %s", childID)
+	}
+	status := rec.Children[childID]
+	if status == nil {
+		s.t.Fatalf("child %s missing from parallel record", childID)
+	}
+	if status.AgentID == "" {
+		s.t.Fatalf("child %s has no agent route", childID)
+	}
+	s.childRoutes[childID] = workflowPermutationChildRoute{
+		AgentID:  status.AgentID,
+		Provider: status.Provider,
+	}
+	return status.AgentID, status.Provider
+}
+
+func (s *workflowPermutationScenario) restart() {
+	s.t.Helper()
+
+	current := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
+	freshTasks := newMemTasks()
+	freshTasks.Put(cloneWorkflowTaskInfo(current))
+
+	s.tasks = freshTasks
+	s.engine = NewEngine(s.store, s.tasks, s.agents, discardLogger())
+	s.restoreRoutes()
+}
+
+func (s *workflowPermutationScenario) restoreRoutes() {
+	s.t.Helper()
+
+	ti := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
+	if ti.Workflow == nil {
+		return
+	}
+
+	s.engine.mu.Lock()
+	defer s.engine.mu.Unlock()
+	for _, rec := range ti.Workflow.ParallelInflight {
+		if rec == nil {
+			continue
+		}
+		for childID, child := range rec.Children {
+			if child == nil || child.AgentID == "" || child.Status != "pending" {
+				continue
+			}
+			s.engine.agentRoutes[child.AgentID] = agentRoute{
+				taskID: workflowPermutationTaskID,
+				stepID: childID,
+			}
+		}
+	}
+}
+
+func (s *workflowPermutationScenario) assertParallelPending(context string) {
+	s.t.Helper()
+
+	wf := mustWorkflow(s.t, s.tasks, workflowPermutationTaskID)
+	if wf.CurrentStep != workflowPermutationParentStep {
+		s.t.Fatalf("%s: current step = %q, want %q", context, wf.CurrentStep, workflowPermutationParentStep)
+	}
+	if wf.State != ExecWaiting {
+		s.t.Fatalf("%s: workflow state = %q, want %q", context, wf.State, ExecWaiting)
+	}
+	rec := wf.ParallelInflight[workflowPermutationParentStep]
+	if rec == nil {
+		s.t.Fatalf("%s: parallel record missing", context)
+	}
+	if rec.AllChildrenDone() {
+		s.t.Fatalf("%s: parallel record already terminal", context)
+	}
+}
+
+func (s *workflowPermutationScenario) result() workflowPermutationResult {
+	s.t.Helper()
+
+	ti := s.tasks.mustGetTask(s.t, workflowPermutationTaskID)
+	if ti.Workflow == nil {
+		s.t.Fatalf("task %s has no workflow", workflowPermutationTaskID)
+	}
+
+	return workflowPermutationResult{
+		EffectCount: s.agents.CallCount(),
+		Effects:     workflowPermutationEffects(s.agents),
+		State:       workflowPermutationStateForTask(ti, s.engine),
+	}
+}
+
+func workflowPermutationEffects(agents *mockAgents) []string {
+	agents.mu.Lock()
+	defer agents.mu.Unlock()
+
+	seen := make(map[string]struct{}, len(agents.calls))
+	for _, call := range agents.calls {
+		identity := call.Role + "|" + call.Provider + "|" + call.Mode
+		seen[identity] = struct{}{}
+	}
+
+	out := make([]string, 0, len(seen))
+	for identity := range seen {
+		out = append(out, identity)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func workflowPermutationStateForTask(ti TaskInfo, engine *Engine) workflowPermutationState {
+	wf := ti.Workflow
+
+	state := workflowPermutationState{
+		TaskStatus:       ti.Status,
+		TaskStatusReason: ti.StatusReason,
+		WorkflowID:       wf.WorkflowID,
+		CurrentStep:      wf.CurrentStep,
+		ExecState:        wf.State,
+		StepHistory:      workflowPermutationStepHistory(wf),
+		StepCounts:       workflowPermutationStepCounts(wf),
+		Variables:        workflowPermutationVars(wf),
+		ParallelInflight: workflowPermutationParallelState(wf),
+		AgentRoutes:      workflowPermutationAgentRoutes(engine),
+	}
+
+	return state
+}
+
+func workflowPermutationStepHistory(wf *Execution) []string {
+	out := make([]string, 0, len(wf.StepHistory))
+	for _, record := range wf.StepHistory {
+		entry := record.StepID + "|" + record.Status
+		if record.Output != "" {
+			entry += "|" + record.Output
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func workflowPermutationStepCounts(wf *Execution) []string {
+	if len(wf.StepCounts) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(wf.StepCounts))
+	for stepID, count := range wf.StepCounts {
+		out = append(out, stepID+"="+itoa(count))
+	}
+	slices.Sort(out)
+	return out
+}
+
+func workflowPermutationVars(wf *Execution) []string {
+	if len(wf.Variables) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(wf.Variables))
+	for key, value := range wf.Variables {
+		out = append(out, key+"="+value)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func workflowPermutationParallelState(wf *Execution) []string {
+	if len(wf.ParallelInflight) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(wf.ParallelInflight))
+	for parentID, rec := range wf.ParallelInflight {
+		if rec == nil {
+			out = append(out, parentID+"=<nil>")
+			continue
+		}
+		children := make([]string, 0, len(rec.Children))
+		for childID, child := range rec.Children {
+			if child == nil {
+				children = append(children, childID+"=<nil>")
+				continue
+			}
+			children = append(children, childID+"="+child.Status)
+		}
+		slices.Sort(children)
+		out = append(out, parentID+":"+join(children))
+	}
+	slices.Sort(out)
+	return out
+}
+
+func workflowPermutationAgentRoutes(engine *Engine) []string {
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+
+	if len(engine.agentRoutes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(engine.agentRoutes))
+	for agentID, route := range engine.agentRoutes {
+		out = append(out, agentID+"="+route.taskID+"/"+route.stepID)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func assertWorkflowPermutationSettled(t *testing.T, result workflowPermutationResult) {
+	t.Helper()
+
+	if result.EffectCount != 2 {
+		t.Fatalf("effect count = %d, want 2", result.EffectCount)
+	}
+	wantEffects := []string{"child_a|claude|headless", "child_b|codex|headless"}
+	if !reflect.DeepEqual(result.Effects, wantEffects) {
+		t.Fatalf("effects = %#v, want %#v", result.Effects, wantEffects)
+	}
+	if result.State.TaskStatus != workflowPermutationStatus {
+		t.Fatalf("task status = %q, want %q", result.State.TaskStatus, workflowPermutationStatus)
+	}
+	if result.State.TaskStatusReason != workflowPermutationReason {
+		t.Fatalf("task status reason = %q, want %q", result.State.TaskStatusReason, workflowPermutationReason)
+	}
+	if result.State.CurrentStep != workflowPermutationGateStep {
+		t.Fatalf("current step = %q, want %q", result.State.CurrentStep, workflowPermutationGateStep)
+	}
+	if result.State.ExecState != ExecWaiting {
+		t.Fatalf("exec state = %q, want %q", result.State.ExecState, ExecWaiting)
+	}
+	if result.State.ParallelInflight != nil {
+		t.Fatalf("parallel inflight = %#v, want nil", result.State.ParallelInflight)
+	}
+	if result.State.AgentRoutes != nil {
+		t.Fatalf("agent routes = %#v, want nil", result.State.AgentRoutes)
+	}
+	wantHistory := []string{
+		"fan_out|completed|child_a=completed, child_b=completed",
+		"set_review|completed",
+	}
+	if !reflect.DeepEqual(result.State.StepHistory, wantHistory) {
+		t.Fatalf("step history = %#v, want %#v", result.State.StepHistory, wantHistory)
+	}
+}
+
+func cloneWorkflowTaskInfo(ti TaskInfo) TaskInfo {
+	cloned := ti
+	cloned.Tags = slices.Clone(ti.Tags)
+	cloned.Attachments = slices.Clone(ti.Attachments)
+	cloned.PlanDrafts = maps.Clone(ti.PlanDrafts)
+	cloned.AgentRuns = slices.Clone(ti.AgentRuns)
+	if ti.Workflow != nil {
+		cloned.Workflow = ti.Workflow.Clone()
+	}
+	return cloned
+}
+
+func join(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += "," + parts[i]
+	}
+	return out
+}
+
+func itoa(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Motivation

Adds a permutation contract harness that exercises the workflow engine with deterministic event reordering, duplicate delivery, restart, and concurrent reconciler calls.

## Implementation information

New test-only file `internal/workflow/permutation_contract_test.go`, plus a `memTasks.GetTask` test-double fix (`engine_test.go`) to deep-clone `Workflow` so the harness's restart scenario isn't corrupted by shared state.

Building the harness surfaced real bugs in the engine, fixed in this PR:
- `engine_events.go`: `HandleAgentComplete` now falls back to matching a completion's `AgentID` against the current parallel step's persisted children (`parallelChildStepByAgentID`) when no in-memory route exists — fixes reconciliation of parallel-step completions after a restart.
- `engine_advance.go`: `executeSteps` reloads the freshest workflow state after a `promote_best_of_n` step, since that step persists its own state and the pre-step `wfExec` would otherwise clobber it.
- `engine_events.go`: `rescheduleRunAgent` / `finishResumeStalledStep` now reload the workflow via `workflowForPostDispatchCleanup` before clearing circuit-breaker/watchdog/transient-fetch-retry state, instead of using a possibly-stale in-memory reference.

## Supporting documentation

Closes https://github.com/Automaat/sybra/issues/2660

> Changelog: fix(workflow): reconcile parallel-step completions and reload fresh state on cleanup
