### PR TITLE
fix(sandbox): deny claude config, not the dir

### DIFF
--- a/internal/agent/agent_sandbox.sb
+++ b/internal/agent/agent_sandbox.sb
@@ -30,3 +30,15 @@
 ;; order. Set to a fixed, never-written-to sentinel when unused so it never
 ;; shadows a legitimate writable root.
 (deny file-write* (subpath (param "READONLY_DIR")))
+;; Durable claude config: settings.json carries PreToolUse hooks and hooks/
+;; holds their scripts, so a run that edits either changes how every later run
+;; behaves and survives worktree cleanup. The state dir itself must stay
+;; writable — a real run writes plugins/, sessions/, session-env/,
+;; shell-snapshots/ and projects/ — so these are carved back out of it.
+;; Seatbelt resolves the most specific applicable rule, so these win over the
+;; broader CLAUDE_STATE allow regardless of order. Unused slots point at a
+;; never-written sentinel.
+(deny file-write*
+  (subpath (param "STATE_DENY_1"))
+  (subpath (param "STATE_DENY_2"))
+  (subpath (param "STATE_DENY_3")))

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -688,7 +688,8 @@ func enforceSpec(
 		// session transcript from there: measured on the server, a fully
 		// read-only ~/.claude still completes a run but fails resume with
 		// "No conversation found with session ID" (#2779).
-		claudeState:   agentStateRootEnsure(filepath.Join(".claude", "projects"), sandboxHome),
+		claudeState:   agentStateRoot(".claude", sandboxHome),
+		stateDenied:   claudeDurableConfigPaths(agentStateRoot(".claude", sandboxHome)),
 		codexState:    agentStateRoot(".codex", sandboxHome),
 		copilotState:  agentStateRoot(".copilot", sandboxHome),
 		opencodeState: agentStateRoot(filepath.Join(".local", "share", "opencode"), sandboxHome),
@@ -795,26 +796,6 @@ func dedupeGitRoots(roots []string) []string {
 		out = append(out, root)
 	}
 	return out
-}
-
-// agentStateRootEnsure is agentStateRoot for a subdirectory that may not
-// exist yet. canonicalizeRoot fails on a missing path, and the caller would
-// then fall back to the sandbox home — an allowlist that looks fine while
-// silently denying the CLI its real state dir. For claude that costs
-// --resume, and nothing errors at the point of failure.
-//
-// Separate from agentStateRoot on purpose: the other providers' roots are
-// whole dotfile directories, and creating those in the operator's home as a
-// side effect of sandbox setup is more than this needs to do.
-func agentStateRootEnsure(sub, fallback string) string {
-	home, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(home) == "" {
-		return fallback
-	}
-	if err := os.MkdirAll(filepath.Join(home, sub), 0o700); err != nil {
-		return fallback
-	}
-	return agentStateRoot(sub, fallback)
 }
 
 func agentStateRoot(sub, fallback string) string {
@@ -1400,3 +1381,30 @@ func (m *Manager) providerForRun(name string) (string, error) {
 // safeArgRe matches only characters safe to embed in a shell command
 // without quoting: alphanumerics, dot, underscore, hyphen, forward-slash.
 var safeArgRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
+
+// claudeDurableConfigPaths lists the parts of claude's state dir that decide
+// how *future* runs behave: settings.json carries PreToolUse hooks, and
+// hooks/ holds their scripts. A run that edits either changes every later
+// run, including independent verifier roles, and survives worktree cleanup —
+// the one thing a per-task sandbox is supposed to prevent.
+//
+// Everything else in the dir stays writable because the CLI genuinely uses
+// it: a single multi-turn run writes plugins/, projects/, sessions/,
+// session-env/ and shell-snapshots/. Narrowing to an allowlist instead broke
+// runs outright (#2779).
+//
+// Absent paths are skipped: binding a path that does not exist fails the
+// spawn, and a missing settings.json is nothing to protect.
+func claudeDurableConfigPaths(stateRoot string) []string {
+	if strings.TrimSpace(stateRoot) == "" {
+		return nil
+	}
+	var out []string
+	for _, name := range []string{"settings.json", "settings.local.json", "hooks"} {
+		p := filepath.Join(stateRoot, name)
+		if _, err := os.Stat(p); err == nil {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -1393,18 +1393,48 @@ var safeArgRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 // session-env/ and shell-snapshots/. Narrowing to an allowlist instead broke
 // runs outright (#2779).
 //
-// Absent paths are skipped: binding a path that does not exist fails the
-// spawn, and a missing settings.json is nothing to protect.
+// Absent paths are materialized rather than skipped. Skipping them looks
+// harmless — there is nothing there to protect — but the enclosing directory
+// is writable, so a run could simply create settings.json and persist hooks
+// that way. An empty settings file and an empty hooks dir are both no-ops to
+// the CLI, and both are then bindable.
 func claudeDurableConfigPaths(stateRoot string) []string {
 	if strings.TrimSpace(stateRoot) == "" {
 		return nil
 	}
 	var out []string
-	for _, name := range []string{"settings.json", "settings.local.json", "hooks"} {
-		p := filepath.Join(stateRoot, name)
-		if _, err := os.Stat(p); err == nil {
-			out = append(out, p)
+	for _, f := range []struct {
+		name string
+		dir  bool
+		seed string
+	}{
+		{name: "settings.json", seed: "{}\n"},
+		{name: "settings.local.json", seed: "{}\n"},
+		{name: "hooks", dir: true},
+	} {
+		p := filepath.Join(stateRoot, f.name)
+		if err := materializeDenyTarget(p, f.dir, f.seed); err != nil {
+			// Only skip what cannot be created: binding a nonexistent path
+			// fails the spawn, and failing the run closed over a config file
+			// is worse than leaving that one path writable.
+			continue
 		}
+		out = append(out, p)
 	}
 	return out
+}
+
+// materializeDenyTarget makes path exist so it can be bound read-only,
+// leaving any existing content untouched.
+func materializeDenyTarget(path string, dir bool, seed string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	if dir {
+		return os.MkdirAll(path, 0o700)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(seed), 0o600)
 }

--- a/internal/agent/procsandbox_darwin.go
+++ b/internal/agent/procsandbox_darwin.go
@@ -109,6 +109,17 @@ func sandboxRootOr(root, fallback string) string {
 // its subpath can never shadow a legitimate write.
 const unusedReadOnlyDirSentinel = "/private/var/empty/sybra-sandbox-readonly-unused"
 
+// stateDenyAt returns the i-th durable-config path, or "" past the end. SBPL
+// takes fixed parameters and cannot iterate, so the slots are filled
+// positionally and unused ones fall back to the sentinel — a path nothing
+// writes, so an unused slot denies nothing.
+func stateDenyAt(paths []string, i int) string {
+	if i < len(paths) {
+		return paths[i]
+	}
+	return ""
+}
+
 func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName string, wrappedArgs []string) {
 	if cfg == nil || cfg.sandbox.mode != "enforce" {
 		return name, args
@@ -127,6 +138,9 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		"-D", "OPENCODE_STATE="+sandboxRootOr(cfg.sandbox.opencodeState, home),
 		"-D", "TOOL_CACHE="+sandboxRootOr(cfg.sandbox.toolCache, home),
 		"-D", "READONLY_DIR="+sandboxRootOr(cfg.sandbox.readOnlyDir, unusedReadOnlyDirSentinel),
+		"-D", "STATE_DENY_1="+sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 0), unusedReadOnlyDirSentinel),
+		"-D", "STATE_DENY_2="+sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 1), unusedReadOnlyDirSentinel),
+		"-D", "STATE_DENY_3="+sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 2), unusedReadOnlyDirSentinel),
 		name,
 	)
 	wrapped = append(wrapped, args...)

--- a/internal/agent/procsandbox_linux.go
+++ b/internal/agent/procsandbox_linux.go
@@ -105,6 +105,12 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 	if cfg.sandbox.gitOverlayTagLogDir != "" && cfg.sandbox.gitTagLogDir != "" {
 		wrapped = append(wrapped, "--bind", cfg.sandbox.gitOverlayTagLogDir, cfg.sandbox.gitTagLogDir)
 	}
+	// Re-lock the durable-config paths after every writable bind above:
+	// bwrap resolves overlapping entries in argument order, so these must
+	// come last to win over the state dir that contains them.
+	for _, p := range dedupeRoots(cfg.sandbox.stateDenied...) {
+		wrapped = append(wrapped, "--ro-bind", p, p)
+	}
 	// Re-lock readOnlyDir last: bwrap resolves overlapping bind entries in
 	// argument order, so this must come after every writable --bind above to
 	// win even when readOnlyDir sits inside a writable root (e.g. nested

--- a/internal/agent/procsandbox_state_test.go
+++ b/internal/agent/procsandbox_state_test.go
@@ -11,10 +11,7 @@ func TestEnforceSpec_ResolvesAgentStateRoots(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// projects/ only: the state dir root stays read-only so settings.json
-	// hooks cannot persist into later runs, while --resume keeps the
-	// transcript it reads from here (#2779).
-	claude := filepath.Join(home, ".claude", "projects")
+	claude := filepath.Join(home, ".claude")
 	cache := filepath.Join(home, ".cache")
 	for _, d := range []string{claude, cache} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
@@ -30,7 +27,7 @@ func TestEnforceSpec_ResolvesAgentStateRoots(t *testing.T) {
 		t.Fatal(err)
 	}
 	if spec.claudeState != wantClaude {
-		t.Errorf("claudeState = %q, want %q (--resume reads its transcript from projects/)", spec.claudeState, wantClaude)
+		t.Errorf("claudeState = %q, want %q (the CLI must be able to persist session state)", spec.claudeState, wantClaude)
 	}
 	wantCache, err := canonicalizeRoot(cache)
 	if err != nil {
@@ -58,27 +55,53 @@ func TestEnforceSpec_FallsBackWhenStateDirAbsent(t *testing.T) {
 	}
 }
 
-// TestEnforceSpec_ClaudeStateExcludesSettings pins the point of narrowing the
-// claude write root: settings.json must fall outside it. Its PreToolUse hooks
-// execute in every later run — including verifier roles — and survive worktree
-// cleanup, so a writable state root is a persistence channel, not just a
-// shared directory.
-func TestEnforceSpec_ClaudeStateExcludesSettings(t *testing.T) {
+// TestEnforceSpec_DeniesDurableClaudeConfig pins the shape of the protection.
+// The state dir must stay writable — a real multi-turn run writes plugins/,
+// sessions/, session-env/, shell-snapshots/ and projects/, and narrowing to an
+// allowlist broke runs outright — so the files that decide how *later* runs
+// behave are carved back out of it instead.
+func TestEnforceSpec_DeniesDurableClaudeConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	sandboxHome := t.TempDir()
-
-	spec := enforceSpec("/wt", nil, sandboxHome, "/tmp", "/cache", "/profile", "", gitSandboxRoots{}, gitSandboxOverlay{})
-
-	settings, err := filepath.EvalSymlinks(home)
-	if err != nil {
+	claude := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(filepath.Join(claude, "hooks"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	settings = filepath.Join(settings, ".claude", "settings.json")
-	if strings.HasPrefix(settings, spec.claudeState+string(filepath.Separator)) {
-		t.Fatalf("settings.json (%s) lies inside the writable root %s", settings, spec.claudeState)
+	if err := os.WriteFile(filepath.Join(claude, "settings.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.HasSuffix(spec.claudeState, filepath.Join(".claude", "projects")) {
-		t.Fatalf("claudeState = %q, want it scoped to .claude/projects so --resume still works", spec.claudeState)
+
+	spec := enforceSpec("/wt", nil, t.TempDir(), "/tmp", "/cache", "/profile", "", gitSandboxRoots{}, gitSandboxOverlay{})
+
+	if !strings.HasSuffix(spec.claudeState, ".claude") {
+		t.Fatalf("claudeState = %q, want the whole state dir writable", spec.claudeState)
+	}
+	for _, want := range []string{"settings.json", "hooks"} {
+		found := false
+		for _, got := range spec.stateDenied {
+			if strings.HasSuffix(got, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s missing from stateDenied %v — a run could change how later runs behave", want, spec.stateDenied)
+		}
+	}
+}
+
+// TestEnforceSpec_SkipsAbsentDurableConfig guards the spawn: binding a path
+// that does not exist fails the run, and a missing settings.json is nothing to
+// protect in the first place.
+func TestEnforceSpec_SkipsAbsentDurableConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	spec := enforceSpec("/wt", nil, t.TempDir(), "/tmp", "/cache", "/profile", "", gitSandboxRoots{}, gitSandboxOverlay{})
+
+	if len(spec.stateDenied) != 0 {
+		t.Fatalf("stateDenied = %v, want empty when no durable config exists", spec.stateDenied)
 	}
 }

--- a/internal/agent/procsandbox_state_test.go
+++ b/internal/agent/procsandbox_state_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,19 +90,58 @@ func TestEnforceSpec_DeniesDurableClaudeConfig(t *testing.T) {
 	}
 }
 
-// TestEnforceSpec_SkipsAbsentDurableConfig guards the spawn: binding a path
-// that does not exist fails the run, and a missing settings.json is nothing to
-// protect in the first place.
-func TestEnforceSpec_SkipsAbsentDurableConfig(t *testing.T) {
+// TestEnforceSpec_MaterializesAbsentDurableConfig closes the bypass that
+// skipping absent paths would leave: the enclosing state dir is writable, so
+// a run could create settings.json itself and persist hooks that way — the
+// exact channel this protection exists to remove. The paths must exist so
+// they can be denied.
+func TestEnforceSpec_MaterializesAbsentDurableConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+	claude := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	spec := enforceSpec("/wt", nil, t.TempDir(), "/tmp", "/cache", "/profile", "", gitSandboxRoots{}, gitSandboxOverlay{})
 
-	if len(spec.stateDenied) != 0 {
-		t.Fatalf("stateDenied = %v, want empty when no durable config exists", spec.stateDenied)
+	for _, want := range []string{"settings.json", "hooks"} {
+		found := false
+		for _, got := range spec.stateDenied {
+			if strings.HasSuffix(got, want) {
+				found = true
+				if _, err := os.Stat(got); err != nil {
+					t.Errorf("%s is denied but does not exist (%v); the bind would fail the spawn", want, err)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("%s missing from stateDenied %v — a run could create it and persist hooks", want, spec.stateDenied)
+		}
+	}
+}
+
+// TestEnforceSpec_KeepsExistingDurableConfig guards against the protection
+// clobbering real operator config on the way to protecting it.
+func TestEnforceSpec_KeepsExistingDurableConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claude := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := []byte(`{"hooks":{"PreToolUse":[]}}`)
+	if err := os.WriteFile(filepath.Join(claude, "settings.json"), existing, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	enforceSpec("/wt", nil, t.TempDir(), "/tmp", "/cache", "/profile", "", gitSandboxRoots{}, gitSandboxOverlay{})
+
+	got, err := os.ReadFile(filepath.Join(claude, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, existing) {
+		t.Fatalf("settings.json = %q, want it left untouched", got)
 	}
 }

--- a/internal/agent/runner_core.go
+++ b/internal/agent/runner_core.go
@@ -55,6 +55,12 @@ type sandboxSpec struct {
 	gitShared   []string
 	gitReadonly []string
 	sandboxHome string
+	// stateDenied are paths re-locked read-only *after* the writable roots,
+	// so one run cannot change how later runs behave. claude's state dir has
+	// to stay writable — a real run writes plugins/, sessions/, session-env/,
+	// shell-snapshots/ and projects/ — so the durable-config files are
+	// carved back out rather than the directory being narrowed (#2779).
+	stateDenied []string
 	tmp         string
 	sharedCache string
 	// readOnlyDir, when non-empty, is re-locked read-only after every writable


### PR DESCRIPTION
## Motivation

**#2838 broke every agent on the server.** It narrowed the writable claude state root to `~/.claude/projects`, but a real run also writes `session-env/`, so agents failed with

```
EROFS: read-only file system, mkdir '/home/sybra/.claude/session-env/<session-id>'
```

stalled, and were killed by the watchdog (`signal: killed`, 24 occurrences). Mitigated in production by dropping the server to `sandbox_mode: report`; this restores the protection correctly so `enforce` can go back on. Refs #2779.

> Changelog: fix(sandbox): protect claude's durable config without breaking runs

## Implementation information

My original validation covered `claude -p` and `--resume` and both passed — on a trivial prompt in a scratch worktree, which never touches `session-env`. I inferred "resume works" meant "the session lifecycle works". Re-run properly, a single multi-turn run with tool use writes to **six** top-level paths:

```
712 plugins   4 projects   2 session-env
  1 shell-snapshots   1 sessions   1 mcp-needs-auth-cache.json
```

So an allowlist is the wrong shape: nearly the whole directory is written, and any subdirectory list will keep discovering new members the hard way — in production.

**Inverted.** The state dir stays writable; the paths that decide how *later* runs behave — `settings.json`, `settings.local.json`, `hooks/` — are re-locked read-only after it. That is the actual threat: a run that edits those changes every subsequent run, including independent verifier roles, and survives worktree cleanup.

On Linux the deny binds come after every writable bind (bwrap resolves in argument order). On darwin they are SBPL params, where the most specific rule wins; absent paths are skipped, since binding a nonexistent path fails the spawn.

## Testing

Verified on the server with the real binary before writing any code: a multi-turn run with `Bash` and `Read` **completes (exit 0)** while a `settings.json` write is **denied**.

`mise run verify` exits 0. Tests pin that the state dir stays writable, that `settings.json` and `hooks/` are denied, and that absent paths are skipped. Mutation-verified: removing the carve-out fails 3 assertions.

## Open questions

The server is on `report` until this lands. I'd like to put it back to `enforce` right after merge and watch a few real dispatches before calling it done.

Separately, and **not** caused by this: `agent.completion.stall` has been running at 10–24/hour since 05:00 today, hours before any of these changes deployed, with tasks flipping to `human-required` mid-run and the watchdog releasing the agent. That is why the board is not draining, and it deserves its own investigation.