### PR TITLE
fix(review): preserve human PR approvals

### DIFF
--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -716,6 +716,7 @@ type MyReviewState struct {
 	Pending     bool   // an unsubmitted draft review exists
 	Submitted   bool   // a submitted (non-draft) review exists
 	Approved    bool   // the latest submitted review is an approval
+	ViewerIsBot bool   // the authenticated viewer is a GitHub App/bot identity
 	ReviewedSHA string // commit_id of the latest submitted review ("" if none)
 	ReviewID    int64  // id of the review carrying the latest verdict (0 if none) — needed to dismiss it
 }
@@ -756,7 +757,7 @@ func fetchMyReviewStateWith(e execer, repo string, number int) (MyReviewState, e
 		return MyReviewState{}, fmt.Errorf("resolve viewer login for %s#%d: %w", repo, number, err)
 	}
 
-	var st MyReviewState
+	st := MyReviewState{ViewerIsBot: isBotLogin(me)}
 	var latestReview, latestVerdict string // submitted_at watermarks
 	for i := range reviews {
 		r := reviews[i]
@@ -792,6 +793,10 @@ func fetchMyReviewStateWith(e execer, repo string, number int) (MyReviewState, e
 		myReviewStateCache.Set(key, st, 30*time.Second)
 	}
 	return st, nil
+}
+
+func isBotLogin(login string) bool {
+	return strings.HasSuffix(login, "[bot]")
 }
 
 // ApprovePR approves a pull request.

--- a/internal/github/viewer_login_test.go
+++ b/internal/github/viewer_login_test.go
@@ -306,7 +306,7 @@ func TestFetchMyReviewState_AttributesAppBotReview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fetchMyReviewState: %v", err)
 	}
-	want := MyReviewState{Submitted: true, Approved: false, ReviewedSHA: "e57e4b5"}
+	want := MyReviewState{Submitted: true, Approved: false, ViewerIsBot: true, ReviewedSHA: "e57e4b5"}
 	if got != want {
 		t.Errorf("got %+v, want %+v — the bot must recognise its own review", got, want)
 	}

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -577,7 +577,8 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 	}
 	r.clearReconcileFailure(t)
 
-	selfApproved := myState.Approved || inApproved
+	viewerApproved := myState.Approved || inApproved
+	selfApproved := myState.ViewerIsBot && viewerApproved
 	if selfApproved {
 		r.dismissSelfApproval(t, myState)
 	}
@@ -625,6 +626,7 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 		CostGuardrailStopped:      latestReviewRunStoppedByCostGuardrail(t),
 		HasDraft:                  myState.Pending,
 		SelfApproved:              selfApproved,
+		Approved:                  viewerApproved,
 		Submitted:                 submitted,
 		ReRequested:               inReq,
 		HeadSHA:                   headSHA,
