### PR TITLE
refactor(workflow): pollers and watchdog become observers, not writers

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -566,6 +566,13 @@ export class Task {
     "testingCycleStartedAt"?: string | null;
     "attachments": Attachment[];
     "agentRuns": AgentRun[];
+
+    /**
+     * EffectLog records durable intent/completion for observer-owned task
+     * status effects (pollers, monitor, recovery) that operate outside a live
+     * workflow execution.
+     */
+    "effectLog"?: workflow$0.EffectRecord[];
     "workflow"?: workflow$0.Execution | null;
     "createdAt": string;
     "updatedAt": string;
@@ -706,7 +713,8 @@ export class Task {
         const $$createField41_0 = $$createType5;
         const $$createField42_0 = $$createType7;
         const $$createField43_0 = $$createType9;
-        const $$createField60_0 = $$createType10;
+        const $$createField44_0 = $$createType11;
+        const $$createField61_0 = $$createType12;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -729,11 +737,14 @@ export class Task {
         if ("agentRuns" in $$parsedSource) {
             $$parsedSource["agentRuns"] = $$createField42_0($$parsedSource["agentRuns"]);
         }
+        if ("effectLog" in $$parsedSource) {
+            $$parsedSource["effectLog"] = $$createField43_0($$parsedSource["effectLog"]);
+        }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField43_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField44_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField60_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField61_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }
@@ -808,6 +819,7 @@ export class Update {
     "MergeCommit": string | null;
     "TestingCycleStartedAt": string | null;
     "Attachments": Attachment[] | null;
+    "EffectLog": workflow$0.EffectRecord[] | null;
 
     /** Creates a new Update instance. */
     constructor($$source: Partial<Update> = {}) {
@@ -949,6 +961,9 @@ export class Update {
         if (!("Attachments" in $$source)) {
             this["Attachments"] = null;
         }
+        if (!("EffectLog" in $$source)) {
+            this["EffectLog"] = null;
+        }
 
         Object.assign(this, $$source);
     }
@@ -957,12 +972,13 @@ export class Update {
      * Creates a new Update instance from a string or object.
      */
     static createFrom($$source: any = {}): Update {
-        const $$createField4_0 = $$createType11;
-        const $$createField7_0 = $$createType12;
-        const $$createField8_0 = $$createType13;
-        const $$createField12_0 = $$createType12;
-        const $$createField30_0 = $$createType14;
-        const $$createField45_0 = $$createType15;
+        const $$createField4_0 = $$createType13;
+        const $$createField7_0 = $$createType14;
+        const $$createField8_0 = $$createType15;
+        const $$createField12_0 = $$createType14;
+        const $$createField30_0 = $$createType16;
+        const $$createField45_0 = $$createType17;
+        const $$createField46_0 = $$createType18;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("Blocker" in $$parsedSource) {
             $$parsedSource["Blocker"] = $$createField4_0($$parsedSource["Blocker"]);
@@ -982,6 +998,9 @@ export class Update {
         if ("Attachments" in $$parsedSource) {
             $$parsedSource["Attachments"] = $$createField45_0($$parsedSource["Attachments"]);
         }
+        if ("EffectLog" in $$parsedSource) {
+            $$parsedSource["EffectLog"] = $$createField46_0($$parsedSource["EffectLog"]);
+        }
         return new Update($$parsedSource as Partial<Update>);
     }
 }
@@ -995,11 +1014,14 @@ const $$createType4 = attachment$0.Attachment.createFrom;
 const $$createType5 = $Create.Array($$createType4);
 const $$createType6 = AgentRun.createFrom;
 const $$createType7 = $Create.Array($$createType6);
-const $$createType8 = workflow$0.Execution.createFrom;
-const $$createType9 = $Create.Nullable($$createType8);
-const $$createType10 = $Create.Map($Create.Any, $Create.Any);
-const $$createType11 = $Create.Nullable($$createType1);
-const $$createType12 = $Create.Nullable($$createType0);
-const $$createType13 = $Create.Nullable($$createType3);
-const $$createType14 = $Create.Nullable($$createType9);
-const $$createType15 = $Create.Nullable($$createType5);
+const $$createType8 = workflow$0.EffectRecord.createFrom;
+const $$createType9 = $Create.Array($$createType8);
+const $$createType10 = workflow$0.Execution.createFrom;
+const $$createType11 = $Create.Nullable($$createType10);
+const $$createType12 = $Create.Map($Create.Any, $Create.Any);
+const $$createType13 = $Create.Nullable($$createType1);
+const $$createType14 = $Create.Nullable($$createType0);
+const $$createType15 = $Create.Nullable($$createType3);
+const $$createType16 = $Create.Nullable($$createType11);
+const $$createType17 = $Create.Nullable($$createType5);
+const $$createType18 = $Create.Nullable($$createType9);

--- a/internal/monitor/dispatcher_test.go
+++ b/internal/monitor/dispatcher_test.go
@@ -61,6 +61,9 @@ func (d dispatcherTasksStub) Get(id string) (task.Task, error) {
 func (d dispatcherTasksStub) Update(string, task.Update) (task.Task, error) {
 	return task.Task{}, errors.New("not implemented")
 }
+func (d dispatcherTasksStub) ApplyStatusEffect(string, task.StatusEffect) (task.Task, error) {
+	return task.Task{}, errors.New("not implemented")
+}
 func (d dispatcherTasksStub) UpdateRun(string, string, task.RunPatch) error {
 	return errors.New("not implemented")
 }

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -16,6 +16,7 @@ type taskAPI interface {
 	List() ([]task.Task, error)
 	Get(id string) (task.Task, error)
 	Update(id string, u task.Update) (task.Task, error)
+	ApplyStatusEffect(id string, eff task.StatusEffect) (task.Task, error)
 	UpdateRun(taskID, agentID string, patch task.RunPatch) error
 }
 
@@ -178,12 +179,14 @@ func (r *remediator) refreshHumanRequiredStuck(a Anomaly) (string, error) {
 // instead of bouncing between in-progress and human-required forever.
 func (r *remediator) retryKnownLostAgentStuck(a Anomaly, t task.Task) (string, error) {
 	tags := append(slices.Clone(t.Tags), monitorAutoRetriedTag)
-	upd := task.Update{
-		Status:       task.Ptr(task.StatusInProgress),
-		StatusReason: task.Ptr("monitor: stall matches an already-tracked lost_agent investigation; auto-retrying"),
-		Tags:         &tags,
-	}
-	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
+	if _, err := r.tasks.ApplyStatusEffect(a.TaskID, task.StatusEffect{
+		Source: "monitor.stuck-human-blocked.retry-known-lost-agent",
+		Update: task.Update{
+			Status:       task.Ptr(task.StatusInProgress),
+			StatusReason: task.Ptr("monitor: stall matches an already-tracked lost_agent investigation; auto-retrying"),
+			Tags:         &tags,
+		},
+	}); err != nil {
 		return "", fmt.Errorf("retry known lost_agent stuck task %s: %w", a.TaskID, err)
 	}
 	return string(a.Kind) + ":retry:" + a.TaskID, nil

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -280,10 +280,13 @@ func (s *Service) closeMergedHumanRequiredPRs(ctx context.Context, tasks []task.
 				continue
 			}
 		} else {
-			if _, err := s.tasks.Update(t.ID, task.Update{
-				Status:       task.Ptr(task.StatusDone),
-				StatusReason: task.Ptr("monitor: linked PR already merged"),
-				Outcome:      task.Ptr("merged"),
+			if _, err := s.tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+				Source: "monitor.close-merged-human-required-pr",
+				Update: task.Update{
+					Status:       task.Ptr(task.StatusDone),
+					StatusReason: task.Ptr("monitor: linked PR already merged"),
+					Outcome:      task.Ptr("merged"),
+				},
 			}); err != nil {
 				s.logger.Warn("monitor.human-required-pr-merged.update_failed", "task_id", t.ID, "pr", t.PRNumber, "err", err)
 				continue

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -75,12 +75,25 @@ func (f *fakeTasks) Update(id string, u task.Update) (task.Task, error) {
 		if u.Outcome != nil {
 			f.tasks[i].Outcome = *u.Outcome
 		}
+		if u.PRNumber != nil {
+			f.tasks[i].PRNumber = *u.PRNumber
+		}
+		if u.Tags != nil {
+			f.tasks[i].Tags = append([]string(nil), (*u.Tags)...)
+		}
+		if u.EffectLog != nil {
+			f.tasks[i].EffectLog = append([]workflow.EffectRecord(nil), (*u.EffectLog)...)
+		}
 		if u.Workflow != nil {
 			f.tasks[i].Workflow = *u.Workflow
 		}
 		return f.tasks[i], nil
 	}
 	return task.Task{}, errNotFound
+}
+
+func (f *fakeTasks) ApplyStatusEffect(id string, eff task.StatusEffect) (task.Task, error) {
+	return f.Update(id, eff.Update)
 }
 
 func (f *fakeTasks) UpdateRun(taskID, agentID string, patch task.RunPatch) error {

--- a/internal/recovery/reconcile.go
+++ b/internal/recovery/reconcile.go
@@ -50,12 +50,15 @@ func (r *Recovery) ReconcileLostPRNumber(ctx context.Context) {
 
 func (r *Recovery) reconcileLandedTask(t *task.Task, prNumber int) {
 	var clearWorkflow *workflow.Execution
-	if _, err := r.Tasks.Update(t.ID, task.Update{
-		PRNumber:     task.Ptr(prNumber),
-		Status:       task.Ptr(task.StatusDone),
-		Outcome:      task.Ptr("merged"),
-		StatusReason: task.Ptr(""),
-		Workflow:     &clearWorkflow,
+	if _, err := r.Tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+		Source: "recovery.reconcile-lost-pr.landed",
+		Update: task.Update{
+			PRNumber:     task.Ptr(prNumber),
+			Status:       task.Ptr(task.StatusDone),
+			Outcome:      task.Ptr("merged"),
+			StatusReason: task.Ptr(""),
+			Workflow:     &clearWorkflow,
+		},
 	}); err != nil {
 		r.Logger.Error("reconcile-lost-pr.landed", "task_id", t.ID, "pr", prNumber, "err", err)
 		return

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -126,7 +126,10 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 	// itself.
 	if lastRun := lastAgentRun(&t); lastRun != nil && (lastRun.Role == "pr-fix" || lastRun.Role == "test-fix") {
 		r.Logger.Info("restart-stale.revert-to-review", "task_id", t.ID)
-		if _, updErr := r.Tasks.Update(t.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); updErr != nil {
+		if _, updErr := r.Tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+			Source: "recovery.restart-stale.pr-fix-run",
+			Update: task.Update{Status: task.Ptr(task.StatusInReview)},
+		}); updErr != nil {
 			r.Logger.Error("restart-stale.revert", "task_id", t.ID, "err", updErr)
 		}
 		return
@@ -270,9 +273,12 @@ func (r *Recovery) handleTerminalWorkflow(t *task.Task) bool {
 		r.Logger.Info("restart-stale.revert-to-review",
 			"task_id", t.ID, "reason", "pr_fix_workflow_not_restartable")
 		reason := "pr-fix terminal workflow is not restartable without PR-event context"
-		if _, updErr := r.Tasks.Update(t.ID, task.Update{
-			Status:       task.Ptr(task.StatusInReview),
-			StatusReason: &reason,
+		if _, updErr := r.Tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+			Source: "recovery.restart-stale.pr-fix-workflow",
+			Update: task.Update{
+				Status:       task.Ptr(task.StatusInReview),
+				StatusReason: &reason,
+			},
 		}); updErr != nil {
 			r.Logger.Error("restart-stale.revert", "task_id", t.ID, "err", updErr)
 		}
@@ -349,9 +355,12 @@ func (r *Recovery) convergeReviewOnPlanWorkflow(t *task.Task) bool {
 	if t.ProjectID == "" || t.PRNumber == 0 {
 		reason := "review task stranded on a terminal plan workflow with no project/PR context to resume pr-review"
 		r.Logger.Warn("restart-stale.review-on-plan.no-context", "task_id", t.ID)
-		if _, updErr := r.Tasks.Update(t.ID, task.Update{
-			Status:       task.Ptr(task.StatusHumanRequired),
-			StatusReason: task.Ptr(reason),
+		if _, updErr := r.Tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+			Source: "recovery.restart-stale.review-on-plan-no-context",
+			Update: task.Update{
+				Status:       task.Ptr(task.StatusHumanRequired),
+				StatusReason: task.Ptr(reason),
+			},
 		}); updErr != nil {
 			r.Logger.Error("restart-stale.review-on-plan.park-failed", "task_id", t.ID, "err", updErr)
 		}
@@ -410,9 +419,12 @@ func (r *Recovery) recoverCancelledPRFix(t *task.Task) bool {
 	status := task.StatusInReview
 	reason := "pr-fix cancelled: " + strings.TrimPrefix(cancelReason, "pr-monitor: ")
 	r.Logger.Info("restart-stale.revert-cancelled-pr-fix", "task_id", t.ID, "reason", reason)
-	if _, updErr := r.Tasks.Update(t.ID, task.Update{
-		Status:       &status,
-		StatusReason: &reason,
+	if _, updErr := r.Tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+		Source: "recovery.restart-stale.cancelled-pr-fix",
+		Update: task.Update{
+			Status:       &status,
+			StatusReason: &reason,
+		},
 	}); updErr != nil {
 		r.Logger.Error("restart-stale.revert-cancelled-pr-fix.failed", "task_id", t.ID, "err", updErr)
 		return false
@@ -455,7 +467,10 @@ func (r *Recovery) surfaceStartFailure(ctx context.Context, taskID string, curre
 	if !failure.Blocker.IsZero() {
 		update.Blocker = &failure.Blocker
 	}
-	if _, uErr := r.Tasks.Update(taskID, update); uErr != nil {
+	if _, uErr := r.Tasks.ApplyStatusEffect(taskID, task.StatusEffect{
+		Source: "recovery.restart-stale.start-failure",
+		Update: update,
+	}); uErr != nil {
 		r.Logger.Error("restart-stale.surface", "task_id", taskID, "err", uErr)
 	}
 }

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -1085,9 +1085,12 @@ func (r *Handler) advanceClosedTaskPR(ctx context.Context, c github.ClosedPR, co
 	// not an operator click, so it classifies the same as auto_recovery.
 	transition := func() error {
 		preTask, preErr := r.tasks.Get(c.TaskID)
-		if _, err := r.tasks.Update(c.TaskID, task.Update{
-			Status:  task.Ptr(landedStatus),
-			Outcome: task.Ptr(base),
+		if _, err := r.tasks.ApplyStatusEffect(c.TaskID, task.StatusEffect{
+			Source: "review.pr-monitor.closed-pr",
+			Update: task.Update{
+				Status:  task.Ptr(landedStatus),
+				Outcome: task.Ptr(base),
+			},
 		}); err != nil {
 			return err
 		}
@@ -1528,9 +1531,12 @@ func (r *Handler) cancelResolvedPRFixWorkflows(tasks []task.Task, issues []githu
 		}
 		status := task.StatusInReview
 		statusReason := "pr-fix cancelled: " + reason + " resolved"
-		if _, updErr := r.tasks.Update(t.ID, task.Update{
-			Status:       &status,
-			StatusReason: &statusReason,
+		if _, updErr := r.tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+			Source: "review.pr-monitor.cancel-resolved",
+			Update: task.Update{
+				Status:       &status,
+				StatusReason: &statusReason,
+			},
 		}); updErr != nil {
 			r.logger.Error("pr-monitor.cancel-resolved.status", "task_id", t.ID, "kind", reason, "err", updErr)
 			continue
@@ -1843,10 +1849,13 @@ func (r *Handler) adoptOrphanPRs(ctx context.Context, tasks []task.Task, prs []g
 			continue
 		}
 		if match != nil {
-			updated, err := r.tasks.Update(t.ID, task.Update{
-				PRNumber:     task.Ptr(match.Number),
-				Status:       task.Ptr(task.StatusInReview),
-				StatusReason: task.Ptr(""),
+			updated, err := r.tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+				Source: "review.pr-monitor.orphan-adopt",
+				Update: task.Update{
+					PRNumber:     task.Ptr(match.Number),
+					Status:       task.Ptr(task.StatusInReview),
+					StatusReason: task.Ptr(""),
+				},
 			})
 			if err != nil {
 				r.logger.Error("pr-monitor.orphan-adopt", "task_id", t.ID, "pr", match.Number, "err", err)
@@ -1943,11 +1952,14 @@ func (r *Handler) adoptOrphanMergedPR(ctx context.Context, t *task.Task) {
 	taskID, repo, branch := t.ID, t.ProjectID, t.Branch
 	const state = "MERGED"
 	base := classifyLandingOutcome(state)
-	updated, err := r.tasks.Update(taskID, task.Update{
-		PRNumber:     task.Ptr(prNum),
-		Status:       task.Ptr(task.StatusDone),
-		Outcome:      task.Ptr(base),
-		StatusReason: task.Ptr(""),
+	updated, err := r.tasks.ApplyStatusEffect(taskID, task.StatusEffect{
+		Source: "review.pr-monitor.orphan-merged-adopt",
+		Update: task.Update{
+			PRNumber:     task.Ptr(prNum),
+			Status:       task.Ptr(task.StatusDone),
+			Outcome:      task.Ptr(base),
+			StatusReason: task.Ptr(""),
+		},
 	})
 	if err != nil {
 		r.logger.Error("pr-monitor.orphan-merged-adopt", "task_id", taskID, "pr", prNum, "err", err)

--- a/internal/sybra/review/outbound.go
+++ b/internal/sybra/review/outbound.go
@@ -107,7 +107,10 @@ func (r *Handler) cancelSettledImplementationWorkflows(ctx context.Context, task
 		if t.PRNumber == 0 && pr.Number > 0 {
 			upd.PRNumber = task.Ptr(pr.Number)
 		}
-		updated, err := r.tasks.Update(t.ID, upd)
+		updated, err := r.tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+			Source: "review.pr-monitor.cancel-implement",
+			Update: upd,
+		})
 		if err != nil {
 			r.logger.Error("pr-monitor.cancel-implement.status", "task_id", t.ID, "pr", pr.Number, "err", err)
 			continue
@@ -287,9 +290,12 @@ func (r *Handler) reactivateLinkedOwnPR(t *task.Task, livePR bool) *task.Task {
 	if !linkedOwnPRHumanRequiredDrift(t, livePR) {
 		return nil
 	}
-	updated, err := r.tasks.Update(t.ID, task.Update{
-		Status:       task.Ptr(task.StatusInReview),
-		StatusReason: task.Ptr(""),
+	updated, err := r.tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+		Source: "review.pr-monitor.reactivate-linked-pr",
+		Update: task.Update{
+			Status:       task.Ptr(task.StatusInReview),
+			StatusReason: task.Ptr(""),
+		},
 	})
 	if err != nil {
 		r.logger.Error("pr-monitor.reactivate-linked-pr", "task_id", t.ID, "pr", t.PRNumber, "err", err)
@@ -550,10 +556,13 @@ func (r *Handler) reconcileHumanRequiredBlockers(tasks []task.Task, monitoredPRs
 		priorReason := t.StatusReason
 		preTask := *t
 		tags := append(append([]string{}, t.Tags...), reconciledLatchTag)
-		updated, err := r.tasks.Update(t.ID, task.Update{
-			Status:       task.Ptr(task.StatusInReview),
-			StatusReason: task.Ptr(""),
-			Tags:         task.Ptr(tags),
+		updated, err := r.tasks.ApplyStatusEffect(t.ID, task.StatusEffect{
+			Source: "review.pr-monitor.reconcile-blocker",
+			Update: task.Update{
+				Status:       task.Ptr(task.StatusInReview),
+				StatusReason: task.Ptr(""),
+				Tags:         task.Ptr(tags),
+			},
 		})
 		if err != nil {
 			r.logger.Error("pr-monitor.reconcile-blocker", "task_id", t.ID, "pr", t.PRNumber, "err", err)

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -488,12 +488,16 @@ type Task struct {
 	// so route_test_result can exclude test-runner runs from prior cycles when
 	// counting toward TestingMaxAttempts. Nil means no re-dispatch has occurred
 	// and all test-runner runs count (correct for first-ever cycles).
-	TestingCycleStartedAt *time.Time          `json:"testingCycleStartedAt,omitempty"`
-	Attachments           []Attachment        `json:"attachments"`
-	AgentRuns             []AgentRun          `json:"agentRuns"`
-	Workflow              *workflow.Execution `json:"workflow,omitempty"`
-	CreatedAt             time.Time           `json:"createdAt"`
-	UpdatedAt             time.Time           `json:"updatedAt"`
+	TestingCycleStartedAt *time.Time   `json:"testingCycleStartedAt,omitempty"`
+	Attachments           []Attachment `json:"attachments"`
+	AgentRuns             []AgentRun   `json:"agentRuns"`
+	// EffectLog records durable intent/completion for observer-owned task
+	// status effects (pollers, monitor, recovery) that operate outside a live
+	// workflow execution.
+	EffectLog []workflow.EffectRecord `json:"effectLog,omitempty"`
+	Workflow  *workflow.Execution     `json:"workflow,omitempty"`
+	CreatedAt time.Time               `json:"createdAt"`
+	UpdatedAt time.Time               `json:"updatedAt"`
 	// StatusChangedAt marks the last time Status actually transitioned, as
 	// opposed to UpdatedAt which is bumped by any field write (tags, audit
 	// sidecars, status_reason, ...). Detectors that need to know "how long

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -30,44 +30,45 @@ type taskFrontmatter struct {
 	// Blocker matches Task's value type (not a pointer): blocker.State
 	// implements IsZeroer, so yaml.v3's omitempty already skips a zero value
 	// without needing pointer indirection to distinguish "unset" from "set".
-	Blocker                blocker.State       `yaml:"blocker,omitempty"`
-	HandoffSourceProvider  string              `yaml:"handoff_source_provider,omitempty"`
-	BlockedByIssue         string              `yaml:"blocked_by_issue,omitempty"`
-	UmbrellaIssue          string              `yaml:"umbrella_issue,omitempty"`
-	RefIssue               string              `yaml:"ref_issue,omitempty"`
-	DependsOn              []string            `yaml:"depends_on,omitempty"`
-	DependsOnConditions    []DepCondition      `yaml:"depends_on_conditions,omitempty"`
-	Reviewed               bool                `yaml:"reviewed,omitempty"`
-	RunRole                string              `yaml:"run_role,omitempty"`
-	SupervisorSteer        string              `yaml:"supervisor_steer,omitempty"`
-	ReviewPhase            string              `yaml:"review_phase,omitempty"`
-	ReviewedHeadSHA        string              `yaml:"reviewed_head_sha,omitempty"`
-	ReviewedHeadAttempts   int                 `yaml:"reviewed_head_attempts,omitempty"`
-	ReconcileFailures      int                 `yaml:"reconcile_failures,omitempty"`
-	PRPhase                string              `yaml:"pr_phase,omitempty"`
-	Priority               Priority            `yaml:"priority,omitempty"`
-	DueDate                *time.Time          `yaml:"due_date,omitempty"`
-	ClosedAt               *time.Time          `yaml:"closed_at,omitempty"`
-	Outcome                string              `yaml:"outcome,omitempty"`
-	MergeCommit            string              `yaml:"merge_commit,omitempty"`
-	MaxTurns               int                 `yaml:"max_turns,omitempty"`
-	RequirePermissions     *bool               `yaml:"require_permissions,omitempty"`
-	HeadlessPermissionMode string              `yaml:"headless_permission_mode,omitempty"`
-	ForkSubagent           bool                `yaml:"fork_subagent,omitempty"`
-	Sandbox                *bool               `yaml:"sandbox,omitempty"`
-	ReasoningEffort        string              `yaml:"reasoning_effort,omitempty"`
-	TestingCycleStartedAt  *time.Time          `yaml:"testing_cycle_started_at,omitempty"`
-	Attachments            []Attachment        `yaml:"attachments,omitempty"`
-	AgentRuns              []agentRunRecord    `yaml:"agent_runs,omitempty"`
-	Workflow               *workflow.Execution `yaml:"workflow,omitempty"`
-	CreatedAt              time.Time           `yaml:"created_at"`
-	UpdatedAt              time.Time           `yaml:"updated_at"`
-	StatusChangedAt        time.Time           `yaml:"status_changed_at,omitempty"`
-	AssignedNode           string              `yaml:"assigned_node,omitempty"`
-	NodeOverride           string              `yaml:"node_override,omitempty"`
-	Generation             int64               `yaml:"generation,omitempty"`
-	MirrorRev              int64               `yaml:"mirror_rev,omitempty"`
-	MirrorUpdatedAt        *time.Time          `yaml:"mirror_updated_at,omitempty"`
+	Blocker                blocker.State           `yaml:"blocker,omitempty"`
+	HandoffSourceProvider  string                  `yaml:"handoff_source_provider,omitempty"`
+	BlockedByIssue         string                  `yaml:"blocked_by_issue,omitempty"`
+	UmbrellaIssue          string                  `yaml:"umbrella_issue,omitempty"`
+	RefIssue               string                  `yaml:"ref_issue,omitempty"`
+	DependsOn              []string                `yaml:"depends_on,omitempty"`
+	DependsOnConditions    []DepCondition          `yaml:"depends_on_conditions,omitempty"`
+	Reviewed               bool                    `yaml:"reviewed,omitempty"`
+	RunRole                string                  `yaml:"run_role,omitempty"`
+	SupervisorSteer        string                  `yaml:"supervisor_steer,omitempty"`
+	ReviewPhase            string                  `yaml:"review_phase,omitempty"`
+	ReviewedHeadSHA        string                  `yaml:"reviewed_head_sha,omitempty"`
+	ReviewedHeadAttempts   int                     `yaml:"reviewed_head_attempts,omitempty"`
+	ReconcileFailures      int                     `yaml:"reconcile_failures,omitempty"`
+	PRPhase                string                  `yaml:"pr_phase,omitempty"`
+	Priority               Priority                `yaml:"priority,omitempty"`
+	DueDate                *time.Time              `yaml:"due_date,omitempty"`
+	ClosedAt               *time.Time              `yaml:"closed_at,omitempty"`
+	Outcome                string                  `yaml:"outcome,omitempty"`
+	MergeCommit            string                  `yaml:"merge_commit,omitempty"`
+	MaxTurns               int                     `yaml:"max_turns,omitempty"`
+	RequirePermissions     *bool                   `yaml:"require_permissions,omitempty"`
+	HeadlessPermissionMode string                  `yaml:"headless_permission_mode,omitempty"`
+	ForkSubagent           bool                    `yaml:"fork_subagent,omitempty"`
+	Sandbox                *bool                   `yaml:"sandbox,omitempty"`
+	ReasoningEffort        string                  `yaml:"reasoning_effort,omitempty"`
+	TestingCycleStartedAt  *time.Time              `yaml:"testing_cycle_started_at,omitempty"`
+	Attachments            []Attachment            `yaml:"attachments,omitempty"`
+	AgentRuns              []agentRunRecord        `yaml:"agent_runs,omitempty"`
+	EffectLog              []workflow.EffectRecord `yaml:"effect_log,omitempty"`
+	Workflow               *workflow.Execution     `yaml:"workflow,omitempty"`
+	CreatedAt              time.Time               `yaml:"created_at"`
+	UpdatedAt              time.Time               `yaml:"updated_at"`
+	StatusChangedAt        time.Time               `yaml:"status_changed_at,omitempty"`
+	AssignedNode           string                  `yaml:"assigned_node,omitempty"`
+	NodeOverride           string                  `yaml:"node_override,omitempty"`
+	Generation             int64                   `yaml:"generation,omitempty"`
+	MirrorRev              int64                   `yaml:"mirror_rev,omitempty"`
+	MirrorUpdatedAt        *time.Time              `yaml:"mirror_updated_at,omitempty"`
 }
 
 type agentRunRecord struct {
@@ -156,6 +157,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		TestingCycleStartedAt:  fm.TestingCycleStartedAt,
 		Attachments:            fm.Attachments,
 		Workflow:               fm.Workflow,
+		EffectLog:              fm.EffectLog,
 		CreatedAt:              fm.CreatedAt,
 		UpdatedAt:              fm.UpdatedAt,
 		StatusChangedAt:        fm.StatusChangedAt,
@@ -229,6 +231,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		TestingCycleStartedAt:  t.TestingCycleStartedAt,
 		Attachments:            t.Attachments,
 		AgentRuns:              agentRunRecordsFromRuns(t.AgentRuns),
+		EffectLog:              t.EffectLog,
 		Workflow:               t.Workflow,
 		CreatedAt:              t.CreatedAt,
 		UpdatedAt:              t.UpdatedAt,

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -101,6 +101,19 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 			HeadSHA:                 "def456",
 			SubagentCallCount:       2,
 		}},
+		EffectLog: []workflow.EffectRecord{{
+			ID: workflow.EffectID{
+				Generation: 2,
+				StepSeq:    4,
+				StepID:     "external:review_pr_monitor:deadbeef",
+				Pos:        0,
+			},
+			IntentAt: now.Add(-15 * time.Minute),
+			CompletedAt: func() *time.Time {
+				t := now.Add(-14 * time.Minute)
+				return &t
+			}(),
+		}},
 		Workflow: &workflow.Execution{
 			WorkflowID:  "workflow-1",
 			CurrentStep: "step-1",
@@ -341,6 +354,20 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 			TestFailureFingerprint:  "fp",
 			HeadSHA:                 "def456",
 			SubagentCallCount:       2,
+		}}
+	case "EffectLog":
+		task.EffectLog = []workflow.EffectRecord{{
+			ID: workflow.EffectID{
+				Generation: 3,
+				StepSeq:    9,
+				StepID:     "external:test:deadbeef",
+				Pos:        0,
+			},
+			IntentAt: now,
+			CompletedAt: func() *time.Time {
+				t := now.Add(time.Minute)
+				return &t
+			}(),
 		}}
 	case "Workflow":
 		task.Workflow = &workflow.Execution{

--- a/internal/task/status_effect.go
+++ b/internal/task/status_effect.go
@@ -23,8 +23,9 @@ type StatusEffect struct {
 }
 
 // ApplyStatusEffect applies a poller/watchdog/recovery-owned status mutation
-// exactly once per logical effect signature. Replays of the same Source+Update
-// reuse the same effect identity and become a no-op after completion.
+// exactly once per consumed task generation and logical effect signature.
+// Replays of the same Source+Update after completion become a no-op until
+// another task mutation advances the generation.
 func (m *Manager) ApplyStatusEffect(id string, eff StatusEffect) (Task, error) {
 	source := strings.TrimSpace(eff.Source)
 	if source == "" {
@@ -44,14 +45,14 @@ func (m *Manager) ApplyStatusEffect(id string, eff StatusEffect) (Task, error) {
 	}
 
 	stepID := statusEffectStepID(source, eff.Update)
-	if statusEffectApplied(cur.EffectLog, stepID) {
+	if statusEffectApplied(cur.EffectLog, cur.Generation-1, stepID) {
 		mu.Unlock()
 		return cur, nil
 	}
 
 	now := time.Now().UTC()
 	log := slices.Clone(cur.EffectLog)
-	idempotencyID, ok := statusEffectIDForStep(log, stepID)
+	idempotencyID, ok := statusEffectIDForStep(log, cur.Generation, stepID)
 	if !ok {
 		idempotencyID = workflow.EffectID{
 			Generation: cur.Generation,
@@ -97,18 +98,18 @@ func (m *Manager) ApplyStatusEffect(id string, eff StatusEffect) (Task, error) {
 	return t, nil
 }
 
-func statusEffectApplied(log []workflow.EffectRecord, stepID string) bool {
+func statusEffectApplied(log []workflow.EffectRecord, generation int64, stepID string) bool {
 	for i := range slices.Backward(log) {
-		if log[i].ID.StepID == stepID && log[i].CompletedAt != nil {
+		if log[i].ID.Generation == generation && log[i].ID.StepID == stepID && log[i].CompletedAt != nil {
 			return true
 		}
 	}
 	return false
 }
 
-func statusEffectIDForStep(log []workflow.EffectRecord, stepID string) (workflow.EffectID, bool) {
+func statusEffectIDForStep(log []workflow.EffectRecord, generation int64, stepID string) (workflow.EffectID, bool) {
 	for i := range slices.Backward(log) {
-		if log[i].ID.StepID == stepID {
+		if log[i].ID.Generation == generation && log[i].ID.StepID == stepID {
 			return log[i].ID, true
 		}
 	}

--- a/internal/task/status_effect.go
+++ b/internal/task/status_effect.go
@@ -1,0 +1,220 @@
+package task
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+// StatusEffect is one observer-owned task mutation recorded durably in
+// Task.EffectLog before it is considered applied.
+type StatusEffect struct {
+	Source string
+	Update Update
+}
+
+// ApplyStatusEffect applies a poller/watchdog/recovery-owned status mutation
+// exactly once per logical effect signature. Replays of the same Source+Update
+// reuse the same effect identity and become a no-op after completion.
+func (m *Manager) ApplyStatusEffect(id string, eff StatusEffect) (Task, error) {
+	source := strings.TrimSpace(eff.Source)
+	if source == "" {
+		return Task{}, fmt.Errorf("apply status effect: source is required")
+	}
+	if eff.Update.Status == nil {
+		return Task{}, fmt.Errorf("apply status effect: update.status is required")
+	}
+
+	mu := m.lockFor(id)
+	mu.Lock()
+
+	cur, err := m.store.Get(id)
+	if err != nil {
+		mu.Unlock()
+		return Task{}, err
+	}
+
+	stepID := statusEffectStepID(source, eff.Update)
+	if statusEffectApplied(cur.EffectLog, stepID) {
+		mu.Unlock()
+		return cur, nil
+	}
+
+	now := time.Now().UTC()
+	log := slices.Clone(cur.EffectLog)
+	idempotencyID, ok := statusEffectIDForStep(log, stepID)
+	if !ok {
+		idempotencyID = workflow.EffectID{
+			Generation: cur.Generation,
+			StepSeq:    nextStatusEffectSeq(cur),
+			StepID:     stepID,
+			Pos:        0,
+		}
+	}
+	record := workflow.EffectRecord{
+		ID:       idempotencyID,
+		IntentAt: now,
+	}
+	record.CompletedAt = &now
+	log = append(log, record)
+
+	u := eff.Update
+	u.EffectLog = &log
+	t, prev, err := m.store.UpdateWithPrev(id, u)
+	if err != nil {
+		mu.Unlock()
+		return Task{}, err
+	}
+
+	var (
+		fireHook            bool
+		prevStatus, newStat string
+	)
+	if m.onStatusHook != nil {
+		prevStatus = string(prev)
+		newStat = string(t.Status)
+		fireHook = newStat != prevStatus
+	}
+	if fireHook {
+		m.recordFiredStatus(id, newStat)
+	}
+	mu.Unlock()
+
+	if fireHook {
+		m.onStatusHook(id, prevStatus, newStat)
+	}
+	metrics.TaskUpdated()
+	m.emitter.Emit(events.TaskUpdated, t.FilePath)
+	return t, nil
+}
+
+func statusEffectApplied(log []workflow.EffectRecord, stepID string) bool {
+	for i := range slices.Backward(log) {
+		if log[i].ID.StepID == stepID && log[i].CompletedAt != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func statusEffectIDForStep(log []workflow.EffectRecord, stepID string) (workflow.EffectID, bool) {
+	for i := range slices.Backward(log) {
+		if log[i].ID.StepID == stepID {
+			return log[i].ID, true
+		}
+	}
+	return workflow.EffectID{}, false
+}
+
+func nextStatusEffectSeq(t Task) int {
+	maxSeq := 0
+	for i := range t.EffectLog {
+		if t.EffectLog[i].ID.StepSeq > maxSeq {
+			maxSeq = t.EffectLog[i].ID.StepSeq
+		}
+	}
+	if t.Workflow != nil {
+		for i := range t.Workflow.EffectLog {
+			if t.Workflow.EffectLog[i].ID.StepSeq > maxSeq {
+				maxSeq = t.Workflow.EffectLog[i].ID.StepSeq
+			}
+		}
+	}
+	return maxSeq + 1
+}
+
+func statusEffectStepID(source string, u Update) string {
+	var b strings.Builder
+	writeStatusEffectField(&b, "status", statusValue(u.Status))
+	writeStatusEffectField(&b, "status_reason", stringValue(u.StatusReason))
+	writeStatusEffectField(&b, "pr_number", intValue(u.PRNumber))
+	writeStatusEffectField(&b, "outcome", stringValue(u.Outcome))
+	writeStatusEffectField(&b, "merge_commit", stringValue(u.MergeCommit))
+	writeStatusEffectField(&b, "tags", tagsValue(u.Tags))
+	writeStatusEffectField(&b, "blocker", blockerValue(u.Blocker))
+	sum := sha256.Sum256([]byte(b.String()))
+	return "external:" + sanitizeEffectSource(source) + ":" + hex.EncodeToString(sum[:6])
+}
+
+func writeStatusEffectField(b *strings.Builder, key, value string) {
+	b.WriteString(key)
+	b.WriteByte('=')
+	b.WriteString(value)
+	b.WriteByte('\n')
+}
+
+func sanitizeEffectSource(source string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(source) {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+		if b.Len() >= 32 {
+			break
+		}
+	}
+	if b.Len() == 0 {
+		return "effect"
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func statusValue(v *Status) string {
+	if v == nil {
+		return "<unset>"
+	}
+	return string(*v)
+}
+
+func stringValue(v *string) string {
+	if v == nil {
+		return "<unset>"
+	}
+	return *v
+}
+
+func intValue(v *int) string {
+	if v == nil {
+		return "<unset>"
+	}
+	return strconv.Itoa(*v)
+}
+
+func tagsValue(v *[]string) string {
+	if v == nil {
+		return "<unset>"
+	}
+	return strings.Join(*v, ",")
+}
+
+func blockerValue(v *blocker.State) string {
+	if v == nil {
+		return "<unset>"
+	}
+	retryAfter := ""
+	if v.RetryAfter != nil {
+		retryAfter = v.RetryAfter.UTC().Format(time.RFC3339Nano)
+	}
+	return strings.Join([]string{
+		string(v.Kind),
+		string(v.Actor),
+		v.Code,
+		v.NextAction,
+		retryAfter,
+		strconv.FormatBool(v.Exhausted),
+	}, "|")
+}

--- a/internal/task/status_effect.go
+++ b/internal/task/status_effect.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
+const maxTaskEffectLog = 200
+
 // StatusEffect is one observer-owned task mutation recorded durably in
 // Task.EffectLog before it is considered applied.
 type StatusEffect struct {
@@ -67,6 +69,9 @@ func (m *Manager) ApplyStatusEffect(id string, eff StatusEffect) (Task, error) {
 	}
 	record.CompletedAt = &now
 	log = append(log, record)
+	if len(log) > maxTaskEffectLog {
+		log = log[len(log)-maxTaskEffectLog:]
+	}
 
 	u := eff.Update
 	u.EffectLog = &log
@@ -171,7 +176,11 @@ func sanitizeEffectSource(source string) string {
 	if b.Len() == 0 {
 		return "effect"
 	}
-	return strings.Trim(b.String(), "_")
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "effect"
+	}
+	return out
 }
 
 func statusValue(v *Status) string {
@@ -199,7 +208,9 @@ func tagsValue(v *[]string) string {
 	if v == nil {
 		return "<unset>"
 	}
-	return strings.Join(*v, ",")
+	tags := slices.Clone(*v)
+	slices.Sort(tags)
+	return strings.Join(tags, ",")
 }
 
 func blockerValue(v *blocker.State) string {

--- a/internal/task/status_effect_test.go
+++ b/internal/task/status_effect_test.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/events"
@@ -147,5 +149,65 @@ func TestManagerApplyStatusEffect_ReappliesAfterGenerationChange(t *testing.T) {
 	}
 	if second.EffectLog[1].ID.StepSeq == first.EffectLog[0].ID.StepSeq {
 		t.Fatalf("second effect step seq = %d, want new seq", second.EffectLog[1].ID.StepSeq)
+	}
+}
+
+func TestManagerApplyStatusEffect_TrimsEffectLog(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	created, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got := created
+	for i := 0; i < maxTaskEffectLog+5; i++ {
+		got, err = m.ApplyStatusEffect(created.ID, StatusEffect{
+			Source: fmt.Sprintf("watchdog.run.%03d", i),
+			Update: Update{
+				Status:       Ptr(StatusTodo),
+				StatusReason: Ptr(fmt.Sprintf("reason-%03d", i)),
+			},
+		})
+		if err != nil {
+			t.Fatalf("ApplyStatusEffect(%d): %v", i, err)
+		}
+	}
+
+	if len(got.EffectLog) != maxTaskEffectLog {
+		t.Fatalf("effect log len = %d, want %d", len(got.EffectLog), maxTaskEffectLog)
+	}
+	if got.EffectLog[0].ID.StepSeq != 6 {
+		t.Fatalf("first retained step seq = %d, want 6 after trimming 5 oldest records", got.EffectLog[0].ID.StepSeq)
+	}
+	if got.EffectLog[len(got.EffectLog)-1].ID.StepSeq != maxTaskEffectLog+5 {
+		t.Fatalf("last retained step seq = %d, want %d", got.EffectLog[len(got.EffectLog)-1].ID.StepSeq, maxTaskEffectLog+5)
+	}
+}
+
+func TestStatusEffectStepID_NormalizesTagOrder(t *testing.T) {
+	t.Parallel()
+
+	left := statusEffectStepID("watchdog.runrate", Update{
+		Status: Ptr(StatusBlocked),
+		Tags:   Ptr([]string{"backend", "bug"}),
+	})
+	right := statusEffectStepID("watchdog.runrate", Update{
+		Status: Ptr(StatusBlocked),
+		Tags:   Ptr([]string{"bug", "backend"}),
+	})
+
+	if left != right {
+		t.Fatalf("step IDs differ for reordered tags: %q vs %q", left, right)
+	}
+}
+
+func TestStatusEffectStepID_FallsBackForPunctuationOnlySource(t *testing.T) {
+	t.Parallel()
+
+	stepID := statusEffectStepID("---", Update{Status: Ptr(StatusDone)})
+	if !strings.HasPrefix(stepID, "external:effect:") {
+		t.Fatalf("step ID = %q, want external:effect: prefix", stepID)
 	}
 }

--- a/internal/task/status_effect_test.go
+++ b/internal/task/status_effect_test.go
@@ -93,3 +93,59 @@ func TestManagerApplyStatusEffect_DedupesCompletedEffect(t *testing.T) {
 		t.Fatalf("events = %v, want only create+first update", names)
 	}
 }
+
+func TestManagerApplyStatusEffect_ReappliesAfterGenerationChange(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	created, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	eff := StatusEffect{
+		Source: "recovery.start-failure",
+		Update: Update{
+			Status:       Ptr(StatusHumanRequired),
+			StatusReason: Ptr("agent start failed"),
+		},
+	}
+	first, err := m.ApplyStatusEffect(created.ID, eff)
+	if err != nil {
+		t.Fatalf("first ApplyStatusEffect: %v", err)
+	}
+	if first.Status != StatusHumanRequired {
+		t.Fatalf("first status = %q, want %q", first.Status, StatusHumanRequired)
+	}
+
+	retried, err := m.Update(created.ID, Update{
+		Status:       Ptr(StatusInProgress),
+		StatusReason: Ptr(""),
+	})
+	if err != nil {
+		t.Fatalf("retry Update: %v", err)
+	}
+	if retried.Generation == first.EffectLog[0].ID.Generation {
+		t.Fatalf("retry generation = %d, want different from first effect generation", retried.Generation)
+	}
+
+	second, err := m.ApplyStatusEffect(created.ID, eff)
+	if err != nil {
+		t.Fatalf("second ApplyStatusEffect: %v", err)
+	}
+	if second.Status != StatusHumanRequired {
+		t.Fatalf("second status = %q, want %q", second.Status, StatusHumanRequired)
+	}
+	if len(second.EffectLog) != 2 {
+		t.Fatalf("effect log len after retry = %d, want 2", len(second.EffectLog))
+	}
+	if second.EffectLog[1].ID.Generation != retried.Generation {
+		t.Fatalf("second effect generation = %d, want retry generation %d", second.EffectLog[1].ID.Generation, retried.Generation)
+	}
+	if second.EffectLog[1].ID.StepID != first.EffectLog[0].ID.StepID {
+		t.Fatalf("second effect step id = %q, want %q", second.EffectLog[1].ID.StepID, first.EffectLog[0].ID.StepID)
+	}
+	if second.EffectLog[1].ID.StepSeq == first.EffectLog[0].ID.StepSeq {
+		t.Fatalf("second effect step seq = %d, want new seq", second.EffectLog[1].ID.StepSeq)
+	}
+}

--- a/internal/task/status_effect_test.go
+++ b/internal/task/status_effect_test.go
@@ -162,7 +162,7 @@ func TestManagerApplyStatusEffect_TrimsEffectLog(t *testing.T) {
 	}
 
 	got := created
-	for i := 0; i < maxTaskEffectLog+5; i++ {
+	for i := range maxTaskEffectLog + 5 {
 		got, err = m.ApplyStatusEffect(created.ID, StatusEffect{
 			Source: fmt.Sprintf("watchdog.run.%03d", i),
 			Update: Update{

--- a/internal/task/status_effect_test.go
+++ b/internal/task/status_effect_test.go
@@ -1,0 +1,95 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/events"
+)
+
+func TestManagerApplyStatusEffect_RecordsEffectAndFiresHookOnce(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	var transitions []string
+	m.SetStatusChangeHook(func(_ string, from, to string) {
+		transitions = append(transitions, from+"->"+to)
+	})
+
+	created, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated, err := m.ApplyStatusEffect(created.ID, StatusEffect{
+		Source: "review.pr-monitor.closed-pr",
+		Update: Update{
+			Status:       Ptr(StatusDone),
+			StatusReason: Ptr(""),
+			Outcome:      Ptr("merged"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyStatusEffect: %v", err)
+	}
+	if updated.Status != StatusDone {
+		t.Fatalf("status = %q, want %q", updated.Status, StatusDone)
+	}
+	if updated.Outcome != "merged" {
+		t.Fatalf("outcome = %q, want merged", updated.Outcome)
+	}
+	if len(updated.EffectLog) != 1 {
+		t.Fatalf("effect log len = %d, want 1", len(updated.EffectLog))
+	}
+	if updated.EffectLog[0].CompletedAt == nil {
+		t.Fatal("completed_at not recorded")
+	}
+	if updated.EffectLog[0].ID.Generation != created.Generation {
+		t.Fatalf("effect generation = %d, want %d", updated.EffectLog[0].ID.Generation, created.Generation)
+	}
+	if len(transitions) != 1 || transitions[0] != "todo->done" {
+		t.Fatalf("transitions = %v, want [todo->done]", transitions)
+	}
+
+	names := emitter.names()
+	if len(names) != 2 || names[1] != events.TaskUpdated {
+		t.Fatalf("events = %v, want create+update", names)
+	}
+}
+
+func TestManagerApplyStatusEffect_DedupesCompletedEffect(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	created, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	eff := StatusEffect{
+		Source: "review.pr-monitor.closed-pr",
+		Update: Update{
+			Status:       Ptr(StatusDone),
+			StatusReason: Ptr(""),
+			Outcome:      Ptr("merged"),
+		},
+	}
+	first, err := m.ApplyStatusEffect(created.ID, eff)
+	if err != nil {
+		t.Fatalf("first ApplyStatusEffect: %v", err)
+	}
+	second, err := m.ApplyStatusEffect(created.ID, eff)
+	if err != nil {
+		t.Fatalf("second ApplyStatusEffect: %v", err)
+	}
+	if len(second.EffectLog) != 1 {
+		t.Fatalf("effect log len after replay = %d, want 1", len(second.EffectLog))
+	}
+	if second.Generation != first.Generation {
+		t.Fatalf("generation after replay = %d, want unchanged %d", second.Generation, first.Generation)
+	}
+
+	names := emitter.names()
+	if len(names) != 2 {
+		t.Fatalf("events = %v, want only create+first update", names)
+	}
+}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -892,6 +892,9 @@ func applyUpdateFields(t *Task, u Update) error {
 	if u.Attachments != nil {
 		t.Attachments = slices.Clone(*u.Attachments)
 	}
+	if u.EffectLog != nil {
+		t.EffectLog = slices.Clone(*u.EffectLog)
+	}
 	return nil
 }
 

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -61,6 +61,7 @@ type Update struct {
 	MergeCommit           *string
 	TestingCycleStartedAt *time.Time
 	Attachments           *[]Attachment
+	EffectLog             *[]workflow.EffectRecord
 }
 
 func (u Update) writesSidecar() bool {

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -240,6 +240,17 @@ type Watchdog struct {
 	verifyNow func(ctx context.Context, taskID string) (verified, passed bool, failedCmd, output string, err error)
 }
 
+func (w *Watchdog) applyStatusEffect(taskID, source string, status task.Status, reason string) error {
+	_, err := w.tasks.ApplyStatusEffect(taskID, task.StatusEffect{
+		Source: source,
+		Update: task.Update{
+			Status:       task.Ptr(status),
+			StatusReason: task.Ptr(reason),
+		},
+	})
+	return err
+}
+
 // New creates a Watchdog. cfg.Model selects the cheap judge model and
 // cfg.LoopThreshold tunes the real-time loop trigger.
 func New(
@@ -597,10 +608,7 @@ func (w *Watchdog) hardStop(ag *agent.Agent, reason string, stall, total time.Du
 		"id", ag.ID, "task_id", ag.TaskID, "reason", reason,
 		"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
 	if ag.TaskID != "" {
-		if _, err := w.tasks.Update(ag.TaskID, task.Update{
-			Status:       task.Ptr(task.StatusInProgress),
-			StatusReason: task.Ptr("watchdog hang: " + reason + " deadline exceeded"),
-		}); err != nil {
+		if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.hard-stop", task.StatusInProgress, "watchdog hang: "+reason+" deadline exceeded"); err != nil {
 			w.logger.Error("agent.watchdog.hard_deadline.task.update", "task_id", ag.TaskID, "err", err)
 		}
 	}
@@ -729,10 +737,7 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 					reason = "watchdog: " + verdict.Reason
 				}
 			}
-			if _, err := w.tasks.Update(ag.TaskID, task.Update{
-				Status:       task.Ptr(status),
-				StatusReason: task.Ptr(reason),
-			}); err != nil {
+			if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.stop", status, reason); err != nil {
 				w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 			}
 		}
@@ -801,10 +806,7 @@ func (w *Watchdog) stopAndVerifyAmbiguousLoop(ctx context.Context, ag *agent.Age
 	if trigger == "budget" {
 		judgeReason = watchdogreason.BudgetStop(verdict.Reason)
 	}
-	if _, err := w.tasks.Update(ag.TaskID, task.Update{
-		Status:       task.Ptr(task.StatusInProgress),
-		StatusReason: task.Ptr("watchdog hang: verifying before deciding — " + judgeReason),
-	}); err != nil {
+	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.verify.pending", task.StatusInProgress, "watchdog hang: verifying before deciding — "+judgeReason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	confirmedStopped := true
@@ -817,10 +819,7 @@ func (w *Watchdog) stopAndVerifyAmbiguousLoop(ctx context.Context, ag *agent.Age
 	if confirmedStopped {
 		status, reason = w.verdictStatusFromVerify(ctx, ag.TaskID, judgeReason)
 	}
-	if _, err := w.tasks.Update(ag.TaskID, task.Update{
-		Status:       task.Ptr(status),
-		StatusReason: task.Ptr(reason),
-	}); err != nil {
+	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.verify.result", status, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 }
@@ -876,10 +875,7 @@ func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict age
 	if ag.TaskID == "" {
 		w.logger.Warn("agent.watchdog.rate_limit.untracked",
 			"id", ag.ID, "trigger", trigger, "provider", ag.Provider, "reason", verdict.Reason)
-	} else if _, err := w.tasks.Update(ag.TaskID, task.Update{
-		Status:       task.Ptr(task.StatusInProgress),
-		StatusReason: task.Ptr(reason),
-	}); err != nil {
+	} else if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.rate-limit", task.StatusInProgress, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if w.recordProviderSignal != nil {
@@ -934,10 +930,7 @@ func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.Insp
 	if verdict.Reason != "" {
 		reason = rewardHackingRetryStatusReason + ": " + verdict.Reason
 	}
-	if _, err := w.tasks.Update(ag.TaskID, task.Update{
-		Status:       task.Ptr(task.StatusInProgress),
-		StatusReason: task.Ptr(reason),
-	}); err != nil {
+	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.reward-hacking-retry", task.StatusInProgress, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if err := w.stopAgent(ag.ID); err != nil {
@@ -975,10 +968,7 @@ func (w *Watchdog) handleZeroOutputStall(ag *agent.Agent, stall, total time.Dura
 	reason := watchdogreason.RateLimit(zeroOutputReason)
 	if ag.TaskID == "" {
 		w.logger.Warn("agent.watchdog.zero_output_stall.untracked", "id", ag.ID, "provider", ag.Provider)
-	} else if _, err := w.tasks.Update(ag.TaskID, task.Update{
-		Status:       task.Ptr(task.StatusInProgress),
-		StatusReason: task.Ptr(reason),
-	}); err != nil {
+	} else if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.zero-output-stall", task.StatusInProgress, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if w.recordProviderSignal != nil {

--- a/internal/watchdog/dwell.go
+++ b/internal/watchdog/dwell.go
@@ -82,10 +82,7 @@ func (w *Watchdog) checkDwell(now time.Time) {
 		w.logger.Info("watchdog.dwell.escalate",
 			"task_id", t.ID, "status", string(t.Status),
 			"dwell_h", now.Sub(t.UpdatedAt).Hours(), "budget_h", budget.Hours())
-		if _, err := w.tasks.Update(t.ID, task.Update{
-			Status:       task.Ptr(task.StatusHumanRequired),
-			StatusReason: task.Ptr(reason),
-		}); err != nil {
+		if err := w.applyStatusEffect(t.ID, "watchdog.dwell", task.StatusHumanRequired, reason); err != nil {
 			w.logger.Error("watchdog.dwell.update", "task_id", t.ID, "err", err)
 		}
 	}

--- a/internal/watchdog/dwell_test.go
+++ b/internal/watchdog/dwell_test.go
@@ -206,6 +206,7 @@ func TestCheckDwell_EscalatesWhenNoLiveHeadlessAgent(t *testing.T) {
 	if got.Status != task.StatusHumanRequired {
 		t.Fatalf("status = %q, want human-required when no live headless agent backs the task", got.Status)
 	}
+	assertWatchdogEffectRecorded(t, got, "external:watchdog_dwell:", tk.Generation)
 }
 
 func TestCheckDwell_EscalatesUnblockedInProgressTask(t *testing.T) {
@@ -242,4 +243,5 @@ func TestCheckDwell_EscalatesUnblockedInProgressTask(t *testing.T) {
 	if got.StatusReason == "dwell exceeded size tag budget" {
 		t.Fatalf("status reason still has hardcoded string; want budget-specific reason")
 	}
+	assertWatchdogEffectRecorded(t, got, "external:watchdog_dwell:", tk.Generation)
 }

--- a/internal/watchdog/runrate.go
+++ b/internal/watchdog/runrate.go
@@ -47,14 +47,16 @@ func (w *Watchdog) checkRunRate(now time.Time) {
 		reason := fmt.Sprintf("run_rate: %d %q runs within %v — dispatch loop suspected", count, role, w.runWindow)
 		w.logger.Info("watchdog.runrate.escalate",
 			"task_id", t.ID, "role", role, "count", count, "window_m", w.runWindow.Minutes())
-		if _, err := w.tasks.Update(t.ID, task.Update{
+		if err := w.applyStatusEffect(
+			t.ID,
+			"watchdog.runrate",
 			// A burst-loop breaker is a machine-stop condition, not a request
 			// for human triage. Parking it blocked prevents ResumeStalled and
 			// restart/reattach recovery from immediately re-dispatching the same
 			// storm again.
-			Status:       task.Ptr(task.StatusBlocked),
-			StatusReason: task.Ptr(reason),
-		}); err != nil {
+			task.StatusBlocked,
+			reason,
+		); err != nil {
 			w.logger.Error("watchdog.runrate.update", "task_id", t.ID, "err", err)
 		}
 	}

--- a/internal/watchdog/runrate_test.go
+++ b/internal/watchdog/runrate_test.go
@@ -9,6 +9,22 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+func assertWatchdogEffectRecorded(t *testing.T, got task.Task, wantPrefix string, wantGeneration int64) {
+	t.Helper()
+	if len(got.EffectLog) != 1 {
+		t.Fatalf("effect log len = %d, want 1", len(got.EffectLog))
+	}
+	if got.EffectLog[0].CompletedAt == nil {
+		t.Fatal("completed_at not recorded")
+	}
+	if got.EffectLog[0].ID.Generation != wantGeneration {
+		t.Fatalf("effect generation = %d, want %d", got.EffectLog[0].ID.Generation, wantGeneration)
+	}
+	if !strings.HasPrefix(got.EffectLog[0].ID.StepID, wantPrefix) {
+		t.Fatalf("effect step id = %q, want prefix %q", got.EffectLog[0].ID.StepID, wantPrefix)
+	}
+}
+
 func newInProgressTask(t *testing.T, mgr *task.Manager) task.Task {
 	t.Helper()
 	tk, err := mgr.Create("burst task", "## Description\nsome work", "headless")
@@ -60,6 +76,7 @@ func TestCheckRunRate_EscalatesBurstOfSameRole(t *testing.T) {
 	if !strings.Contains(got.StatusReason, "run_rate") || !strings.Contains(got.StatusReason, "implementation") {
 		t.Fatalf("status reason = %q, want it to mention run_rate and the role", got.StatusReason)
 	}
+	assertWatchdogEffectRecorded(t, got, "external:watchdog_runrate:", tk.Generation)
 }
 
 func TestCheckRunRate_SkipsBelowThreshold(t *testing.T) {
@@ -180,6 +197,7 @@ func TestCheckRunRate_EscalatesBurstOnInReviewTask(t *testing.T) {
 	if !strings.Contains(got.StatusReason, "run_rate") || !strings.Contains(got.StatusReason, "pr-fix") {
 		t.Fatalf("status reason = %q, want it to mention run_rate and pr-fix", got.StatusReason)
 	}
+	assertWatchdogEffectRecorded(t, got, "external:watchdog_runrate:", tk.Generation)
 }
 
 func TestCheckRunRate_DoesNotSumAcrossRoles(t *testing.T) {


### PR DESCRIPTION
## Motivation

Closes #2662. Pollers and watchdog were directly writing task state, creating concurrent writer races. This refactor moves them to observer-owned effect log entries, so state changes are serialized through the effect pipeline.

## Implementation information

- New persisted observer-owned effect log on tasks via `internal/task/status_effect.go`
- Status-effect dedupe is generation-aware, preserving immediate replay idempotency while allowing reapply after operator retry
- Regression test added for retry generation behavior

> Changelog: refactor(workflow): pollers and watchdog become observers, not writers

_Generated by Sybra harness_