### PR TITLE
fix(test): isolate queue-drain pool contention

### DIFF
--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -100,9 +100,11 @@ func setupManualQueueApp(t *testing.T, taskDir, queueDir string, maxConcurrent i
 	fakebin := t.TempDir()
 	fakeClaude := filepath.Join(fakebin, "claude")
 	if err := os.WriteFile(fakeClaude, []byte("#!/usr/bin/env bash\n"+
-		"trap 'exit 0' TERM INT\n"+
 		"printf '{\"type\":\"system\",\"session_id\":\"fake-session\"}\\n'\n"+
-		"sleep 5\n"+
+		"sleep 5 &\n"+
+		"child=$!\n"+
+		"trap 'kill \"$child\" 2>/dev/null; wait \"$child\" 2>/dev/null; exit 0' TERM INT\n"+
+		"wait \"$child\"\n"+
 		"printf '{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"fake-session\",\"result\":\"done\",\"total_cost_usd\":0.01,\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\\n'\n"),
 		0o755); err != nil {
 		t.Fatalf("write fake claude: %v", err)

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -100,10 +100,11 @@ func setupManualQueueApp(t *testing.T, taskDir, queueDir string, maxConcurrent i
 	fakebin := t.TempDir()
 	fakeClaude := filepath.Join(fakebin, "claude")
 	if err := os.WriteFile(fakeClaude, []byte("#!/usr/bin/env bash\n"+
-		"printf '{\"type\":\"system\",\"session_id\":\"fake-session\"}\\n'\n"+
+		"child=''\n"+
+		"trap 'test -z \"$child\" || { kill \"$child\" 2>/dev/null; wait \"$child\" 2>/dev/null; }; exit 0' TERM INT\n"+
 		"sleep 5 &\n"+
 		"child=$!\n"+
-		"trap 'kill \"$child\" 2>/dev/null; wait \"$child\" 2>/dev/null; exit 0' TERM INT\n"+
+		"printf '{\"type\":\"system\",\"session_id\":\"fake-session\"}\\n'\n"+
 		"wait \"$child\"\n"+
 		"printf '{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"fake-session\",\"result\":\"done\",\"total_cost_usd\":0.01,\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\\n'\n"),
 		0o755); err != nil {


### PR DESCRIPTION
## Motivation

Prevent the queue-drain test fixture from retaining an agent-pool slot after it is stopped, which made unrelated task verification nondeterministic under load.

## Implementation

- make the fake provider's sleeping child interruptible
- install child cleanup before reporting readiness
- retain the existing queue-drain behavior while ensuring `StopAgent` releases capacity promptly

## Verification

- `go test ./internal/sybra -run '^TestQueueDrainPassDrainsManualStartsForEveryRole$' -count=30`
- adversarial: `go test -count=100 -run '^TestQueueDrainPassDrainsManualStartsForEveryRole$' -timeout 3m ./internal/sybra`
- adversarial: `go test -race -count=30 -run '^TestQueueDrainPassDrainsManualStartsForEveryRole$' -timeout 3m ./internal/sybra`

Closes #2997

> [!NOTE]
> Changelog: Stabilize queue-drain verification by cleaning up its fake provider child process immediately when stopped.