### PR TITLE
fix(watchdog): recover search-loop stalls before escalation

### DIFF
--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -688,18 +688,16 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 			w.stopAndVerifyAmbiguousLoop(ctx, ag, trigger, verdict)
 			return
 		}
-		// Reward-hacking loop/budget stops are usually terminal, but a narrow
-		// subset can safely retry from the same workflow state instead of
-		// parking human-required immediately:
-		//   - fix-review with a concrete finding already named in the sidecar
-		//   - implementation, resuming from the same worktree/NOTES
-		//   - plan / plan-critic when reusable planning artifacts already exist
-		// Anything outside those bounded lanes still escalates as before.
-		if ag.TaskID != "" && verdict.ReasonKind == "reward_hacking" && (trigger == "loop" || trigger == "budget") {
-			if status, ok := w.retriableRewardHackingStatus(ag); ok {
-				w.stopForRewardHackingRetry(ag, verdict, status)
-				return
-			}
+		// #2229 plus #2687: reward_hacking stops are retryable only when the
+		// workflow still has grounded context to continue from. That is true
+		// for implementation (same worktree/NOTES), for planning roles when
+		// planning artifacts already exist, and for fix-review when the code
+		// review sidecar still names a concrete finding location. Everything
+		// else still escalates immediately.
+		if ag.TaskID != "" && verdict.ReasonKind == "reward_hacking" && (trigger == "loop" || trigger == "budget") &&
+			w.retriableRewardHacking(ag) {
+			w.stopForRewardHackingRetry(ag, verdict)
+			return
 		}
 		// Set the task state before stopping so the completion callback sees the
 		// intended recovery path. rate_limit is already handled above regardless
@@ -888,35 +886,48 @@ func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict age
 		"id", ag.ID, "task_id", ag.TaskID, "trigger", trigger, "provider", ag.Provider, "reason", verdict.Reason)
 }
 
-// retriableRewardHackingStatus reports whether a reward_hacking "stop" verdict
-// for ag should be retried instead of escalated, and if so which non-terminal
-// task status should be restored for the retry. fix-review stays narrowly
-// scoped to a concrete review finding; implementation always resumes from the
-// same worktree/NOTES; planning roles retry only once they have reusable plan
-// artifacts to refine instead of starting discovery from scratch.
-func (w *Watchdog) retriableRewardHackingStatus(ag *agent.Agent) (task.Status, bool) {
+// retriableRewardHacking reports whether a reward_hacking "stop" verdict for
+// ag should be retried instead of escalated. The retry requires existing
+// workflow context to continue from: implementation reuses the same
+// worktree/NOTES, planning reuses already-written planning artifacts, and
+// fix-review reuses a concrete review finding.
+func (w *Watchdog) retriableRewardHacking(ag *agent.Agent) bool {
+	switch ag.EffectiveRole() {
+	case agent.RoleImplementation:
+		return true
+	case agent.RolePlan, agent.RolePlanCritic, agent.RoleFixReview:
+	default:
+		return false
+	}
+
 	t, err := w.tasks.Get(ag.TaskID)
 	if err != nil {
-		return "", false
+		return false
 	}
-	role := ag.Role
-	if role == "" {
-		var ok bool
-		role, ok = agent.ParseRoleFromName(ag.Name)
-		if !ok {
-			return "", false
+	switch ag.EffectiveRole() {
+	case agent.RolePlan, agent.RolePlanCritic:
+		return hasUsablePlanningArtifacts(t)
+	case agent.RoleFixReview:
+		return hasUnaddressedReviewFinding(t.CodeReview)
+	default:
+		return false
+	}
+}
+
+func hasUsablePlanningArtifacts(t task.Task) bool {
+	for _, content := range []string{
+		t.Plan,
+		t.PlanContract,
+		t.PlanResearch,
+		t.PlanDecisions,
+		t.PlanBrief,
+		t.PlanCritique,
+	} {
+		if strings.TrimSpace(content) != "" {
+			return true
 		}
 	}
-	switch role {
-	case agent.RoleFixReview:
-		return task.StatusInProgress, hasUnaddressedReviewFinding(t.CodeReview)
-	case agent.RoleImplementation:
-		return task.StatusInProgress, true
-	case agent.RolePlan, agent.RolePlanCritic:
-		return task.StatusPlanning, hasUsablePlanningArtifacts(t)
-	default:
-		return "", false
-	}
+	return false
 }
 
 // hasUnaddressedReviewFinding reports whether a code-review sidecar still
@@ -929,38 +940,25 @@ func hasUnaddressedReviewFinding(codeReview string) bool {
 	return strings.Contains(codeReview, "Location:")
 }
 
-func hasUsablePlanningArtifacts(t task.Task) bool {
-	for _, artifact := range []string{
-		t.PlanContract,
-		t.Plan,
-		t.PlanResearch,
-		t.PlanDecisions,
-		t.PlanBrief,
-	} {
-		if strings.TrimSpace(artifact) != "" {
-			return true
-		}
-	}
-	return false
-}
-
 // stopForRewardHackingRetry handles a "stop" verdict whose ReasonKind is
-// "reward_hacking" on a workflow-owned role that has a bounded recovery path.
-// The task stays on its active workflow status (planning/in-progress) with a
-// distinct status-reason prefix the workflow engine recognizes on the next
-// ResumeStalled tick and re-dispatches from the same worktree/notes.
-func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.InspectorVerdict, status task.Status) {
+// "reward_hacking" on a role that retriableRewardHacking has already
+// confirmed can continue from existing grounded context. The task is left
+// in-progress (not human-required) with a distinct status-reason prefix the
+// workflow engine recognizes on the next ResumeStalled tick and re-dispatches
+// with role-specific guidance, before falling back to human-required once that
+// bounded retry budget is exhausted.
+func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.InspectorVerdict) {
 	reason := rewardHackingRetryStatusReason
 	if verdict.Reason != "" {
 		reason = rewardHackingRetryStatusReason + ": " + verdict.Reason
 	}
-	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.reward-hacking-retry", status, reason); err != nil {
+	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.reward-hacking-retry", task.StatusInProgress, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
 	}
-	w.logger.Info("agent.watchdog.reward_hacking.retry", "id", ag.ID, "task_id", ag.TaskID, "role", ag.EffectiveRole(), "status", status, "reason", verdict.Reason)
+	w.logger.Info("agent.watchdog.reward_hacking.retry", "id", ag.ID, "task_id", ag.TaskID, "reason", verdict.Reason)
 }
 
 // rewardHackingRetryStatusReason must stay in sync with

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -688,18 +688,18 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 			w.stopAndVerifyAmbiguousLoop(ctx, ag, trigger, verdict)
 			return
 		}
-		// #2229: a reward_hacking stop on a fix-review agent that still has a
-		// concrete, unaddressed review finding to anchor a retry on (the
-		// "stalled re-reading instead of editing the file the reviewer already
-		// named" pattern) is retried once via the workflow engine's own
-		// reward-hacking retry budget, instead of escalating immediately. Any
-		// other reward_hacking stop — a different role, or no finding to point
-		// the retry at — falls through to the unconditional escalation below,
-		// preserving the cautious default.
-		if ag.TaskID != "" && verdict.ReasonKind == "reward_hacking" && (trigger == "loop" || trigger == "budget") &&
-			w.retriableRewardHackingFixReview(ag) {
-			w.stopForRewardHackingRetry(ag, verdict)
-			return
+		// Reward-hacking loop/budget stops are usually terminal, but a narrow
+		// subset can safely retry from the same workflow state instead of
+		// parking human-required immediately:
+		//   - fix-review with a concrete finding already named in the sidecar
+		//   - implementation, resuming from the same worktree/NOTES
+		//   - plan / plan-critic when reusable planning artifacts already exist
+		// Anything outside those bounded lanes still escalates as before.
+		if ag.TaskID != "" && verdict.ReasonKind == "reward_hacking" && (trigger == "loop" || trigger == "budget") {
+			if status, ok := w.retriableRewardHackingStatus(ag); ok {
+				w.stopForRewardHackingRetry(ag, verdict, status)
+				return
+			}
 		}
 		// Set the task state before stopping so the completion callback sees the
 		// intended recovery path. rate_limit is already handled above regardless
@@ -888,23 +888,35 @@ func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict age
 		"id", ag.ID, "task_id", ag.TaskID, "trigger", trigger, "provider", ag.Provider, "reason", verdict.Reason)
 }
 
