### PR TITLE
feat(workflow): CAS/lease effect claiming

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -622,7 +622,9 @@ func runSignalKill() {
 func runHang() {
 	emitSystem()
 	emitAssistant("Hanging...")
-	select {} // block until SIGTERM/SIGKILL arrives
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 // runMalformedPROutput emits a long stream of malformed PR-URL fragments

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -264,6 +264,8 @@ export class EffectID {
 export class EffectRecord {
     "id": EffectID;
     "intentAt": string;
+    "owner"?: string;
+    "leaseExpiresAt"?: string | null;
     "completedAt"?: string | null;
 
     /** Creates a new EffectRecord instance. */

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -32,6 +32,8 @@ import (
 	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
+var errWorkflowEffectNoPersist = errors.New("workflow effect claim requires no persistence")
+
 // Compile-time interface checks.
 var (
 	_ workflow.TaskProvider           = (*taskAdapter)(nil)
@@ -244,6 +246,62 @@ func (a *taskAdapter) ReplaceTaskBody(id, body string) error {
 func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	_, err := a.tasks.Update(id, task.Update{Workflow: &wf})
 	return err
+}
+
+func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
+	var result workflow.EffectClaimResult
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if cur.Workflow == nil {
+			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
+		}
+		wf := cur.Workflow.Clone()
+		result.Workflow = wf
+		claimResult, claimErr := wf.ClaimEffect(claim)
+		claimResult.Workflow = wf
+		result = claimResult
+		if claimErr != nil {
+			if errors.Is(claimErr, workflow.ErrEffectClaimConflict) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				return task.Update{}, errWorkflowEffectNoPersist
+			}
+			return task.Update{}, claimErr
+		}
+		return task.Update{Workflow: &wf}, nil
+	})
+	if err != nil {
+		if errors.Is(err, errWorkflowEffectNoPersist) {
+			return result, nil
+		}
+		return workflow.EffectClaimResult{}, err
+	}
+	return result, nil
+}
+
+func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
+	var result workflow.EffectClaimResult
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if cur.Workflow == nil {
+			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
+		}
+		wf := cur.Workflow.Clone()
+		result.Workflow = wf
+		claimResult, claimErr := wf.CompleteEffect(claim)
+		claimResult.Workflow = wf
+		result = claimResult
+		if claimErr != nil {
+			if errors.Is(claimErr, workflow.ErrEffectClaimLost) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				return task.Update{}, errWorkflowEffectNoPersist
+			}
+			return task.Update{}, claimErr
+		}
+		return task.Update{Workflow: &wf}, nil
+	})
+	if err != nil {
+		if errors.Is(err, errWorkflowEffectNoPersist) {
+			return result, nil
+		}
+		return workflow.EffectClaimResult{}, err
+	}
+	return result, nil
 }
 
 func (a *taskAdapter) ConsumeSupervisorSteer(taskID, prompt string) (string, error) {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -250,6 +250,7 @@ func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 
 func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
 	var result workflow.EffectClaimResult
+	var fenceErr error
 	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
 		if cur.Workflow == nil {
 			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
@@ -261,6 +262,7 @@ func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim)
 		result = claimResult
 		if claimErr != nil {
 			if errors.Is(claimErr, workflow.ErrEffectClaimConflict) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				fenceErr = claimErr
 				return task.Update{}, errWorkflowEffectNoPersist
 			}
 			return task.Update{}, claimErr
@@ -269,7 +271,7 @@ func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim)
 	})
 	if err != nil {
 		if errors.Is(err, errWorkflowEffectNoPersist) {
-			return result, nil
+			return result, fenceErr
 		}
 		return workflow.EffectClaimResult{}, err
 	}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -278,6 +278,7 @@ func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim)
 
 func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
 	var result workflow.EffectClaimResult
+	var fenceErr error
 	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
 		if cur.Workflow == nil {
 			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
@@ -289,6 +290,7 @@ func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectCla
 		result = claimResult
 		if claimErr != nil {
 			if errors.Is(claimErr, workflow.ErrEffectClaimLost) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				fenceErr = claimErr
 				return task.Update{}, errWorkflowEffectNoPersist
 			}
 			return task.Update{}, claimErr
@@ -297,7 +299,7 @@ func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectCla
 	})
 	if err != nil {
 		if errors.Is(err, errWorkflowEffectNoPersist) {
-			return result, nil
+			return result, fenceErr
 		}
 		return workflow.EffectClaimResult{}, err
 	}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -3196,6 +3196,17 @@ func TestE2E_StaleAgentCompletionAfterWorkflowTerminal(t *testing.T) {
 	if tkCompleted.Workflow.CurrentStep != "" {
 		t.Fatalf("precondition: current_step = %q, want empty", tkCompleted.Workflow.CurrentStep)
 	}
+	waitFor(t, 5*time.Second, "terminal workflow callbacks drain", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil || tk.Workflow == nil {
+			return false
+		}
+		return tk.Workflow.State == workflow.ExecCompleted &&
+			tk.Workflow.CurrentStep == "" &&
+			!env.agents.HasRunningAgentForTask(created.ID) &&
+			env.pendingCompletions.Load() == 0
+	})
+	tkCompleted, _ = env.tasks.Get(created.ID)
 	historyBefore := len(tkCompleted.Workflow.StepHistory)
 	updatedAtBefore := tkCompleted.UpdatedAt
 

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,6 +13,8 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 )
+
+var errWorkflowEffectNoPersist = errors.New("workflow effect claim requires no persistence")
 
 // taskAdapter and agentAdapter are minimal test-only stand-ins for the real
 // bridges (internal/sybra's private taskAdapter/agentAdapter) that let a
@@ -124,6 +127,62 @@ func (a *taskAdapter) ReplaceTaskBody(id, body string) error {
 func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	_, err := a.tasks.Update(id, task.Update{Workflow: &wf})
 	return err
+}
+
+func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
+	var result workflow.EffectClaimResult
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if cur.Workflow == nil {
+			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
+		}
+		wf := cur.Workflow.Clone()
+		result.Workflow = wf
+		claimResult, claimErr := wf.ClaimEffect(claim)
+		claimResult.Workflow = wf
+		result = claimResult
+		if claimErr != nil {
+			if errors.Is(claimErr, workflow.ErrEffectClaimConflict) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				return task.Update{}, errWorkflowEffectNoPersist
+			}
+			return task.Update{}, claimErr
+		}
+		return task.Update{Workflow: &wf}, nil
+	})
+	if err != nil {
+		if errors.Is(err, errWorkflowEffectNoPersist) {
+			return result, nil
+		}
+		return workflow.EffectClaimResult{}, err
+	}
+	return result, nil
+}
+
+func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
+	var result workflow.EffectClaimResult
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if cur.Workflow == nil {
+			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
+		}
+		wf := cur.Workflow.Clone()
+		result.Workflow = wf
+		claimResult, claimErr := wf.CompleteEffect(claim)
+		claimResult.Workflow = wf
+		result = claimResult
+		if claimErr != nil {
+			if errors.Is(claimErr, workflow.ErrEffectClaimLost) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				return task.Update{}, errWorkflowEffectNoPersist
+			}
+			return task.Update{}, claimErr
+		}
+		return task.Update{Workflow: &wf}, nil
+	})
+	if err != nil {
+		if errors.Is(err, errWorkflowEffectNoPersist) {
+			return result, nil
+		}
+		return workflow.EffectClaimResult{}, err
+	}
+	return result, nil
 }
 
 func (a *taskAdapter) ConsumeSupervisorSteer(taskID, prompt string) (string, error) {

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -159,6 +159,7 @@ func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim)
 
 func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
 	var result workflow.EffectClaimResult
+	var fenceErr error
 	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
 		if cur.Workflow == nil {
 			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
@@ -170,6 +171,7 @@ func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectCla
 		result = claimResult
 		if claimErr != nil {
 			if errors.Is(claimErr, workflow.ErrEffectClaimLost) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				fenceErr = claimErr
 				return task.Update{}, errWorkflowEffectNoPersist
 			}
 			return task.Update{}, claimErr
@@ -178,7 +180,7 @@ func (a *taskAdapter) CompleteWorkflowEffect(id string, claim workflow.EffectCla
 	})
 	if err != nil {
 		if errors.Is(err, errWorkflowEffectNoPersist) {
-			return result, nil
+			return result, fenceErr
 		}
 		return workflow.EffectClaimResult{}, err
 	}

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -131,6 +131,7 @@ func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 
 func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
 	var result workflow.EffectClaimResult
+	var fenceErr error
 	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
 		if cur.Workflow == nil {
 			return task.Update{}, fmt.Errorf("task %s has no workflow", id)
@@ -142,6 +143,7 @@ func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim)
 		result = claimResult
 		if claimErr != nil {
 			if errors.Is(claimErr, workflow.ErrEffectClaimConflict) || errors.Is(claimErr, workflow.ErrEffectAlreadyComplete) {
+				fenceErr = claimErr
 				return task.Update{}, errWorkflowEffectNoPersist
 			}
 			return task.Update{}, claimErr
@@ -150,7 +152,7 @@ func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim)
 	})
 	if err != nil {
 		if errors.Is(err, errWorkflowEffectNoPersist) {
-			return result, nil
+			return result, fenceErr
 		}
 		return workflow.EffectClaimResult{}, err
 	}

--- a/internal/workflow/effect_claim.go
+++ b/internal/workflow/effect_claim.go
@@ -33,24 +33,35 @@ type EffectClaimResult struct {
 	Completed bool
 }
 
