### PR TITLE
perf(agent): retune role effort and close leaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,10 +185,11 @@ EXPOSE 8080
 # (cluster.tls) serves https on the same port, so an http-only probe would mark
 # it permanently unhealthy. -k is safe here: the probe is localhost-only and the
 # leader, not the container, is what pins the certificate.
+# Explicit `sh -c` (JSON exec form) rather than shell form: the probe needs
+# shell semantics for ${SYBRA_PORT} and the `||` chain, and hadolint's DL3025
+# rejects the implicit shell form.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -sf "http://localhost:${SYBRA_PORT}/health" \
-     || curl -skf "https://localhost:${SYBRA_PORT}/health" \
-     || exit 1
+    CMD ["/bin/sh", "-c", "curl -sf \"http://localhost:${SYBRA_PORT}/health\" || curl -skf \"https://localhost:${SYBRA_PORT}/health\" || exit 1"]
 
 # Mounts expected (host dirs must be chowned to uid:gid 1000:1000):
 #   ~/.sybra  → /home/sybra/.sybra  (task store, config, projects)

--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -287,6 +287,37 @@ func (c Config) Validate() error {
 	return nil
 }
 
+// WithoutInvalidExperiments returns a copy with every experiment that would
+// fail selection-time validation removed, calling report once per drop.
+// Selection validates each experiment as it matches (see selectFromExperiment)
+// and propagates the error to the dispatcher, so one malformed experiment
+// otherwise wedges every role it targets — the workflow step fails to start an
+// agent, indefinitely, with nothing logged at startup.
+//
+// Dropping at load turns that into a warning plus unrouted (default-provider)
+// dispatch, which is recoverable. It matters for edits made outside Sybra and
+// for configs a code change retroactively invalidates: the per-role
+// reasoning-effort baseline decides what an omitted variant effort resolves to,
+// so retuning a role can invalidate an operator's prompt/skill experiment.
+func (c Config) WithoutInvalidExperiments(report func(id string, err error)) Config {
+	if len(c.Experiments) == 0 {
+		return c
+	}
+	kept := make([]Experiment, 0, len(c.Experiments))
+	for i := range c.Experiments {
+		exp := c.Experiments[i]
+		if err := validateExperiment(exp, nil); err != nil {
+			if report != nil {
+				report(exp.ID, err)
+			}
+			continue
+		}
+		kept = append(kept, exp)
+	}
+	c.Experiments = kept
+	return c
+}
+
 // EnabledValue reports whether A/B assignment should run.
 func (c Config) EnabledValue() bool {
 	return c.Enabled != nil && *c.Enabled

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -7,13 +7,9 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/roleeffort"
 	"github.com/Automaat/sybra/internal/skillinvoke"
 )
-
-// defaultReasoningEffort mirrors agent.DefaultReasoningEffort. It cannot be
-// imported directly: internal/agent transitively depends on internal/config,
-// which depends on internal/abtest, so importing agent here would cycle.
-const defaultReasoningEffort = "medium"
 
 // Select deterministically chooses a variant for the task/stage. It returns
 // ok=false when A/B is disabled or no enabled experiment matches the role.
@@ -417,7 +413,8 @@ func validatePromptSkillHomogeneity(exp Experiment, providerAllowed func(string)
 		return nil
 	}
 	base := eligible[0]