-// retriableRewardHackingFixReview reports whether a reward_hacking "stop"
-// verdict for ag should be retried instead of escalated. Scoped narrowly to
-// fix-review agents (see agent.RoleFixReview) whose task still carries a
-// code-review sidecar naming a concrete, unaddressed finding location — the
-// exact "stalled re-reading instead of editing the file the reviewer already
-// named" pattern from #2229. A fix-review agent with no such anchor, or any
-// other role, still escalates immediately: retrying blind would just burn
-// budget on a genuinely stuck loop.
-func (w *Watchdog) retriableRewardHackingFixReview(ag *agent.Agent) bool {
-	if ag.EffectiveRole() != agent.RoleFixReview {
-		return false
-	}
+// retriableRewardHackingStatus reports whether a reward_hacking "stop" verdict
+// for ag should be retried instead of escalated, and if so which non-terminal
+// task status should be restored for the retry. fix-review stays narrowly
+// scoped to a concrete review finding; implementation always resumes from the
+// same worktree/NOTES; planning roles retry only once they have reusable plan
+// artifacts to refine instead of starting discovery from scratch.
+func (w *Watchdog) retriableRewardHackingStatus(ag *agent.Agent) (task.Status, bool) {
 	t, err := w.tasks.Get(ag.TaskID)
 	if err != nil {
-		return false
+		return "", false
 	}
-	return hasUnaddressedReviewFinding(t.CodeReview)
+	role := ag.Role
+	if role == "" {
+		var ok bool
+		role, ok = agent.ParseRoleFromName(ag.Name)
+		if !ok {
+			return "", false
+		}
+	}
+	switch role {
+	case agent.RoleFixReview:
+		return task.StatusInProgress, hasUnaddressedReviewFinding(t.CodeReview)
+	case agent.RoleImplementation:
+		return task.StatusInProgress, true
+	case agent.RolePlan, agent.RolePlanCritic:
+		return task.StatusPlanning, hasUsablePlanningArtifacts(t)
+	default:
+		return "", false
+	}
 }
 
 // hasUnaddressedReviewFinding reports whether a code-review sidecar still
@@ -917,26 +929,38 @@ func hasUnaddressedReviewFinding(codeReview string) bool {
 	return strings.Contains(codeReview, "Location:")
 }
 
+func hasUsablePlanningArtifacts(t task.Task) bool {
+	for _, artifact := range []string{
+		t.PlanContract,
+		t.Plan,
+		t.PlanResearch,
+		t.PlanDecisions,
+		t.PlanBrief,
+	} {
+		if strings.TrimSpace(artifact) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // stopForRewardHackingRetry handles a "stop" verdict whose ReasonKind is
-// "reward_hacking" on a fix-review agent that retriableRewardHackingFixReview
-// has already confirmed has a concrete review finding to retry against. The
-// task is left in-progress (not human-required) with a distinct status-reason
-// prefix the workflow engine's handleWatchdogRewardHackingRetry recognizes on
-// the next ResumeStalled tick: it re-dispatches the fix_review step once more
-// with a steer pointing at the sidecar's named location, before falling back
-// to human-required if that retry also stalls.
-func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.InspectorVerdict) {
+// "reward_hacking" on a workflow-owned role that has a bounded recovery path.
+// The task stays on its active workflow status (planning/in-progress) with a
+// distinct status-reason prefix the workflow engine recognizes on the next
+// ResumeStalled tick and re-dispatches from the same worktree/notes.
+func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.InspectorVerdict, status task.Status) {
 	reason := rewardHackingRetryStatusReason
 	if verdict.Reason != "" {
 		reason = rewardHackingRetryStatusReason + ": " + verdict.Reason
 	}
-	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.reward-hacking-retry", task.StatusInProgress, reason); err != nil {
+	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.reward-hacking-retry", status, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
 	}
-	w.logger.Info("agent.watchdog.reward_hacking.retry", "id", ag.ID, "task_id", ag.TaskID, "reason", verdict.Reason)
+	w.logger.Info("agent.watchdog.reward_hacking.retry", "id", ag.ID, "task_id", ag.TaskID, "role", ag.EffectiveRole(), "status", status, "reason", verdict.Reason)
 }
 
 // rewardHackingRetryStatusReason must stay in sync with

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -694,10 +694,11 @@ func (w *Watchdog) applyVerdict(ctx context.Context, ag *agent.Agent, trigger st
 		// planning artifacts already exist, and for fix-review when the code
 		// review sidecar still names a concrete finding location. Everything
 		// else still escalates immediately.
-		if ag.TaskID != "" && verdict.ReasonKind == "reward_hacking" && (trigger == "loop" || trigger == "budget") &&
-			w.retriableRewardHacking(ag) {
-			w.stopForRewardHackingRetry(ag, verdict)
-			return
+		if ag.TaskID != "" && verdict.ReasonKind == "reward_hacking" && (trigger == "loop" || trigger == "budget") {
+			if status, ok := w.retriableRewardHackingStatus(ag); ok {
+				w.stopForRewardHackingRetry(ag, verdict, status)
+				return
+			}
 		}
 		// Set the task state before stopping so the completion callback sees the
 		// intended recovery path. rate_limit is already handled above regardless
@@ -886,31 +887,29 @@ func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict age
 		"id", ag.ID, "task_id", ag.TaskID, "trigger", trigger, "provider", ag.Provider, "reason", verdict.Reason)
 }
 
-// retriableRewardHacking reports whether a reward_hacking "stop" verdict for
-// ag should be retried instead of escalated. The retry requires existing
-// workflow context to continue from: implementation reuses the same
-// worktree/NOTES, planning reuses already-written planning artifacts, and
-// fix-review reuses a concrete review finding.
-func (w *Watchdog) retriableRewardHacking(ag *agent.Agent) bool {
+// retriableRewardHackingStatus reports whether a reward_hacking "stop"
+// verdict for ag should be retried instead of escalated, and if so which
+// active task status should be restored for the retry.
+func (w *Watchdog) retriableRewardHackingStatus(ag *agent.Agent) (task.Status, bool) {
 	switch ag.EffectiveRole() {
 	case agent.RoleImplementation:
-		return true
+		return task.StatusInProgress, true
 	case agent.RolePlan, agent.RolePlanCritic, agent.RoleFixReview:
 	default:
-		return false
+		return "", false
 	}
 
 	t, err := w.tasks.Get(ag.TaskID)
 	if err != nil {
-		return false
+		return "", false
 	}
 	switch ag.EffectiveRole() {
 	case agent.RolePlan, agent.RolePlanCritic:
-		return hasUsablePlanningArtifacts(t)
+		return task.StatusPlanning, hasUsablePlanningArtifacts(t)
 	case agent.RoleFixReview:
-		return hasUnaddressedReviewFinding(t.CodeReview)
+		return task.StatusInProgress, hasUnaddressedReviewFinding(t.CodeReview)
 	default:
-		return false
+		return "", false
 	}
 }
 
@@ -941,18 +940,16 @@ func hasUnaddressedReviewFinding(codeReview string) bool {
 }
 
 // stopForRewardHackingRetry handles a "stop" verdict whose ReasonKind is
-// "reward_hacking" on a role that retriableRewardHacking has already
-// confirmed can continue from existing grounded context. The task is left
-// in-progress (not human-required) with a distinct status-reason prefix the
-// workflow engine recognizes on the next ResumeStalled tick and re-dispatches
-// with role-specific guidance, before falling back to human-required once that
-// bounded retry budget is exhausted.
-func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.InspectorVerdict) {
+// "reward_hacking" on a role that retriableRewardHackingStatus has already
+// confirmed can continue from existing grounded context. The task is restored
+// to its active workflow status with a distinct status-reason prefix the
+// workflow engine recognizes on the next ResumeStalled tick.
+func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.InspectorVerdict, status task.Status) {
 	reason := rewardHackingRetryStatusReason
 	if verdict.Reason != "" {
 		reason = rewardHackingRetryStatusReason + ": " + verdict.Reason
 	}
-	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.reward-hacking-retry", task.StatusInProgress, reason); err != nil {
+	if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.reward-hacking-retry", status, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if err := w.stopAgent(ag.ID); err != nil {

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1012,10 +1012,10 @@ func TestApplyVerdict_BudgetStopWithGenericStallMarksRetryableHang(t *testing.T)
 	}
 }
 
