### PR TITLE
fix(project): bound remote git operations

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -69,12 +69,33 @@ var ErrDivergedNeedsResolve = errors.New("branch diverged from remote; needs age
 // auth isn't configured, matching the prior ambient-only behavior exactly.
 var fetchEnv = github.GHEnv
 
+// networkGitTimeout bounds a remote Git operation while it holds a repository
+// lock. A black-holed connection must eventually release that lock; otherwise
+// every worktree operation for the project remains blocked indefinitely.
+const defaultNetworkGitTimeout = 10 * time.Minute
+
+var networkGitTimeout = defaultNetworkGitTimeout
+
 // runBare is used by both local-only bare-repo ops (git config, branch -f,
 // ...) and the network-touching fetches in this file (FetchOrigin,
 // FetchRemoteBranch, FetchPRHead). Injecting fetchEnv() unconditionally is
 // harmless for the local ops — it only ever appends GH_TOKEN/GITHUB_TOKEN.
 func runBare(ctx context.Context, barePath string, args ...string) error {
 	return executil.RunEnv(ctx, barePath, fetchEnv(), "git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
+}
+
+func networkGitContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, networkGitTimeout)
+}
+
+func runNetworkGit(ctx context.Context, dir string, env []string, args ...string) error {
+	networkCtx, cancel := networkGitContext(ctx)
+	defer cancel()
+	return executil.RunEnv(networkCtx, dir, env, "git", args...)
+}
+
+func runBareFetch(ctx context.Context, barePath string, args ...string) error {
+	return runNetworkGit(ctx, barePath, fetchEnv(), append([]string{"-c", "safe.bareRepository=all"}, args...)...)
 }
 
 func outputBare(ctx context.Context, barePath string, args ...string) (string, error) {
@@ -326,7 +347,7 @@ func splitOwnerRepo(path string) (owner, repo string, err error) {
 // `git fetch origin` calls actually update refs/remotes/origin/* (a bare
 // clone otherwise leaves it empty).
 func CloneBare(ctx context.Context, repoURL, destPath string) error {
-	if err := executil.RunEnv(ctx, "", fetchEnv(), "git", "clone", "--bare", repoURL, destPath); err != nil {
+	if err := runNetworkGit(ctx, "", fetchEnv(), "clone", "--bare", repoURL, destPath); err != nil {
 		return err
 	}
 	if err := InstallSignoffHook(ctx, destPath); err != nil {
@@ -439,12 +460,12 @@ func FetchOrigin(ctx context.Context, barePath string) error {
 			// Explicit refspec heals bare repos cloned before remote.origin.fetch
 			// was configured, where `git fetch origin` silently skipped updating
 			// refs/remotes/origin/*.
-			return runBare(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+			return runBareFetch(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 		})
 		if err != nil && IsBadRefError(err) {
 			if _, repairErr := repairBareCloneLocked(ctx, barePath, ""); repairErr == nil {
 				retryErr := withLockRetry(func() error {
-					return runBare(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+					return runBareFetch(ctx, barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 				})
 				if retryErr == nil {
 					markFetched(barePath)
@@ -471,7 +492,7 @@ func FetchRemoteBranch(ctx context.Context, barePath, remote, branch string) err
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
 	return withBareRepoLock(barePath, func() error {
 		return withLockRetry(func() error {
-			return runBare(ctx, barePath, "fetch", remote, refspec)
+			return runBareFetch(ctx, barePath, "fetch", remote, refspec)
 		})
 	})
 }
@@ -489,7 +510,7 @@ func FetchPRHead(ctx context.Context, barePath string, prNumber int) (string, er
 	refspec := fmt.Sprintf("+refs/pull/%d/head:%s", prNumber, localRef)
 	err := withBareRepoLock(barePath, func() error {
 		return withLockRetry(func() error {
-			return runBare(ctx, barePath, "fetch", "origin", refspec)
+			return runBareFetch(ctx, barePath, "fetch", "origin", refspec)
 		})
 	})
 	if err != nil {
@@ -1044,7 +1065,7 @@ func pushLocked(ctx context.Context, worktreePath string, args ...string) error 
 		attempts := credentialAttempts(pushEnv())
 		var injectedErr error
 		for idx, attempt := range attempts {
-			err := executil.RunEnv(ctx, worktreePath, attempt.env, "git", args...)
+			err := runNetworkGit(ctx, worktreePath, attempt.env, args...)
 			if err == nil {
 				return nil
 			}
@@ -1250,7 +1271,9 @@ func isAncestor(ctx context.Context, worktreePath, ancestor, descendant string) 
 func remoteBranchHead(ctx context.Context, worktreePath, remote, branch string) (string, error) {
 	var out string
 	err := withNetworkRetry(ctx, func() error {
-		cmd := exec.CommandContext(ctx, "git", "ls-remote", remote, "refs/heads/"+branch)
+		networkCtx, cancel := networkGitContext(ctx)
+		defer cancel()
+		cmd := exec.CommandContext(networkCtx, "git", "ls-remote", remote, "refs/heads/"+branch)
 		cmd.Dir = worktreePath
 		cmd.Env = fetchEnv()
 		raw, runErr := cmd.CombinedOutput()
@@ -1291,7 +1314,7 @@ func refreshTrackingRef(ctx context.Context, worktreePath, remote, branch string
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
 	fetchErr := withNetworkRetry(ctx, func() error {
 		return withLockRetry(func() error {
-			return executil.RunEnv(ctx, worktreePath, fetchEnv(), "git", "fetch", remote, refspec)
+			return runNetworkGit(ctx, worktreePath, fetchEnv(), "fetch", remote, refspec)
 		})
 	})
 	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
@@ -1627,7 +1650,9 @@ func pushPreflightRefspec(ctx context.Context, worktreePath string) (string, err
 var runGitPushProbe = execGitPushProbe
 
 func execGitPushProbe(ctx context.Context, dir string, env []string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	networkCtx, cancel := networkGitContext(ctx)
+	defer cancel()
+	cmd := exec.CommandContext(networkCtx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -276,6 +276,108 @@ func TestFetchOriginNoRemote(t *testing.T) {
 	}
 }
 
+func TestFetchRemoteBranchTimesOutNetworkGit(t *testing.T) {
+	oldTimeout := networkGitTimeout
+	networkGitTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { networkGitTimeout = oldTimeout })
+
+	bin := t.TempDir()
+	git := filepath.Join(bin, "git")
+	if err := os.WriteFile(git, []byte("#!/bin/sh\nexec sleep 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	started := time.Now()
+	err := FetchRemoteBranch(context.Background(), t.TempDir(), "fork", "main")
+	if err == nil {
+		t.Fatal("FetchRemoteBranch succeeded with a hung git process")
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("FetchRemoteBranch returned after %s, want bounded network timeout", elapsed)
+	}
+}
+
+func TestRemoteGitOperationsTimeOut(t *testing.T) {
+	oldTimeout := networkGitTimeout
+	networkGitTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { networkGitTimeout = oldTimeout })
+
+	pushWorktree := initRepoWithCommit(t)
+	bin := t.TempDir()
+	git := filepath.Join(bin, "git")
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("locate git: %v", err)
+	}
+	// pushLocked resolves the shared git dir before it starts the remote
+	// transport. Preserve only that local rev-parse call, then hang every
+	// remote operation the test exercises.
+	fakeGit := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = rev-parse ]; then exec %q \"$@\"; fi\nexec sleep 1\n", realGit)
+	if err := os.WriteFile(git, []byte(fakeGit), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "ls-remote",
+			run: func() error {
+				_, err := RemoteBranchHead(context.Background(), t.TempDir(), "origin", "main")
+				return err
+			},
+		},
+		{
+			name: "linked-worktree-fetch",
+			run: func() error {
+				return refreshTrackingRef(context.Background(), t.TempDir(), "origin", "main")
+			},
+		},
+		{
+			name: "push",
+			run: func() error {
+				return pushLocked(context.Background(), pushWorktree, "push", "origin", "main")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			started := time.Now()
+			if err := tt.run(); err == nil {
+				t.Fatal("remote git operation succeeded with a hung git process")
+			}
+			if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+				t.Fatalf("remote git operation returned after %s, want bounded network timeout", elapsed)
+			}
+		})
+	}
+}
+
+func TestExecGitPushProbeTimesOut(t *testing.T) {
+	oldTimeout := networkGitTimeout
+	networkGitTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { networkGitTimeout = oldTimeout })
+
+	bin := t.TempDir()
+	git := filepath.Join(bin, "git")
+	if err := os.WriteFile(git, []byte("#!/bin/sh\nexec sleep 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	started := time.Now()
+	_, err := execGitPushProbe(context.Background(), t.TempDir(), nil, "push", "--dry-run", "origin", "HEAD")
+	if err == nil {
+		t.Fatal("push credential probe succeeded with a hung git process")
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("push credential probe returned after %s, want bounded network timeout", elapsed)
+	}
+}
+
 // TestFetchOriginTTLSkipsRepeatFetch proves the FetchTTL cache added for
 // issue #1527: within TTL, a second FetchOrigin call against the same bare
 // clone must not see a commit pushed to origin after the first call — the

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -124,7 +124,7 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 		refspecs = append(refspecs, "+refs/heads/"+taskBranch+":refs/remotes/origin/"+taskBranch)
 	}
 	fetchArgs := append([]string{"fetch", "origin"}, refspecs...)
-	if fetchErr := runBare(ctx, barePath, fetchArgs...); fetchErr == nil {
+	if fetchErr := runBareFetch(ctx, barePath, fetchArgs...); fetchErr == nil {
 		report.RefetchedBranches = refspecs
 	}
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -153,9 +153,13 @@ type App struct {
 	// rather than silently refusing to dispatch.
 	schedulerDisabled atomic.Bool
 	brainDisabled     atomic.Bool
-	recovery          *recovery.Recovery
-	snapshotter       *tasksnapshot.Snapshotter
-	agentCompletion   *completion.Handler
+	// maintenanceCleanupRunning prevents slow git cleanup from stacking across
+	// maintenance ticks. Cleanup itself runs outside the orchestrator loop.
+	maintenanceCleanupRunning atomic.Bool
+	worktreeCleanupFn         func(context.Context) // test seam; nil uses worktrees
+	recovery                  *recovery.Recovery
+	snapshotter               *tasksnapshot.Snapshotter
+	agentCompletion           *completion.Handler
 	// umbrellaCloseIssue closes the umbrella GitHub issue on full roll-up.
 	// nil defaults to github.CloseIssue; overridden in tests.
 	umbrellaCloseIssue func(repo string, number int, comment string) error

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -155,7 +155,7 @@ func (a *App) maintenancePass(ctx context.Context) {
 	if a.taskSvc != nil {
 		a.taskSvc.ReconcilePendingEnrichment()
 	}
-	a.worktrees.CleanupOrphaned(ctx)
+	a.startWorktreeCleanup(ctx)
 	if a.sandboxes != nil && a.tasks != nil {
 		if tasks, err := a.tasks.List(); err == nil {
 			var hasAgent func(string) bool
@@ -171,6 +171,26 @@ func (a *App) maintenancePass(ctx context.Context) {
 			a.sandboxes.CleanupOrphaned(ctx, tasks, hasAgent, hasUnpushedCommits)
 		}
 	}
+}
+
+// startWorktreeCleanup keeps slow bare-repo pruning out of the orchestrator's
+// select loop. A hung remote operation can still delay this best-effort
+// maintenance work, but it can no longer stop dispatch or queue nudges.
+func (a *App) startWorktreeCleanup(ctx context.Context) {
+	if a.worktrees == nil && a.worktreeCleanupFn == nil {
+		return
+	}
+	if !a.maintenanceCleanupRunning.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer a.maintenanceCleanupRunning.Store(false)
+		if a.worktreeCleanupFn != nil {
+			a.worktreeCleanupFn(ctx)
+			return
+		}
+		a.worktrees.CleanupOrphaned(ctx)
+	}()
 }
 
 func (a *App) queueDrainPass(ctx context.Context) {

--- a/internal/sybra/app_orchestrator_test.go
+++ b/internal/sybra/app_orchestrator_test.go
@@ -1,0 +1,41 @@
+package sybra
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStartWorktreeCleanupRunsAsyncAndSingleFlights(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	a := &App{worktreeCleanupFn: func(context.Context) {
+		calls.Add(1)
+		close(started)
+		<-release
+	}}
+
+	a.startWorktreeCleanup(t.Context())
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not start asynchronously")
+	}
+	a.startWorktreeCleanup(t.Context())
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("concurrent cleanup calls = %d, want 1", got)
+	}
+
+	close(release)
+	deadline := time.After(time.Second)
+	for a.maintenanceCleanupRunning.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("cleanup remained marked running after return")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Bound remote Git operations and keep worktree cleanup outside the orchestrator loop to prevent a stalled transport from blocking fleet dispatch.

## Implementation information

Adds a deadline to every remote Git transport, covers the timeout boundary with hanging-process regressions, and single-flights cleanup in a background goroutine.

Closes #2852

> Changelog: fix(project): bound remote git operations