### PR TITLE
test(test): remove load-sensitive timing flakes

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -411,30 +411,30 @@ export class AgentDefaults {
      * Creates a new AgentDefaults instance from a string or object.
      */
     static createFrom($$source: any = {}): AgentDefaults {
-        const $$createField29_0 = $$createType0;
-        const $$createField30_0 = $$createType1;
-        const $$createField31_0 = $$createType2;
-        const $$createField32_0 = $$createType3;
-        const $$createField33_0 = $$createType4;
-        const $$createField34_0 = $$createType5;
+        const $$createField30_0 = $$createType0;
+        const $$createField31_0 = $$createType1;
+        const $$createField32_0 = $$createType2;
+        const $$createField33_0 = $$createType3;
+        const $$createField34_0 = $$createType4;
+        const $$createField35_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("roleEffort" in $$parsedSource) {
-            $$parsedSource["roleEffort"] = $$createField29_0($$parsedSource["roleEffort"]);
+            $$parsedSource["roleEffort"] = $$createField30_0($$parsedSource["roleEffort"]);
         }
         if ("playwrightMcp" in $$parsedSource) {
-            $$parsedSource["playwrightMcp"] = $$createField30_0($$parsedSource["playwrightMcp"]);
+            $$parsedSource["playwrightMcp"] = $$createField31_0($$parsedSource["playwrightMcp"]);
         }
         if ("k8sJobs" in $$parsedSource) {
-            $$parsedSource["k8sJobs"] = $$createField31_0($$parsedSource["k8sJobs"]);
+            $$parsedSource["k8sJobs"] = $$createField32_0($$parsedSource["k8sJobs"]);
         }
         if ("queue" in $$parsedSource) {
-            $$parsedSource["queue"] = $$createField32_0($$parsedSource["queue"]);
+            $$parsedSource["queue"] = $$createField33_0($$parsedSource["queue"]);
         }
         if ("classReservations" in $$parsedSource) {
-            $$parsedSource["classReservations"] = $$createField33_0($$parsedSource["classReservations"]);
+            $$parsedSource["classReservations"] = $$createField34_0($$parsedSource["classReservations"]);
         }
         if ("evidence" in $$parsedSource) {
-            $$parsedSource["evidence"] = $$createField34_0($$parsedSource["evidence"]);
+            $$parsedSource["evidence"] = $$createField35_0($$parsedSource["evidence"]);
         }
         return new AgentDefaults($$parsedSource as Partial<AgentDefaults>);
     }

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -301,10 +301,10 @@ func TestFetchRemoteBranchTimesOutNetworkGit(t *testing.T) {
 // hungGitReturnCeiling bounds how long a remote git call may take to return
 // once its network timeout has fired. It is deliberately far below the fake
 // git's sleep and far above the timeout itself: the assertion's power comes
-// from that gap (5s ceiling vs a 10s sleep), not from a tight wall-clock
-// bound. The previous 500ms ceiling
-// against a 1s sleep left too little room, and returning under load took
-// seconds — so a correctly-bounded timeout still failed the test (#2896).
+// from that gap (5s ceiling vs a 10s sleep), not from a tight wall-clock bound.
+// The previous 500ms ceiling against a 1s sleep left too little room: returning
+// under suite load took seconds, so a correctly-bounded timeout still failed
+// the test (#2896).
 const hungGitReturnCeiling = 5 * time.Second
 
 func TestRemoteGitOperationsTimeOut(t *testing.T) {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -283,7 +283,7 @@ func TestFetchRemoteBranchTimesOutNetworkGit(t *testing.T) {
 
 	bin := t.TempDir()
 	git := filepath.Join(bin, "git")
-	if err := os.WriteFile(git, []byte("#!/bin/sh\nexec sleep 1\n"), 0o755); err != nil {
+	if err := os.WriteFile(git, []byte("#!/bin/sh\nexec sleep 10\n"), 0o755); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -293,10 +293,19 @@ func TestFetchRemoteBranchTimesOutNetworkGit(t *testing.T) {
 	if err == nil {
 		t.Fatal("FetchRemoteBranch succeeded with a hung git process")
 	}
-	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+	if elapsed := time.Since(started); elapsed > hungGitReturnCeiling {
 		t.Fatalf("FetchRemoteBranch returned after %s, want bounded network timeout", elapsed)
 	}
 }
+
+// hungGitReturnCeiling bounds how long a remote git call may take to return
+// once its network timeout has fired. It is deliberately far below the fake
+// git's sleep and far above the timeout itself: the assertion's power comes
+// from that gap (5s ceiling vs a 10s sleep), not from a tight wall-clock
+// bound. The previous 500ms ceiling
+// against a 1s sleep left too little room, and returning under load took
+// seconds — so a correctly-bounded timeout still failed the test (#2896).
+const hungGitReturnCeiling = 5 * time.Second
 
 func TestRemoteGitOperationsTimeOut(t *testing.T) {
 	oldTimeout := networkGitTimeout
@@ -313,7 +322,7 @@ func TestRemoteGitOperationsTimeOut(t *testing.T) {
 	// pushLocked resolves the shared git dir before it starts the remote
 	// transport. Preserve only that local rev-parse call, then hang every
 	// remote operation the test exercises.
-	fakeGit := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = rev-parse ]; then exec %q \"$@\"; fi\nexec sleep 1\n", realGit)
+	fakeGit := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = rev-parse ]; then exec %q \"$@\"; fi\nexec sleep 10\n", realGit)
 	if err := os.WriteFile(git, []byte(fakeGit), 0o755); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
@@ -349,7 +358,7 @@ func TestRemoteGitOperationsTimeOut(t *testing.T) {
 			if err := tt.run(); err == nil {
 				t.Fatal("remote git operation succeeded with a hung git process")
 			}
-			if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+			if elapsed := time.Since(started); elapsed > hungGitReturnCeiling {
 				t.Fatalf("remote git operation returned after %s, want bounded network timeout", elapsed)
 			}
 		})
@@ -363,7 +372,7 @@ func TestExecGitPushProbeTimesOut(t *testing.T) {
 
 	bin := t.TempDir()
 	git := filepath.Join(bin, "git")
-	if err := os.WriteFile(git, []byte("#!/bin/sh\nexec sleep 1\n"), 0o755); err != nil {
+	if err := os.WriteFile(git, []byte("#!/bin/sh\nexec sleep 10\n"), 0o755); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -373,7 +382,7 @@ func TestExecGitPushProbeTimesOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("push credential probe succeeded with a hung git process")
 	}
-	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+	if elapsed := time.Since(started); elapsed > hungGitReturnCeiling {
 		t.Fatalf("push credential probe returned after %s, want bounded network timeout", elapsed)
 	}
 }

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -95,7 +95,7 @@ func CheckBareCloneHealth(ctx context.Context, barePath string) error {
 }
 
 // CheckWorktreeIndexes reports the first linked worktree whose index git
-// cannot read.
+// cannot use.
 //
 // Split out of CheckBareCloneHealth because the two answer different
 // questions and only one of them should gate dispatch. An index git cannot
@@ -104,9 +104,7 @@ func CheckBareCloneHealth(ctx context.Context, barePath string) error {
 // from a single unscoped `git fsck` exit code conflated them, so ordinary
 // worktree churn read as clone corruption.
 //
-// Reads the index via `git ls-files` rather than `git status`: it parses the
-// index without stat-ing the working tree, which matters when this runs
-// across dozens of live worktrees on every dispatch.
+// See indexUsable for what "cannot read" covers and why it is two probes.
 func CheckWorktreeIndexes(ctx context.Context, barePath string) error {
 	entries, err := os.ReadDir(filepath.Join(barePath, "worktrees"))
 	if err != nil {
@@ -132,22 +130,47 @@ func CheckWorktreeIndexes(ctx context.Context, barePath string) error {
 		if _, err := os.Stat(filepath.Join(adminDir, "index")); err != nil {
 			continue
 		}
-		if err := indexReadable(ctx, checkoutPath); err != nil {
-			return fmt.Errorf("worktrees/%s/index file is unreadable: %w", entry.Name(), err)
+		if err := indexUsable(ctx, checkoutPath); err != nil {
+			return fmt.Errorf("worktrees/%s: %w", entry.Name(), err)
 		}
 	}
 	return nil
 }
 
-// indexReadable reports whether git can parse the worktree's index.
+// indexUsable reports whether git can both parse the worktree's index and
+// resolve every object it names.
 //
-// Discards stdout rather than using executil.Run: this runs per worktree on
-// the dispatch path, and ls-files on a large repo emits thousands of paths
-// that would otherwise be buffered in full only to be thrown away. Only
-// stderr is kept, since that is what explains a parse failure.
-func indexReadable(ctx context.Context, checkoutPath string) error {
-	cmd := exec.CommandContext(ctx, "git", "ls-files")
-	cmd.Dir = checkoutPath
+// Two probes, because they fail differently and only one was covered before:
+// ls-files catches an index git cannot parse at all, while write-tree catches
+// an index that parses but names a blob the object database no longer has.
+// The second is the shape behind the "codegen gate could not checkpoint:
+// recovery commit: invalid object <sha> for '<path>'" failures seen on the
+// board — write-tree is the operation a commit performs, so it reproduces the
+// break exactly rather than approximating it.
+//
+// Missing that second case was not merely incomplete reporting:
+// rebuildWorktreeIndexes early-returns when this check passes, so an index in
+// that state received no repair at all and the checkpoint kept failing.
+//
+// This runs on the repair path (rebuildWorktreeIndexes), not per dispatch, so
+// write-tree's cost and its unreferenced-tree side effect are acceptable —
+// the tree it writes is one a commit would have written anyway, and it is
+// unreferenced garbage that gc collects.
+func indexUsable(ctx context.Context, checkoutPath string) error {
+	if err := runQuietGit(ctx, checkoutPath, "ls-files"); err != nil {
+		return fmt.Errorf("index is unparseable: %w", err)
+	}
+	if err := runQuietGit(ctx, checkoutPath, "write-tree"); err != nil {
+		return fmt.Errorf("index names an unresolvable object: %w", err)
+	}
+	return nil
+}
+
+// runQuietGit runs git in dir, discarding stdout and surfacing only stderr,
+// which is the part that explains a failure.
+func runQuietGit(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
 	cmd.Stdout = io.Discard
 	var stderr strings.Builder
 	cmd.Stderr = &stderr

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -98,13 +98,17 @@ func CheckBareCloneHealth(ctx context.Context, barePath string) error {
 // cannot use.
 //
 // Split out of CheckBareCloneHealth because the two answer different
-// questions and only one of them should gate dispatch. An index git cannot
-// parse makes that one worktree unusable and is worth repairing; an index
-// that parses but whose cache-tree names pruned blobs is inert. Deriving both
-// from a single unscoped `git fsck` exit code conflated them, so ordinary
-// worktree churn read as clone corruption.
+// questions and only one of them should gate dispatch. A damaged index makes
+// its own worktree unusable and is worth repairing, but it says nothing about
+// whether the shared clone is fit for every other task. Deriving both from a
+// single unscoped `git fsck` exit code conflated them, so ordinary worktree
+// churn read as clone corruption.
 //
-// See indexUsable for what "cannot read" covers and why it is two probes.
+// Note the reflog case stays out of scope on purpose: a worktree reflog naming
+// a pruned object is genuinely inert, and folding it in is what made the old
+// gate fail permanently. An index naming a missing object is not inert — it
+// breaks the next commit — so indexUsable treats it as repair-worthy. See
+// indexUsable for both probes.
 func CheckWorktreeIndexes(ctx context.Context, barePath string) error {
 	entries, err := os.ReadDir(filepath.Join(barePath, "worktrees"))
 	if err != nil {

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -382,3 +382,54 @@ func TestCheckBareCloneHealth_StillDetectsMissingReachableObject(t *testing.T) {
 		t.Fatal("health gate passed with the HEAD commit object deleted")
 	}
 }
+
+// The index parses fine here but names a blob the object database no longer
+// has — the shape behind the "recovery commit: invalid object <sha> for
+// <path>" checkpoint failures. ls-files alone reports it healthy, so
+// rebuildWorktreeIndexes used to early-return and repair nothing.
+func TestCheckWorktreeIndexes_DetectsIndexNamingMissingObject(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "obj-task", "origin/"+branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "staged.txt"), []byte("staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "add", "staged.txt").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v: %s", err, out)
+	}
+	shaOut, err := exec.Command("git", "-C", wtPath, "rev-parse", ":staged.txt").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sha := strings.TrimSpace(string(shaOut))
+	loose := filepath.Join(bare, "objects", sha[:2], sha[2:])
+	if _, statErr := os.Stat(loose); statErr != nil {
+		t.Skipf("staged blob is not a loose object: %v", statErr)
+	}
+	if err := os.Remove(loose); err != nil {
+		t.Fatal(err)
+	}
+
+	// Guard: if ls-files started failing here, this test would pass for the
+	// wrong reason and stop covering the write-tree probe.
+	if err := runQuietGit(context.Background(), wtPath, "ls-files"); err != nil {
+		t.Fatalf("ls-files already fails, so this no longer isolates the write-tree probe: %v", err)
+	}
+	if err := CheckWorktreeIndexes(context.Background(), bare); err == nil {
+		t.Fatal("index naming a missing object reported healthy")
+	}
+}

--- a/internal/workflow/check_timeout.go
+++ b/internal/workflow/check_timeout.go
@@ -12,6 +12,11 @@ import (
 // genuine hang into an effectively unbounded wait.
 const verifyTimeoutScaleCeiling int64 = 8
 
+// verifyTimeoutScaleCeilingLoad is the load-per-CPU at which scaling saturates.
+// Tests that must exercise the widest budget stub this rather than an arbitrary
+// value, so a change to the ceiling keeps them in step.
+const verifyTimeoutScaleCeilingLoad = float64(verifyTimeoutScaleCeiling)
+
 var workflowCheckLoadPerCPU = pressure.CurrentLoadPerCPU
 
 // resolveWorkflowCheckTimeout derives the effective timeout budget for

--- a/internal/workflow/engine_steps_codegen_test.go
+++ b/internal/workflow/engine_steps_codegen_test.go
@@ -247,7 +247,14 @@ func TestExecCodegenGate_TimeoutFlagsHumanRequired(t *testing.T) {
 
 func TestExecCodegenGate_ScaledTimeoutAbsorbsHostOversubscription(t *testing.T) {
 	orig := workflowCheckLoadPerCPU
-	workflowCheckLoadPerCPU = func() (float64, bool) { return 3.0, true }
+	// Stubbed at the scale ceiling, not just above 1: the assertion needs the
+	// scaled budget to clear `sleep 0.2` plus real process-spawn cost on a
+	// machine already running the rest of the suite. At load 3 the budget was
+	// 300ms against a 200ms sleep, and that 100ms margin is what made this
+	// flake under `go test ./...` while passing in isolation. At the ceiling
+	// the budget is 800ms, while the unscaled 100ms still fails without
+	// scaling — so the test proves the same thing with 4x the headroom.
+	workflowCheckLoadPerCPU = func() (float64, bool) { return verifyTimeoutScaleCeilingLoad, true }
 	t.Cleanup(func() { workflowCheckLoadPerCPU = orig })
 
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})

--- a/internal/workflow/engine_steps_focused_checks_test.go
+++ b/internal/workflow/engine_steps_focused_checks_test.go
@@ -130,7 +130,14 @@ func TestExecFocusedChecks_PassIsClean(t *testing.T) {
 
 func TestExecFocusedChecks_ScaledTimeoutAbsorbsHostOversubscription(t *testing.T) {
 	orig := workflowCheckLoadPerCPU
-	workflowCheckLoadPerCPU = func() (float64, bool) { return 3.0, true }
+	// Stubbed at the scale ceiling, not just above 1: the assertion needs the
+	// scaled budget to clear `sleep 0.2` plus real process-spawn cost on a
+	// machine already running the rest of the suite. At load 3 the budget was
+	// 300ms against a 200ms sleep, and that 100ms margin is what made this
+	// flake under `go test ./...` while passing in isolation. At the ceiling
+	// the budget is 800ms, while the unscaled 100ms still fails without
+	// scaling — so the test proves the same thing with 4x the headroom.
+	workflowCheckLoadPerCPU = func() (float64, bool) { return verifyTimeoutScaleCeilingLoad, true }
 	t.Cleanup(func() { workflowCheckLoadPerCPU = orig })
 
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -180,7 +180,14 @@ func TestVerifyTaskNow_TimeoutFailsClosed(t *testing.T) {
 
 func TestVerifyTaskNow_ScaledTimeoutAbsorbsHostOversubscription(t *testing.T) {
 	orig := workflowCheckLoadPerCPU
-	workflowCheckLoadPerCPU = func() (float64, bool) { return 3.0, true }
+	// Stubbed at the scale ceiling, not just above 1: the assertion needs the
+	// scaled budget to clear `sleep 0.2` plus real process-spawn cost on a
+	// machine already running the rest of the suite. At load 3 the budget was
+	// 300ms against a 200ms sleep, and that 100ms margin is what made this
+	// flake under `go test ./...` while passing in isolation. At the ceiling
+	// the budget is 800ms, while the unscaled 100ms still fails without
+	// scaling — so the test proves the same thing with 4x the headroom.
+	workflowCheckLoadPerCPU = func() (float64, bool) { return verifyTimeoutScaleCeilingLoad, true }
 	t.Cleanup(func() { workflowCheckLoadPerCPU = orig })
 
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
@@ -321,7 +328,9 @@ func TestResolveWorkflowCheckTimeout_ScalesWithHostLoad(t *testing.T) {
 
 func TestExecVerifyChecks_ScaledTimeoutAbsorbsHostOversubscription(t *testing.T) {
 	orig := workflowCheckLoadPerCPU
-	workflowCheckLoadPerCPU = func() (float64, bool) { return 3.0, true }
+	// Ceiling load, not 3.0 — see the sibling tests: a 300ms budget against a
+	// 200ms sleep left only 100ms for process spawn and flaked under suite load.
+	workflowCheckLoadPerCPU = func() (float64, bool) { return verifyTimeoutScaleCeilingLoad, true }
 	t.Cleanup(func() { workflowCheckLoadPerCPU = orig })
 
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})


### PR DESCRIPTION
## Motivation

Closes #2896.

`mise run verify` — the documented pre-commit gate — has been failing on darwin for reasons unrelated to whatever is being committed. That trains contributors to re-run until green, and re-running until green is how a real regression gets waved through.

> Changelog: test(test): remove load-sensitive timing flakes from the verify gate

## Implementation information

**The diagnosis recorded on #2896 was wrong, and this PR corrects it.** I wrote that the scaling helper reads Linux-only `/proc/loadavg`. It does not: `internal/testutil/loadscale/hostload_darwin.go` has a working darwin implementation via `sysctl -n vm.loadavg`. The load reading was never the problem.

The actual cause is thin wall-clock margins in two test families.

**`*_ScaledTimeoutAbsorbsHostOversubscription` (4 tests).** They stubbed load at `3.0`, so a 100ms base scaled to a **300ms budget** while the command under test was `sleep 0.2`. That leaves 100ms for a shell spawn. The observed failure took 1.15s. They now stub at `verifyTimeoutScaleCeilingLoad`, giving an 800ms budget against the same 200ms sleep — 4x the headroom. The unscaled 100ms still fails without scaling, so each test proves exactly what it did before.

**`TestRemoteGitOperationsTimeOut` + siblings (3 assertions).** They required a hung remote git call to return within **500ms** of a 20ms timeout, against a fake git sleeping 1s. Under suite load the return itself took seconds. The discriminating power here comes from the gap between the timeout and the sleep, not from a tight wall-clock bound — so the fake git now sleeps 10s and the ceiling is 5s, via a named `hungGitReturnCeiling` constant.

## Supporting documentation

Mutation-tested in both directions, because widening a margin is exactly the change that can silently turn a flaky test into a dead one:

- Replacing `networkGitContext`'s `WithTimeout` with `WithCancel` (i.e. removing the network timeout entirely) still fails `TestRemoteGitOperationsTimeOut` — the wider ceiling has not traded a flake for a blind spot.
- The scaling math already has direct, race-free coverage (`resolveWorkflowCheckTimeout(2s) == 6s`), so these four keep their distinct job: proving the scaled budget is actually plumbed into the exec path.

`./internal/project/` and `./internal/workflow/` both pass. Timings are unchanged in the normal case — the git tests still return in ~20ms; only the failure path is slower, which is the correct trade.

**Second commit, separate concern:** `CheckWorktreeIndexes` only ran `git ls-files`, catching an index git cannot parse but not one that parses while naming a blob the object database no longer has. That second shape produced the `codegen gate could not checkpoint: recovery commit: invalid object <sha> for <path>` failures on the board. It was not just incomplete reporting — `rebuildWorktreeIndexes` early-returns when the check passes, so an index in that state got **no repair at all**. Adds a `git write-tree` probe (the operation a commit actually performs) plus a regression test that first guards that `ls-files` still succeeds, so it cannot pass for the wrong reason. Mutation-tested: dropping the probe fails it.

Note `main` is separately red on Wails Bindings Sync — fixed in #2929, not here.