-func (e *Engine) effectClaimForStep(t TaskInfo, stepID string, pos int) EffectClaim {
+func (e *Engine) effectClaimForStep(t TaskInfo, step *Step, pos int) EffectClaim {
+	stepID := step.ID
+	reuseCompleted := !isAsyncWorkflowStep(step.Type)
+	skippedCompleted := false
 	if t.Workflow != nil {
 		if existing, ok := t.Workflow.EffectIDForStep(stepID, pos); ok {
 			currentSeq := executionStepSeq(t.Workflow)
-			if rec, found := t.Workflow.effectRecord(existing); found && rec.ID.StepSeq == currentSeq {
-				return EffectClaim{
-					EffectID: existing,
-					Owner:    e.ownerID,
-					LeaseTTL: e.effectLeaseTTL,
-					Now:      e.now(),
+			if rec, found := t.Workflow.effectRecord(existing); found && rec.ID.StepSeq >= currentSeq {
+				if rec.CompletedAt != nil && !reuseCompleted {
+					skippedCompleted = true
+				} else {
+					return EffectClaim{
+						EffectID: existing,
+						Owner:    e.ownerID,
+						LeaseTTL: e.effectLeaseTTL,
+						Now:      e.now(),
+					}
 				}
 			}
 		}
 	}
+	stepSeq := executionStepSeq(t.Workflow)
+	if skippedCompleted {
+		stepSeq = nextEffectStepSeq(t.Workflow, t.Generation, stepSeq)
+	}
 	return EffectClaim{
 		EffectID: EffectID{
 			Generation: t.Generation,
-			StepSeq:    executionStepSeq(t.Workflow),
+			StepSeq:    stepSeq,
 			StepID:     stepID,
 			Pos:        pos,
 		},
@@ -60,8 +71,21 @@ func (e *Engine) effectClaimForStep(t TaskInfo, stepID string, pos int) EffectCl
 	}
 }
 
-func (e *Engine) claimStepEffect(taskID string, t TaskInfo, stepID string, pos int) (*Execution, EffectID, error) {
-	claim := e.effectClaimForStep(t, stepID, pos)
+func nextEffectStepSeq(wf *Execution, generation int64, base int) int {
+	if wf == nil {
+		return base
+	}
+	next := base
+	for _, rec := range wf.EffectLog {
+		if rec.ID.Generation == generation && rec.ID.StepSeq >= next {
+			next = rec.ID.StepSeq + 1
+		}
+	}
+	return next
+}
+
+func (e *Engine) claimStepEffect(taskID string, t TaskInfo, step *Step, pos int) (*Execution, EffectID, error) {
+	claim := e.effectClaimForStep(t, step, pos)
 	result, err := e.tasks.ClaimWorkflowEffect(taskID, claim)
 	if err != nil {
 		return result.Workflow, claim.EffectID, err

--- a/internal/workflow/effect_claim.go
+++ b/internal/workflow/effect_claim.go
@@ -1,0 +1,238 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+)
+
+var (
+	ErrEffectClaimConflict   = errors.New("workflow effect is claimed by another owner")
+	ErrEffectAlreadyComplete = errors.New("workflow effect is already complete")
+	ErrEffectClaimLost       = errors.New("workflow effect claim is not held by this owner")
+)
+
+const (
+	effectPosStepAction = iota
+	effectPosAsyncAdvance
+)
+
+type EffectClaim struct {
+	EffectID EffectID
+	Owner    string
+	LeaseTTL time.Duration
+	Now      time.Time
+}
+
+type EffectClaimResult struct {
+	Workflow  *Execution
+	Record    EffectRecord
+	Acquired  bool
+	Refreshed bool
+	Completed bool
+}
+
+func (e *Engine) effectClaimForStep(t TaskInfo, stepID string, pos int) EffectClaim {
+	if t.Workflow != nil {
+		if existing, ok := t.Workflow.EffectIDForStep(stepID, pos); ok {
+			currentSeq := executionStepSeq(t.Workflow)
+			if rec, found := t.Workflow.effectRecord(existing); found && rec.ID.StepSeq == currentSeq {
+				return EffectClaim{
+					EffectID: existing,
+					Owner:    e.ownerID,
+					LeaseTTL: e.effectLeaseTTL,
+					Now:      e.now(),
+				}
+			}
+		}
+	}
+	return EffectClaim{
+		EffectID: EffectID{
+			Generation: t.Generation,
+			StepSeq:    executionStepSeq(t.Workflow),
+			StepID:     stepID,
+			Pos:        pos,
+		},
+		Owner:    e.ownerID,
+		LeaseTTL: e.effectLeaseTTL,
+		Now:      e.now(),
+	}
+}
+
+func (e *Engine) claimStepEffect(taskID string, t TaskInfo, stepID string, pos int) (*Execution, EffectID, error) {
+	claim := e.effectClaimForStep(t, stepID, pos)
+	result, err := e.tasks.ClaimWorkflowEffect(taskID, claim)
+	if err != nil {
+		return result.Workflow, claim.EffectID, err
+	}
+	return result.Workflow, claim.EffectID, nil
+}
+
+func (e *Engine) completeClaimedEffect(taskID string, effectID EffectID) (*Execution, error) {
+	result, err := e.tasks.CompleteWorkflowEffect(taskID, EffectClaim{
+		EffectID: effectID,
+		Owner:    e.ownerID,
+		LeaseTTL: e.effectLeaseTTL,
+		Now:      e.now(),
+	})
+	if err != nil {
+		return result.Workflow, err
+	}
+	return result.Workflow, nil
+}
+
+func effectClaimFence(err error) bool {
+	return errors.Is(err, ErrEffectClaimConflict) ||
+		errors.Is(err, ErrEffectAlreadyComplete) ||
+		errors.Is(err, ErrEffectClaimLost)
+}
+
+func mergeClaimedEffectLog(active, claimed *Execution) *Execution {
+	switch {
+	case active == nil:
+		if claimed == nil {
+			return nil
+		}
+		return claimed.Clone()
+	case claimed == nil:
+		return active
+	}
+	active.EffectLog = slices.Clone(claimed.EffectLog)
+	for i := range active.EffectLog {
+		active.EffectLog[i] = cloneEffectRecord(active.EffectLog[i])
+	}
+	return active
+}
+
+func isAsyncWorkflowStep(stepType StepType) bool {
+	switch stepType {
+	case StepRunAgent, StepParallel, StepBestOfN, StepWaitHuman:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c EffectClaim) validate() error {
+	switch {
+	case c.Owner == "":
+		return errors.New("workflow effect claim owner is required")
+	case c.EffectID.StepID == "":
+		return fmt.Errorf("workflow effect claim id %q has empty step id", c.EffectID.String())
+	case c.LeaseTTL <= 0:
+		return fmt.Errorf("workflow effect claim lease ttl must be > 0, got %s", c.LeaseTTL)
+	case c.Now.IsZero():
+		return errors.New("workflow effect claim time is required")
+	default:
+		return nil
+	}
+}
+
+func (e *Execution) ClaimEffect(claim EffectClaim) (EffectClaimResult, error) {
+	if e == nil {
+		return EffectClaimResult{}, errors.New("workflow execution is nil")
+	}
+	if err := claim.validate(); err != nil {
+		return EffectClaimResult{}, err
+	}
+
+	rec, found := e.effectRecord(claim.EffectID)
+	if !found {
+		expiresAt := claim.Now.UTC().Add(claim.LeaseTTL)
+		e.EffectLog = append(e.EffectLog, EffectRecord{
+			ID:             claim.EffectID,
+			IntentAt:       claim.Now.UTC(),
+			Owner:          claim.Owner,
+			LeaseExpiresAt: &expiresAt,
+		})
+		if len(e.EffectLog) > maxEffectLog {
+			e.EffectLog = e.EffectLog[len(e.EffectLog)-maxEffectLog:]
+		}
+		rec = &e.EffectLog[len(e.EffectLog)-1]
+		return EffectClaimResult{
+			Record:    cloneEffectRecord(*rec),
+			Acquired:  true,
+			Refreshed: false,
+		}, nil
+	}
+	if rec.CompletedAt != nil {
+		return EffectClaimResult{
+			Record:    cloneEffectRecord(*rec),
+			Completed: true,
+		}, ErrEffectAlreadyComplete
+	}
+	if rec.Owner != "" && rec.Owner != claim.Owner && rec.leaseActiveAt(claim.Now) {
+		return EffectClaimResult{Record: cloneEffectRecord(*rec)}, ErrEffectClaimConflict
+	}
+	expiresAt := claim.Now.UTC().Add(claim.LeaseTTL)
+	refreshed := rec.Owner == claim.Owner
+	rec.Owner = claim.Owner
+	rec.LeaseExpiresAt = &expiresAt
+	if rec.IntentAt.IsZero() {
+		rec.IntentAt = claim.Now.UTC()
+	}
+	return EffectClaimResult{
+		Record:    cloneEffectRecord(*rec),
+		Acquired:  true,
+		Refreshed: refreshed,
+	}, nil
+}
+
+func (e *Execution) CompleteEffect(claim EffectClaim) (EffectClaimResult, error) {
+	if e == nil {
+		return EffectClaimResult{}, errors.New("workflow execution is nil")
+	}
+	if err := claim.validate(); err != nil {
+		return EffectClaimResult{}, err
+	}
+
+	rec, found := e.effectRecord(claim.EffectID)
+	if !found {
+		return EffectClaimResult{}, ErrEffectClaimLost
+	}
+	if rec.CompletedAt != nil {
+		return EffectClaimResult{
+			Record:    cloneEffectRecord(*rec),
+			Completed: true,
+		}, ErrEffectAlreadyComplete
+	}
+	if rec.Owner != claim.Owner || !rec.leaseActiveAt(claim.Now) {
+		return EffectClaimResult{Record: cloneEffectRecord(*rec)}, ErrEffectClaimLost
+	}
+	completedAt := claim.Now.UTC()
+	rec.CompletedAt = &completedAt
+	return EffectClaimResult{
+		Record:    cloneEffectRecord(*rec),
+		Completed: true,
+	}, nil
+}
+
+func (e *Execution) effectRecord(id EffectID) (*EffectRecord, bool) {
+	for i := range e.EffectLog {
+		if e.EffectLog[i].ID.Equal(id) {
+			return &e.EffectLog[i], true
+		}
+	}
+	return nil, false
+}
+
+func (r EffectRecord) leaseActiveAt(now time.Time) bool {
+	if r.LeaseExpiresAt == nil {
+		return false
+	}
+	return r.LeaseExpiresAt.After(now.UTC())
+}
+
+func cloneEffectRecord(rec EffectRecord) EffectRecord {
+	out := rec
+	if rec.LeaseExpiresAt != nil {
+		t := *rec.LeaseExpiresAt
+		out.LeaseExpiresAt = &t
+	}
+	if rec.CompletedAt != nil {
+		t := *rec.CompletedAt
+		out.CompletedAt = &t
+	}
+	return out
+}

--- a/internal/workflow/effect_claim_test.go
+++ b/internal/workflow/effect_claim_test.go
@@ -1,0 +1,175 @@
+package workflow
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEffectClaim_FirstOwnerWins(t *testing.T) {
+	exec := &Execution{}
+	now := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+
+	result, err := exec.ClaimEffect(EffectClaim{
+		EffectID: makeID("create_pr", effectPosStepAction),
+		Owner:    "engine-a",
+		LeaseTTL: time.Minute,
+		Now:      now,
+	})
+	if err != nil {
+		t.Fatalf("ClaimEffect: %v", err)
+	}
+	if !result.Acquired || result.Refreshed {
+		t.Fatalf("claim result = %+v, want acquired new lease", result)
+	}
+	if result.Record.Owner != "engine-a" {
+		t.Fatalf("owner = %q, want engine-a", result.Record.Owner)
+	}
+	if result.Record.LeaseExpiresAt == nil || !result.Record.LeaseExpiresAt.Equal(now.Add(time.Minute)) {
+		t.Fatalf("lease expiry = %v, want %v", result.Record.LeaseExpiresAt, now.Add(time.Minute))
+	}
+}
+
+func TestEffectClaim_SameOwnerRefreshes(t *testing.T) {
+	exec := &Execution{}
+	now := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	claim := EffectClaim{
+		EffectID: makeID("create_pr", effectPosStepAction),
+		Owner:    "engine-a",
+		LeaseTTL: time.Minute,
+		Now:      now,
+	}
+	if _, err := exec.ClaimEffect(claim); err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+
+	result, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claim.EffectID,
+		Owner:    "engine-a",
+		LeaseTTL: 2 * time.Minute,
+		Now:      now.Add(30 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("refresh claim: %v", err)
+	}
+	if !result.Acquired || !result.Refreshed {
+		t.Fatalf("claim result = %+v, want refreshed lease", result)
+	}
+	if result.Record.LeaseExpiresAt == nil || !result.Record.LeaseExpiresAt.Equal(now.Add(150*time.Second)) {
+		t.Fatalf("lease expiry = %v, want %v", result.Record.LeaseExpiresAt, now.Add(150*time.Second))
+	}
+}
+
+func TestEffectClaim_ActiveOwnerConflict(t *testing.T) {
+	exec := &Execution{}
+	now := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	claimID := makeID("create_pr", effectPosStepAction)
+	if _, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-a",
+		LeaseTTL: time.Minute,
+		Now:      now,
+	}); err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+
+	result, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-b",
+		LeaseTTL: time.Minute,
+		Now:      now.Add(30 * time.Second),
+	})
+	if !errors.Is(err, ErrEffectClaimConflict) {
+		t.Fatalf("ClaimEffect err = %v, want %v", err, ErrEffectClaimConflict)
+	}
+	if result.Record.Owner != "engine-a" {
+		t.Fatalf("owner = %q, want engine-a", result.Record.Owner)
+	}
+}
+
+func TestEffectClaim_ExpiredOwnerReclaim(t *testing.T) {
+	exec := &Execution{}
+	now := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	claimID := makeID("create_pr", effectPosStepAction)
+	if _, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-a",
+		LeaseTTL: time.Minute,
+		Now:      now,
+	}); err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+
+	result, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-b",
+		LeaseTTL: time.Minute,
+		Now:      now.Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if result.Record.Owner != "engine-b" {
+		t.Fatalf("owner = %q, want engine-b", result.Record.Owner)
+	}
+}
+
+func TestEffectClaim_StaleOwnerCannotCompleteAfterReclaim(t *testing.T) {
+	exec := &Execution{}
+	now := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	claimID := makeID("create_pr", effectPosStepAction)
+	if _, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-a",
+		LeaseTTL: time.Minute,
+		Now:      now,
+	}); err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+	if _, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-b",
+		LeaseTTL: time.Minute,
+		Now:      now.Add(2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+
+	_, err := exec.CompleteEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-a",
+		LeaseTTL: time.Minute,
+		Now:      now.Add(2*time.Minute + time.Second),
+	})
+	if !errors.Is(err, ErrEffectClaimLost) {
+		t.Fatalf("CompleteEffect err = %v, want %v", err, ErrEffectClaimLost)
+	}
+}
+
+func TestEffectClaim_CompletedEffectCannotReplay(t *testing.T) {
+	exec := &Execution{}
+	now := time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC)
+	claimID := makeID("create_pr", effectPosStepAction)
+	claim := EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-a",
+		LeaseTTL: time.Minute,
+		Now:      now,
+	}
+	if _, err := exec.ClaimEffect(claim); err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+	if _, err := exec.CompleteEffect(claim); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	_, err := exec.ClaimEffect(EffectClaim{
+		EffectID: claimID,
+		Owner:    "engine-b",
+		LeaseTTL: time.Minute,
+		Now:      now.Add(2 * time.Minute),
+	})
+	if !errors.Is(err, ErrEffectAlreadyComplete) {
+		t.Fatalf("ClaimEffect err = %v, want %v", err, ErrEffectAlreadyComplete)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,10 @@ const (
 	maxSyncSteps   = 100 // depth limit for synchronous step chains
 	maxStepHistory = 50  // max step records kept per execution
 	shellTimeout   = 30 * time.Second
+	// Deliberately generous: effect leases have no heartbeat yet, so they must
+	// outlive the longest expected synchronous step execution to avoid false
+	// reclaims mid-step.
+	defaultEffectLeaseTTL = 30 * time.Minute
 )
 
 // TaskInfo is the subset of task data the engine needs.
@@ -126,6 +131,8 @@ type TaskProvider interface {
 	// body (see stripTestFailuresSections).
 	ReplaceTaskBody(id, body string) error
 	SetWorkflow(id string, wf *Execution) error
+	ClaimWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error)
+	CompleteWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error)
 	// ConsumeSupervisorSteer prepends a pending watchdog headless-nudge steer to
 	// prompt and clears it, so a re-dispatched (resumed) step's agent carries the
 	// correction exactly once. Returns prompt unchanged when none is pending.
