### PR TITLE
fix(shutdown): gate late tracked work during drain

### DIFF
--- a/internal/loopagent/scheduler.go
+++ b/internal/loopagent/scheduler.go
@@ -35,6 +35,8 @@ type Scheduler struct {
 	homeDir string
 
 	mu          sync.Mutex
+	runMu       sync.Mutex // serializes RunNow admission with Stop
+	stopped     bool
 	fetchers    map[string]*runningFetcher
 	agentToLoop map[string]string
 	wg          sync.WaitGroup
@@ -87,6 +89,9 @@ func (s *Scheduler) SyncContext(ctx context.Context) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.stopped {
+		return
+	}
 
 	// Cancel fetchers whose record is gone, disabled, or has changed
 	// timing fields. Restart-on-change ensures interval edits take effect.
@@ -219,6 +224,14 @@ func (s *Scheduler) fire(la LoopAgent) (string, error) {
 // next tick still happens at its natural time — RunNow does not reset the
 // fetcher's clock.
 func (s *Scheduler) RunNow(id string) (string, error) {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	s.mu.Lock()
+	stopped := s.stopped
+	s.mu.Unlock()
+	if stopped {
+		return "", errors.New("loop agent scheduler stopped")
+	}
 	la, err := s.store.Get(id)
 	if err != nil {
 		return "", err
@@ -263,7 +276,14 @@ func (s *Scheduler) persistRun(id string, mutate func(*LoopAgent)) (LoopAgent, e
 
 // Stop cancels every running fetcher and waits for the goroutines to drain.
 func (s *Scheduler) Stop() {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
 	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
 	for id, rf := range s.fetchers {
 		rf.cancel()
 		delete(s.fetchers, id)

--- a/internal/loopagent/scheduler_test.go
+++ b/internal/loopagent/scheduler_test.go
@@ -233,3 +233,34 @@ func TestSchedulerStopWaitsForGoroutines(t *testing.T) {
 		t.Fatal("RunningIDs should be empty after Stop")
 	}
 }
+
+func TestSchedulerStopPreventsLaterSyncFromStartingFetchers(t *testing.T) {
+	sched, store, _ := newSched(t)
+	defer sched.Stop()
+
+	la, err := store.Create(LoopAgent{Name: "late", Prompt: "/late", IntervalSec: 60, Enabled: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	sched.Stop()
+	sched.Sync()
+	if got := sched.RunningIDs(); len(got) != 0 {
+		t.Fatalf("Sync started fetchers after Stop: %v", got)
+	}
+	_ = la
+}
+
+func TestSchedulerStopPreventsRunNow(t *testing.T) {
+	sched, store, runner := newSched(t)
+	la, err := store.Create(LoopAgent{Name: "late", Prompt: "/late", IntervalSec: 60, Enabled: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	sched.Stop()
+	if _, err := sched.RunNow(la.ID); err == nil {
+		t.Fatal("RunNow after Stop succeeded")
+	}
+	if got := runner.Calls(); len(got) != 0 {
+		t.Fatalf("RunNow after Stop started agent: %+v", got)
+	}
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -77,6 +77,7 @@ type App struct {
 	watcherCtx      context.Context
 	watcherCancel   context.CancelFunc
 	lifecycle       atomic.Uint32
+	backgroundMu    sync.Mutex // serializes tracked background work with drain
 	wg              sync.WaitGroup
 	// fetchPRHeadSHA overrides the PR-head lookup in tests; nil uses GitHub.
 	fetchPRHeadSHA    func(ctx context.Context, repo string, number int) (string, error)
@@ -214,6 +215,26 @@ type App struct {
 
 	// HTTP-only services. QueueService must stay out of V3Services().
 	queueSvc *QueueService
+}
+
+// goWhileRunning adds tracked background work only while shutdown has not
+// begun. BeginDrain holds the same lock before it transitions lifecycle state,
+// closing the WaitGroup Add-vs-Wait window during Shutdown.
+func (a *App) goWhileRunning(fn func()) bool {
+	if a == nil || fn == nil {
+		return false
+	}
+	a.backgroundMu.Lock()
+	defer a.backgroundMu.Unlock()
+	switch a.lifecycleState() {
+	case lifecycleStateIdle, lifecycleStateRunning:
+		// Tests and startup code may schedule work before the running marker is
+		// installed; both states are safe until BeginDrain takes backgroundMu.
+	case lifecycleStateDraining, lifecycleStateStopping, lifecycleStateStopped:
+		return false
+	}
+	a.wg.Go(fn)
+	return true
 }
 
 // Option configures App behaviour at construction time.

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -597,7 +597,7 @@ func (a *App) taskStatusForAgent(taskID string) (string, bool) {
 }
 
 func (a *App) startLiveLimitPolling(ctx context.Context, limitStore *limits.Store, policy limits.Policy) {
-	a.wg.Go(func() {
+	a.goWhileRunning(func() {
 		state := newLiveLimitPollState(time.Now().UTC())
 		for {
 			if ctx.Err() != nil {
@@ -817,7 +817,7 @@ func (a *App) releaseTaskAgents(taskID string) {
 	// Tracking it here only needs to guarantee the signal is sent — once
 	// StopAgent's SIGINT/SIGKILL reaches the OS, delivery no longer depends
 	// on this process staying alive.
-	a.wg.Go(func() {
+	a.goWhileRunning(func() {
 		for _, ag := range filtered {
 			var err error
 			if ag.Mode == "headless" && ag.CompletedSuccessfully() {
@@ -984,7 +984,7 @@ func (a *App) dispatchTaskCreatedWorkflow(taskID string) {
 	if taskID == "" {
 		return
 	}
-	a.wg.Go(func() {
+	a.goWhileRunning(func() {
 		t, err := a.tasks.Get(taskID)
 		if err != nil {
 			return

--- a/internal/sybra/app_lifecycle.go
+++ b/internal/sybra/app_lifecycle.go
@@ -46,6 +46,8 @@ func (a *App) BeginDrain() bool {
 	if a == nil {
 		return false
 	}
+	a.backgroundMu.Lock()
+	defer a.backgroundMu.Unlock()
 	for {
 		state := lifecycleState(a.lifecycle.Load())
 		switch state {

--- a/internal/sybra/app_shutdown_test.go
+++ b/internal/sybra/app_shutdown_test.go
@@ -116,6 +116,24 @@ func TestBeginDrainCancelsSchedulerOnly(t *testing.T) {
 	}
 }
 
+func TestBeginDrainRejectsLateTrackedBackgroundWork(t *testing.T) {
+	a := &App{}
+	a.initLifecycle(context.Background())
+	if !a.BeginDrain() {
+		t.Fatal("BeginDrain = false, want true")
+	}
+
+	ran := make(chan struct{}, 1)
+	if a.goWhileRunning(func() { ran <- struct{}{} }) {
+		t.Fatal("goWhileRunning admitted work after drain")
+	}
+	select {
+	case <-ran:
+		t.Fatal("late background work ran after drain")
+	default:
+	}
+}
+
 func TestBeginShutdownCancelsAcceptedWork(t *testing.T) {
 	a := &App{logger: discardLogger()}
 	a.initLifecycle(context.Background())

--- a/internal/sybra/app_umbrella_recover.go
+++ b/internal/sybra/app_umbrella_recover.go
@@ -57,10 +57,12 @@ func (a *App) recoverDegradedUmbrellas() {
 		if a.umbrellaRecoverFn != nil {
 			recoverFn = a.umbrellaRecoverFn
 		}
-		a.wg.Go(func() {
+		if !a.goWhileRunning(func() {
 			defer a.clearUmbrellaRecoveryInFlight(key)
 			recoverFn(tracker)
-		})
+		}) {
+			a.clearUmbrellaRecoveryInFlight(key)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #2862.\n\nPrevents shutdown WaitGroup Add-vs-Wait races by serializing tracked background-work admission with drain, latching loop scheduler stop, and serializing RunNow with Stop.\n\nValidated with focused race tests, repeated scheduler stress runs, lint, adversarial review, and adversarial testing.