### PR TITLE
fix(task): prevent task ID collision overwrites

### DIFF
--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -63,6 +63,46 @@ func AtomicWrite(path string, data []byte) error {
 	return syncDir(dir)
 }
 
+// AtomicWriteNew writes data to a previously absent path without ever
+// replacing an existing file. Like AtomicWrite, readers see either no file or
+// the complete, synced contents. It returns an error satisfying
+// errors.Is(err, fs.ErrExist) when another writer has already created path.
+//
+// os.Link provides the exclusive publish operation: linking the completed
+// temporary file to path fails if path exists, unlike os.Rename which replaces
+// its destination. The temporary file and destination are in the same
+// directory, so the link is atomic and cannot cross filesystems.
+func AtomicWriteNew(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Link(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Remove(tmp); err != nil {
+		return err
+	}
+	return syncDir(dir)
+}
+
 // RemoveAllForce removes path and everything under it, tolerating read-only
 // files and directories (e.g. Go module cache entries, which ship 0444/0555
 // permissions). It tries a plain os.RemoveAll first; on failure it walks the

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -2,6 +2,8 @@ package fsutil
 
 import (
 	"bytes"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,6 +46,24 @@ func TestAtomicWrite_Overwrite(t *testing.T) {
 	}
 	if string(got) != "new" {
 		t.Errorf("got %q, want %q", got, "new")
+	}
+}
+
+func TestAtomicWriteNew_RefusesExistingFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "file.txt")
+	if err := AtomicWrite(path, []byte("old")); err != nil {
+		t.Fatal(err)
+	}
+	if err := AtomicWriteNew(path, []byte("new")); !errors.Is(err, fs.ErrExist) {
+		t.Fatalf("AtomicWriteNew error = %v, want fs.ErrExist", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("existing file = %q, want unchanged old contents", got)
 	}
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -39,7 +39,10 @@ type Store struct {
 	listCache     []Task
 	listValid     bool
 	listSnapshot  map[string]listFileState
+	newTaskID     func() string
 }
+
+const maxTaskIDAttempts = 16
 
 // NewStore creates dir if it does not exist and returns a Store rooted
 // there, along with its sidecar stores (comments, plans, code reviews).
@@ -60,6 +63,7 @@ func NewStore(dir string) (*Store, error) {
 		planBrief:     NewPlanningSidecarStore(dir, ".plan-brief.md", "plan brief"),
 		codeReviews:   NewCodeReviewStore(dir),
 		locker:        fsutil.NewKeyedLocker(),
+		newTaskID:     func() string { return uuid.NewString()[:8] },
 	}, nil
 }
 
@@ -144,6 +148,29 @@ func (s *Store) lockTask(id string) (func(), error) {
 	unlock, err := s.locker.Lock(id, path)
 	if err != nil {
 		return nil, fmt.Errorf("lock task %s: %w", id, err)
+	}
+	return unlock, nil
+}
+
+// lockNewTask serializes candidate-ID reservation without creating a visible
+// task-dir entry. Ordinary task locks deliberately sit beside their task file,
+// but creation has no file yet and must not leave a spurious .md.lock artifact
+// that callers can mistake for task data.
+func (s *Store) lockNewTask(id string) (func(), error) {
+	// Resolve aliases first: two Store instances may address the same task
+	// directory through a real path and a symlink, and must still contend on
+	// one candidate-ID lock.
+	taskDir, err := filepath.EvalSymlinks(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve task dir for creation lock: %w", err)
+	}
+	dir := filepath.Join(filepath.Dir(taskDir), ".task-create-locks")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create task lock dir: %w", err)
+	}
+	unlock, err := s.locker.Lock("create:"+id, filepath.Join(dir, id))
+	if err != nil {
+		return nil, fmt.Errorf("lock new task %s: %w", id, err)
 	}
 	return unlock, nil
 }
@@ -455,8 +482,9 @@ func (s *Store) safePath(id string) (string, error) {
 	return path, nil
 }
 
-// Create writes a new task file with a fresh 8-char ID, status "todo", and
-// type "normal". mode defaults to AgentModeHeadless when empty and is
+// Create writes a new task file with a fresh ID, status "todo", and type
+// "normal". Creation never replaces an existing task: a generated ID that
+// already exists is retried. mode defaults to AgentModeHeadless when empty and is
 // validated via ValidateMintableAgentMode. Use CreateFull to set additional
 // fields (tags, project, priority, ...) atomically at creation time.
 func (s *Store) Create(title, body, mode string) (Task, error) {
@@ -467,9 +495,7 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 		return Task{}, err
 	}
 	now := time.Now().UTC()
