### PR TITLE
docs(docs): correct sandbox posture claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,17 +278,25 @@ into an unexported `RunConfig.sandbox` spec:
   mechanism or profile/setup is unavailable. It is **never** reached by
   leaving the key unset — the built-in default is `report`, so every
   deployment that wants containment must set `agent.sandbox_mode: enforce`
-  explicitly (the server does, via Linux `bwrap`; the laptop via
-  `sandbox-exec`). Under it the real operator board under `~/.sybra` and the
+  explicitly. Under it the real operator board under `~/.sybra` and the
   deploy checkout `/opt/sybra/src` stay read-only to agents.
 
-Treat the live posture as something to check, not to assume: `report` and
-`enforce` are indistinguishable except for whether the spawn is wrapped, so a
-config that silently resolves to `report` looks identical to a contained one.
-Grep the journal — `agent.sandbox.enforce` means wrapped spawns,
-`agent.sandbox.report` means unwrapped. This drifted unnoticed once: the
-server logged 2098 `report` lines and zero `enforce` while this section
-claimed it ran `enforce`.
+Do not record which posture a given deployment runs here — that claim drifts
+silently and this section already carried a false one for months. Read it from
+the host instead. The postures are distinguishable only by their log line and
+by whether setup failures abort the run, never by observable agent behaviour on
+a healthy host, so a config that quietly resolves to `report` looks exactly
+like a contained one. Grep the app log (`~/.sybra/logs/sybra.log`, or
+`/data/sybra/home/logs/sybra.log` on the server) — **not** the systemd journal,
+which carries only build and start output:
+
+- `agent.sandbox.enforce` — spawn wrapped.
+- `agent.sandbox.report` — spawn **not** wrapped; allowlist logged only.
+- `agent.sandbox.report.unavailable` — `report` that fell back to unwrapped
+  because `bwrap`/`sandbox-exec` was missing.
+- *neither line for a run* — resolved `off`, via config or the per-task
+  `sandbox: false` escape hatch; `injectProcessSandbox` returns before it logs
+  anything. Absence of both is the widest-blast-radius case, not the quiet one.
 
 The escape hatch's use is operator-visible: `agentorch.logSandboxEscapeHatch`
 logs a warning and records `audit.EventAgentSandboxDisabled`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,10 +275,20 @@ into an unexported `RunConfig.sandbox` spec:
   explicit `enforce` posture, never the default rollout posture. This is
   why `report` is safe to ship as the default.
 - `enforce`: wraps the spawn and fails the run closed if the host sandbox
-  mechanism or profile/setup is unavailable. The server runs this posture now
-  (`agent.sandbox_mode: enforce` via Linux `bwrap`), so the real operator
-  board under `~/.sybra` and deploy checkout `/opt/sybra/src` stay read-only
-  to agents.
+  mechanism or profile/setup is unavailable. It is **never** reached by
+  leaving the key unset — the built-in default is `report`, so every
+  deployment that wants containment must set `agent.sandbox_mode: enforce`
+  explicitly (the server does, via Linux `bwrap`; the laptop via
+  `sandbox-exec`). Under it the real operator board under `~/.sybra` and the
+  deploy checkout `/opt/sybra/src` stay read-only to agents.
+
+Treat the live posture as something to check, not to assume: `report` and
+`enforce` are indistinguishable except for whether the spawn is wrapped, so a
+config that silently resolves to `report` looks identical to a contained one.
+Grep the journal — `agent.sandbox.enforce` means wrapped spawns,
+`agent.sandbox.report` means unwrapped. This drifted unnoticed once: the
+server logged 2098 `report` lines and zero `enforce` while this section
+claimed it ran `enforce`.
 
 The escape hatch's use is operator-visible: `agentorch.logSandboxEscapeHatch`
 logs a warning and records `audit.EventAgentSandboxDisabled`.


### PR DESCRIPTION
## Motivation

The OS process sandbox section asserted "The server runs this posture now (`agent.sandbox_mode: enforce` via Linux `bwrap`)". It did not — the key was unset on both deployment targets, so `DefaultSandboxMode()` resolved to `report`, which validates the write allowlist and logs it but never wraps the spawn. Every agent subprocess has been running unsandboxed while this doc said otherwise.

> Changelog: skip

## Implementation information

Rather than replace the stale claim with a fresh one, this removes per-deployment posture from the doc entirely — recording deployment state in a checked-in file is what let it drift silently in the first place. In its place: how to read the live posture off the host.

Two corrections an adversarial review caught in the first draft, both verified against source and against both live hosts:

- The events are in the **app log** (`~/.sybra/logs/sybra.log`), not the systemd journal. `internal/logging/logger.go:16` writes only to that rotating file, with no stdout tee — `journalctl -u sybra | grep agent.sandbox` returns 0 on the server while the app log has thousands. The first draft sent operators to a stream containing neither event.
- `report` vs `enforce` differ in more than wrapping: in `enforce` a missing wrapper, a failed `canonicalizeRoot`, or unresolvable git roots abort the run before any spawn, while `report` degrades to unwrapped and proceeds.

Also documents the case both drafts missed: a run resolving to `off` (config or the per-task `sandbox: false` hatch) returns at `manager_run.go:427` before logging anything, so absence of *both* event names means every run was unwrapped — not that nothing ran.

Event names re-verified at `manager_run.go:453/513/604/620`.

Closes #2776

## Open questions

The config flips this issue also asks for are outside this repo: the laptop `~/.sybra/config.yaml` is done, and the server template is Automaat/home-nas#543 (pending merge + `deploy-sybra.yml`). This doc change is deliberately independent of both, so it is correct whichever posture a host ends up on.