### PR TITLE
fix(frontend): regenerate wails config bindings

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -411,30 +411,30 @@ export class AgentDefaults {
      * Creates a new AgentDefaults instance from a string or object.
      */
     static createFrom($$source: any = {}): AgentDefaults {
-        const $$createField29_0 = $$createType0;
-        const $$createField30_0 = $$createType1;
-        const $$createField31_0 = $$createType2;
-        const $$createField32_0 = $$createType3;
-        const $$createField33_0 = $$createType4;
-        const $$createField34_0 = $$createType5;
+        const $$createField30_0 = $$createType0;
+        const $$createField31_0 = $$createType1;
+        const $$createField32_0 = $$createType2;
+        const $$createField33_0 = $$createType3;
+        const $$createField34_0 = $$createType4;
+        const $$createField35_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("roleEffort" in $$parsedSource) {
-            $$parsedSource["roleEffort"] = $$createField29_0($$parsedSource["roleEffort"]);
+            $$parsedSource["roleEffort"] = $$createField30_0($$parsedSource["roleEffort"]);
         }
         if ("playwrightMcp" in $$parsedSource) {
-            $$parsedSource["playwrightMcp"] = $$createField30_0($$parsedSource["playwrightMcp"]);
+            $$parsedSource["playwrightMcp"] = $$createField31_0($$parsedSource["playwrightMcp"]);
         }
         if ("k8sJobs" in $$parsedSource) {
-            $$parsedSource["k8sJobs"] = $$createField31_0($$parsedSource["k8sJobs"]);
+            $$parsedSource["k8sJobs"] = $$createField32_0($$parsedSource["k8sJobs"]);
         }
         if ("queue" in $$parsedSource) {
-            $$parsedSource["queue"] = $$createField32_0($$parsedSource["queue"]);
+            $$parsedSource["queue"] = $$createField33_0($$parsedSource["queue"]);
         }
         if ("classReservations" in $$parsedSource) {
-            $$parsedSource["classReservations"] = $$createField33_0($$parsedSource["classReservations"]);
+            $$parsedSource["classReservations"] = $$createField34_0($$parsedSource["classReservations"]);
         }
         if ("evidence" in $$parsedSource) {
-            $$parsedSource["evidence"] = $$createField34_0($$parsedSource["evidence"]);
+            $$parsedSource["evidence"] = $$createField35_0($$parsedSource["evidence"]);
         }
         return new AgentDefaults($$parsedSource as Partial<AgentDefaults>);
     }


### PR DESCRIPTION
## Motivation

`main` is currently red. The latest CI run on `main` (`30788372971`) fails exactly one job — **Wails Bindings Sync** — so every PR branched off `main` inherits a failing gate that has nothing to do with its own change.

#2925 added an agent config field without regenerating bindings. That shifted every `createField` index in the `AgentDefaults` decoder by one, so the committed TypeScript no longer matches what `wails3 generate bindings` produces.

> Changelog: fix(frontend): regenerate the Wails config bindings

## Implementation information

Ran the exact command CI runs:

```
wails3 generate bindings -ts -clean -d frontend/bindings ./...
```

Regenerated output only — no hand edits. The diff is confined to `internal/config/models.ts` and is purely the index renumbering (`createField30_0` → `createField31_0` and so on through 34 → 35).

## Supporting documentation

Verified the drift is pre-existing on `main` rather than introduced by any local branch: regenerating in a clean detached worktree at `origin/main` produces the same 12-line diff. That is what confirmed this belongs in its own PR instead of being folded into unrelated work.

Worth noting the gap this exposes: `mise run verify` and CI both catch bindings drift, but only *after* a merge that skipped the regeneration step. The `Wails Bindings Sync` job is a post-hoc detector, not a pre-merge guard, so a PR that forgets it goes green on its own branch and reddens `main` for everyone afterwards.
