### PR TITLE
fix(watchdog): retry workflow search-loop stalls

### DIFF
--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -688,16 +688,14 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 			w.stopAndVerifyAmbiguousLoop(ctx, ag, trigger, verdict)
 			return
 		}
-		// #2229: a reward_hacking stop on a fix-review agent that still has a
-		// concrete, unaddressed review finding to anchor a retry on (the
-		// "stalled re-reading instead of editing the file the reviewer already
-		// named" pattern) is retried once via the workflow engine's own
-		// reward-hacking retry budget, instead of escalating immediately. Any
-		// other reward_hacking stop — a different role, or no finding to point
-		// the retry at — falls through to the unconditional escalation below,
-		// preserving the cautious default.
+		// #2229: a reward_hacking stop with concrete workflow context
+		// is retried once via the workflow engine's reward-hacking retry budget
+		// instead of escalating immediately. That covers fix-review runs with a
+		// named finding, plus plan/plan-critic/implementation runs whose workflow
+		// can re-dispatch the same step from existing sidecars/NOTES.md. Unknown
+		// or context-free runs still fall through to human-required.
 		if ag.TaskID != "" && verdict.ReasonKind == "reward_hacking" && (trigger == "loop" || trigger == "budget") &&
-			w.retriableRewardHackingFixReview(ag) {
+			w.retriableRewardHackingStop(ag) {
 			w.stopForRewardHackingRetry(ag, verdict)
 			return
 		}
@@ -888,23 +886,35 @@ func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict age
 		"id", ag.ID, "task_id", ag.TaskID, "trigger", trigger, "provider", ag.Provider, "reason", verdict.Reason)
 }
 
-// retriableRewardHackingFixReview reports whether a reward_hacking "stop"
-// verdict for ag should be retried instead of escalated. Scoped narrowly to
-// fix-review agents (see agent.RoleFixReview) whose task still carries a
-// code-review sidecar naming a concrete, unaddressed finding location — the
-// exact "stalled re-reading instead of editing the file the reviewer already
-// named" pattern from #2229. A fix-review agent with no such anchor, or any
-// other role, still escalates immediately: retrying blind would just burn
-// budget on a genuinely stuck loop.
-func (w *Watchdog) retriableRewardHackingFixReview(ag *agent.Agent) bool {
-	if ag.EffectiveRole() != agent.RoleFixReview {
-		return false
-	}
+// retriableRewardHackingStop reports whether a reward_hacking "stop" verdict
+// for ag should be retried instead of escalated. The retry is deliberately
+// bounded in internal/workflow: this helper only decides whether there is
+// enough concrete context to make one clean re-dispatch useful.
+func (w *Watchdog) retriableRewardHackingStop(ag *agent.Agent) bool {
 	t, err := w.tasks.Get(ag.TaskID)
 	if err != nil {
 		return false
 	}
-	return hasUnaddressedReviewFinding(t.CodeReview)
+	role := ag.EffectiveRole()
+	if role == agent.RoleFixReview {
+		return hasUnaddressedReviewFinding(t.CodeReview)
+	}
+	if !rewardHackingRoleCanRetry(role) {
+		return false
+	}
+	if t.Workflow == nil || strings.TrimSpace(t.Workflow.CurrentStep) == "" {
+		return false
+	}
+	return true
+}
+
+func rewardHackingRoleCanRetry(role agent.Role) bool {
+	switch role {
+	case agent.RoleImplementation, agent.RolePlan, agent.RolePlanCritic:
+		return true
+	default:
+		return false
+	}
 }
 
 // hasUnaddressedReviewFinding reports whether a code-review sidecar still
@@ -918,13 +928,10 @@ func hasUnaddressedReviewFinding(codeReview string) bool {
 }
 
 // stopForRewardHackingRetry handles a "stop" verdict whose ReasonKind is
-// "reward_hacking" on a fix-review agent that retriableRewardHackingFixReview
-// has already confirmed has a concrete review finding to retry against. The
-// task is left in-progress (not human-required) with a distinct status-reason
-// prefix the workflow engine's handleWatchdogRewardHackingRetry recognizes on
-// the next ResumeStalled tick: it re-dispatches the fix_review step once more
-// with a steer pointing at the sidecar's named location, before falling back
-// to human-required if that retry also stalls.
+// "reward_hacking" when retriableRewardHackingStop has already confirmed there
+// is enough context to retry once. The task is left in-progress (not
+// human-required) with a distinct status-reason prefix the workflow engine's
+// handleWatchdogRewardHackingRetry recognizes on the next ResumeStalled tick.
 func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.InspectorVerdict) {
 	reason := rewardHackingRetryStatusReason
 	if verdict.Reason != "" {

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/watchdogreason"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 func TestStallLimit(t *testing.T) {
@@ -557,6 +558,113 @@ func TestApplyVerdict_RewardHackingFixReviewWithFindingRetries(t *testing.T) {
 				t.Fatal("stopAgent not called on retriable reward_hacking stop")
 			}
 		})
