### PR TITLE
fix(review): publish recovered PR branches safely

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1562,7 +1562,11 @@ func RemoteURL(ctx context.Context, worktreePath, remote string) (string, error)
 	if err != nil {
 		return "", fmt.Errorf("resolve remote %s URL: %w", remote, err)
 	}
-	return strings.TrimSpace(remoteURL), nil
+	remoteURL = strings.TrimSpace(remoteURL)
+	if parsed, parseErr := url.Parse(remoteURL); parseErr == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.User != nil {
+		return "", fmt.Errorf("remote %s URL must not contain HTTP userinfo", remote)
+	}
+	return remoteURL, nil
 }
 
 // PushSyncToPinnedRemote synchronizes branch to a pre-validated source remote

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1023,6 +1023,22 @@ func RemoteConfigured(ctx context.Context, repoPath, remote string) bool {
 // so the error message itself documents the policy.
 const forkOnlyDisabledPushURL = "sybra-disabled-do-not-push-to-upstream-use-fork"
 
+// OriginPushHasForkOnlyGuard reports whether origin's push URL is the exact
+// sentinel owned by EnforceForkOnlyPush. Foreign user-configured push URLs are
+// intentionally not treated as Sybra's guard and must retain normal Git push
+// behavior.
+func OriginPushHasForkOnlyGuard(ctx context.Context, worktreePath string) (bool, error) {
+	pushURL, err := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote.origin.pushurl")
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(pushURL) == forkOnlyDisabledPushURL, nil
+}
+
 // EnforceForkOnlyPush configures a worktree so pushes never reach origin
 // when a "fork" remote exists. It overrides remote.origin.pushurl with a
 // deliberately invalid value; git push fails before any network call, which
@@ -1537,6 +1553,36 @@ func worktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
 //
 // Returns ErrBranchMissing if the local branch ref does not exist.
 func PushSync(ctx context.Context, worktreePath, branch string) error {
+	return pushSyncToRemote(ctx, worktreePath, branch, PushRemote(ctx, worktreePath), "")
+}
+
+// RemoteURL returns a configured remote's fetch URL.
+func RemoteURL(ctx context.Context, worktreePath, remote string) (string, error) {
+	url, err := executil.Output(ctx, worktreePath, "git", "remote", "get-url", remote)
+	if err != nil {
+		return "", fmt.Errorf("resolve remote %s URL: %w", remote, err)
+	}
+	return strings.TrimSpace(url), nil
+}
+
+// PushSyncToPinnedRemote synchronizes branch to a pre-validated source remote
+// URL without force-pushing. It is the narrow trusted Sybra workflow path for
+// publishing a same-repository PR recovery despite EnforceForkOnlyPush's
+// origin push-url sentinel. The remote must still resolve to expectedURL when
+// this runs, so an agent cannot redirect the host-credential push by editing
+// the worktree's Git configuration during its recovery run.
+func PushSyncToPinnedRemote(ctx context.Context, worktreePath, branch, remote, expectedURL string) error {
+	currentURL, err := RemoteURL(ctx, worktreePath, remote)
+	if err != nil {
+		return err
+	}
+	if expectedURL == "" || currentURL != expectedURL {
+		return fmt.Errorf("push remote %q URL changed during recovery", remote)
+	}
+	return pushSyncToRemote(ctx, worktreePath, branch, remote, expectedURL)
+}
+
+func pushSyncToRemote(ctx context.Context, worktreePath, branch, remote, pinnedPushURL string) error {
 	if err := executil.Run(ctx, worktreePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
@@ -1545,7 +1591,9 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 		return err
 	}
 
-	remote := PushRemote(ctx, worktreePath)
+	if !RemoteConfigured(ctx, worktreePath, remote) {
+		return fmt.Errorf("push remote %q is not configured", remote)
+	}
 	localSHA, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "refs/heads/"+branch)
 	if err != nil {
 		return err
@@ -1565,7 +1613,7 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 	remoteSHA, remoteOK := remoteTrackingRef(ctx, worktreePath, remote, branch)
 	if !remoteOK {
 		// Remote tracking ref unknown — first push, set upstream.
-		return pushLocked(ctx, worktreePath, "push", "-u", remote, branch)
+		return pushBranchToRemote(ctx, worktreePath, remote, branch, pinnedPushURL)
 	}
 	remoteAdvanced := beforeRefreshOK && beforeRefreshSHA != remoteSHA
 
@@ -1575,7 +1623,7 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 
 	// Fast-forward when remote SHA is reachable from local SHA.
 	if isAncestor(ctx, worktreePath, remoteSHA, localSHA) {
-		return pushLocked(ctx, worktreePath, "push", "-u", remote, branch)
+		return pushBranchToRemote(ctx, worktreePath, remote, branch, pinnedPushURL)
 	}
 
 	// Divergence path: never force-push. remoteSHA reflects the freshly
@@ -1586,6 +1634,14 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 		return fmt.Errorf("%w: %w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, ErrRemoteAdvanced, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
 	}
 	return fmt.Errorf("%w: local %s vs remote %s/%s %s diverged", ErrDivergedNeedsResolve, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
+}
+
+func pushBranchToRemote(ctx context.Context, worktreePath, remote, branch, pinnedPushURL string) error {
+	if pinnedPushURL == "" {
+		return pushLocked(ctx, worktreePath, "push", "-u", remote, branch)
+	}
+	refspec := "refs/heads/" + branch + ":refs/heads/" + branch
+	return pushLocked(ctx, worktreePath, "push", pinnedPushURL, refspec)
 }
 
 // pushPreflightRetryBackoffs bounds retries for a push-credential preflight

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1558,11 +1558,11 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 
 // RemoteURL returns a configured remote's fetch URL.
 func RemoteURL(ctx context.Context, worktreePath, remote string) (string, error) {
-	url, err := executil.Output(ctx, worktreePath, "git", "remote", "get-url", remote)
+	remoteURL, err := executil.Output(ctx, worktreePath, "git", "remote", "get-url", remote)
 	if err != nil {
 		return "", fmt.Errorf("resolve remote %s URL: %w", remote, err)
 	}
-	return strings.TrimSpace(url), nil
+	return strings.TrimSpace(remoteURL), nil
 }
 
 // PushSyncToPinnedRemote synchronizes branch to a pre-validated source remote

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -2620,6 +2620,92 @@ func TestPushSync_FirstPushSetsTracking(t *testing.T) {
 	}
 }
 
+// A fork-only setup deliberately replaces origin's push URL with a sentinel so
+// an agent cannot accidentally publish to the upstream repository. Recovery
+// of a same-repository PR is the narrow trusted exception: it must still be
+// able to publish the reconciled, non-force merge to the PR's source remote.
+func TestPushSyncToPinnedRemote_PublishesDespiteForkOnlyOriginSentinel(t *testing.T) {
+	t.Parallel()
+
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	localSHA := makeCommit(t, wtPath, "trusted-recovery")
+	if out, err := exec.Command("git", "-C", wtPath, "config", "remote.origin.pushurl", "sybra-disabled-do-not-push-to-upstream-use-fork").CombinedOutput(); err != nil {
+		t.Fatalf("install origin push sentinel: %v: %s", err, out)
+	}
+
+	if err := PushSync(context.Background(), wtPath, branch); err == nil {
+		t.Fatal("PushSync unexpectedly bypassed origin's fork-only push sentinel")
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != "" {
+		t.Fatalf("origin changed through sentinel: got %q", got)
+	}
+
+	if err := PushSyncToPinnedRemote(context.Background(), wtPath, branch, "origin", remoteBare); err != nil {
+		t.Fatalf("trusted PushSyncToPinnedRemote: %v", err)
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != localSHA {
+		t.Fatalf("trusted push SHA = %q, want %q", got, localSHA)
+	}
+}
+
+func TestPushSyncToPinnedRemote_RejectsChangedRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "trusted-recovery")
+	redirectBare := filepath.Join(t.TempDir(), "redirect.git")
+	if out, err := exec.Command("git", "init", "--bare", redirectBare).CombinedOutput(); err != nil {
+		t.Fatalf("init redirect bare: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "remote", "set-url", "origin", redirectBare).CombinedOutput(); err != nil {
+		t.Fatalf("redirect origin: %v: %s", err, out)
+	}
+
+	err := PushSyncToPinnedRemote(context.Background(), wtPath, branch, "origin", remoteBare)
+	if err == nil || !strings.Contains(err.Error(), "URL changed") {
+		t.Fatalf("PushSyncToPinnedRemote = %v, want changed URL rejection", err)
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != "" {
+		t.Fatalf("original remote changed after URL rejection: %q", got)
+	}
+	if got := remoteRefSHA(t, redirectBare, branch); got != "" {
+		t.Fatalf("redirect remote changed after URL rejection: %q", got)
+	}
+}
+
+func TestOriginPushHasForkOnlyGuard_OnlyMatchesSybraSentinel(t *testing.T) {
+	t.Parallel()
+
+	_, wtPath, _ := setupPushSyncWorktree(t)
+	for _, tc := range []struct {
+		name    string
+		pushURL string
+		want    bool
+	}{
+		{name: "no push URL", want: false},
+		{name: "foreign push URL", pushURL: "ssh://example.invalid/writable.git", want: false},
+		{name: "sybra sentinel", pushURL: forkOnlyDisabledPushURL, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Exit status 5 means the key was absent, which is exactly the
+			// starting state required by the first table case.
+			_ = exec.Command("git", "-C", wtPath, "config", "--unset-all", "remote.origin.pushurl").Run()
+			if tc.pushURL != "" {
+				if out, err := exec.Command("git", "-C", wtPath, "config", "remote.origin.pushurl", tc.pushURL).CombinedOutput(); err != nil {
+					t.Fatalf("set pushurl: %v: %s", err, out)
+				}
+			}
+			got, err := OriginPushHasForkOnlyGuard(context.Background(), wtPath)
+			if err != nil {
+				t.Fatalf("OriginPushHasForkOnlyGuard: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("OriginPushHasForkOnlyGuard = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPushSync_NoopWhenSynced(t *testing.T) {
 	t.Parallel()
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)

--- a/internal/sybra/review/autoresolve_test.go
+++ b/internal/sybra/review/autoresolve_test.go
@@ -558,8 +558,11 @@ func TestPrepareWorktree_SameBranchConflictUsesForkRemote(t *testing.T) {
 	if strings.Contains(prompt, "git merge refs/remotes/origin/"+h.branch) {
 		t.Fatalf("prompt merges origin instead of fork:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "PUSH_REMOTE=fork") {
-		t.Fatalf("prompt does not push fork-backed PR to fork:\n%s", prompt)
+	if got.Workflow.Variables[workflow.WorkflowVarBranchConflictPushRemote] != "" || got.Workflow.Variables[workflow.WorkflowVarBranchConflictPushURL] != "" {
+		t.Fatalf("fork recovery unexpectedly received trusted origin push variables: %+v", got.Workflow.Variables)
+	}
+	if strings.Contains(prompt, "git push ") {
+		t.Fatalf("prompt still permits fork-backed recovery agent to push:\n%s", prompt)
 	}
 }
 
@@ -648,8 +651,14 @@ func TestPrepareWorktree_SameBranchConflictKeepsOriginBackedPR(t *testing.T) {
 	if strings.Contains(prompt, "refs/remotes/fork/"+h.branch) {
 		t.Fatalf("prompt uses stale fork branch for origin-backed PR:\n%s", prompt)
 	}
-	if strings.Contains(prompt, "PUSH_REMOTE=fork") {
-		t.Fatalf("prompt pushes origin-backed PR to fork:\n%s", prompt)
+	if got.Workflow.Variables[workflow.WorkflowVarBranchConflictPushRemote] != "origin" {
+		t.Fatalf("trusted recovery push remote = %q, want origin", got.Workflow.Variables[workflow.WorkflowVarBranchConflictPushRemote])
+	}
+	if got.Workflow.Variables[workflow.WorkflowVarBranchConflictPushURL] == "" {
+		t.Fatal("origin-backed recovery did not pin its source URL before agent dispatch")
+	}
+	if strings.Contains(prompt, "git push ") {
+		t.Fatalf("prompt still permits origin-backed recovery agent to push:\n%s", prompt)
 	}
 }
 

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -69,6 +69,7 @@ type taskBranchConflictRecoverySpec struct {
 	retryKind      github.PRIssueKind
 	branchOverride string
 	remoteOverride string
+	trustedOrigin  bool
 	allowRecreate  bool
 	prompt         func(context.Context, task.Task, string) string
 }
@@ -79,7 +80,7 @@ type dispatchFixOptions struct {
 }
 
 const PRFixResultContract = "\n\nBefore your final response, decide the outcome:\n" +
-	"- If you completed and pushed the fix, end with `SYBRA_PR_FIX_RESULT: continue`.\n" +
+	"- If you completed the fix, end with `SYBRA_PR_FIX_RESULT: continue`.\n" +
 	"- If this PR's diff is correct and CI failed for reasons unrelated to it — a " +
 	"flaky test, an infrastructure failure, or a breakage that reproduces on the " +
 	"base branch — end with `SYBRA_PR_FIX_RESULT: flake` and `SYBRA_PR_FIX_REASON: " +
@@ -1427,7 +1428,7 @@ func (r *Handler) recoverBranchConflictNoPR(t task.Task) bool {
 	})
 }
 
-func (r *Handler) recoverSameBranchConflict(ctx context.Context, t task.Task, branch, remote string) bool {
+func (r *Handler) recoverSameBranchConflict(ctx context.Context, t task.Task, branch, remote string, trustedOrigin bool) bool {
 	if remote == "" {
 		remote = "origin"
 	}
@@ -1435,13 +1436,14 @@ func (r *Handler) recoverSameBranchConflict(ctx context.Context, t task.Task, br
 		retryKind:      sameBranchConflictRetryKind,
 		branchOverride: branch,
 		remoteOverride: remote,
+		trustedOrigin:  trustedOrigin && remote == "origin",
 		prompt: func(ctx context.Context, t task.Task, _ string) string {
 			return sameBranchConflictPrompt(ctx, t, remote)
 		},
 	})
 }
 
-func (r *Handler) sameBranchConflictRemote(ctx context.Context, t task.Task, pr github.PullRequest) string {
+func (r *Handler) sameBranchConflictRemote(ctx context.Context, t task.Task, pr github.PullRequest) (remote string, trustedOrigin bool) {
 	baseOwner := ""
 	if pr.Repository != "" {
 		baseOwner, _, _ = strings.Cut(pr.Repository, "/")
@@ -1449,17 +1451,17 @@ func (r *Handler) sameBranchConflictRemote(ctx context.Context, t task.Task, pr 
 	if baseOwner == "" && t.ProjectID != "" {
 		baseOwner, _, _ = strings.Cut(t.ProjectID, "/")
 	}
-	if pr.HeadRepoOwner == "" || strings.EqualFold(pr.HeadRepoOwner, baseOwner) {
-		return "origin"
+	if pr.HeadRepoOwner != "" && baseOwner != "" && strings.EqualFold(pr.HeadRepoOwner, baseOwner) {
+		return "origin", true
 	}
 	if r.projects == nil || t.ProjectID == "" {
-		return "origin"
+		return "origin", false
 	}
 	proj, err := r.projects.Get(t.ProjectID)
 	if err != nil || proj.ClonePath == "" {
-		return "origin"
+		return "origin", false
 	}
-	return project.PushRemote(ctx, proj.ClonePath)
+	return project.PushRemote(ctx, proj.ClonePath), false
 }
 
 func (r *Handler) recoverTaskBranchConflict(ctx context.Context, t task.Task, spec taskBranchConflictRecoverySpec) bool {
@@ -1543,7 +1545,23 @@ func (r *Handler) recoverTaskBranchConflict(ctx context.Context, t task.Task, sp
 	if shaErr != nil {
 		r.logger.Warn("pr-monitor.branch-conflict.head-sha", "task_id", taskID, "err", shaErr)
 	}
-	return r.dispatchBranchConflictRecovery(ctx, taskID, dir, spec.prompt(ctx, t, base), t, headSHA, resume, hadActiveWorkflow, spec.retryKind)
+	trustedPushURL := ""
+	if spec.trustedOrigin {
+		hasGuard, guardErr := project.OriginPushHasForkOnlyGuard(ctx, dir)
+		if guardErr != nil {
+			r.logger.Warn("pr-monitor.branch-conflict.origin-push-guard", "task_id", taskID, "err", guardErr)
+			return false
+		}
+		if hasGuard {
+			var urlErr error
+			trustedPushURL, urlErr = project.RemoteURL(ctx, dir, "origin")
+			if urlErr != nil || trustedPushURL == "" {
+				r.logger.Warn("pr-monitor.branch-conflict.origin-url", "task_id", taskID, "err", urlErr)
+				return false
+			}
+		}
+	}
+	return r.dispatchBranchConflictRecoveryToRemote(ctx, taskID, dir, spec.prompt(ctx, t, base), t, headSHA, resume, hadActiveWorkflow, spec.retryKind, trustedPushURL)
 }
 
 func (r *Handler) recreateExhaustedNoPRBranch(ctx context.Context, t task.Task) bool {
@@ -1656,11 +1674,19 @@ func (r *Handler) recoverRetryablePRFixDispatch(taskID string, startErr error) b
 // what avoids a guaranteed reentrant "start in progress" failure there (see
 // workflow.Engine.ReplaceWorkflow's doc).
 func (r *Handler) dispatchBranchConflictRecovery(ctx context.Context, taskID, dir, prompt string, t task.Task, headSHA string, resume branchConflictResumeState, hadActiveWorkflow bool, retryKind github.PRIssueKind) bool {
+	return r.dispatchBranchConflictRecoveryToRemote(ctx, taskID, dir, prompt, t, headSHA, resume, hadActiveWorkflow, retryKind, "")
+}
+
+func (r *Handler) dispatchBranchConflictRecoveryToRemote(ctx context.Context, taskID, dir, prompt string, t task.Task, headSHA string, resume branchConflictResumeState, hadActiveWorkflow bool, retryKind github.PRIssueKind, trustedPushURL string) bool {
 	vars := map[string]string{
 		"prompt":                prompt + PRFixResultContract,
 		workflow.WorkflowVarDir: dir,
 		"resume_status":         resume.status,
 		"resume_status_reason":  resume.statusReason,
+	}
+	if trustedPushURL != "" {
+		vars[workflow.WorkflowVarBranchConflictPushRemote] = "origin"
+		vars[workflow.WorkflowVarBranchConflictPushURL] = trustedPushURL
 	}
 	if resume.workflowID != "" {
 		vars["resume_workflow_id"] = resume.workflowID
@@ -2019,10 +2045,9 @@ func sameBranchConflictPrompt(ctx context.Context, t task.Task, remote string) s
 			"# If the merge already completed on its own (clean/no-op), do not run git\n"+
 			"# commit again.\n"+
 			"# Do NOT rebase, amend, or force-push: this branch already backs a live PR.\n"+
-			"%s\n"+
 			"```\n\n"+
-			"After pushing, summarize what conflicted and how you resolved it.",
-		branch, prCtx, remote, branch, remote, branch, remote, branch, project.CommitSignFlags(ctx), prFixPushPromptWithRemote(branch, "", false, false, remote),
+			"Do not push: Sybra will verify and publish this completed merge through its trusted, non-force workflow step. Summarize what conflicted and how you resolved it.",
+		branch, prCtx, remote, branch, remote, branch, remote, branch, project.CommitSignFlags(ctx),
 	)
 }
 
@@ -2057,8 +2082,8 @@ func (r *Handler) prepareWorktree(ctx context.Context, t task.Task, issue github
 			return "", false
 		}
 		if errors.Is(wtErr, project.ErrBranchDiverged) {
-			remote := r.sameBranchConflictRemote(ctx, t, issue.PR)
-			if r.recoverSameBranchConflict(ctx, t, issue.PR.HeadRefName, remote) {
+			remote, trustedOrigin := r.sameBranchConflictRemote(ctx, t, issue.PR)
+			if r.recoverSameBranchConflict(ctx, t, issue.PR.HeadRefName, remote, trustedOrigin) {
 				return "", false
 			}
 		}

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -165,6 +165,33 @@ func TestBranchConflictPrompt_AllowsRebaseBeforePRExists(t *testing.T) {
 	}
 }
 
+func TestSameBranchConflictPrompt_DefersPublishToTrustedWorkflow(t *testing.T) {
+	t.Parallel()
+
+	prompt := sameBranchConflictPrompt(context.Background(), task.Task{Branch: "fix/example", PRNumber: 1178}, "origin")
+	for _, want := range []string{
+		"git fetch origin +refs/heads/fix/example:refs/remotes/origin/fix/example",
+		"Do NOT rebase, amend, or force-push",
+		"Do not push: Sybra will verify and publish this completed merge through its trusted, non-force workflow step",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("same-branch conflict prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "PUSH_REMOTE=") || strings.Contains(prompt, "git push ") {
+		t.Fatalf("same-branch conflict prompt still authorizes an agent push:\n%s", prompt)
+	}
+}
+
+func TestSameBranchConflictRemote_UnknownHeadOwnerIsNotTrusted(t *testing.T) {
+	t.Parallel()
+
+	remote, trusted := (&Handler{}).sameBranchConflictRemote(context.Background(), task.Task{ProjectID: "acme/widgets"}, github.PullRequest{Repository: "acme/widgets"})
+	if remote != "origin" || trusted {
+		t.Fatalf("unknown head owner resolved to remote=%q trusted=%v, want origin and untrusted", remote, trusted)
+	}
+}
+
 // A pr-fix agent that backgrounds its test run and then narrates "still
 // waiting" status messages instead of blocking on it trips the watchdog's
 // semantic-loop detector and burns the run for nothing. Both conflict

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -168,6 +168,16 @@ type AttemptWorktreeManager interface {
 // already prepared the worktree (e.g. PR-fix flow that needs PrepareForFix).
 const WorkflowVarDir = "_dir"
 
+// WorkflowVarBranchConflictPushRemote is the trusted origin remote for a
+// verified same-repository branch-conflict recovery. Ordinary workflow pushes
+// continue to use project.PushRemote and therefore retain the fork-only policy.
+const WorkflowVarBranchConflictPushRemote = "_branch_conflict_push_remote"
+
+// WorkflowVarBranchConflictPushURL pins the source URL captured before the
+// recovery agent started. It is required with WorkflowVarBranchConflictPushRemote
+// before the workflow may use the trusted origin push path.
+const WorkflowVarBranchConflictPushURL = "_branch_conflict_push_url"
+
 // WorkflowVarSidecarDir is the reserved variable naming a per-task directory
 // that stays writable even when the worktree does not. Verifier roles
 // (review, plan, plan-critic, eval) run against a read-only worktree so they

--- a/internal/workflow/builtin/branch-conflict-fix.yaml
+++ b/internal/workflow/builtin/branch-conflict-fix.yaml
@@ -57,6 +57,20 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - goto: push_recovered_branch
+
+  # The agent only resolves and commits the merge. Sybra publishes it through
+  # its deterministic, non-force push path so fork-only safeguards stay in
+  # effect for agent subprocesses.
+  - id: push_recovered_branch
+    name: Push Recovered Branch
+    type: push_branch
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: verify_commits
 
   # Mechanical check (no LLM): verifies the branch has at least one commit

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -245,8 +245,15 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 		pushURL = strings.TrimSpace(wfExec.Variables[WorkflowVarBranchConflictPushURL])
 	}
 	var pushErr error
-	if pushRemote == "origin" && pushURL != "" {
-		pushErr = project.PushSyncToPinnedRemote(pushCtx, wtPath, branch, pushRemote, pushURL)
+	if wfExec != nil && wfExec.WorkflowID == "branch-conflict-fix" && pushRemote == "origin" && pushURL != "" {
+		hasGuard, guardErr := project.OriginPushHasForkOnlyGuard(pushCtx, wtPath)
+		if guardErr != nil {
+			pushErr = fmt.Errorf("verify fork-only origin guard: %w", guardErr)
+		} else if !hasGuard {
+			pushErr = errors.New("fork-only origin guard changed during branch recovery")
+		} else {
+			pushErr = project.PushSyncToPinnedRemote(pushCtx, wtPath, branch, pushRemote, pushURL)
+		}
 	} else {
 		pushErr = project.PushSync(pushCtx, wtPath, branch)
 	}

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -247,11 +247,12 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 	var pushErr error
 	if wfExec != nil && wfExec.WorkflowID == "branch-conflict-fix" && pushRemote == "origin" && pushURL != "" {
 		hasGuard, guardErr := project.OriginPushHasForkOnlyGuard(pushCtx, wtPath)
-		if guardErr != nil {
+		switch {
+		case guardErr != nil:
 			pushErr = fmt.Errorf("verify fork-only origin guard: %w", guardErr)
-		} else if !hasGuard {
+		case !hasGuard:
 			pushErr = errors.New("fork-only origin guard changed during branch recovery")
-		} else {
+		default:
 			pushErr = project.PushSyncToPinnedRemote(pushCtx, wtPath, branch, pushRemote, pushURL)
 		}
 	} else {

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -238,7 +238,18 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 	// non-auth retry bucket (#2160/#2386).
 	pushCtx, pushCancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer pushCancel()
-	pushErr := project.PushSync(pushCtx, wtPath, branch)
+	pushRemote := ""
+	pushURL := ""
+	if wfExec != nil {
+		pushRemote = strings.TrimSpace(wfExec.Variables[WorkflowVarBranchConflictPushRemote])
+		pushURL = strings.TrimSpace(wfExec.Variables[WorkflowVarBranchConflictPushURL])
+	}
+	var pushErr error
+	if pushRemote == "origin" && pushURL != "" {
+		pushErr = project.PushSyncToPinnedRemote(pushCtx, wtPath, branch, pushRemote, pushURL)
+	} else {
+		pushErr = project.PushSync(pushCtx, wtPath, branch)
+	}
 	if pushErr == nil {
 		return StepOutput{}, nil, true
 	}

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -213,7 +213,7 @@ func TestExecPushBranch_BranchConflictUsesTrustedSelectedRemote(t *testing.T) {
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
 
-	wfExec := &Execution{Variables: map[string]string{
+	wfExec := &Execution{WorkflowID: "branch-conflict-fix", Variables: map[string]string{
 		WorkflowVarBranchConflictPushRemote: "origin",
 		WorkflowVarBranchConflictPushURL:    originURL,
 	}}

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -192,6 +192,43 @@ func TestExecPushBranch_Success(t *testing.T) {
 	}
 }
 
+// Branch-conflict recovery may target origin for a same-repository PR even
+// when the worktree has the fork-only origin push sentinel installed. The
+// deterministic workflow is the trusted exception; an agent subprocess still
+// uses the normal PushSync path and remains blocked by that sentinel.
+func TestExecPushBranch_BranchConflictUsesTrustedSelectedRemote(t *testing.T) {
+	bare, wtPath := newPRWorktree(t, "feat/existing-pr")
+	commitFile(t, wtPath, "change.txt", "feat: recovered merge")
+	if out, err := exec.Command("git", "-C", wtPath, "config", "remote.origin.pushurl", "sybra-disabled-do-not-push-to-upstream-use-fork").CombinedOutput(); err != nil {
+		t.Fatalf("install origin push sentinel: %v\n%s", err, out)
+	}
+	originURL, err := project.RemoteURL(context.Background(), wtPath, "origin")
+	if err != nil {
+		t.Fatalf("resolve origin URL: %v", err)
+	}
+
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
+	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
+
+	wfExec := &Execution{Variables: map[string]string{
+		WorkflowVarBranchConflictPushRemote: "origin",
+		WorkflowVarBranchConflictPushURL:    originURL,
+	}}
+	out, err := engine.execPushBranch("t1", newPushBranchStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
+	if err != nil {
+		t.Fatalf("execPushBranch: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, want completed", out.Status)
+	}
+	if got := strings.TrimSpace(runGitAt(t, bare, "rev-parse", "feat/existing-pr")); got != headSHA(t, wtPath) {
+		t.Fatalf("bare remote head = %q, want trusted recovered branch head", got)
+	}
+}
+
 // TestExecPushBranch_PreflightFailureFallsThroughToSuccessfulPush covers the
 // #2386 false-block: the dry-run preflight probe can fail transiently (e.g. a
 // stale app-token cache) even though the real push would succeed. The step


### PR DESCRIPTION
Fixes #2998.\n\nRecovery agents now resolve and commit branch conflicts without pushing. Sybra publishes the completed non-force merge deterministically, using a pre-dispatch pinned origin URL only when its own fork-only sentinel would otherwise block a confirmed same-repository PR.\n\nThe change preserves fork and user-configured push URLs, rejects altered remote configuration, and adds regression coverage for both paths.