### PR TITLE
fix(workflow): type human-action errors as 4xx

### DIFF
--- a/internal/sybra/svc_planning.go
+++ b/internal/sybra/svc_planning.go
@@ -107,7 +107,7 @@ func recoverCompletedPlanReview(t workflow.TaskInfo) (*workflow.Execution, bool,
 		return nil, false, nil
 	}
 	if problems := completedPlanReviewRecoveryProblems(t); len(problems) > 0 {
-		return nil, false, fmt.Errorf("cannot recover plan review workflow for task %s: %s", t.ID, strings.Join(problems, "; "))
+		return nil, false, conflictError(fmt.Sprintf("cannot recover plan review workflow for task %s: %s", t.ID, strings.Join(problems, "; ")))
 	}
 
 	wf := *t.Workflow

--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -1,7 +1,9 @@
 package sybra
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/httpapi"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 )
@@ -146,8 +149,16 @@ func TestPlanningService_ApprovePlan_ErrorWhenNotWaiting(t *testing.T) {
 	}
 
 	// No workflow running → approve should fail.
-	if _, err := planSvc.ApprovePlan(created.ID); err == nil {
+	_, err = planSvc.ApprovePlan(created.ID)
+	if err == nil {
 		t.Fatal("expected error when approving task without active workflow")
+	}
+	var ce httpapi.ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("want a 4xx httpapi.ClientError so a cluster follower's rejection relays as a readable error instead of a sanitized 500, got %T: %v", err, err)
+	}
+	if ce.HTTPStatus() != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", ce.HTTPStatus(), http.StatusConflict)
 	}
 }
 
@@ -419,8 +430,16 @@ func TestPlanningService_RejectPlan_ErrorWhenNotWaiting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := planSvc.RejectPlan(created.ID, "bad plan"); err == nil {
+	_, err = planSvc.RejectPlan(created.ID, "bad plan")
+	if err == nil {
 		t.Fatal("expected error when rejecting task without active workflow")
+	}
+	var ce httpapi.ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("want a 4xx httpapi.ClientError so a cluster follower's rejection relays as a readable error instead of a sanitized 500, got %T: %v", err, err)
+	}
+	if ce.HTTPStatus() != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", ce.HTTPStatus(), http.StatusConflict)
 	}
 }
 

