### PR TITLE
feat(models): move codex tiers to gpt-5.6 family

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,10 +185,12 @@ EXPOSE 8080
 # (cluster.tls) serves https on the same port, so an http-only probe would mark
 # it permanently unhealthy. -k is safe here: the probe is localhost-only and the
 # leader, not the container, is what pins the certificate.
+#
+# Exec form with an explicit `sh -c` rather than shell form (DL3025): the probe
+# needs ${SYBRA_PORT} expansion and `||`, which is exactly what Docker wrapped
+# the shell form in anyway, so the semantics are unchanged.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -sf "http://localhost:${SYBRA_PORT}/health" \
-     || curl -skf "https://localhost:${SYBRA_PORT}/health" \
-     || exit 1
+    CMD ["/bin/sh", "-c", "curl -sf \"http://localhost:${SYBRA_PORT}/health\" || curl -skf \"https://localhost:${SYBRA_PORT}/health\" || exit 1"]
 
 # Mounts expected (host dirs must be chowned to uid:gid 1000:1000):
 #   ~/.sybra  → /home/sybra/.sybra  (task store, config, projects)

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -46,7 +46,7 @@ Edit `~/.sybra/config.yaml`:
 ```yaml
 agent:
   provider: codex
-  model: gpt-5.4   # optional; gpt-5.4 is the cheap/sonnet-class default
+  model: gpt-5.6-terra   # optional; gpt-5.6-terra is the cheap/sonnet-class default
 ```
 
 To revert to Claude:
@@ -62,10 +62,14 @@ Sybra maps generic aliases to provider-specific model IDs at runtime:
 
 | Sybra alias | Codex model |
 |---------------|-------------|
-| `sonnet` (default) | `gpt-5.4` |
-| `opus` | `gpt-5.5` |
-| `haiku` | `gpt-5.4-mini` |
+| `sonnet` (default) | `gpt-5.6-terra` |
+| `opus` | `gpt-5.6-sol` |
+| `haiku` | `gpt-5.6-luna` |
 | any other string | passed through verbatim |
+
+Requires codex CLI 0.145.0+. `gpt-5.4` and `gpt-5.4-mini` — the previous
+`sonnet`/`haiku` mappings — retire in Codex on 2026-08-31 for ChatGPT-signed-in
+accounts, which is why all three tiers moved to the gpt-5.6 family at once.
 
 ## How Codex Runs in Sybra
 
@@ -75,7 +79,7 @@ Sybra spawns a `codex exec` subprocess per task:
 
 ```bash
 # Headless mode always uses bypass (regardless of RequirePermissions)
-codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -C <worktree> "<prompt>"
+codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.6-terra -C <worktree> "<prompt>"
 ```
 
 `--sandbox workspace-write` is intentionally not used in headless mode. That mode requests user approval for writes outside the workspace; in a headless run there is no TTY or UI to serve the approval prompt, so every such request is auto-rejected and the agent run fails. The worktree directory itself provides task isolation.

