### PR TITLE
test(test): drain agent routes before mutating

### DIFF
--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -4915,21 +4915,29 @@ func TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Wait for AgentRoutes to drain, not just for the rearm to land.
+	// rearm_no_commit_author persists the workflow while the finished agent's
+	// route is still on the record, and clearAgentStep removes it in a second,
+	// separate write. Proceeding between those two writes leaves an engine
+	// writer live for this task while the mutation below runs.
 	waitFor(t, 30*time.Second, "verify_commits parks one no-commit retry", func() bool {
 		tk, gErr := env.tasks.Get(created.ID)
 		return gErr == nil && tk.Workflow != nil &&
 			tk.Workflow.WorkflowID == "simple-task-implement" &&
 			tk.Workflow.CurrentStep == "implement" &&
 			tk.Workflow.State == workflow.ExecWaiting &&
+			len(tk.Workflow.AgentRoutes) == 0 &&
 			tk.Workflow.Variables["step.verify_commits.no_commit_retry"] == "1"
 	})
-	tk, err := env.tasks.Get(created.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tk.Workflow.SetVar("workflow.retry_after", time.Now().Add(-time.Minute).UTC().Format(time.RFC3339))
-	wf := tk.Workflow
-	if _, err := env.tasks.Update(created.ID, task.Update{Workflow: &wf}); err != nil {
+	// Mutate under the per-task lock. A Get followed by a whole-Execution
+	// Update is a lost update against any concurrent engine writer, and the
+	// field most likely to be clobbered back is AgentRoutes — a route to an
+	// agent that will never complete wedges ResumeStalled permanently.
+	if _, err := env.tasks.UpdateFn(created.ID, func(cur task.Task) (task.Update, error) {
+		wf := cur.Workflow
+		wf.SetVar("workflow.retry_after", time.Now().Add(-time.Minute).UTC().Format(time.RFC3339))
+		return task.Update{Workflow: &wf}, nil
+	}); err != nil {
 		t.Fatal(err)
 	}
 	env.engine.ResumeStalled()
@@ -4942,7 +4950,7 @@ func TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired(t *testing.T) {
 			tk.Workflow.State == workflow.ExecCompleted
 	})
 
-	tk, _ = env.tasks.Get(created.ID)
+	tk, _ := env.tasks.Get(created.ID)
 	if tk.Status != task.StatusHumanRequired {
 		t.Fatalf("status = %q, want human-required", tk.Status)
 	}


### PR DESCRIPTION
## Motivation

`TestE2E_VerifyCommits_BranchAtBaseMarksHumanRequired` fails only in CI, and it is **not** a timeout problem — the deadline work in #2811 gave it more time and it still died. In the failing run the engine logs

```
workflow.resume-stalled.skip task_id=… reason=agent-pending-completion step=implement
```

**471 times** — the whole 6 minutes spent refusing to resume the task. It blocks every PR touching `internal/sybra` (currently #2810 and #2821).

> Changelog: skip

## Implementation information

`tryMarkResumeDispatching` derives `hasOutstandingAgent` purely from persisted `AgentRoutes` (`internal/workflow/engine_events.go:1108`) and never checks whether that agent still exists. A route left pointing at a finished agent therefore wedges the workflow permanently: nothing clears routes except an agent-completion path, and no agent will ever complete.

The window: `rearm_no_commit_author` persists the workflow while the finished agent's route is still on the record, and `clearAgentStep` removes it in a *second, separate* write. The test's first `waitFor` is satisfied by the first of those writes, so it proceeds while an engine writer is still live for the task — then does its own blind `Get` → `Update{Workflow:…}`, which can lose the concurrent route clear.

Two changes: wait for `AgentRoutes` to drain rather than for the rearm alone, and mutate through `UpdateFn` under the per-task lock instead of the unsynchronised read-modify-write.

## Testing

Fixed test passes 5/5, and 3/3 with delays injected at every `clearAgentStep` call site to force the interleaving. Full `-race -tags e2e -p 1 ./internal/sybra/` green; lint clean.

## Open questions

**I could not reproduce the CI failure locally**, so I cannot prove this fixes it. Injecting delays at all six `clearAgentStep` sites (100ms and 400ms) plus a 400ms gap in the test did not wedge the pre-fix test — I verified the pre-fix code was genuinely restored before concluding that. So the lost update is a plausible trigger, not an established one, and this PR is worth landing on its own merits — waiting for a quiescent record and taking the documented lock are both strictly safer — while CI is the only place that can actually confirm it.

Regardless of whether this closes the CI failure, the underlying defect is in product code and reachable in production: any concurrent whole-workflow writer (GUI, `sybra-cli`, monitor) can strand a route, and the only signal is a DEBUG log while the task silently stops advancing. `hasOutstandingAgent` should be liveness-aware. Filing that separately.