### PR TITLE
fix(workflow): retry user-interrupted agents

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -30,7 +30,8 @@ import (
 type State string
 
 const (
-	ErrorKindToolUseAborted = "tool_use_aborted"
+	ErrorKindToolUseAborted  = "tool_use_aborted"
+	ErrorKindUserInterrupted = "user_interrupted"
 )
 
 const (

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -627,6 +627,8 @@ func (m *Manager) resolveHeadlessAttemptExit(a *Agent, waitErr error, stderrOut 
 	attemptEvents := attemptEventsFrom(a.Output(), prevLen)
 	if toolUseAborted(attemptEvents) {
 		a.SetError(ErrorKindToolUseAborted, "provider run aborted after tool use was rejected")
+	} else if userInterruptedStream(attemptEvents) {
+		a.SetError(ErrorKindUserInterrupted, "provider run was interrupted by the user before completion")
 	}
 	switch {
 	case waitErr != nil:
@@ -657,6 +659,8 @@ func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
 	evs := attemptEventsFrom(a.Output(), prevLen)
 	if toolUseAborted(evs) {
 		a.SetError(ErrorKindToolUseAborted, "provider run aborted after tool use was rejected")
+	} else if userInterruptedStream(evs) {
+		a.SetError(ErrorKindUserInterrupted, "provider run was interrupted by the user before completion")
 	}
 	if streamErr := resultStreamError(evs); streamErr != nil {
 		a.SetExitErr(streamErr)
@@ -680,6 +684,19 @@ func toolUseAborted(streamEvents []StreamEvent) bool {
 		return e.TerminalReason == "aborted_tools" ||
 			strings.Contains(content, "request interrupted by user for tool use") ||
 			strings.Contains(content, "tool use was rejected")
+	}
+	return false
+}
+
+func userInterruptedStream(streamEvents []StreamEvent) bool {
+	for i := range slices.Backward(streamEvents) {
+		e := streamEvents[i]
+		if e.Type != "result" {
+			continue
+		}
+		content := strings.ToLower(e.Content)
+		return e.TerminalReason == "aborted_streaming" ||
+			strings.Contains(content, "request interrupted by user")
 	}
 	return false
 }

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -511,6 +511,20 @@ func TestParseClaudeLine_ResultTerminalReason(t *testing.T) {
 	}
 }
 
+func TestUserInterruptedStream(t *testing.T) {
+	t.Parallel()
+
+	if !userInterruptedStream([]StreamEvent{{Type: "result", TerminalReason: "aborted_streaming"}}) {
+		t.Fatal("userInterruptedStream(aborted_streaming) = false, want true")
+	}
+	if !userInterruptedStream([]StreamEvent{{Type: "result", Content: "[Request interrupted by user]"}}) {
+		t.Fatal("userInterruptedStream(marker) = false, want true")
+	}
+	if userInterruptedStream([]StreamEvent{{Type: "result", TerminalReason: "aborted_tools"}}) {
+		t.Fatal("userInterruptedStream(aborted_tools) = true, want false")
+	}
+}
+
 func TestLastHeadlessResultMarksStructuredError(t *testing.T) {
 	a := &Agent{}
 	a.AppendOutput(StreamEvent{Type: "result", Content: "You've hit your weekly limit", ErrorType: "rate_limit", ErrorStatus: 429})

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -494,7 +494,7 @@ func (h *Handler) buildRunPatch(ag *agent.Agent, state agent.State, cost, premiu
 // notifyWorkflowEngine advances the workflow engine for a completed agent.
 // Returns false if the caller should return immediately. Signal kills and
 // Sybra-initiated stops stall for recovery; rate limits, malformed tool calls,
-// and rejected-tool interruptions immediately re-drive the same step so
+// and rejected-tool/user interruptions immediately re-drive the same step so
 // provider failover can choose a healthy peer. Auth failures fall through
 // (need human login) and take the normal failed path.
 //
@@ -518,11 +518,11 @@ func (h *Handler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, ex
 	if stall.Stalled {
 		h.logger.Warn("agent.completion.stall",
 			"task_id", ag.TaskID, "agent_id", ag.ID,
-			"signaled", isSignalKill(exitErr), "stopped", stall.StopStalled, "rate_limited", stall.RateLimited, "malformed_tool", stall.MalformedTool, "tool_use_aborted", stall.ToolUseAborted, "checkpoint", stall.CheckpointStopped)
+			"signaled", isSignalKill(exitErr), "stopped", stall.StopStalled, "rate_limited", stall.RateLimited, "malformed_tool", stall.MalformedTool, "tool_use_aborted", stall.ToolUseAborted, "user_interrupted", stall.UserInterrupted, "checkpoint", stall.CheckpointStopped)
 		switch {
 		case stall.CheckpointStopped:
 			h.workflowEngine.RescheduleCheckpointedAgent(ag.TaskID, ag.ID)
-		case stall.ToolUseAborted:
+		case stall.ToolUseAborted || stall.UserInterrupted:
 			h.workflowEngine.RescheduleInterruptedAgent(ag.TaskID, ag.ID)
 		case stall.RateLimited || stall.MalformedTool:
 			h.workflowEngine.RescheduleRateLimitedAgent(ag.TaskID, ag.ID)
@@ -553,15 +553,17 @@ type stallDisposition struct {
 	RateLimited       bool
 	MalformedTool     bool
 	ToolUseAborted    bool
+	UserInterrupted   bool
 	StopStalled       bool
 	CheckpointStopped bool
 }
 
 func classifyStall(ag *agent.Agent, exitErr error) stallDisposition {
 	out := stallDisposition{
-		RateLimited:    isRateLimitedRun(ag, exitErr),
-		MalformedTool:  ag.GetErrorKind() == "malformed_tool_call",
-		ToolUseAborted: isToolUseAbortedRun(ag),
+		RateLimited:     isRateLimitedRun(ag, exitErr),
+		MalformedTool:   ag.GetErrorKind() == "malformed_tool_call",
+		ToolUseAborted:  isToolUseAbortedRun(ag),
+		UserInterrupted: isUserInterruptedRun(ag),
 	}
 	// Cost guardrails intentionally hard-stop the subprocess, but they are a
 	// budget failure, not an infra stall. Let them flow through the bounded
@@ -570,7 +572,7 @@ func classifyStall(ag *agent.Agent, exitErr error) stallDisposition {
 	checkpointFailed := ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpointFailed
 	out.CheckpointStopped = ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpoint
 	out.StopStalled = ag.WasStopped() && !ag.WasCompletedByResult() && !costStopped && !checkpointFailed && !out.CheckpointStopped
-	out.Stalled = isSignalKill(exitErr) || out.StopStalled || out.RateLimited || out.MalformedTool || out.ToolUseAborted || out.CheckpointStopped
+	out.Stalled = isSignalKill(exitErr) || out.StopStalled || out.RateLimited || out.MalformedTool || out.ToolUseAborted || out.UserInterrupted || out.CheckpointStopped
 	return out
 }
 
@@ -954,6 +956,10 @@ func isRateLimitedRun(ag *agent.Agent, exitErr error) bool {
 
 func isToolUseAbortedRun(ag *agent.Agent) bool {
 	return ag.GetErrorKind() == agent.ErrorKindToolUseAborted
+}
+
+func isUserInterruptedRun(ag *agent.Agent) bool {
+	return ag.GetErrorKind() == agent.ErrorKindUserInterrupted
 }
 
 // isSignalKill reports whether err represents a process killed by an OS signal.

--- a/internal/sybra/completion/completion_test.go
+++ b/internal/sybra/completion/completion_test.go
@@ -125,6 +125,17 @@ func TestRunOutcome(t *testing.T) {
 			want:    "stalled",
 		},
 		{
+			name: "user_interrupted_is_a_stall",
+			role: agent.RoleTestRunner,
+			agent: func() *agent.Agent {
+				ag := &agent.Agent{}
+				ag.SetError(agent.ErrorKindUserInterrupted, "provider run was interrupted by the user before completion")
+				return ag
+			},
+			exitErr: errBoom,
+			want:    "stalled",
+		},
+		{
 			// A budget breach is a deliberate hard-stop, not an infra stall —
 			// it must stay countable as a real failure (classifyStall).
 			name: "cost_guardrail_stop_stays_a_failure",
@@ -568,9 +579,20 @@ func TestClassifyStall_CheckpointDisposition(t *testing.T) {
 		ag.SetError(agent.ErrorKindToolUseAborted, "provider run aborted after tool use was rejected")
 
 		stall := classifyStall(ag, errors.New("provider result error provider_error"))
-		if !stall.Stalled || stall.RateLimited || stall.MalformedTool || !stall.ToolUseAborted || stall.StopStalled || stall.CheckpointStopped {
-			t.Fatalf("classifyStall(tool_use_aborted) = stalled=%v rateLimited=%v malformedTool=%v toolUseAborted=%v stopStalled=%v checkpointStopped=%v",
-				stall.Stalled, stall.RateLimited, stall.MalformedTool, stall.ToolUseAborted, stall.StopStalled, stall.CheckpointStopped)
+		if !stall.Stalled || stall.RateLimited || stall.MalformedTool || !stall.ToolUseAborted || stall.UserInterrupted || stall.StopStalled || stall.CheckpointStopped {
+			t.Fatalf("classifyStall(tool_use_aborted) = stalled=%v rateLimited=%v malformedTool=%v toolUseAborted=%v userInterrupted=%v stopStalled=%v checkpointStopped=%v",
+				stall.Stalled, stall.RateLimited, stall.MalformedTool, stall.ToolUseAborted, stall.UserInterrupted, stall.StopStalled, stall.CheckpointStopped)
+		}
+	})
+
+	t.Run("user interrupted stalls for retry", func(t *testing.T) {
+		ag := &agent.Agent{}
+		ag.SetError(agent.ErrorKindUserInterrupted, "provider run was interrupted by the user before completion")
+
+		stall := classifyStall(ag, errors.New("provider result error provider_error"))
+		if !stall.Stalled || stall.RateLimited || stall.MalformedTool || stall.ToolUseAborted || !stall.UserInterrupted || stall.StopStalled || stall.CheckpointStopped {
+			t.Fatalf("classifyStall(user_interrupted) = stalled=%v rateLimited=%v malformedTool=%v toolUseAborted=%v userInterrupted=%v stopStalled=%v checkpointStopped=%v",
+				stall.Stalled, stall.RateLimited, stall.MalformedTool, stall.ToolUseAborted, stall.UserInterrupted, stall.StopStalled, stall.CheckpointStopped)
 		}
 	})
 }

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -715,6 +715,9 @@ func interruptedRecoveryStatus(workflowID string) string {
 	if workflowID == "simple-task-plan" {
 		return "planning"
 	}
+	if workflowID == "testing-task" {
+		return "testing"
+	}
 	return "in-progress"
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4129,6 +4129,9 @@ func TestInterruptedRecoveryStatus_PlanningWorkflow(t *testing.T) {
 	if got := interruptedRecoveryStatus("simple-task-plan"); got != "planning" {
 		t.Fatalf("interruptedRecoveryStatus(simple-task-plan) = %q, want planning", got)
 	}
+	if got := interruptedRecoveryStatus("testing-task"); got != "testing" {
+		t.Fatalf("interruptedRecoveryStatus(testing-task) = %q, want testing", got)
+	}
 	if got := interruptedRecoveryStatus("simple-task-implement"); got != "in-progress" {
 		t.Fatalf("interruptedRecoveryStatus(simple-task-implement) = %q, want in-progress", got)
 	}


### PR DESCRIPTION
## Summary
- classify Claude aborted_streaming/user-interrupt result events as retryable user interruptions
- route user-interrupted completions through the interrupted-agent reschedule path instead of generic completion stall handling
- keep interrupted testing-task retries in testing status rather than moving them to in-progress

## Test
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/agent ./internal/sybra/completion ./internal/workflow