### PR TITLE
fix(workflow): start implementation after plan approval

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -689,9 +689,8 @@ func (a *App) initStatusHook() {
 
 		switch to {
 		case string(task.StatusTodo):
-			// Human plan approval parks at todo as a stable post-review state;
-			// auto-reentering task.created here would immediately reopen the
-			// plan/implement pipeline and erase the approved transition.
+			// Todo is the entry point for new work. Approved plans now transition
+			// directly to in-progress and skip this lane.
 			if !runsNoAgent && from != string(task.StatusPlanReview) {
 				a.dispatchTaskCreatedWorkflow(taskID)
 			}
@@ -997,21 +996,15 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 			}
 			return
 		}
-		// A StatusTodo task can mean two different things: brand new (no plan
-		// sidecars yet) or the "stable post-review resting state" that
-		// set_todo_and_end deliberately lands on after a human/auto-approved
-		// plan-review (see simple-task-plan.yaml's set_todo_and_end comment).
-		// Re-running task.created/triage on the latter overwrites its status
-		// back to "planning" and mints a brand-new plan agent, discarding the
-		// approved contract — the classifier has no memory of the prior
-		// planning cycle. Skip re-dispatch for a todo task that already
-		// carries a structurally valid plan contract; it stays parked until
-		// something explicitly promotes it to in-progress (UI/CLI start),
-		// exactly like a human-required task that clears via ship-as-is.
-		// Scoped to after the runsTaskLocally routing block above so a
-		// non-local task with an approved contract still gets routed/assigned
-		// to its home node instead of stalling unrouted on the leader.
+		// Before approved plans handed directly to implementation, they landed
+		// in todo. Promote those legacy records instead of replaying task.created
+		// and discarding their approved contracts by re-running triage.
+		// This runs after node routing, so a remote task is still assigned to its
+		// owner before that owner starts implementation.
 		if t.Status == task.StatusTodo && hasApprovedPlanContract(t) {
+			if _, err := a.tasks.Update(taskID, task.Update{Status: task.Ptr(task.StatusInProgress)}); err != nil {
+				a.logger.Error("workflow.approved-plan.promote", "task_id", taskID, "err", err)
+			}
 			return
 		}
 		// pr-fix / ordinary existing-PR tasks are driven outside task.created.

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1002,7 +1002,10 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 		// This runs after node routing, so a remote task is still assigned to its
 		// owner before that owner starts implementation.
 		if t.Status == task.StatusTodo && hasApprovedPlanContract(t) {
-			if _, err := a.tasks.Update(taskID, task.Update{Status: task.Ptr(task.StatusInProgress)}); err != nil {
+			if _, err := a.tasks.ApplyStatusEffect(taskID, task.StatusEffect{
+				Source:   "workflow.legacy-approved-plan",
+				ToStatus: task.StatusInProgress,
+			}); err != nil {
 				a.logger.Error("workflow.approved-plan.promote", "task_id", taskID, "err", err)
 			}
 			return

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -202,13 +202,9 @@ steps:
 	}
 }
 
