### PR TITLE
fix(agent): skip disabled provider failover targets

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -832,10 +832,19 @@ func (m *Manager) ProviderCanFailover(name string) bool {
 		return false
 	}
 	resolved := prov.Name()
-	healthy := func(p string) bool {
-		return g == nil || g.IsHealthy(p)
+	enabled := func(p string) bool {
+		return providerPolicyEnabled(lp, p)
 	}
-	if g != nil && g.Failover(resolved) != "" {
+	healthy := func(p string) bool {
+		return enabled(p) && (g == nil || g.IsHealthy(p))
+	}
+	if g != nil {
+		alt := g.Failover(resolved)
+		if alt != "" && healthy(alt) {
+			return true
+		}
+	}
+	if !enabled(resolved) && firstHealthyProvider(resolved, providerid.All(), healthy) != "" {
 		return true
 	}
 	if lg == nil {

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -60,6 +60,59 @@ func TestGateProvider_UnhealthyWithFailover(t *testing.T) {
 	}
 }
 
+func TestGateProvider_SkipsDisabledHealthFailoverTarget(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{
+		healthy:  map[string]bool{"claude": false, "codex": true, "copilot": true},
+		failover: map[string]string{"claude": "copilot"},
+		reasons:  map[string]string{"claude": "rate_limited"},
+	})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "claude",
+		LimitPolicy: limits.Policy{
+			ProviderEnabled: map[string]bool{
+				limits.ProviderClaude:  true,
+				limits.ProviderCodex:   true,
+				limits.ProviderCopilot: false,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceRuntimeConfig: %v", err)
+	}
+
+	got, err := m.gateProvider(RunConfig{Provider: "claude"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "codex" {
+		t.Fatalf("provider = %q, want codex", got)
+	}
+}
+
+func TestGateProvider_ConfigDisabledRequestedProviderFailsOver(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"codex": true, "copilot": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "copilot",
+		LimitPolicy: limits.Policy{
+			ProviderEnabled: map[string]bool{
+				limits.ProviderCodex:   true,
+				limits.ProviderCopilot: false,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceRuntimeConfig: %v", err)
+	}
+
+	got, err := m.gateProvider(RunConfig{Provider: "copilot"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "codex" {
+		t.Fatalf("provider = %q, want codex", got)
+	}
+}
+
 // TestPrepareRunConfig_InteractiveFailsOverLikeHeadless is a regression guard
 // for the "interactive doesn't fail over" premise: it does. Both modes resolve
 // the provider through the same prepareRunConfig -> gateProvider path, so an

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -1139,44 +1139,30 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (resolvedProvider, rout
 	maxInFlight := m.maxInFlightPerProvider
 	live := maps.Clone(m.liveByProvider)
 	m.mu.RUnlock()
+	enabled := func(p string) bool {
+		return providerPolicyEnabled(lp, p)
+	}
 	underCap := func(p string) bool {
 		return maxInFlight <= 0 || live[p] < maxInFlight
 	}
 	healthy := func(p string) bool {
-		return (g == nil || g.IsHealthy(p)) && underCap(p)
+		return enabled(p) && (g == nil || g.IsHealthy(p)) && underCap(p)
 	}
 	candidateProviders := providerid.All()
+	if !enabled(resolved) {
+		var disabledEvents []providerGateEvent
+		resolved, routingReason, disabledEvents, err = failoverDisabledProvider(resolved, routingReason, cfg, candidateProviders, healthy)
+		gateEvents = append(gateEvents, disabledEvents...)
+		if err != nil {
+			return "", routingReason, gateEvents, err
+		}
+	}
 	if g != nil && !g.IsHealthy(resolved) {
-		if cfg.DisableProviderFailover {
-			reason := g.Reason(resolved)
-			gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
-			return "", routingReason, gateEvents, newProviderUnhealthy(resolved, reason)
-		}
-		alt := g.Failover(resolved)
-		if alt != "" && !underCap(alt) {
-			// g.Failover only consults health, so its pick may already be at
-			// its in-flight cap. AutoFailover being enabled is established by
-			// alt != "", so it's safe to look for another peer that is both
-			// healthy and under cap before settling for the at-cap pick.
-			if capAlt := firstHealthyProvider(resolved, candidateProviders, healthy); capAlt != "" {
-				alt = capAlt
-			}
-		}
-		if alt != "" {
-			altProv, err := lookupProvider(alt)
-			if err != nil {
-				return "", routingReason, gateEvents, err
-			}
-			gateEvents = append(gateEvents, providerGateEvent{
-				kind: "failover", from: resolved, to: altProv.Name(),
-				reason: g.Reason(resolved), logKey: "agent.run.failover", logLevel: "warn", taskID: cfg.TaskID,
-			})
-			resolved = altProv.Name()
-			routingReason = "failover"
-		} else {
-			reason := g.Reason(resolved)
-			gateEvents = append(gateEvents, providerGateEvent{kind: "gated", provider: resolved, reason: reason})
-			return "", routingReason, gateEvents, newProviderUnhealthy(resolved, reason)
+		var healthEvents []providerGateEvent
+		resolved, routingReason, healthEvents, err = failoverUnhealthyProvider(resolved, routingReason, cfg, candidateProviders, g, healthy)
+		gateEvents = append(gateEvents, healthEvents...)
+		if err != nil {
+			return "", routingReason, gateEvents, err
 		}
 	}
 	if lg == nil {
@@ -1236,6 +1222,65 @@ func (m *Manager) resolveProviderDecision(cfg RunConfig) (resolvedProvider, rout
 	} else {
 		return m.softLimitLastResort(resolved, routingReason, reason, gateEvents, cfg.TaskID)
 	}
+}
+
+func providerPolicyEnabled(policy limits.Policy, providerName string) bool {
+	if ok, exists := policy.ProviderEnabled[providerName]; exists && !ok {
+		return false
+	}
+	return true
+}
+
+func failoverDisabledProvider(resolved, routingReason string, cfg RunConfig, candidates []string, healthy func(string) bool) (selectedProvider, selectedRoutingReason string, gateEvents []providerGateEvent, err error) {
+	reason := "provider disabled"
+	if cfg.DisableProviderFailover {
+		return "", routingReason,
+			[]providerGateEvent{{kind: "gated", provider: resolved, reason: reason}},
+			newProviderUnhealthy(resolved, reason)
+	}
+	alt := firstHealthyProvider(resolved, candidates, healthy)
+	if alt == "" {
+		return "", routingReason,
+			[]providerGateEvent{{kind: "gated", provider: resolved, reason: reason}},
+			newProviderUnhealthy(resolved, reason)
+	}
+	return alt, "failover",
+		[]providerGateEvent{{
+			kind: "failover", from: resolved, to: alt,
+			reason: reason, logKey: "agent.run.failover", logLevel: "warn", taskID: cfg.TaskID,
+		}},
+		nil
+}
+
+func failoverUnhealthyProvider(resolved, routingReason string, cfg RunConfig, candidates []string, g provider.HealthGate, healthy func(string) bool) (selectedProvider, selectedRoutingReason string, gateEvents []providerGateEvent, err error) {
+	reason := g.Reason(resolved)
+	if cfg.DisableProviderFailover {
+		return "", routingReason,
+			[]providerGateEvent{{kind: "gated", provider: resolved, reason: reason}},
+			newProviderUnhealthy(resolved, reason)
+	}
+	alt := g.Failover(resolved)
+	if alt != "" && !healthy(alt) {
+		// g.Failover only consults the health checker. Runtime policy and
+		// in-flight caps live in the agent manager, so revalidate the pick
+		// before accepting it as a runnable provider.
+		alt = firstHealthyProvider(resolved, candidates, healthy)
+	}
+	if alt == "" {
+		return "", routingReason,
+			[]providerGateEvent{{kind: "gated", provider: resolved, reason: reason}},
+			newProviderUnhealthy(resolved, reason)
+	}
+	altProv, err := lookupProvider(alt)
+	if err != nil {
+		return "", routingReason, nil, err
+	}
+	return altProv.Name(), "failover",
+		[]providerGateEvent{{
+			kind: "failover", from: resolved, to: altProv.Name(),
+			reason: reason, logKey: "agent.run.failover", logLevel: "warn", taskID: cfg.TaskID,
+		}},
+		nil
 }
 
 func (m *Manager) softLimitLastResort(resolved, routingReason, reason string, gateEvents []providerGateEvent, taskID string) (selectedProvider, selectedRoutingReason string, updatedGateEvents []providerGateEvent, err error) {

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -283,7 +283,7 @@ func (a *App) healthPressureStatus() *health.PressureStatus {
 func (lm *LifecycleManager) StartWatchers(ctx context.Context) {
 	a := lm.app
 	cfgPath := filepath.Join(config.HomeDir(), "config.yaml")
-	cw := confighot.New(cfgPath, func() {
+	cw := confighot.New(cfgPath, func() { //nolint:contextcheck // config reload emits process-global provider health UI events from a file watcher callback.
 		result, err := a.configSvc.ReloadFromDisk()
 		if err != nil {
 			a.logger.Error("config.reload.failed", "err", err)

--- a/internal/sybra/services_wire_config.go
+++ b/internal/sybra/services_wire_config.go
@@ -9,6 +9,7 @@ func (a *App) wireConfigService() {
 	a.configSvc.notifier = a.notifier
 	a.configSvc.agents = a.agents
 	a.configSvc.limits = a.limits
+	a.configSvc.providerHealth = a.providerHealth
 	a.configSvc.workflowEngine = a.workflowEngine
 	a.configSvc.logger = a.logger
 	a.configSvc.policy = a.limitPolicy

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/notification"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/workflow"
 	"gopkg.in/yaml.v3"
 )
@@ -27,6 +28,7 @@ type ConfigService struct {
 	notifier       *notification.Emitter
 	agents         *agent.Manager
 	limits         *limits.Store
+	providerHealth *provider.Checker
 	workflowEngine *workflow.Engine
 	logger         *slog.Logger
 	policy         func() limits.Policy
@@ -399,7 +401,31 @@ func (s *ConfigService) applyHotChangesLocked(result ConfigMutationResult, nextA
 	if slices.Contains(result.Applied, "agent") {
 		s.applyAgentGuardrails(*nextActive)
 	}
+	if providerHealthRuntimeChanged(result.Applied) {
+		s.applyProviderHealthRuntime(*nextActive)
+	}
 	return nil
+}
+
+func providerHealthRuntimeChanged(paths []string) bool {
+	for _, path := range paths {
+		switch path {
+		case "providers.auto_failover", "providers.claude", "providers.codex", "providers.copilot", "providers.opencode":
+			return true
+		}
+	}
+	return false
+}
+
+func (s *ConfigService) applyProviderHealthRuntime(cfg config.Config) {
+	if s.providerHealth == nil {
+		return
+	}
+	s.providerHealth.SetAutoFailover(cfg.Providers.AutoFailover)
+	s.providerHealth.SetProviderEnabled("claude", cfg.Providers.Claude.Enabled)
+	s.providerHealth.SetProviderEnabled("codex", cfg.Providers.Codex.Enabled)
+	s.providerHealth.SetProviderEnabled("copilot", cfg.Providers.Copilot.Enabled)
+	s.providerHealth.SetProviderEnabled("opencode", cfg.Providers.OpenCode.Enabled)
 }
 
 func (s *ConfigService) applyAgentGuardrails(cfg config.Config) {

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/notification"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/routing"
 	"github.com/Automaat/sybra/internal/workflow"
 	"gopkg.in/yaml.v3"
@@ -620,6 +621,32 @@ func TestReloadFromDisk_RefreshesLimitPolicyForProviderChanges(t *testing.T) {
 	}
 	if svc.agents.LimitPolicy().ProviderEnabled[limits.ProviderCodex] {
 		t.Fatal("manager limit policy stayed stale after provider reload")
+	}
+}
+
+func TestReloadFromDisk_RefreshesProviderHealthRuntimeFlags(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	svc.providerHealth = provider.New(provider.Config{
+		ClaudeEnabled:   svc.cfg.Providers.Claude.Enabled,
+		CodexEnabled:    svc.cfg.Providers.Codex.Enabled,
+		CopilotEnabled:  svc.cfg.Providers.Copilot.Enabled,
+		OpenCodeEnabled: svc.cfg.Providers.OpenCode.Enabled,
+		AutoFailover:    svc.cfg.Providers.AutoFailover,
+	}, nil, slog.New(slog.DiscardHandler))
+
+	next := *svc.cfg
+	next.Providers.AutoFailover = false
+	next.Providers.Codex.Enabled = false
+	writeConfigYAML(t, cfgPath, &next)
+
+	if _, err := svc.ReloadFromDisk(); err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if svc.providerHealth.AutoFailover() {
+		t.Fatal("provider health auto-failover flag stayed stale after provider reload")
+	}
+	if got := svc.providerHealth.Snapshot()["codex"]; got.Reason != "disabled" {
+		t.Fatalf("codex health reason = %q, want disabled", got.Reason)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make agent provider routing treat providers.<name>.enabled=false as a hard eligibility filter for failover candidates
- revalidate health-check failover picks against manager runtime policy and in-flight caps before dispatch
- hot-reload provider health checker enabled/auto-failover flags when config.yaml provider settings change

## Tests
- go test ./internal/agent
- go test ./internal/sybra -run 'TestReloadFromDisk|TestConfig'