### PR TITLE
fix(project): lock tracking ref fetches

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1312,9 +1312,15 @@ func BranchPushed(ctx context.Context, worktreePath, branch string) bool {
 
 func refreshTrackingRef(ctx context.Context, worktreePath, remote, branch string) error {
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
-	fetchErr := withNetworkRetry(ctx, func() error {
-		return withLockRetry(func() error {
-			return runNetworkGit(ctx, worktreePath, fetchEnv(), "fetch", remote, refspec)
+	barePath, err := gitCommonDir(ctx, worktreePath)
+	if err != nil {
+		return err
+	}
+	fetchErr := withBareRepoLock(barePath, func() error {
+		return withNetworkRetry(ctx, func() error {
+			return withLockRetry(func() error {
+				return runNetworkGit(ctx, worktreePath, fetchEnv(), "fetch", remote, refspec)
+			})
 		})
 	})
 	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1311,6 +1311,14 @@ func BranchPushed(ctx context.Context, worktreePath, branch string) bool {
 }
 
 func refreshTrackingRef(ctx context.Context, worktreePath, remote, branch string) error {
+	return refreshTrackingRefWithFetch(ctx, worktreePath, remote, branch, func(refspec string) error {
+		return runNetworkGit(ctx, worktreePath, fetchEnv(), "fetch", remote, refspec)
+	})
+}
+
+// refreshTrackingRefWithFetch keeps the shared-bare locking policy testable
+// without making the regression depend on a local git fetch's timing.
+func refreshTrackingRefWithFetch(ctx context.Context, worktreePath, remote, branch string, fetch func(refspec string) error) error {
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
 	barePath, err := gitCommonDir(ctx, worktreePath)
 	if err != nil {
@@ -1319,7 +1327,7 @@ func refreshTrackingRef(ctx context.Context, worktreePath, remote, branch string
 	fetchErr := withBareRepoLock(barePath, func() error {
 		return withNetworkRetry(ctx, func() error {
 			return withLockRetry(func() error {
-				return runNetworkGit(ctx, worktreePath, fetchEnv(), "fetch", remote, refspec)
+				return fetch(refspec)
 			})
 		})
 	})

--- a/internal/project/git_lock.go
+++ b/internal/project/git_lock.go
@@ -38,6 +38,14 @@ func withBareRepoPushLock(barePath string, fn func() error) error {
 
 func withPathLock(locks *sync.Map, path string, fn func() error) error {
 	key := filepath.Clean(path)
+	// Git resolves macOS /var paths through the /private/var symlink when it
+	// reports a linked worktree's common directory. Canonicalize existing
+	// paths so that representation shares the lock with callers using /var.
+	// Keep the cleaned input when it does not exist yet; callers may lock a
+	// destination before creating the bare clone.
+	if resolved, err := filepath.EvalSymlinks(key); err == nil {
+		key = filepath.Clean(resolved)
+	}
 	v, _ := locks.LoadOrStore(key, &sync.Mutex{})
 	mu, ok := v.(*sync.Mutex)
 	if !ok {

--- a/internal/project/git_lock_test.go
+++ b/internal/project/git_lock_test.go
@@ -131,6 +131,64 @@ func TestWithBareRepoPushLock_DoesNotBlockBareRepoLockForSameClonePath(t *testin
 	}
 }
 
+func TestRefreshTrackingRefWaitsForBareRepoLock(t *testing.T) {
+	t.Parallel()
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	wt := filepath.Join(t.TempDir(), "worktree")
+	if err := CreateWorktree(context.Background(), bare, wt, "task-branch", "origin/"+branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	commonDir, err := gitCommonDir(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("resolve common dir: %v", err)
+	}
+	canonicalBare, err := filepath.EvalSymlinks(bare)
+	if err != nil {
+		t.Fatalf("canonicalize bare path: %v", err)
+	}
+	if filepath.Clean(commonDir) != filepath.Clean(canonicalBare) {
+		t.Fatalf("common dir = %q, want bare clone %q", commonDir, bare)
+	}
+
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- withBareRepoLock(bare, func() error {
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+	<-locked
+
+	fetched := make(chan error, 1)
+	go func() { fetched <- refreshTrackingRef(context.Background(), wt, "origin", branch) }()
+	select {
+	case err := <-fetched:
+		t.Fatalf("tracking fetch completed while bare lock held: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if err := <-lockDone; err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	if err := <-fetched; err != nil {
+		t.Fatalf("refresh tracking ref: %v", err)
+	}
+}
+
 func TestWithLockRetry_RetriesOnLockContention(t *testing.T) {
 	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
 	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })

--- a/internal/project/git_lock_test.go
+++ b/internal/project/git_lock_test.go
@@ -173,11 +173,17 @@ func TestRefreshTrackingRefWaitsForBareRepoLock(t *testing.T) {
 	}()
 	<-locked
 
+	fetchStarted := make(chan struct{})
 	fetched := make(chan error, 1)
-	go func() { fetched <- refreshTrackingRef(context.Background(), wt, "origin", branch) }()
+	go func() {
+		fetched <- refreshTrackingRefWithFetch(context.Background(), wt, "origin", branch, func(string) error {
+			close(fetchStarted)
+			return nil
+		})
+	}()
 	select {
-	case err := <-fetched:
-		t.Fatalf("tracking fetch completed while bare lock held: %v", err)
+	case <-fetchStarted:
+		t.Fatal("tracking fetch started while bare lock held")
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(release)


### PR DESCRIPTION
## Summary
- serialize linked-worktree tracking-ref fetches with the shared bare clone lock
- canonicalize existing lock paths so equivalent symlinked paths share a mutex
- cover a tracking-ref fetch blocked by a concurrent bare-repo operation

## Verification
- go test -race ./internal/project

Closes #2885