### PR TITLE
fix(agent): make gh shim independent of agent path

### DIFF
--- a/internal/agent/ghshim.go
+++ b/internal/agent/ghshim.go
@@ -115,17 +115,21 @@ if [ "$1" = "api" ]; then
 	# Refuse a review payload we cannot inspect rather than assume it is benign.
 	[ "$sawhidden$sawreviews" = "11" ] && printf '%%s\n' '%[1]s' >&2 && exit 1
 fi
-if command -v sybra-cli >/dev/null 2>&1; then
+if [ -n '%[3]s' ] && [ -x '%[3]s' ]; then
+	token="$('%[3]s' github-app-token 2>/dev/null || true)"
+elif command -v sybra-cli >/dev/null 2>&1; then
 	token="$(sybra-cli github-app-token 2>/dev/null || true)"
-	[ -z "$token" ] || {
-		export GH_TOKEN="$token"
-		export GITHUB_TOKEN="$token"
-	}
+else
+	token=
 fi
+[ -z "$token" ] || {
+	export GH_TOKEN="$token"
+	export GITHUB_TOKEN="$token"
+}
 exec '%[2]s' "$@"
 `
 
-const gitCredentialShimScript = `#!/bin/sh
+const gitCredentialShimTemplate = `#!/bin/sh
 case "$1" in
 get)
 	protocol=
@@ -139,13 +143,17 @@ get)
 	done
 	case "$protocol:$host" in
 	https:github.com)
-		if command -v sybra-cli >/dev/null 2>&1; then
+		if [ -n '%[1]s' ] && [ -x '%[1]s' ]; then
+			token="$('%[1]s' github-app-token 2>/dev/null || true)"
+		elif command -v sybra-cli >/dev/null 2>&1; then
 			token="$(sybra-cli github-app-token 2>/dev/null || true)"
-			[ -z "$token" ] || {
-				printf 'username=x-access-token\n'
-				printf '` + "pass" + `word=%s\n' "$token"
-			}
+		else
+			token=
 		fi
+	[ -z "$token" ] || {
+			printf 'username=x-access-token\n'
+			printf '` + "pass" + `word=%%s\n' "$token"
+		}
 		;;
 	esac
 	;;
@@ -185,6 +193,25 @@ func lookRealGh() string {
 	return path
 }
 
+func lookRealSybraCLI() string {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			dir = "."
+		}
+		candidate := filepath.Join(dir, "sybra-cli")
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue
+		}
+		abs, err := filepath.Abs(candidate)
+		if err != nil {
+			return ""
+		}
+		return abs
+	}
+	return ""
+}
+
 func writeGhShim(dir string) (string, error) {
 	found := lookRealGh()
 	if !shellSingleQuoteSafe(GhShimReason) {
@@ -194,7 +221,13 @@ func writeGhShim(dir string) (string, error) {
 		return "", fmt.Errorf("create gh shim dir: %w", err)
 	}
 
-	if err := writeExecutableAtomic(filepath.Join(dir, "git-credential-sybra"), gitCredentialShimScript); err != nil {
+	sybraCLI := lookRealSybraCLI()
+	if strings.ContainsAny(sybraCLI, "'\n") {
+		return "", fmt.Errorf("sybra-cli path %q is not shell-safe", sybraCLI)
+	}
+
+	credentialScript := fmt.Sprintf(gitCredentialShimTemplate, sybraCLI)
+	if err := writeExecutableAtomic(filepath.Join(dir, "git-credential-sybra"), credentialScript); err != nil {
 		return "", err
 	}
 	if found != "" {
@@ -205,7 +238,7 @@ func writeGhShim(dir string) (string, error) {
 		if strings.ContainsAny(realGh, "'\n") {
 			return "", fmt.Errorf("gh path %q is not shell-safe", realGh)
 		}
-		script := fmt.Sprintf(ghShimScript, GhShimReason, realGh)
+		script := fmt.Sprintf(ghShimScript, GhShimReason, realGh, sybraCLI)
 		if err := writeExecutableAtomic(filepath.Join(dir, "gh"), script); err != nil {
 			return "", err
 		}

--- a/internal/agent/ghshim_test.go
+++ b/internal/agent/ghshim_test.go
@@ -130,6 +130,77 @@ func TestGhShim_MintsFreshAppTokenPerGhInvocation(t *testing.T) {
 	}
 }
 
+func TestGhShim_UsesResolvedSybraCLIWhenInvocationPathOmitsIt(t *testing.T) {
+	ghDir := t.TempDir()
+	realGh := filepath.Join(ghDir, "gh")
+	ghScript := "#!/bin/sh\nprintf 'REAL-GH GH_TOKEN=%s GITHUB_TOKEN=%s\\n' \"$GH_TOKEN\" \"$GITHUB_TOKEN\"\n"
+	if err := os.WriteFile(realGh, []byte(ghScript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(realGh, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cliDir := t.TempDir()
+	fakeCLI := filepath.Join(cliDir, "sybra-cli")
+	cliScript := "#!/bin/sh\n[ \"$1\" = \"github-app-token\" ] || exit 2\nprintf 'resolved-token\\n'\n"
+	if err := os.WriteFile(fakeCLI, []byte(cliScript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(fakeCLI, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", ghDir+string(os.PathListSeparator)+cliDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	shimDir, err := writeGhShim(t.TempDir())
+	if err != nil {
+		t.Fatalf("writeGhShim: %v", err)
+	}
+
+	t.Setenv("PATH", ghDir)
+	stdout, stderr, code := runShim(t, shimDir, "api", "rate_limit")
+	if code != 0 {
+		t.Fatalf("shim call failed without sybra-cli on PATH: exit=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stdout, "GH_TOKEN=resolved-token GITHUB_TOKEN=resolved-token") {
+		t.Fatalf("shim did not use resolved sybra-cli path: %q", stdout)
+	}
+}
+
+func TestLookRealSybraCLI_ReturnsAbsolutePath(t *testing.T) {
+	fakeGhOnPath(t)
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeCLI := filepath.Join(binDir, "sybra-cli")
+	if err := os.WriteFile(fakeCLI, []byte("#!/bin/sh\nexit 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(fakeCLI, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+	t.Setenv("PATH", "bin")
+
+	got := lookRealSybraCLI()
+	if !filepath.IsAbs(got) {
+		t.Fatalf("lookRealSybraCLI() = %q, want absolute path", got)
+	}
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat resolved path %q: %v", got, err)
+	}
+	wantInfo, err := os.Stat(fakeCLI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("lookRealSybraCLI() = %q, not same file as %q", got, fakeCLI)
+	}
+}
+
 func TestGitCredentialShim_MintsFreshAppTokenPerLookup(t *testing.T) {
 	fakeGhOnPath(t)
 	cliDir := t.TempDir()


### PR DESCRIPTION
## Summary
- bake the resolved sybra-cli path into the generated gh and git credential shims
- keep PATH lookup as a fallback for dev/test environments
- add regression coverage for invoking the gh shim after sybra-cli has disappeared from PATH

## Why
The server deploy of #2836 fixed source ownership and raw git credential lookup, but live restarted agents still hit `gh auth login` when their execution PATH exposed the gh shim without also exposing `sybra-cli`. The wrapper minted no App token and fell through to unauthenticated /usr/bin/gh.

## Verification
- `GOCACHE=/tmp/sybra-go-cache go test ./internal/agent -run 'GhShim|SandboxHome_GitHub'`
- `GOCACHE=/tmp/sybra-go-cache go test ./internal/agent ./cmd/sybra-cli` (rerun outside sandbox because httptest port binding is blocked locally)

Follow-up to #2834.