### PR TITLE
fix(review): stop park reaping its review agent

### DIFF
--- a/internal/sybra/app_agent_release_lifecycle_test.go
+++ b/internal/sybra/app_agent_release_lifecycle_test.go
@@ -154,3 +154,35 @@ func TestApp_TaskTerminal_AsksLiveSteerableAgentToExit(t *testing.T) {
 		})
 	}
 }
+
+// releaseTaskAgents spares agents started after a human-required park, so the
+// park cannot reap the very agent dispatched to clear it. That exemption must
+// not extend to terminal statuses: a done task has no more work, so an agent
+// running against it is a leak regardless of when it started.
+func TestApp_ReleaseTaskAgents_TerminalReapsEvenNewerAgent(t *testing.T) {
+	a := newFakeSteerableClaudeApp(t)
+
+	created, err := a.tasks.Create("terminal reap", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.tasks.Apply(task.TransitionIntent{
+		TaskID: created.ID, ToStatus: task.StatusDone, Actor: "test", OperatorOverride: true,
+	}); err != nil {
+		t.Fatalf("mark done: %v", err)
+	}
+
+	// This agent starts strictly after the terminal transition, which is the
+	// exact shape the human-required exemption spares.
+	ag, pid := startIdleSteerableAgent(t, a, created.ID)
+
+	a.releaseTaskAgents(created.ID)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && processAliveForTest(pid) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if processAliveForTest(pid) {
+		t.Fatalf("agent %s still running against a done task; the newer-agent exemption must not apply to terminal statuses", ag.ID)
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -807,8 +807,12 @@ func (a *App) releaseTaskAgents(taskID string) {
 	// had its review agent killed 1.6ms after start at 08:47, and since
 	// human-required is what the review phase asserts to mean "needs you",
 	// the only agent that could clear it was the one being killed.
+	// Scoped to human-required only. releaseTaskAgents also runs for terminal
+	// statuses, and a done/cancelled task must reap every agent regardless of
+	// when it started — otherwise a restart can leave work running against a
+	// task that is already finished.
 	parkedAt := time.Time{}
-	if t, err := a.tasks.Get(taskID); err == nil {
+	if t, err := a.tasks.Get(taskID); err == nil && t.Status == task.StatusHumanRequired {
 		parkedAt = t.StatusChangedAt
 	}
 	filtered := make([]*agent.Agent, 0, len(targets))
@@ -816,7 +820,9 @@ func (a *App) releaseTaskAgents(taskID string) {
 		if ag.EffectiveRole().DiagnosesBlockedTask() {
 			continue
 		}
-		if !parkedAt.IsZero() && ag.StartedAt.After(parkedAt) {
+		// !Before, not After: a tie means the agent started in the same instant
+		// the park was recorded, which is the dispatch that triggered it.
+		if !parkedAt.IsZero() && !ag.StartedAt.Before(parkedAt) {
 			a.logger.Info("task.status.release-agent.skip-newer",
 				"task_id", taskID, "agent_id", ag.ID,
 				"started_at", ag.StartedAt, "status_changed_at", parkedAt)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -796,9 +796,30 @@ func (a *App) releaseTaskAgents(taskID string) {
 	if len(targets) == 0 {
 		return
 	}
+	// Agents started after the park are deliberate new dispatches, not
+	// leftovers from before it, so they are not this release's to reap.
+	//
+	// The status hook fires with prev == "" the first time this process
+	// observes a task, which happens on every restart. For an
+	// already-parked task that fabricates a fresh transition into
+	// human-required and reaps whatever is running — including a review
+	// agent dispatched seconds earlier. Measured: a task parked at 08:08
+	// had its review agent killed 1.6ms after start at 08:47, and since
+	// human-required is what the review phase asserts to mean "needs you",
+	// the only agent that could clear it was the one being killed.
+	parkedAt := time.Time{}
+	if t, err := a.tasks.Get(taskID); err == nil {
+		parkedAt = t.StatusChangedAt
+	}
 	filtered := make([]*agent.Agent, 0, len(targets))
 	for _, ag := range targets {
 		if ag.EffectiveRole().DiagnosesBlockedTask() {
+			continue
+		}
+		if !parkedAt.IsZero() && ag.StartedAt.After(parkedAt) {
+			a.logger.Info("task.status.release-agent.skip-newer",
+				"task_id", taskID, "agent_id", ag.ID,
+				"started_at", ag.StartedAt, "status_changed_at", parkedAt)
 			continue
 		}
 		filtered = append(filtered, ag)

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -729,6 +729,11 @@ func latestReviewRunStoppedByCostGuardrail(t *task.Task) bool {
 	return false
 }
 
+// defaultManualReviewReason explains the manual review phase on the board.
+// Without it a task parked by computeReviewPhase carries no status reason at
+// all, so the operator sees a needs-you badge with no stated cause.
+const defaultManualReviewReason = "no automated review exists for this PR yet — review it, or reopen the task to let an agent draft one"
+
 // applyReviewPhase persists only the fields that changed. Status is set only
 // when the result names one and it differs (so an unchanged status never
 // clears a triage-authored reason); the reason follows a status or phase change.
@@ -750,8 +755,22 @@ func (r *Handler) applyReviewPhase(t *task.Task, res reviewPhaseResult) {
 	if phaseChanged {
 		u.ReviewPhase = task.Ptr(res.Phase)
 	}
-	if res.Reason != "" && (statusChanged || phaseChanged) {
-		u.StatusReason = task.Ptr(res.Reason)
+	reason := res.Reason
+	// A phase that asserts human-required but names no reason (manual) leaves
+	// the board showing "needs you" with nothing said, which is
+	// indistinguishable from a bug.
+	//
+	// The empty reason exists so an existing triage/reconciliation blocker
+	// survives — but that only holds while the status is unchanged, since a
+	// transition clears the reason regardless. So fill on a transition (where
+	// nothing is preserved either way) or when the reason is genuinely blank,
+	// and leave an existing reason alone on a phase-only update.
+	if reason == "" && res.Status == task.StatusHumanRequired &&
+		(statusChanged || strings.TrimSpace(t.StatusReason) == "") {
+		reason = defaultManualReviewReason
+	}
+	if reason != "" && (statusChanged || phaseChanged) {
+		u.StatusReason = task.Ptr(reason)
 	}
 
 	prev := t.ReviewPhase

--- a/internal/sybra/review/inbound_test.go
+++ b/internal/sybra/review/inbound_test.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
@@ -45,4 +46,80 @@ func TestStartFixReviewAgentSkipsWhenDispatchClaimHeld(t *testing.T) {
 	if len(fresh.AgentRuns) != 0 {
 		t.Fatalf("AgentRuns = %d, want 0: a fix-review agent must not start while another dispatch claim is held", len(fresh.AgentRuns))
 	}
+}
+
+// A manual-phase park asserts human-required as a "needs you" signal but names
+// no reason, so the board showed a needs-you badge with nothing said — which
+// reads as a bug rather than a handoff.
+func TestApplyReviewPhase_ManualParkExplainsItself(t *testing.T) {
+	h, tasks := newOutboundTestHandler(t)
+	tk := mustReviewTask(t, tasks, "Review PR")
+
+	h.applyReviewPhase(&tk, reviewPhaseResult{
+		Phase:  ReviewPhaseManual,
+		Status: task.StatusHumanRequired,
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if strings.TrimSpace(got.StatusReason) == "" {
+		t.Fatal("manual park left the board with a needs-you badge and no reason")
+	}
+}
+
+// On a phase-only update the blank-fill must not overwrite a reason triage or
+// reconciliation set — that is why computeReviewPhase returns an empty reason.
+// (On a status transition the reason is cleared regardless, so there is
+// nothing to preserve and the default is filled in instead.)
+func TestApplyReviewPhase_ManualParkKeepsExistingReason(t *testing.T) {
+	h, tasks := newOutboundTestHandler(t)
+	tk := mustReviewTask(t, tasks, "Review PR keep")
+	const existing = "blocked on an upstream release"
+	// Park first, so applyReviewPhase sees an unchanged status and this is a
+	// phase-only update — the case where preservation is meant to hold.
+	if _, err := tasks.Apply(task.TransitionIntent{
+		TaskID: tk.ID, ToStatus: task.StatusHumanRequired, Actor: "test",
+		Extra: task.Update{StatusReason: task.Ptr(existing)}, OperatorOverride: true,
+	}); err != nil {
+		t.Fatalf("seed park: %v", err)
+	}
+	seeded, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if seeded.StatusReason != existing {
+		t.Fatalf("seed did not persist: StatusReason = %q", seeded.StatusReason)
+	}
+
+	h.applyReviewPhase(&seeded, reviewPhaseResult{
+		Phase:  ReviewPhaseManual,
+		Status: task.StatusHumanRequired,
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.StatusReason != existing {
+		t.Fatalf("StatusReason = %q, want the pre-existing %q preserved", got.StatusReason, existing)
+	}
+}
+
+func mustReviewTask(t *testing.T, tasks *task.Manager, title string) task.Task {
+	t.Helper()
+	created, err := tasks.Create(title, "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := tasks.Update(created.ID, task.Update{
+		ProjectID: task.Ptr("Automaat/sybra"),
+		PRNumber:  task.Ptr(127),
+		Tags:      &[]string{"review"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return updated
 }


### PR DESCRIPTION
## Motivation

A review task parked at `review_phase: manual` can never leave that state. Observed on a live task:

```
10:47:02.658  agent.sandbox.enforce   task_id=dbf0eb30
10:47:02.658  agent.start   8e63d856  (review, opus)
10:47:02.702  agent.headless.start    pid 89057
10:47:02.703  agent.stop              ← 1.6ms later
10:47:02.708  agent.headless.exit     "signal: interrupt"
10:47:02.887  review.agent-started    ← logged against an already-dead agent
10:47:03.668  agent.completion.stall
```

Two subsystems hold incompatible views of the same task:

- `computeReviewPhase` asserts **human-required** for the `manual` phase, deliberately, as a needs-you signal.
- `releaseTaskAgents` reaps **every** agent on a human-required task.

So the only agent that could produce the draft that moves the phase off `manual` is killed on arrival. The task cannot escape on its own.

> Changelog: fix(review): stop a manual-phase park from reaping the review agent that would clear it

## Implementation information

**The trigger is a restart, not a real transition.** The status hook only fires on genuine transitions — but `firedStatus` starts empty, so the *first* observation of a task in a fresh process fires with `prev == ""`. For an already-parked task that fabricates a transition into human-required and reaps whatever is running. The task above was parked at 08:08 and had its agent reaped at 08:47.

`releaseTaskAgents` now skips agents whose `StartedAt` is after the task's `StatusChangedAt`. Those are deliberate new dispatches, not leftovers from before the park — which is what the reap exists to clean up. The skip is logged (`task.status.release-agent.skip-newer`) so it is observable rather than silent.

**Second fix:** the `manual` phase asserted human-required while emitting no `status_reason`, so the board showed a needs-you badge with **nothing said**. That is indistinguishable from a bug — it is why this was reported as one. It now fills a default.

The empty reason exists so an existing triage blocker survives. But that only holds while the status is unchanged: a transition clears the reason regardless. So the default fills on a transition (where nothing is preserved either way) or when the reason is genuinely blank, and a phase-only update still leaves an existing reason alone.

## Supporting documentation

- `TestApplyReviewPhase_ManualParkExplainsItself` — a manual park no longer lands with a blank reason.
- `TestApplyReviewPhase_ManualParkKeepsExistingReason` — scoped to a phase-only update, the case where preservation actually holds.

Worth recording: I wrote that second test expecting preservation across a *status change*, and it failed. That is how I found that a transition clears `StatusReason` regardless — pre-existing behaviour, not introduced here. The condition and the test were rescoped to match what the code actually does rather than what I assumed.

`mise run verify` green. One caveat: an earlier run of it exited 1 with its output discarded, so I cannot say what failed; two subsequent full runs are clean. Flagging it rather than asserting the branch is definitively flake-free.

Follow-on, not fixed here: the same class of "two mechanisms, incompatible views, no reconciling invariant" also strands umbrella children behind a stale `umbrella-gated` tag. Worth one owner rather than case-by-case patches.
