### PR TITLE
fix(workflow): wake classify backoff on drain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,15 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
-        with:
-          dockerfile: Dockerfile
-          config: .hadolint.yaml
-          failure-threshold: warning
+      # Uses the mise-pinned hadolint rather than hadolint-action's bundled
+      # binary. The action shipped an older hadolint than mise.toml, so a
+      # Renovate bump of the pin made `mise run verify` fail locally on rules
+      # CI never ran — silently red pre-commit hook, green CI. mise.toml is now
+      # the only place the version is declared.
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      # .hadolint.yaml supplies the config and failure-threshold.
+      - run: hadolint Dockerfile
 
   check-wailsjs:
     name: Wails Bindings Sync

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -29,6 +30,87 @@ import (
 
 func testLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
+}
+
+// syncBuffer is a concurrency-safe log sink: slog handlers are written to from
+// whatever background goroutines the App starts, not just the test goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// stubProviderCLIs shadows the provider binaries with stubs that fail
+// immediately, for the length of the test.
+//
+// With workflows enabled, creating a task drives the engine's classify step
+// into llmexec, which shells out to whichever provider CLI is on PATH. On a
+// developer machine that is the real, metered `claude` — so `go test ./...`
+// would spend credits and block App.Shutdown for its whole grace waiting on
+// the child. On CI, where no provider is installed, the exec fails instantly
+// and the same test passes. Stubbing makes both behave like CI.
+//
+// Only the provider names are shadowed; git and everything else still resolve
+// from the rest of PATH.
+func stubProviderCLIs(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range []string{"claude", "codex", "copilot"} {
+		stub := "#!/bin/sh\necho 'provider CLI stubbed in tests' >&2\nexit 1\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(stub), 0o755); err != nil {
+			t.Fatalf("write %s stub: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// startupLikeApp boots a real App against a throwaway SYBRA_HOME and tears it
+// down on cleanup.
+//
+// The home is deliberately not t.TempDir(). App.Shutdown waits a bounded grace
+// (appShutdownWaitGrace) for background goroutines and then proceeds
+// regardless, so on a loaded machine a straggler can still write into
+// home/tasks after Shutdown returns. Under t.TempDir that surfaces as
+// "TempDir RemoveAll cleanup: directory not empty" — a failure that names the
+// filesystem rather than the goroutine, and lands on whichever test was
+// running. Removal here is best-effort instead, and the condition that actually
+// matters is asserted directly: if Shutdown's wait ever times out, the test
+// fails with the goroutine dump Shutdown already logs.
+func startupLikeApp(t *testing.T, opts ...sybra.Option) *sybra.App {
+	t.Helper()
+	home, err := os.MkdirTemp("", "sybra-server-test-*")
+	if err != nil {
+		t.Fatalf("create test home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
+	stubProviderCLIs(t)
+
+	var logs syncBuffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	app := sybra.NewApp(logger, &slog.LevelVar{}, startupLikeServerTestConfig(home), opts...)
+	if err := app.Startup(context.Background()); err != nil {
+		t.Fatalf("Startup: %v", err)
+	}
+	t.Cleanup(func() {
+		app.Shutdown(context.Background())
+		if strings.Contains(logs.String(), "app.shutdown.wait_timeout") {
+			t.Errorf("App.Shutdown timed out waiting for background goroutines; a straggler outlived shutdown and can still write into SYBRA_HOME:\n%s", logs.String())
+		}
+	})
+	return app
 }
 
 func okHandler() http.Handler {
@@ -304,28 +386,16 @@ func TestShutdownHardDeadlineCoversSequentialGracefulBudgets(t *testing.T) {
 }
 
 func TestWebhookHandlerPersistsTaskAndEmitsCreatedEvent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SYBRA_HOME", home)
-	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
-
-	cfg := startupLikeServerTestConfig(home)
-	logger := slog.New(slog.DiscardHandler)
 	var emitted eventRecorder
-	app := sybra.NewApp(logger, &slog.LevelVar{}, cfg, sybra.WithEmit(func(event string, data any) {
+	app := startupLikeApp(t, sybra.WithEmit(func(event string, data any) {
 		emitted.append(event, data)
 	}))
-	if err := app.Startup(context.Background()); err != nil {
-		t.Fatalf("Startup: %v", err)
-	}
-	t.Cleanup(func() {
-		app.Shutdown(context.Background())
-	})
 
 	creator, err := resolveWebhookTaskCreator(app)
 	if err != nil {
 		t.Fatalf("resolveWebhookTaskCreator: %v", err)
 	}
-	handler := newWebhookHandler(logger, "", creator, nil)
+	handler := newWebhookHandler(testLogger(), "", creator, nil)
 	body := []byte(`{"title":"from webhook","body":"hook body","tags":["webhook","ext"],"project_id":"Automaat/sybra"}`)
 	req := httptest.NewRequest(http.MethodPost, "/webhook/task", strings.NewReader(string(body)))
 	rr := httptest.NewRecorder()
@@ -377,25 +447,13 @@ func TestWebhookHandlerPersistsTaskAndEmitsCreatedEvent(t *testing.T) {
 }
 
 func TestWebhookHandlerRejectsTaskCreationDuringDrain(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SYBRA_HOME", home)
-	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
-
-	cfg := startupLikeServerTestConfig(home)
-	logger := slog.New(slog.DiscardHandler)
-	app := sybra.NewApp(logger, &slog.LevelVar{}, cfg)
-	if err := app.Startup(context.Background()); err != nil {
-		t.Fatalf("Startup: %v", err)
-	}
-	t.Cleanup(func() {
-		app.Shutdown(context.Background())
-	})
+	app := startupLikeApp(t)
 
 	creator, err := resolveWebhookTaskCreator(app)
 	if err != nil {
 		t.Fatalf("resolveWebhookTaskCreator: %v", err)
 	}
-	handler := newWebhookHandler(logger, "", creator, func() error {
+	handler := newWebhookHandler(testLogger(), "", creator, func() error {
 		return app.HTTPAdmission("TaskService", "CreateTask", httpapi.MethodMeta{})
 	})
 	app.BeginDrain()

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -25,6 +25,12 @@ var providerOrder = providerid.All()
 
 const streamScannerBuffer = 4 * 1024 * 1024
 
+// providerWaitDelay bounds how long Wait blocks after ctx cancellation before
+// force-closing the provider's output pipes. Kept well under App.Shutdown's
+// grace so a one-shot provider call can never be the goroutine that outlives
+// shutdown.
+const providerWaitDelay = 5 * time.Second
+
 // errSchemaDelivery wraps failures creating/writing the codex output-schema
 // temp file. RunJSON treats it as a failover-eligible provider failure rather
 // than a hard error, so a codex-local filesystem issue falls back to the next
@@ -192,6 +198,12 @@ func runProvider(ctx context.Context, p, prompt, model string, disableTools bool
 
 	name, args, stdin := invocation(p, effectivePrompt, model, disableTools, schemaPath)
 	cmd := exec.CommandContext(ctx, name, args...)
+	// Without WaitDelay, cancelling ctx kills the provider CLI but Wait still
+	// blocks until every write end of the output pipe closes — a grandchild
+	// that outlives its parent holds it open indefinitely, so the exec
+	// survives shutdown and keeps writing into SYBRA_HOME. Same failure the
+	// agent runners already guard against.
+	cmd.WaitDelay = providerWaitDelay
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
 	}

--- a/internal/project/testmain_test.go
+++ b/internal/project/testmain_test.go
@@ -5,15 +5,28 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/testutil/gitenv"
 )
 
 // TestMain fails the whole package immediately if git is missing, rather
 // than letting individual tests silently t.Skip — a stripped-down test
 // environment should show up as a red CI run, not quietly reduced coverage.
+//
+// It also cuts the developer's global/system git config out of the run: an
+// ambient `insteadOf` URL rewrite otherwise reshapes remotes behind the tests'
+// backs and makes them assert against code paths that never execute.
 func TestMain(m *testing.M) {
 	if _, err := exec.LookPath("git"); err != nil {
 		fmt.Fprintln(os.Stderr, "internal/project tests require git on PATH:", err)
 		os.Exit(1)
 	}
-	os.Exit(m.Run())
+	cleanup, err := gitenv.Isolate()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "internal/project tests require an isolated git config:", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1238,6 +1238,7 @@ func (a *App) initWorkflowEngine() {
 		a.workflowEngine.SetEvidenceRecorder(&evidenceRecorderAdapter{store: a.evidenceStore})
 	}
 	a.workflowEngine.SetContext(a.ctx)
+	a.workflowEngine.SetDrainContext(a.schedulerCtx)
 	// Recover worktree-prep rebase conflicts via the conflict pr-fix instead of
 	// escalating to a human. Wired here (not at construction) because the
 	// orchestrator is built before the reviewer. Routed through

--- a/internal/testutil/gitenv/gitenv.go
+++ b/internal/testutil/gitenv/gitenv.go
@@ -1,0 +1,50 @@
+// Package gitenv isolates git-dependent tests from the developer's own git
+// configuration.
+//
+// Without this, ambient config silently changes what the tests exercise. The
+// motivating case: a `url."ssh://git@github.com/".insteadOf` rewrite (a common
+// setup) turns the HTTPS remote a test just configured into an ssh:// URL when
+// git reads it back, so PreflightPushCredentials' isGitHubHTTPSRemote gate says
+// "not a GitHub HTTPS remote" and returns nil before probing anything. The test
+// then asserts against a code path that never ran — red on that machine, green
+// in CI, and green for the wrong reason on any machine where the rewrite exists
+// but the assertion happens to be satisfied anyway.
+package gitenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Isolate points git at a throwaway global config and disables system config
+// for the remainder of the process, returning a cleanup func.
+//
+// Call it from a package's TestMain, before m.Run(). Repo-local config that
+// tests set themselves still applies — only the developer's global/system
+// layers are cut out.
+func Isolate() (cleanup func(), err error) {
+	dir, err := os.MkdirTemp("", "sybra-gitenv-*")
+	if err != nil {
+		return nil, fmt.Errorf("create git config dir: %w", err)
+	}
+	cfg := filepath.Join(dir, "gitconfig")
+	// Identity is set so repos that don't configure their own can still
+	// commit; nothing here rewrites URLs or touches credentials.
+	const contents = "[user]\n\tname = Sybra Test\n\temail = test@test.com\n[init]\n\tdefaultBranch = main\n"
+	if err := os.WriteFile(cfg, []byte(contents), 0o600); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("write git config: %w", err)
+	}
+	for k, v := range map[string]string{
+		"GIT_CONFIG_GLOBAL":   cfg,
+		"GIT_CONFIG_SYSTEM":   os.DevNull,
+		"GIT_CONFIG_NOSYSTEM": "1",
+	} {
+		if err := os.Setenv(k, v); err != nil {
+			_ = os.RemoveAll(dir)
+			return nil, fmt.Errorf("set %s: %w", k, err)
+		}
+	}
+	return func() { _ = os.RemoveAll(dir) }, nil
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -410,6 +410,7 @@ type Engine struct {
 	now              func() time.Time
 	logger           *slog.Logger
 	ctx              context.Context
+	drainCtx         context.Context
 	mu               sync.Mutex
 	inflightMutexes  map[string]*sync.Mutex     // taskID → advance serializer (parallel-aware)
 	routeMutexes     map[string]*sync.Mutex     // taskID → serialize run_agent route publication vs completion reads
@@ -543,6 +544,25 @@ func newEffectOwnerID() string {
 // context.WithTimeout(parent, shellTimeout) so they are cancelled when
 // the parent context is cancelled (e.g. on app shutdown).
 func (e *Engine) SetContext(ctx context.Context) { e.ctx = ctx }
+
+// SetDrainContext binds the context that is cancelled when the app begins
+// draining, ahead of the hard stop that cancels SetContext's context.
+//
+// Retry backoffs wait on this rather than e.ctx. A backoff is idle waiting,
+// not accepted work: parking it on e.ctx made it outlive the whole drain,
+// because the drain waits for goroutines to finish before the hard stop that
+// cancels e.ctx ever fires — so the wait blocked on the cancellation it was
+// itself delaying. Running steps keep e.ctx and still drain normally.
+func (e *Engine) SetDrainContext(ctx context.Context) { e.drainCtx = ctx }
+
+// drainContext returns the drain-tier context, falling back to e.ctx when no
+// drain context is bound (tests, embedders that never begin a drain).
+func (e *Engine) drainContext() context.Context {
+	if e.drainCtx != nil {
+		return e.drainCtx
+	}
+	return e.ctx
+}
 
 // SetDispatchGate installs a predicate that reports whether a task should run
 // its workflow on this node. ResumeStalled skips any task the gate rejects — in

--- a/internal/workflow/engine_drain_test.go
+++ b/internal/workflow/engine_drain_test.go
@@ -12,7 +12,7 @@ import (
 func TestDrainContextFallsBackToEngineContext(t *testing.T) {
 	t.Parallel()
 
-	engineCtx, cancel := context.WithCancel(context.Background())
+	engineCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	e := &Engine{ctx: engineCtx}
 
@@ -20,7 +20,7 @@ func TestDrainContextFallsBackToEngineContext(t *testing.T) {
 		t.Fatalf("drainContext() = %v, want the engine context when no drain context is bound", got)
 	}
 
-	drainCtx, drainCancel := context.WithCancel(context.Background())
+	drainCtx, drainCancel := context.WithCancel(t.Context())
 	defer drainCancel()
 	e.SetDrainContext(drainCtx)
 	if got := e.drainContext(); got != drainCtx {
@@ -45,10 +45,10 @@ func TestExecClassifyTask_BackoffAbandonsOnDrain(t *testing.T) {
 	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetTaskClassifier(&ctxCancelClassifier{})
 
-	engineCtx, cancelEngine := context.WithCancel(context.Background())
+	engineCtx, cancelEngine := context.WithCancel(t.Context())
 	defer cancelEngine()
 	engine.SetContext(engineCtx)
-	drainCtx, beginDrain := context.WithCancel(context.Background())
+	drainCtx, beginDrain := context.WithCancel(t.Context())
 	engine.SetDrainContext(drainCtx)
 
 	done := make(chan struct{})
@@ -79,9 +79,9 @@ func TestClassifyRetryBackoffWakesOnDrain(t *testing.T) {
 	t.Parallel()
 
 	// Engine context stays live, mirroring the drain phase.
-	engineCtx, cancelEngine := context.WithCancel(context.Background())
+	engineCtx, cancelEngine := context.WithCancel(t.Context())
 	defer cancelEngine()
-	drainCtx, beginDrain := context.WithCancel(context.Background())
+	drainCtx, beginDrain := context.WithCancel(t.Context())
 	e := &Engine{ctx: engineCtx, drainCtx: drainCtx}
 
 	done := make(chan struct{})

--- a/internal/workflow/engine_drain_test.go
+++ b/internal/workflow/engine_drain_test.go
@@ -1,0 +1,106 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestDrainContextFallsBackToEngineContext keeps the drain tier optional:
+// embedders and tests that never bind one must still get an interruptible
+// wait rather than a nil context.
+func TestDrainContextFallsBackToEngineContext(t *testing.T) {
+	t.Parallel()
+
+	engineCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	e := &Engine{ctx: engineCtx}
+
+	if got := e.drainContext(); got != engineCtx {
+		t.Fatalf("drainContext() = %v, want the engine context when no drain context is bound", got)
+	}
+
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	defer drainCancel()
+	e.SetDrainContext(drainCtx)
+	if got := e.drainContext(); got != drainCtx {
+		t.Fatalf("drainContext() = %v, want the bound drain context", got)
+	}
+}
+
+// TestExecClassifyTask_BackoffAbandonsOnDrain is the call-site guard: it fails
+// if execClassifyTask waits on the engine context instead of the drain
+// context. The engine context stays live throughout, exactly as it does during
+// App.Shutdown's drain phase, so a backoff bound to it would block until the
+// real (multi-second) retry schedule elapsed rather than returning at once.
+func TestExecClassifyTask_BackoffAbandonsOnDrain(t *testing.T) {
+	// Not parallel: it swaps the package-level backoff schedule that the test
+	// init() zeroes out, and must restore it for the other classify tests.
+	restore := classifyTaskRetryBackoffs
+	classifyTaskRetryBackoffs = []time.Duration{time.Hour, time.Hour, time.Hour}
+	t.Cleanup(func() { classifyTaskRetryBackoffs = restore })
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetTaskClassifier(&ctxCancelClassifier{})
+
+	engineCtx, cancelEngine := context.WithCancel(context.Background())
+	defer cancelEngine()
+	engine.SetContext(engineCtx)
+	drainCtx, beginDrain := context.WithCancel(context.Background())
+	engine.SetDrainContext(drainCtx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = engine.execClassifyTask("t1", newClassifyTaskStep(), &Execution{})
+	}()
+
+	// Let the first attempt fail and enter the backoff, then begin draining.
+	time.Sleep(50 * time.Millisecond)
+	beginDrain()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("execClassifyTask did not return once the app began draining; its retry backoff is bound to the engine context, which App.Shutdown cancels only after the drain it blocks")
+	}
+}
+
+// TestClassifyRetryBackoffWakesOnDrain is the regression guard for the
+// shutdown deadlock: the classify retry backoff has to abandon when the app
+// begins draining, which happens strictly before the hard stop that cancels
+// the engine context. Waiting on the engine context instead made the backoff
+// outlive the drain — and since the drain waits for exactly this goroutine,
+// it blocked on the cancellation it was itself delaying, burning App.Shutdown's
+// full grace and then proceeding with the goroutine still live.
+func TestClassifyRetryBackoffWakesOnDrain(t *testing.T) {
+	t.Parallel()
+
+	// Engine context stays live, mirroring the drain phase.
+	engineCtx, cancelEngine := context.WithCancel(context.Background())
+	defer cancelEngine()
+	drainCtx, beginDrain := context.WithCancel(context.Background())
+	e := &Engine{ctx: engineCtx, drainCtx: drainCtx}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		classifyTaskWait(e.drainContext(), time.Hour)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("backoff returned before the drain began")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	beginDrain()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("classify retry backoff did not wake when the app began draining")
+	}
+}

--- a/internal/workflow/engine_steps_classify.go
+++ b/internal/workflow/engine_steps_classify.go
@@ -65,11 +65,13 @@ func (e *Engine) execClassifyTask(taskID string, step *Step, wfExec *Execution) 
 		}
 		e.logger.Warn("workflow.classify-task.retry", "task_id", taskID, "step", step.ID,
 			"attempt", attempt+1, "max", len(classifyTaskRetryBackoffs), "err", err)
-		// Interruptible backoff on e.ctx (not the now-canceled attemptCtx): an
-		// engine shutdown wakes the wait immediately, so the retry loop never
-		// blocks teardown. The next iteration's e.ctx check then routes a
+		// Interruptible backoff on the drain context (not the now-canceled
+		// attemptCtx, and not e.ctx): the app starts draining well before the
+		// hard stop that cancels e.ctx, and the drain waits for this goroutine
+		// to finish first — so waiting on e.ctx here deadlocked teardown for
+		// the whole grace. The next iteration's e.ctx check then routes a
 		// shutdown to the resume-on-next-boot path above.
-		classifyTaskWait(e.ctx, classifyTaskRetryBackoffs[attempt])
+		classifyTaskWait(e.drainContext(), classifyTaskRetryBackoffs[attempt])
 	}
 
 	return e.humanRequiredClassify(taskID, step, "triage classify failed: "+err.Error())

--- a/internal/worktree/testmain_test.go
+++ b/internal/worktree/testmain_test.go
@@ -5,15 +5,27 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/testutil/gitenv"
 )
 
 // TestMain fails the whole package immediately if git is missing, rather
 // than letting individual tests silently t.Skip — a stripped-down test
 // environment should show up as a red CI run, not quietly reduced coverage.
+//
+// It also cuts the developer's global/system git config out of the run, so an
+// ambient `insteadOf` URL rewrite cannot reshape remotes behind the tests.
 func TestMain(m *testing.M) {
 	if _, err := exec.LookPath("git"); err != nil {
 		fmt.Fprintln(os.Stderr, "internal/worktree tests require git on PATH:", err)
 		os.Exit(1)
 	}
-	os.Exit(m.Run())
+	cleanup, err := gitenv.Isolate()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "internal/worktree tests require an isolated git config:", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
 }


### PR DESCRIPTION
## Motivation

> Changelog: fix(workflow): wake classify backoff on drain

Three gates were failing or lying, all flagged while shipping the gpt-5.6 tier move. Chasing the third one turned up a real shutdown deadlock.

1. Six `PreflightPushCredentials` tests failed on `origin/main` on my machine but passed in CI.
2. The hadolint pin bump made the pre-commit hook reject **every** commit in the repo, while CI's Dockerfile Lint job stayed green.
3. `cmd/sybra-server`'s webhook test intermittently failed CI with `TempDir RemoveAll cleanup: directory not empty`.

## Implementation information

### The shutdown deadlock (#3, and the reason this PR is more than test hygiene)

The temp-dir error was a symptom. Making the test assert the real condition instead — "did `Shutdown`'s wait time out?" — reproduced **deterministically at 15.1s**, every run. Not a flake at all.

`App.Shutdown` drains accepted work before the hard stop that cancels `a.ctx`. That ordering is deliberate and contract-tested by `TestShutdownDrainsAcceptedWorkBeforeCancel`. But the `classify_task` retry backoff waited on that same `a.ctx` — so it could not finish until a cancellation the drain was itself delaying. The drain blocked for its whole 15s grace, then proceeded with the goroutine still live and free to write into `SYBRA_HOME`. That trailing write is what raced `RemoveAll`.

The comment above the wait already claimed "an engine shutdown wakes the wait immediately". It was simply untrue of the context it was handed.

A backoff is idle waiting, not accepted work, so it now binds to the drain-tier context (`schedulerCtx`, cancelled when the drain begins). Running steps keep `e.ctx` and drain exactly as before, so the existing contract is untouched.

I first tried reordering `Shutdown` to cancel before waiting. `TestShutdownDrainsAcceptedWorkBeforeCancel` caught it immediately — that ordering is load-bearing, and the drain-tier context is the correct seam. Reverted.

Effect on the affected test: 15.1s of dead wait per run to 2.35s for five runs. On the server this was burning the full grace on every redeploy that caught a classify retry in flight.

Also set `WaitDelay` on the `llmexec` provider spawn. Cancelling the context kills the CLI, but `Wait` still blocks until every write end of the pipe closes, so a grandchild can hold a one-shot provider call open past shutdown. Same guard the agent runners already carry.

### Tests were spawning real, metered provider CLIs

Root-causing the above surfaced this: with workflows enabled, creating a task drives the classify step into `llmexec`, which shells out to whatever provider CLI is on `PATH`. On a developer machine that is the real `claude` — so `go test ./...` was spending credits and blocking on the child. Where no provider is installed the exec fails instantly, which is exactly why CI mostly passed and my machine did not. Provider binaries are now stubbed for these tests.

### Ambient git config silently disabled six tests (#1)

`url."ssh://git@github.com/".insteadOf` — a common setup, and the one on my machine. The test sets an HTTPS push URL; git hands back `ssh://`; `isGitHubHTTPSRemote` returns false; `PreflightPushCredentials` returns `nil` before probing anything. The tests then asserted against a code path that never executed.

`internal/testutil/gitenv` points git at a throwaway global config and disables system config, so only repo-local config the tests set themselves applies. Wired into `internal/project` and `internal/worktree`, whose TestMains already fail hard on missing git for the same "a broken environment should be red, not quietly less covered" reason.

### hadolint local/CI drift (#2)

`hadolint-action` bundles its own hadolint, older than the mise.toml pin. Renovate bumped the pin to 2.15.1, whose new DL3025 rule fired locally against `failure-threshold: warning`, so the pre-commit hook blocked every commit while CI stayed green. A gate that is red locally and green in CI gets bypassed, not fixed. hadolint now installs through mise like every other tool in the workflow, so the version is declared once.

## Supporting documentation

- `TestExecClassifyTask_BackoffAbandonsOnDrain` is the call-site guard for the deadlock. I verified by mutation that it fails (at 10s) when the wait is pointed back at `e.ctx` — the unit tests alone did not catch that, which is why the guard is at the call site rather than on the helper.
- Full `go test -race ./internal/... ./cmd/...` and the `-tags e2e` suite pass clean.

One judgment call worth flagging: `TestWebhookHandlerPersistsTaskAndEmitsCreatedEvent` keeps `SYBRA_DISABLE_WORKFLOWS=0`. Turning workflows off would have made the symptom vanish without fixing anything, and the test's value is that it exercises the real engine path.
