### PR TITLE
fix(workflow): preserve human approval and follower task state

### DIFF
--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -317,6 +317,16 @@ func (c *Client) AssignTask(ctx context.Context, t task.Task) error {
 	return err
 }
 
+// BlessTampering records the human tamper decision on the follower that owns
+// execution, returning its resulting task state for callers that need it.
+func (c *Client) BlessTampering(ctx context.Context, taskID string) (task.Task, error) {
+	raw, err := c.Call(ctx, "TaskService", "BlessTampering", taskID)
+	if err != nil {
+		return task.Task{}, err
+	}
+	return decode[task.Task](raw)
+}
+
 // ImportAttachment replicates one attachment blob onto a follower before the
 // task metadata that references it is assigned there.
 func (c *Client) ImportAttachment(ctx context.Context, taskID string, meta task.Attachment, data []byte) (task.Attachment, error) {

--- a/internal/sybra/clusterlead/assigner.go
+++ b/internal/sybra/clusterlead/assigner.go
@@ -156,6 +156,25 @@ func (a *Assigner) PushFieldUpdate(ctx context.Context, t task.Task) (pushed boo
 	return true, nil
 }
 
+// BlessTampering forwards a human tamper blessing to the follower that owns
+// execution. The follower must perform the transition itself so its workflow
+// can resume from the same authoritative state the leader displays.
+func (a *Assigner) BlessTampering(ctx context.Context, t task.Task) (task.Task, bool, error) {
+	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
+	if home.Local || t.AssignedNode != home.Name {
+		return task.Task{}, false, nil
+	}
+	client, ok := a.roster.Client(home.Name)
+	if !ok || client == nil {
+		return task.Task{}, false, fmt.Errorf("clusterlead: no follower client for node %q", home.Name)
+	}
+	updated, err := client.BlessTampering(ctx, t.ID)
+	if err != nil {
+		return task.Task{}, false, fmt.Errorf("clusterlead: bless tampering for %s on %s: %w", t.ID, home.Name, err)
+	}
+	return updated, true, nil
+}
+
 func (a *Assigner) route(ctx context.Context, t task.Task, force bool) (routed bool, err error) {
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -416,6 +416,22 @@ func isMissingArtifactError(err error) bool {
 // BlessTampering records a human bless for a tamper-flagged task and sends it
 // back to the review workflow.
 func (s *TaskService) BlessTampering(taskID string) (task.Task, error) {
+	// A follower owns task execution. Ask it to bless first, before changing
+	// the leader mirror, so the board cannot claim the task resumed when the
+	// worker rejected or never received the transition.
+	if s.assigner != nil {
+		current, err := s.tasks.Get(taskID)
+		if err != nil {
+			return task.Task{}, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), fieldPushTimeout)
+		defer cancel()
+		if _, forwarded, err := s.assigner.BlessTampering(ctx, current); err != nil {
+			return task.Task{}, err
+		} else if forwarded {
+			s.logger.Info("cluster.task.tamper_bless.forwarded", "task_id", taskID, "node", current.AssignedNode)
+		}
+	}
 	var (
 		cur      task.Task
 		tagAdded bool

--- a/internal/sybra/svc_tasks_cluster_push_test.go
+++ b/internal/sybra/svc_tasks_cluster_push_test.go
@@ -5,12 +5,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sync"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // followerPushStub is a minimal follower TaskService double for asserting
@@ -20,6 +22,7 @@ type followerPushStub struct {
 	mu       sync.Mutex
 	live     task.Task
 	assigned []task.Task
+	blessed  int
 }
 
 func (f *followerPushStub) server(t *testing.T) *httptest.Server {
@@ -44,6 +47,17 @@ func (f *followerPushStub) server(t *testing.T) *httptest.Server {
 				f.mu.Unlock()
 			}
 			w.WriteHeader(http.StatusOK)
+		case "/api/TaskService/BlessTampering":
+			f.mu.Lock()
+			f.blessed++
+			f.live.Status = task.StatusReadyReview
+			f.live.TamperFlagged = false
+			if !slices.Contains(f.live.Tags, workflow.TamperBlessedTag) {
+				f.live.Tags = append(f.live.Tags, workflow.TamperBlessedTag)
+			}
+			updated := f.live
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(updated)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -51,6 +65,12 @@ func (f *followerPushStub) server(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func (f *followerPushStub) blessCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.blessed
 }
 
 func (f *followerPushStub) lastAssigned() (task.Task, bool) {
@@ -128,6 +148,49 @@ func TestUpdateTaskPushesTagEditToFollowerAtWriteTime(t *testing.T) {
 	}
 	if len(got.AgentRuns) != 1 || got.AgentRuns[0].AgentID != "still-running" {
 		t.Errorf("push dropped the follower's live AgentRuns, got %+v — rolled back follower progress", got.AgentRuns)
+	}
+}
+
+func TestBlessTamperingForwardsTransitionToAssignedFollower(t *testing.T) {
+	reason := workflow.TamperFlaggedReasonPrefix + " added-skip in internal/foo_test.go"
+	stub := &followerPushStub{live: task.Task{
+		ID:           "task-bless",
+		Status:       task.StatusHumanRequired,
+		StatusReason: reason,
+		ProjectID:    "owner/pet",
+		AssignedNode: "pet-box",
+		Tags:         []string{"backend"},
+	}}
+	srv := stub.server(t)
+
+	cfg := &config.Config{Cluster: config.ClusterConfig{
+		Role:      config.ClusterRoleLeader,
+		Followers: []config.Follower{{Name: "pet-box", Endpoints: []string{srv.URL}, Homes: []string{"owner/pet"}}},
+	}}
+	roster, err := clusterlead.NewRoster(cfg, discardLogger())
+	if err != nil || roster == nil {
+		t.Fatalf("NewRoster: roster=%v err=%v", roster, err)
+	}
+	leaderTasks := newTaskManagerForMonitorCluster(t)
+	if _, _, err := leaderTasks.Put(stub.live); err != nil {
+		t.Fatalf("seed leader task: %v", err)
+	}
+	svc := &TaskService{
+		tasks:    leaderTasks,
+		cfg:      cfg,
+		assigner: clusterlead.NewAssigner(cfg, leaderTasks, roster, func(string) bool { return false }, nil, discardLogger()),
+		logger:   discardLogger(),
+	}
+
+	got, err := svc.BlessTampering("task-bless")
+	if err != nil {
+		t.Fatalf("BlessTampering: %v", err)
+	}
+	if stub.blessCount() != 1 {
+		t.Fatalf("follower bless calls = %d, want 1", stub.blessCount())
+	}
+	if got.Status != task.StatusReadyReview || !slices.Contains(got.Tags, workflow.TamperBlessedTag) {
+		t.Fatalf("leader result = status %q tags %v, want ready-review with %q", got.Status, got.Tags, workflow.TamperBlessedTag)
 	}
 }
 

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -83,16 +83,6 @@ steps:
     next:
       - goto: ""
 
-  # Human approval is the authorization to spend the implementation run.
-  # Hand it directly to the implementation workflow via the status cascade.
-  - id: set_in_progress_after_plan_and_end
-    name: Hand Off to Implement
-    type: set_status
-    config:
-      status: in-progress
-    next:
-      - goto: ""
-
   # Single plan step: one opus agent does the research and scrutiny, but writes
   # separate artifacts. The canonical plan sidecar is now a compact execution
   # contract only; research, decisions, and human-review brief stay separate so
@@ -539,7 +529,7 @@ steps:
           field: vars.human_action
           operator: equals
           value: approve
-        goto: set_in_progress_after_plan_and_end
+        goto: set_in_progress_and_end
       - when:
           field: vars.human_action
           operator: equals

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -21,8 +21,8 @@ func TestBuiltinSimpleTaskPlan_ApprovalStartsImplementation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveTransition: %v", err)
 	}
-	if got != "set_in_progress_after_plan_and_end" {
-		t.Fatalf("approval next = %q, want set_in_progress_after_plan_and_end", got)
+	if got != "set_in_progress_and_end" {
+		t.Fatalf("approval next = %q, want set_in_progress_and_end", got)
 	}
 	step := plan.StepByID(got)
 	if step == nil || step.Type != StepSetStatus || step.Config.Status != "in-progress" {


### PR DESCRIPTION
## Summary
- preserve human approval attribution through the workflow handoff
- forward tamper blessings to the follower that owns task execution before updating the leader mirror
- cover follower-side tamper blessing forwarding with a regression test

## Verification
- go test ./internal/sybra ./internal/cluster ./internal/sybra/clusterlead