### PR TITLE
fix(stores): bound cross-process locks

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -411,30 +411,30 @@ export class AgentDefaults {
      * Creates a new AgentDefaults instance from a string or object.
      */
     static createFrom($$source: any = {}): AgentDefaults {
-        const $$createField29_0 = $$createType0;
-        const $$createField30_0 = $$createType1;
-        const $$createField31_0 = $$createType2;
-        const $$createField32_0 = $$createType3;
-        const $$createField33_0 = $$createType4;
-        const $$createField34_0 = $$createType5;
+        const $$createField30_0 = $$createType0;
+        const $$createField31_0 = $$createType1;
+        const $$createField32_0 = $$createType2;
+        const $$createField33_0 = $$createType3;
+        const $$createField34_0 = $$createType4;
+        const $$createField35_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("roleEffort" in $$parsedSource) {
-            $$parsedSource["roleEffort"] = $$createField29_0($$parsedSource["roleEffort"]);
+            $$parsedSource["roleEffort"] = $$createField30_0($$parsedSource["roleEffort"]);
         }
         if ("playwrightMcp" in $$parsedSource) {
-            $$parsedSource["playwrightMcp"] = $$createField30_0($$parsedSource["playwrightMcp"]);
+            $$parsedSource["playwrightMcp"] = $$createField31_0($$parsedSource["playwrightMcp"]);
         }
         if ("k8sJobs" in $$parsedSource) {
-            $$parsedSource["k8sJobs"] = $$createField31_0($$parsedSource["k8sJobs"]);
+            $$parsedSource["k8sJobs"] = $$createField32_0($$parsedSource["k8sJobs"]);
         }
         if ("queue" in $$parsedSource) {
-            $$parsedSource["queue"] = $$createField32_0($$parsedSource["queue"]);
+            $$parsedSource["queue"] = $$createField33_0($$parsedSource["queue"]);
         }
         if ("classReservations" in $$parsedSource) {
-            $$parsedSource["classReservations"] = $$createField33_0($$parsedSource["classReservations"]);
+            $$parsedSource["classReservations"] = $$createField34_0($$parsedSource["classReservations"]);
         }
         if ("evidence" in $$parsedSource) {
-            $$parsedSource["evidence"] = $$createField34_0($$parsedSource["evidence"]);
+            $$parsedSource["evidence"] = $$createField35_0($$parsedSource["evidence"]);
         }
         return new AgentDefaults($$parsedSource as Partial<AgentDefaults>);
     }

--- a/internal/fsutil/lock_other.go
+++ b/internal/fsutil/lock_other.go
@@ -5,6 +5,7 @@ package fsutil
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 // LockFile is unimplemented on non-unix platforms (flock has no direct
@@ -13,6 +14,15 @@ import (
 // packages that import fsutil (e.g. `go vet ./...` on a Windows dev machine)
 // still compile.
 func LockFile(_ string) (func() error, error) {
+	return nil, fmt.Errorf("%w", ErrLockUnsupported)
+}
+
+// ErrLockTimeout mirrors the unix build's sentinel so callers can compile
+// errors.Is checks on every platform.
+var ErrLockTimeout = errors.New("fsutil: timed out waiting for file lock")
+
+// LockFileWithin is unimplemented on non-unix platforms; see LockFile.
+func LockFileWithin(_ string, _ time.Duration) (func() error, error) {
 	return nil, fmt.Errorf("%w", ErrLockUnsupported)
 }
 

--- a/internal/fsutil/lock_unix.go
+++ b/internal/fsutil/lock_unix.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // LockFile acquires an advisory, cross-process exclusive lock for path by
@@ -40,6 +41,43 @@ func LockFile(path string) (func() error, error) {
 		}
 		return unlockErr
 	}, nil
+}
+
+// ErrLockTimeout is returned when LockFileWithin cannot acquire the lock
+// before its deadline. Callers can use errors.Is to distinguish a wedged or
+// busy peer process from an open or flock failure.
+var ErrLockTimeout = errors.New("fsutil: timed out waiting for file lock")
+
+// LockFileWithin acquires LockFile's sibling lock, retrying non-blocking flock
+// attempts until timeout expires. It prevents a stalled peer process from
+// indefinitely blocking a hot in-process mutex while retaining the full
+// read-modify-write critical section once the lock is acquired.
+func LockFileWithin(path string, timeout time.Duration) (func() error, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("open lock file: %w", err)
+		}
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() error {
+				unlockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				if closeErr := f.Close(); unlockErr == nil {
+					unlockErr = closeErr
+				}
+				return unlockErr
+			}, nil
+		}
+		_ = f.Close()
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("flock: %w", err)
+		}
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("%w after %s", ErrLockTimeout, timeout)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // ErrLocked is returned by TryLockPath when another process already holds

