### PR TITLE
fix(agent): prevent finalizing steer loss

### DIFF
--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1649,6 +1649,32 @@ func TestSendMessage_HeadlessRejectsWhenFinalizing(t *testing.T) {
 	}
 }
 
+// TestSendMessage_HeadlessRejectsAfterEmptyBoundary proves that the terminal
+// boundary atomically commits finalization before a later steer can enqueue.
+// This is the former pop-empty / set-finalizing TOCTOU window.
+func TestSendMessage_HeadlessRejectsAfterEmptyBoundary(t *testing.T) {
+	m, _ := newTestManager(t)
+	r, w := io.Pipe()
+	a := &Agent{ID: "h-empty-boundary", TaskID: "task-1", Mode: "headless", Provider: "claude", State: StateRunning}
+	if err := a.convo.installStdinPipe(w); err != nil {
+		t.Fatalf("installStdinPipe: %v", err)
+	}
+	putAgent(t, m, a)
+	t.Cleanup(func() { _ = r.Close() })
+
+	if _, ok := a.PopPendingPromptOrBeginFinalizing(); ok {
+		t.Fatal("empty queue unexpectedly yielded a prompt")
+	}
+	err := m.SendMessage(a.ID, "too late")
+	if err == nil {
+		t.Fatal("expected finalizing conflict after empty terminal boundary")
+	}
+	assertConflictClientError(t, err)
+	if got := a.PendingPromptCount(); got != 0 {
+		t.Errorf("PendingPromptCount = %d, want 0", got)
+	}
+}
+
 // assertConflictClientError verifies err implements httpapi.ClientError
 // (structurally: error + HTTPStatus() int) with a 409 status, so the HTTP
 // API surfaces it as a clear rejection instead of a generic 500 — see

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -996,21 +996,27 @@ func (a *Agent) EnqueuePrompt(text string) {
 	a.mu.Unlock()
 }
 
-// TryEnqueuePrompt appends text to the pending queue iff its current length
-// is below max, checking and appending under a single lock acquisition.
+// TryEnqueuePrompt appends text to the pending queue iff the run has not begun
+// finalizing and its current queue length is below max. All three checks and
+// the append share one lock acquisition, so a steer accepted by this method
+// cannot race a terminal boundary into a queue that will never be drained.
 // Callers that check PendingPromptCount() and then call EnqueuePrompt() as
 // two separate steps leave a TOCTOU window: concurrent callers can each pass
 // the check while the queue is below max and all append, overshooting the
 // cap the check was meant to enforce. Returns the queue length after the
-// call and whether the prompt was enqueued.
-func (a *Agent) TryEnqueuePrompt(text string, limit int) (queueLen int, enqueued bool) {
+// call, whether the prompt was enqueued, and whether finalization caused a
+// rejection (rather than the queue limit).
+func (a *Agent) TryEnqueuePrompt(text string, limit int) (queueLen int, enqueued, finalizing bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.finalizing {
+		return len(a.convo.pendingPrompts), false, true
+	}
 	if len(a.convo.pendingPrompts) >= limit {
-		return len(a.convo.pendingPrompts), false
+		return len(a.convo.pendingPrompts), false, false
 	}
 	a.convo.pendingPrompts = append(a.convo.pendingPrompts, text)
-	return len(a.convo.pendingPrompts), true
+	return len(a.convo.pendingPrompts), true, false
 }
 
 // PopPendingPrompt returns the next queued prompt and a flag indicating
@@ -1024,6 +1030,24 @@ func (a *Agent) PopPendingPrompt() (string, bool) {
 	next := a.convo.pendingPrompts[0]
 	a.convo.pendingPrompts = a.convo.pendingPrompts[1:]
 	return next, true
+}
+
+// PopPendingPromptOrBeginFinalizing atomically reserves the next pending
+// prompt or, when there is none, permanently prevents any later enqueue. The
+// latter transition must share the queue lock with TryEnqueuePrompt: otherwise
+// a message can be accepted after the empty-pop check but before stdin closes.
+func (a *Agent) PopPendingPromptOrBeginFinalizing() (string, bool) {
+	a.mu.Lock()
+	if len(a.convo.pendingPrompts) > 0 {
+		next := a.convo.pendingPrompts[0]
+		a.convo.pendingPrompts = a.convo.pendingPrompts[1:]
+		a.mu.Unlock()
+		return next, true
+	}
+	a.finalizing = true
+	a.mu.Unlock()
+	a.refreshCanSteer()
+	return "", false
 }
 
 // PendingPromptCount returns the size of the pending prompt queue.

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -209,17 +209,7 @@ func (m *Manager) reattachHeadless(ctx context.Context, a *Agent, startOffset in
 		}
 	}
 