@@ -404,6 +411,9 @@ type Engine struct {
 	// HandleStatusChange, ResumeStalled — all called from agent/workflow
 	// goroutines) run concurrently with no shared lock between them.
 	dispatchDisabled atomic.Bool
+	ownerID          string
+	effectLeaseTTL   time.Duration
+	now              func() time.Time
 	logger           *slog.Logger
 	ctx              context.Context
 	mu               sync.Mutex
@@ -481,6 +491,8 @@ type Engine struct {
 	admissionDecisionHook func(TaskInfo, AdmissionDecision)
 }
 
+var effectOwnerSeq atomic.Uint64
+
 // AdmissionDecision summarizes one admission_preflight step outcome, passed
 // to the hook installed via SetAdmissionDecisionHook.
 type AdmissionDecision struct {
@@ -517,6 +529,9 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		store:                  store,
 		tasks:                  tasks,
 		agents:                 agents,
+		ownerID:                newEffectOwnerID(),
+		effectLeaseTTL:         defaultEffectLeaseTTL,
+		now:                    func() time.Time { return time.Now().UTC() },
 		logger:                 logger,
 		ctx:                    context.Background(),
 		inflightMutexes:        make(map[string]*sync.Mutex),
@@ -533,6 +548,22 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		resumeSkip:             logging.NewInfoThrottle(),
 		openPROnUnrunnableGate: true,
 	}
+}
+
+func newEffectOwnerID() string {
+	return fmt.Sprintf("workflow-engine-%d-%d", time.Now().UTC().UnixNano(), effectOwnerSeq.Add(1))
+}
+
+func (e *Engine) setEffectLeaseTTLForTest(ttl time.Duration) {
+	e.effectLeaseTTL = ttl
+}
+
+func (e *Engine) setNowForTest(now func() time.Time) {
+	if now == nil {
+		e.now = func() time.Time { return time.Now().UTC() }
+		return
+	}
+	e.now = func() time.Time { return now().UTC() }
 }
 
 // SetContext binds a parent context to the engine. Shell steps use

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -554,18 +554,6 @@ func newEffectOwnerID() string {
 	return fmt.Sprintf("workflow-engine-%d-%d", time.Now().UTC().UnixNano(), effectOwnerSeq.Add(1))
 }
 
