### PR TITLE
fix(selfmonitor): bound judge attempts

### DIFF
--- a/internal/selfmonitor/judge.go
+++ b/internal/selfmonitor/judge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/llmexec"
@@ -13,6 +14,11 @@ import (
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+// judgeAttemptTimeout bounds each provider invocation, including llmjob repair
+// attempts. A judge is advisory: a wedged CLI must not freeze the sequential
+// self-monitor loop indefinitely.
+const judgeAttemptTimeout = 2 * time.Minute
 
 // Judge classifies a single health Finding given its distilled log summary
 // and optional task context. Returns a filled Verdict; callers should treat
@@ -40,15 +46,20 @@ func (j *ClaudeJudge) Judge(ctx context.Context, f health.Finding, ls *LogSummar
 
 	prompt := buildJudgePrompt(f, ls, t)
 
-	v, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[Verdict]{
-		Name:     "selfmonitor-judge",
-		Tier:     selfMonitorTier(model),
-		Validate: validateJudgeVerdict,
-	}, llmexec.Options{Logger: j.Logger, Gate: j.Gate})
+	v, _, err := llmjob.Run(ctx, prompt, judgeJobSpec(model), llmexec.Options{Logger: j.Logger, Gate: j.Gate})
 	if err != nil {
 		return Verdict{Classification: VerdictPending}, err
 	}
 	return v, nil
+}
+
+func judgeJobSpec(model string) llmjob.Spec[Verdict] {
+	return llmjob.Spec[Verdict]{
+		Name:           "selfmonitor-judge",
+		Tier:           selfMonitorTier(model),
+		Validate:       validateJudgeVerdict,
+		AttemptTimeout: judgeAttemptTimeout,
+	}
 }
 
 func selfMonitorTier(model string) llmjob.Tier {

--- a/internal/selfmonitor/judge_test.go
+++ b/internal/selfmonitor/judge_test.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/task"
 )
 
 func TestJudgeJobSpecBoundsEachProviderAttempt(t *testing.T) {
-	spec := judgeJobSpec("claude-haiku-4-5-20251001")
-	if got, want := spec.AttemptTimeout, 2*time.Minute; got != want {
+	const model = "claude-haiku-4-5-20251001"
+	spec := judgeJobSpec(model)
+	if got, want := spec.AttemptTimeout, judgeAttemptTimeout; got != want {
 		t.Errorf("AttemptTimeout = %s, want %s", got, want)
 	}
-	if got, want := spec.Tier, selfMonitorTier("claude-haiku-4-5-20251001"); got != want {
+	if got, want := spec.Tier, selfMonitorTier(model); got != want {
 		t.Errorf("Tier = %v, want %v", got, want)
 	}
 }

--- a/internal/selfmonitor/judge_test.go
+++ b/internal/selfmonitor/judge_test.go
@@ -4,10 +4,21 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+func TestJudgeJobSpecBoundsEachProviderAttempt(t *testing.T) {
+	spec := judgeJobSpec("claude-haiku-4-5-20251001")
+	if got, want := spec.AttemptTimeout, 2*time.Minute; got != want {
+		t.Errorf("AttemptTimeout = %s, want %s", got, want)
+	}
+	if got, want := spec.Tier, selfMonitorTier("claude-haiku-4-5-20251001"); got != want {
+		t.Errorf("Tier = %v, want %v", got, want)
+	}
+}
 
 // stubJudge satisfies the Judge interface for unit tests.
 type stubJudge struct {


### PR DESCRIPTION
## Motivation

A hung self-monitor judge provider could block the sequential monitor loop indefinitely because the job inherited the app-lifetime context.

## Implementation information

Give each self-monitor judge provider attempt a two-minute llmjob deadline, including repair attempts. The existing job runner preserves transient-error handling and retries with fresh bounded contexts.

Closes #2871

> Changelog: fix(selfmonitor): bound judge attempts