--- a/frontend/e2e/lib/providers.ts
+++ b/frontend/e2e/lib/providers.ts
@@ -13,7 +13,7 @@ export const providerMatrix: ProviderSpec[] = [
   {
     provider: 'codex',
     modelLabel: 'Default (gpt-5.6-terra)',
-    expectedOptions: ['Default (gpt-5.6-terra)', 'GPT-5.6 Sol', 'GPT-5.6 Terra', 'GPT-5.6 Luna'],
+    expectedOptions: ['Default (gpt-5.6-terra)', 'GPT-5.6 Sol', 'GPT-5.6 Terra', 'GPT-5.6 Luna', 'GPT-5.5 (legacy)'],
   },
   {
     provider: 'copilot',

--- a/frontend/e2e/lib/providers.ts
+++ b/frontend/e2e/lib/providers.ts
@@ -12,8 +12,8 @@ export const providerMatrix: ProviderSpec[] = [
   },
   {
     provider: 'codex',
-    modelLabel: 'Default (gpt-5.5)',
-    expectedOptions: ['Default (gpt-5.5)', 'GPT-5.4', 'GPT-5.4 Mini', 'GPT-5.3 Codex'],
+    modelLabel: 'Default (gpt-5.6-terra)',
+    expectedOptions: ['Default (gpt-5.6-terra)', 'GPT-5.6 Sol', 'GPT-5.6 Terra', 'GPT-5.6 Luna'],
   },
   {
     provider: 'copilot',

--- a/frontend/e2e/settings-provider.spec.ts
+++ b/frontend/e2e/settings-provider.spec.ts
@@ -84,7 +84,7 @@ test.describe('Settings provider matrix', { tag: '@integration' }, () => {
 
       await page.locator('#agent-provider').selectOption('codex')
       await expect(page.locator('#agent-model')).toHaveValue('')
-      await expect(page.locator('#agent-model option').first()).toHaveText('Default (gpt-5.5)')
+      await expect(page.locator('#agent-model option').first()).toHaveText('Default (gpt-5.6-terra)')
     } finally {
       await restoreAgentSettings(page, original)
     }

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -90,11 +90,16 @@
   const clientVersion = String(import.meta.env.VITE_APP_VERSION || 'dev')
 
   type ModelOption = { value: string; label: string }
+  // Only used when GetCodexModels() fails, which is also the state an
+  // older/broken codex CLI lands in — so keep one pre-5.6 slug selectable.
+  // Without it a CLI below 0.145.0 has no UI path to the models it accepts,
+  // and the ProbeCodex "pin an older model" warning points nowhere.
   const codexFallbackModels: ModelOption[] = [
     { value: '', label: 'Default (gpt-5.6-terra)' },
     { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
     { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
     { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+    { value: 'gpt-5.5', label: 'GPT-5.5 (legacy)' },
   ]
   let codexDynamicModels = $state<ModelOption[]>([])
   const copilotFallbackModels: ModelOption[] = [

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -91,10 +91,10 @@
 
   type ModelOption = { value: string; label: string }
   const codexFallbackModels: ModelOption[] = [
-    { value: '', label: 'Default (gpt-5.5)' },
-    { value: 'gpt-5.4', label: 'GPT-5.4' },
-    { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-    { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+    { value: '', label: 'Default (gpt-5.6-terra)' },
+    { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
+    { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
+    { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
   ]
   let codexDynamicModels = $state<ModelOption[]>([])
   const copilotFallbackModels: ModelOption[] = [

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -683,7 +683,7 @@ describe('Settings', () => {
   it('switches model options when provider changes to codex', async () => {
     mockGetSettings.mockResolvedValue(baseSettings())
     mockGetCodexModels.mockResolvedValue([
-      { slug: 'gpt-5.4', display_name: 'GPT-5.4' },
+      { slug: 'gpt-5.6-terra', display_name: 'GPT-5.6 Terra' },
     ])
     render(Settings)
     await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
@@ -691,7 +691,7 @@ describe('Settings', () => {
     const providerSelect = screen.getByLabelText('Agent type') as HTMLSelectElement
     await fireEvent.change(providerSelect, { target: { value: 'codex' } })
     await vi.waitFor(() => {
-      expect(screen.getByText('GPT-5.4')).toBeDefined()
+      expect(screen.getByText('GPT-5.6 Terra')).toBeDefined()
     })
   })
 

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -202,7 +202,7 @@ func TestPrepareRunConfig_FailoverRemapsKnownConcreteModel(t *testing.T) {
 
 	cfg, prov, err := m.prepareRunConfig(RunConfig{
 		Provider: "codex",
-		Model:    "gpt-5.5",
+		Model:    "gpt-5.6-sol",
 		Mode:     "headless",
 		Dir:      t.TempDir(),
 	})
@@ -258,8 +258,8 @@ func TestPrepareRunConfig_CodexRemapsClaudeModelLiteral(t *testing.T) {
 	if cfg.Model != "claude-haiku-4-5-20251001" {
 		t.Fatalf("requested model = %q, want original literal preserved for metadata", cfg.Model)
 	}
-	if cfg.resolvedModel != "gpt-5.4-mini" {
-		t.Fatalf("resolved model = %q, want gpt-5.4-mini", cfg.resolvedModel)
+	if cfg.resolvedModel != "gpt-5.6-luna" {
+		t.Fatalf("resolved model = %q, want gpt-5.6-luna", cfg.resolvedModel)
 	}
 }
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1157,17 +1157,17 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex default model mapping",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.6-terra",
 		},
 		{
 			name:    "codex maps haiku to mini",
 			cfg:     RunConfig{Provider: "codex", Model: "haiku"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4-mini",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.6-luna",
 		},
 		{
 			name:    "codex with RequirePermissions uses workspace-write sandbox",
 			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox workspace-write --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox workspace-write --model gpt-5.6-terra",
 		},
 		{
 			name:    "fable alias",
@@ -1202,7 +1202,7 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex with reasoning effort high",
 			cfg:     RunConfig{Provider: "codex", ReasoningEffort: "high"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -c model_reasoning_effort=high",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.6-terra -c model_reasoning_effort=high",
 		},
 	}
 
@@ -1241,19 +1241,19 @@ func TestNormalizeModel(t *testing.T) {
 		{prov: "claude", model: "fable[1m] ", want: "fable"},      // trailing whitespace stripped first
 		{prov: "claude", model: "foo[1m]bar", want: "foo[1m]bar"}, // only trailing stripped
 		// Codex path — no [1m] stripping
-		{prov: "codex", model: "", want: "gpt-5.4"},
-		{prov: "codex", model: "sonnet", want: "gpt-5.4"},
+		{prov: "codex", model: "", want: "gpt-5.6-terra"},
+		{prov: "codex", model: "sonnet", want: "gpt-5.6-terra"},
 		{prov: "codex", model: "fable", want: "fable"},
-		{prov: "codex", model: "opus", want: "gpt-5.5"},
-		{prov: "codex", model: "haiku", want: "gpt-5.4-mini"},
+		{prov: "codex", model: "opus", want: "gpt-5.6-sol"},
+		{prov: "codex", model: "haiku", want: "gpt-5.6-luna"},
 		{prov: "codex", model: "gpt-5.4[1m]", want: "gpt-5.4[1m]"}, // unchanged on codex path
 		// Foreign vendor literals: codex is not a multi-vendor gateway, so a
 		// Claude model ID reaching it directly (e.g. a role default set
 		// before failover ever triggers, see #2639) must still resolve to a
 		// codex-native model instead of being rejected by the CLI.
-		{prov: "codex", model: "claude-haiku-4-5-20251001", want: "gpt-5.4-mini"},
-		{prov: "codex", model: "claude-sonnet-4-6", want: "gpt-5.4"},
-		{prov: "codex", model: "claude-opus-4-20250514", want: "gpt-5.5"},
+		{prov: "codex", model: "claude-haiku-4-5-20251001", want: "gpt-5.6-luna"},
+		{prov: "codex", model: "claude-sonnet-4-6", want: "gpt-5.6-terra"},
+		{prov: "codex", model: "claude-opus-4-20250514", want: "gpt-5.6-sol"},
 	}
 
 	for _, tt := range tests {
@@ -1278,12 +1278,12 @@ func TestCodexSandboxDisabledViaEnv(t *testing.T) {
 		{
 			name:    "codex default with sandbox disabled",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.6-terra",
 		},
 		{
 			name:    "codex RequirePermissions honored as danger-full-access when sandbox disabled",
 			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
-			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.6-terra",
 		},
 	}
 

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -196,7 +196,7 @@ func TestRunAvoidProviderExcludedFromOrder(t *testing.T) {
 
 func TestRunSetsTierModels(t *testing.T) {
 	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
-		want := map[string]string{"claude": "sonnet", "codex": "gpt-5.4", "copilot": "claude-sonnet-4.6", "opencode": "openrouter/deepseek/deepseek-v4-flash"}
+		want := map[string]string{"claude": "sonnet", "codex": "gpt-5.6-terra", "copilot": "claude-sonnet-4.6", "opencode": "openrouter/deepseek/deepseek-v4-flash"}
 		if !reflect.DeepEqual(opts.Models, want) {
 			t.Fatalf("models = %#v, want %#v", opts.Models, want)
 		}
@@ -211,7 +211,7 @@ func TestRunSetsTierModels(t *testing.T) {
 
 func TestRunSetsSuperCheapTierModels(t *testing.T) {
 	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
-		want := map[string]string{"claude": "haiku", "codex": "gpt-5.4-mini", "copilot": "gpt-5-mini", "opencode": "openrouter/qwen/qwen3-32b"}
+		want := map[string]string{"claude": "haiku", "codex": "gpt-5.6-luna", "copilot": "gpt-5-mini", "opencode": "openrouter/qwen/qwen3-32b"}
 		if !reflect.DeepEqual(opts.Models, want) {
 			t.Fatalf("models = %#v, want %#v", opts.Models, want)
 		}
@@ -235,7 +235,7 @@ func TestStandardTierIsCheapAlias(t *testing.T) {
 
 func TestRunPreservesExplicitModels(t *testing.T) {
 	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
-		want := map[string]string{"claude": "opus", "codex": "gpt-5.4", "copilot": "claude-sonnet-4.6", "opencode": "openrouter/deepseek/deepseek-v4-flash"}
+		want := map[string]string{"claude": "opus", "codex": "gpt-5.6-terra", "copilot": "claude-sonnet-4.6", "opencode": "openrouter/deepseek/deepseek-v4-flash"}
 		if !reflect.DeepEqual(opts.Models, want) {
 			t.Fatalf("models = %#v, want %#v", opts.Models, want)
 		}
@@ -276,7 +276,7 @@ func TestModelsForClones(t *testing.T) {
 	got := modelsFor(Standard)
 	got["claude"] = "mutated"
 	again := modelsFor(Standard)
-	if again["claude"] != "sonnet" || again["codex"] != "gpt-5.4" || again["copilot"] != "claude-sonnet-4.6" || again["opencode"] != "openrouter/deepseek/deepseek-v4-flash" {
+	if again["claude"] != "sonnet" || again["codex"] != "gpt-5.6-terra" || again["copilot"] != "claude-sonnet-4.6" || again["opencode"] != "openrouter/deepseek/deepseek-v4-flash" {
 		t.Fatalf("modelsFor did not clone standard row: %#v", again)
 	}
 }

--- a/internal/modeltier/tier.go
+++ b/internal/modeltier/tier.go
@@ -20,19 +20,19 @@ const (
 var models = map[Tier]map[string]string{
 	SuperCheap: {
 		"claude":   "haiku",
-		"codex":    "gpt-5.4-mini",
+		"codex":    "gpt-5.6-luna",
 		"copilot":  "gpt-5-mini",
 		"opencode": "openrouter/qwen/qwen3-32b",
 	},
 	Cheap: {
 		"claude":   "sonnet",
-		"codex":    "gpt-5.4",
+		"codex":    "gpt-5.6-terra",
 		"copilot":  "claude-sonnet-4.6",
 		"opencode": "openrouter/deepseek/deepseek-v4-flash",
 	},
 	Expensive: {
 		"claude":   "opus",
-		"codex":    "gpt-5.5",
+		"codex":    "gpt-5.6-sol",
 		"copilot":  "gemini-3.1-pro-preview",
 		"opencode": "openrouter/z-ai/glm-5.2",
 	},
@@ -77,6 +77,11 @@ func InferTier(model string) (Tier, bool) {
 		return SuperCheap, true
 	case "opus":
 		return Expensive, true
+	case "gpt-5.6":
+		// Codex's bare generation alias resolves to Sol. Matched exactly here
+		// rather than by Contains below, where it would also swallow the
+		// -terra and -luna slugs and misclassify them as Expensive.
+		return Expensive, true
 	}
 	for tier, row := range models {
 		for _, candidate := range row {
@@ -85,17 +90,22 @@ func InferTier(model string) (Tier, bool) {
 			}
 		}
 	}
+	// The retired gpt-5.4/5.5 slugs stay matched so historical run records and
+	// hand-pinned task YAML still classify into a tier.
 	switch {
 	case strings.Contains(trimmed, "haiku"),
+		strings.Contains(trimmed, "gpt-5.6-luna"),
 		strings.Contains(trimmed, "gpt-5.4-mini"),
 		strings.Contains(trimmed, "qwen3-32b"):
 		return SuperCheap, true
 	case strings.Contains(trimmed, "opus"),
+		strings.Contains(trimmed, "gpt-5.6-sol"),
 		strings.Contains(trimmed, "gpt-5.5"),
 		strings.Contains(trimmed, "gemini-3.1-pro"),
 		strings.Contains(trimmed, "glm-5.2"):
 		return Expensive, true
 	case strings.Contains(trimmed, "sonnet"),
+		strings.Contains(trimmed, "gpt-5.6-terra"),
 		strings.Contains(trimmed, "gpt-5.4"),
 		strings.Contains(trimmed, "deepseek-v4-flash"):
 		return Cheap, true

--- a/internal/modeltier/tier_test.go
+++ b/internal/modeltier/tier_test.go
@@ -34,7 +34,16 @@ func TestInferTier(t *testing.T) {
 		{model: "sonnet", want: Cheap, ok: true},
 		{model: "haiku", want: SuperCheap, ok: true},
 		{model: "opus", want: Expensive, ok: true},
+		{model: "gpt-5.6-sol", want: Expensive, ok: true},
+		{model: "gpt-5.6-terra", want: Cheap, ok: true},
+		{model: "gpt-5.6-luna", want: SuperCheap, ok: true},
+		// The bare generation alias resolves to Sol, and must not be matched
+		// by a Contains rule that would also swallow -terra and -luna.
+		{model: "gpt-5.6", want: Expensive, ok: true},
+		// Retired codex slugs stay classifiable for historical run records.
 		{model: "gpt-5.5", want: Expensive, ok: true},
+		{model: "gpt-5.4", want: Cheap, ok: true},
+		{model: "gpt-5.4-mini", want: SuperCheap, ok: true},
 		{model: "claude-sonnet-4.6", want: Cheap, ok: true},
 		{model: "claude-haiku-4.5", want: SuperCheap, ok: true},
 		{model: "custom-model", ok: false},

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -78,15 +78,17 @@ func TestCodexVersionAtLeast(t *testing.T) {
 		have string
 		want bool
 	}{
-		{"equal", "0.142.2", true},
-		{"newer_patch", "0.142.3", true},
-		{"newer_minor", "0.143.0", true},
+		{"equal", "0.145.0", true},
+		{"newer_patch", "0.145.1", true},
+		{"newer_minor", "0.146.0", true},
 		{"newer_major", "1.0.0", true},
-		{"older_patch", "0.142.1", false},
-		{"older_minor", "0.141.9", false},
-		{"shorter_equal_prefix", "0.142", false},
-		{"longer_equal_prefix", "0.142.2.1", true},
-		{"suffix_tolerated", "0.142.2-beta", true},
+		{"older_patch", "0.144.9", false},
+		{"older_minor", "0.142.2", false},
+		// A missing trailing component reads as zero, so "0.145" == "0.145.0".
+		{"shorter_equal_prefix", "0.145", true},
+		{"shorter_older_prefix", "0.144", false},
+		{"longer_equal_prefix", "0.145.0.1", true},
+		{"suffix_tolerated", "0.145.0-beta", true},
 		{"unparseable_fails_open", "", true},
 		{"garbage_fails_open", "vNext", true},
 	}

--- a/internal/provider/probes.go
+++ b/internal/provider/probes.go
@@ -16,10 +16,12 @@ import (
 
 const probeTimeout = 10 * time.Second
 
-// minCodexVersion is the lowest codex CLI version that ships the default model
-// (gpt-5.5). Older CLIs reject `--model gpt-5.5` at exec time, so the probe
-// surfaces a warning instead of letting every default run fail silently.
-const minCodexVersion = "0.142.2"
+// minCodexVersion is the lowest codex CLI version whose bundled model
+// selections are the gpt-5.6 family Sybra now maps every tier onto (0.145.0
+// migrated them off gpt-5.4; earlier 5.6 mentions are Bedrock-only). Older
+// CLIs reject `--model gpt-5.6-*` at exec time, so the probe surfaces a
+// warning instead of letting every run fail silently.
+const minCodexVersion = "0.145.0"
 
 var codexVersionRe = regexp.MustCompile(`\d+\.\d+(?:\.\d+)*`)
 
@@ -72,7 +74,7 @@ func ProbeCodex(ctx context.Context) (Status, error) {
 		// Reuse cctx so the login and version probes share one probeTimeout
 		// budget rather than allowing ProbeCodex to run for up to 2× of it.
 		if v := probeCodexVersion(cctx); v != "" && !codexVersionAtLeast(v, minCodexVersion) {
-			warning := fmt.Sprintf("codex %s is older than %s; the default model gpt-5.5 requires %s+ — upgrade codex or pin an older model", v, minCodexVersion, minCodexVersion)
+			warning := fmt.Sprintf("codex %s is older than %s; the gpt-5.6 models require %s+ — upgrade codex or pin an older model", v, minCodexVersion, minCodexVersion)
 			if st.Detail != "" {
 				st.Detail += " — " + warning
 			} else {

--- a/internal/stats/pricing.go
+++ b/internal/stats/pricing.go
@@ -32,6 +32,9 @@ var (
 	gpt5Price            = modelPrice{in: 1.25, out: 10.00, cacheRead: 0.125}
 	gpt5MiniPrice        = modelPrice{in: 0.25, out: 2.00, cacheRead: 0.025}
 	gpt5NanoPrice        = modelPrice{in: 0.05, out: 0.40, cacheRead: 0.005}
+	gpt56SolPrice        = modelPrice{in: 5.00, out: 30.00, cacheRead: 0.50}
+	gpt56TerraPrice      = modelPrice{in: 2.50, out: 15.00, cacheRead: 0.25}
+	gpt56LunaPrice       = modelPrice{in: 1.00, out: 6.00, cacheRead: 0.10}
 	haiku45Price         = modelPrice{in: 1.00, out: 5.00, cacheRead: 0.10, cacheWrite5m: 1.25, cacheWrite1h: 2.00}
 	sonnet46Price        = modelPrice{in: 3.00, out: 15.00, cacheRead: 0.30, cacheWrite5m: 3.75, cacheWrite1h: 6.00}
 	sonnet5IntroPrice    = modelPrice{in: 2.00, out: 10.00, cacheRead: 0.20, cacheWrite5m: 2.50, cacheWrite1h: 4.00}
@@ -52,17 +55,29 @@ func sonnet5Tiers() []pricedTier {
 }
 
 var pricingTable = map[string][]pricedTier{
-	// OpenAI / Codex CLI defaults.
+	// OpenAI / Codex CLI. Cached input is billed at 10% of standard input.
+	//
+	// The gpt-5.6 trio backs all three modeltier classes (luna/terra/sol =
+	// super_cheap/cheap/expensive). Rates are the standard short-context
+	// tier; a request whose input exceeds 272K tokens reprices at 2× input /
+	// 1.5× output, which modelPrice has no way to express — such runs are
+	// under-costed, so treat the estimate as a floor for the spend ceilings.
+	"gpt-5.6":       tiers(gpt56SolPrice), // bare generation alias routes to Sol
+	"gpt-5.6-sol":   tiers(gpt56SolPrice),
+	"gpt-5.6-terra": tiers(gpt56TerraPrice),
+	"gpt-5.6-luna":  tiers(gpt56LunaPrice),
+
+	// Retired or superseded, kept so historical run records still price.
 	// gpt-5 / gpt-5-mini are the underlying models behind `gpt-5.4` (codex
-	// alias) and `gpt-5.4-mini`. Cached input is billed at 10% of standard.
+	// alias) and `gpt-5.4-mini`.
 	"gpt-5":         tiers(gpt5Price),
 	"gpt-5-codex":   tiers(gpt5Price),
 	"gpt-5-mini":    tiers(gpt5MiniPrice),
 	"gpt-5-nano":    tiers(gpt5NanoPrice),
-	"gpt-5.5":       tiers(gpt5Price), // codex default (0.142.2+)
-	"gpt-5.4":       tiers(gpt5Price), // codex alias
-	"gpt-5.4-mini":  tiers(gpt5MiniPrice),
-	"gpt-5.3-codex": tiers(gpt5Price), // selectable codex option; gpt-5-codex pricing
+	"gpt-5.5":       tiers(gpt5Price),
+	"gpt-5.4":       tiers(gpt5Price),     // retired in codex 2026-08-31
+	"gpt-5.4-mini":  tiers(gpt5MiniPrice), // retired in codex 2026-08-31
+	"gpt-5.3-codex": tiers(gpt5Price),     // gpt-5-codex pricing
 
 	// Legacy OpenAI (kept for back-compat with old run records).
 	"o4-mini":      tiers(modelPrice{in: 1.10, out: 4.40, cacheRead: 0.275}),

--- a/internal/stats/pricing_test.go
+++ b/internal/stats/pricing_test.go
@@ -3,6 +3,8 @@ package stats
 import (
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/modeltier"
 )
 
 func TestEstimateCost(t *testing.T) {
@@ -18,6 +20,10 @@ func TestEstimateCost(t *testing.T) {
 		{"gpt-4o-mini", 1_000_000, 1_000_000, 0.15 + 0.60},
 		{"gpt-5", 1_000_000, 1_000_000, 1.25 + 10.00},
 		{"gpt-5-mini", 1_000_000, 1_000_000, 0.25 + 2.00},
+		{"gpt-5.6-sol", 1_000_000, 1_000_000, 5.00 + 30.00},
+		{"gpt-5.6-terra", 1_000_000, 1_000_000, 2.50 + 15.00},
+		{"gpt-5.6-luna", 1_000_000, 1_000_000, 1.00 + 6.00},
+		{"gpt-5.6", 1_000_000, 1_000_000, 5.00 + 30.00},
 		{"gpt-5.5", 1_000_000, 1_000_000, 1.25 + 10.00},
 		{"gpt-5.4", 1_000_000, 1_000_000, 1.25 + 10.00},
 		{"gpt-5.4-mini", 1_000_000, 1_000_000, 0.25 + 2.00},
@@ -228,6 +234,30 @@ func TestEstimateAgentCost(t *testing.T) {
 			got := EstimateAgentCost(tc.usage)
 			if diff := got - tc.want; diff > tc.delta || diff < -tc.delta {
 				t.Errorf("EstimateAgentCost = %.4f, want %.4f (±%.4f)", got, tc.want, tc.delta)
+			}
+		})
+	}
+}
+
+// TestPricingTableCoversModeltier guards the invariant that keeps the spend
+// ceilings alive for codex: it reports no USD, so EstimateAgentCost prices its
+// runs from tokens via lookupPrice, which returns 0 for a model missing from
+// pricingTable. A tier pointed at an unpriced codex model therefore reads as
+// free and silently disarms max_cost_usd / max_task_cost_usd.
+//
+// Only codex is checked. Copilot is unmetered in tokens too but routes to
+// EstimateCopilotCost (premium requests), and opencode is an openrouter
+// passthrough billed by the gateway — neither reaches lookupPrice, so neither
+// needs a pricingTable entry for its tier models.
+func TestPricingTableCoversModeltier(t *testing.T) {
+	for _, tier := range []modeltier.Tier{modeltier.SuperCheap, modeltier.Cheap, modeltier.Expensive} {
+		model := modeltier.Model(tier, "codex")
+		t.Run(string(tier), func(t *testing.T) {
+			if model == "" {
+				t.Fatalf("modeltier %s has no codex model", tier)
+			}
+			if _, ok := lookupPrice(model, time.Time{}); !ok {
+				t.Errorf("modeltier %s codex = %q has no pricingTable entry", tier, model)
 			}
 		})
 	}

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -2361,7 +2361,7 @@ func TestOnComplete_StructuredVerdictFailure_RetriesAlternateProvider(t *testing
 				ID:        "hr-structured-2",
 				TaskID:    cfg.TaskID,
 				Provider:  "codex",
-				Model:     "gpt-5.4-mini",
+				Model:     "gpt-5.6-luna",
 				StartedAt: time.Now().UTC(),
 			}, nil
 		},
@@ -2390,8 +2390,8 @@ func TestOnComplete_StructuredVerdictFailure_RetriesAlternateProvider(t *testing
 	if !got.AgentRuns[0].VerdictRendered {
 		t.Fatalf("first run not rendered: %+v", got.AgentRuns[0])
 	}
-	if got.AgentRuns[1].Provider != "codex" || got.AgentRuns[1].Model != "gpt-5.4-mini" {
-		t.Fatalf("fallback run = %+v, want codex/gpt-5.4-mini", got.AgentRuns[1])
+	if got.AgentRuns[1].Provider != "codex" || got.AgentRuns[1].Model != "gpt-5.6-luna" {
+		t.Fatalf("fallback run = %+v, want codex/gpt-5.6-luna", got.AgentRuns[1])
 	}
 	if _, busy := h.inflight[tk.ID]; !busy {
 		t.Fatal("fallback retry should keep the replacement run inflight")
@@ -2435,7 +2435,7 @@ func TestOnComplete_StructuredVerdictFailure_SecondFailureRendersDurableNote(t *
 		Role:      string(agent.RoleHumanReview),
 		Mode:      "headless",
 		Provider:  "codex",
-		Model:     "gpt-5.4-mini",
+		Model:     "gpt-5.6-luna",
 		State:     "running",
 		StartedAt: start,
 	}); err != nil {
@@ -2447,7 +2447,7 @@ func TestOnComplete_StructuredVerdictFailure_SecondFailureRendersDurableNote(t *
 		TaskID:   tk.ID,
 		Name:     agent.RoleHumanReview.AgentName(tk.Title),
 		Provider: "codex",
-		Model:    "gpt-5.4-mini",
+		Model:    "gpt-5.6-luna",
 	}
 	ag.SetHasOutputSchema(true)
 	h.inflight[tk.ID] = currentAgentID

--- a/internal/sybra/e2e_stats_test.go
+++ b/internal/sybra/e2e_stats_test.go
@@ -46,9 +46,9 @@ func TestE2E_Stats_RecordedOnAgentComplete(t *testing.T) {
 			provider: "codex",
 			scenario: "success",
 			// Codex emits no cost — agent_completion estimates it via
-			// stats.EstimateCostDetailed("gpt-5.4", 100 in, 20 out, 0, 0, 0, time.Now())
-			// = 100*1.25/1M + 20*10/1M = 0.000325.
-			wantCost:     0.000325,
+			// stats.EstimateCostDetailed("gpt-5.6-terra", 100 in, 20 out, 0, 0, 0, time.Now())
+			// = 100*2.50/1M + 20*15/1M = 0.00055.
+			wantCost:     0.00055,
 			wantIn:       100,
 			wantOut:      20,
 			wantOutcome:  "completed",

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -752,7 +752,7 @@ func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
 				"--json",
 				"--skip-git-repo-check",
 				"--dangerously-bypass-approvals-and-sandbox",
-				"--model\ngpt-5.4",
+				"--model\ngpt-5.6-terra",
 			} {
 				if !strings.Contains(args, want) {
 					t.Errorf("expected %q in args:\n%s", want, args)
@@ -1279,8 +1279,8 @@ steps:
 	if tk.AgentRuns[0].Provider != "claude" || tk.AgentRuns[1].Provider != "codex" {
 		t.Fatalf("AgentRun providers = [%s %s], want [claude codex]", tk.AgentRuns[0].Provider, tk.AgentRuns[1].Provider)
 	}
-	if tk.AgentRuns[1].Model != "gpt-5.4-mini" {
-		t.Fatalf("fallback model = %q, want gpt-5.4-mini", tk.AgentRuns[1].Model)
+	if tk.AgentRuns[1].Model != "gpt-5.6-luna" {
+		t.Fatalf("fallback model = %q, want gpt-5.6-luna", tk.AgentRuns[1].Model)
 	}
 	if !strings.Contains(tk.Body, "Auto-review: unblocked") {
 		t.Fatalf("body missing unblocked note:\n%s", tk.Body)
@@ -1399,7 +1399,7 @@ func TestE2E_ProviderMatrix_ModelAliasMapping(t *testing.T) {
 
 		want := "--model\nhaiku"
 		if p.provider == "codex" {
-			want = "--model\ngpt-5.4-mini"
+			want = "--model\ngpt-5.6-luna"
 		}
 		if !strings.Contains(args, want) {
 			t.Fatalf("expected %q in args:\n%s", want, args)


### PR DESCRIPTION
## Motivation

> Changelog: feat(models): move codex tiers to gpt-5.6 family

`gpt-5.4` and `gpt-5.4-mini` retire in Codex on **2026-08-31** for accounts signed in with ChatGPT, which is how both Sybra instances authenticate (`~/.codex/auth.json` has `auth_mode` set and no `OPENAI_API_KEY`, on laptop and server alike). Those two slugs back the `cheap` and `super_cheap` tiers, so two of three codex tiers break next month.

The third, `gpt-5.5`, is superseded. Since the gpt-5.6 family ships exactly three tiers, all three map cleanly at once.

## Implementation information

Tier map (`internal/modeltier`), following OpenAI's own stated replacements:

| Tier | Was | Now |
|---|---|---|
| `super_cheap` | `gpt-5.4-mini` | `gpt-5.6-luna` |
| `cheap` | `gpt-5.4` | `gpt-5.6-terra` |
| `expensive` | `gpt-5.5` | `gpt-5.6-sol` |

`InferTier` matches the three new slugs plus the bare `gpt-5.6` alias. The alias is matched exactly rather than by `Contains`, since a `Contains("gpt-5.6")` rule would also swallow `-terra` and `-luna` and misclassify both as `Expensive`. The retired 5.4/5.5 slugs stay matched so historical run records still classify.

**Pricing is load-bearing, not bookkeeping.** Codex reports no USD, so `EstimateAgentCost` prices its runs from tokens via `lookupPrice`; a model missing from `pricingTable` returns 0, which reads as free and silently disarms both `max_cost_usd` and `max_task_cost_usd`. New entries (standard short-context, per 1M):

| Model | in | out | cache read |
|---|---|---|---|
| `gpt-5.6-sol` | $5.00 | $30.00 | $0.50 |
| `gpt-5.6-terra` | $2.50 | $15.00 | $0.25 |
| `gpt-5.6-luna` | $1.00 | $6.00 | $0.10 |

`TestPricingTableCoversModeltier` now asserts every codex tier model resolves to a pricing entry, so a future tier change cannot quietly blind the ceilings. Copilot and opencode are exempt and documented as such — copilot routes to `EstimateCopilotCost` (premium requests) and opencode is billed by the gateway, so neither reaches `lookupPrice`.

Two caveats worth knowing:

- Rates are the short-context tier. Above 272K input tokens a request reprices at 2x input / 1.5x output, which `modelPrice` has no way to express, so the estimate is a floor.
- Per-token cost rises across the board (expensive 4x in / 3x out, cheap 2x / 1.5x, super_cheap 4x / 3x). On plan-based auth no USD is actually billed, so this shifts *when the ceilings fire*, not the bill — but `max_task_cost_usd` is checked before dispatch and will start tripping on work that passed before. Likely needs re-tuning as a follow-up.

Also updated: `minCodexVersion` 0.142.2 to 0.145.0 (the release that migrated bundled selections off gpt-5.4; earlier 5.6 mentions in the changelog are Bedrock-only) and its warning text; the `codexFallbackModels` picker used when `codex debug models` fails; `docs/codex-setup.md`. The dynamic model list and the reasoning-effort options need no change — both already read from `codex debug models`.

The second commit is an unrelated unblock: hadolint 2.15.1 (bumped by a recent Renovate PR) raises DL3025 on the shell-form `HEALTHCHECK`, and `.hadolint.yaml` sets `failure-threshold: warning`, so the pre-commit hook was rejecting every commit in the repo. CI never saw it because its `hadolint-action` pins an older hadolint. The probe needs `${SYBRA_PORT}` expansion and `||`, so it keeps a shell — the exec form just makes the `sh -c` wrapper explicit instead of leaving it to Docker.

## Supporting documentation

- Local `~/.codex/models_cache.json` (codex CLI 0.146.0) — the three slugs, their priorities, and supported reasoning levels
- OpenAI Codex rate card — the 2026-08-31 retirement and its recommended replacements
- openai/codex release notes, `rust-v0.145.0` — "Migrated bundled GPT-5.4 selections and internal uses to the corresponding GPT-5.6 Terra and Luna variants"

Not included, flagged for follow-up: gpt-5.6 adds `max` and `ultra` reasoning levels that Sybra's allowlists reject. `ultra` in particular delegates to subagents and multiplies cost invisibly, which the per-run ceiling cannot pre-empt, so it deserves its own gated change rather than riding along here.