-	// If the run already emitted its terminal result while the app was down, it
-	// is parked at a steer turn boundary that no live tailer ever processed —
-	// rehydrateFromLog replays the result's stats but not the drain/close
-	// boundary that handleHeadlessResult runs live. Replicate that boundary now,
-	// before tailing: with nothing queued at reattach, drainOrCloseHeadlessSteer
-	// closes stdin so the child sees EOF and exits like an unsteered one-shot,
-	// instead of hanging (or accepting a post-reattach steer that would queue
-	// forever with no further result to flush it).
-	if found, _ := resultBeforeOnlyForkOutput(a.Output()); found {
-		m.drainOrCloseHeadlessSteer(a)
-	}
+	m.reconcileReattachedHeadlessTerminalResult(a)
 	procDone := make(chan struct{})
 	go watchPID(ctx, a.GetPID(), procStart, procDone)
 
@@ -249,6 +239,22 @@ func (m *Manager) reattachHeadless(ctx context.Context, a *Agent, startOffset in
 	m.emit(events.AgentState(a.ID), a)
 	m.fireComplete(ctx, a, a.GetExitErr() == nil)
 	m.markAgentDone(ctx, a)
+}
+
+// reconcileReattachedHeadlessTerminalResult applies the terminal stdin
+// boundary that was missed while the app was down. Error results deliberately
+// retain queued steers for a retry; only a clean result may flush one into the
+// still-live child.
+func (m *Manager) reconcileReattachedHeadlessTerminalResult(a *Agent) {
+	found, isError := resultBeforeOnlyForkOutput(a.Output())
+	if !found {
+		return
+	}
+	if isError {
+		m.closeHeadlessSteerAfterError(a)
+		return
+	}
+	m.drainOrCloseHeadlessSteer(a)
 }
 
 // watchPID closes done when the process exits or is replaced by a PID-reuse

--- a/internal/agent/reattach_escalation_test.go
+++ b/internal/agent/reattach_escalation_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -61,5 +62,28 @@ func TestResultBeforeOnlyForkOutput(t *testing.T) {
 	}
 	if found, _ := resultBeforeOnlyForkOutput([]StreamEvent{{Type: "result"}, {Type: "init"}}); found {
 		t.Fatal("top-level retry event must hide prior result")
+	}
+}
+
+func TestReattachErrorResultPreservesQueuedSteer(t *testing.T) {
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "reattach-error-steer", TaskID: "task-1", Mode: "headless", Provider: "claude"}
+	r, w := io.Pipe()
+	if err := a.convo.installStdinPipe(w); err != nil {
+		t.Fatalf("installStdinPipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	a.EnqueuePrompt("preserve across retry")
+	a.AppendOutput(StreamEvent{Type: "result", Subtype: "error", ErrorType: "overloaded_error"})
+
+	m.reconcileReattachedHeadlessTerminalResult(a)
+	if got := a.PendingPromptCount(); got != 1 {
+		t.Fatalf("PendingPromptCount = %d, want preserved queued steer", got)
+	}
+	if !a.isFinalizing() {
+		t.Fatal("reattached error result must reject new messages")
+	}
+	if a.convo.hasStdinPipe() {
+		t.Fatal("reattached error result must close the stale stdin")
 	}
 }

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1223,11 +1223,15 @@ func (m *Manager) handleHeadlessResult(ctx context.Context, a *Agent, event Stre
 		}
 	}
 
-	m.drainOrCloseHeadlessSteer(a)
 	if resultSubtypeIsError(event.Subtype) || event.ErrorType != "" || event.ErrorStatus != 0 {
+		// A queued steer belongs to the next successful turn, not to this failed
+		// result. Preserve it for the runner's retry while closing this stdin and
+		// rejecting any new input that cannot be delivered by this process.
+		m.closeHeadlessSteerAfterError(a)
 		a.ClearPostResultWait()
 		return true
 	}
