### PR TITLE
fix(worktree): harden sandbox prerequisites

### DIFF
--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -3,7 +3,9 @@ package executil
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -25,7 +27,7 @@ func Run(ctx context.Context, dir, name string, args ...string) error {
 // current process environment", matching exec.Cmd's own zero-value behavior
 // and Run's default.
 func RunEnv(ctx context.Context, dir string, env []string, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := commandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -36,11 +38,40 @@ func RunEnv(ctx context.Context, dir string, env []string, name string, args ...
 
 // Output executes a command in dir and returns its trimmed stdout.
 func Output(ctx context.Context, dir, name string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := commandContext(ctx, name, args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// commandContext avoids exec.LookPath accepting a stale executable symlink.
+// This matters for long-lived desktop processes after a profile-manager
+// upgrade: a now-dangling git shim can remain first on PATH even though a
+// usable system git follows it. Worktree preparation must not fail before the
+// provider sandbox is even reached.
+func commandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	if name == "git" {
+		if path := usablePathExecutable(name); path != "" {
+			return exec.CommandContext(ctx, path, args...)
+		}
+	}
+	return exec.CommandContext(ctx, name, args...)
+}
+
+func usablePathExecutable(name string) string {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		candidate := filepath.Join(dir, name)
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(resolved)
+		if err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+			return resolved
+		}
+	}
+	return ""
 }

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -430,11 +430,11 @@ func commitIdentity(ctx context.Context) (name, email string) {
 }
 
 func gitGlobalConfig(ctx context.Context, key string) string {
-	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--get", key).Output()
+	out, err := executil.Output(ctx, "", "git", "config", "--global", "--get", key)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(out)
 }
 
 // DefaultBranch resolves barePath's HEAD symbolic ref (e.g.

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -258,7 +258,7 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 	releaseDeadWorktreeRefs(ctx, barePath, &report)
 	rebuildWorktreeIndexes(ctx, barePath, &report)
 
-	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)")
+	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes/origin")
 	if err != nil {
 		return report, fmt.Errorf("enumerate refs: %w", err)
 	}

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -258,9 +258,9 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 	releaseDeadWorktreeRefs(ctx, barePath, &report)
 	rebuildWorktreeIndexes(ctx, barePath, &report)
 
-	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)", "refs/heads")
+	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)")
 	if err != nil {
-		return report, fmt.Errorf("enumerate refs/heads: %w", err)
+		return report, fmt.Errorf("enumerate refs: %w", err)
 	}
 	for line := range strings.SplitSeq(strings.TrimSpace(refsOut), "\n") {
 		ref := strings.TrimSpace(line)
@@ -270,8 +270,7 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 		if checkErr := runBare(ctx, barePath, "cat-file", "-e", ref+"^{object}"); checkErr == nil {
 			continue
 		}
-		badValue, _ := outputBare(ctx, barePath, "rev-parse", ref)
-		QuarantineRef(barePath, ref, strings.TrimSpace(badValue))
+		QuarantineRef(barePath, ref, "unresolvable")
 		delErr := withLockRetry(func() error {
 			return runBare(ctx, barePath, "update-ref", "-d", ref)
 		})

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -48,6 +48,25 @@ func TestFetchOrigin_RepairsPoisonedSiblingRef(t *testing.T) {
 	}
 }
 
+func TestFetchOrigin_RepairsPoisonedRemoteRef(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	plantBadRef(t, bare, "refs/remotes/origin/"+branch)
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("FetchOrigin should repair poisoned remote ref: %v", err)
+	}
+	if _, err := outputBare(context.Background(), bare, "rev-parse", "--verify", "refs/remotes/origin/"+branch); err != nil {
+		t.Fatalf("refetched remote ref is missing: %v", err)
+	}
+}
+
 func TestRepairBareClone_QuarantinesRefsAndWorktreeHead(t *testing.T) {
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")

--- a/internal/task/transitions.go
+++ b/internal/task/transitions.go
@@ -67,6 +67,10 @@ var allowedTransitions = map[Status]map[Status]bool{
 		StatusDone:          true,
 	},
 	StatusInProgress: {
+		// A resumed planning workflow can already carry in-progress after an
+		// interrupted agent retry; its review gate must still be able to park at
+		// plan-review rather than tripping the circuit breaker.
+		StatusPlanReview:    true,
 		StatusInReview:      true,
 		StatusTodo:          true,
 		StatusTesting:       true,

--- a/internal/task/transitions_test.go
+++ b/internal/task/transitions_test.go
@@ -83,6 +83,7 @@ func TestIsTransitionAllowed_NamedLegalMoves(t *testing.T) {
 		{StatusInProgress, StatusInReview},
 		{StatusInReview, StatusDone},
 		{StatusInProgress, StatusTodo},
+		{StatusInProgress, StatusPlanReview},
 		{StatusHumanRequired, StatusInProgress},
 		{StatusHumanRequired, StatusInReview},
 	}


### PR DESCRIPTION
## Motivation

Work-task preparation must remain reliable while OS-level agent sandboxing stays enforced.

## Implementation information

- skip stale executable symlinks when resolving Git for host-side worktree operations
- quarantine corrupt remote-tracking refs and refetch them during bare-clone repair
- allow a resumed planning workflow to return to its plan-review gate

> Changelog: fix(worktree): harden sandbox prerequisites