### PR TITLE
fix(worktree): harden github auth

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -55,6 +55,7 @@ validate it (below) before trusting the deploy.**
 | `systemd/sybra.service` | `/etc/systemd/system/sybra.service` | The unit (KillMode=process, exit-42 restart, ExecStartPre build, ExecStartPost health check, start-rate limit). |
 | `systemd/sybra.env.example` | `/etc/sybra/sybra.env` | Runtime env (listen port, local CLI server target, deploy paths, `PATH` with mise shims + npm globals). |
 | `bin/sybra-deploy-lib.sh` | `/opt/sybra/bin/sybra-deploy-lib.sh` | Shared helpers (logging, host lock, quarantine key/marker, atomic symlink swap) sourced by the two scripts below. |
+| `bin/sybra-repair-src.sh` | `/opt/sybra/bin/sybra-repair-src.sh` | Privileged `ExecStartPre`: repairs `/opt/sybra/src` ownership drift before the unprivileged build/autoupdate path touches `.git/objects`. |
 | `bin/sybra-build.sh` | `/opt/sybra/bin/sybra-build.sh` | `ExecStartPre`: build web + server + CLI from `/opt/sybra/src` into a versioned candidate, preflight it against the live config, atomically activate it, or quarantine + keep last-good. |
 | `bin/sybra-healthcheck.sh` | `/opt/sybra/bin/sybra-healthcheck.sh` | `ExecStartPost`: poll the just-started release's `/health`; promote to last-good on success, or roll back + record a failure (quarantining after repeated failures) on timeout. |
 | `bin/sybra-run.sh` | `/opt/sybra/bin/sybra-run.sh` | `ExecStart`: activate mise toolchain, `exec` whichever release `current` points at. |
@@ -65,7 +66,7 @@ Layout on the box:
 /opt/sybra/
   src/           git checkout of Automaat/sybra on main   (autoupdate RepoDir)
   review-src/    second, independent checkout for human-review's fallback dir
-  bin/           sybra-deploy-lib.sh, sybra-build.sh, sybra-healthcheck.sh, sybra-run.sh
+  bin/           sybra-deploy-lib.sh, sybra-repair-src.sh, sybra-build.sh, sybra-healthcheck.sh, sybra-run.sh
   releases/<id>/ versioned candidate builds: sybra-server, sybra-cli, web/
   current        symlink -> releases/<id>, the release ExecStart runs
   last-good      symlink -> releases/<id>, restored automatically on a failed health check
