### PR TITLE
fix(config): isolate orchestrator from operator config

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/configservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/configservice.ts
@@ -53,7 +53,9 @@ export function GetSettings(): $CancellablePromise<$models.AppSettings> {
 /**
  * ReloadFromDisk re-reads ~/.sybra/config.yaml, validates it, diffs against
  * the persisted intent snapshot, and applies only hot-reloadable changes.
- * Restart-required values stay pending until process restart. Never writes to disk.
+ * Restart-required values stay pending until process restart. If an external
+ * writer leaves config.yaml unreadable or invalid, restore the last-known-good
+ * file so the process does not stay wedged on a broken operator config.
  */
 export function ReloadFromDisk(): $CancellablePromise<$models.ConfigMutationResult> {
     return $Call.ByID(742653545).then(($result: any) => {

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -315,7 +315,7 @@ func systemSandboxKey(cfg *RunConfig) string {
 		raw = strings.TrimSpace(string(cfg.Role))
 	}
 	if raw == "" {
-		raw = "system"
+		return "system-run"
 	}
 	raw = strings.ToLower(raw)
 	var b strings.Builder

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -256,9 +256,9 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 // injectSandboxHome routes every task-scoped agent subprocess's default
 // SYBRA_HOME through the per-task sandbox home, so no fresh agent (any
 // provider, any role) can resolve the operator's real ~/.sybra by default —
-// see #1576. System/probe runs with an empty TaskID (health checks,
-// orchestrator-internal probes) are the only ones allowed to skip this: they
-// have no task-scoped worktree/sandbox to isolate into.
+// see #1576. Taskless system runs skip this only when IsolateHome is false;
+// long-lived/judgment agents such as the orchestrator opt in so stale Sybra
+// source checkouts or sybra-cli invocations cannot rewrite the operator config.
 //
 // cfg.ExtraEnv is normalized before the trusted values are appended: any
 // existing SYBRA_HOME/SYBRA_CONTROL_HOME entries (caller-supplied or
@@ -266,32 +266,38 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 // control home are appended last, so they always win regardless of duplicate
 // env var resolution order in the target process.
 func (m *Manager) injectSandboxHome(cfg *RunConfig) error {
-	if cfg.TaskID == "" {
-		return nil
+	sandboxKey := strings.TrimSpace(cfg.TaskID)
+	if sandboxKey == "" {
+		if !cfg.IsolateHome {
+			return nil
+		}
+		sandboxKey = systemSandboxKey(cfg)
 	}
+	cfg.sandboxKey = sandboxKey
+
 	m.mu.RLock()
 	resolve := m.sandboxHome
 	controlHome := m.controlHome
 	m.mu.RUnlock()
 	if resolve == nil {
-		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "err", "no sandbox home resolver configured")
-		return fmt.Errorf("agent.Run: no sandbox home resolver configured for task-scoped run %q", cfg.TaskID)
+		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "sandbox_key", sandboxKey, "err", "no sandbox home resolver configured")
+		return fmt.Errorf("agent.Run: no sandbox home resolver configured for run %q", sandboxKey)
 	}
-	dir, err := resolve(cfg.TaskID)
+	dir, err := resolve(sandboxKey)
 	if err != nil {
-		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "err", err)
-		return fmt.Errorf("agent.Run: resolve sandbox home for task %q: %w", cfg.TaskID, err)
+		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "sandbox_key", sandboxKey, "err", err)
+		return fmt.Errorf("agent.Run: resolve sandbox home for run %q: %w", sandboxKey, err)
 	}
 	if strings.TrimSpace(dir) == "" {
-		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "err", "resolver returned empty path")
-		return fmt.Errorf("agent.Run: sandbox home resolver returned empty path for task %q", cfg.TaskID)
+		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "sandbox_key", sandboxKey, "err", "resolver returned empty path")
+		return fmt.Errorf("agent.Run: sandbox home resolver returned empty path for run %q", sandboxKey)
 	}
 	if info, statErr := os.Stat(dir); statErr != nil || !info.IsDir() {
 		if statErr == nil {
 			statErr = fmt.Errorf("%q is not a directory", dir)
 		}
-		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "err", statErr)
-		return fmt.Errorf("agent.Run: sandbox home %q for task %q is not accessible: %w", dir, cfg.TaskID, statErr)
+		m.logger.Error("agent.sandbox_home.failed", "task_id", cfg.TaskID, "sandbox_key", sandboxKey, "err", statErr)
+		return fmt.Errorf("agent.Run: sandbox home %q for run %q is not accessible: %w", dir, sandboxKey, statErr)
 	}
 
 	cfg.ExtraEnv = stripEnvKeys(cfg.ExtraEnv, "SYBRA_HOME", "SYBRA_CONTROL_HOME")
