### PR TITLE
fix(workflow): reset watchdog retry budgets

### DIFF
--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -97,7 +97,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		// round (reached only after a fresh code_review cycle re-enters this
 		// same step ID) starts from a full budget instead of inheriting an
 		// already-exhausted counter from a prior round (#2229 stop-and-reset).
-		clearWatchdogRewardHackingRetry(wfExec, output.StepID)
+		clearWatchdogRetryCounters(wfExec, output.StepID)
 	}
 	if output.Output != "" {
 		wfExec.SetVar("step."+output.StepID+".output", truncate(output.Output, 2000))

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1741,15 +1741,22 @@ func watchdogRewardHackingRetryKey(stepID string) string {
 	return watchdogRewardHackingRetryVarPrefix + stepID
 }
 
-// clearWatchdogRewardHackingRetry drops the per-step reward-hacking retry
-// counter once that step's run completes cleanly. Without this, a later,
-// unrelated round of the same step ID would inherit an already-exhausted
-// counter and escalate immediately instead of getting its own bounded retry.
-func clearWatchdogRewardHackingRetry(wf *Execution, stepID string) {
+// clearWatchdogRetryCounters drops every per-step watchdog retry counter once
+// the step completes cleanly. A later workflow round may legitimately re-enter
+// the same step ID, and must start with a fresh consecutive-failure budget.
+func clearWatchdogRetryCounters(wf *Execution, stepID string) {
 	if wf == nil || wf.Variables == nil || stepID == "" {
 		return
 	}
-	delete(wf.Variables, watchdogRewardHackingRetryKey(stepID))
+	for _, key := range []string{
+		watchdogRewardHackingRetryKey(stepID),
+		watchdogHangRetryKey(stepID),
+		watchdogStopRetryKey(stepID),
+		watchdogRateLimitRetryKey(stepID),
+		watchdogZeroOutputFreshRetryKey(stepID),
+	} {
+		delete(wf.Variables, key)
+	}
 }
 
 // buildRewardHackingFixReviewReaskNote builds the steer prepended to a

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -534,8 +534,12 @@ steps:
 		CurrentStep: "fix_review",
 		State:       ExecWaiting,
 		Variables: map[string]string{
-			// Budget already spent by an earlier reward-hacking retry round.
-			watchdogRewardHackingRetryKey("fix_review"): "1",
+			// Budgets already spent by earlier watchdog retry rounds.
+			watchdogRewardHackingRetryKey("fix_review"):   "1",
+			watchdogHangRetryKey("fix_review"):            "1",
+			watchdogStopRetryKey("fix_review"):            "1",
+			watchdogRateLimitRetryKey("fix_review"):       "1",
+			watchdogZeroOutputFreshRetryKey("fix_review"): "1",
 		},
 		StartedAt: time.Now().UTC(),
 	}
@@ -549,8 +553,16 @@ steps:
 	if err != nil {
 		t.Fatalf("get task: %v", err)
 	}
-	if _, ok := fresh.Workflow.Variables[watchdogRewardHackingRetryKey("fix_review")]; ok {
-		t.Fatal("reward-hacking retry counter should be cleared after a clean fix_review completion")
+	for _, key := range []string{
+		watchdogRewardHackingRetryKey("fix_review"),
+		watchdogHangRetryKey("fix_review"),
+		watchdogStopRetryKey("fix_review"),
+		watchdogRateLimitRetryKey("fix_review"),
+		watchdogZeroOutputFreshRetryKey("fix_review"),
+	} {
+		if _, ok := fresh.Workflow.Variables[key]; ok {
+			t.Fatalf("watchdog retry counter %q should be cleared after a clean completion", key)
+		}
 	}
 
 	// A reward_hacking stop on a later round of the same step must retry


### PR DESCRIPTION
## Motivation

Prevent successful workflow rounds from exhausting watchdog retry budgets for later re-entries of the same step.

## Implementation information

Clean completion now clears every per-step watchdog retry counter, including the zero-output fresh-session marker. Regression coverage exercises all counters.

Closes #2880

> Changelog: fix(workflow): reset watchdog retry budgets