### PR TITLE
feat(sandbox): make enforce posture non-droppable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,11 @@ jobs:
           cat > "$SYBRA_HOME/config.yaml" <<EOF
           agent:
             provider: ${{ matrix.provider }}
+            # sybra-server refuses to start without an explicit posture, so a
+            # config that merely omits the key can never be mistaken for a
+            # contained one. "off" is correct here: this suite drives the HTTP
+            # API against fake providers and starts no real agent subprocess.
+            sandbox_mode: "off"
           server:
             auth_token: e2e-test-token
           monitor:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -34,6 +34,11 @@ jobs:
           # destructive task cleanup without it (#1576).
           touch "$SYBRA_HOME/.sybra-e2e-home"
           cat > "$SYBRA_HOME/config.yaml" <<EOF
+          agent:
+            # sybra-server refuses to start without an explicit posture. "off"
+            # is correct here: this job only screenshots the UI and starts no
+            # agent subprocess.
+            sandbox_mode: "off"
           server:
             auth_token: e2e-test-token
           EOF

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -104,6 +104,10 @@ func run() (int, error) {
 		return 1, fmt.Errorf("config: %w", err)
 	}
 
+	if err := requireExplicitSandboxMode(cfg); err != nil {
+		return 1, fmt.Errorf("config: %w", err)
+	}
+
 	logger, levelVar, cleanup, err := logging.New(cfg.Logging)
 	if err != nil {
 		return 1, fmt.Errorf("logger: %w", err)
@@ -196,6 +200,25 @@ func run() (int, error) {
 		return autoupdate.RestartExitCode, nil
 	}
 	return 0, nil
+}
+
+// requireExplicitSandboxMode refuses to start an unattended server whose
+// agent.sandbox_mode is unset. An empty value resolves to "report", which
+// validates the write allowlist and logs it but never wraps the spawn — so a
+// config that simply omits the key is indistinguishable from a contained one
+// until you grep the logs. That is exactly how the server ran unsandboxed for
+// months while the docs claimed otherwise. Any of off/report/enforce is
+// accepted; the requirement is that an operator chose it.
+//
+// Server-only on purpose: the desktop app and CLI keep the "report" default,
+// so this cannot break a local checkout.
+func requireExplicitSandboxMode(cfg *config.Config) error {
+	if strings.TrimSpace(cfg.Agent.SandboxMode) != "" {
+		return nil
+	}
+	return fmt.Errorf(
+		"agent.sandbox_mode is unset; set it explicitly to one of off, report, enforce " +
+			"(enforce is the contained posture — off and report leave agent writes unrestricted)")
 }
 
 const (

--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -53,6 +53,14 @@ import (
 )
 
 func main() {
+	// Unattended: an unset agent.sandbox_mode resolves to "report", which
+	// never wraps the spawn, so an omitted key is indistinguishable from a
+	// deliberately unsandboxed one. Set before any config load so the
+	// requirement covers startup, -check-config, and every later hot reload
+	// through the same validator — a boot-only check is defeated by the
+	// config watcher re-applying an edited file.
+	config.RequireExplicitSandboxMode(true)
+
 	checkConfig := flag.Bool("check-config", false, "load and validate the live config (SYBRA_HOME/config.yaml), then exit without starting the server: 0 if valid, 1 otherwise")
 	flag.Parse()
 	if *checkConfig {
@@ -101,10 +109,6 @@ func run() (int, error) {
 	}
 
 	if err := cfg.ValidateCluster(); err != nil {
-		return 1, fmt.Errorf("config: %w", err)
-	}
-
-	if err := requireExplicitSandboxMode(cfg); err != nil {
 		return 1, fmt.Errorf("config: %w", err)
 	}
 
@@ -200,25 +204,6 @@ func run() (int, error) {
 		return autoupdate.RestartExitCode, nil
 	}
 	return 0, nil
-}
-
-// requireExplicitSandboxMode refuses to start an unattended server whose
-// agent.sandbox_mode is unset. An empty value resolves to "report", which
-// validates the write allowlist and logs it but never wraps the spawn — so a
-// config that simply omits the key is indistinguishable from a contained one
-// until you grep the logs. That is exactly how the server ran unsandboxed for
-// months while the docs claimed otherwise. Any of off/report/enforce is
-// accepted; the requirement is that an operator chose it.
-//
-// Server-only on purpose: the desktop app and CLI keep the "report" default,
-// so this cannot break a local checkout.
-func requireExplicitSandboxMode(cfg *config.Config) error {
-	if strings.TrimSpace(cfg.Agent.SandboxMode) != "" {
-		return nil
-	}
-	return fmt.Errorf(
-		"agent.sandbox_mode is unset; set it explicitly to one of off, report, enforce " +
-			"(enforce is the contained posture — off and report leave agent writes unrestricted)")
 }
 
 const (

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -788,35 +788,3 @@ func TestRunCheckConfig(t *testing.T) {
 		}
 	})
 }
