### PR TITLE
fix(review): coalesce branch conflict recovery

### DIFF
--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1409,11 +1409,11 @@ func (r *Handler) prFixParkedOnConflict(taskID string) bool {
 // success resumes the task's original interrupted workflow/stage rather than
 // jumping to a terminal status.
 //
-// Guards fail closed exactly like the PR-numbered path: a missing dependency,
-// an exhausted no-PR branch-conflict retry budget, or an already-in-flight
-// recovery for this task
-// (branchRecoveryMu/branchRecoveryInFlight) all return false so the caller
-// (agentorch.MarkRebaseBlocked helper) escalates to human-required as before. Never loops:
+// Guards fail closed exactly like the PR-numbered path: missing dependencies
+// and exhausted no-PR branch-conflict retry budgets return false so the caller
+// (agentorch.MarkRebaseBlocked helper) escalates to human-required. An
+// already-in-flight recovery is treated as handled, so a concurrent caller
+// cannot cancel the workflow the first caller is preparing. Never loops:
 // a conflict discovered while resolving THIS conflict re-enters
 // agentorch.MarkRebaseBlocked -> RecoverStaleBranchConflict -> here, and the in-flight
 // marker (still held from the outer call, since this method runs
@@ -1488,7 +1488,12 @@ func (r *Handler) recoverTaskBranchConflict(ctx context.Context, t task.Task, sp
 	}
 	if _, busy := r.branchRecoveryInFlight[taskID]; busy {
 		r.branchRecoveryMu.Unlock()
-		return false
+		// Another caller is already preparing or dispatching the bounded
+		// recovery for this task. Treat that as handled: callers interpret
+		// false as "escalate to human-required", which would otherwise cancel
+		// the recovery workflow the first caller has just started. The owner
+		// of the in-flight attempt still reports its own real failure.
+		return true
 	}
 	r.branchRecoveryInFlight[taskID] = struct{}{}
 	r.branchRecoveryMu.Unlock()

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -771,19 +771,20 @@ func TestRecoverBranchConflictNoPR_MissingBranchEscalates(t *testing.T) {
 }
 
 // TestRecoverBranchConflictNoPR_InFlightGuardPreventsDoubleDispatch verifies
-// that a second recovery attempt for a task already mid-recovery bails out
-// instead of starting a duplicate worktree prep / workflow dispatch.
+// that a second recovery attempt for a task already mid-recovery treats the
+// existing attempt as handled instead of starting a duplicate worktree prep /
+// workflow dispatch or escalating the task to human-required.
 func TestRecoverBranchConflictNoPR_InFlightGuardPreventsDoubleDispatch(t *testing.T) {
 	r, tk := setupBranchConflictNoPRHandler(t, task.StatusInProgress, nil)
 	r.branchRecoveryMu.Lock()
 	r.branchRecoveryInFlight = map[string]struct{}{tk.ID: {}}
 	r.branchRecoveryMu.Unlock()
 
-	if r.RecoverStaleBranchConflict(tk.ID) {
-		t.Fatal("RecoverStaleBranchConflict returned true while a recovery was already marked in-flight")
+	if !r.RecoverStaleBranchConflict(tk.ID) {
+		t.Fatal("RecoverStaleBranchConflict returned false while a recovery was already marked in-flight")
 	}
 	if r.prTracker.Retries(tk.ID, github.PRIssueBranchConflictNoPR) != 0 {
-		t.Fatal("branch-conflict retry budget was marked handled despite the in-flight guard rejecting the attempt")
+		t.Fatal("branch-conflict retry budget was marked handled despite the in-flight guard coalescing the attempt")
 	}
 }
 

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -240,10 +240,12 @@ func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (Step
 // resolveOriginBase returns the remote ref to use as the base for commit
 // range comparisons. It checks for origin/HEAD (set when the remote HEAD
 // symbolic ref is configured), then falls back to probing master and main.
+// A plain rev-parse accepts a syntactically valid but missing object ID, so
+// each candidate must resolve to a commit before it can be used in a range.
 // Returns "origin/main" if nothing resolves.
 func resolveOriginBase(ctx context.Context, wtPath string) string {
 	for _, candidate := range []string{"origin/HEAD", "origin/master", "origin/main"} {
-		if gitOK(ctx, wtPath, "rev-parse", "--verify", candidate) {
+		if gitOK(ctx, wtPath, "rev-parse", "--verify", candidate+"^{commit}") {
 			return candidate
 		}
 	}

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -238,18 +239,34 @@ func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (Step
 }
 
 // resolveOriginBase returns the remote ref to use as the base for commit
-// range comparisons. It checks for origin/HEAD (set when the remote HEAD
-// symbolic ref is configured), then falls back to probing master and main.
-// A plain rev-parse accepts a syntactically valid but missing object ID, so
-// each candidate must resolve to a commit before it can be used in a range.
+// range comparisons. It first resolves the linked repository's default branch,
+// then checks origin/HEAD, followed by compatibility fallbacks. A plain
+// rev-parse accepts a syntactically valid but missing object ID, so each
+// candidate must resolve to a commit before it can be used in a range.
 // Returns "origin/main" if nothing resolves.
 func resolveOriginBase(ctx context.Context, wtPath string) string {
-	for _, candidate := range []string{"origin/HEAD", "origin/master", "origin/main"} {
+	candidates := originBaseCandidates(ctx, wtPath)
+	for _, candidate := range candidates {
 		if gitOK(ctx, wtPath, "rev-parse", "--verify", candidate+"^{commit}") {
 			return candidate
 		}
 	}
 	return "origin/main"
+}
+
+func originBaseCandidates(ctx context.Context, wtPath string) []string {
+	candidates := make([]string, 0, 4)
+	if commonDir, err := gitStdout(ctx, wtPath, "rev-parse", "--git-common-dir"); err == nil && commonDir != "" {
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(wtPath, commonDir)
+		}
+		if bare, err := gitStdout(ctx, commonDir, "rev-parse", "--is-bare-repository"); err == nil && bare == "true" {
+			if branch, err := gitStdout(ctx, commonDir, "symbolic-ref", "--short", "HEAD"); err == nil && branch != "" {
+				candidates = append(candidates, "origin/"+branch)
+			}
+		}
+	}
+	return append(candidates, "origin/HEAD", "origin/master", "origin/main")
 }
 
 func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -9115,6 +9115,41 @@ func TestResolveOriginBase_FallsBackFromDanglingOriginHEAD(t *testing.T) {
 	}
 }
 
+func TestResolveOriginBase_UsesLinkedRepositoryDefaultBranch(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "origin.git")
+	runGitAt(t, "", "init", "--bare", remote)
+	seed := filepath.Join(t.TempDir(), "seed")
+	if err := os.MkdirAll(seed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, seed, "init", "-b", "trunk")
+	runGitAt(t, seed, "config", "user.email", "test@test.com")
+	runGitAt(t, seed, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("init\\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, seed, "add", "README.md")
+	runGitAt(t, seed, "commit", "-m", "init")
+	runGitAt(t, seed, "remote", "add", "origin", remote)
+	runGitAt(t, seed, "push", "origin", "trunk")
+
+	// Sybra worktrees are linked to a bare clone. Its HEAD, unlike a normal
+	// checkout's HEAD, identifies the default branch for all linked worktrees.
+	runGitAt(t, "", "-C", remote, "symbolic-ref", "HEAD", "refs/heads/trunk")
+	runGitAt(t, "", "-C", remote, "update-ref", "refs/remotes/origin/trunk", "refs/heads/trunk")
+	wtPath := filepath.Join(t.TempDir(), "worktree")
+	runGitAt(t, "", "-C", remote, "worktree", "add", wtPath, "trunk")
+
+	refPath := filepath.Join(remote, "refs", "remotes", "origin", "HEAD")
+	if err := os.WriteFile(refPath, []byte(strings.Repeat("f", 40)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveOriginBase(context.Background(), wtPath); got != "origin/trunk" {
+		t.Fatalf("resolveOriginBase() = %q, want origin/trunk from linked repository HEAD", got)
+	}
+}
+
 func runGitAt(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	out, err := gitCombinedAt(dir, args...)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -9100,6 +9100,21 @@ func makeGitRepo(t *testing.T, withExtraCommit bool) string {
 	return dir
 }
 
+func TestResolveOriginBase_FallsBackFromDanglingOriginHEAD(t *testing.T) {
+	wtPath := makeGitRepo(t, false)
+	refPath := filepath.Join(wtPath, ".git", "refs", "remotes", "origin", "HEAD")
+	if err := os.MkdirAll(filepath.Dir(refPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(refPath, []byte(strings.Repeat("f", 40)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveOriginBase(context.Background(), wtPath); got != "origin/main" {
+		t.Fatalf("resolveOriginBase() = %q, want origin/main when origin/HEAD is dangling", got)
+	}
+}
+
 func runGitAt(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	out, err := gitCombinedAt(dir, args...)


### PR DESCRIPTION
## Summary
- keep an in-flight branch-conflict recovery authoritative
- prevent concurrent recovery callers from parking the task as human-required
- cover the coalescing contract with a regression test

## Verification
- `go test ./internal/sybra/review -count=1`
- focused recovery-dispatch tests
- `git diff --check`