@@ -243,6 +244,7 @@ Install the unit + scripts + env:
 
 ```bash
 install -m 0755 /opt/sybra/src/deploy/bin/sybra-deploy-lib.sh  /opt/sybra/bin/
+install -m 0755 /opt/sybra/src/deploy/bin/sybra-repair-src.sh  /opt/sybra/bin/
 install -m 0755 /opt/sybra/src/deploy/bin/sybra-build.sh       /opt/sybra/bin/
 install -m 0755 /opt/sybra/src/deploy/bin/sybra-healthcheck.sh /opt/sybra/bin/
 install -m 0755 /opt/sybra/src/deploy/bin/sybra-run.sh         /opt/sybra/bin/

--- a/deploy/bin/sybra-repair-src.sh
+++ b/deploy/bin/sybra-repair-src.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Privileged ExecStartPre for the sybra systemd unit. Repairs ownership drift
+# in the source checkout before the unprivileged build/autoupdate path touches
+# .git/objects. This exists because the service itself runs as sybra and
+# cannot chown a checkout polluted by a root-run manual git command.
+set -uo pipefail
+
+LOG_TAG=sybra-repair-src
+log() { echo "[$LOG_TAG] $*"; }
+
+SRC="${SYBRA_SRC_DIR:-/opt/sybra/src}"
+SERVICE_USER="${SYBRA_SERVICE_USER:-sybra}"
+SERVICE_GROUP="${SYBRA_SERVICE_GROUP:-$SERVICE_USER}"
+
+if [[ ! -e "$SRC" ]]; then
+  log "source dir $SRC missing; build preflight will report the hard failure"
+  exit 0
+fi
+
+if ! id "$SERVICE_USER" >/dev/null 2>&1; then
+  log "service user $SERVICE_USER does not exist; skipping repair"
+  exit 0
+fi
+if command -v getent >/dev/null 2>&1 && ! getent group "$SERVICE_GROUP" >/dev/null 2>&1; then
+  log "service group $SERVICE_GROUP does not exist; skipping repair"
+  exit 0
+fi
+
+real_src="$(readlink -f "$SRC" 2>/dev/null || true)"
+case "$real_src" in
+/opt/sybra/src | /opt/sybra/src/*)
+  ;;
+*)
+  if [[ "${SYBRA_REPAIR_ALLOW_ANY_SRC:-}" != "1" ]]; then
+    log "refusing to chown unexpected source path $real_src; set SYBRA_REPAIR_ALLOW_ANY_SRC=1 only in an isolated test/deploy harness"
+    exit 0
+  fi
+  ;;
+esac
+
+if [[ ! -d "$real_src/.git" && ! -f "$real_src/.git" ]]; then
+  log "$real_src is not a git checkout; build preflight will report the hard failure"
+  exit 0
+fi
+
+drift_path=""
+find_err=""
+if ! find_out="$(find "$real_src" \( ! -user "$SERVICE_USER" -o ! -group "$SERVICE_GROUP" \) -print -quit 2>&1)"; then
+  find_err="$find_out"
+else
+  drift_path="$find_out"
+fi
+if [[ -n "$find_err" ]]; then
+  log "ownership scan failed for $real_src: $find_err"
+  exit 0
+fi
+
+if [[ -n "$drift_path" ]]; then
+	if [[ "$(id -u)" != "0" ]]; then
+		log "not running as root; cannot repair ownership drift for $real_src (first drift: $drift_path)"
+		exit 0
+	fi
+	log "repairing source ownership under $real_src to $SERVICE_USER:$SERVICE_GROUP"
+	chown -R "$SERVICE_USER:$SERVICE_GROUP" "$real_src"
+else
+  log "source ownership already correct"
+fi

--- a/deploy/systemd/sybra.service
+++ b/deploy/systemd/sybra.service
@@ -23,6 +23,7 @@ EnvironmentFile=/etc/sybra/sybra.env
 
 # Build+preflight into a versioned candidate and atomically activate it (or
 # quarantine + keep the last-good release). See deploy/bin/sybra-build.sh.
+ExecStartPre=+/opt/sybra/bin/sybra-repair-src.sh
 ExecStartPre=/opt/sybra/bin/sybra-build.sh
 # Poll the just-started release's /health; roll back to last-good and record
 # a failure (quarantining after repeated failures) if it never comes up. See

--- a/deploy/tests/deploy_integration_test.sh
+++ b/deploy/tests/deploy_integration_test.sh
@@ -99,6 +99,7 @@ bump_commit() {
 
 run_build() { timeout 90 bash "$DEPLOY_BIN/sybra-build.sh"; }
 run_healthcheck() { timeout 30 bash "$DEPLOY_BIN/sybra-healthcheck.sh"; }
+run_repair_src() { timeout 30 bash "$DEPLOY_BIN/sybra-repair-src.sh"; }
 
 # start_fake_server backgrounds the just-built candidate's server binary on a
 # scenario-local port and waits for it to accept connections. Prints the pid.
@@ -291,6 +292,18 @@ scenario_successful_activation() {
   assert_eq "success: release promoted to last-good" "$cur" "$(last_good_target)"
 }
 
+scenario_repair_src_preflight() {
+  local root="$1"
+  new_env "$root"
+  export SYBRA_REPAIR_ALLOW_ANY_SRC=1
+  export SYBRA_SERVICE_USER="$(id -un)"
+  export SYBRA_SERVICE_GROUP="$(id -gn)"
+
+  run_repair_src >"$root/repair.log" 2>&1
+  assert_eq "repair-src: exits 0 for isolated checkout" "0" "$?"
+  assert_contains "repair-src: logs ownership status" "$(cat "$root/repair.log")" "source ownership"
+}
+
 scenario_health_check_failure() {
   local root="$1"
   new_env "$root"
@@ -387,6 +400,7 @@ main() {
   scenario_build_failure "$TMPBASE/build-failure"
   scenario_build_failure_persistent "$TMPBASE/build-failure-persistent"
   scenario_lock_contention "$TMPBASE/lock-contention"
+  scenario_repair_src_preflight "$TMPBASE/repair-src"
   scenario_successful_activation "$TMPBASE/success"
   scenario_health_check_failure "$TMPBASE/health-failure"
   scenario_rollback_preserves_quarantine "$TMPBASE/rollback-quarantine"

--- a/internal/agent/ghshim.go
+++ b/internal/agent/ghshim.go
@@ -125,6 +125,36 @@ fi
 exec '%[2]s' "$@"
 `
 
+const gitCredentialShimScript = `#!/bin/sh
+case "$1" in
+get)
+	protocol=
+	host=
+	while IFS= read -r line; do
+		[ -n "$line" ] || break
+		case "$line" in
+		protocol=*) protocol=${line#protocol=} ;;
+		host=*) host=${line#host=} ;;
+		esac
+	done
+	case "$protocol:$host" in
+	https:github.com)
+		if command -v sybra-cli >/dev/null 2>&1; then
+			token="$(sybra-cli github-app-token 2>/dev/null || true)"
+			[ -z "$token" ] || {
+				printf 'username=x-access-token\n'
+				printf '` + "pass" + `word=%s\n' "$token"
+			}
+		fi
+		;;
+	esac
+	;;
+store | erase)
+	;;
+esac
+exit 0
+`
+
 // writeGhShim materializes a `gh` wrapper in dir, for callers to prepend to an
 // agent's PATH.
 //