--- a/internal/workflow/client_errors.go
+++ b/internal/workflow/client_errors.go
@@ -1,0 +1,29 @@
+package workflow
+
+import "net/http"
+
+// ClientError is a user-facing error that internal/httpapi's handler
+// surfaces directly (status + message) instead of sanitizing it to a
+// generic 500 internal error. Implements httpapi.ClientError structurally
+// (error + HTTPStatus() int) without importing that package.
+type ClientError struct {
+	status int
+	msg    string
+}
+
+func (e *ClientError) Error() string   { return e.msg }
+func (e *ClientError) HTTPStatus() int { return e.status }
+
+// conflictError reports that a task is not in the workflow state a human
+// action (approve/reject/input) requires right now — retrying the same call
+// won't help until the task's state changes, but it's not a malformed
+// request.
+func conflictError(msg string) error {
+	return &ClientError{status: http.StatusConflict, msg: msg}
+}
+
+// validationError reports a caller input mistake, e.g. an action name the
+// current wait_human step does not accept.
+func validationError(msg string) error {
+	return &ClientError{status: http.StatusBadRequest, msg: msg}
+}

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -115,7 +115,7 @@ func (e *Engine) withHumanActionLock(taskID string, fn func() error) error {
 	e.mu.Lock()
 	if _, busy := e.humanAction[taskID]; busy {
 		e.mu.Unlock()
-		return fmt.Errorf("task %s human action already in progress", taskID)
+		return conflictError(fmt.Sprintf("task %s human action already in progress", taskID))
 	}
 	e.humanAction[taskID] = struct{}{}
 	e.mu.Unlock()
@@ -146,7 +146,7 @@ func (e *Engine) handleHumanAction(taskID, action string, data map[string]string
 		}
 	}
 	if t.Workflow == nil || t.Workflow.State != ExecWaiting {
-		return fmt.Errorf("task %s is not waiting for human action", taskID)
+		return conflictError(fmt.Sprintf("task %s is not waiting for human action", taskID))
 	}
 	def, err := e.store.Get(t.Workflow.WorkflowID)
 	if err != nil {
@@ -167,7 +167,7 @@ func (e *Engine) handleHumanAction(taskID, action string, data map[string]string
 				return err
 			}
 			if t.Workflow == nil {
-				return fmt.Errorf("task %s is not waiting for human action", taskID)
+				return conflictError(fmt.Sprintf("task %s is not waiting for human action", taskID))
 			}
 			def, err = e.store.Get(t.Workflow.WorkflowID)
 			if err != nil {
@@ -180,7 +180,7 @@ func (e *Engine) handleHumanAction(taskID, action string, data map[string]string
 		}
 	}
 	if currentStep.Type != StepWaitHuman {
-		return fmt.Errorf("task %s is not at a wait_human step", taskID)
+		return conflictError(fmt.Sprintf("task %s is not at a wait_human step", taskID))
 	}
 	if err := validateHumanAction(currentStep, action); err != nil {
 		return err
@@ -239,7 +239,7 @@ func (e *Engine) recoverMissedWaitForStatusHumanGate(taskID string, t TaskInfo, 
 
 func validateHumanAction(step *Step, action string) error {
 	if len(step.Config.HumanActions) > 0 && !slices.Contains(step.Config.HumanActions, action) {
-		return fmt.Errorf("invalid human action %q for step %q", action, step.ID)
+		return validationError(fmt.Sprintf("invalid human action %q for step %q", action, step.ID))
 	}
 	return nil
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5422,6 +5422,13 @@ func TestHandleHumanAction_NotWaiting(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-waiting task")
 	}
+	var ce *ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("want *ClientError so httpapi surfaces it as a 4xx instead of a sanitized 500, got %T: %v", err, err)
+	}
+	if ce.HTTPStatus() != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", ce.HTTPStatus(), http.StatusConflict)
+	}
 }
 
 func TestHandleHumanAction_InvalidActionAlreadyWaitingDoesNotMutate(t *testing.T) {
@@ -5445,6 +5452,13 @@ func TestHandleHumanAction_InvalidActionAlreadyWaitingDoesNotMutate(t *testing.T
 	err := engine.HandleHumanAction("t1", "bogus", nil)
 	if err == nil || !strings.Contains(err.Error(), "invalid human action") {
 		t.Fatalf("HandleHumanAction error = %v, want invalid human action", err)
+	}
+	var ce *ClientError
+	if !errors.As(err, &ce) {
+		t.Fatalf("want *ClientError so httpapi surfaces it as a 4xx instead of a sanitized 500, got %T: %v", err, err)
+	}
+	if ce.HTTPStatus() != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", ce.HTTPStatus(), http.StatusBadRequest)
 	}
 
 	got, err := tasks.GetTask("t1")


### PR DESCRIPTION
## Motivation

> Changelog: fix(workflow): type human-action errors as 4xx

A cluster leader calling `ApprovePlan`/`RejectPlan` on a task on a
follower that isn't actually waiting for human action surfaced only
as an opaque `RuntimeError: cluster call to node <node> failed`,
with the real reason discoverable only by grepping the follower's
own server log.

Root cause: `handleHumanAction`'s state-precondition errors ("task
is not waiting for human action", "invalid human action for step")
were plain `fmt.Errorf`, so `internal/httpapi`'s handler flattened
them to a generic 500. `ClusterService.relayFollowerError` only
forwards a follower's 4xx text verbatim to the leader's caller — a
5xx is deliberately sanitized to avoid leaking follower internals,
which is correct for genuine server errors but wrong for a
precondition failure the caller could otherwise read and act on.

## Implementation information

- Added `internal/workflow/client_errors.go`, a `ClientError` type
  implementing `httpapi.ClientError` structurally (`error` +
  `HTTPStatus() int`), matching the existing pattern in
  `internal/agent` and `internal/sybra`.
- `handleHumanAction`'s state-mismatch errors ("not waiting for
  human action", "not at a wait_human step", "human action already
  in progress") now return a 409 `conflictError`.
- `validateHumanAction`'s "invalid human action" now returns a 400
  `validationError` — it's a caller input mistake, not a state
  conflict.
- `recoverCompletedPlanReview` in `internal/sybra/svc_planning.go`
  (same `HandleHumanActionRecovering` call path) now uses the
  package's existing `conflictError` helper for the same reason.
- Extended the existing unit tests
  (`TestHandleHumanAction_NotWaiting`,
  `TestHandleHumanAction_InvalidActionAlreadyWaitingDoesNotMutate`,
  `TestPlanningService_ApprovePlan_ErrorWhenNotWaiting`,
  `TestPlanningService_RejectPlan_ErrorWhenNotWaiting`) to assert
  the returned error is a typed 4xx `ClientError`/`httpapi.ClientError`,
  not just non-nil.

No behavior change for the single-node/non-cluster case — the error
text is unchanged, only the HTTP status classification. The generic
`relayFollowerError`/`stripErrorResult` mechanisms that read this
typed status were already covered by existing tests
(`TestRelayFollowerError`, `internal/httpapi`'s handler tests) and
are unchanged here.

## Supporting documentation

`mise run verify` passes locally (full CI-aligned gate: build, unit
+ e2e tests, golangci-lint, frontend build/check/coverage/oxlint,
api-shim sync, no-home-fallback, bindings drift, hadolint).