### PR TITLE
fix(workflow): push review fixes before verify

### DIFF
--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -274,8 +274,9 @@ steps:
         For each actionable finding (critical/high/medium severity), fix the code.
         Skip low-severity nitpicks and style-only comments.
 
-        When done, commit your changes (do NOT push yet — push happens with PR
-        creation). Sign commits with `git commit -s -S`.
+        When done, commit your changes (do NOT push yet — Sybra will push the
+        branch deterministically before verification and PR creation). Sign
+        commits with `git commit -s -S`.
         Use conventional commit format: `fix(review): address review comments`.
 
         Never weaken, skip, delete, or hardcode tests to satisfy a review
@@ -286,6 +287,27 @@ steps:
         {{getvar .Vars "watchdog_reask_note"}}
         {{- end}}
     next:
+      - goto: push_review_fix_branch
+
+  # Mechanical sync point: the fix-review agent is intentionally told not to
+  # push, so make the branch push an explicit workflow step before verifying
+  # the post-fix HEAD. A best-effort completion hook is not enough here: if a
+  # local fix commit is stranded, verify/testing/PR creation can observe a
+  # different branch state than the one the review fixer produced.
+  - id: push_review_fix_branch
+    name: Push Review Fix Branch
+    type: push_branch
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: blocked
+        goto: ""
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: verify_checks
 
   # Mechanical check (no LLM): re-run the project's checks.verify suite after

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -1028,6 +1028,60 @@ func TestBuiltinSimpleTaskPR_CreateAndPushAreDeterministic(t *testing.T) {
 	}
 }
 
+// TestBuiltinSimpleTaskReview_FixReviewPushesBeforeVerify guards the
+// post-review-fix handoff. The fix-review agent commits locally and is
+// intentionally told not to push, so the workflow must sync the branch through
+// the deterministic push_branch step before verify_checks observes the final
+// HEAD.
+func TestBuiltinSimpleTaskReview_FixReviewPushesBeforeVerify(t *testing.T) {
+	t.Parallel()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-review" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-review builtin definition not found")
+		return
+	}
+
+	fixStep := simple.StepByID("fix_review")
+	if fixStep == nil {
+		t.Fatal("fix_review step not found in simple-task-review")
+		return
+	}
+	if fixStep.Type != StepRunAgent {
+		t.Fatalf("fix_review step type = %q, want %q", fixStep.Type, StepRunAgent)
+	}
+	if strings.Contains(fixStep.Config.Prompt, "git push") {
+		t.Fatalf("fix_review prompt asks the agent to push; push must be deterministic:\n%s", fixStep.Config.Prompt)
+	}
+	if len(fixStep.Next) != 1 || fixStep.Next[0].GoTo != "push_review_fix_branch" {
+		t.Fatalf("fix_review next = %+v, want push_review_fix_branch", fixStep.Next)
+	}
+
+	pushStep := simple.StepByID("push_review_fix_branch")
+	if pushStep == nil {
+		t.Fatal("push_review_fix_branch step not found in simple-task-review")
+		return
+	}
+	if pushStep.Type != StepPushBranch {
+		t.Fatalf("push_review_fix_branch step type = %q, want %q", pushStep.Type, StepPushBranch)
+	}
+	if pushStep.Config.Prompt != "" {
+		t.Fatalf("push_review_fix_branch step carries an agent prompt: %q", pushStep.Config.Prompt)
+	}
+	if len(pushStep.Next) == 0 || pushStep.Next[len(pushStep.Next)-1].GoTo != "verify_checks" {
+		t.Fatalf("push_review_fix_branch next = %+v, want default goto verify_checks", pushStep.Next)
+	}
+}
+
 // TestBuiltinSimpleTaskPR_NoCodegenAfterTesting guards the PR handoff
 // workflow's non-mutating contract: after review/testing pass, the workflow
 // may sync, push, create, and link a PR, but it must not run codegen_gate and

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -171,10 +171,10 @@ func (e *Engine) linkTaskPR(taskID string, t TaskInfo, newPR int) error {
 }
 
 // prWorktreeAndBranch resolves the on-disk worktree and branch used by
