### PR TITLE
fix(workflow): guard condition reroutes

### DIFF
--- a/internal/workflow/engine_agent_routes.go
+++ b/internal/workflow/engine_agent_routes.go
@@ -168,7 +168,7 @@ func (e *Engine) pruneStaleAgentRoutes(taskID string, step *Step) {
 	if taskID == "" || step == nil {
 		return
 	}
-	if e.completionInFlight(taskID) || e.agents.HasRunningAgent(taskID) || e.agents.IsDispatching(taskID) {
+	if e.completionInFlight(taskID) || e.resumeDispatching(taskID) || e.agents.HasRunningAgent(taskID) || e.agents.IsDispatching(taskID) {
 		return
 	}
 	t, err := e.tasks.GetTask(taskID)

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -813,6 +813,13 @@ func (e *Engine) clearResumeDispatching(taskID string) {
 	e.mu.Unlock()
 }
 
+func (e *Engine) resumeDispatching(taskID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, ok := e.dispatching[taskID]
+	return ok
+}
+
 // RescheduleCheckpointedAgent immediately re-drives the current run_agent step
 // after a durable turn-ceiling checkpoint handoff, bounded by a persisted
 // per-step checkpoint counter.
@@ -1393,8 +1400,42 @@ func (e *Engine) resumeStalledRerouteStaleConditionBranch(t *TaskInfo, def *Defi
 	if nextID == step.ID {
 		return false
 	}
+	// The reroute replaces the current step and re-executes the condition, so it
+	// must participate in the same claim protocol as every other ResumeStalled
+	// dispatch. In particular, recovery can be routing a completion after the
+	// manager has stopped reporting its agent as running. Without this claim,
+	// the reroute can erase that agent's route before its completion advances it.
+	reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
+	if !acquired {
+		e.resumeSkip.Log(e.logger, "workflow.resume-stalled.condition-reroute.skip", t.ID,
+			reason+"|"+step.ID,
+			"task_id", t.ID, "reason", reason, "step", step.ID)
+		return true
+	}
+	defer e.clearResumeDispatching(t.ID)
+	fresh, abort := e.resolveFreshTaskForResume(t, step, def)
+	if abort {
+		return true
+	}
 
-	wf := t.Workflow.Clone()
+	// The completion which previously owned this step may have advanced it
+	// between the first condition evaluation and our claim. Recompute from the
+	// fresh execution snapshot so a stale reroute cannot overwrite that advance.
+	condition = latestConditionPredecessor(def, fresh.Workflow, step.ID)
+	if condition == nil {
+		return false
+	}
+	nextID, err = ResolveTransition(condition.Next, e.transitionFields(fresh, fresh.Workflow))
+	if err != nil {
+		e.logger.Warn("workflow.resume-stalled.condition-reroute.transition",
+			"task_id", fresh.ID, "condition", condition.ID, "step", step.ID, "err", err)
+		return false
+	}
+	if nextID == step.ID {
+		return false
+	}
+
+	wf := fresh.Workflow.Clone()
 	if wf == nil {
 		e.logger.Warn("workflow.resume-stalled.condition-reroute.clone",
 			"task_id", t.ID, "condition", condition.ID, "step", step.ID)
@@ -1405,20 +1446,20 @@ func (e *Engine) resumeStalledRerouteStaleConditionBranch(t *TaskInfo, def *Defi
 	wf.CompletedAt = nil
 	wf.ClearStepRecords(condition.ID)
 	wf.ClearStepRecords(step.ID)
-	if err := e.tasks.SetWorkflow(t.ID, wf); err != nil {
+	if err := e.tasks.SetWorkflow(fresh.ID, wf); err != nil {
 		e.logger.Warn("workflow.resume-stalled.condition-reroute.persist",
-			"task_id", t.ID, "condition", condition.ID, "step", step.ID, "err", err)
+			"task_id", fresh.ID, "condition", condition.ID, "step", step.ID, "err", err)
 		return true
 	}
 
 	e.logger.Info("workflow.resume-stalled.condition-reroute",
-		"task_id", t.ID, "condition", condition.ID, "from", step.ID, "to", nextID)
-	comp, rErr := e.executeSteps(t.ID, def, condition, wf)
+		"task_id", fresh.ID, "condition", condition.ID, "from", step.ID, "to", nextID)
+	comp, rErr := e.executeSteps(fresh.ID, def, condition, wf)
 	rErr = normalizeExecuteStepsErr(rErr)
 	e.fireComplete(comp)
-	e.resumeError.Log(e.logger, "workflow.resume-stalled.condition-reroute.exec", t.ID, rErr, "task_id", t.ID)
+	e.resumeError.Log(e.logger, "workflow.resume-stalled.condition-reroute.exec", fresh.ID, rErr, "task_id", fresh.ID)
 	if rErr != nil {
-		e.surfaceStartFailure(t.ID, t.Status, rErr, wf, condition.ID)
+		e.surfaceStartFailure(fresh.ID, fresh.Status, rErr, wf, condition.ID)
 	}
 	return true
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4040,6 +4040,9 @@ steps:
 	// its reroute claim. The reroute must re-read rather than write stale back.
 	completed := stale
 	completed.Workflow = stale.Workflow.Clone()
+	if completed.Workflow == nil {
+		t.Fatal("stale workflow clone is nil")
+	}
 	completed.Workflow.CurrentStep = "review_plan"
 	completed.Workflow.ClearAgentRoute("agent-1")
 	tasks.Put(completed)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3933,6 +3933,138 @@ steps:
 	}
 }
 
+func TestResumeStalled_DoesNotRerouteConditionWhileDispatchClaimed(t *testing.T) {
+	store := newInlineTestStore(t, "condition-reroute-claimed", `
+id: condition-reroute-claimed
+steps:
+  - id: maybe_critique
+    type: condition
+    next:
+      - when:
+          field: task.tags
+          operator: not_contains
+          value: nocritic
+        goto: critique_plan
+      - goto: review_plan
+  - id: critique_plan
+    type: run_agent
+    config:
+      role: plan-critic
+      mode: headless
+      prompt: critique
+    next:
+      - goto: review_plan
+  - id: review_plan
+    type: wait_human
+    config:
+      status: plan-review
+`)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	now := time.Now().UTC()
+	tasks.Put(TaskInfo{
+		ID: "t1", Status: "planning", Tags: []string{"nocritic"},
+		Workflow: &Execution{
+			WorkflowID: "condition-reroute-claimed", CurrentStep: "critique_plan", State: ExecWaiting,
+			StepHistory: []StepRecord{{StepID: "maybe_critique", Status: "completed", StartedAt: now, EndedAt: now}},
+			AgentRoutes: map[string]string{"agent-1": "critique_plan"},
+		},
+	})
+
+	// This models recovery's lost-callback bridge: the manager no longer sees
+	// the agent, but HandleAgentComplete has already claimed the task while it
+	// advances the persisted route.
+	engine.mu.Lock()
+	engine.dispatching["t1"] = struct{}{}
+	engine.mu.Unlock()
+	defer engine.clearResumeDispatching("t1")
+
+	engine.ResumeStalled()
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Workflow.CurrentStep != "critique_plan" {
+		t.Fatalf("CurrentStep = %q, want critique_plan while completion owns dispatch", ti.Workflow.CurrentStep)
+	}
+	if _, ok := ti.Workflow.AgentRoute("agent-1"); !ok {
+		t.Fatal("condition reroute cleared the completing agent route")
+	}
+	if agents.CallCount() != 0 {
+		t.Fatalf("agent starts = %d, want 0", agents.CallCount())
+	}
+}
+
+func TestResumeStalled_ConditionRerouteDoesNotOverwriteFreshCompletion(t *testing.T) {
+	store := newInlineTestStore(t, "condition-reroute-fresh", `
+id: condition-reroute-fresh
+steps:
+  - id: maybe_critique
+    type: condition
+    next:
+      - when:
+          field: task.tags
+          operator: not_contains
+          value: nocritic
+        goto: critique_plan
+      - goto: review_plan
+  - id: critique_plan
+    type: run_agent
+    config:
+      role: plan-critic
+      mode: headless
+      prompt: critique
+    next:
+      - goto: review_plan
+  - id: review_plan
+    type: wait_human
+    config:
+      status: plan-review
+`)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	now := time.Now().UTC()
+	stale := TaskInfo{
+		ID: "t1", Status: "planning", Tags: []string{"nocritic"},
+		Workflow: &Execution{
+			WorkflowID: "condition-reroute-fresh", CurrentStep: "critique_plan", State: ExecWaiting,
+			StepHistory: []StepRecord{{StepID: "maybe_critique", Status: "completed", StartedAt: now, EndedAt: now}},
+			AgentRoutes: map[string]string{"agent-1": "critique_plan"},
+		},
+	}
+	tasks.Put(stale)
+
+	// A recovered completion advances after ResumeStalled read stale but before
+	// its reroute claim. The reroute must re-read rather than write stale back.
+	completed := stale
+	completed.Workflow = stale.Workflow.Clone()
+	completed.Workflow.CurrentStep = "review_plan"
+	completed.Workflow.ClearAgentRoute("agent-1")
+	tasks.Put(completed)
+
+	def, err := store.Get("condition-reroute-fresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	step := def.StepByID("critique_plan")
+	if step == nil {
+		t.Fatal("critique_plan step missing")
+	}
+	if !engine.resumeStalledRerouteStaleConditionBranch(&stale, &def, step) {
+		t.Fatal("stale reroute was not consumed")
+	}
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow.CurrentStep != "review_plan" {
+		t.Fatalf("CurrentStep = %q, want completion's review_plan", got.Workflow.CurrentStep)
+	}
+}
+
 func TestResumeStalled_RunAgent(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Motivation

Prevent recovery-time condition rerouting from erasing or overwriting a concurrently bridged agent completion.

## Implementation information

Condition reroutes now use the normal resume dispatch claim, stale-route pruning honors that local claim, and reroutes re-read the workflow after claiming before persisting. Added race-focused regression coverage for claimed and freshly completed routes.

Closes #2879

> Changelog: fix(workflow): guard condition reroutes