### PR TITLE
fix(workflow): harden non-human escalation loops

### DIFF
--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -3,6 +3,9 @@ package provider
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -112,6 +115,35 @@ func TestCodexVersionRegexExtracts(t *testing.T) {
 		if got := codexVersionRe.FindString(in); got != want {
 			t.Errorf("FindString(%q): got %q want %q", in, got, want)
 		}
+	}
+}
+
+func TestProbeCodexOldCLIMarksProviderUnhealthy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex")
+	body := "#!/bin/sh\n" +
+		"case \"$1:$2\" in\n" +
+		"  login:status) printf 'Logged in using ChatGPT\\n' ;;\n" +
+		"  --version:) printf 'codex-cli 0.142.1\\n' ;;\n" +
+		"  *) exit 2 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	st, err := ProbeCodex(context.Background())
+	if err != nil {
+		t.Fatalf("ProbeCodex: %v", err)
+	}
+	if st.Healthy {
+		t.Fatal("Healthy = true, want false for an old Codex CLI")
+	}
+	if st.Reason != "cli_too_old" {
+		t.Fatalf("Reason = %q, want cli_too_old", st.Reason)
+	}
+	if !strings.Contains(st.Detail, "0.142.1") || !strings.Contains(st.Detail, minCodexVersion) {
+		t.Fatalf("Detail = %q, want old and minimum versions", st.Detail)
 	}
 }
 

--- a/internal/provider/probes.go
+++ b/internal/provider/probes.go
@@ -74,12 +74,9 @@ func ProbeCodex(ctx context.Context) (Status, error) {
 		// Reuse cctx so the login and version probes share one probeTimeout
 		// budget rather than allowing ProbeCodex to run for up to 2× of it.
 		if v := probeCodexVersion(cctx); v != "" && !codexVersionAtLeast(v, minCodexVersion) {
-			warning := fmt.Sprintf("codex %s is older than %s; the gpt-5.6 models require %s+ — upgrade codex or pin an older model", v, minCodexVersion, minCodexVersion)
-			if st.Detail != "" {
-				st.Detail += " — " + warning
-			} else {
-				st.Detail = warning
-			}
+			st.Healthy = false
+			st.Reason = "cli_too_old"
+			st.Detail = fmt.Sprintf("codex %s is older than %s; the gpt-5.6 models require %s+ — upgrade codex or disable the provider", v, minCodexVersion, minCodexVersion)
 		}
 	}
 	return st, perr

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -4877,7 +4877,7 @@ func TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired(t *testing.T) {
 	// so only "success" (implement) remains in the queue. The default
 	// classifier verdict (env.classifier) already routes to status=todo,
 	// matching the old "triage" fake-claude scenario.
-	env := setupE2EMultiProvider(t, "claude", []string{"success"})
+	env := setupE2EMultiProvider(t, "claude", []string{"success", "success"})
 	loadBuiltinWorkflow(t, env, "simple-task-plan")
 	loadBuiltinWorkflow(t, env, "simple-task-implement")
 
@@ -4899,14 +4899,34 @@ func TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	waitFor(t, 30*time.Second, "verify_commits parks one no-commit retry", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		return gErr == nil && tk.Workflow != nil &&
+			tk.Workflow.WorkflowID == "simple-task-implement" &&
+			tk.Workflow.CurrentStep == "implement" &&
+			tk.Workflow.State == workflow.ExecWaiting &&
+			tk.Workflow.Variables["step.verify_commits.no_commit_retry"] == "1"
+	})
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk.Workflow.SetVar("workflow.retry_after", time.Now().Add(-time.Minute).UTC().Format(time.RFC3339))
+	wf := tk.Workflow
+	if _, err := env.tasks.Update(created.ID, task.Update{Workflow: &wf}); err != nil {
+		t.Fatal(err)
+	}
+	env.engine.ResumeStalled()
+
 	waitFor(t, 30*time.Second, "implement workflow completes after verify_commits", func() bool {
+		env.engine.ResumeStalled()
 		tk, gErr := env.tasks.Get(created.ID)
 		return gErr == nil && tk.Workflow != nil &&
 			tk.Workflow.WorkflowID == "simple-task-implement" &&
 			tk.Workflow.State == workflow.ExecCompleted
 	})
 