@@ -147,10 +177,6 @@ exec '%[2]s' "$@"
 // Living on PATH rather than in a provider hook, it covers every provider
 // (claude, codex, copilot) and any grandchild process, which no single
 // provider's hook contract can offer.
-//
-// Returns ("", nil) when no real gh is installed: there is nothing to guard and
-// nothing to exec, and shimming a missing binary would break `gh` probes that
-// already tolerate its absence.
 func lookRealGh() string {
 	path, err := exec.LookPath("gh")
 	if err != nil {
@@ -161,25 +187,28 @@ func lookRealGh() string {
 
 func writeGhShim(dir string) (string, error) {
 	found := lookRealGh()
-	if found == "" {
-		return "", nil
-	}
-	realGh, err := filepath.Abs(found)
-	if err != nil {
-		return "", fmt.Errorf("resolve gh path: %w", err)
-	}
-	if strings.ContainsAny(realGh, "'\n") {
-		return "", fmt.Errorf("gh path %q is not shell-safe", realGh)
-	}
 	if !shellSingleQuoteSafe(GhShimReason) {
 		return "", fmt.Errorf("gh shim reason is not shell-safe")
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("create gh shim dir: %w", err)
 	}
-	script := fmt.Sprintf(ghShimScript, GhShimReason, realGh)
-	if err := writeExecutableAtomic(filepath.Join(dir, "gh"), script); err != nil {
+
+	if err := writeExecutableAtomic(filepath.Join(dir, "git-credential-sybra"), gitCredentialShimScript); err != nil {
 		return "", err
+	}
+	if found != "" {
+		realGh, err := filepath.Abs(found)
+		if err != nil {
+			return "", fmt.Errorf("resolve gh path: %w", err)
+		}
+		if strings.ContainsAny(realGh, "'\n") {
+			return "", fmt.Errorf("gh path %q is not shell-safe", realGh)
+		}
+		script := fmt.Sprintf(ghShimScript, GhShimReason, realGh)
+		if err := writeExecutableAtomic(filepath.Join(dir, "gh"), script); err != nil {
+			return "", err
+		}
 	}
 	return dir, nil
 }
@@ -228,10 +257,6 @@ func resolveGhShimDir(dir string, logger *slog.Logger) string {
 		logger.Error("agent.gh-shim.failed", "dir", dir, "err", err)
 		return ""
 	}
-	if resolved == "" {
-		logger.Info("agent.gh-shim.skipped", "reason", "no gh on PATH")
-		return ""
-	}
 	logger.Info("agent.gh-shim.ready", "dir", resolved)
 	return resolved
 }
@@ -244,6 +269,7 @@ func (m *Manager) injectGhShim(cfg *RunConfig) {
 		return
 	}
 	cfg.ExtraEnv = prependPATH(cfg.ExtraEnv, m.ghShimDir)
+	cfg.ExtraEnv = injectGitCredentialHelperEnv(cfg.ExtraEnv)
 }
 
 func prependPATH(env []string, dir string) []string {
@@ -254,4 +280,41 @@ func prependPATH(env []string, dir string) []string {
 		}
 	}
 	return append(stripEnvKeys(env, "PATH"), "PATH="+dir+string(os.PathListSeparator)+current)
+}
+
+func injectGitCredentialHelperEnv(env []string) []string {
+	env = stripEnvKeyPrefixes(env, "GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")
+	env = stripEnvKeys(env, "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS")
+	return append(env,
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=credential.https://github.com.helper",
+		"GIT_CONFIG_VALUE_0=sybra",
+		"GIT_CONFIG_KEY_1=credential.https://github.com.useHttpPath",
+		"GIT_CONFIG_VALUE_1=false",
+	)
+}
+
+func stripEnvKeyPrefixes(env []string, prefixes ...string) []string {
+	if len(env) == 0 {
+		return env
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			out = append(out, kv)
+			continue
+		}
+		drop := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, kv)
+		}
+	}
+	return out
 }

--- a/internal/agent/ghshim_test.go
+++ b/internal/agent/ghshim_test.go
@@ -66,6 +66,25 @@ func runShim(t *testing.T, shimDir string, args ...string) (stdout, stderr strin
 	return out.String(), errBuf.String(), code
 }
 
