### PR TITLE
fix(sandbox): never emit an empty profile param

### DIFF
--- a/internal/agent/procsandbox_darwin.go
+++ b/internal/agent/procsandbox_darwin.go
@@ -102,6 +102,23 @@ func sandboxRootOr(root, fallback string) string {
 	return root
 }
 
+// unusedWritableRootSentinel stands in for a writable root that this run
+// legitimately has none of — WORKTREE on a RunConfig.ReadOnlyDir run, where
+// injectReadOnlyProcessSandbox deliberately passes an empty worktree so Dir is
+// never writable.
+//
+// The profile references every param unconditionally, and sandbox-exec rejects
+// an empty pattern with "sandbox-exec: empty subpath pattern" and refuses to
+// launch. That surfaced as the agent producing no output at all — a 36-byte
+// stderr and a workflow that blamed missing sidecars — rather than as a
+// sandbox error, so it must be impossible to reach rather than merely fixed at
+// the one site that hit it.
+//
+// A reserved, never-written path keeps the allow rule inert. Distinct from
+// unusedReadOnlyDirSentinel so an unused *allow* root can never alias an
+// unused *deny* root.
+const unusedWritableRootSentinel = "/private/var/empty/sybra-sandbox-unused-writable"
+
 // unusedReadOnlyDirSentinel is READONLY_DIR's value on every run that isn't
 // RunConfig.ReadOnlyDir: the profile's READONLY_DIR deny rule is
 // unconditional, so it always needs a value, and this one is a fixed,
@@ -171,24 +188,32 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		return name, args
 	}
 	home := cfg.sandbox.sandboxHome
-	wrapped := make([]string, 0, len(args)+21)
-	wrapped = append(wrapped,
-		"-f", cfg.sandbox.profilePath,
-		"-D", "WORKTREE="+cfg.sandbox.worktree,
-		"-D", "SANDBOX_HOME="+home,
-		"-D", "TMP="+cfg.sandbox.tmp,
-		"-D", "SHARED_CACHE="+cfg.sandbox.sharedCache,
-		"-D", "CLAUDE_STATE="+sandboxRootOr(cfg.sandbox.claudeState, home),
-		"-D", "CODEX_STATE="+sandboxRootOr(cfg.sandbox.codexState, home),
-		"-D", "COPILOT_STATE="+sandboxRootOr(cfg.sandbox.copilotState, home),
-		"-D", "OPENCODE_STATE="+sandboxRootOr(cfg.sandbox.opencodeState, home),
-		"-D", "TOOL_CACHE="+sandboxRootOr(cfg.sandbox.toolCache, home),
-		"-D", "READONLY_DIR="+sandboxRootOr(cfg.sandbox.readOnlyDir, unusedReadOnlyDirSentinel),
-		"-D", "STATE_DENY_1="+sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 0), unusedReadOnlyDirSentinel),
-		"-D", "STATE_DENY_2="+sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 1), unusedReadOnlyDirSentinel),
-		"-D", "STATE_DENY_3="+sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 2), unusedReadOnlyDirSentinel),
-		name,
-	)
+	params := [][2]string{
+		{"WORKTREE", cfg.sandbox.worktree},
+		{"SANDBOX_HOME", home},
+		{"TMP", cfg.sandbox.tmp},
+		{"SHARED_CACHE", cfg.sandbox.sharedCache},
+		{"CLAUDE_STATE", sandboxRootOr(cfg.sandbox.claudeState, home)},
+		{"CODEX_STATE", sandboxRootOr(cfg.sandbox.codexState, home)},
+		{"COPILOT_STATE", sandboxRootOr(cfg.sandbox.copilotState, home)},
+		{"OPENCODE_STATE", sandboxRootOr(cfg.sandbox.opencodeState, home)},
+		{"TOOL_CACHE", sandboxRootOr(cfg.sandbox.toolCache, home)},
+		{"READONLY_DIR", sandboxRootOr(cfg.sandbox.readOnlyDir, unusedReadOnlyDirSentinel)},
+		{"STATE_DENY_1", sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 0), unusedReadOnlyDirSentinel)},
+		{"STATE_DENY_2", sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 1), unusedReadOnlyDirSentinel)},
+		{"STATE_DENY_3", sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 2), unusedReadOnlyDirSentinel)},
+	}
+	wrapped := make([]string, 0, len(args)+2*len(params)+3)
+	wrapped = append(wrapped, "-f", cfg.sandbox.profilePath)
+	for _, p := range params {
+		// Every param is templated into an unconditional (subpath (param ...))
+		// rule, and seatbelt rejects an empty pattern outright — see
+		// unusedWritableRootSentinel. Substituting here is the single
+		// chokepoint that keeps a legitimately-absent root from producing a
+		// malformed profile.
+		wrapped = append(wrapped, "-D", p[0]+"="+sandboxRootOr(p[1], unusedWritableRootSentinel))
+	}
+	wrapped = append(wrapped, name)
 	wrapped = append(wrapped, args...)
 	return sandboxExecPath, wrapped
 }

