### PR TITLE
Simplify board filters and search projects

### DIFF
--- a/frontend/src/components/TaskFilterPanel.svelte
+++ b/frontend/src/components/TaskFilterPanel.svelte
@@ -58,6 +58,7 @@
   }: Props = $props()
 
   let projectDropdownOpen = $state(false)
+  let projectQuery = $state('')
   let projectDropdownRef = $state<HTMLDivElement | null>(null)
   let searchInputRef = $state<HTMLInputElement | null>(null)
 
@@ -89,6 +90,19 @@
           return p ? `${p.owner}/${p.repo}` : selectedProjectId
         })()
       : 'All projects',
+  )
+
+  const sortedProjects = $derived(
+    [...projectStore.list].sort((a, b) =>
+      a.repo.localeCompare(b.repo, undefined, { sensitivity: 'base' })
+      || a.owner.localeCompare(b.owner, undefined, { sensitivity: 'base' }),
+    ),
+  )
+
+  const matchingProjects = $derived(
+    projectQuery.trim()
+      ? sortedProjects.filter((p) => `${p.owner}/${p.repo}`.toLowerCase().includes(projectQuery.trim().toLowerCase()))
+      : sortedProjects,
   )
 
   function addTag(tag: string) {
@@ -166,30 +180,45 @@
       <button
         type="button"
         class="flex h-8 items-center gap-2 rounded-md border border-surface-300 bg-surface-50 px-2.5 text-sm dark:border-surface-700 dark:bg-surface-800"
-        onclick={() => (projectDropdownOpen = !projectDropdownOpen)}
+        onclick={() => {
+          projectDropdownOpen = !projectDropdownOpen
+          if (!projectDropdownOpen) projectQuery = ''
+        }}
         data-testid="project-filter-button"
       >
         <span class={selectedProjectId ? '' : 'text-surface-400'}>{selectedProjectLabel}</span>
         <ChevronDown size={14} class="text-surface-400" />
       </button>
       {#if projectDropdownOpen}
-        <div class="absolute top-full z-10 mt-1 min-w-full rounded-md border border-surface-300 bg-surface-50 py-1 shadow-lg dark:border-surface-700 dark:bg-surface-800">
+        <div class="absolute top-full z-10 mt-1 min-w-64 rounded-md border border-surface-300 bg-surface-50 py-1 shadow-lg dark:border-surface-700 dark:bg-surface-800">
+          <div class="px-2 pb-1">
+            <input
+              bind:value={projectQuery}
+              type="text"
+              placeholder="Find project..."
+              aria-label="Find project"
+              class="h-8 w-full rounded border border-surface-300 bg-white px-2 text-sm outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-600 dark:bg-surface-900 dark:focus:border-primary-500 dark:focus:ring-primary-500"
+            />
+          </div>
           <button
             type="button"
             class="w-full whitespace-nowrap px-3 py-1.5 text-left text-sm hover:bg-surface-200 dark:hover:bg-surface-700 {selectedProjectId === '' ? 'font-medium text-primary-500' : ''}"
-            onmousedown={() => { onprojectChange?.(''); projectDropdownOpen = false }}
+            onmousedown={() => { onprojectChange?.(''); projectDropdownOpen = false; projectQuery = '' }}
           >
             All projects
           </button>
-          {#each projectStore.list as p (p.id)}
+          {#each matchingProjects as p (p.id)}
             <button
               type="button"
               class="w-full whitespace-nowrap px-3 py-1.5 text-left text-sm hover:bg-surface-200 dark:hover:bg-surface-700 {selectedProjectId === p.id ? 'font-medium text-primary-500' : ''}"
-              onmousedown={() => { onprojectChange?.(p.id); projectDropdownOpen = false }}
+              onmousedown={() => { onprojectChange?.(p.id); projectDropdownOpen = false; projectQuery = '' }}
             >
               {p.owner}/{p.repo}
             </button>
           {/each}
+          {#if matchingProjects.length === 0}
+            <p class="px-3 py-1.5 text-sm text-surface-400">No matching projects</p>
+          {/if}
         </div>
       {/if}
     </div>

--- a/frontend/src/components/TaskFilterPanel.svelte
+++ b/frontend/src/components/TaskFilterPanel.svelte
@@ -99,11 +99,12 @@
     ),
   )
 
-  const matchingProjects = $derived(
-    projectQuery.trim()
-      ? sortedProjects.filter((p) => `${p.owner}/${p.repo}`.toLowerCase().includes(projectQuery.trim().toLowerCase()))
-      : sortedProjects,
-  )
+  const matchingProjects = $derived.by(() => {
+    const query = projectQuery.trim().toLowerCase()
+    return query
+      ? sortedProjects.filter((p) => `${p.owner}/${p.repo}`.toLowerCase().includes(query))
+      : sortedProjects
+  })
 
   function addTag(tag: string) {
     if (!ontagsChange) return

--- a/frontend/src/components/TaskFilterPanel.svelte.test.ts
+++ b/frontend/src/components/TaskFilterPanel.svelte.test.ts
@@ -51,6 +51,23 @@ describe('TaskFilterPanel', () => {
     expect(onprojectChange).toHaveBeenCalledWith('foo/bar')
   })
 
+  it('filters alphabetically sorted projects by typed name', async () => {
+    render(TaskFilterPanel, {
+      props: {
+        query: '',
+        onqueryChange: vi.fn(),
+        showProject: true,
+      },
+    })
+    await fireEvent.click(screen.getByTestId('project-filter-button'))
+    const projects = screen.getAllByRole('button', { name: /^(baz\/qux|foo\/bar)$/ })
+    expect(projects.map((project) => project.textContent)).toEqual(['foo/bar', 'baz/qux'])
+
+    await fireEvent.input(screen.getByLabelText('Find project'), { target: { value: 'foo' } })
+    expect(screen.getByText('foo/bar')).toBeDefined()
+    expect(screen.queryByText('baz/qux')).toBeNull()
+  })
+
   it('renders status pills and emits onstatusChange', async () => {
     const onstatusChange = vi.fn()
     render(TaskFilterPanel, {

--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -9,7 +9,6 @@
     searchQuery: string
     selectedProjectId: string
     selectedTags: string[]
-    selectedAgentMode: string
     allTags: string[]
     showDone: boolean
     hasActiveFilters: boolean
@@ -24,7 +23,6 @@
     searchQuery = $bindable(),
     selectedProjectId = $bindable(),
     selectedTags = $bindable(),
-    selectedAgentMode = $bindable(),
     allTags,
     showDone = $bindable(),
     hasActiveFilters,
@@ -33,12 +31,6 @@
     onclear,
     onviewchange,
   }: Props = $props()
-
-  const agentModes = [
-    { value: '', label: 'All' },
-    { value: 'headless', label: 'Headless' },
-    { value: 'interactive', label: 'Interactive' },
-  ]
 
   function pickViewMode(m: ViewMode) {
     viewModeStore.set(m)
@@ -59,20 +51,6 @@
     selectedTags={selectedTags}
     ontagsChange={(tags) => (selectedTags = tags)}
   />
-
-  <div class="flex h-8 rounded-md border border-surface-300 dark:border-surface-700">
-    {#each agentModes as mode}
-      <button
-        type="button"
-        class="px-2.5 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {selectedAgentMode === mode.value
-          ? 'bg-primary-500 text-white dark:bg-primary-600'
-          : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
-        onclick={() => (selectedAgentMode = mode.value)}
-      >
-        {mode.label}
-      </button>
-    {/each}
-  </div>
 
   <div class="ml-auto flex items-center gap-3">
     {#if hasActiveFilters}

--- a/frontend/src/lib/task-filters.test.ts
+++ b/frontend/src/lib/task-filters.test.ts
@@ -3,7 +3,6 @@ import {
   matchesQuery,
   matchesProject,
   matchesTags,
-  matchesAgentMode,
   matchesDateRange,
 } from './task-filters.js'
 import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
@@ -68,16 +67,6 @@ describe('matchesTags', () => {
   })
   it('rejects when task tags missing', () => {
     expect(matchesTags(task({ tags: undefined as unknown as string[] }), ['a'])).toBe(false)
-  })
-})
-
-describe('matchesAgentMode', () => {
-  it('passes empty', () => {
-    expect(matchesAgentMode(task(), '')).toBe(true)
-  })
-  it('matches and rejects', () => {
-    expect(matchesAgentMode(task({ agentMode: 'headless' }), 'headless')).toBe(true)
-    expect(matchesAgentMode(task({ agentMode: 'interactive' }), 'headless')).toBe(false)
   })
 })
 

--- a/frontend/src/lib/task-filters.ts
+++ b/frontend/src/lib/task-filters.ts
@@ -21,11 +21,6 @@ export function matchesTags(task: Task, tags: string[]): boolean {
   return tags.every((tag) => taskTags.includes(tag))
 }
 
-export function matchesAgentMode(task: Task, mode: string): boolean {
-  if (!mode) return true
-  return task.agentMode === mode
-}
-
 export type DateField = 'closedAt' | 'updatedAt' | 'createdAt' | 'dueDate'
 
 export function matchesDateRange(

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -276,11 +276,12 @@
       || a.owner.localeCompare(b.owner, undefined, { sensitivity: 'base' }),
     ),
   )
-  const mobileMatchingProjects = $derived(
-    mobileProjectQuery.trim()
-      ? sortedProjects.filter((p) => `${p.owner}/${p.repo}`.toLowerCase().includes(mobileProjectQuery.trim().toLowerCase()))
-      : sortedProjects,
-  )
+  const mobileMatchingProjects = $derived.by(() => {
+    const query = mobileProjectQuery.trim().toLowerCase()
+    return query
+      ? sortedProjects.filter((p) => `${p.owner}/${p.repo}`.toLowerCase().includes(query))
+      : sortedProjects
+  })
 
   function filteredByStatuses(statuses: string[]): Task[] {
     return taskStore.list.filter((t: Task) => {

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -14,7 +14,7 @@
     type UmbrellaProgress,
   } from '../lib/umbrella-progress.js'
   import { navStore } from '../lib/navigation.svelte.js'
-  import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
+  import { matchesQuery, matchesProject, matchesTags } from '../lib/task-filters.js'
   import TaskTimeline from '../components/TaskTimeline.svelte'
   import StatusPicker from '../components/StatusPicker.svelte'
   import PriorityPicker from '../components/PriorityPicker.svelte'
@@ -96,7 +96,6 @@
       if (!matchesQuery(t, searchQuery)) return false
       if (!matchesProject(t, selectedProjectId)) return false
       if (!matchesTags(t, selectedTags)) return false
-      if (!matchesAgentMode(t, selectedAgentMode)) return false
       return true
     })
   }
@@ -118,7 +117,6 @@
         if (!matchesQuery(t, searchQuery)) return false
         if (!matchesProject(t, selectedProjectId)) return false
         if (!matchesTags(t, selectedTags)) return false
-        if (!matchesAgentMode(t, selectedAgentMode)) return false
         return true
       })
       .sort((a, b) => reviewPhaseRank(a) - reviewPhaseRank(b))
@@ -265,12 +263,23 @@
   // Filter state
   let searchQuery = $state('')
   let selectedProjectId = $state('')
+  let mobileProjectQuery = $state('')
   let selectedTags = $state<string[]>([])
-  let selectedAgentMode = $state('')
   let showDone = $state(false)
   // Derived: unique tags across all tasks
   const allTags = $derived(
     [...new Set(taskStore.list.flatMap((t: Task) => t.tags ?? []))].sort()
+  )
+  const sortedProjects = $derived(
+    [...projectStore.list].sort((a, b) =>
+      a.repo.localeCompare(b.repo, undefined, { sensitivity: 'base' })
+      || a.owner.localeCompare(b.owner, undefined, { sensitivity: 'base' }),
+    ),
+  )
+  const mobileMatchingProjects = $derived(
+    mobileProjectQuery.trim()
+      ? sortedProjects.filter((p) => `${p.owner}/${p.repo}`.toLowerCase().includes(mobileProjectQuery.trim().toLowerCase()))
+      : sortedProjects,
   )
 
   function filteredByStatuses(statuses: string[]): Task[] {
@@ -280,7 +289,6 @@
       if (!matchesQuery(t, searchQuery)) return false
       if (!matchesProject(t, selectedProjectId)) return false
       if (!matchesTags(t, selectedTags)) return false
-      if (!matchesAgentMode(t, selectedAgentMode)) return false
       return true
     })
   }
@@ -305,7 +313,6 @@
       if (!matchesQuery(t, searchQuery)) return false
       if (!matchesProject(t, selectedProjectId)) return false
       if (!matchesTags(t, selectedTags)) return false
-      if (!matchesAgentMode(t, selectedAgentMode)) return false
       return true
     }).sort((a, b) => {
       const statusDiff = (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99)
@@ -324,14 +331,14 @@
   const needYouCount = $derived(allFilteredTasks.filter((t: Task) => activeTaskNeedsUserAttention(t)).length)
 
   const hasActiveFilters = $derived(
-    Boolean(searchQuery) || Boolean(selectedProjectId) || selectedTags.length > 0 || Boolean(selectedAgentMode)
+    Boolean(searchQuery) || Boolean(selectedProjectId) || selectedTags.length > 0
   )
 
   function clearFilters() {
     searchQuery = ''
     selectedProjectId = ''
+    mobileProjectQuery = ''
     selectedTags = []
-    selectedAgentMode = ''
   }
 
   function addTag(tag: string) {
@@ -344,11 +351,6 @@
     selectedTags = selectedTags.filter((t) => t !== tag)
   }
 
-  const agentModes = [
-    { value: '', label: 'All' },
-    { value: 'headless', label: 'Headless' },
-    { value: 'interactive', label: 'Interactive' },
-  ]
 </script>
 
 {#if statusPickerOpen && focusedTask}
@@ -404,7 +406,6 @@
     bind:searchQuery
     bind:selectedProjectId
     bind:selectedTags
-    bind:selectedAgentMode
     bind:showDone
     {allTags}
     {hasActiveFilters}
@@ -472,34 +473,24 @@
     {#if projectStore.list.length > 0}
       <div class="flex flex-col gap-2">
         <span class="text-xs font-semibold uppercase tracking-wider text-surface-500">Project</span>
+        <input
+          bind:value={mobileProjectQuery}
+          type="text"
+          placeholder="Find project..."
+          aria-label="Find project"
+          class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-3 text-base outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-600 dark:bg-surface-700 dark:focus:border-primary-500 dark:focus:ring-primary-500"
+        />
         <select
           bind:value={selectedProjectId}
           class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-3 text-base dark:border-surface-600 dark:bg-surface-700"
         >
           <option value="">All projects</option>
-          {#each projectStore.list as p (p.id)}
+          {#each mobileMatchingProjects as p (p.id)}
             <option value={p.id}>{p.owner}/{p.repo}</option>
           {/each}
         </select>
       </div>
     {/if}
-
-    <div class="flex flex-col gap-2">
-      <span class="text-xs font-semibold uppercase tracking-wider text-surface-500">Agent mode</span>
-      <div class="flex rounded-lg border border-surface-300 dark:border-surface-700">
-        {#each agentModes as mode}
-          <button
-            type="button"
-            class="tap flex-1 px-3 py-2.5 text-sm font-medium transition-colors first:rounded-l-lg last:rounded-r-lg {selectedAgentMode === mode.value
-              ? 'bg-primary-500 text-white dark:bg-primary-600'
-              : 'bg-surface-50 text-surface-600 active:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:active:bg-surface-700'}"
-            onclick={() => (selectedAgentMode = mode.value)}
-          >
-            {mode.label}
-          </button>
-        {/each}
-      </div>
-    </div>
 
     {#if allTags.length > 0}
       <div class="flex flex-col gap-2">

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -282,12 +282,11 @@ describe('TaskList', () => {
     })
   })
 
-  describe('agent mode filter chip', () => {
-    it('renders All, Headless, Interactive buttons', () => {
+  describe('agent mode filter', () => {
+    it('is not rendered', () => {
       render(TaskList, { props: { onselect: vi.fn() } })
-      expect(screen.getByText('All')).toBeDefined()
-      expect(screen.getByText('Headless')).toBeDefined()
-      expect(screen.getByText('Interactive')).toBeDefined()
+      expect(screen.queryByText('Headless')).toBeNull()
+      expect(screen.queryByText('Interactive')).toBeNull()
     })
   })
 
@@ -523,17 +522,6 @@ describe('TaskList', () => {
       await vi.waitFor(() => {
         expect(onfocusedtaskchange).toHaveBeenCalledWith('t-1')
       })
-    })
-  })
-
-  describe('agent mode filter chip rendering', () => {
-    it('renders All button as initially selected with primary styling', () => {
-      render(TaskList, { props: { onselect: vi.fn() } })
-      const allBtn = screen.getByText('All')
-      // All button is the default-selected mode; lives inside the filter bar
-      expect(allBtn).toBeDefined()
-      expect(screen.getByText('Headless')).toBeDefined()
-      expect(screen.getByText('Interactive')).toBeDefined()
     })
   })
 


### PR DESCRIPTION
## Summary
- remove the obsolete headless/interactive task filter
- sort project choices by project name
- add searchable project pickers on desktop and mobile

## Validation
- npm test -- --run src/components/TaskFilterPanel.svelte.test.ts src/pages/TaskList.svelte.test.ts src/lib/task-filters.test.ts
- npm run check
- npm run lint (pre-existing warning in src/stores/agents.svelte.ts)