### PR TITLE
fix(project): disable git auto-maintenance

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -356,10 +356,31 @@ func CloneBare(ctx context.Context, repoURL, destPath string) error {
 	if err := configureCommitIdentity(ctx, destPath); err != nil {
 		return fmt.Errorf("configure commit identity: %w", err)
 	}
+	if err := DisableAutoMaintenance(ctx, destPath); err != nil {
+		return fmt.Errorf("disable auto maintenance: %w", err)
+	}
 	// `git clone --bare` leaves remote.origin.fetch empty, so later `git fetch
 	// origin` becomes a no-op against refs/remotes/origin/*. Configure the
 	// standard refspec so fetches actually update tracking refs.
 	return runBare(ctx, destPath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+}
+
+// DisableAutoMaintenance turns off git's default maintenance.auto, which
+// otherwise lets any plain `git fetch` in any linked worktree silently
+// trigger a detached `git maintenance run --auto` against this shared bare
+// clone's object store. Concurrent tasks each have their own worktree but
+// share one clone: a repack from one task's auto-maintenance can run while
+// a sibling task is mid-commit (object written, ref not yet updated) and
+// conclude the new object is unreachable, dropping it — corrupting the
+// sibling's branch with no warning until something later fails to read it
+// ("fatal: bad object HEAD"). This closes only the *implicit* trigger; an
+// agent running `git gc`/`git repack`/`git maintenance run` explicitly in
+// its own worktree reproduces the identical race and is not prevented here
+// (see internal/agent/manager_run.go's git-sandbox write grants, which
+// intentionally permit those paths). Exported so a startup migration can
+// retrofit already-registered projects, not just newly cloned ones.
+func DisableAutoMaintenance(ctx context.Context, barePath string) error {
+	return runBare(ctx, barePath, "config", "maintenance.auto", "false")
 }
 
 // configureCommitIdentity sets an explicit git identity on the bare clone.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -255,6 +255,27 @@ func TestCloneBare_CommitIdentityRespectsEnvOverride(t *testing.T) {
 	}
 }
 
