### PR TITLE
fix(umbrella): surface blocked completion

### DIFF
--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -779,6 +779,8 @@ func (a *App) releaseCapped(ctx context.Context, ready []string, byID map[string
 // long rather than up to 30s per stuck release.
 const pushReleaseTimeout = 5 * time.Second
 
+const blockedTrackerChildrenCompleteReason = "children complete, tracker blocked — needs release"
+
 // pushReleaseToHomeNode forwards a just-released child's new state to its
 // home follower when the task isn't homed locally. The local a.tasks.Update
 // above only ever touches this leader's own canonical copy; Mirror only pulls
@@ -850,6 +852,20 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 			continue
 		}
 		if st.tracker.Status == task.StatusBlocked {
+			// A blocked tracker can be owned by an operator or another workflow
+			// path. Preserve that ownership while work remains, but once every
+			// materialized child is done stamp an explicit, actionable reason
+			// instead of leaving an invisible permanent dead end. Do not close
+			// the umbrella or override the blocked status: release remains an
+			// operator decision.
+			if st.total > 0 && st.doneCount == st.total &&
+				st.tracker.StatusReason != blockedTrackerChildrenCompleteReason {
+				if _, err := a.tasks.Update(st.tracker.ID, task.Update{
+					StatusReason: task.Ptr(blockedTrackerChildrenCompleteReason),
+				}); err != nil {
+					a.logger.Error("umbrella.tracker.blocked_complete.update.failed", "task_id", st.tracker.ID, "err", err)
+				}
+			}
 			continue
 		}
 		// A tracker is "settled" once it has outlived the creation window, so a

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -851,6 +851,13 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 		if st.tracker == nil {
 			continue
 		}
+		// A tracker is "settled" once it has outlived the creation window, so a
+		// childless tally that just reflects children still being materialized
+		// is not mistaken for a completed umbrella. A zero CreatedAt (e.g. a
+		// task file missing created_at) is treated as not settled rather than
+		// infinitely old, so it never bypasses the guard.
+		settled := !st.tracker.CreatedAt.IsZero() &&
+			time.Since(st.tracker.CreatedAt) > umbrellaSettleDelay
 		if st.tracker.Status == task.StatusBlocked {
 			// A blocked tracker can be owned by an operator or another workflow
 			// path. Preserve that ownership while work remains, but once every
@@ -858,7 +865,8 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 			// instead of leaving an invisible permanent dead end. Do not close
 			// the umbrella or override the blocked status: release remains an
 			// operator decision.
-			if st.total > 0 && st.doneCount == st.total &&
+			desired, _, doClose := trackerRollup(st, cyclic[key], settled)
+			if desired == task.StatusDone && doClose &&
 				st.tracker.StatusReason != blockedTrackerChildrenCompleteReason {
 				if _, err := a.tasks.Update(st.tracker.ID, task.Update{
 					StatusReason: task.Ptr(blockedTrackerChildrenCompleteReason),
@@ -868,13 +876,6 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 			}
 			continue
 		}
-		// A tracker is "settled" once it has outlived the creation window, so a
-		// childless tally that just reflects children still being materialized
-		// is not mistaken for a completed umbrella. A zero CreatedAt (e.g. a
-		// task file missing created_at) is treated as not settled rather than
-		// infinitely old, so it never bypasses the guard.
-		settled := !st.tracker.CreatedAt.IsZero() &&
-			time.Since(st.tracker.CreatedAt) > umbrellaSettleDelay
 		desired, reason, doClose := trackerRollup(st, cyclic[key], settled)
 		if body := umbrellaTrackerBody(st.tracker.Body, st.children); body != st.tracker.Body {
 			if _, err := a.tasks.Update(st.tracker.ID, task.Update{

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -623,7 +623,7 @@ func TestReleaseUnblockedChildren_CancelledChildSurfaces(t *testing.T) {
 	}
 }
 
-func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
+func TestReleaseUnblockedChildren_BlockedTrackerReasonTransitions(t *testing.T) {
 	t.Parallel()
 	const reason = "auto-review: provider failure (local task abc12345; issue filing failed)"
 	tests := []struct {
@@ -663,6 +663,25 @@ func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
 				t.Fatalf("umbrella was closed %d times while tracker blocked", closes)
 			}
 		})
+	}
+}
+
+func TestReleaseUnblockedChildren_StampsBlockedTrackerWithResolvedDuplicate(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+	if _, err := m.Update(tracker.ID, task.Update{Status: task.Ptr(task.StatusBlocked)}); err != nil {
+		t.Fatalf("block tracker: %v", err)
+	}
+	mkChild(t, m, "cancelled duplicate", "Automaat/sybra#1", umb, nil, task.StatusCancelled)
+	mkChild(t, m, "completed duplicate", "Automaat/sybra#1", umb, nil, task.StatusDone)
+
+	app.releaseUnblockedChildren(context.Background())
+
+	got := mustTask(t, m, tracker.ID)
+	if got.Status != task.StatusBlocked || got.StatusReason != blockedTrackerChildrenCompleteReason {
+		t.Fatalf("tracker = (%q, %q), want blocked with completion marker", got.Status, got.StatusReason)
 	}
 }
 

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -307,6 +307,36 @@ func TestReleaseUnblockedChildren_RollupClosesUmbrella(t *testing.T) {
 	}
 }
 
+func TestReleaseUnblockedChildren_StampsCompletedBlockedTracker(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	closes := 0
+	app.umbrellaCloseIssue = func(string, int, string) error { closes++; return nil }
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+	if _, err := m.Update(tracker.ID, task.Update{
+		Status:       task.Ptr(task.StatusBlocked),
+		StatusReason: task.Ptr("confidentiality review needs release"),
+	}); err != nil {
+		t.Fatalf("block tracker: %v", err)
+	}
+	mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusDone)
+	mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusDone)
+
+	app.releaseUnblockedChildren(context.Background())
+
+	got := mustTask(t, m, tracker.ID)
+	if got.Status != task.StatusBlocked {
+		t.Fatalf("tracker = %q, want blocked after all children complete", got.Status)
+	}
+	if got.StatusReason != blockedTrackerChildrenCompleteReason {
+		t.Fatalf("tracker reason = %q, want %q", got.StatusReason, blockedTrackerChildrenCompleteReason)
+	}
+	if closes != 0 {
+		t.Fatalf("umbrella close calls = %d, want 0 while tracker remains blocked", closes)
+	}
+}
+
 func TestReleaseUnblockedChildren_UpdatesTrackerProgressChecklist(t *testing.T) {
 	t.Parallel()
 	app, m := newUmbrellaGateApp(t)
@@ -595,12 +625,14 @@ func TestReleaseUnblockedChildren_CancelledChildSurfaces(t *testing.T) {
 
 func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
 	t.Parallel()
+	const reason = "auto-review: provider failure (local task abc12345; issue filing failed)"
 	tests := []struct {
 		name        string
 		childStatus task.Status
+		wantReason  string
 	}{
-		{"human-required child", task.StatusHumanRequired},
-		{"completed child", task.StatusDone},
+		{"human-required child", task.StatusHumanRequired, reason},
+		{"completed child", task.StatusDone, blockedTrackerChildrenCompleteReason},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -610,7 +642,6 @@ func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
 			app.umbrellaCloseIssue = func(string, int, string) error { closes++; return nil }
 			const umb = "https://github.com/Automaat/sybra/issues/100"
 			tracker := mkTracker(t, m, umb, 5)
-			const reason = "auto-review: provider failure (local task abc12345; issue filing failed)"
 			if _, err := m.Update(tracker.ID, task.Update{
 				Status:       task.Ptr(task.StatusBlocked),
 				StatusReason: task.Ptr(reason),
@@ -625,8 +656,8 @@ func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
 			if got.Status != task.StatusBlocked {
 				t.Fatalf("tracker = %q, want blocked", got.Status)
 			}
-			if got.StatusReason != reason {
-				t.Fatalf("tracker reason = %q, want %q", got.StatusReason, reason)
+			if got.StatusReason != tt.wantReason {
+				t.Fatalf("tracker reason = %q, want %q", got.StatusReason, tt.wantReason)
 			}
 			if closes != 0 {
 				t.Fatalf("umbrella was closed %d times while tracker blocked", closes)


### PR DESCRIPTION
## Summary
- preserve blocked umbrella tracker ownership while work remains
- stamp an explicit release-needed reason when every materialized child is complete
- cover incomplete, completed, and expansion-failure tracker states

## Verification
- go test -race ./internal/sybra
- golangci-lint run ./internal/sybra/...

Closes #2886