### PR TITLE
fix(sandbox): grant codex its app-support root

### DIFF
--- a/internal/agent/agent_sandbox.sb
+++ b/internal/agent/agent_sandbox.sb
@@ -19,7 +19,12 @@
   (subpath (param "CODEX_STATE"))
   (subpath (param "COPILOT_STATE"))
   (subpath (param "OPENCODE_STATE"))
-  (subpath (param "TOOL_CACHE")))
+  (subpath (param "TOOL_CACHE"))
+  ;; APP_SUPPORT is the macOS per-user application-data root. codex's
+  ;; in-process app-server creates its own directory there at startup, so it
+  ;; needs write on the parent; a codex-named subpath alone was measured to
+  ;; fail. Unused slots resolve to a never-written sentinel.
+  (subpath (param "APP_SUPPORT")))
 ;; READONLY_DIR re-denies writes for a run whose Dir must stay read-only
 ;; (RunConfig.ReadOnlyDir) even though it sits inside one of the allowed
 ;; roots above (TMP in particular is the whole system temp dir, so a

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -699,6 +699,7 @@ func enforceSpec(
 		copilotState:  agentStateRoot(".copilot", sandboxHome),
 		opencodeState: agentStateRoot(filepath.Join(".local", "share", "opencode"), sandboxHome),
 		toolCache:     agentStateRoot(".cache", sandboxHome),
+		appSupport:    providerAppSupportRoot(),
 	}
 }
 
@@ -954,6 +955,26 @@ func (m *Manager) resolveSandboxReadRoots(cfg *RunConfig) []string {
 		add(p)
 	}
 	return dedupeRoots(roots...)
+}
+
+// providerAppSupportRoot returns the macOS per-user application-data root, or
+// "" where it does not exist (Linux, or a home that has none).
+//
+// Granted because the codex CLI's in-process app-server creates a directory
+// under it at startup. Narrower grants were measured and do not work: naming
+// a codex-specific subpath still fails, because creating that subdirectory
+// requires write on the parent.
+func providerAppSupportRoot() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	root := filepath.Join(home, "Library", "Application Support")
+	canon, err := canonicalizeRoot(root)
+	if err != nil {
+		return ""
+	}
+	return canon
 }
 
 func agentStateRoot(sub, fallback string) string {

--- a/internal/agent/procsandbox_darwin.go
+++ b/internal/agent/procsandbox_darwin.go
@@ -198,6 +198,7 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		{"COPILOT_STATE", sandboxRootOr(cfg.sandbox.copilotState, home)},
 		{"OPENCODE_STATE", sandboxRootOr(cfg.sandbox.opencodeState, home)},
 		{"TOOL_CACHE", sandboxRootOr(cfg.sandbox.toolCache, home)},
+		{"APP_SUPPORT", cfg.sandbox.appSupport},
 		{"READONLY_DIR", sandboxRootOr(cfg.sandbox.readOnlyDir, unusedReadOnlyDirSentinel)},
 		{"STATE_DENY_1", sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 0), unusedReadOnlyDirSentinel)},
 		{"STATE_DENY_2", sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 1), unusedReadOnlyDirSentinel)},

--- a/internal/agent/procsandbox_linux.go
+++ b/internal/agent/procsandbox_linux.go
@@ -87,6 +87,7 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		cfg.sandbox.copilotState,
 		cfg.sandbox.opencodeState,
 		cfg.sandbox.toolCache,
+		cfg.sandbox.appSupport,
 	)
 	roots = dedupeRoots(append(roots, cfg.sandbox.gitShared...)...)
 	for _, root := range roots {

--- a/internal/agent/procsandbox_read_darwin_test.go
+++ b/internal/agent/procsandbox_read_darwin_test.go
@@ -149,3 +149,42 @@ func TestUnusedRootSentinelsAreDistinct(t *testing.T) {
 		t.Fatal("an unused allow root aliases an unused deny root")
 	}
 }
+
+// codex's in-process app-server creates a directory under the macOS per-user
+// application-data root at startup. Without a write grant there it dies with
+// "failed to initialize in-process app-server client: Operation not
+// permitted" before producing any output, which surfaced downstream as a
+// missing skill-conformance receipt rather than as a sandbox denial.
+func TestWrapInvocation_GrantsAppSupportRoot(t *testing.T) {
+	const appSupport = "/Users/u/Library/Application Support"
+	cfg := &RunConfig{sandbox: sandboxSpec{
+		mode:        "enforce",
+		worktree:    "/data/wt",
+		sandboxHome: "/data/home",
+		tmp:         "/tmp",
+		sharedCache: "/data/cache",
+		appSupport:  appSupport,
+	}}
+
+	_, args := wrapInvocation("codex", []string{"exec"}, cfg)
+
+	var got string
+	for i := range len(args) - 1 {
+		if args[i] == "-D" {
+			if name, value, ok := strings.Cut(args[i+1], "="); ok && name == "APP_SUPPORT" {
+				got = value
+			}
+		}
+	}
+	if got != appSupport {
+		t.Fatalf("APP_SUPPORT = %q, want %q", got, appSupport)
+	}
+}
+
+// The embedded profile must actually reference the param, or the -D value is
+// inert and the grant silently does nothing.
+func TestSandboxProfile_ReferencesAppSupport(t *testing.T) {
+	if !strings.Contains(string(agentSandboxProfile), `(subpath (param "APP_SUPPORT"))`) {
+		t.Fatal("profile has no APP_SUPPORT write rule, so the resolved root grants nothing")
+	}
+}

