### PR TITLE
fix(workflow): stop plan-review auto-approve loop

### DIFF
--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -325,6 +325,35 @@ func TestApp_MaybeStartWorkflowForExternalTask_RemoteMirrorDoesNotReroute(t *tes
 	}
 }
 
+// TestApp_MaybeStartWorkflowForExternalTask_UnroutedTodoWithPlanContractStillRoutes
+// guards against a regression where the approved-plan-contract skip (added to
+// stop a todo task with an already-approved plan from being swept back into
+// triage) accidentally short-circuited cluster routing too. A todo task that
+// belongs to a follower's project and has no AssignedNode yet must still be
+// routed/assigned on the leader, even though it already carries a valid plan
+// contract.
+func TestApp_MaybeStartWorkflowForExternalTask_UnroutedTodoWithPlanContractStillRoutes(t *testing.T) {
+	fixture := setupRemoteMirrorFixture(t)
+
+	unrouted := task.Task{
+		ID:           "ext-unrouted",
+		Title:        "unrouted with plan contract",
+		Status:       task.StatusTodo,
+		AgentMode:    task.AgentModeHeadless,
+		ProjectID:    "owner/pet",
+		PlanContract: validTestPlanContract("ext-unrouted"),
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}
+	path := fixture.write(unrouted)
+	fixture.app.maybeStartWorkflowForExternalTask(path)
+	fixture.app.wg.Wait()
+
+	if got := fixture.assignedTasks(); len(got) != 1 {
+		t.Fatalf("unrouted todo task with a plan contract was routed %d times, want 1", len(got))
+	}
+}
+
 func TestApp_MaybeStartWorkflowForExternalTask_RemoteMirrorBatchStaysIdle(t *testing.T) {
 	fixture := setupRemoteMirrorFixture(t)
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -983,20 +983,6 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
 			return
 		}
-		// A StatusTodo task can mean two different things: brand new (no plan
-		// sidecars yet) or the "stable post-review resting state" that
-		// set_todo_and_end deliberately lands on after a human/auto-approved
-		// plan-review (see simple-task-plan.yaml's set_todo_and_end comment).
-		// Re-running task.created/triage on the latter overwrites its status
-		// back to "planning" and mints a brand-new plan agent, discarding the
-		// approved contract — the classifier has no memory of the prior
-		// planning cycle. Skip re-dispatch for a todo task that already
-		// carries a structurally valid plan contract; it stays parked until
-		// something explicitly promotes it to in-progress (UI/CLI start),
-		// exactly like a human-required task that clears via ship-as-is.
-		if t.Status == task.StatusTodo && hasApprovedPlanContract(t) {
-			return
-		}
 		if !a.runsTaskLocally(t) {
 			// A follower-owned mirror write already carries AssignedNode; sending
 			// it back through the leader's route path turns a no-op watcher wakeup
@@ -1009,6 +995,23 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 					a.logger.Warn("cluster.assign.failed", "task_id", taskID, "err", err)
 				}
 			}
+			return
+		}
+		// A StatusTodo task can mean two different things: brand new (no plan
+		// sidecars yet) or the "stable post-review resting state" that
+		// set_todo_and_end deliberately lands on after a human/auto-approved
+		// plan-review (see simple-task-plan.yaml's set_todo_and_end comment).
+		// Re-running task.created/triage on the latter overwrites its status
+		// back to "planning" and mints a brand-new plan agent, discarding the
+		// approved contract — the classifier has no memory of the prior
+		// planning cycle. Skip re-dispatch for a todo task that already
+		// carries a structurally valid plan contract; it stays parked until
+		// something explicitly promotes it to in-progress (UI/CLI start),
+		// exactly like a human-required task that clears via ship-as-is.
+		// Scoped to after the runsTaskLocally routing block above so a
+		// non-local task with an approved contract still gets routed/assigned
+		// to its home node instead of stalling unrouted on the leader.
+		if t.Status == task.StatusTodo && hasApprovedPlanContract(t) {
 			return
 		}
 		// pr-fix / ordinary existing-PR tasks are driven outside task.created.

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -983,6 +983,20 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
 			return
 		}
+		// A StatusTodo task can mean two different things: brand new (no plan
+		// sidecars yet) or the "stable post-review resting state" that
+		// set_todo_and_end deliberately lands on after a human/auto-approved
+		// plan-review (see simple-task-plan.yaml's set_todo_and_end comment).
+		// Re-running task.created/triage on the latter overwrites its status
+		// back to "planning" and mints a brand-new plan agent, discarding the
+		// approved contract — the classifier has no memory of the prior
+		// planning cycle. Skip re-dispatch for a todo task that already
+		// carries a structurally valid plan contract; it stays parked until
+		// something explicitly promotes it to in-progress (UI/CLI start),
+		// exactly like a human-required task that clears via ship-as-is.
+		if t.Status == task.StatusTodo && hasApprovedPlanContract(t) {
+			return
+		}
 		if !a.runsTaskLocally(t) {
 			// A follower-owned mirror write already carries AssignedNode; sending
 			// it back through the leader's route path turns a no-op watcher wakeup

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -195,6 +195,87 @@ steps:
 	}
 }
 
