### PR TITLE
feat(agent): pin the MCP surface on every run

### DIFF
--- a/internal/agent/mcp.go
+++ b/internal/agent/mcp.go
@@ -61,6 +61,10 @@ func mcpOwnerForAgent(a *Agent) mcpOwner {
 	}
 }
 
+// emptyMCPConfigJSON declares no servers. Paired with --strict-mcp-config it
+// is how a run says "exactly none" rather than "whatever the host has".
+const emptyMCPConfigJSON = `{"mcpServers":{}}`
+
 func wrapMCPConfigWithOwnership(mcpJSON string, owner mcpOwner) (string, error) {
 	if strings.TrimSpace(mcpJSON) == "" {
 		return "", nil

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -74,16 +74,26 @@ func (claudeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headless
 	if cfg.OutputSchema != "" {
 		args = append(args, "--json-schema", cfg.OutputSchema)
 	}
-	if cfg.MCPConfigJSON != "" {
-		mcpJSON, err := wrapMCPConfigWithOwnership(cfg.MCPConfigJSON, mcpOwnerForAgent(a))
-		if err != nil {
-			return headlessInvocation{}, err
-		}
-		// --strict-mcp-config always pairs with --mcp-config: without it Claude
-		// also loads any project/user-level MCP servers, which would leak an
-		// operator's unrelated MCP tools into an unattended test-runner run.
-		args = append(args, "--mcp-config", mcpJSON, "--strict-mcp-config")
+	// Pin the MCP surface on every run, not only the ones that attach a server
+	// of their own. Without --strict-mcp-config Claude also loads whatever
+	// project/user-level MCP servers the host account happens to have
+	// connected, so an unattended agent inherits the operator's tools — a
+	// window where Gmail, Calendar and Drive connectors were offered to
+	// headless runs is what prompted this (#2790). Attaching it only alongside
+	// a per-run config left every other run open.
+	//
+	// The empty document is what makes the flag usable standalone:
+	// --strict-mcp-config means "use exactly these servers", so with no
+	// servers declared it means "none".
+	mcpJSON := cfg.MCPConfigJSON
+	if strings.TrimSpace(mcpJSON) == "" {
+		mcpJSON = emptyMCPConfigJSON
 	}
+	wrapped, err := wrapMCPConfigWithOwnership(mcpJSON, mcpOwnerForAgent(a))
+	if err != nil {
+		return headlessInvocation{}, err
+	}
+	args = append(args, "--mcp-config", wrapped, "--strict-mcp-config")
 	// Wire the same PreToolUse approval hook the conversational runner uses
 	// whenever this run requires permission gating. Without this, a headless
 	// agent under require_permissions:true has no path to approve a tool

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -2313,14 +2314,32 @@ func TestBuildHeadlessInvocation_PlaywrightMCP(t *testing.T) {
 		}
 	})
 
-	t.Run("claude_empty_mcp_config_is_noop", func(t *testing.T) {
+	// A run that attaches no server of its own is exactly the run that must
+	// still be pinned: without --strict-mcp-config, Claude loads whatever the
+	// host account has connected, which is how an operator's Gmail/Drive
+	// connectors reached headless agents (#2790). "No config" has to mean
+	// "no servers", not "inherit the host's".
+	t.Run("claude_pins_empty_surface_when_no_config", func(t *testing.T) {
 		a := &Agent{ID: "a", Provider: "claude"}
 		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "test"})
 		if err != nil {
 			t.Fatalf("buildHeadlessInvocation: %v", err)
 		}
-		if slices.Contains(args, "--mcp-config") || slices.Contains(args, "--strict-mcp-config") {
-			t.Fatalf("mcp flags must be absent when MCPConfigJSON empty; got %v", args)
+		if !slices.Contains(args, "--strict-mcp-config") {
+			t.Fatalf("--strict-mcp-config must be present even with no per-run config; got %v", args)
+		}
+		i := slices.Index(args, "--mcp-config")
+		if i < 0 || i+1 >= len(args) {
+			t.Fatalf("--mcp-config must accompany --strict-mcp-config; got %v", args)
+		}
+		var doc struct {
+			MCPServers map[string]json.RawMessage `json:"mcpServers"`
+		}
+		if err := json.Unmarshal([]byte(args[i+1]), &doc); err != nil {
+			t.Fatalf("mcp config is not valid JSON (%v): %s", err, args[i+1])
+		}
+		if len(doc.MCPServers) != 0 {
+			t.Fatalf("declared %d servers, want none: %s", len(doc.MCPServers), args[i+1])
 		}
 	})
 


### PR DESCRIPTION
## Motivation

Three headless runs were offered the host account's claude.ai connector tools — Gmail (read/draft/label), Google Calendar (create/delete events), Google Drive (read/create files). None were invoked, and they are currently unauthenticated, but nothing *prevents* them: a re-auth on that host silently re-adds mailbox and Drive access to every unattended agent. Closes #2790, part of #2775.

The OS sandbox has no reach here — these execute in the provider's service, not as filesystem operations.

> Changelog: feat(agent): restrict agents to Sybra's own MCP servers

## Implementation information

The mechanism already existed and was simply scoped too narrowly. `--strict-mcp-config` was appended **only when a run attached a server config of its own** — in practice, only playwright-enabled test-runner runs. Its own comment stated the intent ("would leak an operator's unrelated MCP tools into an unattended run"), but every run without a per-run config got no `--mcp-config` at all and therefore inherited whatever the host account had connected.

Now the flag is unconditional: a run that attaches no server declares `{"mcpServers":{}}`. Paired with `--strict-mcp-config` that means *exactly none* rather than *whatever the host has*. Playwright runs are unaffected — they still declare their own server and go through the same ownership wrapping.

## Testing

`mise run verify` exits 0.

The existing `claude_empty_mcp_config_is_noop` case asserted the opposite contract — that no flags appear when no config is set — which is precisely the hole. Replaced with `claude_pins_empty_surface_when_no_config`, which asserts both flags are present and that the declared server set parses and is empty.

Mutation-verified: restoring the early return for the no-config case fails 3 assertions.

## Open questions

Scoped to the claude provider, which is where the exposure was observed. Copilot passes `--additional-mcp-config`, whose name suggests it *adds* to an ambient set rather than replacing it — if so it has the same hole and no equivalent strict flag, which needs confirming against the CLI rather than guessed at. Codex is untouched. Worth a follow-up issue once both are checked.

This also does not stop an operator deliberately configuring an MCP server for Sybra to use; it stops agents inheriting servers nobody chose for them.