-	tk, _ := env.tasks.Get(created.ID)
+	tk, _ = env.tasks.Get(created.ID)
 	if tk.Status != task.StatusHumanRequired {
 		t.Fatalf("status = %q, want human-required", tk.Status)
 	}

--- a/internal/workflow/engine_steps_focused_checks.go
+++ b/internal/workflow/engine_steps_focused_checks.go
@@ -383,11 +383,14 @@ func (e *Engine) reaskFocusedChecks(taskID string, step *Step, wfExec *Execution
 	if wfExec == nil || wfExec.CountStep(verifyChecksImplStepID) == 0 {
 		return e.flagFocusedChecks(taskID, step, reason, failedCmd)
 	}
+	fingerprint := autoFixFailureFingerprint(failedCmd, output)
 	armed, attempt, err := e.rewindRetry(taskID, wfExec, t, rewindRetryPolicy{
-		counterKey: "step." + step.ID + ".auto_fix",
-		max:        verifyChecksAutoFixCeiling,
-		rewindStep: verifyChecksImplStepID,
-		backoff:    autoFixBackoff,
+		counterKey:             "step." + step.ID + ".auto_fix",
+		max:                    verifyChecksAutoFixCeiling,
+		rewindStep:             verifyChecksImplStepID,
+		backoff:                autoFixBackoff,
+		fingerprint:            fingerprint,
+		maxSameFingerprintRuns: 2,
 		onArm: func(wfExec *Execution, attempt int) {
 			wfExec.SetVar(focusedChecksReaskNoteVar, buildFocusedChecksReaskNote(selected, changedFiles, failedCmd, output))
 		},
@@ -397,7 +400,7 @@ func (e *Engine) reaskFocusedChecks(taskID string, step *Step, wfExec *Execution
 		return StepOutput{}, fmt.Errorf("focused-checks: rewind to implement: %w", err)
 	}
 	if !armed {
-		exhausted := fmt.Sprintf("%s — escalating after %d auto-fix attempts without passing",
+		exhausted := fmt.Sprintf("%s — escalating after repeated identical auto-fix failures or %d attempts without passing",
 			reason, verifyChecksAutoFixCeiling)
 		return e.flagFocusedChecks(taskID, step, exhausted, "auto-fix-exhausted: "+trimDiffLine(failedCmd))
 	}

--- a/internal/workflow/engine_steps_focused_checks_test.go
+++ b/internal/workflow/engine_steps_focused_checks_test.go
@@ -337,7 +337,7 @@ func TestExecFocusedChecks_FailureReasksImplement(t *testing.T) {
 	}
 }
 
-func TestExecFocusedChecks_FailureReasksPastOldCap(t *testing.T) {
+func TestExecFocusedChecks_FailureReasksBelowCeiling(t *testing.T) {
 	t.Parallel()
 
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
@@ -352,10 +352,10 @@ func TestExecFocusedChecks_FailureReasksPastOldCap(t *testing.T) {
 	}}, nil)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	// Past the old cap of 2, a code-fixable focused-check failure keeps being
-	// re-asked; it escalates only at verifyChecksAutoFixCeiling.
+	// A code-fixable focused-check failure below the generic ceiling keeps
+	// being re-asked.
 	wf := implementedExec()
-	wf.Variables["step.focused_checks.auto_fix"] = "9"
+	wf.Variables["step.focused_checks.auto_fix"] = "2"
 	out, err := engine.execFocusedChecks("t1", newFocusedChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
 	if !errors.Is(err, errStepParked) {
 		t.Fatalf("err = %v, want errStepParked (keep re-asking, never escalate)", err)
@@ -366,8 +366,8 @@ func TestExecFocusedChecks_FailureReasksPastOldCap(t *testing.T) {
 	if wf.CurrentStep != verifyChecksImplStepID || wf.State != ExecWaiting {
 		t.Fatalf("workflow after rewind = %+v, want implement/ExecWaiting", wf)
 	}
-	if got := wf.Variables["step.focused_checks.auto_fix"]; got != "10" {
-		t.Fatalf("auto_fix counter = %q, want 10", got)
+	if got := wf.Variables["step.focused_checks.auto_fix"]; got != "3" {
+		t.Fatalf("auto_fix counter = %q, want 3", got)
 	}
 	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "in-progress" {
 		t.Fatalf("status = %q, want in-progress (never escalated to human)", ti.Status)

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/attribution"
 	"github.com/Automaat/sybra/internal/evidence"
@@ -302,7 +303,7 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution,
 	}
 
 	if strings.TrimSpace(string(output)) == "" {
-		return e.verifyCommitsHandleEmptyOutput(taskID, step, wfExec, wtPath), nil
+		return e.verifyCommitsHandleEmptyOutput(taskID, step, wfExec, t, wtPath)
 	}
 
 	if finalSource == "" {
@@ -431,15 +432,18 @@ func (e *Engine) verifyCommitsRecoveredRemoteAdopt(taskID, wtPath string, t Task
 	}
 }
 
-func (e *Engine) verifyCommitsHandleEmptyOutput(taskID string, step *Step, wfExec *Execution, wtPath string) StepOutput {
-	if wfExec.LastAgentStepFailed() {
+func (e *Engine) verifyCommitsHandleEmptyOutput(taskID string, step *Step, wfExec *Execution, t TaskInfo, wtPath string) (StepOutput, error) {
+	if wfExec != nil && wfExec.LastAgentStepFailed() {
 		reason := "implementation agent failed before committing — no commits on branch"
 		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
 			e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
 		}
 		e.logger.Warn("workflow.verify-commits.agent-failed", "task_id", taskID)
 		e.recordEvidence(taskID, step.ID, evidenceCriterionVerifyCommits, evidence.ProofDeterministicCheck, 1, "", reason)
-		return StepOutput{StepID: step.ID, Status: "completed", Output: "agent failed before commit: flipped to human-required"}
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "agent failed before commit: flipped to human-required"}, nil
+	}
+	if e.rearmNoCommitAuthorRun(taskID, wfExec, t) {
+		return StepOutput{}, errStepParked
 	}
 	// branchMergedIntoBase(e.ctx, wtPath) used to gate a "done" verdict here,
 	// on the theory that HEAD == base could mean the fix already landed via a
@@ -461,7 +465,42 @@ func (e *Engine) verifyCommitsHandleEmptyOutput(taskID string, step *Step, wfExe
 		e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
 	}
 	e.recordEvidence(taskID, step.ID, evidenceCriterionVerifyCommits, evidence.ProofDeterministicCheck, 1, "", reason)
-	return StepOutput{StepID: step.ID, Status: "completed", Output: "no commits: flipped to human-required"}
+	return StepOutput{StepID: step.ID, Status: "completed", Output: "no commits: flipped to human-required"}, nil
+}
+
+func (e *Engine) rearmNoCommitAuthorRun(taskID string, wfExec *Execution, t TaskInfo) bool {
+	if wfExec == nil {
+		return false
+	}
+	agentID := wfExec.LastAgentID()
+	run, ok := agentRunInfoByID(t.AgentRuns, agentID)
+	if !ok || !isCodeAuthorRun(run) {
+		return false
+	}
+	stepID := wfExec.LastAgentStepID()
+	if stepID == "" {
+		return false
+	}
+	const counterKey = "step.verify_commits.no_commit_retry"
+	if parseWorkflowInt(wfExec.Variables[counterKey]) >= 1 {
+		return false
+	}
+	wfExec.SetVar(counterKey, "1")
+	wfExec.SetVar(verifyReaskNoteVar, "The previous implementation run completed without producing commits. Make the required code changes, then commit and push them before finishing.")
+	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(verifyChecksAutoFixBackoff).Format(time.RFC3339))
+	wfExec.ClearStepRecords(stepID)
+	wfExec.CurrentStep = stepID
+	wfExec.State = ExecWaiting
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		e.logger.Error("workflow.verify-commits.no-commit-retry.workflow", "task_id", taskID, "err", err)
+		return false
+	}
+	if err := e.tasks.UpdateTaskStatus(taskID, t.Status, "retrying implementation once after no commits were produced"); err != nil {
+		e.logger.Error("workflow.verify-commits.no-commit-retry.status", "task_id", taskID, "err", err)
+		return false
+	}
+	e.logger.Warn("workflow.verify-commits.no-commit-retry", "task_id", taskID, "step", stepID, "agent_id", agentID)
+	return true
 }
 
 func (e *Engine) recordFinalCommitState(taskID string, wfExec *Execution, wtPath, source string) {

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -46,7 +48,7 @@ const (
 	autoFixBackoffMax          = 15 * time.Minute
 	// verifyChecksAutoFixCeiling bounds auto-fix re-asks so a deterministic
 	// failure no agent can fix reaches a human instead of looping forever.
-	verifyChecksAutoFixCeiling = 20
+	verifyChecksAutoFixCeiling = 5
 	// Full verify suites are CPU-heavy and already serialized by workflow
 	// retries; a single local slot prevents one saturated host from piling
 	// multiple suites on top of each other and timing them all out.
@@ -839,11 +841,14 @@ func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Ex
 	if wfExec == nil || wfExec.CountStep(verifyChecksImplStepID) == 0 {
 		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
 	}
+	fingerprint := autoFixFailureFingerprint(failedCmd, output)
 	armed, attempt, err := e.rewindRetry(taskID, wfExec, t, rewindRetryPolicy{
-		counterKey: "step." + step.ID + ".auto_fix",
-		max:        verifyChecksAutoFixCeiling,
-		rewindStep: verifyChecksImplStepID,
-		backoff:    autoFixBackoff,
+		counterKey:             "step." + step.ID + ".auto_fix",
+		max:                    verifyChecksAutoFixCeiling,
+		rewindStep:             verifyChecksImplStepID,
+		backoff:                autoFixBackoff,
+		fingerprint:            fingerprint,
+		maxSameFingerprintRuns: 2,
 		onArm: func(wfExec *Execution, attempt int) {
 			wfExec.SetVar(verifyReaskNoteVar, buildVerifyReaskNote(failedCmd, output))
 		},
@@ -855,13 +860,18 @@ func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Ex
 		return StepOutput{}, fmt.Errorf("verify-checks: rewind to implement: %w", err)
 	}
 	if !armed {
-		exhausted := fmt.Sprintf("%s — escalating after %d auto-fix attempts without passing",
+		exhausted := fmt.Sprintf("%s — escalating after repeated identical auto-fix failures or %d attempts without passing",
 			reason, verifyChecksAutoFixCeiling)
 		return e.flagVerifyChecks(taskID, step, exhausted, "auto-fix-exhausted: "+trimDiffLine(failedCmd))
 	}
 	e.logger.Info("workflow.verify-checks.auto-fix",
 		"task_id", taskID, "attempt", attempt, "cmd", trimDiffLine(failedCmd))
 	return StepOutput{}, errStepParked
+}
+
+func autoFixFailureFingerprint(failedCmd, output string) string {
+	h := sha256.Sum256([]byte(strings.TrimSpace(failedCmd) + "\n" + highestSignalVerifyFailureExcerpt(failedCmd, output)))
+	return hex.EncodeToString(h[:])
 }
 
 func buildVerifyReaskNote(failedCmd, output string) string {

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -870,7 +870,11 @@ func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Ex
 }
 
 func autoFixFailureFingerprint(failedCmd, output string) string {
-	h := sha256.Sum256([]byte(strings.TrimSpace(failedCmd) + "\n" + highestSignalVerifyFailureExcerpt(failedCmd, output)))
+	excerpt := highestSignalVerifyFailureExcerpt(failedCmd, output)
+	if excerpt == "" {
+		excerpt = tailString(strings.TrimSpace(output), 1200)
+	}
+	h := sha256.Sum256([]byte(strings.TrimSpace(failedCmd) + "\n" + excerpt))
 	return hex.EncodeToString(h[:])
 }
 

--- a/internal/workflow/engine_steps_verify_checks_autofix_test.go
+++ b/internal/workflow/engine_steps_verify_checks_autofix_test.go
@@ -173,12 +173,27 @@ func TestExecVerifyChecks_AutoFixIdenticalFingerprintEscalatesEarly(t *testing.T
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
 	wf := implementedExec()
-	fp := autoFixFailureFingerprint(cmd, "$ "+cmd+"\n"+lintVerifyOutput("internal/foo/foo.go"))
-	wf.Variables["step.verify_checks.auto_fix"] = "2"
-	wf.Variables["step.verify_checks.auto_fix.fingerprint"] = fp
-	wf.Variables["step.verify_checks.auto_fix.fingerprint_count"] = "2"
-
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("first attempt err = %v, want errStepParked", err)
+	}
+	if out != (StepOutput{}) {
+		t.Fatalf("first parked output should be zero, got %+v", out)
+	}
+	now := time.Now().UTC()
+	wf.RecordStep(StepRecord{StepID: verifyChecksImplStepID, Status: "completed", StartedAt: now, EndedAt: now})
+
+	out, err = engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("second attempt err = %v, want errStepParked", err)
+	}
+	if out != (StepOutput{}) {
+		t.Fatalf("second parked output should be zero, got %+v", out)
+	}
+	now = time.Now().UTC()
+	wf.RecordStep(StepRecord{StepID: verifyChecksImplStepID, Status: "completed", StartedAt: now, EndedAt: now})
+
+	out, err = engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -191,6 +206,17 @@ func TestExecVerifyChecks_AutoFixIdenticalFingerprintEscalatesEarly(t *testing.T
 	}
 	if !strings.Contains(ti.StatusReason, "repeated identical auto-fix failures") {
 		t.Fatalf("reason = %q, want identical-failure exhaustion", ti.StatusReason)
+	}
+}
+
+func TestAutoFixFailureFingerprintFallsBackToOutputTail(t *testing.T) {
+	t.Parallel()
+	const cmd = "mise exec -- go test ./internal/workflow"
+
+	first := autoFixFailureFingerprint(cmd, "$ "+cmd+"\n--- FAIL: TestAlpha\n    alpha_test.go:12: got false\nFAIL\n")
+	second := autoFixFailureFingerprint(cmd, "$ "+cmd+"\n--- FAIL: TestBeta\n    beta_test.go:34: got 0\nFAIL\n")
+	if first == second {
+		t.Fatal("fingerprints matched for distinct non-frontend failures under the same command")
 	}
 }
 

--- a/internal/workflow/engine_steps_verify_checks_autofix_test.go
+++ b/internal/workflow/engine_steps_verify_checks_autofix_test.go
@@ -137,16 +137,16 @@ func TestExecVerifyChecks_AutoFixRewindsToImplement(t *testing.T) {
 	}
 }
 
-func TestExecVerifyChecks_AutoFixReasksPastOldCap(t *testing.T) {
+func TestExecVerifyChecks_AutoFixReasksBelowCeiling(t *testing.T) {
 	t.Parallel()
 	wt := makeLintVerifyRepo(t)
 	engine, tasks := newVerifyChecksEngine(t, wt, []string{lintVerifyCommand("internal/foo/foo.go")})
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
-	// Past the old cap of 2, a code-fixable lint failure keeps being re-asked
-	// rather than escalating; it escalates only at verifyChecksAutoFixCeiling.
+	// A code-fixable lint failure below the generic ceiling keeps being
+	// re-asked rather than escalating.
 	wf := implementedExec()
-	wf.Variables["step.verify_checks.auto_fix"] = "9"
+	wf.Variables["step.verify_checks.auto_fix"] = "2"
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
 	if !errors.Is(err, errStepParked) {
 		t.Fatalf("err = %v, want errStepParked (keep re-asking, never escalate)", err)
@@ -157,11 +157,40 @@ func TestExecVerifyChecks_AutoFixReasksPastOldCap(t *testing.T) {
 	if wf.CurrentStep != verifyChecksImplStepID || wf.State != ExecWaiting {
 		t.Fatalf("workflow after rewind = %+v, want implement/ExecWaiting", wf)
 	}
-	if got := wf.Variables["step.verify_checks.auto_fix"]; got != "10" {
-		t.Errorf("auto_fix counter = %q, want 10", got)
+	if got := wf.Variables["step.verify_checks.auto_fix"]; got != "3" {
+		t.Errorf("auto_fix counter = %q, want 3", got)
 	}
 	if ti := mustGetTaskInfo(t, tasks, "t1"); ti.Status != "in-progress" {
 		t.Errorf("status = %q, want in-progress (never escalated to human)", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_AutoFixIdenticalFingerprintEscalatesEarly(t *testing.T) {
+	t.Parallel()
+	wt := makeLintVerifyRepo(t)
+	cmd := lintVerifyCommand("internal/foo/foo.go")
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{cmd})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	wf := implementedExec()
+	fp := autoFixFailureFingerprint(cmd, "$ "+cmd+"\n"+lintVerifyOutput("internal/foo/foo.go"))
+	wf.Variables["step.verify_checks.auto_fix"] = "2"
+	wf.Variables["step.verify_checks.auto_fix.fingerprint"] = fp
+	wf.Variables["step.verify_checks.auto_fix.fingerprint_count"] = "2"
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged", out.Output)
+	}
+	ti := mustGetTaskInfo(t, tasks, "t1")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if !strings.Contains(ti.StatusReason, "repeated identical auto-fix failures") {
+		t.Fatalf("reason = %q, want identical-failure exhaustion", ti.StatusReason)
 	}
 }
 
@@ -366,7 +395,7 @@ func TestExecVerifyChecks_DeterministicFrontendFailureRewindsToImplement(t *test
 	}
 }
 
-func TestExecVerifyChecks_DeterministicFrontendFailureKeepsReasking(t *testing.T) {
+func TestExecVerifyChecks_DeterministicFrontendFailureReasksBelowCeiling(t *testing.T) {
 	t.Parallel()
 	wt := makeFrontendVerifyRepo(t)
 	binDir := writeFrontendVerifyMise(t)
@@ -375,7 +404,7 @@ func TestExecVerifyChecks_DeterministicFrontendFailureKeepsReasking(t *testing.T
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
 	wf := implementedExec()
-	wf.Variables["step.verify_checks.auto_fix"] = "9"
+	wf.Variables["step.verify_checks.auto_fix"] = "2"
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
 	if !errors.Is(err, errStepParked) {
 		t.Fatalf("err = %v, want errStepParked (keep re-asking, never escalate)", err)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -9393,6 +9393,69 @@ func TestExecVerifyCommits_BranchAtBaseFlipsHumanRequired(t *testing.T) {
 	}
 }
 
+func TestExecVerifyCommits_NoCommitAuthorRunRetriesOnce(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	wfExec := &Execution{Variables: map[string]string{}}
+	wfExec.RecordStep(StepRecord{StepID: "implement", Status: "completed", AgentID: "a1", Provider: "claude"})
+	ti := TaskInfo{
+		ID: "t1", Status: "in-progress",
+		AgentRuns: []AgentRunInfo{{AgentID: "a1", Role: "implementation"}},
+	}
+
+	_, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, ti)
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	if wfExec.CurrentStep != "implement" || wfExec.State != ExecWaiting {
+		t.Fatalf("workflow = %+v, want rearmed implement/ExecWaiting", wfExec)
+	}
+	if got := wfExec.Variables["step.verify_commits.no_commit_retry"]; got != "1" {
+		t.Fatalf("no_commit_retry = %q, want 1", got)
+	}
+	if got := wfExec.Variables[verifyReaskNoteVar]; !strings.Contains(got, "without producing commits") {
+		t.Fatalf("verify reask note = %q, want no-commit guidance", got)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress retry", ti.Status)
+	}
+}
+
+func TestExecVerifyCommits_NoCommitAuthorRunEscalatesAfterRetry(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	wfExec := &Execution{Variables: map[string]string{"step.verify_commits.no_commit_retry": "1"}}
+	wfExec.RecordStep(StepRecord{StepID: "implement", Status: "completed", AgentID: "a1", Provider: "claude"})
+	ti := TaskInfo{
+		ID: "t1", Status: "in-progress",
+		AgentRuns: []AgentRunInfo{{AgentID: "a1", Role: "implementation"}},
+	}
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, ti)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.Output, "no commits") {
+		t.Fatalf("Output = %q, want no commits", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required after one retry", ti.Status)
+	}
+}
+
 // TestExecVerifyCommits_BranchAncestorOfBaseFlipsHumanRequired covers the
 // regression from issue #670: HEAD is an ancestor of origin/main (branch tip
 // equals an older commit on main, with newer commits on top — typical of

--- a/internal/workflow/rewind_retry.go
+++ b/internal/workflow/rewind_retry.go
@@ -28,6 +28,10 @@ type rewindRetryPolicy struct {
 	// backoff computes the retry-after delay from the pre-increment attempt
 	// count (verify-checks grows it per attempt; testing uses a constant).
 	backoff func(attempts int) time.Duration
+	// fingerprint identifies the failure being retried. When set, repeated
+	// identical failures can exhaust earlier than the generic attempt ceiling.
+	fingerprint            string
+	maxSameFingerprintRuns int
 	// onArm sets any additional workflow variables the rewound step's prompt
 	// needs (reask note, cleared verdict vars) once the counter has been
 	// bumped to `attempt`, before the workflow is persisted. Optional.
@@ -49,9 +53,26 @@ func (e *Engine) rewindRetry(taskID string, wfExec *Execution, t TaskInfo, p rew
 	if attempts >= p.max {
 		return false, attempts, nil
 	}
+	if p.fingerprint != "" && p.maxSameFingerprintRuns > 0 {
+		fpKey := p.counterKey + ".fingerprint"
+		fpCountKey := p.counterKey + ".fingerprint_count"
+		if wfExec.Variables[fpKey] == p.fingerprint && parseWorkflowInt(wfExec.Variables[fpCountKey]) >= p.maxSameFingerprintRuns {
+			return false, attempts, nil
+		}
+	}
 
 	attempt = attempts + 1
 	wfExec.SetVar(p.counterKey, strconv.Itoa(attempt))
+	if p.fingerprint != "" {
+		fpKey := p.counterKey + ".fingerprint"
+		fpCountKey := p.counterKey + ".fingerprint_count"
+		count := 1
+		if wfExec.Variables[fpKey] == p.fingerprint {
+			count = parseWorkflowInt(wfExec.Variables[fpCountKey]) + 1
+		}
+		wfExec.SetVar(fpKey, p.fingerprint)
+		wfExec.SetVar(fpCountKey, strconv.Itoa(count))
+	}
 	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(p.backoff(attempts)).Format(time.RFC3339))
 	if p.onArm != nil {
 		p.onArm(wfExec, attempt)


### PR DESCRIPTION
## Summary
- mark too-old Codex CLIs unhealthy so provider failover can avoid unsupported model runs
- retry successful code-author runs once when verify_commits finds no commits, then escalate only after the retry also produces no commits
- lower verify/focused auto-fix ceilings and stop early on repeated identical failure fingerprints

## Tests
- go test ./internal/provider ./internal/workflow