### PR TITLE
fix(watchdog): spare agents sent to unblock a task

### DIFF
--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -77,6 +77,24 @@ func (r Role) JudgesWithoutWriting() bool {
 	}
 }
 
+// DiagnosesBlockedTask reports whether the role is dispatched *because* a
+// task is in a state that otherwise means "no agent should be running" —
+// human-required, or terminal.
+//
+// Both status reapers (watchdog.reapTaskAgentForStatus and
+// App.releaseTaskAgents) stop agents whose task reaches such a status. These
+// roles are the exception: killing them for the very condition they were sent
+// to resolve leaves the task stuck and the detector re-dispatching on its next
+// cycle, which is a livelock that costs a full agent run each pass.
+func (r Role) DiagnosesBlockedTask() bool {
+	switch r {
+	case RoleHumanReview, RoleMonitor:
+		return true
+	default:
+		return false
+	}
+}
+
 // AuthorsCode reports whether the role produces code commits and may therefore
 // be primed with the task's NOTES.md working memory. Only these roles inherit
 // the scratchpad: independent verifier roles (review, test-runner, eval) must

--- a/internal/agent/role_diagnostic_test.go
+++ b/internal/agent/role_diagnostic_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import "testing"
+
+// TestDiagnosesBlockedTaskCoversDetectorRoles pins the roles the status
+// reapers must not kill. Both reapers stop agents whose task has reached
+// human-required or a terminal status; these roles are dispatched *because*
+// of that status, so reaping them leaves the task stuck and the detector
+// re-dispatching next cycle — a livelock costing a full agent run per pass.
+// That is exactly what happened to monitor:stuck_human_blocked agents, which
+// were killed ~26s in, every cycle, without ever unblocking anything.
+func TestDiagnosesBlockedTaskCoversDetectorRoles(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		role Role
+		want bool
+		why  string
+	}{
+		{role: RoleHumanReview, want: true, why: "dispatched on the human-required transition to unblock it"},
+		{role: RoleMonitor, want: true, why: "stuck_human_blocked detector acts on human-required tasks"},
+
+		{role: RoleImplementation, want: false, why: "must stop when its task is no longer actionable"},
+		{role: RoleReview, want: false, why: "same"},
+		{role: RoleTestRunner, want: false, why: "same"},
+		{role: RolePlan, want: false, why: "same"},
+		{role: RoleFixReview, want: false, why: "same"},
+		{role: RolePRFix, want: false, why: "same"},
+		{role: RoleOrchestrator, want: false, why: "not task-scoped"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.role), func(t *testing.T) {
+			t.Parallel()
+			if got := tc.role.DiagnosesBlockedTask(); got != tc.want {
+				t.Errorf("%s.DiagnosesBlockedTask() = %v, want %v (%s)", tc.role, got, tc.want, tc.why)
+			}
+		})
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -790,7 +790,7 @@ func (a *App) releaseTaskAgents(taskID string) {
 	}
 	filtered := make([]*agent.Agent, 0, len(targets))
 	for _, ag := range targets {
-		if ag.EffectiveRole() == agent.RoleHumanReview {
+		if ag.EffectiveRole().DiagnosesBlockedTask() {
 			continue
 		}
 		filtered = append(filtered, ag)

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -515,7 +515,7 @@ func (w *Watchdog) reapTaskAgentForStatus(ag *agent.Agent) bool {
 	if t.TaskType == task.TaskTypeUmbrella {
 		return false
 	}
-	if !shouldReleaseTaskAgentForStatus(t.Status) || isHumanReviewAgent(ag) {
+	if !shouldReleaseTaskAgentForStatus(t.Status) || ag.EffectiveRole().DiagnosesBlockedTask() {
 		return false
 	}
 	w.logger.Warn("agent.watchdog.status_release",
@@ -528,21 +528,6 @@ func (w *Watchdog) reapTaskAgentForStatus(ag *agent.Agent) bool {
 
 func shouldReleaseTaskAgentForStatus(status task.Status) bool {
 	return status == task.StatusHumanRequired || task.IsTerminalStatus(status)
-}
-
-// isHumanReviewAgent reports whether ag is the human-review agent
-// (internal/sybra/app_human_review.go), which app.go dispatches the moment a
-// task transitions to human-required specifically to diagnose and unblock
-// it. The status-release reapers above must not kill it just because the
-// task's status is — by design — human-required; if it gets stuck itself,
-// the normal stall/budget/loop triggers in inspectHeadless still apply. This
-// mirrors the same exclusion App.releaseTaskAgents already applies at the
-// point of the status transition (internal/sybra/app_init.go) — a role-based
-// check, not a timing-based one, so it can't be widened by a future status
-// change to spare an unrelated agent that raced onto an already-terminal
-// task, which is unconditionally an orphan under this reaper's contract.
-func isHumanReviewAgent(ag *agent.Agent) bool {
-	return ag.EffectiveRole() == agent.RoleHumanReview
 }
 
 func (w *Watchdog) stopForRelease(ag *agent.Agent) error {


### PR DESCRIPTION
## Motivation

The board has not been draining: 19 tasks parked in `human-required`, agents starting and dying continuously, ~$0.13 burned per attempt. This is a livelock, and it has been running at 10–24 stalls/hour since at least 05:00.

The sequence, from one task's log:

```
14:33:02 agent.start        id=eba804eb task=5aa2287b
14:33:28 agent.watchdog.status_release status=human-required
14:33:28 agent.stop
14:33:33 agent.completion.stall
```

The killed agents are `monitor:stuck_human_blocked:<task>` — the monitor's detector for tasks stuck in `human-required`. It is dispatched *because* the task is human-required, and the watchdog kills it *because* the task is human-required. Nothing gets unblocked, the detector fires again next cycle, forever.

> Changelog: fix(watchdog): stop reaping the agents dispatched to unblock a task

## Implementation information

Both status reapers — `watchdog.reapTaskAgentForStatus` and `App.releaseTaskAgents` — stop agents whose task has reached `human-required` or a terminal status, with an exemption for `RoleHumanReview`. The existing comment on that exemption states the reasoning exactly:

> dispatched the moment a task transitions to human-required specifically to diagnose and unblock it. The status-release reapers above must not kill it just because the task's status is — by design — human-required

That reasoning applies verbatim to `RoleMonitor`, which had no exemption.

Replaced the role equality check in both reapers with a shared `Role.DiagnosesBlockedTask()` predicate, so they cannot drift apart about which roles exist to act on a blocked task — they were already two independent copies of the same rule, which is how one of them came to be missing a role.

## Testing

`mise run verify` exits 0. Table test pins both diagnostic roles as exempt and every task-scoped worker role as reapable; mutation-verified — removing `RoleMonitor` fails 3 assertions.

## Open questions

This stops the livelock and lets the detector actually run. Whether the monitor then *succeeds* in unblocking those 19 tasks is a separate question — it has never once been allowed to finish, so there is no evidence either way yet. Worth watching after deploy rather than assuming.

Found while investigating a production stall. Not caused by the sandbox work in #2838/#2841 — this signature predates those deploys by hours, which I confirmed before looking for a cause.