-// TestApplyVerdict_BudgetStopWithoutGenericStallEscalates covers the empty
-// reason_kind case: without an explicit generic_stall or reward_hacking
-// classification, a budget stop still escalates straight to human-required.
-func TestApplyVerdict_BudgetStopWithoutGenericStallEscalates(t *testing.T) {
+// TestApplyVerdict_BudgetStopWithoutReasonKindEscalates covers the empty
+// reason_kind case: without an explicit classification, a budget stop still
+// escalates straight to human-required.
+func TestApplyVerdict_BudgetStopWithoutReasonKindEscalates(t *testing.T) {
 	tasks, tk := newTestTasks(t)
 
 	stopped := false

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -249,8 +249,8 @@ func TestApplyVerdict_EscalateLeavesTaskRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if got.Status != task.StatusPlanning {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
 	}
 	if got.StatusReason != "" {
 		t.Fatalf("status_reason = %q, want empty", got.StatusReason)
@@ -395,8 +395,8 @@ func TestApplyVerdict_StallStopMarksRetryableHang(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if got.Status != task.StatusPlanning {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
 	}
 	if got.StatusReason != "watchdog hang: no stream activity" {
 		t.Fatalf("status_reason = %q, want retryable watchdog hang marker", got.StatusReason)
@@ -432,8 +432,8 @@ func TestApplyVerdict_LoopStopWithGenericStallMarksRetryableHang(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if got.Status != task.StatusPlanning {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
 	}
 	if got.StatusReason != "watchdog hang: repeating identical investigation commands" {
 		t.Fatalf("status_reason = %q, want retryable watchdog hang marker", got.StatusReason)

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -249,8 +249,8 @@ func TestApplyVerdict_EscalateLeavesTaskRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if got.Status != task.StatusInProgress {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	if got.Status != task.StatusPlanning {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
 	}
 	if got.StatusReason != "" {
 		t.Fatalf("status_reason = %q, want empty", got.StatusReason)
@@ -395,8 +395,8 @@ func TestApplyVerdict_StallStopMarksRetryableHang(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if got.Status != task.StatusInProgress {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	if got.Status != task.StatusPlanning {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
 	}
 	if got.StatusReason != "watchdog hang: no stream activity" {
 		t.Fatalf("status_reason = %q, want retryable watchdog hang marker", got.StatusReason)
@@ -432,8 +432,8 @@ func TestApplyVerdict_LoopStopWithGenericStallMarksRetryableHang(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if got.Status != task.StatusInProgress {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	if got.Status != task.StatusPlanning {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
 	}
 	if got.StatusReason != "watchdog hang: repeating identical investigation commands" {
 		t.Fatalf("status_reason = %q, want retryable watchdog hang marker", got.StatusReason)
@@ -560,38 +560,6 @@ func TestApplyVerdict_RewardHackingFixReviewWithFindingRetries(t *testing.T) {
 	}
 }
 
-func TestApplyVerdict_RewardHackingImplementationRetries(t *testing.T) {
-	tasks, tk := newTestTasks(t)
-
-	stopped := false
-	w := &Watchdog{
-		tasks:     tasks,
-		logger:    slog.New(slog.DiscardHandler),
-		stopAgent: func(string) error { stopped = true; return nil },
-	}
-
-	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: "implementation:demo", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
-		Stuck:          true,
-		Reason:         "re-reading the same files without changing code",
-		Recommendation: "stop",
-		ReasonKind:     "reward_hacking",
-	})
-
-	got, err := tasks.Get(tk.ID)
-	if err != nil {
-		t.Fatalf("get task: %v", err)
-	}
-	if got.Status != task.StatusInProgress {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
-	}
-	if got.StatusReason != "watchdog: reward-hacking retry: re-reading the same files without changing code" {
-		t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)
-	}
-	if !stopped {
-		t.Fatal("stopAgent not called on retriable implementation reward_hacking stop")
-	}
-}
-
 func TestApplyVerdict_RewardHackingPlanCriticWithArtifactsRetries(t *testing.T) {
 	tasks, tk := newTestTasks(t)
 	plan := "# Execution Plan\n\n## Decision\nGrounded plan\n"
@@ -617,8 +585,8 @@ func TestApplyVerdict_RewardHackingPlanCriticWithArtifactsRetries(t *testing.T) 
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if got.Status != task.StatusInProgress {
-		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	if got.Status != task.StatusPlanning {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
 	}
 	if got.StatusReason != "watchdog: reward-hacking retry: re-reading the plan without writing critique" {
 		t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -458,7 +458,7 @@ func TestApplyVerdict_LoopStopWithRewardHackingEscalates(t *testing.T) {
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: "review:demo", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
 		Stuck:          true,
 		Reason:         "repeating the same failing fix with fabricated progress",
 		Recommendation: "stop",
@@ -490,7 +490,7 @@ func TestApplyVerdict_LoopStopWithRewardHackingEmptyReasonPersistsKind(t *testin
 		stopAgent: func(string) error { stopped = true; return nil },
 	}
 
-	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: "review:demo", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
 		Stuck:          true,
 		Recommendation: "stop",
 		ReasonKind:     "reward_hacking",
@@ -557,6 +557,74 @@ func TestApplyVerdict_RewardHackingFixReviewWithFindingRetries(t *testing.T) {
 				t.Fatal("stopAgent not called on retriable reward_hacking stop")
 			}
 		})
+	}
+}
+
+func TestApplyVerdict_RewardHackingImplementationRetries(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: "implementation:demo", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "re-reading the same files without changing code",
+		Recommendation: "stop",
+		ReasonKind:     "reward_hacking",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	}
+	if got.StatusReason != "watchdog: reward-hacking retry: re-reading the same files without changing code" {
+		t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on retriable implementation reward_hacking stop")
+	}
+}
+
+func TestApplyVerdict_RewardHackingPlanCriticWithArtifactsRetries(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	plan := "# Execution Plan\n\n## Decision\nGrounded plan\n"
+	if _, err := tasks.Update(tk.ID, task.Update{Plan: task.Ptr(plan)}); err != nil {
+		t.Fatalf("seed plan sidecar: %v", err)
+	}
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: "plan-critic:demo", TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "re-reading the plan without writing critique",
+		Recommendation: "stop",
+		ReasonKind:     "reward_hacking",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	}
+	if got.StatusReason != "watchdog: reward-hacking retry: re-reading the plan without writing critique" {
+		t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on retriable planning reward_hacking stop")
 	}
 }
 

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1087,54 +1087,70 @@ func TestApplyVerdict_BudgetStopWithGenericStallMarksRetryableHang(t *testing.T)
 // (including empty, for older judges) still escalates straight to
 // human-required — only the explicit generic_stall reason gets the retry.
 func TestApplyVerdict_BudgetStopWithoutGenericStallEscalates(t *testing.T) {
-	tests := []struct {
-		name       string
-		kind       string
-		wantReason string
-	}{
-		{
-			name:       "empty kind",
-			kind:       "",
-			wantReason: "watchdog: budget stop: burned through budget with no forward progress",
-		},
-		{
-			name:       "reward_hacking",
-			kind:       "reward_hacking",
-			wantReason: "watchdog: reward_hacking: burned through budget with no forward progress",
-		},
+	tasks, tk := newTestTasks(t)
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tasks, tk := newTestTasks(t)
 
-			stopped := false
-			w := &Watchdog{
-				tasks:     tasks,
-				logger:    slog.New(slog.DiscardHandler),
-				stopAgent: func(string) error { stopped = true; return nil },
-			}
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "burned through budget with no forward progress",
+		Recommendation: "stop",
+		ReasonKind:     "",
+	})
 
-			w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", TaskID: tk.ID}, "budget", agent.InspectorVerdict{
-				Stuck:          true,
-				Reason:         "burned through budget with no forward progress",
-				Recommendation: "stop",
-				ReasonKind:     tc.kind,
-			})
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+	if got.StatusReason != "watchdog: budget stop: burned through budget with no forward progress" {
+		t.Fatalf("status_reason = %q, want budget-stop marker", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on budget stop verdict")
+	}
+}
 
-			got, err := tasks.Get(tk.ID)
-			if err != nil {
-				t.Fatalf("get task: %v", err)
-			}
-			if got.Status != task.StatusHumanRequired {
-				t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
-			}
-			if got.StatusReason != tc.wantReason {
-				t.Fatalf("status_reason = %q, want %q", got.StatusReason, tc.wantReason)
-			}
-			if !stopped {
-				t.Fatal("stopAgent not called on budget stop verdict")
-			}
-		})
+func TestApplyVerdict_BudgetRewardHackingImplementationRetries(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(t.Context(), &agent.Agent{
+		ID:     "a1",
+		Name:   "implementation:demo",
+		TaskID: tk.ID,
+	}, "budget", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "burned through budget re-reading the same files",
+		Recommendation: "stop",
+		ReasonKind:     "reward_hacking",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	}
+	if got.StatusReason != "watchdog: reward-hacking retry: burned through budget re-reading the same files" {
+		t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on reward_hacking budget stop")
 	}
 }
 

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -601,6 +601,119 @@ func TestApplyVerdict_RewardHackingFixReviewWithoutFindingEscalates(t *testing.T
 	}
 }
 
+func TestApplyVerdict_RewardHackingImplementationRetries(t *testing.T) {
+	for _, trigger := range []string{"loop", "budget"} {
+		t.Run(trigger, func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+
+			stopped := false
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				stopAgent: func(string) error { stopped = true; return nil },
+			}
+
+			w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: "implementation:demo", TaskID: tk.ID}, trigger, agent.InspectorVerdict{
+				Stuck:          true,
+				Reason:         "repeated repo searches without editing",
+				Recommendation: "stop",
+				ReasonKind:     "reward_hacking",
+			})
+
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != task.StatusInProgress {
+				t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+			}
+			if got.StatusReason != "watchdog: reward-hacking retry: repeated repo searches without editing" {
+				t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)
+			}
+			if !stopped {
+				t.Fatal("stopAgent not called on retriable implementation reward_hacking stop")
+			}
+		})
+	}
+}
+
+func TestApplyVerdict_RewardHackingPlanningWithArtifactsRetries(t *testing.T) {
+	for _, role := range []agent.Role{agent.RolePlan, agent.RolePlanCritic} {
+		t.Run(string(role), func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+			status := task.StatusPlanning
+			plan := "# Execution Plan\n\n- refine the existing contract"
+			if _, err := tasks.Update(tk.ID, task.Update{Status: &status, Plan: &plan}); err != nil {
+				t.Fatalf("seed planning artifacts: %v", err)
+			}
+
+			stopped := false
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				stopAgent: func(string) error { stopped = true; return nil },
+			}
+
+			w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: role.AgentName("demo"), TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+				Stuck:          true,
+				Reason:         "kept re-reading files instead of refining the plan",
+				Recommendation: "stop",
+				ReasonKind:     "reward_hacking",
+			})
+
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != task.StatusPlanning {
+				t.Fatalf("status = %q, want %q", got.Status, task.StatusPlanning)
+			}
+			if got.StatusReason != "watchdog: reward-hacking retry: kept re-reading files instead of refining the plan" {
+				t.Fatalf("status_reason = %q, want reward-hacking retry marker", got.StatusReason)
+			}
+			if !stopped {
+				t.Fatal("stopAgent not called on retriable planning reward_hacking stop")
+			}
+		})
+	}
+}
+
+func TestApplyVerdict_RewardHackingPlanningWithoutArtifactsEscalates(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+	status := task.StatusPlanning
+	if _, err := tasks.Update(tk.ID, task.Update{Status: &status}); err != nil {
+		t.Fatalf("set planning status: %v", err)
+	}
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(t.Context(), &agent.Agent{ID: "a1", Name: agent.RolePlan.AgentName("demo"), TaskID: tk.ID}, "loop", agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "kept searching without producing a plan artifact",
+		Recommendation: "stop",
+		ReasonKind:     "reward_hacking",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+	if got.StatusReason != "watchdog: reward_hacking: kept searching without producing a plan artifact" {
+		t.Fatalf("status_reason = %q, want structured watchdog reason", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on non-retriable planning reward_hacking stop")
+	}
+}
+
 // TestApplyVerdict_LoopStopWithEmptyReasonKindVerifiesFirst covers #2147/#2155:
 // an unclassified ("") loop stop is exactly the ambiguous case the judge's own
 // prompt steers toward when reward-hacking is merely possible — re-run verify

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -129,6 +129,10 @@ steps:
         `<type>/<other-slug>-<other-id>`, IGNORE them — they belong to
         other concurrent tasks against the same project repo and have
         nothing to do with you.
+        {{- if getvar .Vars "watchdog_reask_note"}}
+
+        {{getvar .Vars "watchdog_reask_note"}}
+        {{- end}}
 
         Process:
           1. Run: sybra-cli --json get {{.Task.ID}}
@@ -450,6 +454,10 @@ steps:
         /plan-critic skill. Use the planning research, decisions, and brief as
         context, but judge whether the compact execution contract is safe to
         implement.
+        {{- if getvar .Vars "watchdog_reask_note"}}
+
+        {{getvar .Vars "watchdog_reask_note"}}
+        {{- end}}
 
         Steps:
           1. Run: sybra-cli --json get {{.Task.ID}}

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -41,8 +41,9 @@ const (
 	// watchdogRewardHackingStatusPrefix must stay in sync with
 	// internal/watchdog/agent.go's rewardHackingRetryStatusReason — the
 	// watchdog writes this exact status-reason prefix when it retries a
-	// reward_hacking stop on a fix-review agent (#2229), and
-	// handleWatchdogRewardHackingRetry below pattern-matches on it.
+	// recoverable reward_hacking stop (fix-review, implementation, or
+	// planning), and handleWatchdogRewardHackingRetry below pattern-matches
+	// on it.
 	watchdogRewardHackingStatusPrefix   = "watchdog: reward-hacking retry"
 	watchdogRewardHackingRetryVarPrefix = "watchdog.reward_hacking_retry."
 	// maxWatchdogRewardHackingRetries is deliberately 1, not the generic hang
@@ -1592,16 +1593,13 @@ func buildWatchdogReaskNote(attempt int) string {
 	return b.String()
 }
 
-// handleWatchdogRewardHackingRetry re-dispatches a fix-review step's agent
-// once, fresh, when the watchdog stopped it for a reward_hacking pattern that
-// it judged retriable (internal/watchdog/agent.go's
-// retriableRewardHackingFixReview — a concrete, unaddressed review finding
-// still exists to point the retry at). Bounded by its own dedicated budget
-// (maxWatchdogRewardHackingRetries), separate from the generic hang budget,
-// since this is a narrower and more targeted retry than a plain no-output
-// hang. Exhausting it escalates to human-required, same as every other
-// bounded watchdog retry.
+// handleWatchdogRewardHackingRetry re-dispatches a recoverable reward_hacking
+// stop from the same workflow state. fix-review keeps its narrow one-shot
+// budget and sidecar-focused steer; planning and implementation reuse the
+// generic watchdog-stop budget so search-loop stalls recover from the same
+// worktree/notes before escalating.
 func (e *Engine) handleWatchdogRewardHackingRetry(t *TaskInfo, step *Step) bool {
+	maxRetries := watchdogRewardHackingRetryLimit(step)
 	return e.boundedRetry(t, step, boundedRetryPolicy{
 		name: "watchdog-reward-hacking",
 		applies: func(_ *Engine, t *TaskInfo, step *Step) bool {
@@ -1612,20 +1610,20 @@ func (e *Engine) handleWatchdogRewardHackingRetry(t *TaskInfo, step *Step) bool 
 		// HasRunningAgent already returned false.
 		busy:       func(e *Engine, t *TaskInfo, step *Step) bool { return e.hasTrackedAgentForTaskStep(t.ID, step.ID) },
 		counterKey: watchdogRewardHackingRetryKey,
-		max:        maxWatchdogRewardHackingRetries,
+		max:        maxRetries,
 		onArm: func(_ *Engine, t *TaskInfo, step *Step, attempt int) {
 			cleanRef := t.Workflow.Variables[tamperBaselineVar(step.ID)]
 			if cleanRef == "" {
 				cleanRef = "HEAD"
 			}
 			t.Workflow.SetVar(watchdogHangCleanRetryKey(step.ID), cleanRef)
-			t.Workflow.SetVar(watchdogReaskNoteVar, buildRewardHackingReaskNote(attempt))
+			t.Workflow.SetVar(watchdogReaskNoteVarForStep(step), buildRewardHackingReaskNote(step, attempt, maxRetries))
 		},
 		onArmed: func(e *Engine, t *TaskInfo, step *Step, attempt int) error {
 			return e.tasks.UpdateTaskStatus(t.ID, t.Status, "")
 		},
 		onExhausted: func(e *Engine, t *TaskInfo, step *Step, attempts int) {
-			reason := fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — review finding still unaddressed", attempts)
+			reason := watchdogRewardHackingExhaustionReason(step, attempts)
 			t.Workflow.State = ExecFailed
 			if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
 				e.logger.Error("workflow.watchdog-reward-hacking.persist", "task_id", t.ID, "step", step.ID, "err", err)
@@ -1637,6 +1635,23 @@ func (e *Engine) handleWatchdogRewardHackingRetry(t *TaskInfo, step *Step) bool 
 			e.logger.Warn("workflow.watchdog-reward-hacking.exhausted", "task_id", t.ID, "step", step.ID, "attempts", attempts)
 		},
 	})
+}
+
+func watchdogRewardHackingRetryLimit(step *Step) int {
+	if step != nil && step.Config.Role == "fix-review" {
+		return maxWatchdogRewardHackingRetries
+	}
+	return maxWatchdogStopRetries
+}
+
+func watchdogRewardHackingExhaustionReason(step *Step, attempts int) string {
+	if step != nil && step.Config.Role == "fix-review" {
+		return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — review finding still unaddressed", attempts)
+	}
+	if step != nil && (step.Config.Role == "plan" || step.Config.Role == "plan-critic") {
+		return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — planning kept looping despite reusable artifacts", attempts)
+	}
+	return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — implementation kept looping without forward progress", attempts)
 }
 
 func isWatchdogRewardHackingReason(reason string) bool {
@@ -1662,17 +1677,27 @@ func clearWatchdogRewardHackingRetry(wf *Execution, stepID string) {
 }
 
 // buildRewardHackingReaskNote builds the steer prepended to a re-dispatched
-// fix-review prompt: the previous attempt looped without editing anything, so
-// point it straight at the finding the reviewer already located instead of
-// re-reading unrelated files.
-func buildRewardHackingReaskNote(attempt int) string {
+// reward-hacking retry. The guidance is role-aware: fix-review should act on
+// the named review finding; planning should refine existing artifacts; and
+// implementation should continue from the existing worktree/NOTES instead of
+// restarting broad search.
+func buildRewardHackingReaskNote(step *Step, attempt, maxRetries int) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "⚠️ Your previous run on this step was TERMINATED because the watchdog detected a "+
 		"reward-hacking pattern — repeating the same non-editing action (reading/navigating) instead of "+
-		"making progress — attempt %d of %d.\n\n", attempt, maxWatchdogRewardHackingRetries)
-	b.WriteString("The previous attempt stalled reading unrelated files; the code review sidecar already " +
-		"names the fix location. Read it, then edit that exact file directly — do not re-read unrelated " +
-		"files or repeat prior investigation.\n\n")
+		"making progress — attempt %d of %d.\n\n", attempt, maxRetries)
+	switch {
+	case step != nil && step.Config.Role == "fix-review":
+		b.WriteString("The previous attempt stalled reading unrelated files; the code review sidecar already " +
+			"names the fix location. Read it, then edit that exact file directly — do not re-read unrelated " +
+			"files or repeat prior investigation.\n\n")
+	case step != nil && (step.Config.Role == "plan" || step.Config.Role == "plan-critic"):
+		b.WriteString("Reusable planning artifacts already exist in the worktree. Refine the existing plan/contract " +
+			"directly, close the gaps, and stop re-reading unrelated files or restarting discovery from scratch.\n\n")
+	default:
+		b.WriteString("Continue from the current worktree and NOTES: inspect the latest concrete errors/diff, then " +
+			"edit the relevant code directly. Do not restart broad repo exploration or repeat prior searches.\n\n")
+	}
 	b.WriteString("If you are genuinely blocked on understanding the finding, STOP and mark the task " +
 		"human-required with the specific blocker instead of looping.")
 	return b.String()

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1717,11 +1717,11 @@ func buildRewardHackingFixReviewReaskNote(attempt int) string {
 	return b.String()
 }
 
-func buildRewardHackingImplementationReaskNote(attempt, max int) string {
+func buildRewardHackingImplementationReaskNote(attempt, maxRetries int) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "⚠️ Your previous implementation run was TERMINATED because the watchdog detected a "+
 		"reward-hacking pattern — repeating the same investigation or command instead of changing code or approach — attempt %d of %d.\n\n",
-		attempt, max)
+		attempt, maxRetries)
 	b.WriteString("Continue from the current worktree state, not from scratch:\n")
 	b.WriteString("- Read `NOTES.md`, `git status --short`, and the current diff before more repo-wide exploration.\n")
 	b.WriteString("- Reuse the progress already on this branch; change the code or command that failed instead of re-reading unrelated files.\n")
@@ -1730,14 +1730,14 @@ func buildRewardHackingImplementationReaskNote(attempt, max int) string {
 	return b.String()
 }
 
-func buildRewardHackingPlanningReaskNote(role string, attempt, max int) string {
+func buildRewardHackingPlanningReaskNote(role string, attempt, maxRetries int) string {
 	var b strings.Builder
 	stage := "planning"
 	if role == "plan-critic" {
 		stage = "plan-critique"
 	}
 	fmt.Fprintf(&b, "⚠️ Your previous %s run was TERMINATED because the watchdog detected a reward-hacking pattern — repeating navigation or rereads without advancing the planning artifacts — attempt %d of %d.\n\n",
-		stage, attempt, max)
+		stage, attempt, maxRetries)
 	b.WriteString("Refine the existing planning artifacts instead of restarting broad exploration:\n")
 	if role == "plan-critic" {
 		b.WriteString("- Start from the current plan contract/plan/brief and produce grounded critique against those artifacts.\n")

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -41,18 +41,13 @@ const (
 	// watchdogRewardHackingStatusPrefix must stay in sync with
 	// internal/watchdog/agent.go's rewardHackingRetryStatusReason — the
 	// watchdog writes this exact status-reason prefix when it retries a
-	// recoverable reward_hacking stop (fix-review, implementation, or
-	// planning), and handleWatchdogRewardHackingRetry below pattern-matches
-	// on it.
+	// reward_hacking stop on a role with grounded recovery context, and
+	// handleWatchdogRewardHackingRetry below pattern-matches on it.
 	watchdogRewardHackingStatusPrefix   = "watchdog: reward-hacking retry"
 	watchdogRewardHackingRetryVarPrefix = "watchdog.reward_hacking_retry."
-	// maxWatchdogRewardHackingRetries is deliberately 1, not the generic hang
-	// budget's 2: this path only fires when the review sidecar already names
-	// the fix location, so a fresh agent that still can't land it after one
-	// steered retry is a genuine stuck loop, not a flake.
-	maxWatchdogRewardHackingRetries = 1
-	transientFetchRetryVarPrefix    = "transient_fetch.retry."
-	maxTransientFetchRetries        = 2
+	maxWatchdogRewardHackingRetries     = 1
+	transientFetchRetryVarPrefix        = "transient_fetch.retry."
+	maxTransientFetchRetries            = 2
 	// worktreeRepairRetryVarPrefix/maxWorktreeRepairRetries bound the automated
 	// retry budget for tasks parked blocked with blocker.KindWorktreeRepair
 	// (disk-space exhaustion or a failed rebase — see start_error.go). These
@@ -1593,13 +1588,23 @@ func buildWatchdogReaskNote(attempt int) string {
 	return b.String()
 }
 
-// handleWatchdogRewardHackingRetry re-dispatches a recoverable reward_hacking
-// stop from the same workflow state. fix-review keeps its narrow one-shot
-// budget and sidecar-focused steer; planning and implementation reuse the
-// generic watchdog-stop budget so search-loop stalls recover from the same
-// worktree/notes before escalating.
+type watchdogRewardHackingRetryProfile struct {
+	max             int
+	note            func(attempt int) string
+	exhaustedReason func(attempts int) string
+}
+
+// handleWatchdogRewardHackingRetry re-dispatches a run_agent step whose last
+// run was stopped for reward_hacking but still had grounded context to resume
+// from: implementation continues from the same worktree/NOTES, planning roles
+// refine existing planning artifacts, and fix-review keeps its existing
+// sidecar-location retry. Exhausting the per-role budget escalates to
+// human-required.
 func (e *Engine) handleWatchdogRewardHackingRetry(t *TaskInfo, step *Step) bool {
-	maxRetries := watchdogRewardHackingRetryLimit(step)
+	profile, ok := rewardHackingRetryProfile(t, step)
+	if !ok {
+		return false
+	}
 	return e.boundedRetry(t, step, boundedRetryPolicy{
 		name: "watchdog-reward-hacking",
 		applies: func(_ *Engine, t *TaskInfo, step *Step) bool {
@@ -1610,20 +1615,20 @@ func (e *Engine) handleWatchdogRewardHackingRetry(t *TaskInfo, step *Step) bool 
 		// HasRunningAgent already returned false.
 		busy:       func(e *Engine, t *TaskInfo, step *Step) bool { return e.hasTrackedAgentForTaskStep(t.ID, step.ID) },
 		counterKey: watchdogRewardHackingRetryKey,
-		max:        maxRetries,
+		max:        profile.max,
 		onArm: func(_ *Engine, t *TaskInfo, step *Step, attempt int) {
 			cleanRef := t.Workflow.Variables[tamperBaselineVar(step.ID)]
 			if cleanRef == "" {
 				cleanRef = "HEAD"
 			}
 			t.Workflow.SetVar(watchdogHangCleanRetryKey(step.ID), cleanRef)
-			t.Workflow.SetVar(watchdogReaskNoteVarForStep(step), buildRewardHackingReaskNote(step, attempt, maxRetries))
+			t.Workflow.SetVar(watchdogReaskNoteVar, profile.note(attempt))
 		},
 		onArmed: func(e *Engine, t *TaskInfo, step *Step, attempt int) error {
 			return e.tasks.UpdateTaskStatus(t.ID, t.Status, "")
 		},
 		onExhausted: func(e *Engine, t *TaskInfo, step *Step, attempts int) {
-			reason := watchdogRewardHackingExhaustionReason(step, attempts)
+			reason := profile.exhaustedReason(attempts)
 			t.Workflow.State = ExecFailed
 			if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
 				e.logger.Error("workflow.watchdog-reward-hacking.persist", "task_id", t.ID, "step", step.ID, "err", err)
@@ -1637,21 +1642,42 @@ func (e *Engine) handleWatchdogRewardHackingRetry(t *TaskInfo, step *Step) bool 
 	})
 }
 
-func watchdogRewardHackingRetryLimit(step *Step) int {
-	if step != nil && step.Config.Role == "fix-review" {
-		return maxWatchdogRewardHackingRetries
+func rewardHackingRetryProfile(t *TaskInfo, step *Step) (watchdogRewardHackingRetryProfile, bool) {
+	if t == nil || t.Workflow == nil || step == nil || step.Type != StepRunAgent || !isWatchdogRewardHackingReason(t.StatusReason) {
+		return watchdogRewardHackingRetryProfile{}, false
 	}
-	return maxWatchdogStopRetries
-}
-
-func watchdogRewardHackingExhaustionReason(step *Step, attempts int) string {
-	if step != nil && step.Config.Role == "fix-review" {
-		return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — review finding still unaddressed", attempts)
+	switch step.Config.Role {
+	case "fix-review":
+		return watchdogRewardHackingRetryProfile{
+			max:  maxWatchdogRewardHackingRetries,
+			note: buildRewardHackingFixReviewReaskNote,
+			exhaustedReason: func(attempts int) string {
+				return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — review finding still unaddressed", attempts)
+			},
+		}, true
+	case "implementation":
+		return watchdogRewardHackingRetryProfile{
+			max: maxWatchdogStopRetries,
+			note: func(attempt int) string {
+				return buildRewardHackingImplementationReaskNote(attempt, maxWatchdogStopRetries)
+			},
+			exhaustedReason: func(attempts int) string {
+				return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatches", attempts)
+			},
+		}, true
+	case "plan", "plan-critic":
+		return watchdogRewardHackingRetryProfile{
+			max: maxWatchdogRewardHackingRetries,
+			note: func(attempt int) string {
+				return buildRewardHackingPlanningReaskNote(step.Config.Role, attempt, maxWatchdogRewardHackingRetries)
+			},
+			exhaustedReason: func(attempts int) string {
+				return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — planning stage kept looping without converging", attempts)
+			},
+		}, true
+	default:
+		return watchdogRewardHackingRetryProfile{}, false
 	}
-	if step != nil && (step.Config.Role == "plan" || step.Config.Role == "plan-critic") {
-		return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — planning kept looping despite reusable artifacts", attempts)
-	}
-	return fmt.Sprintf("watchdog: reward-hacking retry budget exhausted after %d clean re-dispatch(es) — implementation kept looping without forward progress", attempts)
 }
 
 func isWatchdogRewardHackingReason(reason string) bool {
@@ -1664,11 +1690,9 @@ func watchdogRewardHackingRetryKey(stepID string) string {
 }
 
 // clearWatchdogRewardHackingRetry drops the per-step reward-hacking retry
-// counter once that step's run completes cleanly. Without this, the same
-// step ID (e.g. fix_review, which loops back through code_review each
-// round) would carry an already-exhausted counter into a later, unrelated
-// round and escalate to human-required on the very first reward_hacking stop
-// of that round instead of retrying once as designed (#2229).
+// counter once that step's run completes cleanly. Without this, a later,
+// unrelated round of the same step ID would inherit an already-exhausted
+// counter and escalate immediately instead of getting its own bounded retry.
 func clearWatchdogRewardHackingRetry(wf *Execution, stepID string) {
 	if wf == nil || wf.Variables == nil || stepID == "" {
 		return
@@ -1676,30 +1700,53 @@ func clearWatchdogRewardHackingRetry(wf *Execution, stepID string) {
 	delete(wf.Variables, watchdogRewardHackingRetryKey(stepID))
 }
 
-// buildRewardHackingReaskNote builds the steer prepended to a re-dispatched
-// reward-hacking retry. The guidance is role-aware: fix-review should act on
-// the named review finding; planning should refine existing artifacts; and
-// implementation should continue from the existing worktree/NOTES instead of
-// restarting broad search.
-func buildRewardHackingReaskNote(step *Step, attempt, maxRetries int) string {
+// buildRewardHackingFixReviewReaskNote builds the steer prepended to a
+// re-dispatched fix-review prompt: the previous attempt looped without editing
+// anything, so point it straight at the finding the reviewer already located
+// instead of re-reading unrelated files.
+func buildRewardHackingFixReviewReaskNote(attempt int) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "⚠️ Your previous run on this step was TERMINATED because the watchdog detected a "+
 		"reward-hacking pattern — repeating the same non-editing action (reading/navigating) instead of "+
-		"making progress — attempt %d of %d.\n\n", attempt, maxRetries)
-	switch {
-	case step != nil && step.Config.Role == "fix-review":
-		b.WriteString("The previous attempt stalled reading unrelated files; the code review sidecar already " +
-			"names the fix location. Read it, then edit that exact file directly — do not re-read unrelated " +
-			"files or repeat prior investigation.\n\n")
-	case step != nil && (step.Config.Role == "plan" || step.Config.Role == "plan-critic"):
-		b.WriteString("Reusable planning artifacts already exist in the worktree. Refine the existing plan/contract " +
-			"directly, close the gaps, and stop re-reading unrelated files or restarting discovery from scratch.\n\n")
-	default:
-		b.WriteString("Continue from the current worktree and NOTES: inspect the latest concrete errors/diff, then " +
-			"edit the relevant code directly. Do not restart broad repo exploration or repeat prior searches.\n\n")
-	}
+		"making progress — attempt %d of %d.\n\n", attempt, maxWatchdogRewardHackingRetries)
+	b.WriteString("The previous attempt stalled reading unrelated files; the code review sidecar already " +
+		"names the fix location. Read it, then edit that exact file directly — do not re-read unrelated " +
+		"files or repeat prior investigation.\n\n")
 	b.WriteString("If you are genuinely blocked on understanding the finding, STOP and mark the task " +
 		"human-required with the specific blocker instead of looping.")
+	return b.String()
+}
+
+func buildRewardHackingImplementationReaskNote(attempt, max int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "⚠️ Your previous implementation run was TERMINATED because the watchdog detected a "+
+		"reward-hacking pattern — repeating the same investigation or command instead of changing code or approach — attempt %d of %d.\n\n",
+		attempt, max)
+	b.WriteString("Continue from the current worktree state, not from scratch:\n")
+	b.WriteString("- Read `NOTES.md`, `git status --short`, and the current diff before more repo-wide exploration.\n")
+	b.WriteString("- Reuse the progress already on this branch; change the code or command that failed instead of re-reading unrelated files.\n")
+	b.WriteString("- Keep checks focused to the files you touched; do not fall back to the full suite.\n")
+	b.WriteString("- If you are genuinely blocked, STOP and mark the task human-required with the specific blocker instead of looping.\n")
+	return b.String()
+}
+
+func buildRewardHackingPlanningReaskNote(role string, attempt, max int) string {
+	var b strings.Builder
+	stage := "planning"
+	if role == "plan-critic" {
+		stage = "plan-critique"
+	}
+	fmt.Fprintf(&b, "⚠️ Your previous %s run was TERMINATED because the watchdog detected a reward-hacking pattern — repeating navigation or rereads without advancing the planning artifacts — attempt %d of %d.\n\n",
+		stage, attempt, max)
+	b.WriteString("Refine the existing planning artifacts instead of restarting broad exploration:\n")
+	if role == "plan-critic" {
+		b.WriteString("- Start from the current plan contract/plan/brief and produce grounded critique against those artifacts.\n")
+		b.WriteString("- Do not spend another turn re-reading unrelated source files unless the existing contract points to a real gap.\n")
+	} else {
+		b.WriteString("- Reuse the current plan research/decisions/brief/contract where possible and tighten the weak spot that caused the loop.\n")
+		b.WriteString("- Do not restart repository-wide discovery unless the existing artifacts are missing a concrete file, symbol, or verification step.\n")
+	}
+	b.WriteString("- If the planning artifact is truly unusable, STOP and mark the task human-required with the specific blocker instead of looping.\n")
 	return b.String()
 }
 

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -354,6 +354,43 @@ func TestHandleWatchdogRewardHackingRetry_SetsReaskNoteOnRetry(t *testing.T) {
 	}
 }
 
+func TestHandleWatchdogRewardHackingRetry_ImplementationUsesImplementationBudget(t *testing.T) {
+	t.Parallel()
+	tasks := newMemTasks()
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "simple-task-implement",
+		CurrentStep: "implement",
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: "watchdog: reward-hacking retry: re-reading the same files without changing code",
+		Workflow:     wf,
+	})
+	ti := TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: "watchdog: reward-hacking retry: re-reading the same files without changing code",
+		Workflow:     wf,
+	}
+
+	escalated := engine.handleWatchdogRewardHackingRetry(&ti, &Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation"}})
+	if escalated {
+		t.Fatal("first implementation reward-hacking stop should retry, not escalate")
+	}
+	note := wf.Variables[watchdogReaskNoteVar]
+	if !strings.Contains(note, "attempt 1 of 2") {
+		t.Fatalf("reask note missing implementation attempt budget:\n%s", note)
+	}
+	if !strings.Contains(note, "NOTES.md") {
+		t.Fatalf("reask note should steer implementation toward existing worktree context:\n%s", note)
+	}
+}
+
 func TestHandleWatchdogRewardHackingRetry_ExhaustedBudgetEscalates(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
@@ -397,19 +434,48 @@ func TestHandleWatchdogRewardHackingRetry_ExhaustedBudgetEscalates(t *testing.T)
 	}
 }
 
-func TestBuildRewardHackingReaskNote_AttemptCount(t *testing.T) {
+func TestBuildRewardHackingFixReviewReaskNote_AttemptCount(t *testing.T) {
 	t.Parallel()
-	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "fix-review"}}, 1, 1); !strings.Contains(got, "attempt 1 of 1") {
-		t.Fatalf("buildRewardHackingReaskNote(fix-review) = %q", got)
+	if got := buildRewardHackingFixReviewReaskNote(1); !strings.Contains(got, "attempt 1 of 1") {
+		t.Fatalf("buildRewardHackingFixReviewReaskNote(1) = %q", got)
 	}
-	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "plan"}}, 2, 2); !strings.Contains(got, "attempt 2 of 2") {
-		t.Fatalf("buildRewardHackingReaskNote(plan) = %q", got)
+}
+
+func TestResumeStalled_WatchdogRewardHackingPlanCriticRendersRetryNote(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.Save(*mustBuiltinDefinition(t, "simple-task-plan")); err != nil {
+		t.Fatalf("save simple-task-plan: %v", err)
 	}
-	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "plan"}}, 1, 2); !strings.Contains(got, "Reusable planning artifacts") {
-		t.Fatalf("plan reward-hacking note missing planning guidance:\n%s", got)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "planning",
+		StatusReason: "watchdog: reward-hacking retry: re-reading the plan without writing critique",
+		Plan:         "# Execution Plan\n\n## Decision\nGrounded plan\n",
+		PlanContract: `{"task_id":"t1","verification":[{"command":"go test ./...","expected":"pass"}],"acceptance_criteria":["done"]}`,
+		AgentMode:    "headless",
+		Workflow: &Execution{
+			WorkflowID:  "simple-task-plan",
+			CurrentStep: "critique_plan",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+			StartedAt:   time.Now().UTC(),
+		},
+	})
+
+	engine.ResumeStalled()
+
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("StartAgent calls = %d, want 1", got)
 	}
