### PR TITLE
fix(workflow): retain watchdog reask notes

### DIFF
--- a/internal/workflow/engine_agent_routes.go
+++ b/internal/workflow/engine_agent_routes.go
@@ -267,6 +267,17 @@ func (e *Engine) deferStartedAgentRoute(taskID, stepID, agentID string, err erro
 	return errWorkflowYield
 }
 
+func (e *Engine) hasPendingAgentRouteForStep(taskID, stepID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for key, routedStepID := range e.pendingRoutes {
+		if strings.HasPrefix(key, taskID+"\x00") && routedStepID == stepID {
+			return true
+		}
+	}
+	return false
+}
+
 func clearAgentRouteFromWorkflow(wf *Execution, agentID string) bool {
 	if wf == nil || agentID == "" {
 		return false

--- a/internal/workflow/engine_agent_routes.go
+++ b/internal/workflow/engine_agent_routes.go
@@ -267,11 +267,14 @@ func (e *Engine) deferStartedAgentRoute(taskID, stepID, agentID string, err erro
 	return errWorkflowYield
 }
 
-func (e *Engine) hasPendingAgentRouteForStep(taskID, stepID string) bool {
+func (e *Engine) hasPendingAgentRouteForStep(taskID string, step *Step) bool {
+	if step == nil {
+		return false
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	for key, routedStepID := range e.pendingRoutes {
-		if strings.HasPrefix(key, taskID+"\x00") && routedStepID == stepID {
+		if strings.HasPrefix(key, taskID+"\x00") && routeMatchesStep(step, routedStepID) {
 			return true
 		}
 	}

--- a/internal/workflow/engine_effect_replay.go
+++ b/internal/workflow/engine_effect_replay.go
@@ -161,7 +161,7 @@ func (e *Engine) replayPendingEffect(t *TaskInfo, step *Step, def *Definition) b
 	cleanupWorkflow := e.workflowForPostDispatchCleanup(fresh.ID)
 	e.clearTransientFetchRetry(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearCircuitBreakerOnSuccess(fresh.ID, cleanupWorkflow, step.ID)
-	e.clearWatchdogReaskNote(fresh.ID, cleanupWorkflow)
+	e.clearDeliveredWatchdogReaskNote(fresh.ID, step, cleanupWorkflow)
 	return true
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1506,7 +1506,7 @@ func (e *Engine) finishResumeStalledStep(taskID string, def *Definition, step *S
 }
 
 func (e *Engine) clearDeliveredWatchdogReaskNote(taskID string, step *Step, wf *Execution) {
-	if wf == nil || wf.Variables == nil {
+	if step == nil || step.ID == "" || wf == nil || wf.Variables == nil {
 		return
 	}
 	if !e.watchdogReaskDelivered(taskID, step, wf) {
@@ -1516,11 +1516,13 @@ func (e *Engine) clearDeliveredWatchdogReaskNote(taskID string, step *Step, wf *
 	e.clearWatchdogReaskNote(taskID, wf)
 	// clearWatchdogReaskNote deliberately no-ops when this role uses a
 	// role-specific note key; persist marker removal in that case too.
-	_ = e.tasks.SetWorkflow(taskID, wf)
+	if err := e.tasks.SetWorkflow(taskID, wf); err != nil {
+		e.logger.Error("workflow.watchdog-reask.delivery-clear", "task_id", taskID, "step", step.ID, "err", err)
+	}
 }
 
 func (e *Engine) watchdogReaskDelivered(taskID string, step *Step, wf *Execution) bool {
-	if workflowHasAgentRouteForStep(wf, step) || e.hasPendingAgentRouteForStep(taskID, step.ID) {
+	if workflowHasAgentRouteForStep(wf, step) || e.hasPendingAgentRouteForStep(taskID, step) {
 		return true
 	}
 	return wf != nil && wf.Variables[watchdogReaskDeliveredKey(step.ID)] == "1"

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -933,7 +933,7 @@ func (e *Engine) rescheduleRunAgent(taskID, agentID string, step *Step, t TaskIn
 	}
 	cleanupWorkflow := e.workflowForPostDispatchCleanup(taskID)
 	e.clearCircuitBreakerOnSuccess(taskID, cleanupWorkflow, step.ID)
-	e.clearWatchdogReaskNote(taskID, cleanupWorkflow)
+	e.clearDeliveredWatchdogReaskNote(taskID, step, cleanupWorkflow)
 }
 
 func (e *Engine) workflowForPostDispatchCleanup(taskID string) *Execution {
@@ -1499,7 +1499,45 @@ func (e *Engine) finishResumeStalledStep(taskID string, def *Definition, step *S
 	cleanupWorkflow := e.workflowForPostDispatchCleanup(taskID)
 	e.clearTransientFetchRetry(fresh.ID, cleanupWorkflow, step.ID)
 	e.clearCircuitBreakerOnSuccess(fresh.ID, cleanupWorkflow, step.ID)
-	e.clearWatchdogReaskNote(fresh.ID, cleanupWorkflow)
+	// A pool-busy start is deliberately normalized to a nil error so ResumeStalled
+	// parks quietly, but it did not start an agent. Keep the watchdog guidance
+	// armed until a persisted route or pending effect proves a real dispatch did.
+	e.clearDeliveredWatchdogReaskNote(fresh.ID, step, cleanupWorkflow)
+}
+
+func (e *Engine) clearDeliveredWatchdogReaskNote(taskID string, step *Step, wf *Execution) {
+	if wf == nil || wf.Variables == nil {
+		return
+	}
+	if !e.watchdogReaskDelivered(taskID, step, wf) {
+		return
+	}
+	delete(wf.Variables, watchdogReaskDeliveredKey(step.ID))
+	e.clearWatchdogReaskNote(taskID, wf)
+	// clearWatchdogReaskNote deliberately no-ops when this role uses a
+	// role-specific note key; persist marker removal in that case too.
+	_ = e.tasks.SetWorkflow(taskID, wf)
+}
+
+func (e *Engine) watchdogReaskDelivered(taskID string, step *Step, wf *Execution) bool {
+	if workflowHasAgentRouteForStep(wf, step) || e.hasPendingAgentRouteForStep(taskID, step.ID) {
+		return true
+	}
+	return wf != nil && wf.Variables[watchdogReaskDeliveredKey(step.ID)] == "1"
+}
+
+func watchdogReaskDeliveredKey(stepID string) string { return "watchdog_reask_delivered." + stepID }
+
+func workflowHasAgentRouteForStep(wf *Execution, step *Step) bool {
+	if wf == nil || step == nil {
+		return false
+	}
+	for _, routedStepID := range wf.AgentRoutes {
+		if routeMatchesStep(step, routedStepID) {
+			return true
+		}
+	}
+	return false
 }
 
 // handleWatchdogRetries checks both bounded watchdog stop-retry paths — a

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -245,6 +245,7 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 				e.agents.StopAgentsForTask(taskID, step.Config.Role)
 			} else {
 				wfExec.State = ExecWaiting
+				wfExec.SetVar(watchdogReaskDeliveredKey(step.ID), "1")
 				e.logger.Info("workflow.reuse-agent", "task_id", taskID, "step", step.ID, "agent_id", agentID)
 				return e.tasks.SetWorkflow(taskID, wfExec)
 			}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4580,6 +4580,31 @@ func TestResumeStalled_WatchdogRateLimitPoolBusyDoesNotBurnRetryBudget(t *testin
 	}
 }
 
+func TestResumeStalled_WatchdogHangPoolBusyRetainsReaskNote(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.SetFailSpawn(ErrAgentPoolBusy)
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	tasks.Put(TaskInfo{
+		ID: "t1", Status: "in-progress", StatusReason: "watchdog hang: no stream activity", AgentMode: "headless",
+		Workflow: &Execution{WorkflowID: "test-simple", CurrentStep: "implement", State: ExecWaiting, Variables: map[string]string{}, StartedAt: time.Now().UTC()},
+	})
+
+	engine.ResumeStalled()
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note := got.Workflow.Variables[watchdogReaskNoteVar]; note == "" {
+		t.Fatal("pool-busy park cleared watchdog guidance before an agent started")
+	}
+	if retry := got.Workflow.Variables[watchdogHangRetryKey("implement")]; retry != "1" {
+		t.Fatalf("hang retry = %q, want 1", retry)
+	}
+}
+
 func TestResumeStalled_WatchdogRateLimitDoesNotClearConcurrentFailure(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Motivation

Prevent pool-capacity parks from discarding watchdog retry guidance before an agent receives it.

## Implementation information

Cleanup now requires a durable delivery signal, covers resume, replay, and reschedule paths, and preserves guidance across pool-busy parks.

Closes #2881

> Changelog: fix(workflow): retain watchdog reask notes