### PR TITLE
fix(project): scope clone health to checkout refs

### DIFF
--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -192,7 +192,11 @@ func runQuietGit(ctx context.Context, dir string, args ...string) error {
 // bareRefTips lists the object ids every ref points at. They are the roots
 // the scoped fsck walks from.
 func bareRefTips(ctx context.Context, barePath string) ([]string, error) {
-	out, err := outputBare(ctx, barePath, "rev-parse", "--all")
+	// Dispatch only needs refs that can seed a task checkout. Keep this in
+	// lockstep with repairBareCloneLocked: tags and non-origin remotes are
+	// neither fetched nor used as checkout bases, so corruption there must not
+	// wedge every task for the project.
+	out, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(objectname)", "refs/heads", "refs/remotes/origin")
 	if err != nil {
 		return nil, fmt.Errorf("list ref tips: %w", err)
 	}

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -58,7 +58,7 @@ func IsBadRefError(err error) bool {
 const fsckRefBatch = 256
 
 // CheckBareCloneHealth reports whether the object database is intact for
-// everything reachable from refs.
+// refs that can seed a task checkout.
 //
 // It scopes fsck to the ref tips rather than running it bare. An unscoped
 // `git fsck` also walks every linked worktree's index and HEAD reflog, and

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -262,7 +262,10 @@ func repairBareCloneLocked(ctx context.Context, barePath, taskBranch string) (Re
 	releaseDeadWorktreeRefs(ctx, barePath, &report)
 	rebuildWorktreeIndexes(ctx, barePath, &report)
 
-	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes/origin")
+	// Fetch rejects any corrupt ref, including tags and non-origin remotes.
+	// Quarantine only refs Git cannot resolve; valid refs outside checkout scope
+	// are left untouched even though they are not part of the dispatch gate.
+	refsOut, err := outputBare(ctx, barePath, "for-each-ref", "--format=%(refname)")
 	if err != nil {
 		return report, fmt.Errorf("enumerate refs: %w", err)
 	}

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -81,6 +81,9 @@ func TestFetchOrigin_IgnoresPoisonedTagOutsideCheckoutScope(t *testing.T) {
 	if err := CheckBareCloneHealth(context.Background(), bare); err != nil {
 		t.Fatalf("checkout-relevant clone health should ignore poisoned tag: %v", err)
 	}
+	if _, err := outputBare(context.Background(), bare, "rev-parse", "--verify", "refs/tags/unrelated-bad-tag"); err == nil {
+		t.Fatal("poisoned tag should be quarantined so fetch can proceed")
+	}
 }
 
 func TestRepairBareClone_QuarantinesRefsAndWorktreeHead(t *testing.T) {

--- a/internal/project/repair_test.go
+++ b/internal/project/repair_test.go
@@ -67,6 +67,22 @@ func TestFetchOrigin_RepairsPoisonedRemoteRef(t *testing.T) {
 	}
 }
 
+func TestFetchOrigin_IgnoresPoisonedTagOutsideCheckoutScope(t *testing.T) {
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(context.Background(), src, bare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	plantBadRef(t, bare, "refs/tags/unrelated-bad-tag")
+	if err := FetchOrigin(context.Background(), bare); err != nil {
+		t.Fatalf("FetchOrigin should ignore a poisoned tag outside checkout scope, got: %v", err)
+	}
+	if err := CheckBareCloneHealth(context.Background(), bare); err != nil {
+		t.Fatalf("checkout-relevant clone health should ignore poisoned tag: %v", err)
+	}
+}
+
 func TestRepairBareClone_QuarantinesRefsAndWorktreeHead(t *testing.T) {
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")


### PR DESCRIPTION
## Motivation
An unrelated corrupt Git reference must not block task checkout or sandboxed agent dispatch.

## Implementation information
- scope bare-clone health checks to branch refs used for checkout
- retain repair coverage for branch corruption and add a poisoned-tag regression test

> Changelog: Fixed task preparation resilience when unrelated Git metadata is corrupt.