### PR TITLE
fix(github): unblock rate-limit gate

### DIFF
--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -292,13 +292,13 @@ func (g *ghRequestGate) runGated(ctx context.Context, run func() ([]byte, error)
 }
 
 func (g *ghRequestGate) lockContext(ctx context.Context) error {
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
 	for !g.mu.TryLock() {
-		timer := time.NewTimer(time.Millisecond)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return ctx.Err()
-		case <-timer.C:
+		case <-ticker.C:
 		}
 	}
 	return nil

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -13,6 +13,7 @@ const (
 	ghLowBudgetThreshold  = 150
 	ghOptionalCooldown    = 30 * time.Second
 	ghFallbackRateBackoff = 1 * time.Minute
+	ghMaxRateLimitWait    = 2 * time.Minute
 	ghMaxRetries          = 2
 	ghRetryBaseBackoff    = 500 * time.Millisecond
 
@@ -219,7 +220,7 @@ func newGHRequestGate() *ghRequestGate {
 // ObserveCallResultCtx) — it is never passed to run, whose closure already
 // carries whatever context its own exec.CommandContext needs.
 func (g *ghRequestGate) execute(ctx context.Context, run func() ([]byte, error)) ([]byte, error) {
-	out, suppressed, retryAfter, err := g.runGated(run)
+	out, suppressed, retryAfter, err := g.runGated(ctx, run)
 	if suppressed {
 		RecordSuppressedCall()
 		return nil, NewAuthCircuitOpenError(retryAfter)
@@ -238,33 +239,81 @@ func (g *ghRequestGate) execute(ctx context.Context, run func() ([]byte, error))
 // runGated runs the gh invocation under g.mu (circuit check, request spacing,
 // rate-limit bookkeeping) and reports the result so execute can observe the
 // outcome — which may trigger a slow token mint — after the lock is released.
-func (g *ghRequestGate) runGated(run func() ([]byte, error)) (out []byte, suppressed bool, retryAfter time.Time, err error) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+func (g *ghRequestGate) runGated(ctx context.Context, run func() ([]byte, error)) (out []byte, suppressed bool, retryAfter time.Time, err error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, false, time.Time{}, err
+		}
+		if err := g.lockContext(ctx); err != nil {
+			return nil, false, time.Time{}, err
+		}
+		// Circuit breaker: while GitHub auth is misconfigured, unavailable, or
+		// rate-limited, skip shelling out entirely rather than repeat a doomed
+		// request every ghRequestSpacing tick. AuthCircuitOpen re-opens the gate
+		// on its own backoff schedule, so ambient poll/task traffic naturally
+		// re-probes for recovery without a dedicated prober goroutine.
+		if open, ra := AuthCircuitOpen(); open {
+			g.mu.Unlock()
+			return nil, true, ra, nil
+		}
 
-	// Circuit breaker: while GitHub auth is misconfigured, unavailable, or
-	// rate-limited, skip shelling out entirely rather than repeat a doomed
-	// request every ghRequestSpacing tick. AuthCircuitOpen re-opens the gate
-	// on its own backoff schedule, so ambient poll/task traffic naturally
-	// re-probes for recovery without a dedicated prober goroutine.
-	if open, ra := AuthCircuitOpen(); open {
-		return nil, true, ra, nil
-	}
+		waitUntil := g.notBefore
+		if next := g.lastRun.Add(ghRequestSpacing); next.After(waitUntil) {
+			waitUntil = next
+		}
+		if wait := time.Until(waitUntil); wait > 0 {
+			if g.notBefore.Equal(waitUntil) && wait > ghMaxRateLimitWait {
+				g.mu.Unlock()
+				return nil, false, time.Time{}, NewRateLimitWallError(waitUntil)
+			}
+			g.mu.Unlock()
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, false, time.Time{}, ctx.Err()
+			case <-timer.C:
+			}
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			g.mu.Unlock()
+			return nil, false, time.Time{}, err
+		}
 
-	waitUntil := g.notBefore
-	if next := g.lastRun.Add(ghRequestSpacing); next.After(waitUntil) {
-		waitUntil = next
+		out, err = run()
+		g.lastRun = time.Now()
+		if err != nil && isRateLimitedMessage(string(out)) {
+			g.bumpLocked(g.lastRun.Add(ghFallbackRateBackoff))
+		}
+		g.mu.Unlock()
+		return out, false, time.Time{}, err
 	}
-	if sleep := time.Until(waitUntil); sleep > 0 {
-		time.Sleep(sleep)
-	}
+}
 
-	out, err = run()
-	g.lastRun = time.Now()
-	if err != nil && isRateLimitedMessage(string(out)) {
-		g.bumpLocked(g.lastRun.Add(ghFallbackRateBackoff))
+func (g *ghRequestGate) lockContext(ctx context.Context) error {
+	for !g.mu.TryLock() {
+		timer := time.NewTimer(time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
 	}
-	return out, false, time.Time{}, err
+	return nil
+}
+
+const rateLimitWallMarker = "github rate-limit wall"
+
+type rateLimitWallError struct{ retryAfter time.Time }
+
+func (e *rateLimitWallError) Error() string {
+	return rateLimitWallMarker + ": suppressing gh calls until " + e.retryAfter.UTC().Format(time.RFC3339)
+}
+
+func NewRateLimitWallError(retryAfter time.Time) error {
+	return &rateLimitWallError{retryAfter: retryAfter}
 }
 
 func (g *ghRequestGate) observe(resp ghHTTPResponse, err error) {
@@ -381,7 +430,8 @@ func (g *ghRequestGate) pressure() (fraction float64, known bool) {
 
 func isRateLimitedMessage(msg string) bool {
 	lower := strings.ToLower(msg)
-	return strings.Contains(lower, "secondary rate limit") ||
+	return strings.Contains(lower, rateLimitWallMarker) ||
+		strings.Contains(lower, "secondary rate limit") ||
 		strings.Contains(lower, "api rate limit exceeded") ||
 		strings.Contains(lower, "rate limit exceeded") ||
 		strings.Contains(lower, "rate_limit") ||

--- a/internal/github/runtime_test.go
+++ b/internal/github/runtime_test.go
@@ -205,10 +205,23 @@ func TestGHRequestGateExecute_WaitHonorsContext(t *testing.T) {
 	g := newGHRequestGate()
 	g.lastRun = time.Now()
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ran := make(chan struct{}, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := g.execute(ctx, func() ([]byte, error) { ran <- struct{}{}; return nil, nil })
+		errCh <- err
+	}()
+	time.Sleep(10 * time.Millisecond)
 	cancel()
-	_, err := g.execute(ctx, func() ([]byte, error) { t.Fatal("run must not start"); return nil, nil })
+	err := <-errCh
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context canceled", err)
+	}
+	select {
+	case <-ran:
+		t.Fatal("run must not start")
+	default:
 	}
 }
 

--- a/internal/github/runtime_test.go
+++ b/internal/github/runtime_test.go
@@ -181,6 +181,59 @@ func TestGHRequestGateExecute_SuppressesCallsWhileAuthCircuitOpen(t *testing.T) 
 	}
 }
 
+func TestGHRequestGateExecute_RateWallDoesNotBlockMutex(t *testing.T) {
+	g := newGHRequestGate()
+	g.notBefore = time.Now().Add(time.Hour)
+	started := time.Now()
+	_, err := g.execute(context.Background(), func() ([]byte, error) { t.Fatal("run must be suppressed"); return nil, nil })
+	if !strings.Contains(err.Error(), rateLimitWallMarker) {
+		t.Fatalf("err = %v, want rate-limit wall", err)
+	}
+	if time.Since(started) > time.Second {
+		t.Fatal("rate wall blocked caller")
+	}
+	done := make(chan struct{})
+	go func() { _ = g.shouldSkipOptional("core", priorityMergePath); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("rate wall held gate mutex")
+	}
+}
+
+func TestGHRequestGateExecute_WaitHonorsContext(t *testing.T) {
+	g := newGHRequestGate()
+	g.lastRun = time.Now()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := g.execute(ctx, func() ([]byte, error) { t.Fatal("run must not start"); return nil, nil })
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context canceled", err)
+	}
+}
+
+func TestGHRequestGateExecute_CanceledContextNeverRuns(t *testing.T) {
+	g := newGHRequestGate()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := g.execute(ctx, func() ([]byte, error) { t.Fatal("run must not start"); return nil, nil })
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context canceled", err)
+	}
+}
+
+func TestGHRequestGateExecute_LockHonorsContext(t *testing.T) {
+	g := newGHRequestGate()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := g.execute(ctx, func() ([]byte, error) { t.Fatal("run must not start"); return nil, nil })
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want deadline exceeded", err)
+	}
+}
+
 // TestGHRequestGateExecute_ObservesCallResult asserts a real (non-suppressed)
 // call result flows into the shared auth-health tracker, so a caller that
 // never explicitly wires ObserveCallResult still gets auth-failure detection


### PR DESCRIPTION
## Motivation

Prevent GitHub rate-limit waits from serializing the entire process behind the request gate.

## Implementation information

Makes gate acquisition and waits context-aware, returns a typed rate-limit wall for long backoffs, and adds concurrency regressions.

Closes #2853

> Changelog: fix(github): unblock rate-limit gate