### PR TITLE
fix(recovery): quarantine dirty worktrees

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -336,6 +336,24 @@ func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	return err
 }
 
+var errWorkflowWriteFenceMismatch = errors.New("workflow write fence mismatch")
+
+func (a *taskAdapter) SetWorkflowIf(id string, fence workflow.WorkflowWriteFence, wf *workflow.Execution) (bool, error) {
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if cur.Generation != fence.Generation || string(cur.Status) != fence.Status ||
+			cur.StatusReason != fence.StatusReason || cur.Workflow == nil ||
+			cur.Workflow.WorkflowID != fence.WorkflowID || cur.Workflow.CurrentStep != fence.CurrentStep ||
+			cur.Workflow.State != fence.State {
+			return task.Update{}, errWorkflowWriteFenceMismatch
+		}
+		return task.Update{Workflow: &wf}, nil
+	})
+	if errors.Is(err, errWorkflowWriteFenceMismatch) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {
 	var result workflow.EffectClaimResult
 	var fenceErr error

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -17,6 +17,7 @@ import (
 var (
 	errWorkflowEffectNoPersist             = errors.New("workflow effect claim requires no persistence")
 	errWorkflowStatusReasonNoLongerMatches = errors.New("workflow status reason no longer matches")
+	errWorkflowWriteFenceMismatch          = errors.New("workflow write fence mismatch")
 )
 
 // taskAdapter and agentAdapter are minimal test-only stand-ins for the real
@@ -146,6 +147,22 @@ func (a *taskAdapter) ReplaceTaskBody(id, body string) error {
 func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	_, err := a.tasks.Update(id, task.Update{Workflow: &wf})
 	return err
+}
+
+func (a *taskAdapter) SetWorkflowIf(id string, fence workflow.WorkflowWriteFence, wf *workflow.Execution) (bool, error) {
+	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+		if cur.Generation != fence.Generation || string(cur.Status) != fence.Status ||
+			cur.StatusReason != fence.StatusReason || cur.Workflow == nil ||
+			cur.Workflow.WorkflowID != fence.WorkflowID || cur.Workflow.CurrentStep != fence.CurrentStep ||
+			cur.Workflow.State != fence.State {
+			return task.Update{}, errWorkflowWriteFenceMismatch
+		}
+		return task.Update{Workflow: &wf}, nil
+	})
+	if errors.Is(err, errWorkflowWriteFenceMismatch) {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 func (a *taskAdapter) ClaimWorkflowEffect(id string, claim workflow.EffectClaim) (workflow.EffectClaimResult, error) {

--- a/internal/watchdogreason/reason.go
+++ b/internal/watchdogreason/reason.go
@@ -114,6 +114,13 @@ func RewardHackingRetry(reason string) string {
 	return withDetail(rewardHackingRetryPrefix, reason)
 }
 
+// IsRewardHacking reports whether reason is the terminal, non-retryable
+// reward-hacking verdict. It deliberately excludes rewardHackingRetryPrefix:
+// that status is owned by ResumeStalled's bounded clean re-dispatch path.
+func IsRewardHacking(reason string) bool {
+	return Parse(reason).Kind == KindRewardHacking
+}
+
 func RateLimit(reason string) string {
 	return withDetail(rateLimitPrefix, reason)
 }

--- a/internal/watchdogreason/reason_test.go
+++ b/internal/watchdogreason/reason_test.go
@@ -72,3 +72,19 @@ func TestIsRewardHackingRetry(t *testing.T) {
 		t.Fatal("plain reward-hacking reason must not match retry classifier")
 	}
 }
+
+func TestIsRewardHacking(t *testing.T) {
+	for _, tc := range []struct {
+		reason string
+		want   bool
+	}{
+		{reason: "watchdog: reward_hacking", want: true},
+		{reason: " watchdog: reward_hacking: repeated fake progress ", want: true},
+		{reason: "watchdog: reward-hacking retry: repeated fake progress", want: false},
+		{reason: "human review requested", want: false},
+	} {
+		if got := IsRewardHacking(tc.reason); got != tc.want {
+			t.Fatalf("IsRewardHacking(%q) = %v, want %v", tc.reason, got, tc.want)
+		}
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -141,6 +141,10 @@ type TaskProvider interface {
 	// body (see stripTestFailuresSections).
 	ReplaceTaskBody(id, body string) error
 	SetWorkflow(id string, wf *Execution) error
+	// SetWorkflowIf atomically replaces the workflow only while the persisted
+	// task still matches fence. It prevents a maintenance scan from overwriting
+	// a newer operator/automation workflow with a stale snapshot.
+	SetWorkflowIf(id string, fence WorkflowWriteFence, wf *Execution) (bool, error)
 	ClaimWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error)
 	CompleteWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error)
 	// ConsumeSupervisorSteer prepends a pending watchdog headless-nudge steer to
@@ -163,6 +167,17 @@ type TaskProvider interface {
 	//       engine derives <name> from the step ID when the YAML kind is
 	//       a bare "plan_draft".
 	WriteSidecar(id, kind, content string) error
+}
+
+// WorkflowWriteFence identifies the exact task/workflow snapshot a
+// maintenance mutation is allowed to replace.
+type WorkflowWriteFence struct {
+	Generation   int64
+	Status       string
+	StatusReason string
+	WorkflowID   string
+	CurrentStep  string
+	State        ExecState
 }
 
 // WorktreeGetter resolves the filesystem path of a task's git worktree.

--- a/internal/workflow/engine_events_resume.go
+++ b/internal/workflow/engine_events_resume.go
@@ -307,6 +307,9 @@ func (e *Engine) terminalizeNonRetryableRewardHacking(t *TaskInfo, step *Step) b
 	}
 
 	failed := t.Workflow.Clone()
+	if failed == nil {
+		return false
+	}
 	failed.State = ExecFailed
 	now := time.Now().UTC()
 	failed.CompletedAt = &now

--- a/internal/workflow/engine_events_resume.go
+++ b/internal/workflow/engine_events_resume.go
@@ -310,9 +310,22 @@ func (e *Engine) terminalizeNonRetryableRewardHacking(t *TaskInfo, step *Step) b
 	failed.State = ExecFailed
 	now := time.Now().UTC()
 	failed.CompletedAt = &now
-	if err := e.tasks.SetWorkflow(t.ID, failed); err != nil {
+	applied, err := e.tasks.SetWorkflowIf(t.ID, WorkflowWriteFence{
+		Generation:   t.Generation,
+		Status:       t.Status,
+		StatusReason: t.StatusReason,
+		WorkflowID:   t.Workflow.WorkflowID,
+		CurrentStep:  t.Workflow.CurrentStep,
+		State:        t.Workflow.State,
+	}, failed)
+	if err != nil {
 		e.logger.Error("workflow.watchdog-reward-hacking.terminalize",
 			"task_id", t.ID, "step", step.ID, "err", err)
+		return true
+	}
+	if !applied {
+		e.logger.Info("workflow.watchdog-reward-hacking.terminalize-stale",
+			"task_id", t.ID, "step", step.ID)
 		return true
 	}
 	t.Workflow = failed

--- a/internal/workflow/engine_events_resume.go
+++ b/internal/workflow/engine_events_resume.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/dispatchorder"
 	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/watchdogreason"
 )
 
 func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
@@ -263,6 +264,9 @@ func (e *Engine) resumePreflightConsumesTick(t *TaskInfo, step *Step, logEvent s
 			"task_id", t.ID, "reason", "retry_after", "retry_after", retryAtStr, "step", step.ID)
 		return true
 	}
+	if e.terminalizeNonRetryableRewardHacking(t, step) {
+		return true
+	}
 	retryableWatchdogStop := e.canRetryWatchdogStop(t, step)
 	retryableWorktreeRepair := e.canRetryWorktreeRepair(t, step)
 	if reason, skip := resumeSkipReasonForStatus(t.Status); skip &&
@@ -289,6 +293,32 @@ func (e *Engine) resumePreflightConsumesTick(t *TaskInfo, step *Step, logEvent s
 		return true
 	}
 	return false
+}
+
+// terminalizeNonRetryableRewardHacking repairs the cross-component invariant
+// between watchdog and workflow state. The watchdog parks unsupported roles
+// at human-required because retrying the same ungrounded context is unsafe;
+// leaving the workflow waiting at the same time makes guarded operator
+// dispatch impossible, because a new workflow may only replace a terminal one.
+func (e *Engine) terminalizeNonRetryableRewardHacking(t *TaskInfo, step *Step) bool {
+	if t == nil || t.Workflow == nil || t.Status != "human-required" ||
+		!watchdogreason.IsRewardHacking(t.StatusReason) {
+		return false
+	}
+
+	failed := t.Workflow.Clone()
+	failed.State = ExecFailed
+	now := time.Now().UTC()
+	failed.CompletedAt = &now
+	if err := e.tasks.SetWorkflow(t.ID, failed); err != nil {
+		e.logger.Error("workflow.watchdog-reward-hacking.terminalize",
+			"task_id", t.ID, "step", step.ID, "err", err)
+		return true
+	}
+	t.Workflow = failed
+	e.logger.Warn("workflow.watchdog-reward-hacking.terminalized",
+		"task_id", t.ID, "step", step.ID)
+	return true
 }
 
 // resolveFreshTaskForResume re-reads the task to guard against stale snapshots

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -598,6 +598,75 @@ func TestBuildRewardHackingFixReviewReaskNote_AttemptCount(t *testing.T) {
 	}
 }
 
