### PR TITLE
fix(triage): preserve pending enrichment stubs

### DIFF
--- a/internal/enrichment/tags.go
+++ b/internal/enrichment/tags.go
@@ -1,0 +1,5 @@
+package enrichment
+
+// PendingTag marks a task stub created from a raw GitHub issue/PR URL while
+// Sybra is still fetching the real title, body, labels, and umbrella metadata.
+const PendingTag = "enrich-pending"

--- a/internal/poll/triage.go
+++ b/internal/poll/triage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/enrichment"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
@@ -97,6 +98,9 @@ func (h *TriageHandler) Poll(ctx context.Context) time.Duration {
 		}
 		t := tasks[i]
 		if t.Status != task.StatusNew {
+			continue
+		}
+		if task.HasFlag(t.Tags, enrichment.PendingTag) {
 			continue
 		}
 		if !t.UpdatedAt.IsZero() && time.Since(t.UpdatedAt) < 5*time.Second {

--- a/internal/poll/triage.go
+++ b/internal/poll/triage.go
@@ -3,6 +3,7 @@ package poll
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/Automaat/sybra/internal/audit"
@@ -100,7 +101,7 @@ func (h *TriageHandler) Poll(ctx context.Context) time.Duration {
 		if t.Status != task.StatusNew {
 			continue
 		}
-		if task.HasFlag(t.Tags, enrichment.PendingTag) {
+		if slices.Contains(t.Tags, enrichment.PendingTag) {
 			continue
 		}
 		if !t.UpdatedAt.IsZero() && time.Since(t.UpdatedAt) < 5*time.Second {

--- a/internal/poll/triage_test.go
+++ b/internal/poll/triage_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/enrichment"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/triage"
@@ -86,5 +87,56 @@ func TestTriageHandlerClassifiesNewTasks(t *testing.T) {
 		if after[i].Status == task.StatusNew {
 			t.Errorf("task %s still new", after[i].ID)
 		}
+	}
+}
+
+func TestTriageHandlerPollSkipsEnrichPendingTasks(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+
+	status := task.StatusNew
+	tags := []string{enrichment.PendingTag}
+	created, err := store.CreateFull("https://github.com/Automaat/sybra/issues/2774", "", task.AgentModeHeadless, task.Update{
+		Status: &status,
+		Tags:   &tags,
+	})
+	if err != nil {
+		t.Fatalf("CreateFull: %v", err)
+	}
+	created.UpdatedAt = time.Now().Add(-time.Minute)
+	if _, err := store.Put(created); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	projDir := t.TempDir()
+	ps, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+
+	fc := &fakeClassifier{}
+	h := NewTriageHandler(mgr, ps, nil,
+		slog.New(slog.DiscardHandler),
+		&config.TriageConfig{Enabled: true, PollSeconds: 5, Model: "sonnet"})
+	h.factory = func(string, *slog.Logger) triage.Classifier { return fc }
+
+	h.Poll(context.Background())
+
+	if fc.calls != 0 {
+		t.Fatalf("classifier calls = %d, want 0 for enrich-pending task", fc.calls)
+	}
+	got, err := mgr.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != task.StatusNew {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusNew)
+	}
+	if !task.HasFlag(got.Tags, enrichment.PendingTag) {
+		t.Fatalf("tags = %v, want %q retained", got.Tags, enrichment.PendingTag)
 	}
 }

--- a/internal/poll/triage_test.go
+++ b/internal/poll/triage_test.go
@@ -3,6 +3,7 @@ package poll
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -136,7 +137,7 @@ func TestTriageHandlerPollSkipsEnrichPendingTasks(t *testing.T) {
 	if got.Status != task.StatusNew {
 		t.Fatalf("status = %q, want %q", got.Status, task.StatusNew)
 	}
-	if !task.HasFlag(got.Tags, enrichment.PendingTag) {
+	if !slices.Contains(got.Tags, enrichment.PendingTag) {
 		t.Fatalf("tags = %v, want %q retained", got.Tags, enrichment.PendingTag)
 	}
 }

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/enrichment"
 	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
@@ -21,7 +22,7 @@ const (
 	// expanded, not implemented. The enrich step clears it and then dispatches.
 	// CLI-created URL tasks use plain Create (no marker), so they keep going
 	// through task.created → triage, which fetches the title itself.
-	enrichPendingTag = "enrich-pending"
+	enrichPendingTag = enrichment.PendingTag
 	// umbrellaDuplicateTag marks a stub whose umbrellaExpand succeeded (a real
 	// tracker + gated children already exist elsewhere) but whose own DeleteTask
 	// cleanup failed. It is deliberately distinct from TaskTypeUmbrella: this

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/enrichment"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
@@ -15,8 +16,11 @@ import (
 // must survive a wholesale tag-replacement in Apply because dropping them
 // would silently break routing the task depends on: escape-hatch opt-outs
 // (see escapeHatchTags), the umbrella dependency gate marker, and local
-// Sybra-bug tracker routing markers.
+// Sybra-bug tracker routing markers. Pending enrichment must survive too:
+// dropping it strands URL stubs outside ReconcilePendingEnrichment and can
+// let umbrella issues be implemented as flat tasks.
 var preservedTags = append(append([]string{}, escapeHatchTags...),
+	enrichment.PendingTag,
 	umbrella.GatedTag,
 	string(task.FlagSybraBug),
 	string(task.FlagScrubbed),

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Automaat/sybra/internal/enrichment"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/promptlab"
 	"github.com/Automaat/sybra/internal/task"
@@ -186,6 +187,33 @@ func TestApplyPreservesUmbrellaGatedTag(t *testing.T) {
 	}
 	if !slices.Contains(updated.Tags, umbrella.GatedTag) {
 		t.Errorf("umbrella-gated tag dropped by triage; got %v", updated.Tags)
+	}
+}
+
+func TestApplyPreservesEnrichPendingTag(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("https://github.com/Automaat/sybra/issues/2774", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created.Tags = []string{enrichment.PendingTag}
+
+	// The classifier vocabulary does not include enrich-pending. Triage must
+	// not drop it, because the reconcile loop uses it to finish URL enrichment
+	// and detect umbrella issues before any flat implementation can dispatch.
+	v := Verdict{
+		Title: "chore(engine): finish state kernel",
+		Tags:  []string{"backend", "medium", "chore"},
+		Size:  "medium",
+		Type:  "chore",
+		Mode:  "headless",
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !slices.Contains(updated.Tags, enrichment.PendingTag) {
+		t.Errorf("enrich-pending tag dropped by triage; got %v", updated.Tags)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a shared enrichment pending tag constant
- preserve enrich-pending through triage tag replacement
- skip enrich-pending URL stubs in the triage poller so issue enrichment can detect umbrellas before dispatch

## Tests
- go test -count=1 ./internal/triage ./internal/poll

## Notes
- Live recovery for #2774 was performed separately by materializing tracker 94d35856 and deleting bad flat stub 05129598.