### PR TITLE
Stop planning loop re-entry

### DIFF
--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -428,6 +428,18 @@ func (a *App) dispatchPlanningWorkflow(taskID string) {
 	if a.agents.HasRunningAgentForTask(taskID) {
 		return
 	}
+	if hasBlockingPlanCritique(t) {
+		reason := "planning blocked: existing plan critique verdict is " +
+			workflow.PlanCritiqueVerdict(t.PlanCritique) +
+			"; use plan review reject to re-plan, or clear the stale planning artifacts before restarting"
+		if _, err := a.tasks.Update(taskID, task.Update{
+			Status:       task.Ptr(task.StatusHumanRequired),
+			StatusReason: task.Ptr(reason),
+		}); err != nil {
+			a.logger.Error("workflow.dispatch.planning.blocked", "task_id", taskID, "err", err)
+		}
+		return
+	}
 	if err := startPlanningWorkflowForTask(a.workflowEngine, t); err != nil &&
 		!errors.Is(err, workflow.ErrWorkflowAlreadyActive) &&
 		!errors.Is(err, workflow.ErrAutoDispatchDisabled) {

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -758,6 +758,54 @@ func TestDispatchPlanningWorkflow_RejectedPlanDoesNotRedispatchImplementation(t 
 	}
 }
 
+func TestDispatchPlanningWorkflow_BlockingPlanCritiqueDoesNotRestartPlanning(t *testing.T) {
+	launcher := &fakeAgentLauncher{}
+	svc, a := setupDispatchTestService(t, launcher)
+	a.workflowEngine = svc.workflowEngine
+
+	created, err := a.tasks.Create("critiqued plan", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.tasks.UpdateMap(created.ID, map[string]any{
+		"status":        string(task.StatusPlanning),
+		"plan_critique": "## Verdict: REFINE\n\nFix the execution order.",
+		"workflow": &workflow.Execution{
+			WorkflowID:  "simple-task-plan",
+			CurrentStep: "",
+			State:       workflow.ExecCompleted,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasBlockingPlanCritique(before) {
+		t.Fatalf("test setup did not persist blocking critique: %q", before.PlanCritique)
+	}
+	if before.Workflow == nil || before.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("test setup workflow = %+v, want completed", before.Workflow)
+	}
+
+	a.dispatchPlanningWorkflow(created.ID)
+
+	got, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if !strings.Contains(got.StatusReason, "existing plan critique verdict is REFINE") {
+		t.Fatalf("status_reason = %q, want blocking critique reason", got.StatusReason)
+	}
+	if launcher.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0", launcher.startCalls)
+	}
+}
+
 func TestDispatchFromHumanRequired_InReviewFlipsStatusOnly(t *testing.T) {
 	launcher := &fakeAgentLauncher{}
 	svc, a := setupDispatchTestService(t, launcher)

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -87,6 +87,15 @@ func hasApprovedPlanContract(t task.Task) bool {
 	return len(workflow.ValidatePlanContractForTask(t.PlanContract, t.ID, t.Body)) == 0
 }
 
+func hasBlockingPlanCritique(t task.Task) bool {
+	switch workflow.PlanCritiqueVerdict(t.PlanCritique) {
+	case "REFINE", "REJECT":
+		return true
+	default:
+		return false
+	}
+}
+
 func allowsTaskCreatedWorkflowWithPR(t task.Task) bool {
 	if slices.Contains(t.Tags, "handoff") {
 		return true

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -190,6 +190,9 @@ func (e *Engine) retryFailedStepIfConfigured(taskID string, def *Definition, cur
 	if done, bErr := e.blockRetryExhaustedTriageIfNeeded(taskID, currentStep, wfExec, output.Output); done || bErr != nil {
 		return true, bErr
 	}
+	if done, bErr := e.blockRetryExhaustedPlanningIfNeeded(taskID, def, currentStep, wfExec, output.Output, retries); done || bErr != nil {
+		return true, bErr
+	}
 	return false, nil
 }
 
@@ -1045,6 +1048,25 @@ func (e *Engine) blockRetryExhaustedTriageIfNeeded(taskID string, step *Step, wf
 		NextAction: "wait_for_operator_reclassify",
 		Exhausted:  true,
 	}); err != nil {
+		return true, err
+	}
+	now := time.Now().UTC()
+	wfExec.State = ExecFailed
+	wfExec.CompletedAt = &now
+	wfExec.CurrentStep = ""
+	return true, e.tasks.SetWorkflow(taskID, wfExec)
+}
+
+func (e *Engine) blockRetryExhaustedPlanningIfNeeded(taskID string, def *Definition, step *Step, wfExec *Execution, output string, attempts int) (bool, error) {
+	if def.ID != "simple-task-plan" || (step.Config.Role != "plan" && step.Config.Role != "plan-critic") {
+		return false, nil
+	}
+	role := step.Config.Role
+	reason := fmt.Sprintf("planning %s retry budget exhausted after %d attempt(s)", role, attempts)
+	if trimmed := strings.TrimSpace(output); trimmed != "" {
+		reason += ": " + truncate(trimmed, 500)
+	}
+	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 		return true, err
 	}
 	now := time.Now().UTC()

--- a/internal/workflow/engine_steps_plancritique.go
+++ b/internal/workflow/engine_steps_plancritique.go
@@ -82,7 +82,7 @@ func canonicalVerdict(word string) string {
 // "" — treated identically to APPROVE by the caller — when none of the three
 // yield a recognizable verdict, preserving today's "any non-empty sidecar is
 // fine" behavior for critics that don't follow the contract at all.
-func parsePlanCritiqueVerdict(content string) string {
+func PlanCritiqueVerdict(content string) string {
 	for _, re := range []*regexp.Regexp{verdictColonLineRe, planReviewTitleRe, verdictSectionRe} {
 		m := re.FindStringSubmatch(content)
 		if m == nil {
@@ -93,4 +93,8 @@ func parsePlanCritiqueVerdict(content string) string {
 		}
 	}
 	return ""
+}
+
+func parsePlanCritiqueVerdict(content string) string {
+	return PlanCritiqueVerdict(content)
 }

--- a/internal/workflow/engine_steps_plancritique.go
+++ b/internal/workflow/engine_steps_plancritique.go
@@ -72,7 +72,7 @@ func canonicalVerdict(word string) string {
 	}
 }
 
-// parsePlanCritiqueVerdict extracts the verdict word from a plan-critique
+// PlanCritiqueVerdict extracts the verdict word from a plan-critique
 // sidecar, checking three locations in order of how closely they match the
 // skill's actual current contract: the "## Verdict: <VERDICT>" line
 // (current), the older "# Plan Review: <VERDICT>" title line, and finally

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1544,6 +1544,54 @@ func TestTriageRetry_Exhausted(t *testing.T) {
 	}
 }
 
+func TestPlanningRetry_ExhaustedParksHumanRequired(t *testing.T) {
+	store := newInlineTestStore(t, "simple-task-plan", `
+id: simple-task-plan
+name: test planning retry
+trigger:
+  on: task.created
+steps:
+  - id: plan
+    type: run_agent
+    config:
+      role: plan
+      max_retries: 1
+    next:
+      - goto: done
+  - id: done
+    type: set_status
+    config:
+      status: todo
+`)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "headless"})
+	if err := engine.StartWorkflowFromStepWithVars("t1", "simple-task-plan", "plan", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for range 2 {
+		agents.SimulateComplete("t1")
+		if err := engine.AdvanceStep("t1", StepOutput{StepID: "plan", Status: "failed", Output: "planner crashed"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if !strings.Contains(ti.StatusReason, "planning plan retry budget exhausted") ||
+		!strings.Contains(ti.StatusReason, "planner crashed") {
+		t.Fatalf("status_reason = %q, want retry exhaustion with output", ti.StatusReason)
+	}
+	if ti.Workflow == nil || ti.Workflow.State != ExecFailed || ti.Workflow.CurrentStep != "" {
+		t.Fatalf("workflow = %+v, want failed terminal workflow", ti.Workflow)
+	}
+}
+
 func TestResumeStalled_WatchdogHangRetriesThenEscalates(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- park simple-task planning when plan or plan-critic retry budgets are exhausted instead of advancing with stale or missing artifacts
- prevent idle planning auto-dispatch from restarting tasks that already have a blocking REFINE/REJECT plan critique
- share the plan-critique verdict parser with app-level dispatch and add focused regression tests

## Test Plan
- env GOCACHE=/private/tmp/sybra-go-cache GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false go test ./internal/workflow -run 'TestPlanningRetry_ExhaustedParksHumanRequired|TestTriageRetry_Exhausted|TestPlanCritiqueVerdict|TestAutoApprove' -count=1
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra -run 'TestDispatchPlanningWorkflow_BlockingPlanCritiqueDoesNotRestartPlanning|TestDispatchPlanningWorkflow_RejectedPlanDoesNotRedispatchImplementation|TestDispatchTaskCreatedWorkflow' -count=1

## Notes
- Full go test ./internal/workflow still has unrelated existing verify-checks failures in TestExecVerifyChecks_BackpressureParksWhilePeerVerifyInFlight and TestExecVerifyChecks_UnrelatedGoPackageFailureBlocks.