### PR TITLE
test(test): budget e2e waits in intended time

### DIFF
--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -122,7 +122,12 @@ func TestQueueDrainPassDrainsManualStartsForEveryRole(t *testing.T) {
 
 func waitForFreeSlot(t *testing.T, a *App) {
 	t.Helper()
-	for range 200 {
+	// 5s flat used to be the whole budget here, unscaled — this helper predates
+	// the deadline scaling and never picked it up, so on a contended runner a
+	// slot that frees in 6s read as a hung pool (#2811).
+	budget := 5 * time.Second * time.Duration(e2eTimeoutScale())
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
 		if a.agents.AvailableQueueDrainSlots(1) > 0 {
 			return
 		}

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -125,7 +125,7 @@ func waitForFreeSlot(t *testing.T, a *App) {
 	// 5s flat used to be the whole budget here, unscaled — this helper predates
 	// the deadline scaling and never picked it up, so on a contended runner a
 	// slot that frees in 6s read as a hung pool (#2811).
-	budget := 5 * time.Second * time.Duration(e2eTimeoutScale())
+	budget := time.Duration(int64(5*time.Second) * e2eTimeoutScale())
 	deadline := time.Now().Add(budget)
 	for time.Now().Before(deadline) {
 		if a.agents.AvailableQueueDrainSlots(1) > 0 {

--- a/internal/sybra/e2e_waitfor_test.go
+++ b/internal/sybra/e2e_waitfor_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+
+package sybra
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAwaitConditionCountsIntendedTimeNotWallClock is #2811's core property.
+// The host is reported idle (scale 1) while every poll costs far more
+// wall-clock than the interval asked for — what a process-spawn/IO-bound suite
+// looks like on darwin, where load-per-CPU stays under 1 and the load-average
+// scaler grants no headroom at all.
+//
+// The wait must still give the condition its full number of chances, because
+// the budget is spent in intended time rather than wall-clock.
+func TestAwaitConditionCountsIntendedTimeNotWallClock(t *testing.T) {
+	const succeedOnCall = 5
+	calls := 0
+	budget, _, ok := awaitCondition(300*time.Millisecond, func() bool {
+		calls++
+		time.Sleep(120 * time.Millisecond) // each poll far outruns the 50ms interval
+		return calls >= succeedOnCall
+	}, func() int64 { return 1 })
+
+	if !ok {
+		t.Fatalf("gave up after %s having polled %d times; a slow host must not cost the condition its chances", budget, calls)
+	}
+	if calls != succeedOnCall {
+		t.Fatalf("condition ran %d times, want %d", calls, succeedOnCall)
+	}
+}
+
+// TestAwaitConditionGivesUpWhenConditionNeverHolds is the counterweight: a
+// condition that never becomes true must still fail, and in bounded time, or
+// counting intended time would turn a genuine hang into an unbounded wait.
+func TestAwaitConditionGivesUpWhenConditionNeverHolds(t *testing.T) {
+	start := time.Now()
+	_, _, ok := awaitCondition(200*time.Millisecond,
+		func() bool { return false },
+		func() int64 { return 1 })
+	if ok {
+		t.Fatal("a never-satisfied condition must not report success")
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("gave up only after %s; the budget is not bounded", elapsed)
+	}
+}
+
+// TestAwaitConditionHonoursTheScale pins that the injected scaler still sizes
+// the budget: a larger scale must buy proportionally more polls.
+func TestAwaitConditionHonoursTheScale(t *testing.T) {
+	count := func(scale int64) int {
+		calls := 0
+		awaitCondition(100*time.Millisecond, func() bool {
+			calls++
+			return false
+		}, func() int64 { return scale })
+		return calls
+	}
+	few, many := count(1), count(4)
+	if many <= few {
+		t.Fatalf("scale 4 polled %d times, scale 1 polled %d; a larger scale must buy more chances", many, few)
+	}
+}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/sybra/completion"
 	"github.com/Automaat/sybra/internal/task"
-	"github.com/Automaat/sybra/internal/testutil/loadscale"
 	"github.com/Automaat/sybra/internal/triage"
 
 	"github.com/Automaat/sybra/internal/workflow"
@@ -466,17 +465,53 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 // defended against per-test.
 func waitFor(t *testing.T, timeout time.Duration, desc string, fn func() bool) {
 	t.Helper()
-	scale := e2eTimeoutScale()
-	scaled := clampToReportingDeadline(time.Duration(int64(timeout) * scale))
-	deadline := time.After(scaled)
+	waitForWithScale(t, timeout, desc, fn, e2eTimeoutScale)
+}
+
+// waitForWithScale is waitFor with the deadline scaler injected, so the
+// adaptive behaviour can be tested without mutating SYBRA_E2E_TIMEOUT_SCALE —
+// that variable is process-global and every concurrently running test's budget
+// reads it, so a test that sets it starves its neighbours.
+func waitForWithScale(t *testing.T, timeout time.Duration, desc string, fn func() bool, scaleFn func() int64) {
+	t.Helper()
+	if budget, scale, ok := awaitCondition(timeout, fn, scaleFn); !ok {
+		t.Fatalf("timeout waiting for: %s (after %s, scale=%d)\n%s", desc, budget, scale, e2eGoroutineDump())
+	}
+}
+
+// awaitCondition polls fn until it holds or its budget is exhausted,
+// reporting the budget and scale so the caller can describe the failure.
+//
+// The budget is spent in *intended* time — the time this loop asked to sleep
+// — not wall-clock. That is the fix for #2811: the load-average scaler is a
+// lagging and, on darwin, frequently blind signal, because a suite that
+// oversubscribes the host through process spawning and I/O leaves
+// load-per-CPU under 1 while wall-clock waits inflate several-fold. Counting
+// intended time makes the deadline mean "this many polls' worth of chances",
+// which is what the test actually cares about, and immune to how slow the
+// host is while it takes them.
+//
+// A wall-clock backstop still applies so a pathologically slow host cannot let
+// one wait consume the whole binary timeout.
+func awaitCondition(timeout time.Duration, fn func() bool, scaleFn func() int64) (time.Duration, int64, bool) {
+	const pollInterval = 50 * time.Millisecond
+	scale := scaleFn()
+	budget := time.Duration(int64(timeout) * scale)
+	maxWall := clampToReportingDeadline(time.Duration(int64(timeout) * e2eTimeoutScaleCeiling))
+	start := time.Now()
+	var slept time.Duration
 	for {
-		select {
-		case <-deadline:
-			t.Fatalf("timeout waiting for: %s (after %s, scale=%d)\n%s", desc, scaled, scale, e2eGoroutineDump())
-		case <-time.After(50 * time.Millisecond):
-			if fn() {
-				return
-			}
+		// Sleep before the first check, matching the original select-based
+		// loop. Polling immediately on entry would let a condition that is
+		// only transiently true at t=0 report success before the behaviour
+		// under test has happened at all.
+		time.Sleep(pollInterval)
+		slept += pollInterval
+		if fn() {
+			return budget, scale, true
+		}
+		if slept >= budget || time.Since(start) >= maxWall {
+			return budget, scale, false
 		}
 	}
 }
@@ -590,40 +625,6 @@ func dropParkedTestGoroutines(dump string) string {
 		out += fmt.Sprintf("\n\n(%d goroutines parked in t.Parallel omitted — they hold nothing)\n", parked)
 	}
 	return out
-}
-
-func e2eTimeoutScale() int64 {
-	return e2eTimeoutScaleResolve()
-}
-
-const (
-	e2eTimeoutScaleCeiling = 20
-	e2eCITimeoutScaleFloor = 12
-)
-
-func e2eTimeoutScaleResolve() int64 {
-	if v := strings.TrimSpace(os.Getenv("SYBRA_E2E_TIMEOUT_SCALE")); v != "" {
-		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
-			return n
-		}
-	}
-	factor := loadscale.HostOversubscriptionFactor(e2eTimeoutScaleCeiling)
-	// CI runners carry a known-bad baseline (slow fork/exec, container I/O
-	// variance) even when the load average looks idle, so they get a fixed
-	// floor on top of the measured factor. Local/dev runs (including a fleet
-	// of concurrent agents on darwin/linux) have no such baseline — they
-	// scale purely off measured host load, same as CI does above the floor.
-	if os.Getenv("CI") == "" && os.Getenv("GITHUB_ACTIONS") == "" {
-		return factor
-	}
-	scaled := e2eCITimeoutScaleFloor * factor
-	if scaled < e2eCITimeoutScaleFloor {
-		return e2eCITimeoutScaleFloor
-	}
-	if scaled > e2eTimeoutScaleCeiling {
-		return e2eTimeoutScaleCeiling
-	}
-	return scaled
 }
 
 func TestE2E_HeadlessAgent_Success(t *testing.T) {

--- a/internal/sybra/testscale_extra_test.go
+++ b/internal/sybra/testscale_extra_test.go
@@ -8,8 +8,10 @@ import (
 
 // TestOversubscriptionFactorIgnoresIdleHost documents the property that made
 // #2811 possible: the factor is derived from a one-minute load average, so a
-// host that is about to become saturated still reports "idle" and yields no
-// scaling. Waits therefore cannot treat the first measurement as final.
+// host oversubscribed through process spawning and I/O — rather than CPU —
+// still reports "idle" and yields no scaling at all. That is why wall-clock
+// deadlines cannot be sized from this signal, and why waits budget in
+// intended time instead.
 func TestOversubscriptionFactorIgnoresIdleHost(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/sybra/testscale_extra_test.go
+++ b/internal/sybra/testscale_extra_test.go
@@ -1,0 +1,50 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/testutil/loadscale"
+)
+
+// TestOversubscriptionFactorIgnoresIdleHost documents the property that made
+// #2811 possible: the factor is derived from a one-minute load average, so a
+// host that is about to become saturated still reports "idle" and yields no
+// scaling. Waits therefore cannot treat the first measurement as final.
+func TestOversubscriptionFactorIgnoresIdleHost(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		load float64
+		ok   bool
+		want int64
+	}{
+		{name: "idle host gets no scaling", load: 0.2, ok: true, want: 1},
+		{name: "exactly one per cpu is not oversubscribed", load: 1, ok: true, want: 1},
+		{name: "unreadable load fails safe to no scaling", load: 9, ok: false, want: 1},
+		{name: "oversubscription rounds up", load: 3.2, ok: true, want: 4},
+		{name: "ceiling caps the factor", load: 99, ok: true, want: 20},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := loadscale.OversubscriptionFactor(tc.load, tc.ok, 20); got != tc.want {
+				t.Errorf("OversubscriptionFactor(%v, %v) = %d, want %d", tc.load, tc.ok, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTimeoutScaleHonoursExplicitOverride pins the escape hatch the adaptive
+// path relies on for testing, and that CI's floor cannot silently drop below
+// itself.
+func TestTimeoutScaleHonoursExplicitOverride(t *testing.T) {
+	t.Setenv("SYBRA_E2E_TIMEOUT_SCALE", "7")
+	if got := e2eTimeoutScale(); got != 7 {
+		t.Fatalf("explicit override = %d, want 7", got)
+	}
+	t.Setenv("SYBRA_E2E_TIMEOUT_SCALE", "")
+	t.Setenv("CI", "1")
+	if got := e2eTimeoutScale(); got < e2eCITimeoutScaleFloor {
+		t.Fatalf("CI scale = %d, want at least the floor %d", got, e2eCITimeoutScaleFloor)
+	}
+}

--- a/internal/sybra/testscale_test.go
+++ b/internal/sybra/testscale_test.go
@@ -1,0 +1,50 @@
+package sybra
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/testutil/loadscale"
+)
+
+// Deadline scaling for every test in this package, tagged or not.
+//
+// It lives in an untagged file because the unscaled waits that motivated
+// #2811 were in untagged tests, which cannot see anything defined behind
+// //go:build e2e. Keeping one definition here is what stops a helper from
+// quietly growing its own hardcoded budget again.
+
+func e2eTimeoutScale() int64 {
+	return e2eTimeoutScaleResolve()
+}
+
+const (
+	e2eTimeoutScaleCeiling = 20
+	e2eCITimeoutScaleFloor = 12
+)
+
+func e2eTimeoutScaleResolve() int64 {
+	if v := strings.TrimSpace(os.Getenv("SYBRA_E2E_TIMEOUT_SCALE")); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	factor := loadscale.HostOversubscriptionFactor(e2eTimeoutScaleCeiling)
+	// CI runners carry a known-bad baseline (slow fork/exec, container I/O
+	// variance) even when the load average looks idle, so they get a fixed
+	// floor on top of the measured factor. Local/dev runs (including a fleet
+	// of concurrent agents on darwin/linux) have no such baseline — they
+	// scale purely off measured host load, same as CI does above the floor.
+	if os.Getenv("CI") == "" && os.Getenv("GITHUB_ACTIONS") == "" {
+		return factor
+	}
+	scaled := e2eCITimeoutScaleFloor * factor
+	if scaled < e2eCITimeoutScaleFloor {
+		return e2eCITimeoutScaleFloor
+	}
+	if scaled > e2eTimeoutScaleCeiling {
+		return e2eTimeoutScaleCeiling
+	}
+	return scaled
+}


### PR DESCRIPTION
## Motivation

`Go E2E Tests` has been failing across `main` and PR branches on three different tests in one afternoon, always with a *waiting* failure rather than a behavioural one. Closes #2811.

The proximate cause is not any single test. Deadlines were sized by a load-average scaler that is lagging and, on darwin, largely blind: a suite that oversubscribes the host through process spawning and I/O leaves load-per-CPU **under 1**, so `OversubscriptionFactor` returns 1 and grants no headroom at all — while wall-clock waits inflate several-fold.

> Changelog: skip

## Implementation information

**Budgets are now spent in intended time** — the time the poll loop asked to sleep — rather than wall-clock. A deadline then means "this many polls' worth of chances", which is what a test actually cares about, and is independent of how slow the host is while taking them. A wall-clock backstop still bounds any single wait so it cannot consume the whole binary timeout.

**`waitForFreeSlot` is scaled.** It had a flat, hardcoded 5s and predated the scaling mechanism entirely, so it never picked it up — that is what `main` was red on. It also lives in an untagged file, so it runs in `Go Tests` too.

**The scale resolver moved to an untagged file.** The unscaled helper could not see it behind `//go:build e2e`; one definition now covers the whole package, which is what stops the next helper from quietly growing its own hardcoded budget.

## Testing

`TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired` reproduced **locally** under full-suite load (~30.8s against its 30s budget; ~8s in isolation). It now passes, and the full `-race -tags e2e -p 1` suite plus `mise run verify` are green.

Three regression tests cover the property and its counterweight: a slow host must not cost a condition its chances; a condition that never holds must still fail, bounded; and a larger scale must buy proportionally more polls.

## Open questions

Two dead ends worth recording so nobody re-walks them:

- I first made the budget re-measure host load on expiry. That does not help, because the signal it re-reads is the one that is blind here — it stayed at 1 throughout.
- I then suspected the `ResumeStalled()` call inside that test's poll condition of contending with the workflow it waits on. Throttling it made the test **worse** (34s), which shows the test depends on that hammering to drive the workflow forward. Whether a test should have to drive the engine that way is a fair question, but it is a separate one.