-	baseEffort := normalizeReasoningEffort(base.ReasoningEffort)
+	omitted := experimentDefaultEffort(exp)
+	baseEffort := normalizeReasoningEffort(base.ReasoningEffort, omitted)
 	for i := 1; i < len(eligible); i++ {
 		v := eligible[i]
 		if v.Provider != base.Provider {
@@ -426,19 +423,46 @@ func validatePromptSkillHomogeneity(exp Experiment, providerAllowed func(string)
 		if v.Model != base.Model {
 			return fmt.Errorf("abtest: experiment %q model mismatch on variant %q", exp.ID, v.ID)
 		}
-		if normalizeReasoningEffort(v.ReasoningEffort) != baseEffort {
+		if normalizeReasoningEffort(v.ReasoningEffort, omitted) != baseEffort {
 			return fmt.Errorf("abtest: experiment %q reasoning_effort mismatch on variant %q", exp.ID, v.ID)
 		}
 	}
 	return nil
 }
 
-// normalizeReasoningEffort treats an omitted effort as the agent runtime's
-// default, so a variant that explicitly sets "medium" is homogeneous with one
-// that leaves the field empty.
-func normalizeReasoningEffort(effort string) string {
+// experimentDefaultEffort returns the level an omitted variant
+// reasoning_effort actually dispatches with for this experiment. That is the
+// per-role baseline, not the global default: a "review" experiment whose
+// variants leave the field empty runs at "high", so declaring "high"
+// explicitly on one arm must stay homogeneous with omitting it on another.
+//
+// Returns "" when the experiment spans roles whose baselines disagree — an
+// omitted effort is then ambiguous and only matches another omitted one.
+func experimentDefaultEffort(exp Experiment) string {
+	roles := exp.Roles
+	if len(roles) == 0 && exp.Subject != nil {
+		roles = []string{exp.Subject.Role}
+	}
+	if len(roles) == 0 {
+		return roleeffort.Global
+	}
+	resolved := roleeffort.Resolve(strings.TrimSpace(roles[0]))
+	for _, r := range roles[1:] {
+		if roleeffort.Resolve(strings.TrimSpace(r)) != resolved {
+			return ""
+		}
+	}
+	return resolved
+}
+
+// normalizeReasoningEffort resolves a variant's declared effort against what an
+// omitted one dispatches with, so a variant that explicitly pins the role's
+// baseline is homogeneous with one that leaves the field empty. An empty
+// roleDefault marks the omitted case as ambiguous (see experimentDefaultEffort)
+// and is deliberately left unresolved so it only matches another omitted value.
+func normalizeReasoningEffort(effort, roleDefault string) string {
 	if effort == "" {
-		return defaultReasoningEffort
+		return roleDefault
 	}
 	return effort
 }

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -436,19 +436,30 @@ func validatePromptSkillHomogeneity(exp Experiment, providerAllowed func(string)
 // variants leave the field empty runs at "high", so declaring "high"
 // explicitly on one arm must stay homogeneous with omitting it on another.
 //
-// Returns "" when the experiment spans roles whose baselines disagree — an
-// omitted effort is then ambiguous and only matches another omitted one.
+// Returns "" when the level is ambiguous — the experiment spans roles whose
+// baselines disagree, or it declares no role at all (roleMatches then matches
+// every role, so the omitted arm's level depends on where it lands). An
+// omitted effort then only matches another omitted one, which forces an
+// operator who wants to mix omitted and explicit efforts to declare the role.
 func experimentDefaultEffort(exp Experiment) string {
 	roles := exp.Roles
 	if len(roles) == 0 && exp.Subject != nil {
 		roles = []string{exp.Subject.Role}
 	}
 	if len(roles) == 0 {
-		return roleeffort.Global
+		return ""
 	}
-	resolved := roleeffort.Resolve(strings.TrimSpace(roles[0]))
-	for _, r := range roles[1:] {
-		if roleeffort.Resolve(strings.TrimSpace(r)) != resolved {
+	resolved := ""
+	for i, r := range roles {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			return ""
+		}
+		if i == 0 {
+			resolved = roleeffort.Resolve(r)
+			continue
+		}
+		if roleeffort.Resolve(r) != resolved {
 			return ""
 		}
 	}

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -670,9 +670,57 @@ func TestConfigValidatePromptSkillAllowsEmptyReasoningEffortAsDefault(t *testing
 		ID:      "prompt-default-effort",
 		Kind:    "prompt",
 		Subject: &Subject{StepID: "implement"},
+		Roles:   []string{"implementation"},
 		Variants: []Variant{
 			{ID: "explicit-medium", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
 			{ID: "omitted-effort", Provider: "claude", Model: "sonnet", ReasoningEffort: "", Weight: 1},
+		},
+	}}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// TestConfigValidatePromptSkillRejectsRolelessMixedEffort covers the ambiguous
+// case: an experiment declaring no role matches every role (see roleMatches),
+// so an omitted reasoning_effort dispatches at whatever baseline the step it
+// lands on carries. Mixing it with an explicit level would silently confound
+// the prompt comparison with an effort change, so it must be rejected until the
+// operator declares the role.
+func TestConfigValidatePromptSkillRejectsRolelessMixedEffort(t *testing.T) {
+	for _, effort := range []string{"medium", "high"} {
+		t.Run(effort, func(t *testing.T) {
+			cfg := Config{Experiments: []Experiment{{
+				ID:      "prompt-roleless-effort",
+				Kind:    "prompt",
+				Subject: &Subject{StepID: "implement"},
+				Variants: []Variant{
+					{ID: "omitted-effort", Provider: "claude", Model: "sonnet", Weight: 1},
+					{ID: "explicit-effort", Provider: "claude", Model: "sonnet", ReasoningEffort: effort, Weight: 1},
+				},
+			}}}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatal("Validate should reject a roleless mix of omitted and explicit reasoning_effort")
+			}
+			if !strings.Contains(err.Error(), "reasoning_effort") {
+				t.Fatalf("error %q does not mention reasoning_effort", err)
+			}
+		})
+	}
+}
+
+// TestConfigValidatePromptSkillAllowsRolelessOmittedEffort proves the
+// ambiguity only bites a mix: leaving the level off every arm stays valid, so
+// the common roleless prompt experiment is unaffected.
+func TestConfigValidatePromptSkillAllowsRolelessOmittedEffort(t *testing.T) {
+	cfg := Config{Experiments: []Experiment{{
+		ID:      "prompt-roleless-omitted",
+		Kind:    "prompt",
+		Subject: &Subject{StepID: "implement"},
+		Variants: []Variant{
+			{ID: "a", Provider: "claude", Model: "sonnet", Weight: 1},
+			{ID: "b", Provider: "claude", Model: "sonnet", Weight: 1},
 		},
 	}}}
 	if err := cfg.Validate(); err != nil {
@@ -1130,5 +1178,61 @@ func TestCloneConfig_DeepCopiesCanary(t *testing.T) {
 	cp.Experiments[0].Canary.PercentBound = 99
 	if cfg.Experiments[0].Canary.PercentBound != 50 {
 		t.Fatalf("original Canary mutated via clone: %d, want unchanged 50", cfg.Experiments[0].Canary.PercentBound)
+	}
+}
+
+// TestWithoutInvalidExperimentsKeepsDispatchAlive covers the migration path for
+// a config a code change retroactively invalidated: selection validates each
+// experiment as it matches and propagates the error to the dispatcher, so an
+// invalid experiment must be dropped (and reported) at load rather than left to
+// wedge every role it targets.
+func TestWithoutInvalidExperimentsKeepsDispatchAlive(t *testing.T) {
+	good := Experiment{
+		ID:       "good",
+		Roles:    []string{"review"},
+		Variants: []Variant{{ID: "a", Provider: "claude", Model: "opus", Weight: 1}},
+	}
+	// Roleless prompt experiment mixing an omitted and an explicit effort:
+	// valid before the per-role baselines were retuned, ambiguous after.
+	bad := Experiment{
+		ID:      "bad",
+		Kind:    "prompt",
+		Subject: &Subject{StepID: "implement"},
+		Variants: []Variant{
+			{ID: "a", Provider: "claude", Model: "sonnet", Weight: 1},
+			{ID: "b", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
+		},
+	}
+	cfg := Config{Experiments: []Experiment{good, bad}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("precondition: the bad experiment should fail validation")
+	}
+
+	var dropped []string
+	got := cfg.WithoutInvalidExperiments(func(id string, err error) {
+		if err == nil {
+			t.Errorf("report called with nil error for %q", id)
+		}
+		dropped = append(dropped, id)
+	})
+
+	if len(dropped) != 1 || dropped[0] != "bad" {
+		t.Fatalf("dropped = %v, want [bad]", dropped)
+	}
+	if len(got.Experiments) != 1 || got.Experiments[0].ID != "good" {
+		t.Fatalf("kept experiments = %+v, want just the good one", got.Experiments)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("survivors must validate: %v", err)
+	}
+	if len(cfg.Experiments) != 2 {
+		t.Fatalf("receiver mutated: len = %d, want 2", len(cfg.Experiments))
+	}
+
+	// A selection that previously errored out now routes normally.
+	enabled := true
+	got.Enabled = &enabled
+	if _, _, err := Select(got, "task-1", "review", "review"); err != nil {
+		t.Fatalf("Select after drop: %v", err)
 	}
 }

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -680,6 +680,61 @@ func TestConfigValidatePromptSkillAllowsEmptyReasoningEffortAsDefault(t *testing
 	}
 }
 
+// TestConfigValidatePromptSkillResolvesEmptyEffortAgainstRoleBaseline covers
+// roles whose built-in baseline is not the global default: on a review
+// experiment an omitted reasoning_effort dispatches at "high", so pinning
+// "high" explicitly on one arm is homogeneous with omitting it on another,
+// while pinning the global "medium" is a genuine mismatch.
+func TestConfigValidatePromptSkillResolvesEmptyEffortAgainstRoleBaseline(t *testing.T) {
+	tests := []struct {
+		name       string
+		roles      []string
+		effort     string
+		wantReject bool
+	}{
+		{name: "review omitted vs explicit baseline", roles: []string{"review"}, effort: "high"},
+		{name: "review omitted vs global default", roles: []string{"review"}, effort: "medium", wantReject: true},
+		{name: "implementation omitted vs global default", roles: []string{"implementation"}, effort: "medium"},
+		{name: "implementation omitted vs explicit high", roles: []string{"implementation"}, effort: "high", wantReject: true},
+		{
+			// plan resolves "high", test-runner resolves "medium": an
+			// omitted effort is ambiguous, so it only matches another
+			// omitted one.
+			name:       "roles with disagreeing baselines stay ambiguous",
+			roles:      []string{"plan", "test-runner"},
+			effort:     "high",
+			wantReject: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Experiments: []Experiment{{
+				ID:      "prompt-role-effort",
+				Kind:    "prompt",
+				Subject: &Subject{StepID: "implement"},
+				Roles:   tt.roles,
+				Variants: []Variant{
+					{ID: "omitted-effort", Provider: "claude", Model: "sonnet", Weight: 1},
+					{ID: "explicit-effort", Provider: "claude", Model: "sonnet", ReasoningEffort: tt.effort, Weight: 1},
+				},
+			}}}
+			err := cfg.Validate()
+			if tt.wantReject {
+				if err == nil {
+					t.Fatal("Validate should reject a reasoning_effort mismatch")
+				}
+				if !strings.Contains(err.Error(), "reasoning_effort") {
+					t.Fatalf("error %q does not mention reasoning_effort", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
+	}
+}
+
 func TestConfigValidateCompoundAllowsProviderModelReasoningDrift(t *testing.T) {
 	cfg := Config{Experiments: []Experiment{{
 		ID:   "compound",

--- a/internal/agent/effort_test.go
+++ b/internal/agent/effort_test.go
@@ -1,0 +1,188 @@
+package agent
+
+import (
+	"testing"
+)
+
+// TestPrepareRunConfig_ResolvesReasoningEffort pins the resolution order every
+// dispatch site now inherits from the Manager: an explicitly pinned effort (an
+// experiment assignment or the task's own reasoning_effort, both resolved
+// upstream) > the operator's agent.role_effort override > the role's built-in
+// baseline > the global default.
+//
+// The no-explicit-effort rows are the regression guard for #2784: seven of the
+// nine RunConfig construction sites set no effort at all, and the Manager used
+// to stamp the global "medium" on them regardless of role.
+func TestPrepareRunConfig_ResolvesReasoningEffort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		role       Role
+		agentName  string
+		explicit   string
+		roleEffort map[string]string
+		want       string
+	}{
+		{name: "review inherits its high baseline", role: RoleReview, want: "high"},
+		{name: "plan inherits its high baseline", role: RolePlan, want: "high"},
+		{name: "monitor inherits its low baseline", role: RoleMonitor, want: "low"},
+		{name: "human-review inherits its low baseline", role: RoleHumanReview, want: "low"},
+		{name: "implementation falls back to the global default", role: RoleImplementation, want: DefaultReasoningEffort},
+		{name: "test-runner falls back to the global default", role: RoleTestRunner, want: DefaultReasoningEffort},
+		{
+			name:     "explicit effort beats the role baseline",
+			role:     RoleReview,
+			explicit: "low",
+			want:     "low",
+		},
+		{
+			name:       "explicit effort beats the config override",
+			role:       RoleReview,
+			explicit:   "low",
+			roleEffort: map[string]string{"review": "xhigh"},
+			want:       "low",
+		},
+		{
+			name:       "config override beats the role baseline",
+			role:       RoleReview,
+			roleEffort: map[string]string{"review": "medium"},
+			want:       "medium",
+		},
+		{
+			name:       "config override applies to a role with no baseline",
+			role:       RoleImplementation,
+			roleEffort: map[string]string{"implementation": "high"},
+			want:       "high",
+		},
+		{
+			name:       "invalid override falls back to the role baseline",
+			role:       RoleReview,
+			roleEffort: map[string]string{"review": "extreme"},
+			want:       "high",
+		},
+		{
+			name:       "empty override falls back to the role baseline",
+			role:       RoleReview,
+			roleEffort: map[string]string{"review": ""},
+			want:       "high",
+		},
+		{
+			name:       "override for another role does not leak",
+			role:       RoleReview,
+			roleEffort: map[string]string{"implementation": "low"},
+			want:       "high",
+		},
+		{
+			// Effort must resolve after ResolveRunRole, so a legacy
+			// prefix-only config still gets its role's baseline.
+			name:      "prefix-only name resolves through its role",
+			agentName: "review:Some task title",
+			want:      "high",
+		},
+		{
+			name:      "unprefixed name is implementation and takes the global default",
+			agentName: "Some task title",
+			want:      DefaultReasoningEffort,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newParseTestManager(t, ManagerConfig{Runtime: ManagerRuntimeConfig{RoleEffort: tt.roleEffort}})
+			cfg, _, err := m.prepareRunConfig(RunConfig{
+				Role:            tt.role,
+				Name:            tt.agentName,
+				Provider:        "claude",
+				Mode:            "headless",
+				Prompt:          "hi",
+				Dir:             t.TempDir(),
+				ReasoningEffort: tt.explicit,
+			})
+			if err != nil {
+				t.Fatalf("prepareRunConfig: %v", err)
+			}
+			if cfg.ReasoningEffort != tt.want {
+				t.Errorf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, tt.want)
+			}
+		})
+	}
+}
+
+// TestPrepareRunConfig_RoleEffortReachesProviderArgv proves the resolved level
+// is not merely stamped on the RunConfig but actually reaches the provider CLI
+// — a verifier role dispatched with no explicit effort must launch at its
+// baseline, not the global default.
+func TestPrepareRunConfig_RoleEffortReachesProviderArgv(t *testing.T) {
+	t.Parallel()
+	m := newParseTestManager(t)
+	cfg, prov, err := m.prepareRunConfig(RunConfig{
+		Role:     RoleReview,
+		Provider: "claude",
+		Mode:     "headless",
+		Prompt:   "hi",
+		Dir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	a := newRunningAgent("a", cfg, prov, func() {})
+	_, args, _, _, err := buildHeadlessInvocation(a, cfg)
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+	if !hasArgPair(args, "--effort", "high") {
+		t.Fatalf("expected --effort high in args; got %v", args)
+	}
+}
+
+// TestReplaceRuntimeConfig_HotUpdatesRoleEffort covers agent.role_effort's
+// documented "hot" reload class: an operator edit must land on the next run
+// without a restart, and clearing the map must restore the built-in baseline.
+func TestReplaceRuntimeConfig_HotUpdatesRoleEffort(t *testing.T) {
+	t.Parallel()
+	m := newParseTestManager(t, ManagerConfig{Runtime: ManagerRuntimeConfig{
+		RoleEffort: map[string]string{"review": "low"},
+	}})
+	if got := m.resolveReasoningEffort(RoleReview, ""); got != "low" {
+		t.Fatalf("resolveReasoningEffort before reload = %q, want %q", got, "low")
+	}
+
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		RoleEffort: map[string]string{"review": "xhigh"},
+	}); err != nil {
+		t.Fatalf("ReplaceRuntimeConfig: %v", err)
+	}
+	if got := m.resolveReasoningEffort(RoleReview, ""); got != "xhigh" {
+		t.Fatalf("resolveReasoningEffort after reload = %q, want %q", got, "xhigh")
+	}
+
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{}); err != nil {
+		t.Fatalf("ReplaceRuntimeConfig clear: %v", err)
+	}
+	if got := m.resolveReasoningEffort(RoleReview, ""); got != "high" {
+		t.Fatalf("resolveReasoningEffort after clear = %q, want built-in %q", got, "high")
+	}
+}
+
+// TestNewManager_CopiesRoleEffort guards against the Manager aliasing the
+// caller's map: a later mutation by the config owner must not silently retune
+// live dispatch.
+func TestNewManager_CopiesRoleEffort(t *testing.T) {
+	t.Parallel()
+	src := map[string]string{"review": "low"}
+	m := newParseTestManager(t, ManagerConfig{Runtime: ManagerRuntimeConfig{RoleEffort: src}})
+	src["review"] = "xhigh"
+	if got := m.resolveReasoningEffort(RoleReview, ""); got != "low" {
+		t.Fatalf("resolveReasoningEffort = %q, want %q (map must be cloned)", got, "low")
+	}
+}
+
+func hasArgPair(args []string, key, value string) bool {
+	for i := range len(args) - 1 {
+		if args[i] == key && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -79,6 +79,10 @@ type Manager struct {
 	// stdin/stream-json shape that accepts mid-run steer messages. See
 	// RunConfig.HeadlessSteerable.
 	headlessSteerable bool
+	// roleEffort mirrors config agent.role_effort: an operator override of the
+	// built-in per-role reasoning-effort baseline, keyed by role name. Read by
+	// resolveReasoningEffort under mu.
+	roleEffort map[string]string
 
 	defaultSandboxMode string
 	gate               provider.HealthGate
@@ -261,6 +265,11 @@ type ManagerRuntimeConfig struct {
 	// Jobs. This is a PoC execution backend and is default-off.
 	K8sJobsEnabled bool
 	K8sJobs        K8sJobRunnerConfig
+	// RoleEffort mirrors config agent.role_effort: an operator override of the
+	// built-in per-role reasoning-effort baseline (Role.DefaultReasoningEffort),
+	// keyed by role name. Invalid levels and unknown roles are ignored at
+	// resolution time, falling back to the built-in baseline.
+	RoleEffort map[string]string
 	// ClassReservations mirrors config agent.class_reservations: a per-class
 	// reserved minimum concurrent slot count. Keyed by WorkloadClass; unknown
 	// keys and an over-budget sum are rejected at config validation, not here.
@@ -305,6 +314,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		maxInFlightPerProvider: cfg.Runtime.MaxInFlightPerProvider,
 		dispatchJitterMs:       cfg.Runtime.DispatchJitterMs,
 		headlessSteerable:      cfg.Runtime.HeadlessSteerable,
+		roleEffort:             maps.Clone(cfg.Runtime.RoleEffort),
 		defaultSandboxMode:     cfg.Runtime.SandboxMode,
 		sandboxHome:            cfg.SandboxHome,
 		controlHome:            cfg.ControlHome,
@@ -554,6 +564,7 @@ func (m *Manager) ReplaceRuntimeConfig(cfg ManagerRuntimeConfig) error {
 	m.maxInFlightPerProvider = cfg.MaxInFlightPerProvider
 	m.dispatchJitterMs = cfg.DispatchJitterMs
 	m.headlessSteerable = cfg.HeadlessSteerable
+	m.roleEffort = maps.Clone(cfg.RoleEffort)
 	m.defaultSandboxMode = cfg.SandboxMode
 	m.playwrightMCPEnabled = cfg.PlaywrightMCPEnabled
 	m.playwrightMCPExtraArgs = cfg.PlaywrightMCPExtraArgs

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/skillattr"
+	"github.com/Automaat/sybra/internal/task"
 	"github.com/google/uuid"
 )
 
@@ -188,7 +189,7 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	}
 	cfg.provider = prov
 	m.warnUnenforceableAllowedTools(cfg, prov)
-	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort)
+	cfg.ReasoningEffort = m.resolveReasoningEffort(cfg.Role, cfg.ReasoningEffort)
 	if cfg.Mode == "headless" {
 		m.mu.RLock()
 		steerable := m.headlessSteerable
@@ -818,9 +819,32 @@ func stripEnvKeys(env []string, keys ...string) []string {
 	return out
 }
 
-func defaultReasoningEffort(effort string) string {
+// resolveReasoningEffort returns the effort level a run dispatches with.
+// Precedence: an effort the caller already pinned (an experiment assignment or
+// the task's own reasoning_effort, both resolved upstream) > the operator's
+// agent.role_effort override for this role > the role's built-in baseline >
+// the global default.
+//
+// This lives in the Manager rather than at each dispatch site on purpose:
+// before #2784 only two of the nine RunConfig construction sites resolved the
+// role baseline, so monitor and human-review ran at "medium" despite
+// defaulting to "low", and implementation re-dispatches on the
+// limit/failover paths silently dropped their baseline. Resolving here means a
+// new dispatch site cannot reintroduce that leak.
+func (m *Manager) resolveReasoningEffort(role Role, effort string) string {
 	if effort != "" {
 		return effort
+	}
+	m.mu.RLock()
+	override, ok := m.roleEffort[string(role)]
+	m.mu.RUnlock()
+	if ok {
+		if valid, err := task.ValidateReasoningEffort(override); err == nil && valid != "" {
+			return valid
+		}
+	}
+	if roleDefault := role.DefaultReasoningEffort(); roleDefault != "" {
+		return roleDefault
 	}
 	return DefaultReasoningEffort
 }

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -820,10 +820,14 @@ func stripEnvKeys(env []string, keys ...string) []string {
 }
 
 // resolveReasoningEffort returns the effort level a run dispatches with.
-// Precedence: an effort the caller already pinned (an experiment assignment or
-// the task's own reasoning_effort, both resolved upstream) > the operator's
+// Precedence: an effort the caller already pinned > the operator's
 // agent.role_effort override for this role > the role's built-in baseline >
 // the global default.
+//
+// The pinned tier covers both an A/B experiment assignment and the task's own
+// reasoning_effort, resolved upstream because only the dispatch site knows
+// which of the two applies — a dispatch site holding a task.Task must pass
+// t.ReasoningEffort through, or the baseline silently outranks the pin.
 //
 // This lives in the Manager rather than at each dispatch site on purpose:
 // before #2784 only two of the nine RunConfig construction sites resolved the

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1806,12 +1806,15 @@ type RunConfig struct {
 	// model when the primary is overloaded. Empty means inherit the manager's
 	// default; the flag is omitted only when the manager default is also empty.
 	FallbackModel string
-	// ReasoningEffort sets the agent's reasoning effort for this run
-	// (low/medium/high/xhigh). Empty is resolved to DefaultReasoningEffort by
-	// Manager.Run for every provider before command construction. Lower-level
-	// command builders still omit the provider flag when handed an empty value
-	// directly. Codex uses `-c model_reasoning_effort=`; claude and copilot use
-	// `--effort`.
+	// ReasoningEffort pins the agent's reasoning effort for this run
+	// (low/medium/high/xhigh), overriding every baseline. Empty is the normal
+	// case: Manager.Run resolves it for every provider before command
+	// construction, preferring the operator's agent.role_effort override, then
+	// the role's built-in baseline (Role.DefaultReasoningEffort), then
+	// DefaultReasoningEffort. Set it only for an effort an experiment
+	// assignment or the task itself pinned. Lower-level command builders still
+	// omit the provider flag when handed an empty value directly. Codex uses
+	// `-c model_reasoning_effort=`; claude and copilot use `--effort`.
 	ReasoningEffort string
 	// RequestedSkill names a workflow-owned skill invocation the dispatcher
 	// expects to run. Empty leaves ad-hoc prompt skill mentions untouched; set

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/roleeffort"
 	"github.com/Automaat/sybra/internal/stats"
 )
 
@@ -51,7 +52,13 @@ func (s State) IsTerminal() bool {
 	return s == StateStopped
 }
 
-const DefaultReasoningEffort = "medium"
+// DefaultReasoningEffort is the level a run dispatches with when neither the
+// caller, the operator's agent.role_effort override, nor the role's own
+// baseline pins one. Defined as roleeffort.Global rather than a literal so it
+// cannot drift from the copy internal/abtest resolves omitted variant efforts
+// against (that package cannot import this one — the dependency cycles through
+// internal/config).
+const DefaultReasoningEffort = roleeffort.Global
 
 type Agent struct {
 	ID                       string  `json:"id"`

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -32,20 +32,24 @@ const (
 	RoleTestFix Role = "test-fix"
 )
 
-// AllRoles lists every known Role. It is the single source of truth for the
-// role set: IsKnown is derived from it, so adding a Role constant here is what
-// makes it dispatchable — and what makes the reasoning-effort coverage test
-// notice it.
+// allRoles is the single source of truth for the role set. Package-level so
+// IsKnown — called on every dispatch through ResolveRunRole — stays
+// allocation-free; AllRoles hands out a copy so no caller can mutate it.
+var allRoles = []Role{
+	RoleTriage, RolePlan, RolePlanCritic, RoleEval, RoleLoop, RoleMonitor,
+	RoleOrchestrator, RolePRFix, RoleReview, RoleFixReview, RoleTestRunner,
+	RoleImplementation, RoleHumanReview, RoleTestFix,
+}
+
+// AllRoles lists every known Role. IsKnown is derived from the same list, so
+// adding a Role constant to it is what makes the role dispatchable — and what
+// makes the reasoning-effort coverage test notice it.
 func AllRoles() []Role {
-	return []Role{
-		RoleTriage, RolePlan, RolePlanCritic, RoleEval, RoleLoop, RoleMonitor,
-		RoleOrchestrator, RolePRFix, RoleReview, RoleFixReview, RoleTestRunner,
-		RoleImplementation, RoleHumanReview, RoleTestFix,
-	}
+	return slices.Clone(allRoles)
 }
 
 func (r Role) IsKnown() bool {
-	return slices.Contains(AllRoles(), r)
+	return slices.Contains(allRoles, r)
 }
 
 // AgentName returns the prefixed name used when launching an agent

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/roleeffort"
 )
 
 // Role identifies the purpose of an agent run.
@@ -242,19 +244,14 @@ func errUnknownRolePrefix(name string) error {
 }
 
 // DefaultReasoningEffort returns the built-in per-role reasoning-effort
-// baseline used when neither an experiment assignment nor the task itself
-// pins a level (see RunConfig.ReasoningEffort). System/verifier roles that
-// mostly classify or check pre-existing work default to "low"; the
-// code-authoring roles that most benefit from deeper reasoning default to
-// "high". Everything else falls back to DefaultReasoningEffort ("medium")
-// via the empty return.
+// baseline used when neither an experiment assignment, the operator's
+// agent.role_effort map, nor the task itself pins a level (see
+// RunConfig.ReasoningEffort). Roles with no opinion return "" and fall back to
+// DefaultReasoningEffort ("medium").
+//
+// The table lives in internal/roleeffort so internal/abtest can share it
+// without importing this package (that direction cycles through
+// internal/config).
 func (r Role) DefaultReasoningEffort() string {
-	switch r {
-	case RoleTriage, RoleEval, RolePlanCritic, RoleHumanReview, RoleMonitor:
-		return "low"
-	case RoleImplementation, RoleFixReview, RolePRFix, RoleTestFix:
-		return "high"
-	default:
-		return ""
-	}
+	return roleeffort.ForRole(string(r))
 }

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -32,15 +32,20 @@ const (
 	RoleTestFix Role = "test-fix"
 )
 
-func (r Role) IsKnown() bool {
-	switch r {
-	case RoleTriage, RolePlan, RolePlanCritic, RoleEval, RoleLoop, RoleMonitor, RoleOrchestrator,
-		RolePRFix, RoleReview, RoleFixReview, RoleTestRunner, RoleImplementation,
-		RoleHumanReview, RoleTestFix:
-		return true
-	default:
-		return false
+// AllRoles lists every known Role. It is the single source of truth for the
+// role set: IsKnown is derived from it, so adding a Role constant here is what
+// makes it dispatchable — and what makes the reasoning-effort coverage test
+// notice it.
+func AllRoles() []Role {
+	return []Role{
+		RoleTriage, RolePlan, RolePlanCritic, RoleEval, RoleLoop, RoleMonitor,
+		RoleOrchestrator, RolePRFix, RoleReview, RoleFixReview, RoleTestRunner,
+		RoleImplementation, RoleHumanReview, RoleTestFix,
 	}
+}
+
+func (r Role) IsKnown() bool {
+	return slices.Contains(AllRoles(), r)
 }
 
 // AgentName returns the prefixed name used when launching an agent

--- a/internal/agent/role_test.go
+++ b/internal/agent/role_test.go
@@ -1,6 +1,10 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/roleeffort"
+)
 
 func TestRole_AgentName(t *testing.T) {
 	t.Parallel()
@@ -70,9 +74,10 @@ func TestRole_DefaultReasoningEffort(t *testing.T) {
 }
 
 // TestRole_DefaultReasoningEffort_CoversEveryKnownRole guards internal/roleeffort's
-// plain-string switch against drift: it keys off role names copied from the
-// Role constants, so a typo there would silently drop a role to the "medium"
-// fallback instead of failing to compile.
+// plain-string switch against drift. It iterates AllRoles rather than a
+// hand-maintained list, so a newly added Role fails here until someone decides
+// its effort baseline, and a typo'd name in roleeffort's switch shows up as the
+// wrong level instead of silently falling back to the global default.
 func TestRole_DefaultReasoningEffort_CoversEveryKnownRole(t *testing.T) {
 	t.Parallel()
 	covered := map[Role]string{
@@ -82,15 +87,8 @@ func TestRole_DefaultReasoningEffort_CoversEveryKnownRole(t *testing.T) {
 		RolePRFix: "high", RoleTestFix: "high",
 		RoleImplementation: "", RoleTestRunner: "", RoleLoop: "", RoleOrchestrator: "",
 	}
-	all := []Role{
-		RoleTriage, RolePlan, RolePlanCritic, RoleEval, RoleLoop, RoleMonitor,
-		RoleOrchestrator, RolePRFix, RoleReview, RoleFixReview, RoleTestRunner,
-		RoleImplementation, RoleHumanReview, RoleTestFix,
-	}
+	all := AllRoles()
 	for _, r := range all {
-		if !r.IsKnown() {
-			t.Errorf("role %q in the coverage list is not IsKnown", r)
-		}
 		want, ok := covered[r]
 		if !ok {
 			t.Errorf("role %q has no expected reasoning effort; add it to the table", r)
@@ -101,7 +99,18 @@ func TestRole_DefaultReasoningEffort_CoversEveryKnownRole(t *testing.T) {
 		}
 	}
 	if len(all) != len(covered) {
-		t.Errorf("coverage list has %d roles, expectations have %d", len(all), len(covered))
+		t.Errorf("AllRoles has %d roles, expectations have %d", len(all), len(covered))
+	}
+}
+
+// TestDefaultReasoningEffort_MatchesRoleEffortGlobal pins the global fallback
+// to the copy internal/abtest resolves omitted variant efforts against. The two
+// packages cannot import each other, so nothing but this would catch a drift.
+func TestDefaultReasoningEffort_MatchesRoleEffortGlobal(t *testing.T) {
+	t.Parallel()
+	if DefaultReasoningEffort != roleeffort.Global {
+		t.Fatalf("DefaultReasoningEffort = %q, roleeffort.Global = %q; they must not drift",
+			DefaultReasoningEffort, roleeffort.Global)
 	}
 }
 

--- a/internal/agent/role_test.go
+++ b/internal/agent/role_test.go
@@ -369,3 +369,23 @@ func TestRole_WorkloadClass(t *testing.T) {
 		}
 	}
 }
+
+// TestAllRolesReturnsACopy proves callers cannot mutate the canonical role set
+// through the accessor — IsKnown reads the same backing list.
+func TestAllRolesReturnsACopy(t *testing.T) {
+	t.Parallel()
+	got := AllRoles()
+	got[0] = Role("clobbered")
+	if !RoleTriage.IsKnown() {
+		t.Fatal("mutating the AllRoles result corrupted the canonical role set")
+	}
+	if AllRoles()[0] != RoleTriage {
+		t.Fatalf("AllRoles()[0] = %q, want %q", AllRoles()[0], RoleTriage)
+	}
+}
+
+func BenchmarkRoleIsKnown(b *testing.B) {
+	for b.Loop() {
+		_ = RoleImplementation.IsKnown()
+	}
+}

--- a/internal/agent/role_test.go
+++ b/internal/agent/role_test.go
@@ -46,13 +46,15 @@ func TestRole_DefaultReasoningEffort(t *testing.T) {
 		{RoleMonitor, "low"},
 		{RolePlanCritic, "low"},
 		{RoleHumanReview, "low"},
-		{RoleImplementation, "high"},
+		{RolePlan, "high"},
+		{RoleReview, "high"},
 		{RoleFixReview, "high"},
 		{RolePRFix, "high"},
 		{RoleTestFix, "high"},
-		{RolePlan, ""},
-		{RoleReview, ""},
+		{RoleImplementation, ""},
 		{RoleTestRunner, ""},
+		{RoleLoop, ""},
+		{RoleOrchestrator, ""},
 		{Role(""), ""},
 	}
 
@@ -64,6 +66,42 @@ func TestRole_DefaultReasoningEffort(t *testing.T) {
 				t.Errorf("DefaultReasoningEffort() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestRole_DefaultReasoningEffort_CoversEveryKnownRole guards internal/roleeffort's
+// plain-string switch against drift: it keys off role names copied from the
+// Role constants, so a typo there would silently drop a role to the "medium"
+// fallback instead of failing to compile.
+func TestRole_DefaultReasoningEffort_CoversEveryKnownRole(t *testing.T) {
+	t.Parallel()
+	covered := map[Role]string{
+		RoleTriage: "low", RoleEval: "low", RoleMonitor: "low",
+		RolePlanCritic: "low", RoleHumanReview: "low",
+		RolePlan: "high", RoleReview: "high", RoleFixReview: "high",
+		RolePRFix: "high", RoleTestFix: "high",
+		RoleImplementation: "", RoleTestRunner: "", RoleLoop: "", RoleOrchestrator: "",
+	}
+	all := []Role{
+		RoleTriage, RolePlan, RolePlanCritic, RoleEval, RoleLoop, RoleMonitor,
+		RoleOrchestrator, RolePRFix, RoleReview, RoleFixReview, RoleTestRunner,
+		RoleImplementation, RoleHumanReview, RoleTestFix,
+	}
+	for _, r := range all {
+		if !r.IsKnown() {
+			t.Errorf("role %q in the coverage list is not IsKnown", r)
+		}
+		want, ok := covered[r]
+		if !ok {
+			t.Errorf("role %q has no expected reasoning effort; add it to the table", r)
+			continue
+		}
+		if got := r.DefaultReasoningEffort(); got != want {
+			t.Errorf("DefaultReasoningEffort(%q) = %q, want %q", r, got, want)
+		}
+	}
+	if len(all) != len(covered) {
+		t.Errorf("coverage list has %d roles, expectations have %d", len(all), len(covered))
 	}
 }
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -1289,6 +1289,9 @@ func applyABTestingDefaults(cfg *Config) {
 		return
 	}
 	reconcileBuiltinExperiments(cfg, def)
+	cfg.ABTesting = cfg.ABTesting.WithoutInvalidExperiments(func(id string, err error) {
+		slog.Warn("config: dropping invalid ab_testing experiment", "experiment", id, "err", err)
+	})
 }
 
 // reconcileBuiltinExperiments refreshes a persisted config's built-in A/B

--- a/internal/roleeffort/roleeffort.go
+++ b/internal/roleeffort/roleeffort.go
@@ -1,0 +1,43 @@
+// Package roleeffort owns the built-in per-role reasoning-effort baseline.
+//
+// It is a dependency-free leaf so that both internal/agent (which resolves the
+// level for a dispatch) and internal/abtest (which must know what an omitted
+// variant reasoning_effort resolves to) can share one table. internal/abtest
+// cannot reach the level through internal/agent: agent transitively depends on
+// internal/config, which depends on abtest.
+package roleeffort
+
+// Global is the level used when neither the caller, the operator config, nor
+// the role itself pins one. Mirrored by agent.DefaultReasoningEffort.
+const Global = "medium"
+
+// ForRole returns the built-in baseline for role, or "" when the role carries
+// no opinion and should inherit Global. Role names are the string values of
+// agent.Role; TestForRole_CoversEveryKnownRole in internal/agent guards the
+// two lists against drift.
+//
+// The ladder spends reasoning depth where a mistake is most expensive to
+// unwind: planning picks the approach every later stage inherits, and review
+// is the gate that decides whether a change lands. Roles that mostly classify
+// or check pre-existing work sit at "low". Implementation is deliberately not
+// "high" — it executes an already-approved plan, and it is the
+// highest-volume role by a wide margin.
+func ForRole(role string) string {
+	switch role {
+	case "triage", "eval", "plan-critic", "human-review", "monitor":
+		return "low"
+	case "plan", "review", "fix-review", "pr-fix", "test-fix":
+		return "high"
+	default:
+		return ""
+	}
+}
+
+// Resolve returns the effective baseline for role, falling back to Global for
+// roles ForRole has no opinion on. Never returns "".
+func Resolve(role string) string {
+	if effort := ForRole(role); effort != "" {
+		return effort
+	}
+	return Global
+}

--- a/internal/roleeffort/roleeffort.go
+++ b/internal/roleeffort/roleeffort.go
@@ -13,8 +13,8 @@ const Global = "medium"
 
 // ForRole returns the built-in baseline for role, or "" when the role carries
 // no opinion and should inherit Global. Role names are the string values of
-// agent.Role; TestForRole_CoversEveryKnownRole in internal/agent guards the
-// two lists against drift.
+// agent.Role; TestRole_DefaultReasoningEffort_CoversEveryKnownRole in
+// internal/agent iterates agent.AllRoles to guard the two against drift.
 //
 // The ladder spends reasoning depth where a mistake is most expensive to
 // unwind: planning picks the approach every later stage inherits, and review

--- a/internal/roleeffort/roleeffort_test.go
+++ b/internal/roleeffort/roleeffort_test.go
@@ -1,0 +1,58 @@
+package roleeffort
+
+import "testing"
+
+func TestForRole(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		role string
+		want string
+	}{
+		{"triage", "low"},
+		{"eval", "low"},
+		{"plan-critic", "low"},
+		{"human-review", "low"},
+		{"monitor", "low"},
+		{"plan", "high"},
+		{"review", "high"},
+		{"fix-review", "high"},
+		{"pr-fix", "high"},
+		{"test-fix", "high"},
+		{"implementation", ""},
+		{"test-runner", ""},
+		{"loop", ""},
+		{"orchestrator", ""},
+		{"", ""},
+		{"not-a-role", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			t.Parallel()
+			if got := ForRole(tt.role); got != tt.want {
+				t.Errorf("ForRole(%q) = %q, want %q", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		role string
+		want string
+	}{
+		{"review", "high"},
+		{"triage", "low"},
+		{"implementation", Global},
+		{"not-a-role", Global},
+		{"", Global},
+	}
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			t.Parallel()
+			if got := Resolve(tt.role); got != tt.want {
+				t.Errorf("Resolve(%q) = %q, want %q", tt.role, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/agentorch/effort_test.go
+++ b/internal/sybra/agentorch/effort_test.go
@@ -38,24 +38,24 @@ func TestResolveRoleEffort(t *testing.T) {
 		want string
 	}{
 		{"nil cfg falls back to role default", agent.RoleTriage, nil, "low"},
-		{"no override falls back to role default", agent.RoleImplementation, &config.Config{}, "high"},
-		{"role with no built-in default returns empty", agent.RolePlan, &config.Config{}, ""},
+		{"no override falls back to role default", agent.RoleReview, &config.Config{}, "high"},
+		{"role with no built-in default returns empty", agent.RoleImplementation, &config.Config{}, ""},
 		{
 			"config override wins",
-			agent.RoleImplementation,
-			&config.Config{Agent: config.AgentDefaults{RoleEffort: map[string]string{"implementation": "medium"}}},
+			agent.RoleReview,
+			&config.Config{Agent: config.AgentDefaults{RoleEffort: map[string]string{"review": "medium"}}},
 			"medium",
 		},
 		{
 			"invalid override ignored, falls back to role default",
-			agent.RoleImplementation,
-			&config.Config{Agent: config.AgentDefaults{RoleEffort: map[string]string{"implementation": "extreme"}}},
+			agent.RoleReview,
+			&config.Config{Agent: config.AgentDefaults{RoleEffort: map[string]string{"review": "extreme"}}},
 			"high",
 		},
 		{
 			"override for unrelated role does not affect this role",
 			agent.RoleTriage,
-			&config.Config{Agent: config.AgentDefaults{RoleEffort: map[string]string{"implementation": "medium"}}},
+			&config.Config{Agent: config.AgentDefaults{RoleEffort: map[string]string{"review": "medium"}}},
 			"low",
 		},
 	}

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -319,14 +319,18 @@ func (h *humanReviewHandler) spawnReviewConfig(t task.Task, taskID, prompt, dir 
 		model = opts.Model
 	}
 	cfg := agent.RunConfig{
-		TaskID:                 taskID,
-		Name:                   agent.RoleHumanReview.AgentName(t.Title),
-		Role:                   agent.RoleHumanReview,
-		Mode:                   "headless",
-		Provider:               strings.TrimSpace(opts.Provider),
-		Model:                  model,
-		Prompt:                 prompt,
-		Dir:                    dir,
+		TaskID:   taskID,
+		Name:     agent.RoleHumanReview.AgentName(t.Title),
+		Role:     agent.RoleHumanReview,
+		Mode:     "headless",
+		Provider: strings.TrimSpace(opts.Provider),
+		Model:    model,
+		Prompt:   prompt,
+		Dir:      dir,
+		// An effort the operator pinned on the task outranks the role
+		// baseline the Manager would otherwise resolve; empty stays empty so
+		// the Manager applies agent.role_effort and then the baseline.
+		ReasoningEffort:        t.ReasoningEffort,
 		ReadOnlyDir:            readOnlyDir,
 		RequirePermissions:     false,
 		OneShot:                true,

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -510,6 +510,7 @@ func (a *App) agentRuntimeConfig(cfg *config.Config) agent.ManagerRuntimeConfig 
 		PlaywrightMCPExtraArgs: cfg.PlaywrightMCPExtraArgs(),
 		K8sJobsEnabled:         cfg.Agent.K8sJobs.Enabled,
 		K8sJobs:                k8sJobRunnerConfigFromConfig(cfg.Agent.K8sJobs),
+		RoleEffort:             cfg.Agent.RoleEffort,
 		ClassReservations:      agent.ParseClassReservations(cfg.Agent.ClassReservations),
 	}
 }

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -134,13 +134,17 @@ func (r *Handler) StartFixReviewAgent(t task.Task) error {
 	) + reviewHoldFixSuffix(r.cfg)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID:                 t.ID,
-		Name:                   agent.RoleFixReview.AgentName(t.Title),
-		Role:                   agent.RoleFixReview,
-		Mode:                   "headless",
-		Prompt:                 prompt,
-		Dir:                    dir,
-		Model:                  "opus",
+		TaskID: t.ID,
+		Name:   agent.RoleFixReview.AgentName(t.Title),
+		Role:   agent.RoleFixReview,
+		Mode:   "headless",
+		Prompt: prompt,
+		Dir:    dir,
+		Model:  "opus",
+		// An effort the operator pinned on the task outranks the role
+		// baseline the Manager would otherwise resolve; empty stays empty so
+		// the Manager applies agent.role_effort and then the baseline.
+		ReasoningEffort:        t.ReasoningEffort,
 		HeadlessPermissionMode: posture,
 		// MaxTurns intentionally not inherited: fix-review agents need
 		// enough turns to fetch the PR, apply fixes, and commit.
@@ -247,13 +251,17 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 // fetch the PR, run the skill, and write findings.
 func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture string) agent.RunConfig {
 	return agent.RunConfig{
-		TaskID:                 t.ID,
-		Name:                   agent.RoleReview.AgentName(t.Title),
-		Role:                   agent.RoleReview,
-		Mode:                   "headless",
-		Prompt:                 prompt,
-		Dir:                    dir,
-		Model:                  "opus",
+		TaskID: t.ID,
+		Name:   agent.RoleReview.AgentName(t.Title),
+		Role:   agent.RoleReview,
+		Mode:   "headless",
+		Prompt: prompt,
+		Dir:    dir,
+		Model:  "opus",
+		// An effort the operator pinned on the task outranks the role
+		// baseline the Manager would otherwise resolve; empty stays empty so
+		// the Manager applies agent.role_effort and then the baseline.
+		ReasoningEffort:        t.ReasoningEffort,
 		HeadlessPermissionMode: posture,
 	}
 }

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -394,6 +394,35 @@ func TestStaffCodeReviewRunConfigLeavesProviderUnpinned(t *testing.T) {
 	}
 }
 
+// TestStaffCodeReviewRunConfigCarriesTaskReasoningEffort proves the operator's
+// per-task pin reaches the run. Without it the Manager would resolve the review
+// role's own baseline instead, silently overriding the pin — this dispatch path
+// does not go through the workflow engine, which is where the other sites
+// resolve effort.
+func TestStaffCodeReviewRunConfigCarriesTaskReasoningEffort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		pinned string
+		want   string
+	}{
+		{name: "pinned effort is carried", pinned: "xhigh", want: "xhigh"},
+		{name: "unpinned stays empty for the Manager to resolve", pinned: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := StaffCodeReviewRunConfig(
+				task.Task{ID: "review-task", Title: "Needs review", ReasoningEffort: tt.pinned},
+				"Run /staff-code-review", t.TempDir(), "default",
+			)
+			if cfg.ReasoningEffort != tt.want {
+				t.Fatalf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, tt.want)
+			}
+		})
+	}
+}
+
 func TestStaffCodeReviewPromptAuthorizesPendingReview(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -491,6 +491,7 @@ func (s *ConfigService) managerRuntimeConfig(cfg config.Config) agent.ManagerRun
 		PlaywrightMCPExtraArgs: cfg.PlaywrightMCPExtraArgs(),
 		K8sJobsEnabled:         cfg.Agent.K8sJobs.Enabled,
 		K8sJobs:                k8sJobRunnerConfigFromConfig(cfg.Agent.K8sJobs),
+		RoleEffort:             cfg.Agent.RoleEffort,
 		ClassReservations:      agent.ParseClassReservations(cfg.Agent.ClassReservations),
 	}
 }

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -827,9 +827,12 @@ func TestReloadFromDisk_ABTestingPreservesRoutingOverlay(t *testing.T) {
 		MinSamplesPerVariant: 20,
 		Experiments: []abtest.Experiment{{
 			ID: "exp",
+			// Model is required by variant validation; config.Load drops
+			// experiments that would fail selection-time validation, so an
+			// underspecified fixture would not survive the reload.
 			Variants: []abtest.Variant{
-				{ID: "v1", Provider: "claude", Weight: 1},
-				{ID: "v2", Provider: "codex", Weight: 1},
+				{ID: "v1", Provider: "claude", Model: "opus", Weight: 1},
+				{ID: "v2", Provider: "codex", Model: "gpt-5.5", Weight: 1},
 			},
 		}},
 	}


### PR DESCRIPTION
## Motivation

> Changelog: perf(agent): retune per-role reasoning effort defaults

Sybra pins a reasoning-effort level per agent role. Two problems, both from
issue 2784.

**The ladder was tuned the wrong way round.** Code authoring sat at `high`
while the two roles that most benefit from depth — planning and review — sat on
the `medium` global fallback. Implementation is the highest-volume role by a
wide margin ($1050 of $2400 fleet spend over 17 days) and is executing an
already-approved plan; plan is 54 runs / $91, so buying it depth is nearly free,
and review is the gate that decides whether a change lands.

**The role baseline only reached 2 of 9 dispatch sites.** Only the workflow
engine and `agentorch` called `ResolveRoleEffort`; the Manager's fallback was
role-blind and stamped the global `medium` on everything else. The fleet data
showed it plainly: `monitor` (n=126) and `human-review` (n=240) ran at `medium`
despite defaulting to `low`, and implementation re-dispatches on the
limit/failover paths (n=401) dropped their baseline. Any `agent.role_effort`
override an operator set was silently ignored on those paths too.

Closes #2784

## Implementation information

**Retuned baselines** — `implementation` `high` → `medium` (global fallback);
`plan` and `review` → `high`. Unchanged: `fix-review`/`pr-fix`/`test-fix` stay
`high`, `triage`/`eval`/`plan-critic`/`human-review`/`monitor` stay `low`,
`test-runner`/`loop`/`orchestrator` stay on the fallback.

**Resolution moved into the Manager** (`prepareRunConfig` →
`resolveReasoningEffort`) rather than adding a ninth call site, so a new
dispatch site cannot reintroduce the leak. `ManagerRuntimeConfig` now carries
`RoleEffort` (cloned, hot-reloadable), giving the documented precedence one
implementation: pinned effort > `agent.role_effort[role]` > role baseline >
global default.

**New leaf package `internal/roleeffort`** holds the table. `internal/abtest`
needs it to know what an omitted variant `reasoning_effort` resolves to but
cannot import `internal/agent` (the dependency cycles through
`internal/config`), so the old fix was a hardcoded `"medium"` mirror that
misjudged homogeneity for any non-medium role. `agent.DefaultReasoningEffort` is
now defined as `roleeffort.Global`, and `IsKnown` is driven by a new `AllRoles`
so the coverage test fails on an undecided new role.

Three defects an adversarial review caught, fixed in the second commit:

- The task's own `reasoning_effort` never reached the dispatch sites that bypass
  the workflow engine, so the role baseline silently outranked an operator's
  per-task pin — worse after the retune than before. Human-review, inbound
  review, and fix-review now pass it through.
- Retuning a role can retroactively invalidate a persisted prompt/skill A/B
  experiment (the baseline decides what an omitted variant effort resolves to).
  Selection validates per experiment and propagates the error to the dispatcher,
  which would wedge every role it targets, indefinitely, with nothing logged at
  startup. Config load now drops invalid experiments with a warning
  (`Config.WithoutInvalidExperiments`) — this also closes a pre-existing gap
  where `Config.Validate` had no non-test callers.
- An experiment declaring no role matches *every* role, so an omitted effort
  there is genuinely ambiguous; it no longer normalizes to the global default.

The first commit is an unrelated unblock: hadolint 2.15.1 (pinned in
`mise.toml` by #2747) flags the Dockerfile HEALTHCHECK's implicit shell form as
DL3025, which fails the local pre-commit hook and `mise run verify` on every
commit in the repo. CI is unaffected — `hadolint-action` bundles its own older
hadolint — so this is local-only breakage. Wrapped in an explicit `sh -c`,
preserving `${SYBRA_PORT}` expansion and the `||` chain.

**Verification.** Adversarial manual testing against a real `sybra-server` in an
isolated `SYBRA_HOME` with fake provider CLIs recording their own argv: every
role's launched effort matches the table for claude/codex/copilot; the leak is
closed on a real non-workflow dispatch (human-review launches `--effort low`,
and `role_effort: {human-review: xhigh}` moves that same site to `xhigh`,
proving the Manager resolves it); hot reload, task pin, experiment pin,
`xhigh`, invalid/unknown/empty override keys, and 12 parallel dispatches across
6 concurrent reloads all behave. `mise run verify` is green except six
`internal/project` `TestPreflightPushCredentials_*` tests that fail identically
on unmodified `origin/main` in this environment.

## Open questions

A hand-edited task file with a whitespace-only `reasoning_effort: "   "` reaches
the provider argv as `--effort` plus spaces, bypassing both the override and the
baseline. Pre-existing and unchanged by this PR (`origin/main` used the
byte-identical `if effort != ""` guard) and unreachable through the supported
mutation path, which validates the value. Left alone as out of scope.