-
-// TestRequireExplicitSandboxMode pins the server's fail-closed startup gate:
-// an unset agent.sandbox_mode resolves to "report", which never wraps the
-// spawn, so the server must refuse to start rather than run unsandboxed on a
-// config that merely omitted the key.
-func TestRequireExplicitSandboxMode(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name    string
-		mode    string
-		wantErr bool
-	}{
-		{name: "unset is rejected", mode: "", wantErr: true},
-		{name: "whitespace is rejected", mode: "   ", wantErr: true},
-		{name: "explicit enforce is accepted", mode: "enforce"},
-		{name: "explicit report is accepted", mode: "report"},
-		{name: "explicit off is accepted", mode: "off"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			cfg := &config.Config{Agent: config.AgentDefaults{SandboxMode: tc.mode}}
-			err := requireExplicitSandboxMode(cfg)
-			if tc.wantErr && err == nil {
-				t.Fatalf("mode %q: want error, got nil", tc.mode)
-			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("mode %q: want nil, got %v", tc.mode, err)
-			}
-		})
-	}
-}

--- a/cmd/sybra-server/main_test.go
+++ b/cmd/sybra-server/main_test.go
@@ -788,3 +788,35 @@ func TestRunCheckConfig(t *testing.T) {
 		}
 	})
 }
+
+// TestRequireExplicitSandboxMode pins the server's fail-closed startup gate:
+// an unset agent.sandbox_mode resolves to "report", which never wraps the
+// spawn, so the server must refuse to start rather than run unsandboxed on a
+// config that merely omitted the key.
+func TestRequireExplicitSandboxMode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		mode    string
+		wantErr bool
+	}{
+		{name: "unset is rejected", mode: "", wantErr: true},
+		{name: "whitespace is rejected", mode: "   ", wantErr: true},
+		{name: "explicit enforce is accepted", mode: "enforce"},
+		{name: "explicit report is accepted", mode: "report"},
+		{name: "explicit off is accepted", mode: "off"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &config.Config{Agent: config.AgentDefaults{SandboxMode: tc.mode}}
+			err := requireExplicitSandboxMode(cfg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("mode %q: want error, got nil", tc.mode)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("mode %q: want nil, got %v", tc.mode, err)
+			}
+		})
+	}
+}

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -46,6 +46,10 @@ agent:
   post_result_cost_usd: 5
   max_assistant_events: 50
   require_permissions: false
