### PR TITLE
fix(dispatch): block implementation after plan rejection

### DIFF
--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -271,10 +271,18 @@ func TestApp_StatusHookRestartsTodoAndPlanningExternalUpdates(t *testing.T) {
 				t.Fatalf("Get: %v", err)
 			}
 			if got.Workflow == nil || got.Workflow.WorkflowID != "simple-task-plan" {
-				t.Fatalf("external %s update did not restart task.created workflow, got %+v", target, got.Workflow)
+				t.Fatalf("external %s update did not restart planning workflow, got %+v", target, got.Workflow)
 			}
 			if got.Workflow.State == workflow.ExecFailed {
 				t.Fatalf("external %s update kept stale failed workflow: %+v", target, got.Workflow)
+			}
+			if target == task.StatusPlanning {
+				if got.Workflow.RecordForStep("triage") != nil {
+					t.Fatalf("external planning update re-entered triage: %+v", got.Workflow.RecordForStep("triage"))
+				}
+				if got.Status == task.StatusInProgress {
+					t.Fatalf("external planning update flipped to %q, want planning-side status", got.Status)
+				}
 			}
 		})
 	}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -974,10 +974,10 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 		if err != nil {
 			return
 		}
-		// Only front-of-pipeline tasks. simple-task-plan's trigger has no status
-		// condition, so without this guard a task.created dispatch could restart
-		// planning on an in-review/done task.
-		if t.Status != task.StatusNew && t.Status != task.StatusTodo && t.Status != task.StatusPlanning {
+		// Only fresh task.created entries. Planning re-entry has its own lane:
+		// restarting simple-task-plan from step 1 would re-run triage, which can
+		// hand a rejected/reset planning task straight back to implementation.
+		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
 			return
 		}
 		if !a.runsTaskLocally(t) {
@@ -1037,7 +1037,16 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 	if id == "" {
 		return
 	}
-	a.dispatchTaskCreatedWorkflow(id)
+	t, err := a.tasks.Get(id)
+	if err != nil {
+		return
+	}
+	switch t.Status {
+	case task.StatusPlanning:
+		a.dispatchPlanningWorkflow(id)
+	default:
+		a.dispatchTaskCreatedWorkflow(id)
+	}
 }
 
 func (a *App) initAudit() {

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -393,7 +393,7 @@ func (a *App) dispatchPlanningWorkflow(taskID string) {
 	if a.agents.HasRunningAgentForTask(taskID) {
 		return
 	}
-	if err := a.workflowEngine.StartWorkflow(taskID, "simple-task-plan"); err != nil &&
+	if err := startPlanningWorkflowForTask(a.workflowEngine, t); err != nil &&
 		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) &&
 		!errors.Is(err, workflow.ErrAutoDispatchDisabled) {
 		a.logger.Error("workflow.dispatch.planning", "task_id", taskID, "err", err)

--- a/internal/sybra/svc_planning.go
+++ b/internal/sybra/svc_planning.go
@@ -42,7 +42,7 @@ func (s *PlanningService) PlanTask(id string) error {
 	if t.Workflow != nil && t.Workflow.State != "" {
 		return nil
 	}
-	if err := s.engine.StartWorkflow(id, "simple-task-plan"); err != nil {
+	if err := startPlanningWorkflowForTask(s.engine, t); err != nil {
 		// Concurrent auto-start (from CreateTask) holds the per-task start
 		// lock — that's also a no-op outcome from the user's perspective.
 		if errors.Is(err, workflow.ErrWorkflowAlreadyActive) {

--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -96,6 +96,46 @@ func TestPlanningService_PlanTask_StartsWorkflow(t *testing.T) {
 	}
 }
 
+func TestPlanningService_PlanTask_ResumesPlanningAtPlanStep(t *testing.T) {
+	planSvc, _, a := setupPlanningService(t)
+
+	created, err := a.tasks.Create("resume planning", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.tasks.UpdateMap(created.ID, map[string]any{
+		"status": string(task.StatusPlanning),
+		"workflow": &workflow.Execution{
+			WorkflowID:  "simple-task-plan",
+			CurrentStep: "review_plan",
+			State:       workflow.ExecFailed,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := planSvc.PlanTask(created.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Workflow == nil {
+		t.Fatal("workflow missing after PlanTask")
+	}
+	if updated.Workflow.WorkflowID != "simple-task-plan" {
+		t.Fatalf("WorkflowID = %q, want simple-task-plan", updated.Workflow.WorkflowID)
+	}
+	if updated.Workflow.RecordForStep("triage") != nil {
+		t.Fatalf("triage record = %+v, want no triage re-entry", updated.Workflow.RecordForStep("triage"))
+	}
+	if updated.Status == task.StatusInProgress {
+		t.Fatalf("Status = %q, want planning-side status, not implementation handoff", updated.Status)
+	}
+}
+
 func TestPlanningService_ApprovePlan_ErrorWhenNotWaiting(t *testing.T) {
 	planSvc, taskSvc, _ := setupPlanningService(t)
 

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -701,8 +701,8 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	if gotUmbrella.Workflow == nil || gotUmbrella.Workflow.WorkflowID != "old-workflow" || gotUmbrella.Workflow.State != workflow.ExecFailed {
 		t.Fatalf("synthetic umbrella task should be left alone, got %+v", gotUmbrella.Workflow)
 	}
-	if launcher.startCalls != 4 {
-		t.Fatalf("startCalls = %d, want 4 for idle/post-plan implementation and inbound review tasks", launcher.startCalls)
+	if launcher.startCalls != 6 {
+		t.Fatalf("startCalls = %d, want 6 for resumed planning, implementation, and inbound review tasks", launcher.startCalls)
 	}
 }
 

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -706,6 +706,57 @@ func TestReconcileRunnableBoardTasksDispatchesIdleRunnableStatuses(t *testing.T)
 	}
 }
 
+func TestDispatchPlanningWorkflow_RejectedPlanDoesNotRedispatchImplementation(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	svc.workflowEngine.SetTaskClassifier(&taskClassifierAdapter{
+		tasks:      a.tasks,
+		classifier: fakeTriageClassifier{},
+	})
+	a.workflowEngine = svc.workflowEngine
+
+	created, err := a.tasks.Create("rejected plan", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.tasks.UpdateMap(created.ID, map[string]any{
+		"status": string(task.StatusPlanning),
+		"workflow": &workflow.Execution{
+			WorkflowID:  "simple-task-plan",
+			CurrentStep: "review_plan",
+			State:       workflow.ExecCompleted,
+			Variables:   map[string]string{},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	a.dispatchPlanningWorkflow(created.ID)
+
+	got, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusPlanning {
+		t.Fatalf("status = %q, want planning", got.Status)
+	}
+	if got.Workflow == nil || got.Workflow.WorkflowID != "simple-task-plan" {
+		t.Fatalf("workflow = %+v, want simple-task-plan", got.Workflow)
+	}
+	if got.Workflow.CurrentStep != "plan" {
+		t.Fatalf("current_step = %q, want plan", got.Workflow.CurrentStep)
+	}
+	if len(got.AgentRuns) != 1 {
+		t.Fatalf("agent runs = %+v, want one planning run", got.AgentRuns)
+	}
+	if got.AgentRuns[0].Role != string(agent.RolePlan) {
+		t.Fatalf("agent role = %q, want %q", got.AgentRuns[0].Role, agent.RolePlan)
+	}
+	if launcher.startCalls != 1 {
+		t.Fatalf("startCalls = %d, want 1 planning dispatch", launcher.startCalls)
+	}
+}
+
 func TestDispatchFromHumanRequired_InReviewFlipsStatusOnly(t *testing.T) {
 	launcher := &fakeAgentLauncher{}
 	svc, a := setupDispatchTestService(t, launcher)

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 const (
@@ -87,4 +88,12 @@ func allowsTaskCreatedWorkflowWithPR(t task.Task) bool {
 	return (t.Status == task.StatusNew || t.Status == task.StatusTodo) &&
 		slices.Contains(t.Tags, "review") &&
 		!slices.Contains(t.Tags, "handoff-pr")
+}
+
+func startPlanningWorkflowForTask(engine *workflow.Engine, t task.Task) error {
+	startStepID := ""
+	if t.Status == task.StatusPlanning {
+		startStepID = "plan"
+	}
+	return engine.StartWorkflowFromStepWithVars(t.ID, "simple-task-plan", startStepID, nil)
 }


### PR DESCRIPTION
## Motivation

Closes #2666. A task in `planning` status after plan rejection could still receive an implementation dispatch, bypassing the planning gate.

## Implementation information

- `workflow_dispatch.go`: guard implementation dispatch to require `todo` status; planning-lane tasks are blocked until plan is approved
- `svc_planning.go`: resume planning tasks at the plan step, not triage
- `app_init.go` / `app_orchestrator.go`: keep external planning updates on the planning lane
- Tests cover rejected-plan redispatch and planning resume expectations

> Changelog: fix(dispatch): block impl after rejected plan

_Generated by Sybra harness_