### PR TITLE
fix(agent): persist failed tool calls

### DIFF
--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -142,6 +142,7 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 	agentID := s.findAgentBySessionWithRetry(r.Context(), input.SessionID)
 	if agentID == "" {
 		s.logger.Warn("approval-server.no-agent", "session_id", input.SessionID)
+		s.recordApprovalFailure(nil, input, "approval-unknown-session", "Unknown session")
 		s.respondDeny(w, "Unknown session")
 		return
 	}
@@ -192,13 +193,46 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 		if resp.Approved {
 			s.respondAllow(w, input.ToolInput)
 		} else {
+			s.recordApprovalFailureByID(agentID, input, "approval-denied", "User denied this action")
 			s.respondDeny(w, "User denied this action")
 		}
 	case <-r.Context().Done():
+		s.recordApprovalFailureByID(agentID, input, "approval-canceled", "Request canceled")
 		s.respondDeny(w, "Request canceled")
 	case <-time.After(5 * time.Minute):
+		s.recordApprovalFailureByID(agentID, input, "approval-timeout", "Approval timed out")
 		s.respondDeny(w, "Approval timed out")
 	}
+}
+
+func (s *ApprovalServer) recordApprovalFailureByID(agentID string, input hookInput, source, reason string) {
+	var a *Agent
+	if s.agents != nil && agentID != "" {
+		if got, err := s.agents.GetAgent(agentID); err == nil {
+			a = got
+		}
+	}
+	s.recordApprovalFailure(a, input, source, reason)
+}
+
+func (s *ApprovalServer) recordApprovalFailure(a *Agent, input hookInput, source, reason string) {
+	agentID := ""
+	if a != nil {
+		agentID = a.ID
+	}
+	logApprovalToolFailure(s.logger, agentID, input.ToolName, input.ToolUseID, source, reason)
+	if s.agents == nil {
+		return
+	}
+	s.agents.recordToolCallFailure(a, ToolCallFailureRecord{
+		Timestamp:        time.Now().UTC(),
+		SessionID:        input.SessionID,
+		ToolUseID:        input.ToolUseID,
+		ToolName:         input.ToolName,
+		ToolInputSummary: summarizeToolInput(input.ToolInput),
+		Source:           source,
+		Reason:           reason,
+	})
 }
 
 func (s *ApprovalServer) respondAllow(w http.ResponseWriter, input map[string]any) {

--- a/internal/agent/logfile.go
+++ b/internal/agent/logfile.go
@@ -60,6 +60,9 @@ func ParseLogFileWithArtifacts(path string, maxEvents int, provider, taskID, pro
 		if ev.Type == "" {
 			continue
 		}
+		if isToolFailureDiagnosticEvent(ev.Type) {
+			continue
+		}
 		ev = bindToolResultEvent(taskID, producerRole, store, ev)
 		events = append(events, ev)
 	}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -326,6 +326,9 @@ func rehydrateFromLogWithArtifacts(a *Agent, path, taskID, producerRole string, 
 		if perr != nil || ev.Type == "" {
 			continue
 		}
+		if isToolFailureDiagnosticEvent(ev.Type) {
+			continue
+		}
 		ev = bindToolResultEvent(taskID, producerRole, store, ev)
 		ev.Timestamp = time.Now().UTC()
 		a.applyStreamEventState(ev)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -917,6 +917,9 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 	if event.Type == "" {
 		return false
 	}
+	if isToolFailureDiagnosticEvent(event.Type) {
+		return false
+	}
 	event = bindToolResultEvent(a.TaskID, string(a.EffectiveRole()), m.artifacts, event)
 
 	event.Timestamp = time.Now().UTC()
@@ -950,6 +953,8 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 	for _, d := range event.permissionDenials {
 		a.NotePermissionDenial(d.ToolUseID, d.Reason)
 	}
+	m.recordToolResultFailures(a, event)
+	m.recordTerminalFailure(a, event)
 	if event.Type == "result" || time.Since(*lastEmit) >= headlessEmitInterval {
 		m.emit(events.AgentOutput(a.ID), event)
 		*lastEmit = time.Now()

--- a/internal/agent/tool_failure.go
+++ b/internal/agent/tool_failure.go
@@ -1,0 +1,184 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	toolFailureEventType = "sybra_tool_failure"
+	toolFailureMaxField  = 2000
+)
+
+// ToolCallFailureRecord is a Sybra-authored diagnostic record persisted beside
+// provider NDJSON so interrupted or denied tool calls can be audited later.
+type ToolCallFailureRecord struct {
+	Type              string    `json:"type"`
+	Timestamp         time.Time `json:"timestamp"`
+	AgentID           string    `json:"agent_id,omitempty"`
+	TaskID            string    `json:"task_id,omitempty"`
+	SessionID         string    `json:"session_id,omitempty"`
+	Provider          string    `json:"provider,omitempty"`
+	ToolUseID         string    `json:"tool_use_id,omitempty"`
+	ToolName          string    `json:"tool_name,omitempty"`
+	ToolInputSummary  string    `json:"tool_input_summary,omitempty"`
+	Source            string    `json:"source"`
+	Reason            string    `json:"reason,omitempty"`
+	TerminalReason    string    `json:"terminal_reason,omitempty"`
+	ErrorType         string    `json:"error_type,omitempty"`
+	ErrorStatus       int       `json:"error_status,omitempty"`
+	ForegroundCommand string    `json:"foreground_command,omitempty"`
+}
+
+func (m *Manager) recordToolCallFailure(a *Agent, rec ToolCallFailureRecord) {
+	if rec.Timestamp.IsZero() {
+		rec.Timestamp = time.Now().UTC()
+	}
+	rec.Type = toolFailureEventType
+	if a != nil {
+		if rec.AgentID == "" {
+			rec.AgentID = a.ID
+		}
+		if rec.TaskID == "" {
+			rec.TaskID = a.TaskID
+		}
+		if rec.SessionID == "" {
+			rec.SessionID = a.GetSessionID()
+		}
+		if rec.Provider == "" {
+			rec.Provider = a.GetProvider()
+		}
+		if rec.ForegroundCommand == "" {
+			if cmd, _, ok := a.ActiveForegroundCommand(); ok {
+				rec.ForegroundCommand = cmd
+			}
+		}
+	}
+	rec.ToolInputSummary = truncateToolFailureField(rec.ToolInputSummary)
+	rec.Reason = truncateToolFailureField(rec.Reason)
+	rec.ForegroundCommand = truncateToolFailureField(rec.ForegroundCommand)
+
+	m.logger.Warn("agent.tool_failure",
+		"id", rec.AgentID,
+		"task_id", rec.TaskID,
+		"tool", rec.ToolName,
+		"tool_use_id", rec.ToolUseID,
+		"source", rec.Source,
+		"reason", rec.Reason,
+		"terminal_reason", rec.TerminalReason)
+
+	if a != nil {
+		m.appendToolFailureRecord(a.GetLogPath(), rec)
+	}
+	m.appendToolFailureRecord(filepath.Join(m.logDir, "tool-failures.ndjson"), rec)
+}
+
+func (m *Manager) recordToolResultFailures(a *Agent, event StreamEvent) {
+	for _, tr := range event.toolResults {
+		if !tr.IsError {
+			continue
+		}
+		toolName, input, _ := a.ToolUseByID(tr.ToolUseID)
+		m.recordToolCallFailure(a, ToolCallFailureRecord{
+			Timestamp:        event.Timestamp,
+			ToolUseID:        tr.ToolUseID,
+			ToolName:         toolName,
+			ToolInputSummary: summarizeToolInput(input),
+			Source:           "provider-tool-result-error",
+			Reason:           tr.Content,
+		})
+	}
+}
+
+func (m *Manager) recordTerminalFailure(a *Agent, event StreamEvent) {
+	if event.Type != "result" {
+		return
+	}
+	source := ""
+	switch {
+	case event.TerminalReason == "aborted_tools":
+		source = "stream-aborted-tools"
+	case event.TerminalReason == "aborted_streaming":
+		source = "stream-aborted-streaming"
+	case resultSubtypeIsError(event.Subtype) || event.ErrorType != "" || event.ErrorStatus != 0:
+		source = "provider-result-error"
+	}
+	if source == "" {
+		return
+	}
+	m.recordToolCallFailure(a, ToolCallFailureRecord{
+		Timestamp:      event.Timestamp,
+		Source:         source,
+		Reason:         event.Content,
+		TerminalReason: event.TerminalReason,
+		ErrorType:      event.ErrorType,
+		ErrorStatus:    event.ErrorStatus,
+	})
+}
+
+func (m *Manager) appendToolFailureRecord(path string, rec ToolCallFailureRecord) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		m.logger.Warn("agent.tool_failure.log_mkdir", "path", path, "err", err)
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		m.logger.Warn("agent.tool_failure.log_open", "path", path, "err", err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	data, err := json.Marshal(rec)
+	if err != nil {
+		m.logger.Warn("agent.tool_failure.marshal", "err", err)
+		return
+	}
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		m.logger.Warn("agent.tool_failure.log_write", "path", path, "err", err)
+	}
+}
+
+func isToolFailureDiagnosticEvent(eventType string) bool {
+	return eventType == toolFailureEventType
+}
+
+func summarizeToolInput(input map[string]any) string {
+	if len(input) == 0 {
+		return ""
+	}
+	for _, key := range []string{"command", "file_path", "path", "description", "url"} {
+		if v, ok := input[key]; ok {
+			if s := strings.TrimSpace(fmt.Sprint(v)); s != "" {
+				return truncateToolFailureField(s)
+			}
+		}
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return truncateToolFailureField(fmt.Sprint(input))
+	}
+	return truncateToolFailureField(string(data))
+}
+
+func truncateToolFailureField(s string) string {
+	if len(s) <= toolFailureMaxField {
+		return s
+	}
+	return s[:toolFailureMaxField] + "...[truncated]"
+}
+
+func logApprovalToolFailure(logger *slog.Logger, agentID, toolName, toolUseID, source, reason string) {
+	logger.Warn("approval-server.tool_failure",
+		"agent_id", agentID,
+		"tool", toolName,
+		"tool_use_id", toolUseID,
+		"source", source,
+		"reason", reason)
+}

--- a/internal/agent/tool_failure_test.go
+++ b/internal/agent/tool_failure_test.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApprovalFailurePersistsAgentAndAggregateRecords(t *testing.T) {
+	mgr := mustNewManager(t, context.Background(), func(string, any) {}, discardLogger(), t.TempDir())
+	logPath := filepath.Join(mgr.logDir, "agents", "agent-1.ndjson")
+	a := &Agent{
+		ID:        "agent-1",
+		TaskID:    "task-1",
+		Mode:      "headless",
+		Provider:  "claude",
+		SessionID: "session-1",
+		LogPath:   logPath,
+		State:     StateRunning,
+		StartedAt: time.Now(),
+	}
+	mgr.mu.Lock()
+	mgr.agents[a.ID] = a
+	mgr.mu.Unlock()
+
+	srv := &ApprovalServer{agents: mgr, logger: discardLogger()}
+	srv.recordApprovalFailureByID(a.ID, hookInput{
+		SessionID: "session-1",
+		ToolName:  "Bash",
+		ToolUseID: "tool-1",
+		ToolInput: map[string]any{"command": "go test ./..."},
+	}, "approval-denied", "User denied this action")
+
+	rec := readLastToolFailure(t, logPath)
+	if rec.Type != toolFailureEventType || rec.Source != "approval-denied" {
+		t.Fatalf("record = %+v, want approval-denied tool failure", rec)
+	}
+	if rec.AgentID != a.ID || rec.TaskID != a.TaskID || rec.SessionID != a.SessionID {
+		t.Fatalf("identity fields = %+v", rec)
+	}
+	if rec.ToolName != "Bash" || rec.ToolUseID != "tool-1" || rec.ToolInputSummary != "go test ./..." {
+		t.Fatalf("tool fields = %+v", rec)
+	}
+
+	agg := readLastToolFailure(t, filepath.Join(mgr.logDir, "tool-failures.ndjson"))
+	if agg.ToolUseID != "tool-1" || agg.Source != "approval-denied" {
+		t.Fatalf("aggregate record = %+v", agg)
+	}
+
+	events, err := ParseLogFile(logPath, 0, "claude")
+	if err != nil {
+		t.Fatalf("ParseLogFile: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("ParseLogFile returned diagnostic events: %+v", events)
+	}
+}
+
+func TestProcessHeadlessLinePersistsToolResultFailure(t *testing.T) {
+	mgr := mustNewManager(t, context.Background(), func(string, any) {}, discardLogger(), t.TempDir())
+	logPath := filepath.Join(mgr.logDir, "agents", "agent-2.ndjson")
+	a := &Agent{
+		ID:        "agent-2",
+		TaskID:    "task-2",
+		Mode:      "headless",
+		Provider:  "claude",
+		SessionID: "session-2",
+		LogPath:   logPath,
+		State:     StateRunning,
+		StartedAt: time.Now(),
+	}
+	prov, err := lookupProvider("claude")
+	if err != nil {
+		t.Fatalf("lookupProvider: %v", err)
+	}
+	lastEmit := time.Now()
+
+	mgr.processHeadlessLine(context.Background(), a, []byte(`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool-2","name":"Bash","input":{"command":"git diff --stat"}}]}}`), &lastEmit, prov)
+	mgr.processHeadlessLine(context.Background(), a, []byte(`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-2","content":"The user doesn't want to proceed with this tool use.","is_error":true}]}}`), &lastEmit, prov)
+
+	rec := readLastToolFailure(t, logPath)
+	if rec.Source != "provider-tool-result-error" {
+		t.Fatalf("Source = %q, want provider-tool-result-error", rec.Source)
+	}
+	if rec.ToolName != "Bash" || rec.ToolUseID != "tool-2" || rec.ToolInputSummary != "git diff --stat" {
+		t.Fatalf("tool fields = %+v", rec)
+	}
+	if !strings.Contains(rec.Reason, "doesn't want to proceed") {
+		t.Fatalf("Reason = %q", rec.Reason)
+	}
+}
+
+func TestProcessHeadlessLinePersistsTerminalAbort(t *testing.T) {
+	mgr := mustNewManager(t, context.Background(), func(string, any) {}, discardLogger(), t.TempDir())
+	logPath := filepath.Join(mgr.logDir, "agents", "agent-3.ndjson")
+	a := &Agent{
+		ID:        "agent-3",
+		TaskID:    "task-3",
+		Mode:      "headless",
+		Provider:  "claude",
+		SessionID: "session-3",
+		LogPath:   logPath,
+		State:     StateRunning,
+		StartedAt: time.Now(),
+	}
+	prov, err := lookupProvider("claude")
+	if err != nil {
+		t.Fatalf("lookupProvider: %v", err)
+	}
+	lastEmit := time.Now()
+
+	mgr.processHeadlessLine(context.Background(), a, []byte(`{"type":"result","terminal_reason":"aborted_tools","result":"stopped on rejected tool"}`), &lastEmit, prov)
+
+	rec := readLastToolFailure(t, logPath)
+	if rec.Source != "stream-aborted-tools" || rec.TerminalReason != "aborted_tools" {
+		t.Fatalf("record = %+v, want stream aborted_tools", rec)
+	}
+}
+
+func TestRecordToolCallFailurePreservesExplicitDiagnosticFields(t *testing.T) {
+	mgr := mustNewManager(t, context.Background(), func(string, any) {}, discardLogger(), t.TempDir())
+	logPath := filepath.Join(mgr.logDir, "agents", "agent-4.ndjson")
+	a := &Agent{
+		ID:        "agent-4",
+		TaskID:    "task-4",
+		Mode:      "headless",
+		Provider:  "claude",
+		SessionID: "agent-session",
+		LogPath:   logPath,
+		State:     StateRunning,
+		StartedAt: time.Now(),
+	}
+	longForeground := strings.Repeat("x", toolFailureMaxField+50)
+
+	mgr.recordToolCallFailure(a, ToolCallFailureRecord{
+		SessionID:         "observed-session",
+		Provider:          "observed-provider",
+		Source:            "test-source",
+		ForegroundCommand: longForeground,
+	})
+
+	rec := readLastToolFailure(t, logPath)
+	if rec.SessionID != "observed-session" || rec.Provider != "observed-provider" {
+		t.Fatalf("record overwritten explicit fields: %+v", rec)
+	}
+	if rec.AgentID != a.ID || rec.TaskID != a.TaskID {
+		t.Fatalf("record did not fill missing agent identity: %+v", rec)
+	}
+	if len(rec.ForegroundCommand) <= toolFailureMaxField {
+		t.Fatalf("ForegroundCommand was not marked truncated: len=%d", len(rec.ForegroundCommand))
+	}
+	if !strings.HasSuffix(rec.ForegroundCommand, "...[truncated]") {
+		t.Fatalf("ForegroundCommand = %q, want truncation marker", rec.ForegroundCommand)
+	}
+}
+
+func readLastToolFailure(t *testing.T, path string) ToolCallFailureRecord {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var last ToolCallFailureRecord
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var rec ToolCallFailureRecord
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if rec.Type == toolFailureEventType {
+			last = rec
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if last.Type == "" {
+		t.Fatalf("no %s record in %s", toolFailureEventType, path)
+	}
+	return last
+}


### PR DESCRIPTION
## Summary
- persist failed tool-call diagnostics beside per-agent NDJSON logs and in an aggregate tool-failures log
- record approval hook denials/timeouts, provider tool-result errors, and terminal aborted/error results
- skip Sybra diagnostic records during history replay and reattach rehydration

## Tests
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/agent