### PR TITLE
fix(task): free tasks stranded between owners

### DIFF
--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -204,9 +204,18 @@ func (a *App) queueDrainPass(ctx context.Context) {
 	}
 	a.reconcileRunnableBoardTasks(ctx)
 	// A repair pass, not a dispatch decision, so it rides the slower recovery
-	// tick rather than the fast one — it costs a full task list, which has no
-	// place in the hot path.
-	a.clearGateTagOnHandedOffChildren()
+	// tick rather than the fast one. Lists once here rather than inside the
+	// pass, so the recovery tick does not pay for a second full store scan.
+	if a.tasks != nil {
+		tasks, err := a.tasks.List()
+		if err != nil {
+			// Logged rather than swallowed: a silent skip here leaves tasks
+			// stranded exactly as before, with nothing in the log to say why.
+			a.logger.Warn("umbrella.gate.stale-tag-scan", "err", err)
+		} else {
+			a.clearGateTagOnHandedOffChildren(tasks)
+		}
+	}
 	if a.workflowEngine != nil {
 		var workflowRecovery workflowRecoveryLoop = a.workflowEngine
 		workflowRecovery.ReplayPersistedEffects()

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -203,6 +203,10 @@ func (a *App) queueDrainPass(ctx context.Context) {
 		return
 	}
 	a.reconcileRunnableBoardTasks(ctx)
+	// A repair pass, not a dispatch decision, so it rides the slower recovery
+	// tick rather than the fast one — it costs a full task list, which has no
+	// place in the hot path.
+	a.clearGateTagOnHandedOffChildren()
 	if a.workflowEngine != nil {
 		var workflowRecovery workflowRecoveryLoop = a.workflowEngine
 		workflowRecovery.ReplayPersistedEffects()

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -654,6 +654,52 @@ func isWorkflowOwnedBlock(t *task.Task) bool {
 
 // isRunningChild reports whether a child status occupies a parallelism slot —
 // i.e. it has been released and is somewhere in the pipeline but not finished.
+// clearGateTagOnHandedOffChildren strips the gating tag from a child that has
+// already run an implementation agent.
+//
+// Once implementation starts, the umbrella gate has handed the child to its
+// own workflow: Awaiting excludes it via hasStartedImplementation, so the gate
+// will never release it again. But the tag it left behind still makes
+// skipTaskCreatedWorkflow refuse the child, and ResumeStalled skips a terminal
+// workflow — so nothing owns the task and it sits in todo forever. Measured on
+// the server: six children stranded this way since 2026-08-01, none of them
+// waiting on an unmet dependency.
+//
+// Clearing the tag is the narrow fix: it hands the child back to the normal
+// dispatcher at exactly the point the gate stopped owning it, and is a no-op
+// for children the gate is still legitimately holding or the workflow parked.
+func (a *App) clearGateTagOnHandedOffChildren() {
+	if a.tasks == nil {
+		return
+	}
+	tasks, err := a.tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if t.UmbrellaIssue == "" || !slices.Contains(t.Tags, umbrellaGatedTag) {
+			continue
+		}
+		// todo only. A child parked `blocked` with implementation history was
+		// put there deliberately by the workflow (watchdog exhaustion,
+		// sybra#2538) and its tag is what marks it as not the gate's to
+		// release — clearing it there would re-release work that was stopped
+		// on purpose. A gated child sitting in todo has no such owner.
+		if t.Status != task.StatusTodo || !hasStartedImplementation(t) {
+			continue
+		}
+		newTags := slices.DeleteFunc(slices.Clone(t.Tags), func(s string) bool {
+			return s == umbrellaGatedTag
+		})
+		if _, err := a.tasks.Update(t.ID, task.Update{Tags: &newTags}); err != nil {
+			a.logger.Warn("umbrella.gate.stale-tag-clear", "task_id", t.ID, "err", err)
+			continue
+		}
+		a.logger.Info("umbrella.gate.stale-tag-cleared", "task_id", t.ID, "umbrella", t.UmbrellaIssue)
+	}
+}
+
 func isRunningChild(s task.Status) bool {
 	switch s {
 	case task.StatusBlocked, task.StatusNew, task.StatusHumanRequired, task.StatusDone, task.StatusCancelled:

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -652,8 +652,6 @@ func isWorkflowOwnedBlock(t *task.Task) bool {
 	return t.Blocker.Actor == blocker.ActorWorkflow
 }
 
-// isRunningChild reports whether a child status occupies a parallelism slot —
-// i.e. it has been released and is somewhere in the pipeline but not finished.
 // clearGateTagOnHandedOffChildren strips the gating tag from a child that has
 // already run an implementation agent.
 //
@@ -668,14 +666,7 @@ func isWorkflowOwnedBlock(t *task.Task) bool {
 // Clearing the tag is the narrow fix: it hands the child back to the normal
 // dispatcher at exactly the point the gate stopped owning it, and is a no-op
 // for children the gate is still legitimately holding or the workflow parked.
-func (a *App) clearGateTagOnHandedOffChildren() {
-	if a.tasks == nil {
-		return
-	}
-	tasks, err := a.tasks.List()
-	if err != nil {
-		return
-	}
+func (a *App) clearGateTagOnHandedOffChildren(tasks []task.Task) {
 	for i := range tasks {
 		t := &tasks[i]
 		if t.UmbrellaIssue == "" || !slices.Contains(t.Tags, umbrellaGatedTag) {
@@ -700,6 +691,8 @@ func (a *App) clearGateTagOnHandedOffChildren() {
 	}
 }
 
+// isRunningChild reports whether a child status occupies a parallelism slot —
+// i.e. it has been released and is somewhere in the pipeline but not finished.
 func isRunningChild(s task.Status) bool {
 	switch s {
 	case task.StatusBlocked, task.StatusNew, task.StatusHumanRequired, task.StatusDone, task.StatusCancelled:

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -1928,3 +1928,79 @@ func TestUmbrellaGroundingWired(t *testing.T) {
 		})
 	}
 }
+
+// Once a child has run an implementation agent the gate has handed it off:
+// Awaiting excludes it via hasStartedImplementation, so the gate will never
+// release it again. The tag it left behind still makes skipTaskCreatedWorkflow
+// refuse the child, and ResumeStalled skips a terminal workflow — so nothing
+// owns the task and it sits in todo forever.
+func TestReleaseUnblockedChildren_ClearsStaleGateTagAfterHandoff(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/300"
+	mkTracker(t, m, umb, 1)
+
+	child := mkChild(t, m, "handed-off", "Automaat/sybra#31", umb, nil, task.StatusTodo)
+	if err := m.AddRun(child.ID, task.AgentRun{
+		AgentID: "a1", Role: string(agent.RoleImplementation), Mode: "headless", State: "stopped",
+	}); err != nil {
+		t.Fatalf("record implementation run: %v", err)
+	}
+
+	app.clearGateTagOnHandedOffChildren()
+
+	got, err := m.Get(child.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(got.Tags, umbrella.GatedTag) {
+		t.Fatal("child that already ran implementation still carries the gate tag; the normal dispatcher will keep refusing it")
+	}
+}
+
+// A child the gate is still legitimately holding must keep its tag — the
+// reconciliation must not release work whose dependencies are unmet.
+func TestReleaseUnblockedChildren_KeepsGateTagBeforeHandoff(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/301"
+	mkTracker(t, m, umb, 1)
+
+	blocked := mkChild(t, m, "still-gated", "Automaat/sybra#32", umb,
+		[]string{"https://github.com/Automaat/sybra/issues/999"}, task.StatusTodo)
+
+	app.releaseUnblockedChildren(context.Background())
+	app.clearGateTagOnHandedOffChildren()
+
+	got, err := m.Get(blocked.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(got.Tags, umbrella.GatedTag) {
+		t.Fatal("child with an unmet dependency lost its gate tag; it would dispatch before its prerequisite")
+	}
+}
+
+// A child parked `blocked` with implementation history was stopped on purpose
+// (watchdog exhaustion, sybra#2538) and its tag marks it as not the gate's to
+// release. The stale-tag pass must leave it alone.
+func TestClearGateTag_LeavesBlockedChildAlone(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/302"
+	mkTracker(t, m, umb, 5)
+
+	child := mkChild(t, m, "watchdog-blocked", "Automaat/sybra#33", umb, nil, task.StatusBlocked)
+	if err := m.AddRun(child.ID, task.AgentRun{
+		AgentID: "a1", Role: string(agent.RoleImplementation),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	app.clearGateTagOnHandedOffChildren()
+
+	got := mustTask(t, m, child.ID)
+	if !slices.Contains(got.Tags, umbrella.GatedTag) {
+		t.Fatal("blocked child lost its gate tag; work the workflow stopped on purpose would be re-released")
+	}
+}

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -1947,7 +1947,7 @@ func TestReleaseUnblockedChildren_ClearsStaleGateTagAfterHandoff(t *testing.T) {
 		t.Fatalf("record implementation run: %v", err)
 	}
 
-	app.clearGateTagOnHandedOffChildren()
+	app.clearGateTagOnHandedOffChildren(mustList(t, m))
 
 	got, err := m.Get(child.ID)
 	if err != nil {
@@ -1970,7 +1970,7 @@ func TestReleaseUnblockedChildren_KeepsGateTagBeforeHandoff(t *testing.T) {
 		[]string{"https://github.com/Automaat/sybra/issues/999"}, task.StatusTodo)
 
 	app.releaseUnblockedChildren(context.Background())
-	app.clearGateTagOnHandedOffChildren()
+	app.clearGateTagOnHandedOffChildren(mustList(t, m))
 
 	got, err := m.Get(blocked.ID)
 	if err != nil {
@@ -1997,10 +1997,19 @@ func TestClearGateTag_LeavesBlockedChildAlone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app.clearGateTagOnHandedOffChildren()
+	app.clearGateTagOnHandedOffChildren(mustList(t, m))
 
 	got := mustTask(t, m, child.ID)
 	if !slices.Contains(got.Tags, umbrella.GatedTag) {
 		t.Fatal("blocked child lost its gate tag; work the workflow stopped on purpose would be re-released")
 	}
+}
+
+func mustList(t *testing.T, m *task.Manager) []task.Task {
+	t.Helper()
+	tasks, err := m.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tasks
 }

--- a/internal/task/transitions.go
+++ b/internal/task/transitions.go
@@ -77,8 +77,14 @@ var allowedTransitions = map[Status]map[Status]bool{
 		StatusCancelled:     true,
 	},
 	StatusReadyReview: {
-		StatusInReview:      true,
-		StatusTesting:       true,
+		StatusInReview: true,
+		StatusTesting:  true,
+		// Recovery needs a route back to in-progress to run its fix agent.
+		// Without it a branch that diverges while the task sits here cannot be
+		// auto-resolved: branch-conflict-fix dispatches, the transition is
+		// rejected, and the task escalates to a human with a message about
+		// git rather than about the state machine that refused it.
+		StatusInProgress:    true,
 		StatusHumanRequired: true,
 		StatusBlocked:       true,
 		StatusDone:          true,
@@ -103,7 +109,10 @@ var allowedTransitions = map[Status]map[Status]bool{
 		StatusCancelled:     true,
 	},
 	StatusReadyPR: {
-		StatusInReview:      true,
+		StatusInReview: true,
+		// Same recovery route as ready-review: a divergence discovered at the
+		// PR-opening stage must be fixable by an agent rather than parked.
+		StatusInProgress:    true,
 		StatusHumanRequired: true,
 		StatusBlocked:       true,
 		StatusDone:          true,

--- a/internal/task/transitions_test.go
+++ b/internal/task/transitions_test.go
@@ -240,3 +240,31 @@ func TestApplyStatusEffect_RejectsIllegalTransition(t *testing.T) {
 		t.Fatalf("ApplyStatusEffect err = %v, want ErrIllegalTransition", err)
 	}
 }
+
+// branch-conflict-fix must move a task back to in-progress to run its fix
+// agent. Observed on the server: a divergence at ready-review dispatched
+// recovery, the transition was rejected, and the task escalated to a human
+// with "branch diverged … needs manual conflict resolution" — a message about
+// git for what was actually the state machine refusing the move.
+func TestTransitions_RecoveryCanReturnToInProgress(t *testing.T) {
+	// Statuses are listed literally, never derived from allowedTransitions:
+	// a test driven by the table it pins passes whatever that table becomes.
+	for _, from := range []Status{
+		StatusPlanning, StatusPlanReview, StatusReadyReview,
+		StatusInReview, StatusTesting, StatusReadyPR, StatusHumanRequired,
+	} {
+		if !allowedTransitions[from][StatusInProgress] {
+			t.Errorf("%s -> in-progress is refused; a task stranded there cannot be recovered by an agent", from)
+		}
+	}
+}
+
+// Terminal statuses must stay terminal — the recovery route above must not
+// have opened a way back out of a finished task.
+func TestTransitions_TerminalStaysTerminal(t *testing.T) {
+	for _, from := range []Status{StatusDone, StatusCancelled} {
+		if allowedTransitions[from][StatusInProgress] {
+			t.Errorf("%s -> in-progress is allowed; a finished task must not resume", from)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Two independent ways a task ends up with **no mechanism willing to move it**. Both were found by tracing why the server board stopped draining.

**1. No route back to `in-progress` from `ready-review` / `ready-pr`.**

`branch-conflict-fix` must move a task to `in-progress` to run its fix agent. Those two rows were the only working statuses that forbade it. Observed on the server:

```
workflow.start  branch-conflict-fix  step=set_recovering
ERROR pr-monitor.branch-conflict.dispatch
      err: transition: "ready-review" -> "in-progress" is not an allowed automated transition
workflow.cancelled  reason="branch diverged … needs manual conflict resolution"
```

So autonomous recovery is fully wired and fires correctly — it is killed by the state machine, and the task escalates reporting a **git** problem for what was a transition being refused.

**2. The `umbrella-gated` tag outlives the gate's ownership.**

Once a child runs an implementation agent, `Awaiting` excludes it via `hasStartedImplementation` — the gate will never release it again. But the leftover tag makes `skipTaskCreatedWorkflow` refuse it, and `ResumeStalled` skips its terminal workflow. Three mechanisms, each correctly saying "not mine", and nothing owns the task.

Measured on the server: **six children stranded since 2026-08-01**, none waiting on an unmet dependency. (Two other gated children *were* legitimately waiting on open issues and are untouched by this.)

> Changelog: fix(task): free tasks stranded between the umbrella gate, the dispatcher, and recovery

## Implementation information

`ready-review` and `ready-pr` gain `StatusInProgress`, matching `planning`, `plan-review`, `in-review`, `testing` and `human-required`.

A reconciliation pass strips the gate tag at the point the gate demonstrably handed off.

**Scoped to `todo` children only** — and that scoping was not my judgement, it was the suite's. My first version cleared the tag for any child with implementation history and broke `TestReleaseUnblockedChildren_WatchdogBlockedChildWithImplementationHistoryNotReleased` (sybra#2538): a child parked `blocked` with implementation history was stopped *deliberately* by the workflow, and its tag is exactly what marks it as not the gate's to release. Clearing it there would re-release work that was halted on purpose.

The pass runs on the **recovery** tick, not the dispatch tick. It costs a full task list, which has no place in the hot path — I first wired it into `dispatchPass` and an e2e test timed out under full-suite load. It passed in isolation and on clean `main`, so I could not prove it was mine, but adding an unconditional `List()` to a fast loop is exactly the shape that tips a loaded suite, so it moved regardless.

## Supporting documentation

- `TestTransitions_RecoveryCanReturnToInProgress` — every working status can return to `in-progress`. Statuses are listed literally rather than derived from the table, so a table change cannot satisfy the test that constrains it.
- `TestTransitions_TerminalStaysTerminal` — `done`/`cancelled` still cannot resume, so the new route did not open a way out of a finished task.
- `TestReleaseUnblockedChildren_ClearsStaleGateTagAfterHandoff` / `_KeepsGateTagBeforeHandoff` / `TestClearGateTag_LeavesBlockedChildAlone` — the three cases that must differ.

Mutation-tested both: removing the reconciliation strands the child again; removing either transition entry fails the recovery test.

`mise run verify` green.