--- a/internal/agent/procsandbox_read_darwin_test.go
+++ b/internal/agent/procsandbox_read_darwin_test.go
@@ -96,3 +96,56 @@ func TestBuildReadProfile_RequiresSandboxHome(t *testing.T) {
 		t.Fatal("buildReadProfile accepted an empty sandbox home")
 	}
 }
+
+// A RunConfig.ReadOnlyDir run legitimately has no writable worktree, so
+// injectReadOnlyProcessSandbox passes an empty one. Templating that straight
+// into the profile made sandbox-exec refuse to launch with
+// "empty subpath pattern", which surfaced as an agent that produced no output
+// at all rather than as a sandbox failure.
+func TestWrapInvocation_NoEmptyProfileParams(t *testing.T) {
+	tests := []struct {
+		name string
+		spec sandboxSpec
+	}{
+		{
+			name: "read-only dir run has no worktree",
+			spec: sandboxSpec{
+				mode:        "enforce",
+				worktree:    "", // what injectReadOnlyProcessSandbox passes
+				sandboxHome: "/data/home",
+				tmp:         "/tmp",
+				sharedCache: "/data/cache",
+				readOnlyDir: "/opt/src",
+			},
+		},
+		{
+			name: "every optional root absent",
+			spec: sandboxSpec{mode: "enforce"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, args := wrapInvocation("claude", []string{"-p", "hi"}, &RunConfig{sandbox: tc.spec})
+			for i := range len(args) - 1 {
+				if args[i] != "-D" {
+					continue
+				}
+				name, value, ok := strings.Cut(args[i+1], "=")
+				if !ok {
+					t.Fatalf("malformed -D arg %q", args[i+1])
+				}
+				if strings.TrimSpace(value) == "" {
+					t.Errorf("param %s is empty; sandbox-exec rejects an empty subpath and refuses to launch", name)
+				}
+			}
+		})
+	}
+}
+
+// The substitute must stay inert: an unused writable root must not alias the
+// sentinel used for unused deny rules.
+func TestUnusedRootSentinelsAreDistinct(t *testing.T) {
+	if unusedWritableRootSentinel == unusedReadOnlyDirSentinel {
+		t.Fatal("an unused allow root aliases an unused deny root")
+	}
+}


### PR DESCRIPTION
## Motivation

An enforce-mode run with `RunConfig.ReadOnlyDir` **cannot start at all** on darwin. The agent process never launches; its entire stderr is 36 bytes:

```
sandbox-exec: empty subpath pattern
```

`injectReadOnlyProcessSandbox` deliberately passes an empty worktree — that is its whole purpose, so `Dir` is never writable — via `enforceSpec("", …)`. But `wrapInvocation` templated it straight into `-D WORKTREE=`, and the profile references that param in an unconditional rule:

```
(allow file-write* (subpath (param "WORKTREE")) …)
```

seatbelt rejects an empty pattern and refuses to launch.

**The symptom pointed somewhere else entirely.** With no agent, no plan sidecars were written, so `workflow.import-sidecar.read` failed five times, `require-sidecar.missing` fired, and the task parked. Every visible signal blamed missing sidecars; nothing pointed at the sandbox.

> Changelog: fix(sandbox): stop an empty profile param from blocking every read-only-dir run on darwin

## Implementation information

Every `-D` now goes through **one** substitution point, instead of a mix of guarded and unguarded call sites. `WORKTREE`, `SANDBOX_HOME`, `TMP` and `SHARED_CACHE` were templated raw, while the state roots already had a `sandboxRootOr(root, home)` fallback — which is why this only ever bit the one param that is legitimately empty.

The state roots keep their sandbox-home fallback. Anything still empty renders as a reserved never-written path, so the rule is inert rather than malformed. That sentinel is deliberately **distinct** from `unusedReadOnlyDirSentinel`, so an unused *allow* root can never alias an unused *deny* root.

## Supporting documentation

Verified against the real `sandbox-exec` with the embedded profile, rather than only in unit tests:

| `WORKTREE` | result |
|---|---|
| empty | `sandbox-exec: empty subpath pattern`, **exit 65** |
| sentinel | `ok`, **exit 0** |

- `TestWrapInvocation_NoEmptyProfileParams` — table-driven over the read-only-dir spec and an all-roots-absent spec, asserting no `-D` value is ever empty. It scans the produced argv rather than checking one param, so a future param added raw is caught too.
- `TestUnusedRootSentinelsAreDistinct` — pins that the allow sentinel cannot collapse into the deny sentinel.

`mise run verify` green.

**Scope:** darwin-only, affecting *every* enforce run with `ReadOnlyDir` — the human-review deploy-checkout fallback and any diagnostic-only run. Linux is unaffected: its wrapper builds bind arguments and skips empty roots.

That last point is worth carrying into the sandbox rollout. This and the detached-HEAD fix were both darwin-only, both fail-closed, and both invisible to the server's `report`-mode soak — `report` never wraps a spawn, so it cannot reach either failure. A clean soak on the server is not evidence that `enforce` is safe on the desktop path.
