### PR TITLE
fix(sybra): bind tool ledger to agent manager

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1141,3 +1141,16 @@ func (m *Manager) SetToolLedger(l *toolledger.Logger) {
 	m.toolLedger = l
 	m.mu.Unlock()
 }
+
+// ToolLedger reports the bound ledger. Exported because a nil ledger is
+// otherwise invisible: Logger.Log guards its own nil receiver, so an unwired
+// manager drops every record without erroring, and only a direct read of the
+// binding can tell a live ledger from a silent one.
+func (m *Manager) ToolLedger() *toolledger.Logger {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.toolLedger
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -481,6 +481,12 @@ func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) erro
 		return fmt.Errorf("agent manager: %w", err)
 	}
 	a.agents.SetGHAppToken(github.CurrentAppToken)
+	// initToolLedger runs before this function, when a.agents is still nil, so
+	// its own SetToolLedger call is skipped. Without re-binding here the
+	// manager's ledger stays nil and Logger.Log's nil guard drops every record
+	// silently — the ledger creates its directory, never writes a line, and
+	// looks healthy while collecting nothing (#2788).
+	a.agents.SetToolLedger(a.toolLedger)
 	if agentCfg.SurviveRestartDir != "" {
 		a.logger.Info("agent.survive-restart.enabled", "dir", agentCfg.SurviveRestartDir)
 	}

--- a/internal/sybra/app_tool_ledger_test.go
+++ b/internal/sybra/app_tool_ledger_test.go
@@ -1,0 +1,72 @@
+package sybra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// initToolLedger runs before initAgentManager during startup, when a.agents is
+// still nil, so its own SetToolLedger call is a no-op. If initAgentManager does
+// not re-bind, Logger.Log's nil-receiver guard drops every record silently: the
+// ledger directory is created, no line is ever written, and nothing errors.
+func TestInitAgentManagerBindsToolLedger(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.Provider = "claude"
+	a := &App{
+		cfg:      cfg,
+		logger:   discardLogger(),
+		logDir:   t.TempDir(),
+		agentSvc: &AgentService{},
+	}
+
+	a.initToolLedger()
+	if a.toolLedger == nil {
+		t.Fatal("initToolLedger did not open a ledger")
+	}
+	if err := a.initAgentManager(t.Context(), func(string, any) {}); err != nil {
+		t.Fatalf("initAgentManager: %v", err)
+	}
+	if a.agentSvc.approval != nil {
+		t.Cleanup(func() { _ = a.agentSvc.approval.Shutdown(context.Background()) })
+	}
+
+	if a.agents.ToolLedger() == nil {
+		t.Fatal("agent manager has no tool ledger bound; every tool call is dropped silently")
+	}
+	if a.agents.ToolLedger() != a.toolLedger {
+		t.Fatal("agent manager bound a different ledger than the app opened")
+	}
+}
+
+// The ledger directory existing is not evidence that anything is recorded — it
+// is created by initToolLedger regardless. This pins the distinction so an
+// empty directory is read as a defect rather than as low traffic.
+func TestToolLedgerDirAloneProvesNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	cfg := config.DefaultConfig()
+	a := &App{cfg: cfg, logger: discardLogger(), logDir: t.TempDir()}
+	a.initToolLedger()
+
+	dir := cfg.ToolLedgerDir()
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("ledger dir not created: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read ledger dir: %v", err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".ndjson" {
+			t.Fatalf("unexpected ledger file %q before any tool call", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Closes #2900.

The always-on tool-call ledger from #2788 has recorded nothing since it shipped. On the production server its directory has existed since the deploy and contains zero files, across a window in which many agents ran:

```
$ ls /data/sybra/home/logs/tool-ledger | wc -l
0
```

> Changelog: fix(sybra): bind the tool-call ledger to the agent manager

## Implementation information

`App.Start` calls `initToolLedger()` (`app.go:412`) before `initAgentManager()` (`app.go:460`). At that point `a.agents` is nil, so the guarded call inside `initToolLedger` is skipped:

```go
a.toolLedger = l
if a.agents != nil {
    a.agents.SetToolLedger(l)   // never runs at startup
}
```

Nothing re-binds it afterwards, so `Manager.toolLedger` stays nil for the process lifetime. `recordToolCall` then calls `Logger.Log` on a nil receiver, which returns `nil` early by design — so every record is dropped, nothing errors, and `agent.tool_ledger.write_failed` can never fire for this failure mode.

The fix re-binds in `initAgentManager` next to the existing `SetGHAppToken` call.

**Why this went unnoticed:** the failure shape is a created-but-empty directory, which reads as "no traffic yet" rather than "wired wrong". That is also why this PR adds `Manager.ToolLedger()` — with `Log` guarding its own nil receiver, a direct read of the binding is the only way to distinguish a live ledger from a silent one.

## Supporting documentation

Two tests:

- `TestInitAgentManagerBindsToolLedger` — drives the real startup order and asserts the manager ends up holding the same ledger the app opened. Mutation-tested: removing the re-bind fails it with *"agent manager has no tool ledger bound; every tool call is dropped silently"*.
- `TestToolLedgerDirAloneProvesNothing` — pins that the directory is created regardless, so an empty one is read as a defect rather than as low traffic.

`mise run verify` clean apart from the pre-existing darwin load flake filed as #2896 (`TestRemoteGitOperationsTimeOut`), reproduced on a clean `origin/main` worktree.

**This unblocks #2777**, which is waiting on ledger data to derive a deny-known-bad tool policy. That sample has been empty the whole time, so the wait would never have ended on its own.
