### PR TITLE
fix(workflow): recover from stale agent routes

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -418,6 +418,7 @@ type Engine struct {
 	starting         map[string]struct{}        // taskID → StartWorkflowWithVars in progress
 	humanAction      map[string]struct{}        // taskID → HandleHumanAction in progress
 	pendingRoutes    map[string]string          // taskID+"\x00"+agentID → stepID while StartAgent succeeded but route persistence has not
+	completing       map[string]int             // taskID → in-flight HandleAgentComplete calls (agent finished, completion not yet routed)
 	cascadeDepth     map[string]int             // taskID → synchronous cascade hop depth (recursion guard)
 	pendingRecovery  map[string]pendingRecovery // taskID → branch-conflict recovery deferred until the outer marker releases
 	resumeError      *logging.ErrorThrottle
@@ -527,6 +528,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		starting:               make(map[string]struct{}),
 		humanAction:            make(map[string]struct{}),
 		pendingRoutes:          make(map[string]string),
+		completing:             make(map[string]int),
 		cascadeDepth:           make(map[string]int),
 		pendingRecovery:        make(map[string]pendingRecovery),
 		resumeError:            logging.NewErrorThrottle(),

--- a/internal/workflow/engine_agent_routes.go
+++ b/internal/workflow/engine_agent_routes.go
@@ -159,11 +159,16 @@ func routeMatchesStep(step *Step, routedStepID string) bool {
 // agent for the task means the route may still be legitimately owned, so this
 // declines to prune. That errs toward the old (skip) behaviour, never toward
 // duplicate dispatch.
+//
+// IsDispatching is consulted separately from HasRunningAgent rather than
+// assumed to be covered by it: the AgentLauncher contract does not promise
+// that a held dispatch claim reads as "running", and tryMarkResumeDispatching
+// already treats the two as independent signals.
 func (e *Engine) pruneStaleAgentRoutes(taskID string, step *Step) {
 	if taskID == "" || step == nil {
 		return
 	}
-	if e.completionInFlight(taskID) || e.agents.HasRunningAgent(taskID) {
+	if e.completionInFlight(taskID) || e.agents.HasRunningAgent(taskID) || e.agents.IsDispatching(taskID) {
 		return
 	}
 	t, err := e.tasks.GetTask(taskID)

--- a/internal/workflow/engine_agent_routes.go
+++ b/internal/workflow/engine_agent_routes.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"slices"
 	"strings"
+	"sync"
 )
 
 // routeStepPending reports whether the task's current step is still inside its
@@ -90,6 +91,112 @@ func (e *Engine) clearAgentStep(taskID, agentID string) {
 		return
 	}
 	_ = e.tasks.SetWorkflow(taskID, t.Workflow)
+}
+
+// enterCompletion marks taskID as having a completion in flight and returns the
+// matching release. It brackets the window HandleAgentComplete opens between
+// "the agent has finished" and "the engine has routed that completion", which
+// is exactly the window a persisted AgentRoute used to stand in for. Callers
+// outside the agent manager (recovery's lost-callback bridge) drive completions
+// for agents the manager no longer reports as running, so liveness alone cannot
+// describe that window — without this marker, pruneStaleAgentRoutes would read
+// the route as orphaned and let ResumeStalled dispatch a duplicate.
+//
+// Counted rather than a set: a parallel step can have several children
+// completing at once, and the last one out must be the one that clears the mark.
+func (e *Engine) enterCompletion(taskID string) func() {
+	if taskID == "" {
+		return func() {}
+	}
+	e.mu.Lock()
+	if e.completing == nil {
+		e.completing = make(map[string]int)
+	}
+	e.completing[taskID]++
+	e.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			e.mu.Lock()
+			defer e.mu.Unlock()
+			if n := e.completing[taskID]; n > 1 {
+				e.completing[taskID] = n - 1
+			} else {
+				delete(e.completing, taskID)
+			}
+		})
+	}
+}
+
+func (e *Engine) completionInFlight(taskID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.completing[taskID] > 0
+}
+
+// routeMatchesStep reports whether a persisted AgentRoute target belongs to
+// step — directly, as a parallel child, or as a best_of_n attempt.
+func routeMatchesStep(step *Step, routedStepID string) bool {
+	if step == nil {
+		return false
+	}
+	return routedStepID == step.ID || parallelHasChild(step, routedStepID) || bestOfNStepMatches(step, routedStepID)
+}
+
+// pruneStaleAgentRoutes drops persisted AgentRoutes for step whose agent no
+// longer exists in any form: not running, not dispatching, and with no
+// completion in flight.
+//
+// Such a route is unrecoverable on its own. Routes are only ever cleared by an
+// agent-completion path, so a route that outlived its agent has nothing left to
+// clear it, and tryMarkResumeDispatching reads it as "agent-pending-completion"
+// on every tick — the task then stalls permanently with no error, no status
+// change, and no escalation (#2824). Clearing it here is what makes the wedge
+// recoverable; the WARN is what makes it visible.
+//
+// Liveness is task-scoped rather than agent-scoped on purpose: any running
+// agent for the task means the route may still be legitimately owned, so this
+// declines to prune. That errs toward the old (skip) behaviour, never toward
+// duplicate dispatch.
+func (e *Engine) pruneStaleAgentRoutes(taskID string, step *Step) {
+	if taskID == "" || step == nil {
+		return
+	}
+	if e.completionInFlight(taskID) || e.agents.HasRunningAgent(taskID) {
+		return
+	}
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil || t.Workflow == nil || len(t.Workflow.AgentRoutes) == 0 {
+		return
+	}
+	stale := make([]string, 0, len(t.Workflow.AgentRoutes))
+	for agentID, routedStepID := range t.Workflow.AgentRoutes {
+		if routeMatchesStep(step, routedStepID) {
+			stale = append(stale, agentID)
+		}
+	}
+	if len(stale) == 0 {
+		return
+	}
+	// Map iteration order is random; sort so the emitted WARNs are stable.
+	slices.Sort(stale)
+	for _, agentID := range stale {
+		e.logger.Warn("workflow.resume-stalled.stale-route",
+			"task_id", taskID, "step", step.ID, "agent_id", agentID,
+			"route_step", t.Workflow.AgentRoutes[agentID])
+		clearAgentRouteFromWorkflow(t.Workflow, agentID)
+	}
+	if err := e.tasks.SetWorkflow(taskID, t.Workflow); err != nil {
+		e.logger.Warn("workflow.resume-stalled.stale-route.clear",
+			"task_id", taskID, "step", step.ID, "err", err)
+		return
+	}
+	e.mu.Lock()
+	for _, agentID := range stale {
+		e.clearPendingAgentStepLocked(taskID, agentID)
+	}
+	e.mu.Unlock()
 }
 
 func pendingAgentRouteKey(taskID, agentID string) string {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -335,6 +335,10 @@ func (e *Engine) HandleStatusChange(taskID, newStatus string) {
 // found" error loop that followed workflow completion in older versions —
 // but that legitimacy still needs to be visible when diagnosing a stall.
 func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
+	// Held past the final clearAgentStep so pruneStaleAgentRoutes cannot mistake
+	// this task's still-needed routes for orphans while the advance is underway.
+	defer e.enterCompletion(taskID)()
+
 	routeMu := e.taskRouteMutex(taskID)
 	routeMu.Lock()
 	e.mu.Lock()
@@ -1101,6 +1105,15 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 		mu.Unlock()
 	}
 
+	// Routes below stand in for "an agent is still working on this step", but
+	// nothing except an agent-completion path ever clears one. Retire the ones
+	// whose agent is gone first, or this task is skipped forever (#2824). Not
+	// while advancing: the route table is mid-rewrite and the skip is decided
+	// anyway.
+	if !advancing {
+		e.pruneStaleAgentRoutes(taskID, step)
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -1108,7 +1121,7 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 	hasOutstandingAgent := false
 	if fresh, err := e.tasks.GetTask(taskID); err == nil && fresh.Workflow != nil {
 		for _, stepID := range fresh.Workflow.AgentRoutes {
-			if stepID == step.ID || parallelHasChild(step, stepID) || bestOfNStepMatches(step, stepID) {
+			if routeMatchesStep(step, stepID) {
 				hasOutstandingAgent = true
 				break
 			}

--- a/internal/workflow/engine_stale_route_test.go
+++ b/internal/workflow/engine_stale_route_test.go
@@ -1,0 +1,253 @@
+package workflow
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// gatedRecorder is an ArtifactRecorder that parks RecordTrace until released.
+// HandleAgentComplete calls it after it has resolved the completion route but
+// before AdvanceStep takes the per-task inflight lock, which is precisely the
+// mid-advance window the stale-route pruner must not touch — the agent has
+// finished, no inflight lock is held, and only the persisted route (or the
+// completion marker replacing it) says the task is still busy.
+type gatedRecorder struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newGatedRecorder() *gatedRecorder {
+	return &gatedRecorder{entered: make(chan struct{}, 1), release: make(chan struct{})}
+}
+
+func (g *gatedRecorder) RecordTrace(string, any) error {
+	select {
+	case g.entered <- struct{}{}:
+	default:
+	}
+	<-g.release
+	return nil
+}
+
+func (g *gatedRecorder) PutPlanSnapshot(string, string, string, string, string) error { return nil }
+func (g *gatedRecorder) PutGeneric(string, string, string, string) error              { return nil }
+
+// staleRouteEngine builds an engine parked on test-simple's implement step with
+// the given persisted agent routes and no agent running for the task.
+func staleRouteEngine(t *testing.T, logger *slog.Logger, routes map[string]string) (*Engine, *memTasks, *mockAgents) {
+	t.Helper()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, logger)
+
+	wf := &Execution{
+		WorkflowID:  "test-simple",
+		CurrentStep: "implement",
+		State:       ExecWaiting,
+	}
+	for agentID, stepID := range routes {
+		wf.SetAgentRoute(agentID, stepID)
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless", Workflow: wf})
+	return engine, tasks, agents
+}
+
+func implementStep(t *testing.T, engine *Engine) *Step {
+	t.Helper()
+	def, err := engine.store.Get("test-simple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	step := def.StepByID("implement")
+	if step == nil {
+		t.Fatal("implement step missing from test-simple")
+	}
+	return step
+}
+
+// TestTryMarkResumeDispatching_StaleRoute covers both directions of #2824: a
+// route whose agent no longer exists must be retired so the task resumes, while
+// every route that still has an owner — a live agent, or a completion the
+// engine has not finished routing — must keep blocking the resume.
+func TestTryMarkResumeDispatching_StaleRoute(t *testing.T) {
+	tests := []struct {
+		name           string
+		routes         map[string]string
+		agentRunning   bool
+		completing     bool
+		wantAcquired   bool
+		wantReason     string
+		wantRoutesLeft int
+		wantWarn       bool
+	}{
+		{
+			name:           "route naming a dead agent is retired and the task resumes",
+			routes:         map[string]string{"agent-ghost": "implement"},
+			wantAcquired:   true,
+			wantRoutesLeft: 0,
+			wantWarn:       true,
+		},
+		{
+			name:           "route backed by a live agent still blocks the resume",
+			routes:         map[string]string{"agent-1": "implement"},
+			agentRunning:   true,
+			wantReason:     "agent-pending-completion",
+			wantRoutesLeft: 1,
+		},
+		{
+			name:           "route with a completion in flight still blocks the resume",
+			routes:         map[string]string{"agent-1": "implement"},
+			completing:     true,
+			wantReason:     "agent-pending-completion",
+			wantRoutesLeft: 1,
+		},
+		{
+			name:           "route for an unrelated step is left alone",
+			routes:         map[string]string{"agent-ghost": "triage"},
+			wantAcquired:   true,
+			wantRoutesLeft: 1,
+		},
+		{
+			name: "only the matching stale route is retired",
+			routes: map[string]string{
+				"agent-ghost": "implement",
+				"agent-other": "triage",
+			},
+			wantAcquired:   true,
+			wantRoutesLeft: 1,
+			wantWarn:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var records []slog.Record
+			logger := slog.New(&demotionRecordHandler{records: &records})
+			engine, tasks, agents := staleRouteEngine(t, logger, tc.routes)
+			step := implementStep(t, engine)
+
+			if tc.agentRunning {
+				agents.mu.Lock()
+				agents.running["t1"] = "agent-1"
+				agents.mu.Unlock()
+			}
+			if tc.completing {
+				defer engine.enterCompletion("t1")()
+			}
+
+			reason, acquired := engine.tryMarkResumeDispatching("t1", step)
+			if acquired != tc.wantAcquired {
+				t.Fatalf("acquired = %v, want %v (reason %q)", acquired, tc.wantAcquired, reason)
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tc.wantReason)
+			}
+
+			got, err := tasks.GetTask("t1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n := len(got.Workflow.AgentRoutes); n != tc.wantRoutesLeft {
+				t.Fatalf("routes left = %d (%v), want %d", n, got.Workflow.AgentRoutes, tc.wantRoutesLeft)
+			}
+
+			warned := false
+			for _, r := range records {
+				if r.Message != "workflow.resume-stalled.stale-route" {
+					continue
+				}
+				warned = true
+				if r.Level != slog.LevelWarn {
+					t.Fatalf("stale-route log level = %v, want Warn", r.Level)
+				}
+				if got := recordAttr(r, "step"); got != "implement" {
+					t.Fatalf("stale-route step attr = %q, want implement", got)
+				}
+			}
+			if warned != tc.wantWarn {
+				t.Fatalf("stale-route warning logged = %v, want %v", warned, tc.wantWarn)
+			}
+		})
+	}
+}
+
+// TestResumeStalled_RecoversFromStaleAgentRoute is the end-to-end shape of the
+// wedge: a task whose only blocker is a route left behind by a finished agent
+// used to log "agent-pending-completion" on every tick forever. It must now
+// re-dispatch instead.
+func TestResumeStalled_RecoversFromStaleAgentRoute(t *testing.T) {
+	engine, _, agents := staleRouteEngine(t, discardLogger(), map[string]string{"agent-ghost": "implement"})
+
+	engine.ResumeStalled()
+
+	if got := roleStartCount(agents, "implementation"); got != 1 {
+		t.Fatalf("implementation dispatches = %d, want 1 — a stale route must not wedge ResumeStalled", got)
+	}
+}
+
+// TestResumeStalled_MidAdvanceCompletionBlocksDuplicateDispatch is the
+// regression guard the route check was written for. It drives the exact
+// interleaving recovery's lost-callback bridge produces: HandleAgentComplete
+// runs for an agent the manager no longer reports as running, and a
+// ResumeStalled tick lands while that completion is between route resolution
+// and AdvanceStep. No second agent may be started.
+func TestResumeStalled_MidAdvanceCompletionBlocksDuplicateDispatch(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	recorder := newGatedRecorder()
+	engine.SetArtifactRecorder(recorder)
+
+	wf := &Execution{
+		WorkflowID:  "test-simple",
+		CurrentStep: "implement",
+		State:       ExecWaiting,
+	}
+	wf.SetAgentRoute("agent-1", "implement")
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless", Workflow: wf})
+
+	completeDone := make(chan struct{})
+	go func() {
+		defer close(completeDone)
+		engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "agent-1", Success: true, Result: "done"})
+	}()
+
+	select {
+	case <-recorder.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleAgentComplete never reached the trace recorder")
+	}
+
+	// The completion is parked mid-advance: the agent is gone from the manager
+	// and no inflight lock is held, so only the completion marker can hold the
+	// resume off.
+	if agents.HasRunningAgent("t1") {
+		t.Fatal("mock reports a running agent; the mid-advance window is not being exercised")
+	}
+	engine.ResumeStalled()
+	if got := roleStartCount(agents, "implementation"); got != 0 {
+		t.Fatalf("implementation dispatches = %d, want 0 — a mid-advance completion must not be duplicated", got)
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Workflow.AgentRoute("agent-1"); !ok {
+		t.Fatal("route for the completing agent was pruned mid-advance")
+	}
+
+	close(recorder.release)
+	<-completeDone
+
+	after, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Workflow.CurrentStep == "implement" {
+		t.Fatalf("workflow did not advance past implement after completion: %+v", after.Workflow)
+	}
+}

--- a/internal/workflow/engine_stale_route_test.go
+++ b/internal/workflow/engine_stale_route_test.go
@@ -173,11 +173,14 @@ func TestTryMarkResumeDispatching_StaleRoute(t *testing.T) {
 	}
 }
 
-// TestResumeStalled_RecoversFromStaleAgentRoute is the end-to-end shape of the
+// TestResumeStalled_StaleRouteRecoversWedgedTask is the end-to-end shape of the
 // wedge: a task whose only blocker is a route left behind by a finished agent
 // used to log "agent-pending-completion" on every tick forever. It must now
 // re-dispatch instead.
-func TestResumeStalled_RecoversFromStaleAgentRoute(t *testing.T) {
+//
+// Every test in this file is named so `go test -run StaleRoute` selects all of
+// them. A mutation run that misses one silently reports a guard as untested.
+func TestResumeStalled_StaleRouteRecoversWedgedTask(t *testing.T) {
 	engine, _, agents := staleRouteEngine(t, discardLogger(), map[string]string{"agent-ghost": "implement"})
 
 	engine.ResumeStalled()
@@ -187,13 +190,17 @@ func TestResumeStalled_RecoversFromStaleAgentRoute(t *testing.T) {
 	}
 }
 
-// TestResumeStalled_MidAdvanceCompletionBlocksDuplicateDispatch is the
+// TestResumeStalled_StaleRoutePrunerSparesMidAdvanceCompletion is the
 // regression guard the route check was written for. It drives the exact
 // interleaving recovery's lost-callback bridge produces: HandleAgentComplete
 // runs for an agent the manager no longer reports as running, and a
 // ResumeStalled tick lands while that completion is between route resolution
 // and AdvanceStep. No second agent may be started.
-func TestResumeStalled_MidAdvanceCompletionBlocksDuplicateDispatch(t *testing.T) {
+//
+// Unlike the table above — which arms the marker by hand and so only proves the
+// pruner honours it — this drives the real HandleAgentComplete entry point, so
+// it is the only test that fails if enterCompletion is dropped from it.
+func TestResumeStalled_StaleRoutePrunerSparesMidAdvanceCompletion(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
@@ -228,6 +235,17 @@ func TestResumeStalled_MidAdvanceCompletionBlocksDuplicateDispatch(t *testing.T)
 	if agents.HasRunningAgent("t1") {
 		t.Fatal("mock reports a running agent; the mid-advance window is not being exercised")
 	}
+	if !engine.completionInFlight("t1") {
+		t.Fatal("HandleAgentComplete did not mark a completion in flight — nothing but the persisted route is holding the resume off")
+	}
+
+	// tryMarkResumeDispatching is asserted directly as well as through
+	// ResumeStalled: the reason pins *why* the resume was refused, so a future
+	// regression cannot pass by refusing for some unrelated reason.
+	if reason, ok := engine.tryMarkResumeDispatching("t1", implementStep(t, engine)); ok || reason != "agent-pending-completion" {
+		t.Fatalf("tryMarkResumeDispatching = (%q, %v), want (agent-pending-completion, false)", reason, ok)
+	}
+
 	engine.ResumeStalled()
 	if got := roleStartCount(agents, "implementation"); got != 0 {
 		t.Fatalf("implementation dispatches = %d, want 0 — a mid-advance completion must not be duplicated", got)

--- a/internal/workflow/engine_stale_route_test.go
+++ b/internal/workflow/engine_stale_route_test.go
@@ -76,6 +76,7 @@ func TestTryMarkResumeDispatching_StaleRoute(t *testing.T) {
 		name           string
 		routes         map[string]string
 		agentRunning   bool
+		dispatchClaim  bool
 		completing     bool
 		wantAcquired   bool
 		wantReason     string
@@ -93,6 +94,18 @@ func TestTryMarkResumeDispatching_StaleRoute(t *testing.T) {
 			name:           "route backed by a live agent still blocks the resume",
 			routes:         map[string]string{"agent-1": "implement"},
 			agentRunning:   true,
+			wantReason:     "agent-pending-completion",
+			wantRoutesLeft: 1,
+		},
+		{
+			// A held claim means StartAgent is mid-flight for this task and the
+			// route may be about to become live. The reason stays
+			// agent-pending-completion because the surviving route wins the
+			// switch ahead of claimed-elsewhere; what this pins is that the
+			// route survives at all.
+			name:           "route inside another dispatcher's claim window is left alone",
+			routes:         map[string]string{"agent-1": "implement"},
+			dispatchClaim:  true,
 			wantReason:     "agent-pending-completion",
 			wantRoutesLeft: 1,
 		},
@@ -131,6 +144,11 @@ func TestTryMarkResumeDispatching_StaleRoute(t *testing.T) {
 			if tc.agentRunning {
 				agents.mu.Lock()
 				agents.running["t1"] = "agent-1"
+				agents.mu.Unlock()
+			}
+			if tc.dispatchClaim {
+				agents.mu.Lock()
+				agents.dispatchClaimed = map[string]bool{"t1": true}
 				agents.mu.Unlock()
 			}
 			if tc.completing {


### PR DESCRIPTION
## Motivation

Closes #2824.

`tryMarkResumeDispatching` decides whether a task already has work in flight by
reading persisted `Workflow.AgentRoutes`, and never checks that the agent a
route names still exists. Nothing clears a route except an agent-completion
path, so a route that outlives its agent has nothing left to clear it:
`ResumeStalled` logs `reason=agent-pending-completion` and skips the task on
every tick, forever. No error, no status change, no escalation — 471
consecutive skips over six minutes in the CI run that surfaced this.

> Changelog: fix(workflow): recover tasks wedged by a stale agent route

## Implementation information

The route check is not gratuitous — it covers the window where
`HandleAgentComplete` has started but has not yet routed the completion.
Deleting it would reintroduce duplicate dispatch. So the fix replaces the
*inference* ("a route exists, therefore an agent is working") with an explicit
signal for that window and prunes routes that fall outside it.

- **`Engine.completing map[string]int`** — per-task count of in-flight
  `HandleAgentComplete` calls. `enterCompletion` bumps it at the top of
  `HandleAgentComplete` and the returned release runs via `defer`, so it is
  held past the trailing `clearAgentStep` on every exit path. Counted, not a
  set, because a `parallel` step can have several children completing at once.
- **`pruneStaleAgentRoutes`** runs in `tryMarkResumeDispatching` before the
  existing decision. It declines to touch anything when a completion is in
  flight, when the agent manager reports a running agent (or a held dispatch
  claim) for the task, or when the advance lock is currently held. Otherwise it
  clears every route pointing at the current step (directly, as a parallel
  child, or as a best_of_n attempt), logs each one at **WARN**
  (`workflow.resume-stalled.stale-route`), and lets the normal resume proceed.
- The decision block itself is unchanged apart from extracting the three-way
  route/step match into `routeMatchesStep`, now shared with the pruner. If the
  pruner declines, behaviour is bit-for-bit what it was.

Liveness is checked task-scoped (`HasRunningAgent`) rather than agent-scoped on
purpose: any running agent for the task makes the pruner stand down. Every
uncertain case therefore errs toward the old skip, never toward a duplicate
dispatch. Adding an agent-scoped liveness query would have meant a new
`AgentLauncher` method for a strictly less conservative answer.

Why this shape over "cross-check the route against `AgentRuns` terminal state"
(alternative 2 in the issue): the recovery paths that bridge a lost completion
callback (`recovery.recoverCompletedHeadlessRun`) drive
`HandleAgentComplete` for an agent that is *already* terminal in `AgentRuns` and
already gone from the manager. A terminal-run check would classify that route as
stale mid-advance and dispatch a duplicate — exactly the regression the route
check exists to prevent. The in-memory marker describes the window directly and
is set for the recovery-driven completion too, since it goes through the same
`Engine.HandleAgentComplete`.

## Testing

New table-driven tests in `internal/workflow/engine_stale_route_test.go`.
`TestResumeStalled_StaleRoutePrunerSparesMidAdvanceCompletion` reproduces the
protected interleaving deterministically: a gated `ArtifactRecorder` parks
`HandleAgentComplete` at `recordAgentCompletionTrace` — after route resolution,
before `AdvanceStep` takes the inflight lock — with the agent already gone from
the manager. The test asserts `HasRunningAgent` is false and
`completionInFlight` is true at that point, so the marker (not agent liveness)
is provably what refuses the resume, then asserts a `ResumeStalled` tick does
not dispatch.

Every assertion was mutation-tested, each mutation applied alone:

```
go test ./internal/workflow/ -run 'StaleRoute' -count=1
```

| # | Mutation | Failing tests |
|---|----------|---------------|
| 1 | Never call `pruneStaleAgentRoutes` (pre-fix behaviour) | 3 — `route naming a dead agent...`, `only the matching stale route is retired`, `StaleRouteRecoversWedgedTask` |
| 2 | Drop the `completionInFlight` guard | 2 — `completion in flight still blocks`, `SparesMidAdvanceCompletion` |
| 3 | Drop the `HasRunningAgent` guard | 1 — `route backed by a live agent still blocks` |
| 4 | Log the stale route at DEBUG instead of WARN | 2 — both stale-route subtests |
| 5 | `routeMatchesStep` returns true unconditionally | 2 — `unrelated step is left alone`, `only the matching stale route is retired` |
| 6 | Remove `enterCompletion` from `HandleAgentComplete` | 1 — `SparesMidAdvanceCompletion` |
| 7 | Drop the `IsDispatching` guard | 1 — `route inside another dispatcher's claim window is left alone` |

All seven restored cleanly; the suite is green with the fix in place. Mutations
1 and 6 are the two that matter most — 1 confirms the recovery tests fail on
today's `main`, 6 confirms the duplicate-dispatch guard is load-bearing rather
than incidentally satisfied.

Mutation 6 is worth being explicit about, because a reviewer initially could not
reproduce it. The cause was test selection, not a weak test: the mid-advance
test was originally named
`TestResumeStalled_MidAdvanceCompletionBlocksDuplicateDispatch`, which matches
neither `-run StaleRoute` nor `-run StaleAgentRoute`, so a filtered run skipped
the only test covering that guard and reported it green. Every test in the file
is now named so a single `-run StaleRoute` selects all of them, and a direct
`completionInFlight` assertion means removing `enterCompletion` fails on the
marker itself rather than on the downstream dispatch count.

`mise run verify` passes, including `go test -race ./...` and the tagged e2e
suite.
## Open questions

- **I could not reproduce the production stranding locally**, and neither could
  the reporter. This is designed from the code path, not from a repro. The
  pruner is written so that being wrong about "stale" costs nothing beyond the
  status quo skip, which is why it is safe to ship without one.
- While auditing engine-internal strand vectors (the issue asks for this but
  does not assume it): route publication is serialized against completion by
  `taskRouteMutex`, and `clearAgentStep` runs on every `HandleAgentComplete`
  exit — with one exception. The `e.tasks.GetTask` failure at the top of
  `HandleAgentComplete` returns after logging `workflow.agent-complete.get`
  **without** clearing the route. A transient store read error there strands
  the route permanently. This change recovers from it rather than preventing
  it; a targeted fix is worth a follow-up but did not belong in this diff.
- The pruner adds one extra `GetTask` per resume-eligible task per tick (the
  decision block re-reads afterwards so it sees post-prune state). Measurable
  only on very large boards; I did not benchmark it.
- Unrelated to and independent of #2823, which is the test-side mitigation.


