### PR TITLE
fix(fsutil): sync atomic writes

### DIFF
--- a/internal/fsutil/atomic_sync_darwin.go
+++ b/internal/fsutil/atomic_sync_darwin.go
@@ -1,20 +1,23 @@
-//go:build unix && !darwin
+//go:build darwin
 
 package fsutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"syscall"
 )
 
-// syncDir persists a completed rename. Syncing the replacement file alone
-// does not guarantee that its directory entry survives a power loss.
+// syncDir makes the directory entry durable when the filesystem supports it.
+// APFS commonly rejects directory fsync with EINVAL, which must not turn a
+// successfully renamed task write into an application failure.
 func syncDir(dir string) error {
 	f, err := os.Open(dir)
 	if err != nil {
 		return fmt.Errorf("open parent directory for sync: %w", err)
 	}
-	if err := f.Sync(); err != nil {
+	if err := f.Sync(); err != nil && !errors.Is(err, syscall.EINVAL) {
 		_ = f.Close()
 		return fmt.Errorf("sync parent directory: %w", err)
 	}

--- a/internal/fsutil/atomic_sync_other.go
+++ b/internal/fsutil/atomic_sync_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package fsutil
+
+// syncDir is a no-op on platforms where opening and syncing a directory is
+// unsupported. Sybra's production server and desktop targets are Unix.
+func syncDir(_ string) error { return nil }

--- a/internal/fsutil/atomic_sync_unix.go
+++ b/internal/fsutil/atomic_sync_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package fsutil
+
+import (
+	"fmt"
+	"os"
+)
+
+// syncDir persists a completed rename. Syncing the replacement file alone
+// does not guarantee that its directory entry survives a power loss.
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open parent directory for sync: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync parent directory: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close parent directory: %w", err)
+	}
+	return nil
+}

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -14,9 +14,12 @@ import (
 var ErrLockUnsupported = errors.New("fsutil: cross-process file locking is not supported on this platform")
 
 // AtomicWrite writes data to path via a temp file + rename to prevent
-// partial reads from concurrent goroutines. The temp file is removed on
-// every error path — including a failed rename into a read-only target
-// directory — so repeated write failures don't fill the disk with orphans.
+// partial reads from concurrent goroutines. It syncs the completed temp file
+// before renaming and syncs the containing directory afterwards, so Unix
+// filesystems persist both the new data and the name replacement across a
+// power loss. The temp file is removed on every pre-rename error path —
+// including a failed rename into a read-only target directory — so repeated
+// write failures don't fill the disk with orphans.
 //
 // The rename preserves whatever mode the temp file has, which os.CreateTemp
 // sets to 0600 regardless of the target's existing permissions. To avoid
@@ -36,23 +39,28 @@ func AtomicWrite(path string, data []byte) error {
 		_ = os.Remove(tmp)
 		return err
 	}
-	if err := f.Close(); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-
 	if info, err := os.Stat(path); err == nil {
-		if err := os.Chmod(tmp, info.Mode().Perm()); err != nil {
+		if err := f.Chmod(info.Mode().Perm()); err != nil {
+			_ = f.Close()
 			_ = os.Remove(tmp)
 			return err
 		}
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
 	}
 
 	if err := os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}
-	return nil
+	return syncDir(dir)
 }
 
 // RemoveAllForce removes path and everything under it, tolerating read-only

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -15,9 +15,9 @@ var ErrLockUnsupported = errors.New("fsutil: cross-process file locking is not s
 
 // AtomicWrite writes data to path via a temp file + rename to prevent
 // partial reads from concurrent goroutines. It syncs the completed temp file
-// before renaming and syncs the containing directory afterwards, so Unix
-// filesystems persist both the new data and the name replacement across a
-// power loss. The temp file is removed on every pre-rename error path —
+// before renaming and then attempts to sync the containing directory, so
+// supported filesystems persist both the new data and the name replacement
+// across a power loss. The temp file is removed on every pre-rename error path —
 // including a failed rename into a read-only target directory — so repeated
 // write failures don't fill the disk with orphans.
 //


### PR DESCRIPTION
## Motivation

A power loss after an atomic rename could leave task and sidecar data non-durable because the temporary file and parent directory were never synced.

## Implementation information

Sync the temporary file after its final mode is established and before rename, then sync the parent directory after rename on Unix. Keep a portable no-op directory-sync fallback for non-Unix builds.

Closes #2872

> Changelog: fix(fsutil): sync atomic writes