### PR TITLE
fix(cluster): preserve leader edits during mirror apply

### DIFF
--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -3,6 +3,7 @@ package clusterlead
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -55,6 +56,11 @@ const reconcileFailureEscalateThreshold = 5
 // its own copy — while a genuinely deleted task, which will 404 forever,
 // still gets cleaned up in bounded time instead of staying a ghost.
 const missingConfirmThreshold = 3
+
+// errFollowerUpdateStale stops an apply after its preliminary work when a
+// newer follower update already reached the canonical task before the final
+// lock-protected merge.
+var errFollowerUpdateStale = errors.New("cluster follower update is stale")
 
 // Mirror keeps the leader's canonical store in sync with follower execution
 // state via a reconcile ticker, applying every update through one authority
@@ -299,20 +305,44 @@ func (m *Mirror) applyFollowerTaskWithContext(ctx context.Context, node string, 
 	if !ok {
 		return false
 	}
-	merged, ok := Merge(canonical, follower)
+	_, ok = Merge(canonical, follower)
 	if !ok {
 		return false
 	}
-	if err := m.writeSidecars(merged); err != nil {
-		m.logger.Warn("cluster.mirror.sidecar.failed", "node", node, "task", follower.ID, "err", err)
-		return false
-	}
-	if _, _, err := m.tasks.Put(merged); err != nil {
+	saved, _, err := m.tasks.PutFn(follower.ID, func(cur task.Task) (task.Task, error) {
+		latest, err := mergeFollowerForNode(cur, node, follower)
+		if err != nil {
+			return task.Task{}, err
+		}
+		if err := m.writeSidecars(latest); err != nil {
+			return task.Task{}, fmt.Errorf("write follower sidecars: %w", err)
+		}
+		return latest, nil
+	})
+	if err != nil {
+		if errors.Is(err, errFollowerUpdateStale) {
+			return false
+		}
 		m.logger.Warn("cluster.mirror.apply.failed", "node", node, "task", follower.ID, "err", err)
 		return false
 	}
-	m.logger.Debug("cluster.mirror.applied", "node", node, "task", follower.ID, "status", string(merged.Status), "rev", merged.MirrorRev)
+	m.logger.Debug("cluster.mirror.applied", "node", node, "task", follower.ID, "status", string(saved.Status), "rev", saved.MirrorRev)
 	return true
+}
+
+// mergeFollowerForNode makes the final, lock-protected acceptance decision.
+// A reassign can stamp a new owner while the old follower's RPCs are in
+// flight, so the reporting node must still own the freshly-read task here,
+// not only at the beginning of applyFollowerTaskWithContext.
+func mergeFollowerForNode(cur task.Task, node string, follower task.Task) (task.Task, error) {
+	if cur.AssignedNode != node {
+		return task.Task{}, errFollowerUpdateStale
+	}
+	latest, ok := Merge(cur, follower)
+	if !ok {
+		return task.Task{}, errFollowerUpdateStale
+	}
+	return latest, nil
 }
 
 // adoptFollowerTask creates the leader's first canonical record for a task

--- a/internal/sybra/clusterlead/mirror_snapshot_gap_test.go
+++ b/internal/sybra/clusterlead/mirror_snapshot_gap_test.go
@@ -1,6 +1,8 @@
 package clusterlead
 
 import (
+	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -30,7 +32,7 @@ func TestMergeSnapshotGapSurvivesInterveningLeaderEdit(t *testing.T) {
 		ID: "task-pet", Title: "follower title", Status: task.StatusInProgress,
 		ProjectID: "attacker/x", AssignedNode: "elsewhere", UpdatedAt: t0.Add(90 * time.Minute),
 	}
-	merged, ok := Merge(canonical, follower)
+	_, ok := Merge(canonical, follower)
 	if !ok {
 		t.Fatal("Merge should accept")
 	}
@@ -38,15 +40,45 @@ func TestMergeSnapshotGapSurvivesInterveningLeaderEdit(t *testing.T) {
 	// Simulates the writeSidecars gap: an unrelated leader edit lands here,
 	// after Merge's snapshot but before the mirror's own Put reaches disk.
 	newTitle := "leader renamed it while mirror apply was in flight"
-	if _, err := mgr.Update("task-pet", task.Update{Title: &newTitle}); err != nil {
+	newTags := []string{"gate-cleared"}
+	newDependsOn := []string{"task-prerequisite"}
+	newPriority := task.PriorityUrgent
+	if _, err := mgr.Update("task-pet", task.Update{
+		Title:     &newTitle,
+		Tags:      &newTags,
+		DependsOn: &newDependsOn,
+		Priority:  &newPriority,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	saved, _, err := mgr.Put(merged)
+	saved, _, err := mgr.PutFn("task-pet", func(cur task.Task) (task.Task, error) {
+		next, accepted := Merge(cur, follower)
+		if !accepted {
+			t.Fatal("fresh merge unexpectedly rejected follower update")
+		}
+		return next, nil
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if saved.Status != task.StatusInProgress {
 		t.Fatalf("status = %q, want in-progress", saved.Status)
+	}
+	if saved.Title != newTitle {
+		t.Fatalf("title = %q, want concurrent leader edit %q preserved", saved.Title, newTitle)
+	}
+	if !slices.Equal(saved.Tags, newTags) || !slices.Equal(saved.DependsOn, newDependsOn) || saved.Priority != newPriority {
+		t.Fatalf("leader-owned fields regressed after fresh merge: tags=%v depends_on=%v priority=%q", saved.Tags, saved.DependsOn, saved.Priority)
+	}
+}
+
+func TestMergeFollowerForNodeRejectsUpdateAfterReassign(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	cur := task.Task{ID: "task-pet", AssignedNode: "new-box", Status: task.StatusTodo, UpdatedAt: t0}
+	follower := task.Task{ID: "task-pet", Status: task.StatusInProgress, UpdatedAt: t0.Add(time.Hour)}
+
+	if _, err := mergeFollowerForNode(cur, "old-box", follower); !errors.Is(err, errFollowerUpdateStale) {
+		t.Fatalf("merge after reassignment error = %v, want errFollowerUpdateStale", err)
 	}
 }

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -278,6 +278,37 @@ func (m *Manager) Put(t Task) (Task, bool, error) {
 	return saved, !existed, nil
 }
 
+// PutFn atomically reads an existing task and writes the fully-formed
+// replacement computed by fn. The callback runs under both Manager's per-task
+// mutex and Store's cross-process task lock, making it safe to merge a stale
+// long-running operation with the latest leader-side edit immediately before
+// the write. It preserves Put's lifecycle events and status-hook behaviour.
+func (m *Manager) PutFn(id string, fn func(cur Task) (Task, error)) (Task, bool, error) {
+	mu := m.lockFor(id)
+	mu.Lock()
+
+	saved, prev, err := m.store.PutFn(id, fn)
+	if err != nil {
+		mu.Unlock()
+		return saved, false, err
+	}
+
+	prevStatus := string(prev.Status)
+	newStatus := string(saved.Status)
+	fireHook := m.onStatusHook != nil && newStatus != prevStatus
+	if fireHook {
+		m.recordFiredStatus(saved.ID, newStatus)
+	}
+	mu.Unlock()
+
+	metrics.TaskUpdated()
+	m.emitter.Emit(events.TaskUpdated, saved.FilePath)
+	if fireHook {
+		m.onStatusHook(saved.ID, prevStatus, newStatus)
+	}
+	return saved, false, nil
+}
+
 // Update applies field updates to a task and emits task:updated.
 // Serializes with other Update/AddRun/UpdateRun/Delete calls for the same id.
 //

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -586,6 +586,40 @@ func (s *Store) Put(t Task) (Task, error) {
 		return Task{}, err
 	}
 	defer unlock()
+	return s.putLocked(t)
+}
+
+// PutFn reads an existing task and writes the fully-formed replacement
+// returned by fn while holding the task's cross-process write lock. It is for
+// callers that need to merge a long-running operation's result with the most
+// recent canonical task without a read-modify-write gap.
+func (s *Store) PutFn(id string, fn func(cur Task) (Task, error)) (saved, previous Task, err error) {
+	if err := ValidateID(id); err != nil {
+		return Task{}, Task{}, err
+	}
+	unlock, err := s.lockTask(id)
+	if err != nil {
+		return Task{}, Task{}, err
+	}
+	defer unlock()
+
+	cur, err := s.read(id)
+	if err != nil {
+		return Task{}, cur, err
+	}
+	next, err := fn(cur)
+	if err != nil {
+		return Task{}, cur, err
+	}
+	if next.ID != id {
+		return Task{}, cur, fmt.Errorf("task: put-fn: callback changed task ID from %q to %q", id, next.ID)
+	}
+	saved, err = s.putLocked(next)
+	return saved, cur, err
+}
+
+// putLocked is Put after the caller has acquired lockTask(t.ID).
+func (s *Store) putLocked(t Task) (Task, error) {
 	now := time.Now().UTC()
 	if t.CreatedAt.IsZero() {
 		t.CreatedAt = now


### PR DESCRIPTION
Fixes #2860

Re-merges follower state under the task’s cross-process write lock immediately before persistence, preserving concurrent leader-owned field edits. The final merge also rejects reports from a node that lost ownership during reassignment.

Verified:
- `go test -race ./internal/task ./internal/sybra/clusterlead`
- `golangci-lint run ./internal/task/... ./internal/sybra/clusterlead/...`
- isolated Sybra server smoke test and repeated mirror race regression