### PR TITLE
fix(audit): select log files by UTC date

### DIFF
--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -24,9 +24,15 @@ func NewLogger(dir string) (*Logger, error) {
 }
 
 func (l *Logger) Log(e Event) error {
+	// Normalize unconditionally, not just when unset. File names are derived
+	// from this timestamp's date, and Read selects files by UTC date, so a
+	// caller supplying a non-UTC Timestamp would file the event under a date
+	// no reader looks for — the same silent mismatch #2826 fixed on the read
+	// side, reintroduced from the write side.
 	if e.Timestamp.IsZero() {
-		e.Timestamp = time.Now().UTC()
+		e.Timestamp = time.Now()
 	}
+	e.Timestamp = e.Timestamp.UTC()
 
 	data, err := json.Marshal(e)
 	if err != nil {

--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -47,8 +47,9 @@ func auditFiles(dir string, since, until time.Time) ([]string, error) {
 		return nil, err
 	}
 
-	// Compare in UTC: Logger.file names each file from the event's UTC
-	// timestamp, while callers pass a window built from time.Now(), which
+	// Compare in UTC: Log normalizes every event's timestamp to UTC and the
+	// file is named from its date, while callers pass a window built from
+	// time.Now(), which
 	// carries the local zone. Formatting the bounds in local time makes the
 	// filename window disagree with the writer for the hours where the two
 	// dates differ — every query in that window silently returns nothing

--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -47,8 +47,14 @@ func auditFiles(dir string, since, until time.Time) ([]string, error) {
 		return nil, err
 	}
 
-	sinceDay := since.Format(time.DateOnly)
-	untilDay := until.Format(time.DateOnly)
+	// Compare in UTC: Logger.file names each file from the event's UTC
+	// timestamp, while callers pass a window built from time.Now(), which
+	// carries the local zone. Formatting the bounds in local time makes the
+	// filename window disagree with the writer for the hours where the two
+	// dates differ — every query in that window silently returns nothing
+	// rather than erroring.
+	sinceDay := since.UTC().Format(time.DateOnly)
+	untilDay := until.UTC().Format(time.DateOnly)
 
 	var paths []string
 	for _, e := range entries {

--- a/internal/audit/reader_timezone_test.go
+++ b/internal/audit/reader_timezone_test.go
@@ -1,0 +1,84 @@
+package audit
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestReadFindsEventsAcrossZoneDateBoundary pins the writer/reader agreement
+// that #2826 broke. Logger names each file from the event's UTC timestamp,
+// while callers build their window from time.Now(), which carries the local
+// zone. For the hours where the local and UTC dates differ, formatting the
+// window in local time makes the reader look for a filename the writer never
+// produced — and the query returns zero events rather than an error, so the
+// failure is silent.
+func TestReadFindsEventsAcrossZoneDateBoundary(t *testing.T) {
+	t.Parallel()
+
+	// 2026-08-01T22:50Z is already 2026-08-02 in CEST (+02:00) and still
+	// 2026-08-01 in UTC — exactly the window that used to read empty.
+	eventUTC := time.Date(2026, 8, 1, 22, 50, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		zone *time.Location
+	}{
+		{name: "ahead of utc, local date already rolled", zone: time.FixedZone("CEST", 2*60*60)},
+		{name: "behind utc, local date not yet rolled", zone: time.FixedZone("PST", -8*60*60)},
+		{name: "utc itself", zone: time.UTC},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			l, err := NewLogger(dir)
+			if err != nil {
+				t.Fatalf("NewLogger: %v", err)
+			}
+			if err := l.Log(Event{Type: EventRoutingReweighted, Timestamp: eventUTC}); err != nil {
+				t.Fatalf("Log: %v", err)
+			}
+
+			// The window a caller would build with time.Now() in that zone.
+			local := eventUTC.In(tc.zone)
+			got, err := Read(dir, Query{
+				Since: local.Add(-time.Minute),
+				Until: local.Add(time.Minute),
+				Type:  EventRoutingReweighted,
+			})
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("Read returned %d events, want 1 — the window was built in %s, where the local date is %s but the file is named %s",
+					len(got), tc.zone, local.Format(time.DateOnly), eventUTC.Format(time.DateOnly))
+			}
+		})
+	}
+}
+
+// TestAuditFilesSelectsByUTCDate pins the selection directly, so a regression
+// is attributed to file naming rather than to event filtering.
+func TestAuditFilesSelectsByUTCDate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	l, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	eventUTC := time.Date(2026, 8, 1, 23, 30, 0, 0, time.UTC)
+	if err := l.Log(Event{Type: "x", Timestamp: eventUTC}); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	local := eventUTC.In(time.FixedZone("CEST", 2*60*60))
+	paths, err := auditFiles(dir, local.Add(-time.Minute), local.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("auditFiles: %v", err)
+	}
+	want := filepath.Join(dir, "2026-08-01.ndjson")
+	if len(paths) != 1 || paths[0] != want {
+		t.Fatalf("auditFiles = %v, want [%s]", paths, want)
+	}
+}

