### PR TITLE
fix(workflow): never truncate task reason

### DIFF
--- a/frontend/src/components/task-detail/TaskStatusBanner.svelte
+++ b/frontend/src/components/task-detail/TaskStatusBanner.svelte
@@ -88,7 +88,7 @@
         </span>
       {/if}
       {#if task.statusReason}
-        <span class={summary ? 'opacity-90' : ''}>{task.statusReason}</span>
+        <span class="line-clamp-3 {summary ? 'opacity-90' : ''}" title={task.statusReason}>{task.statusReason}</span>
       {/if}
       {#if isTamperFlagged}
         <div class="mt-1 flex flex-col gap-2 rounded border border-warning-300 bg-warning-100/70 p-2 text-xs dark:border-warning-700 dark:bg-warning-950/40">

--- a/frontend/src/components/task-detail/TaskStatusBanner.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskStatusBanner.svelte.test.ts
@@ -44,4 +44,19 @@ describe('TaskStatusBanner', () => {
     // A status_reason elevates an otherwise-quiet sub-state to the warm banner.
     expect(container.querySelector('[role="status"]')?.className).toMatch(/border-warning/)
   })
+
+  // Backend status_reason is no longer capped at 200 chars (see issue #2953),
+  // so a long multi-paragraph diagnosis can now reach this banner. It must
+  // clamp visually (not push the layout out) while still exposing the full
+  // text via the native title tooltip — never silently drop any of it.
+  it('clamps a long status reason but keeps the full text via title', () => {
+    const longReason = 'Root cause investigation.'.repeat(30)
+    const { container } = render(TaskStatusBanner, {
+      props: { task: task({ status: 'human-required', statusReason: longReason }) },
+    })
+    const reasonEl = screen.getByTitle(longReason)
+    expect(reasonEl.textContent).toBe(longReason)
+    expect(reasonEl.className).toMatch(/line-clamp-3/)
+    expect(container.querySelector('[role="status"]')).not.toBeNull()
+  })
 })

--- a/internal/workflow/engine_steps_codegen.go
+++ b/internal/workflow/engine_steps_codegen.go
@@ -90,7 +90,7 @@ func (e *Engine) execCodegenGate(taskID string, step *Step) (StepOutput, error) 
 	}
 
 	report.Committed = committed
-	report.OutputTail = tailString(tail.String(), verifyChecksOutputTail)
+	report.OutputTail = tail.String()
 	if e.recorder != nil {
 		if data, mErr := json.MarshalIndent(report, "", "  "); mErr == nil {
 			if recErr := e.recorder.PutGeneric(taskID, "codegen-gate.json", step.ID, string(data)); recErr != nil {

--- a/internal/workflow/engine_steps_codegen_test.go
+++ b/internal/workflow/engine_steps_codegen_test.go
@@ -148,6 +148,35 @@ func TestExecCodegenGate_DriftCommits(t *testing.T) {
 	}
 }
 
+// Regression: the artifact used to cap stored output to the last 8000 bytes
+// (tailString), which silently drops whatever ran before the cut. The stored
+// output must never be cut.
+func TestExecCodegenGate_LongOutputNotTruncated(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newCodegenGateEngine(t, wt, []string{"echo MARKER_START; yes x | head -c 9000"})
+	rec := &recordingArtifactRecorder{}
+	engine.SetArtifactRecorder(rec)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execCodegenGate("t1", newCodegenGateStep())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Fatalf("Output = %q, want clean", out.Output)
+	}
+	if len(rec.puts) != 1 || rec.puts[0].name != "codegen-gate.json" {
+		t.Fatalf("artifacts = %+v, want one codegen-gate.json artifact", rec.puts)
+	}
+	if len(rec.puts[0].content) < 9000 {
+		t.Fatalf("artifact content = %d bytes, want the full >9000-byte output preserved", len(rec.puts[0].content))
+	}
+	if !strings.Contains(rec.puts[0].content, "MARKER_START") {
+		t.Errorf("artifact lost the start of the output — the old tail-only truncation would have dropped it")
+	}
+}
+
 func TestExecCodegenGate_UsesTaskScopedGoBuildCache(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})

