### PR TITLE
fix(review): unblock PR tasks from stale planning workflows

### DIFF
--- a/internal/sybra/review/automerge_test.go
+++ b/internal/sybra/review/automerge_test.go
@@ -1600,6 +1600,83 @@ func TestHandleTaskPRIssues_ExhaustedRetryParksOnlyWhenNoSiblingHandleable(t *te
 	}
 }
 
+func TestHandleTaskPRIssues_CancelsStalePlanWorkflowForLinkedPR(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wfStore.Dir(), "test-pr-fix.yaml"),
+		[]byte(mechanicalPRFixYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(
+		wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	created, err := tasks.Create("linked PR stuck in plan review", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitingPlan := &workflow.Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "review_plan",
+		State:       workflow.ExecWaiting,
+		Variables:   map[string]string{"step.flag_plan_critique_verdict.output": "verdict: REJECT"},
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:   task.Ptr(task.StatusHumanRequired),
+		PRNumber: task.Ptr(17669),
+		Workflow: &waitingPlan,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &Handler{
+		logger:          logger,
+		tasks:           tasks,
+		agents:          agentMgr,
+		prTracker:       github.NewIssueTracker(time.Minute),
+		WorkflowEngine:  engine,
+		pushPreflightFn: stubPushPreflight(nil),
+	}
+	pr := github.PullRequest{
+		Number: 17669, Repository: "o/r", HeadRefName: "feat", HeadSHA: "sha1",
+		URL: "https://github.com/o/r/pull/17669", FeedbackSig: "review-feedback",
+	}
+
+	r.handleTaskPRIssues(context.Background(), created.ID, []github.PRIssue{
+		{Kind: github.PRIssueComments, TaskID: created.ID, PR: pr},
+	})
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil {
+		t.Fatal("workflow missing after PR issue dispatch")
+	}
+	if got.Workflow.WorkflowID != "test-pr-fix" {
+		t.Fatalf("workflow id = %q, want test-pr-fix; stale plan workflow was not cancelled", got.Workflow.WorkflowID)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress from PR-fix workflow", got.Status)
+	}
+	if got.PRNumber != 17669 {
+		t.Fatalf("PRNumber = %d, want preserved linked PR 17669", got.PRNumber)
+	}
+}
+
 // TestHandleKnownPRConflictsViaREST_SkipsCommentsWithoutGraphQLThreadData locks
 // the REST-degraded fallback's kind filter: when GraphQL budget is exhausted and
 // the monitor falls back to REST-sourced PR fetches (no thread-resolution data),

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -800,6 +800,9 @@ func (r *Handler) handleTaskPRIssues(ctx context.Context, taskID string, issues 
 		kinds = append(kinds, string(issues[i].Kind))
 	}
 	r.logger.Info("reviews.task-issues", "task_id", taskID, "kinds", kinds)
+	if !r.cancelStalePlanningWorkflowForPRTask(taskID) {
+		return
+	}
 	if r.hasBlockingAgentForTask(ctx, taskID) {
 		r.logger.Info("reviews.dispatch.gate", "task_id", taskID, "gate", "running_agent")
 		return
@@ -882,6 +885,30 @@ func (r *Handler) handleTaskPRIssues(ctx context.Context, taskID string, issues 
 	case merge != nil:
 		r.handleAutoMerge(ctx, *merge)
 	}
+}
+
+func (r *Handler) cancelStalePlanningWorkflowForPRTask(taskID string) bool {
+	if r.WorkflowEngine == nil || r.tasks == nil {
+		return true
+	}
+	t, err := r.tasks.Get(taskID)
+	if err != nil {
+		r.logger.Warn("reviews.cancel-stale-plan.get", "task_id", taskID, "err", err)
+		return false
+	}
+	if t.PRNumber == 0 || t.Workflow == nil || t.Workflow.WorkflowID != "simple-task-plan" {
+		return true
+	}
+	if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
+		return true
+	}
+	step, err := r.WorkflowEngine.CancelWorkflow(taskID, "pr-monitor: linked PR supersedes planning workflow")
+	if err != nil {
+		r.logger.Error("reviews.cancel-stale-plan", "task_id", taskID, "err", err)
+		return false
+	}
+	r.logger.Info("reviews.cancel-stale-plan", "task_id", taskID, "step", step, "pr", t.PRNumber)
+	return true
 }
 
 func prRefCacheKey(repo string, number int) string {


### PR DESCRIPTION
## Summary
- cancel active simple-task-plan workflows when PR monitoring finds actionable issues for a task that already has a linked PR
- let the normal PR-fix/merge decision path run after cancelling the stale plan workflow
- add regression coverage for a linked PR task stuck at plan review

## Tests
- go test ./internal/sybra/review