### PR TITLE
fix(review): retry conflicts when PR base moves

### DIFF
--- a/internal/github/debounce.go
+++ b/internal/github/debounce.go
@@ -93,6 +93,9 @@ func (t *IssueTracker) Decide(taskID string, kind PRIssueKind, sha, sig string) 
 	if sha != "" && t.lastSHA[key] == sha {
 		return DispatchSkip
 	}
+	if sha != "" && t.lastSHA[key] != "" && t.lastSHA[key] != sha {
+		return DispatchHandle
+	}
 	last, ok := t.handled[key]
 	if !ok {
 		return DispatchHandle

--- a/internal/github/debounce_test.go
+++ b/internal/github/debounce_test.go
@@ -82,11 +82,11 @@ func TestIssueTracker(t *testing.T) {
 		}
 	})
 
-	t.Run("new sha within cooldown is still blocked", func(t *testing.T) {
+	t.Run("new sha within cooldown is handleable", func(t *testing.T) {
 		tracker.MarkHandled("t6", PRIssueCIFailure, "sha-a")
 		now = now.Add(5 * time.Minute) // within cooldown
-		if tracker.ShouldHandle("t6", PRIssueCIFailure, "sha-b") {
-			t.Fatal("expected ShouldHandle=false: new SHA but within cooldown")
+		if !tracker.ShouldHandle("t6", PRIssueCIFailure, "sha-b") {
+			t.Fatal("expected ShouldHandle=true: new SHA should bypass cooldown")
 		}
 	})
 

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1230,7 +1230,7 @@ func (r *Handler) dispatchPRIssueWithOptions(ctx context.Context, t task.Task, p
 	}
 
 	for i := range handle {
-		r.prTracker.MarkHandled(t.ID, handle[i].Kind, handle[i].PR.HeadSHA)
+		r.prTracker.MarkHandled(t.ID, handle[i].Kind, r.prIssueDispatchSHA(ctx, handle[i]))
 	}
 	r.logAudit(audit.EventPRFixAgentStarted, t.ID, "", map[string]any{
 		"issue": string(primary.Kind), "kinds": strings.Join(kinds, ","),

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1113,7 +1113,12 @@ func (r *Handler) autoResolveConflict(ctx context.Context, t task.Task, pr githu
 		return false
 	}
 
-	r.prTracker.MarkHandled(t.ID, github.PRIssueConflict, mergedHead)
+	pr.HeadSHA = mergedHead
+	r.prTracker.MarkHandled(t.ID, github.PRIssueConflict, r.prIssueDispatchSHA(ctx, github.PRIssue{
+		Kind:   github.PRIssueConflict,
+		TaskID: t.ID,
+		PR:     pr,
+	}))
 	r.evictReadyPRCache(pr.Repository, pr.Number)
 	r.logAudit(audit.EventPRConflictAutoResolved, t.ID, "", map[string]any{
 		"pr": pr.Number, "issue": string(github.PRIssueConflict),

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -904,7 +904,7 @@ func (r *Handler) prIssueDispatchSHA(ctx context.Context, issue github.PRIssue) 
 	baseSHA, err := fetchBaseSHA(ctx, issue.PR.Repository, issue.PR.Number)
 	if err != nil || baseSHA == "" {
 		r.logger.Warn("reviews.dispatch.conflict-base-sha",
-			"task_id", issue.TaskID, "pr", issue.PR.Number, "err", err)
+			"task_id", issue.TaskID, "repo", issue.PR.Repository, "pr", issue.PR.Number, "err", err)
 		return sha
 	}
 	return sha + ":" + baseSHA

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -109,6 +109,9 @@ type Handler struct {
 	// review-task's PR is still open. Overridable in tests; nil falls back to
 	// github.FetchPRState.
 	fetchPRStateFn func(repo string, number int) (github.PRState, error)
+	// fetchPRBaseSHAFn reads the PR base SHA for conflict retry identity.
+	// Overridable in tests; nil falls back to github.FetchPRBaseSHAContext.
+	fetchPRBaseSHAFn func(ctx context.Context, repo string, number int) (string, error)
 	// fetchKnownPRFn fetches one linked PR without using a GitHub search leg.
 	// Used by the single-PR conflict-recovery path. Overridable in tests; nil
 	// falls back to github.FetchPRForMonitor.
@@ -318,6 +321,7 @@ func New(
 		fetchThreads:        github.FetchReviewThreads,
 		resolveThread:       github.ResolveReviewThread,
 		fetchHeadStateFn:    github.FetchPRHeadState,
+		fetchPRBaseSHAFn:    github.FetchPRBaseSHAContext,
 		cfg:                 cfg,
 		experience:          experienceStore,
 		tryCleanMergeFn:     project.TryCleanMerge,
@@ -836,15 +840,16 @@ func (r *Handler) handleTaskPRIssues(ctx context.Context, taskID string, issues 
 			}
 			continue
 		}
-		// Only the comments kind carries a feedback fingerprint; conflict,
-		// ci_failure, and ready_to_merge fall back to SHA-only gating.
+		// Only the comments kind carries a feedback fingerprint. Conflict
+		// issues use a head+base identity because the base can move underneath
+		// an unchanged PR head and create a new conflict that deserves a retry.
 		var sig string
 		if issues[i].Kind == github.PRIssueComments {
 			sig = issues[i].PR.FeedbackSig
 		}
 		decision := github.DispatchHandle
 		if r.prTracker != nil {
-			decision = r.prTracker.Decide(taskID, issues[i].Kind, issues[i].PR.HeadSHA, sig)
+			decision = r.prTracker.Decide(taskID, issues[i].Kind, r.prIssueDispatchSHA(ctx, issues[i]), sig)
 		}
 		switch decision {
 		case github.DispatchHandle:
@@ -885,6 +890,24 @@ func (r *Handler) handleTaskPRIssues(ctx context.Context, taskID string, issues 
 	case merge != nil:
 		r.handleAutoMerge(ctx, *merge)
 	}
+}
+
+func (r *Handler) prIssueDispatchSHA(ctx context.Context, issue github.PRIssue) string {
+	sha := issue.PR.HeadSHA
+	if issue.Kind != github.PRIssueConflict || issue.PR.Repository == "" || issue.PR.Number <= 0 || sha == "" {
+		return sha
+	}
+	fetchBaseSHA := r.fetchPRBaseSHAFn
+	if fetchBaseSHA == nil {
+		fetchBaseSHA = github.FetchPRBaseSHAContext
+	}
+	baseSHA, err := fetchBaseSHA(ctx, issue.PR.Repository, issue.PR.Number)
+	if err != nil || baseSHA == "" {
+		r.logger.Warn("reviews.dispatch.conflict-base-sha",
+			"task_id", issue.TaskID, "pr", issue.PR.Number, "err", err)
+		return sha
+	}
+	return sha + ":" + baseSHA
 }
 
 func (r *Handler) cancelStalePlanningWorkflowForPRTask(taskID string) bool {

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -83,6 +83,42 @@ func TestConflictPrompt_UsesMergeNotRebase(t *testing.T) {
 	}
 }
 
+func TestConflictDispatchIdentityIncludesBaseSHA(t *testing.T) {
+	t.Parallel()
+
+	baseSHA := "base-1"
+	r := &Handler{
+		logger:    slog.New(slog.DiscardHandler),
+		prTracker: github.NewIssueTracker(time.Minute),
+		fetchPRBaseSHAFn: func(context.Context, string, int) (string, error) {
+			return baseSHA, nil
+		},
+	}
+	issue := github.PRIssue{
+		Kind:   github.PRIssueConflict,
+		TaskID: "task-1",
+		PR: github.PullRequest{
+			Repository: "owner/repo",
+			Number:     42,
+			HeadSHA:    "head-1",
+		},
+	}
+
+	key := r.prIssueDispatchSHA(context.Background(), issue)
+	if got := r.prTracker.Decide(issue.TaskID, issue.Kind, key, ""); got != github.DispatchHandle {
+		t.Fatalf("first conflict decision = %v, want handle", got)
+	}
+	r.prTracker.MarkHandled(issue.TaskID, issue.Kind, key)
+	if got := r.prTracker.Decide(issue.TaskID, issue.Kind, r.prIssueDispatchSHA(context.Background(), issue), ""); got != github.DispatchSkip {
+		t.Fatalf("same head/base decision = %v, want skip", got)
+	}
+
+	baseSHA = "base-2"
+	if got := r.prTracker.Decide(issue.TaskID, issue.Kind, r.prIssueDispatchSHA(context.Background(), issue), ""); got != github.DispatchHandle {
+		t.Fatalf("same head with new base decision = %v, want handle", got)
+	}
+}
+
 func TestConflictPrompt_UsesPRBaseRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- include the PR base SHA in conflict retry identity so a moved base can re-dispatch even when the PR head SHA is unchanged
- let changed dispatch identities bypass cooldown immediately
- add regression coverage for unchanged head plus changed base

## Tests
- go test ./internal/github ./internal/sybra/review