-	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "implementation"}}, 1, 2); !strings.Contains(got, "current worktree and NOTES") {
-		t.Fatalf("implementation reward-hacking note missing worktree guidance:\n%s", got)
+	prompt := agents.calls[0].Prompt
+	if !strings.Contains(prompt, "watchdog detected a reward-hacking pattern") {
+		t.Fatalf("critique_plan prompt missing reward-hacking context:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "plan-critique run") {
+		t.Fatalf("critique_plan prompt missing stage-specific retry guidance:\n%s", prompt)
 	}
 }
 

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -327,7 +327,7 @@ func TestHandleWatchdogRewardHackingRetry_SetsReaskNoteOnRetry(t *testing.T) {
 		Workflow:     wf,
 	}
 
-	escalated := engine.handleWatchdogRewardHackingRetry(&ti, &Step{ID: "fix_review", Type: StepRunAgent})
+	escalated := engine.handleWatchdogRewardHackingRetry(&ti, &Step{ID: "fix_review", Type: StepRunAgent, Config: StepConfig{Role: "fix-review"}})
 	if escalated {
 		t.Fatal("first reward-hacking stop should retry, not escalate")
 	}
@@ -378,7 +378,7 @@ func TestHandleWatchdogRewardHackingRetry_ExhaustedBudgetEscalates(t *testing.T)
 		Workflow:     wf,
 	}
 
