### PR TITLE
fix(agent): recover forked reattach results

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1458,6 +1458,27 @@ func bufferedResultEvent(events []StreamEvent) (found, isError bool) {
 	return found, isError
 }
 
+// resultBeforeOnlyForkOutput accepts a terminal result followed only by forked
+// child events or background-task bookkeeping. Top-level events after a result
+// otherwise delimit a new retry attempt and must not let reattach finalize the
+// prior attempt.
+func resultBeforeOnlyForkOutput(events []StreamEvent) (found, isError bool) {
+	for i := range slices.Backward(events) {
+		e := events[i]
+		if e.parentToolUseID != "" {
+			continue
+		}
+		if e.Type == "system" && e.Subtype == "background_tasks_changed" {
+			continue
+		}
+		if e.Type == "result" {
+			return true, resultSubtypeIsError(e.Subtype) || e.ErrorType != "" || e.ErrorStatus != 0
+		}
+		return false, false
+	}
+	return false, false
+}
+
 // backgroundTaskGrace is the extra idle time granted to a post-result-hang
 // guard (runner_headless.go's postResultGrace, watchdog's completedHangGrace)
 // while the agent has outstanding CLI background bash tasks. Bounded rather

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -142,7 +142,7 @@ func (m *Manager) finalizeIfCompleted(r Record) bool {
 	if mt, ok := logActivityTime(r.LogPath); ok {
 		a.SetLastEventAt(mt)
 	}
-	found, isError := a.lastHeadlessResult()
+	found, isError := resultBeforeOnlyForkOutput(a.Output())
 	if !found {
 		return false
 	}
@@ -217,7 +217,7 @@ func (m *Manager) reattachHeadless(ctx context.Context, a *Agent, startOffset in
 	// closes stdin so the child sees EOF and exits like an unsteered one-shot,
 	// instead of hanging (or accepting a post-reattach steer that would queue
 	// forever with no further result to flush it).
-	if found, _ := a.lastHeadlessResult(); found {
+	if found, _ := resultBeforeOnlyForkOutput(a.Output()); found {
 		m.drainOrCloseHeadlessSteer(a)
 	}
 	procDone := make(chan struct{})
@@ -232,7 +232,7 @@ func (m *Manager) reattachHeadless(ctx context.Context, a *Agent, startOffset in
 	}
 
 	outputs := a.Output()
-	if found, isError := lastHeadlessResultEvent(outputs); !found {
+	if found, isError := resultBeforeOnlyForkOutput(outputs); !found {
 		a.SetExitErr(errReattachedGone)
 	} else if isError {
 		if err := resultStreamError(outputs); err != nil {

--- a/internal/agent/reattach_escalation_test.go
+++ b/internal/agent/reattach_escalation_test.go
@@ -53,3 +53,13 @@ func TestTailHeadlessFile_ShutdownDuringTurnsEscalationDetaches(t *testing.T) {
 		t.Fatal("tailer did not exit after shutdown")
 	}
 }
+
+func TestResultBeforeOnlyForkOutput(t *testing.T) {
+	events := []StreamEvent{{Type: "result"}, {Type: "assistant", parentToolUseID: "fork"}, {Type: "result", Subtype: "error", parentToolUseID: "fork"}, {Type: "system", Subtype: "background_tasks_changed"}}
+	if found, isError := resultBeforeOnlyForkOutput(events); !found || isError {
+		t.Fatalf("resultBeforeOnlyForkOutput = (%v, %v), want clean result", found, isError)
+	}
+	if found, _ := resultBeforeOnlyForkOutput([]StreamEvent{{Type: "result"}, {Type: "init"}}); found {
+		t.Fatal("top-level retry event must hide prior result")
+	}
+}


### PR DESCRIPTION
## Summary
- recover terminal parent results followed by fork-subagent stream output during reattach
- retain retry boundaries and ignore child result records when deciding parent completion
- restore the reattached stdin-close boundary for completed forked runs

## Verification
- `go test -race ./internal/agent`
- `golangci-lint run ./internal/agent/...`
- isolated Sybra server health/API smoke and focused reattach regression suite

Closes #2856