### PR TITLE
fix(provider): keep liveness-only auth failures sticky

### DIFF
--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -378,6 +378,16 @@ func (c *Checker) setStatusLocked(name string, next Status, fromProbe bool) (Sta
 	}
 	var flip bool
 	if fromProbe {
+		// Copilot and OpenCode probes only execute `--version`; unlike the
+		// Claude/Codex auth-status probes, that proves liveness but says nothing
+		// about credentials. Do not let it resurrect a provider a real run just
+		// reported as logged out.
+		if next.Healthy && prev.Reason == "logged_out" && livenessOnlyProbe(name) {
+			// Keep the auth failure authoritative, while still recording that the
+			// liveness probe completed successfully for diagnostics/UI freshness.
+			prev.LastCheck = next.LastCheck
+			return *prev, false
+		}
 		// Active probes overwrite unconditionally, but preserve an in-flight
 		// rate-limit window when the probe still reports healthy — the window
 		// should be cleared by clearExpiredRateLimits or a newer passive signal.
@@ -409,6 +419,10 @@ func (c *Checker) setStatusLocked(name string, next Status, fromProbe bool) (Sta
 	}
 	snapshot := *prev
 	return snapshot, flip
+}
+
+func livenessOnlyProbe(provider string) bool {
+	return provider == "copilot" || provider == "opencode"
 }
 
 func statusChanged(a, b *Status) bool {

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -683,6 +683,20 @@ func TestChecker_PassiveAuthPersistsUntilProbe(t *testing.T) {
 	}
 }
 
+func TestChecker_LivenessOnlyProbeDoesNotClearPassiveAuthFailure(t *testing.T) {
+	for _, provider := range []string{"copilot", "opencode"} {
+		t.Run(provider, func(t *testing.T) {
+			c, _, _ := newTestChecker(t)
+			c.setStatus(provider, Status{Provider: provider, Healthy: true, Reason: "ok"}, true)
+			c.ReportAuthFailure(provider, "logged_out")
+			c.setStatus(provider, Status{Provider: provider, Healthy: true, Reason: "ok"}, true)
+			if c.IsHealthy(provider) || c.Reason(provider) != "logged_out" {
+				t.Fatalf("version-only probe resurrected logged-out %s: healthy=%v reason=%q", provider, c.IsHealthy(provider), c.Reason(provider))
+			}
+		})
+	}
+}
+
 func TestChecker_RateLimitExpires(t *testing.T) {
 	c, _, clock := newTestChecker(t)
 	c.setStatus("claude", Status{Provider: "claude", Healthy: true, Reason: "ok"}, true)


### PR DESCRIPTION
Fixes #2857

Prevents Copilot/OpenCode version-only health probes from clearing a real passive `logged_out` signal. Claude/Codex auth-capable probe recovery remains unchanged.

Verified:
- `go test -race ./internal/provider`
- `golangci-lint run ./internal/provider/...`
- isolated server smoke test plus repeated sticky-auth regression