+func TestResumePreflight_TerminalizesNonRetryableRewardHackingPark(t *testing.T) {
+	tasks := newMemTasks()
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "branch-conflict-fix",
+		CurrentStep: "fix",
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	ti := TaskInfo{
+		ID:           "t1",
+		Status:       "human-required",
+		StatusReason: "watchdog: reward_hacking: repeated fake progress",
+		Workflow:     wf,
+	}
+	tasks.Put(ti)
+
+	if !engine.resumePreflightConsumesTick(&ti, &Step{ID: "fix", Type: StepRunAgent}, "test") {
+		t.Fatal("non-retryable reward-hacking park must consume the resume tick")
+	}
+	fresh, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if fresh.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", fresh.Status)
+	}
+	if fresh.Workflow.State != ExecFailed {
+		t.Fatalf("workflow state = %q, want ExecFailed", fresh.Workflow.State)
+	}
+	if fresh.Workflow.CompletedAt == nil {
+		t.Fatal("workflow completed_at not set")
+	}
+	if fresh.Workflow.CurrentStep != "fix" {
+		t.Fatalf("current step = %q, want preserved for diagnosis", fresh.Workflow.CurrentStep)
+	}
+}
+
+func TestResumePreflight_DoesNotTerminalizeOrdinaryHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "branch-conflict-fix",
+		CurrentStep: "fix",
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	ti := TaskInfo{
+		ID:           "t1",
+		Status:       "human-required",
+		StatusReason: "operator decision required",
+		Workflow:     wf,
+	}
+	tasks.Put(ti)
+
+	if !engine.resumePreflightConsumesTick(&ti, &Step{ID: "fix", Type: StepRunAgent}, "test") {
+		t.Fatal("human-required task must consume the resume tick")
+	}
+	fresh, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if fresh.Workflow.State != ExecWaiting {
+		t.Fatalf("workflow state = %q, want ExecWaiting", fresh.Workflow.State)
+	}
+}
+
 func TestResumeStalled_WatchdogRewardHackingPlanCriticRendersRetryNote(t *testing.T) {
 	store := newTestStore(t)
 	if err := store.Save(*mustBuiltinDefinition(t, "simple-task-plan")); err != nil {

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -667,6 +667,49 @@ func TestResumePreflight_DoesNotTerminalizeOrdinaryHumanRequired(t *testing.T) {
 	}
 }
 
+func TestResumePreflight_DoesNotOverwriteReplacementWorkflow(t *testing.T) {
+	tasks := newMemTasks()
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	staleWorkflow := &Execution{
+		WorkflowID:  "branch-conflict-fix",
+		CurrentStep: "fix",
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	stale := TaskInfo{
+		ID:           "t1",
+		Generation:   7,
+		Status:       "human-required",
+		StatusReason: "watchdog: reward_hacking: repeated fake progress",
+		Workflow:     staleWorkflow,
+	}
+	replacement := &Execution{
+		WorkflowID:  "simple-task-implement",
+		CurrentStep: "implement",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	tasks.Put(TaskInfo{
+		ID:         "t1",
+		Generation: 8,
+		Status:     "in-progress",
+		Workflow:   replacement,
+	})
+
+	if !engine.resumePreflightConsumesTick(&stale, &Step{ID: "fix", Type: StepRunAgent}, "test") {
+		t.Fatal("stale maintenance snapshot must consume the tick")
+	}
+	fresh, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if fresh.Workflow.WorkflowID != replacement.WorkflowID || fresh.Workflow.CurrentStep != replacement.CurrentStep || fresh.Workflow.State != ExecRunning {
+		t.Fatalf("replacement workflow was overwritten: %+v", fresh.Workflow)
+	}
+}
+
 func TestResumeStalled_WatchdogRewardHackingPlanCriticRendersRetryNote(t *testing.T) {
 	store := newTestStore(t)
 	if err := store.Save(*mustBuiltinDefinition(t, "simple-task-plan")); err != nil {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -840,6 +840,23 @@ func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	return nil
 }
 
+func (m *memTasks) SetWorkflowIf(id string, fence WorkflowWriteFence, wf *Execution) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return false, fmt.Errorf("task %s not found", id)
+	}
+	if t.Generation != fence.Generation || t.Status != fence.Status ||
+		t.StatusReason != fence.StatusReason || t.Workflow == nil ||
+		t.Workflow.WorkflowID != fence.WorkflowID || t.Workflow.CurrentStep != fence.CurrentStep ||
+		t.Workflow.State != fence.State {
+		return false, nil
+	}
+	t.Workflow = wf.Clone()
+	return true, nil
+}
+
 func (m *memTasks) ClaimWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -438,6 +438,10 @@ func TestPrepareForFix_ReconcilesOrphanWorktreeDir(t *testing.T) {
 	if project.WorktreeHealthy(context.Background(), wtPath) {
 		t.Fatalf("expected worktree to be unhealthy after dropping its admin entry")
 	}
+	sentinel := filepath.Join(wtPath, "uncommitted-sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("recoverable local edit"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected orphan checkout dir to still exist: %v", err)
 	}
@@ -458,6 +462,18 @@ func TestPrepareForFix_ReconcilesOrphanWorktreeDir(t *testing.T) {
 	}
 	if gotBranch := strings.TrimSpace(string(headBranch)); gotBranch != branch {
 		t.Errorf("worktree branch = %q, want %q", gotBranch, branch)
+	}
+	quarantineRoot := filepath.Join(h.wtDir, worktreeQuarantineDirName)
+	slots, err := os.ReadDir(quarantineRoot)
+	if err != nil {
+		t.Fatalf("read quarantine: %v", err)
+	}
+	if len(slots) != 1 {
+		t.Fatalf("quarantine entries = %d, want 1", len(slots))
+	}
+	quarantinedSentinel := filepath.Join(quarantineRoot, slots[0].Name(), "worktree", "uncommitted-sentinel.txt")
+	if body, readErr := os.ReadFile(quarantinedSentinel); readErr != nil || string(body) != "recoverable local edit" {
+		t.Fatalf("quarantined sentinel body=%q err=%v", body, readErr)
 	}
 }
 

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -309,8 +309,9 @@ func (m *Manager) RepairAll(ctx context.Context) {
 	}
 }
 