-// push_branch/create_pr. Both are reached only from the ready-pr stage of
-// simple-task-pr, after implementation/testing already produced a worktree —
-// a missing WorktreeGetter or worktree is therefore an unrecoverable setup
-// problem, not a transient one, so it flips straight to human-required.
+// push_branch/create_pr. These steps run only after implementation/review has
+// already produced a worktree, so a missing WorktreeGetter or worktree is an
+// unrecoverable setup problem, not a transient one, and flips straight to
+// human-required.
 func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtPath, branch string, out StepOutput, done bool) {
 	if e.worktrees == nil {
 		out, _ = e.humanRequiredPR(taskID, step, "no worktree getter configured")

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -1808,16 +1808,31 @@ func TestBuiltinSimpleTaskReview_DetectTamperingWiring(t *testing.T) {
 		t.Fatal("fix_review step missing from simple-task-review")
 		return
 	}
-	// fix_review commits code changes, so verify_checks must re-run before
-	// tamper detection to keep verify_checks evidence fresh at the post-fix
-	// HEAD (and catch a fix that broke the suite) ahead of require_evidence.
+	// fix_review commits code changes, so the branch must be pushed
+	// deterministically, then verify_checks must re-run before tamper detection
+	// to keep verify_checks evidence fresh at the post-fix HEAD (and catch a
+	// fix that broke the suite) ahead of require_evidence.
+	push := rev.StepByID("push_review_fix_branch")
+	if push == nil {
+		t.Fatal("push_review_fix_branch step missing from simple-task-review")
+		return
+	}
+	if push.Type != StepPushBranch {
+		t.Fatalf("push_review_fix_branch type = %q, want %q", push.Type, StepPushBranch)
+	}
 	verify := rev.StepByID("verify_checks")
 	if verify == nil {
 		t.Fatal("verify_checks step missing from simple-task-review")
 		return
 	}
-	if got, _ := ResolveTransition(fix.Next, map[string]string{"task.status": "ready-review"}); got != "verify_checks" {
-		t.Errorf("fix_review goto = %q, want verify_checks", got)
+	if got, _ := ResolveTransition(fix.Next, map[string]string{"task.status": "ready-review"}); got != "push_review_fix_branch" {
+		t.Errorf("fix_review goto = %q, want push_review_fix_branch", got)
+	}
+	if got, _ := ResolveTransition(push.Next, map[string]string{"task.status": "ready-review"}); got != "verify_checks" {
+		t.Errorf("push_review_fix_branch goto = %q, want verify_checks", got)
+	}
+	if got, _ := ResolveTransition(push.Next, map[string]string{"task.status": "human-required"}); got != "" {
+		t.Errorf("push_review_fix_branch human-required goto = %q, want end", got)
 	}
 	if got, _ := ResolveTransition(verify.Next, map[string]string{"task.status": "ready-review"}); got != "detect_tampering" {
 		t.Errorf("verify_checks goto = %q, want detect_tampering", got)


### PR DESCRIPTION
## Summary
- route simple-task-review fix_review through a deterministic push_branch step before verify_checks
- update the fix-review prompt to keep agents from pushing while making Sybra own the branch sync
- add wiring tests so review fixes cannot bypass the push-before-verify handoff

## Verification
- GOCACHE=/Users/marcin.skalski/orca/workspaces/synapse/ship-bug/.cache/go-build GIT_CONFIG_GLOBAL=/dev/null go test ./internal/workflow -run 'TestBuiltinSimpleTaskReview_FixReviewPushesBeforeVerify|TestBuiltinSimpleTaskReview_DetectTamperingWiring'
- GOCACHE=/Users/marcin.skalski/orca/workspaces/synapse/ship-bug/.cache/go-build GIT_CONFIG_GLOBAL=/dev/null go test ./internal/workflow