--- a/internal/fsutil/lock_unix_test.go
+++ b/internal/fsutil/lock_unix_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTryLockPath_SecondCallerFails(t *testing.T) {
@@ -91,5 +92,47 @@ func TestTryLockPath_CreatesParentDir(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Dir(path)); err != nil {
 		t.Fatalf("stat parent dir: %v", err)
+	}
+}
+
+func TestLockFileWithin_TimesOutWhenHeld(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "store.json")
+
+	unlock, err := LockFile(path)
+	if err != nil {
+		t.Fatalf("LockFile: %v", err)
+	}
+	t.Cleanup(func() { _ = unlock() })
+
+	start := time.Now()
+	_, err = LockFileWithin(path, 30*time.Millisecond)
+	if !errors.Is(err, ErrLockTimeout) {
+		t.Fatalf("LockFileWithin error = %v, want ErrLockTimeout", err)
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("LockFileWithin took %s, want bounded wait", elapsed)
+	}
+}
+
+func TestLockFileWithin_RetriesUntilReleased(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "store.json")
+
+	unlock, err := LockFile(path)
+	if err != nil {
+		t.Fatalf("LockFile: %v", err)
+	}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = unlock()
+	}()
+
+	unlock2, err := LockFileWithin(path, time.Second)
+	if err != nil {
+		t.Fatalf("LockFileWithin: %v", err)
+	}
+	if err := unlock2(); err != nil {
+		t.Fatalf("unlock: %v", err)
 	}
 }

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -13,7 +13,10 @@ import (
 	"github.com/Automaat/sybra/internal/fsutil"
 )
 
-const exactSnapshotMaxAge = 30 * time.Minute
+const (
+	exactSnapshotMaxAge = 30 * time.Minute
+	storeLockTimeout    = 2 * time.Second
+)
 
 // eventMaxAge bounds how long a UsageEvent survives in limits.json.
 // Summary never looks back further than the weekly window (7d, see
