### PR TITLE
feat(monitor): detect a stalled board

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/monitor/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/monitor/models.ts
@@ -69,6 +69,7 @@ export enum AnomalyKind {
     KindLostAgent = "lost_agent",
     KindFailureSpike = "failure_spike",
     KindBottleneck = "bottleneck",
+    KindBoardStalled = "board_stalled",
 
     /**
      * KindClusterDrift is filed by clusterlead.Mirror, not Detect — a leader

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -115,7 +115,10 @@ const defaultStallBudgetHours = 1.0
 // RequiresLLM is false for the same reason: acting on this must not depend on
 // the dispatch path that is the thing suspected of being broken.
 func detectBoardStalled(in DetectInput, counts Counts) []Anomaly {
-	if counts.Todo == 0 || counts.InProgress > 0 || len(in.LiveAgents) > 0 {
+	// Running, not merely present: LiveAgents carries entries with
+	// Running=false, and counting those would suppress the anomaly while
+	// nothing is actually executing — the exact condition this detects.
+	if counts.Todo == 0 || counts.InProgress > 0 || anyAgentRunning(in.LiveAgents) {
 		return nil
 	}
 	budget := stallBudgetHours(in.Cfg)
@@ -149,6 +152,15 @@ func detectBoardStalled(in DetectInput, counts Counts) []Anomaly {
 		Evidence:    ev,
 		DetectedAt:  in.Now,
 	}}
+}
+
+func anyAgentRunning(agents []liveAgent) bool {
+	for i := range agents {
+		if agents[i].Running {
+			return true
+		}
+	}
+	return false
 }
 
 // stallBudgetHours reuses the todo bottleneck budget when an operator has set

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -41,6 +41,7 @@ func Detect(in DetectInput) Report {
 		Counts:      countByStatus(in.Tasks),
 	}
 	report.Anomalies = append(report.Anomalies, detectBoardWide(in, report.Counts)...)
+	report.Anomalies = append(report.Anomalies, detectBoardStalled(in, report.Counts)...)
 	report.Anomalies = append(report.Anomalies, detectPerTask(in)...)
 	report.Anomalies = append(report.Anomalies, detectFromAudit(in)...)
 	return report
@@ -93,6 +94,70 @@ func detectBoardWide(in DetectInput, counts Counts) []Anomaly {
 		Evidence:    ev,
 		DetectedAt:  in.Now,
 	}}
+}
+
+// defaultStallBudgetHours is how long queued work may sit with nothing running
+// before the board counts as stalled. Deliberately short: the failure this
+// catches is total, so waiting out a 12-hour bottleneck budget means noticing
+// a dead board the next day.
+const defaultStallBudgetHours = 1.0
+
+// detectBoardStalled reports a board with queued work, nothing running, and
+// spare capacity — the shape of a dispatcher that has stopped dispatching.
+//
+// This reads task state rather than audit events on purpose. KindBottleneck
+// derives its dwell from HourSummary.StatusBottlenecks, which is built from
+// the last hour of audit events — so a board that has genuinely stopped
+// produces no events, and the detector meant to notice is blind precisely
+// when it matters. Measured: a stall ran from 2026-08-01 to 2026-08-03,
+// reporting in_progress=0 todo=12 on every tick, and nothing escalated.
+//
+// RequiresLLM is false for the same reason: acting on this must not depend on
+// the dispatch path that is the thing suspected of being broken.
+func detectBoardStalled(in DetectInput, counts Counts) []Anomaly {
+	if counts.Todo == 0 || counts.InProgress > 0 || len(in.LiveAgents) > 0 {
+		return nil
+	}
+	budget := stallBudgetHours(in.Cfg)
+	oldest := 0.0
+	for i := range in.Tasks {
+		t := &in.Tasks[i]
+		if t.Status != task.StatusTodo || t.StatusChangedAt.IsZero() {
+			continue
+		}
+		if !projectAllowed(in.AllowsProject, t.ProjectID) {
+			continue
+		}
+		if h := in.Now.Sub(t.StatusChangedAt).Hours(); h > oldest {
+			oldest = h
+		}
+	}
+	if oldest <= budget {
+		return nil
+	}
+	ev := map[string]any{
+		"todo":          counts.Todo,
+		"in_progress":   counts.InProgress,
+		"oldest_todo_h": oldest,
+		"budget_h":      budget,
+	}
+	return []Anomaly{{
+		Kind:        KindBoardStalled,
+		Severity:    SeverityError,
+		RequiresLLM: false,
+		Fingerprint: Fingerprint(KindBoardStalled, "", ev),
+		Evidence:    ev,
+		DetectedAt:  in.Now,
+	}}
+}
+
+// stallBudgetHours reuses the todo bottleneck budget when an operator has set
+// one, rather than adding a second knob for the same idea.
+func stallBudgetHours(cfg config.MonitorConfig) float64 {
+	if v, ok := cfg.BottleneckHours["todo"]; ok && v > 0 {
+		return v
+	}
+	return defaultStallBudgetHours
 }
 
 func detectPerTask(in DetectInput) []Anomaly {

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -1255,8 +1255,14 @@ func TestDetect_BoardStalled(t *testing.T) {
 		{
 			name:  "an agent is live even though no task reads in-progress",
 			tasks: []task.Task{{ID: "a", Status: task.StatusTodo, StatusChangedAt: stale}},
-			live:  []liveAgent{{}},
+			live:  []liveAgent{{TaskID: "b", Running: true}},
 			want:  false,
+		},
+		{
+			name:  "a known-but-stopped agent must not mask the stall",
+			tasks: []task.Task{{ID: "a", Status: task.StatusTodo, StatusChangedAt: stale}},
+			live:  []liveAgent{{TaskID: "b", Running: false}},
+			want:  true,
 		},
 		{
 			name:  "queue is fresh",

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -1224,3 +1224,67 @@ func SortAnomalyKinds(k []AnomalyKind) {
 		}
 	}
 }
+
+// The Aug 1–3 stall: queued work, nothing running, spare capacity, and every
+// monitor tick reporting in_progress=0 todo=12 without escalating. The
+// existing bottleneck detector could not see it — its dwell comes from the
+// last hour of audit events, and a stalled board emits none.
+func TestDetect_BoardStalled(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-6 * time.Hour)
+
+	tests := []struct {
+		name  string
+		tasks []task.Task
+		live  []liveAgent
+		want  bool
+	}{
+		{
+			name:  "queued work with nothing running and no agents",
+			tasks: []task.Task{{ID: "a", Status: task.StatusTodo, StatusChangedAt: stale}},
+			want:  true,
+		},
+		{
+			name: "work is running",
+			tasks: []task.Task{
+				{ID: "a", Status: task.StatusTodo, StatusChangedAt: stale},
+				{ID: "b", Status: task.StatusInProgress, StatusChangedAt: stale},
+			},
+			want: false,
+		},
+		{
+			name:  "an agent is live even though no task reads in-progress",
+			tasks: []task.Task{{ID: "a", Status: task.StatusTodo, StatusChangedAt: stale}},
+			live:  []liveAgent{{}},
+			want:  false,
+		},
+		{
+			name:  "queue is fresh",
+			tasks: []task.Task{{ID: "a", Status: task.StatusTodo, StatusChangedAt: now.Add(-2 * time.Minute)}},
+			want:  false,
+		},
+		{
+			name:  "empty board",
+			tasks: nil,
+			want:  false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := Detect(DetectInput{Now: now, Tasks: tc.tasks, LiveAgents: tc.live})
+
+			got := false
+			for _, a := range rep.Anomalies {
+				if a.Kind == KindBoardStalled {
+					got = true
+					if a.RequiresLLM {
+						t.Error("board-stall anomaly requires an LLM dispatch; acting on it must not depend on the dispatch path suspected of being broken")
+					}
+				}
+			}
+			if got != tc.want {
+				t.Fatalf("board_stalled detected = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/monitor/report.go
+++ b/internal/monitor/report.go
@@ -47,6 +47,7 @@ func AllAnomalyKinds() []AnomalyKind {
 		KindLostAgent,
 		KindFailureSpike,
 		KindBottleneck,
+		KindBoardStalled,
 		KindClusterDrift,
 	}
 }

--- a/internal/monitor/report.go
+++ b/internal/monitor/report.go
@@ -27,6 +27,7 @@ const (
 	KindLostAgent         AnomalyKind = "lost_agent"
 	KindFailureSpike      AnomalyKind = "failure_spike"
 	KindBottleneck        AnomalyKind = "bottleneck"
+	KindBoardStalled      AnomalyKind = "board_stalled"
 	// KindClusterDrift is filed by clusterlead.Mirror, not Detect — a leader
 	// canonical task's Tags/DependsOn disagree with what its home follower
 	// reports, meaning a leader-side write never reached the node that


### PR DESCRIPTION
## Motivation

Nothing alerted when the board stopped moving. From **2026-08-01 to 2026-08-03** every monitor tick reported

```
monitor.tick  in_progress=0  todo=12  anomalies=7  dispatched=0
```

with capacity free — and no anomaly fired. The stall was found only because a human asked whether the board was progressing.

**`KindBottleneck` structurally cannot catch this.** Its dwell comes from `HourSummary.StatusBottlenecks`, which is built from the last hour of **audit events**. A board that has genuinely stopped emits no events, so the detector meant to notice a stall has nothing to measure. It is blind exactly when it matters.

> Changelog: feat(monitor): detect a stalled board — queued work with nothing running

## Implementation information

`detectBoardStalled` reads **task state** rather than audit events: queued work, nothing in progress, no live agent, and the oldest queued task past a stall budget.

Two deliberate choices:

- **`RequiresLLM: false`.** Acting on a suspected dispatch failure must not depend on the dispatch path. Every existing board-wide anomaly that would plausibly cover this (`bottleneck`, `failure_spike`) requires an LLM dispatch — which is the very thing that is not happening.
- **`SeverityError`, not warn.** This failure is total, not a slow lane.

The budget reuses `bottleneck_hours[todo]` when an operator has set one, rather than adding a second knob for the same idea. It defaults to **one hour** — a 12-hour bottleneck budget would mean noticing a dead board the next day.

The live-agent check matters independently of the task counts: an agent can be running while no task reads `in-progress` (mid-transition, or a role that does not move status), and that is not a stall.

## Supporting documentation

Table-driven over the five cases that must differ: stalled, work running, agent live but no in-progress task, fresh queue, empty board. The test also asserts `RequiresLLM` is false, so a later change cannot quietly make escalation depend on dispatch.

**Replayed against the real incident shape** — 12 tasks queued since Aug 1, `in_progress=0`:

```
DETECTED severity=error requiresLLM=false
evidence=map[budget_h:1 in_progress:0 oldest_todo_h:35.77 todo:12]
```

It would have escalated at the one-hour mark rather than running unnoticed for 35+ hours.

Mutation-tested: unwiring the detector from `Detect` fails the suite.

`mise run verify` green (includes the regenerated bindings for the new enum value).

## Scope

This detects and escalates. It does not attempt to *fix* a stall — the causes found in this incident were varied (an umbrella gate stranding children, a health gate failing permanently, a provider unable to start), and auto-remediating a condition with that many distinct roots would be guessing. Surfacing it within the hour is the win.
