### PR TITLE
fix(sandbox): allow detached HEAD worktrees

### DIFF
--- a/internal/agent/procsandbox_git.go
+++ b/internal/agent/procsandbox_git.go
@@ -133,19 +133,25 @@ func resolveGitSharedWritablePaths(ctx context.Context, worktree string) (gitSha
 			paths.objectDir = paths.readonly[len(paths.readonly)-1]
 		}
 	}
-	branchRefDir, err := ensureGitPathDir(ctx, worktree, filepath.Dir(branchRef))
-	if err != nil {
-		return gitSharedPaths{}, fmt.Errorf("resolve current branch dir: %w", err)
-	}
-	paths.branchRefDir = branchRefDir
+	// Detached HEAD (branchRef == "") has no branch ref or reflog to make
+	// writable, so there is nothing to resolve. prepareGitSandboxOverlay
+	// already skips its branch-overlay work on an empty branchRef, so the
+	// spec stays coherent — the run simply gets no branch-scoped grant.
+	if branchRef != "" {
+		branchRefDir, err := ensureGitPathDir(ctx, worktree, filepath.Dir(branchRef))
+		if err != nil {
+			return gitSharedPaths{}, fmt.Errorf("resolve current branch dir: %w", err)
+		}
+		paths.branchRefDir = branchRefDir
 
-	branchLogDir, err := ensureGitPathDir(ctx, worktree, filepath.Dir(filepath.Join("logs", branchRef)))
-	if err != nil {
-		return gitSharedPaths{}, fmt.Errorf("resolve current branch log dir: %w", err)
-	}
-	paths.branchLogDir = branchLogDir
-	if _, err := ensureGitPathFile(ctx, worktree, filepath.Join("logs", branchRef)); err != nil {
-		return gitSharedPaths{}, fmt.Errorf("resolve current branch log: %w", err)
+		branchLogDir, err := ensureGitPathDir(ctx, worktree, filepath.Dir(filepath.Join("logs", branchRef)))
+		if err != nil {
+			return gitSharedPaths{}, fmt.Errorf("resolve current branch log dir: %w", err)
+		}
+		paths.branchLogDir = branchLogDir
+		if _, err := ensureGitPathFile(ctx, worktree, filepath.Join("logs", branchRef)); err != nil {
+			return gitSharedPaths{}, fmt.Errorf("resolve current branch log: %w", err)
+		}
 	}
 	for _, spec := range []struct {
 		label string
@@ -378,21 +384,49 @@ func gitPathRaw(ctx context.Context, worktree string, args ...string) (string, e
 	return path, nil
 }
 
+// gitExitCode reports a git process exit code, or -1 when err is not an exit
+// failure (spawn error, context cancellation).
+func gitExitCode(err error) int {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
+}
+
 func gitRevParsePath(ctx context.Context, worktree, arg string) (string, error) {
 	return gitPath(ctx, worktree, arg)
 }
 
+// gitSymbolicRef returns the branch ref HEAD points at, or "" when HEAD is
+// detached.
+//
+// A detached HEAD is a normal state here, not a failure: a review worktree
+// checked out at a pull-request head has no branch. Treating it as an error
+// failed the whole run closed under sandbox enforce with a bare
+// "git symbolic-ref -q HEAD: exit status 1", which reads like a broken repo
+// rather than "this checkout has no branch".
+//
+// `-q` is what makes the two distinguishable: it suppresses the
+// "ref HEAD is not a symbolic ref" message, so a detached HEAD exits 1 with
+// empty output, while a real failure (not a repository, unreadable HEAD)
+// exits 128 and prints. Only the first is swallowed.
 func gitSymbolicRef(ctx context.Context, worktree string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
 	cmd.Dir = worktree
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
+		if msg == "" && gitExitCode(err) == 1 {
+			return "", nil
+		}
 		if msg == "" {
 			return "", fmt.Errorf("git symbolic-ref -q HEAD: %w", err)
 		}
 		return "", fmt.Errorf("git symbolic-ref -q HEAD: %w: %s", err, msg)
 	}
+	// Exit 0 with no ref is not a state git produces; treat it as a real fault
+	// rather than silently reporting "detached".
 	ref := strings.TrimSpace(string(out))
 	if ref == "" {
 		return "", fmt.Errorf("git symbolic-ref -q HEAD: empty ref")

--- a/internal/agent/procsandbox_git_test.go
+++ b/internal/agent/procsandbox_git_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+	"os/exec"
 	"slices"
 	"testing"
 )
@@ -9,5 +11,56 @@ func TestDedupeRoots_DropsEmptyAndDuplicate(t *testing.T) {
 	got := dedupeRoots("/a", "/a", "", "/b", "  ", "/a")
 	if !slices.Equal(got, []string{"/a", "/b"}) {
 		t.Errorf("dedupeRoots = %v, want [/a /b]", got)
+	}
+}
+
+// A review worktree checked out at a pull-request head has no branch. Treating
+// that as an error failed the entire run closed under sandbox enforce with a
+// bare "git symbolic-ref -q HEAD: exit status 1".
+func TestResolveGitSharedWritablePaths_DetachedHeadIsNotAnError(t *testing.T) {
+	wt := t.TempDir()
+	runGitOrFail(t, wt, "init", "-q", ".")
+	runGitOrFail(t, wt, "config", "user.email", "t@example.com")
+	runGitOrFail(t, wt, "config", "user.name", "T")
+	runGitOrFail(t, wt, "config", "commit.gpgsign", "false")
+	runGitOrFail(t, wt, "commit", "-q", "--allow-empty", "-m", "seed")
+
+	attached, err := resolveGitSharedWritablePaths(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("attached HEAD: %v", err)
+	}
+	if attached.branchRef == "" {
+		t.Fatal("attached HEAD resolved an empty branch ref")
+	}
+
+	runGitOrFail(t, wt, "checkout", "-q", "--detach")
+
+	detached, err := resolveGitSharedWritablePaths(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("detached HEAD must not fail sandbox setup: %v", err)
+	}
+	if detached.branchRef != "" {
+		t.Fatalf("branchRef = %q, want empty on a detached HEAD", detached.branchRef)
+	}
+	// The object dir is what the run actually needs; only the branch-scoped
+	// grants drop away.
+	if detached.objectDir == "" {
+		t.Fatal("detached HEAD lost the git object dir grant")
+	}
+}
+
+// Exit 128 (not a repository) must still fail rather than be read as detached.
+func TestGitSymbolicRef_RealFailureStillErrors(t *testing.T) {
+	if _, err := gitSymbolicRef(context.Background(), t.TempDir()); err == nil {
+		t.Fatal("gitSymbolicRef succeeded outside a git repository")
+	}
+}
+
+func runGitOrFail(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
 	}
 }


### PR DESCRIPTION
## Motivation

A worktree with a **detached HEAD** cannot run under `sandbox_mode: enforce` at all. The run aborts before spawning anything:

```
agent.Run: sandbox git metadata roots: resolve current branch ref:
git symbolic-ref -q HEAD: exit status 1
```

`resolveGitSharedWritablePaths` treated `git symbolic-ref`'s exit 1 as fatal. But a detached HEAD is a normal state, not a fault — a **review worktree checked out at a pull-request head has no branch**. That makes this reachable for an entire role rather than an edge case, and the message reads like a broken repository rather than "this checkout has no branch".

Reported from a live run; reproduced locally against the failing worktree (`symbolic-ref -q HEAD` → exit 1, empty output).

> Changelog: fix(sandbox): stop failing enforce-mode runs on a detached-HEAD worktree

## Implementation information

`-q` is what makes the cases separable, and the fix keys on exactly that:

| State | exit | output |
|---|---|---|
| on a branch | 0 | `refs/heads/…` |
| **detached HEAD** | **1** | **empty** (`-q` suppresses "not a symbolic ref") |
| not a repository | 128 | `fatal: not a git repository…` |

Only *exit 1 with empty output* is swallowed and reported as "no branch ref". Anything else still errors, and the exit-128 case keeps its own test so the swallow cannot widen unnoticed. Exit 0 with an empty ref stays a hard error — git does not produce that, so treating it as "detached" would hide a real fault.

When there is no branch ref, the branch-scoped grants are skipped. `prepareGitSandboxOverlay` already returned early on an empty `branchRef`, so the spec stays coherent — the run simply gets no branch-scoped grant, which is correct: there is no branch ref or reflog to make writable.

## Supporting documentation

- `TestResolveGitSharedWritablePaths_DetachedHeadIsNotAnError` — resolves the same worktree attached and then detached, asserting the detached case succeeds with an empty `branchRef` while **keeping the object-dir grant** the run actually needs.
- `TestGitSymbolicRef_RealFailureStillErrors` — a non-repository still errors, so this does not trade a fail-closed bug for a silent pass.
- Mutation-tested: removing the detached branch reproduces the reported failure verbatim, `resolve current branch ref: git symbolic-ref -q HEAD: exit status 1`.

`mise run verify` green end to end.

Worth noting for the sandbox rollout: this is a *fail-closed* path, so it did not corrupt anything — it refused to start. But it means any role whose worktree is a detached checkout was silently unable to run under enforce, which is the kind of gap the report-mode soak would not surface, since report never wraps and never reaches this resolver's failure as a run-abort.