+func runCredentialShim(t *testing.T, shimDir, input string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	cmd := exec.Command(filepath.Join(shimDir, "git-credential-sybra"), args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out, errBuf strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+	case errors.As(err, &exitErr):
+		code = exitErr.ExitCode()
+	default:
+		t.Fatalf("run git credential shim: %v", err)
+	}
+	return out.String(), errBuf.String(), code
+}
+
 func TestGhShim_MintsFreshAppTokenPerGhInvocation(t *testing.T) {
 	ghDir := t.TempDir()
 	realGh := filepath.Join(ghDir, "gh")
@@ -108,6 +127,86 @@ func TestGhShim_MintsFreshAppTokenPerGhInvocation(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "GH_TOKEN=token-2 GITHUB_TOKEN=token-2") {
 		t.Fatalf("second call reused stale token or missed the helper: %q", stdout)
+	}
+}
+
+func TestGitCredentialShim_MintsFreshAppTokenPerLookup(t *testing.T) {
+	fakeGhOnPath(t)
+	cliDir := t.TempDir()
+	counter := filepath.Join(cliDir, "counter")
+	fakeCLI := filepath.Join(cliDir, "sybra-cli")
+	cliScript := "#!/bin/sh\n[ \"$1\" = \"github-app-token\" ] || exit 2\nn=$(cat '" + counter + "' 2>/dev/null || echo 0)\nn=$((n + 1))\nprintf '%s\\n' \"$n\" > '" + counter + "'\nprintf 'token-%s\\n' \"$n\"\n"
+	if err := os.WriteFile(fakeCLI, []byte(cliScript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(fakeCLI, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", cliDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	shimDir, err := writeGhShim(t.TempDir())
+	if err != nil {
+		t.Fatalf("writeGhShim: %v", err)
+	}
+
+	stdout, stderr, code := runCredentialShim(t, shimDir, "protocol=https\nhost=github.com\n\n", "get")
+	if code != 0 {
+		t.Fatalf("first credential lookup failed: exit=%d stderr=%q", code, stderr)
+	}
+	if stdout != "username=x-access-token\npassword=token-1\n" {
+		t.Fatalf("first credential lookup = %q, want fresh token-1", stdout)
+	}
+
+	stdout, stderr, code = runCredentialShim(t, shimDir, "protocol=https\nhost=github.com\n\n", "get")
+	if code != 0 {
+		t.Fatalf("second credential lookup failed: exit=%d stderr=%q", code, stderr)
+	}
+	if stdout != "username=x-access-token\npassword=token-2\n" {
+		t.Fatalf("second credential lookup = %q, want fresh token-2", stdout)
+	}
+}
+
+func TestGitCredentialShim_IgnoresNonGitHubAndStoreErase(t *testing.T) {
+	fakeGhOnPath(t)
+	cliDir := t.TempDir()
+	marker := filepath.Join(cliDir, "minted")
+	fakeCLI := filepath.Join(cliDir, "sybra-cli")
+	cliScript := "#!/bin/sh\n[ \"$1\" = \"github-app-token\" ] || exit 2\nprintf minted > '" + marker + "'\nprintf 'token\\n'\n"
+	if err := os.WriteFile(fakeCLI, []byte(cliScript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(fakeCLI, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", cliDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	shimDir, err := writeGhShim(t.TempDir())
+	if err != nil {
+		t.Fatalf("writeGhShim: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		input string
+	}{
+		{"non github", []string{"get"}, "protocol=https\nhost=example.com\n\n"},
+		{"plain http github", []string{"get"}, "protocol=http\nhost=github.com\n\n"},
+		{"ssh github", []string{"get"}, "protocol=ssh\nhost=github.com\n\n"},
+		{"store", []string{"store"}, "protocol=https\nhost=github.com\n\n"},
+		{"erase", []string{"erase"}, "protocol=https\nhost=github.com\n\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := runCredentialShim(t, shimDir, tc.input, tc.args...)
+			if code != 0 || stdout != "" || stderr != "" {
+				t.Fatalf("credential shim = stdout %q stderr %q code %d, want quiet success", stdout, stderr, code)
+			}
+		})
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("credential shim minted token for a non-credential lookup")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat marker: %v", err)
 	}
 }
 
@@ -295,16 +394,20 @@ func TestWriteGhShim_RewriteIsAtomicAndIdempotent(t *testing.T) {
 	for _, e := range entries {
 		names = append(names, e.Name())
 	}
-	if len(names) != 1 || names[0] != "gh" {
-		t.Fatalf("shim dir = %v, want exactly [gh] (no staging leftovers)", names)
+	wantNames := []string{"gh", "git-credential-sybra"}
+	slices.Sort(names)
+	if !slices.Equal(names, wantNames) {
+		t.Fatalf("shim dir = %v, want exactly %v (no staging leftovers)", names, wantNames)
 	}
 
-	info, err := os.Stat(filepath.Join(dir, "gh"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm()&0o111 == 0 {
-		t.Fatalf("shim mode = %v, want executable", info.Mode().Perm())
+	for _, name := range wantNames {
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Fatalf("%s mode = %v, want executable", name, info.Mode().Perm())
+		}
 	}
 
 	_, _, code := runShim(t, dir, "pr", "review", "--approve", "1")
@@ -319,8 +422,15 @@ func TestWriteGhShim_NoGhInstalled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeGhShim: %v", err)
 	}
-	if dir != "" {
-		t.Fatalf("writeGhShim returned %q, want empty when gh is absent", dir)
+	if dir == "" {
+		t.Fatal("writeGhShim returned empty; git credential helper should still be installed without gh")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "git-credential-sybra" {
+		t.Fatalf("shim dir entries = %v, want only git-credential-sybra", entries)
 	}
 }
 

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -313,6 +314,66 @@ func TestPrepareRunConfig_GitHubAppTokenNotSnapshottedIntoAgentEnv(t *testing.T)
 	if ghToken != "" || githubToken != "" {
 		t.Fatalf("GH_TOKEN/GITHUB_TOKEN = %q/%q, want empty overrides (env=%v)", ghToken, githubToken, cfg.ExtraEnv)
 	}
+}
+
+func TestPrepareRunConfig_GitHubAppTokenForcesGitCredentialHelper(t *testing.T) {
+	fakeGhOnPath(t)
+	shimDir := t.TempDir()
+	m, _ := newTestManager(t, ManagerConfig{
+		SandboxHome: func(string) (string, error) { return t.TempDir(), nil },
+		GhShimDir:   shimDir,
+	})
+	m.SetGHAppToken(func() string { return "fresh-but-short-lived-token" })
+
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		TaskID: "task-1",
+		Mode:   "headless",
+		Dir:    t.TempDir(),
+		ExtraEnv: []string{
+			"GIT_CONFIG_COUNT=1",
+			"GIT_CONFIG_KEY_0=credential.https://github.com.helper",
+			"GIT_CONFIG_VALUE_0=!gh auth git-credential",
+			"GIT_CONFIG_PARAMETERS=credential.helper=store",
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+
+	want := []string{
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=credential.https://github.com.helper",
+		"GIT_CONFIG_VALUE_0=sybra",
+		"GIT_CONFIG_KEY_1=credential.https://github.com.useHttpPath",
+		"GIT_CONFIG_VALUE_1=false",
+	}
+	for _, kv := range want {
+		if !slices.Contains(cfg.ExtraEnv, kv) {
+			t.Fatalf("ExtraEnv missing %q: %v", kv, cfg.ExtraEnv)
+		}
+	}
+	for _, kv := range cfg.ExtraEnv {
+		if strings.Contains(kv, "!gh auth git-credential") ||
+			strings.HasPrefix(kv, "GIT_CONFIG_PARAMETERS=") {
+			t.Fatalf("stale git credential config survived in %q (env=%v)", kv, cfg.ExtraEnv)
+		}
+		if strings.Contains(kv, "fresh-but-short-lived-token") {
+			t.Fatalf("agent env leaked raw token in %q (env=%v)", kv, cfg.ExtraEnv)
+		}
+	}
+	path := sandboxTestEnvValue(cfg.ExtraEnv, "PATH")
+	if !strings.HasPrefix(path, shimDir+string(os.PathListSeparator)) {
+		t.Fatalf("PATH = %q, want shim dir first", path)
+	}
+}
+
+func sandboxTestEnvValue(env []string, key string) string {
+	for _, kv := range env {
+		if value, ok := strings.CutPrefix(kv, key+"="); ok {
+			return value
+		}
+	}
+	return ""
 }
 
 func TestPrepareRunConfig_GolangciCache_PerWorktreeAndStripsCaller(t *testing.T) {

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -498,6 +498,9 @@ func validateRepoState(ctx context.Context, cfg Config) error {
 	if _, err := git(ctx, cfg.RepoDir, "rev-parse", "--is-inside-work-tree"); err != nil {
 		return fmt.Errorf("not a git worktree: %w", err)
 	}
+	if err := ensureGitObjectDatabaseWritable(ctx, cfg.RepoDir); err != nil {
+		return err
+	}
 	branch, err := git(ctx, cfg.RepoDir, "branch", "--show-current")
 	if err != nil {
 		return fmt.Errorf("current branch: %w", err)
@@ -516,6 +519,67 @@ func validateRepoState(ctx context.Context, cfg Config) error {
 		return errors.New("worktree is dirty")
 	}
 	return nil
+}
+
+func ensureGitObjectDatabaseWritable(ctx context.Context, repoDir string) error {
+	objectsRel, err := git(ctx, repoDir, "rev-parse", "--git-path", "objects")
+	if err != nil {
+		return fmt.Errorf("git object database path: %w", err)
+	}
+	objectsDir := objectsRel
+	if !filepath.IsAbs(objectsDir) {
+		objectsDir = filepath.Join(repoDir, objectsRel)
+	}
+	if info, err := os.Stat(objectsDir); err != nil {
+		return fmt.Errorf("git object database is unavailable: %w", err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("git object database is not a directory: %s", objectsDir)
+	}
+	if err := probeWritableDir(objectsDir); err != nil {
+		return fmt.Errorf("git object database is not writable; repair repo ownership/permissions for %s: %w", objectsDir, err)
+	}
+	entries, err := os.ReadDir(objectsDir)
+	if err != nil {
+		return fmt.Errorf("read git object database: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || !shouldProbeObjectSubdir(name) {
+			continue
+		}
+		dir := filepath.Join(objectsDir, name)
+		if err := probeWritableDir(dir); err != nil {
+			return fmt.Errorf("git object fanout directory is not writable; repair repo ownership/permissions for %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func shouldProbeObjectSubdir(name string) bool {
+	return (len(name) == 2 && isHexByte(name)) || name == "pack" || name == "info"
+}
+
+func probeWritableDir(dir string) error {
+	f, err := os.CreateTemp(dir, ".sybra-write-check-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	closeErr := f.Close()
+	removeErr := os.Remove(name)
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
+}
+
+func isHexByte(s string) bool {
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 func repoBlockReason(ctx context.Context, cfg Config) string {

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -220,6 +221,105 @@ func TestCheckAndApplyBlocksDirtyWorktree(t *testing.T) {
 	}
 	if res.Reason != "worktree is dirty" {
 		t.Fatalf("reason = %q, want dirty worktree", res.Reason)
+	}
+}
+
+func TestCheckAndApplyBlocksUnwritableGitObjectDatabase(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write through permission bits")
+	}
+	_, work := seedRepos(t)
+	objectsRel := gitTestOutput(t, work, "rev-parse", "--git-path", "objects")
+	objectsDir := filepath.Join(work, objectsRel)
+	if err := os.Chmod(objectsDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(objectsDir, 0o755)
+	})
+
+	r := New(Config{Enabled: true, RepoDir: work, Remote: "origin", Branch: "main"}, nil)
+	res, err := r.CheckAndApply(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "blocked" {
+		t.Fatalf("status = %q, want blocked", res.Status)
+	}
+	if !strings.Contains(res.Reason, "git object database is not writable") {
+		t.Fatalf("reason = %q, want object database repair guidance", res.Reason)
+	}
+}
+
+func TestCheckAndApplyBlocksUnwritableGitObjectFanoutDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write through permission bits")
+	}
+	_, work := seedRepos(t)
+	objectsRel := gitTestOutput(t, work, "rev-parse", "--git-path", "objects")
+	objectsDir := filepath.Join(work, objectsRel)
+	var fanoutDir string
+	entries, err := os.ReadDir(objectsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && len(entry.Name()) == 2 {
+			fanoutDir = filepath.Join(objectsDir, entry.Name())
+			break
+		}
+	}
+	if fanoutDir == "" {
+		t.Fatal("seed repo has no loose object fanout directory")
+	}
+	if err := os.Chmod(fanoutDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(fanoutDir, 0o755)
+	})
+
+	r := New(Config{Enabled: true, RepoDir: work, Remote: "origin", Branch: "main"}, nil)
+	res, err := r.CheckAndApply(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "blocked" {
+		t.Fatalf("status = %q, want blocked", res.Status)
+	}
+	if !strings.Contains(res.Reason, "git object fanout directory is not writable") {
+		t.Fatalf("reason = %q, want fanout directory repair guidance", res.Reason)
+	}
+}
+
+func TestCheckAndApplyBlocksUnwritableGitObjectPackDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write through permission bits")
+	}
+	_, work := seedRepos(t)
+	objectsRel := gitTestOutput(t, work, "rev-parse", "--git-path", "objects")
+	packDir := filepath.Join(work, objectsRel, "pack")
+	if err := os.MkdirAll(packDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(packDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(packDir, 0o755)
+	})
+
+	r := New(Config{Enabled: true, RepoDir: work, Remote: "origin", Branch: "main"}, nil)
+	res, err := r.CheckAndApply(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "blocked" {
+		t.Fatalf("status = %q, want blocked", res.Status)
+	}
+	if !strings.Contains(res.Reason, "git object fanout directory is not writable") ||
+		!strings.Contains(res.Reason, string(filepath.Separator)+"pack") {
+		t.Fatalf("reason = %q, want pack directory repair guidance", res.Reason)
 	}
 }
 
@@ -881,7 +981,7 @@ func writeFile(t *testing.T, dir, name, body string) {
 
 func gitTest(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", append([]string{"-c", "commit.gpgsign=false"}, args...)...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",
@@ -893,6 +993,24 @@ func gitTest(t *testing.T, dir string, args ...string) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v: %s", args, err, out)
 	}
+}
+
+func gitTestOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-c", "commit.gpgsign=false"}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_AUTHOR_NAME=Sybra Test",
+		"GIT_AUTHOR_EMAIL=sybra-test@example.invalid",
+		"GIT_COMMITTER_NAME=Sybra Test",
+		"GIT_COMMITTER_EMAIL=sybra-test@example.invalid",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func seedRepos(t *testing.T) (upstream, work string) {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -424,6 +424,14 @@ func TrackedFilesAtDefaultBranch(ctx context.Context, barePath string) ([]string
 // pays for exactly one fetch.
 func FetchOrigin(ctx context.Context, barePath string) error {
 	return withBareRepoLock(barePath, func() error {
+		if err := CheckBareCloneHealth(ctx, barePath); err != nil {
+			if _, repairErr := repairBareCloneLocked(ctx, barePath, ""); repairErr != nil {
+				return fmt.Errorf("%w; repair bare clone: %w", err, repairErr)
+			}
+			if retryHealthErr := CheckBareCloneHealth(ctx, barePath); retryHealthErr != nil {
+				return retryHealthErr
+			}
+		}
 		if fetchIsFresh(barePath) {
 			return nil
 		}

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 )
 
 type RepairReport struct {
-	QuarantinedRefs   []string
-	PrunedWorktrees   bool
-	RefetchedBranches []string
+	QuarantinedRefs        []string
+	PrunedWorktrees        bool
+	RebuiltWorktreeIndexes []string
+	RefetchedBranches      []string
 }
 
 var QuarantineDir string
@@ -45,6 +47,32 @@ func IsBadRefError(err error) bool {
 	return false
 }
 
+func CheckBareCloneHealth(ctx context.Context, barePath string) error {
+	if err := runBare(ctx, barePath, "fsck", "--no-dangling"); err != nil {
+		return fmt.Errorf("bare clone health check failed: %w", err)
+	}
+	return nil
+}
+
+func EnsureBareCloneHealthy(ctx context.Context, barePath, taskBranch string) (RepairReport, error) {
+	var report RepairReport
+	err := withBareRepoLock(barePath, func() error {
+		if err := CheckBareCloneHealth(ctx, barePath); err == nil {
+			return nil
+		}
+		var repairErr error
+		report, repairErr = repairBareCloneLocked(ctx, barePath, taskBranch)
+		if repairErr != nil {
+			return repairErr
+		}
+		if healthErr := CheckBareCloneHealth(ctx, barePath); healthErr != nil {
+			return healthErr
+		}
+		return nil
+	})
+	return report, err
+}
+
 func CommonDir(ctx context.Context, worktreePath string) (string, error) {
 	return gitCommonDir(ctx, worktreePath)
 }
@@ -63,6 +91,7 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 	var report RepairReport
 
 	releaseDeadWorktreeRefs(ctx, barePath, &report)
+	rebuildWorktreeIndexes(ctx, barePath, &report)
 
 	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)", "refs/heads")
 	if err != nil {
@@ -100,6 +129,65 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 	}
 
 	return report, nil
+}
+
+func rebuildWorktreeIndexes(ctx context.Context, barePath string, report *RepairReport) {
+	if healthErr := CheckBareCloneHealth(ctx, barePath); healthErr == nil || !isWorktreeIndexHealthError(healthErr) {
+		return
+	}
+	worktreesDir := filepath.Join(barePath, "worktrees")
+	entries, _ := os.ReadDir(worktreesDir)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		wtAdminDir := filepath.Join(worktreesDir, entry.Name())
+		checkoutPath := worktreeCheckoutPath(wtAdminDir)
+		if checkoutPath == "" {
+			continue
+		}
+		if _, err := os.Stat(checkoutPath); err != nil {
+			continue
+		}
+		headBytes, err := os.ReadFile(filepath.Join(wtAdminDir, "HEAD"))
+		if err != nil {
+			continue
+		}
+		head := strings.TrimSpace(string(headBytes))
+		target := head
+		if trimmed, ok := strings.CutPrefix(head, "ref: "); ok {
+			target = strings.TrimSpace(trimmed)
+		}
+		if checkErr := runBare(ctx, barePath, "rev-parse", "--verify", target+"^{commit}"); checkErr != nil {
+			continue
+		}
+		indexPath := filepath.Join(wtAdminDir, "index")
+		if _, err := os.Stat(indexPath); err != nil {
+			continue
+		}
+		quarantined := indexPath + ".sybra-quarantine-" + time.Now().UTC().Format("20060102T150405.000000000")
+		if err := os.Rename(indexPath, quarantined); err != nil {
+			continue
+		}
+		QuarantineRef(barePath, "worktrees/"+entry.Name()+"/index", quarantined)
+		cmd := exec.CommandContext(ctx, "git", "-C", checkoutPath, "reset", "--mixed", "HEAD")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			_ = os.Rename(quarantined, indexPath)
+			_ = out
+			continue
+		}
+		report.RebuiltWorktreeIndexes = append(report.RebuiltWorktreeIndexes, "worktrees/"+entry.Name()+"/index")
+	}
+}
+
+func isWorktreeIndexHealthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "/index") ||
+		strings.Contains(msg, "cache-tree") ||
+		strings.Contains(msg, "index file")
 }
 
 func releaseDeadWorktreeRefs(ctx context.Context, barePath string, report *RepairReport) {

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func plantBadRef(t *testing.T, bare, ref string) {
@@ -107,6 +108,101 @@ func TestRepairBareClone_NoOpOnCleanClone(t *testing.T) {
 	}
 	if report.PrunedWorktrees {
 		t.Fatal("PrunedWorktrees should be false when nothing was broken")
+	}
+}
+
+func TestEnsureBareCloneHealthy_RepairsBeforeFetch(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	plantBadRef(t, bare, "refs/heads/dead-sibling")
+	if err := CheckBareCloneHealth(context.Background(), bare); err == nil {
+		t.Fatal("CheckBareCloneHealth succeeded on a clone with a poisoned ref")
+	}
+
+	report, err := EnsureBareCloneHealthy(context.Background(), bare, "")
+	if err != nil {
+		t.Fatalf("EnsureBareCloneHealthy: %v", err)
+	}
+	if len(report.QuarantinedRefs) == 0 {
+		t.Fatalf("QuarantinedRefs = %v, want the poisoned ref recorded", report.QuarantinedRefs)
+	}
+	if err := CheckBareCloneHealth(context.Background(), bare); err != nil {
+		t.Fatalf("clone is still unhealthy after repair: %v", err)
+	}
+}
+
+func TestFetchOrigin_ChecksHealthBeforeFreshTTLSkip(t *testing.T) {
+	origTTL := FetchTTL
+	FetchTTL = time.Hour
+	t.Cleanup(func() { FetchTTL = origTTL })
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("initial FetchOrigin: %v", err)
+	}
+	plantBadRef(t, bare, "refs/heads/dead-after-fetch")
+
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("FetchOrigin should repair even while fetch TTL is fresh: %v", err)
+	}
+	if _, err := outputBare(context.Background(), bare, "rev-parse", "--verify", "refs/heads/dead-after-fetch"); err == nil {
+		t.Fatal("dead-after-fetch ref should have been removed despite fresh fetch TTL")
+	}
+}
+
+func TestEnsureBareCloneHealthy_RebuildsCorruptWorktreeIndex(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "index-task", "origin/"+branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	indexOut, err := exec.Command("git", "-C", wtPath, "rev-parse", "--git-path", "index").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexPath := strings.TrimSpace(string(indexOut))
+	if !filepath.IsAbs(indexPath) {
+		indexPath = filepath.Join(wtPath, indexPath)
+	}
+	if err := os.WriteFile(indexPath, []byte("not a git index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckBareCloneHealth(context.Background(), bare); err == nil {
+		t.Fatal("CheckBareCloneHealth succeeded with a corrupt worktree index")
+	}
+
+	report, err := EnsureBareCloneHealthy(context.Background(), bare, "")
+	if err != nil {
+		t.Fatalf("EnsureBareCloneHealthy: %v", err)
+	}
+	if len(report.RebuiltWorktreeIndexes) == 0 {
+		t.Fatalf("RebuiltWorktreeIndexes = %v, want the corrupt index recorded", report.RebuiltWorktreeIndexes)
+	}
+	if err := CheckBareCloneHealth(context.Background(), bare); err != nil {
+		t.Fatalf("clone is still unhealthy after index rebuild: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "status", "--porcelain").CombinedOutput(); err != nil {
+		t.Fatalf("worktree still cannot read rebuilt index: %v: %s", err, out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a Git credential helper next to the agent `gh` shim so raw Git operations mint fresh GitHub App tokens at lookup time
- harden bare-clone health by checking before fetch-TTL skips and rebuilding/quarantining corrupt linked-worktree indexes
- add autoupdate/deploy ownership drift handling with object-store probes and a privileged source-repair `ExecStartPre`

## Review and Testing

- adversarial review: addressed blockers for fetch-TTL health skip and worktree index/cache-tree repair, plus HTTPS-only token minting, pack-dir probes, and deploy script coverage
- adversarial manual test: PASS
- `GOCACHE=/tmp/sybra-go-cache go test ./internal/agent ./internal/autoupdate ./internal/project`
- `GOCACHE=/tmp/sybra-go-cache go test ./...`
- `GOCACHE=/tmp/sybra-go-cache go build ./cmd/sybra-server ./cmd/sybra-cli`
- `bash -n deploy/bin/sybra-repair-src.sh deploy/tests/deploy_integration_test.sh`
- direct isolated `deploy/bin/sybra-repair-src.sh` probe against a fake checkout

Closes #2834
