### PR TITLE
fix(worktree): keep unpushed work on recreate

### DIFF
--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -309,6 +309,31 @@ func (m *Manager) RepairAll(ctx context.Context) {
 	}
 }
 
+// refuseRecreateWithUnpushedWork stops healOrRecreate from wiping a worktree
+// that still holds commits origin has never seen.
+//
+// Remove and CleanupOrphaned already refuse in that case (#2593), but the
+// branch-mismatch recreate path deleted unconditionally. A worktree can be
+// healthy yet on an unexpected branch — precisely the state a merge or
+// conflict resolution leaves — and wiping it discards work an agent already
+// did and verified, with the only record being the original push failure.
+//
+// Scoped to that path on purpose. The unrepairable path stays unguarded: a
+// broken worktree's commits are not reliably readable, so there is nothing
+// dependable to preserve, and refusing there would wedge the task with no
+// route forward.
+//
+// Failing loudly is the point: the task surfaces a real error a human can act
+// on while the commits still exist, rather than the work disappearing and the
+// task reporting only why the push was blocked.
+func (m *Manager) refuseRecreateWithUnpushedWork(ctx context.Context, taskID, wtPath, reason string) error {
+	if !project.HasUnpushedCommits(ctx, wtPath) {
+		return nil
+	}
+	m.logger.Error("worktree.recreate.unpushed-commits", "task_id", taskID, "path", wtPath, "reason", reason)
+	return fmt.Errorf("refusing to recreate %s worktree %s: it holds commits that never reached origin", reason, wtPath)
+}
+
 // healOrRecreate ensures the worktree at wtPath has resolvable git metadata
 // and sits on wantBranch. Returns (true, nil) if the worktree is usable on
 // return, (false, nil) if it was wiped and the caller should re-create it, or
