### PR TITLE
fix(review): reactivate stale pr-fix parks

### DIFF
--- a/internal/sybra/review/outbound.go
+++ b/internal/sybra/review/outbound.go
@@ -315,7 +315,7 @@ func linkedOwnPRHumanRequiredDrift(t *task.Task, livePR bool) bool {
 	if t.Workflow == nil {
 		return false
 	}
-	if t.Workflow.WorkflowID != "simple-task-pr" || t.Workflow.State != workflow.ExecCompleted || t.Workflow.CompletedAt == nil {
+	if !completedOutboundPRWorkflow(t.Workflow) {
 		return false
 	}
 	completedAt := *t.Workflow.CompletedAt
@@ -323,6 +323,18 @@ func linkedOwnPRHumanRequiredDrift(t *task.Task, livePR bool) bool {
 		return false
 	}
 	return completedAt.Sub(t.UpdatedAt) <= linkedPRDriftWindow
+}
+
+func completedOutboundPRWorkflow(wf *workflow.Execution) bool {
+	if wf == nil || wf.State != workflow.ExecCompleted || wf.CompletedAt == nil {
+		return false
+	}
+	switch wf.WorkflowID {
+	case "simple-task-pr", "pr-fix":
+		return true
+	default:
+		return false
+	}
 }
 
 func staleImplementationWorkflowEligible(t *task.Task) bool {

--- a/internal/sybra/review/outbound_test.go
+++ b/internal/sybra/review/outbound_test.go
@@ -646,6 +646,66 @@ func TestLinkedOwnPRHumanRequiredDrift(t *testing.T) {
 	}
 }
 
+func TestLinkedOwnPRHumanRequiredDriftIncludesPRFix(t *testing.T) {
+	completedAt := time.Now().UTC()
+	ts := completedAt.Add(-time.Minute)
+	drifted := &task.Task{
+		Status:       task.StatusHumanRequired,
+		PRNumber:     42,
+		UpdatedAt:    ts,
+		StatusReason: "",
+		Workflow: &workflow.Execution{
+			WorkflowID:  "pr-fix",
+			State:       workflow.ExecCompleted,
+			CompletedAt: &completedAt,
+		},
+	}
+	if !linkedOwnPRHumanRequiredDrift(drifted, true) {
+		t.Fatal("expected completed pr-fix workflow to count as linked PR drift")
+	}
+}
+
+func TestReconcilePRPhasesReactivatesEmptyReasonAfterPRFix(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+
+	created := mkOwnPRTask(t, tasks, 42, nil)
+	completedAt := time.Now().UTC().Add(500 * time.Millisecond)
+	wf := &workflow.Execution{
+		WorkflowID:  "pr-fix",
+		State:       workflow.ExecCompleted,
+		CompletedAt: &completedAt,
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(""),
+		Workflow:     &wf,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.reconcilePRPhases(context.Background(), all, []github.PullRequest{{
+		Number:         42,
+		ReviewDecision: "APPROVED",
+		Mergeable:      "MERGEABLE",
+		CIStatus:       "SUCCESS",
+	}})
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInReview {
+		t.Errorf("status = %q, want in-review", got.Status)
+	}
+	if got.StatusReason != "" {
+		t.Errorf("statusReason = %q, want cleared", got.StatusReason)
+	}
+}
+
 func TestReconcilePRPhasesDoesNotReactivateFreshManualHumanRequired(t *testing.T) {
 	r, tasks := newOutboundTestHandler(t)
 

--- a/internal/sybra/review/outbound_test.go
+++ b/internal/sybra/review/outbound_test.go
@@ -669,7 +669,7 @@ func TestReconcilePRPhasesReactivatesEmptyReasonAfterPRFix(t *testing.T) {
 	r, tasks := newOutboundTestHandler(t)
 
 	created := mkOwnPRTask(t, tasks, 42, nil)
-	completedAt := time.Now().UTC().Add(500 * time.Millisecond)
+	completedAt := time.Now().UTC().Add(time.Minute)
 	wf := &workflow.Execution{
 		WorkflowID:  "pr-fix",
 		State:       workflow.ExecCompleted,


### PR DESCRIPTION
## Summary
- treat completed pr-fix workflows as outbound PR handoff drift candidates
- restore empty-reason human-required linked PR tasks back to in-review when the live PR is present
- add regression coverage for the pr-fix stale park shape

## Tests
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra/review -run 'TestLinkedOwnPRHumanRequiredDrift|TestReconcilePRPhases'
- GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra/review