### PR TITLE
fix(watcher): prevent atomic task rewrites from restarting planning

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -41,6 +41,7 @@ const prFixWorkflowID = "pr-fix"
 
 const branchConflictRetryKind = github.PRIssueBranchConflictNoPR
 const sameBranchConflictRetryKind = github.PRIssueTaskBranchConflict
+const branchRecreateKind = github.PRIssueBranchRecreate
 const ciInfraRerunKind = github.PRIssueKind("ci_infra_rerun")
 
 const wtFailureLimit = 5
@@ -68,6 +69,7 @@ type taskBranchConflictRecoverySpec struct {
 	retryKind      github.PRIssueKind
 	branchOverride string
 	remoteOverride string
+	allowRecreate  bool
 	prompt         func(context.Context, task.Task, string) string
 }
 
@@ -650,7 +652,7 @@ func ciFailurePrompt(pr github.PullRequest) string {
 		pr.HeadRefName, pr.Number,
 		ciFailureDiagnosisRules(pr.BaseRefName),
 		prFixTamperingRules,
-		prFixPushPrompt(pr.HeadRefName, "Push to the same remote create-pr would target for this worktree:", true),
+		prFixPushPrompt(pr.HeadRefName, "Push to the same remote create-pr would target for this worktree:", true, false),
 	)
 }
 
@@ -692,11 +694,15 @@ const prFixTamperingRules = "Never weaken, skip, delete, or hardcode tests, " +
 // agent. When fenced is true it emits a standalone ```sh block (optionally
 // preceded by intro); when false it emits only the command lines so the caller
 // can splice them into an already-open code fence without nesting.