--- a/internal/workflow/engine_steps_focused_checks.go
+++ b/internal/workflow/engine_steps_focused_checks.go
@@ -88,7 +88,7 @@ func (e *Engine) execFocusedChecks(taskID string, step *Step, wfExec *Execution,
 	failedCmd, output, runErr := e.runVerifyCommands(ctx, taskID, wtPath, cmds)
 
 	report.FailedCmd = failedCmd
-	report.OutputTail = tailString(output, verifyChecksOutputTail)
+	report.OutputTail = output
 	if err := e.recordFocusedChecksReport(taskID, step.ID, report); err != nil {
 		e.logger.Warn("workflow.focused-checks.artifact", "task_id", taskID, "err", err)
 	}

--- a/internal/workflow/engine_steps_focused_checks_test.go
+++ b/internal/workflow/engine_steps_focused_checks_test.go
@@ -347,6 +347,54 @@ func TestExecFocusedChecks_FailureReasksImplement(t *testing.T) {
 	}
 }
 
+// Regression: the artifact used to cap stored output to the last 8000 bytes
+// (tailString), which silently drops whatever ran before the cut. For a
+// verbose command this reliably discards the actual failure signal near the
+// start of the output. The stored output must never be cut.
+func TestExecFocusedChecks_LongOutputNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	writeRepoFile(t, wt, "internal/workflow/model.go", "package workflow\n")
+	gitRun(t, wt, "add", ".")
+	gitRun(t, wt, "commit", "-m", "feat: touch workflow")
+
+	engine, tasks, rec := newFocusedChecksEngine(t, wt, []project.FocusedCheck{{
+		Name:     "workflow",
+		Paths:    []string{"internal/workflow/**"},
+		Packages: []string{"./internal/workflow/..."},
+		Commands: []string{"echo MARKER_START; yes x | head -c 9000; exit 1"},
+	}}, nil)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	wf := implementedExec()
+	_, err := engine.execFocusedChecks("t1", newFocusedChecksStep(), wf, TaskInfo{ID: "t1", Status: "in-progress"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+
+	var report *focusedChecksReport
+	for _, put := range rec.puts {
+		if put.name != "focused-checks.json" {
+			continue
+		}
+		var r focusedChecksReport
+		if err := json.Unmarshal([]byte(put.content), &r); err != nil {
+			t.Fatalf("unmarshal artifact: %v", err)
+		}
+		report = &r
+	}
+	if report == nil {
+		t.Fatalf("no focused-checks.json artifact recorded; puts: %+v", rec.puts)
+	}
+	if len(report.OutputTail) < 9000 {
+		t.Fatalf("OutputTail = %d bytes, want the full >9000-byte output preserved", len(report.OutputTail))
+	}
+	if !strings.Contains(report.OutputTail, "MARKER_START") {
+		t.Errorf("artifact lost the start of the output — the old tail-only truncation would have dropped it")
+	}
+}
+
 func TestExecFocusedChecks_FailureReasksBelowCeiling(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -202,7 +202,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 		if reason == "no agent result to evaluate" {
 			switch {
 			case last.Status == "failed":
-				reason = truncate(strings.TrimSpace(last.Output), 200)
+				reason = strings.TrimSpace(last.Output)
 				if reason == "" {
 					reason = "agent failed with no output"
 				}

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -476,10 +476,10 @@ func prFixVerdict(wfExec *Execution) (verdict PRFixVerdict, reason string) {
 
 // prFixFailingTests returns the specific failing tests a pr-fix agent named
 // via repeated SYBRA_PR_FIX_FAILING_TEST: lines alongside a human-required
-// verdict — the concrete repro info a human (or a future scoped test-fix
-// follow-up) needs, instead of just the free-text reason, which truncate()s
-// to 200 chars and would otherwise drop it. Mirrors prFixVerdict's own
-// var-first-then-reclassify lookup so both stay consistent across a resume.
+// verdict — structured repro info a human (or a future scoped test-fix
+// follow-up) can consume directly, instead of re-parsing it out of the
+// free-text reason. Mirrors prFixVerdict's own var-first-then-reclassify
+// lookup so both stay consistent across a resume.
 func prFixFailingTests(wfExec *Execution) []string {
 	if wfExec == nil {
 		return nil
@@ -560,7 +560,7 @@ func classifyPRFixResult(output string) (verdict PRFixVerdict, reason string) {
 	}
 	for _, phrase := range humanPhrases {
 		if strings.Contains(lower, phrase) {
-			return PRFixHuman, "pr-fix agent requested human review: " + truncate(firstNonEmptyLine(output), 200)
+			return PRFixHuman, "pr-fix agent requested human review: " + firstNonEmptyLine(output)
 		}
 	}
 	return PRFixContinue, ""
@@ -573,7 +573,7 @@ func sentinelReason(output string) string {
 		return ""
 	}
 	m := matches[len(matches)-1]
-	return truncate(strings.TrimSpace(m[1]), 200)
+	return strings.TrimSpace(m[1])
 }
 
 func extractPRFixReason(output string) string {

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -560,7 +560,7 @@ func classifyPRFixResult(output string) (verdict PRFixVerdict, reason string) {
 	}
 	for _, phrase := range humanPhrases {
 		if strings.Contains(lower, phrase) {
-			return PRFixHuman, "pr-fix agent requested human review: " + firstNonEmptyLine(output)
+			return PRFixHuman, "pr-fix agent requested human review: " + strings.TrimSpace(output)
 		}
 	}
 	return PRFixContinue, ""
@@ -594,14 +594,4 @@ func extractPRFixFailingTests(output string) []string {
 		}
 	}
 	return tests
-}
-
-func firstNonEmptyLine(s string) string {
-	for line := range strings.Lines(s) {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			return line
-		}
-	}
-	return ""
 }

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -15,7 +15,18 @@ import (
 )
 
 var prFixSentinelRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_RESULT:\s*([a-z_-]+)\s*$`)
-var prFixReasonRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_REASON:\s*(.+?)\s*$`)
+
+// prFixReasonLineRe locates where a SYBRA_PR_FIX_REASON: value begins. It is
+// intentionally a prefix match, not a single-line capture: a real diagnosis
+// is routinely more than one line, and `$` in (?m) mode ends at the next
+// newline, so a capturing group here would silently drop everything past
+// line 1 — see sentinelReason for how the value's end is actually found.
+var prFixReasonLineRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_REASON:\s*`)
+
+// prFixSentinelKeyRe matches the start of any SYBRA_PR_FIX_* sentinel line,
+// used to find where a multi-line REASON value ends: at the next sentinel
+// line, or end of output if there is none.
+var prFixSentinelKeyRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_(?:RESULT|REASON|FAILING_TEST):`)
 
 // prFixFailingTestRe matches each repeated SYBRA_PR_FIX_FAILING_TEST: line a
 // pr-fix agent emits alongside a human-required verdict for non-merge test
@@ -567,13 +578,22 @@ func classifyPRFixResult(output string) (verdict PRFixVerdict, reason string) {
 }
 
 // Empty when the agent gave no reason; only human-required defaults its text. EXC:FILE011:load-bearing-invariant
+// sentinelReason returns the last SYBRA_PR_FIX_REASON: value, spanning as
+// many lines as the agent wrote — the value ends at the next SYBRA_PR_FIX_*
+// sentinel line, or at the end of output if there is none. RE2 has no
+// lookahead, so the end boundary is found with a second, separate search
+// rather than a single capturing regex.
 func sentinelReason(output string) string {
-	matches := prFixReasonRe.FindAllStringSubmatch(output, -1)
-	if len(matches) == 0 {
+	starts := prFixReasonLineRe.FindAllStringIndex(output, -1)
+	if len(starts) == 0 {
 		return ""
 	}
-	m := matches[len(matches)-1]
-	return strings.TrimSpace(m[1])
+	valueStart := starts[len(starts)-1][1]
+	value := output[valueStart:]
+	if end := prFixSentinelKeyRe.FindStringIndex(value); end != nil {
+		value = value[:end[0]]
+	}
+	return strings.TrimSpace(value)
 }
 
 func extractPRFixReason(output string) string {

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -98,6 +98,25 @@ func TestClassifyPRFixResult(t *testing.T) {
 			wantVerdict: PRFixHuman,
 			wantReason:  "real blocker",
 		},
+		{
+			// Regression for a real production incident: an agent's own diagnosis
+			// ran past the old 200-char truncate() cap and got cut mid-sentence
+			// before it reached the actual root cause, leaving the task
+			// undiagnosable. The reason must survive in full, however long.
+			name: "sentinel reason longer than the old 200-char cap survives in full",
+			output: "SYBRA_PR_FIX_RESULT: human-required\n" +
+				"SYBRA_PR_FIX_REASON: " + strings.Repeat("environment-specific detail ", 20) + "root cause at the end\n",
+			wantVerdict: PRFixHuman,
+			wantReason:  strings.Repeat("environment-specific detail ", 20) + "root cause at the end",
+		},
+		{
+			name: "legacy free-text reason longer than the old 200-char cap survives in full",
+			output: strings.Repeat("investigation detail. ", 20) +
+				"As instructed, I ran git rebase --abort. This task requires human review.",
+			wantVerdict: PRFixHuman,
+			wantReason: "pr-fix agent requested human review: " + strings.Repeat("investigation detail. ", 20) +
+				"As instructed, I ran git rebase --abort. This task requires human review.",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -117,6 +117,21 @@ func TestClassifyPRFixResult(t *testing.T) {
 			wantReason: "pr-fix agent requested human review: " + strings.Repeat("investigation detail. ", 20) +
 				"As instructed, I ran git rebase --abort. This task requires human review.",
 		},
+		{
+			// Regression: the free-text fallback used to read only the first
+			// non-empty line via firstNonEmptyLine, so a multi-line narrative
+			// with the actual root cause on a later line — and the trigger
+			// phrase only at the very end — silently dropped everything but
+			// line 1. The full multi-line narrative must survive.
+			name: "legacy free-text reason with root cause on a later line survives in full",
+			output: "I looked into this PR failure.\n" +
+				"The root cause is a sandbox limitation unrelated to this diff.\n" +
+				"This task requires human review.\n",
+			wantVerdict: PRFixHuman,
+			wantReason: "pr-fix agent requested human review: I looked into this PR failure.\n" +
+				"The root cause is a sandbox limitation unrelated to this diff.\n" +
+				"This task requires human review.",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -110,6 +110,34 @@ func TestClassifyPRFixResult(t *testing.T) {
 			wantReason:  strings.Repeat("environment-specific detail ", 20) + "root cause at the end",
 		},
 		{
+			// Regression: prFixReasonRe used to be a single capturing regex
+			// anchored with (?m) `^`/`$`, so `.` never matched past the first
+			// newline — a multi-line SYBRA_PR_FIX_REASON value (the realistic
+			// shape of any non-trivial diagnosis) was cut at line 1 even after
+			// the 200-char truncate() wrapper was removed. Found via a live
+			// end-to-end run of the workflow engine against a real task, not
+			// just this unit test — the value must span every line it wrote.
+			name: "sentinel reason spanning multiple lines survives in full",
+			output: "SYBRA_PR_FIX_RESULT: human-required\n" +
+				"SYBRA_PR_FIX_REASON: first line of the diagnosis\n" +
+				"second line with more detail\n" +
+				"third line with the actual root cause\n",
+			wantVerdict: PRFixHuman,
+			wantReason:  "first line of the diagnosis\nsecond line with more detail\nthird line with the actual root cause",
+		},
+		{
+			// A multi-line reason must still stop at the next sentinel line
+			// (e.g. a following SYBRA_PR_FIX_FAILING_TEST:) rather than
+			// swallowing it — only the reason's own lines belong to it.
+			name: "sentinel reason spanning multiple lines stops at the next sentinel",
+			output: "SYBRA_PR_FIX_RESULT: human-required\n" +
+				"SYBRA_PR_FIX_REASON: first line of the diagnosis\n" +
+				"second line with more detail\n" +
+				"SYBRA_PR_FIX_FAILING_TEST: pkg/a_test.go:1 TestA\n",
+			wantVerdict: PRFixHuman,
+			wantReason:  "first line of the diagnosis\nsecond line with more detail",
+		},
+		{
 			name: "legacy free-text reason longer than the old 200-char cap survives in full",
 			output: strings.Repeat("investigation detail. ", 20) +
 				"As instructed, I ran git rebase --abort. This task requires human review.",

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -31,9 +31,6 @@ const verifyChecksDefaultTimeout = 10 * time.Minute
 // output streams into a fixed-size tail buffer rather than a growing slice.
 const verifyChecksMaxOutput = 64 * 1024
 
-// verifyChecksOutputTail caps how much of that buffer is stored in the artifact.
-const verifyChecksOutputTail = 8000
-
 // verifyBlessedTag lets a human accept a verify failure (e.g. a known-flaky
 // suite) and let the task proceed instead of re-blocking on every re-dispatch.
 const verifyBlessedTag = "verify-blessed"
@@ -193,7 +190,7 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, wfExec *Execution, 
 	}
 
 	report := verifyChecksReport{
-		Commands: cmds, FailedCmd: failedCmd, OutputTail: tailString(output, verifyChecksOutputTail),
+		Commands: cmds, FailedCmd: failedCmd, OutputTail: output,
 	}
 	classification := e.classifyVerifyFailure(taskID, wtPath, failedCmd, output)
 	if classification != nil {

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -28,7 +28,8 @@ const verifyChecksDefaultTimeout = 10 * time.Minute
 
 // verifyChecksMaxOutput bounds how much command output is retained in memory.
 // A noisy or malicious verify command must not be able to OOM the engine, so
-// output streams into a fixed-size tail buffer rather than a growing slice.
+// output streams into a fixed-size head+tail buffer (see boundedTail) rather
+// than a growing slice.
 const verifyChecksMaxOutput = 64 * 1024
 
 // verifyBlessedTag lets a human accept a verify failure (e.g. a known-flaky

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -1250,8 +1250,8 @@ func ownedByNpm(dir string) bool {
 // that passes on any attempt moves on. A non-nil err means the suite could not
 // even be prepared/run cleanly (ctx timeout/cancel or isolated-cache prep
 // failure) and is never retried — the budget is already spent; the caller
-// decides the policy. Output streams into a fixed-size tail buffer so a flood
-// of stdout/stderr cannot exhaust memory.
+// decides the policy. Output streams into a fixed-size head+tail buffer (see
+// boundedTail) so a flood of stdout/stderr cannot exhaust memory.
 func (e *Engine) runVerifyCommands(ctx context.Context, taskID, wtPath string, cmds []string) (failedCmd, output string, err error) {
 	tail := &boundedTail{max: verifyChecksMaxOutput}
 	cmdEnv, err := verifyCommandEnv(ctx, taskID, wtPath, cmds...)
@@ -1294,21 +1294,51 @@ func (e *Engine) runVerifyCommands(ctx context.Context, taskID, wtPath string, c
 	return "", tail.String(), nil
 }
 
-// boundedTail is a concurrency-safe io.Writer that retains only the last `max`
-// bytes written. os/exec writes stdout and stderr from separate goroutines when
-// they share a non-*os.File writer, so Write must be guarded.
+// boundedTail is a concurrency-safe io.Writer that retains only `max` bytes
+// total, so a flood of stdout/stderr cannot exhaust memory. os/exec writes
+// stdout and stderr from separate goroutines when they share a non-*os.File
+// writer, so Write must be guarded.
+//
+// It keeps the first half and the last half of the stream rather than a plain
+// tail: `go test ./internal/...` across ~80 packages reports the failing
+// package near where it fails, then keeps emitting `ok` lines for every
+// package that finishes afterward — a tail-only buffer reliably evicts the
+// one line (`--- FAIL: TestXxx`) a human needs to diagnose the run.
 type boundedTail struct {
-	mu  sync.Mutex
-	max int
-	buf []byte
+	mu         sync.Mutex
+	max        int
+	buf        []byte // accumulates here until total exceeds max
+	head       []byte // frozen first-half once truncation begins
+	tail       []byte // rolling last-half once truncation begins
+	total      int
+	truncating bool
 }
 
 func (b *boundedTail) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.buf = append(b.buf, p...)
-	if len(b.buf) > b.max {
-		b.buf = b.buf[len(b.buf)-b.max:]
+	b.total += len(p)
+	if !b.truncating {
+		b.buf = append(b.buf, p...)
+		if len(b.buf) <= b.max {
+			return len(p), nil
+		}
+		b.truncating = true
+		half := min(b.max/2, len(b.buf))
+		b.head = append([]byte(nil), b.buf[:half]...)
+		rest := b.buf[half:]
+		tailCap := b.max - len(b.head)
+		if len(rest) > tailCap {
+			rest = rest[len(rest)-tailCap:]
+		}
+		b.tail = append([]byte(nil), rest...)
+		b.buf = nil
+		return len(p), nil
+	}
+	tailCap := b.max - len(b.head)
+	b.tail = append(b.tail, p...)
+	if len(b.tail) > tailCap {
+		b.tail = b.tail[len(b.tail)-tailCap:]
 	}
 	return len(p), nil
 }
@@ -1316,7 +1346,11 @@ func (b *boundedTail) Write(p []byte) (int, error) {
 func (b *boundedTail) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return string(b.buf)
+	if !b.truncating {
+		return string(b.buf)
+	}
+	elided := b.total - len(b.head) - len(b.tail)
+	return string(b.head) + fmt.Sprintf("\n...(%d bytes elided)...\n", elided) + string(b.tail)
 }
 
 // tailString returns the last n bytes of s, prefixed with an elision marker

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -365,8 +365,9 @@ func TestExecVerifyChecks_LongOutputNotTruncated(t *testing.T) {
 func TestExecVerifyChecks_OutputPastStreamingCapKeepsStartAndEnd(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	// 100000 alone exceeds verifyChecksMaxOutput, independent of flake retries.
 	engine, tasks := newVerifyChecksEngine(t, wt,
-		[]string{"echo MARKER_START; yes x | head -c 40000; echo MARKER_END; exit 1"})
+		[]string{"echo MARKER_START; yes x | head -c 100000; echo MARKER_END; exit 1"})
 	rec := &recordingArtifactRecorder{}
 	engine.SetArtifactRecorder(rec)
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -275,6 +276,48 @@ func TestExecVerifyChecks_FailureFlags(t *testing.T) {
 	}
 	if r := tasks.Reason("t1"); r == "" {
 		t.Errorf("expected a non-empty status reason")
+	}
+}
+
+// Regression: the artifact used to cap stored output to the last 8000 bytes
+// (tailString), which for a verbose failing command silently drops whatever
+// ran before the cut — including, in production, the actual `--- FAIL:` line
+// a human needs to diagnose the task. The stored output must never be cut.
+func TestExecVerifyChecks_LongOutputNotTruncated(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"echo MARKER_START; yes x | head -c 9000; exit 1"})
+	rec := &recordingArtifactRecorder{}
+	engine.SetArtifactRecorder(rec)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged", out.Output)
+	}
+
+	var report *verifyChecksReport
+	for _, put := range rec.puts {
+		if put.name != "verify-checks.json" {
+			continue
+		}
+		var r verifyChecksReport
+		if err := json.Unmarshal([]byte(put.content), &r); err != nil {
+			t.Fatalf("unmarshal artifact: %v", err)
+		}
+		report = &r
+	}
+	if report == nil {
+		t.Fatalf("no verify-checks.json artifact recorded; puts: %+v", rec.puts)
+	}
+	if len(report.OutputTail) < 9000 {
+		t.Fatalf("OutputTail = %d bytes, want the full >9000-byte output preserved", len(report.OutputTail))
+	}
+	if !strings.Contains(report.OutputTail, "MARKER_START") {
+		t.Errorf("artifact lost the start of the output — the old tail-only truncation would have dropped it:\n%s", report.OutputTail[:min(200, len(report.OutputTail))])
 	}
 }
 

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -279,6 +280,39 @@ func TestExecVerifyChecks_FailureFlags(t *testing.T) {
 	}
 }
 
+func TestBoundedTail_UnderCapKeepsEverything(t *testing.T) {
+	t.Parallel()
+	tail := &boundedTail{max: 100}
+	_, _ = io.WriteString(tail, "hello world")
+	if got := tail.String(); got != "hello world" {
+		t.Fatalf("String() = %q, want the untouched input", got)
+	}
+}
+
+// Regression: boundedTail used to keep only the last `max` bytes, so a
+// failure signal near the START of a long-running command's output (the
+// realistic shape of `go test ./internal/...`: the failing package's
+// `--- FAIL:` line, followed by many other packages' trailing `ok` lines)
+// would be evicted before it ever reached the artifact layer, independent of
+// any cap applied when persisting the artifact. Both the start and the end
+// of the stream must survive; only the middle may be elided.
+func TestBoundedTail_OverCapKeepsHeadAndTail(t *testing.T) {
+	t.Parallel()
+	tail := &boundedTail{max: 100}
+	_, _ = io.WriteString(tail, "START-MARKER "+strings.Repeat("x", 500)+" END-MARKER")
+
+	got := tail.String()
+	if !strings.Contains(got, "START-MARKER") {
+		t.Errorf("output lost the start of the stream: %q", got)
+	}
+	if !strings.Contains(got, "END-MARKER") {
+		t.Errorf("output lost the end of the stream: %q", got)
+	}
+	if !strings.Contains(got, "elided") {
+		t.Errorf("output has no elision marker despite exceeding the cap: %q", got)
+	}
+}
+
 // Regression: the artifact used to cap stored output to the last 8000 bytes
 // (tailString), which for a verbose failing command silently drops whatever
 // ran before the cut — including, in production, the actual `--- FAIL:` line
@@ -318,6 +352,52 @@ func TestExecVerifyChecks_LongOutputNotTruncated(t *testing.T) {
 	}
 	if !strings.Contains(report.OutputTail, "MARKER_START") {
 		t.Errorf("artifact lost the start of the output — the old tail-only truncation would have dropped it:\n%s", report.OutputTail[:min(200, len(report.OutputTail))])
+	}
+}
+
+// Regression: fixing the artifact-level 8000-byte cap is not enough on its
+// own — the upstream boundedTail streaming buffer that produces `output` in
+// the first place (verifyChecksMaxOutput, 64KB) used the same tail-only
+// eviction strategy, so a run large enough to exceed *that* cap (realistic
+// for `go test ./internal/...` across ~80 packages) would still lose the
+// failure signal before the artifact layer ever saw it. This drives output
+// past the 64KB streaming cap, not just the old 8KB artifact cap.
+func TestExecVerifyChecks_OutputPastStreamingCapKeepsStartAndEnd(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt,
+		[]string{"echo MARKER_START; yes x | head -c 40000; echo MARKER_END; exit 1"})
+	rec := &recordingArtifactRecorder{}
+	engine.SetArtifactRecorder(rec)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged", out.Output)
+	}
+
+	var report *verifyChecksReport
+	for _, put := range rec.puts {
+		if put.name != "verify-checks.json" {
+			continue
+		}
+		var r verifyChecksReport
+		if err := json.Unmarshal([]byte(put.content), &r); err != nil {
+			t.Fatalf("unmarshal artifact: %v", err)
+		}
+		report = &r
+	}
+	if report == nil {
+		t.Fatalf("no verify-checks.json artifact recorded; puts: %+v", rec.puts)
+	}
+	if !strings.Contains(report.OutputTail, "MARKER_START") {
+		t.Errorf("artifact lost the start of a >64KB run — the streaming buffer evicted it before the artifact layer ever saw it")
+	}
+	if !strings.Contains(report.OutputTail, "MARKER_END") {
+		t.Errorf("artifact lost the end of a >64KB run")
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -10827,7 +10827,7 @@ func TestExecEvaluate_LastAgentFailedFlipsHumanRequired(t *testing.T) {
 	}
 }
 
-func TestExecEvaluate_LastAgentFailedTruncatesLongReason(t *testing.T) {
+func TestExecEvaluate_LastAgentFailedKeepsFullReason(t *testing.T) {
 	long := strings.Repeat("x", 500)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
@@ -10842,11 +10842,11 @@ func TestExecEvaluate_LastAgentFailedTruncatesLongReason(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := tasks.Reason("t1")
-	if !strings.Contains(got, "(truncated)") {
-		t.Errorf("reason missing truncation marker: %q", got)
+	if strings.Contains(got, "(truncated)") {
+		t.Errorf("reason should not be truncated: %q", got)
 	}
-	if len(got) >= len(long) {
-		t.Errorf("reason not truncated: %d chars", len(got))
+	if got != long {
+		t.Errorf("reason = %d chars, want the full %d-char output preserved", len(got), len(long))
 	}
 }
 


### PR DESCRIPTION
## Motivation

19 tasks were stuck (14 human-required, 5 blocked) on the production board. Several places hard-truncate an agent's diagnostic output before persisting it as a task's `status_reason` or into a debug artifact — the cut lands mid-sentence with no regard for where the actual failure signal is, so the one piece of text that would explain why a task is stuck gets thrown away at write time.

Recovered the untruncated original for task `5aa2287b` directly from the raw task file: a PR-fix agent had done a correct, thorough diagnosis (merge complete and verified, but the local pre-push hook fails because this sandboxed environment can't run nested git subprocesses against local temp-dir repos — reproduces on a pristine, code-free checkout). None of that reached `status_reason` — it read "...blocks the real push because this e" and stopped.

## Implementation information

Three commits, in order:

1. Removed the 200-char/8000-byte `truncate()`/`tailString()` wrappers from the four places that had them: the pr-fix sentinel/free-text reason (`engine_steps_prfix.go`), the generic step-failure evaluate reason (`engine_steps_link.go`), and the three gate-report artifact builders (`engine_steps_verify_checks.go`, `engine_steps_focused_checks.go`, `engine_steps_codegen.go`).
2. An adversarial code-review pass on that first commit found three residual truncation paths and fixed them: `firstNonEmptyLine` still read only the first line of a multi-line free-text narrative; the shared `boundedTail` streaming buffer (64KB cap, feeding all three gate artifacts) still kept only the *last* 64KB, so a failure signal near the start of a long `go test` run was still evicted before the artifact layer ever saw it — rewritten to retain head+tail instead of tail-only; and the frontend `TaskStatusBanner` rendered an now-unbounded reason with no visual clamp — added `line-clamp-3` + a `title` tooltip carrying the full text.
3. Live end-to-end testing against the real workflow engine (isolated `SYBRA_HOME`, fake provider CLI, real HTTP API) found a fourth, deeper bug: `sentinelReason`'s regex was anchored with `(?m)` `^`/`$`, so `.` never matches `\n` — any multi-line `SYBRA_PR_FIX_REASON:` value was silently cut at its first line break, independent of the truncate() removal. Replaced the single capturing regex with a two-step scan (find where the value starts, then find where it ends — at the next `SYBRA_PR_FIX_*` sentinel line or end of output) so a multi-paragraph diagnosis survives intact.

Verified via two independent live runs of the real `sybra-server` (isolated `SYBRA_HOME`, fake provider CLIs, no unit-test shortcuts): a multi-paragraph, multi-thousand-byte `SYBRA_PR_FIX_REASON:` now survives verbatim through the real workflow engine into the task's persisted `statusReason`, correctly stops at a following `SYBRA_PR_FIX_FAILING_TEST:` sentinel, and a `verify_checks` command emitting >70KB of output (past both the old 8000-byte artifact cap and the 64KB streaming cap) produces an artifact retaining both the start and end of the output. Full `go test ./...`, `go test -race ./internal/workflow/...`, `golangci-lint`, and the frontend `svelte-check`/`test:coverage`/`oxlint` suites are green.

## Open questions

`prFixShouldResumeNoPRRecovery`/`prFixAllowsResolvedMergeRecovery` (`engine_steps_prfix.go`) route on `strings.Contains` substring checks against the reason text. This risk already existed pre-fix (the checks never required proximity, only presence), but removing the length cap widens the amount of text those substring checks scan, marginally increasing the odds of an incidental phrase co-occurrence in a longer diagnosis misrouting a park. Flagged, not fixed here — it's a distinct routing-heuristic design question, not a truncation bug, and out of scope for this issue.

Closes #2953

> Changelog: fix(workflow): stop truncating stuck-task diagnosis
