### PR TITLE
fix(project): archive corrupt worktrees

### DIFF
--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -13,12 +13,17 @@ import (
 
 type RepairReport struct {
 	QuarantinedRefs        []string
+	ArchivedWorktrees      []string
 	PrunedWorktrees        bool
 	RebuiltWorktreeIndexes []string
 	RefetchedBranches      []string
 }
 
 var QuarantineDir string
+
+// WorktreesDir is the sole root whose linked checkouts repair may archive.
+// It is configured by the app alongside QuarantineDir.
+var WorktreesDir string
 
 var badRefMarkers = []string{
 	"fatal: bad object",
@@ -363,15 +368,93 @@ func releaseDeadWorktreeRefs(ctx context.Context, barePath string, report *Repai
 		}
 		QuarantineRef(barePath, wtRef, head)
 		report.QuarantinedRefs = append(report.QuarantinedRefs, wtRef)
-		if checkoutPath := worktreeCheckoutPath(wtAdminDir); checkoutPath != "" {
-			_ = withLockRetry(func() error {
-				return runBare(ctx, barePath, "worktree", "remove", "--force", checkoutPath)
-			})
+		if checkoutPath := registeredWorktreeCheckoutPath(wtAdminDir); checkoutPath != "" {
+			// A broken ref does not mean the checkout is worthless: its files can
+			// be the only surviving copy of work whose commit object was lost.
+			// Preserve the whole checkout before pruning its now-invalid Git
+			// registration. QuarantineDir is on the same Sybra data volume in
+			// production, so rename is atomic and keeps ignored files too.
+			if archived, ok := archiveCorruptWorktree(checkoutPath); ok {
+				report.ArchivedWorktrees = append(report.ArchivedWorktrees, archived)
+			}
+			// Do not force-remove a checkout after a failed archive. WorktreesDir
+			// can be on another filesystem from QuarantineDir, and losing the
+			// checkout is worse than retaining a stale registration for recovery.
 		}
 	}
 	_ = withLockRetry(func() error {
 		return runBare(ctx, barePath, "worktree", "prune")
 	})
+}
+
+// registeredWorktreeCheckoutPath returns a checkout only when its .git file
+// points back at this exact linked-worktree admin directory. The admin
+// directory's gitdir file is mutable metadata, so treating it as authoritative
+// would let a corrupt entry redirect repair's archive move outside the managed
+// worktree.
+func registeredWorktreeCheckoutPath(adminDir string) string {
+	if WorktreesDir == "" {
+		return ""
+	}
+	checkoutPath := worktreeCheckoutPath(adminDir)
+	if checkoutPath == "" {
+		return ""
+	}
+	gitFile, err := os.ReadFile(filepath.Join(checkoutPath, ".git"))
+	if err != nil {
+		return ""
+	}
+	gitdir, ok := strings.CutPrefix(strings.TrimSpace(string(gitFile)), "gitdir: ")
+	if !ok || strings.TrimSpace(gitdir) == "" {
+		return ""
+	}
+	gitdir = strings.TrimSpace(gitdir)
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(checkoutPath, gitdir)
+	}
+	canonicalAdminDir, err := filepath.EvalSymlinks(adminDir)
+	if err != nil {
+		return ""
+	}
+	canonicalGitDir, err := filepath.EvalSymlinks(gitdir)
+	if err != nil || canonicalGitDir != canonicalAdminDir {
+		return ""
+	}
+	canonicalWorktreesDir, err := filepath.EvalSymlinks(WorktreesDir)
+	if err != nil || !pathWithin(canonicalWorktreesDir, checkoutPath) {
+		return ""
+	}
+	return checkoutPath
+}
+
+func pathWithin(root, path string) bool {
+	canonicalPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(root, canonicalPath)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// archiveCorruptWorktree moves a worktree whose HEAD is unresolvable out of
+// the active worktree root before repair prunes Git's stale registration. The
+// archive deliberately includes the .git file and ignored files: it is a
+// forensic/recovery copy, not a usable checkout. Returns false when no safe
+// archive destination is configured or the move fails.
+func archiveCorruptWorktree(checkoutPath string) (string, bool) {
+	if QuarantineDir == "" {
+		return "", false
+	}
+	archiveRoot := filepath.Join(QuarantineDir, "worktrees")
+	if err := os.MkdirAll(archiveRoot, 0o755); err != nil {
+		return "", false
+	}
+	name := filepath.Base(filepath.Clean(checkoutPath)) + "-" + time.Now().UTC().Format("20060102T150405.000000000")
+	archivePath := filepath.Join(archiveRoot, name)
+	if err := os.Rename(checkoutPath, archivePath); err != nil {
+		return "", false
+	}
+	return archivePath, true
 }
 
 func worktreeCheckoutPath(adminDir string) string {

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -230,6 +230,9 @@ func TestRepairBareClone_DeletesRefStillCheckedOutByDeadWorktree(t *testing.T) {
 	if err := CreateWorktree(context.Background(), bare, wtPath, "task-branch", "origin/"+branch); err != nil {
 		t.Fatalf("create worktree: %v", err)
 	}
+	origWorktreesDir := WorktreesDir
+	WorktreesDir = filepath.Dir(wtPath)
+	t.Cleanup(func() { WorktreesDir = origWorktreesDir })
 	if err := os.WriteFile(filepath.Join(wtPath, "extra.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -263,6 +266,127 @@ func TestRepairBareClone_DeletesRefStillCheckedOutByDeadWorktree(t *testing.T) {
 
 	if _, err := outputBare(context.Background(), bare, "rev-parse", "--verify", "refs/heads/task-branch"); err == nil {
 		t.Fatal("dead task-branch ref should have been deleted, but a live worktree HEAD still pinned it")
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt worktree still active after repair: stat err=%v", err)
+	}
+	archives, err := os.ReadDir(filepath.Join(QuarantineDir, "worktrees"))
+	if err != nil {
+		t.Fatalf("read archived worktrees: %v", err)
+	}
+	if len(archives) != 1 {
+		t.Fatalf("archived worktrees = %v, want one", archives)
+	}
+	archivedFile := filepath.Join(QuarantineDir, "worktrees", archives[0].Name(), "extra.txt")
+	if got, err := os.ReadFile(archivedFile); err != nil || string(got) != "x" {
+		t.Fatalf("archived worktree did not preserve extra.txt: got %q err=%v", got, err)
+	}
+}
+
+func TestRegisteredWorktreeCheckoutPath_RejectsPoisonedAdminGitdir(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "task-branch", "origin/"+branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	origWorktreesDir := WorktreesDir
+	WorktreesDir = filepath.Dir(wtPath)
+	t.Cleanup(func() { WorktreesDir = origWorktreesDir })
+	adminDirBytes, err := os.ReadFile(filepath.Join(wtPath, ".git"))
+	if err != nil {
+		t.Fatalf("read worktree .git: %v", err)
+	}
+	gitdir, ok := strings.CutPrefix(strings.TrimSpace(string(adminDirBytes)), "gitdir: ")
+	if !ok {
+		t.Fatalf("worktree .git = %q, want gitdir declaration", adminDirBytes)
+	}
+	adminDir := strings.TrimSpace(gitdir)
+
+	victim := t.TempDir()
+	if err := os.WriteFile(filepath.Join(victim, ".git"), []byte("not a worktree"), 0o644); err != nil {
+		t.Fatalf("write victim git file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(victim, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write victim file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(adminDir, "gitdir"), []byte(filepath.Join(victim, ".git")+"\n"), 0o644); err != nil {
+		t.Fatalf("poison admin gitdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(adminDir, "HEAD"), []byte("ref: refs/heads/missing\n"), 0o644); err != nil {
+		t.Fatalf("poison admin HEAD: %v", err)
+	}
+
+	if got := registeredWorktreeCheckoutPath(adminDir); got != "" {
+		t.Fatalf("registered checkout = %q, want empty for poisoned gitdir", got)
+	}
+	if got, err := os.ReadFile(filepath.Join(victim, "keep.txt")); err != nil || string(got) != "keep" {
+		t.Fatalf("victim contents changed: got %q err=%v", got, err)
+	}
+	if _, err := RepairBareClone(context.Background(), bare, ""); err != nil {
+		t.Fatalf("repair poisoned worktree metadata: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(victim, "keep.txt")); err != nil || string(got) != "keep" {
+		t.Fatalf("repair moved victim contents: got %q err=%v", got, err)
+	}
+}
+
+func TestRepairBareClone_PreservesWorktreeWhenArchiveUnavailable(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("fetch origin: %v", err)
+	}
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(context.Background(), bare, wtPath, "task-branch", "origin/"+branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	origWorktreesDir := WorktreesDir
+	WorktreesDir = filepath.Dir(wtPath)
+	t.Cleanup(func() { WorktreesDir = origWorktreesDir })
+	if err := os.WriteFile(filepath.Join(wtPath, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"-C", wtPath, "config", "user.email", "test@test.com"}, {"-C", wtPath, "config", "user.name", "Test"}, {"-C", wtPath, "add", "."}, {"-C", wtPath, "commit", "-m", "keep"}} {
+		if out, cmdErr := exec.Command("git", args...).CombinedOutput(); cmdErr != nil {
+			t.Fatalf("git %v: %v: %s", args, cmdErr, out)
+		}
+	}
+	headOut, err := exec.Command("git", "-C", wtPath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	headSHA := strings.TrimSpace(string(headOut))
+	if err := os.Remove(filepath.Join(bare, "objects", headSHA[:2], headSHA[2:])); err != nil {
+		t.Fatalf("corrupt commit object: %v", err)
+	}
+	origQuarantineDir := QuarantineDir
+	QuarantineDir = ""
+	t.Cleanup(func() { QuarantineDir = origQuarantineDir })
+
+	if _, err := RepairBareClone(context.Background(), bare, ""); err != nil {
+		t.Fatalf("repair with unavailable archive: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(wtPath, "keep.txt")); err != nil || string(got) != "keep" {
+		t.Fatalf("worktree lost after archive failure: got %q err=%v", got, err)
 	}
 }
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -507,7 +507,7 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.prTracker = github.NewIssueTrackerWithMaxRetries(30*time.Minute, a.cfg.GitHub.PRFixRetries())
 
-	configureProjectGitDefaults()
+	configureProjectGitDefaults(a.worktreesDir)
 	// Initialize domain services (dependency order: worktrees → agentOrch → reviewer, workflow)
 	a.worktrees = worktree.New(worktree.Config{
 		WorktreesDir:      a.worktreesDir,
@@ -567,9 +567,10 @@ func (a *App) taskEventEmitter(store *task.Store) func(string, any) {
 	}
 }
 
-func configureProjectGitDefaults() {
+func configureProjectGitDefaults(worktreesDir string) {
 	project.FetchTTL = 60 * time.Second
 	project.QuarantineDir = filepath.Join(config.HomeDir(), "quarantine")
+	project.WorktreesDir = worktreesDir
 }
 
 // sandboxRetentionWindow translates the resolved sandbox.retention_hours


### PR DESCRIPTION
Closes #2983

## Summary
- archive a corrupt linked worktree before repair prunes its registration
- restrict archival to the configured managed worktree root with reciprocal Git metadata validation
- retain the checkout when archival is unavailable or fails

## Verification
- `mise run verify`
- isolated adversarial corrupt-object recovery probe
- adversarial code review