### PR TITLE
fix(project): disable gc.auto too

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -365,22 +365,34 @@ func CloneBare(ctx context.Context, repoURL, destPath string) error {
 	return runBare(ctx, destPath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
 }
 
-// DisableAutoMaintenance turns off git's default maintenance.auto, which
-// otherwise lets any plain `git fetch` in any linked worktree silently
-// trigger a detached `git maintenance run --auto` against this shared bare
-// clone's object store. Concurrent tasks each have their own worktree but
-// share one clone: a repack from one task's auto-maintenance can run while
-// a sibling task is mid-commit (object written, ref not yet updated) and
-// conclude the new object is unreachable, dropping it — corrupting the
-// sibling's branch with no warning until something later fails to read it
-// ("fatal: bad object HEAD"). This closes only the *implicit* trigger; an
-// agent running `git gc`/`git repack`/`git maintenance run` explicitly in
-// its own worktree reproduces the identical race and is not prevented here
-// (see internal/agent/manager_run.go's git-sandbox write grants, which
+// DisableAutoMaintenance turns off both of git's independent implicit-repack
+// triggers, either of which otherwise lets an ordinary command in any linked
+// worktree silently repack this shared bare clone's object store:
+//   - maintenance.auto (git 2.30+): `git fetch` runs a detached
+//     `git maintenance run --auto` afterward.
+//   - gc.auto (older, separate mechanism `maintenance.auto` does NOT
+//     disable): `git commit`/`checkout`/`merge`/`fetch` and others run
+//     `git gc --auto` once loose objects exceed a threshold (default 6700).
+//
+// Concurrent tasks each have their own worktree but share one clone: a
+// repack from either trigger can run while a sibling task is mid-commit
+// (object written, ref not yet updated) and conclude the new object is
+// unreachable, dropping it — corrupting the sibling's branch with no warning
+// until something later fails to read it ("fatal: bad object HEAD").
+// Confirmed in production: disabling only maintenance.auto still let this
+// happen via gc.auto on the very next commit to the same clone.
+//
+// This closes only the *implicit* triggers; an agent running `git
+// gc`/`git repack`/`git maintenance run` explicitly in its own worktree
+// reproduces the identical race and is not prevented here (see
+// internal/agent/manager_run.go's git-sandbox write grants, which
 // intentionally permit those paths). Exported so a startup migration can
 // retrofit already-registered projects, not just newly cloned ones.
 func DisableAutoMaintenance(ctx context.Context, barePath string) error {
-	return runBare(ctx, barePath, "config", "maintenance.auto", "false")
+	if err := runBare(ctx, barePath, "config", "maintenance.auto", "false"); err != nil {
+		return err
+	}
+	return runBare(ctx, barePath, "config", "gc.auto", "0")
 }
 
 // configureCommitIdentity sets an explicit git identity on the bare clone.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -274,6 +274,18 @@ func TestCloneBare_DisablesAutoMaintenance(t *testing.T) {
 	if got := strings.TrimSpace(raw); got != "false" {
 		t.Errorf("maintenance.auto = %q, want %q", got, "false")
 	}
+
+	// gc.auto is a separate, older auto-gc mechanism maintenance.auto=false
+	// does not disable — git commit/checkout/merge/fetch all still trigger
+	// `git gc --auto` once loose objects cross gc.auto's threshold (default
+	// 6700) unless this is also set to 0.
+	gcAuto, err := outputBare(context.Background(), bare, "config", "gc.auto")
+	if err != nil {
+		t.Fatalf("read gc.auto: %v", err)
+	}
+	if got := strings.TrimSpace(gcAuto); got != "0" {
+		t.Errorf("gc.auto = %q, want %q", got, "0")
+	}
 }
 
 func TestDefaultBranch(t *testing.T) {

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -540,6 +540,14 @@ func TestStoreMigrateDisableAutoMaintenance_RetrofitsExistingClone(t *testing.T)
 	if got := strings.TrimSpace(raw); got != "false" {
 		t.Errorf("maintenance.auto = %q, want %q", got, "false")
 	}
+
+	gcAuto, err := outputBare(context.Background(), bare, "config", "gc.auto")
+	if err != nil {
+		t.Fatalf("read gc.auto: %v", err)
+	}
+	if got := strings.TrimSpace(gcAuto); got != "0" {
+		t.Errorf("gc.auto = %q, want %q", got, "0")
+	}
 }
 
 // disableAutoMaintenanceLocked's re-check must only swallow the two expected


### PR DESCRIPTION
## Motivation

`maintenance.auto=false` (PR #2979) only stops `git fetch`'s post-fetch detached `git maintenance run --auto`. `gc.auto` is a separate, older mechanism — unaffected by `maintenance.auto` — that `git commit`/`checkout`/`merge`/`fetch` and others still consult to auto-trigger `git gc --auto` once loose objects cross a threshold (default 6700).

Confirmed in production within hours of #2979 merging: the same kumahq/kuma task recovered from the `maintenance.auto` corruption hit the identical `fatal: bad object HEAD` corruption again on its very next commit — via `gc.auto`, not `maintenance.auto`.

Immediate mitigation applied by hand to every existing clone: `git config gc.auto 0`.

## Implementation information

`DisableAutoMaintenance` now sets `gc.auto 0` alongside `maintenance.auto false`, closing both implicit auto-repack triggers. No changes needed to the startup migration — it already calls this same function, so both new and already-registered projects pick this up.

Verified fail-then-pass: both new test assertions (`TestCloneBare_DisablesAutoMaintenance`, `TestStoreMigrateDisableAutoMaintenance_RetrofitsExistingClone`) fail against the pre-fix code and pass with it.

Closes #2980

> Changelog: fix(project): disable gc.auto too