### PR TITLE
fix(sybra): join CreateTask goroutine in tests

### DIFF
--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -268,12 +268,6 @@ func setupTaskService(t *testing.T) (*TaskService, *App) {
 	t.Helper()
 	a := setupApp(t)
 	var wg sync.WaitGroup
-	// t.Cleanup runs last-added-first: placing this before any t.TempDir()
-	// below joins CreateTask's background workflow goroutine before those
-	// dirs are removed, closing a race where a goroutine still mid-write
-	// when the context cancels loses to RemoveAll ("directory not empty") —
-	// reproduced live under the OS sandbox's added scheduling latency.
-	t.Cleanup(wg.Wait)
 
 	wfDir := t.TempDir()
 	wfStore, err := workflow.NewStore(wfDir)
@@ -317,6 +311,13 @@ func setupTaskService(t *testing.T) (*TaskService, *App) {
 			t.Fatalf("attachments.DeleteTask(%s): %v", id, err)
 		}
 	})
+	// t.Cleanup runs last-added-first: registering this after every t.TempDir()
+	// above (including setupApp's WorktreesDir) joins CreateTask's background
+	// workflow goroutine before any of those dirs are removed, closing a race
+	// where a goroutine still mid-write when the context cancels loses to
+	// RemoveAll ("directory not empty") — reproduced live under the OS
+	// sandbox's added scheduling latency.
+	t.Cleanup(wg.Wait)
 	return svc, a
 }
 

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -268,6 +268,12 @@ func setupTaskService(t *testing.T) (*TaskService, *App) {
 	t.Helper()
 	a := setupApp(t)
 	var wg sync.WaitGroup
+	// t.Cleanup runs last-added-first: placing this before any t.TempDir()
+	// below joins CreateTask's background workflow goroutine before those
+	// dirs are removed, closing a race where a goroutine still mid-write
+	// when the context cancels loses to RemoveAll ("directory not empty") —
+	// reproduced live under the OS sandbox's added scheduling latency.
+	t.Cleanup(wg.Wait)
 
 	wfDir := t.TempDir()
 	wfStore, err := workflow.NewStore(wfDir)


### PR DESCRIPTION
## Motivation

Four otherwise-complete, fully-verified PRs (`5aa2287b`, `67a50203`, `d3c44e69`, `838a6680`) were stuck in `human-required`, each diagnosing the same symptom: the local pre-push hook's `go test ./...` fails inside this environment, and every agent's own investigation concluded it was an unfixable environment/sandbox limitation around nested git subprocesses.

That diagnosis was wrong about the mechanism, though right that it's environment-triggered. Root-caused by reproducing the pre-push hook's `go test ./...` inside the real `bwrap` sandbox profile a headless agent actually runs under (`agent.sandbox_mode: enforce`), not a synthetic repro. Confirmed failure, unrelated to git entirely:

```
--- FAIL: TestPlanningService_AssembleFeedback (0.09s)
    --- FAIL: TestPlanningService_AssembleFeedback/all_comments_resolved_→_free_text_only (0.01s)
        testing.go:1464: TempDir RemoveAll cleanup: unlinkat /tmp/TestPlanningService_AssembleFeedbackall_comments_resolved__f2655557081: directory not empty
```

Root cause: `internal/sybra/app_test.go`'s `setupTaskService` creates a `sync.WaitGroup` tracking background goroutines `TaskService.CreateTask` spawns (e.g. the async `simple-task-plan` workflow start via `s.wg.Go(...)` in `svc_tasks.go`), but the test helper never waited on it during cleanup. `setupApp`'s own `tasksDir` already documents this exact class of race (see its `os.MkdirTemp`-instead-of-`t.TempDir()` comment), but `WorktreesDir: t.TempDir()` never got the same treatment, and `engine.SetContext(t.Context())` only cancels the background workflow — it doesn't wait for the goroutine to actually stop touching the filesystem before `t.TempDir()`'s cleanup runs.

Under normal (fast, unsandboxed) execution the race window is narrow enough to almost never lose. Under the `bwrap`-sandboxed pre-push hook run (added scheduling/syscall overhead from the mount/PID namespace), the window widens enough to lose reliably.

## Implementation information

Fix: register `t.Cleanup(wg.Wait)` at the end of `setupTaskService`, after every `t.TempDir()` call the function (and the `setupApp` it calls) makes. `t.Cleanup` runs last-added-first, so this guarantees the background goroutine has fully unwound before any temp dir gets removed.

An initial version placed the registration right after `var wg sync.WaitGroup` instead of at the end — an adversarial review caught that this only protected the two dirs registered *before* that point (`setupApp`'s `tasksDir`/`WorktreesDir`), while `wfDir` and the attachments store dir (registered *after*) were still unprotected by the same LIFO logic. Fixed by moving the registration to the very end of the function.

Verified live against the actual repo, not just locally: copied the fixed `app_test.go` into one of the four stuck tasks' real worktrees on the server and repeatedly re-ran `go test ./internal/sybra/...` inside the exact `bwrap` sandbox profile a headless agent uses — reliable failure before the fix, 0 failures across 12+ runs (targeted and full-package) after.

## Open questions

The same adversarial review flagged two things intentionally left out of scope here:
- `wg.Wait()` in cleanup can now block on unexported, non-context-aware `time.Sleep`-based retries deeper in `internal/workflow` (`engine_retry.go`'s `prVerifySleep`/`verifyCommitsRetrySleep`) if a background-dispatched workflow reaches those retry sites during a test. Not reproduced live in this checkout (agent dispatch fails fast on a missing `claude` binary before reaching those steps in the current test suite), but the mechanism is real and could add up to ~12s of unexplained teardown latency to a future test whose async dispatch reaches it under a genuine transient failure.
- A few other call sites construct `&TaskService{...}` directly with their own separate, un-joined `sync.WaitGroup` (`svc_planning_test.go`, `svc_tasks_cluster_push_test.go`, `e2e_workflow_test.go`). Currently inert because none of them wire a `workflowEngine` that would reach `s.wg.Go`, but a future edit that does would reopen the same race at that call site.

Both are follow-up-shaped, not blockers for this fix, and weren't touched here to keep the change minimal and reviewable.

Closes #2961

> Changelog: fix(sybra): join CreateTask goroutine before test cleanup
