### PR TITLE
fix(workflow): recover recurring human-required gates

### DIFF
--- a/internal/diskreclaim/reclaimer_test.go
+++ b/internal/diskreclaim/reclaimer_test.go
@@ -239,6 +239,22 @@ func TestReclaimerTryRunStartsWhenIdleAndCooldownElapsed(t *testing.T) {
 	if !r.TryRun() {
 		t.Fatal("TryRun should start a pass when idle and the cooldown has elapsed")
 	}
+	waitForReclaimerIdle(t, r)
+}
+
+func waitForReclaimerIdle(t *testing.T, r *Reclaimer) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		running := r.running
+		r.mu.Unlock()
+		if !running {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("reclaimer did not finish")
 }
 
 func TestReclaimerTryRunNilReclaimerIsSafe(t *testing.T) {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -613,11 +613,30 @@ func looksLikeGitDir(dir string) bool {
 	return true
 }
 
+var checkpointRunRecoveryCommit = runRecoveryCommit
+
 // CheckpointCommit stages and commits the current worktree state with message.
 // Returns committed=false when the tree is already clean. Unlike
 // AutoCommitUncommitted this is strict: any git failure is returned so callers
 // never assume durable state exists when the checkpoint commit did not land.
+//
+// Linked worktrees share one bare clone object store. When a stale worktree
+// admin ref or missing object poisons that shared store, `git add`/`commit` can
+// fail with "invalid object" even though the task's edits are otherwise
+// recoverable. Repair the shared clone and retry once before surfacing the
+// failure to the workflow.
 func CheckpointCommit(ctx context.Context, wtPath, message string) (committed bool, err error) {
+	committed, err = checkpointCommitOnce(ctx, wtPath, message)
+	if err == nil || !IsBadRefError(err) {
+		return committed, err
+	}
+	if repairErr := repairCheckpointWorktree(ctx, wtPath); repairErr != nil {
+		return false, err
+	}
+	return checkpointCommitOnce(ctx, wtPath, message)
+}
+
+func checkpointCommitOnce(ctx context.Context, wtPath, message string) (committed bool, err error) {
 	statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 	statusCmd.Dir = wtPath
 	statusOut, err := statusCmd.CombinedOutput()
@@ -634,10 +653,20 @@ func CheckpointCommit(ctx context.Context, wtPath, message string) (committed bo
 		return false, fmt.Errorf("git add -A: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 
-	if err := runRecoveryCommit(ctx, wtPath, message); err != nil {
+	if err := checkpointRunRecoveryCommit(ctx, wtPath, message); err != nil {
 		return false, fmt.Errorf("checkpoint: %w", err)
 	}
 	return true, nil
+}
+
+func repairCheckpointWorktree(ctx context.Context, wtPath string) error {
+	commonDir, err := gitCommonDir(ctx, wtPath)
+	if err != nil {
+		return err
+	}
+	branchOut, _ := exec.CommandContext(ctx, "git", "-C", wtPath, "branch", "--show-current").Output()
+	_, err = RepairBareClone(ctx, commonDir, strings.TrimSpace(string(branchOut)))
+	return err
 }
 
 // SanitizeWorktree cleans up worktree state that would confuse agents:

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -858,8 +858,6 @@ func TestSanitizeWorktree_AutoCommitsUncommitted(t *testing.T) {
 }
 
 func TestCheckpointCommit(t *testing.T) {
-	t.Parallel()
-
 	t.Run("dirty tree commits", func(t *testing.T) {
 		t.Parallel()
 		repo := initRepoWithCommit(t)
@@ -966,6 +964,42 @@ func TestCheckpointCommit(t *testing.T) {
 		}
 		if committed {
 			t.Fatal("CheckpointCommit reported committed=true on git failure")
+		}
+	})
+
+	t.Run("bad object commit failure repairs and retries once", func(t *testing.T) {
+		repo := initRepoWithCommit(t)
+		if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		origCommit := checkpointRunRecoveryCommit
+		calls := 0
+		checkpointRunRecoveryCommit = func(ctx context.Context, wtPath, message string) error {
+			calls++
+			if calls == 1 {
+				return errors.New("checkpoint: recovery commit: invalid object 100644 deadbeef for 'main.go'")
+			}
+			return origCommit(ctx, wtPath, message)
+		}
+		t.Cleanup(func() { checkpointRunRecoveryCommit = origCommit })
+
+		committed, err := CheckpointCommit(context.Background(), repo, "chore(checkpoint): save progress")
+		if err != nil {
+			t.Fatalf("CheckpointCommit: %v", err)
+		}
+		if !committed {
+			t.Fatal("CheckpointCommit reported committed=false on a dirty tree")
+		}
+		if calls != 2 {
+			t.Fatalf("checkpoint commit attempts = %d, want 2", calls)
+		}
+		statusOut, err := exec.Command("git", "-C", repo, "status", "--porcelain").Output()
+		if err != nil {
+			t.Fatalf("git status: %v", err)
+		}
+		if got := strings.TrimSpace(string(statusOut)); got != "" {
+			t.Fatalf("worktree not clean after retry: %s", got)
 		}
 	})
 }

--- a/internal/workflow/engine_skill_receipt.go
+++ b/internal/workflow/engine_skill_receipt.go
@@ -67,6 +67,15 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 		return false
 	}
 	if retries >= maxSkillReceiptRecoveryAttempts {
+		if present, kind := importedSidecarPresentForStep(currentStep, fresh); present {
+			delete(fresh.Workflow.Variables, retryKey)
+			if err := e.tasks.SetWorkflow(taskID, fresh.Workflow); err != nil {
+				e.logger.Warn("workflow.skill-receipt.sidecar-present.persist", "task_id", taskID, "step", spawnedStep, "err", err)
+			}
+			e.logger.Warn("workflow.skill-receipt.sidecar-present",
+				"task_id", taskID, "step", spawnedStep, "skill", run.RequestedSkill, "sidecar", kind)
+			return false
+		}
 		delete(fresh.Workflow.Variables, retryKey)
 		// Finalize the Execution like finishTerminalStepOutput does for every
 		// other human-required escalation (e.g. checkpoint_failed). Left
@@ -124,6 +133,45 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 		return true
 	default:
 		return false
+	}
+}
+
+func importedSidecarPresentForStep(step *Step, t TaskInfo) (present bool, kind string) {
+	if step == nil {
+		return false, ""
+	}
+	for _, cfg := range step.Config.sidecarImports() {
+		sidecarKind := cfg.Kind
+		if sidecarKind == "plan_draft" {
+			sidecarKind = "plan_draft." + step.ID
+		}
+		if strings.TrimSpace(taskSidecarContent(t, sidecarKind)) != "" {
+			return true, sidecarKind
+		}
+	}
+	return false, ""
+}
+
+func taskSidecarContent(t TaskInfo, kind string) string {
+	switch {
+	case kind == "plan":
+		return t.Plan
+	case kind == "plan_contract":
+		return t.PlanContract
+	case kind == "plan_critique":
+		return t.PlanCritique
+	case kind == "plan_research":
+		return t.PlanResearch
+	case kind == "plan_decisions":
+		return t.PlanDecisions
+	case kind == "plan_brief":
+		return t.PlanBrief
+	case kind == "code_review":
+		return t.CodeReview
+	case strings.HasPrefix(kind, "plan_draft."):
+		return t.PlanDrafts[strings.TrimPrefix(kind, "plan_draft.")]
+	default:
+		return ""
 	}
 }
 

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -92,6 +92,10 @@ const (
 		"output, the expected behaviour citing the task's own words, and a code line quoted from the " +
 		"CURRENT file (file:line). Re-run the probes and produce that evidence — or, if the feature " +
 		"actually works, emit PASS with the required manual-testing evidence."
+	fixSuggestionsReask = "Your previous FAIL report was rejected because it contained fix suggestions " +
+		"instead of observed symptoms. Re-run adversarial testing and report only what you directly " +
+		"observed: commands, outputs, expected behaviour, actual behaviour, and cited evidence. Do not " +
+		"propose implementation changes; if you cannot prove a product defect, emit PASS."
 )
 
 func testingAutoRetryKey(outcome string) string {
@@ -2377,21 +2381,16 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 
 	if violation := wfExec.Variables["step."+testVerdictSourceStep+"."+testVerdictTaintedKey]; violation != "" {
-		// A missing-evidence report describes the runner, not the code — re-ask
-		// the tester (with the specific evidence it owes) before a human. A
-		// fix-suggestions violation already had one in-step retry and rarely
-		// improves on re-ask, so it still escalates immediately.
+		// Protocol violations describe the runner, not the code. Re-ask the
+		// tester with the specific contract it broke before involving a human.
 		if violation == testProtocolMissingEvidence {
 			return e.retryOrEscalateTransient(taskID, step.ID, testOutcomeMissingEvidence, missingEvidenceReask,
 				"test-runner report lacked machine-checkable evidence after auto-retries — needs local reproduction",
 				"protocol violation: "+violation, "workflow.test.protocol-violation", wfExec, t)
 		}
-		reason := "test-runner report violated testing protocol after retry: contained fix suggestions instead of observed symptoms"
-		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
-			return StepOutput{}, err
-		}
-		e.logger.Warn("workflow.test.protocol-violation", "task_id", taskID, "violation", violation)
-		return StepOutput{StepID: step.ID, Status: "completed", Output: "protocol violation: " + violation}, nil
+		return e.retryOrEscalateTransient(taskID, step.ID, testOutcomeProtocolViolation, fixSuggestionsReask,
+			"test-runner report violated testing protocol after auto-retries — needs local reproduction",
+			"protocol violation: "+violation, "workflow.test.protocol-violation", wfExec, t)
 	}
 	outcome := wfExec.Variables["step."+testVerdictSourceStep+"."+testVerdictOutcomeKey]
 	if out, handled, err := e.routeNonProductTestOutcome(taskID, step.ID, outcome, wfExec, t); handled || err != nil {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -2270,8 +2270,10 @@ func TestAdvanceStep_TestProtocolViolationAfterRetryStopsWithProtocolReason(t *t
 		WorkflowID:  "testing-task",
 		CurrentStep: testVerdictSourceStep,
 		State:       ExecWaiting,
-		Variables:   map[string]string{},
-		StartedAt:   time.Now().UTC(),
+		Variables: map[string]string{
+			testingAutoRetryKey(testOutcomeProtocolViolation): strconv.Itoa(testingAutoRetryCap),
+		},
+		StartedAt: time.Now().UTC(),
 		StepHistory: []StepRecord{{
 			StepID: testVerdictSourceStep,
 			Status: "failed",

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6879,6 +6879,94 @@ steps:
 	}
 }
 
+func TestHandleAgentComplete_UnverifiedSkillAfterRetryContinuesWithImportedSidecar(t *testing.T) {
+	store := newInlineTestStore(t, "skill-receipt", `id: skill-receipt
+name: Skill Receipt
+trigger:
+  on: task.created
+steps:
+  - id: run
+    name: Run
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      provider: codex
+      prompt: "Run /adversarial-review now."
+      import_sidecar:
+        from: '{{getvar .Vars "_dir"}}/.sybra-review-{{.Task.ID}}.md'
+        kind: code_review
+        required: true
+    next:
+      - goto: require_review
+  - id: require_review
+    name: Require Review
+    type: require_sidecar
+    config:
+      sidecar: code_review
+    next:
+      - goto: done
+  - id: done
+    name: Done
+    type: set_status
+    config:
+      status: done
+`)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".sybra-review-t1.md"), []byte("Review Verdict: CLEAN\n\nNo findings.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow: &Execution{
+			WorkflowID:  "skill-receipt",
+			CurrentStep: "run",
+			State:       ExecWaiting,
+			Variables: map[string]string{
+				WorkflowVarDir:                 dir,
+				skillReceiptRecoveryKey("run"): "1",
+			},
+		},
+		AgentRuns: []AgentRunInfo{{
+			AgentID:            "agent-2",
+			Role:               "review",
+			Provider:           "codex",
+			RequestedSkill:     "adversarial-review",
+			SkillExecutionMode: "injected",
+			SkillConformance:   "unverified",
+		}},
+	})
+
+	engine.HandleAgentComplete("t1", AgentCompletion{
+		AgentID: "agent-2",
+		Result:  "review complete without receipt",
+		Success: true,
+	})
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Status != "done" {
+		t.Fatalf("Status = %q, want done", ti.Status)
+	}
+	if !strings.Contains(ti.CodeReview, "Review Verdict: CLEAN") {
+		t.Fatalf("CodeReview = %q, want imported review sidecar", ti.CodeReview)
+	}
+	if got := ti.Workflow.Variables[skillReceiptRecoveryKey("run")]; got != "" {
+		t.Fatalf("skill receipt retry var = %q, want cleared after sidecar continuation", got)
+	}
+	if len(agents.calls) != 0 {
+		t.Fatalf("StartAgent calls = %d, want no third attempt", len(agents.calls))
+	}
+}
+
 // TestHandleAgentComplete_UnverifiedSkillExhaustionAllowsFreshWorkflowStart
 // covers the human-review recovery handoff: once skill-receipt exhaustion
 // marks a task human-required, a subsequent recovery attempt must be able to


### PR DESCRIPTION
## Summary
- retry checkpoint commits once after repairing bad shared bare-clone state
- continue mandatory-skill workflows when the required sidecar was imported despite a missing receipt
- re-ask test runners on protocol violations instead of immediately parking human-required

## Tests
- HOME=/tmp/sybra-test-home GOCACHE=/tmp/sybra-go-build-cache go test ./internal/project -run 'TestCheckpointCommit|TestIsBadRefError'
- HOME=/tmp/sybra-test-home GOCACHE=/tmp/sybra-go-build-cache go test ./internal/workflow -run 'TestHandleAgentComplete_UnverifiedSkill|TestAdvanceStep_TestProtocol|TestExecCodegenGate'
- HOME=/tmp/sybra-test-home GOCACHE=/tmp/sybra-go-build-cache go test ./internal/project ./internal/workflow
- go test ./internal/skillattr
- git diff --check