+	}
+}
+
+// TestApplyVerdict_RewardHackingWorkflowRolesRetry covers search-loop false
+// positives: a reward_hacking stop on plan, plan-critic, or implementation
+// with an active workflow should retry once through the workflow engine instead
+// of parking human-required immediately. The retry budget still lives in
+// workflow, so a second identical stop escalates there.
+func TestApplyVerdict_RewardHackingWorkflowRolesRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		role agent.Role
+	}{
+		{"implementation", agent.RoleImplementation},
+		{"plan", agent.RolePlan},
+		{"plan-critic", agent.RolePlanCritic},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+			currentStep := string(tc.role)
+			if tc.role == agent.RoleImplementation {
+				currentStep = "implement"
+			}
+			wf := &workflow.Execution{
+				WorkflowID:  "simple-task",
+				CurrentStep: currentStep,
+				State:       workflow.ExecWaiting,
+				Variables:   map[string]string{},
+				AgentRoutes: map[string]string{},
+				StartedAt:   time.Now().UTC(),
+				CompletedAt: nil,
+				StepCounts:  map[string]int{},
+			}
+			if _, err := tasks.Update(tk.ID, task.Update{
+				Workflow: &wf,
+			}); err != nil {
+				t.Fatalf("seed workflow: %v", err)
+			}
+
+			stopped := false
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				stopAgent: func(string) error { stopped = true; return nil },
+			}
+
+			w.applyVerdict(t.Context(), &agent.Agent{
+				ID:     "a1",
+				Name:   tc.role.AgentName("demo"),
+				TaskID: tk.ID,
+			}, "loop", agent.InspectorVerdict{
+				Stuck:          true,
+				Reason:         "repeating the same search/edit sequence after restart",
+				Recommendation: "stop",
+				ReasonKind:     "reward_hacking",
+			})
+
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != task.StatusInProgress {
+				t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+			}
+			if got.StatusReason != "watchdog: reward-hacking retry: repeating the same search/edit sequence after restart" {
+				t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)
+			}
+			if !stopped {
+				t.Fatal("stopAgent not called on retriable reward_hacking stop")
+			}
+		})
+	}
+}
+
+func TestApplyVerdict_RewardHackingWorkflowRoleWithoutWorkflowEscalates(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(t.Context(), &agent.Agent{
+		ID:     "a1",
+		Name:   agent.RoleImplementation.AgentName("demo"),
+		TaskID: tk.ID,
+	}, "loop", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "looping without workflow context",
+		Recommendation: "stop",
+		ReasonKind:     "reward_hacking",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+	if !strings.Contains(got.StatusReason, "looping without workflow context") {
+		t.Fatalf("status_reason = %q, want original watchdog reason", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on non-retriable reward_hacking stop")
 	}
 }
 

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -568,23 +568,21 @@ func TestApplyVerdict_RewardHackingFixReviewWithFindingRetries(t *testing.T) {
 // workflow, so a second identical stop escalates there.
 func TestApplyVerdict_RewardHackingWorkflowRolesRetry(t *testing.T) {
 	tests := []struct {
-		name string
-		role agent.Role
+		name       string
+		role       agent.Role
+		workflowID string
+		stepID     string
 	}{
-		{"implementation", agent.RoleImplementation},
-		{"plan", agent.RolePlan},
-		{"plan-critic", agent.RolePlanCritic},
+		{"implementation", agent.RoleImplementation, "simple-task-implement", "implement"},
+		{"plan", agent.RolePlan, "simple-task-plan", "plan"},
+		{"plan-critic", agent.RolePlanCritic, "simple-task-plan", "critique_plan"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tasks, tk := newTestTasks(t)
-			currentStep := string(tc.role)
-			if tc.role == agent.RoleImplementation {
-				currentStep = "implement"
-			}
 			wf := &workflow.Execution{
-				WorkflowID:  "simple-task",
-				CurrentStep: currentStep,
+				WorkflowID:  tc.workflowID,
+				CurrentStep: tc.stepID,
 				State:       workflow.ExecWaiting,
 				Variables:   map[string]string{},
 				AgentRoutes: map[string]string{},

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -41,14 +41,15 @@ const (
 	// watchdogRewardHackingStatusPrefix must stay in sync with
 	// internal/watchdog/agent.go's rewardHackingRetryStatusReason — the
 	// watchdog writes this exact status-reason prefix when it retries a
-	// reward_hacking stop on a fix-review agent (#2229), and
-	// handleWatchdogRewardHackingRetry below pattern-matches on it.
+	// reward_hacking stop with enough workflow context to make one clean
+	// re-dispatch useful, and handleWatchdogRewardHackingRetry below
+	// pattern-matches on it.
 	watchdogRewardHackingStatusPrefix   = "watchdog: reward-hacking retry"
 	watchdogRewardHackingRetryVarPrefix = "watchdog.reward_hacking_retry."
 	// maxWatchdogRewardHackingRetries is deliberately 1, not the generic hang
-	// budget's 2: this path only fires when the review sidecar already names
-	// the fix location, so a fresh agent that still can't land it after one
-	// steered retry is a genuine stuck loop, not a flake.
+	// budget's 2: this path only fires when there is concrete workflow context
+	// for a fresh retry, so a new agent that repeats the same pattern after one
+	// steered retry is a real stuck loop, not a flake.
 	maxWatchdogRewardHackingRetries = 1
 	transientFetchRetryVarPrefix    = "transient_fetch.retry."
 	maxTransientFetchRetries        = 2
@@ -1592,11 +1593,9 @@ func buildWatchdogReaskNote(attempt int) string {
 	return b.String()
 }
 
-// handleWatchdogRewardHackingRetry re-dispatches a fix-review step's agent
+// handleWatchdogRewardHackingRetry re-dispatches the current run_agent step
 // once, fresh, when the watchdog stopped it for a reward_hacking pattern that
-// it judged retriable (internal/watchdog/agent.go's
-// retriableRewardHackingFixReview — a concrete, unaddressed review finding
-// still exists to point the retry at). Bounded by its own dedicated budget
+// it judged retriable. Bounded by its own dedicated budget
 // (maxWatchdogRewardHackingRetries), separate from the generic hang budget,
 // since this is a narrower and more targeted retry than a plain no-output
 // hang. Exhausting it escalates to human-required, same as every other
@@ -1625,7 +1624,7 @@ func (e *Engine) handleWatchdogRewardHackingRetry(t *TaskInfo, step *Step) bool 
 			return e.tasks.UpdateTaskStatus(t.ID, t.Status, "")
 		},
 		onExhausted: func(e *Engine, t *TaskInfo, step *Step, attempts int) {
-			reason := fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — review finding still unaddressed", attempts)
+			reason := fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — agent repeated the same non-progress pattern", attempts)
 			t.Workflow.State = ExecFailed
 			if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
 				e.logger.Error("workflow.watchdog-reward-hacking.persist", "task_id", t.ID, "step", step.ID, "err", err)
@@ -1662,19 +1661,20 @@ func clearWatchdogRewardHackingRetry(wf *Execution, stepID string) {
 }
 
 // buildRewardHackingReaskNote builds the steer prepended to a re-dispatched
-// fix-review prompt: the previous attempt looped without editing anything, so
-// point it straight at the finding the reviewer already located instead of
-// re-reading unrelated files.
+// prompt: the previous attempt looped without making progress, so make the
+// retry resume from existing task artifacts/notes and force a concrete next
+// action instead of repeating investigation.
 func buildRewardHackingReaskNote(attempt int) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "⚠️ Your previous run on this step was TERMINATED because the watchdog detected a "+
 		"reward-hacking pattern — repeating the same non-editing action (reading/navigating) instead of "+
 		"making progress — attempt %d of %d.\n\n", attempt, maxWatchdogRewardHackingRetries)
-	b.WriteString("The previous attempt stalled reading unrelated files; the code review sidecar already " +
-		"names the fix location. Read it, then edit that exact file directly — do not re-read unrelated " +
-		"files or repeat prior investigation.\n\n")
-	b.WriteString("If you are genuinely blocked on understanding the finding, STOP and mark the task " +
-		"human-required with the specific blocker instead of looping.")
+	b.WriteString("Do not restart broad investigation. Read the existing task sidecars, NOTES.md, and the " +
+		"latest command output, then take the next concrete action for this step: edit the named file, " +
+		"tighten the plan artifact, or run the single verification command that advances the workflow. " +
+		"Do not repeat the same search/read sequence.\n\n")
+	b.WriteString("If you are genuinely blocked, STOP and mark the task human-required with the specific " +
+		"blocker instead of looping.")
 	return b.String()
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1670,8 +1670,7 @@ func buildRewardHackingReaskNote(attempt int) string {
 		"reward-hacking pattern — repeating the same non-editing action (reading/navigating) instead of "+
 		"making progress — attempt %d of %d.\n\n", attempt, maxWatchdogRewardHackingRetries)
 	b.WriteString("Do not restart broad investigation. Read the existing task sidecars, NOTES.md, and the " +
-		"latest command output, then take the next concrete action for this step: edit the named file, " +
-		"tighten the plan artifact, or run the single verification command that advances the workflow. " +
+		"latest command output, then take the next concrete action allowed by this step's instructions. " +
 		"Do not repeat the same search/read sequence.\n\n")
 	b.WriteString("If you are genuinely blocked, STOP and mark the task human-required with the specific " +
 		"blocker instead of looping.")

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -338,8 +338,11 @@ func TestHandleWatchdogRewardHackingRetry_SetsReaskNoteOnRetry(t *testing.T) {
 	if !strings.Contains(note, "attempt 1 of 1") {
 		t.Fatalf("reask note missing attempt count:\n%s", note)
 	}
-	if !strings.Contains(note, "sidecar already") {
-		t.Fatalf("reask note should point at the sidecar's named location:\n%s", note)
+	if !strings.Contains(note, "existing task sidecars") {
+		t.Fatalf("reask note should point at existing workflow context:\n%s", note)
+	}
+	if !strings.Contains(note, "Do not repeat the same search/read sequence") {
+		t.Fatalf("reask note should prohibit repeating the same search loop:\n%s", note)
 	}
 	if !strings.Contains(note, "human-required") {
 		t.Fatalf("reask note should offer the human-required escape hatch:\n%s", note)


### PR DESCRIPTION
## Summary
- retry reward_hacking watchdog stops once for workflow-backed plan, plan-critic, and implementation runs instead of immediately parking human-required
- keep fix-review retry behavior anchored on concrete review findings
- make the reward-hacking retry steer role-neutral so agents resume from sidecars/NOTES.md and take a concrete next action

## Verification
- go test ./internal/watchdog ./internal/workflow
- git diff --check

## Notes
- Started from latest origin/main at 74746062.
- Broader check attempted: go test ./internal/sybra. It failed in existing TestProbe_TaskTerminal_KillsLiveInteractiveAgent because the test constructs invalid agent_mode "interactive"; unrelated to this watchdog change.