@@ -301,6 +307,41 @@ func (m *Manager) injectSandboxHome(cfg *RunConfig) error {
 	}
 	cfg.resolvedSandboxHome = dir
 	return nil
+}
+
+func systemSandboxKey(cfg *RunConfig) string {
+	raw := strings.TrimSpace(cfg.Name)
+	if raw == "" {
+		raw = strings.TrimSpace(string(cfg.Role))
+	}
+	if raw == "" {
+		raw = "system"
+	}
+	raw = strings.ToLower(raw)
+	var b strings.Builder
+	b.Grow(len("system-") + len(raw))
+	b.WriteString("system-")
+	lastDash := false
+	for _, r := range raw {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '.' || r == '-'
+		if !ok {
+			if lastDash {
+				continue
+			}
+			r = '-'
+		}
+		if r == '-' {
+			lastDash = true
+		} else {
+			lastDash = false
+		}
+		b.WriteRune(r)
+	}
+	key := strings.Trim(b.String(), "-.")
+	if key == "system" || key == "" {
+		return "system-run"
+	}
+	return key
 }
 
 func (m *Manager) injectGitHubToken(cfg *RunConfig) {
@@ -339,7 +380,11 @@ func (m *Manager) injectSharedBuildCache(cfg *RunConfig) error {
 	if cfg.resolvedSandboxHome == "" {
 		return nil
 	}
-	goBuild := buildcache.TaskGoBuildDir(cfg.TaskID)
+	cacheKey := cfg.TaskID
+	if cacheKey == "" {
+		cacheKey = cfg.sandboxKey
+	}
+	goBuild := buildcache.TaskGoBuildDir(cacheKey)
 	goMod := buildcache.SharedGoModDir()
 	npm := buildcache.SharedNPMDir()
 	for _, d := range []string{goBuild, goMod, npm} {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1749,6 +1749,12 @@ type RunConfig struct {
 	// and system-critical sessions; user-initiated runs leave this false so
 	// they surface a clear error instead of wasting a hopeless request.
 	IgnoreHealthGate bool
+	// IsolateHome routes SYBRA_HOME through a sandbox home even when TaskID is
+	// empty. Use this for taskless system agents that may run sybra-cli or old
+	// Sybra source checkouts: they still need to read the operator board via
+	// SYBRA_CONTROL_HOME, but must never be able to rewrite the operator's real
+	// config.yaml by inheriting ~/.sybra as their default home.
+	IsolateHome bool
 	// DisableProviderFailover keeps provider selection fixed for A/B variants:
 	// an unhealthy/limited provider fails the run instead of silently becoming a
 	// different provider while retaining stale variant attribution.
@@ -1871,6 +1877,9 @@ type RunConfig struct {
 	// injectSandboxHome, reused by injectProcessSandbox as one of the
 	// sandbox's allowed write roots. Never set by callers.
 	resolvedSandboxHome string
+	// sandboxKey is the task id or synthetic system-run id used for per-run
+	// sandbox/cache directories. Never set by callers.
+	sandboxKey string
 	// sandbox is the resolved OS-level process-sandbox spec for this run,
 	// computed once by injectProcessSandbox and consumed by wrapInvocation
 	// at each provider spawn site. Never set by callers.

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -65,6 +65,58 @@ func TestPrepareRunConfig_SandboxHome_SystemRunSkipsInjection(t *testing.T) {
 	}
 }
 
+// TestPrepareRunConfig_SandboxHome_IsolatedSystemRun pins the orchestrator
+// hardening: selected taskless system agents still get a sandbox SYBRA_HOME, so
+// stale sybra-cli/source invocations cannot rewrite the operator's real home.
+func TestPrepareRunConfig_SandboxHome_IsolatedSystemRun(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	sandboxDir := t.TempDir()
+	var gotKey string
+	m, _ := newTestManager(t, ManagerConfig{
+		SandboxHome: func(key string) (string, error) {
+			gotKey = key
+			return sandboxDir, nil
+		},
+		ControlHome: "/real/home",
+	})
+
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		Name:        "Sybra Orchestrator",
+		Mode:        "headless",
+		Dir:         t.TempDir(),
+		IsolateHome: true,
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	if gotKey != "system-sybra-orchestrator" {
+		t.Fatalf("sandbox key = %q, want system-sybra-orchestrator", gotKey)
+	}
+	base := sharedBuildCacheDir()
+	want := []string{
+		"SYBRA_HOME=" + sandboxDir,
+		"SYBRA_CONTROL_HOME=/real/home",
+		"GOLANGCI_LINT_CACHE=" + filepath.Join(sandboxDir, "golangci-lint-cache"),
+		"GOCACHE=" + filepath.Join(base, "go-build", "system-sybra-orchestrator"),
+		"GOMODCACHE=" + filepath.Join(base, "go-mod"),
+		"npm_config_cache=" + filepath.Join(base, "npm"),
+	}
+	if len(cfg.ExtraEnv) != len(want) {
+		t.Fatalf("ExtraEnv = %v, want %v", cfg.ExtraEnv, want)
+	}
+	for i, v := range want {
+		if cfg.ExtraEnv[i] != v {
+			t.Fatalf("ExtraEnv[%d] = %q, want %q (full: %v)", i, cfg.ExtraEnv[i], v, cfg.ExtraEnv)
+		}
+	}
+	if cfg.resolvedSandboxHome != sandboxDir {
+		t.Fatalf("resolvedSandboxHome = %q, want %q", cfg.resolvedSandboxHome, sandboxDir)
+	}
+	if cfg.sandboxKey != "system-sybra-orchestrator" {
+		t.Fatalf("sandboxKey = %q, want system-sybra-orchestrator", cfg.sandboxKey)
+	}
+}
+
 // TestPrepareRunConfig_SandboxHome_NilResolverFailsClosed pins that a
 // task-scoped run with no resolver configured aborts before spawn rather than
 // silently inheriting the ambient/operator SYBRA_HOME.

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -117,6 +117,12 @@ func TestPrepareRunConfig_SandboxHome_IsolatedSystemRun(t *testing.T) {
 	}
 }
 
+func TestSystemSandboxKey_EmptyIdentity(t *testing.T) {
+	if got := systemSandboxKey(&RunConfig{}); got != "system-run" {
+		t.Fatalf("systemSandboxKey(empty) = %q, want system-run", got)
+	}
+}
+
 // TestPrepareRunConfig_SandboxHome_NilResolverFailsClosed pins that a
 // task-scoped run with no resolver configured aborts before spawn rather than
 // silently inheriting the ambient/operator SYBRA_HOME.

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -19,7 +19,7 @@ func (s *ConfigService) ReloadFromDisk() (ConfigMutationResult, error) {
 			result.Recovery = &ConfigRecovery{
 				Message: fmt.Sprintf("config reload failed and last-known-good restore failed: %v", restoreErr),
 			}
-			return result, fmt.Errorf("%w; restore last-known-good: %w", err, restoreErr)
+			return result, err
 		}
 		result.Recovery = &ConfigRecovery{
 			RestoredLastKnownGood: true,

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -1,14 +1,31 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/config"
+import (
+	"fmt"
+
+	"github.com/Automaat/sybra/internal/config"
+)
 
 // ReloadFromDisk re-reads ~/.sybra/config.yaml, validates it, diffs against
 // the persisted intent snapshot, and applies only hot-reloadable changes.
-// Restart-required values stay pending until process restart. Never writes to disk.
+// Restart-required values stay pending until process restart. If an external
+// writer leaves config.yaml unreadable or invalid, restore the last-known-good
+// file so the process does not stay wedged on a broken operator config.
 func (s *ConfigService) ReloadFromDisk() (ConfigMutationResult, error) {
 	next, err := config.LoadNoPersist()
 	if err != nil {
-		return ConfigMutationResult{}, err
+		result := ConfigMutationResult{}
+		if restoreErr := config.RestoreLastKnownGoodConfig(); restoreErr != nil {
+			result.Recovery = &ConfigRecovery{
+				Message: fmt.Sprintf("config reload failed and last-known-good restore failed: %v", restoreErr),
+			}
+			return result, fmt.Errorf("%w; restore last-known-good: %w", err, restoreErr)
+		}
+		result.Recovery = &ConfigRecovery{
+			RestoredLastKnownGood: true,
+			Message:               "restored config.yaml from last-known-good after reload failure",
+		}
+		return result, err
 	}
 
 	s.mu.Lock()

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -41,6 +41,13 @@ func setupConfigSvc(t *testing.T) (svc *ConfigService, cfgPath string) {
 
 	cfgPath = filepath.Join(home, "config.yaml")
 	writeConfigYAML(t, cfgPath, seed)
+	rawSeed, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read seed config: %v", err)
+	}
+	if err := os.WriteFile(config.LastKnownGoodConfigPath(), rawSeed, 0o600); err != nil {
+		t.Fatalf("write last-known-good seed: %v", err)
+	}
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -289,35 +296,92 @@ func TestReloadFromDisk_LogLevel(t *testing.T) {
 
 func TestReloadFromDisk_InvalidYAML(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)
+	before, err := os.ReadFile(config.LastKnownGoodConfigPath())
+	if err != nil {
+		t.Fatalf("read last-known-good: %v", err)
+	}
 
 	if err := os.WriteFile(cfgPath, []byte(":::invalid yaml{{{\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	origMax := svc.cfg.Agent.MaxConcurrent
-	_, err := svc.ReloadFromDisk()
+	result, err := svc.ReloadFromDisk()
 	if err == nil {
 		t.Fatal("expected error for invalid YAML, got nil")
 	}
+	if result.Recovery == nil || !result.Recovery.RestoredLastKnownGood {
+		t.Fatalf("expected last-known-good recovery on invalid YAML, got %+v", result.Recovery)
+	}
 	if svc.cfg.Agent.MaxConcurrent != origMax {
 		t.Errorf("cfg mutated on error: got %d, want %d", svc.cfg.Agent.MaxConcurrent, origMax)
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read restored config: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("config.yaml not restored after invalid YAML\nbefore:\n%s\nafter:\n%s", before, after)
 	}
 }
 
 func TestReloadFromDisk_ValidationError(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)
+	before, err := os.ReadFile(config.LastKnownGoodConfigPath())
+	if err != nil {
+		t.Fatalf("read last-known-good: %v", err)
+	}
 
 	next := *svc.cfg
 	next.Logging.Level = "verbose" // invalid
 	writeConfigYAML(t, cfgPath, &next)
 
 	origLevel := svc.cfg.Logging.Level
-	_, err := svc.ReloadFromDisk()
+	result, err := svc.ReloadFromDisk()
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
 	}
+	if result.Recovery == nil || !result.Recovery.RestoredLastKnownGood {
+		t.Fatalf("expected last-known-good recovery on validation error, got %+v", result.Recovery)
+	}
 	if svc.cfg.Logging.Level != origLevel {
 		t.Errorf("cfg.Logging.Level mutated on validation error")
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read restored config: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("config.yaml not restored after validation error\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestReloadFromDisk_UnknownLegacyKeyRestoresLastKnownGood(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	before, err := os.ReadFile(config.LastKnownGoodConfigPath())
+	if err != nil {
+		t.Fatalf("read last-known-good: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, append(before, []byte("\ntodoist:\n  enabled: true\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.ReloadFromDisk()
+	if err == nil {
+		t.Fatal("expected unknown key error, got nil")
+	}
+	if !strings.Contains(err.Error(), "todoist") {
+		t.Fatalf("error = %v, want todoist unknown-key context", err)
+	}
+	if result.Recovery == nil || !result.Recovery.RestoredLastKnownGood {
+		t.Fatalf("expected last-known-good recovery on unknown key, got %+v", result.Recovery)
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read restored config: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("config.yaml not restored after unknown legacy key\nbefore:\n%s\nafter:\n%s", before, after)
 	}
 }
 

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -204,8 +204,10 @@ func (s *OrchestratorService) StartOrchestratorContext(ctx context.Context) erro
 		Role:                   agent.RoleOrchestrator,
 		Mode:                   "headless",
 		Dir:                    config.HomeDir(),
+		ReadOnlyDir:            true,
 		Prompt:                 orchestratorKickoffPrompt,
 		IgnoreConcurrencyLimit: true,
+		IsolateHome:            true,
 	}, s.abTesting, orchestratorABKey(), orchestratorRole))
 	if err != nil {
 		return fmt.Errorf("start orchestrator agent: %w", err)


### PR DESCRIPTION
## Summary
- route taskless orchestrator runs through an isolated sandbox SYBRA_HOME while keeping SYBRA_CONTROL_HOME for board access
- mark the orchestrator home checkout read-only for enforced process sandboxing
- restore config.last-known-good.yaml when hot reload sees an invalid external config write, including stale legacy keys like todoist

## Tests
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/agent -run 'SandboxHome|SharedBuildCache|ProcessSandbox'
- SYBRA_HOME=/private/tmp/sybra-agent-test-home GOCACHE=/private/tmp/sybra-go-cache go test ./internal/agent
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra -run 'ReloadFromDisk_(InvalidYAML|ValidationError|UnknownLegacyKeyRestoresLastKnownGood)|SaveRawConfig_RestoresLastKnownGoodOnHotApplyFailure'
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra -run 'Orchestrator|RawConfig|ConfigReload'