### PR TITLE
feat(workflow): replay persisted effects on restart

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -54,8 +54,10 @@ var (
 	monitorTicks     metric.Int64Counter
 	monitorAnomalies metric.Int64Counter
 
-	orchestratorTicks         metric.Int64Counter
-	orchestratorStaleRestarts metric.Int64Counter
+	orchestratorTicks                  metric.Int64Counter
+	orchestratorStaleRestarts          metric.Int64Counter
+	orchestratorEffectReplays          metric.Int64Counter
+	orchestratorResumeStalledFallbacks metric.Int64Counter
 
 	providerProbes        metric.Int64Counter
 	providerHealthFlips   metric.Int64Counter
@@ -291,9 +293,21 @@ func createOrchestratorInstruments() error {
 	); err != nil {
 		return err
 	}
-	orchestratorStaleRestarts, err = m.Int64Counter(
+	if orchestratorStaleRestarts, err = m.Int64Counter(
 		"sybra_orchestrator_stale_restarts_total",
 		metric.WithDescription("Orchestrator stale in-progress task restart attempts, by result."),
+	); err != nil {
+		return err
+	}
+	if orchestratorEffectReplays, err = m.Int64Counter(
+		"sybra_orchestrator_effect_replays_total",
+		metric.WithDescription("Persisted workflow effect replay decisions, by result."),
+	); err != nil {
+		return err
+	}
+	orchestratorResumeStalledFallbacks, err = m.Int64Counter(
+		"sybra_orchestrator_resume_stalled_fallbacks_total",
+		metric.WithDescription("ResumeStalled fallback executions after persisted effect replay."),
 	)
 	return err
 }
@@ -780,6 +794,21 @@ func OrchestratorStaleRestart(ctx context.Context, ok bool) {
 	}
 	orchestratorStaleRestarts.Add(ctx, 1,
 		metric.WithAttributes(attribute.String("result", resultLabel(ok))))
+}
+
+func OrchestratorEffectReplay(ctx context.Context, result string) {
+	if orchestratorEffectReplays == nil {
+		return
+	}
+	orchestratorEffectReplays.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("result", result)))
+}
+
+func OrchestratorResumeStalledFallback(ctx context.Context) {
+	if orchestratorResumeStalledFallbacks == nil {
+		return
+	}
+	orchestratorResumeStalledFallbacks.Add(ctx, 1)
 }
 
 func ProviderProbe(ctx context.Context, name string, ok bool) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -28,6 +28,8 @@ func TestMetricsPipeline(t *testing.T) {
 	MonitorTick(context.Background())
 	MonitorAnomaly(context.Background(), "lost_agent")
 	OrchestratorTick(context.Background())
+	OrchestratorEffectReplay(context.Background(), "replayed")
+	OrchestratorResumeStalledFallback(context.Background())
 	ProviderProbe(context.Background(), "claude", true)
 	ProviderHealthFlip(context.Background(), "claude", false)
 	ProviderAuthFailure("claude")
@@ -60,6 +62,9 @@ func TestMetricsPipeline(t *testing.T) {
 	OrchestratorTick(context.Background())
 	OrchestratorStaleRestart(context.Background(), true)
 	OrchestratorStaleRestart(context.Background(), false)
+	OrchestratorEffectReplay(context.Background(), "replayed")
+	OrchestratorEffectReplay(context.Background(), "already_completed")
+	OrchestratorResumeStalledFallback(context.Background())
 	ProviderProbe(context.Background(), "claude", true)
 	ProviderProbe(context.Background(), "codex", false)
 	ProviderHealthFlip(context.Background(), "claude", false)
@@ -114,6 +119,8 @@ func TestMetricsPipeline(t *testing.T) {
 		"sybra_monitor_anomalies_total",
 		"sybra_orchestrator_ticks_total",
 		"sybra_orchestrator_stale_restarts_total",
+		"sybra_orchestrator_effect_replays_total",
+		"sybra_orchestrator_resume_stalled_fallbacks_total",
 		"sybra_tasks_by_status",
 		"sybra_agents_active",
 		"sybra_renovate_prs_fetched",
@@ -138,6 +145,8 @@ func TestMetricsPipeline(t *testing.T) {
 		`kind="lost_agent"`,
 		`kind="pr_gap"`,
 		`provider="claude"`,
+		`result="replayed"`,
+		`result="already_completed"`,
 		`from="claude"`,
 		`to="codex"`,
 		`state="healthy"`,

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -43,6 +43,7 @@ type WorkflowRestarter interface {
 	// restarting a stale WorkflowID.
 	DispatchEvent(taskID, event string, extraFields, vars map[string]string) (string, error)
 	HandleAgentComplete(taskID string, completion workflow.AgentCompletion)
+	ReplayPersistedEffects()
 }
 
 // PRResolver resolves the GitHub PR a task lost track of when its pr_number was
@@ -128,6 +129,9 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 	r.cleanupOrphanedSandboxes(ctx)
 	r.cleanStaleRuns()
 	r.pruneAgentLogs()
+	if r.WorkflowEngine != nil {
+		r.WorkflowEngine.ReplayPersistedEffects()
+	}
 	r.RestartStaleInProgress(ctx)
 }
 

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -44,6 +44,7 @@ type WorkflowRestarter interface {
 	DispatchEvent(taskID, event string, extraFields, vars map[string]string) (string, error)
 	HandleAgentComplete(taskID string, completion workflow.AgentCompletion)
 	ReplayPersistedEffects()
+	ReplayPersistedEffectsForTask(taskID string) bool
 }
 
 // PRResolver resolves the GitHub PR a task lost track of when its pr_number was

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -166,8 +166,8 @@ func TestRunStartupCleanup_ReplaysEffectsBeforeStaleRestart(t *testing.T) {
 	r.RunStartupCleanup(context.Background())
 	wg.Wait()
 
-	if !slices.Equal(order, []string{"replay", "restart"}) {
-		t.Fatalf("startup order = %v, want [replay restart]", order)
+	if !slices.Equal(order, []string{"replay", "replay:" + created.ID, "restart"}) {
+		t.Fatalf("startup order = %v, want [replay replay:%s restart]", order, created.ID)
 	}
 }
 
@@ -1235,6 +1235,8 @@ type stubWorkflowEngine struct {
 
 	replayCalls int
 	callOrder   *[]string
+	replayTasks []string
+	replayTask  bool
 
 	dispatchEventCalls  []map[string]string
 	dispatchEventResult string
@@ -1261,6 +1263,14 @@ func (s *stubWorkflowEngine) ReplayPersistedEffects() {
 	if s.callOrder != nil {
 		*s.callOrder = append(*s.callOrder, "replay")
 	}
+}
+
+func (s *stubWorkflowEngine) ReplayPersistedEffectsForTask(taskID string) bool {
+	s.replayTasks = append(s.replayTasks, taskID)
+	if s.callOrder != nil {
+		*s.callOrder = append(*s.callOrder, "replay:"+taskID)
+	}
+	return s.replayTask
 }
 
 // TestRestartStalePRFixWorkflowRevertsToInReview verifies the root cause of the
@@ -2143,6 +2153,70 @@ func (s *recordingWorkflowStub) HandleAgentComplete(taskID string, _ workflow.Ag
 }
 
 func (*recordingWorkflowStub) ReplayPersistedEffects() {}
+
+func (*recordingWorkflowStub) ReplayPersistedEffectsForTask(string) bool { return false }
+
+func TestRestartTaskIfStale_ReplaysPersistedEffectsBeforeFallback(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	ctx := context.Background()
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("stale replay", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tasks.UpdateMap(created.ID, map[string]any{
+		"status":     string(task.StatusInProgress),
+		"project_id": "owner/repo",
+		"workflow": &workflow.Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       workflow.ExecWaiting,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wfStub := &stubWorkflowEngine{replayTask: true}
+	orch := &stubOrchestrator{}
+	var wg sync.WaitGroup
+	r := &recovery.Recovery{
+		Tasks:          tasks,
+		Agents:         agents,
+		Worktrees:      wm,
+		WorkflowEngine: wfStub,
+		Orchestrator:   orch,
+		Logger:         logger,
+		Throttle:       logging.NewErrorThrottle(),
+		WG:             &wg,
+		LogDir:         t.TempDir(),
+	}
+
+	if err := r.RestartTaskIfStale(ctx, created.ID); err != nil {
+		t.Fatalf("RestartTaskIfStale: %v", err)
+	}
+	wg.Wait()
+
+	if !slices.Equal(wfStub.replayTasks, []string{created.ID}) {
+		t.Fatalf("task replay calls = %v, want [%s]", wfStub.replayTasks, created.ID)
+	}
+	if orch.startCalls != 0 {
+		t.Fatalf("StartAgent calls = %d, want 0 when workflow replay consumed the recovery tick", orch.startCalls)
+	}
+}
 
 // TestRestartStaleConcurrentPathsDoNotDoubleFireHandleAgentComplete is a
 // regression test for sybra#2452's actual race, reproduced with real

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -112,6 +113,62 @@ func TestRunStartupCleanupEmpty(t *testing.T) {
 	}
 	r.RunStartupCleanup(context.Background())
 	wg.Wait()
+}
+
+func TestRunStartupCleanup_ReplaysEffectsBeforeStaleRestart(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("startup replay ordering", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.UpdateMap(created.ID, map[string]any{
+		"status":     string(task.StatusInProgress),
+		"project_id": "owner/repo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	var order []string
+	wfStub := &stubWorkflowEngine{callOrder: &order}
+	orch := &stubOrchestrator{
+		onStart: func() {
+			order = append(order, "restart")
+		},
+	}
+
+	var wg sync.WaitGroup
+	r := &recovery.Recovery{
+		Tasks:          tasks,
+		Agents:         agents,
+		Worktrees:      wm,
+		WorkflowEngine: wfStub,
+		Orchestrator:   orch,
+		Logger:         logger,
+		Throttle:       logging.NewErrorThrottle(),
+		WG:             &wg,
+		LogDir:         t.TempDir(),
+	}
+	r.RunStartupCleanup(context.Background())
+	wg.Wait()
+
+	if !slices.Equal(order, []string{"replay", "restart"}) {
+		t.Fatalf("startup order = %v, want [replay restart]", order)
+	}
 }
 
 func TestRunStartupCleanup_CleansOrphanedSandboxes(t *testing.T) {
@@ -1176,6 +1233,9 @@ type stubWorkflowEngine struct {
 	startWorkflowErr   error
 	completions        []workflow.AgentCompletion
 
+	replayCalls int
+	callOrder   *[]string
+
 	dispatchEventCalls  []map[string]string
 	dispatchEventResult string
 	dispatchEventErr    error
@@ -1194,6 +1254,13 @@ func (s *stubWorkflowEngine) DispatchEvent(_, _ string, extraFields, _ map[strin
 
 func (s *stubWorkflowEngine) HandleAgentComplete(_ string, c workflow.AgentCompletion) {
 	s.completions = append(s.completions, c)
+}
+
+func (s *stubWorkflowEngine) ReplayPersistedEffects() {
+	s.replayCalls++
+	if s.callOrder != nil {
+		*s.callOrder = append(*s.callOrder, "replay")
+	}
 }
 
 // TestRestartStalePRFixWorkflowRevertsToInReview verifies the root cause of the
@@ -2075,6 +2142,8 @@ func (s *recordingWorkflowStub) HandleAgentComplete(taskID string, _ workflow.Ag
 	_, _ = s.tasks.Update(taskID, task.Update{Workflow: &wf})
 }
 
+func (*recordingWorkflowStub) ReplayPersistedEffects() {}
+
 // TestRestartStaleConcurrentPathsDoNotDoubleFireHandleAgentComplete is a
 // regression test for sybra#2452's actual race, reproduced with real
 // goroutines rather than a pre-held claim: the periodic
@@ -2161,6 +2230,7 @@ type stubOrchestrator struct {
 	lastMode      string
 	lastPrompt    string
 	lastOneShot   bool
+	onStart       func()
 }
 
 func (s *stubOrchestrator) StartAgent(_, mode, prompt string, _, oneShot bool) (*agent.Agent, error) {
@@ -2168,6 +2238,9 @@ func (s *stubOrchestrator) StartAgent(_, mode, prompt string, _, oneShot bool) (
 	s.lastMode = mode
 	s.lastPrompt = prompt
 	s.lastOneShot = oneShot
+	if s.onStart != nil {
+		s.onStart()
+	}
 	return s.startReturned, s.startErr
 }
 

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -105,6 +105,9 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 	if r.handleTerminalWorkflow(&t) {
 		return
 	}
+	if r.WorkflowEngine != nil && r.WorkflowEngine.ReplayPersistedEffectsForTask(t.ID) {
+		return
+	}
 	// Debounce respawn when a previous run started recently. Covers
 	// the dev-reload case: app restarts every few seconds, but a
 	// headless subprocess from the prior lifecycle is still alive.

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -20,6 +20,11 @@ import (
 
 const inboundReviewRedispatchCooldown = 10 * time.Minute
 
+type workflowRecoveryLoop interface {
+	ReplayPersistedEffects()
+	ResumeStalled()
+}
+
 // orchestratorLoop runs two cadences. The cheap, latency-sensitive dispatch pass
 // (start the orchestrator, release unblocked children) fires on a fast ticker and
 // on demand via dispatchNudge, so a freshly-ready task isn't left idle. The
@@ -174,11 +179,9 @@ func (a *App) queueDrainPass(ctx context.Context) {
 	}
 	a.reconcileRunnableBoardTasks(ctx)
 	if a.workflowEngine != nil {
-		// workflow.Engine derives its shell-step context from its own e.ctx
-		// field (Engine.SetContext, bound once from App's root ctx), not an
-		// explicit per-call parameter.
-		a.workflowEngine.ReplayPersistedEffects()
-		a.workflowEngine.ResumeStalled() //nolint:contextcheck // Engine uses its own e.ctx field, see comment above
+		var workflowRecovery workflowRecoveryLoop = a.workflowEngine
+		workflowRecovery.ReplayPersistedEffects()
+		workflowRecovery.ResumeStalled()
 	}
 }
 

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -177,6 +177,7 @@ func (a *App) queueDrainPass(ctx context.Context) {
 		// workflow.Engine derives its shell-step context from its own e.ctx
 		// field (Engine.SetContext, bound once from App's root ctx), not an
 		// explicit per-call parameter.
+		a.workflowEngine.ReplayPersistedEffects()
 		a.workflowEngine.ResumeStalled() //nolint:contextcheck // Engine uses its own e.ctx field, see comment above
 	}
 }

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // preventFetchTTLLeak guards against Startup's project.FetchTTL = 60s
@@ -250,6 +251,94 @@ func TestAppStartup_QueueInitFailureDegradesGracefully(t *testing.T) {
 	}
 }
 
+func TestQueueDrainPass_ReplaysPersistedEffectsBeforeResumeFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	store, err := task.NewStore(filepath.Join(home, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+
+	created, err := taskMgr.Create("queue replay", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := taskMgr.UpdateMap(created.ID, map[string]any{
+		"status": string(task.StatusInProgress),
+		"workflow": &workflow.Execution{
+			WorkflowID:  "replay-set-status",
+			CurrentStep: "mark_testing",
+			State:       workflow.ExecWaiting,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err = taskMgr.UpdateMap(created.ID, map[string]any{
+		"workflow": &workflow.Execution{
+			WorkflowID:  "replay-set-status",
+			CurrentStep: "mark_testing",
+			State:       workflow.ExecWaiting,
+			EffectLog: []workflow.EffectRecord{{
+				ID: workflow.EffectID{
+					Generation: updated.Generation + 1,
+					StepSeq:    0,
+					StepID:     "mark_testing",
+					Pos:        0,
+				},
+				IntentAt: time.Now().UTC(),
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wfDir := filepath.Join(home, "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const yaml = `id: replay-set-status
+name: Replay Set Status
+steps:
+  - id: mark_testing
+    type: set_status
+    config:
+      status: testing
+`
+	if err := os.WriteFile(filepath.Join(wfDir, "replay-set-status.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wfStore, err := workflow.NewStore(wfDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	engine := workflow.NewEngine(wfStore, &taskAdapter{tasks: taskMgr}, &recordingAgentLauncher{}, discardLogger())
+	app := &App{
+		cfg:            config.DefaultConfig(),
+		workflowEngine: engine,
+	}
+
+	app.queueDrainPass(context.Background())
+
+	got, err := taskMgr.Get(updated.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusTesting {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusTesting)
+	}
+	if got.Workflow == nil {
+		t.Fatal("workflow = nil, want completed workflow after replay")
+	}
+	if got.Workflow.State != workflow.ExecCompleted || got.Workflow.CurrentStep != "" {
+		t.Fatalf("workflow = %+v, want completed with empty current step", got.Workflow)
+	}
+}
+
 func TestAppShutdownBeforeStartupDoesNotPanic(t *testing.T) {
 	app := NewApp(slog.New(slog.DiscardHandler), &slog.LevelVar{}, startupTestConfig(t.TempDir()))
 
@@ -360,6 +449,9 @@ func assertStartupCoreWiring(t *testing.T, app *App, logger *slog.Logger, cfg *c
 	}
 	if app.agentCompletion == nil || app.recovery == nil {
 		t.Fatal("completion/recovery handlers were not initialized")
+	}
+	if app.recovery.WorkflowEngine != app.workflowEngine {
+		t.Fatal("recovery was not wired to the workflow engine")
 	}
 	if app.evaluationSvc == nil || app.routingSvc == nil {
 		t.Fatal("evaluation/routing services were not initialized before Startup returned")

--- a/internal/workflow/effect_claim.go
+++ b/internal/workflow/effect_claim.go
@@ -42,7 +42,7 @@ func currentStepEffectRecord(t TaskInfo, step *Step, pos int) (EffectRecord, boo
 		return EffectRecord{}, false
 	}
 	currentSeq := executionStepSeq(t.Workflow)
-	if rec.ID.Generation != t.Generation || rec.ID.StepSeq < currentSeq {
+	if rec.ID.StepSeq < currentSeq {
 		return EffectRecord{}, false
 	}
 	return rec, true

--- a/internal/workflow/effect_claim.go
+++ b/internal/workflow/effect_claim.go
@@ -33,24 +33,34 @@ type EffectClaimResult struct {
 	Completed bool
 }
 
+func currentStepEffectRecord(t TaskInfo, step *Step, pos int) (EffectRecord, bool) {
+	if t.Workflow == nil {
+		return EffectRecord{}, false
+	}
+	rec, ok := t.Workflow.EffectRecordForStep(step.ID, pos)
+	if !ok {
+		return EffectRecord{}, false
+	}
+	currentSeq := executionStepSeq(t.Workflow)
+	if rec.ID.Generation != t.Generation || rec.ID.StepSeq < currentSeq {
+		return EffectRecord{}, false
+	}
+	return rec, true
+}
+
 func (e *Engine) effectClaimForStep(t TaskInfo, step *Step, pos int) EffectClaim {
 	stepID := step.ID
 	reuseCompleted := !isAsyncWorkflowStep(step.Type)
 	skippedCompleted := false
-	if t.Workflow != nil {
-		if existing, ok := t.Workflow.EffectIDForStep(stepID, pos); ok {
-			currentSeq := executionStepSeq(t.Workflow)
-			if rec, found := t.Workflow.effectRecord(existing); found && rec.ID.StepSeq >= currentSeq {
-				if rec.CompletedAt != nil && !reuseCompleted {
-					skippedCompleted = true
-				} else {
-					return EffectClaim{
-						EffectID: existing,
-						Owner:    e.ownerID,
-						LeaseTTL: e.effectLeaseTTL,
-						Now:      e.now(),
-					}
-				}
+	if rec, ok := currentStepEffectRecord(t, step, pos); ok {
+		if rec.CompletedAt != nil && !reuseCompleted {
+			skippedCompleted = true
+		} else {
+			return EffectClaim{
+				EffectID: rec.ID,
+				Owner:    e.ownerID,
+				LeaseTTL: e.effectLeaseTTL,
+				Now:      e.now(),
 			}
 		}
 	}

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -527,7 +527,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return nil, err
 		}
 		t = e.withManualTestConfig(t)
-		ctx, err := e.prepareStepTemplateContext(taskID, step, wfExec, t)
+		tmplCtx, err := e.prepareStepTemplateContext(taskID, step, wfExec, t)
 		if err != nil {
 			return nil, err
 		}
@@ -542,7 +542,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 
 		// Async steps: execute and return. Callback (HandleAgentComplete/HandleHumanAction)
 		// will call AdvanceStep later.
-		if handled, comp, asyncErr := e.executeAsyncWorkflowStep(taskID, def, step, wfExec, ctx, effectID); handled {
+		if handled, comp, asyncErr := e.executeAsyncWorkflowStep(taskID, def, step, wfExec, tmplCtx, effectID); handled {
 			if errors.Is(asyncErr, errWorkflowYield) {
 				return nil, asyncErr
 			}
@@ -570,7 +570,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			}
 		} else {
 			var execErr error
-			output, execErr = e.execSyncStep(taskID, step, wfExec, ctx, t)
+			output, execErr = e.execSyncStep(taskID, step, wfExec, tmplCtx, t)
 			if execErr != nil {
 				// The step parked the workflow in ExecWaiting (it persisted the new
 				// CurrentStep/State itself). Stop without recording/advancing/

--- a/internal/workflow/engine_effect_replay.go
+++ b/internal/workflow/engine_effect_replay.go
@@ -82,8 +82,12 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 		return
 	}
 
-	fresh, abort := e.refreshTaskForReplay(t.ID, t.Workflow)
+	fresh, abort := e.resolveFreshTaskForResume(t, step, &def)
 	if abort {
+		return
+	}
+	if e.agents.HasRunningAgent(fresh.ID) || e.agents.IsDispatching(fresh.ID) {
+		e.clearResumeDispatching(fresh.ID)
 		return
 	}
 	if e.dispatchGate != nil && !e.dispatchGate(fresh) {
@@ -132,17 +136,4 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 	e.clearTransientFetchRetry(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearCircuitBreakerOnSuccess(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearWatchdogReaskNote(fresh.ID, cleanupWorkflow)
-}
-
-func (e *Engine) refreshTaskForReplay(taskID string, wf *Execution) (TaskInfo, bool) {
-	fresh, skip := e.shouldSkipResumeAfterFreshRead(taskID, wf)
-	if skip {
-		e.clearResumeDispatching(taskID)
-		return fresh, true
-	}
-	if e.agents.HasRunningAgent(taskID) || e.agents.IsDispatching(taskID) {
-		e.clearResumeDispatching(taskID)
-		return fresh, true
-	}
-	return fresh, false
 }

--- a/internal/workflow/engine_effect_replay.go
+++ b/internal/workflow/engine_effect_replay.go
@@ -70,7 +70,11 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 	if step == nil {
 		return
 	}
-	if _, ok := currentStepEffectRecord(*t, step, effectPosStepAction); !ok {
+	rec, ok := currentStepEffectRecord(*t, step, effectPosStepAction)
+	if !ok {
+		return
+	}
+	if rec.CompletedAt == nil && e.resumePreflightConsumesTick(t, step, "workflow.effect-replay.skip") {
 		return
 	}
 
@@ -105,7 +109,7 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 		e.clearResumeDispatching(t.ID)
 		return
 	}
-	rec, ok := currentStepEffectRecord(fresh, step, effectPosStepAction)
+	rec, ok = currentStepEffectRecord(fresh, step, effectPosStepAction)
 	if !ok {
 		e.clearResumeDispatching(t.ID)
 		return
@@ -115,6 +119,14 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 		e.logger.Info("workflow.effect-replay.noop",
 			"task_id", fresh.ID, "step", step.ID, "effect", rec.ID.String())
 		metrics.OrchestratorEffectReplay(e.metricContext(), "already_completed")
+		return
+	}
+	if e.handleTransientFetchRetry(&fresh, step) {
+		e.clearResumeDispatching(t.ID)
+		return
+	}
+	if e.handleWatchdogRateLimitRetry(&fresh, step) {
+		e.clearResumeDispatching(t.ID)
 		return
 	}
 

--- a/internal/workflow/engine_effect_replay.go
+++ b/internal/workflow/engine_effect_replay.go
@@ -44,89 +44,104 @@ func (e *Engine) ReplayPersistedEffects() {
 	}
 }
 
-func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
+// ReplayPersistedEffectsForTask replays or reconciles the persisted current-step
+// effect for one task. It reports whether durable effect state consumed the
+// caller's recovery tick, even if the effect resolved as a no-op or was fenced
+// by an existing dispatcher.
+func (e *Engine) ReplayPersistedEffectsForTask(taskID string) bool {
+	if e.dispatchDisabled.Load() {
+		return false
+	}
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil {
+		return false
+	}
+	return e.replayPersistedEffectsTask(&t)
+}
+
+func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) bool {
 	if t.Workflow == nil || t.Workflow.CurrentStep == "" {
-		return
+		return false
 	}
 	if e.dispatchGate != nil && !e.dispatchGate(*t) {
-		return
+		return false
 	}
 	switch t.Workflow.State {
 	case ExecCompleted, ExecFailed:
-		return
+		return false
 	case ExecRunning, ExecWaiting:
 	default:
-		return
+		return false
 	}
 	if e.agents.HasRunningAgent(t.ID) || e.agents.IsDispatching(t.ID) {
-		return
+		return false
 	}
 
 	def, err := e.store.Get(t.Workflow.WorkflowID)
 	if err != nil {
-		return
+		return false
 	}
 	step := def.StepByID(t.Workflow.CurrentStep)
 	if step == nil {
-		return
+		return false
 	}
 	rec, ok := currentStepEffectRecord(*t, step, effectPosStepAction)
 	if !ok {
-		return
+		return false
 	}
 	if rec.CompletedAt == nil && e.resumePreflightConsumesTick(t, step, "workflow.effect-replay.skip") {
-		return
+		return true
 	}
-	e.replayPendingEffect(t, step, &def)
+	return e.replayPendingEffect(t, step, &def)
 }
 
-func (e *Engine) replayPendingEffect(t *TaskInfo, step *Step, def *Definition) {
+func (e *Engine) replayPendingEffect(t *TaskInfo, step *Step, def *Definition) bool {
 	reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
 	if !acquired {
 		e.resumeSkip.Log(e.logger, "workflow.effect-replay.skip", t.ID,
 			reason+"|"+step.ID,
 			"task_id", t.ID, "reason", reason, "step", step.ID)
-		return
+		return true
 	}
 
 	fresh, abort := e.resolveFreshTaskForResume(t, step, def)
 	if abort {
-		return
+		return true
 	}
 	if e.agents.HasRunningAgent(fresh.ID) || e.agents.IsDispatching(fresh.ID) {
 		e.clearResumeDispatching(fresh.ID)
-		return
+		return true
 	}
 	if e.dispatchGate != nil && !e.dispatchGate(fresh) {
 		e.clearResumeDispatching(t.ID)
-		return
+		return true
 	}
 
 	var err error
 	*def, err = e.store.Get(fresh.Workflow.WorkflowID)
 	if err != nil {
 		e.clearResumeDispatching(t.ID)
-		return
+		return true
 	}
 	step = def.StepByID(fresh.Workflow.CurrentStep)
 	if step == nil {
 		e.clearResumeDispatching(t.ID)
-		return
+		return true
 	}
 	rec, ok := currentStepEffectRecord(fresh, step, effectPosStepAction)
 	if !ok {
 		e.clearResumeDispatching(t.ID)
-		return
+		return true
 	}
 	if rec.CompletedAt != nil {
 		e.clearResumeDispatching(t.ID)
 		e.logger.Info("workflow.effect-replay.noop",
 			"task_id", fresh.ID, "step", step.ID, "effect", rec.ID.String())
 		metrics.OrchestratorEffectReplay(e.metricContext(), "already_completed")
-		return
+		return true
 	}
 	if e.effectReplayConsumedRetry(&fresh, step, t.ID) {
-		return
+		return true
 	}
 
 	e.logger.Info("workflow.effect-replay", "task_id", fresh.ID, "step", step.ID, "effect", rec.ID.String())
@@ -139,7 +154,7 @@ func (e *Engine) replayPendingEffect(t *TaskInfo, step *Step, def *Definition) {
 	if rErr != nil {
 		metrics.OrchestratorEffectReplay(e.metricContext(), "error")
 		e.surfaceStartFailure(fresh.ID, fresh.Status, rErr, fresh.Workflow, step.ID)
-		return
+		return true
 	}
 
 	metrics.OrchestratorEffectReplay(e.metricContext(), "replayed")
@@ -147,6 +162,7 @@ func (e *Engine) replayPendingEffect(t *TaskInfo, step *Step, def *Definition) {
 	e.clearTransientFetchRetry(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearCircuitBreakerOnSuccess(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearWatchdogReaskNote(fresh.ID, cleanupWorkflow)
+	return true
 }
 
 func (e *Engine) effectReplayConsumedRetry(t *TaskInfo, step *Step, claimTaskID string) bool {

--- a/internal/workflow/engine_effect_replay.go
+++ b/internal/workflow/engine_effect_replay.go
@@ -1,0 +1,148 @@
+package workflow
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	"github.com/Automaat/sybra/internal/dispatchorder"
+	"github.com/Automaat/sybra/internal/metrics"
+)
+
+func (e *Engine) metricContext() context.Context {
+	if e.ctx != nil {
+		return e.ctx
+	}
+	return context.Background()
+}
+
+// ReplayPersistedEffects re-enters the current workflow step when a persisted
+// step-effect intent exists without a matching completion. Completed records are
+// reconciled as a no-op so restart recovery can prefer durable effect state
+// over free-form task-status inference.
+func (e *Engine) ReplayPersistedEffects() {
+	if e.dispatchDisabled.Load() {
+		return
+	}
+
+	tasks, err := e.tasks.ListTasks()
+	if err != nil {
+		e.logger.Error("workflow.effect-replay.list", "err", err)
+		return
+	}
+
+	if e.dispatchComparator != nil {
+		slices.SortStableFunc(tasks, e.dispatchComparator())
+	} else {
+		slices.SortStableFunc(tasks, func(a, b TaskInfo) int {
+			return cmp.Compare(dispatchorder.Rank(a.Status), dispatchorder.Rank(b.Status))
+		})
+	}
+
+	for i := range tasks {
+		e.replayPersistedEffectsTask(&tasks[i])
+	}
+}
+
+func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
+	if t.Workflow == nil || t.Workflow.CurrentStep == "" {
+		return
+	}
+	if e.dispatchGate != nil && !e.dispatchGate(*t) {
+		return
+	}
+	switch t.Workflow.State {
+	case ExecCompleted, ExecFailed:
+		return
+	case ExecRunning, ExecWaiting:
+	default:
+		return
+	}
+	if e.agents.HasRunningAgent(t.ID) || e.agents.IsDispatching(t.ID) {
+		return
+	}
+
+	def, err := e.store.Get(t.Workflow.WorkflowID)
+	if err != nil {
+		return
+	}
+	step := def.StepByID(t.Workflow.CurrentStep)
+	if step == nil {
+		return
+	}
+	if _, ok := currentStepEffectRecord(*t, step, effectPosStepAction); !ok {
+		return
+	}
+
+	reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
+	if !acquired {
+		e.resumeSkip.Log(e.logger, "workflow.effect-replay.skip", t.ID,
+			reason+"|"+step.ID,
+			"task_id", t.ID, "reason", reason, "step", step.ID)
+		return
+	}
+
+	fresh, abort := e.refreshTaskForReplay(t.ID, t.Workflow)
+	if abort {
+		return
+	}
+	if e.dispatchGate != nil && !e.dispatchGate(fresh) {
+		e.clearResumeDispatching(t.ID)
+		return
+	}
+
+	def, err = e.store.Get(fresh.Workflow.WorkflowID)
+	if err != nil {
+		e.clearResumeDispatching(t.ID)
+		return
+	}
+	step = def.StepByID(fresh.Workflow.CurrentStep)
+	if step == nil {
+		e.clearResumeDispatching(t.ID)
+		return
+	}
+	rec, ok := currentStepEffectRecord(fresh, step, effectPosStepAction)
+	if !ok {
+		e.clearResumeDispatching(t.ID)
+		return
+	}
+	if rec.CompletedAt != nil {
+		e.clearResumeDispatching(t.ID)
+		e.logger.Info("workflow.effect-replay.noop",
+			"task_id", fresh.ID, "step", step.ID, "effect", rec.ID.String())
+		metrics.OrchestratorEffectReplay(e.metricContext(), "already_completed")
+		return
+	}
+
+	e.logger.Info("workflow.effect-replay", "task_id", fresh.ID, "step", step.ID, "effect", rec.ID.String())
+	comp, rErr := e.executeSteps(fresh.ID, &def, step, fresh.Workflow)
+	rErr = normalizeExecuteStepsErr(rErr)
+	e.clearResumeDispatching(fresh.ID)
+	e.fireComplete(comp)
+	e.drainPendingConflictRecovery(fresh.ID)
+	e.resumeError.Log(e.logger, "workflow.effect-replay.exec", fresh.ID, rErr, "task_id", fresh.ID)
+	if rErr != nil {
+		metrics.OrchestratorEffectReplay(e.metricContext(), "error")
+		e.surfaceStartFailure(fresh.ID, fresh.Status, rErr, fresh.Workflow, step.ID)
+		return
+	}
+
+	metrics.OrchestratorEffectReplay(e.metricContext(), "replayed")
+	cleanupWorkflow := e.workflowForPostDispatchCleanup(fresh.ID)
+	e.clearTransientFetchRetry(fresh.ID, cleanupWorkflow, step.ID)
+	e.clearCircuitBreakerOnSuccess(fresh.ID, cleanupWorkflow, step.ID)
+	e.clearWatchdogReaskNote(fresh.ID, cleanupWorkflow)
+}
+
+func (e *Engine) refreshTaskForReplay(taskID string, wf *Execution) (TaskInfo, bool) {
+	fresh, skip := e.shouldSkipResumeAfterFreshRead(taskID, wf)
+	if skip {
+		e.clearResumeDispatching(taskID)
+		return fresh, true
+	}
+	if e.agents.HasRunningAgent(taskID) || e.agents.IsDispatching(taskID) {
+		e.clearResumeDispatching(taskID)
+		return fresh, true
+	}
+	return fresh, false
+}

--- a/internal/workflow/engine_effect_replay.go
+++ b/internal/workflow/engine_effect_replay.go
@@ -77,7 +77,10 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 	if rec.CompletedAt == nil && e.resumePreflightConsumesTick(t, step, "workflow.effect-replay.skip") {
 		return
 	}
+	e.replayPendingEffect(t, step, &def)
+}
 
+func (e *Engine) replayPendingEffect(t *TaskInfo, step *Step, def *Definition) {
 	reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
 	if !acquired {
 		e.resumeSkip.Log(e.logger, "workflow.effect-replay.skip", t.ID,
@@ -86,7 +89,7 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 		return
 	}
 
-	fresh, abort := e.resolveFreshTaskForResume(t, step, &def)
+	fresh, abort := e.resolveFreshTaskForResume(t, step, def)
 	if abort {
 		return
 	}
@@ -99,7 +102,8 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 		return
 	}
 
-	def, err = e.store.Get(fresh.Workflow.WorkflowID)
+	var err error
+	*def, err = e.store.Get(fresh.Workflow.WorkflowID)
 	if err != nil {
 		e.clearResumeDispatching(t.ID)
 		return
@@ -109,7 +113,7 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 		e.clearResumeDispatching(t.ID)
 		return
 	}
-	rec, ok = currentStepEffectRecord(fresh, step, effectPosStepAction)
+	rec, ok := currentStepEffectRecord(fresh, step, effectPosStepAction)
 	if !ok {
 		e.clearResumeDispatching(t.ID)
 		return
@@ -121,17 +125,12 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 		metrics.OrchestratorEffectReplay(e.metricContext(), "already_completed")
 		return
 	}
-	if e.handleTransientFetchRetry(&fresh, step) {
-		e.clearResumeDispatching(t.ID)
-		return
-	}
-	if e.handleWatchdogRateLimitRetry(&fresh, step) {
-		e.clearResumeDispatching(t.ID)
+	if e.effectReplayConsumedRetry(&fresh, step, t.ID) {
 		return
 	}
 
 	e.logger.Info("workflow.effect-replay", "task_id", fresh.ID, "step", step.ID, "effect", rec.ID.String())
-	comp, rErr := e.executeSteps(fresh.ID, &def, step, fresh.Workflow)
+	comp, rErr := e.executeSteps(fresh.ID, def, step, fresh.Workflow)
 	rErr = normalizeExecuteStepsErr(rErr)
 	e.clearResumeDispatching(fresh.ID)
 	e.fireComplete(comp)
@@ -148,4 +147,16 @@ func (e *Engine) replayPersistedEffectsTask(t *TaskInfo) {
 	e.clearTransientFetchRetry(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearCircuitBreakerOnSuccess(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearWatchdogReaskNote(fresh.ID, cleanupWorkflow)
+}
+
+func (e *Engine) effectReplayConsumedRetry(t *TaskInfo, step *Step, claimTaskID string) bool {
+	if e.handleTransientFetchRetry(t, step) {
+		e.clearResumeDispatching(claimTaskID)
+		return true
+	}
+	if e.handleWatchdogRateLimitRetry(t, step) {
+		e.clearResumeDispatching(claimTaskID)
+		return true
+	}
+	return false
 }

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/blocker"
 	"github.com/Automaat/sybra/internal/dispatchorder"
+	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/watchdogreason"
 	"github.com/Automaat/sybra/internal/worktreeerr"
 )
@@ -1423,6 +1424,7 @@ func (e *Engine) resumeStalledReconcileWaitHumanStatus(t TaskInfo, step *Step) {
 
 func (e *Engine) finishResumeStalledStep(taskID string, def *Definition, step *Step, wf *Execution, fresh TaskInfo) {
 	e.logger.Info("workflow.resume-stalled", "task_id", taskID, "step", step.ID)
+	metrics.OrchestratorResumeStalledFallback(e.metricContext())
 	comp, rErr := e.executeSteps(taskID, def, step, wf)
 	rErr = normalizeExecuteStepsErr(rErr)
 	e.clearResumeDispatching(taskID)

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1308,36 +1308,7 @@ func (e *Engine) resumeStalledTask(t *TaskInfo) {
 	if !isResumableStepType(step.Type) {
 		return
 	}
-	if retryAt, ok := workflowRetryAfter(t.Workflow); ok && time.Now().Before(retryAt) {
-		retryAtStr := retryAt.Format(time.RFC3339)
-		e.resumeSkip.Log(e.logger, "workflow.resume-stalled.skip", t.ID,
-			"retry_after|"+step.ID+"|"+retryAtStr,
-			"task_id", t.ID, "reason", "retry_after", "retry_after", retryAtStr, "step", step.ID)
-		return
-	}
-	retryableWatchdogStop := e.canRetryWatchdogStop(t, step)
-	retryableWorktreeRepair := e.canRetryWorktreeRepair(t, step)
-	if reason, skip := resumeSkipReasonForStatus(t.Status); skip &&
-		(reason != "human_required" || !retryableWatchdogStop) &&
-		(reason != "blocked" || !retryableWorktreeRepair) {
-		e.resumeSkip.Log(e.logger, "workflow.resume-stalled.skip", t.ID,
-			reason+"|"+t.Status+"|"+step.ID,
-			"task_id", t.ID, "reason", reason, "status", t.Status, "step", step.ID)
-		return
-	}
-	if e.agents.HasRunningAgent(t.ID) {
-		return
-	}
-	if e.shouldSkipResumeForRateLimitedProvider(t, step) {
-		return
-	}
-	if retryableWatchdogStop && e.handleWatchdogStopRetry(t, step) {
-		return
-	}
-	if retryableWorktreeRepair && e.handleWorktreeRepairRetry(t, step) {
-		return
-	}
-	if e.handleWatchdogRetries(t, step) {
+	if e.resumePreflightConsumesTick(t, step, "workflow.resume-stalled.skip") {
 		return
 	}
 	reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
@@ -1368,6 +1339,42 @@ func (e *Engine) resumeStalledTask(t *TaskInfo) {
 	}
 
 	e.finishResumeStalledStep(t.ID, &def, step, fresh.Workflow, fresh)
+}
+
+func (e *Engine) resumePreflightConsumesTick(t *TaskInfo, step *Step, logEvent string) bool {
+	if retryAt, ok := workflowRetryAfter(t.Workflow); ok && time.Now().Before(retryAt) {
+		retryAtStr := retryAt.Format(time.RFC3339)
+		e.resumeSkip.Log(e.logger, logEvent, t.ID,
+			"retry_after|"+step.ID+"|"+retryAtStr,
+			"task_id", t.ID, "reason", "retry_after", "retry_after", retryAtStr, "step", step.ID)
+		return true
+	}
+	retryableWatchdogStop := e.canRetryWatchdogStop(t, step)
+	retryableWorktreeRepair := e.canRetryWorktreeRepair(t, step)
+	if reason, skip := resumeSkipReasonForStatus(t.Status); skip &&
+		(reason != "human_required" || !retryableWatchdogStop) &&
+		(reason != "blocked" || !retryableWorktreeRepair) {
+		e.resumeSkip.Log(e.logger, logEvent, t.ID,
+			reason+"|"+t.Status+"|"+step.ID,
+			"task_id", t.ID, "reason", reason, "status", t.Status, "step", step.ID)
+		return true
+	}
+	if e.agents.HasRunningAgent(t.ID) {
+		return true
+	}
+	if e.shouldSkipResumeForRateLimitedProvider(t, step) {
+		return true
+	}
+	if retryableWatchdogStop && e.handleWatchdogStopRetry(t, step) {
+		return true
+	}
+	if retryableWorktreeRepair && e.handleWorktreeRepairRetry(t, step) {
+		return true
+	}
+	if e.handleWatchdogRetries(t, step) {
+		return true
+	}
+	return false
 }
 
 // resolveFreshTaskForResume re-reads and reconciles the task's current step to guard

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -269,7 +269,7 @@ func workflowMetricValue(t *testing.T, name string, labels []string) float64 {
 	req := httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody)
 	rec := httptest.NewRecorder()
 	promhttp.Handler().ServeHTTP(rec, req)
-	for _, line := range strings.Split(rec.Body.String(), "\n") {
+	for line := range strings.SplitSeq(rec.Body.String(), "\n") {
 		if strings.HasPrefix(line, "#") || !strings.HasPrefix(line, name) {
 			continue
 		}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -288,6 +288,93 @@ steps:
 		}
 	})
 
+	t.Run("pending intent waits for retry_after", func(t *testing.T) {
+		store := newInlineTestStore(t, "replay-verify", `
+id: replay-verify
+name: Replay Verify
+trigger:
+  on: task.created
+steps:
+  - id: verify_checks
+    type: verify_checks
+    next:
+      - goto: ""
+`)
+		tasks := &memTasks{tasks: map[string]*TaskInfo{
+			"t1": {
+				ID:         "t1",
+				Generation: 1,
+				Status:     "in-progress",
+				Workflow: &Execution{
+					WorkflowID:  "replay-verify",
+					CurrentStep: "verify_checks",
+					State:       ExecWaiting,
+					Variables: map[string]string{
+						workflowRetryAfterVar: time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+					},
+					EffectLog: []EffectRecord{{
+						ID:       EffectID{Generation: 1, StepSeq: 0, StepID: "verify_checks", Pos: effectPosStepAction},
+						IntentAt: time.Now().UTC(),
+					}},
+				},
+			},
+		}, gets: map[string]int{}}
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+
+		engine.ReplayPersistedEffects()
+
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Workflow == nil {
+			t.Fatal("workflow = nil, want active workflow")
+		}
+		if got.Workflow.CurrentStep != "verify_checks" {
+			t.Fatalf("current step = %q, want verify_checks", got.Workflow.CurrentStep)
+		}
+		if got.Workflow.EffectLog[0].CompletedAt != nil {
+			t.Fatalf("effect log = %+v, want pending effect while retry_after is in future", got.Workflow.EffectLog)
+		}
+	})
+
+	t.Run("pending run_agent intent waits for provider cooldown", func(t *testing.T) {
+		store := newTestStore(t)
+		tasks := &memTasks{tasks: map[string]*TaskInfo{
+			"t1": {
+				ID:         "t1",
+				Generation: 1,
+				Status:     "in-progress",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					EffectLog: []EffectRecord{{
+						ID:       EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction},
+						IntentAt: time.Now().UTC(),
+					}},
+				},
+			},
+		}, gets: map[string]int{}}
+		agents := newMockAgents()
+		agents.SetProviderRateLimited(true)
+		engine := NewEngine(store, tasks, agents, discardLogger())
+
+		engine.ReplayPersistedEffects()
+
+		if len(agents.calls) != 0 {
+			t.Fatalf("StartAgent calls = %d, want 0", len(agents.calls))
+		}
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Workflow.EffectLog[0].CompletedAt != nil {
+			t.Fatalf("effect log = %+v, want pending effect while provider is rate-limited", got.Workflow.EffectLog)
+		}
+	})
+
 	t.Run("completed async effect reconciles as no-op", func(t *testing.T) {
 		now := time.Now().UTC()
 		completedAt := now

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -179,6 +179,48 @@ func TestReplayPersistedEffects(t *testing.T) {
 		}
 	})
 
+	t.Run("pending intent survives unrelated task generation change", func(t *testing.T) {
+		store := newTestStore(t)
+		originalID := EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction}
+		tasks := &memTasks{tasks: map[string]*TaskInfo{
+			"t1": {
+				ID:         "t1",
+				Generation: 2,
+				Status:     "in-progress",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					EffectLog: []EffectRecord{{
+						ID:       originalID,
+						IntentAt: time.Now().UTC(),
+					}},
+				},
+			},
+		}, gets: map[string]int{}}
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+
+		engine.ReplayPersistedEffects()
+
+		if len(agents.calls) != 1 {
+			t.Fatalf("StartAgent calls = %d, want 1", len(agents.calls))
+		}
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got.Workflow.EffectLog) != 1 {
+			t.Fatalf("effect log len = %d, want 1: %+v", len(got.Workflow.EffectLog), got.Workflow.EffectLog)
+		}
+		if !got.Workflow.EffectLog[0].ID.Equal(originalID) {
+			t.Fatalf("effect ID = %s, want original %s", got.Workflow.EffectLog[0].ID.String(), originalID.String())
+		}
+		if got.Workflow.EffectLog[0].CompletedAt == nil {
+			t.Fatalf("effect log = %+v, want completed replayed effect", got.Workflow.EffectLog)
+		}
+	})
+
 	t.Run("completed async effect reconciles as no-op", func(t *testing.T) {
 		now := time.Now().UTC()
 		completedAt := now

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -339,6 +339,66 @@ steps:
 		}
 	})
 
+	t.Run("task-scoped replay only touches requested task", func(t *testing.T) {
+		store := newTestStore(t)
+		tasks := &memTasks{tasks: map[string]*TaskInfo{
+			"t1": {
+				ID:         "t1",
+				Generation: 1,
+				Status:     "in-progress",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					EffectLog: []EffectRecord{{
+						ID:       EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction},
+						IntentAt: time.Now().UTC(),
+					}},
+				},
+			},
+			"t2": {
+				ID:         "t2",
+				Generation: 1,
+				Status:     "in-progress",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					EffectLog: []EffectRecord{{
+						ID:       EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction},
+						IntentAt: time.Now().UTC(),
+					}},
+				},
+			},
+		}, gets: map[string]int{}}
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+
+		if handled := engine.ReplayPersistedEffectsForTask("t2"); !handled {
+			t.Fatal("ReplayPersistedEffectsForTask returned false, want true")
+		}
+		if len(agents.calls) != 1 {
+			t.Fatalf("StartAgent calls = %d, want 1", len(agents.calls))
+		}
+		if agents.calls[0].TaskID != "t2" {
+			t.Fatalf("replayed task = %q, want t2", agents.calls[0].TaskID)
+		}
+		got1, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got1.Workflow.EffectLog[0].CompletedAt != nil {
+			t.Fatalf("t1 effect log = %+v, want pending untouched effect", got1.Workflow.EffectLog)
+		}
+		got2, err := tasks.GetTask("t2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got2.Workflow.EffectLog[0].CompletedAt == nil {
+			t.Fatalf("t2 effect log = %+v, want completed replayed effect", got2.Workflow.EffectLog)
+		}
+	})
+
 	t.Run("pending run_agent intent waits for provider cooldown", func(t *testing.T) {
 		store := newTestStore(t)
 		tasks := &memTasks{tasks: map[string]*TaskInfo{

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,10 +23,12 @@ import (
 	"github.com/Automaat/sybra/internal/blocker"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/dispatchorder"
+	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/prompteval"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/watchdogreason"
 	"github.com/Automaat/sybra/internal/worktreeerr"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // TestTaskFields_PlanCritiqueAndReplanCount locks the two fields the
@@ -128,6 +132,168 @@ func newInlineTestStore(t *testing.T, name, yaml string) *Store {
 		t.Fatalf("write inline workflow %s: %v", name, err)
 	}
 	return store
+}
+
+func TestReplayPersistedEffects(t *testing.T) {
+	t.Run("pending intent replays through executeSteps", func(t *testing.T) {
+		store := newTestStore(t)
+		tasks := &memTasks{tasks: map[string]*TaskInfo{
+			"t1": {
+				ID:         "t1",
+				Generation: 1,
+				Status:     "in-progress",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					EffectLog: []EffectRecord{{
+						ID:       EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction},
+						IntentAt: time.Now().UTC(),
+					}},
+				},
+			},
+		}, gets: map[string]int{}}
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+
+		engine.ReplayPersistedEffects()
+
+		if len(agents.calls) != 1 {
+			t.Fatalf("StartAgent calls = %d, want 1", len(agents.calls))
+		}
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Workflow == nil {
+			t.Fatal("workflow = nil, want active workflow after replay")
+		}
+		if got.Workflow.CurrentStep != "implement" {
+			t.Fatalf("current step = %q, want implement", got.Workflow.CurrentStep)
+		}
+		if len(got.Workflow.StepHistory) != 0 {
+			t.Fatalf("step history = %+v, want no sync completion for async replay", got.Workflow.StepHistory)
+		}
+		if got.Workflow.EffectLog[0].CompletedAt == nil {
+			t.Fatalf("effect log = %+v, want completed replayed effect", got.Workflow.EffectLog)
+		}
+	})
+
+	t.Run("completed async effect reconciles as no-op", func(t *testing.T) {
+		now := time.Now().UTC()
+		completedAt := now
+		store := newTestStore(t)
+		tasks := &memTasks{tasks: map[string]*TaskInfo{
+			"t1": {
+				ID:         "t1",
+				Generation: 1,
+				Status:     "in-progress",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					EffectLog: []EffectRecord{{
+						ID:          EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction},
+						IntentAt:    now.Add(-time.Minute),
+						CompletedAt: &completedAt,
+					}},
+				},
+			},
+		}, gets: map[string]int{}}
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+
+		engine.ReplayPersistedEffects()
+
+		if len(agents.calls) != 0 {
+			t.Fatalf("StartAgent calls = %d, want 0", len(agents.calls))
+		}
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Workflow == nil {
+			t.Fatal("workflow = nil, want workflow preserved")
+		}
+		if got.Workflow.CurrentStep != "implement" {
+			t.Fatalf("current step = %q, want implement", got.Workflow.CurrentStep)
+		}
+		if got.Workflow.State != ExecWaiting {
+			t.Fatalf("state = %q, want %q", got.Workflow.State, ExecWaiting)
+		}
+		if len(got.Workflow.StepHistory) != 0 {
+			t.Fatalf("step history = %+v, want unchanged workflow", got.Workflow.StepHistory)
+		}
+	})
+}
+
+func TestResumeStalled_RecordsFallbackMetric(t *testing.T) {
+	if !metrics.Enabled() {
+		if err := metrics.Init(config.MetricsConfig{Enabled: true}); err != nil {
+			t.Fatalf("metrics.Init: %v", err)
+		}
+	}
+
+	before := workflowMetricValue(t, "sybra_orchestrator_resume_stalled_fallbacks_total", nil)
+
+	store := newTestStore(t)
+	tasks := &memTasks{tasks: map[string]*TaskInfo{
+		"t1": {
+			ID:         "t1",
+			Generation: 1,
+			Status:     "in-progress",
+			Workflow: &Execution{
+				WorkflowID:  "test-simple",
+				CurrentStep: "implement",
+				State:       ExecWaiting,
+			},
+		},
+	}, gets: map[string]int{}}
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	engine.ResumeStalled()
+
+	if len(agents.calls) != 1 {
+		t.Fatalf("StartAgent calls = %d, want 1", len(agents.calls))
+	}
+	after := workflowMetricValue(t, "sybra_orchestrator_resume_stalled_fallbacks_total", nil)
+	if after != before+1 {
+		t.Fatalf("fallback metric delta = %.0f, want 1 (before=%.0f after=%.0f)", after-before, before, after)
+	}
+}
+
+func workflowMetricValue(t *testing.T, name string, labels []string) float64 {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody)
+	rec := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(rec, req)
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		if strings.HasPrefix(line, "#") || !strings.HasPrefix(line, name) {
+			continue
+		}
+		matches := true
+		for _, label := range labels {
+			if !strings.Contains(line, label) {
+				matches = false
+				break
+			}
+		}
+		if !matches {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			t.Fatalf("parse metric %q from %q: %v", name, line, err)
+		}
+		return v
+	}
+	return 0
 }
 
 // --- In-memory TaskProvider ---

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -221,6 +221,73 @@ func TestReplayPersistedEffects(t *testing.T) {
 		}
 	})
 
+	t.Run("pending intent reconciles stale downstream wait status", func(t *testing.T) {
+		store := newInlineTestStore(t, "replay-stale-status", `
+id: replay-stale-status
+name: Replay Stale Status
+trigger:
+  on: task.created
+steps:
+  - id: implement
+    type: run_agent
+    config:
+      role: implementation
+      mode: headless
+      model: sonnet
+      wait_for_status: agent-finished
+      prompt: "Implement {{.Task.ID}}"
+    next:
+      - goto: review_plan
+  - id: review_plan
+    type: wait_human
+    config:
+      status: plan-review
+    next:
+      - goto: ""
+`)
+		tasks := &memTasks{tasks: map[string]*TaskInfo{
+			"t1": {
+				ID:         "t1",
+				Generation: 1,
+				Status:     "plan-review",
+				AgentMode:  "headless",
+				Workflow: &Execution{
+					WorkflowID:  "replay-stale-status",
+					CurrentStep: "implement",
+					State:       ExecWaiting,
+					EffectLog: []EffectRecord{{
+						ID:       EffectID{Generation: 1, StepSeq: 0, StepID: "implement", Pos: effectPosStepAction},
+						IntentAt: time.Now().UTC(),
+					}},
+				},
+			},
+		}, gets: map[string]int{}}
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+
+		engine.ReplayPersistedEffects()
+
+		if len(agents.calls) != 0 {
+			t.Fatalf("StartAgent calls = %d, want 0", len(agents.calls))
+		}
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Workflow == nil {
+			t.Fatal("workflow = nil, want active workflow")
+		}
+		if got.Workflow.CurrentStep != "review_plan" {
+			t.Fatalf("current step = %q, want review_plan", got.Workflow.CurrentStep)
+		}
+		if got.Workflow.State != ExecWaiting {
+			t.Fatalf("state = %q, want %q", got.Workflow.State, ExecWaiting)
+		}
+		if len(got.Workflow.EffectLog) != 1 || got.Workflow.EffectLog[0].CompletedAt != nil {
+			t.Fatalf("effect log = %+v, want original pending intent preserved", got.Workflow.EffectLog)
+		}
+	})
+
 	t.Run("completed async effect reconciles as no-op", func(t *testing.T) {
 		now := time.Now().UTC()
 		completedAt := now

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -288,15 +288,25 @@ func (e *Execution) EffectPending(id EffectID) bool {
 	return false
 }
 
+// EffectRecordForStep returns the most-recently recorded effect whose StepID
+// and Pos match the given values.
+func (e *Execution) EffectRecordForStep(stepID string, pos int) (EffectRecord, bool) {
+	for i := range slices.Backward(e.EffectLog) {
+		if e.EffectLog[i].ID.StepID == stepID && e.EffectLog[i].ID.Pos == pos {
+			return cloneEffectRecord(e.EffectLog[i]), true
+		}
+	}
+	return EffectRecord{}, false
+}
+
 // EffectIDForStep returns the most-recently recorded EffectID whose StepID and
 // Pos match the given values, so a retried effect can reuse the same key.
 func (e *Execution) EffectIDForStep(stepID string, pos int) (EffectID, bool) {
-	for i := range slices.Backward(e.EffectLog) {
-		if e.EffectLog[i].ID.StepID == stepID && e.EffectLog[i].ID.Pos == pos {
-			return e.EffectLog[i].ID, true
-		}
+	rec, ok := e.EffectRecordForStep(stepID, pos)
+	if !ok {
+		return EffectID{}, false
 	}
-	return EffectID{}, false
+	return rec.ID, true
 }
 
 // AllChildrenDone reports whether every child reached a terminal status.


### PR DESCRIPTION
## Motivation

Part of #2464 (step 6): make restart recovery replay unapplied effects and reconcile completed effects instead of redispatching from free-form status. Directly retires `ResumeStalled`'s phantom-completion guessing.

## Implementation information

- Replay persisted workflow effects before stale fallback recovery
- Add replay/fallback metrics and focused recovery wiring
- Add workflow tests for replay path

## Supporting documentation

Closes #2664

> Changelog: feat(workflow): replay persisted effects on restart