### PR TITLE
fix(workflow): recover stale plan review actions

### DIFF
--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -226,6 +226,63 @@ func TestPlanningService_ApprovePlan_RecoversCompletedPlanReviewWorkflow(t *test
 	}
 }
 
+func TestWorkflowService_HandleHumanAction_RecoversCompletedPlanReviewWorkflow(t *testing.T) {
+	_, taskSvc, a := setupPlanningService(t)
+	workflowSvc := &WorkflowService{engine: taskSvc.workflowEngine}
+
+	created, err := a.tasks.Create("approve stale plan through workflow service", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := task.StatusPlanReview
+	completedAt := time.Now().UTC()
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "",
+		State:       workflow.ExecCompleted,
+		StepHistory: []workflow.StepRecord{
+			{StepID: "validate_plan_contract", Status: "completed"},
+			{StepID: "maybe_critique", Status: "completed"},
+		},
+		StartedAt:   completedAt.Add(-time.Minute),
+		CompletedAt: &completedAt,
+	}
+	plan := "# Execution Plan\n\n## Steps\n1. Fix it."
+	planContract := validPlanningContract(created.ID)
+	planResearch := "researched relevant files"
+	planDecisions := "# Decisions\n\nNo open decisions."
+	planBrief := "safe to approve"
+	if _, err := a.tasks.Update(created.ID, task.Update{
+		Status:        &status,
+		Workflow:      &wf,
+		Plan:          &plan,
+		PlanContract:  &planContract,
+		PlanResearch:  &planResearch,
+		PlanDecisions: &planDecisions,
+		PlanBrief:     &planBrief,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := workflowSvc.HandleHumanAction(created.ID, "approve", nil); err != nil {
+		t.Fatalf("HandleHumanAction approve: %v", err)
+	}
+
+	updated, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusInProgress {
+		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusInProgress)
+	}
+	if updated.Workflow == nil || updated.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow = %+v, want completed", updated.Workflow)
+	}
+	if updated.Workflow.CurrentStep != "" {
+		t.Fatalf("CurrentStep = %q, want empty after approval", updated.Workflow.CurrentStep)
+	}
+}
+
 func TestPlanningService_ApprovePlan_DoesNotRecoverWithoutValidatedPlan(t *testing.T) {
 	planSvc, _, a := setupPlanningService(t)
 

--- a/internal/sybra/svc_workflow.go
+++ b/internal/sybra/svc_workflow.go
@@ -53,5 +53,17 @@ func (s *WorkflowService) StartWorkflow(taskID, workflowID string) error {
 
 // HandleHumanAction processes approve/reject/input for a waiting workflow step.
 func (s *WorkflowService) HandleHumanAction(taskID, action string, data map[string]string) error {
+	if isPlanReviewHumanAction(action) {
+		return s.engine.HandleHumanActionRecovering(taskID, action, data, recoverCompletedPlanReview)
+	}
 	return s.engine.HandleHumanAction(taskID, action, data)
+}
+
+func isPlanReviewHumanAction(action string) bool {
+	switch action {
+	case "approve", "reject":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Summary
- route generic workflow approve/reject actions through completed plan-review recovery
- add regression coverage for the stale completed simple-task-plan shape

## Verification
- GOCACHE=/tmp/sybra-go-build-cache go test ./internal/sybra -run 'Test(PlanningService|WorkflowService|ClusterService).*Plan'