### PR TITLE
fix(workflow): resolve default branch base

### DIFF
--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -240,10 +240,12 @@ func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (Step
 // resolveOriginBase returns the remote ref to use as the base for commit
 // range comparisons. It checks for origin/HEAD (set when the remote HEAD
 // symbolic ref is configured), then falls back to probing master and main.
+// A plain rev-parse accepts a syntactically valid but missing object ID, so
+// each candidate must resolve to a commit before it can be used in a range.
 // Returns "origin/main" if nothing resolves.
 func resolveOriginBase(ctx context.Context, wtPath string) string {
 	for _, candidate := range []string{"origin/HEAD", "origin/master", "origin/main"} {
-		if gitOK(ctx, wtPath, "rev-parse", "--verify", candidate) {
+		if gitOK(ctx, wtPath, "rev-parse", "--verify", candidate+"^{commit}") {
 			return candidate
 		}
 	}

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -238,18 +239,34 @@ func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (Step
 }
 
 // resolveOriginBase returns the remote ref to use as the base for commit
-// range comparisons. It checks for origin/HEAD (set when the remote HEAD
-// symbolic ref is configured), then falls back to probing master and main.
-// A plain rev-parse accepts a syntactically valid but missing object ID, so
-// each candidate must resolve to a commit before it can be used in a range.
+// range comparisons. It first resolves the linked repository's default branch,
+// then checks origin/HEAD, followed by compatibility fallbacks. A plain
+// rev-parse accepts a syntactically valid but missing object ID, so each
+// candidate must resolve to a commit before it can be used in a range.
 // Returns "origin/main" if nothing resolves.
 func resolveOriginBase(ctx context.Context, wtPath string) string {
-	for _, candidate := range []string{"origin/HEAD", "origin/master", "origin/main"} {
+	candidates := originBaseCandidates(ctx, wtPath)
+	for _, candidate := range candidates {
 		if gitOK(ctx, wtPath, "rev-parse", "--verify", candidate+"^{commit}") {
 			return candidate
 		}
 	}
 	return "origin/main"
+}
+
+func originBaseCandidates(ctx context.Context, wtPath string) []string {
+	candidates := make([]string, 0, 4)
+	if commonDir, err := gitStdout(ctx, wtPath, "rev-parse", "--git-common-dir"); err == nil && commonDir != "" {
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(wtPath, commonDir)
+		}
+		if bare, err := gitStdout(ctx, commonDir, "rev-parse", "--is-bare-repository"); err == nil && bare == "true" {
+			if branch, err := gitStdout(ctx, commonDir, "symbolic-ref", "--short", "HEAD"); err == nil && branch != "" {
+				candidates = append(candidates, "origin/"+branch)
+			}
+		}
+	}
+	return append(candidates, "origin/HEAD", "origin/master", "origin/main")
 }
 
 func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -9115,6 +9115,41 @@ func TestResolveOriginBase_FallsBackFromDanglingOriginHEAD(t *testing.T) {
 	}
 }
 
+func TestResolveOriginBase_UsesLinkedRepositoryDefaultBranch(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	runGitAt(t, "", "init", "--bare", remote)
+	seed := filepath.Join(t.TempDir(), "seed")
+	if err := os.MkdirAll(seed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, seed, "init", "-b", "trunk")
+	runGitAt(t, seed, "config", "user.email", "test@test.com")
+	runGitAt(t, seed, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("init\\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, seed, "add", "README.md")
+	runGitAt(t, seed, "commit", "-m", "init")
+	runGitAt(t, seed, "remote", "add", "origin", remote)
+	runGitAt(t, seed, "push", "origin", "trunk")
+
+	// Sybra worktrees are linked to a bare clone. Its HEAD, unlike a normal
+	// checkout's HEAD, identifies the default branch for all linked worktrees.
+	runGitAt(t, "", "-C", remote, "symbolic-ref", "HEAD", "refs/heads/trunk")
+	runGitAt(t, "", "-C", remote, "update-ref", "refs/remotes/origin/trunk", "refs/heads/trunk")
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+	runGitAt(t, "", "-C", remote, "worktree", "add", wtPath, "trunk")
+
+	refPath := filepath.Join(remote, "refs", "remotes", "origin", "HEAD")
+	if err := os.WriteFile(refPath, []byte(strings.Repeat("f", 40)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveOriginBase(context.Background(), wtPath); got != "origin/trunk" {
+		t.Fatalf("resolveOriginBase() = %q, want origin/trunk from linked repository HEAD", got)
+	}
+}
+
 func runGitAt(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	out, err := gitCombinedAt(dir, args...)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -9100,6 +9100,21 @@ func makeGitRepo(t *testing.T, withExtraCommit bool) string {
 	return dir
 }
 
+func TestResolveOriginBase_FallsBackFromDanglingOriginHEAD(t *testing.T) {
+	wtPath := makeGitRepo(t, false)
+	refPath := filepath.Join(wtPath, ".git", "refs", "remotes", "origin", "HEAD")
+	if err := os.MkdirAll(filepath.Dir(refPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(refPath, []byte(strings.Repeat("f", 40)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveOriginBase(context.Background(), wtPath); got != "origin/main" {
+		t.Fatalf("resolveOriginBase() = %q, want origin/main when origin/HEAD is dangling", got)
+	}
+}
+
 func runGitAt(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	out, err := gitCombinedAt(dir, args...)


### PR DESCRIPTION
## Motivation

Task verification must not be blocked when remote HEAD metadata is missing or stale.

## Implementation

- resolve the commit-comparison base from the linked repository default branch
- validate candidates as commits before using them
- add coverage for dangling remote HEAD and non-main default branches

> Changelog: Fixed worktree verification when remote HEAD metadata is stale.