-	id := uuid.NewString()[:8]
 	t := Task{
-		ID:              id,
 		Slug:            Slugify(title),
 		Title:           title,
 		Status:          StatusTodo,
@@ -482,15 +508,8 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 		Body:            body,
 	}
 
-	data, err := Marshal(t)
-	if err != nil {
+	if err := s.createNewTask(&t, nil); err != nil {
 		return Task{}, err
-	}
-
-	filename := fmt.Sprintf("%s.md", t.ID)
-	t.FilePath = filepath.Join(s.dir, filename)
-	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
-		return Task{}, fmt.Errorf("write task file: %w", err)
 	}
 	s.storeTaskCache(t)
 	return t, nil
@@ -510,9 +529,7 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 		return Task{}, err
 	}
 	now := time.Now().UTC()
-	id := uuid.NewString()[:8]
 	t := Task{
-		ID:              id,
 		Slug:            Slugify(title),
 		Title:           title,
 		Status:          StatusTodo,
@@ -530,21 +547,86 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	if err := normalizeSandboxEscapeHatch(&t); err != nil {
 		return Task{}, err
 	}
-	if err := s.writeSidecars(t.ID, init, &t); err != nil {
+	if err := s.createNewTask(&t, func() error {
+		return s.writeSidecars(t.ID, init, &t)
+	}); err != nil {
 		return Task{}, err
-	}
-
-	data, err := Marshal(t)
-	if err != nil {
-		return Task{}, err
-	}
-	filename := fmt.Sprintf("%s.md", t.ID)
-	t.FilePath = filepath.Join(s.dir, filename)
-	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
-		return Task{}, fmt.Errorf("write task file: %w", err)
 	}
 	s.storeTaskCache(t)
 	return t, nil
+}
+
+// createNewTask locks a candidate ID, invokes beforePublish while no task file
+// is visible, then exclusively publishes the primary task file. The lock spans
+// the whole operation so a failed sidecar write can be rolled back before
+// another current Store process can reuse the candidate ID. AtomicWriteNew
+// independently refuses to replace an already-published primary task file.
+func (s *Store) createNewTask(t *Task, beforePublish func() error) error {
+	for range maxTaskIDAttempts {
+		t.ID = s.newTaskID()
+		t.FilePath = filepath.Join(s.dir, t.ID+".md")
+		unlock, err := s.lockNewTask(t.ID)
+		if err != nil {
+			return err
+		}
+		if _, err := os.Stat(t.FilePath); err == nil {
+			unlock()
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			unlock()
+			return fmt.Errorf("stat task file: %w", err)
+		}
+		files, err := s.taskFiles(t.ID)
+		if err != nil {
+			unlock()
+			return err
+		}
+		if len(files) > 0 {
+			// A prior interrupted CreateFull may have left sidecars without
+			// its primary file. Never bind that history to a fresh task.
+			unlock()
+			continue
+		}
+		if beforePublish != nil {
+			if err := beforePublish(); err != nil {
+				s.removeNewTaskSidecars(t.ID)
+				unlock()
+				return err
+			}
+		}
+		data, err := Marshal(*t)
+		if err != nil {
+			s.removeNewTaskSidecars(t.ID)
+			unlock()
+			return err
+		}
+		writeErr := fsutil.AtomicWriteNew(t.FilePath, data)
+		if writeErr == nil {
+			unlock()
+			return nil
+		}
+		// A writer outside Store raced our protected reservation. Do not
+		// delete the sidecars: they may now belong to that writer's task.
+		unlock()
+		if errors.Is(writeErr, os.ErrExist) {
+			continue
+		}
+		return fmt.Errorf("write task file: %w", writeErr)
+	}
+	return fmt.Errorf("create task: generated ID collided %d times", maxTaskIDAttempts)
+}
+
+// removeNewTaskSidecars rolls back sidecars written before task publication.
+// createNewTask verifies this ID has no task or sidecars while holding the
+// current Store's cross-process lock, so every sidecar found here belongs to
+// this failed creation attempt. It deliberately never removes the primary
+// task file.
+func (s *Store) removeNewTaskSidecars(id string) {
+	if files, err := s.taskFiles(id); err == nil {
+		for _, name := range files {
+			_ = os.Remove(filepath.Join(s.dir, name))
+		}
+	}
 }
 
 // applyCreateInit applies the CreateFull init overrides onto a fresh task.

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -68,6 +69,204 @@ func TestStoreCreate(t *testing.T) {
 
 	if _, err := os.Stat(task.FilePath); err != nil {
 		t.Errorf("file not written: %v", err)
+	}
+}
+
+func TestStoreCreate_RetriesIDCollisionWithoutOverwriting(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := Task{
+		ID:         "deadbeef",
+		Title:      "original task",
+		Slug:       "original-task",
+		Status:     StatusTodo,
+		Generation: 1,
+		AgentMode:  AgentModeHeadless,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	originalData, err := Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalPath := filepath.Join(store.Dir(), original.ID+".md")
+	if err := os.WriteFile(originalPath, originalData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ids := []string{"deadbeef", "cafebabe"}
+	store.newTaskID = func() string {
+		id := ids[0]
+		ids = ids[1:]
+		return id
+	}
+	created, err := store.Create("new task", "new body", AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.ID != "cafebabe" {
+		t.Fatalf("created ID = %q, want collision retry ID cafebabe", created.ID)
+	}
+	got, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, originalData) {
+		t.Fatal("collision replaced the original task file")
+	}
+}
+
+func TestStoreCreateFull_RetriesBeforeWritingSidecars(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := Task{
+		ID:         "deadbeef",
+		Title:      "original task",
+		Slug:       "original-task",
+		Status:     StatusTodo,
+		Generation: 1,
+		AgentMode:  AgentModeHeadless,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+	}
+	originalData, err := Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalPath := filepath.Join(store.Dir(), original.ID+".md")
+	if err := os.WriteFile(originalPath, originalData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Plans().Write(original.ID, "original plan"); err != nil {
+		t.Fatal(err)
+	}
+
+	ids := []string{"deadbeef", "cafebabe"}
+	store.newTaskID = func() string {
+		id := ids[0]
+		ids = ids[1:]
+		return id
+	}
+	plan := "new plan"
+	created, err := store.CreateFull("new task", "new body", AgentModeHeadless, Update{Plan: &plan})
+	if err != nil {
+		t.Fatalf("CreateFull: %v", err)
+	}
+	if created.ID != "cafebabe" {
+		t.Fatalf("created ID = %q, want collision retry ID cafebabe", created.ID)
+	}
+	got, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, originalData) {
+		t.Fatal("collision replaced the original task file")
+	}
+	originalPlan, err := store.Plans().Read(original.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if originalPlan != "original plan" {
+		t.Fatalf("original sidecar = %q, want unchanged original plan", originalPlan)
+	}
+	newPlan, err := store.Plans().Read(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newPlan != plan {
+		t.Fatalf("new sidecar = %q, want %q", newPlan, plan)
+	}
+}
+
+func TestStoreCreate_DoesNotReuseIDWithOrphanedSidecars(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Plans().Write("deadbeef", "interrupted creation plan"); err != nil {
+		t.Fatal(err)
+	}
+	ids := []string{"deadbeef", "cafebabe"}
+	store.newTaskID = func() string {
+		id := ids[0]
+		ids = ids[1:]
+		return id
+	}
+	created, err := store.Create("new task", "new body", AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.ID != "cafebabe" {
+		t.Fatalf("created ID = %q, want retry ID cafebabe", created.ID)
+	}
+	plan, err := store.Plans().Read("deadbeef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan != "interrupted creation plan" {
+		t.Fatalf("orphaned sidecar = %q, want preserved contents", plan)
+	}
+}
+
+func TestStoreLockNewTask_SymlinkAliasSharesReservation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink setup requires elevated Windows privileges")
+	}
+	root := t.TempDir()
+	realDir := filepath.Join(root, "tasks")
+	realStore, err := NewStore(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := filepath.Join(root, "tasks-alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Fatal(err)
+	}
+	alias, err := NewStore(aliasDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := realStore.lockNewTask("deadbeef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			unlock()
+		}
+	}()
+	acquired := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		otherUnlock, err := alias.lockNewTask("deadbeef")
+		if err != nil {
+			errCh <- err
+			return
+		}
+		close(acquired)
+		otherUnlock()
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("symlink-alias store acquired an already-held creation reservation")
+	case err := <-errCh:
+		t.Fatalf("symlink-alias reservation: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	unlock()
+	released = true
+	select {
+	case <-acquired:
+	case err := <-errCh:
+		t.Fatalf("symlink-alias reservation: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("symlink-alias store did not acquire reservation after release")
 	}
 }
 


### PR DESCRIPTION
Fixes #2874.

Task creation now locks candidate IDs across Store processes, rejects IDs with existing primary files or sidecars, and uses exclusive filesystem publication so a collision is retried rather than replacing task history. `CreateFull` preserves its sidecars-before-primary watcher guarantee and rolls back only transaction-owned partial sidecars.