### PR TITLE
fix(sandbox): seal claude state except sessions

### DIFF
--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -681,11 +681,18 @@ func enforceSpec(
 		gitOverlayRemoteLogDir: gitOverlay.remoteLogDir,
 		gitOverlayTagRefDir:    gitOverlay.tagRefDir,
 		gitOverlayTagLogDir:    gitOverlay.tagLogDir,
-		claudeState:            agentStateRoot(".claude", sandboxHome),
-		codexState:             agentStateRoot(".codex", sandboxHome),
-		copilotState:           agentStateRoot(".copilot", sandboxHome),
-		opencodeState:          agentStateRoot(filepath.Join(".local", "share", "opencode"), sandboxHome),
-		toolCache:              agentStateRoot(".cache", sandboxHome),
+		// Only projects/ — not the whole state dir. Sealing the root closes
+		// settings.json, whose PreToolUse hooks would otherwise execute in
+		// every later run, including verifier roles, and survive worktree
+		// cleanup. projects/ has to stay writable because --resume reads the
+		// session transcript from there: measured on the server, a fully
+		// read-only ~/.claude still completes a run but fails resume with
+		// "No conversation found with session ID" (#2779).
+		claudeState:   agentStateRootEnsure(filepath.Join(".claude", "projects"), sandboxHome),
+		codexState:    agentStateRoot(".codex", sandboxHome),
+		copilotState:  agentStateRoot(".copilot", sandboxHome),
+		opencodeState: agentStateRoot(filepath.Join(".local", "share", "opencode"), sandboxHome),
+		toolCache:     agentStateRoot(".cache", sandboxHome),
 	}
 }
 
@@ -788,6 +795,26 @@ func dedupeGitRoots(roots []string) []string {
 		out = append(out, root)
 	}
 	return out
