### PR TITLE
fix(workflow): preserve watchdog retry budget

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -32,7 +32,10 @@ import (
 	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
-var errWorkflowEffectNoPersist = errors.New("workflow effect claim requires no persistence")
+var (
+	errWorkflowEffectNoPersist             = errors.New("workflow effect claim requires no persistence")
+	errWorkflowStatusReasonNoLongerMatches = errors.New("workflow status reason no longer matches")
+)
 
 // Compile-time interface checks.
 var (
@@ -190,6 +193,22 @@ func (a *taskAdapter) UpdateTaskStatus(id, status, reason string) error {
 		Extra:    extra,
 	})
 	return err
+}
+
+func (a *taskAdapter) ClearTaskStatusReasonIf(id, expectedStatus, expectedReason string) (bool, error) {
+	cleared := false
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if string(cur.Status) != expectedStatus || cur.StatusReason != expectedReason {
+			return task.Update{}, errWorkflowStatusReasonNoLongerMatches
+		}
+		empty := ""
+		cleared = true
+		return task.Update{StatusReason: &empty}, nil
+	})
+	if errors.Is(err, errWorkflowStatusReasonNoLongerMatches) {
+		return false, nil
+	}
+	return cleared, err
 }
 
 func (a *taskAdapter) UpdateTaskBlocker(id, status, reason string, state blocker.State) error {

--- a/internal/sybra/app_workflow_reason_test.go
+++ b/internal/sybra/app_workflow_reason_test.go
@@ -85,3 +85,45 @@ func TestTaskAdapterUpdateTaskStatusSynthesizesHumanRequiredReasonFromLatestRun(
 		t.Fatalf("StatusReason = %q, want %q", updated.StatusReason, want)
 	}
 }