+	m.drainOrCloseHeadlessSteer(a)
 	if !shouldTrackPostResultWait(a) {
 		a.ClearPostResultWait()
 		return true
@@ -1267,9 +1271,8 @@ func (m *Manager) drainOrCloseHeadlessSteer(a *Agent) {
 	if !a.convo.hasStdinPipe() {
 		return
 	}
-	next, ok := a.PopPendingPrompt()
+	next, ok := a.PopPendingPromptOrBeginFinalizing()
 	if !ok {
-		a.setFinalizing(true)
 		a.convo.closeStdinPipe()
 		return
 	}
@@ -1302,6 +1305,19 @@ func (m *Manager) drainOrCloseHeadlessSteer(a *Agent) {
 	m.logger.Info("agent.headless.steer.flushed", "id", a.ID, "remaining", a.PendingPromptCount())
 }
 
+// closeHeadlessSteerAfterError stops the failed stdin turn without consuming
+// queued follow-ups. A retry starts a fresh stdin transport and can deliver
+// those prompts in order; a new message is rejected rather than falsely
+// acknowledged after the terminal error has already arrived.
+func (m *Manager) closeHeadlessSteerAfterError(a *Agent) {
+	if !a.convo.hasStdinPipe() {
+		return
+	}
+	a.setFinalizing(true)
+	m.saveRegistry(m.ctx, a)
+	a.convo.closeStdinPipe()
+}
+
 // sendHeadlessSteerMessage queues a follow-up message for a steerable
 // headless claude run. Unlike the conversational turn boundary
 // (advanceClaudeTurn), there is no idle state to write into directly — a
@@ -1310,11 +1326,11 @@ func (m *Manager) drainOrCloseHeadlessSteer(a *Agent) {
 // Rejects once the run has begun finalizing (its stdin is being closed for
 // good) so a message is never silently queued for a process that is exiting.
 func (m *Manager) sendHeadlessSteerMessage(a *Agent, text string) error {
-	if a.isFinalizing() {
-		return conflictError(fmt.Sprintf("agent %s is finalizing and can no longer accept messages", a.ID))
-	}
-	queueLen, enqueued := a.TryEnqueuePrompt(text, MaxPendingHeadlessSteerPrompts)
+	queueLen, enqueued, finalizing := a.TryEnqueuePrompt(text, MaxPendingHeadlessSteerPrompts)
 	if !enqueued {
+		if finalizing {
+			return conflictError(fmt.Sprintf("agent %s is finalizing and can no longer accept messages", a.ID))
+		}
 		return conflictError(fmt.Sprintf("agent %s has too many pending steer messages (%d max)", a.ID, MaxPendingHeadlessSteerPrompts))
 	}
 	m.saveRegistry(m.ctx, a)

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -3113,6 +3113,70 @@ func TestHeadlessUnsteeredClosesAndCompletes(t *testing.T) {
 	}
 }
 
+// TestHeadlessErrorResultPreservesQueuedSteer verifies that a provider error
+// never flushes an operator's follow-up into the failed terminal turn. The
+// queued prompt survives for a retry while the old stdin closes.
+func TestHeadlessErrorResultPreservesQueuedSteer(t *testing.T) {
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "error-steer", TaskID: "task-1", Mode: "headless", Provider: "claude"}
+	r, w := io.Pipe()
+	if err := a.convo.installStdinPipe(w); err != nil {
+		t.Fatalf("installStdinPipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	a.EnqueuePrompt("retry this instruction")
+
+	resultLine := []byte(`{"type":"result","subtype":"error","error_type":"overloaded_error"}`)
+	var lastEmit time.Time
+	if stop := m.processHeadlessLine(context.Background(), a, resultLine, &lastEmit, providerByName("claude")); stop {
+		t.Fatal("error result must not request an unrelated guardrail stop")
+	}
+	if got := a.PendingPromptCount(); got != 1 {
+		t.Fatalf("PendingPromptCount = %d, want preserved queued steer", got)
+	}
+	if !a.isFinalizing() {
+		t.Fatal("agent must reject new messages after terminal error")
+	}
+	if a.convo.hasStdinPipe() {
+		t.Fatal("failed turn stdin must be closed")
+	}
+}
+
+// TestHeadlessSteerTerminalBoundarySerializes races the two operations that
+// formerly had an acknowledgement-loss window: a terminal empty-queue check
+// and a concurrent steer enqueue. Every accepted enqueue must be reserved by
+// the boundary; otherwise the boundary must finalize first and reject it.
+func TestHeadlessSteerTerminalBoundarySerializes(t *testing.T) {
+	for range 1000 {
+		a := &Agent{ID: "terminal-race", Mode: "headless", Provider: "claude"}
+		a.mu.Lock()
+		type enqueueResult struct {
+			enqueued   bool
+			finalizing bool
+		}
+		dequeued := make(chan bool, 1)
+		enqueued := make(chan enqueueResult, 1)
+		go func() {
+			_, ok := a.PopPendingPromptOrBeginFinalizing()
+			dequeued <- ok
+		}()
+		go func() {
+			_, ok, finalizing := a.TryEnqueuePrompt("operator instruction", MaxPendingHeadlessSteerPrompts)
+			enqueued <- enqueueResult{enqueued: ok, finalizing: finalizing}
+		}()
+		a.mu.Unlock()
+
+		gotDequeue := <-dequeued
+		gotEnqueue := <-enqueued
+		if gotEnqueue.enqueued != gotDequeue {
+			t.Fatalf("enqueue accepted=%v, boundary dequeued=%v: accepted steer was lost", gotEnqueue.enqueued, gotDequeue)
+		}
+		if !gotEnqueue.enqueued && !gotEnqueue.finalizing {
+			t.Fatal("enqueue rejected without queue limit or finalization")
+		}
+	}
+}
+
 func TestProcessHeadlessLine_ResultWaitsForBackgroundTasksThenStopsWhenCleared(t *testing.T) {
 	m := newParseTestManager(t)
 	a := &Agent{ID: "bg-close", TaskID: "t", Mode: "headless", Provider: "claude", StartedAt: time.Now().UTC()}


### PR DESCRIPTION
Fixes #2875.

Atomically reserves a queued steer or begins finalization, so an accepted message cannot be lost between an empty terminal queue check and stdin closure. Error-result and reattach paths retain pending steers for retry rather than flushing them into a failed turn.

Verification:
- go test -race -timeout 5m ./internal/agent/...
- golangci-lint run ./internal/agent/...
- focused terminal-boundary/error/reattach regressions repeated with -race