### PR TITLE
fix(config): publish immutable hot-reload snapshots

### DIFF
--- a/internal/poll/renovate.go
+++ b/internal/poll/renovate.go
@@ -26,6 +26,7 @@ type RenovateHandler struct {
 	logger              *slog.Logger
 	emit                func(string, any)
 	cfg                 *config.RenovateConfig
+	config              func() *config.RenovateConfig
 	allowsType          func(project.ProjectType) bool
 	fetchPRsFn          func(context.Context, string, []string) ([]github.RenovatePR, error)
 	lastPRsCount        atomic.Int64
@@ -70,8 +71,18 @@ func NewRenovateHandler(
 		logger:      logger,
 		emit:        emit,
 		cfg:         cfg,
+		config:      func() *config.RenovateConfig { return cfg },
 		allowsType:  allowsType,
 		authCircuit: NewAuthCircuit("renovate", logger),
+	}
+}
+
+// SetConfigSource makes each poll read one immutable Renovate configuration
+// snapshot. It is installed during app wiring and remains safe across hot
+// reloads because the source itself is never replaced.
+func (h *RenovateHandler) SetConfigSource(source func() *config.RenovateConfig) {
+	if source != nil {
+		h.config = source
 	}
 }
 
@@ -125,7 +136,11 @@ func (h *RenovateHandler) pollRenovatePRs(ctx context.Context) time.Duration {
 	if h.fetchPRsFn != nil {
 		fetchFn = h.fetchPRsFn
 	}
-	prs, err := fetchFn(ctx, h.cfg.Author, repos)
+	cfg := h.cfg
+	if h.config != nil {
+		cfg = h.config()
+	}
+	prs, err := fetchFn(ctx, cfg.Author, repos)
 	metrics.RenovatePoll(ctx, err == nil)
 	if err != nil {
 		switch {

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -132,15 +132,19 @@ type App struct {
 	promptLab         *promptLabCoordinator
 	triage            *triageCoordinator
 	humanReview       *humanReviewHandler
-	cfg               *config.Config
-	baseABTesting     atomic.Value
-	liveABTesting     atomic.Value
-	logLevel          *slog.LevelVar
-	emit              func(string, any)
-	emitFactory       func(context.Context) func(string, any)
-	openBrowser       func(string)
-	requestRestart    func()
-	restartStaleErr   *logging.ErrorThrottle
+	// activeCfg is the immutable configuration snapshot used by concurrent
+	// runtime readers. cfg remains the construction-time snapshot for legacy
+	// startup wiring and tests; hot reloads must never mutate it in place.
+	activeCfg       atomic.Pointer[config.Config]
+	cfg             *config.Config
+	baseABTesting   atomic.Value
+	liveABTesting   atomic.Value
+	logLevel        *slog.LevelVar
+	emit            func(string, any)
+	emitFactory     func(context.Context) func(string, any)
+	openBrowser     func(string)
+	requestRestart  func()
+	restartStaleErr *logging.ErrorThrottle
 	// dispatchNudge wakes the orchestrator dispatch pass on demand (e.g. on a
 	// status change) so a freshly-ready task isn't left idle until the next
 	// fast tick. Buffered, size 1, coalescing — see nudgeDispatch.
@@ -264,6 +268,7 @@ func NewApp(logger *slog.Logger, logLevel *slog.LevelVar, cfg *config.Config, op
 		dispatchNudge:            make(chan struct{}, 1),
 		umbrellaRecoveryInFlight: make(map[string]bool),
 	}
+	a.activeCfg.Store(cfg)
 	// Pre-allocate service structs so Wails can bind them before startup().
 	// Fields are populated in startup() once dependencies are initialized.
 	a.taskSvc = &TaskService{}
@@ -288,6 +293,19 @@ func NewApp(logger *slog.Logger, logLevel *slog.LevelVar, cfg *config.Config, op
 	}
 	a.initializeABTesting(cfg.ABTesting)
 	return a
+}
+
+// currentConfig returns one immutable configuration snapshot for the caller's
+// whole operation. A reload publishes a replacement snapshot atomically, so a
+// reader can never observe a torn struct or a mixture of two configurations.
+func (a *App) currentConfig() *config.Config {
+	if a == nil {
+		return nil
+	}
+	if cfg := a.activeCfg.Load(); cfg != nil {
+		return cfg
+	}
+	return a.cfg
 }
 
 // acquireHomeLock takes an exclusive, non-blocking flock on

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -833,7 +833,8 @@ func (a *App) releaseTaskAgents(taskID string) {
 }
 
 func (a *App) runsTaskLocally(t task.Task) bool {
-	return a.cfg == nil || a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride).Local
+	cfg := a.currentConfig()
+	return cfg == nil || cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride).Local
 }
 
 func (a *App) isWorkProject(projectID string) bool {
@@ -857,7 +858,8 @@ func (a *App) auditClusterBlock(taskID, node, reason string) {
 func (a *App) initCluster() {
 	if a.workflowEngine != nil {
 		a.workflowEngine.SetDispatchGate(func(ti workflow.TaskInfo) bool {
-			return a.cfg == nil || a.cfg.HomeNodeForTask(ti.ProjectID, ti.NodeOverride).Local
+			cfg := a.currentConfig()
+			return cfg == nil || cfg.HomeNodeForTask(ti.ProjectID, ti.NodeOverride).Local
 		})
 	}
 	if a.cfg == nil || !a.cfg.IsLeader() {

--- a/internal/sybra/app_renovate.go
+++ b/internal/sybra/app_renovate.go
@@ -20,9 +20,17 @@ type renovateCoordinator struct {
 	logger                *slog.Logger
 	emit                  func(string, any)
 	cfg                   *config.Config
+	currentConfig         func() *config.Config
 	allowsProjectType     func(project.ProjectType) bool
 	handler               *poll.RenovateHandler
 	monitorTransientFails int
+}
+
+func (c *renovateCoordinator) config() *config.Config {
+	if c.currentConfig != nil {
+		return c.currentConfig()
+	}
+	return c.cfg
 }
 
 func newRenovateCoordinator(
@@ -42,13 +50,15 @@ func newRenovateCoordinator(
 }
 
 func (c *renovateCoordinator) init() {
-	if !c.cfg.Renovate.Enabled {
+	cfg := c.config()
+	if !cfg.Renovate.Enabled {
 		return
 	}
 	c.monitorTransientFails = 0
-	c.handler = poll.NewRenovateHandler(c.projects, c.logger, c.emit, &c.cfg.Renovate, c.allowsProjectType)
-	c.handler.SetIntervals(c.cfg.GitHub.RenovateFast(), c.cfg.GitHub.RenovateSlow())
-	c.logger.Info("renovate.enabled", "author", c.cfg.Renovate.Author)
+	c.handler = poll.NewRenovateHandler(c.projects, c.logger, c.emit, &cfg.Renovate, c.allowsProjectType)
+	c.handler.SetConfigSource(func() *config.RenovateConfig { return &c.config().Renovate })
+	c.handler.SetIntervals(cfg.GitHub.RenovateFast(), cfg.GitHub.RenovateSlow())
+	c.logger.Info("renovate.enabled", "author", cfg.Renovate.Author)
 }
 
 func (c *renovateCoordinator) poller() *poll.RenovateHandler {
@@ -84,7 +94,7 @@ func (c *renovateCoordinator) prsForMonitor() []github.PullRequest {
 	if c.handler != nil && c.handler.AuthCircuitOpen() {
 		return nil
 	}
-	rps, err := github.FetchRenovatePRs(context.Background(), c.cfg.Renovate.Author, repos)
+	rps, err := github.FetchRenovatePRs(context.Background(), c.config().Renovate.Author, repos)
 	if err != nil {
 		c.recordMonitorFetchError(err)
 		return nil
@@ -128,7 +138,8 @@ func (c *renovateCoordinator) resetMonitorFetchErrors() {
 }
 
 func (a *App) initRenovate(emit func(string, any)) {
-	a.renovate = newRenovateCoordinator(a.projects, a.logger, emit, a.cfg, a.allowsProjectType)
+	a.renovate = newRenovateCoordinator(a.projects, a.logger, emit, a.currentConfig(), a.allowsProjectType)
+	a.renovate.currentConfig = a.currentConfig
 	a.renovate.init()
 }
 

--- a/internal/sybra/services_wire_config.go
+++ b/internal/sybra/services_wire_config.go
@@ -1,10 +1,15 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/abtest"
+import (
+	"github.com/Automaat/sybra/internal/abtest"
+	"github.com/Automaat/sybra/internal/config"
+)
 
 func (a *App) wireConfigService() {
-	a.configSvc.cfg = a.cfg
-	a.configSvc.persisted = cloneConfig(a.cfg)
+	cfg := a.currentConfig()
+	a.configSvc.cfg = cfg
+	a.configSvc.persisted = cloneConfig(cfg)
+	a.configSvc.publishConfig = func(next *config.Config) { a.activeCfg.Store(next) }
 	a.configSvc.logLevel = a.logLevel
 	a.configSvc.notifier = a.notifier
 	a.configSvc.agents = a.agents

--- a/internal/sybra/services_wire_integrations.go
+++ b/internal/sybra/services_wire_integrations.go
@@ -6,11 +6,13 @@ func (a *App) wireIntegrationService() {
 	a.intgSvc.agents = a.agents
 	a.intgSvc.worktrees = a.worktrees
 	a.intgSvc.audit = a.audit
-	a.intgSvc.cfg = a.cfg
+	a.intgSvc.cfg = a.currentConfig()
+	a.intgSvc.currentConfig = a.currentConfig
 	a.intgSvc.logger = a.logger
 	a.intgSvc.renovate = a.renovate
 	a.intgSvc.workflowEngine = a.workflowEngine
 	a.intgSvc.providerHealth = a.providerHealth
-	// Read a.cfg inside the closure so config reloads save the current config.
-	a.intgSvc.saveConfig = func() error { return a.cfg.Save() }
+	// Read the current snapshot inside the closure so config reloads save the
+	// current config without mutating a shared config object.
+	a.intgSvc.saveConfig = func() error { return a.currentConfig().Save() }
 }

--- a/internal/sybra/services_wire_tasks.go
+++ b/internal/sybra/services_wire_tasks.go
@@ -20,7 +20,8 @@ func (a *App) wireTaskService() {
 	a.taskSvc.wg = &a.wg
 	a.taskSvc.logger = a.logger
 	a.taskSvc.audit = a.audit
-	a.taskSvc.cfg = a.cfg
+	a.taskSvc.cfg = a.currentConfig()
+	a.taskSvc.currentConfig = a.currentConfig
 	a.taskSvc.projects = a.projects
 	a.taskSvc.intervention = a.intervention
 	a.taskSvc.abTesting = a.abTestingConfig
@@ -35,14 +36,16 @@ func (a *App) wireTaskService() {
 	// Expand a manually-added umbrella issue into a gated child DAG instead of
 	// a flat task. Wired unconditionally; enrichFromIssue gates the call on
 	// cfg.Umbrella.Enabled so a config reload toggles it without re-wiring.
-	// Read a.cfg inside the closure so config reloads update the planner model.
+	// Read one current snapshot inside the closure so config reloads update the
+	// planner model without mixing settings from different snapshots.
 	// Mirrors initIssuesFetcher's poll-loop expander (same Expand entry point).
 	a.taskSvc.umbrellaExpand = func(issueURL string) (umbrella.Result, error) {
+		cfg := a.currentConfig()
 		var opts []umbrella.ExpandOption
-		if a.cfg.Umbrella.Ground {
-			opts = append(opts, umbrella.WithExpandGrounder(buildGroundLister(a.projects), a.cfg.Umbrella.GroundMinSubIssues))
+		if cfg.Umbrella.Ground {
+			opts = append(opts, umbrella.WithExpandGrounder(buildGroundLister(a.projects), cfg.Umbrella.GroundMinSubIssues))
 		}
-		return umbrella.Expand(a.ctx, a.tasks, umbrella.FallbackPlannerRunner(a.cfg.Umbrella.Model, a.providerHealth), issueURL, opts...)
+		return umbrella.Expand(a.ctx, a.tasks, umbrella.FallbackPlannerRunner(cfg.Umbrella.Model, a.providerHealth), issueURL, opts...)
 	}
 	if a.humanReview != nil {
 		a.humanReview.dispatchFromHumanRequired = func(id, target, reason, completingAgentID string) (task.Task, error) {

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -33,6 +33,10 @@ type ConfigService struct {
 	logger         *slog.Logger
 	policy         func() limits.Policy
 	applyRuntime   func(config.Config) error
+	// publishConfig atomically exposes a successfully applied immutable
+	// snapshot to App runtime readers. It is set by App wiring; standalone
+	// ConfigService tests intentionally leave it nil.
+	publishConfig func(*config.Config)
 	// reapplyRouting re-merges the persisted routing overlay on top of the
 	// freshly hot-reloaded base A/B config and fans it back out to every
 	// selection site. Called after an ab_testing hot change so a base edit
@@ -354,7 +358,12 @@ func (s *ConfigService) mutateLocked(candidate *config.Config, persist func() er
 		}
 		return result, &configMutationError{result: result, cause: err}
 	}
-	*s.cfg = *nextActive
+	// Do not overwrite the shared object: lock-free App readers retain old
+	// snapshots while a reload publishes this complete replacement.
+	s.cfg = nextActive
+	if s.publishConfig != nil {
+		s.publishConfig(nextActive)
+	}
 	s.persisted = cloneConfig(candidate)
 	if slices.Contains(result.Applied, "ab_testing") && s.applyABTestingBase != nil {
 		s.applyABTestingBase(nextActive.ABTesting)

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/abtest"
@@ -776,6 +777,48 @@ func TestReloadFromDisk_ReadersSeeWholePersistedSnapshots(t *testing.T) {
 	case err := <-errCh:
 		t.Fatal(err)
 	default:
+	}
+}
+
+func TestMutateLocked_PublishesImmutableAppSnapshot(t *testing.T) {
+	initial := config.DefaultConfig()
+	app := NewApp(slog.New(slog.DiscardHandler), new(slog.LevelVar), initial)
+	svc := &ConfigService{
+		cfg:       initial,
+		persisted: cloneConfig(initial),
+		publishConfig: func(next *config.Config) {
+			app.activeCfg.Store(next)
+		},
+	}
+
+	var readers sync.WaitGroup
+	done := make(chan struct{})
+	readers.Go(func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = app.currentConfig().Cluster.Followers
+			}
+		}
+	})
+
+	next := cloneConfig(initial)
+	next.Logging.Level = "debug"
+	svc.mu.Lock()
+	_, err := svc.mutateLocked(next, nil)
+	svc.mu.Unlock()
+	close(done)
+	readers.Wait()
+	if err != nil {
+		t.Fatalf("mutateLocked: %v", err)
+	}
+	if got := app.currentConfig(); got != svc.cfg {
+		t.Fatal("App did not receive the published config snapshot")
+	}
+	if app.cfg == svc.cfg {
+		t.Fatal("hot reload mutated the construction-time config snapshot")
 	}
 }
 

--- a/internal/sybra/svc_integrations.go
+++ b/internal/sybra/svc_integrations.go
@@ -28,11 +28,19 @@ type IntegrationService struct {
 	worktrees      *worktree.Manager
 	audit          *audit.Logger
 	cfg            *config.Config
+	currentConfig  func() *config.Config
 	logger         *slog.Logger
 	renovate       *renovateCoordinator
 	workflowEngine *workflow.Engine
 	providerHealth *provider.Checker
 	saveConfig     func() error
+}
+
+func (s *IntegrationService) config() *config.Config {
+	if s.currentConfig != nil {
+		return s.currentConfig()
+	}
+	return s.cfg
 }
 
 // FetchRenovatePRs returns Renovate PRs for manual refresh.
@@ -41,7 +49,7 @@ func (s *IntegrationService) FetchRenovatePRs() ([]github.RenovatePR, error) {
 	if len(repos) == 0 {
 		return nil, nil
 	}
-	return github.FetchRenovatePRs(context.Background(), s.cfg.Renovate.Author, repos)
+	return github.FetchRenovatePRs(context.Background(), s.config().Renovate.Author, repos)
 }
 
 // MergeRenovatePR merges a Renovate PR.

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -47,6 +47,7 @@ type TaskService struct {
 	logger         *slog.Logger
 	audit          *audit.Logger
 	cfg            *config.Config
+	currentConfig  func() *config.Config
 	// projects and intervention back recordInterventionOnUnblock only; nil in
 	// tests that don't exercise the human-required unblock path (the method
 	// guards on both being non-nil before doing anything).
@@ -84,6 +85,13 @@ type TaskService struct {
 	// Initial async enrichment is not gated; this only prevents a permanently
 	// broken stub from spending GitHub calls on every reconcile tick.
 	enrichRetryCooldown sync.Map
+}
+
+func (s *TaskService) config() *config.Config {
+	if s.currentConfig != nil {
+		return s.currentConfig()
+	}
+	return s.cfg
 }
 
 const enrichPendingRetryCooldown = time.Hour
@@ -299,11 +307,12 @@ func (s *TaskService) ListTaskArtifacts(taskID string) ([]TaskArtifactDTO, error
 
 func (s *TaskService) GetTaskSetupLog(taskID string) (TaskSetupLogDTO, error) {
 	dto := TaskSetupLogDTO{TaskID: taskID}
-	if s.cfg == nil || s.cfg.Logging.Dir == "" {
+	cfg := s.config()
+	if cfg == nil || cfg.Logging.Dir == "" {
 		return dto, nil
 	}
-	path := filepath.Join(s.cfg.Logging.Dir, "worktrees", taskID+"-setup.log")
-	root := filepath.Join(s.cfg.Logging.Dir, "worktrees")
+	path := filepath.Join(cfg.Logging.Dir, "worktrees", taskID+"-setup.log")
+	root := filepath.Join(cfg.Logging.Dir, "worktrees")
 	cleanRoot := filepath.Clean(root) + string(filepath.Separator)
 	cleanPath := filepath.Clean(path)
 	if !strings.HasPrefix(cleanPath, cleanRoot) {
@@ -327,7 +336,8 @@ func (s *TaskService) GetTaskSetupLog(taskID string) (TaskSetupLogDTO, error) {
 }
 
 func (s *TaskService) ListTaskAuditEvents(taskID string, days int) ([]TaskAuditEventDTO, error) {
-	if s.cfg == nil || s.cfg.Logging.Dir == "" {
+	cfg := s.config()
+	if cfg == nil || cfg.Logging.Dir == "" {
 		return []TaskAuditEventDTO{}, nil
 	}
 	if days <= 0 || days > 90 {
@@ -335,7 +345,7 @@ func (s *TaskService) ListTaskAuditEvents(taskID string, days int) ([]TaskAuditE
 	}
 	until := time.Now().UTC().Add(time.Minute)
 	since := until.AddDate(0, 0, -days)
-	events, err := audit.Read(s.cfg.AuditDir(), audit.Query{
+	events, err := audit.Read(cfg.AuditDir(), audit.Query{
 		Since:  since,
 		Until:  until,
 		TaskID: taskID,
@@ -840,7 +850,7 @@ func (s *TaskService) startCreatedWorkflow(t task.Task) {
 	if s.workflowEngine == nil || t.Status != task.StatusTodo {
 		return
 	}
-	if s.cfg != nil && !s.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride).Local {
+	if cfg := s.config(); cfg != nil && !cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride).Local {
 		return
 	}
 	// pr-fix / ordinary existing-PR tasks are driven outside task.created.
@@ -1223,7 +1233,7 @@ func (s *TaskService) recordInterventionOnUnblock(cur task.Task, target, reason,
 	if exceptAgentID != "" {
 		class = intervention.OperatorActionAutoRecovery
 	}
-	intervention.Capture(s.intervention, s.cfg, s.projects, s.audit, s.logger, cur, target, reason, class)
+	intervention.Capture(s.intervention, s.config(), s.projects, s.audit, s.logger, cur, target, reason, class)
 }
 
 // logDispatchAudit records a human-required dispatch attempt and its outcome
@@ -1522,7 +1532,8 @@ func (s *TaskService) enrichPendingRetryCoolingDown(taskID string) bool {
 // auto-expanded on the manual-create path. Read live (not wired-once) so a
 // config reload toggling umbrella.enabled takes effect without re-wiring.
 func (s *TaskService) umbrellaExpansionEnabled() bool {
-	return s.cfg != nil && s.cfg.Umbrella.Enabled && s.umbrellaExpand != nil
+	cfg := s.config()
+	return cfg != nil && cfg.Umbrella.Enabled && s.umbrellaExpand != nil
 }
 
 // expandUmbrellaStub expands a manually-created stub whose URL resolved to a


### PR DESCRIPTION
Fixes #2861.\n\nPublishes complete immutable config snapshots atomically after successful hot apply, moves concurrent task routing reads to a single snapshot, and keeps hot Renovate/integration consumers current without in-place mutation.\n\nValidated with focused race tests, cluster tests, and an isolated server smoke test.