### PR TITLE
fix(project): scope clone health gate to refs

### DIFF
--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/executil"
 )
 
 type RepairReport struct {
@@ -47,17 +49,119 @@ func IsBadRefError(err error) bool {
 	return false
 }
 
+// fsckRefBatch bounds how many ref tips are passed to one `git fsck`
+// invocation, so a repo with thousands of refs cannot overflow the argv limit.
+const fsckRefBatch = 256
+
+// CheckBareCloneHealth reports whether the object database is intact for
+// everything reachable from refs.
+//
+// It scopes fsck to the ref tips rather than running it bare. An unscoped
+// `git fsck` also walks every linked worktree's index and HEAD reflog, and
+// those go stale as a matter of normal operation: a worktree reflog keeps
+// pointing at objects a later prune removed, and an index cache-tree keeps
+// naming blobs from a discarded state. Neither is reachable from any ref and
+// neither affects what an agent can check out, but both make fsck exit
+// non-zero forever.
+//
+// Measured on the deploy host with 40 live worktrees: 141 errors, of which
+// 115 were stale worktree reflog entries and 26 were worktree index
+// cache-tree references — while all 33,629 ref-reachable objects were
+// present. The unscoped check therefore failed permanently on a healthy
+// clone, and because the failure is permanent it could never clear: the
+// agent-start circuit breaker tripped and parked tasks human-required with
+// "bare clone health check failed" that no retry could resolve.
 func CheckBareCloneHealth(ctx context.Context, barePath string) error {
-	if err := runBare(ctx, barePath, "fsck", "--no-dangling"); err != nil {
+	refs, err := bareRefTips(ctx, barePath)
+	if err != nil {
 		return fmt.Errorf("bare clone health check failed: %w", err)
 	}
+	if len(refs) == 0 {
+		// No refs to scope to (fresh or fully quarantined clone). Nothing has
+		// been checked out yet either, so the unscoped walk has no worktree
+		// state to trip over.
+		if err := runBare(ctx, barePath, "fsck", "--no-dangling"); err != nil {
+			return fmt.Errorf("bare clone health check failed: %w", err)
+		}
+		return nil
+	}
+	for start := 0; start < len(refs); start += fsckRefBatch {
+		end := min(start+fsckRefBatch, len(refs))
+		args := append([]string{"fsck", "--no-dangling", "--no-reflogs"}, refs[start:end]...)
+		if err := runBare(ctx, barePath, args...); err != nil {
+			return fmt.Errorf("bare clone health check failed: %w", err)
+		}
+	}
 	return nil
+}
+
+// CheckWorktreeIndexes reports the first linked worktree whose index git
+// cannot read.
+//
+// Split out of CheckBareCloneHealth because the two answer different
+// questions and only one of them should gate dispatch. An index git cannot
+// parse makes that one worktree unusable and is worth repairing; an index
+// that parses but whose cache-tree names pruned blobs is inert. Deriving both
+// from a single unscoped `git fsck` exit code conflated them, so ordinary
+// worktree churn read as clone corruption.
+//
+// Reads the index via `git ls-files` rather than `git status`: it parses the
+// index without stat-ing the working tree, which matters when this runs
+// across dozens of live worktrees on every dispatch.
+func CheckWorktreeIndexes(ctx context.Context, barePath string) error {
+	entries, _ := os.ReadDir(filepath.Join(barePath, "worktrees"))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		adminDir := filepath.Join(barePath, "worktrees", entry.Name())
+		checkoutPath := worktreeCheckoutPath(adminDir)
+		if checkoutPath == "" {
+			continue
+		}
+		if _, err := os.Stat(checkoutPath); err != nil {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(adminDir, "index")); err != nil {
+			continue
+		}
+		if err := executil.Run(ctx, checkoutPath, "git", "ls-files"); err != nil {
+			return fmt.Errorf("worktrees/%s/index file is unreadable: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+// bareRefTips lists the object ids every ref points at. They are the roots
+// the scoped fsck walks from.
+func bareRefTips(ctx context.Context, barePath string) ([]string, error) {
+	out, err := outputBare(ctx, barePath, "rev-parse", "--all")
+	if err != nil {
+		return nil, fmt.Errorf("list ref tips: %w", err)
+	}
+	var refs []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if tip := strings.TrimSpace(line); tip != "" {
+			refs = append(refs, tip)
+		}
+	}
+	return refs, nil
+}
+
+// bareCloneAndWorktreesHealthy is the repair trigger: it covers both the
+// object database and the linked worktree indexes, so EnsureBareCloneHealthy
+// still repairs an unreadable index even though that no longer gates dispatch.
+func bareCloneAndWorktreesHealthy(ctx context.Context, barePath string) error {
+	if err := CheckBareCloneHealth(ctx, barePath); err != nil {
+		return err
+	}
+	return CheckWorktreeIndexes(ctx, barePath)
 }
 
 func EnsureBareCloneHealthy(ctx context.Context, barePath, taskBranch string) (RepairReport, error) {
 	var report RepairReport
 	err := withBareRepoLock(barePath, func() error {
-		if err := CheckBareCloneHealth(ctx, barePath); err == nil {
+		if err := bareCloneAndWorktreesHealthy(ctx, barePath); err == nil {
 			return nil
 		}
 		var repairErr error
@@ -65,10 +169,7 @@ func EnsureBareCloneHealthy(ctx context.Context, barePath, taskBranch string) (R
 		if repairErr != nil {
 			return repairErr
 		}
-		if healthErr := CheckBareCloneHealth(ctx, barePath); healthErr != nil {
-			return healthErr
-		}
-		return nil
+		return bareCloneAndWorktreesHealthy(ctx, barePath)
 	})
 	return report, err
 }
@@ -132,7 +233,7 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 }
 
 func rebuildWorktreeIndexes(ctx context.Context, barePath string, report *RepairReport) {
-	if healthErr := CheckBareCloneHealth(ctx, barePath); healthErr == nil || !isWorktreeIndexHealthError(healthErr) {
+	if CheckWorktreeIndexes(ctx, barePath) == nil {
 		return
 	}
 	worktreesDir := filepath.Join(barePath, "worktrees")
@@ -178,16 +279,6 @@ func rebuildWorktreeIndexes(ctx context.Context, barePath string, report *Repair
 		}
 		report.RebuiltWorktreeIndexes = append(report.RebuiltWorktreeIndexes, "worktrees/"+entry.Name()+"/index")
 	}
-}
-
-func isWorktreeIndexHealthError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "/index") ||
-		strings.Contains(msg, "cache-tree") ||
-		strings.Contains(msg, "index file")
 }
 
 func releaseDeadWorktreeRefs(ctx context.Context, barePath string, report *RepairReport) {

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -3,13 +3,12 @@ package project
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/Automaat/sybra/internal/executil"
 )
 
 type RepairReport struct {
@@ -109,7 +108,15 @@ func CheckBareCloneHealth(ctx context.Context, barePath string) error {
 // index without stat-ing the working tree, which matters when this runs
 // across dozens of live worktrees on every dispatch.
 func CheckWorktreeIndexes(ctx context.Context, barePath string) error {
-	entries, _ := os.ReadDir(filepath.Join(barePath, "worktrees"))
+	entries, err := os.ReadDir(filepath.Join(barePath, "worktrees"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// A clone with no linked worktrees has no indexes to check.
+			return nil
+		}
+		// Any other read failure (permissions, IO) is not evidence of health.
+		return fmt.Errorf("read worktrees dir: %w", err)
+	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -125,9 +132,27 @@ func CheckWorktreeIndexes(ctx context.Context, barePath string) error {
 		if _, err := os.Stat(filepath.Join(adminDir, "index")); err != nil {
 			continue
 		}
-		if err := executil.Run(ctx, checkoutPath, "git", "ls-files"); err != nil {
+		if err := indexReadable(ctx, checkoutPath); err != nil {
 			return fmt.Errorf("worktrees/%s/index file is unreadable: %w", entry.Name(), err)
 		}
+	}
+	return nil
+}
+
+// indexReadable reports whether git can parse the worktree's index.
+//
+// Discards stdout rather than using executil.Run: this runs per worktree on
+// the dispatch path, and ls-files on a large repo emits thousands of paths
+// that would otherwise be buffered in full only to be thrown away. Only
+// stderr is kept, since that is what explains a parse failure.
+func indexReadable(ctx context.Context, checkoutPath string) error {
+	cmd := exec.CommandContext(ctx, "git", "ls-files")
+	cmd.Dir = checkoutPath
+	cmd.Stdout = io.Discard
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 	return nil
 }
@@ -148,9 +173,16 @@ func bareRefTips(ctx context.Context, barePath string) ([]string, error) {
 	return refs, nil
 }
 
-// bareCloneAndWorktreesHealthy is the repair trigger: it covers both the
-// object database and the linked worktree indexes, so EnsureBareCloneHealthy
-// still repairs an unreadable index even though that no longer gates dispatch.
+// bareCloneAndWorktreesHealthy covers both the object database and the linked
+// worktree indexes, for callers that want the union rather than the dispatch
+// gate alone.
+//
+// Production index repair does not run through here: FetchOrigin calls
+// CheckBareCloneHealth and, on failure, repairBareCloneLocked, which reaches
+// rebuildWorktreeIndexes -> CheckWorktreeIndexes. repairCheckpointWorktree is
+// the other live entry point. EnsureBareCloneHealthy below has no non-test
+// callers today — that predates this change and is left alone rather than
+// deleted as unrelated scope.
 func bareCloneAndWorktreesHealthy(ctx context.Context, barePath string) error {
 	if err := CheckBareCloneHealth(ctx, barePath); err != nil {
 		return err

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -187,8 +187,14 @@ func TestEnsureBareCloneHealthy_RebuildsCorruptWorktreeIndex(t *testing.T) {
 	if err := os.WriteFile(indexPath, []byte("not a git index"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := CheckBareCloneHealth(context.Background(), bare); err == nil {
-		t.Fatal("CheckBareCloneHealth succeeded with a corrupt worktree index")
+	// An unreadable worktree index is CheckWorktreeIndexes' business, not the
+	// object-database gate's: a broken index makes one worktree unusable, it
+	// does not make the clone unusable for every other task.
+	if err := CheckWorktreeIndexes(context.Background(), bare); err == nil {
+		t.Fatal("CheckWorktreeIndexes succeeded with a corrupt worktree index")
+	}
+	if err := CheckBareCloneHealth(context.Background(), bare); err != nil {
+		t.Fatalf("one worktree's broken index failed the clone-wide health gate: %v", err)
 	}
 
 	report, err := EnsureBareCloneHealthy(context.Background(), bare, "")
@@ -284,3 +290,95 @@ func TestIsBadRefError(t *testing.T) {
 type testError string
 
 func (e testError) Error() string { return string(e) }
+
+// Reproduces the production wedge: a worktree HEAD reflog naming an object the
+// bare clone no longer has. Unscoped `git fsck` exits non-zero on this forever,
+// which parked tasks human-required with "bare clone health check failed" that
+// no retry could clear, even though every ref-reachable object was present.
+func TestCheckBareCloneHealth_IgnoresStaleWorktreeReflog(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "reflog-task", "origin/"+branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+
+	// Commit in the worktree so its HEAD reflog names the new commit, then
+	// drop the branch and the object so nothing reachable references it —
+	// exactly the state a pruned bare clone leaves behind.
+	if err := os.WriteFile(filepath.Join(wtPath, "scratch.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", wtPath, "config", "user.email", "test@test.com"},
+		{"git", "-C", wtPath, "config", "user.name", "Test"},
+		{"git", "-C", wtPath, "add", "."},
+		{"git", "-C", wtPath, "commit", "-m", "scratch"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	shaOut, err := exec.Command("git", "-C", wtPath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sha := strings.TrimSpace(string(shaOut))
+	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", "HEAD~1").CombinedOutput(); err != nil {
+		t.Fatalf("reset: %v: %s", err, out)
+	}
+	loose := filepath.Join(bare, "objects", sha[:2], sha[2:])
+	if _, statErr := os.Stat(loose); statErr != nil {
+		t.Skipf("scratch commit is not a loose object: %v", statErr)
+	}
+	if err := os.Remove(loose); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runBare(context.Background(), bare, "fsck", "--no-dangling"); err == nil {
+		t.Fatal("unscoped fsck passed; this test no longer reproduces the wedge it pins")
+	}
+	if err := CheckBareCloneHealth(context.Background(), bare); err != nil {
+		t.Fatalf("stale worktree reflog failed the health gate: %v", err)
+	}
+}
+
+// Real object-database damage must still fail the gate, or the fix above would
+// have traded a false positive for a false negative.
+func TestCheckBareCloneHealth_StillDetectsMissingReachableObject(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	if err := CheckBareCloneHealth(context.Background(), bare); err != nil {
+		t.Fatalf("freshly cloned bare repo is unhealthy: %v", err)
+	}
+
+	headSHA, err := outputBare(context.Background(), bare, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	sha := strings.TrimSpace(headSHA)
+	loose := filepath.Join(bare, "objects", sha[:2], sha[2:])
+	if _, statErr := os.Stat(loose); statErr != nil {
+		t.Skipf("HEAD commit is packed, not loose: %v", statErr)
+	}
+	if err := os.Remove(loose); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CheckBareCloneHealth(context.Background(), bare); err == nil {
+		t.Fatal("health gate passed with the HEAD commit object deleted")
+	}
+}


### PR DESCRIPTION
## Motivation

The board stopped draining: 21 tasks sat `human-required` and kept cycling without clearing. The systemic slice traces to one self-sustaining wedge.

`CheckBareCloneHealth` ran an unscoped `git fsck --no-dangling` and treated any non-zero exit as corruption. An unscoped fsck also walks every linked worktree's index and HEAD reflog, and those go stale as a matter of normal operation — a worktree reflog keeps naming objects a later prune removed.

Measured on the deploy host with 40 live worktrees:

| fsck error | count | reachable from refs? |
|---|---|---|
| `invalid reflog entry` on `worktrees/*/HEAD` | 115 | no |
| `missing blob` (worktree index cache-trees) | 25 | no |
| `invalid sha1 pointer in cache-tree` | 1 | no |

Meanwhile the object database was provably intact: `rev-list --objects --all` returned **33,629 objects, exit 0**, and `cat-file --batch-check` over every one reported **0 missing**.

So the gate failed permanently on a healthy clone. Because the failure is permanent it could never clear:

```
fsck exit 10 → health check fails → repair, re-check, still fails
→ agent start fails → circuit breaker trips after 3 → task parked human-required
```

That is verbatim what task `d70ba5c1` is parked on.

> Changelog: fix(project): scope the bare-clone health gate to ref-reachable objects

## Implementation information

Scopes fsck to the ref tips (`git rev-parse --all`), batched at 256 so a repo with thousands of refs cannot overflow argv. Verified on the host: the current check exits **10**, the scoped check exits **0** with full content validation — this is not `--connectivity-only`, so corrupt-but-present objects are still caught.

Detecting an *unreadable* worktree index was tangled into the same exit code, via `isWorktreeIndexHealthError` string-matching fsck's output. That splits out into `CheckWorktreeIndexes`, which reads each index with `git ls-files` (parses the index without stat-ing the working tree — this runs across dozens of worktrees per dispatch).

Index repair stays wired, though not via `EnsureBareCloneHealthy` — that function has no non-test callers, which predates this PR. The live paths are `FetchOrigin` → `repairBareCloneLocked` → `rebuildWorktreeIndexes` → `CheckWorktreeIndexes`, and `repairCheckpointWorktree`.

Two deliberate behaviour changes, stated plainly:
1. **One worktree's broken index no longer blocks dispatch for every other task.**
2. Because the gate no longer fails permanently, `FetchOrigin` stops invoking repair on every fetch — so worktree indexes are no longer rebuilt as an incidental side effect of a check that was always failing. Repair now runs when something is actually wrong: real object-database damage, or a checkpoint failure via `repairCheckpointWorktree`, which is the path the `invalid object` checkpoint failures on the board actually take.

`TestEnsureBareCloneHealthy_RebuildsCorruptWorktreeIndex` had an assertion that `CheckBareCloneHealth` fails on a corrupt index. That moved to `CheckWorktreeIndexes`, and the test now also asserts the clone-wide gate *passes* — the split is the point. Every other guarantee in that test is unchanged.

**This is not what #2820 fixes.** That PR adds loose-object repair machinery but leaves the gate keyed to raw fsck exit, so it repairs, re-checks, and still fails. It is also currently `CONFLICTING`, and its own task is one of the 21 parked.

## Supporting documentation

Two new tests:

- `TestCheckBareCloneHealth_IgnoresStaleWorktreeReflog` — builds the real state (commit in a worktree, drop the branch, remove the now-unreachable object) and first asserts **unscoped fsck still fails**, so the test cannot silently stop reproducing the wedge. Mutation-tested: reverting to the unscoped check fails it with the exact production error, `invalid reflog entry`.
- `TestCheckBareCloneHealth_StillDetectsMissingReachableObject` — deletes the HEAD commit object and requires the gate to fail, so the fix cannot trade a false positive for a false negative.

`mise run verify` clean apart from the pre-existing darwin load flake filed as #2896; `./internal/project/` passes in isolation (`ok 22.9s`).

Not all 21 parked tasks are this cause — the rest are genuine (verify-suite failures, watchdog reward-hacking stops, a broken remote branch). This clears the systemic slice.

