### PR TITLE
fix(cluster): forward follower task status edits

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -596,6 +596,7 @@ export class Task {
     "statusChangedAt": string;
     "assignedNode"?: string;
     "nodeOverride"?: string;
+    "assignmentRev"?: number;
     "generation"?: number;
     "mirrorRev"?: number;
     "mirrorUpdatedAt"?: string | null;
@@ -722,7 +723,7 @@ export class Task {
         const $$createField43_0 = $$createType7;
         const $$createField44_0 = $$createType9;
         const $$createField45_0 = $$createType11;
-        const $$createField62_0 = $$createType12;
+        const $$createField63_0 = $$createType12;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -752,7 +753,7 @@ export class Task {
             $$parsedSource["workflow"] = $$createField45_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField62_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField63_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/cluster/client.go
+++ b/internal/cluster/client.go
@@ -327,6 +327,30 @@ func (c *Client) BlessTampering(ctx context.Context, taskID string) (task.Task, 
 	return decode[task.Task](raw)
 }
 
+// UpdateTaskStatus applies a status edit on the follower that owns task
+// execution. The follower enforces its own live-agent and workflow guards,
+// which a leader mirror cannot observe.
+func (c *Client) UpdateTaskStatus(ctx context.Context, taskID, status string) (task.Task, error) {
+	return c.UpdateTask(ctx, taskID, map[string]any{"status": status})
+}
+
+// UpdateTask applies a narrow leader-originated field update on a follower.
+func (c *Client) UpdateTask(ctx context.Context, taskID string, updates map[string]any) (task.Task, error) {
+	raw, err := c.Call(ctx, "TaskService", "UpdateTask", taskID, updates)
+	if err != nil {
+		return task.Task{}, err
+	}
+	return decode[task.Task](raw)
+}
+
+func (c *Client) DispatchFromHumanRequired(ctx context.Context, taskID, target, reason string) (task.Task, error) {
+	raw, err := c.Call(ctx, "TaskService", "DispatchFromHumanRequired", taskID, target, reason)
+	if err != nil {
+		return task.Task{}, err
+	}
+	return decode[task.Task](raw)
+}
+
 // ImportAttachment replicates one attachment blob onto a follower before the
 // task metadata that references it is assigned there.
 func (c *Client) ImportAttachment(ctx context.Context, taskID string, meta task.Attachment, data []byte) (task.Attachment, error) {

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -361,7 +361,7 @@ func (a *App) startLifecycle(schedulerCtx, watcherCtx context.Context, emit func
 	a.initFileWatcher(watcherCtx, emit)
 
 	issuesFetcher := a.initAutomations(emit)
-	a.wireServices(emit)
+	a.wireServices(emit) //nolint:contextcheck // TaskService uses the app-bound root context; see Startup's contextcheck note.
 	if a.humanReview != nil {
 		a.wg.Go(a.humanReview.recoverRenderedUnblockedTasks)
 	}

--- a/internal/sybra/clusterlead/assigner.go
+++ b/internal/sybra/clusterlead/assigner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/Automaat/sybra/internal/attachment"
 	"github.com/Automaat/sybra/internal/cluster"
@@ -31,6 +32,27 @@ type Assigner struct {
 	attachments   *attachment.Store
 
 	stopLocalAgents func(taskID string)
+}
+
+func (a *Assigner) lockOwnership(taskID string) func() {
+	return lockTaskOwnership(taskID)
+}
+
+func (a *Assigner) freshOwnership(snapshot task.Task) (task.Task, error) {
+	// Small unit-test and no-store construction paths use Assigner only as a
+	// follower RPC adapter. Production leader routing always has a manager;
+	// without one there is no canonical generation to refresh or fence.
+	if a.tasks == nil {
+		return snapshot, nil
+	}
+	current, err := a.tasks.Get(snapshot.ID)
+	if err != nil {
+		return task.Task{}, err
+	}
+	if current.AssignedNode != snapshot.AssignedNode || current.AssignmentRev != snapshot.AssignmentRev {
+		return task.Task{}, fmt.Errorf("ownership changed for %s", snapshot.ID)
+	}
+	return current, nil
 }
 
 // SetStopLocalAgents supplies the hook Reassign uses to stop the leader's own
@@ -134,6 +156,11 @@ func (a *Assigner) PushUpdate(ctx context.Context, t task.Task) (pushed bool, er
 // isn't assigned to one yet — Route/Tick's own first push already carries
 // the task's current Tags/DependsOn, so there is nothing to forward.
 func (a *Assigner) PushFieldUpdate(ctx context.Context, t task.Task) (pushed bool, err error) {
+	unlock := a.lockOwnership(t.ID)
+	defer unlock()
+	if t, err = a.freshOwnership(t); err != nil {
+		return false, err
+	}
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local || t.AssignedNode != home.Name {
 		return false, nil
@@ -160,6 +187,12 @@ func (a *Assigner) PushFieldUpdate(ctx context.Context, t task.Task) (pushed boo
 // execution. The follower must perform the transition itself so its workflow
 // can resume from the same authoritative state the leader displays.
 func (a *Assigner) BlessTampering(ctx context.Context, t task.Task) (task.Task, bool, error) {
+	unlock := a.lockOwnership(t.ID)
+	defer unlock()
+	var err error
+	if t, err = a.freshOwnership(t); err != nil {
+		return task.Task{}, false, err
+	}
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local || t.AssignedNode != home.Name {
 		return task.Task{}, false, nil
@@ -175,10 +208,62 @@ func (a *Assigner) BlessTampering(ctx context.Context, t task.Task) (task.Task, 
 	return updated, true, nil
 }
 
+// UpdateTaskStatus forwards a status transition to the follower that owns
+// execution. A leader's mirror cannot know whether that node has a live agent,
+// so callers must wait for this before updating their local mirror.
+func (a *Assigner) UpdateTaskStatus(ctx context.Context, t task.Task, updates map[string]any) (task.Task, bool, error) {
+	unlock := a.lockOwnership(t.ID)
+	defer unlock()
+	var err error
+	if t, err = a.freshOwnership(t); err != nil {
+		return task.Task{}, false, err
+	}
+	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
+	if home.Local || t.AssignedNode != home.Name {
+		return task.Task{}, false, nil
+	}
+	client, ok := a.roster.Client(home.Name)
+	if !ok || client == nil {
+		return task.Task{}, false, fmt.Errorf("clusterlead: no follower client for node %q", home.Name)
+	}
+	updated, err := client.UpdateTask(ctx, t.ID, updates)
+	if err != nil {
+		return task.Task{}, false, fmt.Errorf("clusterlead: update status for %s on %s: %w", t.ID, home.Name, err)
+	}
+	return updated, true, nil
+}
+
+func (a *Assigner) DispatchFromHumanRequired(ctx context.Context, t task.Task, target, reason string) (task.Task, bool, error) {
+	unlock := a.lockOwnership(t.ID)
+	defer unlock()
+	var err error
+	if t, err = a.freshOwnership(t); err != nil {
+		return task.Task{}, false, err
+	}
+	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
+	if home.Local || t.AssignedNode != home.Name {
+		return task.Task{}, false, nil
+	}
+	client, ok := a.roster.Client(home.Name)
+	if !ok || client == nil {
+		return task.Task{}, false, fmt.Errorf("clusterlead: no follower client for node %q", home.Name)
+	}
+	updated, err := client.DispatchFromHumanRequired(ctx, t.ID, target, reason)
+	if err != nil {
+		return task.Task{}, false, fmt.Errorf("clusterlead: dispatch human-required %s on %s: %w", t.ID, home.Name, err)
+	}
+	return updated, true, nil
+}
+
 func (a *Assigner) route(ctx context.Context, t task.Task, force bool) (routed bool, err error) {
+	unlock := a.lockOwnership(t.ID)
+	defer unlock()
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
 	if home.Local {
 		return false, nil
+	}
+	if t, err = a.freshOwnership(t); err != nil {
+		return false, err
 	}
 	if !force && t.AssignedNode == home.Name {
 		return false, nil
@@ -199,12 +284,18 @@ func (a *Assigner) route(ctx context.Context, t task.Task, force bool) (routed b
 	if err := client.AssignTask(ctx, push); err != nil {
 		return false, fmt.Errorf("clusterlead: assign %s to %s: %w", t.ID, home.Name, err)
 	}
-	cur, err := a.tasks.Get(t.ID)
+	_, _, err = a.tasks.PutFn(t.ID, func(cur task.Task) (task.Task, error) {
+		// The push may take seconds. Do not let a route planned from an old
+		// snapshot overwrite an intervening operator reassignment.
+		if cur.AssignedNode != t.AssignedNode || cur.AssignmentRev != t.AssignmentRev {
+			return task.Task{}, fmt.Errorf("ownership changed while routing %s", t.ID)
+		}
+		cur.AssignedNode = home.Name
+		cur.AssignmentRev++
+		cur.UpdatedAt = time.Now().UTC()
+		return cur, nil
+	})
 	if err != nil {
-		return true, fmt.Errorf("clusterlead: reload %s after assign: %w", t.ID, err)
-	}
-	cur.AssignedNode = home.Name
-	if _, _, err := a.tasks.Put(cur); err != nil {
 		return true, fmt.Errorf("clusterlead: stamp assigned_node on %s: %w", t.ID, err)
 	}
 	return true, nil

--- a/internal/sybra/clusterlead/merge_test.go
+++ b/internal/sybra/clusterlead/merge_test.go
@@ -12,15 +12,16 @@ func TestMergeAuthoritySplit(t *testing.T) {
 	t1 := t0.Add(time.Hour)
 
 	canonical := task.Task{
-		ID:           "task-1",
-		ProjectID:    "owner/repo",
-		AssignedNode: "pet-box",
-		Title:        "leader ingested title",
-		Issue:        "https://github.com/owner/repo/issues/9",
-		Status:       task.StatusTodo,
-		CreatedAt:    t0,
-		UpdatedAt:    t0,
-		MirrorRev:    4,
+		ID:            "task-1",
+		ProjectID:     "owner/repo",
+		AssignedNode:  "pet-box",
+		Title:         "leader ingested title",
+		Issue:         "https://github.com/owner/repo/issues/9",
+		Status:        task.StatusTodo,
+		CreatedAt:     t0,
+		UpdatedAt:     t0,
+		AssignmentRev: 6,
+		MirrorRev:     4,
 	}
 	follower := task.Task{
 		ID:            "task-1",
@@ -62,6 +63,9 @@ func TestMergeAuthoritySplit(t *testing.T) {
 		out.Title != "leader ingested title" || out.Issue != canonical.Issue ||
 		!out.CreatedAt.Equal(t0) {
 		t.Errorf("identity fields must stay leader-authoritative: %+v", out)
+	}
+	if out.AssignmentRev != canonical.AssignmentRev {
+		t.Errorf("AssignmentRev = %d, want leader-owned %d", out.AssignmentRev, canonical.AssignmentRev)
 	}
 
 	if out.Status != task.StatusInReview || out.StatusReason != "review drafted" ||

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -221,10 +221,27 @@ func (m *Mirror) reconcileMissing(ctx context.Context, node string, client *clus
 				// permanently gating downstream rollup logic (like
 				// trackerRollup's cancelled-child check) on a ghost task the
 				// follower will never offer again.
+				// A move can race the old node's delayed 404. Take the same
+				// ownership lock as Reassign and confirm this is still the exact
+				// canonical generation we checked before deleting it.
+				unlock := lockTaskOwnership(t.ID)
+				current, cerr := m.tasks.Get(t.ID)
+				if cerr != nil {
+					unlock()
+					m.logger.Warn("cluster.mirror.reconcile_missing.refresh_failed", "node", node, "task", t.ID, "err", cerr)
+					continue
+				}
+				if current.AssignedNode != node || current.AssignmentRev != t.AssignmentRev {
+					unlock()
+					m.clearMissingStreak(node, t.ID)
+					continue
+				}
 				if derr := m.tasks.Delete(t.ID); derr != nil {
+					unlock()
 					m.logger.Warn("cluster.mirror.reconcile_missing.trash_failed", "node", node, "task", t.ID, "err", derr)
 					continue
 				}
+				unlock()
 				m.clearMissingStreak(node, t.ID)
 				m.logger.Info("cluster.mirror.reconcile_missing.trashed", "node", node, "task", t.ID, "confirmations", streak)
 				continue
@@ -432,6 +449,20 @@ const driftRepairTimeout = 5 * time.Second
 // driftRepairTimeout first. Every failure path logs its own Warn; a failed
 // repair simply retries on the next reconcile tick.
 func (m *Mirror) repairDrift(ctx context.Context, node string, canonical task.Task) {
+	// Serialize against ownership transfer before contacting the follower. A
+	// stale repair of the former owner must never resurrect its task after a
+	// reassignment has completed.
+	unlock := lockTaskOwnership(canonical.ID)
+	defer unlock()
+	current, err := m.tasks.Get(canonical.ID)
+	if err != nil {
+		m.logger.Warn("cluster.mirror.drift_repair.refresh_failed", "task", canonical.ID, "node", node, "err", err)
+		return
+	}
+	if current.AssignedNode != node || current.AssignmentRev != canonical.AssignmentRev {
+		return
+	}
+	canonical = current
 	client, ok := m.roster.Client(node)
 	if !ok || client == nil {
 		m.logger.Warn("cluster.mirror.drift_repair.no_client", "task", canonical.ID, "node", node)

--- a/internal/sybra/clusterlead/ownership.go
+++ b/internal/sybra/clusterlead/ownership.go
@@ -1,0 +1,19 @@
+package clusterlead
+
+import "sync"
+
+// taskOwnershipLocks serializes every operation that can observe or mutate a
+// task's follower ownership. It is deliberately package-wide: reconciliation
+// repairs run from Mirror while manual moves and leader edits run from
+// Assigner, and separate lock sets would let an old-node repair race a move.
+var taskOwnershipLocks sync.Map
+
+func lockTaskOwnership(taskID string) func() {
+	v, _ := taskOwnershipLocks.LoadOrStore(taskID, &sync.Mutex{})
+	mu, ok := v.(*sync.Mutex)
+	if !ok {
+		panic("clusterlead: invalid ownership lock")
+	}
+	mu.Lock()
+	return mu.Unlock
+}

--- a/internal/sybra/clusterlead/reassign.go
+++ b/internal/sybra/clusterlead/reassign.go
@@ -58,6 +58,8 @@ func mayHaveLiveAgent(t task.Task) bool {
 // the push then fails, the move is rolled back so the task is never left
 // pointing at a node that never received it.
 func (a *Assigner) Reassign(ctx context.Context, taskID, node string) error {
+	unlock := a.lockOwnership(taskID)
+	defer unlock()
 	node = strings.TrimSpace(node)
 	if node == "" {
 		return fmt.Errorf("%w: %q", ErrUnknownNode, node)
@@ -137,6 +139,10 @@ func (a *Assigner) stampNode(taskID, override, assigned string) (task.Task, erro
 	cur.NodeOverride = override
 	cur.AssignedNode = assigned
 	cur.WorktreeDir = ""
+	// Advance the persisted ownership revision even when an ABA move returns
+	// to the same node name. UpdatedAt records the ordinary task write.
+	cur.AssignmentRev++
+	cur.UpdatedAt = time.Now().UTC()
 	cur.MirrorRev = 0
 	cur.MirrorUpdatedAt = nil
 	saved, _, err := a.tasks.Put(cur)
@@ -152,10 +158,14 @@ func (a *Assigner) rollbackNode(taskID string, previous, moved task.Task) {
 		a.logger.Error("cluster.reassign.rollback.failed", "task", taskID, "err", err)
 		return
 	}
-	if cur.AssignedNode != moved.AssignedNode {
+	if cur.AssignedNode != moved.AssignedNode || cur.AssignmentRev != moved.AssignmentRev {
 		return
 	}
 	cur.AssignedNode = previous.AssignedNode
+	// A rollback is still an ownership change. Advance the revision so an
+	// RPC response from the failed assignment cannot apply afterwards.
+	cur.AssignmentRev++
+	cur.UpdatedAt = time.Now().UTC()
 	cur.NodeOverride = previous.NodeOverride
 	cur.WorktreeDir = previous.WorktreeDir
 	cur.MirrorRev = previous.MirrorRev

--- a/internal/sybra/clusterlead/reassign_test.go
+++ b/internal/sybra/clusterlead/reassign_test.go
@@ -167,6 +167,9 @@ func TestReassignRepushesToNewNodeAndClearsWorktree(t *testing.T) {
 	if got.AssignedNode != "new-box" {
 		t.Fatalf("assigned_node = %q, want new-box", got.AssignedNode)
 	}
+	if got.AssignmentRev != 1 {
+		t.Fatalf("assignment_rev = %d, want 1 after reassignment", got.AssignmentRev)
+	}
 	if got.WorktreeDir != "" {
 		t.Fatalf("worktree must be cleared (it is not transferable), got %q", got.WorktreeDir)
 	}
@@ -183,6 +186,9 @@ func TestReassignRepushesToNewNodeAndClearsWorktree(t *testing.T) {
 	}
 	if pushed[0].AssignedNode != "new-box" {
 		t.Fatalf("pushed task carries node %q, want new-box", pushed[0].AssignedNode)
+	}
+	if pushed[0].AssignmentRev != got.AssignmentRev {
+		t.Fatalf("pushed assignment_rev = %d, want %d", pushed[0].AssignmentRev, got.AssignmentRev)
 	}
 	if got := oldNode.assignedTasks(); len(got) != 0 {
 		t.Fatalf("task must not be re-pushed to the old node: %+v", got)

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -85,6 +85,10 @@ type TaskService struct {
 	// Initial async enrichment is not gated; this only prevents a permanently
 	// broken stub from spending GitHub calls on every reconcile tick.
 	enrichRetryCooldown sync.Map
+	// followerStatusMu serializes each follower RPC with the corresponding
+	// leader mirror write, preventing concurrent UI transitions from applying
+	// remote and local statuses in opposite orders.
+	followerStatusMu sync.Mutex
 }
 
 func (s *TaskService) config() *config.Config {
@@ -430,16 +434,36 @@ func (s *TaskService) BlessTampering(taskID string) (task.Task, error) {
 	// the leader mirror, so the board cannot claim the task resumed when the
 	// worker rejected or never received the transition.
 	if s.assigner != nil {
+		s.followerStatusMu.Lock()
+		defer s.followerStatusMu.Unlock()
 		current, err := s.tasks.Get(taskID)
 		if err != nil {
 			return task.Task{}, err
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), fieldPushTimeout)
+		ctx, cancel := context.WithTimeout(s.recoveryCtx(), fieldPushTimeout)
 		defer cancel()
-		if _, forwarded, err := s.assigner.BlessTampering(ctx, current); err != nil {
+		remote, forwarded, err := s.assigner.BlessTampering(ctx, current)
+		if err != nil {
 			return task.Task{}, err
 		} else if forwarded {
+			result, _, putErr := s.tasks.PutFn(taskID, func(local task.Task) (task.Task, error) {
+				if local.AssignedNode != current.AssignedNode || local.AssignmentRev != current.AssignmentRev {
+					return task.Task{}, conflictError("task ownership changed while follower tamper blessing was in flight")
+				}
+				merged, ok := clusterlead.Merge(local, remote)
+				if !ok {
+					return local, nil
+				}
+				if !slices.Contains(merged.Tags, workflow.TamperBlessedTag) {
+					merged.Tags = append(merged.Tags, workflow.TamperBlessedTag)
+				}
+				return merged, nil
+			})
+			if putErr != nil {
+				return task.Task{}, putErr
+			}
 			s.logger.Info("cluster.task.tamper_bless.forwarded", "task_id", taskID, "node", current.AssignedNode)
+			return result, nil
 		}
 	}
 	var (
@@ -894,6 +918,8 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 	}
 
 	if status, ok := updates["status"].(string); ok {
+		s.followerStatusMu.Lock()
+		defer s.followerStatusMu.Unlock()
 		// Reject status regressions while an agent is running on this task.
 		// Moving back to todo/new/done/cancelled while an agent is active loses in-flight work.
 		agentBlockedStatuses := map[string]bool{
@@ -912,6 +938,41 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 				cur.Workflow.State != workflow.ExecFailed {
 				return cur, conflictError(fmt.Sprintf("cannot move to testing: task has active workflow %q (state=%s)",
 					cur.Workflow.WorkflowID, cur.Workflow.State))
+			}
+		}
+		// A follower owns its task's live agents and workflow. Validate this
+		// local request first, then forward before changing the leader mirror so
+		// a rejected remote transition cannot silently revert a success response.
+		if s.assigner != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), fieldPushTimeout)
+			defer cancel()
+			remoteUpdates := map[string]any{"status": status}
+			if statusReason, hasReason := updates["status_reason"]; hasReason {
+				remoteUpdates["status_reason"] = statusReason
+			}
+			remote, forwarded, forwardErr := s.assigner.UpdateTaskStatus(ctx, cur, remoteUpdates)
+			if forwardErr != nil {
+				return cur, forwardErr
+			} else if forwarded {
+				// Merge the follower's returned execution snapshot, including its
+				// clock watermark, instead of rebuilding just status locally. A
+				// delayed mirror poll from before this RPC is then stale by
+				// construction and cannot undo the accepted transition.
+				t, _, putErr := s.tasks.PutFn(id, func(local task.Task) (task.Task, error) {
+					if local.AssignedNode != cur.AssignedNode || local.AssignmentRev != cur.AssignmentRev {
+						return task.Task{}, conflictError("task ownership changed while follower status update was in flight")
+					}
+					merged, ok := clusterlead.Merge(local, remote)
+					if !ok {
+						return local, nil
+					}
+					return merged, nil
+				})
+				if putErr != nil {
+					return cur, putErr
+				}
+				s.logger.Info("cluster.task.status_update.forwarded", "task_id", id, "node", cur.AssignedNode, "status", status)
+				return t, nil
 			}
 		}
 	}
@@ -1117,6 +1178,35 @@ func (s *TaskService) dispatchFromHumanRequiredLockedAllowingAgent(id, target, r
 	spec := dispatchTargets[target]
 	if spec.requiresPR && cur.PRNumber == 0 {
 		return task.Task{}, conflictError(fmt.Sprintf("cannot dispatch to %q: task has no linked PR", target))
+	}
+	if s.assigner != nil {
+		s.followerStatusMu.Lock()
+		ctx, cancel := context.WithTimeout(s.recoveryCtx(), fieldPushTimeout)
+		remote, forwarded, forwardErr := s.assigner.DispatchFromHumanRequired(ctx, cur, target, reason)
+		cancel()
+		if forwardErr != nil {
+			s.followerStatusMu.Unlock()
+			return task.Task{}, forwardErr
+		}
+		if forwarded {
+			local, _, localErr := s.tasks.PutFn(id, func(current task.Task) (task.Task, error) {
+				if current.AssignedNode != cur.AssignedNode || current.AssignmentRev != cur.AssignmentRev {
+					return task.Task{}, conflictError("task ownership changed while follower dispatch was in flight")
+				}
+				merged, ok := clusterlead.Merge(current, remote)
+				if !ok {
+					return current, nil
+				}
+				return merged, nil
+			})
+			s.followerStatusMu.Unlock()
+			if localErr != nil {
+				return task.Task{}, localErr
+			}
+			s.logDispatchAudit(id, target, string(cur.Status), reason, "forwarded")
+			return local, nil
+		}
+		s.followerStatusMu.Unlock()
 	}
 	hasRunning := s.agents.HasRunningAgentForTask(id)
 	if exceptAgentID != "" {

--- a/internal/sybra/svc_tasks_cluster_push_test.go
+++ b/internal/sybra/svc_tasks_cluster_push_test.go
@@ -23,6 +23,7 @@ type followerPushStub struct {
 	live     task.Task
 	assigned []task.Task
 	blessed  int
+	dispatch int
 }
 
 func (f *followerPushStub) server(t *testing.T) *httptest.Server {
@@ -58,6 +59,37 @@ func (f *followerPushStub) server(t *testing.T) *httptest.Server {
 			updated := f.live
 			f.mu.Unlock()
 			_ = json.NewEncoder(w).Encode(updated)
+		case "/api/TaskService/UpdateTask":
+			var args []json.RawMessage
+			_ = json.Unmarshal(body, &args)
+			if len(args) != 2 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			var updates map[string]any
+			_ = json.Unmarshal(args[1], &updates)
+			status, _ := updates["status"].(string)
+			f.mu.Lock()
+			f.live.Status = task.Status(status)
+			updated := f.live
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(updated)
+		case "/api/TaskService/DispatchFromHumanRequired":
+			var args []json.RawMessage
+			_ = json.Unmarshal(body, &args)
+			var target string
+			if len(args) > 1 {
+				_ = json.Unmarshal(args[1], &target)
+			}
+			f.mu.Lock()
+			f.dispatch++
+			f.live.Status = task.Status(target)
+			if len(args) > 2 {
+				_ = json.Unmarshal(args[2], &f.live.StatusReason)
+			}
+			updated := f.live
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(updated)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -65,6 +97,91 @@ func (f *followerPushStub) server(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func TestDispatchFromHumanRequiredForwardsToAssignedFollower(t *testing.T) {
+	stub := &followerPushStub{live: task.Task{ID: "task-human", Status: task.StatusHumanRequired, ProjectID: "owner/pet", AssignedNode: "pet-box"}}
+	srv := stub.server(t)
+	cfg := &config.Config{Cluster: config.ClusterConfig{Role: config.ClusterRoleLeader, Followers: []config.Follower{{Name: "pet-box", Endpoints: []string{srv.URL}, Homes: []string{"owner/pet"}}}}}
+	roster, err := clusterlead.NewRoster(cfg, discardLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaderTasks := newTaskManagerForMonitorCluster(t)
+	if _, _, err := leaderTasks.Put(stub.live); err != nil {
+		t.Fatal(err)
+	}
+	// The remote branch returns before local agent/workflow checks; this is
+	// intentional because the follower is authoritative for those checks.
+	svc := &TaskService{tasks: leaderTasks, cfg: cfg, assigner: clusterlead.NewAssigner(cfg, leaderTasks, roster, func(string) bool { return false }, nil, discardLogger()), logger: discardLogger(), wg: &sync.WaitGroup{}}
+	got, err := svc.DispatchFromHumanRequired("task-human", "done", "completed remotely")
+	if err != nil {
+		t.Fatalf("DispatchFromHumanRequired: %v", err)
+	}
+	stub.mu.Lock()
+	calls := stub.dispatch
+	follower := stub.live
+	stub.mu.Unlock()
+	if calls != 1 || got.Status != task.StatusDone || follower.Status != task.StatusDone {
+		t.Fatalf("dispatch/status = %d/%q/%q, want 1/done/done", calls, got.Status, follower.Status)
+	}
+}
+
+func TestUpdateTaskForwardsStatusToAssignedFollowerBeforeLeaderMirror(t *testing.T) {
+	stub := &followerPushStub{live: task.Task{ID: "task-status", Status: task.StatusInProgress, ProjectID: "owner/pet", AssignedNode: "pet-box"}}
+	srv := stub.server(t)
+	cfg := &config.Config{Cluster: config.ClusterConfig{Role: config.ClusterRoleLeader, Followers: []config.Follower{{Name: "pet-box", Endpoints: []string{srv.URL}, Homes: []string{"owner/pet"}}}}}
+	roster, err := clusterlead.NewRoster(cfg, discardLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaderTasks := newTaskManagerForMonitorCluster(t)
+	if _, _, err := leaderTasks.Put(stub.live); err != nil {
+		t.Fatal(err)
+	}
+	svc := &TaskService{tasks: leaderTasks, cfg: cfg, assigner: clusterlead.NewAssigner(cfg, leaderTasks, roster, func(string) bool { return false }, nil, discardLogger()), logger: discardLogger(), wg: &sync.WaitGroup{}}
+
+	if _, err := svc.UpdateTask("task-status", map[string]any{"status": string(task.StatusInReview)}); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	got, err := leaderTasks.Get("task-status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInReview || stub.live.Status != task.StatusInReview {
+		t.Fatalf("leader/follower status = %q/%q, want in-review", got.Status, stub.live.Status)
+	}
+}
+
+func TestUpdateTaskKeepsLeaderMirrorWhenAssignedFollowerRejectsStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/TaskService/UpdateTask" {
+			http.Error(w, "running agent", http.StatusConflict)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	cfg := &config.Config{Cluster: config.ClusterConfig{Role: config.ClusterRoleLeader, Followers: []config.Follower{{Name: "pet-box", Endpoints: []string{srv.URL}, Homes: []string{"owner/pet"}}}}}
+	roster, err := clusterlead.NewRoster(cfg, discardLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaderTasks := newTaskManagerForMonitorCluster(t)
+	if _, _, err := leaderTasks.Put(task.Task{ID: "task-reject", Status: task.StatusInProgress, ProjectID: "owner/pet", AssignedNode: "pet-box"}); err != nil {
+		t.Fatal(err)
+	}
+	svc := &TaskService{tasks: leaderTasks, cfg: cfg, assigner: clusterlead.NewAssigner(cfg, leaderTasks, roster, func(string) bool { return false }, nil, discardLogger()), logger: discardLogger(), wg: &sync.WaitGroup{}}
+	if _, err := svc.UpdateTask("task-reject", map[string]any{"status": string(task.StatusInReview)}); err == nil {
+		t.Fatal("UpdateTask error = nil, want follower rejection")
+	}
+	got, err := leaderTasks.Get("task-reject")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("leader status = %q, want unchanged in-progress", got.Status)
+	}
 }
 
 func (f *followerPushStub) blessCount() int {

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -513,6 +513,7 @@ type Task struct {
 
 	AssignedNode    string     `json:"assignedNode,omitempty"`
 	NodeOverride    string     `json:"nodeOverride,omitempty"`
+	AssignmentRev   int64      `json:"assignmentRev,omitempty"`
 	Generation      int64      `json:"generation,omitempty"`
 	MirrorRev       int64      `json:"mirrorRev,omitempty"`
 	MirrorUpdatedAt *time.Time `json:"mirrorUpdatedAt,omitempty"`

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -67,6 +67,7 @@ type taskFrontmatter struct {
 	StatusChangedAt        time.Time               `yaml:"status_changed_at,omitempty"`
 	AssignedNode           string                  `yaml:"assigned_node,omitempty"`
 	NodeOverride           string                  `yaml:"node_override,omitempty"`
+	AssignmentRev          int64                   `yaml:"assignment_rev,omitempty"`
 	Generation             int64                   `yaml:"generation,omitempty"`
 	MirrorRev              int64                   `yaml:"mirror_rev,omitempty"`
 	MirrorUpdatedAt        *time.Time              `yaml:"mirror_updated_at,omitempty"`
@@ -165,6 +166,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		StatusChangedAt:        fm.StatusChangedAt,
 		AssignedNode:           fm.AssignedNode,
 		NodeOverride:           fm.NodeOverride,
+		AssignmentRev:          fm.AssignmentRev,
 		Generation:             fm.Generation,
 		MirrorRev:              fm.MirrorRev,
 		MirrorUpdatedAt:        fm.MirrorUpdatedAt,
@@ -241,6 +243,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		StatusChangedAt:        t.StatusChangedAt,
 		AssignedNode:           t.AssignedNode,
 		NodeOverride:           t.NodeOverride,
+		AssignmentRev:          t.AssignmentRev,
 		Generation:             t.Generation,
 		MirrorRev:              t.MirrorRev,
 		MirrorUpdatedAt:        t.MirrorUpdatedAt,

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -127,6 +127,7 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		UpdatedAt:       now,
 		AssignedNode:    "pet-box",
 		NodeOverride:    "gpu-box",
+		AssignmentRev:   3,
 		Generation:      2,
 		MirrorRev:       7,
 		MirrorUpdatedAt: &completedAt,
@@ -391,6 +392,8 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.AssignedNode = "pet-box"
 	case "NodeOverride":
 		task.NodeOverride = "gpu-box"
+	case "AssignmentRev":
+		task.AssignmentRev = 3
 	case "Generation":
 		task.Generation = 2
 	case "MirrorRev":


### PR DESCRIPTION
Fixes #2864.

Leader-side status edits for follower-assigned tasks now synchronously execute on the follower first. A rejected or unavailable follower leaves the leader mirror unchanged, preventing accept-then-revert status drift.

Validation: repeated focused race tests and cluster/service lint.