### PR TITLE
feat(workflow): add EffectLog to Execution

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/index.ts
@@ -7,6 +7,8 @@ export {
     ChildStatus,
     Condition,
     Definition,
+    EffectID,
+    EffectRecord,
     ExecState,
     Execution,
     ImportSidecar,

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -218,6 +218,80 @@ export class Definition {
 }
 
 /**
+ * EffectID identifies one reducer-emitted effect within a task generation.
+ * Generation scopes ids across retries/resets, StepSeq orders steps within that
+ * generation, StepID anchors the originating workflow step, and Pos
+ * distinguishes sibling effects from the same reducer decision.
+ */
+export class EffectID {
+    "Generation": number;
+    "StepSeq": number;
+    "StepID": string;
+    "Pos": number;
+
+    /** Creates a new EffectID instance. */
+    constructor($$source: Partial<EffectID> = {}) {
+        if (!("Generation" in $$source)) {
+            this["Generation"] = 0;
+        }
+        if (!("StepSeq" in $$source)) {
+            this["StepSeq"] = 0;
+        }
+        if (!("StepID" in $$source)) {
+            this["StepID"] = "";
+        }
+        if (!("Pos" in $$source)) {
+            this["Pos"] = 0;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new EffectID instance from a string or object.
+     */
+    static createFrom($$source: any = {}): EffectID {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new EffectID($$parsedSource as Partial<EffectID>);
+    }
+}
+
+/**
+ * EffectRecord pairs an EffectID with intent and completion timestamps.
+ * It is stored on Execution.EffectLog so retried effects can reuse their
+ * original EffectID as an idempotency key.
+ */
+export class EffectRecord {
+    "id": EffectID;
+    "intentAt": string;
+    "completedAt"?: string | null;
+
+    /** Creates a new EffectRecord instance. */
+    constructor($$source: Partial<EffectRecord> = {}) {
+        if (!("id" in $$source)) {
+            this["id"] = (new EffectID());
+        }
+        if (!("intentAt" in $$source)) {
+            this["intentAt"] = "0001-01-01T00:00:00.000Z";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new EffectRecord instance from a string or object.
+     */
+    static createFrom($$source: any = {}): EffectRecord {
+        const $$createField0_0 = $$createType6;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("id" in $$parsedSource) {
+            $$parsedSource["id"] = $$createField0_0($$parsedSource["id"]);
+        }
+        return new EffectRecord($$parsedSource as Partial<EffectRecord>);
+    }
+}
+
+/**
  * ExecState tracks the overall execution state.
  */
 export enum ExecState {
@@ -283,6 +357,13 @@ export class Execution {
      */
     "bestOfNInflight"?: { [_ in string]?: BestOfNInflight | null };
 
+    /**
+     * EffectLog records intent-before and completion-after for each effect so
+     * retried effects can reuse their original EffectID as an idempotency key.
+     * Trimmed to maxEffectLog oldest-first. Not wired into the engine yet.
+     */
+    "effectLog"?: EffectRecord[];
+
     /** Creates a new Execution instance. */
     constructor($$source: Partial<Execution> = {}) {
         if (!("workflowId" in $$source)) {
@@ -314,11 +395,12 @@ export class Execution {
      * Creates a new Execution instance from a string or object.
      */
     static createFrom($$source: any = {}): Execution {
-        const $$createField3_0 = $$createType7;
-        const $$createField4_0 = $$createType8;
-        const $$createField8_0 = $$createType11;
-        const $$createField9_0 = $$createType12;
-        const $$createField10_0 = $$createType15;
+        const $$createField3_0 = $$createType8;
+        const $$createField4_0 = $$createType9;
+        const $$createField8_0 = $$createType12;
+        const $$createField9_0 = $$createType13;
+        const $$createField10_0 = $$createType16;
+        const $$createField11_0 = $$createType18;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("stepHistory" in $$parsedSource) {
             $$parsedSource["stepHistory"] = $$createField3_0($$parsedSource["stepHistory"]);
@@ -334,6 +416,9 @@ export class Execution {
         }
         if ("bestOfNInflight" in $$parsedSource) {
             $$parsedSource["bestOfNInflight"] = $$createField10_0($$parsedSource["bestOfNInflight"]);
+        }
+        if ("effectLog" in $$parsedSource) {
+            $$parsedSource["effectLog"] = $$createField11_0($$parsedSource["effectLog"]);
         }
         return new Execution($$parsedSource as Partial<Execution>);
     }
@@ -411,7 +496,7 @@ export class ParallelChildren {
      * Creates a new ParallelChildren instance from a string or object.
      */
     static createFrom($$source: any = {}): ParallelChildren {
-        const $$createField2_0 = $$createType18;
+        const $$createField2_0 = $$createType21;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("children" in $$parsedSource) {
             $$parsedSource["children"] = $$createField2_0($$parsedSource["children"]);
@@ -495,10 +580,10 @@ export class Step {
      * Creates a new Step instance from a string or object.
      */
     static createFrom($$source: any = {}): Step {
-        const $$createField3_0 = $$createType19;
-        const $$createField4_0 = $$createType21;
+        const $$createField3_0 = $$createType22;
+        const $$createField4_0 = $$createType24;
         const $$createField5_0 = $$createType5;
-        const $$createField6_0 = $$createType23;
+        const $$createField6_0 = $$createType26;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("config" in $$parsedSource) {
             $$parsedSource["config"] = $$createField3_0($$parsedSource["config"]);
@@ -746,14 +831,14 @@ export class StepConfig {
      * Creates a new StepConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): StepConfig {
-        const $$createField5_0 = $$createType24;
-        const $$createField7_0 = $$createType24;
-        const $$createField10_0 = $$createType26;
-        const $$createField18_0 = $$createType24;
-        const $$createField19_0 = $$createType24;
-        const $$createField20_0 = $$createType28;
-        const $$createField21_0 = $$createType29;
-        const $$createField24_0 = $$createType24;
+        const $$createField5_0 = $$createType27;
+        const $$createField7_0 = $$createType27;
+        const $$createField10_0 = $$createType29;
+        const $$createField18_0 = $$createType27;
+        const $$createField19_0 = $$createType27;
+        const $$createField20_0 = $$createType31;
+        const $$createField21_0 = $$createType32;
+        const $$createField24_0 = $$createType27;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField5_0($$parsedSource["allowedTools"]);
@@ -1062,7 +1147,7 @@ export class Transition {
      * Creates a new Transition instance from a string or object.
      */
     static createFrom($$source: any = {}): Transition {
-        const $$createField0_0 = $$createType26;
+        const $$createField0_0 = $$createType29;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("when" in $$parsedSource) {
             $$parsedSource["when"] = $$createField0_0($$parsedSource["when"]);
@@ -1112,8 +1197,8 @@ export class Trigger {
      * Creates a new Trigger instance from a string or object.
      */
     static createFrom($$source: any = {}): Trigger {
-        const $$createField2_0 = $$createType30;
-        const $$createField3_0 = $$createType23;
+        const $$createField2_0 = $$createType33;
+        const $$createField3_0 = $$createType26;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("conditions" in $$parsedSource) {
             $$parsedSource["conditions"] = $$createField2_0($$parsedSource["conditions"]);
@@ -1132,28 +1217,31 @@ const $$createType2 = $Create.Map($Create.Any, $$createType1);
 const $$createType3 = Trigger.createFrom;
 const $$createType4 = Step.createFrom;
 const $$createType5 = $Create.Array($$createType4);
-const $$createType6 = StepRecord.createFrom;
-const $$createType7 = $Create.Array($$createType6);
-const $$createType8 = $Create.Map($Create.Any, $Create.Any);
-const $$createType9 = ParallelChildren.createFrom;
-const $$createType10 = $Create.Nullable($$createType9);
-const $$createType11 = $Create.Map($Create.Any, $$createType10);
-const $$createType12 = $Create.Map($Create.Any, $Create.Any);
-const $$createType13 = BestOfNInflight.createFrom;
-const $$createType14 = $Create.Nullable($$createType13);
-const $$createType15 = $Create.Map($Create.Any, $$createType14);
-const $$createType16 = ChildStatus.createFrom;
-const $$createType17 = $Create.Nullable($$createType16);
-const $$createType18 = $Create.Map($Create.Any, $$createType17);
-const $$createType19 = StepConfig.createFrom;
-const $$createType20 = Transition.createFrom;
-const $$createType21 = $Create.Array($$createType20);
-const $$createType22 = Position.createFrom;
-const $$createType23 = $Create.Nullable($$createType22);
-const $$createType24 = $Create.Array($Create.Any);
-const $$createType25 = Condition.createFrom;
+const $$createType6 = EffectID.createFrom;
+const $$createType7 = StepRecord.createFrom;
+const $$createType8 = $Create.Array($$createType7);
+const $$createType9 = $Create.Map($Create.Any, $Create.Any);
+const $$createType10 = ParallelChildren.createFrom;
+const $$createType11 = $Create.Nullable($$createType10);
+const $$createType12 = $Create.Map($Create.Any, $$createType11);
+const $$createType13 = $Create.Map($Create.Any, $Create.Any);
+const $$createType14 = BestOfNInflight.createFrom;
+const $$createType15 = $Create.Nullable($$createType14);
+const $$createType16 = $Create.Map($Create.Any, $$createType15);
+const $$createType17 = EffectRecord.createFrom;
+const $$createType18 = $Create.Array($$createType17);
+const $$createType19 = ChildStatus.createFrom;
+const $$createType20 = $Create.Nullable($$createType19);
+const $$createType21 = $Create.Map($Create.Any, $$createType20);
+const $$createType22 = StepConfig.createFrom;
+const $$createType23 = Transition.createFrom;
+const $$createType24 = $Create.Array($$createType23);
+const $$createType25 = Position.createFrom;
 const $$createType26 = $Create.Nullable($$createType25);
-const $$createType27 = ImportSidecar.createFrom;
-const $$createType28 = $Create.Nullable($$createType27);
-const $$createType29 = $Create.Array($$createType27);
-const $$createType30 = $Create.Array($$createType25);
+const $$createType27 = $Create.Array($Create.Any);
+const $$createType28 = Condition.createFrom;
+const $$createType29 = $Create.Nullable($$createType28);
+const $$createType30 = ImportSidecar.createFrom;
+const $$createType31 = $Create.Nullable($$createType30);
+const $$createType32 = $Create.Array($$createType30);
+const $$createType33 = $Create.Array($$createType28);

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -224,24 +224,24 @@ export class Definition {
  * distinguishes sibling effects from the same reducer decision.
  */
 export class EffectID {
-    "Generation": number;
-    "StepSeq": number;
-    "StepID": string;
-    "Pos": number;
+    "generation": number;
+    "stepSeq": number;
+    "stepID": string;
+    "pos": number;
 
     /** Creates a new EffectID instance. */
     constructor($$source: Partial<EffectID> = {}) {
-        if (!("Generation" in $$source)) {
-            this["Generation"] = 0;
+        if (!("generation" in $$source)) {
+            this["generation"] = 0;
         }
-        if (!("StepSeq" in $$source)) {
-            this["StepSeq"] = 0;
+        if (!("stepSeq" in $$source)) {
+            this["stepSeq"] = 0;
         }
-        if (!("StepID" in $$source)) {
-            this["StepID"] = "";
+        if (!("stepID" in $$source)) {
+            this["stepID"] = "";
         }
-        if (!("Pos" in $$source)) {
-            this["Pos"] = 0;
+        if (!("pos" in $$source)) {
+            this["pos"] = 0;
         }
 
         Object.assign(this, $$source);

--- a/internal/workflow/effect_id.go
+++ b/internal/workflow/effect_id.go
@@ -10,10 +10,10 @@ import (
 // generation, StepID anchors the originating workflow step, and Pos
 // distinguishes sibling effects from the same reducer decision.
 type EffectID struct {
-	Generation int64
-	StepSeq    int
-	StepID     string
-	Pos        int
+	Generation int64  `yaml:"generation" json:"generation"`
+	StepSeq    int    `yaml:"step_seq" json:"stepSeq"`
+	StepID     string `yaml:"step_id" json:"stepID"`
+	Pos        int    `yaml:"pos" json:"pos"`
 }
 
 // IsZero reports whether the id has not been assigned yet.

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -6,6 +6,17 @@ import (
 	"time"
 )
 
+const maxEffectLog = 200
+
+// EffectRecord pairs an EffectID with intent and completion timestamps.
+// It is stored on Execution.EffectLog so retried effects can reuse their
+// original EffectID as an idempotency key.
+type EffectRecord struct {
+	ID          EffectID   `yaml:"id" json:"id"`
+	IntentAt    time.Time  `yaml:"intent_at" json:"intentAt"`
+	CompletedAt *time.Time `yaml:"completed_at,omitempty" json:"completedAt,omitempty"`
+}
+
 // ExecState tracks the overall execution state.
 type ExecState string
 
@@ -52,6 +63,10 @@ type Execution struct {
 	// promoteBestOfN can locate the winning attempt's worktree without
 	// depending on live agent state.
 	BestOfNInflight map[string]*BestOfNInflight `yaml:"best_of_n_inflight,omitempty" json:"bestOfNInflight,omitempty"`
+	// EffectLog records intent-before and completion-after for each effect so
+	// retried effects can reuse their original EffectID as an idempotency key.
+	// Trimmed to maxEffectLog oldest-first. Not wired into the engine yet.
+	EffectLog []EffectRecord `yaml:"effect_log,omitempty" json:"effectLog,omitempty"`
 }
 
 // BestOfNInflight is the in-flight bookkeeping for one `best_of_n` parent.
@@ -203,7 +218,70 @@ func (e *Execution) Clone() *Execution {
 			cloned.BestOfNInflight[key] = &parentClone
 		}
 	}
+	if e.EffectLog != nil {
+		cloned.EffectLog = slices.Clone(e.EffectLog)
+	}
 	return &cloned
+}
+
+// RecordEffectIntent records that an effect is about to be applied.
+// Idempotent: a second call with the same ID is a no-op.
+// Trims EffectLog to maxEffectLog by evicting oldest entries.
+func (e *Execution) RecordEffectIntent(id EffectID, now time.Time) {
+	for i := range e.EffectLog {
+		if e.EffectLog[i].ID.Equal(id) {
+			return
+		}
+	}
+	e.EffectLog = append(e.EffectLog, EffectRecord{ID: id, IntentAt: now})
+	if len(e.EffectLog) > maxEffectLog {
+		e.EffectLog = e.EffectLog[len(e.EffectLog)-maxEffectLog:]
+	}
+}
+
+// RecordEffectCompletion marks an effect as applied.
+// No-op if the intent was never recorded or if completion is already set.
+func (e *Execution) RecordEffectCompletion(id EffectID, now time.Time) {
+	for i := range e.EffectLog {
+		if e.EffectLog[i].ID.Equal(id) {
+			if e.EffectLog[i].CompletedAt == nil {
+				t := now
+				e.EffectLog[i].CompletedAt = &t
+			}
+			return
+		}
+	}
+}
+
+// EffectApplied reports whether the effect was both intended and completed.
+func (e *Execution) EffectApplied(id EffectID) bool {
+	for i := range e.EffectLog {
+		if e.EffectLog[i].ID.Equal(id) {
+			return e.EffectLog[i].CompletedAt != nil
+		}
+	}
+	return false
+}
+
+// EffectPending reports whether the effect was intended but not yet completed.
+func (e *Execution) EffectPending(id EffectID) bool {
+	for i := range e.EffectLog {
+		if e.EffectLog[i].ID.Equal(id) {
+			return e.EffectLog[i].CompletedAt == nil
+		}
+	}
+	return false
+}
+
+// EffectIDForStep returns the most-recently recorded EffectID whose StepID and
+// Pos match the given values, so a retried effect can reuse the same key.
+func (e *Execution) EffectIDForStep(stepID string, pos int) (EffectID, bool) {
+	for i := range slices.Backward(e.EffectLog) {
+		if e.EffectLog[i].ID.StepID == stepID && e.EffectLog[i].ID.Pos == pos {
+			return e.EffectLog[i].ID, true
+		}
+	}
+	return EffectID{}, false
 }
 
 // AllChildrenDone reports whether every child reached a terminal status.

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -220,6 +220,12 @@ func (e *Execution) Clone() *Execution {
 	}
 	if e.EffectLog != nil {
 		cloned.EffectLog = slices.Clone(e.EffectLog)
+		for i := range cloned.EffectLog {
+			if cloned.EffectLog[i].CompletedAt != nil {
+				t := *cloned.EffectLog[i].CompletedAt
+				cloned.EffectLog[i].CompletedAt = &t
+			}
+		}
 	}
 	return &cloned
 }

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -248,6 +248,9 @@ func (e *Execution) RecordEffectIntent(id EffectID, now time.Time) {
 // RecordEffectCompletion marks an effect as applied.
 // No-op if the intent was never recorded or if completion is already set.
 func (e *Execution) RecordEffectCompletion(id EffectID, now time.Time) {
+	if e == nil {
+		return
+	}
 	for i := range e.EffectLog {
 		if e.EffectLog[i].ID.Equal(id) {
 			if e.EffectLog[i].CompletedAt == nil {

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -332,6 +332,9 @@ func TestEffectLog_CloneIsolation(t *testing.T) {
 	e.RecordEffectIntent(id, time.Now())
 
 	cloned := e.Clone()
+	if cloned == nil {
+		t.Fatal("Clone of non-nil Execution returned nil")
+	}
 	now2 := time.Now().Add(time.Second)
 	cloned.RecordEffectCompletion(id, now2)
 
@@ -347,6 +350,9 @@ func TestEffectLog_CloneDeepCopiesCompletedAt(t *testing.T) {
 	e.RecordEffectCompletion(id, time.Now())
 
 	cloned := e.Clone()
+	if cloned == nil {
+		t.Fatal("Clone of non-nil Execution returned nil")
+	}
 	if cloned.EffectLog[0].CompletedAt == e.EffectLog[0].CompletedAt {
 		t.Fatal("clone should not alias original's CompletedAt pointer")
 	}

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -216,3 +216,126 @@ func TestRecordForStep_ReturnsNilForMissing(t *testing.T) {
 		t.Errorf("expected nil for missing step, got %v", got)
 	}
 }
+
+func makeID(stepID string, pos int) EffectID {
+	return EffectID{Generation: 1, StepSeq: 1, StepID: stepID, Pos: pos}
+}
+
+func TestEffectLog_RecordIntentIdempotent(t *testing.T) {
+	e := &Execution{}
+	id := makeID("implement", 0)
+	now := time.Now()
+	e.RecordEffectIntent(id, now)
+	e.RecordEffectIntent(id, now.Add(time.Second))
+	if len(e.EffectLog) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(e.EffectLog))
+	}
+}
+
+func TestEffectLog_RecordCompletionOnAbsent(t *testing.T) {
+	e := &Execution{}
+	id := makeID("implement", 0)
+	e.RecordEffectCompletion(id, time.Now())
+	if len(e.EffectLog) != 0 {
+		t.Fatalf("completion before intent should add no record, got %d", len(e.EffectLog))
+	}
+}
+
+func TestEffectLog_RecordCompletionIdempotent(t *testing.T) {
+	e := &Execution{}
+	id := makeID("implement", 0)
+	now := time.Now()
+	e.RecordEffectIntent(id, now)
+	e.RecordEffectCompletion(id, now.Add(time.Second))
+	first := *e.EffectLog[0].CompletedAt
+	e.RecordEffectCompletion(id, now.Add(2*time.Second))
+	if *e.EffectLog[0].CompletedAt != first {
+		t.Fatalf("double completion should be idempotent, CompletedAt changed")
+	}
+}
+
+func TestEffectLog_EffectAppliedAndPending(t *testing.T) {
+	e := &Execution{}
+	id := makeID("implement", 0)
+	now := time.Now()
+
+	// neither intent nor completion
+	if e.EffectApplied(id) || e.EffectPending(id) {
+		t.Fatal("no record: both should be false")
+	}
+
+	// intent only
+	e.RecordEffectIntent(id, now)
+	if e.EffectApplied(id) {
+		t.Fatal("intent-only: EffectApplied should be false")
+	}
+	if !e.EffectPending(id) {
+		t.Fatal("intent-only: EffectPending should be true")
+	}
+
+	// intent + completion
+	e.RecordEffectCompletion(id, now.Add(time.Second))
+	if !e.EffectApplied(id) {
+		t.Fatal("after completion: EffectApplied should be true")
+	}
+	if e.EffectPending(id) {
+		t.Fatal("after completion: EffectPending should be false")
+	}
+}
+
+func TestEffectLog_EffectIDForStep(t *testing.T) {
+	e := &Execution{}
+	now := time.Now()
+	id1 := EffectID{Generation: 1, StepSeq: 1, StepID: "implement", Pos: 0}
+	id2 := EffectID{Generation: 1, StepSeq: 2, StepID: "implement", Pos: 0}
+	e.RecordEffectIntent(id1, now)
+	e.RecordEffectIntent(id2, now.Add(time.Second))
+
+	got, ok := e.EffectIDForStep("implement", 0)
+	if !ok {
+		t.Fatal("expected hit for implement/0")
+	}
+	if !got.Equal(id2) {
+		t.Fatalf("expected most-recent id2, got %v", got)
+	}
+
+	_, ok = e.EffectIDForStep("missing", 0)
+	if ok {
+		t.Fatal("expected miss for unknown step")
+	}
+
+	_, ok = e.EffectIDForStep("implement", 99)
+	if ok {
+		t.Fatal("expected miss for wrong pos")
+	}
+}
+
+func TestEffectLog_TrimToMaxCap(t *testing.T) {
+	e := &Execution{}
+	now := time.Now()
+	for i := range maxEffectLog + 5 {
+		id := EffectID{Generation: 1, StepSeq: i, StepID: "step", Pos: 0}
+		e.RecordEffectIntent(id, now)
+	}
+	if len(e.EffectLog) != maxEffectLog {
+		t.Fatalf("expected log trimmed to %d, got %d", maxEffectLog, len(e.EffectLog))
+	}
+	// oldest entries evicted; first remaining should be index 5
+	if e.EffectLog[0].ID.StepSeq != 5 {
+		t.Fatalf("expected oldest remaining StepSeq=5, got %d", e.EffectLog[0].ID.StepSeq)
+	}
+}
+
+func TestEffectLog_CloneIsolation(t *testing.T) {
+	e := &Execution{}
+	id := makeID("implement", 0)
+	e.RecordEffectIntent(id, time.Now())
+
+	cloned := e.Clone()
+	now2 := time.Now().Add(time.Second)
+	cloned.RecordEffectCompletion(id, now2)
+
+	if e.EffectApplied(id) {
+		t.Fatal("mutating clone's EffectLog should not affect original")
+	}
+}

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -339,3 +339,21 @@ func TestEffectLog_CloneIsolation(t *testing.T) {
 		t.Fatal("mutating clone's EffectLog should not affect original")
 	}
 }
+
+func TestEffectLog_CloneDeepCopiesCompletedAt(t *testing.T) {
+	e := &Execution{}
+	id := makeID("implement", 0)
+	e.RecordEffectIntent(id, time.Now())
+	e.RecordEffectCompletion(id, time.Now())
+
+	cloned := e.Clone()
+	if cloned.EffectLog[0].CompletedAt == e.EffectLog[0].CompletedAt {
+		t.Fatal("clone should not alias original's CompletedAt pointer")
+	}
+
+	original := *e.EffectLog[0].CompletedAt
+	*cloned.EffectLog[0].CompletedAt = original.Add(time.Hour)
+	if !e.EffectLog[0].CompletedAt.Equal(original) {
+		t.Fatal("mutating clone's CompletedAt pointee should not affect original")
+	}
+}


### PR DESCRIPTION
## Motivation

Step 3 of the durable-effects work (parent: #2464): persist effect intent before execution and completion after, so retried effects can reuse their original EffectID as an idempotency key. Closes #2661.

## Implementation information

- Adds `EffectRecord` type (`ID EffectID`, `IntentAt`, `CompletedAt`) to `internal/workflow/execution.go`
- Adds `EffectLog []EffectRecord` field to `Execution`; trimmed to 200 oldest-first
- Extends `Clone()` to deep-copy `EffectLog`
- Adds five helpers: `RecordEffectIntent`, `RecordEffectCompletion`, `EffectApplied`, `EffectPending`, `EffectIDForStep`
- All helpers are idempotent and pure (no I/O, no goroutines)
- Not wired into production engine paths; behaviorally inert outside unit tests
- Full table-driven test coverage in `execution_test.go`

## Supporting documentation

Depends on #2671 (monotonic effect identity, merged).