### PR TITLE
fix(workflow): retry watchdog stops for all agent roles

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1935,7 +1935,6 @@ func (e *Engine) canRetryWatchdogStop(t *TaskInfo, step *Step) bool {
 		step != nil &&
 		step.Type == StepRunAgent &&
 		t.Status == "human-required" &&
-		step.Config.Role == "implementation" &&
 		watchdogreason.IsRetryableStop(t.StatusReason)
 }
 
@@ -1955,7 +1954,7 @@ func (e *Engine) handleWatchdogStopRetry(t *TaskInfo, step *Step) bool {
 				cleanRef = "HEAD"
 			}
 			t.Workflow.SetVar(watchdogHangCleanRetryKey(step.ID), cleanRef)
-			t.Workflow.SetVar(watchdogReaskNoteVar, buildWatchdogStopReaskNote(t.StatusReason, attempt))
+			t.Workflow.SetVar(watchdogReaskNoteVarForStep(step), buildWatchdogStopReaskNote(t.StatusReason, attempt))
 		},
 		onArmed: func(e *Engine, t *TaskInfo, step *Step, attempt int) error {
 			if err := e.tasks.UpdateTaskStatus(t.ID, "in-progress", ""); err != nil {
@@ -2034,7 +2033,7 @@ func (e *Engine) handleWorktreeRepairRetry(t *TaskInfo, step *Step) bool {
 
 func buildWatchdogStopReaskNote(reason string, attempt int) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "⚠️ Your previous implementation run was STOPPED by the watchdog for loop-like behavior — attempt %d of %d.\n\n",
+	fmt.Fprintf(&b, "⚠️ Your previous agent run was STOPPED by the watchdog for loop-like behavior — attempt %d of %d.\n\n",
 		attempt, maxWatchdogStopRetries)
 	if reason = strings.TrimSpace(reason); reason != "" {
 		b.WriteString("Previous watchdog reason: ")

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -152,6 +152,24 @@ func TestHandleWatchdogHangRetry_RunTestPrioritizesManualTestSurface(t *testing.
 	}
 }
 
+func TestHandleWatchdogStopRetry_TestRunnerUsesTestingGuidance(t *testing.T) {
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(newTestStore(t), tasks, agents, discardLogger())
+	wf := &Execution{WorkflowID: "testing-task", CurrentStep: "run_test", State: ExecWaiting, Variables: map[string]string{}, StartedAt: time.Now().UTC()}
+	tasks.Put(TaskInfo{ID: "t1", Status: "human-required", StatusReason: "watchdog: loop stop: repeated test", AgentMode: "headless", Workflow: wf})
+	ti := TaskInfo{ID: "t1", Status: "human-required", StatusReason: "watchdog: loop stop: repeated test", AgentMode: "headless", Workflow: wf}
+	if engine.handleWatchdogStopRetry(&ti, &Step{ID: "run_test", Type: StepRunAgent, Config: StepConfig{Role: testRunnerRole}}) {
+		t.Fatal("armed retry should continue to normal dispatch")
+	}
+	if agents.CallCount() != 0 || wf.Variables[watchdogStopRetryKey("run_test")] != "1" {
+		t.Fatalf("retry did not arm correctly: calls=%d vars=%v", agents.CallCount(), wf.Variables)
+	}
+	if wf.Variables[testingReaskNoteVar] == "" || wf.Variables[watchdogReaskNoteVar] != "" {
+		t.Fatalf("guidance routing = %v, want testing-only note", wf.Variables)
+	}
+}
+
 func TestHandleWatchdogHangRetry_NonReadyPRStillRetries(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()


### PR DESCRIPTION
Fixes #2859

Allows retryable watchdog loop-stop recovery for every run_agent role and routes the retry guidance to each role’s prompt channel.

Verified:
- `go test -race ./internal/workflow`
- `golangci-lint run ./internal/workflow/...`
- isolated server smoke test and adversarial workflow regression