--- a/internal/agent/runner_core.go
+++ b/internal/agent/runner_core.go
@@ -97,6 +97,14 @@ type sandboxSpec struct {
 	copilotState  string
 	opencodeState string
 	toolCache     string
+	// appSupport is the macOS per-user application-data root
+	// (~/Library/Application Support). The codex CLI's in-process app-server
+	// creates its own directory there at startup, which needs write on the
+	// parent — granting only a codex-named subpath fails, measured. Without
+	// it codex dies immediately under enforce with "failed to initialize
+	// in-process app-server client: Operation not permitted". Empty off
+	// darwin, where no such path exists.
+	appSupport string
 
 	// readRoots, when non-empty, switches the wrapper from "everything is
 	// readable" to deny-by-default reads over exactly these roots (#2781).
@@ -118,6 +126,7 @@ func (s sandboxSpec) writeRoots() []string {
 	roots := []string{
 		s.worktree, s.sandboxHome, s.tmp, s.sharedCache,
 		s.claudeState, s.codexState, s.copilotState, s.opencodeState, s.toolCache,
+		s.appSupport,
 		s.gitAdminDir, s.gitCommonDir, s.gitWorktrees, s.gitObjectDir,
 		s.gitOverlayObjectDir, s.gitOverlayRefDir, s.gitOverlayLogDir,
 		s.gitOverlayRemoteRefDir, s.gitOverlayRemoteLogDir,


### PR DESCRIPTION
## Motivation

Every codex agent dies at startup under `sandbox_mode: enforce` on darwin:

```
Error: failed to initialize in-process app-server client: Operation not permitted (os error 1)
```

codex's in-process app-server creates a directory under the macOS per-user application-data root at startup, and no sandbox root granted write there. `~/.codex` being writable is **not** sufficient — codex uses the platform-standard location in addition to its own dotfile dir.

**The failure was invisible where it happened.** The agent produced a 238-byte stderr and no output at all, so the workflow blamed a missing skill-conformance receipt. Two tasks were parked with `mandatory workflow skill … produced no conformance receipt`, with nothing pointing at the sandbox.

> Changelog: fix(sandbox): grant codex the macOS application-support root it needs to start

## Implementation information

Bisected against the real profile rather than reasoned about:

| Granted root | codex |
|---|---|
| unsandboxed / writes everywhere | works |
| the agent sandbox's normal roots | **fails** |
| `~/Library/Caches` | fails |
| `~/Library/Preferences` | fails |
| `~/Library/Logs` | fails |
| `~/Library/Containers` | fails |
| `~/Library/Application Support/codex` | **fails** |
| `~/Library/Application Support` | **works** |

The codex-named subpath fails because codex *creates* that subdirectory, which requires write on the **parent**. So the narrow grant cannot work — this is the tightest root that does.

Resolved once via `providerAppSupportRoot()`, which returns `""` where the path does not exist (Linux, or a home without one). Threaded through the darwin `-D` params, the seatbelt profile, the Linux bind roots, and `writeRoots()` so read enforcement grants it too.

## Supporting documentation

Proven end-to-end with the regenerated profile and the real codex CLI:

- `APP_SUPPORT` = sentinel → fails with the reported error
- `APP_SUPPORT` = granted → `turn.completed`

Two tests, deliberately covering both halves of the wiring:

- `TestWrapInvocation_GrantsAppSupportRoot` — the `-D` reaches the invocation.
- `TestSandboxProfile_ReferencesAppSupport` — the embedded profile actually references the param. Without this, a correctly-resolved root with no matching rule would grant nothing while every other test still passed.

`mise run verify` green.

**Scope:** darwin-only, affecting *every* codex agent under enforce — which is most review runs, since A/B routes review to codex.

This is the third sandbox defect on the desktop path in a row (after the detached-HEAD resolver and the empty profile param), and all three were invisible to the server's `report`-mode soak: `report` never wraps a spawn, so it cannot reach any of them. A clean soak there is not evidence that `enforce` is safe on darwin — worth weighing before the #2781 rollout is promoted.