+
+func TestTaskAdapterClearTaskStatusReasonIfIsAtomicGuard(t *testing.T) {
+	t.Parallel()
+
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	created, err := tasks.CreateFull("guard reason", "", "headless", task.Update{
+		Status:       task.Ptr(task.StatusInProgress),
+		StatusReason: task.Ptr("watchdog: rate limit: quota exhausted"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ta := &taskAdapter{tasks: tasks}
+	cleared, err := ta.ClearTaskStatusReasonIf(created.ID, string(task.StatusInProgress), "stale marker")
+	if err != nil || cleared {
+		t.Fatalf("mismatched clear = (%v, %v), want (false, nil)", cleared, err)
+	}
+	current, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.StatusReason != "watchdog: rate limit: quota exhausted" {
+		t.Fatalf("mismatched clear overwrote reason %q", current.StatusReason)
+	}
+
+	cleared, err = ta.ClearTaskStatusReasonIf(created.ID, string(task.StatusInProgress), current.StatusReason)
+	if err != nil || !cleared {
+		t.Fatalf("matched clear = (%v, %v), want (true, nil)", cleared, err)
+	}
+	current, err = tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Status != task.StatusInProgress || current.StatusReason != "" {
+		t.Fatalf("matched clear left status=%q reason=%q, want in-progress with empty reason", current.Status, current.StatusReason)
+	}
+}

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
-var errWorkflowEffectNoPersist = errors.New("workflow effect claim requires no persistence")
+var (
+	errWorkflowEffectNoPersist             = errors.New("workflow effect claim requires no persistence")
+	errWorkflowStatusReasonNoLongerMatches = errors.New("workflow status reason no longer matches")
+)
 
 // taskAdapter and agentAdapter are minimal test-only stand-ins for the real
 // bridges (internal/sybra's private taskAdapter/agentAdapter) that let a
@@ -65,6 +68,22 @@ func (a *taskAdapter) UpdateTaskStatus(id, status, reason string) error {
 	}
 	_, err = a.tasks.Update(id, u)
 	return err
+}
+
+func (a *taskAdapter) ClearTaskStatusReasonIf(id, expectedStatus, expectedReason string) (bool, error) {
+	cleared := false
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if string(cur.Status) != expectedStatus || cur.StatusReason != expectedReason {
+			return task.Update{}, errWorkflowStatusReasonNoLongerMatches
+		}
+		empty := ""
+		cleared = true
+		return task.Update{StatusReason: &empty}, nil
+	})
+	if errors.Is(err, errWorkflowStatusReasonNoLongerMatches) {
+		return false, nil
+	}
+	return cleared, err
 }
 
 func (a *taskAdapter) UpdateTaskBlocker(id, status, reason string, state blocker.State) error {

--- a/internal/workflow/bounded_retry.go
+++ b/internal/workflow/bounded_retry.go
@@ -1,6 +1,14 @@
 package workflow
 
-import "strconv"
+import (
+	"errors"
+	"strconv"
+)
+
+// errRetryArmingSuperseded tells boundedRetry that a concurrent state change
+// won after the counter was persisted but before the retry could dispatch.
+// It is a normal fence, not a persistence failure.
+var errRetryArmingSuperseded = errors.New("retry arming superseded by concurrent task update")
 
 // boundedRetryPolicy is the shape shared by every capped auto-retry the
 // engine runs against a stalled run_agent step: read a per-step attempt
@@ -92,6 +100,10 @@ func (e *Engine) boundedRetry(t *TaskInfo, step *Step, p boundedRetryPolicy) boo
 	}
 	if p.onArmed != nil {
 		if err := p.onArmed(e, t, step, attempt); err != nil {
+			if errors.Is(err, errRetryArmingSuperseded) {
+				e.logger.Debug("workflow."+p.name+".superseded", "task_id", t.ID, "step", step.ID)
+				return true
+			}
 			e.logger.Error("workflow."+p.name+".clear", "task_id", t.ID, "step", step.ID, "err", err)
 			return true
 		}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -119,6 +119,10 @@ type TaskProvider interface {
 	GetTask(id string) (TaskInfo, error)
 	ListTasks() ([]TaskInfo, error)
 	UpdateTaskStatus(id, status, reason string) error
+	// ClearTaskStatusReasonIf atomically clears a status reason only when the
+	// task still has the exact status and reason the caller observed. It keeps a
+	// stale retry cleanup from erasing a newer failure or operator decision.
+	ClearTaskStatusReasonIf(id, expectedStatus, expectedReason string) (bool, error)
 	UpdateTaskBlocker(id, status, reason string, state blocker.State) error
 	UpdateTaskPR(id string, prNumber int) error
 	MarkTaskReviewed(id string) error

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1838,6 +1838,22 @@ func (e *Engine) handleWatchdogRateLimitRetry(t *TaskInfo, step *Step) bool {
 		},
 		counterKey: watchdogRateLimitRetryKey,
 		max:        maxWatchdogRateLimitRetries,
+		onArmed: func(e *Engine, t *TaskInfo, _ *Step, _ int) error {
+			// The counter now represents a real retry attempt. Clear the watchdog
+			// marker before dispatch so a benign capacity park cannot make the
+			// next ResumeStalled tick re-arm and burn this budget again. The
+			// compare is atomic: a concurrent terminal failure must win rather
+			// than being reopened from this stale retry snapshot.
+			cleared, err := e.tasks.ClearTaskStatusReasonIf(t.ID, t.Status, t.StatusReason)
+			if err != nil {
+				return err
+			}
+			if !cleared {
+				return errRetryArmingSuperseded
+			}
+			t.StatusReason = ""
+			return nil
+		},
 		onExhausted: func(e *Engine, t *TaskInfo, step *Step, attempts int) {
 			retryKey := watchdogRateLimitRetryKey(step.ID)
 			freshKey := watchdogZeroOutputFreshRetryKey(step.ID)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -561,6 +561,7 @@ type memTasks struct {
 	steers           map[string]string
 	gets             map[string]int
 	onGet            func(id string, t *TaskInfo, count int)
+	onSetWorkflow    func(id string)
 	appendErr        error
 	failGet          bool
 	failSetWorkflow  bool
@@ -672,6 +673,21 @@ func (m *memTasks) UpdateTaskStatus(id, status, reason string) error {
 	t.StatusReason = reason
 	m.reasons[id] = reason
 	return nil
+}
+
+func (m *memTasks) ClearTaskStatusReasonIf(id, expectedStatus, expectedReason string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return false, fmt.Errorf("task %s not found", id)
+	}
+	if t.Status != expectedStatus || t.StatusReason != expectedReason {
+		return false, nil
+	}
+	t.StatusReason = ""
+	m.reasons[id] = ""
+	return true, nil
 }
 
 func (m *memTasks) UpdateTaskBlocker(id, status, reason string, state blocker.State) error {
@@ -803,18 +819,24 @@ func (m *memTasks) ReplaceTaskBody(id, body string) error {
 
 func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.failSetWorkflow || m.failSetWorkflowN > 0 {
 		if m.failSetWorkflowN > 0 {
 			m.failSetWorkflowN--
 		}
+		m.mu.Unlock()
 		return fmt.Errorf("simulated write failure for task %s", id)
 	}
 	t, ok := m.tasks[id]
 	if !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("task %s not found", id)
 	}
 	t.Workflow = wf.Clone()
+	hook := m.onSetWorkflow
+	m.mu.Unlock()
+	if hook != nil {
+		hook(id)
+	}
 	return nil
 }
 
@@ -4150,7 +4172,7 @@ func TestRescheduleRateLimitedAgent_WatchdogRetriesThenEscalates(t *testing.T) {
 			name:       "first watchdog rate limit reruns",
 			wantStarts: 1,
 			wantStatus: "in-progress",
-			wantReason: "watchdog: rate limit: org-level quota exhausted",
+			wantReason: "",
 			wantRetry:  "1",
 		},
 		{
@@ -4230,7 +4252,7 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			retries:    "1",
 			wantStarts: 1,
 			wantStatus: "in-progress",
-			wantReason: watchdogreason.RateLimit(watchdogreason.ZeroOutputBeforeStartup),
+			wantReason: "",
 			wantRetry:  "2",
 		},
 		{
@@ -4376,6 +4398,86 @@ func TestResumeStalled_WatchdogZeroOutputFreshRoundDispatches(t *testing.T) {
 	}
 	if final.Status == "blocked" {
 		t.Fatalf("task latched blocked despite a fresh-session recovery being available")
+	}
+}
+
+func TestResumeStalled_WatchdogRateLimitPoolBusyDoesNotBurnRetryBudget(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.SetFailSpawn(ErrAgentPoolBusy)
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: "watchdog: rate limit: org-level quota exhausted",
+		AgentMode:    "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+
+	// The first retry is armed then hits a benign capacity park. A later tick
+	// must retry dispatch normally instead of re-arming the rate-limit policy.
+	for range maxWatchdogRateLimitRetries + 1 {
+		engine.ResumeStalled()
+	}
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress", got.Status)
+	}
+	if got.StatusReason != "" {
+		t.Fatalf("status_reason = %q, want cleared after arming retry", got.StatusReason)
+	}
+	if retry := got.Workflow.Variables[watchdogRateLimitRetryKey("implement")]; retry != "1" {
+		t.Fatalf("rate-limit retry var = %q, want 1 after repeated pool-busy parks", retry)
+	}
+	if got.Workflow.State == ExecFailed {
+		t.Fatal("pool-busy parks must not exhaust the watchdog retry budget")
+	}
+}
+
+func TestResumeStalled_WatchdogRateLimitDoesNotClearConcurrentFailure(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: "watchdog: rate limit: org-level quota exhausted",
+		AgentMode:    "headless",
+		Workflow:     &Execution{WorkflowID: "test-simple", CurrentStep: "implement", State: ExecWaiting, Variables: map[string]string{}},
+	})
+	var once sync.Once
+	tasks.onSetWorkflow = func(id string) {
+		once.Do(func() {
+			if err := tasks.UpdateTaskStatus(id, "human-required", "concurrent permanent failure"); err != nil {
+				t.Errorf("set concurrent failure: %v", err)
+			}
+		})
+	}
+
+	engine.ResumeStalled()
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != "human-required" || got.StatusReason != "concurrent permanent failure" {
+		t.Fatalf("concurrent failure was overwritten: status=%q reason=%q", got.Status, got.StatusReason)
+	}
+	if starts := agents.CallCount(); starts != 0 {
+		t.Fatalf("concurrent failure must fence dispatch, started %d agents", starts)
 	}
 }
 
@@ -4912,7 +5014,7 @@ func TestRescheduleRateLimitedAgent_ParallelChildWatchdogRetriesThenEscalates(t 
 			name:       "first watchdog rate limit reruns child",
 			wantStarts: 1,
 			wantStatus: "in-progress",
-			wantReason: "watchdog: rate limit: org-level quota exhausted",
+			wantReason: "",
 			wantRetry:  "1",
 		},
 		{


### PR DESCRIPTION
## Summary
- clear an armed watchdog rate-limit marker so transient pool-capacity parks cannot repeatedly consume its budget
- atomically fence that clear against a concurrent terminal status update, and abort dispatch when the newer update wins
- cover pool-busy, zero-output, and concurrent-failure interleavings

## Verification
- `go test -race ./internal/workflow -count=1`
- targeted workflow and production-adapter race regressions
- `golangci-lint run ./internal/workflow/... ./internal/sybra/... ./internal/sybra/review/...`
- isolated Sybra server health/API smoke

Closes #2858