+func TestDispatchTaskCreatedWorkflowSkipsApprovedTodoPlan(t *testing.T) {
+	// Reproduces #997b365c's stall→reset loop: a todo task that already
+	// carries a valid, approved plan contract must not be swept back into
+	// task.created/triage (which would overwrite it to "planning" and mint a
+	// brand-new plan agent, discarding the approved contract). A todo task
+	// with no plan contract — the ordinary brand-new path — must still
+	// dispatch normally.
+	const createdWF = `id: probe-created
+name: Probe Created
+trigger:
+  on: task.created
+steps:
+  - id: mark_planning
+    name: Mark Planning
+    type: set_status
+    config:
+      status: planning
+    next:
+      - goto: ""
+`
+	cases := []struct {
+		name            string
+		hasPlanContract bool
+		wantDispatch    bool
+	}{
+		{name: "todo with approved plan contract stays parked", hasPlanContract: true, wantDispatch: false},
+		{name: "brand new todo with no plan contract still dispatches", hasPlanContract: false, wantDispatch: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := setupApp(t)
+			a.cfg = config.DefaultConfig()
+
+			wfDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(wfDir, "probe-created.yaml"), []byte(createdWF), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			wfStore, err := workflow.NewStore(wfDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ta := &taskAdapter{tasks: a.tasks}
+			aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
+			a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+			a.applyInstanceRole()
+
+			created, err := a.tasks.Create("todo plan-contract probe", "", "headless")
+			if err != nil {
+				t.Fatal(err)
+			}
+			planContract := ""
+			if tc.hasPlanContract {
+				planContract = validTestPlanContract(created.ID)
+			}
+			if _, err := a.tasks.Update(created.ID, task.Update{
+				Status:       task.Ptr(task.StatusTodo),
+				PlanContract: task.Ptr(planContract),
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			a.dispatchTaskCreatedWorkflow(created.ID)
+			a.wg.Wait()
+
+			tk, err := a.tasks.Get(created.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := tk.Workflow != nil; got != tc.wantDispatch {
+				t.Fatalf("workflow attached = %v, want %v", got, tc.wantDispatch)
+			}
+			if tc.wantDispatch && tk.Status != task.StatusPlanning {
+				t.Errorf("status = %q, want planning (probe workflow ran)", tk.Status)
+			}
+			if !tc.wantDispatch && tk.Status != task.StatusTodo {
+				t.Errorf("status = %q, want todo (dispatch skipped, task left parked)", tk.Status)
+			}
+		})
+	}
+}
+
 func TestTaskCreatedDispatchRespectsInstanceRole(t *testing.T) {
 	const createdWF = `id: probe-created
 name: Probe Created

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
@@ -71,6 +72,19 @@ func skipTaskCreatedWorkflow(t task.Task) bool {
 		return true
 	}
 	return false
+}
+
+// hasApprovedPlanContract reports whether t already carries a structurally
+// valid plan contract — the signal that a StatusTodo task reached todo via
+// simple-task-plan's set_todo_and_end hand-off (a completed plan + optional
+// critique cycle) rather than as a brand-new, never-triaged task. A brand new
+// task never has a non-empty PlanContract, so this is a safe, low-cost check
+// with no false positives against the ordinary new-task path.
+func hasApprovedPlanContract(t task.Task) bool {
+	if strings.TrimSpace(t.PlanContract) == "" {
+		return false
+	}
+	return len(workflow.ValidatePlanContractForTask(t.PlanContract, t.ID, t.Body)) == 0
 }
 
 func allowsTaskCreatedWorkflowWithPR(t task.Task) bool {

--- a/internal/sybra/workflow_dispatch_test.go
+++ b/internal/sybra/workflow_dispatch_test.go
@@ -8,6 +8,42 @@ import (
 	"github.com/Automaat/sybra/internal/umbrella"
 )
 
+func TestHasApprovedPlanContractEmpty(t *testing.T) {
+	tsk := task.Task{ID: "t1", Status: task.StatusTodo}
+	if hasApprovedPlanContract(tsk) {
+		t.Error("expected a brand-new todo task with no plan contract to report false")
+	}
+}
+
+func TestHasApprovedPlanContractValid(t *testing.T) {
+	tsk := task.Task{ID: "t1", Status: task.StatusTodo, PlanContract: validTestPlanContract("t1")}
+	if !hasApprovedPlanContract(tsk) {
+		t.Error("expected a todo task with a structurally valid plan contract to report true")
+	}
+}
+
+func TestHasApprovedPlanContractInvalid(t *testing.T) {
+	tsk := task.Task{ID: "t1", Status: task.StatusTodo, PlanContract: "not json"}
+	if hasApprovedPlanContract(tsk) {
+		t.Error("expected a todo task with a malformed plan contract to report false")
+	}
+}
+
+func validTestPlanContract(taskID string) string {
+	return `{
+  "task_id": "` + taskID + `",
+  "branch": "feat/example-` + taskID + `",
+  "worktree": "/home/sybra/.sybra/worktrees/example-` + taskID + `",
+  "files": [{"path": "internal/workflow/engine.go", "purpose": "edit"}],
+  "steps": ["wire the contract through the workflow"],
+  "verification": [{"command": "go test ./internal/workflow", "expected": "tests pass"}],
+  "acceptance_criteria": ["implementation prompt includes the contract"],
+  "risk_tier": "medium",
+  "permission_tier": "repo-write",
+  "rollback": "revert the workflow and sidecar changes"
+}`
+}
+
 func TestSkipTaskCreatedWorkflowUmbrellaGated(t *testing.T) {
 	tsk := task.Task{Tags: []string{umbrella.GatedTag}}
 	if !skipTaskCreatedWorkflow(tsk) {

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -744,6 +744,16 @@ func (e *Engine) shouldAutoApprovePlanReview(t TaskInfo) bool {
 	if PlanHasOpenDecisions(t.PlanDecisions) {
 		return false
 	}
+	// "No open decisions" only means nothing needs a human's judgment call —
+	// it says nothing about whether the plan-critic found the contract itself
+	// unsafe to execute. A REFINE/REJECT verdict names concrete blockers (e.g.
+	// a compile-breaking gap in the file list) that execFlagPlanCritique's own
+	// doc comment says review_plan is supposed to require an explicit human
+	// look at, regardless of open decisions. Auto-approving through that flag
+	// silently discarded every REFINE finding straight into implementation.
+	if verdict := parsePlanCritiqueVerdict(t.PlanCritique); verdict == "REFINE" || verdict == "REJECT" {
+		return false
+	}
 	if strings.TrimSpace(t.PlanContract) == "" {
 		return false
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7128,6 +7128,32 @@ func TestAutoApprovePlanReview_InvalidContractStaysWaiting(t *testing.T) {
 	assertRemainsPlanReviewWaiting(t, tasks, "t1", 200*time.Millisecond)
 }
 
+func TestAutoApprovePlanReview_RefineVerdictStaysWaiting(t *testing.T) {
+	engine, tasks := startAutoApprovePlanReview(t, TaskInfo{
+		ID:            "t1",
+		Status:        "planning",
+		PlanDecisions: "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.",
+		PlanContract:  validPlanContract("t1"),
+		PlanCritique:  "## Verdict: REFINE\n\nMissing caller file in the file list; compile will break.",
+	})
+	engine.SetAutoApprovePlansWithoutDecisions(true)
+
+	if err := engine.execWaitHuman("t1", autoApproveReviewStep(), &Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "review_plan",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A REFINE verdict names concrete blockers a human must look at even
+	// though the decisions sidecar has nothing left for a human to choose
+	// between — "no open decisions" is not the same as "safe to execute
+	// as-is". Auto-approve must not paper over that.
+	assertRemainsPlanReviewWaiting(t, tasks, "t1", 200*time.Millisecond)
+}
+
 func startAutoApprovePlanReview(t *testing.T, task TaskInfo) (*Engine, *memTasks) {
 	t.Helper()
 	store, err := NewStore(t.TempDir())

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7128,30 +7128,47 @@ func TestAutoApprovePlanReview_InvalidContractStaysWaiting(t *testing.T) {
 	assertRemainsPlanReviewWaiting(t, tasks, "t1", 200*time.Millisecond)
 }
 
-func TestAutoApprovePlanReview_RefineVerdictStaysWaiting(t *testing.T) {
-	engine, tasks := startAutoApprovePlanReview(t, TaskInfo{
-		ID:            "t1",
-		Status:        "planning",
-		PlanDecisions: "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.",
-		PlanContract:  validPlanContract("t1"),
-		PlanCritique:  "## Verdict: REFINE\n\nMissing caller file in the file list; compile will break.",
-	})
-	engine.SetAutoApprovePlansWithoutDecisions(true)
-
-	if err := engine.execWaitHuman("t1", autoApproveReviewStep(), &Execution{
-		WorkflowID:  "simple-task-plan",
-		CurrentStep: "review_plan",
-		State:       ExecRunning,
-		Variables:   map[string]string{},
-	}); err != nil {
-		t.Fatal(err)
+func TestAutoApprovePlanReview_UnfavorableVerdictStaysWaiting(t *testing.T) {
+	cases := []struct {
+		name     string
+		critique string
+	}{
+		{
+			name:     "REFINE",
+			critique: "## Verdict: REFINE\n\nMissing caller file in the file list; compile will break.",
+		},
+		{
+			name:     "REJECT",
+			critique: "## Verdict: REJECT\n\nApproach fundamentally unsound; needs a full replan.",
+		},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, tasks := startAutoApprovePlanReview(t, TaskInfo{
+				ID:            "t1",
+				Status:        "planning",
+				PlanDecisions: "# Decisions\n\nNo open decisions. The recommended execution contract is fully specified.",
+				PlanContract:  validPlanContract("t1"),
+				PlanCritique:  tc.critique,
+			})
+			engine.SetAutoApprovePlansWithoutDecisions(true)
 
-	// A REFINE verdict names concrete blockers a human must look at even
-	// though the decisions sidecar has nothing left for a human to choose
-	// between — "no open decisions" is not the same as "safe to execute
-	// as-is". Auto-approve must not paper over that.
-	assertRemainsPlanReviewWaiting(t, tasks, "t1", 200*time.Millisecond)
+			if err := engine.execWaitHuman("t1", autoApproveReviewStep(), &Execution{
+				WorkflowID:  "simple-task-plan",
+				CurrentStep: "review_plan",
+				State:       ExecRunning,
+				Variables:   map[string]string{},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			// A REFINE/REJECT verdict names concrete blockers a human must look
+			// at even though the decisions sidecar has nothing left for a human
+			// to choose between — "no open decisions" is not the same as "safe
+			// to execute as-is". Auto-approve must not paper over that.
+			assertRemainsPlanReviewWaiting(t, tasks, "t1", 200*time.Millisecond)
+		})
+	}
 }
 
 func startAutoApprovePlanReview(t *testing.T, task TaskInfo) (*Engine, *memTasks) {


### PR DESCRIPTION
## Motivation

> Changelog: fix(workflow): stop plan-review auto-approve loop

A task could loop indefinitely between `planning` and `plan-review`
without ever reaching implementation, burning agent spend each cycle.
Root cause was two compounding bugs:

1. `shouldAutoApprovePlanReview` only checked "no open decisions" and
   contract schema validity — it never looked at the plan-critic's own
   verdict. A REFINE/REJECT verdict naming concrete blockers (e.g. a
   missing caller file that would break the build) still auto-approved,
   because those blockers aren't "decisions for a human to choose
   between." This silently defeated `execFlagPlanCritique`'s own stated
   guarantee that `review_plan` requires an explicit human look
   regardless of verdict.
2. `dispatchTaskCreatedWorkflow` treated every `todo` task identically,
   whether brand new or already carrying an approved plan contract from
   `set_todo_and_end`'s "stable post-review resting state." The
   orchestrator's periodic reconcile tick swept any `todo` task back
   into full `task.created`/triage, which has no memory of the prior
   planning cycle and resets status to `planning` from scratch —
   discarding the approved contract.

Together: plan -> critique (REFINE, ignored) -> auto-approve anyway ->
`todo` -> swept back to `planning` -> repeat.

## Implementation information

- `shouldAutoApprovePlanReview` (`internal/workflow/engine_steps_agent.go`)
  now refuses to auto-approve when `parsePlanCritiqueVerdict` returns
  REFINE or REJECT.
- `dispatchTaskCreatedWorkflow` (`internal/sybra/app_init.go`) now skips
  re-dispatch for a `todo` task that already carries a structurally
  valid plan contract, via a new `hasApprovedPlanContract` helper
  (`internal/sybra/workflow_dispatch.go`). Such a task stays parked in
  `todo` instead of being reset, matching the workflow's own documented
  intent for that status.
- Added test coverage: `TestAutoApprovePlanReview_RefineVerdictStaysWaiting`,
  `TestHasApprovedPlanContract{Empty,Valid,Invalid}`, and
  `TestDispatchTaskCreatedWorkflowSkipsApprovedTodoPlan` (both the fixed
  case and the still-must-work brand-new-todo case).

## Supporting documentation

Diagnosed from task `997b365c`'s audit log
(`~/.sybra/logs/audit/2026-07-27.ndjson`), which showed
`plan-review -> todo` immediately followed 16-27s later by
`todo -> planning` — matching the orchestrator's reconcile tick cadence
and confirming the re-triage sweep as the deterministic loop driver.

## Test plan

- [x] `go test ./internal/workflow/... ./internal/sybra/...` passes
- [x] `golangci-lint run ./internal/sybra/... ./internal/workflow/...` clean
- [x] `gofmt -l` clean on all changed files