--- a/internal/audit/reader_timezone_test.go
+++ b/internal/audit/reader_timezone_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -55,6 +56,43 @@ func TestReadFindsEventsAcrossZoneDateBoundary(t *testing.T) {
 					len(got), tc.zone, local.Format(time.DateOnly), eventUTC.Format(time.DateOnly))
 			}
 		})
+	}
+}
+
+// TestLogNormalizesNonUTCTimestamps closes the write side of the same
+// mismatch: file names come from the event timestamp's date, so a caller
+// handing Log a non-UTC time would file the event under a date no reader
+// looks for. Log must normalize rather than trust its input.
+func TestLogNormalizesNonUTCTimestamps(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	l, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+
+	// 00:30 on Aug 2 in CEST is still 22:30 on Aug 1 in UTC.
+	caller := time.Date(2026, 8, 2, 0, 30, 0, 0, time.FixedZone("CEST", 2*60*60))
+	if err := l.Log(Event{Type: "x", Timestamp: caller}); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	want := filepath.Join(dir, "2026-08-01.ndjson")
+	if _, statErr := os.Stat(want); statErr != nil {
+		entries, _ := os.ReadDir(dir)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("event filed as %v, want %s — the caller's zone must not decide the file name", names, want)
+	}
+
+	got, err := Read(dir, Query{Since: caller.Add(-time.Hour), Until: caller.Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Read returned %d events, want 1", len(got))
 	}
 }
 


### PR DESCRIPTION
## Motivation

`TestAppStartup_PrimesRoutingBeforeReturning` failed on `main` with `routing audit events = 0, want 1`. The cause is not in that test — it is a real defect in `internal/audit` that makes **every audit query silently return nothing** for part of each day. Closes #2826.

`Logger.file` names each file from the event's UTC timestamp (`logger.go:78`, with `Log` stamping `time.Now().UTC()`). `auditFiles` formatted the query bounds in *their own* zone — and callers build those from `time.Now()`, which carries the local zone. When the local and UTC dates differ, the reader looks for a filename the writer never produced, finds no files, and returns zero events **without an error**.

The affected window is the offset between local time and UTC: 00:00–02:00 daily in CEST, and a far wider evening window in US zones. Every audit consumer is affected — learning digest, monitor, evaluation, `sybra-cli`.

> Changelog: fix(audit): read audit logs correctly across the UTC date boundary

## Implementation information

`auditFiles` now formats both bounds as `.UTC()`, matching the writer exactly. `retention.go` already normalised to UTC; `logger.go` was already correct. One line each, plus the comment explaining why the two sides must agree.

## Testing

Two table-driven tests in `internal/audit`: one drives the real `Logger` → `Read` round trip with query windows built in zones ahead of, behind, and equal to UTC; the other pins `auditFiles` selection directly so a regression is attributed to file naming rather than event filtering.

Mutation-verified: reverting the fix fails 3 subtests, restoring passes. `mise run verify` exits 0.

## Open questions

`summary.go:27` formats the reported period label in the caller's zone. That is cosmetic rather than a data-selection bug, so I left it — but it means a summary's displayed date range can disagree with the UTC dates the events were filed under.

Worth noting how this presented: the test failed deterministically for me last night and passes now, which reads like flakiness but is not. It fails precisely while the local date is ahead of the UTC date, so on a UTC CI runner it would never fail at all, and on a developer machine it fails only in a fixed window each day. That is exactly the shape of bug that gets dismissed as flaky and re-run away.