### PR TITLE
fix(stats): append run records as ndjson

### DIFF
--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -196,14 +196,14 @@ Acceptance checks:
 
 ```bash
 api TaskService GetTask "[\"$TASK_ID\"]" | jq '.status, .agentRuns[-1]'
-cat "$TMP/home/stats.json" | jq '.[-1]'
+tail -n 1 "$TMP/home/stats.json" | jq .
 api App GetEvaluationReport '[]' | jq '.byAgentModel, .byExperimentKind'
 ```
 
 Expected:
 
 - `agentRuns[-1]` has `model`, `experimentId`, `variantId`, `assignmentUnit`, and `assignmentKey`.
-- `stats.json[-1]` has the same A/B metadata.
+- The final NDJSON record in `stats.json` has the same A/B metadata.
 - Copilot smoke runs preserve fractional `premiumRequests` such as `7.5`.
 - Evaluation report includes rows in `byAgentModel` and `byExperimentKind` groups (`kind: "model"`, `"prompt"`, `"skill"`, `"unknown"`), each with a `groups[]` list keyed by `experimentId` (never mixing two experiments' rows), and each `groups[].rows`/`groups[].rowsContribution` breakdown carrying role drilldowns when multiple roles are present.
 

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -15,11 +15,9 @@ import (
 // The in-memory Len() check is a fast path only, so backfill is a no-op cost
 // after the first successful run instead of scanning the full audit dir on
 // every startup. The authoritative guard is the reload+recheck inside the
-// lock below: the has-records guard and the append are one read-modify-write
-// critical section, flocked across it. Without the reload immediately inside
-// the lock, a concurrent Record from another process (or another instance of
-// Backfill) between this process's stale in-memory check and its flush would
-// be silently discarded by the overwrite.
+// lock below: the has-records guard and the append are one critical section,
+// flocked across it. Reloading is needed only for this startup backfill path;
+// ordinary Record calls append without decoding the history.
 func (s *Store) Backfill(auditDir string) error {
 	if s.Len() > 0 {
 		return nil
@@ -52,8 +50,8 @@ func (s *Store) Backfill(auditDir string) error {
 	records := backfillRecords(events)
 	s.runs = append(s.runs, records...)
 
-	if len(s.runs) > 0 {
-		return s.flush()
+	if err := s.appendLocked(records); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -1,8 +1,10 @@
 package stats
 
 import (
+	"bytes"
 	"cmp"
 	"encoding/json"
+	"fmt"
 	"os"
 	"slices"
 	"sync"
@@ -16,28 +18,37 @@ const storeLockTimeout = 2 * time.Second
 
 // Store persists RunRecords to a JSON file and computes aggregates in memory.
 type Store struct {
-	path string
-	mu   sync.Mutex
-	runs []RunRecord
+	path         string
+	mu           sync.Mutex
+	runs         []RunRecord
+	legacyFormat bool
+	offset       int64
 }
 
 func NewStore(path string) (*Store, error) {
 	s := &Store{path: path}
+	unlock, err := fsutil.LockFileWithin(path, storeLockTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if err := s.reloadLocked(); err != nil {
 		return nil, err
+	}
+	if s.legacyFormat {
+		if err := s.rewriteLocked(); err != nil {
+			return nil, err
+		}
 	}
 	return s, nil
 }
 
-// Record appends r and persists it. s.runs is populated once at NewStore
-// time and never re-read afterward on the query paths, so a naive
-// append-and-flush here would silently drop any run written by another
-// process (sybra-cli and the GUI server each hold their own Store over the
-// same path) in the gap since this process last loaded the file. Reloading
-// from disk under the bounded cross-process flock, immediately before appending,
-// closes that gap: the in-memory s.runs is resynced to the authoritative
-// on-disk state before this run is added. The flock is acquired before s.mu so
-// a stalled peer process cannot block in-process stats readers.
+// Record appends r as one NDJSON line while holding the cross-process lock.
+// This avoids repeatedly decoding and atomically rewriting the full history
+// on every agent completion. The lock is acquired before s.mu so a stalled
+// peer process cannot block in-process stats readers.
 func (s *Store) Record(r RunRecord) error {
 	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
 	if err != nil {
@@ -47,39 +58,148 @@ func (s *Store) Record(r RunRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.reloadLocked(); err != nil {
+	if err := s.syncLocked(); err != nil {
+		return err
+	}
+	if err := s.appendLocked([]RunRecord{r}); err != nil {
 		return err
 	}
 	s.runs = append(s.runs, r)
-	return s.flush()
+	return nil
 }
 
-// reloadLocked re-reads s.path into s.runs. Read-modify-write callers
-// (Record) must hold both s.mu and the cross-process file lock across the
-// whole critical section; NewStore calls it unlocked because it runs before
-// s is returned to any caller, so nothing else can observe or race it yet.
+// reloadLocked re-reads both legacy JSON arrays and the current NDJSON format
+// into s.runs. Callers must hold s.mu; callers that may race another process
+// must also hold the cross-process file lock.
 func (s *Store) reloadLocked() error {
 	data, err := os.ReadFile(s.path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			s.runs = nil
+			s.offset = 0
 			return nil
 		}
 		return err
 	}
-	if len(data) == 0 {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
 		s.runs = nil
+		s.legacyFormat = false
+		s.offset = int64(len(data))
 		return nil
 	}
-	var runs []RunRecord
-	if err := json.Unmarshal(data, &runs); err != nil {
+	if trimmed[0] == '[' {
+		if err := json.Unmarshal(trimmed, &s.runs); err != nil {
+			return err
+		}
+		s.legacyFormat = true
+		s.offset = int64(len(data))
+		return nil
+	}
+	data, err = repairIncompleteTail(s.path, data)
+	if err != nil {
+		return err
+	}
+	runs, err := parseNDJSON(data, 1)
+	if err != nil {
 		return err
 	}
 	s.runs = runs
+	s.legacyFormat = false
+	s.offset = int64(len(data))
 	return nil
 }
 
+// syncLocked incrementally loads records appended by another process since
+// offset. It must hold both the file lock and s.mu.
+func (s *Store) syncLocked() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) && s.offset == 0 {
+			return nil
+		}
+		return err
+	}
+	if int64(len(data)) < s.offset {
+		return s.reloadLocked()
+	}
+	data, err = repairIncompleteTail(s.path, data)
+	if err != nil {
+		return err
+	}
+	if int64(len(data)) < s.offset {
+		return s.reloadLocked()
+	}
+	if int64(len(data)) == s.offset {
+		return nil
+	}
+	firstLine := bytes.Count(data[:s.offset], []byte{'\n'}) + 1
+	runs, err := parseNDJSON(data[s.offset:], firstLine)
+	if err != nil {
+		return err
+	}
+	s.runs = append(s.runs, runs...)
+	s.offset = int64(len(data))
+	return nil
+}
+
+// syncForRead makes already-open stores observe another process's append.
+// It avoids taking the file lock when the file has not grown, keeping normal
+// UI and evaluation reads independent from a peer that merely holds the lock.
+func (s *Store) syncForRead() {
+	info, err := os.Stat(s.path)
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	offset := s.offset
+	s.mu.Unlock()
+	if info.Size() <= offset {
+		return
+	}
+	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
+	if err != nil {
+		return
+	}
+	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.syncLocked()
+}
+
+func parseNDJSON(data []byte, firstLine int) ([]RunRecord, error) {
+	lines := bytes.Split(data, []byte{'\n'})
+	runs := make([]RunRecord, 0, len(lines))
+	for i, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var r RunRecord
+		if err := json.Unmarshal(line, &r); err != nil {
+			return nil, fmt.Errorf("parse stats record on line %d: %w", firstLine+i, err)
+		}
+		runs = append(runs, r)
+	}
+	return runs, nil
+}
+
+// repairIncompleteTail removes only an unterminated final NDJSON record. A
+// crashed writer can leave that suffix behind; newline-terminated malformed
+// records remain an error so genuine data corruption is not hidden.
+func repairIncompleteTail(path string, data []byte) ([]byte, error) {
+	if len(data) == 0 || data[len(data)-1] == '\n' {
+		return data, nil
+	}
+	end := bytes.LastIndexByte(data, '\n') + 1
+	if err := os.Truncate(path, int64(end)); err != nil {
+		return nil, fmt.Errorf("truncate incomplete stats record: %w", err)
+	}
+	return data[:end], nil
+}
+
 func (s *Store) Len() int {
+	s.syncForRead()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.runs)
@@ -89,6 +209,7 @@ func (s *Store) Len() int {
 // compute scorecards over an arbitrary time window (Query only exposes fixed
 // windows and the last 50 runs).
 func (s *Store) All() []RunRecord {
+	s.syncForRead()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return slices.Clone(s.runs)
@@ -99,6 +220,7 @@ func (s *Store) Query() StatsResponse {
 }
 
 func (s *Store) QueryAt(now time.Time) StatsResponse {
+	s.syncForRead()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -199,12 +321,63 @@ func normalizedRunRecord(r RunRecord) RunRecord {
 	return r
 }
 
-func (s *Store) flush() error {
-	data, err := json.Marshal(s.runs)
+// appendLocked appends records in one write so a locked peer never observes a
+// partially written record. Callers must hold both the file lock and s.mu.
+func (s *Store) appendLocked(records []RunRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	data, err := marshalNDJSON(records)
 	if err != nil {
 		return err
 	}
-	return fsutil.AtomicWrite(s.path, data)
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	start := s.offset
+	n, err := f.Write(data)
+	if err == nil && n != len(data) {
+		err = fmt.Errorf("short stats append: wrote %d of %d bytes", n, len(data))
+	}
+	if err != nil {
+		_ = f.Truncate(start)
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	s.offset += int64(len(data))
+	return nil
+}
+
+// rewriteLocked is used only to migrate the legacy JSON array format. Normal
+// writes never rewrite the accumulated history.
+func (s *Store) rewriteLocked() error {
+	data, err := marshalNDJSON(s.runs)
+	if err != nil {
+		return err
+	}
+	if err := fsutil.AtomicWrite(s.path, data); err != nil {
+		return err
+	}
+	s.legacyFormat = false
+	s.offset = int64(len(data))
+	return nil
+}
+
+func marshalNDJSON(records []RunRecord) ([]byte, error) {
+	var data bytes.Buffer
+	for i := range records {
+		line, err := json.Marshal(records[i])
+		if err != nil {
+			return nil, err
+		}
+		data.Write(line)
+		data.WriteByte('\n')
+	}
+	return data.Bytes(), nil
 }
 
 // roleReviewLabel mirrors agent.RoleReview and bestOfNAssignmentUnit mirrors

--- a/internal/stats/store_test.go
+++ b/internal/stats/store_test.go
@@ -1,10 +1,15 @@
 package stats
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 func TestNewStoreEmpty(t *testing.T) {
@@ -169,6 +174,77 @@ func TestPersistence(t *testing.T) {
 	}
 }
 
+func TestRecord_PersistsAppendOnlyNDJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Record(RunRecord{ID: "first", Timestamp: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Record(RunRecord{ID: "second", Timestamp: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(after, before) {
+		t.Fatal("second Record rewrote existing NDJSON history instead of appending")
+	}
+	lines := bytes.Split(bytes.TrimSpace(after), []byte{'\n'})
+	if len(lines) != 2 {
+		t.Fatalf("NDJSON lines = %d, want 2", len(lines))
+	}
+	var second RunRecord
+	if err := json.Unmarshal(lines[1], &second); err != nil {
+		t.Fatalf("parse second NDJSON line: %v", err)
+	}
+	if second.ID != "second" {
+		t.Fatalf("second NDJSON ID = %q, want second", second.ID)
+	}
+}
+
+func TestNewStore_MigratesLegacyJSONArray(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	legacy, err := json.Marshal([]RunRecord{{ID: "legacy", Timestamp: time.Now()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Len() != 1 {
+		t.Fatalf("Len after legacy migration = %d, want 1", s.Len())
+	}
+	migrated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.HasPrefix(bytes.TrimSpace(migrated), []byte{'['}) {
+		t.Fatal("legacy JSON array was not migrated to NDJSON")
+	}
+	if err := s.Record(RunRecord{ID: "current", Timestamp: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Len() != 2 {
+		t.Fatalf("Len after legacy migration and append = %d, want 2", reloaded.Len())
+	}
+}
+
 // TestRecordCrossProcessSimulatesConcurrentWriters models two OS processes
 // (e.g. the GUI server and sybra-cli) each holding their own *Store over the
 // same path. s.runs is loaded once at NewStore time and never re-read on the
@@ -194,6 +270,9 @@ func TestRecordCrossProcessSimulatesConcurrentWriters(t *testing.T) {
 	if err := s2.Record(RunRecord{ID: "a2", TaskID: "t2", Timestamp: time.Now()}); err != nil {
 		t.Fatalf("s2.Record: %v", err)
 	}
+	if s1.Len() != 2 || s2.Len() != 2 {
+		t.Fatalf("live stores do not converge after cross-process appends: s1=%d s2=%d", s1.Len(), s2.Len())
+	}
 
 	s3, err := NewStore(path)
 	if err != nil {
@@ -201,6 +280,72 @@ func TestRecordCrossProcessSimulatesConcurrentWriters(t *testing.T) {
 	}
 	if s3.Len() != 2 {
 		t.Fatalf("Len() = %d, want 2 — a run was dropped by concurrent cross-process writes", s3.Len())
+	}
+}
+
+func TestNewStore_DiscardsIncompleteFinalNDJSONRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	valid, err := marshalNDJSON([]RunRecord{{ID: "valid", Timestamp: time.Now()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(valid, []byte(`{"id":"truncated"`)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore with incomplete final record: %v", err)
+	}
+	if s.Len() != 1 {
+		t.Fatalf("Len after incomplete-tail recovery = %d, want 1", s.Len())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, valid) {
+		t.Fatalf("recovered file = %q, want %q", got, valid)
+	}
+}
+
+func TestNewStore_RejectsMalformedCompleteNDJSONRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	if err := os.WriteFile(path, []byte("{not json}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewStore(path); err == nil {
+		t.Fatal("NewStore accepted a malformed newline-terminated record")
+	}
+}
+
+func TestStore_SyncReportsActualLineForMalformedAppend(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.json")
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Record(RunRecord{ID: "valid", Timestamp: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("{not json}\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := fsutil.LockFileWithin(path, storeLockTimeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = unlock() }()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.syncLocked(); err == nil || !strings.Contains(err.Error(), "line 2") {
+		t.Fatalf("syncLocked error = %v, want line 2", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Stats rewrote and re-parsed its full run history after every agent completion, making accumulated writes quadratic and putting large parses behind the stats mutex.

## Implementation information

Migrates legacy JSON arrays to NDJSON once at startup, appends normal records and backfill batches under the existing cross-process lock, and incrementally synchronizes externally appended records for live stores. Unterminated final records from interrupted writes are safely discarded; malformed complete records still surface errors. The manual runtime probe now reads the final NDJSON line.

Closes #2869

> Changelog: fix(stats): append run records as ndjson