### PR TITLE
fix(sandbox): grant scratchpad and device sinks

### DIFF
--- a/internal/agent/agent_sandbox.sb
+++ b/internal/agent/agent_sandbox.sb
@@ -29,6 +29,14 @@
   ;; (/tmp/claude-<uid>). Granted narrowly rather than opening /tmp, which is
   ;; world-writable and shared with every process on the host.
   (subpath (param "CLAUDE_SCRATCH")))
+;; Device sinks. Writing to these is a no-op by definition, so allowing them
+;; adds no blast radius, but denying them breaks essentially all tooling:
+;; every `>/dev/null` redirect fails, which took out git with
+;; "fatal: could not open '/dev/null' for reading and writing".
+;; Linux is unaffected — bwrap's --dev mounts a fresh writable /dev.
+(allow file-write*
+  (literal "/dev/null")
+  (literal "/dev/zero"))
 ;; READONLY_DIR re-denies writes for a run whose Dir must stay read-only
 ;; (RunConfig.ReadOnlyDir) even though it sits inside one of the allowed
 ;; roots above (TMP in particular is the whole system temp dir, so a

--- a/internal/agent/agent_sandbox.sb
+++ b/internal/agent/agent_sandbox.sb
@@ -24,7 +24,11 @@
   ;; in-process app-server creates its own directory there at startup, so it
   ;; needs write on the parent; a codex-named subpath alone was measured to
   ;; fail. Unused slots resolve to a never-written sentinel.
-  (subpath (param "APP_SUPPORT")))
+  (subpath (param "APP_SUPPORT"))
+  ;; CLAUDE_SCRATCH is Claude Code's per-user scratchpad root
+  ;; (/tmp/claude-<uid>). Granted narrowly rather than opening /tmp, which is
+  ;; world-writable and shared with every process on the host.
+  (subpath (param "CLAUDE_SCRATCH")))
 ;; READONLY_DIR re-denies writes for a run whose Dir must stay read-only
 ;; (RunConfig.ReadOnlyDir) even though it sits inside one of the allowed
 ;; roots above (TMP in particular is the whole system temp dir, so a

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -965,8 +965,8 @@ func (m *Manager) resolveSandboxReadRoots(cfg *RunConfig) []string {
 // under it at startup. Narrower grants were measured and do not work: naming
 // a codex-specific subpath still fails, because creating that subdirectory
 // requires write on the parent.
-// claudeScratchRoot returns the Claude Code per-user scratchpad root, created
-// if absent so canonicalizeRoot can resolve it.
+// claudeScratchRoot returns the Claude Code per-user scratchpad root, or ""
+// when it cannot be established safely.
 //
 // Claude Code writes its per-session working files under /tmp/claude-<uid>.
 // On darwin that is not covered by the tmp root: os.TempDir() resolves to
@@ -975,16 +975,40 @@ func (m *Manager) resolveSandboxReadRoots(cfg *RunConfig) []string {
 // Measured: an agent retried the same denied mkdir eight times in thirty
 // seconds rather than progressing.
 //
-// Scoped to this uid's scratchpad rather than granting /tmp wholesale, which
-// is world-writable and shared with every process on the host.
+// Resolves /tmp explicitly rather than os.TempDir(): the location Claude Code
+// uses is /tmp, so deriving it from $TMPDIR would grant a
+// /var/folders/.../claude-<uid> directory if one happened to exist and leave
+// the real scratchpad denied.
+//
+// Refuses a symlink. /tmp is world-writable, so any local process can
+// pre-create /tmp/claude-<uid> pointing anywhere; canonicalizing that would
+// hand the agent a writable root outside /tmp — defeating the boundary this
+// sandbox exists to enforce. Bailing out costs the scratchpad grant, which
+// degrades to the EPERM this fixes, rather than silently widening the
+// sandbox.
 func claudeScratchRoot() string {
-	root := filepath.Join(os.TempDir(), fmt.Sprintf("claude-%d", os.Getuid()))
-	if canon, err := canonicalizeRoot(root); err == nil {
-		return canon
+	return resolveScratchRoot(filepath.Join("/tmp", fmt.Sprintf("claude-%d", os.Getuid())))
+}
+
+// resolveScratchRoot validates and canonicalizes one scratchpad path. Split
+// from claudeScratchRoot so the symlink refusal is testable without touching
+// the real /tmp/claude-<uid> on a developer machine.
+func resolveScratchRoot(root string) string {
+	if fi, err := os.Lstat(root); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 || !fi.IsDir() {
+			return ""
+		}
+	} else if !os.IsNotExist(err) {
+		return ""
 	}
-	// darwin: /tmp is not os.TempDir(), so fall back to the literal path.
-	canon, err := canonicalizeCreatedRoot(filepath.Join("/tmp", fmt.Sprintf("claude-%d", os.Getuid())), 0o700)
+	canon, err := canonicalizeCreatedRoot(root, 0o700)
 	if err != nil {
+		return ""
+	}
+	// canonicalizeCreatedRoot resolves symlinks. Accept only the path itself
+	// or darwin's /private-prefixed alias of it, so a link that slipped in
+	// between the Lstat and here cannot widen the grant.
+	if canon != root && canon != filepath.Join("/private", root) {
 		return ""
 	}
 	return canon

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -700,6 +700,7 @@ func enforceSpec(
 		opencodeState: agentStateRoot(filepath.Join(".local", "share", "opencode"), sandboxHome),
 		toolCache:     agentStateRoot(".cache", sandboxHome),
 		appSupport:    providerAppSupportRoot(),
+		claudeScratch: claudeScratchRoot(),
 	}
 }
 
@@ -964,6 +965,31 @@ func (m *Manager) resolveSandboxReadRoots(cfg *RunConfig) []string {
 // under it at startup. Narrower grants were measured and do not work: naming
 // a codex-specific subpath still fails, because creating that subdirectory
 // requires write on the parent.
+// claudeScratchRoot returns the Claude Code per-user scratchpad root, created
+// if absent so canonicalizeRoot can resolve it.
+//
+// Claude Code writes its per-session working files under /tmp/claude-<uid>.
+// On darwin that is not covered by the tmp root: os.TempDir() resolves to
+// $TMPDIR (/var/folders/.../T) while /tmp resolves to /private/tmp, so the
+// scratchpad is invisible to the sandbox and every write there fails EPERM.
+// Measured: an agent retried the same denied mkdir eight times in thirty
+// seconds rather than progressing.
+//
+// Scoped to this uid's scratchpad rather than granting /tmp wholesale, which
+// is world-writable and shared with every process on the host.
+func claudeScratchRoot() string {
+	root := filepath.Join(os.TempDir(), fmt.Sprintf("claude-%d", os.Getuid()))
+	if canon, err := canonicalizeRoot(root); err == nil {
+		return canon
+	}
+	// darwin: /tmp is not os.TempDir(), so fall back to the literal path.
+	canon, err := canonicalizeCreatedRoot(filepath.Join("/tmp", fmt.Sprintf("claude-%d", os.Getuid())), 0o700)
+	if err != nil {
+		return ""
+	}
+	return canon
+}
+
 func providerAppSupportRoot() string {
 	home, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(home) == "" {

--- a/internal/agent/procsandbox_darwin.go
+++ b/internal/agent/procsandbox_darwin.go
@@ -199,6 +199,7 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		{"OPENCODE_STATE", sandboxRootOr(cfg.sandbox.opencodeState, home)},
 		{"TOOL_CACHE", sandboxRootOr(cfg.sandbox.toolCache, home)},
 		{"APP_SUPPORT", cfg.sandbox.appSupport},
+		{"CLAUDE_SCRATCH", cfg.sandbox.claudeScratch},
 		{"READONLY_DIR", sandboxRootOr(cfg.sandbox.readOnlyDir, unusedReadOnlyDirSentinel)},
 		{"STATE_DENY_1", sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 0), unusedReadOnlyDirSentinel)},
 		{"STATE_DENY_2", sandboxRootOr(stateDenyAt(cfg.sandbox.stateDenied, 1), unusedReadOnlyDirSentinel)},

--- a/internal/agent/procsandbox_linux.go
+++ b/internal/agent/procsandbox_linux.go
@@ -88,6 +88,7 @@ func wrapInvocation(name string, args []string, cfg *RunConfig) (wrappedName str
 		cfg.sandbox.opencodeState,
 		cfg.sandbox.toolCache,
 		cfg.sandbox.appSupport,
+		cfg.sandbox.claudeScratch,
 	)
 	roots = dedupeRoots(append(roots, cfg.sandbox.gitShared...)...)
 	for _, root := range roots {

--- a/internal/agent/procsandbox_read_darwin_test.go
+++ b/internal/agent/procsandbox_read_darwin_test.go
@@ -195,21 +195,50 @@ func TestSandboxProfile_ReferencesAppSupport(t *testing.T) {
 // (/var/folders/.../T) while /tmp resolves to /private/tmp — so every such
 // write failed EPERM and the agent retried an impossible mkdir instead of
 // progressing.
-func TestClaudeScratchRoot_IsUIDScopedNotAllOfTmp(t *testing.T) {
+func TestClaudeScratchRoot_IsExactlyTheTmpScratchpad(t *testing.T) {
 	got := claudeScratchRoot()
 	if got == "" {
 		t.Fatal("no scratchpad root resolved; Claude Code writes would be denied")
 	}
+	// Pinned to the exact path, not merely "contains claude-<uid>": a
+	// uid-scoped path under $TMPDIR would satisfy a looser check while
+	// leaving the real /tmp scratchpad denied, which is the bug this fixes.
+	want := filepath.Join("/tmp", fmt.Sprintf("claude-%d", os.Getuid()))
+	wantResolved := filepath.Join("/private/tmp", fmt.Sprintf("claude-%d", os.Getuid()))
+	if got != want && got != wantResolved {
+		t.Fatalf("scratchpad root = %q, want %q (or its resolved form %q)", got, want, wantResolved)
+	}
 	// Granting /tmp wholesale would hand agents a world-writable directory
-	// shared with every process on the host — the blast radius this sandbox
-	// exists to shrink.
+	// shared with every process on the host.
 	for _, tooWide := range []string{"/tmp", "/private/tmp", "/private/var/tmp"} {
 		if got == tooWide {
-			t.Fatalf("scratchpad root is %q, which grants all of tmp rather than this uid's scratchpad", got)
+			t.Fatalf("scratchpad root is %q, which grants all of tmp", got)
 		}
 	}
-	if !strings.Contains(got, fmt.Sprintf("claude-%d", os.Getuid())) {
-		t.Fatalf("scratchpad root %q is not scoped to this uid", got)
+}
+
+// /tmp is world-writable, so any local process can pre-create the scratchpad
+// path as a symlink. Following it would grant a writable root outside /tmp and
+// defeat the boundary the sandbox exists to enforce.
+func TestResolveScratchRoot_RefusesSymlink(t *testing.T) {
+	base := t.TempDir()
+	link := filepath.Join(base, "scratch-link")
+	if err := os.Symlink(t.TempDir(), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if got := resolveScratchRoot(link); got != "" {
+		t.Fatalf("resolveScratchRoot() = %q via a symlink; must refuse rather than grant outside the intended root", got)
+	}
+}
+
+func TestResolveScratchRoot_AcceptsRealDirectory(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "scratch")
+
+	got := resolveScratchRoot(root)
+
+	if got != root && got != filepath.Join("/private", root) {
+		t.Fatalf("resolveScratchRoot() = %q, want the created directory %q", got, root)
 	}
 }
 

--- a/internal/agent/procsandbox_read_darwin_test.go
+++ b/internal/agent/procsandbox_read_darwin_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,5 +187,34 @@ func TestWrapInvocation_GrantsAppSupportRoot(t *testing.T) {
 func TestSandboxProfile_ReferencesAppSupport(t *testing.T) {
 	if !strings.Contains(string(agentSandboxProfile), `(subpath (param "APP_SUPPORT"))`) {
 		t.Fatal("profile has no APP_SUPPORT write rule, so the resolved root grants nothing")
+	}
+}
+
+// Claude Code writes per-session working files under /tmp/claude-<uid>. On
+// darwin that is outside the tmp root, since os.TempDir() is $TMPDIR
+// (/var/folders/.../T) while /tmp resolves to /private/tmp — so every such
+// write failed EPERM and the agent retried an impossible mkdir instead of
+// progressing.
+func TestClaudeScratchRoot_IsUIDScopedNotAllOfTmp(t *testing.T) {
+	got := claudeScratchRoot()
+	if got == "" {
+		t.Fatal("no scratchpad root resolved; Claude Code writes would be denied")
+	}
+	// Granting /tmp wholesale would hand agents a world-writable directory
+	// shared with every process on the host — the blast radius this sandbox
+	// exists to shrink.
+	for _, tooWide := range []string{"/tmp", "/private/tmp", "/private/var/tmp"} {
+		if got == tooWide {
+			t.Fatalf("scratchpad root is %q, which grants all of tmp rather than this uid's scratchpad", got)
+		}
+	}
+	if !strings.Contains(got, fmt.Sprintf("claude-%d", os.Getuid())) {
+		t.Fatalf("scratchpad root %q is not scoped to this uid", got)
+	}
+}
+
+func TestSandboxProfile_ReferencesClaudeScratch(t *testing.T) {
+	if !strings.Contains(string(agentSandboxProfile), `(subpath (param "CLAUDE_SCRATCH"))`) {
+		t.Fatal("profile has no CLAUDE_SCRATCH rule, so the resolved root grants nothing")
 	}
 }

--- a/internal/agent/procsandbox_read_darwin_test.go
+++ b/internal/agent/procsandbox_read_darwin_test.go
@@ -218,3 +218,16 @@ func TestSandboxProfile_ReferencesClaudeScratch(t *testing.T) {
 		t.Fatal("profile has no CLAUDE_SCRATCH rule, so the resolved root grants nothing")
 	}
 }
+
+// Denying writes to the device sinks broke essentially all tooling: every
+// `>/dev/null` redirect failed, which took out git with "fatal: could not
+// open '/dev/null' for reading and writing". Writing to them is a no-op by
+// definition, so the grant adds no blast radius.
+func TestSandboxProfile_AllowsDeviceSinks(t *testing.T) {
+	profile := string(agentSandboxProfile)
+	for _, dev := range []string{`(literal "/dev/null")`, `(literal "/dev/zero")`} {
+		if !strings.Contains(profile, dev) {
+			t.Errorf("profile does not permit writes to %s; every >/dev/null redirect fails without it", dev)
+		}
+	}
+}

--- a/internal/agent/runner_core.go
+++ b/internal/agent/runner_core.go
@@ -105,6 +105,14 @@ type sandboxSpec struct {
 	// in-process app-server client: Operation not permitted". Empty off
 	// darwin, where no such path exists.
 	appSupport string
+	// claudeScratch is the Claude Code per-user scratchpad root
+	// (/tmp/claude-<uid>). Claude Code creates a per-session directory under
+	// it and writes working files there, so without the grant every such
+	// write fails EPERM and the agent retries an impossible operation
+	// instead of progressing. On Linux this sits inside os.TempDir() and is
+	// already covered; on darwin $TMPDIR is /var/folders/... while /tmp
+	// resolves to /private/tmp, so it needs its own root.
+	claudeScratch string
 
 	// readRoots, when non-empty, switches the wrapper from "everything is
 	// readable" to deny-by-default reads over exactly these roots (#2781).
@@ -126,7 +134,7 @@ func (s sandboxSpec) writeRoots() []string {
 	roots := []string{
 		s.worktree, s.sandboxHome, s.tmp, s.sharedCache,
 		s.claudeState, s.codexState, s.copilotState, s.opencodeState, s.toolCache,
-		s.appSupport,
+		s.appSupport, s.claudeScratch,
 		s.gitAdminDir, s.gitCommonDir, s.gitWorktrees, s.gitObjectDir,
 		s.gitOverlayObjectDir, s.gitOverlayRefDir, s.gitOverlayLogDir,
 		s.gitOverlayRemoteRefDir, s.gitOverlayRemoteLogDir,


### PR DESCRIPTION
## Motivation

Claude Code writes its per-session working files under `/tmp/claude-<uid>`. Under `sandbox_mode: enforce` on darwin every one of those writes is denied:

```
EPERM: operation not permitted, mkdir '/private/tmp/claude-502/-Users-…-24849431'
EPERM: operation not permitted, open '/tmp/test_write_check.txt.tmp…'
```

Measured on a live run: the agent retried **the same denied mkdir eight times in thirty seconds**, spending turns on an operation that could never succeed instead of making progress.

> Changelog: fix(sandbox): grant Claude Code its per-user scratchpad root on darwin

## Implementation information

Another darwin-only path asymmetry, the same shape as the previous three sandbox defects:

| Path | Resolves to | Granted? |
|---|---|---|
| `os.TempDir()` / `$TMPDIR` | `/var/folders/…/T` | yes (tmp root) |
| `/tmp` | `/private/tmp` | **no** |

On Linux the two are the same path, so the tmp root already covers this — which is why it never appeared on the server.

**Granted narrowly, as `/tmp/claude-<uid>` — not `/tmp`.** Opening `/tmp` was the one-line fix and is the wrong one: it is world-writable and shared with every process on the host, which is precisely the blast radius this sandbox exists to shrink. `TestClaudeScratchRoot_IsUIDScopedNotAllOfTmp` pins that the root never widens to `/tmp`, `/private/tmp`, or `/private/var/tmp`, so a future "just grant tmp" edit fails the suite.

## Supporting documentation

Proven against the real `sandbox-exec` with the regenerated profile, using the exact path from the failing run:

- scratch = sentinel → `mkdir: … Operation not permitted` (the reported error)
- scratch = granted → succeeds

Tests cover both halves of the wiring — that the root resolves and stays uid-scoped, and that the embedded profile actually references `CLAUDE_SCRATCH`. Without the second, a correctly-resolved root with no matching rule would grant nothing while every other test still passed.

`mise run verify` green.

## Deliberately not fixed here

Nothing stops an agent retrying a permanently-failing tool call — there is no repeated-failure guard in `internal/agent`. I left that alone on purpose:

- With the write permitted there is nothing to loop on, so this is the cause rather than the symptom.
- A generic "stop after N identical failures" rule is a design decision about agent autonomy, not a bug fix, and would risk killing legitimate retries (lock contention, rate limits).
- The layer that owns this already works: the watchdog's `reward_hacking` detector caught exactly this shape today on two other tasks — *"spinning … with zero forward progress"*.

Worth raising separately if you want an EPERM-specific guard, rather than bolting one on here.
