### PR TITLE
fix(agent): preserve pending escalations

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -499,7 +499,7 @@ func fromRecord(r Record) *Agent {
 	if requestedModel == "" {
 		requestedModel = r.Model
 	}
-	return &Agent{
+	a := &Agent{
 		ID:                      r.ID,
 		TaskID:                  r.TaskID,
 		Name:                    r.Name,
@@ -544,6 +544,10 @@ func fromRecord(r Record) *Agent {
 		unrenderedSkills:        slices.Clone(r.UnrenderedSkills),
 		detached:                true,
 	}
+	if r.Mode == "headless" {
+		a.escalationCh = make(chan bool, 1)
+	}
+	return a
 }
 
 // SetState atomically updates the agent state.

--- a/internal/agent/reattach_escalation_test.go
+++ b/internal/agent/reattach_escalation_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFromRecordHeadlessRestoresEscalationChannel(t *testing.T) {
+	a := fromRecord(Record{ID: "a", Mode: "headless"})
+	if a.escalationCh == nil {
+		t.Fatal("headless reattach omitted escalation channel")
+	}
+	if err := (&Manager{}).RespondEscalation("missing", true); err == nil {
+		t.Fatal("sanity: manager should reject missing agent")
+	}
+}
+
+func TestTailHeadlessFile_ShutdownDuringTurnsEscalationDetaches(t *testing.T) {
+	escalated := make(chan struct{}, 1)
+	m := mustNewManager(t, context.Background(), func(event string, _ any) {
+		if strings.HasPrefix(event, "agent:escalation:") {
+			escalated <- struct{}{}
+		}
+	}, slog.New(slog.DiscardHandler), t.TempDir())
+	m.SetGuardrails(Guardrails{MaxTurns: 1})
+	logPath := filepath.Join(t.TempDir(), "run.ndjson")
+	if err := os.WriteFile(logPath, []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"tick"}]}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := &Agent{ID: "a", Name: RoleReview.AgentName("task"), Provider: "claude", escalationCh: make(chan bool, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	procDone := make(chan struct{})
+	done := make(chan bool, 1)
+	go func() { exited, _ := m.tailHeadlessFile(ctx, a, logPath, 0, procDone); done <- exited }()
+	select {
+	case <-escalated:
+	case <-time.After(time.Second):
+		t.Fatal("turns escalation was not raised")
+	}
+	cancel()
+	select {
+	case exited := <-done:
+		if exited {
+			t.Fatal("shutdown during pending escalation finalized instead of detaching")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tailer did not exit after shutdown")
+	}
+}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -837,6 +837,12 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 		}
 
 		if drain() {
+			// A turns escalation may be waiting when shutdown cancels ctx. The
+			// guardrail reports stop in that case, but the detached child was not
+			// intentionally stopped and must survive for reattach.
+			if ctx.Err() != nil && !a.WasStopped() {
+				return false, end()
+			}
 			// Guardrail kill: force the child to stop, wait for it, finalize.
 			m.signalKill(a)
 			waitExit()
@@ -1437,6 +1443,7 @@ func (m *Manager) checkTurnsGuardrail(ctx context.Context, a *Agent) bool {
 			// Caller terminates the subprocess: streamHeadlessOutput cancels
 			// the context (pipe-backed); tailHeadlessFile signal-kills the
 			// detached child by PID.
+			a.MarkStopped()
 			return false
 		}
 		a.SetEscalationReason("")


### PR DESCRIPTION
## Motivation

Preserve detached headless agents across a redeploy while turns escalation is pending, and restore reattached escalation control.

## Implementation information

Shutdown now detaches a pending escalation without killing the child; explicit denial remains an intentional stop. Reattached headless agents recreate their escalation channel, with regression coverage for both paths.

Closes #2854
Closes #2855

> Changelog: fix(agent): preserve pending escalations