### PR TITLE
refactor(agent): deny tools headless cannot use

### DIFF
--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1092,22 +1092,22 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "no model no tools",
 			cfg:     RunConfig{},
-			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model sonnet",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools " + deniedToolsArg() + " --model sonnet",
 		},
 		{
 			name:    "valid model",
 			cfg:     RunConfig{Model: "claude-opus-4-6"},
-			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model claude-opus-4-6",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools " + deniedToolsArg() + " --model claude-opus-4-6",
 		},
 		{
 			name:    "valid tools",
 			cfg:     RunConfig{AllowedTools: []string{"Read", "Write", "Bash"}},
-			wantCmd: "claude --allowedTools Read,Write,Bash --disallowedTools ScheduleWakeup --model sonnet",
+			wantCmd: "claude --allowedTools Read,Write,Bash --disallowedTools " + deniedToolsArg() + " --model sonnet",
 		},
 		{
 			name:    "valid model and tools",
 			cfg:     RunConfig{Model: "claude-sonnet-4-6", AllowedTools: []string{"Read"}},
-			wantCmd: "claude --allowedTools Read --disallowedTools ScheduleWakeup --model claude-sonnet-4-6",
+			wantCmd: "claude --allowedTools Read --disallowedTools " + deniedToolsArg() + " --model claude-sonnet-4-6",
 		},
 		{
 			name:    "model with shell metachar semicolon",
@@ -1152,7 +1152,7 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "valid model with slash and dot",
 			cfg:     RunConfig{Model: "anthropic/claude-3.5-sonnet"},
-			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model anthropic/claude-3.5-sonnet",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools " + deniedToolsArg() + " --model anthropic/claude-3.5-sonnet",
 		},
 		{
 			name:    "codex default model mapping",
@@ -1172,22 +1172,22 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "fable alias",
 			cfg:     RunConfig{Model: "fable"},
-			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model fable",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools " + deniedToolsArg() + " --model fable",
 		},
 		{
 			name:    "fable with 1m suffix stripped",
 			cfg:     RunConfig{Model: "fable[1m]"},
-			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model fable",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools " + deniedToolsArg() + " --model fable",
 		},
 		{
 			name:    "claude-fable-5 with 1m suffix stripped",
 			cfg:     RunConfig{Model: "claude-fable-5[1m]"},
-			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model claude-fable-5",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools " + deniedToolsArg() + " --model claude-fable-5",
 		},
 		{
 			name:    "sonnet with 1m suffix stripped",
 			cfg:     RunConfig{Model: "sonnet[1m]"},
-			wantCmd: "claude --dangerously-skip-permissions --disallowedTools ScheduleWakeup --model sonnet",
+			wantCmd: "claude --dangerously-skip-permissions --disallowedTools " + deniedToolsArg() + " --model sonnet",
 		},
 		{
 			name:    "codex fable passes through as explicit model",

--- a/internal/agent/permissions_test.go
+++ b/internal/agent/permissions_test.go
@@ -13,14 +13,14 @@ func TestClaudePermissionArgs(t *testing.T) {
 		mode         string
 		want         []string
 	}{
-		{"allowlist wins over bypass", []string{"Bash", "Read"}, false, "bypass", []string{"--allowedTools", "Bash,Read", "--disallowedTools", "ScheduleWakeup"}},
-		{"allowlist wins over auto", []string{"Bash"}, false, "auto", []string{"--allowedTools", "Bash", "--disallowedTools", "ScheduleWakeup"}},
-		{"allowlist wins over requirePerms", []string{"Read"}, true, "auto", []string{"--allowedTools", "Read", "--disallowedTools", "ScheduleWakeup"}},
-		{"requirePerms → disallow only", nil, true, "bypass", []string{"--disallowedTools", "ScheduleWakeup"}},
-		{"requirePerms with auto → disallow only", nil, true, "auto", []string{"--disallowedTools", "ScheduleWakeup"}},
-		{"auto mode", nil, false, "auto", []string{"--permission-mode", "auto", "--disallowedTools", "ScheduleWakeup"}},
-		{"bypass mode", nil, false, "bypass", []string{"--dangerously-skip-permissions", "--disallowedTools", "ScheduleWakeup"}},
-		{"empty mode → bypass", nil, false, "", []string{"--dangerously-skip-permissions", "--disallowedTools", "ScheduleWakeup"}},
+		{"allowlist wins over bypass", []string{"Bash", "Read"}, false, "bypass", []string{"--allowedTools", "Bash,Read", "--disallowedTools", deniedToolsArg()}},
+		{"allowlist wins over auto", []string{"Bash"}, false, "auto", []string{"--allowedTools", "Bash", "--disallowedTools", deniedToolsArg()}},
+		{"allowlist wins over requirePerms", []string{"Read"}, true, "auto", []string{"--allowedTools", "Read", "--disallowedTools", deniedToolsArg()}},
+		{"requirePerms → disallow only", nil, true, "bypass", []string{"--disallowedTools", deniedToolsArg()}},
+		{"requirePerms with auto → disallow only", nil, true, "auto", []string{"--disallowedTools", deniedToolsArg()}},
+		{"auto mode", nil, false, "auto", []string{"--permission-mode", "auto", "--disallowedTools", deniedToolsArg()}},
+		{"bypass mode", nil, false, "bypass", []string{"--dangerously-skip-permissions", "--disallowedTools", deniedToolsArg()}},
+		{"empty mode → bypass", nil, false, "", []string{"--dangerously-skip-permissions", "--disallowedTools", deniedToolsArg()}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -176,7 +176,44 @@ func effortArgs(effort string) []string {
 // wakeup and then ends its turn strands itself — zero commits, clean exit —
 // which verify_commits cannot tell apart from a task with nothing to do.
 func claudePermissionArgs(allowed []string, requirePerms bool, mode string) []string {
-	return append(claudePermissionModeArgs(allowed, requirePerms, mode), "--disallowedTools", "ScheduleWakeup")
+	return append(claudePermissionModeArgs(allowed, requirePerms, mode),
+		"--disallowedTools", strings.Join(headlessDeniedTools, ","))
+}
+
+// headlessDeniedTools names tools a Sybra headless run has no legitimate use
+// for. Denial rather than an allowlist is deliberate: a non-empty
+// --allowedTools outranks agent.require_permissions entirely (see the
+// precedence in claudePermissionModeArgs), so an allowlist would silently
+// switch the permission layer off as a side effect of shrinking the surface.
+//
+// Each entry is denied because the capability is either meaningless for a
+// single-shot process or already owned by Sybra itself, not merely because a
+// log sample happened not to exercise it. Tools that are plausibly useful but
+// unused — WebFetch, WebSearch, Workflow — are deliberately left available:
+// absence of use over one window is not evidence a capability is unwanted,
+// and the sample is dominated by the orchestrator role.
+var headlessDeniedTools = []string{
+	// A headless run is one `claude -p` process that reads a stream and
+	// exits, so nothing re-invokes it later. A run that schedules a wakeup
+	// and ends its turn strands itself — zero commits, clean exit — which
+	// verify_commits cannot tell apart from a task with nothing to do.
+	"ScheduleWakeup",
+	// Scheduling belongs to the operator's own cron, outside Sybra entirely
+	// (see the orchestrator brain in CLAUDE.md). An agent creating cron
+	// entries would outlive the task that spawned it.
+	"CronCreate", "CronDelete", "CronList",
+	// Sybra owns worktree lifecycle: it prepares one per task before the
+	// agent starts and cleans it up after. An agent moving itself between
+	// worktrees would invalidate the tamper baseline its review is diffed
+	// against.
+	"EnterWorktree", "ExitWorktree",
+	// Task state is mutated through sybra-cli, which applies the same
+	// validation the GUI does. These bypass it.
+	"TaskGet", "TaskList",
+	// No notebooks in any project Sybra drives.
+	"NotebookEdit",
+	// Outward-facing side effects with no task-scoped meaning.
+	"PushNotification", "RemoteTrigger", "DesignSync",
 }
 
 func claudePermissionModeArgs(allowed []string, requirePerms bool, mode string) []string {

--- a/internal/agent/provider_claude_denied_test.go
+++ b/internal/agent/provider_claude_denied_test.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// deniedToolsArg renders the denial list the way it appears on the command
+// line, so assertions track the list instead of restating it — a restated
+// copy would have to be edited in lockstep and would drift.
+func deniedToolsArg() string { return strings.Join(headlessDeniedTools, ",") }
+
+// TestHeadlessDeniedToolsDenyRatherThanAllow pins the choice of lever. A
+// non-empty --allowedTools outranks agent.require_permissions entirely, so
+// shrinking the surface with an allowlist would switch the permission layer
+// off as a side effect. Denial composes with every permission posture.
+func TestHeadlessDeniedToolsDenyRatherThanAllow(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		allowed      []string
+		requirePerms bool
+		mode         string
+	}{
+		{name: "skip-permissions posture"},
+		{name: "approval-hook posture", requirePerms: true},
+		{name: "auto classifier posture", mode: "auto"},
+		{name: "explicit allowlist posture", allowed: []string{"Read", "Bash"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			args := claudePermissionArgs(tc.allowed, tc.requirePerms, tc.mode)
+			i := slices.Index(args, "--disallowedTools")
+			if i < 0 || i+1 >= len(args) {
+				t.Fatalf("args = %v, want a --disallowedTools flag in every posture", args)
+			}
+			// Named explicitly rather than ranged over headlessDeniedTools:
+			// iterating the production list makes the assertion shrink with
+			// it, so dropping an entry would pass. Each of these has a stated
+			// reason on the list; removing one should be a deliberate edit in
+			// two places.
+			denied := strings.Split(args[i+1], ",")
+			for _, tool := range []string{
+				"ScheduleWakeup",
+				"CronCreate", "CronDelete", "CronList",
+				"EnterWorktree", "ExitWorktree",
+				"TaskGet", "TaskList",
+				"NotebookEdit",
+				"PushNotification", "RemoteTrigger", "DesignSync",
+			} {
+				if !slices.Contains(denied, tool) {
+					t.Errorf("%q missing from denied list %q", tool, args[i+1])
+				}
+			}
+		})
+	}
+}
+
+// TestHeadlessDeniedToolsKeepResearchTools guards against over-cutting. These
+// went unused in the sampled window, but absence of use over one window is not
+// evidence a capability is unwanted — and that sample was dominated by a
+// single role.
+func TestHeadlessDeniedToolsKeepResearchTools(t *testing.T) {
+	t.Parallel()
+	for _, keep := range []string{"WebFetch", "WebSearch", "Workflow", "Read", "Bash", "Edit", "Write"} {
+		if slices.Contains(headlessDeniedTools, keep) {
+			t.Errorf("%q is denied; it is either load-bearing or merely unused, neither of which justifies removing it", keep)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Mining a week of agent logs found a set of tools offered to every headless run and never invoked once across 928 runs. Unused capability is unearned attack surface. Closes #2789, part of #2775.

> Changelog: refactor(agent): shrink the headless agent tool surface

## Implementation information

**Denial, not an allowlist.** A non-empty `--allowedTools` outranks `agent.require_permissions` entirely (see the precedence in `claudePermissionModeArgs`), so shrinking the surface with an allowlist would silently switch the permission layer off as a side effect. `--disallowedTools` composes with every posture instead, and the mechanism already existed for `ScheduleWakeup`.

**Denied for a reason, not for a statistic.** Each entry is denied because the capability is meaningless for a single-shot process or already owned by Sybra:

- `ScheduleWakeup` — a headless run reads one stream and exits; scheduling a wakeup strands the run with zero commits, which `verify_commits` cannot distinguish from a task with nothing to do.
- `CronCreate`/`CronDelete`/`CronList` — scheduling lives in the operator's own cron, outside Sybra; an agent-created entry outlives the task that spawned it.
- `EnterWorktree`/`ExitWorktree` — Sybra owns worktree lifecycle; an agent relocating itself invalidates the tamper baseline its review is diffed against.
- `TaskGet`/`TaskList` — task state goes through `sybra-cli`, which applies the same validation the GUI does.
- `NotebookEdit` — no notebooks in any project Sybra drives.
- `PushNotification`/`RemoteTrigger`/`DesignSync` — outward-facing side effects with no task-scoped meaning.

**Deliberately kept:** `WebFetch`, `WebSearch`, `Workflow`. They were also unused in the sample, but absence of use over one window is not evidence a capability is unwanted — and that sample was dominated by the orchestrator role, with code roles contributing 5–48 runs each. There is a test asserting they stay available.

## Testing

`mise run verify` exits 0. New tests assert the denial applies under all four permission postures (bypass, approval hook, auto classifier, explicit allowlist) and that the research tools are not cut.

Existing assertions now derive the flag value from the list rather than restating it, so the list can grow without churning unrelated tests.

Mutation-verified: dropping entries from the list fails 12 assertions. My first version of that test ranged over the production list, which made it tautological — it shrank along with the list and passed. It now names the entries explicitly, so removing one has to be a deliberate edit in two places.

## Open questions

This covers the claude provider. Codex and copilot expose their own tool surfaces through different mechanisms and are untouched here — worth a follow-up once the equivalent flags are confirmed.