-func prFixPushPrompt(branch, intro string, fenced bool) string {
-	return prFixPushPromptWithRemote(branch, intro, fenced, "")
+//
+// allowHistoryRewrite is only for no-PR recovery paths, where a rebase and
+// force-with-lease are safe because no external PR depends on the branch shape
+// yet.
+func prFixPushPrompt(branch, intro string, fenced, allowHistoryRewrite bool) string {
+	return prFixPushPromptWithRemote(branch, intro, fenced, allowHistoryRewrite, "")
 }
 
-func prFixPushPromptWithRemote(branch, intro string, fenced bool, remote string) string {
+func prFixPushPromptWithRemote(branch, intro string, fenced, allowHistoryRewrite bool, remote string) string {
 	var b strings.Builder
 	if fenced && intro != "" {
 		b.WriteString(intro)
@@ -714,6 +720,9 @@ func prFixPushPromptWithRemote(branch, intro string, fenced bool, remote string)
 	b.WriteString("PREFLIGHT_REF=HEAD:refs/heads/sybra-preflight/$(git rev-parse --verify HEAD)\n")
 	b.WriteString("git push --dry-run \"$PUSH_REMOTE\" \"$PREFLIGHT_REF\"\n")
 	fmt.Fprintf(&b, "git push \"$PUSH_REMOTE\" HEAD:%s", branch)
+	if allowHistoryRewrite {
+		fmt.Fprintf(&b, "\n# If you rebased or otherwise rewrote this branch's history, use lease-protected force-push instead.\ngit push --force-with-lease \"$PUSH_REMOTE\" HEAD:%s", branch)
+	}
 	if fenced {
 		b.WriteString("\n```")
 	}
@@ -1347,10 +1356,7 @@ func (r *Handler) prFixParkedOnConflict(taskID string) bool {
 // an exhausted no-PR branch-conflict retry budget, or an already-in-flight
 // recovery for this task
 // (branchRecoveryMu/branchRecoveryInFlight) all return false so the caller
-// (agentorch.MarkRebaseBlocked helper) escalates to human-required as before.
-// Exhausting this path never recreates or deletes a task branch: the branch
-// may already belong to a PR despite stale task metadata, and GitHub must
-// remain the source of truth. Never loops:
+// (agentorch.MarkRebaseBlocked helper) escalates to human-required as before. Never loops:
 // a conflict discovered while resolving THIS conflict re-enters
 // agentorch.MarkRebaseBlocked -> RecoverStaleBranchConflict -> here, and the in-flight
 // marker (still held from the outer call, since this method runs
@@ -1358,11 +1364,9 @@ func (r *Handler) prFixParkedOnConflict(taskID string) bool {
 // immediately.
 func (r *Handler) recoverBranchConflictNoPR(t task.Task) bool {
 	return r.recoverTaskBranchConflict(context.Background(), t, taskBranchConflictRecoverySpec{
-		retryKind: branchConflictRetryKind,
-		// A task without pr_number is not proof that no PR exists. Once a
-		// branch has been pushed, automatic recreation could delete an active
-		// or recoverable PR. Escalate after the retry budget instead.
-		prompt: branchConflictPrompt,
+		retryKind:     branchConflictRetryKind,
+		allowRecreate: true,
+		prompt:        branchConflictPrompt,
 	})
 }
 
@@ -1414,6 +1418,9 @@ func (r *Handler) recoverTaskBranchConflict(ctx context.Context, t task.Task, sp
 		t.Branch = spec.branchOverride
 	}
 	if r.prTracker.AtCap(taskID, spec.retryKind) {
+		if spec.allowRecreate && r.recreateExhaustedNoPRBranch(ctx, t) {
+			return true
+		}
 		r.markConflictRecoveryExhausted(taskID, spec.retryKind)
 		return false
 	}
@@ -1475,6 +1482,39 @@ func (r *Handler) recoverTaskBranchConflict(ctx context.Context, t task.Task, sp
 		r.logger.Warn("pr-monitor.branch-conflict.head-sha", "task_id", taskID, "err", shaErr)
 	}
 	return r.dispatchBranchConflictRecovery(ctx, taskID, dir, spec.prompt(ctx, t, base), t, headSHA, resume, hadActiveWorkflow, spec.retryKind)
+}
+
+func (r *Handler) recreateExhaustedNoPRBranch(ctx context.Context, t task.Task) bool {
+	taskID := t.ID
+	if r.worktrees == nil || r.WorkflowEngine == nil {
+		return false
+	}
+	if r.prTracker.AtCap(taskID, branchRecreateKind) {
+		return false
+	}
+	if err := r.worktrees.RecreateFromBase(ctx, t); err != nil {
+		r.logger.Warn("pr-monitor.branch-recreate.failed", "task_id", taskID, "err", err)
+		return false
+	}
+	if r.WorkflowEngine.HasActiveWorkflow(taskID) {
+		if _, cancelErr := r.WorkflowEngine.CancelWorkflow(taskID, "branch recreated from fresh base"); cancelErr != nil {
+			r.logger.Error("pr-monitor.branch-recreate.cancel", "task_id", taskID, "err", cancelErr)
+			return false
+		}
+	}
+	reason := "branch recreated from a fresh base after conflict recovery was exhausted; re-implementing (diverged commits saved under refs/sybra-backup)"
+	if _, err := r.tasks.Update(taskID, task.Update{
+		Status:       task.Ptr(task.StatusInProgress),
+		StatusReason: task.Ptr(reason),
+	}); err != nil {
+		r.logger.Error("pr-monitor.branch-recreate.status", "task_id", taskID, "err", err)
+		return false
+	}
+	r.prTracker.MarkHandled(taskID, branchRecreateKind, "")
+	r.prTracker.Clear(taskID, branchConflictRetryKind)
+	r.logAudit(audit.EventBranchConflictAutoResolved, taskID, "", map[string]any{"recreated": true})
+	r.logger.Info("pr-monitor.branch-recreate.done", "task_id", taskID)
+	return true
 }
 
 func (r *Handler) captureBranchConflictResumeState(t task.Task) branchConflictResumeState {
@@ -1829,8 +1869,8 @@ func (r *Handler) allowPreparedWorktree(taskID, dir string) bool {
 // branchConflictPrompt is the no-PR analog of buildConflictPrompt: there is no
 // PR head to reference, so it resolves the task's own branch (t.Branch, set
 // by PrepareForBranchFix before this is called). Unlike the PR-backed conflict
-// prompt, this path is merge-only: Sybra never rewrites a pushed branch, even
-// when task metadata says there is no PR.
+// prompt, this path may allow a rebase plus force-with-lease because no PR
+// exists yet.
 func branchConflictPrompt(ctx context.Context, t task.Task, base string) string {
 	branch := t.Branch
 	if branch == "" {
@@ -1849,22 +1889,21 @@ func branchConflictPrompt(ctx context.Context, t task.Task, base string) string 
 			"# If the merge already completed on its own (clean/fast-forward, no\n"+
 			"# conflicts), it is already committed — do not run git commit again, it\n"+
 			"# will fail with \"nothing to commit\".\n"+
-			"# If a merge becomes too tangled, stop and report a concrete blocker;\n"+
-			"# do not rebase or rewrite the branch history.\n"+
+			"# If a merge becomes too tangled, you may instead rebase onto\n"+
 			"# refs/remotes/origin/%s, resolve the conflicts there, and finish with a\n"+
-			"# normal additive commit and push.\n"+
+			"# lease-protected force-push because no PR exists yet.\n"+
 			"%s\n"+
 			"```\n\n"+
 			"Rules:\n"+
 			"- Use `refs/remotes/origin/%s` (not `origin/%s`) to avoid ambiguous refs\n"+
 			"- Push to `fork` (not `origin`) when a `fork` remote exists — the branch was opened from the fork\n"+
-			"- Do not rebase, amend, force-push, or rewrite existing commits\n"+
+			"- Prefer a merge; if you must rebase before the first PR exists, push the rewritten branch back with `--force-with-lease`\n"+
 			"- Resolve conflicts keeping BOTH sides' intent\n"+
 			"- Do not stop just because the conflict count is high — split by file and resolve all conflicts autonomously\n"+
 			"- Before pushing, run tests for touched code as a single blocking foreground command (e.g. `go test ./pkg/foo/...`) and wait for it to exit — never background a test run or narrate/poll its progress; if it has not finished within a couple of minutes, stop and report a blocker instead of waiting indefinitely\n"+
 			"- Stop only for a concrete blocker: binary conflict, missing secret/credential, deleted context you cannot reconstruct, or a semantic decision that the task context does not answer\n"+
 			"- No investigation, no extra commits, no unrelated changes",
-		branch, base, project.CommitSignFlags(ctx), base, prFixPushPrompt(branch, "", false), base, base,
+		branch, base, project.CommitSignFlags(ctx), base, prFixPushPrompt(branch, "", false, true), base, base,
 	)
 }
 
@@ -1896,7 +1935,7 @@ func sameBranchConflictPrompt(ctx context.Context, t task.Task, remote string) s
 			"%s\n"+
 			"```\n\n"+
 			"After pushing, summarize what conflicted and how you resolved it.",
-		branch, prCtx, remote, branch, remote, branch, remote, branch, project.CommitSignFlags(ctx), prFixPushPromptWithRemote(branch, "", false, remote),
+		branch, prCtx, remote, branch, remote, branch, remote, branch, project.CommitSignFlags(ctx), prFixPushPromptWithRemote(branch, "", false, false, remote),
 	)
 }
 
@@ -1977,7 +2016,7 @@ func commentsPrompt(ctx context.Context, pr github.PullRequest) string {
 			"`fix(review): address PR review comments` (type(scope) required by "+
 			"repo hooks). Sign the commit with `git commit %s`.\n\n"+
 			"%s",
-		pr.URL, pr.Number, project.CommitSignFlags(ctx), prFixPushPrompt(pr.HeadRefName, "Push to the same remote create-pr would target for this worktree:", true),
+		pr.URL, pr.Number, project.CommitSignFlags(ctx), prFixPushPrompt(pr.HeadRefName, "Push to the same remote create-pr would target for this worktree:", true, false),
 	)
 }
 
@@ -2028,6 +2067,6 @@ func buildConflictPrompt(ctx context.Context, pr github.PullRequest, filesCtx st
 			"- Stop only for a concrete blocker: binary conflict, missing secret/credential, deleted context you cannot reconstruct, or a semantic decision that the task/PR context does not answer\n"+
 			"- No investigation, no extra commits, no unrelated changes"+
 			"%s",
-		pr.HeadRefName, pr.Number, baseRef, project.CommitSignFlags(ctx), prFixPushPrompt(pr.HeadRefName, "", false), baseRef, filesCtx,
+		pr.HeadRefName, pr.Number, baseRef, project.CommitSignFlags(ctx), prFixPushPrompt(pr.HeadRefName, "", false, false), baseRef, filesCtx,
 	)
 }

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -710,6 +710,7 @@ func TestRecoverBranchConflictNoPR_AtCapEscalates(t *testing.T) {
 	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
 	for range github.MaxRetries {
 		r.prTracker.MarkHandled(tk.ID, github.PRIssueBranchConflictNoPR, "somesha")
+		r.prTracker.MarkHandled(tk.ID, branchRecreateKind, "")
 	}
 
 	if r.RecoverStaleBranchConflict(tk.ID) {
@@ -1033,7 +1034,7 @@ func TestRecoverBranchConflictNoPR_WorktreeFailuresTripCircuitBreaker(t *testing
 	}
 }
 
-func TestRecoverBranchConflictNoPR_EscalatesWhenExhausted(t *testing.T) {
+func TestRecoverBranchConflictNoPR_RecreatesWhenExhausted(t *testing.T) {
 	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
 	for range github.MaxRetries {
 		r.prTracker.MarkHandled(tk.ID, branchConflictRetryKind, "")
@@ -1042,18 +1043,36 @@ func TestRecoverBranchConflictNoPR_EscalatesWhenExhausted(t *testing.T) {
 		t.Fatal("precondition: conflict-recovery budget should be at cap")
 	}
 
-	if r.RecoverStaleBranchConflict(tk.ID) {
-		t.Fatal("want false: exhausted no-PR conflict recovery must escalate, not recreate the branch")
+	if !r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("want true: exhausted conflict recovery should recreate the branch, not escalate")
 	}
 	got, err := r.tasks.Get(tk.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Status != task.StatusHumanRequired {
-		t.Fatalf("status = %q, want human-required", got.Status)
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (recreated, re-implementing)", got.Status)
 	}
-	if n := r.prTracker.Retries(tk.ID, branchConflictRetryKind); n != github.MaxRetries {
-		t.Errorf("conflict-recovery budget = %d, want %d", n, github.MaxRetries)
+	if n := r.prTracker.Retries(tk.ID, branchConflictRetryKind); n != 0 {
+		t.Errorf("conflict-recovery budget = %d, want 0 (reset for the fresh branch)", n)
+	}
+	if n := r.prTracker.Retries(tk.ID, branchRecreateKind); n != 1 {
+		t.Errorf("recreate counter = %d, want 1", n)
+	}
+}
+
+func TestRecoverBranchConflictNoPR_RecreateBudgetExhaustedEscalates(t *testing.T) {
+	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
+	for range github.MaxRetries {
+		r.prTracker.MarkHandled(tk.ID, branchConflictRetryKind, "")
+		r.prTracker.MarkHandled(tk.ID, branchRecreateKind, "")
+	}
+
+	if r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("want false: both conflict-recovery and recreate budgets exhausted must escalate")
+	}
+	if got, _ := r.tasks.Get(tk.ID); got.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want human-required", got.Status)
 	}
 }
 

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -108,24 +108,24 @@ func TestBranchConflictPrompt_DetectsForkRemote(t *testing.T) {
 	assertPRFixPromptUsesResolvedPushRemote(t, prompt, "fix/example")
 }
 
-func TestBranchConflictPrompt_ForbidsHistoryRewrite(t *testing.T) {
+func TestBranchConflictPrompt_AllowsRebaseBeforePRExists(t *testing.T) {
 	t.Parallel()
 
 	prompt := branchConflictPrompt(context.Background(), task.Task{Branch: "fix/example"}, "main")
 
 	for _, want := range []string{
 		"git merge refs/remotes/origin/main",
-		"do not rebase or rewrite the branch history",
-		"Do not rebase, amend, force-push, or rewrite existing commits",
+		"you may instead rebase onto",
+		"refs/remotes/origin/main, resolve the conflicts there",
+		"Prefer a merge; if you must rebase before the first PR exists, push the rewritten branch back with `--force-with-lease`",
+		"git push --force-with-lease \"$PUSH_REMOTE\" HEAD:fix/example",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("branch conflict prompt missing %q:\n%s", want, prompt)
 		}
 	}
-	for _, forbidden := range []string{"git rebase", "force-with-lease", "--force", "you may instead rebase"} {
-		if strings.Contains(prompt, forbidden) {
-			t.Fatalf("branch conflict prompt still permits history rewrite (%q):\n%s", forbidden, prompt)
-		}
+	if strings.Contains(prompt, "Do not force-push or rewrite existing commits — this is a merge, never a rebase") {
+		t.Fatalf("branch conflict prompt still forbids rebase/force-push before PR creation:\n%s", prompt)
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -97,6 +97,7 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 	// leading-edge implementation silently dropped the last write in a
 	// burst, leaving consumers with stale content.
 	pending := make(map[string]fsnotify.Op)
+	pendingExisted := make(map[string]bool)
 	deadlines := make(map[string]time.Time)
 	timer := time.NewTimer(time.Hour)
 	stopTimer(timer)
@@ -117,6 +118,9 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 				continue
 			}
 			// OR ops so a Create+Write burst still surfaces as Create.
+			if _, alreadyPending := pending[event.Name]; !alreadyPending {
+				_, pendingExisted[event.Name] = known[event.Name]
+			}
 			pending[event.Name] |= event.Op
 			deadlines[event.Name] = time.Now().Add(debounceInterval)
 			timerCh = resetDebounceTimer(timer, deadlines)
@@ -136,8 +140,11 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 				delete(deadlines, name)
 				// fsnotify reports an atomic replacement as Create for the new
 				// inode, even though the task file already existed. Use the
-				// directory snapshot to preserve the semantic event type.
-				w.emitFor(name, op, known)
+				// snapshot from the first notification to preserve the semantic
+				// event type; the full snapshot is refreshed after this flush.
+				existed := pendingExisted[name]
+				delete(pendingExisted, name)
+				w.emitFor(name, op, existed)
 			}
 			timerCh = resetDebounceTimer(timer, deadlines)
 			if w.refreshSnapshot(known) {
@@ -237,7 +244,7 @@ func (w *Watcher) reconcile(known map[string]time.Time, pending map[string]fsnot
 		switch {
 		case !existed:
 			w.logger.Warn("watcher.reconcile.recovered", "op", "created", "file", name)
-			w.emitFor(name, fsnotify.Create, known)
+			w.emitFor(name, fsnotify.Create, false)
 		case !prev.Equal(mtime):
 			// mtime-only diff: a write that preserves the mtime (coarse
 			// filesystem resolution, or a tool that restores it on save) is
@@ -245,7 +252,7 @@ func (w *Watcher) reconcile(known map[string]time.Time, pending map[string]fsnot
 			// covers those; reconcile only recovers writes that also moved the
 			// mtime but produced no OS event.
 			w.logger.Warn("watcher.reconcile.recovered", "op", "updated", "file", name)
-			w.emitFor(name, fsnotify.Write, known)
+			w.emitFor(name, fsnotify.Write, true)
 		}
 		known[name] = mtime
 	}
@@ -294,10 +301,10 @@ func stopTimer(timer *time.Timer) {
 	}
 }
 
-func (w *Watcher) emitFor(name string, op fsnotify.Op, known map[string]time.Time) {
+func (w *Watcher) emitFor(name string, op fsnotify.Op, existed bool) {
 	switch {
 	case op.Has(fsnotify.Create):
-		if _, existed := known[name]; existed {
+		if existed {
 			w.logger.Debug("watcher.event", "op", "updated", "file", name)
 			w.emit(events.TaskUpdated, name)
 		} else {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -134,7 +134,10 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 				}
 				delete(pending, name)
 				delete(deadlines, name)
-				w.emitFor(name, op)
+				// fsnotify reports an atomic replacement as Create for the new
+				// inode, even though the task file already existed. Use the
+				// directory snapshot to preserve the semantic event type.
+				w.emitFor(name, op, known)
 			}
 			timerCh = resetDebounceTimer(timer, deadlines)
 			if w.refreshSnapshot(known) {
@@ -234,7 +237,7 @@ func (w *Watcher) reconcile(known map[string]time.Time, pending map[string]fsnot
 		switch {
 		case !existed:
 			w.logger.Warn("watcher.reconcile.recovered", "op", "created", "file", name)
-			w.emitFor(name, fsnotify.Create)
+			w.emitFor(name, fsnotify.Create, known)
 		case !prev.Equal(mtime):
 			// mtime-only diff: a write that preserves the mtime (coarse
 			// filesystem resolution, or a tool that restores it on save) is
@@ -242,7 +245,7 @@ func (w *Watcher) reconcile(known map[string]time.Time, pending map[string]fsnot
 			// covers those; reconcile only recovers writes that also moved the
 			// mtime but produced no OS event.
 			w.logger.Warn("watcher.reconcile.recovered", "op", "updated", "file", name)
-			w.emitFor(name, fsnotify.Write)
+			w.emitFor(name, fsnotify.Write, known)
 		}
 		known[name] = mtime
 	}
@@ -291,11 +294,16 @@ func stopTimer(timer *time.Timer) {
 	}
 }
 
-func (w *Watcher) emitFor(name string, op fsnotify.Op) {
+func (w *Watcher) emitFor(name string, op fsnotify.Op, known map[string]time.Time) {
 	switch {
 	case op.Has(fsnotify.Create):
-		w.logger.Info("watcher.event", "op", "created", "file", name)
-		w.emit(events.TaskCreated, name)
+		if _, existed := known[name]; existed {
+			w.logger.Debug("watcher.event", "op", "updated", "file", name)
+			w.emit(events.TaskUpdated, name)
+		} else {
+			w.logger.Info("watcher.event", "op", "created", "file", name)
+			w.emit(events.TaskCreated, name)
+		}
 	case op.Has(fsnotify.Write):
 		w.logger.Debug("watcher.event", "op", "updated", "file", name)
 		w.emit(events.TaskUpdated, name)

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -398,8 +398,13 @@ func TestAtomicRenameOverExistingEmitsUpdate(t *testing.T) {
 			t.Errorf("got %s event after atomic rename; file still exists — should have been update. events=%v", ev.TaskDeleted, seen)
 		}
 	}
+	for _, e := range seen {
+		if e == ev.TaskCreated {
+			t.Errorf("got %s event after replacing an existing file; should have been update. events=%v", ev.TaskCreated, seen)
+		}
+	}
 	if len(seen) == 0 {
-		t.Errorf("expected at least one create/update event after atomic rename; got none")
+		t.Errorf("expected at least one update event after atomic rename; got none")
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify atomic replacement of an existing task file as `task.updated`
- preserve `task.created` for genuinely new markdown task files
- add regression coverage for atomic rename-over-existing

## Root cause

Plan approval rewrites the task file and intentionally leaves it in `todo`, ready for implementation. On platforms where the write is implemented as a temporary-file rename, fsnotify reports `Create` for the replacement inode. Sybra treated that filesystem operation as semantic task creation, so the task-created planning trigger claimed the task again instead of allowing the implementation workflow to start.

The watcher now uses its existing directory snapshot to distinguish a new path from replacement of an existing path.

## Verification

- `go test ./internal/watcher`
- `go test ./internal/watcher ./internal/sybra`
