### PR TITLE
feat(github): add comment-command webhook trigger

### DIFF
--- a/cmd/gen-config-docs/main_test.go
+++ b/cmd/gen-config-docs/main_test.go
@@ -38,12 +38,14 @@ func TestWalkRendersRepeatedLocalStructsAtEachYAMLPath(t *testing.T) {
 		"| `routing` | Adaptive provider-routing policy that tunes experiment weights from observed execution outcomes. | `routing` |",
 		"## Routing",
 		"### RoutingConfig (`routing`)",
-		"| `webhook` | Inbound external task-creation webhook listener and request-signing controls. | `webhook` |",
-		"## Webhook",
-		"### WebhookConfig (`webhook`)",
+		"### GitHubWebhookConfig (`integrations.github.webhook`)",
+		"| `integrations.github.webhook.enabled` |",
 	} {
 		if !strings.Contains(doc, want) {
 			t.Fatalf("generated docs missing %q", want)
 		}
+	}
+	if strings.Contains(doc, "### WebhookConfig (`webhook`)") {
+		t.Fatal("generated docs retained the deprecated top-level WebhookConfig section")
 	}
 }

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -1228,7 +1228,8 @@ func TestConfigDumpRedactsTaggedSecrets(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.Server.AuthToken = "server-secret"
-	cfg.Webhook.Secret = "webhook-secret"
+	cfg.GitHub.Webhook.Secret = "github-webhook-secret"
+	cfg.GitHub.Webhook.TaskSecret = "webhook-secret"
 
 	code, out := captureStdout(t, func() int {
 		return cmdConfigDump(cfg, false)
@@ -1236,11 +1237,12 @@ func TestConfigDumpRedactsTaggedSecrets(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("config dump exit %d:\n%s", code, out)
 	}
-	if strings.Contains(out, "server-secret") || strings.Contains(out, "webhook-secret") {
+	if strings.Contains(out, "server-secret") || strings.Contains(out, "webhook-secret") ||
+		strings.Contains(out, "github-webhook-secret") {
 		t.Fatalf("config dump leaked secret:\n%s", out)
 	}
-	if strings.Count(out, config.RedactedPlaceholder) != 2 {
-		t.Fatalf("config dump redaction count = %d, want 2:\n%s", strings.Count(out, config.RedactedPlaceholder), out)
+	if strings.Count(out, config.RedactedPlaceholder) != 3 {
+		t.Fatalf("config dump redaction count = %d, want 3:\n%s", strings.Count(out, config.RedactedPlaceholder), out)
 	}
 }
 

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -10,6 +10,7 @@
 //	SYBRA_HOST       HTTP listen host (default: all interfaces; a configured
 //	                   cluster.bind_addr(s) wins over this)
 //	SYBRA_AUTH_TOKEN Bearer token for the HTTP control plane
+//	SYBRA_GITHUB_WEBHOOK_SECRET GitHub App webhook signing secret
 //	SYBRA_STATIC_DIR Directory to serve as /; set to frontend/dist for SPA
 //	                   (optional — omit to skip static file serving)
 package main
@@ -419,6 +420,7 @@ const webhookSignatureHeader = "X-Sybra-Signature"
 
 type webhookTaskCreator interface {
 	CreateTaskWithInit(title, body, mode string, init task.Update) (task.Task, error)
+	ListTasks() ([]task.Task, error)
 }
 
 type webhookAdmissionFunc func() error
@@ -453,8 +455,30 @@ func resolveWebhookTaskCreator(app *sybra.App) (webhookTaskCreator, error) {
 }
 
 func newWebhookHandler(logger *slog.Logger, secret string, creator webhookTaskCreator, admit webhookAdmissionFunc) http.Handler {
+	return newWebhookMux(logger, secret, true, config.GitHubConfig{}, creator, admit)
+}
+
+func newWebhookHandlerWithGitHub(
+	logger *slog.Logger,
+	secret string,
+	githubCfg config.GitHubConfig,
+	creator webhookTaskCreator,
+	admit webhookAdmissionFunc,
+) http.Handler {
+	taskRouteEnabled := githubCfg.Webhook.TaskEnabled || strings.TrimSpace(secret) != ""
+	return newWebhookMux(logger, secret, taskRouteEnabled, githubCfg, creator, admit)
+}
+
+func newWebhookMux(
+	logger *slog.Logger,
+	secret string,
+	taskRouteEnabled bool,
+	githubCfg config.GitHubConfig,
+	creator webhookTaskCreator,
+	admit webhookAdmissionFunc,
+) http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/webhook/task", func(w http.ResponseWriter, r *http.Request) {
+	taskHandler := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			writeWebhookError(w, logger, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 			return
@@ -515,7 +539,11 @@ func newWebhookHandler(logger *slog.Logger, secret string, creator webhookTaskCr
 			return
 		}
 		writeWebhookJSON(w, http.StatusCreated, webhookTaskResponse{TaskID: created.ID})
-	})
+	}
+	if taskRouteEnabled {
+		mux.HandleFunc("/webhook/task", taskHandler)
+	}
+	mux.Handle("/webhook/github", newGitHubWebhookHandler(logger, githubCfg, creator, admit))
 	return mux
 }
 
@@ -578,7 +606,7 @@ func writeWebhookAdmissionError(w http.ResponseWriter, logger *slog.Logger, err 
 }
 
 func startWebhookServer(ctx context.Context, cfg *config.Config, app *sybra.App, logger *slog.Logger) (*http.Server, chan error, error) {
-	if cfg == nil || !cfg.Webhook.Enabled {
+	if cfg == nil || !cfg.GitHub.Webhook.Enabled {
 		return nil, nil, nil
 	}
 	creator, err := resolveWebhookTaskCreator(app)
@@ -588,10 +616,11 @@ func startWebhookServer(ctx context.Context, cfg *config.Config, app *sybra.App,
 	admit := func() error {
 		return app.HTTPAdmission("TaskService", "CreateTask", httpapi.MethodMeta{})
 	}
-	return startWebhookServerWithHandler(ctx, cfg.Webhook, newWebhookHandler(logger, cfg.Webhook.Secret, creator, admit), logger)
+	handler := newWebhookHandlerWithGitHub(logger, cfg.GitHub.Webhook.TaskSecret, cfg.GitHub, creator, admit)
+	return startWebhookServerWithHandler(ctx, cfg.GitHub.Webhook, handler, logger)
 }
 
-func startWebhookServerWithHandler(ctx context.Context, cfg config.WebhookConfig, handler http.Handler, logger *slog.Logger) (*http.Server, chan error, error) {
+func startWebhookServerWithHandler(ctx context.Context, cfg config.GitHubWebhookConfig, handler http.Handler, logger *slog.Logger) (*http.Server, chan error, error) {
 	if !cfg.Enabled {
 		return nil, nil, nil
 	}

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -40,6 +40,8 @@ func okHandler() http.Handler {
 type fakeWebhookTaskCreator struct {
 	created task.Task
 	err     error
+	listed  []task.Task
+	listErr error
 
 	gotTitle string
 	gotBody  string
@@ -58,6 +60,13 @@ func (f *fakeWebhookTaskCreator) CreateTaskWithInit(title, body, mode string, in
 		return task.Task{}, f.err
 	}
 	return f.created, nil
+}
+
+func (f *fakeWebhookTaskCreator) ListTasks() ([]task.Task, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return append([]task.Task(nil), f.listed...), nil
 }
 
 type recordedEvent struct {
@@ -420,7 +429,7 @@ func TestWebhookHandlerRejectsTaskCreationDuringDrain(t *testing.T) {
 }
 
 func TestStartWebhookServerDisabledNoop(t *testing.T) {
-	srv, errCh, err := startWebhookServerWithHandler(t.Context(), config.WebhookConfig{}, okHandler(), testLogger())
+	srv, errCh, err := startWebhookServerWithHandler(t.Context(), config.GitHubWebhookConfig{}, okHandler(), testLogger())
 	if err != nil {
 		t.Fatalf("startWebhookServerWithHandler: %v", err)
 	}
@@ -436,7 +445,7 @@ func TestStartWebhookServerFailsOnBindError(t *testing.T) {
 	}
 	defer ln.Close()
 
-	cfg := config.WebhookConfig{Enabled: true, Port: ln.Addr().(*net.TCPAddr).Port}
+	cfg := config.GitHubWebhookConfig{Enabled: true, Port: ln.Addr().(*net.TCPAddr).Port}
 	srv, errCh, err := startWebhookServerWithHandler(t.Context(), cfg, okHandler(), testLogger())
 	if err == nil {
 		if srv != nil {

--- a/cmd/sybra-server/webhook_github.go
+++ b/cmd/sybra-server/webhook_github.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/httpapi"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+const (
+	githubEventHeader     = "X-GitHub-Event"
+	githubSignatureHeader = "X-Hub-Signature-256"
+
+	githubEventIssueComment = "issue_comment"
+	githubCommentAction     = "created"
+
+	githubCommandShip   = "ship"
+	githubCommandReview = "review"
+
+	githubCommentTagPrefix = "github-comment:"
+)
+
+type githubIssueCommentPayload struct {
+	Action  string `json:"action"`
+	Comment struct {
+		ID                int64  `json:"id"`
+		Body              string `json:"body"`
+		AuthorAssociation string `json:"author_association"`
+		User              struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		} `json:"user"`
+	} `json:"comment"`
+	Issue struct {
+		Number      int             `json:"number"`
+		Title       string          `json:"title"`
+		Body        string          `json:"body"`
+		HTMLURL     string          `json:"html_url"`
+		PullRequest json.RawMessage `json:"pull_request"`
+	} `json:"issue"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Installation struct {
+		ID int64 `json:"id"`
+	} `json:"installation"`
+}
+
+type githubWebhookTask struct {
+	title string
+	body  string
+	init  task.Update
+	tag   string
+}
+
+func newGitHubWebhookHandler(
+	logger *slog.Logger,
+	cfg config.GitHubConfig,
+	creator webhookTaskCreator,
+	admit webhookAdmissionFunc,
+) http.Handler {
+	var createMu sync.Mutex
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeWebhookError(w, logger, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			return
+		}
+		if !cfg.Enabled {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, httpapi.MaxRequestBody)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				writeWebhookError(w, logger, http.StatusRequestEntityTooLarge, "payload_too_large", "request body too large")
+				return
+			}
+			writeWebhookError(w, logger, http.StatusBadRequest, "validation_error", "failed to read request body")
+			return
+		}
+		if strings.TrimSpace(cfg.Webhook.Secret) == "" ||
+			!validWebhookSignature(cfg.Webhook.Secret, r.Header.Get(githubSignatureHeader), body) {
+			writeWebhookError(w, logger, http.StatusUnauthorized, "unauthorized", "invalid GitHub webhook signature")
+			return
+		}
+		if r.Header.Get(githubEventHeader) != githubEventIssueComment {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		var payload githubIssueCommentPayload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			writeWebhookError(w, logger, http.StatusBadRequest, "validation_error", "invalid JSON payload")
+			return
+		}
+		if payload.Action != githubCommentAction ||
+			!trustedGitHubCommentAuthor(payload.Comment.AuthorAssociation, payload.Comment.User.Type) {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if cfg.App.InstallationID > 0 && payload.Installation.ID != cfg.App.InstallationID {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		command, ok := parseGitHubCommentCommand(payload.Comment.Body, cfg.Webhook.CommandPrefix)
+		if !ok {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		isPullRequest := len(payload.Issue.PullRequest) > 0 && string(payload.Issue.PullRequest) != "null"
+		if (command == githubCommandReview) != isPullRequest {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		request, err := githubTaskFromComment(payload, command)
+		if err != nil {
+			writeWebhookError(w, logger, http.StatusBadRequest, "validation_error", err.Error())
+			return
+		}
+
+		createMu.Lock()
+		defer createMu.Unlock()
+
+		existing, found, err := findWebhookTaskByTag(creator, request.tag)
+		if err != nil {
+			logger.Error("webhook.github.dedup", "err", err)
+			writeWebhookError(w, logger, http.StatusInternalServerError, "internal_error", "internal error")
+			return
+		}
+		if found {
+			writeWebhookJSON(w, http.StatusOK, webhookTaskResponse{TaskID: existing.ID})
+			return
+		}
+		if admit != nil {
+			if err := admit(); err != nil {
+				writeWebhookAdmissionError(w, logger, err)
+				return
+			}
+		}
+
+		created, err := creator.CreateTaskWithInit(request.title, request.body, task.AgentModeHeadless, request.init)
+		if err != nil {
+			logger.Error("webhook.github.create_task", "err", err)
+			writeWebhookError(w, logger, http.StatusInternalServerError, "internal_error", "internal error")
+			return
+		}
+		writeWebhookJSON(w, http.StatusCreated, webhookTaskResponse{TaskID: created.ID})
+	})
+}
+
+func trustedGitHubCommentAuthor(association, userType string) bool {
+	if strings.EqualFold(strings.TrimSpace(userType), "Bot") {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(association)) {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseGitHubCommentCommand(body, prefix string) (string, bool) {
+	fields := strings.Fields(body)
+	if len(fields) != 2 || !strings.EqualFold(fields[0], strings.TrimSpace(prefix)) {
+		return "", false
+	}
+	switch command := strings.ToLower(fields[1]); command {
+	case githubCommandShip, githubCommandReview:
+		return command, true
+	default:
+		return "", false
+	}
+}
+
+func githubTaskFromComment(payload githubIssueCommentPayload, command string) (githubWebhookTask, error) {
+	repo := strings.TrimSpace(payload.Repository.FullName)
+	if repo == "" || payload.Issue.Number <= 0 || payload.Comment.ID <= 0 {
+		return githubWebhookTask{}, fmt.Errorf("GitHub payload is missing repository, issue number, or comment ID")
+	}
+
+	url := strings.TrimSpace(payload.Issue.HTMLURL)
+	if url == "" {
+		kind := "issues"
+		if command == githubCommandReview {
+			kind = "pull"
+		}
+		url = fmt.Sprintf("https://github.com/%s/%s/%d", repo, kind, payload.Issue.Number)
+	}
+	body := url
+	if description := strings.TrimSpace(payload.Issue.Body); description != "" {
+		body += "\n\n" + description
+	}
+
+	sourceTag := githubCommentTagPrefix + strconv.FormatInt(payload.Comment.ID, 10)
+	init := task.Update{
+		ProjectID: task.Ptr(repo),
+	}
+	var title string
+	switch command {
+	case githubCommandReview:
+		title = fmt.Sprintf("Review PR #%d in %s", payload.Issue.Number, repo)
+		init.PRNumber = task.Ptr(payload.Issue.Number)
+		init.Tags = task.Ptr([]string{"review", "pr-review", sourceTag})
+	case githubCommandShip:
+		title = fmt.Sprintf("Implement issue #%d: %s", payload.Issue.Number, strings.TrimSpace(payload.Issue.Title))
+		init.Issue = task.Ptr(url)
+		init.Tags = task.Ptr([]string{"ship-issue", sourceTag})
+	default:
+		return githubWebhookTask{}, fmt.Errorf("unsupported GitHub command %q", command)
+	}
+
+	return githubWebhookTask{title: title, body: body, init: init, tag: sourceTag}, nil
+}
+
+func findWebhookTaskByTag(creator webhookTaskCreator, tag string) (task.Task, bool, error) {
+	tasks, err := creator.ListTasks()
+	if err != nil {
+		return task.Task{}, false, err
+	}
+	for i := range tasks {
+		if slices.Contains(tasks[i].Tags, tag) {
+			return tasks[i], true, nil
+		}
+	}
+	return task.Task{}, false, nil
+}

--- a/cmd/sybra-server/webhook_github_test.go
+++ b/cmd/sybra-server/webhook_github_test.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type githubWebhookFixture struct {
+	action             string
+	command            string
+	association        string
+	userType           string
+	repo               string
+	number             int
+	title              string
+	description        string
+	url                string
+	commentID          int64
+	installationID     int64
+	includePullRequest bool
+}
+
+func githubWebhookBody(t *testing.T, fixture githubWebhookFixture) []byte {
+	t.Helper()
+	if fixture.action == "" {
+		fixture.action = githubCommentAction
+	}
+	if fixture.association == "" {
+		fixture.association = "MEMBER"
+	}
+	if fixture.userType == "" {
+		fixture.userType = "User"
+	}
+	if fixture.repo == "" {
+		fixture.repo = "example-org/example-repo"
+	}
+	if fixture.number == 0 {
+		fixture.number = 42
+	}
+	if fixture.title == "" {
+		fixture.title = "Make the change"
+	}
+	if fixture.url == "" {
+		fixture.url = "https://github.com/" + fixture.repo + "/issues/42"
+		if fixture.includePullRequest {
+			fixture.url = "https://github.com/" + fixture.repo + "/pull/42"
+		}
+	}
+	if fixture.commentID == 0 {
+		fixture.commentID = 991
+	}
+	if fixture.installationID == 0 {
+		fixture.installationID = 77
+	}
+
+	issue := map[string]any{
+		"number":   fixture.number,
+		"title":    fixture.title,
+		"body":     fixture.description,
+		"html_url": fixture.url,
+	}
+	if fixture.includePullRequest {
+		issue["pull_request"] = map[string]any{"url": "https://api.github.com/repos/example-org/example-repo/pulls/42"}
+	}
+	payload := map[string]any{
+		"action": fixture.action,
+		"comment": map[string]any{
+			"id":                 fixture.commentID,
+			"body":               fixture.command,
+			"author_association": fixture.association,
+			"user": map[string]any{
+				"login": "trusted-user",
+				"type":  fixture.userType,
+			},
+		},
+		"issue": issue,
+		"repository": map[string]any{
+			"full_name": fixture.repo,
+		},
+		"installation": map[string]any{
+			"id": fixture.installationID,
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal GitHub webhook fixture: %v", err)
+	}
+	return body
+}
+
+func serveGitHubWebhook(
+	t *testing.T,
+	cfg config.GitHubConfig,
+	creator *fakeWebhookTaskCreator,
+	event string,
+	body []byte,
+	signingSecret string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	handler := newWebhookHandlerWithGitHub(testLogger(), "", cfg, creator, nil)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/github", strings.NewReader(string(body)))
+	req.Header.Set(githubEventHeader, event)
+	req.Header.Set(githubSignatureHeader, webhookSignature(signingSecret, body))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func githubWebhookConfig(prefix string) config.GitHubConfig {
+	return config.GitHubConfig{
+		Enabled: true,
+		Webhook: config.GitHubWebhookConfig{
+			Secret:        "github-secret",
+			CommandPrefix: prefix,
+		},
+		App: config.GitHubAppConfig{
+			InstallationID: 77,
+		},
+	}
+}
+
+func TestGitHubWebhookCreatesPRReviewTaskWithCustomPrefix(t *testing.T) {
+	creator := &fakeWebhookTaskCreator{created: task.Task{ID: "task-review"}}
+	cfg := githubWebhookConfig("/reviewer")
+	body := githubWebhookBody(t, githubWebhookFixture{
+		command:            "/reviewer review",
+		description:        "Please inspect the implementation.",
+		includePullRequest: true,
+	})
+
+	rr := serveGitHubWebhook(t, cfg, creator, githubEventIssueComment, body, "github-secret")
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	if creator.calls != 1 {
+		t.Fatalf("CreateTaskWithInit calls = %d, want 1", creator.calls)
+	}
+	if creator.gotTitle != "Review PR #42 in example-org/example-repo" {
+		t.Fatalf("title = %q", creator.gotTitle)
+	}
+	if creator.gotBody != "https://github.com/example-org/example-repo/pull/42\n\nPlease inspect the implementation." {
+		t.Fatalf("body = %q", creator.gotBody)
+	}
+	if creator.gotMode != task.AgentModeHeadless {
+		t.Fatalf("mode = %q, want headless", creator.gotMode)
+	}
+	if creator.gotInit.ProjectID == nil || *creator.gotInit.ProjectID != "example-org/example-repo" {
+		t.Fatalf("project_id = %v", creator.gotInit.ProjectID)
+	}
+	if creator.gotInit.PRNumber == nil || *creator.gotInit.PRNumber != 42 {
+		t.Fatalf("pr_number = %v", creator.gotInit.PRNumber)
+	}
+	if creator.gotInit.Tags == nil {
+		t.Fatal("tags = nil")
+	}
+	for _, want := range []string{"review", "pr-review", "github-comment:991"} {
+		if !slices.Contains(*creator.gotInit.Tags, want) {
+			t.Fatalf("tags = %v, missing %q", *creator.gotInit.Tags, want)
+		}
+	}
+}
+
+func TestGitHubWebhookCreatesIssueImplementationTask(t *testing.T) {
+	creator := &fakeWebhookTaskCreator{created: task.Task{ID: "task-ship"}}
+	cfg := githubWebhookConfig("/sybra")
+	body := githubWebhookBody(t, githubWebhookFixture{
+		command:     "/sybra ship",
+		title:       "Handle the edge case",
+		description: "Expected behavior and acceptance criteria.",
+	})
+
+	rr := serveGitHubWebhook(t, cfg, creator, githubEventIssueComment, body, "github-secret")
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	if creator.gotTitle != "Implement issue #42: Handle the edge case" {
+		t.Fatalf("title = %q", creator.gotTitle)
+	}
+	if creator.gotInit.Issue == nil || *creator.gotInit.Issue != "https://github.com/example-org/example-repo/issues/42" {
+		t.Fatalf("issue = %v", creator.gotInit.Issue)
+	}
+	if creator.gotInit.PRNumber != nil {
+		t.Fatalf("pr_number = %v, want nil", creator.gotInit.PRNumber)
+	}
+	if creator.gotInit.Tags == nil || !slices.Equal(*creator.gotInit.Tags, []string{"ship-issue", "github-comment:991"}) {
+		t.Fatalf("tags = %v", creator.gotInit.Tags)
+	}
+}
+
+func TestGitHubWebhookRejectsInvalidSignature(t *testing.T) {
+	creator := &fakeWebhookTaskCreator{}
+	cfg := githubWebhookConfig("/sybra")
+	body := githubWebhookBody(t, githubWebhookFixture{command: "/sybra ship"})
+
+	rr := serveGitHubWebhook(t, cfg, creator, githubEventIssueComment, body, "wrong-secret")
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if creator.calls != 0 {
+		t.Fatalf("CreateTaskWithInit calls = %d, want 0", creator.calls)
+	}
+}
+
+func TestGitHubWebhookDoesNotExposeUnsignedTaskRoute(t *testing.T) {
+	creator := &fakeWebhookTaskCreator{}
+	handler := newWebhookHandlerWithGitHub(testLogger(), "", githubWebhookConfig("/sybra"), creator, nil)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/task", strings.NewReader(`{"title":"unsigned"}`))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+	if creator.calls != 0 {
+		t.Fatalf("CreateTaskWithInit calls = %d, want 0", creator.calls)
+	}
+}
+
+func TestGitHubWebhookPreservesExplicitUnsignedTaskRoute(t *testing.T) {
+	creator := &fakeWebhookTaskCreator{created: task.Task{ID: "task-legacy"}}
+	cfg := githubWebhookConfig("/sybra")
+	cfg.Webhook.TaskEnabled = true
+	handler := newWebhookHandlerWithGitHub(testLogger(), "", cfg, creator, nil)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/task", strings.NewReader(`{"title":"legacy task"}`))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	if creator.calls != 1 {
+		t.Fatalf("CreateTaskWithInit calls = %d, want 1", creator.calls)
+	}
+}
+
+func TestGitHubWebhookIgnoresNonMatchingDeliveries(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   string
+		fixture githubWebhookFixture
+		mutate  func(*config.GitHubConfig)
+	}{
+		{
+			name:    "unhandled event",
+			event:   "push",
+			fixture: githubWebhookFixture{command: "/sybra ship"},
+		},
+		{
+			name:    "unhandled action",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{action: "edited", command: "/sybra ship"},
+		},
+		{
+			name:    "wrong prefix",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{command: "/other ship"},
+		},
+		{
+			name:    "extra command text",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{command: "/sybra ship now"},
+		},
+		{
+			name:    "outside contributor",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{command: "/sybra ship", association: "CONTRIBUTOR"},
+		},
+		{
+			name:    "bot commenter",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{command: "/sybra ship", userType: "Bot"},
+		},
+		{
+			name:    "review command on issue",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{command: "/sybra review"},
+		},
+		{
+			name:  "ship command on pull request",
+			event: githubEventIssueComment,
+			fixture: githubWebhookFixture{
+				command:            "/sybra ship",
+				includePullRequest: true,
+			},
+		},
+		{
+			name:    "wrong installation",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{command: "/sybra ship", installationID: 88},
+		},
+		{
+			name:    "integration disabled",
+			event:   githubEventIssueComment,
+			fixture: githubWebhookFixture{command: "/sybra ship"},
+			mutate: func(cfg *config.GitHubConfig) {
+				cfg.Enabled = false
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			creator := &fakeWebhookTaskCreator{}
+			cfg := githubWebhookConfig("/sybra")
+			if tc.mutate != nil {
+				tc.mutate(&cfg)
+			}
+			body := githubWebhookBody(t, tc.fixture)
+
+			rr := serveGitHubWebhook(t, cfg, creator, tc.event, body, "github-secret")
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+			}
+			if creator.calls != 0 {
+				t.Fatalf("CreateTaskWithInit calls = %d, want 0", creator.calls)
+			}
+		})
+	}
+}
+
+func TestGitHubWebhookDeduplicatesComment(t *testing.T) {
+	creator := &fakeWebhookTaskCreator{
+		listed: []task.Task{{
+			ID:   "existing-task",
+			Tags: []string{"ship-issue", "github-comment:991"},
+		}},
+	}
+	cfg := githubWebhookConfig("/sybra")
+	body := githubWebhookBody(t, githubWebhookFixture{command: "/sybra ship"})
+
+	rr := serveGitHubWebhook(t, cfg, creator, githubEventIssueComment, body, "github-secret")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if creator.calls != 0 {
+		t.Fatalf("CreateTaskWithInit calls = %d, want 0", creator.calls)
+	}
+	var response webhookTaskResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.TaskID != "existing-task" {
+		t.Fatalf("task_id = %q, want existing-task", response.TaskID)
+	}
+}
+
+func TestParseGitHubCommentCommand(t *testing.T) {
+	tests := []struct {
+		body   string
+		prefix string
+		want   string
+		ok     bool
+	}{
+		{body: "/sybra ship", prefix: "/sybra", want: "ship", ok: true},
+		{body: "  /Custom REVIEW\n", prefix: "/custom", want: "review", ok: true},
+		{body: "/sybra", prefix: "/sybra"},
+		{body: "/sybra review later", prefix: "/sybra"},
+		{body: "please /sybra review", prefix: "/sybra"},
+		{body: "/other review", prefix: "/sybra"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.body, func(t *testing.T) {
+			got, ok := parseGitHubCommentCommand(tc.body, tc.prefix)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("parseGitHubCommentCommand(%q, %q) = (%q, %v), want (%q, %v)",
+					tc.body, tc.prefix, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,7 +19,6 @@ Regenerate with `go generate ./internal/config/...` after changing a struct tag 
 | `observability` | Logs, audit, metrics, experimentation, and operator evidence retention. | `observability.logging`, `observability.audit`, `observability.metrics`, `observability.experience`, `observability.intervention`, `observability.ab_testing` |
 | `routing` | Adaptive provider-routing policy that tunes experiment weights from observed execution outcomes. | `routing` |
 | `server` | Local API/server exposure and auth for the running Sybra instance. | `server` |
-| `webhook` | Inbound external task-creation webhook listener and request-signing controls. | `webhook` |
 | `cluster` | Cluster/task-trust policy for multi-node execution backends. | `cluster` |
 | `auto_update` | Deployment self-update behavior for long-running Sybra installs. | `auto_update` |
 
@@ -358,6 +357,7 @@ External systems Sybra talks to on the operator's behalf.
 | `integrations.github.reviews_stable_backoff_max_ticks` | `int` | `0` |  |  | `github.reviews_stable_backoff_max_ticks` | `false` | `restart` |  | ReviewsStableBackoffMaxTicks caps the exponential skip window for linked PRs whose head SHA and updatedAt stay unchanged across polls. Zero falls back to the built-in default; resolved non-positive values disable the backoff entirely. |
 | `integrations.github.issues` | `int` | `0` | `seconds` |  | `github.issues_seconds`, `github.issues` | `false` | `restart` |  | Deprecated compatibility input for github.polling.issues.interval. |
 | `integrations.github.mention_trigger_phrase` | `string` | `""` |  |  | `github.mention_trigger_phrase` | `false` | `restart` |  | MentionTriggerPhrase, when set, gates a comment-mention search alongside the existing assigned/labeled issue paths: an open issue whose comments contain this phrase (e.g. "@sybra") gets a task via the same dedup/creation path. Empty (default) disables the feature — existing installs see no behavior change. |
+| `integrations.github.webhook` | `GitHubWebhookConfig` | _(see below)_ |  |  |  | `false` |  |  | Webhook configures the GitHub App webhook listener, authentication, and comment commands. |
 | `integrations.github.renovate_fast` | `int` | `0` | `seconds` |  | `github.renovate_fast_seconds`, `github.renovate_fast` | `false` | `restart` |  |  |
 | `integrations.github.renovate_slow` | `int` | `0` | `seconds` |  | `github.renovate_slow_seconds`, `github.renovate_slow` | `false` | `restart` |  |  |
 | `integrations.github.app` | `GitHubAppConfig` | _(see below)_ |  |  |  | `false` |  |  | App configures GitHub App installation-token auth. When enabled, Sybra mints a short-lived installation token and injects it into the gh subprocess (GH_TOKEN), raising the REST ceiling to 15k/hr. Unset = fall back to gh's own auth. |
@@ -397,6 +397,20 @@ External systems Sybra talks to on the operator's behalf.
 | `integrations.github.polling.assigned_prs.enabled` | `bool` | `true` |  |  | `github.polling.assigned_prs.enabled` | `false` | `restart` |  |  |
 | `integrations.github.polling.assigned_prs.active_interval` | `int` | `0` | `seconds` |  | `github.polling.assigned_prs.active_interval_seconds`, `github.polling.assigned_prs.active_interval` | `false` | `restart` |  |  |
 | `integrations.github.polling.assigned_prs.idle_interval` | `int` | `0` | `seconds` |  | `github.polling.assigned_prs.idle_interval_seconds`, `github.polling.assigned_prs.idle_interval` | `false` | `restart` |  |  |
+
+### GitHubWebhookConfig (`integrations.github.webhook`)
+
+GitHubWebhookConfig controls GitHub App deliveries sent to
+POST /webhook/github.
+
+| YAML key | Type | Default | Unit | Env override | Legacy aliases | Secret | Reload | Constraints | Description |
+|---|---|---|---|---|---|---|---|---|---|
+| `integrations.github.webhook.enabled` | `bool` | `false` |  |  | `github.webhook.enabled`, `webhook.enabled` | `false` | `restart` |  | Enabled starts the inbound GitHub webhook listener. |
+| `integrations.github.webhook.port` | `int` | `8081` |  |  | `github.webhook.port`, `webhook.port` | `false` | `restart` |  | Port is the dedicated webhook listener port. |
+| `integrations.github.webhook.secret` | `string` | `[redacted]` |  | `SYBRA_GITHUB_WEBHOOK_SECRET` | `github.webhook.secret` | `true` | `restart` |  | Secret authenticates X-Hub-Signature-256. It is intentionally distinct from TaskSecret, which authenticates POST /webhook/task. Empty disables GitHub comment-command ingestion. |
+| `integrations.github.webhook.command_prefix` | `string` | `"/sybra"` |  |  | `github.webhook.command_prefix` | `false` | `restart` |  | CommandPrefix is the literal slash-command prefix accepted in issue and pull-request comments, for example "/sybra". The supported commands are "<prefix> ship" and "<prefix> review". |
+| `integrations.github.webhook.task_enabled` | `bool` | `false` |  |  | `github.webhook.task_enabled` | `false` | `restart` |  | TaskEnabled exposes the generic POST /webhook/task sibling route. Legacy top-level webhook.enabled configurations are migrated with this enabled. |
+| `integrations.github.webhook.task_secret` | `string` | `[redacted]` |  | `SYBRA_WEBHOOK_SECRET` | `github.webhook.task_secret`, `webhook.secret` | `true` | `restart` |  | TaskSecret authenticates the generic route's X-Sybra-Signature header. A non-empty value also enables the route. |
 
 ### GitHubAppConfig (`integrations.github.app`)
 
@@ -834,23 +848,6 @@ if left empty, never to config.yaml — see applyServerDefaults.
 |---|---|---|---|---|---|---|---|---|---|
 | `server.auth_token` | `string` | `[redacted]` |  | `SYBRA_AUTH_TOKEN` |  | `true` | `restart` |  |  |
 | `server.allowed_origins` | `[]string` |  |  | `SYBRA_ALLOWED_ORIGINS` |  | `false` | `restart` |  |  |
-
-## Webhook
-
-Inbound external task-creation webhook listener and request-signing controls.
-
-### WebhookConfig (`webhook`)
-
-WebhookConfig controls the optional inbound HTTP webhook used for external
-task creation. When Enabled is true, sybra-server starts a separate listener
-on Port and serves POST /webhook/task. Secret optionally enables HMAC-SHA256
-request signing via X-Sybra-Signature: sha256=<hex>.
-
-| YAML key | Type | Default | Unit | Env override | Legacy aliases | Secret | Reload | Constraints | Description |
-|---|---|---|---|---|---|---|---|---|---|
-| `webhook.enabled` | `bool` | `false` |  |  |  | `false` | `restart` |  |  |
-| `webhook.port` | `int` | `8081` |  |  |  | `false` | `restart` |  |  |
-| `webhook.secret` | `string` | `[redacted]` |  | `SYBRA_WEBHOOK_SECRET` |  | `true` | `restart` |  |  |
 
 ## Cluster
 

--- a/docs/github-rate-limits.md
+++ b/docs/github-rate-limits.md
@@ -93,7 +93,12 @@ When unset/disabled, `gh` uses its own auth unchanged.
 2. **Permissions** — Repository: *Contents* (read/write), *Issues* (read/write),
    *Pull requests* (read/write), *Metadata* (read). Organization/Account: none.
    Match these to what your automations actually do.
-3. **Webhook** — uncheck *Active* (Sybra polls; it doesn't receive webhooks).
+3. **Webhook** — to enable comment-command task creation, keep *Active*
+   checked, set the URL to the externally reachable `/webhook/github` route,
+   set a webhook secret, and subscribe to **Issue comments**. Configure the
+   same secret in `integrations.github.webhook.secret` and enable that nested
+   webhook block. If comment commands are not used, uncheck *Active*. See
+   [GitHub comment-command webhooks](github-webhooks.md).
 4. **Create**, then note the **App ID** (shown on the App's page).
 5. **Generate a private key** — on the App's page, *Private keys → Generate a
    private key*. A `.pem` downloads. Put it where the server can read it

--- a/docs/github-webhooks.md
+++ b/docs/github-webhooks.md
@@ -1,0 +1,63 @@
+# GitHub comment-command webhooks
+
+Sybra can create tasks from comments delivered by its GitHub App:
+
+- `<prefix> ship` on an issue creates an implementation task.
+- `<prefix> review` on a pull request creates an inbound PR-review task.
+
+The prefix defaults to `/sybra` and is configurable. Commands must be the
+entire comment apart from surrounding or repeated whitespace.
+
+## Configuration
+
+```yaml
+integrations:
+  github:
+    enabled: true
+    webhook:
+      enabled: true
+      port: 8081
+      secret: replace-with-the-github-app-webhook-secret
+      command_prefix: /sybra
+    app:
+      enabled: true
+      app_id: 123456
+      installation_id: 7891011
+      private_key_path: /data/sybra/github-app.pem
+```
+
+`SYBRA_GITHUB_WEBHOOK_SECRET` overrides the YAML secret. The command prefix is
+configured only in YAML. The optional `task_secret` setting enables and signs
+the generic `POST /webhook/task` sibling route using `X-Sybra-Signature`;
+`SYBRA_WEBHOOK_SECRET` can override that value. Set `task_enabled: true` only
+when that route must remain available without a signature. Legacy top-level
+`webhook.enabled: true` configurations migrate with `task_enabled` set so their
+existing behavior is preserved.
+
+In the GitHub App registration:
+
+1. Set the webhook URL to the externally reachable
+   `https://<host>/webhook/github` route.
+2. Set the webhook secret to the same value as
+   `integrations.github.webhook.secret`.
+3. Grant at least read access to repository metadata, issues, and pull
+   requests.
+4. Subscribe to the **Issue comments** event.
+
+The deployment must route `/webhook/github` to the webhook listener port. The
+main control-plane bearer token does not apply to this separate listener;
+GitHub's HMAC signature authenticates the request.
+
+## Processing rules
+
+Sybra verifies `X-Hub-Signature-256` against the unmodified request body before
+parsing it. Missing or invalid signatures return `401`.
+
+Only `issue_comment.created` deliveries authored by an `OWNER`, `MEMBER`, or
+`COLLABORATOR` are eligible. Bot comments, outside contributors, other events,
+unknown commands, and commands used on the wrong GitHub object return `200`
+without creating a task.
+
+The App installation ID is checked when `github.app.installation_id` is set.
+The GitHub comment ID is stored as a task tag, so manual webhook redelivery
+returns the existing task instead of creating a duplicate.

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/index.ts
@@ -13,6 +13,7 @@ export {
     GitHubPRPollingConfig,
     GitHubPollingConfig,
     GitHubPollingStreamConfig,
+    GitHubWebhookConfig,
     K8sJobEnvVar,
     K8sJobSecretEnvVar,
     K8sJobVolume,

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -693,6 +693,12 @@ export class GitHubConfig {
      * installs see no behavior change.
      */
     "mentionTriggerPhrase": string;
+
+    /**
+     * Webhook configures the GitHub App webhook listener, authentication, and
+     * comment commands.
+     */
+    "webhook": GitHubWebhookConfig;
     "renovateFastSeconds": number;
     "renovateSlowSeconds": number;
 
@@ -787,6 +793,9 @@ export class GitHubConfig {
         if (!("mentionTriggerPhrase" in $$source)) {
             this["mentionTriggerPhrase"] = "";
         }
+        if (!("webhook" in $$source)) {
+            this["webhook"] = (new GitHubWebhookConfig());
+        }
         if (!("renovateFastSeconds" in $$source)) {
             this["renovateFastSeconds"] = 0;
         }
@@ -820,13 +829,17 @@ export class GitHubConfig {
      */
     static createFrom($$source: any = {}): GitHubConfig {
         const $$createField1_0 = $$createType6;
-        const $$createField13_0 = $$createType7;
+        const $$createField11_0 = $$createType7;
+        const $$createField14_0 = $$createType8;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("polling" in $$parsedSource) {
             $$parsedSource["polling"] = $$createField1_0($$parsedSource["polling"]);
         }
+        if ("webhook" in $$parsedSource) {
+            $$parsedSource["webhook"] = $$createField11_0($$parsedSource["webhook"]);
+        }
         if ("app" in $$parsedSource) {
-            $$parsedSource["app"] = $$createField13_0($$parsedSource["app"]);
+            $$parsedSource["app"] = $$createField14_0($$parsedSource["app"]);
         }
         return new GitHubConfig($$parsedSource as Partial<GitHubConfig>);
     }
@@ -885,9 +898,9 @@ export class GitHubPollingConfig {
      * Creates a new GitHubPollingConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): GitHubPollingConfig {
-        const $$createField0_0 = $$createType8;
-        const $$createField1_0 = $$createType9;
-        const $$createField2_0 = $$createType9;
+        const $$createField0_0 = $$createType9;
+        const $$createField1_0 = $$createType10;
+        const $$createField2_0 = $$createType10;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("issues" in $$parsedSource) {
             $$parsedSource["issues"] = $$createField0_0($$parsedSource["issues"]);
@@ -924,6 +937,80 @@ export class GitHubPollingStreamConfig {
     static createFrom($$source: any = {}): GitHubPollingStreamConfig {
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         return new GitHubPollingStreamConfig($$parsedSource as Partial<GitHubPollingStreamConfig>);
+    }
+}
+
+/**
+ * GitHubWebhookConfig controls GitHub App deliveries sent to
+ * POST /webhook/github.
+ */
+export class GitHubWebhookConfig {
+    /**
+     * Enabled starts the inbound GitHub webhook listener.
+     */
+    "enabled": boolean;
+
+    /**
+     * Port is the dedicated webhook listener port.
+     */
+    "port": number;
+
+    /**
+     * Secret authenticates X-Hub-Signature-256. It is intentionally distinct
+     * from TaskSecret, which authenticates POST /webhook/task. Empty disables
+     * GitHub comment-command ingestion.
+     */
+    "secret": string;
+
+    /**
+     * CommandPrefix is the literal slash-command prefix accepted in issue and
+     * pull-request comments, for example "/sybra". The supported commands are
+     * "<prefix> ship" and "<prefix> review".
+     */
+    "commandPrefix": string;
+
+    /**
+     * TaskEnabled exposes the generic POST /webhook/task sibling route. Legacy
+     * top-level webhook.enabled configurations are migrated with this enabled.
+     */
+    "taskEnabled": boolean;
+
+    /**
+     * TaskSecret authenticates the generic route's X-Sybra-Signature header.
+     * A non-empty value also enables the route.
+     */
+    "taskSecret": string;
+
+    /** Creates a new GitHubWebhookConfig instance. */
+    constructor($$source: Partial<GitHubWebhookConfig> = {}) {
+        if (!("enabled" in $$source)) {
+            this["enabled"] = false;
+        }
+        if (!("port" in $$source)) {
+            this["port"] = 0;
+        }
+        if (!("secret" in $$source)) {
+            this["secret"] = "";
+        }
+        if (!("commandPrefix" in $$source)) {
+            this["commandPrefix"] = "";
+        }
+        if (!("taskEnabled" in $$source)) {
+            this["taskEnabled"] = false;
+        }
+        if (!("taskSecret" in $$source)) {
+            this["taskSecret"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new GitHubWebhookConfig instance from a string or object.
+     */
+    static createFrom($$source: any = {}): GitHubWebhookConfig {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new GitHubWebhookConfig($$parsedSource as Partial<GitHubWebhookConfig>);
     }
 }
 
@@ -1090,10 +1177,10 @@ export class K8sJobsConfig {
      * Creates a new K8sJobsConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): K8sJobsConfig {
-        const $$createField3_0 = $$createType10;
-        const $$createField8_0 = $$createType12;
-        const $$createField9_0 = $$createType14;
-        const $$createField10_0 = $$createType16;
+        const $$createField3_0 = $$createType11;
+        const $$createField8_0 = $$createType13;
+        const $$createField9_0 = $$createType15;
+        const $$createField10_0 = $$createType17;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("command" in $$parsedSource) {
             $$parsedSource["command"] = $$createField3_0($$parsedSource["command"]);
@@ -1226,7 +1313,7 @@ export class MonitorConfig {
      * Creates a new MonitorConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): MonitorConfig {
-        const $$createField9_0 = $$createType17;
+        const $$createField9_0 = $$createType18;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("bottleneckHours" in $$parsedSource) {
             $$parsedSource["bottleneckHours"] = $$createField9_0($$parsedSource["bottleneckHours"]);
@@ -1353,7 +1440,7 @@ export class OrchestratorConfig {
      * Creates a new OrchestratorConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): OrchestratorConfig {
-        const $$createField6_0 = $$createType18;
+        const $$createField6_0 = $$createType19;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("pressure" in $$parsedSource) {
             $$parsedSource["pressure"] = $$createField6_0($$parsedSource["pressure"]);
@@ -1391,10 +1478,10 @@ export class PathDescriptor {
      * Creates a new PathDescriptor instance from a string or object.
      */
     static createFrom($$source: any = {}): PathDescriptor {
-        const $$createField2_0 = $$createType10;
-        const $$createField3_0 = $$createType10;
-        const $$createField4_0 = $$createType10;
-        const $$createField7_0 = $$createType10;
+        const $$createField2_0 = $$createType11;
+        const $$createField3_0 = $$createType11;
+        const $$createField4_0 = $$createType11;
+        const $$createField7_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("queryPaths" in $$parsedSource) {
             $$parsedSource["queryPaths"] = $$createField2_0($$parsedSource["queryPaths"]);
@@ -1475,7 +1562,7 @@ export class PlaywrightMCPConfig {
      * Creates a new PlaywrightMCPConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): PlaywrightMCPConfig {
-        const $$createField1_0 = $$createType10;
+        const $$createField1_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("extraArgs" in $$parsedSource) {
             $$parsedSource["extraArgs"] = $$createField1_0($$parsedSource["extraArgs"]);
@@ -1737,12 +1824,12 @@ export class ProvidersConfig {
      * Creates a new ProvidersConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): ProvidersConfig {
-        const $$createField0_0 = $$createType19;
-        const $$createField1_0 = $$createType20;
-        const $$createField2_0 = $$createType20;
-        const $$createField3_0 = $$createType20;
-        const $$createField4_0 = $$createType20;
-        const $$createField5_0 = $$createType21;
+        const $$createField0_0 = $$createType20;
+        const $$createField1_0 = $$createType21;
+        const $$createField2_0 = $$createType21;
+        const $$createField3_0 = $$createType21;
+        const $$createField4_0 = $$createType21;
+        const $$createField5_0 = $$createType22;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("healthCheck" in $$parsedSource) {
             $$parsedSource["healthCheck"] = $$createField0_0($$parsedSource["healthCheck"]);
@@ -1901,9 +1988,9 @@ export class RoutingSummary {
      * Creates a new RoutingSummary instance from a string or object.
      */
     static createFrom($$source: any = {}): RoutingSummary {
-        const $$createField6_0 = $$createType10;
-        const $$createField7_0 = $$createType23;
-        const $$createField8_0 = $$createType10;
+        const $$createField6_0 = $$createType11;
+        const $$createField7_0 = $$createType24;
+        const $$createField8_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("precedence" in $$parsedSource) {
             $$parsedSource["precedence"] = $$createField6_0($$parsedSource["precedence"]);
@@ -2076,7 +2163,7 @@ export class SelfMonitorConfig {
      * Creates a new SelfMonitorConfig instance from a string or object.
      */
     static createFrom($$source: any = {}): SelfMonitorConfig {
-        const $$createField6_0 = $$createType10;
+        const $$createField6_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("autoActCategories" in $$parsedSource) {
             $$parsedSource["autoActCategories"] = $$createField6_0($$parsedSource["autoActCategories"]);
@@ -2253,20 +2340,21 @@ const $$createType3 = QueueConfig.createFrom;
 const $$createType4 = $Create.Map($Create.Any, $Create.Any);
 const $$createType5 = EvidenceConfig.createFrom;
 const $$createType6 = GitHubPollingConfig.createFrom;
-const $$createType7 = GitHubAppConfig.createFrom;
-const $$createType8 = GitHubPollingStreamConfig.createFrom;
-const $$createType9 = GitHubPRPollingConfig.createFrom;
-const $$createType10 = $Create.Array($Create.Any);
-const $$createType11 = K8sJobEnvVar.createFrom;
-const $$createType12 = $Create.Array($$createType11);
-const $$createType13 = K8sJobSecretEnvVar.createFrom;
-const $$createType14 = $Create.Array($$createType13);
-const $$createType15 = K8sJobVolume.createFrom;
-const $$createType16 = $Create.Array($$createType15);
-const $$createType17 = $Create.Map($Create.Any, $Create.Any);
-const $$createType18 = PressureConfig.createFrom;
-const $$createType19 = ProviderHealthCheckConfig.createFrom;
-const $$createType20 = ProviderEntryConfig.createFrom;
-const $$createType21 = ProviderLimitsConfig.createFrom;
-const $$createType22 = RoutingEligibleVariant.createFrom;
-const $$createType23 = $Create.Array($$createType22);
+const $$createType7 = GitHubWebhookConfig.createFrom;
+const $$createType8 = GitHubAppConfig.createFrom;
+const $$createType9 = GitHubPollingStreamConfig.createFrom;
+const $$createType10 = GitHubPRPollingConfig.createFrom;
+const $$createType11 = $Create.Array($Create.Any);
+const $$createType12 = K8sJobEnvVar.createFrom;
+const $$createType13 = $Create.Array($$createType12);
+const $$createType14 = K8sJobSecretEnvVar.createFrom;
+const $$createType15 = $Create.Array($$createType14);
+const $$createType16 = K8sJobVolume.createFrom;
+const $$createType17 = $Create.Array($$createType16);
+const $$createType18 = $Create.Map($Create.Any, $Create.Any);
+const $$createType19 = PressureConfig.createFrom;
+const $$createType20 = ProviderHealthCheckConfig.createFrom;
+const $$createType21 = ProviderEntryConfig.createFrom;
+const $$createType22 = ProviderLimitsConfig.createFrom;
+const $$createType23 = RoutingEligibleVariant.createFrom;
+const $$createType24 = $Create.Array($$createType23);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,6 @@ type Config struct {
 	Providers      ProvidersConfig      `yaml:"providers" json:"providers"`
 	Metrics        MetricsConfig        `yaml:"metrics" json:"metrics"`
 	Server         ServerConfig         `yaml:"server" json:"server"`
-	Webhook        WebhookConfig        `yaml:"webhook" json:"webhook"`
 	Cluster        ClusterConfig        `yaml:"cluster" json:"cluster"`
 	AutoUpdate     AutoUpdateConfig     `yaml:"auto_update" json:"autoUpdate"`
 	Browser        BrowserConfig        `yaml:"browser" json:"browser"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -698,6 +698,10 @@ func defaultSeedConfig() *Config {
 			Author:  "app/renovate",
 		},
 		GitHub: GitHubConfig{
+			Webhook: GitHubWebhookConfig{
+				CommandPrefix: DefaultGitHubWebhookCommandPrefix,
+				Port:          DefaultWebhookPort,
+			},
 			Polling: GitHubPollingConfig{
 				Issues:      GitHubPollingStreamConfig{Enabled: true},
 				SybraPRs:    GitHubPRPollingConfig{Enabled: true},
@@ -743,9 +747,6 @@ func defaultSeedConfig() *Config {
 		},
 		Cluster: ClusterConfig{
 			Role: ClusterRoleStandalone,
-		},
-		Webhook: WebhookConfig{
-			Port: DefaultWebhookPort,
 		},
 		Orchestrator: OrchestratorConfig{
 			Role: InstanceRoleFull,

--- a/internal/config/config_github.go
+++ b/internal/config/config_github.go
@@ -1,5 +1,9 @@
 package config
 
+// DefaultGitHubWebhookCommandPrefix is the literal command token accepted in
+// issue and pull-request comments when GitHub webhook ingestion is configured.
+const DefaultGitHubWebhookCommandPrefix = "/sybra"
+
 type GitHubPollingConfig struct {
 	Issues      GitHubPollingStreamConfig `yaml:"issues" json:"issues"`
 	SybraPRs    GitHubPRPollingConfig     `yaml:"sybra_prs" json:"sybraPrs"`
@@ -66,8 +70,11 @@ type GitHubConfig struct {
 	// dedup/creation path. Empty (default) disables the feature — existing
 	// installs see no behavior change.
 	MentionTriggerPhrase string `yaml:"mention_trigger_phrase" json:"mentionTriggerPhrase"`
-	RenovateFastSeconds  int    `yaml:"renovate_fast_seconds" json:"renovateFastSeconds"`
-	RenovateSlowSeconds  int    `yaml:"renovate_slow_seconds" json:"renovateSlowSeconds"`
+	// Webhook configures the GitHub App webhook listener, authentication, and
+	// comment commands.
+	Webhook             GitHubWebhookConfig `yaml:"webhook" json:"webhook"`
+	RenovateFastSeconds int                 `yaml:"renovate_fast_seconds" json:"renovateFastSeconds"`
+	RenovateSlowSeconds int                 `yaml:"renovate_slow_seconds" json:"renovateSlowSeconds"`
 	// App configures GitHub App installation-token auth. When enabled, Sybra
 	// mints a short-lived installation token and injects it into the gh
 	// subprocess (GH_TOKEN), raising the REST ceiling to 15k/hr. Unset = fall
@@ -106,6 +113,29 @@ type GitHubConfig struct {
 	// deterministic. Zero falls back to the built-in default; see
 	// GitHubConfig.FlakyThreshold().
 	FlakySuccessThreshold float64 `yaml:"flaky_success_threshold" json:"flakySuccessThreshold"`
+}
+
+// GitHubWebhookConfig controls GitHub App deliveries sent to
+// POST /webhook/github.
+type GitHubWebhookConfig struct {
+	// Enabled starts the inbound GitHub webhook listener.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Port is the dedicated webhook listener port.
+	Port int `yaml:"port" json:"port"`
+	// Secret authenticates X-Hub-Signature-256. It is intentionally distinct
+	// from TaskSecret, which authenticates POST /webhook/task. Empty disables
+	// GitHub comment-command ingestion.
+	Secret string `yaml:"secret" json:"secret" secret:"true"`
+	// CommandPrefix is the literal slash-command prefix accepted in issue and
+	// pull-request comments, for example "/sybra". The supported commands are
+	// "<prefix> ship" and "<prefix> review".
+	CommandPrefix string `yaml:"command_prefix" json:"commandPrefix"`
+	// TaskEnabled exposes the generic POST /webhook/task sibling route. Legacy
+	// top-level webhook.enabled configurations are migrated with this enabled.
+	TaskEnabled bool `yaml:"task_enabled" json:"taskEnabled"`
+	// TaskSecret authenticates the generic route's X-Sybra-Signature header.
+	// A non-empty value also enables the route.
+	TaskSecret string `yaml:"task_secret" json:"taskSecret" secret:"true"`
 }
 
 // GitHubAppConfig holds GitHub App installation-token credentials. The private

--- a/internal/config/config_metadata.go
+++ b/internal/config/config_metadata.go
@@ -42,6 +42,11 @@ func RedactedCopy(cfg *Config) Config {
 func initSecretMetadata() {
 	pathSet := map[string]struct{}{}
 	collectSecretYAMLPaths(pathSet, reflect.TypeFor[Config](), nil)
+	for _, spec := range fieldAliasSpecs {
+		if _, secret := pathSet[joinPath(spec.aliasPath)]; secret {
+			pathSet[joinPath(spec.legacyPath)] = struct{}{}
+		}
+	}
 	secretYAMLPathSet = pathSet
 	secretYAMLPaths = make([]string, 0, len(pathSet))
 	for path := range pathSet {

--- a/internal/config/config_metadata_test.go
+++ b/internal/config/config_metadata_test.go
@@ -7,7 +7,12 @@ import (
 
 func TestSecretYAMLPaths(t *testing.T) {
 	got := SecretYAMLPaths()
-	for _, want := range []string{"server.auth_token", "webhook.secret"} {
+	for _, want := range []string{
+		"server.auth_token",
+		"github.webhook.secret",
+		"github.webhook.task_secret",
+		"webhook.secret",
+	} {
 		if !slices.Contains(got, want) {
 			t.Fatalf("SecretYAMLPaths() missing %q: %v", want, got)
 		}
@@ -34,14 +39,18 @@ func TestSecretYAMLPaths(t *testing.T) {
 func TestRedactedCopy(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Server.AuthToken = "server-secret"
-	cfg.Webhook.Secret = "webhook-secret"
+	cfg.GitHub.Webhook.Secret = "github-webhook-secret"
+	cfg.GitHub.Webhook.TaskSecret = "webhook-secret"
 
 	redacted := RedactedCopy(cfg)
 	if redacted.Server.AuthToken != RedactedPlaceholder {
 		t.Fatalf("server auth token = %q, want %q", redacted.Server.AuthToken, RedactedPlaceholder)
 	}
-	if redacted.Webhook.Secret != RedactedPlaceholder {
-		t.Fatalf("webhook secret = %q, want %q", redacted.Webhook.Secret, RedactedPlaceholder)
+	if redacted.GitHub.Webhook.Secret != RedactedPlaceholder {
+		t.Fatalf("GitHub webhook secret = %q, want %q", redacted.GitHub.Webhook.Secret, RedactedPlaceholder)
+	}
+	if redacted.GitHub.Webhook.TaskSecret != RedactedPlaceholder {
+		t.Fatalf("GitHub task webhook secret = %q, want %q", redacted.GitHub.Webhook.TaskSecret, RedactedPlaceholder)
 	}
 	if redacted.Logging.Level != cfg.Logging.Level {
 		t.Fatalf("non-secret field changed: logging.level %q -> %q", cfg.Logging.Level, redacted.Logging.Level)

--- a/internal/config/config_migration.go
+++ b/internal/config/config_migration.go
@@ -27,7 +27,6 @@ var v2NamespaceDocs = []V2NamespaceDoc{
 	{Name: "observability", OwnershipRule: "Logs, audit, metrics, experimentation, and operator evidence retention.", Paths: []string{"observability.logging", "observability.audit", "observability.metrics", "observability.experience", "observability.intervention", "observability.ab_testing"}},
 	{Name: "routing", OwnershipRule: "Adaptive provider-routing policy that tunes experiment weights from observed execution outcomes.", Paths: []string{"routing"}},
 	{Name: "server", OwnershipRule: "Local API/server exposure and auth for the running Sybra instance.", Paths: []string{"server"}},
-	{Name: "webhook", OwnershipRule: "Inbound external task-creation webhook listener and request-signing controls.", Paths: []string{"webhook"}},
 	{Name: "cluster", OwnershipRule: "Cluster/task-trust policy for multi-node execution backends.", Paths: []string{"cluster"}},
 	{Name: "auto_update", OwnershipRule: "Deployment self-update behavior for long-running Sybra installs.", Paths: []string{"auto_update"}},
 }
@@ -65,6 +64,7 @@ var topLevelNamespaceRules = []topLevelNamespaceRule{
 	{legacyKey: "admission", canonical: []string{"workflow", "admission"}, deprecated: "workflow.admission", namespace: "workflow"},
 	{legacyKey: "notification", canonical: []string{"integrations", "notification"}, deprecated: "integrations.notification", namespace: "integrations"},
 	{legacyKey: "github", canonical: []string{"integrations", "github"}, deprecated: "integrations.github", namespace: "integrations"},
+	{legacyKey: "webhook", canonical: []string{"integrations", "github", "webhook"}, deprecated: "integrations.github.webhook", namespace: "integrations"},
 	{legacyKey: "review_hold", canonical: []string{"integrations", "github", "review_hold"}, deprecated: "integrations.github.review_hold", namespace: "integrations"},
 	{legacyKey: "renovate", canonical: []string{"integrations", "renovate"}, deprecated: "integrations.renovate", namespace: "integrations"},
 	{legacyKey: "browser", canonical: []string{"integrations", "browser"}, deprecated: "integrations.browser", namespace: "integrations"},
@@ -246,6 +246,7 @@ func MigrateRawConfig(raw []byte, toVersion int) (*MigrationResult, error) {
 	}
 	applyLegacyUnboundedReviewLoop(canonical, fileCfg)
 	relocateLegacyGitHubReviewRoundsPerHour(canonical)
+	preserveLegacyWebhookTaskRoute(canonical, fileCfg)
 	canonicalBytes, err := marshalYAMLDocument(canonical.document())
 	if err != nil {
 		return nil, err
@@ -262,6 +263,36 @@ func MigrateRawConfig(raw []byte, toVersion int) (*MigrationResult, error) {
 		Moves:       moves,
 		Warnings:    fileCfg.Warnings(),
 	}, nil
+}
+
+func preserveLegacyWebhookTaskRoute(canonical *canonicalConfigBuilder, fileCfg *FileConfig) {
+	if fileCfg == nil {
+		return
+	}
+	enabledNode, ok := fileCfg.authoredNodeAt("webhook", "enabled")
+	if !ok {
+		return
+	}
+	var enabled bool
+	if err := enabledNode.Decode(&enabled); err != nil || !enabled {
+		return
+	}
+	integrationsNode, ok := yamlMappingValue(canonical.root, "integrations")
+	if !ok {
+		return
+	}
+	githubNode, ok := yamlMappingValue(integrationsNode, "github")
+	if !ok {
+		return
+	}
+	webhookNode, ok := yamlMappingValue(githubNode, "webhook")
+	if !ok || yamlMappingHasKey(webhookNode, "task_enabled") {
+		return
+	}
+	webhookNode.Content = append(webhookNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "task_enabled"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+	)
 }
 
 func normalizeYAMLBytes(raw []byte) []byte {
@@ -358,10 +389,13 @@ func canonicalMovePathForLegacy(legacyPath string) (string, bool) {
 			return canonical, true
 		}
 	}
+	if canonical, ok := CanonicalFilePathForLegacy(legacyPath); ok {
+		return canonical, true
+	}
 	if IsSecretYAMLPath(legacyPath) {
 		return legacyPath, true
 	}
-	return CanonicalFilePathForLegacy(legacyPath)
+	return "", false
 }
 
 func renderMoveValues(legacyPath string, node *yaml.Node) (before, after string) {

--- a/internal/config/config_server_test.go
+++ b/internal/config/config_server_test.go
@@ -12,6 +12,7 @@ func isolateServerEnv(t *testing.T) {
 	t.Setenv("SYBRA_AUTH_TOKEN", "")
 	t.Setenv("SYBRA_ALLOWED_ORIGINS", "")
 	t.Setenv("SYBRA_WEBHOOK_SECRET", "")
+	t.Setenv("SYBRA_GITHUB_WEBHOOK_SECRET", "")
 }
 
 func TestLoadGeneratesAndPersistsServerAuthToken(t *testing.T) {
@@ -162,14 +163,21 @@ func TestLoadWebhookDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Webhook.Enabled {
-		t.Fatal("Webhook.Enabled = true, want false by default")
+	if cfg.GitHub.Webhook.Enabled {
+		t.Fatal("GitHub.Webhook.Enabled = true, want false by default")
 	}
-	if cfg.Webhook.Port != DefaultWebhookPort {
-		t.Fatalf("Webhook.Port = %d, want %d", cfg.Webhook.Port, DefaultWebhookPort)
+	if cfg.GitHub.Webhook.Port != DefaultWebhookPort {
+		t.Fatalf("GitHub.Webhook.Port = %d, want %d", cfg.GitHub.Webhook.Port, DefaultWebhookPort)
 	}
-	if cfg.Webhook.Secret != "" {
-		t.Fatalf("Webhook.Secret = %q, want empty by default", cfg.Webhook.Secret)
+	if cfg.GitHub.Webhook.Secret != "" || cfg.GitHub.Webhook.TaskSecret != "" {
+		t.Fatalf("GitHub.Webhook secrets = (%q, %q), want empty by default",
+			cfg.GitHub.Webhook.Secret, cfg.GitHub.Webhook.TaskSecret)
+	}
+	if cfg.GitHub.Webhook.TaskEnabled {
+		t.Fatal("GitHub.Webhook.TaskEnabled = true, want false by default")
+	}
+	if cfg.GitHub.Webhook.CommandPrefix != DefaultGitHubWebhookCommandPrefix {
+		t.Fatalf("GitHub.Webhook.CommandPrefix = %q, want %q", cfg.GitHub.Webhook.CommandPrefix, DefaultGitHubWebhookCommandPrefix)
 	}
 }
 
@@ -179,7 +187,7 @@ func TestLoadWebhookSecretEnvOverride(t *testing.T) {
 	t.Setenv("SYBRA_HOME", dir)
 	t.Setenv("SYBRA_WEBHOOK_SECRET", "env-webhook-secret")
 
-	yaml := []byte("webhook:\n  secret: file-secret\n")
+	yaml := []byte("webhook:\n  enabled: true\n  port: 9092\n  secret: file-secret\n")
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +196,41 @@ func TestLoadWebhookSecretEnvOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Webhook.Secret != "env-webhook-secret" {
-		t.Fatalf("Webhook.Secret = %q, want env override", cfg.Webhook.Secret)
+	if cfg.GitHub.Webhook.TaskSecret != "env-webhook-secret" {
+		t.Fatalf("GitHub.Webhook.TaskSecret = %q, want env override", cfg.GitHub.Webhook.TaskSecret)
+	}
+	if !cfg.GitHub.Webhook.Enabled || cfg.GitHub.Webhook.Port != 9092 {
+		t.Fatalf("legacy webhook listener = (%v, %d), want (true, 9092)",
+			cfg.GitHub.Webhook.Enabled, cfg.GitHub.Webhook.Port)
+	}
+	if !cfg.GitHub.Webhook.TaskEnabled {
+		t.Fatal("legacy webhook did not preserve the generic task route")
+	}
+}
+
+func TestLoadGitHubWebhookEnvOverrides(t *testing.T) {
+	dir := t.TempDir()
+	isolateServerEnv(t)
+	t.Setenv("SYBRA_HOME", dir)
+	t.Setenv("SYBRA_GITHUB_WEBHOOK_SECRET", "env-github-secret")
+
+	yaml := []byte("github:\n  webhook:\n    enabled: true\n    port: 9091\n    secret: file-secret\n    command_prefix: /file-agent\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.GitHub.Webhook.Secret != "env-github-secret" {
+		t.Fatalf("GitHub.Webhook.Secret = %q, want env override", cfg.GitHub.Webhook.Secret)
+	}
+	if cfg.GitHub.Webhook.CommandPrefix != "/file-agent" {
+		t.Fatalf("GitHub.Webhook.CommandPrefix = %q, want /file-agent", cfg.GitHub.Webhook.CommandPrefix)
+	}
+	if !cfg.GitHub.Webhook.Enabled || cfg.GitHub.Webhook.Port != 9091 {
+		t.Fatalf("GitHub.Webhook listener = (%v, %d), want (true, 9091)",
+			cfg.GitHub.Webhook.Enabled, cfg.GitHub.Webhook.Port)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -594,6 +594,54 @@ func TestMigrateRawConfig_RelocatesLegacyGitHubReviewRoundsPerHour(t *testing.T)
 	}
 }
 
+func TestMigrateRawConfigMovesWebhookUnderGitHub(t *testing.T) {
+	raw := []byte(strings.Join([]string{
+		"webhook:",
+		"  enabled: true",
+		"  port: 9093",
+		"  secret: task-secret",
+		"",
+	}, "\n"))
+
+	result, err := MigrateRawConfig(raw, CurrentSchemaVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(result.MigratedRaw)
+	for _, want := range []string{
+		"integrations:",
+		"  github:",
+		"    webhook:",
+		"      enabled: true",
+		"      port: 9093",
+		"      task_enabled: true",
+		"      task_secret: task-secret",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("migrated config missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "\nwebhook:") {
+		t.Fatalf("migrated config retained top-level webhook:\n%s", text)
+	}
+	var foundSecretMove bool
+	for _, move := range result.Moves {
+		if move.From != "webhook.secret" {
+			continue
+		}
+		foundSecretMove = true
+		if move.To != "integrations.github.webhook.task_secret" {
+			t.Fatalf("webhook secret move target = %q", move.To)
+		}
+		if move.ValueFrom != RedactedPlaceholder || move.ValueTo != RedactedPlaceholder {
+			t.Fatalf("webhook secret move leaked value: %#v", move)
+		}
+	}
+	if !foundSecretMove {
+		t.Fatalf("migration moves missing webhook.secret: %#v", result.Moves)
+	}
+}
+
 func TestMigrateRawConfigRewritesGuardrailAliasesAndPreservesExplicitReviewLoop(t *testing.T) {
 	raw := []byte(strings.Join([]string{
 		"agent:",

--- a/internal/config/config_webhook.go
+++ b/internal/config/config_webhook.go
@@ -1,13 +1,10 @@
 package config
 
-// DefaultWebhookPort is the inbound webhook listener's default port when the
-// feature is enabled and webhook.port is unset or invalid.
+// DefaultWebhookPort is the inbound GitHub webhook listener's default port.
 const DefaultWebhookPort = 8081
 
-// WebhookConfig controls the optional inbound HTTP webhook used for external
-// task creation. When Enabled is true, sybra-server starts a separate listener
-// on Port and serves POST /webhook/task. Secret optionally enables HMAC-SHA256
-// request signing via X-Sybra-Signature: sha256=<hex>.
+// WebhookConfig is the deprecated top-level webhook shape. Resolve maps its
+// fields into GitHubWebhookConfig so existing installations keep working.
 type WebhookConfig struct {
 	Enabled bool   `yaml:"enabled" json:"enabled"`
 	Port    int    `yaml:"port" json:"port"`

--- a/internal/config/explain.go
+++ b/internal/config/explain.go
@@ -107,10 +107,17 @@ var envOverrideSpecs = []envOverrideSpec{
 		},
 	},
 	{
-		runtimePath: "webhook.secret",
+		runtimePath: "github.webhook.task_secret",
 		envVar:      "SYBRA_WEBHOOK_SECRET",
 		value: func(env Environment) (any, bool) {
 			return env.WebhookSecret, strings.TrimSpace(env.WebhookSecret) != ""
+		},
+	},
+	{
+		runtimePath: "github.webhook.secret",
+		envVar:      "SYBRA_GITHUB_WEBHOOK_SECRET",
+		value: func(env Environment) (any, bool) {
+			return env.GitHubWebhookSecret, strings.TrimSpace(env.GitHubWebhookSecret) != ""
 		},
 	},
 }

--- a/internal/config/file_config.go
+++ b/internal/config/file_config.go
@@ -273,6 +273,9 @@ var durationAliasSpecs = []durationAliasSpec{
 }
 
 var fieldAliasSpecs = []fieldAliasSpec{
+	{aliasPath: []string{"github", "webhook", "enabled"}, legacyPath: []string{"webhook", "enabled"}, fieldPath: []string{"GitHub", "Webhook", "Enabled"}},
+	{aliasPath: []string{"github", "webhook", "port"}, legacyPath: []string{"webhook", "port"}, fieldPath: []string{"GitHub", "Webhook", "Port"}},
+	{aliasPath: []string{"github", "webhook", "task_secret"}, legacyPath: []string{"webhook", "secret"}, fieldPath: []string{"GitHub", "Webhook", "TaskSecret"}},
 	{aliasPath: []string{"agent", "post_result_cost_usd"}, legacyPath: []string{"agent", "max_cost_usd"}, fieldPath: []string{"Agent", "MaxCostUSD"}},
 	{aliasPath: []string{"agent", "max_assistant_events"}, legacyPath: []string{"agent", "max_turns"}, fieldPath: []string{"Agent", "MaxTurns"}},
 	{aliasPath: []string{"agent", "checkpoint_on_assistant_event_ceiling"}, legacyPath: []string{"agent", "checkpoint_on_turn_ceiling"}, fieldPath: []string{"Agent", "CheckpointOnTurnCeiling"}},
@@ -455,6 +458,12 @@ func validateNodeAgainstType(node *yaml.Node, typ reflect.Type, path []string, a
 				continue
 			}
 			if _, ok := allowedFieldAliases[key]; ok {
+				continue
+			}
+			if parent == "" && key == "webhook" {
+				if err := validateNodeAgainstType(valNode, reflect.TypeFor[WebhookConfig](), []string{"webhook"}, aliases, fieldAliases); err != nil {
+					return err
+				}
 				continue
 			}
 			if removedConfigKeys[parent][key] {

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -11,21 +11,23 @@ import (
 // Environment holds the supported config env overrides so Resolve is
 // deterministic and testable.
 type Environment struct {
-	LogLevel       string
-	LogDir         string
-	TasksDir       string
-	AuthToken      string
-	WebhookSecret  string
-	AllowedOrigins []string
+	LogLevel            string
+	LogDir              string
+	TasksDir            string
+	AuthToken           string
+	WebhookSecret       string
+	GitHubWebhookSecret string
+	AllowedOrigins      []string
 }
 
 func environmentFromOS() Environment {
 	env := Environment{
-		LogLevel:      os.Getenv("SYBRA_LOG_LEVEL"),
-		LogDir:        os.Getenv("SYBRA_LOG_DIR"),
-		TasksDir:      os.Getenv("SYBRA_TASKS_DIR"),
-		AuthToken:     os.Getenv("SYBRA_AUTH_TOKEN"),
-		WebhookSecret: os.Getenv("SYBRA_WEBHOOK_SECRET"),
+		LogLevel:            os.Getenv("SYBRA_LOG_LEVEL"),
+		LogDir:              os.Getenv("SYBRA_LOG_DIR"),
+		TasksDir:            os.Getenv("SYBRA_TASKS_DIR"),
+		AuthToken:           os.Getenv("SYBRA_AUTH_TOKEN"),
+		WebhookSecret:       os.Getenv("SYBRA_WEBHOOK_SECRET"),
+		GitHubWebhookSecret: os.Getenv("SYBRA_GITHUB_WEBHOOK_SECRET"),
 	}
 	if raw := os.Getenv("SYBRA_ALLOWED_ORIGINS"); raw != "" {
 		parts := strings.Split(raw, ",")
@@ -135,7 +137,10 @@ func applyEnvironmentOverrides(cfg *ResolvedConfig, env Environment) {
 		cfg.Server.AuthToken = env.AuthToken
 	}
 	if env.WebhookSecret != "" {
-		cfg.Webhook.Secret = env.WebhookSecret
+		cfg.GitHub.Webhook.TaskSecret = env.WebhookSecret
+	}
+	if env.GitHubWebhookSecret != "" {
+		cfg.GitHub.Webhook.Secret = env.GitHubWebhookSecret
 	}
 	if len(env.AllowedOrigins) > 0 {
 		cfg.Server.AllowedOrigins = append([]string(nil), env.AllowedOrigins...)
@@ -173,8 +178,14 @@ func applyResolvedDefaults(cfg *ResolvedConfig, file *FileConfig) {
 	if cfg.Attachments.MaxSizeMB <= 0 {
 		cfg.Attachments.MaxSizeMB = DefaultAttachmentMaxSizeMB
 	}
-	if cfg.Webhook.Port <= 0 {
-		cfg.Webhook.Port = DefaultWebhookPort
+	if cfg.GitHub.Webhook.Port <= 0 {
+		cfg.GitHub.Webhook.Port = DefaultWebhookPort
+	}
+	if strings.TrimSpace(cfg.GitHub.Webhook.CommandPrefix) == "" {
+		cfg.GitHub.Webhook.CommandPrefix = DefaultGitHubWebhookCommandPrefix
+	}
+	if file != nil && file.Has("webhook", "enabled") && cfg.GitHub.Webhook.Enabled {
+		cfg.GitHub.Webhook.TaskEnabled = true
 	}
 	if cfg.Renovate.Author == "" {
 		cfg.Renovate.Author = "app/renovate"

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -161,6 +161,10 @@ func validateGitHubConfig(cfg *ResolvedConfig, add func(format string, a ...any)
 	if cfg.GitHub.App.Enabled && strings.TrimSpace(cfg.GitHub.App.PrivateKeyPath) == "" {
 		add("github.app.enabled requires github.app.private_key_path")
 	}
+	commandPrefix := strings.TrimSpace(cfg.GitHub.Webhook.CommandPrefix)
+	if !strings.HasPrefix(commandPrefix, "/") || len(commandPrefix) < 2 || strings.ContainsAny(commandPrefix, " \t\r\n") {
+		add("github.webhook.command_prefix must start with \"/\" and contain no whitespace, got %q", cfg.GitHub.Webhook.CommandPrefix)
+	}
 	if cfg.AutoUpdate.Enabled && cfg.AutoUpdate.Mode == "auto" && countNonEmpty(cfg.AutoUpdate.RequiredChecks) == 0 {
 		add("auto_update.required_checks must be non-empty when auto_update.mode=auto")
 	}

--- a/internal/config/validation_github_webhook_test.go
+++ b/internal/config/validation_github_webhook_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateResolvedConfigGitHubWebhookCommandPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{name: "default", prefix: "/sybra"},
+		{name: "custom", prefix: "/review-agent"},
+		{name: "missing slash", prefix: "sybra", wantErr: true},
+		{name: "slash only", prefix: "/", wantErr: true},
+		{name: "whitespace", prefix: "/review agent", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.GitHub.Webhook.CommandPrefix = tc.prefix
+			err := ValidateResolvedConfig(cfg)
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "github.webhook.command_prefix") {
+					t.Fatalf("ValidateResolvedConfig() err = %v, want command-prefix error", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateResolvedConfig() err = %v", err)
+			}
+		})
+	}
+}

--- a/internal/sybra/app_config.go
+++ b/internal/sybra/app_config.go
@@ -45,3 +45,9 @@ type AppSettings struct {
 	ProjectTypes    []string                  `json:"projectTypes"`
 	Directories     map[string]string         `json:"directories"`
 }
+
+func githubSettingsWithoutSecrets(github config.GitHubConfig) config.GitHubConfig {
+	github.Webhook.Secret = ""
+	github.Webhook.TaskSecret = ""
+	return github
+}

--- a/internal/sybra/app_config.go
+++ b/internal/sybra/app_config.go
@@ -47,7 +47,11 @@ type AppSettings struct {
 }
 
 func githubSettingsWithoutSecrets(github config.GitHubConfig) config.GitHubConfig {
-	github.Webhook.Secret = ""
-	github.Webhook.TaskSecret = ""
+	if github.Webhook.Secret != "" {
+		github.Webhook.Secret = config.RedactedPlaceholder
+	}
+	if github.Webhook.TaskSecret != "" {
+		github.Webhook.TaskSecret = config.RedactedPlaceholder
+	}
 	return github
 }

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -69,7 +69,7 @@ func (s *ConfigService) GetSettings() AppSettings {
 			ABTestingMinSamplesPerVariant: c.ABTesting.MinSamplesPerVariant,
 			Summary:                       config.BuildRoutingSummary(c),
 		},
-		GitHub:       c.GitHub,
+		GitHub:       githubSettingsWithoutSecrets(c.GitHub),
 		Monitor:      c.Monitor,
 		SelfMonitor:  c.SelfMonitor,
 		Triage:       c.Triage,
@@ -522,6 +522,12 @@ func settingsToConfig(existing *config.Config, settings AppSettings) config.Conf
 		next.ABTesting.MinSamplesPerVariant = settings.ProviderRouting.ABTestingMinSamplesPerVariant
 	}
 	next.GitHub = settings.GitHub
+	if next.GitHub.Webhook.Secret == "" || next.GitHub.Webhook.Secret == config.RedactedPlaceholder {
+		next.GitHub.Webhook.Secret = existing.GitHub.Webhook.Secret
+	}
+	if next.GitHub.Webhook.TaskSecret == "" || next.GitHub.Webhook.TaskSecret == config.RedactedPlaceholder {
+		next.GitHub.Webhook.TaskSecret = existing.GitHub.Webhook.TaskSecret
+	}
 	next.Monitor = settings.Monitor
 	next.SelfMonitor = settings.SelfMonitor
 	next.Triage = settings.Triage

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -522,10 +522,10 @@ func settingsToConfig(existing *config.Config, settings AppSettings) config.Conf
 		next.ABTesting.MinSamplesPerVariant = settings.ProviderRouting.ABTestingMinSamplesPerVariant
 	}
 	next.GitHub = settings.GitHub
-	if next.GitHub.Webhook.Secret == "" || next.GitHub.Webhook.Secret == config.RedactedPlaceholder {
+	if next.GitHub.Webhook.Secret == config.RedactedPlaceholder {
 		next.GitHub.Webhook.Secret = existing.GitHub.Webhook.Secret
 	}
-	if next.GitHub.Webhook.TaskSecret == "" || next.GitHub.Webhook.TaskSecret == config.RedactedPlaceholder {
+	if next.GitHub.Webhook.TaskSecret == config.RedactedPlaceholder {
 		next.GitHub.Webhook.TaskSecret = existing.GitHub.Webhook.TaskSecret
 	}
 	next.Monitor = settings.Monitor

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -55,7 +55,7 @@ func configToSettings(c *config.Config) AppSettings {
 			ABTestingMinSamplesPerVariant: c.ABTesting.MinSamplesPerVariant,
 			Summary:                       config.BuildRoutingSummary(c),
 		},
-		GitHub:       c.GitHub,
+		GitHub:       githubSettingsWithoutSecrets(c.GitHub),
 		Monitor:      c.Monitor,
 		SelfMonitor:  c.SelfMonitor,
 		Triage:       c.Triage,

--- a/internal/sybra/svc_config_settings_test.go
+++ b/internal/sybra/svc_config_settings_test.go
@@ -1,11 +1,40 @@
 package sybra
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/config"
 )
+
+func TestGetSettingsRedactsAndPreservesGitHubWebhookSecrets(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	svc.cfg.GitHub.Webhook.Secret = "github-secret"
+	svc.cfg.GitHub.Webhook.TaskSecret = "task-secret"
+	svc.persisted = cloneConfig(svc.cfg)
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	settings := svc.GetSettings()
+	data, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "github-secret") || strings.Contains(string(data), "task-secret") {
+		t.Fatalf("GetSettings leaked webhook secrets: %s", data)
+	}
+
+	settings.GitHub.Enabled = !settings.GitHub.Enabled
+	if _, err := svc.UpdateSettings(settings); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+	if svc.persisted.GitHub.Webhook.Secret != "github-secret" {
+		t.Fatalf("GitHub webhook secret = %q, want preserved value", svc.persisted.GitHub.Webhook.Secret)
+	}
+	if svc.persisted.GitHub.Webhook.TaskSecret != "task-secret" {
+		t.Fatalf("task webhook secret = %q, want preserved value", svc.persisted.GitHub.Webhook.TaskSecret)
+	}
+}
 
 func TestUpdateSettings_ValidationRejectsBadFallbackModel(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)

--- a/internal/sybra/svc_config_settings_test.go
+++ b/internal/sybra/svc_config_settings_test.go
@@ -23,6 +23,12 @@ func TestGetSettingsRedactsAndPreservesGitHubWebhookSecrets(t *testing.T) {
 	if strings.Contains(string(data), "github-secret") || strings.Contains(string(data), "task-secret") {
 		t.Fatalf("GetSettings leaked webhook secrets: %s", data)
 	}
+	if settings.GitHub.Webhook.Secret != config.RedactedPlaceholder {
+		t.Fatalf("GitHub webhook secret = %q, want redaction placeholder", settings.GitHub.Webhook.Secret)
+	}
+	if settings.GitHub.Webhook.TaskSecret != config.RedactedPlaceholder {
+		t.Fatalf("task webhook secret = %q, want redaction placeholder", settings.GitHub.Webhook.TaskSecret)
+	}
 
 	settings.GitHub.Enabled = !settings.GitHub.Enabled
 	if _, err := svc.UpdateSettings(settings); err != nil {
@@ -33,6 +39,19 @@ func TestGetSettingsRedactsAndPreservesGitHubWebhookSecrets(t *testing.T) {
 	}
 	if svc.persisted.GitHub.Webhook.TaskSecret != "task-secret" {
 		t.Fatalf("task webhook secret = %q, want preserved value", svc.persisted.GitHub.Webhook.TaskSecret)
+	}
+
+	settings = svc.GetSettings()
+	settings.GitHub.Webhook.Secret = ""
+	settings.GitHub.Webhook.TaskSecret = ""
+	if _, err := svc.UpdateSettings(settings); err != nil {
+		t.Fatalf("UpdateSettings clearing secrets: %v", err)
+	}
+	if svc.persisted.GitHub.Webhook.Secret != "" {
+		t.Fatalf("GitHub webhook secret = %q, want cleared value", svc.persisted.GitHub.Webhook.Secret)
+	}
+	if svc.persisted.GitHub.Webhook.TaskSecret != "" {
+		t.Fatalf("task webhook secret = %q, want cleared value", svc.persisted.GitHub.Webhook.TaskSecret)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add signed POST /webhook/github handling for configurable comment commands on issues and pull requests
- consolidate listener settings under integrations.github.webhook while migrating the legacy top-level webhook configuration
- deduplicate redeliveries, filter trusted commenters/installations, and keep webhook secrets out of settings responses
- document GitHub App setup and the optional generic task route compatibility controls

## Verification

- go test -count=1 ./internal/config ./cmd/sybra-server ./cmd/sybra-cli ./internal/sybra ./cmd/gen-config-docs
- mise run lint
- independent adversarial review: CLEAN
- mise run verify reached the full race suite; all packages passed except six pre-existing internal/project Git credential-preflight tests