### PR TITLE
fix(task): serialize watcher cache refresh

### DIFF
--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -23,23 +23,24 @@ import (
 // task's own frontmatter+body. Safe for concurrent use within a process; see
 // lockTask for the cross-process locking story.
 type Store struct {
-	dir           string
-	trashDir      string
-	comments      *CommentStore
-	plans         *PlanStore
-	planContracts *PlanningSidecarStore
-	planDrafts    *PlanDraftStore
-	planCritiques *PlanCritiqueStore
-	planResearch  *PlanningSidecarStore
-	planDecisions *PlanningSidecarStore
-	planBrief     *PlanningSidecarStore
-	codeReviews   *CodeReviewStore
-	locker        *fsutil.KeyedLocker
-	cacheMu       sync.RWMutex
-	listCache     []Task
-	listValid     bool
-	listSnapshot  map[string]listFileState
-	newTaskID     func() string
+	dir               string
+	trashDir          string
+	comments          *CommentStore
+	plans             *PlanStore
+	planContracts     *PlanningSidecarStore
+	planDrafts        *PlanDraftStore
+	planCritiques     *PlanCritiqueStore
+	planResearch      *PlanningSidecarStore
+	planDecisions     *PlanningSidecarStore
+	planBrief         *PlanningSidecarStore
+	codeReviews       *CodeReviewStore
+	locker            *fsutil.KeyedLocker
+	cacheMu           sync.RWMutex
+	listCache         []Task
+	listValid         bool
+	listSnapshot      map[string]listFileState
+	newTaskID         func() string
+	refreshBeforeLock func()
 }
 
 const maxTaskIDAttempts = 16

--- a/internal/task/store_cache.go
+++ b/internal/task/store_cache.go
@@ -54,6 +54,15 @@ func (s *Store) InvalidatePath(path string) {
 // A vanished file removes the entry; an unexpected read error falls back to a
 // full invalidate. No-op when the cache is cold (storeTaskCache guards on it).
 func (s *Store) refreshCachedTask(id string) {
+	s.cacheMu.RLock()
+	warm := s.listValid
+	s.cacheMu.RUnlock()
+	if !warm {
+		return
+	}
+	if s.refreshBeforeLock != nil {
+		s.refreshBeforeLock()
+	}
 	unlock, err := s.lockTask(id)
 	if err != nil {
 		s.invalidateListCache()

--- a/internal/task/store_cache.go
+++ b/internal/task/store_cache.go
@@ -54,6 +54,13 @@ func (s *Store) InvalidatePath(path string) {
 // A vanished file removes the entry; an unexpected read error falls back to a
 // full invalidate. No-op when the cache is cold (storeTaskCache guards on it).
 func (s *Store) refreshCachedTask(id string) {
+	unlock, err := s.lockTask(id)
+	if err != nil {
+		s.invalidateListCache()
+		return
+	}
+	defer unlock()
+
 	t, err := s.Get(id)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -2829,8 +2829,11 @@ func TestInvalidatePathWaitsForTaskWriterBeforeRefreshingCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	started := make(chan struct{})
+	store.refreshBeforeLock = func() { close(started) }
 	done := make(chan struct{})
 	go func() { store.InvalidatePath(tk.FilePath); close(done) }()
+	<-started
 	select {
 	case <-done:
 		t.Fatal("refresh ran while task writer lock was held")
@@ -2840,7 +2843,11 @@ func TestInvalidatePathWaitsForTaskWriterBeforeRefreshingCache(t *testing.T) {
 	if _, err := store.Update(tk.ID, Update{Title: Ptr("After")}); err != nil {
 		t.Fatal(err)
 	}
-	<-done
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not complete after writer lock release")
+	}
 	listed, err := store.List()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -2811,6 +2811,47 @@ func TestStoreListInvalidatePathTargetedRefresh(t *testing.T) {
 	}
 }
 
+func TestInvalidatePathWaitsForTaskWriterBeforeRefreshingCache(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk, err := store.Create("Before", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.List(); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := store.lockTask(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() { store.InvalidatePath(tk.FilePath); close(done) }()
+	select {
+	case <-done:
+		t.Fatal("refresh ran while task writer lock was held")
+	case <-time.After(50 * time.Millisecond):
+	}
+	unlock()
+	if _, err := store.Update(tk.ID, Update{Title: Ptr("After")}); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	listed, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, got := range listed {
+		if got.ID == tk.ID && got.Title != "After" {
+			t.Fatalf("cached title = %q, want After", got.Title)
+		}
+	}
+}
+
 func TestReasoningEffortRoundTrip(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())


### PR DESCRIPTION
## Motivation

Prevent a watcher refresh from pinning stale task data alongside a newer list-cache snapshot.

## Implementation information

Watcher refresh now shares the per-task lock with writers; added deterministic cache-lock regression coverage.

Closes #2883

> Changelog: fix(task): serialize watcher cache refresh