@@ -320,8 +345,10 @@ func (m *Manager) healOrRecreate(ctx context.Context, taskID, clonePath, wtPath,
 		return true, nil
 	}
 	if healthy {
+		if err := m.refuseRecreateWithUnpushedWork(ctx, taskID, wtPath, "branch-mismatch"); err != nil {
+			return false, err
+		}
 		m.logger.Warn("worktree.branch-mismatch-recreate", "task_id", taskID, "path", wtPath, "branch", wantBranch)
-		m.logger.Warn("worktree.unrepairable-recreate", "task_id", taskID, "path", wtPath)
 		_ = project.RemoveWorktree(ctx, clonePath, wtPath)
 		if err := os.RemoveAll(wtPath); err != nil {
 			return false, fmt.Errorf("remove mismatched-branch worktree %s: %w", wtPath, err)
@@ -337,6 +364,11 @@ func (m *Manager) healOrRecreate(ctx context.Context, taskID, clonePath, wtPath,
 		m.logger.Info("worktree.repaired", "task_id", taskID, "path", wtPath)
 		return true, nil
 	}
+	// Deliberately unguarded, unlike the branch-mismatch path above: this
+	// worktree is broken, so its commits are not reliably readable and there
+	// is no usable state to preserve. Refusing here would wedge the task
+	// forever with no route forward, trading a recoverable loss for a
+	// permanent stall.
 	m.logger.Warn("worktree.unrepairable-recreate", "task_id", taskID, "path", wtPath)
 	_ = project.RemoveWorktree(ctx, clonePath, wtPath)
 	if err := os.RemoveAll(wtPath); err != nil {

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -2078,3 +2078,56 @@ func TestPrepareForTask_BootstrapFailureBlocks(t *testing.T) {
 		t.Errorf("error does not carry bootstrap command text: %v", err)
 	}
 }
+
+// healOrRecreate wipes a worktree it considers unusable. Remove and
+// CleanupOrphaned already refuse when the worktree holds commits origin has
+// never seen (#2593), but both recreate paths deleted unconditionally — and a
+// worktree can be healthy yet on an unexpected branch, which is exactly the
+// state a merge or conflict resolution leaves behind.
+func TestManager_RefuseRecreateWithUnpushedWork(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(Config{WorktreesDir: dir, Tasks: task.NewManager(store, nil), Logger: discardLogger()})
+
+	wt := filepath.Join(dir, "unpushed-work")
+	makePushedGitDir(t, wt)
+	if err := os.WriteFile(filepath.Join(wt, "f.txt"), []byte("merge resolution"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, wt, "git", "add", "-A")
+	mustRunInDir(t, wt, "git", "commit", "-q", "-m", "resolve conflict")
+
+	// branch-mismatch only: the unrepairable path stays unguarded by design,
+	// since a broken worktree has no dependably-readable state to preserve.
+	err = m.refuseRecreateWithUnpushedWork(context.Background(), "t1", wt, "branch-mismatch")
+
+	if err == nil {
+		t.Fatal("recreate allowed on a worktree holding commits origin never saw; that discards the agent's work")
+	}
+	if _, statErr := os.Stat(filepath.Join(wt, "f.txt")); statErr != nil {
+		t.Fatalf("worktree contents gone: %v", statErr)
+	}
+}
+
+// A worktree whose work already reached origin is safe to recreate — the
+// guard must not block ordinary recovery.
+func TestManager_AllowsRecreateWhenPushed(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(Config{WorktreesDir: dir, Tasks: task.NewManager(store, nil), Logger: discardLogger()})
+
+	wt := filepath.Join(dir, "pushed-work")
+	makePushedGitDir(t, wt)
+
+	if err := m.refuseRecreateWithUnpushedWork(context.Background(), "t1", wt, "branch-mismatch"); err != nil {
+		t.Fatalf("guard blocked recreate of a fully-pushed worktree: %v", err)
+	}
+}

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -2081,9 +2081,13 @@ func TestPrepareForTask_BootstrapFailureBlocks(t *testing.T) {
 
 // healOrRecreate wipes a worktree it considers unusable. Remove and
 // CleanupOrphaned already refuse when the worktree holds commits origin has
-// never seen (#2593), but both recreate paths deleted unconditionally — and a
-// worktree can be healthy yet on an unexpected branch, which is exactly the
-// state a merge or conflict resolution leaves behind.
+// never seen (#2593); the branch-mismatch recreate path used to delete
+// regardless, which is what this pins. A worktree can be healthy yet on an
+// unexpected branch — exactly the state a merge or conflict resolution leaves
+// behind — so its commits are readable and worth preserving.
+//
+// The unrepairable recreate path is still unguarded, by design: see
+// refuseRecreateWithUnpushedWork.
 func TestManager_RefuseRecreateWithUnpushedWork(t *testing.T) {
 	dir := t.TempDir()
 	tasksDir := t.TempDir()


### PR DESCRIPTION
## Motivation

`healOrRecreate` wipes a worktree it judges unusable **without checking whether that worktree still holds commits origin has never seen**. `Remove` and `CleanupOrphaned` already refuse in that case (#2593); the recreate paths did not.

The branch-mismatch case is the dangerous one: the worktree is *healthy*, its commits are readable, and sitting on an unexpected branch is exactly the state a merge or conflict resolution leaves behind. Wiping it discards work an agent already did and verified, leaving only the original push failure on record.

> Changelog: fix(worktree): stop a branch-mismatch recreate from discarding unpushed commits

**How this surfaced.** Four tasks on the server are parked reporting a completed, verified merge that the local pre-push hook (`go test ./...`) blocked under resource pressure. Checking those branches:

- the remote branches exist but **do not contain** the merge commits
- those commits **no longer exist in the object database at all**
- the worktrees were reclaimed, taking the only copy

Stated precisely: I could **not** attribute those four losses to this code path from the retained logs — the relevant events had rotated out. So this PR is not presented as their proven cause. But `worktree.branch-mismatch-recreate` does fire in production (found for two other tasks in rotated logs), and the gap is real on its own merits.

## Implementation information

Adds `refuseRecreateWithUnpushedWork`, which fails loudly rather than deleting — the task surfaces an actionable error *while the commits still exist*, instead of the work vanishing and the task reporting only why the push was blocked.

**Deliberately scoped to branch-mismatch.** The unrepairable path stays unguarded: a broken worktree's commits are not reliably readable, so there is nothing dependable to preserve, and refusing there would wedge the task permanently with no route forward — trading a recoverable loss for a guaranteed stall.

That scoping is not a judgement call I made up front. My first version guarded both paths and broke `TestPrepareForFix_ReconcilesOrphanWorktreeDir`, which sets up an unrepairable orphan and requires it to be recreated. The existing suite caught the over-reach.

Also drops a duplicate log line — the branch-mismatch path emitted *both* `branch-mismatch-recreate` and `unrepairable-recreate` for the same event, which makes the two indistinguishable in exactly the logs you would use to investigate this.

## Supporting documentation

- `TestManager_RefuseRecreateWithUnpushedWork` — a worktree with a local-only commit is refused, and its contents verified still present afterwards. Mutation-tested: making the guard always allow fails it with *"recreate allowed on a worktree holding commits origin never saw"*.
- `TestManager_AllowsRecreateWhenPushed` — a fully-pushed worktree is still recreatable, so the guard does not block ordinary recovery.

`mise run verify` green.

## Follow-on, not fixed here

The proximate cause of those four parked tasks is the **local pre-push hook running `go test ./...` on a resource-constrained server**, duplicating a suite the workflow already runs as `checks.verify`. That wants its own fix — narrowing what the hook runs, or scaling its budget under load — not a bypass.
