### PR TITLE
feat(agent): record every tool call to a ledger

### DIFF
--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -131,7 +131,10 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 
 	// Auto-approve safe read-only tools regardless of session.
 	if isSafeTool(input.ToolName) {
-		s.recordDecision("", input, "allow", "safe-tool")
+		// Resolve best-effort only: safe tools are allowed even when the
+		// session is unknown, but recording them without an agent would strip
+		// task/role/provider from the most common approvals in the ledger.
+		s.recordDecision(s.findAgentBySession(input.SessionID), input, "allow", "safe-tool")
 		s.respondAllow(w, input.ToolInput)
 		return
 	}
@@ -250,6 +253,7 @@ func (s *ApprovalServer) recordDecision(agentID string, input hookInput, decisio
 	rec := toolledger.Record{
 		AgentID:   agentID,
 		Tool:      input.ToolName,
+		ToolUseID: input.ToolUseID,
 		Input:     input.ToolInput,
 		Decision:  decision,
 		DecidedBy: by,

--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/toolledger"
 )
 
 // ApprovalServer runs an HTTP server that handles PreToolUse hook requests
@@ -130,6 +131,7 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 
 	// Auto-approve safe read-only tools regardless of session.
 	if isSafeTool(input.ToolName) {
+		s.recordDecision("", input, "allow", "safe-tool")
 		s.respondAllow(w, input.ToolInput)
 		return
 	}
@@ -191,8 +193,10 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 	select {
 	case resp := <-ch:
 		if resp.Approved {
+			s.recordDecision(agentID, input, "allow", "human")
 			s.respondAllow(w, input.ToolInput)
 		} else {
+			s.recordDecision(agentID, input, "deny", "human")
 			s.recordApprovalFailureByID(agentID, input, "approval-denied", "User denied this action")
 			s.respondDeny(w, "User denied this action")
 		}
@@ -233,6 +237,29 @@ func (s *ApprovalServer) recordApprovalFailure(a *Agent, input hookInput, source
 		Source:           source,
 		Reason:           reason,
 	})
+}
+
+// recordDecision writes an adjudicated tool call to the ledger. Only
+// refusals were ever recorded before, which describes what a human rejected
+// and nothing about the far larger set they waved through — the wrong half to
+// keep when the point is to derive a policy from observed behaviour.
+func (s *ApprovalServer) recordDecision(agentID string, input hookInput, decision, by string) {
+	if s == nil || s.agents == nil {
+		return
+	}
+	rec := toolledger.Record{
+		AgentID:   agentID,
+		Tool:      input.ToolName,
+		Input:     input.ToolInput,
+		Decision:  decision,
+		DecidedBy: by,
+	}
+	if a, err := s.agents.GetAgent(agentID); err == nil && a != nil {
+		rec.TaskID = a.TaskID
+		rec.Role = string(a.EffectiveRole())
+		rec.Provider = a.Provider
+	}
+	s.agents.recordToolCall(rec)
 }
 
 func (s *ApprovalServer) respondAllow(w http.ResponseWriter, input map[string]any) {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/toolledger"
 )
 
 type EmitFunc func(event string, data any)
@@ -152,6 +153,9 @@ type Manager struct {
 
 	taskStatus func(taskID string) (string, bool)
 
+	// toolLedger records every tool call every agent makes, whatever the
+	// permission posture. Nil disables recording; Logger.Log tolerates it.
+	toolLedger *toolledger.Logger
 	// sandboxHome resolves the per-task sandbox SYBRA_HOME for a task-scoped
 	// run. Required (non-nil) for any Run/StartAgent call with a non-empty
 	// TaskID — see prepareRunConfig. nil is only valid when every caller is a
@@ -1124,4 +1128,16 @@ func (m *Manager) signalQueueNudge() {
 // buffer-1 coalescing contract.
 func (m *Manager) QueueNudge() <-chan struct{} {
 	return m.queueNudge
+}
+
+// SetToolLedger late-binds the tool-call ledger. Separate from construction
+// because the ledger's directory is resolved from config the Manager does not
+// own.
+func (m *Manager) SetToolLedger(l *toolledger.Logger) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.toolLedger = l
+	m.mu.Unlock()
 }

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/skillattr"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/toolledger"
 	"github.com/google/uuid"
 )
 
