### PR TITLE
fix(workflow): reject worktree parallel children

### DIFF
--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -64,6 +64,20 @@ func TestParallelValidation_Rejects(t *testing.T) {
 			errSub: "nests another parallel",
 		},
 		{
+			name: "child needs worktree",
+			def: Definition{
+				ID: "x",
+				Steps: []Step{{
+					ID: "p", Type: StepParallel,
+					Parallel: []Step{
+						{ID: "a", Type: StepRunAgent, Config: StepConfig{NeedsWorktree: true}},
+						{ID: "b", Type: StepRunAgent},
+					},
+				}},
+			},
+			errSub: "cannot set needs_worktree",
+		},
+		{
 			name: "duplicate child id",
 			def: Definition{
 				ID: "x",

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -400,7 +400,8 @@ func (d *Definition) Validate() error {
 }
 
 // validateParallelStep enforces that a `parallel` step has at least two
-// run_agent children, no nested parallels, and globally-unique child IDs.
+// run_agent children without worktree preparation or nested parallels, and
+// globally-unique child IDs.
 // The constraints exist because the engine's step bookkeeping (persisted agent
 // routes, ImportSidecar lookup, retry counter) is keyed by step ID —
 // duplicates would cause cross-step state to clobber each other.
@@ -422,6 +423,14 @@ func validateParallelStep(s *Step, seenIDs map[string]bool) error {
 		}
 		if len(c.Parallel) > 0 {
 			return fmt.Errorf("step %q: parallel child %q nests another parallel block (not supported)", s.ID, c.ID)
+		}
+		// Parallel children share the parent workflow directory. Preparing a
+		// worktree here can block StartAgent for minutes and, unlike a regular
+		// run_agent step, dispatch must keep the child route durable while the
+		// parent is still being established. Reject this unsupported shape rather
+		// than letting a user-authored workflow stall the engine.
+		if c.Config.NeedsWorktree {
+			return fmt.Errorf("step %q: parallel child %q cannot set needs_worktree", s.ID, c.ID)
 		}
 		if c.Config.MaxRetries > maxRetries {
 			return fmt.Errorf("step %q: child %q max_retries %d exceeds limit %d", s.ID, c.ID, c.Config.MaxRetries, maxRetries)

--- a/internal/workflow/store.go
+++ b/internal/workflow/store.go
@@ -121,11 +121,8 @@ func (s *Store) parseFile(path string) (Definition, error) {
 	if err := yaml.Unmarshal(data, &def); err != nil {
 		return Definition{}, fmt.Errorf("unmarshal workflow %s: %w", filepath.Base(path), err)
 	}
-	// Warn-but-return on semantic validation failures so a single broken
-	// hand-edited workflow can't take the whole app offline. Save() still
-	// rejects strictly, so GUI edits get caught at write time.
 	if vErr := def.Validate(); vErr != nil {
-		slog.Default().Warn("workflow.validate", "file", filepath.Base(path), "id", def.ID, "err", vErr)
+		return Definition{}, fmt.Errorf("validate workflow %s: %w", filepath.Base(path), vErr)
 	}
 	return def, nil
 }

--- a/internal/workflow/store_test.go
+++ b/internal/workflow/store_test.go
@@ -212,13 +212,10 @@ func TestStore_SafePath_AbsoluteAndWeirdPaths(t *testing.T) {
 	}
 }
 
-// TestStore_ParseFile_WarnOnInvalidFieldsButReturn confirms the read path
-// stays non-disruptive: a hand-edited user workflow with an unknown field
-// still loads (so the app boots and the user can fix it in the GUI),
-// while the Save path remains strict (enforced by other tests). This
-// split is deliberate — failing Load on any invalid workflow would
-// cascade a single bad file into a crashed app startup.
-func TestStore_ParseFile_WarnOnInvalidFieldsButReturn(t *testing.T) {
+// TestStore_ParseFile_SkipsInvalidDefinitions confirms a bad hand-edited
+// workflow cannot enter the dispatchable definition set, while List stays
+// non-disruptive for the rest of the app and valid workflow files.
+func TestStore_ParseFile_SkipsInvalidDefinitions(t *testing.T) {
 	t.Parallel()
 	s, err := NewStore(t.TempDir())
 	if err != nil {
@@ -248,25 +245,51 @@ steps:
 		t.Fatalf("write hand-edited: %v", err)
 	}
 
-	// List must still return the def (warn-not-fail on load).
+	// List skips invalid definitions instead of letting them reach engine
+	// dispatch. A malformed file must not make the entire store unavailable.
 	defs, err := s.List()
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	var found *Definition
-	for i := range defs {
-		if defs[i].ID == "hand-edited" {
-			found = &defs[i]
-			break
-		}
+	if len(defs) != 0 {
+		t.Fatalf("List returned %d definitions, want invalid workflow skipped", len(defs))
 	}
-	if found == nil {
-		t.Fatal("hand-edited workflow should still load despite invalid field")
-		return
+	if _, err := s.Get("hand-edited"); err == nil {
+		t.Fatal("Get should reject an invalid workflow definition")
+	}
+}
+
+func TestStore_ParseFile_RejectsParallelChildWorktree(t *testing.T) {
+	t.Parallel()
+	s := mustNewStore(t)
+	raw := `id: parallel-worktree
+name: Invalid Parallel Worktree
+trigger:
+  on: task.created
+steps:
+  - id: parallel
+    type: parallel
+    parallel:
+      - id: first
+        type: run_agent
+        config:
+          needs_worktree: true
+      - id: second
+        type: run_agent
+`
+	path := filepath.Join(s.Dir(), "parallel-worktree.yaml")
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write hand-edited workflow: %v", err)
 	}
 
-	// But Save must reject the same definition — strict write-path check.
-	if err := s.Save(*found); err == nil {
-		t.Error("Save should reject workflow with unknown field")
+	if _, err := s.Get("parallel-worktree"); err == nil {
+		t.Fatal("Get should reject a parallel child with needs_worktree")
+	}
+	defs, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(defs) != 0 {
+		t.Fatalf("List returned %d definitions, want invalid workflow skipped", len(defs))
 	}
 }


### PR DESCRIPTION
Fixes #2863.

Parallel workflow children can no longer request `needs_worktree`. This rejects the unsupported user-authored shape before dispatch, avoiding an engine-wide deadlock caused by worktree preparation under the workflow mutex.

Validation: `go test -race ./internal/workflow -count=3`; `golangci-lint run ./internal/workflow/...`.