+// A plain `git fetch` in any linked worktree defaults to triggering a
+// detached `git maintenance run --auto` against this shared clone's object
+// store — a repack racing a sibling worktree's in-flight commit can drop the
+// object before its ref update lands. CloneBare must disable this by default.
+func TestCloneBare_DisablesAutoMaintenance(t *testing.T) {
+	t.Parallel()
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	raw, err := outputBare(context.Background(), bare, "config", "maintenance.auto")
+	if err != nil {
+		t.Fatalf("read maintenance.auto: %v", err)
+	}
+	if got := strings.TrimSpace(raw); got != "false" {
+		t.Errorf("maintenance.auto = %q, want %q", got, "false")
+	}
+}
+
 func TestDefaultBranch(t *testing.T) {
 	t.Parallel()
 	bare := initBareRepo(t)

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -115,11 +115,19 @@ func (s *Store) disableAutoMaintenanceLocked(ctx context.Context, id, snapshotCl
 	defer unlock()
 
 	current, err := s.Get(id)
-	if err != nil || current.ClonePath != snapshotClonePath || (current.Status != "" && current.Status != ProjectStatusReady) {
+	if errors.Is(err, ErrProjectNotRegistered) {
 		return nil
 	}
-	if _, statErr := os.Stat(current.ClonePath); statErr != nil {
+	if err != nil {
+		return fmt.Errorf("%s: %w", id, err)
+	}
+	if current.ClonePath != snapshotClonePath || (current.Status != "" && current.Status != ProjectStatusReady) {
 		return nil
+	}
+	if _, statErr := os.Stat(current.ClonePath); errors.Is(statErr, os.ErrNotExist) {
+		return nil
+	} else if statErr != nil {
+		return fmt.Errorf("%s: stat clone: %w", id, statErr)
 	}
 
 	runCtx, cancel := context.WithTimeout(ctx, migrateMaintenanceAutoPerProjectTimeout)

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -64,6 +64,72 @@ func (s *Store) lock(id string) (func(), error) {
 	return unlock, nil
 }
 
+// migrateMaintenanceAutoPerProjectTimeout bounds each project's git config
+// call so one stalled clone (hung disk, lock contention with a concurrent
+// mutation) cannot block every other project's retrofit, or the app startup
+// path calling this, indefinitely.
+const migrateMaintenanceAutoPerProjectTimeout = 10 * time.Second
+
+// MigrateDisableAutoMaintenance retrofits maintenance.auto=false (see
+// DisableAutoMaintenance) onto every already-registered project's clone, so
+// projects created before that CloneBare step existed get the same
+// protection without a re-clone. Safe to run on every startup: git config is
+// idempotent. Skips a project whose clone directory is missing, or whose
+// Status is not ready/unset — CreateProject's async clone path (unlike
+// Store.Create) writes directly into the final ClonePath rather than a temp
+// path plus atomic rename, so a project mid-clone already has a directory
+// `os.Stat` succeeds against; touching it here would race CloneBare's own
+// `.git/config` writes. Each project is processed under the same per-ID lock
+// every other mutation holds, so it also cannot race a concurrent Delete.
+// Errors are joined and returned so the caller can log without treating this
+// as fatal.
+func (s *Store) MigrateDisableAutoMaintenance(ctx context.Context) error {
+	projects, err := s.List()
+	if err != nil {
+		return fmt.Errorf("list projects: %w", err)
+	}
+	var errs []error
+	for i := range projects {
+		p := &projects[i]
+		if p.ClonePath == "" {
+			continue
+		}
+		if p.Status != "" && p.Status != ProjectStatusReady {
+			continue
+		}
+		if err := s.disableAutoMaintenanceLocked(ctx, p.ID, p.ClonePath); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// disableAutoMaintenanceLocked re-checks id's current clone path under the
+// per-project lock before touching it, so a Delete that lands between
+// MigrateDisableAutoMaintenance's List() snapshot and this call is not raced.
+func (s *Store) disableAutoMaintenanceLocked(ctx context.Context, id, snapshotClonePath string) error {
+	unlock, err := s.lock(id)
+	if err != nil {
+		return fmt.Errorf("%s: %w", id, err)
+	}
+	defer unlock()
+
+	current, err := s.Get(id)
+	if err != nil || current.ClonePath != snapshotClonePath || (current.Status != "" && current.Status != ProjectStatusReady) {
+		return nil
+	}
+	if _, statErr := os.Stat(current.ClonePath); statErr != nil {
+		return nil
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, migrateMaintenanceAutoPerProjectTimeout)
+	defer cancel()
+	if err := DisableAutoMaintenance(runCtx, current.ClonePath); err != nil {
+		return fmt.Errorf("%s: %w", id, err)
+	}
+	return nil
+}
+
 // List returns every registered project. A file that fails to parse is
 // silently skipped rather than failing the whole call.
 func (s *Store) List() ([]Project, error) {

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -497,5 +499,104 @@ func TestStoreDeleteCleansClone(t *testing.T) {
 	}
 	if _, err := os.Stat(store.filePath("org/tool")); !os.IsNotExist(err) {
 		t.Error("YAML file should be removed")
+	}
+}
+
+// A project registered before DisableAutoMaintenance existed in CloneBare
+// never got maintenance.auto=false, leaving its clone exposed to the same
+// cross-worktree repack race a fresh clone is now protected against.
+// MigrateDisableAutoMaintenance must retrofit it without a re-clone.
+func TestStoreMigrateDisableAutoMaintenance_RetrofitsExistingClone(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "pre-fix-bare.git")
+	if out, err := exec.Command("git", "clone", "-q", "--bare", src, bare).CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %v: %s", err, out)
+	}
+	// Simulate the pre-fix state: no CloneBare-set config at all, so
+	// maintenance.auto falls back to git's own default (true). --unset exits
+	// non-zero when the key was never set, which is the expected outcome
+	// here — plain `git clone --bare` sets no such key.
+	_ = exec.Command("git", "-C", bare, "config", "--unset", "maintenance.auto").Run()
+
+	p := Project{ID: "org/pre-fix", Owner: "org", Repo: "pre-fix", ClonePath: bare}
+	if err := store.writeFile(p); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.MigrateDisableAutoMaintenance(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	raw, err := outputBare(context.Background(), bare, "config", "maintenance.auto")
+	if err != nil {
+		t.Fatalf("read maintenance.auto: %v", err)
+	}
+	if got := strings.TrimSpace(raw); got != "false" {
+		t.Errorf("maintenance.auto = %q, want %q", got, "false")
+	}
+}
+
+// A project mid-clone (ClonePath set but the directory not yet created) or
+// mid-delete (directory already removed) must not fail the whole migration
+// pass for every other registered project.
+func TestStoreMigrateDisableAutoMaintenance_SkipsMissingClone(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	missing := Project{ID: "org/missing", Owner: "org", Repo: "missing", ClonePath: filepath.Join(t.TempDir(), "never-created.git")}
+	if err := store.writeFile(missing); err != nil {
+		t.Fatal(err)
+	}
+	empty := Project{ID: "org/empty", Owner: "org", Repo: "empty"}
+	if err := store.writeFile(empty); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.MigrateDisableAutoMaintenance(context.Background()); err != nil {
+		t.Fatalf("migrate should skip missing/empty clones rather than error: %v", err)
+	}
+}
+
+// CreateProject's async clone path writes directly into the final ClonePath
+// (no temp-path-plus-atomic-rename like Store.Create uses), so a project
+// genuinely mid-clone has a directory that already exists and os.Stat
+// succeeds against — Status=cloning, not a missing directory, is the real
+// signal MigrateDisableAutoMaintenance must key off to avoid racing
+// CloneBare's own .git/config writes.
+func TestStoreMigrateDisableAutoMaintenance_SkipsInProgressClone(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "mid-clone-bare.git")
+	if out, err := exec.Command("git", "clone", "-q", "--bare", src, bare).CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %v: %s", err, out)
+	}
+	_ = exec.Command("git", "-C", bare, "config", "--unset", "maintenance.auto").Run()
+
+	p := Project{ID: "org/mid-clone", Owner: "org", Repo: "mid-clone", ClonePath: bare, Status: ProjectStatusCloning}
+	if err := store.writeFile(p); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.MigrateDisableAutoMaintenance(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	raw, err := outputBare(context.Background(), bare, "config", "maintenance.auto")
+	if err == nil && strings.TrimSpace(raw) == "false" {
+		t.Fatal("migrate touched a clone still marked Status=cloning; must wait for it to reach ready")
 	}
 }

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -542,6 +542,36 @@ func TestStoreMigrateDisableAutoMaintenance_RetrofitsExistingClone(t *testing.T)
 	}
 }
 
+// disableAutoMaintenanceLocked's re-check must only swallow the two expected
+// races (project deleted, clone directory removed) — a genuine read/parse
+// failure has to surface in the joined error, not be silently dropped, or a
+// real filesystem problem would be indistinguishable from a healthy startup.
+func TestStoreDisableAutoMaintenanceLocked_PropagatesRealReadError(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := Project{ID: "org/broken", Owner: "org", Repo: "broken", ClonePath: t.TempDir()}
+	if err := store.writeFile(p); err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt the record after it's written, simulating a genuine read/parse
+	// failure distinct from "file does not exist" (ErrProjectNotRegistered).
+	if err := os.WriteFile(store.filePath(p.ID), []byte("not: [valid yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.disableAutoMaintenanceLocked(context.Background(), p.ID, p.ClonePath)
+	if err == nil {
+		t.Fatal("expected the parse error to propagate, got nil")
+	}
+	if errors.Is(err, ErrProjectNotRegistered) {
+		t.Fatalf("a real parse error must not be reported as ErrProjectNotRegistered: %v", err)
+	}
+}
+
 // A project mid-clone (ClonePath set but the directory not yet created) or
 // mid-delete (directory already removed) must not fail the whole migration
 // pass for every other registered project.

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -473,6 +473,10 @@ func (a *App) Startup(ctx context.Context) error {
 		return fmt.Errorf("project store: %w", err)
 	}
 	a.projects = projStore
+	// Retrofits maintenance.auto=false onto existing clones; see #2978.
+	if err := projStore.MigrateDisableAutoMaintenance(appCtx); err != nil {
+		a.logger.Warn("project.store.migrate_maintenance_auto", "err", err)
+	}
 
 	if err := a.initLoopAgents(); err != nil {
 		return fmt.Errorf("loop agents: %w", err)


### PR DESCRIPTION
## Motivation

Multiple Sybra task worktrees share one bare git clone. Git's default `maintenance.auto=true` lets any plain `git fetch` in any worktree silently trigger a detached repack against the shared clone's object store. A repack racing a sibling worktree's in-flight commit (object written, ref not yet updated) can conclude the object is unreachable and drop it, corrupting the sibling's branch with no warning until something later fails to read it (`fatal: bad object HEAD`).

Confirmed in production: two concurrent kumahq/kuma tasks both hit this once the darwin sandbox git-write fix let gc/maintenance succeed for the first time, where it previously always failed closed on darwin (masking the hazard, not preventing it).

## Implementation information

- `internal/project/git.go`: `CloneBare` now runs `git config maintenance.auto false` on every new clone (`DisableAutoMaintenance`).
- `internal/project/store.go`: `Store.MigrateDisableAutoMaintenance` retrofits already-registered projects at startup — skips anything not in a ready state (avoids racing `CreateProject`'s in-place, non-atomic async clone), re-checks under the project's own lock (avoids racing a concurrent `Delete`), and bounds each project's config write so one stalled clone can't block startup.
- Immediate mitigation already applied by hand to every existing local clone (`git config maintenance.auto false`) while this PR was in flight — this PR is the durable fix so new and existing clones stay protected without a manual step.

### Open questions

- This closes only the *implicit* fetch-triggered path. An agent running `git gc`/`git repack`/`git maintenance run` explicitly in its own worktree reproduces the identical race and is not prevented here — the darwin sandbox's git write grants intentionally permit those paths. Noted in `DisableAutoMaintenance`'s doc comment; not fixed in this PR.

Closes #2978

> Changelog: fix(project): disable git auto-maintenance