-	escalated := engine.handleWatchdogRewardHackingRetry(&ti, &Step{ID: "fix_review", Type: StepRunAgent})
+	escalated := engine.handleWatchdogRewardHackingRetry(&ti, &Step{ID: "fix_review", Type: StepRunAgent, Config: StepConfig{Role: "fix-review"}})
 	if !escalated {
 		t.Fatal("exhausted reward-hacking retry budget should escalate")
 	}
@@ -399,8 +399,17 @@ func TestHandleWatchdogRewardHackingRetry_ExhaustedBudgetEscalates(t *testing.T)
 
 func TestBuildRewardHackingReaskNote_AttemptCount(t *testing.T) {
 	t.Parallel()
-	if got := buildRewardHackingReaskNote(1); !strings.Contains(got, "attempt 1 of 1") {
-		t.Fatalf("buildRewardHackingReaskNote(1) = %q", got)
+	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "fix-review"}}, 1, 1); !strings.Contains(got, "attempt 1 of 1") {
+		t.Fatalf("buildRewardHackingReaskNote(fix-review) = %q", got)
+	}
+	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "plan"}}, 2, 2); !strings.Contains(got, "attempt 2 of 2") {
+		t.Fatalf("buildRewardHackingReaskNote(plan) = %q", got)
+	}
+	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "plan"}}, 1, 2); !strings.Contains(got, "Reusable planning artifacts") {
+		t.Fatalf("plan reward-hacking note missing planning guidance:\n%s", got)
+	}
+	if got := buildRewardHackingReaskNote(&Step{Config: StepConfig{Role: "implementation"}}, 1, 2); !strings.Contains(got, "current worktree and NOTES") {
+		t.Fatalf("implementation reward-hacking note missing worktree guidance:\n%s", got)
 	}
 }
 