+}
+
+// agentStateRootEnsure is agentStateRoot for a subdirectory that may not
+// exist yet. canonicalizeRoot fails on a missing path, and the caller would
+// then fall back to the sandbox home — an allowlist that looks fine while
+// silently denying the CLI its real state dir. For claude that costs
+// --resume, and nothing errors at the point of failure.
+//
+// Separate from agentStateRoot on purpose: the other providers' roots are
+// whole dotfile directories, and creating those in the operator's home as a
+// side effect of sandbox setup is more than this needs to do.
+func agentStateRootEnsure(sub, fallback string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return fallback
+	}
+	if err := os.MkdirAll(filepath.Join(home, sub), 0o700); err != nil {
+		return fallback
+	}
+	return agentStateRoot(sub, fallback)
 }
 
 func agentStateRoot(sub, fallback string) string {

--- a/internal/agent/procsandbox_state_test.go
+++ b/internal/agent/procsandbox_state_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -10,7 +11,10 @@ func TestEnforceSpec_ResolvesAgentStateRoots(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	claude := filepath.Join(home, ".claude")
+	// projects/ only: the state dir root stays read-only so settings.json
+	// hooks cannot persist into later runs, while --resume keeps the
+	// transcript it reads from here (#2779).
+	claude := filepath.Join(home, ".claude", "projects")
 	cache := filepath.Join(home, ".cache")
 	for _, d := range []string{claude, cache} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
@@ -26,7 +30,7 @@ func TestEnforceSpec_ResolvesAgentStateRoots(t *testing.T) {
 		t.Fatal(err)
 	}
 	if spec.claudeState != wantClaude {
-		t.Errorf("claudeState = %q, want %q (the CLI must be able to persist session state)", spec.claudeState, wantClaude)
+		t.Errorf("claudeState = %q, want %q (--resume reads its transcript from projects/)", spec.claudeState, wantClaude)
 	}
 	wantCache, err := canonicalizeRoot(cache)
 	if err != nil {
@@ -51,5 +55,30 @@ func TestEnforceSpec_FallsBackWhenStateDirAbsent(t *testing.T) {
 		if got != sandboxHome {
 			t.Errorf("%s = %q, want fallback to sandboxHome %q — an absent state dir must not produce an empty write root", name, got, sandboxHome)
 		}
+	}
+}
+
+// TestEnforceSpec_ClaudeStateExcludesSettings pins the point of narrowing the
+// claude write root: settings.json must fall outside it. Its PreToolUse hooks
+// execute in every later run — including verifier roles — and survive worktree
+// cleanup, so a writable state root is a persistence channel, not just a
+// shared directory.
+func TestEnforceSpec_ClaudeStateExcludesSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sandboxHome := t.TempDir()
+
+	spec := enforceSpec("/wt", nil, sandboxHome, "/tmp", "/cache", "/profile", "", gitSandboxRoots{}, gitSandboxOverlay{})
+
+	settings, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings = filepath.Join(settings, ".claude", "settings.json")
+	if strings.HasPrefix(settings, spec.claudeState+string(filepath.Separator)) {
+		t.Fatalf("settings.json (%s) lies inside the writable root %s", settings, spec.claudeState)
+	}
+	if !strings.HasSuffix(spec.claudeState, filepath.Join(".claude", "projects")) {
+		t.Fatalf("claudeState = %q, want it scoped to .claude/projects so --resume still works", spec.claudeState)
 	}
 }


### PR DESCRIPTION
## Motivation

`~/.claude` is bound writable for every agent, and it is the operator's **real** state dir, not a per-task copy. That makes it a persistence channel rather than merely a shared directory: an agent can write `settings.json` PreToolUse hooks that then execute in every later run — including verifier roles — surviving worktree cleanup and invisible to the diff-based `detect_tampering` / `verify_checks` gates. Part of #2779, under #2775.

Log mining found agents already writing there (`~/.claude/plan-reviews/`), so the channel is live, not theoretical.

> Changelog: fix(sandbox): restrict the writable claude state dir to sessions

## Implementation information

The write root narrows from `~/.claude` to `~/.claude/projects`. The base bind is read-only, so everything else in the state dir — `settings.json` included — becomes unwritable without any new deny rule.

**Why `projects/` specifically, rather than sealing the lot.** Measured on the server with isolated `bwrap` runs mirroring the enforce profile, using a run that stores a value and a second that resumes by session id and must recall it:

| Variant | `claude -p` | `--resume` |
|---|---|---|
| whole `~/.claude` writable (today) | ok | recalls the value |
| fully read-only | ok | **fails: `No conversation found with session ID`** |
| read-only except `projects/` | ok | recalls the value |

Sealing everything looks fine on a single-shot run and silently breaks resume, which Sybra depends on for implementation continuation. `projects/` is the minimal writable set.

`agentStateRootEnsure` creates the subdirectory when absent. Without it `canonicalizeRoot` fails on a missing path and the caller falls back to the sandbox home — an allowlist that looks correct while denying the CLI its real state dir, with nothing erroring at the point of failure. It is deliberately separate from `agentStateRoot`: the other providers' roots are whole dotfile directories, and creating those in the operator's home as a side effect of sandbox setup is more than this needs to do.

## Testing

`mise run verify` exits 0. New test asserts `settings.json` falls outside the writable root and that the root stays scoped to `projects/`; mutation-verified against restoring the old root.

An existing test asserting the fallback-when-absent behaviour for codex/copilot/opencode still passes unchanged — that was what caught my first attempt, which had widened directory creation to every provider.

## Open questions

Scoped to claude, because that is what the experiment covers. **Codex, copilot and opencode state dirs are untouched**: codex has no `--resume` at all (NOTES.md is its continuation mechanism), so its writable set is likely different and deserves its own experiment rather than an assumption carried over from claude.

The other two parts of #2779 remain open and are not addressed here — the `/tmp` de-sharing (validated as safe for `TMPDIR`-respecting toolchains, but a hardcoded `/tmp/…` write fails closed, which reaches arbitrary project `setup:` commands) and the shared build cache. Results are posted on the issue.