-func TestDispatchTaskCreatedWorkflowSkipsApprovedTodoPlan(t *testing.T) {
-	// Reproduces #997b365c's stall→reset loop: a todo task that already
-	// carries a valid, approved plan contract must not be swept back into
-	// task.created/triage (which would overwrite it to "planning" and mint a
-	// brand-new plan agent, discarding the approved contract). A todo task
-	// with no plan contract — the ordinary brand-new path — must still
-	// dispatch normally.
+func TestDispatchTaskCreatedWorkflowPromotesApprovedTodoPlan(t *testing.T) {
+	// Legacy approved plans were left in todo. They must enter implementation
+	// without replaying task.created/triage and discarding their contract.
 	const createdWF = `id: probe-created
 name: Probe Created
 trigger:
@@ -225,10 +221,10 @@ steps:
 	cases := []struct {
 		name            string
 		hasPlanContract bool
-		wantDispatch    bool
+		wantStatus      task.Status
 	}{
-		{name: "todo with approved plan contract stays parked", hasPlanContract: true, wantDispatch: false},
-		{name: "brand new todo with no plan contract still dispatches", hasPlanContract: false, wantDispatch: true},
+		{name: "todo with approved plan contract enters implementation", hasPlanContract: true, wantStatus: task.StatusInProgress},
+		{name: "brand new todo with no plan contract still dispatches", hasPlanContract: false, wantStatus: task.StatusPlanning},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -270,14 +266,8 @@ steps:
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := tk.Workflow != nil; got != tc.wantDispatch {
-				t.Fatalf("workflow attached = %v, want %v", got, tc.wantDispatch)
-			}
-			if tc.wantDispatch && tk.Status != task.StatusPlanning {
-				t.Errorf("status = %q, want planning (probe workflow ran)", tk.Status)
-			}
-			if !tc.wantDispatch && tk.Status != task.StatusTodo {
-				t.Errorf("status = %q, want todo (dispatch skipped, task left parked)", tk.Status)
+			if tk.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", tk.Status, tc.wantStatus)
 			}
 		})
 	}

--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -198,8 +198,8 @@ func TestPlanningService_ApprovePlan_RecoversCompletedPlanReviewWorkflow(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.Status != task.StatusTodo {
-		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusTodo)
+	if updated.Status != task.StatusInProgress {
+		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusInProgress)
 	}
 	if updated.Workflow == nil || updated.Workflow.State != workflow.ExecCompleted {
 		t.Fatalf("workflow = %+v, want completed", updated.Workflow)
@@ -289,8 +289,8 @@ func TestPlanningService_ApprovePlan_RecoversMarkdownOnlyMigrationPlan(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.Status != task.StatusTodo {
-		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusTodo)
+	if updated.Status != task.StatusInProgress {
+		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusInProgress)
 	}
 }
 
@@ -342,12 +342,12 @@ func TestPlanningService_ApprovePlan_RecoversManualVerificationContract(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.Status != task.StatusTodo {
-		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusTodo)
+	if updated.Status != task.StatusInProgress {
+		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusInProgress)
 	}
 }
 
-func TestPlanningService_ApprovePlan_StaleReviewPersistsTodoUnderStatusHook(t *testing.T) {
+func TestPlanningService_ApprovePlan_StaleReviewPersistsImplementationReadyStateUnderStatusHook(t *testing.T) {
 	planSvc, taskSvc, a := setupPlanningService(t)
 	a.workflowEngine = taskSvc.workflowEngine
 	a.initStatusHook()
@@ -390,8 +390,8 @@ func TestPlanningService_ApprovePlan_StaleReviewPersistsTodoUnderStatusHook(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.Status != task.StatusTodo {
-		t.Fatalf("ApprovePlan status = %q, want %q", updated.Status, task.StatusTodo)
+	if updated.Status != task.StatusInProgress {
+		t.Fatalf("ApprovePlan status = %q, want %q", updated.Status, task.StatusInProgress)
 	}
 
 	time.Sleep(150 * time.Millisecond)
@@ -400,14 +400,14 @@ func TestPlanningService_ApprovePlan_StaleReviewPersistsTodoUnderStatusHook(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if after.Status != task.StatusTodo {
-		t.Fatalf("status after hook = %q, want %q", after.Status, task.StatusTodo)
+	if after.Status != task.StatusInProgress {
+		t.Fatalf("status after hook = %q, want %q", after.Status, task.StatusInProgress)
 	}
 	if after.StatusReason != "" {
 		t.Fatalf("status_reason = %q, want empty", after.StatusReason)
 	}
 	if after.Workflow == nil || after.Workflow.WorkflowID != "simple-task-plan" || after.Workflow.State != workflow.ExecCompleted {
-		t.Fatalf("workflow after hook = %+v, want completed simple-task-plan", after.Workflow)
+		t.Fatalf("workflow after hook = %+v, want completed simple-task-plan pending scheduler dispatch", after.Workflow)
 	}
 }
 

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -74,12 +74,8 @@ func skipTaskCreatedWorkflow(t task.Task) bool {
 	return false
 }
 
-// hasApprovedPlanContract reports whether t already carries a structurally
-// valid plan contract — the signal that a StatusTodo task reached todo via
-// simple-task-plan's set_todo_and_end hand-off (a completed plan + optional
-// critique cycle) rather than as a brand-new, never-triaged task. A brand new
-// task never has a non-empty PlanContract, so this is a safe, low-cost check
-// with no false positives against the ordinary new-task path.
+// hasApprovedPlanContract identifies legacy todo tasks that completed plan
+// review before approval began handing work directly to implementation.
 func hasApprovedPlanContract(t task.Task) bool {
 	if strings.TrimSpace(t.PlanContract) == "" {
 		return false

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -1,6 +1,6 @@
 id: simple-task-plan
 name: Simple Task — Plan
-description: Triage a new task and (when planning is required) drive the plan / critique / human-review loop. Human approval lands the task in todo as a stable ready-for-implementation state.
+description: Triage a new task and (when planning is required) drive the plan / critique / human-review loop. Human approval hands the task directly to implementation.
 builtin: true
 trigger:
   on: task.created
@@ -83,13 +83,13 @@ steps:
     next:
       - goto: ""
 
-  # Complex tasks that passed human plan review land on todo as a stable
-  # post-review resting state; approval itself must not start implementation.
-  - id: set_todo_and_end
-    name: Hand Off to Todo
+  # Human approval is the authorization to spend the implementation run.
+  # Hand it directly to the implementation workflow via the status cascade.
+  - id: set_in_progress_after_plan_and_end
+    name: Hand Off to Implement
     type: set_status
     config:
-      status: todo
+      status: in-progress
     next:
       - goto: ""
 
@@ -539,7 +539,7 @@ steps:
           field: vars.human_action
           operator: equals
           value: approve
-        goto: set_todo_and_end
+        goto: set_in_progress_after_plan_and_end
       - when:
           field: vars.human_action
           operator: equals

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -9,6 +9,27 @@ import (
 	"testing"
 )
 
+func TestBuiltinSimpleTaskPlan_ApprovalStartsImplementation(t *testing.T) {
+	t.Parallel()
+
+	plan := mustBuiltinDefinition(t, "simple-task-plan")
+	review := plan.StepByID("review_plan")
+	if review == nil {
+		t.Fatal("review_plan step not found in simple-task-plan")
+	}
+	got, err := ResolveTransition(review.Next, map[string]string{"vars.human_action": "approve"})
+	if err != nil {
+		t.Fatalf("ResolveTransition: %v", err)
+	}
+	if got != "set_in_progress_after_plan_and_end" {
+		t.Fatalf("approval next = %q, want set_in_progress_after_plan_and_end", got)
+	}
+	step := plan.StepByID(got)
+	if step == nil || step.Config.Status != "in-progress" {
+		t.Fatalf("approval handoff = %+v, want set_status in-progress", step)
+	}
+}
+
 // TestBuiltinSimpleTask_MaybeCritiqueReplanSkip locks the behavior that
 // critique_plan runs only on the first plan pass. On replan (after a human
 // reject), `vars.step.review_plan.output` exists, so maybe_critique must

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -25,7 +25,7 @@ func TestBuiltinSimpleTaskPlan_ApprovalStartsImplementation(t *testing.T) {
 		t.Fatalf("approval next = %q, want set_in_progress_after_plan_and_end", got)
 	}
 	step := plan.StepByID(got)
-	if step == nil || step.Config.Status != "in-progress" {
+	if step == nil || step.Type != StepSetStatus || step.Config.Status != "in-progress" {
 		t.Fatalf("approval handoff = %+v, want set_status in-progress", step)
 	}
 }


### PR DESCRIPTION
## Summary
- hand approved plans directly to the implementation workflow
- promote legacy approved Todo tasks without replaying planning
- cover approval handoff and recovery with regression tests

## Verification
- bash scripts/check-no-direct-status-write.sh
- go test -race -tags e2e -run 'TestPlanningService_ApprovePlan_(RecoversCompletedPlanReviewWorkflow|RecoversMarkdownOnlyMigrationPlan|RecoversManualVerificationContract|StaleReviewPersistsImplementationReadyStateUnderStatusHook)$' ./internal/sybra
- go test ./internal/workflow -run TestBuiltinSimpleTaskPlan_ApprovalStartsImplementation