-// refuseRecreateWithUnpushedWork stops healOrRecreate from wiping a worktree
-// that still holds commits origin has never seen.
+// refuseRecreateWithLocalWork stops healOrRecreate from wiping a worktree
+// that still holds commits origin has never seen or uncommitted filesystem
+// state.
 //
 // Remove and CleanupOrphaned already refuse in that case (#2593), but the
 // branch-mismatch recreate path deleted unconditionally. A worktree can be
@@ -318,20 +319,23 @@ func (m *Manager) RepairAll(ctx context.Context) {
 // conflict resolution leaves — and wiping it discards work an agent already
 // did and verified, with the only record being the original push failure.
 //
-// Scoped to that path on purpose. The unrepairable path stays unguarded: a
-// broken worktree's commits are not reliably readable, so there is nothing
-// dependable to preserve, and refusing there would wedge the task with no
-// route forward.
-//
 // Failing loudly is the point: the task surfaces a real error a human can act
-// on while the commits still exist, rather than the work disappearing and the
-// task reporting only why the push was blocked.
-func (m *Manager) refuseRecreateWithUnpushedWork(ctx context.Context, taskID, wtPath, reason string) error {
-	if !project.HasUnpushedCommits(ctx, wtPath) {
-		return nil
+// on while the local state still exists.
+func (m *Manager) refuseRecreateWithLocalWork(ctx context.Context, taskID, wtPath, reason string) error {
+	if project.HasUnpushedCommits(ctx, wtPath) {
+		m.logger.Error("worktree.recreate.unpushed-commits", "task_id", taskID, "path", wtPath, "reason", reason)
+		return fmt.Errorf("refusing to recreate %s worktree %s: it holds commits that never reached a remote", reason, wtPath)
 	}
-	m.logger.Error("worktree.recreate.unpushed-commits", "task_id", taskID, "path", wtPath, "reason", reason)
-	return fmt.Errorf("refusing to recreate %s worktree %s: it holds commits that never reached origin", reason, wtPath)
+	dirty, err := project.IsWorktreeDirty(ctx, wtPath)
+	if err != nil {
+		m.logger.Error("worktree.recreate.inspect-local-work", "task_id", taskID, "path", wtPath, "reason", reason, "err", err)
+		return fmt.Errorf("refusing to recreate %s worktree %s: cannot verify that its local state is clean: %w", reason, wtPath, err)
+	}
+	if dirty {
+		m.logger.Error("worktree.recreate.uncommitted-work", "task_id", taskID, "path", wtPath, "reason", reason)
+		return fmt.Errorf("refusing to recreate %s worktree %s: it holds uncommitted work", reason, wtPath)
+	}
+	return nil
 }
 
 // healOrRecreate ensures the worktree at wtPath has resolvable git metadata
@@ -345,7 +349,7 @@ func (m *Manager) healOrRecreate(ctx context.Context, taskID, clonePath, wtPath,
 		return true, nil
 	}
 	if healthy {
-		if err := m.refuseRecreateWithUnpushedWork(ctx, taskID, wtPath, "branch-mismatch"); err != nil {
+		if err := m.refuseRecreateWithLocalWork(ctx, taskID, wtPath, "branch-mismatch"); err != nil {
 			return false, err
 		}
 		m.logger.Warn("worktree.branch-mismatch-recreate", "task_id", taskID, "path", wtPath, "branch", wantBranch)
@@ -364,11 +368,11 @@ func (m *Manager) healOrRecreate(ctx context.Context, taskID, clonePath, wtPath,
 		m.logger.Info("worktree.repaired", "task_id", taskID, "path", wtPath)
 		return true, nil
 	}
-	// Deliberately unguarded, unlike the branch-mismatch path above: this
-	// worktree is broken, so its commits are not reliably readable and there
-	// is no usable state to preserve. Refusing here would wedge the task
-	// forever with no route forward, trading a recoverable loss for a
-	// permanent stall.
+	// Deliberately unguarded, unlike the healthy branch-mismatch path above:
+	// broken linked-worktree metadata makes git status and reachability
+	// unreadable, including for clean orphan directories left after their admin
+	// entry disappears. Repair was already attempted; recreate is the only
+	// deterministic route forward for that class.
 	m.logger.Warn("worktree.unrepairable-recreate", "task_id", taskID, "path", wtPath)
 	_ = project.RemoveWorktree(ctx, clonePath, wtPath)
 	if err := os.RemoveAll(wtPath); err != nil {

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -20,6 +20,8 @@ var (
 	suffixTaskIDRe = regexp.MustCompile(`-([0-9a-f]{8})$`)
 )
 
+const worktreeQuarantineDirName = ".quarantine"
+
 // taskIDFromWorktreeDir extracts the owning task ID from a worktree directory
 // name: task.Task.DirName() is either the bare 8-hex-char ID (no slug yet) or
 // "<slug>-<8hex-id>". Anything else returns "" (no match).
@@ -91,6 +93,9 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 
 	for _, e := range entries {
 		if !e.IsDir() {
+			continue
+		}
+		if e.Name() == worktreeQuarantineDirName {
 			continue
 		}
 		name := e.Name()
@@ -368,18 +373,34 @@ func (m *Manager) healOrRecreate(ctx context.Context, taskID, clonePath, wtPath,
 		m.logger.Info("worktree.repaired", "task_id", taskID, "path", wtPath)
 		return true, nil
 	}
-	// Deliberately unguarded, unlike the healthy branch-mismatch path above:
-	// broken linked-worktree metadata makes git status and reachability
-	// unreadable, including for clean orphan directories left after their admin
-	// entry disappears. Repair was already attempted; recreate is the only
-	// deterministic route forward for that class.
-	m.logger.Warn("worktree.unrepairable-recreate", "task_id", taskID, "path", wtPath)
-	_ = project.RemoveWorktree(ctx, clonePath, wtPath)
-	if err := os.RemoveAll(wtPath); err != nil {
-		return false, fmt.Errorf("remove unhealthy worktree %s: %w", wtPath, err)
+	// Broken linked-worktree metadata makes git status and reachability
+	// unreadable. Preserve the entire checkout before recreating: unreadable is
+	// not evidence that its filesystem contents are disposable.
+	quarantined, err := m.quarantineWorktreeDir(wtPath)
+	if err != nil {
+		return false, fmt.Errorf("quarantine unhealthy worktree %s: %w", wtPath, err)
 	}
+	m.logger.Warn("worktree.unrepairable-recreate", "task_id", taskID, "path", wtPath, "quarantine", quarantined)
+	_ = project.RemoveWorktree(ctx, clonePath, wtPath)
 	_ = project.PruneWorktrees(ctx, clonePath)
 	return false, nil
+}
+
+func (m *Manager) quarantineWorktreeDir(wtPath string) (string, error) {
+	root := filepath.Join(m.dir, worktreeQuarantineDirName)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", err
+	}
+	slot, err := os.MkdirTemp(root, filepath.Base(wtPath)+"-")
+	if err != nil {
+		return "", err
+	}
+	destination := filepath.Join(slot, "worktree")
+	if err := os.Rename(wtPath, destination); err != nil {
+		_ = os.Remove(slot)
+		return "", err
+	}
+	return destination, nil
 }
 
 // onExpectedBranch reports whether wtPath is currently checked out on

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -2086,8 +2086,8 @@ func TestPrepareForTask_BootstrapFailureBlocks(t *testing.T) {
 // unexpected branch — exactly the state a merge or conflict resolution leaves
 // behind — so its commits are readable and worth preserving.
 //
-// The unrepairable recreate path is still unguarded, by design: see
-// refuseRecreateWithUnpushedWork.
+// The unrepairable recreate path is still unguarded, by design: broken linked
+// worktree metadata cannot distinguish local work from a clean orphan.
 func TestManager_RefuseRecreateWithUnpushedWork(t *testing.T) {
 	dir := t.TempDir()
 	tasksDir := t.TempDir()
@@ -2107,7 +2107,7 @@ func TestManager_RefuseRecreateWithUnpushedWork(t *testing.T) {
 
 	// branch-mismatch only: the unrepairable path stays unguarded by design,
 	// since a broken worktree has no dependably-readable state to preserve.
-	err = m.refuseRecreateWithUnpushedWork(context.Background(), "t1", wt, "branch-mismatch")
+	err = m.refuseRecreateWithLocalWork(context.Background(), "t1", wt, "branch-mismatch")
 
 	if err == nil {
 		t.Fatal("recreate allowed on a worktree holding commits origin never saw; that discards the agent's work")
@@ -2131,7 +2131,31 @@ func TestManager_AllowsRecreateWhenPushed(t *testing.T) {
 	wt := filepath.Join(dir, "pushed-work")
 	makePushedGitDir(t, wt)
 
-	if err := m.refuseRecreateWithUnpushedWork(context.Background(), "t1", wt, "branch-mismatch"); err != nil {
+	if err := m.refuseRecreateWithLocalWork(context.Background(), "t1", wt, "branch-mismatch"); err != nil {
 		t.Fatalf("guard blocked recreate of a fully-pushed worktree: %v", err)
+	}
+}
+
+func TestManager_RefuseRecreateWithUncommittedWork(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(Config{WorktreesDir: dir, Tasks: task.NewManager(store, nil), Logger: discardLogger()})
+
+	wt := filepath.Join(dir, "dirty-work")
+	makePushedGitDir(t, wt)
+	if err := os.WriteFile(filepath.Join(wt, "uncommitted.txt"), []byte("local recovery state"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err = m.refuseRecreateWithLocalWork(context.Background(), "t1", wt, "branch-mismatch")
+	if err == nil {
+		t.Fatal("recreate allowed on a worktree holding uncommitted work")
+	}
+	if _, statErr := os.Stat(filepath.Join(wt, "uncommitted.txt")); statErr != nil {
+		t.Fatalf("uncommitted worktree contents gone: %v", statErr)
 	}
 }

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -515,8 +515,12 @@ func (m *Manager) reuseBranchConflictWorktree(ctx context.Context, taskID, clone
 	if !usable {
 		return false, nil
 	}
+	if _, err := project.CheckpointCommit(ctx, wtPath,
+		"wip: checkpoint before branch conflict recovery\n\nSybra preserved local work before preparing conflict recovery."); err != nil {
+		return false, fmt.Errorf("checkpoint branch-conflict worktree: %w", err)
+	}
 	if err := project.SanitizeWorktree(ctx, wtPath); err != nil {
-		m.logger.Warn("branch-conflict.worktree.sanitize", "task_id", taskID, "err", err)
+		return false, fmt.Errorf("sanitize branch-conflict worktree: %w", err)
 	}
 	return true, nil
 }

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -262,6 +262,129 @@ func TestPrepareForBranchFix_ReusesHealthyWorktree(t *testing.T) {
 	}
 }
 
+func TestPrepareForBranchConflict_CheckpointsDirtyReusedWorktree(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	const branch = "fix/conflict-checkpoint"
+	srcGit := func(args ...string) string {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		out, err := exec.Command("git", full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("base"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "initial branch commit")
+	srcGit("checkout", "main")
+
+	tk, err := h.tasks.Create("checkpoint conflict worktree", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"branch":     branch,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForBranchConflict(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchConflict (initial): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "partial-resolution.txt"), []byte("preserve me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := h.m.PrepareForBranchConflict(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchConflict (reuse): %v", err)
+	}
+	if got != wtPath {
+		t.Fatalf("reused path = %q, want %q", got, wtPath)
+	}
+	wtGit := func(args ...string) string {
+		t.Helper()
+		full := append([]string{"-C", wtPath}, args...)
+		out, err := exec.Command("git", full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	if status := wtGit("status", "--porcelain"); status != "" {
+		t.Fatalf("reused worktree remained dirty: %s", status)
+	}
+	if gotSubject := wtGit("log", "-1", "--format=%s"); gotSubject != "wip: checkpoint before branch conflict recovery" {
+		t.Fatalf("checkpoint subject = %q", gotSubject)
+	}
+	if gotBody := wtGit("show", "HEAD:partial-resolution.txt"); gotBody != "preserve me" {
+		t.Fatalf("checkpointed content = %q", gotBody)
+	}
+}
+
+func TestPrepareForBranchConflict_QuarantinesDetachedDirtyWorktree(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	const branch = "fix/conflict-detached-dirty"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("base"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "initial branch commit")
+	srcGit("checkout", "main")
+
+	tk, err := h.tasks.Create("quarantine detached dirty conflict worktree", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"branch":     branch,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForBranchConflict(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchConflict (initial): %v", err)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "checkout", "--detach").CombinedOutput(); err != nil {
+		t.Fatalf("detach worktree: %v: %s", err, out)
+	}
+	partialPath := filepath.Join(wtPath, "partial-resolution.txt")
+	if err := os.WriteFile(partialPath, []byte("preserve me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = h.m.PrepareForBranchConflict(context.Background(), tk)
+	if err == nil || !strings.Contains(err.Error(), "uncommitted work") {
+		t.Fatalf("PrepareForBranchConflict error = %v, want uncommitted-work quarantine", err)
+	}
+	if got, readErr := os.ReadFile(partialPath); readErr != nil || string(got) != "preserve me" {
+		t.Fatalf("quarantined work changed or disappeared: body=%q err=%v", got, readErr)
+	}
+	if branchOut, branchErr := exec.Command("git", "-C", wtPath, "branch", "--show-current").CombinedOutput(); branchErr != nil || strings.TrimSpace(string(branchOut)) != "" {
+		t.Fatalf("worktree was recreated instead of quarantined: branch=%q err=%v", branchOut, branchErr)
+	}
+}
+
 // TestPrepareForBranchFix_SetupFailureDoesNotBlock is the regression test for
 // issue #1454: a project whose setup: command fails (e.g. a broken build)
 // must not prevent PrepareForBranchFix from creating the fix worktree — that


### PR DESCRIPTION
## Motivation

A non-retryable watchdog stop could leave an active workflow that blocked guarded redispatch, while conflict recovery could encounter detached, dirty, or unreadable worktree state. That combination could strand the task or risk losing local recovery work.

## Implementation information

- terminalize non-retryable reward-hacking workflows through an atomic task/workflow fence
- checkpoint dirty work on the expected branch and fail closed for detached dirty checkouts
- move worktrees with unreadable Git metadata into protected quarantine before rebuilding
- cover replacement-workflow races, detached dirty recovery, and broken metadata with regression tests

The source incident was recorded as a scrubbed local task because it originated from a work-typed project; no source-project content is included here.

> Changelog: fix(recovery): quarantine dirty worktrees