@@ -678,7 +680,7 @@ func (r *Handler) reverseLiveSelfApproval(t *task.Task, inApproved bool) {
 // "approved" phase regardless. A dismissal failure is logged, never fatal:
 // escalating the task to human-required does not depend on it succeeding.
 func (r *Handler) dismissSelfApproval(t *task.Task, myState github.MyReviewState) {
-	if !myState.Approved || myState.ReviewID == 0 {
+	if !myState.ViewerIsBot || !myState.Approved || myState.ReviewID == 0 {
 		return
 	}
 	dismissFn := github.DismissReview

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -577,7 +577,7 @@ func (r *Handler) reconcileReviewTask(t *task.Task, requested, approved map[stri
 	}
 	r.clearReconcileFailure(t)
 
-	viewerApproved := myState.Approved || inApproved
+	viewerApproved := myState.Approved || (!myState.Submitted && inApproved)
 	selfApproved := myState.ViewerIsBot && viewerApproved
 	if selfApproved {
 		r.dismissSelfApproval(t, myState)

--- a/internal/sybra/review/review_phase.go
+++ b/internal/sybra/review/review_phase.go
@@ -41,6 +41,7 @@ type reviewSignals struct {
 	CostGuardrailStopped      bool   // a review agent was cost-stopped before producing a draft/submission
 	HasDraft                  bool   // viewer has a PENDING (unsubmitted) review
 	SelfApproved              bool   // our own bot identity's latest submitted review is an approval — always an anomaly, never a legitimate green light
+	Approved                  bool   // viewer's latest submitted review is an approval
 	Submitted                 bool   // viewer has a submitted (non-draft) review
 	ReRequested               bool   // PR is back in viewer's review-requested list
 	HeadSHA                   string // current PR head commit ("" if unknown)
@@ -133,6 +134,22 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 			Phase:  ReviewPhaseDrafted,
 			Status: task.StatusHumanRequired,
 			Reason: "Draft review ready — verify & submit on GitHub",
+		}
+	}
+
+	if s.Approved {
+		advanced := reviewAdvancedPastReviewed(s)
+		if s.ReRequested || advanced {
+			return reviewPhaseResult{
+				Phase:  ReviewPhaseNeedsApproval,
+				Status: task.StatusInReview,
+				Reason: "Author updated PR — do a final review & approve",
+			}
+		}
+		return reviewPhaseResult{
+			Phase:  ReviewPhaseApproved,
+			Status: task.StatusInReview,
+			Reason: "Approved — waiting for merge",
 		}
 	}
 

--- a/internal/sybra/review/review_phase_test.go
+++ b/internal/sybra/review/review_phase_test.go
@@ -48,6 +48,16 @@ func TestComputeReviewPhase(t *testing.T) {
 			want: reviewPhaseResult{Phase: ReviewPhaseDrafted, Status: task.StatusHumanRequired, Reason: "Draft review ready — verify & submit on GitHub"},
 		},
 		{
+			name: "human approval at current head → approved",
+			sig:  reviewSignals{Approved: true, Submitted: true, HeadSHA: "sha1", ReviewedSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseApproved, Status: task.StatusInReview, Reason: "Approved — waiting for merge"},
+		},
+		{
+			name: "human approval pushed past reviewed commit → needs approval",
+			sig:  reviewSignals{Approved: true, Submitted: true, HeadSHA: "sha2", ReviewedSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusInReview, Reason: "Author updated PR — do a final review & approve"},
+		},
+		{
 			name: "submitted at current head, not re-requested → awaiting author",
 			sig:  reviewSignals{Submitted: true, HeadSHA: "sha1", ReviewedSHA: "sha1"},
 			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},

--- a/internal/sybra/review/selfapproval_test.go
+++ b/internal/sybra/review/selfapproval_test.go
@@ -192,17 +192,17 @@ func TestReconcileReviewTask_HumanViewerApprovalIsNotDismissed(t *testing.T) {
 	}
 }
 
-// The reviewed-by:@me search leg (inApproved) is the only signal in some
-// polls — e.g. right after the REST fetch already observed a later verdict.
-// Without a REST-fetched review ID there is nothing to dismiss yet, but the
-// task must still never read as "approved".
+// The reviewed-by:@me search leg (inApproved) is the only signal in some polls.
+// If REST has not observed a submitted viewer review, treat it as a fallback
+// self-approval signal. Without a REST-fetched review ID there is nothing to
+// dismiss yet, but the task must still never read as "approved".
 func TestReconcileReviewTask_SelfApprovalFromSearchLegWithoutReviewID(t *testing.T) {
 	r, tasks := newReconcileFailureHandler(t)
 	tk := newReviewTaskInPhase(t, tasks, "reviewing")
 
 	dismissCalled := false
 	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
-		return github.MyReviewState{Submitted: true, ViewerIsBot: true, ReviewedSHA: "e57e4b5"}, nil
+		return github.MyReviewState{ViewerIsBot: true, ReviewedSHA: "e57e4b5"}, nil
 	}
 	r.dismissReviewFn = func(string, int, int64, string) error {
 		dismissCalled = true
@@ -224,5 +224,38 @@ func TestReconcileReviewTask_SelfApprovalFromSearchLegWithoutReviewID(t *testing
 	if final.ReviewPhase != ReviewPhaseSelfApprovalBlocked {
 		t.Errorf("review_phase = %q, want %q even without a dismissable review ID",
 			final.ReviewPhase, ReviewPhaseSelfApprovalBlocked)
+	}
+}
+
+// If REST sees a submitted viewer verdict, it is more precise than the
+// reviewed-by:@me search leg. A later CHANGES_REQUESTED/COMMENTED verdict must
+// not be overwritten by stale search-leg approval.
+func TestReconcileReviewTask_SearchLegApprovalDoesNotOverrideSubmittedRESTVerdict(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	dismissCalled := false
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{Submitted: true, Approved: false, ViewerIsBot: true, ReviewedSHA: "e57e4b5"}, nil
+	}
+	r.dismissReviewFn = func(string, int, int64, string) error {
+		dismissCalled = true
+		return nil
+	}
+
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	approved := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	got := mustGet(t, tasks, tk.ID)
+	r.reconcileReviewTask(&got, map[string]github.PullRequest{}, approved)
+
+	if dismissCalled {
+		t.Fatal("stale search-leg approval was dismissed as a live bot self-approval")
+	}
+	final := mustGet(t, tasks, tk.ID)
+	if final.ReviewPhase != ReviewPhaseAwaitingAuthor {
+		t.Errorf("review_phase = %q, want %q", final.ReviewPhase, ReviewPhaseAwaitingAuthor)
 	}
 }

--- a/internal/sybra/review/selfapproval_test.go
+++ b/internal/sybra/review/selfapproval_test.go
@@ -20,7 +20,7 @@ func TestReconcileReviewTask_DismissesSelfApprovalAndEscalates(t *testing.T) {
 	var dismissedNumber int
 	var dismissedReviewID int64
 	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
-		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 555, ReviewedSHA: "e57e4b5"}, nil
+		return github.MyReviewState{Submitted: true, Approved: true, ViewerIsBot: true, ReviewID: 555, ReviewedSHA: "e57e4b5"}, nil
 	}
 	r.dismissReviewFn = func(repo string, number int, reviewID int64, message string) error {
 		dismissedRepo, dismissedNumber, dismissedReviewID = repo, number, reviewID
@@ -61,7 +61,7 @@ func TestReconcileReviewTask_DismissFailureStillEscalates(t *testing.T) {
 	tk := newReviewTaskInPhase(t, tasks, "reviewing")
 
 	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
-		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 555, ReviewedSHA: "e57e4b5"}, nil
+		return github.MyReviewState{Submitted: true, Approved: true, ViewerIsBot: true, ReviewID: 555, ReviewedSHA: "e57e4b5"}, nil
 	}
 	r.dismissReviewFn = func(string, int, int64, string) error {
 		return errors.New("gh api: HTTP 403")
@@ -100,7 +100,7 @@ func TestReconcileReviewTask_RunningAgentStillDismissesSelfApproval(t *testing.T
 
 	var dismissedReviewID int64
 	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
-		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 777}, nil
+		return github.MyReviewState{Submitted: true, Approved: true, ViewerIsBot: true, ReviewID: 777}, nil
 	}
 	r.dismissReviewFn = func(_ string, _ int, reviewID int64, _ string) error {
 		dismissedReviewID = reviewID
@@ -132,7 +132,7 @@ func TestReconcileReviewTask_ConflictStillDismissesSelfApproval(t *testing.T) {
 
 	var dismissedReviewID int64
 	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
-		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 888}, nil
+		return github.MyReviewState{Submitted: true, Approved: true, ViewerIsBot: true, ReviewID: 888}, nil
 	}
 	r.dismissReviewFn = func(_ string, _ int, reviewID int64, _ string) error {
 		dismissedReviewID = reviewID
@@ -155,6 +155,43 @@ func TestReconcileReviewTask_ConflictStillDismissesSelfApproval(t *testing.T) {
 	}
 }
 
+// When Sybra is authenticated with a human PAT, a browser approval and an
+// agent-submitted approval have the same GitHub login. Outcome-only detection
+// cannot distinguish them, so the self-approval backstop must not dismiss
+// personal-account approvals as if they were bot approvals.
+func TestReconcileReviewTask_HumanViewerApprovalIsNotDismissed(t *testing.T) {
+	r, tasks := newReconcileFailureHandler(t)
+	tk := newReviewTaskInPhase(t, tasks, "needs-approval")
+
+	dismissCalled := false
+	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
+		return github.MyReviewState{Submitted: true, Approved: true, ReviewID: 999, ReviewedSHA: "e57e4b5"}, nil
+	}
+	r.dismissReviewFn = func(string, int, int64, string) error {
+		dismissCalled = true
+		return nil
+	}
+
+	key := reviewPRKey(tk.ProjectID, tk.PRNumber)
+	approved := map[string]github.PullRequest{
+		key: {Number: tk.PRNumber, Repository: tk.ProjectID, Mergeable: "MERGEABLE", HeadSHA: "e57e4b5"},
+	}
+
+	got := mustGet(t, tasks, tk.ID)
+	r.reconcileReviewTask(&got, map[string]github.PullRequest{}, approved)
+
+	if dismissCalled {
+		t.Fatal("human viewer approval was dismissed as a bot self-approval")
+	}
+	final := mustGet(t, tasks, tk.ID)
+	if final.ReviewPhase != ReviewPhaseApproved {
+		t.Errorf("review_phase = %q, want %q", final.ReviewPhase, ReviewPhaseApproved)
+	}
+	if final.Status != task.StatusInReview {
+		t.Errorf("status = %q, want %q", final.Status, task.StatusInReview)
+	}
+}
+
 // The reviewed-by:@me search leg (inApproved) is the only signal in some
 // polls — e.g. right after the REST fetch already observed a later verdict.
 // Without a REST-fetched review ID there is nothing to dismiss yet, but the
@@ -165,7 +202,7 @@ func TestReconcileReviewTask_SelfApprovalFromSearchLegWithoutReviewID(t *testing
 
 	dismissCalled := false
 	r.fetchMyReviewStateFn = func(string, int) (github.MyReviewState, error) {
-		return github.MyReviewState{Submitted: true, ReviewedSHA: "e57e4b5"}, nil
+		return github.MyReviewState{Submitted: true, ViewerIsBot: true, ReviewedSHA: "e57e4b5"}, nil
 	}
 	r.dismissReviewFn = func(string, int, int64, string) error {
 		dismissCalled = true


### PR DESCRIPTION
## Summary
- distinguish bot/App review identities from personal-account viewers in PR-review reconciliation
- only dismiss self-approvals when the authenticated viewer is a bot identity
- treat human viewer approvals as the inbound review task's approved phase

## Tests
- GOCACHE=/tmp/sybra-go-cache go test ./internal/github
- GOCACHE=/tmp/sybra-go-cache go test ./internal/sybra/review