### PR TITLE
fix(agent): synchronize command assignment

### DIFF
--- a/internal/agent/k8s_job_runner.go
+++ b/internal/agent/k8s_job_runner.go
@@ -146,7 +146,7 @@ func (r *k8sJobRunner) Run(ctx context.Context, m *Manager, a *Agent, cfg RunCon
 		m.finalizeRun(ctx, a, "agent.k8s.done")
 		return
 	}
-	a.Command = "kubernetes job/" + jobName
+	a.SetCommand("kubernetes job/" + jobName)
 	m.emit(events.AgentState(a.ID), a)
 
 	prevLen := len(a.Output())

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -689,6 +689,13 @@ func (a *Agent) SetLogPath(p string) {
 	a.mu.Unlock()
 }
 
+// SetCommand records the command used to run the agent.
+func (a *Agent) SetCommand(command string) {
+	a.mu.Lock()
+	a.Command = command
+	a.mu.Unlock()
+}
+
 // SetSessionID records the provider session ID.
 func (a *Agent) SetSessionID(id string) {
 	a.mu.Lock()

--- a/internal/agent/model_json_test.go
+++ b/internal/agent/model_json_test.go
@@ -153,6 +153,7 @@ func TestAgentView_ConcurrentWithMutation(t *testing.T) {
 			default:
 			}
 			a.SetState(StateRunning)
+			a.SetCommand("claude -p")
 			a.AddResultStats("session", float64(i), i, i, i)
 			a.AppendOutput(StreamEvent{Type: "assistant"})
 		}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -267,7 +267,7 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 		cmd.Env = append(os.Environ(), inv.env...)
 		cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
 	}
-	a.Command = inv.command
+	a.SetCommand(inv.command)
 
 	stdout, pipeErr := cmd.StdoutPipe()
 	if pipeErr != nil {
@@ -439,7 +439,7 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 		cmd.Env = append(os.Environ(), invokeEnv...)
 		cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
 	}
-	a.Command = command
+	a.SetCommand(command)
 	cmd.Stdout = outFile
 
 	// Steerable claude runs get an O_RDWR FIFO stdin, exactly like a detached


### PR DESCRIPTION
Fixes #2877.

Routes every `Agent.Command` write through a mutex-protected `SetCommand`, matching the existing locked `View` snapshot. Extends the concurrent View/JSON race regression to exercise command mutation.

Verified locally:
- `go test -race -timeout 5m ./internal/agent/...`
- `golangci-lint run ./internal/agent/...`
- independent adversarial review and repeated race testing of View, headless, and Kubernetes paths