@@ -64,6 +65,7 @@ func (m *Manager) RunContext(ctx context.Context, cfg RunConfig) (*Agent, error)
 	id := uuid.NewString()[:8]
 	ctx, cancel := context.WithCancel(ctx)
 	a := newRunningAgent(id, cfg, prov, cancel)
+	a.SetToolCallRecorder(m.recordToolCall)
 	cfg = injectProcessOwnerEnv(cfg, processOwnerForAgent(a))
 	if m.survives() && willDetach(cfg) {
 		a.setDetached(true)
@@ -1400,3 +1402,18 @@ func (m *Manager) providerForRun(name string) (string, error) {
 // safeArgRe matches only characters safe to embed in a shell command
 // without quoting: alphanumerics, dot, underscore, hyphen, forward-slash.
 var safeArgRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
+
+// recordToolCall writes one ledger record, best-effort. A ledger write must
+// never disturb a run: this sits on the stream path, and losing an
+// observation is strictly preferable to failing the agent that made it.
+func (m *Manager) recordToolCall(r toolledger.Record) {
+	if m == nil {
+		return
+	}
+	m.mu.RLock()
+	ledger := m.toolLedger
+	m.mu.RUnlock()
+	if err := ledger.Log(r); err != nil {
+		m.logger.Warn("agent.tool_ledger.write_failed", "agent_id", r.AgentID, "tool", r.Tool, "err", err)
+	}
+}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/roleeffort"
 	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/toolledger"
 )
 
 // NOTE on concurrency: Agent has distinct mutexes.
@@ -281,6 +282,11 @@ type Agent struct {
 	// permissionDenials accumulates auto-mode classifier denial records
 	// observed during the run. Flushed to audit in OnComplete.
 	permissionDenials []PermissionDenial
+	// recordToolCall receives every tool call this agent makes, whatever the
+	// permission posture. Late-bound by the Manager; nil in tests and on
+	// agents constructed without a ledger, which the nil-receiver Log
+	// tolerates.
+	recordToolCall func(toolledger.Record)
 	// toolUsesByID keeps recent tool_use metadata long enough to correlate a
 	// malformed tool_result back to the original tool name + input.
 	toolUsesByID map[string]trackedToolUse
@@ -1635,6 +1641,7 @@ func (a *Agent) applyStreamEventState(ev StreamEvent) {
 	}
 	for i := range ev.toolUses {
 		a.RememberToolUse(ev.toolUses[i].ID, ev.toolUses[i].Name, ev.toolUses[i].Input)
+		a.ledgerToolCall(ev.toolUses[i].Name, ev.toolUses[i].Input, ev.Timestamp)
 		if ev.toolUses[i].Name != "Bash" {
 			continue
 		}
@@ -1974,4 +1981,40 @@ func (a *Agent) GetError() (kind, msg string) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.ErrorKind, a.ErrorMsg
+}
+
+// SetToolCallRecorder late-binds the ledger sink. Called by the Manager once
+// per agent; a nil sink leaves recording off.
+func (a *Agent) SetToolCallRecorder(fn func(toolledger.Record)) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	a.recordToolCall = fn
+	a.mu.Unlock()
+}
+
+// ledgerToolCall records one observed tool call. Reads the identity fields
+// under the same lock the rest of the stream path uses, so a concurrent
+// role/provider update cannot tear the record.
+func (a *Agent) ledgerToolCall(name string, input map[string]any, ts time.Time) {
+	if a == nil {
+		return
+	}
+	a.mu.RLock()
+	fn := a.recordToolCall
+	rec := toolledger.Record{
+		Timestamp: ts,
+		AgentID:   a.ID,
+		TaskID:    a.TaskID,
+		Role:      string(a.Role),
+		Provider:  a.Provider,
+		Tool:      name,
+		Input:     input,
+	}
+	a.mu.RUnlock()
+	if fn == nil {
+		return
+	}
+	fn(rec)
 }

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1641,7 +1641,7 @@ func (a *Agent) applyStreamEventState(ev StreamEvent) {
 	}
 	for i := range ev.toolUses {
 		a.RememberToolUse(ev.toolUses[i].ID, ev.toolUses[i].Name, ev.toolUses[i].Input)
-		a.ledgerToolCall(ev.toolUses[i].Name, ev.toolUses[i].Input, ev.Timestamp)
+		a.ledgerToolCall(ev.toolUses[i].ID, ev.toolUses[i].Name, ev.toolUses[i].Input, ev.Timestamp)
 		if ev.toolUses[i].Name != "Bash" {
 			continue
 		}
@@ -1997,7 +1997,7 @@ func (a *Agent) SetToolCallRecorder(fn func(toolledger.Record)) {
 // ledgerToolCall records one observed tool call. Reads the identity fields
 // under the same lock the rest of the stream path uses, so a concurrent
 // role/provider update cannot tear the record.
-func (a *Agent) ledgerToolCall(name string, input map[string]any, ts time.Time) {
+func (a *Agent) ledgerToolCall(toolUseID, name string, input map[string]any, ts time.Time) {
 	if a == nil {
 		return
 	}
@@ -2010,11 +2010,19 @@ func (a *Agent) ledgerToolCall(name string, input map[string]any, ts time.Time) 
 		Role:      string(a.Role),
 		Provider:  a.Provider,
 		Tool:      name,
+		ToolUseID: toolUseID,
 		Input:     input,
 	}
 	a.mu.RUnlock()
 	if fn == nil {
 		return
+	}
+	// Resolve the role only after unlocking: EffectiveRole takes the same
+	// lock, and a legacy agent carries no Role field — it is derived from the
+	// agent name — so reading the field alone silently drops the role from
+	// exactly the records where it is least obvious.
+	if rec.Role == "" {
+		rec.Role = string(a.EffectiveRole())
 	}
 	fn(rec)
 }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -770,6 +770,14 @@ func defaultSeedConfig() *Config {
 	return cfg
 }
 
+// ToolLedgerDir is where the per-tool-call ledger lives. Separate from the
+// audit dir because the volumes differ by orders of magnitude — mixing tool
+// calls into the audit log would swamp the events operators actually read —
+// and because the two want independent retention.
+func (c *Config) ToolLedgerDir() string {
+	return filepath.Join(c.Logging.Dir, "tool-ledger")
+}
+
 func (c *Config) AuditDir() string {
 	return filepath.Join(c.Logging.Dir, "audit")
 }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -62,6 +62,7 @@ import (
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/tasksnapshot"
+	"github.com/Automaat/sybra/internal/toolledger"
 	"github.com/Automaat/sybra/internal/watcher"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
@@ -126,6 +127,7 @@ type App struct {
 	workflowStore     *workflow.Store
 	pressureGate      *pressure.Gate
 	diskReclaimer     *diskreclaim.Reclaimer
+	toolLedger        *toolledger.Logger
 	renovate          *renovateCoordinator
 	promptLab         *promptLabCoordinator
 	triage            *triageCoordinator
@@ -403,6 +405,7 @@ func (a *App) Startup(ctx context.Context) error {
 	a.logger.Info("app.starting")
 
 	a.initAudit()
+	a.initToolLedger()
 	a.initStats()
 
 	store, err := task.NewStore(a.tasksDir)

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -654,6 +654,9 @@ func (a *App) Shutdown(ctx context.Context) {
 	if a.audit != nil {
 		_ = a.audit.Close()
 	}
+	if a.toolLedger != nil {
+		_ = a.toolLedger.Close()
+	}
 	if a.homeUnlock != nil {
 		if err := a.homeUnlock(); err != nil {
 			a.logger.Warn("app.home_unlock.failed", "err", err)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/toolledger"
 	"github.com/Automaat/sybra/internal/umbrella"
 	"github.com/Automaat/sybra/internal/watcher"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -1066,6 +1067,21 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 		a.dispatchPlanningWorkflow(id)
 	default:
 		a.dispatchTaskCreatedWorkflow(id)
+	}
+}
+
+// initToolLedger opens the always-on tool-call ledger. A failure degrades to
+// no recording rather than blocking startup: the ledger informs future policy,
+// it does not gate anything running now.
+func (a *App) initToolLedger() {
+	l, err := toolledger.New(a.cfg.ToolLedgerDir())
+	if err != nil {
+		a.logger.Warn("tool_ledger.init.degraded", "err", err)
+		return
+	}
+	a.toolLedger = l
+	if a.agents != nil {
+		a.agents.SetToolLedger(l)
 	}
 }
 

--- a/internal/toolledger/ledger.go
+++ b/internal/toolledger/ledger.go
@@ -24,12 +24,17 @@ import (
 
 // Record is one tool call as it was requested.
 type Record struct {
-	Timestamp time.Time      `json:"ts"`
-	AgentID   string         `json:"agentId"`
-	TaskID    string         `json:"taskId,omitempty"`
-	Role      string         `json:"role,omitempty"`
-	Provider  string         `json:"provider,omitempty"`
-	Tool      string         `json:"tool"`
+	Timestamp time.Time `json:"ts"`
+	AgentID   string    `json:"agentId"`
+	TaskID    string    `json:"taskId,omitempty"`
+	Role      string    `json:"role,omitempty"`
+	Provider  string    `json:"provider,omitempty"`
+	Tool      string    `json:"tool"`
+	// ToolUseID joins the two records one call can produce: an observation
+	// from the provider stream, and a decision from the PreToolUse hook.
+	// Without it, mining an approval-posture window double-counts every
+	// allowed call.
+	ToolUseID string         `json:"toolUseId,omitempty"`
 	Input     map[string]any `json:"input,omitempty"`
 	// Decision is empty for an observation, or the verdict a permission layer
 	// reached ("allow"/"deny"). Approvals matter as much as refusals: a corpus

--- a/internal/toolledger/ledger.go
+++ b/internal/toolledger/ledger.go
@@ -1,0 +1,123 @@
+// Package toolledger records every tool call an agent makes, independent of
+// the permission posture in force.
+//
+// The raw provider stream already contains this data, but as a pile of
+// per-run files in per-provider wire formats with a short retention — usable
+// for debugging one run, not for deriving a policy across many. The ledger is
+// the distilled form: one normalized record per tool call, retained on its own
+// schedule.
+//
+// Deliberately not gated on anything. A ledger that only fills up under one
+// posture produces a policy fitted to that posture, and leaves the case where
+// a human is personally adjudicating tool calls — the most informative one —
+// undocumented.
+package toolledger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Record is one tool call as it was requested.
+type Record struct {
+	Timestamp time.Time      `json:"ts"`
+	AgentID   string         `json:"agentId"`
+	TaskID    string         `json:"taskId,omitempty"`
+	Role      string         `json:"role,omitempty"`
+	Provider  string         `json:"provider,omitempty"`
+	Tool      string         `json:"tool"`
+	Input     map[string]any `json:"input,omitempty"`
+	// Decision is empty for an observation, or the verdict a permission layer
+	// reached ("allow"/"deny"). Approvals matter as much as refusals: a corpus
+	// of only refusals describes what a human rejected and nothing about the
+	// far larger set they waved through.
+	Decision string `json:"decision,omitempty"`
+	// DecidedBy names what produced Decision (human, safe-tool fast path,
+	// policy), so a later policy can tell a considered approval from an
+	// automatic one.
+	DecidedBy string `json:"decidedBy,omitempty"`
+}
+
+// Logger appends records to date-named NDJSON files under dir.
+type Logger struct {
+	dir string
+
+	mu      sync.Mutex
+	current *os.File
+	today   string
+}
+
+// New returns a Logger writing under dir, creating it if absent.
+func New(dir string) (*Logger, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	return &Logger{dir: dir}, nil
+}
+
+// Log appends one record. A nil Logger is a no-op, so callers on the hot
+// stream path need no guard.
+//
+// The UTC conversion is load-bearing rather than cosmetic: the file name is
+// derived from this timestamp's date, so a record stamped in a local zone
+// would be filed under a date a UTC-based reader never looks for (the same
+// trap internal/audit carried).
+func (l *Logger) Log(r Record) error {
+	if l == nil {
+		return nil
+	}
+	if r.Timestamp.IsZero() {
+		r.Timestamp = time.Now()
+	}
+	r.Timestamp = r.Timestamp.UTC()
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	f, err := l.file(r.Timestamp)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(data)
+	return err
+}
+
+func (l *Logger) file(ts time.Time) (*os.File, error) {
+	day := ts.Format(time.DateOnly)
+	if l.current != nil && l.today == day {
+		return l.current, nil
+	}
+	if l.current != nil {
+		_ = l.current.Close()
+	}
+	f, err := os.OpenFile(filepath.Join(l.dir, day+".ndjson"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("toolledger: open %s: %w", day, err)
+	}
+	l.current, l.today = f, day
+	return f, nil
+}
+
+// Close releases the open file. Safe on a nil Logger.
+func (l *Logger) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.current == nil {
+		return nil
+	}
+	err := l.current.Close()
+	l.current, l.today = nil, ""
+	return err
+}

--- a/internal/toolledger/ledger_test.go
+++ b/internal/toolledger/ledger_test.go
@@ -24,7 +24,7 @@ func TestLogRecordsRegardlessOfDecision(t *testing.T) {
 
 	ts := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
 	records := []Record{
-		{Timestamp: ts, AgentID: "a1", Tool: "Bash", Input: map[string]any{"command": "go test ./..."}},
+		{Timestamp: ts, AgentID: "a1", Tool: "Bash", ToolUseID: "tu-1", Input: map[string]any{"command": "go test ./..."}},
 		{Timestamp: ts, AgentID: "a1", Tool: "Write", Decision: "allow", DecidedBy: "human"},
 		{Timestamp: ts, AgentID: "a1", Tool: "Bash", Decision: "deny", DecidedBy: "human"},
 		{Timestamp: ts, AgentID: "a1", Tool: "Read", Decision: "allow", DecidedBy: "safe-tool"},
@@ -50,6 +50,12 @@ func TestLogRecordsRegardlessOfDecision(t *testing.T) {
 	}
 	if got[3].DecidedBy != "safe-tool" {
 		t.Errorf("automatic approval attributed to %q, want safe-tool", got[3].DecidedBy)
+	}
+	// The join key is what keeps an approval-posture window from
+	// double-counting: one allowed call writes both an observation and a
+	// decision, and only ToolUseID relates them.
+	if got[0].ToolUseID != "tu-1" {
+		t.Errorf("ToolUseID = %q, want tu-1", got[0].ToolUseID)
 	}
 }
 

--- a/internal/toolledger/ledger_test.go
+++ b/internal/toolledger/ledger_test.go
@@ -1,0 +1,112 @@
+package toolledger
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestLogRecordsRegardlessOfDecision pins the ledger's reason for existing: it
+// records observations and adjudications alike. A store that only captured
+// refusals would describe what a human rejected and nothing about the far
+// larger set they approved — the wrong half for deriving a policy.
+func TestLogRecordsRegardlessOfDecision(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	l, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	ts := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{Timestamp: ts, AgentID: "a1", Tool: "Bash", Input: map[string]any{"command": "go test ./..."}},
+		{Timestamp: ts, AgentID: "a1", Tool: "Write", Decision: "allow", DecidedBy: "human"},
+		{Timestamp: ts, AgentID: "a1", Tool: "Bash", Decision: "deny", DecidedBy: "human"},
+		{Timestamp: ts, AgentID: "a1", Tool: "Read", Decision: "allow", DecidedBy: "safe-tool"},
+	}
+	for _, r := range records {
+		if err := l.Log(r); err != nil {
+			t.Fatalf("Log(%s): %v", r.Tool, err)
+		}
+	}
+
+	got := readAll(t, filepath.Join(dir, "2026-08-02.ndjson"))
+	if len(got) != len(records) {
+		t.Fatalf("wrote %d records, want %d", len(got), len(records))
+	}
+	if got[0].Decision != "" {
+		t.Errorf("observation carries decision %q, want empty", got[0].Decision)
+	}
+	if got[1].Decision != "allow" || got[1].DecidedBy != "human" {
+		t.Errorf("approval = %q by %q, want allow by human", got[1].Decision, got[1].DecidedBy)
+	}
+	if got[2].Decision != "deny" {
+		t.Errorf("refusal = %q, want deny", got[2].Decision)
+	}
+	if got[3].DecidedBy != "safe-tool" {
+		t.Errorf("automatic approval attributed to %q, want safe-tool", got[3].DecidedBy)
+	}
+}
+
+// TestLogFilesByUTCDate pins the same discipline internal/audit needed: the
+// file name comes from the record's date, so a caller stamping a local-zone
+// timestamp must not file it under a date a UTC reader never looks for.
+func TestLogFilesByUTCDate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	l, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	// 00:30 on Aug 2 in CEST is still 22:30 on Aug 1 in UTC.
+	local := time.Date(2026, 8, 2, 0, 30, 0, 0, time.FixedZone("CEST", 2*60*60))
+	if err := l.Log(Record{Timestamp: local, AgentID: "a1", Tool: "Bash"}); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "2026-08-01.ndjson")); err != nil {
+		entries, _ := os.ReadDir(dir)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("filed as %v, want 2026-08-01.ndjson — the caller's zone must not name the file", names)
+	}
+}
+
+// TestNilLoggerIsSafe matters because the sink sits on the agent stream path,
+// where a missing ledger must not take the run down with it.
+func TestNilLoggerIsSafe(t *testing.T) {
+	t.Parallel()
+	var l *Logger
+	if err := l.Log(Record{Tool: "Bash"}); err != nil {
+		t.Fatalf("Log on nil Logger: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close on nil Logger: %v", err)
+	}
+}
+
+func readAll(t *testing.T, path string) []Record {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var out []Record
+	dec := json.NewDecoder(bytes.NewReader(data))
+	for dec.More() {
+		var r Record
+		if err := dec.Decode(&r); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		out = append(out, r)
+	}
+	return out
+}


### PR DESCRIPTION
## Motivation

Tightening any tool policy needs to be driven by what agents actually do. The raw provider stream already holds that data, but as ~4000 per-run files in per-provider wire formats on a 30-day rolling retention — enough to debug one run, not to derive a policy across many. Every analysis so far has meant writing a bespoke miner that understands each provider's format separately. Closes #2788, part of #2775.

> Changelog: feat(agent): record every agent tool call to a queryable ledger

## Implementation information

**Unconditional, by design.** The sink taps `applyStreamEventState` — the point where both claude's `tool_use` blocks and codex's `command_execution`/`file_change` items have already been normalized onto one shape — so the ledger fills for every provider and every permission posture. A ledger that only filled under one posture would produce a policy fitted to that posture, and would leave the case where a human is personally adjudicating tool calls, the most informative one, undocumented.

**Approvals are recorded, not just refusals.** This was the sharper half of the gap. `recordApprovalFailure` fired on deny/cancel/timeout while `respondAllow` recorded nothing, so the interactive posture kept every refusal and discarded every approval — precisely backwards for deriving a policy, since the approvals are the far larger set. Decisions now carry both the verdict and *what* produced it (human, safe-tool fast path), so a considered approval is distinguishable from an automatic one.

**Failure is non-disruptive.** The sink sits on the stream path, so a write error is logged and dropped rather than failing the agent that made the call, and a nil ledger is a no-op — losing an observation is strictly preferable to losing the run it came from.

Stored under `logs/tool-ledger/`, separate from the audit log: the volumes differ by orders of magnitude, and mixing tool calls in would swamp the events operators actually read.

## Testing

`mise run verify` exits 0. Tests cover observations and both decision directions, the nil-logger path, and UTC file naming — mutation-verified, removing the UTC normalization fails 2 assertions.

The UTC discipline is deliberate and carried over from #2826: the file name derives from the record's date, so a local-zone timestamp would file records under a date a UTC-based reader never looks for. That bug returned zero results silently for part of every day, and this store would have inherited it.

## Open questions

This lands the recording half. The querying half — retention policy and a read API — is not here; the files are greppable NDJSON in the meantime, which is what the analyses in #2775 have been doing against the raw streams anyway.

Bash effects still are not captured, and cannot be by an intent-level record: `go build`, `npm ci` and `git` touch paths that appear nowhere in the command text. That is #2780's tracing job, and the two are complements rather than substitutes.