-func (e *Engine) setEffectLeaseTTLForTest(ttl time.Duration) {
-	e.effectLeaseTTL = ttl
-}
-
-func (e *Engine) setNowForTest(now func() time.Time) {
-	if now == nil {
-		e.now = func() time.Time { return time.Now().UTC() }
-		return
-	}
-	e.now = func() time.Time { return now().UTC() }
-}
-
 // SetContext binds a parent context to the engine. Shell steps use
 // context.WithTimeout(parent, shellTimeout) so they are cancelled when
 // the parent context is cancelled (e.g. on app shutdown).

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -628,6 +628,9 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 				}
 				return nil, err
 			}
+			if wfExec == nil {
+				return nil, fmt.Errorf("completeStepEffect returned nil execution for task %s step %s", taskID, step.ID)
+			}
 		}
 		if nextStep == nil {
 			return comp, nil // workflow completed; caller fires onComplete after marker release

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -654,7 +654,7 @@ func (e *Engine) recordSyncStepOutput(taskID string, step *Step, wfExec *Executi
 }
 
 func (e *Engine) claimAndRevalidateStepEffect(taskID string, step *Step, t *TaskInfo, wfExec **Execution) (EffectID, bool, error) {
-	claimedExec, effectID, claimErr := e.claimStepEffect(taskID, *t, step.ID, effectPosStepAction)
+	claimedExec, effectID, claimErr := e.claimStepEffect(taskID, *t, step, effectPosStepAction)
 	mergedExec, replayCompleted, err := e.handleStepClaimResult(taskID, step, *wfExec, claimedExec, effectID, claimErr)
 	if err != nil || replayCompleted {
 		*wfExec = mergedExec
@@ -664,7 +664,7 @@ func (e *Engine) claimAndRevalidateStepEffect(taskID string, step *Step, t *Task
 	*wfExec = mergedExec
 	t.Workflow = mergedExec
 
-	claimedExec, _, claimErr = e.claimStepEffect(taskID, *t, step.ID, effectPosStepAction)
+	claimedExec, _, claimErr = e.claimStepEffect(taskID, *t, step, effectPosStepAction)
 	mergedExec, replayCompleted, err = e.handleStepClaimResult(taskID, step, *wfExec, claimedExec, effectID, claimErr)
 	*wfExec = mergedExec
 	t.Workflow = mergedExec

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -583,38 +583,10 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 				return nil, wrapDispatchErr(step.ID, execErr)
 			}
 		}
-		if step.Type == StepPromoteBestOfN {
-			// execPromoteBestOfN reloads and persists the freshest workflow state
-			// itself so it can preserve judge-step vars and the promoted canonical
-			// dir. Continue from that persisted copy rather than the stale pre-step
-			// wfExec passed into executeSteps.
-			fresh, err := e.tasks.GetTask(taskID)
-			if err != nil {
-				return nil, err
-			}
-			if fresh.Workflow != nil {
-				wfExec = fresh.Workflow
-			}
-		}
-
-		now := time.Now().UTC()
-		wfExec.RecordStep(StepRecord{
-			StepID:    step.ID,
-			Status:    output.Status,
-			Output:    truncate(output.Output, 4000),
-			StartedAt: now,
-			EndedAt:   now,
-		})
-		if output.Output != "" {
-			wfExec.SetVar("step."+step.ID+".output", truncate(output.Output, 2000))
-		}
-
-		// Re-read task for latest state (set_status changes task).
-		t, err = e.tasks.GetTask(taskID)
+		wfExec, t, err = e.recordSyncStepOutput(taskID, step, wfExec, output, t)
 		if err != nil {
 			return nil, err
 		}
-		t.Workflow = wfExec
 
 		nextStep, comp, nErr := e.resolveNext(taskID, def, step, wfExec, t)
 		if nErr != nil {
@@ -640,6 +612,45 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		step = nextStep
 	}
 	return nil, fmt.Errorf("workflow exceeded max sync step depth (%d)", maxSyncSteps)
+}
+
+// recordSyncStepOutput handles post-execution bookkeeping for a sync step:
+// it reloads the workflow state for BestOfN steps, records the step result,
+// and re-reads the task to pick up any status changes made by the step.
+func (e *Engine) recordSyncStepOutput(taskID string, step *Step, wfExec *Execution, output StepOutput, t TaskInfo) (*Execution, TaskInfo, error) {
+	if step.Type == StepPromoteBestOfN {
+		// execPromoteBestOfN reloads and persists the freshest workflow state
+		// itself so it can preserve judge-step vars and the promoted canonical
+		// dir. Continue from that persisted copy rather than the stale pre-step
+		// wfExec passed into executeSteps.
+		fresh, err := e.tasks.GetTask(taskID)
+		if err != nil {
+			return nil, t, err
+		}
+		if fresh.Workflow != nil {
+			wfExec = fresh.Workflow
+		}
+	}
+
+	now := time.Now().UTC()
+	wfExec.RecordStep(StepRecord{
+		StepID:    step.ID,
+		Status:    output.Status,
+		Output:    truncate(output.Output, 4000),
+		StartedAt: now,
+		EndedAt:   now,
+	})
+	if output.Output != "" {
+		wfExec.SetVar("step."+step.ID+".output", truncate(output.Output, 2000))
+	}
+
+	// Re-read task for latest state (set_status changes task).
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil {
+		return nil, t, err
+	}
+	t.Workflow = wfExec
+	return wfExec, t, nil
 }
 
 func (e *Engine) claimAndRevalidateStepEffect(taskID string, step *Step, t *TaskInfo, wfExec **Execution) (EffectID, bool, error) {

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -519,6 +519,7 @@ func (e *CycleError) Error() string {
 func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec *Execution) (*CompletionInfo, error) {
 	visited := make(map[string]int) // stepID → first-seen iteration index
 	for i := range maxSyncSteps {
+		replayCompleted := false
 		t, err := e.tasks.GetTask(taskID)
 		if err != nil {
 			return nil, err
@@ -547,6 +548,44 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			}
 		}
 
+		claimedExec, effectID, claimErr := e.claimStepEffect(taskID, t, step.ID, effectPosStepAction)
+		if claimErr != nil {
+			if errors.Is(claimErr, ErrEffectAlreadyComplete) && !isAsyncWorkflowStep(step.Type) {
+				replayCompleted = true
+				wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
+				t.Workflow = wfExec
+			} else {
+				if effectClaimFence(claimErr) {
+					e.logger.Info("workflow.effect.fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", claimErr)
+					return nil, nil
+				}
+				return nil, claimErr
+			}
+		}
+		if claimedExec != nil && !replayCompleted {
+			wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
+			t.Workflow = wfExec
+		}
+		if !replayCompleted {
+			if claimedExec, _, claimErr = e.claimStepEffect(taskID, t, step.ID, effectPosStepAction); claimErr != nil {
+				if errors.Is(claimErr, ErrEffectAlreadyComplete) && !isAsyncWorkflowStep(step.Type) {
+					replayCompleted = true
+					wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
+					t.Workflow = wfExec
+				} else {
+					if effectClaimFence(claimErr) {
+						e.logger.Info("workflow.effect.fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", claimErr)
+						return nil, nil
+					}
+					return nil, claimErr
+				}
+			}
+		}
+		if claimedExec != nil && !replayCompleted {
+			wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
+			t.Workflow = wfExec
+		}
+
 		// Async steps: execute and return. Callback (HandleAgentComplete/HandleHumanAction)
 		// will call AdvanceStep later.
 		switch step.Type {
@@ -554,17 +593,72 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			if comp, handled, bErr := e.preflightRunAgentBudget(taskID, def, step, wfExec); handled {
 				return comp, wrapDispatchErr(step.ID, bErr)
 			}
-			return nil, wrapDispatchErr(step.ID, e.execRunAgent(taskID, step, wfExec, ctx))
+			if err := e.execRunAgent(taskID, step, wfExec, ctx); err != nil {
+				return nil, wrapDispatchErr(step.ID, err)
+			}
+			if e.agents.HasRunningAgent(taskID) {
+				completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
+				if cErr != nil {
+					err = cErr
+					if effectClaimFence(err) {
+						e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
+						return nil, nil
+					}
+					return nil, err
+				}
+				wfExec = mergeClaimedEffectLog(wfExec, completedExec)
+			}
+			return nil, nil
 		case StepParallel:
-			return e.execParallel(taskID, def, step, wfExec, ctx)
+			comp, err := e.execParallel(taskID, def, step, wfExec, ctx)
+			if err != nil {
+				return comp, err
+			}
+			if comp != nil || e.agents.HasRunningAgent(taskID) {
+				completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
+				if cErr != nil {
+					err = cErr
+					if effectClaimFence(err) {
+						e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
+						return nil, nil
+					}
+					return nil, err
+				}
+				wfExec = mergeClaimedEffectLog(wfExec, completedExec)
+			}
+			return comp, nil
 		case StepBestOfN:
 			comp, err := e.execBestOfN(taskID, def, step, wfExec, ctx)
+			if err == nil || (errors.Is(err, errBestOfNParked) && e.agents.HasRunningAgent(taskID)) {
+				if completedExec, cErr := e.completeClaimedEffect(taskID, effectID); cErr != nil {
+					if effectClaimFence(cErr) {
+						e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", cErr)
+						return nil, nil
+					}
+					return nil, cErr
+				} else if completedExec != nil {
+					wfExec = mergeClaimedEffectLog(wfExec, completedExec)
+				}
+			}
 			if errors.Is(err, errBestOfNParked) {
 				return nil, errBestOfNParked
 			}
 			return comp, err
 		case StepWaitHuman:
-			return nil, wrapDispatchErr(step.ID, e.execWaitHuman(taskID, step, wfExec))
+			if err := e.execWaitHuman(taskID, step, wfExec); err != nil {
+				return nil, wrapDispatchErr(step.ID, err)
+			}
+			completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
+			if cErr != nil {
+				err = cErr
+				if effectClaimFence(err) {
+					e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
+					return nil, nil
+				}
+				return nil, err
+			}
+			wfExec = mergeClaimedEffectLog(wfExec, completedExec)
+			return nil, nil
 		case StepClearPlanArtifacts, StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepFlagPlanCritique, StepDetectTampering, StepVerifyChecks, StepFocusedChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch, StepCreatePR, StepClassifyTask, StepAdmissionPreflight, StepRequireEvidence:
 			// handled below as sync steps
 		default:
@@ -580,17 +674,30 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		visited[step.ID] = i
 
 		// Sync steps: execute, record result, resolve next, loop.
-		output, execErr := e.execSyncStep(taskID, step, wfExec, ctx, t)
-		if execErr != nil {
-			// The step parked the workflow in ExecWaiting (it persisted the new
-			// CurrentStep/State itself). Stop without recording/advancing/
-			// completing: completing here would fire the status-change cascade.
-			// ResumeStalled re-drives the re-armed run_agent step once idle.
-			if errors.Is(execErr, errStepParked) {
-				var parkedNoCompletion *CompletionInfo
-				return parkedNoCompletion, nil
+		var output StepOutput
+		if replayCompleted {
+			output = StepOutput{
+				StepID: step.ID,
+				Status: "completed",
+				Output: wfExec.Variables["step."+step.ID+".output"],
 			}
-			return nil, wrapDispatchErr(step.ID, execErr)
+			if output.Output == "" {
+				output.Output = "skipped: effect already completed"
+			}
+		} else {
+			var execErr error
+			output, execErr = e.execSyncStep(taskID, step, wfExec, ctx, t)
+			if execErr != nil {
+				// The step parked the workflow in ExecWaiting (it persisted the new
+				// CurrentStep/State itself). Stop without recording/advancing/
+				// completing: completing here would fire the status-change cascade.
+				// ResumeStalled re-drives the re-armed run_agent step once idle.
+				if errors.Is(execErr, errStepParked) {
+					var parkedNoCompletion *CompletionInfo
+					return parkedNoCompletion, nil
+				}
+				return nil, wrapDispatchErr(step.ID, execErr)
+			}
 		}
 		if step.Type == StepPromoteBestOfN {
 			// execPromoteBestOfN reloads and persists the freshest workflow state
@@ -628,6 +735,18 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		nextStep, comp, nErr := e.resolveNext(taskID, def, step, wfExec, t)
 		if nErr != nil {
 			return nil, nErr
+		}
+		if !replayCompleted {
+			completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
+			if cErr != nil {
+				err = cErr
+				if effectClaimFence(err) {
+					e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
+					return nil, nil
+				}
+				return nil, err
+			}
+			wfExec = mergeClaimedEffectLog(wfExec, completedExec)
 		}
 		if nextStep == nil {
 			return comp, nil // workflow completed; caller fires onComplete after marker release

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -281,6 +281,7 @@ func (e *Engine) finishTerminalStepOutput(taskID string, wfExec *Execution, outp
 
 func (e *Engine) executeNextSteps(taskID string, def *Definition, step *Step, wfExec *Execution) error {
 	comp, err := e.executeSteps(taskID, def, step, wfExec)
+	err = normalizeExecuteStepsErr(err)
 	if errors.Is(err, errBestOfNParked) {
 		err = nil
 	}
@@ -507,6 +508,8 @@ func (e *CycleError) Error() string {
 		e.StepID, e.At, e.FirstAt)
 }
 
+var errWorkflowYield = errors.New("workflow yielded without completion")
+
 // executeSteps iterates through synchronous steps until it hits an async step
 // (run_agent, wait_human) or the workflow ends. This avoids recursive calls
 // between executeStep/AdvanceStep that caused inflight guard deadlocks.
@@ -519,150 +522,31 @@ func (e *CycleError) Error() string {
 func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec *Execution) (*CompletionInfo, error) {
 	visited := make(map[string]int) // stepID → first-seen iteration index
 	for i := range maxSyncSteps {
-		replayCompleted := false
 		t, err := e.tasks.GetTask(taskID)
 		if err != nil {
 			return nil, err
 		}
 		t = e.withManualTestConfig(t)
-
-		// Snapshot the execution for the template context so that clearing
-		// the Recovered flag below doesn't affect what the template sees.
-		execSnap := *wfExec
-		ctx := TemplateContext{
-			Task:     t,
-			Step:     *step,
-			Prev:     wfExec.LastRecord(),
-			Vars:     wfExec.Variables,
-			Project:  nil,
-			Workflow: &execSnap,
+		ctx, err := e.prepareStepTemplateContext(taskID, step, wfExec, t)
+		if err != nil {
+			return nil, err
 		}
 
-		// Consume the recovery flag: it applies only to the step being
-		// dispatched here. Clear and persist before spawning the agent so
-		// subsequent HandleAgentComplete reloads don't see a stale flag.
-		if wfExec.Recovered {
-			wfExec.Recovered = false
-			if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-				return nil, err
-			}
-		}
-
-		claimedExec, effectID, claimErr := e.claimStepEffect(taskID, t, step.ID, effectPosStepAction)
+		effectID, replayCompleted, claimErr := e.claimAndRevalidateStepEffect(taskID, step, &t, &wfExec)
 		if claimErr != nil {
-			if errors.Is(claimErr, ErrEffectAlreadyComplete) && !isAsyncWorkflowStep(step.Type) {
-				replayCompleted = true
-				wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
-				t.Workflow = wfExec
-			} else {
-				if effectClaimFence(claimErr) {
-					e.logger.Info("workflow.effect.fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", claimErr)
-					return nil, nil
-				}
+			if errors.Is(claimErr, errWorkflowYield) {
 				return nil, claimErr
 			}
-		}
-		if claimedExec != nil && !replayCompleted {
-			wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
-			t.Workflow = wfExec
-		}
-		if !replayCompleted {
-			if claimedExec, _, claimErr = e.claimStepEffect(taskID, t, step.ID, effectPosStepAction); claimErr != nil {
-				if errors.Is(claimErr, ErrEffectAlreadyComplete) && !isAsyncWorkflowStep(step.Type) {
-					replayCompleted = true
-					wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
-					t.Workflow = wfExec
-				} else {
-					if effectClaimFence(claimErr) {
-						e.logger.Info("workflow.effect.fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", claimErr)
-						return nil, nil
-					}
-					return nil, claimErr
-				}
-			}
-		}
-		if claimedExec != nil && !replayCompleted {
-			wfExec = mergeClaimedEffectLog(wfExec, claimedExec)
-			t.Workflow = wfExec
+			return nil, claimErr
 		}
 
 		// Async steps: execute and return. Callback (HandleAgentComplete/HandleHumanAction)
 		// will call AdvanceStep later.
-		switch step.Type {
-		case StepRunAgent:
-			if comp, handled, bErr := e.preflightRunAgentBudget(taskID, def, step, wfExec); handled {
-				return comp, wrapDispatchErr(step.ID, bErr)
+		if handled, comp, asyncErr := e.executeAsyncWorkflowStep(taskID, def, step, wfExec, ctx, effectID); handled {
+			if errors.Is(asyncErr, errWorkflowYield) {
+				return nil, asyncErr
 			}
-			if err := e.execRunAgent(taskID, step, wfExec, ctx); err != nil {
-				return nil, wrapDispatchErr(step.ID, err)
-			}
-			if e.agents.HasRunningAgent(taskID) {
-				completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
-				if cErr != nil {
-					err = cErr
-					if effectClaimFence(err) {
-						e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
-						return nil, nil
-					}
-					return nil, err
-				}
-				wfExec = mergeClaimedEffectLog(wfExec, completedExec)
-			}
-			return nil, nil
-		case StepParallel:
-			comp, err := e.execParallel(taskID, def, step, wfExec, ctx)
-			if err != nil {
-				return comp, err
-			}
-			if comp != nil || e.agents.HasRunningAgent(taskID) {
-				completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
-				if cErr != nil {
-					err = cErr
-					if effectClaimFence(err) {
-						e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
-						return nil, nil
-					}
-					return nil, err
-				}
-				wfExec = mergeClaimedEffectLog(wfExec, completedExec)
-			}
-			return comp, nil
-		case StepBestOfN:
-			comp, err := e.execBestOfN(taskID, def, step, wfExec, ctx)
-			if err == nil || (errors.Is(err, errBestOfNParked) && e.agents.HasRunningAgent(taskID)) {
-				if completedExec, cErr := e.completeClaimedEffect(taskID, effectID); cErr != nil {
-					if effectClaimFence(cErr) {
-						e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", cErr)
-						return nil, nil
-					}
-					return nil, cErr
-				} else if completedExec != nil {
-					wfExec = mergeClaimedEffectLog(wfExec, completedExec)
-				}
-			}
-			if errors.Is(err, errBestOfNParked) {
-				return nil, errBestOfNParked
-			}
-			return comp, err
-		case StepWaitHuman:
-			if err := e.execWaitHuman(taskID, step, wfExec); err != nil {
-				return nil, wrapDispatchErr(step.ID, err)
-			}
-			completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
-			if cErr != nil {
-				err = cErr
-				if effectClaimFence(err) {
-					e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
-					return nil, nil
-				}
-				return nil, err
-			}
-			wfExec = mergeClaimedEffectLog(wfExec, completedExec)
-			return nil, nil
-		case StepClearPlanArtifacts, StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepFlagPlanCritique, StepDetectTampering, StepVerifyChecks, StepFocusedChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch, StepCreatePR, StepClassifyTask, StepAdmissionPreflight, StepRequireEvidence:
-			// handled below as sync steps
-		default:
-			return nil, fmt.Errorf("unknown step type %q", step.Type)
+			return comp, asyncErr
 		}
 
 		// Detect cycles: a sync step revisited without an async break means
@@ -737,16 +621,13 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return nil, nErr
 		}
 		if !replayCompleted {
-			completedExec, cErr := e.completeClaimedEffect(taskID, effectID)
-			if cErr != nil {
-				err = cErr
-				if effectClaimFence(err) {
-					e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", err)
-					return nil, nil
+			wfExec, err = e.completeStepEffect(taskID, step.ID, effectID, wfExec)
+			if err != nil {
+				if errors.Is(err, errWorkflowYield) {
+					return nil, err
 				}
 				return nil, err
 			}
-			wfExec = mergeClaimedEffectLog(wfExec, completedExec)
 		}
 		if nextStep == nil {
 			return comp, nil // workflow completed; caller fires onComplete after marker release
@@ -756,6 +637,131 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		step = nextStep
 	}
 	return nil, fmt.Errorf("workflow exceeded max sync step depth (%d)", maxSyncSteps)
+}
+
+func (e *Engine) claimAndRevalidateStepEffect(taskID string, step *Step, t *TaskInfo, wfExec **Execution) (EffectID, bool, error) {
+	claimedExec, effectID, claimErr := e.claimStepEffect(taskID, *t, step.ID, effectPosStepAction)
+	mergedExec, replayCompleted, err := e.handleStepClaimResult(taskID, step, *wfExec, claimedExec, effectID, claimErr)
+	if err != nil || replayCompleted {
+		*wfExec = mergedExec
+		t.Workflow = mergedExec
+		return effectID, replayCompleted, err
+	}
+	*wfExec = mergedExec
+	t.Workflow = mergedExec
+
+	claimedExec, _, claimErr = e.claimStepEffect(taskID, *t, step.ID, effectPosStepAction)
+	mergedExec, replayCompleted, err = e.handleStepClaimResult(taskID, step, *wfExec, claimedExec, effectID, claimErr)
+	*wfExec = mergedExec
+	t.Workflow = mergedExec
+	return effectID, replayCompleted, err
+}
+
+func (e *Engine) prepareStepTemplateContext(taskID string, step *Step, wfExec *Execution, t TaskInfo) (TemplateContext, error) {
+	// Snapshot the execution for the template context so that clearing
+	// the Recovered flag below doesn't affect what the template sees.
+	execSnap := *wfExec
+	ctx := TemplateContext{
+		Task:     t,
+		Step:     *step,
+		Prev:     wfExec.LastRecord(),
+		Vars:     wfExec.Variables,
+		Project:  nil,
+		Workflow: &execSnap,
+	}
+
+	// Consume the recovery flag: it applies only to the step being
+	// dispatched here. Clear and persist before spawning the agent so
+	// subsequent HandleAgentComplete reloads don't see a stale flag.
+	if !wfExec.Recovered {
+		return ctx, nil
+	}
+	wfExec.Recovered = false
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		return TemplateContext{}, err
+	}
+	return ctx, nil
+}
+
+func (e *Engine) handleStepClaimResult(taskID string, step *Step, wfExec, claimedExec *Execution, effectID EffectID, claimErr error) (*Execution, bool, error) {
+	if claimErr == nil {
+		return mergeClaimedEffectLog(wfExec, claimedExec), false, nil
+	}
+	if errors.Is(claimErr, ErrEffectAlreadyComplete) && !isAsyncWorkflowStep(step.Type) {
+		return mergeClaimedEffectLog(wfExec, claimedExec), true, nil
+	}
+	if effectClaimFence(claimErr) {
+		e.logger.Info("workflow.effect.fenced", "task_id", taskID, "step", step.ID, "effect", effectID.String(), "err", claimErr)
+		return wfExec, false, errWorkflowYield
+	}
+	return wfExec, false, claimErr
+}
+
+func (e *Engine) executeAsyncWorkflowStep(taskID string, def *Definition, step *Step, wfExec *Execution, ctx TemplateContext, effectID EffectID) (bool, *CompletionInfo, error) {
+	switch step.Type {
+	case StepRunAgent:
+		if comp, handled, bErr := e.preflightRunAgentBudget(taskID, def, step, wfExec); handled {
+			return true, comp, wrapDispatchErr(step.ID, bErr)
+		}
+		if err := e.execRunAgent(taskID, step, wfExec, ctx); err != nil {
+			return true, nil, wrapDispatchErr(step.ID, err)
+		}
+		if !e.agents.HasRunningAgent(taskID) {
+			return true, nil, errWorkflowYield
+		}
+		_, err := e.completeStepEffect(taskID, step.ID, effectID, wfExec)
+		return true, nil, err
+	case StepParallel:
+		comp, err := e.execParallel(taskID, def, step, wfExec, ctx)
+		if err != nil {
+			return true, comp, err
+		}
+		if comp == nil && !e.agents.HasRunningAgent(taskID) {
+			return true, comp, nil
+		}
+		_, err = e.completeStepEffect(taskID, step.ID, effectID, wfExec)
+		return true, comp, err
+	case StepBestOfN:
+		comp, err := e.execBestOfN(taskID, def, step, wfExec, ctx)
+		if err == nil || (errors.Is(err, errBestOfNParked) && e.agents.HasRunningAgent(taskID)) {
+			if _, cErr := e.completeStepEffect(taskID, step.ID, effectID, wfExec); cErr != nil {
+				return true, nil, cErr
+			}
+		}
+		if errors.Is(err, errBestOfNParked) {
+			return true, nil, errBestOfNParked
+		}
+		return true, comp, err
+	case StepWaitHuman:
+		if err := e.execWaitHuman(taskID, step, wfExec); err != nil {
+			return true, nil, wrapDispatchErr(step.ID, err)
+		}
+		_, err := e.completeStepEffect(taskID, step.ID, effectID, wfExec)
+		return true, nil, err
+	case StepClearPlanArtifacts, StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepFlagPlanCritique, StepDetectTampering, StepVerifyChecks, StepFocusedChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepCodegenGate, StepResumeWorkflow, StepPromoteBestOfN, StepPushBranch, StepCreatePR, StepClassifyTask, StepAdmissionPreflight, StepRequireEvidence:
+		return false, nil, nil
+	default:
+		return true, nil, fmt.Errorf("unknown step type %q", step.Type)
+	}
+}
+
+func (e *Engine) completeStepEffect(taskID, stepID string, effectID EffectID, wfExec *Execution) (*Execution, error) {
+	completedExec, err := e.completeClaimedEffect(taskID, effectID)
+	if err == nil {
+		return mergeClaimedEffectLog(wfExec, completedExec), nil
+	}
+	if effectClaimFence(err) {
+		e.logger.Info("workflow.effect.complete-fenced", "task_id", taskID, "step", stepID, "effect", effectID.String(), "err", err)
+		return wfExec, errWorkflowYield
+	}
+	return wfExec, err
+}
+
+func normalizeExecuteStepsErr(err error) error {
+	if errors.Is(err, errWorkflowYield) {
+		return nil
+	}
+	return err
 }
 
 // execSyncStep dispatches to a synchronous step handler and returns its output.

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -139,6 +139,7 @@ func (e *Engine) startWorkflowCore(taskID, workflowID, startStepID string, vars 
 
 	e.logger.Info("workflow.start", "task_id", taskID, "workflow", workflowID, "step", start.ID)
 	comp, err := e.executeSteps(taskID, &def, start, wfExec)
+	err = normalizeExecuteStepsErr(err)
 	if errors.Is(err, errBestOfNParked) {
 		return nil, errBestOfNParked
 	}

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -929,6 +929,7 @@ func (e *Engine) rescheduleRunAgent(taskID, agentID string, step *Step, t TaskIn
 		e.logger.Info(logPrefix+".retry", "task_id", taskID, "step", step.ID)
 		comp, rErr = e.executeSteps(taskID, def, step, t.Workflow)
 	}
+	rErr = normalizeExecuteStepsErr(rErr)
 	e.fireComplete(comp)
 	e.drainPendingConflictRecovery(taskID)
 	e.resumeError.Log(e.logger, logPrefix+".exec", taskID, rErr, "task_id", taskID)
@@ -1403,6 +1404,7 @@ func (e *Engine) resumeStalledReconcileWaitHumanStatus(t TaskInfo, step *Step) {
 func (e *Engine) finishResumeStalledStep(taskID string, def *Definition, step *Step, wf *Execution, fresh TaskInfo) {
 	e.logger.Info("workflow.resume-stalled", "task_id", taskID, "step", step.ID)
 	comp, rErr := e.executeSteps(taskID, def, step, wf)
+	rErr = normalizeExecuteStepsErr(rErr)
 	e.clearResumeDispatching(taskID)
 	// Most resumable steps dispatch async work and return nil; sync retry steps
 	// such as verify_checks can finish the workflow here.

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -925,11 +925,12 @@ func (e *Engine) rescheduleRunAgent(taskID, agentID string, step *Step, t TaskIn
 
 	e.logger.Info(logPrefix, "task_id", taskID, "step", step.ID)
 	comp, rErr := e.executeSteps(taskID, def, step, t.Workflow)
+	rErr = normalizeExecuteStepsErr(rErr)
 	if rErr == nil && e.shouldRetryGhostPark(taskID, step.ID) {
 		e.logger.Info(logPrefix+".retry", "task_id", taskID, "step", step.ID)
 		comp, rErr = e.executeSteps(taskID, def, step, t.Workflow)
+		rErr = normalizeExecuteStepsErr(rErr)
 	}
-	rErr = normalizeExecuteStepsErr(rErr)
 	e.fireComplete(comp)
 	e.drainPendingConflictRecovery(taskID)
 	e.resumeError.Log(e.logger, logPrefix+".exec", taskID, rErr, "task_id", taskID)

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -136,6 +136,18 @@ func (e *Engine) handleHumanAction(taskID, action string, data map[string]string
 	if err != nil {
 		return err
 	}
+	if t.Workflow != nil && t.Workflow.State == ExecWaiting && t.Workflow.CurrentStep != "" {
+		def, err := e.store.Get(t.Workflow.WorkflowID)
+		if err != nil {
+			return err
+		}
+		currentStep := def.StepByID(t.Workflow.CurrentStep)
+		if currentStep != nil && currentStep.Type == StepWaitHuman {
+			if err := validateHumanAction(currentStep, action); err != nil {
+				return err
+			}
+		}
+	}
 	t, err = e.advanceSatisfiedWaitForStatus(taskID, t)
 	if err != nil {
 		return err
@@ -154,8 +166,8 @@ func (e *Engine) handleHumanAction(taskID, action string, data map[string]string
 	if currentStep.Type != StepWaitHuman {
 		return fmt.Errorf("task %s is not at a wait_human step", taskID)
 	}
-	if len(currentStep.Config.HumanActions) > 0 && !slices.Contains(currentStep.Config.HumanActions, action) {
-		return fmt.Errorf("invalid human action %q for step %q", action, currentStep.ID)
+	if err := validateHumanAction(currentStep, action); err != nil {
+		return err
 	}
 
 	wfExec := t.Workflow
@@ -173,6 +185,13 @@ func (e *Engine) handleHumanAction(taskID, action string, data map[string]string
 		Status: "completed",
 		Output: action,
 	})
+}
+
+func validateHumanAction(step *Step, action string) error {
+	if len(step.Config.HumanActions) > 0 && !slices.Contains(step.Config.HumanActions, action) {
+		return fmt.Errorf("invalid human action %q for step %q", action, step.ID)
+	}
+	return nil
 }
 
 // advanceSatisfiedWaitForStatus repairs stale workflow position before a human

--- a/internal/workflow/engine_reconcile.go
+++ b/internal/workflow/engine_reconcile.go
@@ -78,6 +78,7 @@ func (e *Engine) findReachableWaitHumanByStatus(def *Definition, current *Step, 
 	fields := e.transitionFields(t, t.Workflow)
 	if current.Type == StepSetStatus && current.Config.Status != "" {
 		fields["task.status"] = current.Config.Status
+		mustExecute = true
 	}
 	nextID, err := ResolveTransition(current.Next, fields)
 	if err != nil || nextID == "" {
@@ -100,6 +101,7 @@ func (e *Engine) findReachableWaitHumanByStatus(def *Definition, current *Step, 
 			if step.Config.Status != "" {
 				fields["task.status"] = step.Config.Status
 			}
+			mustExecute = true
 		case StepRequireSidecar, StepFlagPlanCritique:
 			mustExecute = true
 		case StepCondition:
@@ -204,13 +206,13 @@ func (e *Engine) executeCurrentStepForStatusReconcile(taskID string, def *Defini
 	e.logger.Info("workflow.current-step.reconcile-status.execute",
 		"task_id", taskID, "from", t.Workflow.CurrentStep, "status", status)
 	switch current.Type {
-	case StepRunAgent:
+	case StepRunAgent, StepParallel, StepBestOfN:
 		return true, e.AdvanceStep(taskID, StepOutput{
 			StepID: current.ID,
 			Status: "completed",
 			Output: "status:" + status,
 		})
-	case StepCondition, StepRequireSidecar, StepFlagPlanCritique:
+	case StepCondition, StepSetStatus, StepRequireSidecar, StepFlagPlanCritique:
 		wf := t.Workflow.Clone()
 		if wf == nil {
 			// Unreachable: t.Workflow is non-nil whenever this function's

--- a/internal/workflow/engine_reconcile_test.go
+++ b/internal/workflow/engine_reconcile_test.go
@@ -231,7 +231,15 @@ func TestHandleStatusChange_ReconcileSideEffectFencedByActiveClaim(t *testing.T)
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}
-	if _, _, err := engineB.claimStepEffect("t1", taskInfo, "flag_plan_critique_verdict", effectPosStepAction); err != nil {
+	def, err := store.Get("plan-critique-reconcile")
+	if err != nil {
+		t.Fatalf("Get definition: %v", err)
+	}
+	step := def.StepByID("flag_plan_critique_verdict")
+	if step == nil {
+		t.Fatal("flag_plan_critique_verdict step missing")
+	}
+	if _, _, err := engineB.claimStepEffect("t1", taskInfo, step, effectPosStepAction); err != nil {
 		t.Fatalf("foreign claim: %v", err)
 	}
 

--- a/internal/workflow/engine_reconcile_test.go
+++ b/internal/workflow/engine_reconcile_test.go
@@ -204,6 +204,54 @@ func TestHandleStatusChange_ReconcileExecutesPlanCritiqueFlag(t *testing.T) {
 	}
 }
 
+func TestHandleStatusChange_ReconcileSideEffectFencedByActiveClaim(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.Save(newPlanCritiqueReconcileDef()); err != nil {
+		t.Fatal(err)
+	}
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engineA := NewEngine(store, tasks, agents, discardLogger())
+	engineB := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "plan-review",
+		Body:         "original body",
+		PlanCritique: "# Plan Review: REJECT\n\nMissing verification.",
+		Workflow: &Execution{
+			WorkflowID:  "plan-critique-reconcile",
+			CurrentStep: "flag_plan_critique_verdict",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+
+	taskInfo, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if _, _, err := engineB.claimStepEffect("t1", taskInfo, "flag_plan_critique_verdict", effectPosStepAction); err != nil {
+		t.Fatalf("foreign claim: %v", err)
+	}
+
+	engineA.HandleStatusChange("t1", "plan-review")
+
+	got, _ := tasks.GetTask("t1")
+	if got.Workflow.CurrentStep != "flag_plan_critique_verdict" {
+		t.Fatalf("CurrentStep = %q, want flag_plan_critique_verdict", got.Workflow.CurrentStep)
+	}
+	if got.Body != "original body" {
+		t.Fatalf("Body = %q, want original body", got.Body)
+	}
+	if _, ok := got.Workflow.Variables["step.flag_plan_critique_verdict.output"]; ok {
+		t.Fatal("flag output recorded despite active foreign claim")
+	}
+	if len(got.Workflow.EffectLog) != 1 || got.Workflow.EffectLog[0].Owner != engineB.ownerID {
+		t.Fatalf("effect log = %+v, want single active claim owned by engineB", got.Workflow.EffectLog)
+	}
+}
+
 func TestHandleStatusChange_DoesNotReconcileRunningRunAgentWithoutWaitForStatus(t *testing.T) {
 	store := newTestStore(t)
 	if err := store.Save(newPlanCritiqueReconcileDef()); err != nil {

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -347,7 +347,8 @@ func (e *Engine) finalizeBestOfNParent(taskID string, def *Definition, parent *S
 		return comp, nil
 	}
 	e.logger.Info("workflow.best-of-n.advance", "task_id", taskID, "from", parent.ID, "to", nextStep.ID)
-	return e.executeSteps(taskID, def, nextStep, wfExec)
+	comp, err = e.executeSteps(taskID, def, nextStep, wfExec)
+	return comp, normalizeExecuteStepsErr(err)
 }
 
 // cleanupAllBestOfNAttempts best-effort removes every attempt worktree dir
@@ -420,7 +421,8 @@ func (e *Engine) failStepClosed(taskID string, def *Definition, step *Step, wfEx
 	if nextStep == nil {
 		return comp, nil
 	}
-	return e.executeSteps(taskID, def, nextStep, wfExec)
+	comp, err = e.executeSteps(taskID, def, nextStep, wfExec)
+	return comp, normalizeExecuteStepsErr(err)
 }
 
 // bestOfNManifestAttempt is one attempt's entry in the JSON manifest artifact

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -303,7 +303,8 @@ func (e *Engine) finalizeParallelParent(taskID string, def *Definition, parent *
 		return comp, nil
 	}
 	e.logger.Info("workflow.parallel.advance", "task_id", taskID, "from", parent.ID, "to", nextStep.ID, "status", parentStatus)
-	return e.executeSteps(taskID, def, nextStep, wfExec)
+	comp, err = e.executeSteps(taskID, def, nextStep, wfExec)
+	return comp, normalizeExecuteStepsErr(err)
 }
 
 // summarizeChildOutputs renders a compact "child=status" summary that

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3150,6 +3150,53 @@ func TestResumeStalled_RunAgent(t *testing.T) {
 	}
 }
 
+func TestResumeStalled_RunAgentAfterCompletedDispatchEffect(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	completedAt := time.Now().UTC()
+	tasks.Put(TaskInfo{
+		ID:         "t1",
+		Generation: 1,
+		Status:     "in-progress",
+		AgentMode:  "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecRunning,
+			Variables:   make(map[string]string),
+			EffectLog: []EffectRecord{{
+				ID:          EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction},
+				IntentAt:    completedAt.Add(-time.Second),
+				Owner:       engine.ownerID,
+				CompletedAt: &completedAt,
+			}},
+		},
+	})
+
+	engine.ResumeStalled()
+
+	if agents.CallCount() != 1 {
+		t.Fatalf("expected 1 agent start, got %d", agents.CallCount())
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if len(got.Workflow.EffectLog) != 2 {
+		t.Fatalf("effect log len = %d, want 2: %+v", len(got.Workflow.EffectLog), got.Workflow.EffectLog)
+	}
+	if got.Workflow.EffectLog[1].ID.StepSeq <= got.Workflow.EffectLog[0].ID.StepSeq {
+		t.Fatalf("new effect StepSeq = %d, want greater than prior completed StepSeq %d",
+			got.Workflow.EffectLog[1].ID.StepSeq, got.Workflow.EffectLog[0].ID.StepSeq)
+	}
+	if got.Workflow.EffectLog[1].CompletedAt == nil {
+		t.Fatalf("new dispatch effect was not completed: %+v", got.Workflow.EffectLog[1])
+	}
+}
+
 func TestResumeStalled_DispatchesRateLimitedProviderForFailover(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
@@ -4479,6 +4526,50 @@ func TestHandleHumanAction_NotWaiting(t *testing.T) {
 	err := engine.HandleHumanAction("t1", "approve", nil)
 	if err == nil {
 		t.Fatal("expected error for non-waiting task")
+	}
+}
+
+func TestHandleHumanAction_InvalidActionAlreadyWaitingDoesNotMutate(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "plan-review",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "review_plan",
+			State:       ExecWaiting,
+			Variables:   map[string]string{"existing": "value"},
+			StepHistory: []StepRecord{{StepID: "plan", Status: "completed"}},
+		},
+	})
+
+	err := engine.HandleHumanAction("t1", "bogus", nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid human action") {
+		t.Fatalf("HandleHumanAction error = %v, want invalid human action", err)
+	}
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow.CurrentStep != "review_plan" {
+		t.Fatalf("CurrentStep = %q, want review_plan", got.Workflow.CurrentStep)
+	}
+	if got.Workflow.State != ExecWaiting {
+		t.Fatalf("State = %q, want %q", got.Workflow.State, ExecWaiting)
+	}
+	if _, ok := got.Workflow.Variables["human_action"]; ok {
+		t.Fatal("human_action var was set for rejected action")
+	}
+	if got.Workflow.Variables["existing"] != "value" {
+		t.Fatalf("existing var = %q, want value", got.Workflow.Variables["existing"])
+	}
+	if len(got.Workflow.StepHistory) != 1 || got.Workflow.StepHistory[0].StepID != "plan" {
+		t.Fatalf("StepHistory changed: %+v", got.Workflow.StepHistory)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -395,6 +395,46 @@ func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	return nil
 }
 
+func (m *memTasks) ClaimWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return EffectClaimResult{}, fmt.Errorf("task %s not found", id)
+	}
+	if t.Workflow == nil {
+		return EffectClaimResult{}, fmt.Errorf("task %s has no workflow", id)
+	}
+	wf := t.Workflow.Clone()
+	result, err := wf.ClaimEffect(claim)
+	result.Workflow = wf
+	if err != nil {
+		return result, err
+	}
+	t.Workflow = wf
+	return result, nil
+}
+
+func (m *memTasks) CompleteWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return EffectClaimResult{}, fmt.Errorf("task %s not found", id)
+	}
+	if t.Workflow == nil {
+		return EffectClaimResult{}, fmt.Errorf("task %s has no workflow", id)
+	}
+	wf := t.Workflow.Clone()
+	result, err := wf.CompleteEffect(claim)
+	result.Workflow = wf
+	if err != nil {
+		return result, err
+	}
+	t.Workflow = wf
+	return result, nil
+}
+
 func (m *memTasks) WriteSidecar(id, kind, content string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -12,9 +12,11 @@ const maxEffectLog = 200
 // It is stored on Execution.EffectLog so retried effects can reuse their
 // original EffectID as an idempotency key.
 type EffectRecord struct {
-	ID          EffectID   `yaml:"id" json:"id"`
-	IntentAt    time.Time  `yaml:"intent_at" json:"intentAt"`
-	CompletedAt *time.Time `yaml:"completed_at,omitempty" json:"completedAt,omitempty"`
+	ID             EffectID   `yaml:"id" json:"id"`
+	IntentAt       time.Time  `yaml:"intent_at" json:"intentAt"`
+	Owner          string     `yaml:"owner,omitempty" json:"owner,omitempty"`
+	LeaseExpiresAt *time.Time `yaml:"lease_expires_at,omitempty" json:"leaseExpiresAt,omitempty"`
+	CompletedAt    *time.Time `yaml:"completed_at,omitempty" json:"completedAt,omitempty"`
 }
 
 // ExecState tracks the overall execution state.
@@ -221,6 +223,10 @@ func (e *Execution) Clone() *Execution {
 	if e.EffectLog != nil {
 		cloned.EffectLog = slices.Clone(e.EffectLog)
 		for i := range cloned.EffectLog {
+			if cloned.EffectLog[i].LeaseExpiresAt != nil {
+				t := *cloned.EffectLog[i].LeaseExpiresAt
+				cloned.EffectLog[i].LeaseExpiresAt = &t
+			}
 			if cloned.EffectLog[i].CompletedAt != nil {
 				t := *cloned.EffectLog[i].CompletedAt
 				cloned.EffectLog[i].CompletedAt = &t
@@ -392,7 +398,9 @@ func (e *Execution) CountStep(stepID string) int {
 // its persistent count (see StepCounts), resetting CountStep(stepID) to 0.
 // Used when a step is deliberately re-armed for a fresh attempt cycle (e.g.
 // route-level auto-retry) so its own in-step max_retries budget is not seen
-// as already exhausted by prior cycles.
+// as already exhausted by prior cycles. It also drops any effect-log records
+// anchored to that step so the fresh attempt gets a fresh claim ID instead of
+// being fenced by a prior completed attempt's durable effect lease.
 func (e *Execution) ClearStepRecords(stepID string) {
 	if len(e.StepHistory) > 0 {
 		kept := e.StepHistory[:0]
@@ -404,6 +412,15 @@ func (e *Execution) ClearStepRecords(stepID string) {
 		e.StepHistory = kept
 	}
 	delete(e.StepCounts, stepID)
+	if len(e.EffectLog) > 0 {
+		kept := e.EffectLog[:0]
+		for i := range e.EffectLog {
+			if e.EffectLog[i].ID.StepID != stepID {
+				kept = append(kept, e.EffectLog[i])
+			}
+		}
+		e.EffectLog = kept
+	}
 }
 
 // RecordForStep returns the latest record for a given step ID, or nil.

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -172,6 +172,8 @@ func TestClearStepRecords_ResetsCountForStep(t *testing.T) {
 	e.RecordStep(StepRecord{StepID: "run_test", Status: "failed"})
 	e.RecordStep(StepRecord{StepID: "run_test", Status: "failed"})
 	e.RecordStep(StepRecord{StepID: "implement", Status: "completed"})
+	e.RecordEffectIntent(makeID("run_test", 0), time.Now())
+	e.RecordEffectIntent(makeID("implement", 0), time.Now())
 
 	e.ClearStepRecords("run_test")
 
@@ -180,6 +182,12 @@ func TestClearStepRecords_ResetsCountForStep(t *testing.T) {
 	}
 	if got := e.CountStep("implement"); got != 1 {
 		t.Errorf("expected unrelated step records to survive, got %d", got)
+	}
+	if _, ok := e.EffectIDForStep("run_test", 0); ok {
+		t.Fatal("expected run_test effect log entries to be cleared")
+	}
+	if _, ok := e.EffectIDForStep("implement", 0); !ok {
+		t.Fatal("expected unrelated effect log entries to survive")
 	}
 
 	// Re-arming should let a fresh in-step retry budget accrue again.
@@ -361,5 +369,32 @@ func TestEffectLog_CloneDeepCopiesCompletedAt(t *testing.T) {
 	*cloned.EffectLog[0].CompletedAt = original.Add(time.Hour)
 	if !e.EffectLog[0].CompletedAt.Equal(original) {
 		t.Fatal("mutating clone's CompletedAt pointee should not affect original")
+	}
+}
+
+func TestEffectLog_CloneDeepCopiesLeaseExpiry(t *testing.T) {
+	e := &Execution{}
+	id := makeID("implement", 0)
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Minute)
+	e.EffectLog = []EffectRecord{{
+		ID:             id,
+		IntentAt:       now,
+		Owner:          "engine-1",
+		LeaseExpiresAt: &expiresAt,
+	}}
+
+	cloned := e.Clone()
+	if cloned == nil {
+		t.Fatal("Clone of non-nil Execution returned nil")
+	}
+	if cloned.EffectLog[0].LeaseExpiresAt == e.EffectLog[0].LeaseExpiresAt {
+		t.Fatal("clone should not alias original's LeaseExpiresAt pointer")
+	}
+
+	original := *e.EffectLog[0].LeaseExpiresAt
+	*cloned.EffectLog[0].LeaseExpiresAt = original.Add(time.Hour)
+	if !e.EffectLog[0].LeaseExpiresAt.Equal(original) {
+		t.Fatal("mutating clone's LeaseExpiresAt pointee should not affect original")
 	}
 }


### PR DESCRIPTION
## Motivation

Implements #2663 — adds compare-and-swap/lease semantics to effect claiming so concurrent reconcilers or a restarted process cannot both believe they own the same effect. Fences stale owners before any external action (dispatch, status write, GitHub call).

Depends on: #2661 (idempotency keys, merged).

## Implementation information

- New `internal/workflow/effect_claim.go` with owner/lease metadata and stale-owner fencing
- CAS claim re-validation hooked into engine reconcile, dispatch, events, and step paths
- Adapters updated in `app_workflow.go`

> Changelog: feat(workflow): add CAS/lease effect claiming with stale-owner fencing

## Supporting documentation

Closes #2663