### PR TITLE
fix(project): scrub alternate Git objects

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -237,7 +237,7 @@ func InstallHooks(ctx context.Context, worktreePath string, checks *ChecksConfig
 		}
 		var sb strings.Builder
 		sb.WriteString("#!/bin/sh\nset -e\n")
-		sb.WriteString("unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY\n")
+		sb.WriteString("unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES\n")
 		sb.WriteString("for __sybra_hook_env_name in $(env | sed -n 's/^\\(SYBRA_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$__sybra_hook_env_name\"; done\n")
 		sb.WriteString("unset __sybra_hook_env_name\n")
 		for _, c := range commands {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -261,6 +261,7 @@ const signoffHook = `#!/bin/sh
 # Auto-installed by Sybra. Guarantees a DCO Signed-off-by trailer on every
 # commit so PRs never fail the DCO check when an agent forgets 'git commit -s'.
 msg_file="$1"
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
 sob=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
 [ -z "$sob" ] && exit 0
 git interpret-trailers --if-exists addIfDifferent --trailer "$sob" --in-place "$msg_file"

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1717,6 +1717,33 @@ func TestInstallHooks_RepoConfigPriority(t *testing.T) {
 	}
 }
 
+func TestInstallHooks_UnsetsGitObjectEnv(t *testing.T) {
+	t.Parallel()
+	_, wtPath := initWorktree(t)
+
+	checks := &ChecksConfig{PrePush: []string{
+		`test -z "$GIT_OBJECT_DIRECTORY"`,
+		`test -z "$GIT_ALTERNATE_OBJECT_DIRECTORIES"`,
+	}}
+	if err := InstallHooks(context.Background(), wtPath, checks); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	gitDir, err := gitCommonDir(context.Background(), wtPath)
+	if err != nil {
+		t.Fatalf("gitCommonDir: %v", err)
+	}
+	cmd := exec.Command(filepath.Join(gitDir, "hooks", "pre-push"))
+	cmd.Dir = wtPath
+	cmd.Env = append(os.Environ(),
+		"GIT_OBJECT_DIRECTORY=/some/sandbox/overlay/objects",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES=/some/other/repo/objects",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("pre-push hook should scrub Git object environment: %v: %s", err, out)
+	}
+}
+
 func TestInstallHooks_NilChecks(t *testing.T) {
 	t.Parallel()
 	_, wtPath := initWorktree(t)

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -3720,6 +3720,24 @@ func TestInstallSignoffHook(t *testing.T) {
 	if err := InstallSignoffHook(context.Background(), wtPath); err != nil {
 		t.Fatalf("InstallSignoffHook: %v", err)
 	}
+	gitDir, err := gitCommonDir(context.Background(), wtPath)
+	if err != nil {
+		t.Fatalf("gitCommonDir: %v", err)
+	}
+	msgPath := filepath.Join(t.TempDir(), "message")
+	if err := os.WriteFile(msgPath, []byte("test message\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hook := exec.Command(filepath.Join(gitDir, "hooks", "prepare-commit-msg"), msgPath)
+	hook.Dir = wtPath
+	hook.Env = append(os.Environ(),
+		"GIT_DIR=/nonexistent/attacker-git-dir",
+		"GIT_OBJECT_DIRECTORY=/nonexistent/attacker-objects",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES=/nonexistent/attacker-alternates",
+	)
+	if out, err := hook.CombinedOutput(); err != nil {
+		t.Fatalf("signoff hook should scrub inherited Git environment: %v: %s", err, out)
+	}
 
 	body := func() string {
 		t.Helper()


### PR DESCRIPTION
## Motivation

Prevent inherited Git object-store environment from leaking through Sybra-generated hooks into unrelated Git operations.

## Implementation information

Scrubs `GIT_ALTERNATE_OBJECT_DIRECTORIES` alongside the existing Git control variables in generated pre-commit/pre-push hooks and the unconditional DCO signoff hook. Adds regression coverage that executes both hook types with poisoned environment values.

Closes #2898

> Changelog: fix(project): scrub alternate Git objects