@@ -465,7 +474,7 @@ steps:
 		StatusReason: "watchdog: reward-hacking retry: still looping",
 		Workflow:     fresh.Workflow,
 	}
-	if escalated := engine.handleWatchdogRewardHackingRetry(&ti, &Step{ID: "fix_review", Type: StepRunAgent}); escalated {
+	if escalated := engine.handleWatchdogRewardHackingRetry(&ti, &Step{ID: "fix_review", Type: StepRunAgent, Config: StepConfig{Role: "fix-review"}}); escalated {
 		t.Fatal("reward-hacking retry budget should have reset after a successful round, not escalate immediately")
 	}
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1782,6 +1782,7 @@ func TestResumeStalled_WatchdogStopImplementationRetriesThenEscalates(t *testing
 func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
 	tests := []struct {
 		name       string
+		role       string
 		status     string
 		stepID     string
 		workflowID string
@@ -1795,6 +1796,7 @@ func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
 	}{
 		{
 			name:       "implementation retries from same worktree",
+			role:       "implementation",
 			status:     "in-progress",
 			stepID:     "implement",
 			workflowID: "test-simple",
@@ -1805,6 +1807,7 @@ func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
 		},
 		{
 			name:       "planning retries when plan artifacts exist",
+			role:       "plan",
 			status:     "planning",
 			stepID:     "plan",
 			workflowID: "test-simple",
@@ -1816,6 +1819,7 @@ func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
 		},
 		{
 			name:       "implementation exhaustion escalates",
+			role:       "implementation",
 			status:     "in-progress",
 			stepID:     "implement",
 			workflowID: "test-simple",
@@ -1838,6 +1842,7 @@ func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
 			}
 			tasks.Put(TaskInfo{
 				ID:           "t1",
+				Role:         tc.role,
 				Status:       tc.status,
 				StatusReason: "watchdog: reward-hacking retry: repeated search without editing",
 				AgentMode:    "headless",

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1778,7 +1778,7 @@ func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
 			retries:    "2",
 			wantStarts: 0,
 			wantStatus: "human-required",
-			wantReason: "watchdog: reward-hacking retry budget exhausted after 2 clean re-dispatch(es) — implementation kept looping without forward progress",
+			wantReason: "watchdog: reward-hacking retry budget exhausted after 2 clean re-dispatches",
 			wantRetry:  "2",
 		},
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1731,6 +1731,115 @@ func TestResumeStalled_WatchdogStopImplementationRetriesThenEscalates(t *testing
 	}
 }
 
+func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		stepID     string
+		role       string
+		workflowID string
+		retries    string
+		plan       string
+		wantStarts int
+		wantStatus string
+		wantReason string
+		wantRetry  string
+		wantClean  string
+	}{
+		{
+			name:       "implementation retries from same worktree",
+			status:     "in-progress",
+			stepID:     "implement",
+			role:       "implementation",
+			workflowID: "test-simple",
+			wantStarts: 1,
+			wantStatus: "in-progress",
+			wantRetry:  "1",
+			wantClean:  "HEAD",
+		},
+		{
+			name:       "planning retries when plan artifacts exist",
+			status:     "planning",
+			stepID:     "plan",
+			role:       "plan",
+			workflowID: "test-simple",
+			plan:       "# Execution Plan\n\n- retry from existing artifacts",
+			wantStarts: 1,
+			wantStatus: "planning",
+			wantRetry:  "1",
+			wantClean:  "HEAD",
+		},
+		{
+			name:       "implementation exhaustion escalates",
+			status:     "in-progress",
+			stepID:     "implement",
+			role:       "implementation",
+			workflowID: "test-simple",
+			retries:    "2",
+			wantStarts: 0,
+			wantStatus: "human-required",
+			wantReason: "watchdog: reward-hacking retry budget exhausted after 2 clean re-dispatch(es) — implementation kept looping without forward progress",
+			wantRetry:  "2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestStore(t)
+			tasks := newMemTasks()
+			agents := newMockAgents()
+			engine := NewEngine(store, tasks, agents, discardLogger())
+			vars := map[string]string{}
+			if tc.retries != "" {
+				vars[watchdogRewardHackingRetryKey(tc.stepID)] = tc.retries
+			}
+			tasks.Put(TaskInfo{
+				ID:           "t1",
+				Status:       tc.status,
+				StatusReason: "watchdog: reward-hacking retry: repeated search without editing",
+				AgentMode:    "headless",
+				Plan:         tc.plan,
+				Workflow: &Execution{
+					WorkflowID:  tc.workflowID,
+					CurrentStep: tc.stepID,
+					State:       ExecWaiting,
+					Variables:   vars,
+					StartedAt:   time.Now().UTC(),
+				},
+			})
+
+			engine.ResumeStalled()
+
+			if got := agents.CallCount(); got != tc.wantStarts {
+				t.Fatalf("StartAgent calls = %d, want %d", got, tc.wantStarts)
+			}
+			got, err := tasks.GetTask("t1")
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if got.StatusReason != tc.wantReason {
+				t.Fatalf("status_reason = %q, want %q", got.StatusReason, tc.wantReason)
+			}
+			if got.Workflow.Variables[watchdogRewardHackingRetryKey(tc.stepID)] != tc.wantRetry {
+				t.Fatalf("reward-hacking retry var = %q, want %q", got.Workflow.Variables[watchdogRewardHackingRetryKey(tc.stepID)], tc.wantRetry)
+			}
+			if tc.wantStatus == "human-required" && got.Workflow.State != ExecFailed {
+				t.Fatalf("workflow state = %q, want ExecFailed after retry exhaustion", got.Workflow.State)
+			}
+			if tc.wantStarts > 0 {
+				if got := agents.calls[0].CleanRetryRef; got != tc.wantClean {
+					t.Fatalf("clean retry ref = %q, want %q", got, tc.wantClean)
+				}
+				if got.Workflow.Variables[watchdogHangCleanRetryKey(tc.stepID)] != "" {
+					t.Fatalf("clean retry marker = %q, want cleared after dispatch", got.Workflow.Variables[watchdogHangCleanRetryKey(tc.stepID)])
+				}
+			}
+		})
+	}
+}
+
 func TestResumeStalled_WorktreeRepairRetriesThenExhausts(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Motivation

Two work-typed tasks parked in human-required after the watchdog classified
agent runs as reward_hacking/search-loop behavior, even though viable
workflow context already existed (planning artifacts and/or implementation
progress) and there was no genuine blocker requiring a human.

> Changelog: fix(watchdog): recover search-loop stalls before escalation

## Implementation information

Reward-hacking loop/budget stops are usually terminal, but this narrows the
escalation default for three bounded lanes that can safely retry from
existing state instead of parking human-required immediately:

- fix-review with a concrete finding already named in the sidecar
- implementation, resuming from the same worktree/NOTES
- plan / plan-critic when reusable planning artifacts already exist

Anything outside those lanes still escalates as before. Adds regression
coverage for a reward_hacking/search-loop verdict on a work-typed task with
existing artifacts — expected outcome is retry/requeue, not human-required.

## Supporting documentation

n/a

_Generated by Sybra harness_