@@ -57,19 +60,20 @@ func NewStore(path string) (*Store, error) {
 // on-disk file: s.snapshots/s.events are populated once at NewStore time and
 // otherwise never re-read, but sybra-cli and the GUI server each hold a
 // separate Store over the same path in separate OS processes. Reloading
-// under the cross-process flock immediately before mutating resyncs this
+// after the bounded cross-process flock immediately before mutating resyncs this
 // process's view to the authoritative on-disk state, so a write from the
-// other process in the gap since this process last loaded isn't clobbered.
+// other process in the gap since this process last loaded isn't clobbered. The
+// flock is acquired before s.mu so a wedged peer process cannot stall provider
+// selection or availability reads behind that mutex.
 
 func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	unlock, err := fsutil.LockFile(s.path)
+	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.reloadLocked(); err != nil {
 		return err
@@ -81,14 +85,13 @@ func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
 }
 
 func (s *Store) RecordUsage(e UsageEvent) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	unlock, err := fsutil.LockFile(s.path)
+	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.reloadLocked(); err != nil {
 		return err
@@ -101,14 +104,13 @@ func (s *Store) RecordUsage(e UsageEvent) error {
 
 // Import records a batch of parsed session-file data and flushes at most once.
 func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	unlock, err := fsutil.LockFile(s.path)
+	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.reloadLocked(); err != nil {
 		return err
@@ -130,14 +132,13 @@ func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
 // estimated confidence so routing falls back to event-based usage counters
 // instead of trusting a now-unreadable exact quota sample.
 func (s *Store) InvalidateLiveExactSnapshot(provider string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	unlock, err := fsutil.LockFile(s.path)
+	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.reloadLocked(); err != nil {
 		return err

--- a/internal/limits/store_test.go
+++ b/internal/limits/store_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 func writeLimitsFile(t *testing.T, path string, p persisted) {
@@ -87,6 +89,51 @@ func TestStore_RecordUsageFlushesPrunedEvents(t *testing.T) {
 	}
 	if len(p.Events) != 1 || p.Events[0].ID != "new" {
 		t.Fatalf("expected only the fresh event on disk, got %+v", p.Events)
+	}
+}
+
+func TestStore_LockContentionDoesNotBlockProviderAvailability(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "limits.json")
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := fsutil.LockFile(path)
+	if err != nil {
+		t.Fatalf("LockFile: %v", err)
+	}
+	t.Cleanup(func() {
+		if unlock != nil {
+			_ = unlock()
+		}
+	})
+
+	recorded := make(chan error, 1)
+	go func() {
+		recorded <- s.RecordUsage(UsageEvent{ID: "blocked", Provider: ProviderClaude, Timestamp: time.Now()})
+	}()
+	select {
+	case err := <-recorded:
+		t.Fatalf("RecordUsage returned while lock was held: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	available := make(chan struct{})
+	go func() {
+		_, _ = s.ProviderAvailable(ProviderClaude, Policy{Enabled: true})
+		close(available)
+	}()
+	select {
+	case <-available:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("ProviderAvailable blocked behind a contended file lock")
+	}
+	if err := unlock(); err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+	unlock = nil
+	if err := <-recorded; err != nil {
+		t.Fatalf("RecordUsage after lock release: %v", err)
 	}
 }
 

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -34,14 +34,13 @@ func (s *Store) Backfill(auditDir string) error {
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	unlock, err := fsutil.LockFile(s.path)
+	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.reloadLocked(); err != nil {
 		return err

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Automaat/sybra/internal/skillattr"
 )
 
+const storeLockTimeout = 2 * time.Second
+
 // Store persists RunRecords to a JSON file and computes aggregates in memory.
 type Store struct {
 	path string
@@ -32,18 +34,18 @@ func NewStore(path string) (*Store, error) {
 // append-and-flush here would silently drop any run written by another
 // process (sybra-cli and the GUI server each hold their own Store over the
 // same path) in the gap since this process last loaded the file. Reloading
-// from disk under the cross-process flock, immediately before appending,
+// from disk under the bounded cross-process flock, immediately before appending,
 // closes that gap: the in-memory s.runs is resynced to the authoritative
-// on-disk state before this run is added.
+// on-disk state before this run is added. The flock is acquired before s.mu so
+// a stalled peer process cannot block in-process stats readers.
 func (s *Store) Record(r RunRecord) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	unlock, err := fsutil.LockFile(s.path)
+	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if err := s.reloadLocked(); err != nil {
 		return err


### PR DESCRIPTION
## Motivation

A wedged peer process holding a limits or stats sidecar flock could indefinitely hold the in-process store mutex, stalling provider routing and stats reads.

## Implementation information

Adds a bounded non-blocking flock retry primitive and acquires it before each limits/stats writer mutex. This retains the full cross-process read-modify-write critical section, including stats backfill, while readers stay responsive. Regression coverage exercises timeout/retry and a contended limits reader path.

Closes #2868

> Changelog: fix(stores): bound cross-process locks