### PR TITLE
fix(project): inherit local Git identity

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -353,7 +352,7 @@ func CloneBare(ctx context.Context, repoURL, destPath string) error {
 	if err := InstallSignoffHook(ctx, destPath); err != nil {
 		return fmt.Errorf("install signoff hook: %w", err)
 	}
-	if err := configureCommitIdentity(ctx, destPath); err != nil {
+	if err := ConfigureCommitIdentity(ctx, destPath); err != nil {
 		return fmt.Errorf("configure commit identity: %w", err)
 	}
 	if err := DisableAutoMaintenance(ctx, destPath); err != nil {
@@ -395,19 +394,18 @@ func DisableAutoMaintenance(ctx context.Context, barePath string) error {
 	return runBare(ctx, barePath, "config", "gc.auto", "0")
 }
 
-// configureCommitIdentity sets an explicit git identity on the bare clone.
-// Headless/interactive agent commits are made by the agent's own bash tool
+// ConfigureCommitIdentity sets an explicit git identity on the bare clone.
+// Headless agent commits are made by the agent's own bash tool
 // calls, not orchestrated Go code, so they inherit whatever identity is
 // already configured on the clone — an empty one fails every commit with
 // "empty ident name", and any stray local override (however it got there)
 // silently becomes the permanent author of every real commit. Setting it
 // explicitly at clone time means neither can happen by accident.
-// GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL let an operator brand commits (e.g. as
-// their own GitHub App bot); the default matches the identity
-// internal/agent/k8s_job_runner.go already falls back to.
-func configureCommitIdentity(ctx context.Context, barePath string) error {
-	name := cmp.Or(os.Getenv("GIT_AUTHOR_NAME"), "Sybra Agent")
-	email := cmp.Or(os.Getenv("GIT_AUTHOR_EMAIL"), "sybra-agent@example.invalid")
+// GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL take precedence. On a developer machine,
+// a complete global Git identity is used next; the placeholder is only for
+// unattended hosts that have neither identity configured.
+func ConfigureCommitIdentity(ctx context.Context, barePath string) error {
+	name, email := commitIdentity(ctx)
 	if err := runBare(ctx, barePath, "config", "user.name", name); err != nil {
 		return fmt.Errorf("set user.name: %w", err)
 	}
@@ -415,6 +413,28 @@ func configureCommitIdentity(ctx context.Context, barePath string) error {
 		return fmt.Errorf("set user.email: %w", err)
 	}
 	return nil
+}
+
+func commitIdentity(ctx context.Context) (name, email string) {
+	name = strings.TrimSpace(os.Getenv("GIT_AUTHOR_NAME"))
+	email = strings.TrimSpace(os.Getenv("GIT_AUTHOR_EMAIL"))
+	if name != "" && email != "" {
+		return name, email
+	}
+	globalName := gitGlobalConfig(ctx, "user.name")
+	globalEmail := gitGlobalConfig(ctx, "user.email")
+	if globalName != "" && globalEmail != "" {
+		return globalName, globalEmail
+	}
+	return "Sybra Agent", "sybra-agent@example.invalid"
+}
+
+func gitGlobalConfig(ctx context.Context, key string) string {
+	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--get", key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // DefaultBranch resolves barePath's HEAD symbolic ref (e.g.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -215,16 +215,16 @@ func TestCloneBare_SetsCommitIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read user.name: %v", err)
 	}
-	if got := strings.TrimSpace(name); got != "Sybra Agent" {
-		t.Errorf("user.name = %q, want %q", got, "Sybra Agent")
+	if got := strings.TrimSpace(name); got != "Sybra Test" {
+		t.Errorf("user.name = %q, want %q", got, "Sybra Test")
 	}
 
 	email, err := outputBare(context.Background(), bare, "config", "user.email")
 	if err != nil {
 		t.Fatalf("read user.email: %v", err)
 	}
-	if got := strings.TrimSpace(email); got != "sybra-agent@example.invalid" {
-		t.Errorf("user.email = %q, want %q", got, "sybra-agent@example.invalid")
+	if got := strings.TrimSpace(email); got != "test@test.com" {
+		t.Errorf("user.email = %q, want %q", got, "test@test.com")
 	}
 }
 
@@ -252,6 +252,26 @@ func TestCloneBare_CommitIdentityRespectsEnvOverride(t *testing.T) {
 	}
 	if got := strings.TrimSpace(email); got != "custom-bot@example.com" {
 		t.Errorf("user.email = %q, want %q", got, "custom-bot@example.com")
+	}
+}
+
+func TestCloneBare_CommitIdentityFallsBackWithoutGlobalIdentity(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "empty-global-config"))
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	name, err := outputBare(context.Background(), bare, "config", "user.name")
+	if err != nil {
+		t.Fatalf("read user.name: %v", err)
+	}
+	email, err := outputBare(context.Background(), bare, "config", "user.email")
+	if err != nil {
+		t.Fatalf("read user.email: %v", err)
+	}
+	if strings.TrimSpace(name) != "Sybra Agent" || strings.TrimSpace(email) != "sybra-agent@example.invalid" {
+		t.Fatalf("fallback identity = %q <%q>", strings.TrimSpace(name), strings.TrimSpace(email))
 	}
 }
 

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -135,6 +135,9 @@ func (s *Store) disableAutoMaintenanceLocked(ctx context.Context, id, snapshotCl
 	if err := DisableAutoMaintenance(runCtx, current.ClonePath); err != nil {
 		return fmt.Errorf("%s: %w", id, err)
 	}
+	if err := ConfigureCommitIdentity(runCtx, current.ClonePath); err != nil {
+		return fmt.Errorf("%s: configure commit identity: %w", id, err)
+	}
 	return nil
 }
 

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -548,6 +548,17 @@ func TestStoreMigrateDisableAutoMaintenance_RetrofitsExistingClone(t *testing.T)
 	if got := strings.TrimSpace(gcAuto); got != "0" {
 		t.Errorf("gc.auto = %q, want %q", got, "0")
 	}
+	name, err := outputBare(context.Background(), bare, "config", "user.name")
+	if err != nil {
+		t.Fatalf("read user.name: %v", err)
+	}
+	email, err := outputBare(context.Background(), bare, "config", "user.email")
+	if err != nil {
+		t.Fatalf("read user.email: %v", err)
+	}
+	if strings.TrimSpace(name) != "Sybra Test" || strings.TrimSpace(email) != "test@test.com" {
+		t.Errorf("migrated identity = %q <%q>", strings.TrimSpace(name), strings.TrimSpace(email))
+	}
 }
 
 // disableAutoMaintenanceLocked's re-check must only swallow the two expected


### PR DESCRIPTION
## Motivation
Local project commits should use the operator identity already configured on the machine.

## Implementation information
- prefer explicit author environment overrides
- otherwise persist a complete global Git identity
- migrate ready existing clones at startup
- retain the fallback only with no usable identity

Closes #2985

> Changelog: fix(project): inherit local Git identity