+  # sybra-server refuses to start without an explicit posture, so an omitted
+  # key can never be mistaken for a contained one. "off" suits this harness:
+  # the fake provider CLIs write only inside $TMP.
+  sandbox_mode: "off"
 orchestrator:
   dispatch_interval_seconds: 3600
   maintenance_interval_seconds: 3600

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -822,6 +822,7 @@ export class Update {
     "MaxTurns": number | null;
     "ForkSubagent": boolean | null;
     "Sandbox": boolean | null;
+    "SandboxOffReason": string | null;
     "ReasoningEffort": string | null;
     "Outcome": string | null;
     "MergeCommit": string | null;
@@ -954,6 +955,9 @@ export class Update {
         if (!("Sandbox" in $$source)) {
             this["Sandbox"] = null;
         }
+        if (!("SandboxOffReason" in $$source)) {
+            this["SandboxOffReason"] = null;
+        }
         if (!("ReasoningEffort" in $$source)) {
             this["ReasoningEffort"] = null;
         }
@@ -985,8 +989,8 @@ export class Update {
         const $$createField8_0 = $$createType15;
         const $$createField12_0 = $$createType14;
         const $$createField30_0 = $$createType16;
-        const $$createField45_0 = $$createType17;
-        const $$createField46_0 = $$createType18;
+        const $$createField46_0 = $$createType17;
+        const $$createField47_0 = $$createType18;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("Blocker" in $$parsedSource) {
             $$parsedSource["Blocker"] = $$createField4_0($$parsedSource["Blocker"]);
@@ -1004,10 +1008,10 @@ export class Update {
             $$parsedSource["Workflow"] = $$createField30_0($$parsedSource["Workflow"]);
         }
         if ("Attachments" in $$parsedSource) {
-            $$parsedSource["Attachments"] = $$createField45_0($$parsedSource["Attachments"]);
+            $$parsedSource["Attachments"] = $$createField46_0($$parsedSource["Attachments"]);
         }
         if ("EffectLog" in $$parsedSource) {
-            $$parsedSource["EffectLog"] = $$createField46_0($$parsedSource["EffectLog"]);
+            $$parsedSource["EffectLog"] = $$createField47_0($$parsedSource["EffectLog"]);
         }
         return new Update($$parsedSource as Partial<Update>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -549,6 +549,14 @@ export class Task {
     "sandbox"?: boolean | null;
 
     /**
+     * SandboxOffReason explains why Sandbox is false. Disabling the sandbox
+     * hands a task's agents unrestricted write access to the host, so the
+     * audit trail needs to say why rather than only that it happened.
+     * Meaningful only alongside Sandbox=false; ignored otherwise.
+     */
+    "sandboxOffReason"?: string;
+
+    /**
      * ReasoningEffort sets the reasoning level for this task's agents
      * (low/medium/high/xhigh). Empty = model default. Applied across providers:
      * codex via -c model_reasoning_effort=<v>, claude and copilot via --effort.
@@ -710,11 +718,11 @@ export class Task {
         const $$createField14_0 = $$createType1;
         const $$createField19_0 = $$createType0;
         const $$createField20_0 = $$createType3;
-        const $$createField41_0 = $$createType5;
-        const $$createField42_0 = $$createType7;
-        const $$createField43_0 = $$createType9;
-        const $$createField44_0 = $$createType11;
-        const $$createField61_0 = $$createType12;
+        const $$createField42_0 = $$createType5;
+        const $$createField43_0 = $$createType7;
+        const $$createField44_0 = $$createType9;
+        const $$createField45_0 = $$createType11;
+        const $$createField62_0 = $$createType12;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -732,19 +740,19 @@ export class Task {
             $$parsedSource["dependsOnConditions"] = $$createField20_0($$parsedSource["dependsOnConditions"]);
         }
         if ("attachments" in $$parsedSource) {
-            $$parsedSource["attachments"] = $$createField41_0($$parsedSource["attachments"]);
+            $$parsedSource["attachments"] = $$createField42_0($$parsedSource["attachments"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField42_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField43_0($$parsedSource["agentRuns"]);
         }
         if ("effectLog" in $$parsedSource) {
-            $$parsedSource["effectLog"] = $$createField43_0($$parsedSource["effectLog"]);
+            $$parsedSource["effectLog"] = $$createField44_0($$parsedSource["effectLog"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField44_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField45_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField61_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField62_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -922,6 +922,9 @@ func load(opts loadOptions) (*ResolvedConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := ValidateUnattendedPosture(resolved.Config); err != nil {
+		return nil, err
+	}
 	ensureServerAuthToken(resolved.Config, opts.persistLoadReconciles)
 	return resolved.Config, nil
 }

--- a/internal/config/unattended_posture_test.go
+++ b/internal/config/unattended_posture_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUnattendedPostureGatesTheLoadPath pins the requirement where it has to
+// hold to be non-droppable: inside the config load every entry point funnels
+// through (server startup, -check-config preflight, and the fsnotify hot
+// reload). A boot-time-only check is defeated by an operator editing
+// config.yaml afterwards, which is the exact silent drift this guards.
+func TestUnattendedPostureGatesTheLoadPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		require bool
+		wantErr bool
+	}{
+		{
+			name:    "unattended rejects an omitted sandbox_mode",
+			yaml:    "schema_version: 2\nexecution:\n  agent:\n    provider: claude\n",
+			require: true,
+			wantErr: true,
+		},
+		{
+			name:    "unattended rejects an empty sandbox_mode",
+			yaml:    "schema_version: 2\nexecution:\n  agent:\n    sandbox_mode: \"\"\n",
+			require: true,
+			wantErr: true,
+		},
+		{
+			name:    "unattended accepts an explicit enforce",
+			yaml:    "schema_version: 2\nexecution:\n  agent:\n    sandbox_mode: enforce\n",
+			require: true,
+		},
+		{
+			name:    "unattended accepts an explicit report",
+			yaml:    "schema_version: 2\nexecution:\n  agent:\n    sandbox_mode: report\n",
+			require: true,
+		},
+		{
+			name:    "attended keeps the report default on an omitted key",
+			yaml:    "schema_version: 2\nexecution:\n  agent:\n    provider: claude\n",
+			require: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("SYBRA_HOME", home)
+			if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			RequireExplicitSandboxMode(tc.require)
+			t.Cleanup(func() { RequireExplicitSandboxMode(false) })
+
+			_, err := LoadNoPersist()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want load error, got nil")
+				}
+				if !strings.Contains(err.Error(), "agent.sandbox_mode is unset") {
+					t.Fatalf("error = %v, want it to name agent.sandbox_mode", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+		})
+	}
+}
+
+// TestDefaultConfigSurvivesUnattendedRequirement guards the trap this check
+// originally fell into: the built-in empty config legitimately has no
+// sandbox_mode, so folding the requirement into ValidateResolvedConfig
+// panicked every DefaultConfig caller in an unattended process.
+func TestDefaultConfigSurvivesUnattendedRequirement(t *testing.T) {
+	RequireExplicitSandboxMode(true)
+	t.Cleanup(func() { RequireExplicitSandboxMode(false) })
+	if cfg := DefaultConfig(); cfg == nil {
+		t.Fatal("DefaultConfig returned nil under the unattended requirement")
+	}
+}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync/atomic"
 
 	"github.com/Automaat/sybra/internal/providerid"
 )
@@ -34,6 +35,47 @@ func (e *ValidationError) Error() string {
 		return ""
 	}
 	return strings.Join(e.Messages, "; ")
+}
+
+// requireExplicitSandboxMode makes an unset agent.sandbox_mode a load-time
+// error rather than a silent fall-through to "report". Off by default so the
+// desktop app and CLI keep working on a config that omits the key; sybra-server
+// turns it on at startup via RequireExplicitSandboxMode.
+//
+// It lives here, in the validator every load and every hot reload funnels
+// through, rather than at the server's startup call site: a boot-time-only
+// check is defeated by the config watcher re-applying an edited file, which
+// is exactly the silent drift the requirement exists to stop.
+var requireExplicitSandboxMode atomic.Bool
+
+// RequireExplicitSandboxMode makes ValidateUnattendedPosture reject a config
+// whose agent.sandbox_mode is unset. Intended for unattended processes, where
+// an omitted key is indistinguishable from a deliberately unsandboxed one.
+func RequireExplicitSandboxMode(require bool) {
+	requireExplicitSandboxMode.Store(require)
+}
+
+// ValidateUnattendedPosture rejects operator config that leaves the OS-level
+// sandbox posture unstated, once RequireExplicitSandboxMode is on. It is
+// deliberately separate from ValidateResolvedConfig: the latter also resolves
+// the built-in empty config (DefaultConfig), which legitimately has no
+// sandbox_mode, so folding this in there would panic every default-config
+// caller in an unattended process.
+//
+// Call it from every path that loads or replaces operator config — startup,
+// preflight, and hot reload — since a boot-only check is defeated by the
+// config watcher re-applying an edited file.
+func ValidateUnattendedPosture(cfg *ResolvedConfig) error {
+	if cfg == nil || !requireExplicitSandboxMode.Load() {
+		return nil
+	}
+	if strings.TrimSpace(cfg.Agent.SandboxMode) != "" {
+		return nil
+	}
+	return &ValidationError{Messages: []string{
+		"agent.sandbox_mode is unset; set it explicitly to one of off, report, enforce " +
+			"(enforce is the contained posture — off and report leave agent writes unrestricted)",
+	}}
 }
 
 func ValidateResolvedConfig(cfg *ResolvedConfig) error {

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -493,13 +493,13 @@ func (o *Orchestrator) logSandboxEscapeHatch(taskID string, t task.Task) {
 	if t.Sandbox == nil || *t.Sandbox {
 		return
 	}
+	// An empty reason is itself the signal: `"reason":""` in the audit line
+	// marks an unexplained bypass as plainly as a separate flag would.
 	reason := strings.TrimSpace(t.SandboxOffReason)
-	o.logger.Warn("agent.sandbox.escape_hatch", "task_id", taskID, "reason", reason,
-		"reason_given", reason != "")
+	o.logger.Warn("agent.sandbox.escape_hatch", "task_id", taskID, "reason", reason)
 	o.LogAudit(audit.EventAgentSandboxDisabled, taskID, "", map[string]any{
 		"configured_default": o.cfg.DefaultSandboxMode(),
 		"reason":             reason,
-		"reason_given":       reason != "",
 	})
 }
 

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -493,9 +493,13 @@ func (o *Orchestrator) logSandboxEscapeHatch(taskID string, t task.Task) {
 	if t.Sandbox == nil || *t.Sandbox {
 		return
 	}
-	o.logger.Warn("agent.sandbox.escape_hatch", "task_id", taskID)
+	reason := strings.TrimSpace(t.SandboxOffReason)
+	o.logger.Warn("agent.sandbox.escape_hatch", "task_id", taskID, "reason", reason,
+		"reason_given", reason != "")
 	o.LogAudit(audit.EventAgentSandboxDisabled, taskID, "", map[string]any{
 		"configured_default": o.cfg.DefaultSandboxMode(),
+		"reason":             reason,
+		"reason_given":       reason != "",
 	})
 }
 

--- a/internal/sybra/agentorch/agentorch_test.go
+++ b/internal/sybra/agentorch/agentorch_test.go
@@ -1,7 +1,9 @@
 package agentorch
 
 import (
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/agentqueue"
+	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
@@ -1100,4 +1103,117 @@ func TestAutoAssignProject(t *testing.T) {
 			t.Fatalf("stored ProjectID = %q, want empty after persist failure", stored.ProjectID)
 		}
 	})
+}
+
+// TestLogSandboxEscapeHatchRecordsReason pins the accountability half of the
+// escape hatch: disabling the sandbox hands a task's agents unrestricted
+// write access, so the audit event must carry the operator's stated reason —
+// and must flag its absence, so an unexplained bypass is greppable rather
+// than merely present.
+func TestLogSandboxEscapeHatchRecordsReason(t *testing.T) {
+	t.Parallel()
+	falseVal, trueVal := false, true
+	cases := []struct {
+		name        string
+		task        task.Task
+		wantEvents  int
+		wantReason  string
+		wantFlagged bool
+	}{
+		{
+			name:       "sandbox unset logs nothing",
+			task:       task.Task{},
+			wantEvents: 0,
+		},
+		{
+			name:       "sandbox true logs nothing",
+			task:       task.Task{Sandbox: &trueVal},
+			wantEvents: 0,
+		},
+		{
+			name:        "reason is recorded",
+			task:        task.Task{Sandbox: &falseVal, SandboxOffReason: "docker-in-docker e2e needs host mounts"},
+			wantEvents:  1,
+			wantReason:  "docker-in-docker e2e needs host mounts",
+			wantFlagged: true,
+		},
+		{
+			name:        "missing reason is flagged, not silently allowed",
+			task:        task.Task{Sandbox: &falseVal},
+			wantEvents:  1,
+			wantReason:  "",
+			wantFlagged: false,
+		},
+		{
+			name:        "whitespace-only reason counts as missing",
+			task:        task.Task{Sandbox: &falseVal, SandboxOffReason: "   "},
+			wantEvents:  1,
+			wantReason:  "",
+			wantFlagged: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			al, err := audit.NewLogger(dir)
+			if err != nil {
+				t.Fatalf("audit.NewLogger: %v", err)
+			}
+			o := New(nil, nil, nil, al, slog.New(slog.DiscardHandler), nil,
+				&config.Config{Agent: config.AgentDefaults{SandboxMode: "enforce"}})
+
+			o.logSandboxEscapeHatch("task-1", tc.task)
+
+			events := readAuditEvents(t, dir)
+			if len(events) != tc.wantEvents {
+				t.Fatalf("got %d audit events, want %d", len(events), tc.wantEvents)
+			}
+			if tc.wantEvents == 0 {
+				return
+			}
+			e := events[0]
+			if e.Type != audit.EventAgentSandboxDisabled {
+				t.Errorf("event type = %q, want %q", e.Type, audit.EventAgentSandboxDisabled)
+			}
+			if got, _ := e.Data["reason"].(string); got != tc.wantReason {
+				t.Errorf("reason = %q, want %q", got, tc.wantReason)
+			}
+			if got, _ := e.Data["reason_given"].(bool); got != tc.wantFlagged {
+				t.Errorf("reason_given = %v, want %v", got, tc.wantFlagged)
+			}
+			if got, _ := e.Data["configured_default"].(string); got != "enforce" {
+				t.Errorf("configured_default = %q, want %q", got, "enforce")
+			}
+		})
+	}
+}
+
+func readAuditEvents(t *testing.T, dir string) []audit.Event {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var events []audit.Event
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			var e audit.Event
+			if err := json.Unmarshal([]byte(line), &e); err != nil {
+				t.Fatalf("unmarshal %q: %v", line, err)
+			}
+			events = append(events, e)
+		}
+	}
+	return events
 }

--- a/internal/sybra/agentorch/agentorch_test.go
+++ b/internal/sybra/agentorch/agentorch_test.go
@@ -1114,11 +1114,10 @@ func TestLogSandboxEscapeHatchRecordsReason(t *testing.T) {
 	t.Parallel()
 	falseVal, trueVal := false, true
 	cases := []struct {
-		name        string
-		task        task.Task
-		wantEvents  int
-		wantReason  string
-		wantFlagged bool
+		name       string
+		task       task.Task
+		wantEvents int
+		wantReason string
 	}{
 		{
 			name:       "sandbox unset logs nothing",
@@ -1131,25 +1130,22 @@ func TestLogSandboxEscapeHatchRecordsReason(t *testing.T) {
 			wantEvents: 0,
 		},
 		{
-			name:        "reason is recorded",
-			task:        task.Task{Sandbox: &falseVal, SandboxOffReason: "docker-in-docker e2e needs host mounts"},
-			wantEvents:  1,
-			wantReason:  "docker-in-docker e2e needs host mounts",
-			wantFlagged: true,
+			name:       "reason is recorded",
+			task:       task.Task{Sandbox: &falseVal, SandboxOffReason: "docker-in-docker e2e needs host mounts"},
+			wantEvents: 1,
+			wantReason: "docker-in-docker e2e needs host mounts",
 		},
 		{
-			name:        "missing reason is flagged, not silently allowed",
-			task:        task.Task{Sandbox: &falseVal},
-			wantEvents:  1,
-			wantReason:  "",
-			wantFlagged: false,
+			name:       "missing reason is flagged, not silently allowed",
+			task:       task.Task{Sandbox: &falseVal},
+			wantEvents: 1,
+			wantReason: "",
 		},
 		{
-			name:        "whitespace-only reason counts as missing",
-			task:        task.Task{Sandbox: &falseVal, SandboxOffReason: "   "},
-			wantEvents:  1,
-			wantReason:  "",
-			wantFlagged: false,
+			name:       "whitespace-only reason counts as missing",
+			task:       task.Task{Sandbox: &falseVal, SandboxOffReason: "   "},
+			wantEvents: 1,
+			wantReason: "",
 		},
 	}
 	for _, tc := range cases {
@@ -1178,9 +1174,6 @@ func TestLogSandboxEscapeHatchRecordsReason(t *testing.T) {
 			}
 			if got, _ := e.Data["reason"].(string); got != tc.wantReason {
 				t.Errorf("reason = %q, want %q", got, tc.wantReason)
-			}
-			if got, _ := e.Data["reason_given"].(bool); got != tc.wantFlagged {
-				t.Errorf("reason_given = %v, want %v", got, tc.wantFlagged)
 			}
 			if got, _ := e.Data["configured_default"].(string); got != "enforce" {
 				t.Errorf("configured_default = %q, want %q", got, "enforce")

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -310,6 +310,7 @@ func (a *App) logAutomationsSummary() {
 		"triage", a.cfg.Triage.Enabled,
 		"human_review", a.humanReview != nil,
 		"project_types", projectTypes,
+		"sandbox_mode", a.cfg.DefaultSandboxMode(),
 		"loop_agents_enabled", loopAgentsEnabled,
 		"prompteval_runner", promptevalRunner.Name(),
 		"promptfoo_present", (&prompteval.PromptfooRunner{}).Available(),

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -310,6 +310,9 @@ func (s *ConfigService) validateSettings(settings AppSettings) error {
 	if err := config.ValidateResolvedConfig(&next); err != nil {
 		return validationError(err.Error())
 	}
+	if err := config.ValidateUnattendedPosture(&next); err != nil {
+		return validationError(err.Error())
+	}
 	return nil
 }
 

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -478,6 +478,11 @@ type Task struct {
 	// NOT tighten posture beyond the system default (ResolveSandboxMode only
 	// treats Sandbox=false as meaningful).
 	Sandbox *bool `json:"sandbox,omitempty"`
+	// SandboxOffReason explains why Sandbox is false. Disabling the sandbox
+	// hands a task's agents unrestricted write access to the host, so the
+	// audit trail needs to say why rather than only that it happened.
+	// Meaningful only alongside Sandbox=false; ignored otherwise.
+	SandboxOffReason string `json:"sandboxOffReason,omitempty"`
 	// ReasoningEffort sets the reasoning level for this task's agents
 	// (low/medium/high/xhigh). Empty = model default. Applied across providers:
 	// codex via -c model_reasoning_effort=<v>, claude and copilot via --effort.

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -55,6 +55,7 @@ type taskFrontmatter struct {
 	HeadlessPermissionMode string                  `yaml:"headless_permission_mode,omitempty"`
 	ForkSubagent           bool                    `yaml:"fork_subagent,omitempty"`
 	Sandbox                *bool                   `yaml:"sandbox,omitempty"`
+	SandboxOffReason       string                  `yaml:"sandbox_off_reason,omitempty"`
 	ReasoningEffort        string                  `yaml:"reasoning_effort,omitempty"`
 	TestingCycleStartedAt  *time.Time              `yaml:"testing_cycle_started_at,omitempty"`
 	Attachments            []Attachment            `yaml:"attachments,omitempty"`
@@ -153,6 +154,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		HeadlessPermissionMode: fm.HeadlessPermissionMode,
 		ForkSubagent:           fm.ForkSubagent,
 		Sandbox:                fm.Sandbox,
+		SandboxOffReason:       fm.SandboxOffReason,
 		ReasoningEffort:        fm.ReasoningEffort,
 		TestingCycleStartedAt:  fm.TestingCycleStartedAt,
 		Attachments:            fm.Attachments,
@@ -227,6 +229,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		HeadlessPermissionMode: t.HeadlessPermissionMode,
 		ForkSubagent:           t.ForkSubagent,
 		Sandbox:                t.Sandbox,
+		SandboxOffReason:       t.SandboxOffReason,
 		ReasoningEffort:        t.ReasoningEffort,
 		TestingCycleStartedAt:  t.TestingCycleStartedAt,
 		Attachments:            t.Attachments,

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -57,6 +57,7 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		HeadlessPermissionMode: "auto",
 		ForkSubagent:           true,
 		Sandbox:                &sandbox,
+		SandboxOffReason:       "host mounts required for docker-in-docker e2e",
 		ReasoningEffort:        "xhigh",
 		TestingCycleStartedAt:  &testingCycleStartedAt,
 		Attachments: []Attachment{{
@@ -308,6 +309,8 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.ForkSubagent = true
 	case "Sandbox":
 		task.Sandbox = &falseValue
+	case "SandboxOffReason":
+		task.SandboxOffReason = "host mounts required for docker-in-docker e2e"
 	case "ReasoningEffort":
 		task.ReasoningEffort = "xhigh"
 	case "TestingCycleStartedAt":

--- a/internal/task/sandbox_off_reason_test.go
+++ b/internal/task/sandbox_off_reason_test.go
@@ -1,0 +1,34 @@
+package task
+
+import "testing"
+
+// TestUpdateFromMapAcceptsSandboxOffReason pins that disabling the sandbox and
+// stating why travel on the same call. UpdateFromMap rejects the whole map on
+// an unknown key, so a missing case here would not merely drop the reason — it
+// would reject the `sandbox: false` flip alongside it and break the escape
+// hatch for anyone who followed the field's documentation.
+func TestUpdateFromMapAcceptsSandboxOffReason(t *testing.T) {
+	t.Parallel()
+	const reason = "docker-in-docker e2e needs host mounts"
+
+	u, err := UpdateFromMap(map[string]any{
+		"sandbox":            false,
+		"sandbox_off_reason": reason,
+	})
+	if err != nil {
+		t.Fatalf("UpdateFromMap: %v", err)
+	}
+	if u.Sandbox == nil || *u.Sandbox {
+		t.Fatalf("Sandbox = %v, want false", u.Sandbox)
+	}
+	if u.SandboxOffReason == nil || *u.SandboxOffReason != reason {
+		t.Fatalf("SandboxOffReason = %v, want %q", u.SandboxOffReason, reason)
+	}
+}
+
+func TestUpdateFromMapRejectsNonStringSandboxOffReason(t *testing.T) {
+	t.Parallel()
+	if _, err := UpdateFromMap(map[string]any{"sandbox_off_reason": 42}); err == nil {
+		t.Fatal("want type error for a non-string reason, got nil")
+	}
+}

--- a/internal/task/sandbox_off_reason_test.go
+++ b/internal/task/sandbox_off_reason_test.go
@@ -32,3 +32,66 @@ func TestUpdateFromMapRejectsNonStringSandboxOffReason(t *testing.T) {
 		t.Fatal("want type error for a non-string reason, got nil")
 	}
 }
+
+// TestSandboxEscapeHatchRequiresReason pins #2778's verification criterion:
+// disabling the sandbox without saying why is refused at the boundary an
+// operator actually calls, rather than recorded and discovered later. The
+// reason is dropped when the hatch is not off, so a task never carries a
+// stale justification for a sandbox that is enabled.
+func TestSandboxEscapeHatchRequiresReason(t *testing.T) {
+	t.Parallel()
+	off, on := false, true
+	const reason = "docker-in-docker e2e needs host mounts"
+
+	cases := []struct {
+		name       string
+		task       Task
+		wantErr    bool
+		wantReason string
+	}{
+		{
+			name:    "disabling without a reason is refused",
+			task:    Task{Sandbox: &off},
+			wantErr: true,
+		},
+		{
+			name:    "whitespace is not a reason",
+			task:    Task{Sandbox: &off, SandboxOffReason: "   "},
+			wantErr: true,
+		},
+		{
+			name:       "disabling with a reason is kept, trimmed",
+			task:       Task{Sandbox: &off, SandboxOffReason: "  " + reason + " "},
+			wantReason: reason,
+		},
+		{
+			name:       "reason is dropped when the sandbox stays on",
+			task:       Task{Sandbox: &on, SandboxOffReason: reason},
+			wantReason: "",
+		},
+		{
+			name:       "reason is dropped when the hatch is unset",
+			task:       Task{SandboxOffReason: reason},
+			wantReason: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.task
+			err := normalizeSandboxEscapeHatch(&got)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+			if got.SandboxOffReason != tc.wantReason {
+				t.Errorf("SandboxOffReason = %q, want %q", got.SandboxOffReason, tc.wantReason)
+			}
+		})
+	}
+}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -550,6 +550,9 @@ func applyCreateInit(t *Task, init Update, now time.Time) {
 	if init.ForkSubagent != nil {
 		t.ForkSubagent = *init.ForkSubagent
 	}
+	if init.SandboxOffReason != nil {
+		t.SandboxOffReason = *init.SandboxOffReason
+	}
 	if init.Sandbox != nil {
 		t.Sandbox = init.Sandbox
 	}
@@ -879,6 +882,9 @@ func applyUpdateFields(t *Task, u Update) error {
 	}
 	if u.ForkSubagent != nil {
 		t.ForkSubagent = *u.ForkSubagent
+	}
+	if u.SandboxOffReason != nil {
+		t.SandboxOffReason = *u.SandboxOffReason
 	}
 	if u.Sandbox != nil {
 		t.Sandbox = u.Sandbox

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -495,6 +495,9 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	// Apply initial field overrides before the first disk write so that any
 	// watcher reading the file sees the complete task from the start.
 	applyCreateInit(&t, init, now)
+	if err := normalizeSandboxEscapeHatch(&t); err != nil {
+		return Task{}, err
+	}
 	if err := s.writeSidecars(t.ID, init, &t); err != nil {
 		return Task{}, err
 	}
@@ -799,6 +802,28 @@ func applyLinkFields(t *Task, u Update) {
 	}
 }
 
+// normalizeSandboxEscapeHatch keeps the escape hatch and its justification in
+// one consistent state. Disabling the sandbox hands a task's agents
+// unrestricted write access to the host, so it must be justified at the point
+// an operator asks for it — an unexplained bypass is not something to discover
+// later in the audit log.
+//
+// The reason is only meaningful while the hatch is actually off, so it is
+// dropped otherwise rather than left behind as stale frontmatter. That makes
+// the flip and its reason a single call: setting sandbox=false in one request
+// and the reason in a later one is refused, not silently accepted half-done.
+func normalizeSandboxEscapeHatch(t *Task) error {
+	if t.Sandbox != nil && !*t.Sandbox {
+		if strings.TrimSpace(t.SandboxOffReason) == "" {
+			return errors.New("sandbox: disabling the sandbox requires sandbox_off_reason explaining why")
+		}
+		t.SandboxOffReason = strings.TrimSpace(t.SandboxOffReason)
+		return nil
+	}
+	t.SandboxOffReason = ""
+	return nil
+}
+
 func applyUpdateFields(t *Task, u Update) error {
 	if u.Title != nil {
 		t.Title = *u.Title
@@ -901,7 +926,7 @@ func applyUpdateFields(t *Task, u Update) error {
 	if u.EffectLog != nil {
 		t.EffectLog = slices.Clone(*u.EffectLog)
 	}
-	return nil
+	return normalizeSandboxEscapeHatch(t)
 }
 
 // UpdateWithPrev applies u under the per-task write lock and returns both

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -56,6 +56,7 @@ type Update struct {
 	MaxTurns              *int
 	ForkSubagent          *bool
 	Sandbox               *bool
+	SandboxOffReason      *string
 	ReasoningEffort       *string
 	Outcome               *string
 	MergeCommit           *string
@@ -135,6 +136,12 @@ func applyMapField(u *Update, k string, v any) error {
 			return fmt.Errorf("field %q: want bool, got %T", k, v)
 		}
 		u.Sandbox = &b
+	case "sandbox_off_reason":
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("field %q: want string, got %T", k, v)
+		}
+		u.SandboxOffReason = &s
 	case "reasoning_effort":
 		s, ok := v.(string)
 		if !ok {

--- a/scripts/dev-mock/backend.sh
+++ b/scripts/dev-mock/backend.sh
@@ -47,6 +47,17 @@ chmod +x "$FAKEBIN/claude" "$FAKEBIN/codex" "$FAKEBIN/copilot"
 # --- seed mock data (idempotent) -------------------------------------------
 SYBRA_HOME="$DEV_HOME" "$REPO_ROOT/scripts/dev-mock/seed.sh"
 
+# sybra-server refuses to start without an explicit sandbox posture, so an
+# omitted key can never be mistaken for a contained one. "off" is right here:
+# the fake provider CLIs above are shell stubs that spawn nothing real. The
+# existence check keeps a hand-edited dev config from being clobbered.
+if [ ! -e "$DEV_HOME/config.yaml" ]; then
+  cat >"$DEV_HOME/config.yaml" <<'YAML'
+agent:
+  sandbox_mode: "off"
+YAML
+fi
+
 # --- run the server --------------------------------------------------------
 echo "sybra-server → http://localhost:${SYBRA_PORT:-8080}  (home: $DEV_HOME)"
 echo "Now run 'mise run dev:web' in another terminal for the HMR frontend."


### PR DESCRIPTION
## Motivation

An unset `agent.sandbox_mode` resolves to `report`, which validates the write allowlist and logs it but never wraps the spawn. So a config that simply omits the key is indistinguishable from a contained one until you grep the logs — which is how the server ran unsandboxed for months while the docs claimed `enforce`. Closes #2778, part of #2775.

> Changelog: feat(sandbox): require an explicit sandbox posture on the server

## Implementation information

Three changes:

**The posture must be stated.** `config.RequireExplicitSandboxMode(true)`, set once by `sybra-server`, makes an unset `agent.sandbox_mode` a load error. Any of `off`/`report`/`enforce` is accepted — the requirement is that an operator chose it. Server-only, so the desktop app and CLI keep the `report` default.

The check sits in the config **load path**, not at the server's startup call site. A boot-only check is defeated by the fsnotify config watcher: `ReloadFromDisk` → `LoadNoPersist` → `ReplaceRuntimeConfig` hot-applies `agent.sandbox_mode`, so deleting the line at runtime would silently drop the fleet back to `report` with no restart and no gate. Putting it in `load()` covers startup, the `-check-config` deploy preflight (so `sybra-build.sh` quarantines a bad candidate instead of promoting one that then restart-loops), and every hot reload — where a rejected load already restores last-known-good.

It is deliberately *not* in `ValidateResolvedConfig`: that also resolves the built-in empty config, so folding it in there panicked every `DefaultConfig` caller. There is a regression test for exactly that.

**Startup states the posture.** `app.automations` now logs `sandbox_mode`, so an instance's containment is visible at a glance alongside its automation roles.

**The escape hatch says why.** `task.SandboxOffReason` is carried into `audit.EventAgentSandboxDisabled`. It has a writer on the supported path — `UpdateFromMap` rejects the whole map on an unknown key, so without a `sandbox_off_reason` case, an operator following the field's documentation would have had their `sandbox: false` flip rejected too, breaking the hatch.

Deliberately *not* hard-rejecting a reasonless `sandbox: false`: the hatch exists for emergencies and must not become unusable. An empty `"reason":""` in the audit line marks an unexplained bypass as plainly as a separate flag would.

## Testing

`mise run verify`. Both new gates were mutation-tested — deleting the `ValidateUnattendedPosture` call site fails the load-path test, and flipping the escape-hatch assertion failed before it was corrected.

## Open questions

`sybra-cli config doctor` still reports clean on an unset `sandbox_mode`. Left as-is: the deploy preflight now fails loudly on the same condition, which is a stronger signal than an advisory warning.

Two unrelated failures surfaced while running the gate, filed rather than fixed here: #2802 (`TestE2E_WaitHuman_InvalidActionRejected`, currently red on `main`) and #2804 (`diskreclaim` TempDir cleanup race). #2802 may make this PR's E2E job red for reasons unrelated to the diff.