### PR TITLE
test(test): pin action rejection, not a timestamp

### DIFF
--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -3078,7 +3078,21 @@ func TestE2E_WaitHuman_InvalidActionRejected(t *testing.T) {
 
 	before, _ := env.tasks.Get(created.ID)
 	historyBefore := len(before.Workflow.StepHistory)
-	updatedBefore := before.UpdatedAt
+	stepBefore := before.Workflow.CurrentStep
+	stateBefore := before.Workflow.State
+
+	// An unrelated write, standing in for the lease renewals and effect-log
+	// appends the engine performs on its own schedule. It bumps UpdatedAt
+	// without touching the state machine, which is exactly the interleaving
+	// that used to fail this test: the rejection was correct, but a timestamp
+	// comparison cannot tell "the bogus action mutated the task" apart from
+	// "something else wrote while we were looking". Doing it deliberately
+	// makes the distinction part of what the test pins.
+	if _, err := env.tasks.Update(created.ID, task.Update{
+		StatusReason: task.Ptr("concurrent write during invalid-action handling"),
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	err = env.engine.HandleHumanAction(created.ID, "bogus", nil)
 	if err == nil {
@@ -3098,8 +3112,9 @@ func TestE2E_WaitHuman_InvalidActionRejected(t *testing.T) {
 	if got := len(after.Workflow.StepHistory); got != historyBefore {
 		t.Errorf("step_history len = %d, want %d", got, historyBefore)
 	}
-	if !after.UpdatedAt.Equal(updatedBefore) {
-		t.Errorf("UpdatedAt changed from %v to %v", updatedBefore, after.UpdatedAt)
+	if after.Workflow.CurrentStep != stepBefore || after.Workflow.State != stateBefore {
+		t.Errorf("workflow moved from %s/%s to %s/%s",
+			stepBefore, stateBefore, after.Workflow.CurrentStep, after.Workflow.State)
 	}
 	if _, set := after.Workflow.Variables["human_action"]; set {
 		t.Errorf("human_action unexpectedly set: %q", after.Workflow.Variables["human_action"])


### PR DESCRIPTION
## Motivation

`TestE2E_WaitHuman_InvalidActionRejected` is currently red on `main` (run [30704328128](https://github.com/Automaat/sybra/actions/runs/30704328128)), so every branch cut from it inherits a failing Go E2E job that has nothing to do with the branch. That is the failure mode where a real regression rides in behind "just the flake". Closes #2802.

> Changelog: skip

## Implementation information

The test asserted `after.UpdatedAt.Equal(updatedBefore)` after a rejected human action. That equality cannot distinguish the two things it is being asked about: a mutation caused by the bogus action, versus any unrelated write landing in the same window. The workflow engine renews leases and appends to the effect log on its own schedule, so a correct rejection produced a red build whenever that interleaving occurred — 10ms apart in the observed failure.

The sibling assertions in the same block already express the actual invariant (state, current step, step-history length, `human_action` unset), and all of them passed in every failing run.

So the timestamp equality is replaced by an explicit check that the state machine did not move, and the test now **performs the concurrent write itself** rather than waiting to lose a race with one. That turns a probabilistic failure into a pinned distinction: an unrelated write must not fail this test, and a state-machine mutation must.

## Testing

- New assertion: 5/5 passes, plus the full `go test -race -tags e2e ./internal/sybra/...` suite green.
- Old assertion, re-added on top of the new deliberate write: fails **3/3**, confirming the test now reproduces the exact interleaving that used to be intermittent rather than merely tolerating it.