### PR TITLE
fix(task): quarantine unreadable task files

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -626,6 +626,15 @@ export class Task {
     "filePath": string;
 
     /**
+     * Degraded marks a synthetic, read-only board entry created for a task file
+     * that could not be parsed. It is never persisted and must never be
+     * dispatched or mirrored; fixing the source file makes the entry disappear
+     * on the next List.
+     */
+    "degraded"?: boolean;
+    "parseError"?: string;
+
+    /**
      * TamperFlagged reports whether this task is parked at human-required
      * pending a tamper bless. Derived from Status/StatusReason (never
      * persisted) so the frontend doesn't need to duplicate

--- a/frontend/src/stores/tasks.svelte.test.ts
+++ b/frontend/src/stores/tasks.svelte.test.ts
@@ -168,6 +168,31 @@ describe('TaskStore', () => {
     })
   })
 
+  describe('patchOne', () => {
+    it('reloads the board when an edited task becomes unreadable', async () => {
+      const degraded = makeTask({ id: 'unreadable-a1b2c3d4', status: 'human-required', title: 'Unreadable task file: t1.md' })
+      mockGetTask.mockRejectedValue(new Error('parse task t1.md: invalid frontmatter'))
+      mockListTasks.mockResolvedValue([degraded])
+
+      await taskStore.patchOne('t1')
+
+      await vi.waitFor(() => expect(mockListTasks).toHaveBeenCalled())
+      expect(taskStore.tasks.get(degraded.id)?.title).toBe(degraded.title)
+    })
+
+    it('removes the degraded entry when the source task is repaired', async () => {
+      const degraded = makeTask({ id: 'unreadable-a1b2c3d4', status: 'human-required', filePath: '/tasks/t1.md', degraded: true })
+      taskStore.tasks.set(degraded.id, degraded)
+      const repaired = makeTask({ id: 't1', filePath: '/tasks/t1.md' })
+      mockGetTask.mockResolvedValue(repaired)
+
+      await taskStore.patchOne('t1')
+
+      expect(taskStore.tasks.has(degraded.id)).toBe(false)
+      expect(taskStore.tasks.get('t1')).toEqual(repaired)
+    })
+  })
+
   describe('create', () => {
     it('creates task and adds to map', async () => {
       const t = makeTask({ id: 'new-1', title: 'New task' })

--- a/frontend/src/stores/tasks.svelte.ts
+++ b/frontend/src/stores/tasks.svelte.ts
@@ -20,6 +20,11 @@ import { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/mod
 import { EntityStore } from './entity-store.svelte.js'
 import { needsPlanApproval } from '../lib/statuses.js'
 
+function taskIDFromFilePath(path: string): string {
+  const base = path.split('/').pop() ?? path
+  return base.split('.')[0] ?? ''
+}
+
 class TaskStore extends EntityStore<Task> {
   // Per-id operation counter guarding the async patchOne against its own
   // out-of-order completion. patchOne re-reads it after GetTask resolves and
@@ -84,9 +89,9 @@ class TaskStore extends EntityStore<Task> {
   // Fetch one task and upsert it into the reactive Map without rebuilding the
   // whole Map. Drives the live task:created/updated event handler so a single
   // changed file re-renders one card instead of forcing a full reload + total
-  // re-render. Swallows errors: the id may have just vanished, or be derived
-  // from a sidecar whose parent is gone — the trailing delete event or the
-  // background poll reconciles.
+  // re-render. If it can no longer be fetched, refresh the board: this also
+  // surfaces Store.List's synthetic degraded entry for a task file that was
+  // edited into an unreadable state.
   async patchOne(id: string): Promise<void> {
     const mine = this.#bumpSeq(id)
     try {
@@ -94,9 +99,17 @@ class TaskStore extends EntityStore<Task> {
       // Superseded by a later remove/patch while this fetch was in flight —
       // applying it now would resurrect a deleted task or clobber newer state.
       if (this.#opSeq.get(id) !== mine) return
+      // A previous failed fetch may have refreshed the board with Store.List's
+      // synthetic degraded entry for this same source file. Once the file is
+      // repaired, remove that warning card as the real task returns.
+      for (const [candidateID, candidate] of this.items) {
+        if (candidate.degraded && candidateID !== result.id && taskIDFromFilePath(candidate.filePath) === id) {
+          this.delete(candidateID)
+        }
+      }
       if (result?.id) this.set(result.id, result)
     } catch {
-      // Task unreadable/removed — leave the Map untouched.
+      void this.load()
     }
   }
 

--- a/internal/sybra/clusterlead/assigner.go
+++ b/internal/sybra/clusterlead/assigner.go
@@ -97,7 +97,7 @@ func (a *Assigner) Tick(ctx context.Context) {
 	}
 	for i := range tasks {
 		t := tasks[i]
-		if task.IsTerminalStatus(t.Status) || t.Status == task.StatusBlocked {
+		if t.Degraded || task.IsTerminalStatus(t.Status) || t.Status == task.StatusBlocked {
 			continue
 		}
 		home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)
@@ -256,6 +256,9 @@ func (a *Assigner) DispatchFromHumanRequired(ctx context.Context, t task.Task, t
 }
 
 func (a *Assigner) route(ctx context.Context, t task.Task, force bool) (routed bool, err error) {
+	if t.Degraded {
+		return false, nil
+	}
 	unlock := a.lockOwnership(t.ID)
 	defer unlock()
 	home := a.cfg.HomeNodeForTask(t.ProjectID, t.NodeOverride)

--- a/internal/sybra/clusterlead/clusterlead_test.go
+++ b/internal/sybra/clusterlead/clusterlead_test.go
@@ -271,6 +271,28 @@ func TestAssignerTickIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestAssignerTickDoesNotRouteDegradedTask(t *testing.T) {
+	stub := &followerStub{}
+	srv := stub.server(t)
+	cfg := leaderConfig(srv.URL, []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	assigner := NewAssigner(cfg, mgr, roster, func(string) bool { return false }, nil, nil)
+
+	created, _, err := mgr.Put(task.Task{ID: "broken-pet", Title: "t", Status: task.StatusTodo, ProjectID: "owner/pet"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(created.FilePath, []byte("not valid frontmatter"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	assigner.Tick(context.Background())
+	if _, ok := stub.lastAssigned(); ok {
+		t.Fatal("AssignTask received degraded task")
+	}
+}
+
 func TestMirrorApplyConvergesAndDropsStale(t *testing.T) {
 	cfg := leaderConfig("http://unused", []string{"owner/pet"})
 	roster, _ := NewRoster(cfg, nil)

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -175,6 +175,11 @@ func (s *TaskService) ListTasksForNode(node string) ([]task.Task, error) {
 	out := all[:0]
 	for i := range all {
 		t := all[i]
+		// Degraded entries deliberately exist only on the local board. They do
+		// not name a valid task payload and must not be replicated to a leader.
+		if t.Degraded {
+			continue
+		}
 		if t.AssignedNode != node && t.AssignedNode != "" {
 			continue
 		}
@@ -675,6 +680,9 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 // it touches disk; a malformed task is rejected with a 400 rather than
 // corrupting the board.
 func (s *TaskService) AssignTask(t task.Task) error {
+	if t.Degraded {
+		return validationError("assigned task must not be degraded")
+	}
 	if err := task.ValidateID(t.ID); err != nil {
 		return validationError(err.Error())
 	}
@@ -686,6 +694,11 @@ func (s *TaskService) AssignTask(t task.Task) error {
 	}
 	if t.AgentMode != "" {
 		if _, err := task.ValidateAgentMode(t.AgentMode); err != nil {
+			return validationError(err.Error())
+		}
+	}
+	if t.Slug != "" {
+		if err := task.ValidateSlug(t.Slug); err != nil {
 			return validationError(err.Error())
 		}
 	}

--- a/internal/sybra/svc_tasks_assign_test.go
+++ b/internal/sybra/svc_tasks_assign_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +40,35 @@ func TestAssignTaskPersistsVerbatim(t *testing.T) {
 	}
 	if got.Body != "## Description\nfrom the leader" {
 		t.Fatalf("mirror did not preserve body: %q", got.Body)
+	}
+}
+
+func TestListTasksForNodeExcludesDegradedEntries(t *testing.T) {
+	svc, app := setupTaskService(t)
+	created, err := app.tasks.Create("will break", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(created.FilePath, []byte("not valid frontmatter"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := svc.ListTasks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 || !all[0].Degraded {
+		t.Fatalf("ListTasks = %+v, want one degraded entry", all)
+	}
+	follower, err := svc.ListTasksForNode("follower")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(follower) != 0 {
+		t.Fatalf("ListTasksForNode replicated degraded entry: %+v", follower)
+	}
+	if filepath.Base(all[0].FilePath) != filepath.Base(created.FilePath) {
+		t.Fatalf("degraded source = %q, want %q", all[0].FilePath, created.FilePath)
 	}
 }
 
@@ -225,6 +255,8 @@ func TestAssignTaskRejectsMalformed(t *testing.T) {
 		{"no title", task.Task{ID: "x", Status: task.StatusTodo}},
 		{"bad status", task.Task{ID: "x", Title: "t", Status: task.Status("bogus")}},
 		{"bad agent mode", task.Task{ID: "x", Title: "t", Status: task.StatusTodo, AgentMode: "telepathy"}},
+		{"bad slug", task.Task{ID: "x", Title: "t", Status: task.StatusTodo, Slug: "../../etc/passwd"}},
+		{"degraded", task.Task{ID: "x", Title: "t", Status: task.StatusHumanRequired, Degraded: true}},
 		{"bad task type", task.Task{ID: "x", Title: "t", Status: task.StatusTodo, TaskType: task.TaskType("weird")}},
 	}
 	for _, c := range cases {

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -536,6 +536,12 @@ type Task struct {
 	// result to Plan.
 	PlanDrafts map[string]string `json:"planDrafts,omitempty"`
 	FilePath   string            `json:"filePath"`
+	// Degraded marks a synthetic, read-only board entry created for a task file
+	// that could not be parsed. It is never persisted and must never be
+	// dispatched or mirrored; fixing the source file makes the entry disappear
+	// on the next List.
+	Degraded   bool   `json:"degraded,omitempty"`
+	ParseError string `json:"parseError,omitempty"`
 	// TamperFlagged reports whether this task is parked at human-required
 	// pending a tamper bless. Derived from Status/StatusReason (never
 	// persisted) so the frontend doesn't need to duplicate

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -211,7 +211,7 @@ func TestPersistenceTypesHaveYAMLTags(t *testing.T) {
 
 func taskSidecarField(name string) bool {
 	switch name {
-	case "Body", "Plan", "PlanContract", "PlanCritique", "PlanResearch", "PlanDecisions", "PlanBrief", "CodeReview", "PlanDrafts", "FilePath", "TamperFlagged":
+	case "Body", "Plan", "PlanContract", "PlanCritique", "PlanResearch", "PlanDecisions", "PlanBrief", "CodeReview", "PlanDrafts", "FilePath", "TamperFlagged", "Degraded", "ParseError":
 		return true
 	default:
 		return false

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -181,8 +182,9 @@ func IsSidecarFile(base string) bool {
 
 // List returns every task under the store's directory, in directory-read
 // order (unspecified — sort by CreatedAt/UpdatedAt if you need an order).
-// A task with a parse error is logged and skipped rather than failing the
-// whole call. Results are served from an in-memory cache invalidated on any
+// A task with a parse error is represented as a non-dispatchable, degraded
+// Human Required entry rather than silently disappearing from the board.
+// Results are served from an in-memory cache invalidated on any
 // Create/Update/Delete; callers do not need to worry about staleness within
 // a single process.
 func (s *Store) List() ([]Task, error) {
@@ -217,7 +219,8 @@ func (s *Store) List() ([]Task, error) {
 	for _, p := range taskPaths {
 		t, err := Parse(p)
 		if err != nil {
-			slog.Default().Warn("task.parse.skip", "file", filepath.Base(p), "err", err)
+			slog.Default().Warn("task.parse.degraded", "file", filepath.Base(p), "err", err)
+			tasks = append(tasks, degradedTask(p, err))
 			parseErr = true
 			continue
 		}
@@ -244,6 +247,35 @@ func (s *Store) List() ([]Task, error) {
 		}
 	}
 	return tasks, nil
+}
+
+// degradedTask exposes an unreadable task file without trusting any of its
+// frontmatter. The generated ID is deterministic for its filename but cannot
+// address a real task file, making the entry read-only by construction.
+func degradedTask(path string, parseErr error) Task {
+	base := filepath.Base(path)
+	sum := sha256.Sum256([]byte(base))
+	id := fmt.Sprintf("unreadable-%x", sum[:8])
+	modified := time.Time{}
+	if info, err := os.Stat(path); err == nil {
+		modified = info.ModTime().UTC()
+	}
+	reason := fmt.Sprintf("Task file %q cannot be parsed; repair it on disk to restore the task.", base)
+	return Task{
+		ID:              id,
+		Slug:            "unreadable-task",
+		Title:           "Unreadable task file: " + base,
+		Status:          StatusHumanRequired,
+		AgentMode:       AgentModeHeadless,
+		StatusReason:    reason,
+		Body:            reason,
+		CreatedAt:       modified,
+		UpdatedAt:       modified,
+		StatusChangedAt: modified,
+		FilePath:        path,
+		Degraded:        true,
+		ParseError:      parseErr.Error(),
+	}
 }
 
 // sidecarIndex holds sidecar contents loaded in a single ReadDir pass,
@@ -620,6 +652,9 @@ func (s *Store) PutFn(id string, fn func(cur Task) (Task, error)) (saved, previo
 
 // putLocked is Put after the caller has acquired lockTask(t.ID).
 func (s *Store) putLocked(t Task) (Task, error) {
+	if err := validateWriteTask(t); err != nil {
+		return Task{}, err
+	}
 	now := time.Now().UTC()
 	if t.CreatedAt.IsZero() {
 		t.CreatedAt = now
@@ -680,6 +715,23 @@ func (s *Store) putLocked(t Task) (Task, error) {
 	}
 	s.storeTaskCache(t)
 	return t, nil
+}
+
+// validateWriteTask enforces the values Parse rejects on every write path,
+// including PutFn, which reaches putLocked directly while holding its task
+// lock. Empty values retain the legacy compatibility accepted by Parse.
+func validateWriteTask(t Task) error {
+	if t.Slug != "" {
+		if err := ValidateSlug(t.Slug); err != nil {
+			return err
+		}
+	}
+	if t.AgentMode != "" {
+		if _, err := ValidateAgentMode(t.AgentMode); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // taskFiles returns the basenames of every sidecar file this store owns for

--- a/internal/task/store_put_test.go
+++ b/internal/task/store_put_test.go
@@ -70,6 +70,62 @@ func TestStorePutVerbatimAndUpsert(t *testing.T) {
 	}
 }
 
+func TestStorePutRejectsInvalidSlug(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Put(Task{ID: "mirror-1", Title: "pushed", Status: StatusTodo, Slug: "../../etc/passwd"}); err == nil {
+		t.Fatal("Put with traversal slug: got nil error, want validation error")
+	}
+	if _, err := os.Stat(filepath.Join(store.dir, "mirror-1.md")); !os.IsNotExist(err) {
+		t.Fatalf("invalid Put wrote task file: %v", err)
+	}
+}
+
+func TestStorePutRejectsInvalidAgentMode(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Put(Task{ID: "mirror-1", Title: "pushed", Status: StatusTodo, AgentMode: "telepathy"}); err == nil {
+		t.Fatal("Put with invalid agent mode: got nil error, want validation error")
+	}
+	if _, err := os.Stat(filepath.Join(store.dir, "mirror-1.md")); !os.IsNotExist(err) {
+		t.Fatalf("invalid Put wrote task file: %v", err)
+	}
+}
+
+func TestStorePutFnRejectsInvalidAgentMode(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := store.Create("valid", "", AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := store.PutFn(created.ID, func(t Task) (Task, error) {
+		t.AgentMode = "telepathy"
+		return t, nil
+	}); err == nil {
+		t.Fatal("PutFn with invalid agent mode: got nil error, want validation error")
+	}
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentMode != AgentModeHeadless {
+		t.Fatalf("PutFn persisted invalid mode: %q", got.AgentMode)
+	}
+}
+
 // TestStorePutRejectsStatusChangeWithoutAdvancingUpdatedAt covers #2203: a
 // Put that changes Status but carries forward a stale/unchanged UpdatedAt
 // (e.g. a push built from a snapshot captured before the change, such as a

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1396,7 +1396,7 @@ func TestStoreCreateDefaultMode(t *testing.T) {
 	}
 }
 
-func TestStoreListSkipsMalformed(t *testing.T) {
+func TestStoreListSurfacesMalformedAsDegraded(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore(dir)
@@ -1417,8 +1417,23 @@ func TestStoreListSkipsMalformed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(tasks) != 1 {
-		t.Errorf("got %d tasks, want 1 (should skip malformed)", len(tasks))
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2 (valid task plus degraded entry)", len(tasks))
+	}
+	var degraded *Task
+	for i := range tasks {
+		if tasks[i].Degraded {
+			degraded = &tasks[i]
+		}
+	}
+	if degraded == nil {
+		t.Fatal("malformed file was not surfaced as degraded")
+	}
+	if degraded.Status != StatusHumanRequired {
+		t.Errorf("degraded status = %q, want %q", degraded.Status, StatusHumanRequired)
+	}
+	if degraded.ParseError == "" || degraded.FilePath != filepath.Join(dir, "bad.md") {
+		t.Errorf("degraded entry = %+v, want parse error and source path", *degraded)
 	}
 }
 
@@ -2517,14 +2532,17 @@ func TestStoreGet_PathTraversalSlugRejected(t *testing.T) {
 		t.Fatal("Store.Get with path-traversal slug: expected error, got nil")
 	}
 
-	// List must also skip the malformed file (it logs and continues).
+	// List must surface the malformed file without returning its unsafe slug.
 	tasks, err := store.List()
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	for _, task := range tasks {
-		if task.ID == tk.ID {
-			t.Errorf("malformed-slug task appeared in List: slug=%q", task.Slug)
+	for _, listed := range tasks {
+		if listed.ID == tk.ID {
+			t.Errorf("malformed-slug task appeared as real task: slug=%q", listed.Slug)
+		}
+		if listed.Degraded && listed.ParseError == "" {
+			t.Error("degraded malformed-slug task lacks parse error")
 		}
 	}
 }


### PR DESCRIPTION
Closes #2873\n\n## Summary\n- Surface malformed task files as read-only Human Required board entries instead of silently skipping them.\n- Keep degraded entries local and non-dispatchable; repair cleanup removes the warning card immediately.\n- Validate slug and agent mode across Put, PutFn, and cluster assignment paths.\n\n## Verification\n- go test -race ./internal/task ./internal/sybra ./internal/sybra/clusterlead\n- cd frontend && npm run check\n- cd frontend && npm test -- --run src/stores/tasks.svelte.test.ts\n- Isolated real sybra-cli probes: invalid mode, traversal slug, malformed frontmatter, and repair restoration.\n- Adversarial code review: clean.