### PR TITLE
fix(project): release lock during clone

### DIFF
--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -211,11 +211,12 @@ type Project struct {
 	Type      ProjectType `yaml:"type" json:"type"`
 	// Status reflects the clone lifecycle. Empty value is treated as ready
 	// so existing projects without this field continue to work.
-	Status        ProjectStatus     `yaml:"status,omitempty" json:"status"`
-	SetupCommands []string          `yaml:"setup_commands,omitempty" json:"setupCommands,omitempty"`
-	Sandbox       *SandboxConfig    `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
-	Checks        *ChecksConfig     `yaml:"checks,omitempty"  json:"checks,omitempty"`
-	ManualTest    *ManualTestConfig `yaml:"manual_test,omitempty" json:"manualTest,omitempty"`
+	Status          ProjectStatus     `yaml:"status,omitempty" json:"status"`
+	CloneGeneration string            `yaml:"clone_generation,omitempty" json:"-"`
+	SetupCommands   []string          `yaml:"setup_commands,omitempty" json:"setupCommands,omitempty"`
+	Sandbox         *SandboxConfig    `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
+	Checks          *ChecksConfig     `yaml:"checks,omitempty"  json:"checks,omitempty"`
+	ManualTest      *ManualTestConfig `yaml:"manual_test,omitempty" json:"manualTest,omitempty"`
 	// WorktreeBaseRef controls the starting point for new worktree branches.
 	// "fresh" (default) branches off origin/<default>; "head" branches off the
 	// local HEAD so unpushed commits are included. Empty value treated as "fresh".

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -137,6 +137,7 @@ func (s *Store) Create(rawURL string, ptype ProjectType) (Project, error) {
 	}
 	if err := s.publishClone(p, clonePath); err != nil {
 		_ = os.RemoveAll(clonePath)
+		_ = s.markCloneError(p)
 		return Project{}, fmt.Errorf("mark ready: %w", err)
 	}
 	return s.Get(p.ID)
@@ -220,6 +221,22 @@ func (s *Store) publishClone(started Project, tempPath string) error {
 // same project generation. An older clone must not mark a re-created project
 // as errored.
 func (s *Store) markCloneError(started Project) error {
+	return s.markCloneStatus(started, ProjectStatusError)
+}
+
+// MarkReadyFor records a successful asynchronous clone only if the metadata
+// record that started it has not been deleted or replaced.
+func (s *Store) MarkReadyFor(started Project) error {
+	return s.markCloneStatus(started, ProjectStatusReady)
+}
+
+// MarkErrorFor records a failed asynchronous clone only if the metadata
+// record that started it has not been deleted or replaced.
+func (s *Store) MarkErrorFor(started Project) error {
+	return s.markCloneError(started)
+}
+
+func (s *Store) markCloneStatus(started Project, status ProjectStatus) error {
 	unlock, err := s.lock(started.ID)
 	if err != nil {
 		return err
@@ -233,7 +250,7 @@ func (s *Store) markCloneError(started Project) error {
 	if p.CloneGeneration != started.CloneGeneration {
 		return errors.New("clone superseded by a newer project record")
 	}
-	p.Status = ProjectStatusError
+	p.Status = status
 	p.CloneGeneration = ""
 	p.UpdatedAt = time.Now().UTC()
 	return s.writeFile(p)

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -2,6 +2,8 @@ package project
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -33,6 +35,7 @@ type Store struct {
 	dir       string
 	clonesDir string
 	locker    *fsutil.KeyedLocker
+	cloneBare func(context.Context, string, string) error
 }
 
 // NewStore creates dir and clonesDir if they do not exist and returns a
@@ -43,7 +46,12 @@ func NewStore(dir, clonesDir string) (*Store, error) {
 			return nil, fmt.Errorf("create dir %s: %w", d, err)
 		}
 	}
-	return &Store{dir: dir, clonesDir: clonesDir, locker: fsutil.NewKeyedLocker()}, nil
+	return &Store{
+		dir:       dir,
+		clonesDir: clonesDir,
+		locker:    fsutil.NewKeyedLocker(),
+		cloneBare: CloneBare,
+	}, nil
 }
 
 // lock acquires the per-project write lock for id's Get-modify-writeFile
@@ -101,60 +109,37 @@ func (s *Store) RawType(id string) (ProjectType, error) {
 	return raw.Type, nil
 }
 
-// Create parses rawURL into an owner/repo ID, clones it as a bare repo
-// under clonesDir, and persists a ready Project record. Fails if a project
-// with the same ID is already registered. See CreateMeta for the
-// register-then-clone-async variant used by the GUI's non-blocking add flow.
+// Create parses rawURL into an owner/repo ID, registers it as cloning, clones
+// it as a bare repo under clonesDir, and then persists a ready Project record.
+// The clone deliberately happens outside the per-project metadata lock: a
+// stalled network clone must not block edits or deletion of the project.
+// Fails if a project with the same ID is already registered. See CreateMeta
+// for the register-then-clone-async variant used by the GUI's non-blocking add
+// flow.
 func (s *Store) Create(rawURL string, ptype ProjectType) (Project, error) {
-	owner, repo, err := ParseGitHubURL(rawURL)
+	p, err := s.CreateMeta(rawURL, ptype)
 	if err != nil {
 		return Project{}, err
 	}
 
-	if ptype == "" {
-		ptype = ProjectTypePet
-	}
-	if ptype != ProjectTypePet && ptype != ProjectTypeWork {
-		return Project{}, fmt.Errorf("invalid project type: %s (must be pet or work)", ptype)
-	}
-
-	id := owner + "/" + repo
-	unlock, err := s.lock(id)
-	if err != nil {
-		return Project{}, err
-	}
-	defer unlock()
-
-	if _, err := s.Get(id); err == nil {
-		return Project{}, fmt.Errorf("project %s already exists", id)
-	}
-
-	clonePath := filepath.Join(s.clonesDir, owner, repo+".git")
-	// context.Background(): Create is a synchronous CLI/Wails-bound entry
-	// point (cmd/sybra-cli and ProjectService.CreateProject) with no ctx to
-	// thread through.
-	if err := CloneBare(context.Background(), rawURL, clonePath); err != nil {
+	// Create is a synchronous CLI/Wails-bound entry point with no caller
+	// context to thread through. Bound the entire clone setup, not just the
+	// network subprocess inside CloneBare.
+	ctx, cancel := context.WithTimeout(context.Background(), networkGitTimeout)
+	defer cancel()
+	clonePath := p.ClonePath + ".clone-" + p.CloneGeneration
+	if err := s.cloneBare(ctx, p.URL, clonePath); err != nil {
+		_ = os.RemoveAll(clonePath)
+		if markErr := s.markCloneError(p); markErr != nil {
+			return Project{}, fmt.Errorf("clone: %w (mark error: %v)", err, markErr)
+		}
 		return Project{}, fmt.Errorf("clone: %w", err)
 	}
-
-	now := time.Now().UTC()
-	p := Project{
-		ID:        id,
-		Name:      repo,
-		Owner:     owner,
-		Repo:      repo,
-		URL:       rawURL,
-		ClonePath: clonePath,
-		Type:      ptype,
-		Status:    ProjectStatusReady,
-		CreatedAt: now,
-		UpdatedAt: now,
+	if err := s.publishClone(p, clonePath); err != nil {
+		_ = os.RemoveAll(clonePath)
+		return Project{}, fmt.Errorf("mark ready: %w", err)
 	}
-
-	if err := s.writeFile(p); err != nil {
-		return Project{}, err
-	}
-	return p, nil
+	return s.Get(p.ID)
 }
 
 // CreateMeta writes project metadata with Status=cloning without starting the
@@ -181,23 +166,85 @@ func (s *Store) CreateMeta(rawURL string, ptype ProjectType) (Project, error) {
 		return Project{}, fmt.Errorf("project %s already exists", id)
 	}
 	clonePath := filepath.Join(s.clonesDir, owner, repo+".git")
+	cloneGeneration, err := newCloneGeneration()
+	if err != nil {
+		return Project{}, err
+	}
 	now := time.Now().UTC()
 	p := Project{
-		ID:        id,
-		Name:      repo,
-		Owner:     owner,
-		Repo:      repo,
-		URL:       rawURL,
-		ClonePath: clonePath,
-		Type:      ptype,
-		Status:    ProjectStatusCloning,
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID:              id,
+		Name:            repo,
+		Owner:           owner,
+		Repo:            repo,
+		URL:             rawURL,
+		ClonePath:       clonePath,
+		Type:            ptype,
+		Status:          ProjectStatusCloning,
+		CloneGeneration: cloneGeneration,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 	if err := s.writeFile(p); err != nil {
 		return Project{}, err
 	}
 	return p, nil
+}
+
+// publishClone atomically makes a completed temporary clone visible only if
+// the same metadata record that started it still exists. Delete and a later
+// re-create therefore cannot be undone by an older clone completing late.
+func (s *Store) publishClone(started Project, tempPath string) error {
+	unlock, err := s.lock(started.ID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	p, err := s.Get(started.ID)
+	if err != nil {
+		return err
+	}
+	if p.CloneGeneration != started.CloneGeneration {
+		return errors.New("clone superseded by a newer project record")
+	}
+	if err := os.Rename(tempPath, p.ClonePath); err != nil {
+		return fmt.Errorf("publish clone: %w", err)
+	}
+	p.Status = ProjectStatusReady
+	p.CloneGeneration = ""
+	p.UpdatedAt = time.Now().UTC()
+	return s.writeFile(p)
+}
+
+// markCloneError records a failed clone only while it still belongs to the
+// same project generation. An older clone must not mark a re-created project
+// as errored.
+func (s *Store) markCloneError(started Project) error {
+	unlock, err := s.lock(started.ID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	p, err := s.Get(started.ID)
+	if err != nil {
+		return err
+	}
+	if p.CloneGeneration != started.CloneGeneration {
+		return errors.New("clone superseded by a newer project record")
+	}
+	p.Status = ProjectStatusError
+	p.CloneGeneration = ""
+	p.UpdatedAt = time.Now().UTC()
+	return s.writeFile(p)
+}
+
+func newCloneGeneration() (string, error) {
+	data := make([]byte, 16)
+	if _, err := rand.Read(data); err != nil {
+		return "", fmt.Errorf("generate clone generation: %w", err)
+	}
+	return hex.EncodeToString(data), nil
 }
 
 // MarkReady transitions a project from cloning to ready after a successful clone.
@@ -213,6 +260,7 @@ func (s *Store) MarkReady(id string) error {
 		return err
 	}
 	p.Status = ProjectStatusReady
+	p.CloneGeneration = ""
 	p.UpdatedAt = time.Now().UTC()
 	return s.writeFile(p)
 }
@@ -230,6 +278,7 @@ func (s *Store) MarkError(id string) error {
 		return err
 	}
 	p.Status = ProjectStatusError
+	p.CloneGeneration = ""
 	p.UpdatedAt = time.Now().UTC()
 	return s.writeFile(p)
 }

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -131,7 +131,7 @@ func (s *Store) Create(rawURL string, ptype ProjectType) (Project, error) {
 	if err := s.cloneBare(ctx, p.URL, clonePath); err != nil {
 		_ = os.RemoveAll(clonePath)
 		if markErr := s.markCloneError(p); markErr != nil {
-			return Project{}, fmt.Errorf("clone: %w (mark error: %v)", err, markErr)
+			return Project{}, fmt.Errorf("clone: %w (mark error: %w)", err, markErr)
 		}
 		return Project{}, fmt.Errorf("clone: %w", err)
 	}

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -1,11 +1,13 @@
 package project
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestNewStore(t *testing.T) {
@@ -197,6 +199,98 @@ func TestStoreCreateDuplicate(t *testing.T) {
 	_, err = store.Create("https://github.com/owner/repo", ProjectTypePet)
 	if err == nil {
 		t.Fatal("expected error for duplicate project")
+	}
+}
+
+// TestStoreCreateDoesNotHoldMetadataLockDuringClone proves synchronous Create
+// uses the same register-clone-complete lifecycle as the asynchronous path.
+// A blocked clone must not prevent a user from editing the pending project.
+func TestStoreCreateDoesNotHoldMetadataLockDuringClone(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cloneStarted := make(chan struct{})
+	releaseClone := make(chan struct{})
+	store.cloneBare = func(_ context.Context, _ string, dest string) error {
+		close(cloneStarted)
+		<-releaseClone
+		return os.MkdirAll(dest, 0o755)
+	}
+
+	created := make(chan error, 1)
+	go func() {
+		_, err := store.Create("https://github.com/owner/repo", ProjectTypePet)
+		created <- err
+	}()
+	<-cloneStarted
+
+	updated := make(chan error, 1)
+	go func() {
+		_, err := store.SetSetupCommands("owner/repo", []string{"npm ci"})
+		updated <- err
+	}()
+	select {
+	case err := <-updated:
+		if err != nil {
+			t.Fatalf("update while cloning: %v", err)
+		}
+	case <-time.After(time.Second):
+		close(releaseClone)
+		t.Fatal("metadata update was blocked by the clone")
+	}
+
+	close(releaseClone)
+	if err := <-created; err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := store.Get("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != ProjectStatusReady {
+		t.Errorf("Status = %q, want %q", got.Status, ProjectStatusReady)
+	}
+	if len(got.SetupCommands) != 1 || got.SetupCommands[0] != "npm ci" {
+		t.Errorf("SetupCommands = %v, want [npm ci]", got.SetupCommands)
+	}
+}
+
+func TestStoreCreateDeleteDuringCloneLeavesNoClone(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cloneStarted := make(chan struct{})
+	releaseClone := make(chan struct{})
+	store.cloneBare = func(_ context.Context, _ string, dest string) error {
+		close(cloneStarted)
+		<-releaseClone
+		return os.MkdirAll(dest, 0o755)
+	}
+
+	created := make(chan error, 1)
+	go func() {
+		_, err := store.Create("https://github.com/owner/repo", ProjectTypePet)
+		created <- err
+	}()
+	<-cloneStarted
+	if err := store.Delete("owner/repo"); err != nil {
+		t.Fatalf("delete while cloning: %v", err)
+	}
+	close(releaseClone)
+	if err := <-created; err == nil {
+		t.Fatal("Create succeeded after its project was deleted")
+	}
+	if _, err := store.Get("owner/repo"); !errors.Is(err, ErrProjectNotRegistered) {
+		t.Fatalf("deleted metadata = %v, want ErrProjectNotRegistered", err)
+	}
+	clonePath := filepath.Join(store.clonesDir, "owner", "repo.git")
+	if _, err := os.Stat(clonePath); !os.IsNotExist(err) {
+		t.Fatalf("clone path remains after delete: %v", err)
 	}
 }
 

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -294,6 +294,35 @@ func TestStoreCreateDeleteDuringCloneLeavesNoClone(t *testing.T) {
 	}
 }
 
+func TestStoreMarkReadyForDoesNotCompleteRecreatedProject(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.CreateMeta("https://github.com/owner/repo", ProjectTypePet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(started.ID); err != nil {
+		t.Fatal(err)
+	}
+	recreated, err := store.CreateMeta("https://github.com/owner/repo", ProjectTypePet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkReadyFor(started); err == nil {
+		t.Fatal("stale completion marked the re-created project ready")
+	}
+	got, err := store.Get(recreated.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != ProjectStatusCloning || got.CloneGeneration != recreated.CloneGeneration {
+		t.Errorf("re-created project changed after stale completion: %+v", got)
+	}
+}
+
 func TestStoreDefaultTypeOnRead(t *testing.T) {
 	store, err := NewStore(t.TempDir(), t.TempDir())
 	if err != nil {

--- a/internal/sybra/svc_projects.go
+++ b/internal/sybra/svc_projects.go
@@ -53,7 +53,7 @@ func (s *ProjectService) CreateProject(url, ptype string) (project.Project, erro
 		// runs in a detached background goroutine with no ctx to thread.
 		if err := project.CloneBare(context.Background(), p.URL, p.ClonePath); err != nil {
 			s.logger.Error("project.clone.failed", "id", p.ID, "err", err)
-			if markErr := s.projects.MarkError(p.ID); markErr != nil {
+			if markErr := s.projects.MarkErrorFor(p); markErr != nil {
 				s.logger.Error("project.mark-error", "id", p.ID, "err", markErr)
 			}
 			if s.bgops != nil && opID != "" {
@@ -65,7 +65,7 @@ func (s *ProjectService) CreateProject(url, ptype string) (project.Project, erro
 			}
 			return
 		}
-		if markErr := s.projects.MarkReady(p.ID); markErr != nil {
+		if markErr := s.projects.MarkReadyFor(p); markErr != nil {
 			s.logger.Error("project.mark-ready", "id", p.ID, "err", markErr)
 		}
 		if s.bgops != nil && opID != "" {


### PR DESCRIPTION
## Summary
- register synchronous projects before cloning and release the metadata lock during the bounded clone
- publish temporary clones only for the active clone generation, preserving delete/re-create semantics
- cover concurrent metadata edits and deletion during a stalled clone

## Verification
- go test -race ./internal/project

Closes #2884