### PR TITLE
refactor(git): add shared exec boundary

### DIFF
--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -3,10 +3,10 @@ package executil
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 // EscapeAppleScript escapes a string for safe embedding inside an AppleScript
@@ -25,8 +25,12 @@ func Run(ctx context.Context, dir, name string, args ...string) error {
 // RunEnv executes a command in dir with an explicit environment, returning a
 // formatted error with stderr on failure. A nil env means "inherit the
 // current process environment", matching exec.Cmd's own zero-value behavior
-// and Run's default.
+// and Run's default. Git delegates to gitexec, which additionally enforces its
+// non-interactive subprocess environment.
 func RunEnv(ctx context.Context, dir string, env []string, name string, args ...string) error {
+	if name == "git" {
+		return gitexec.Run(ctx, gitexec.Options{Dir: dir, Env: env}, args...)
+	}
 	cmd := commandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Env = env
@@ -38,6 +42,9 @@ func RunEnv(ctx context.Context, dir string, env []string, name string, args ...
 
 // Output executes a command in dir and returns its trimmed stdout.
 func Output(ctx context.Context, dir, name string, args ...string) (string, error) {
+	if name == "git" {
+		return gitexec.Output(ctx, gitexec.Options{Dir: dir}, args...)
+	}
 	cmd := commandContext(ctx, name, args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
@@ -47,31 +54,6 @@ func Output(ctx context.Context, dir, name string, args ...string) (string, erro
 	return strings.TrimSpace(string(out)), nil
 }
 
-// commandContext avoids exec.LookPath accepting a stale executable symlink.
-// This matters for long-lived desktop processes after a profile-manager
-// upgrade: a now-dangling git shim can remain first on PATH even though a
-// usable system git follows it. Worktree preparation must not fail before the
-// provider sandbox is even reached.
 func commandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	if name == "git" {
-		if path := usablePathExecutable(name); path != "" {
-			return exec.CommandContext(ctx, path, args...)
-		}
-	}
 	return exec.CommandContext(ctx, name, args...)
-}
-
-func usablePathExecutable(name string) string {
-	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
-		candidate := filepath.Join(dir, name)
-		resolved, err := filepath.EvalSymlinks(candidate)
-		if err != nil {
-			continue
-		}
-		info, err := os.Stat(resolved)
-		if err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
-			return resolved
-		}
-	}
-	return ""
 }

--- a/internal/gitexec/cancel_other.go
+++ b/internal/gitexec/cancel_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin && !linux
+
+package gitexec
+
+import "os/exec"
+
+// Sybra's supported production hosts are darwin and Linux. Keep the package
+// buildable elsewhere while retaining exec.CommandContext's direct-child
+// cancellation fallback.
+func configureProcessGroupCancel(_ *exec.Cmd) {}

--- a/internal/gitexec/cancel_unix.go
+++ b/internal/gitexec/cancel_unix.go
@@ -1,0 +1,27 @@
+//go:build darwin || linux
+
+package gitexec
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func configureProcessGroupCancel(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.WaitDelay = time.Second
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+}

--- a/internal/gitexec/executable_other.go
+++ b/internal/gitexec/executable_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package gitexec
+
+import "os"
+
+func executableByCurrentUser(_ string, info os.FileInfo) bool {
+	return info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
+}

--- a/internal/gitexec/executable_unix.go
+++ b/internal/gitexec/executable_unix.go
@@ -1,0 +1,13 @@
+//go:build darwin || linux
+
+package gitexec
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func executableByCurrentUser(path string, info os.FileInfo) bool {
+	return info.Mode().IsRegular() && unix.Access(path, unix.X_OK) == nil
+}

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -151,7 +151,7 @@ func usablePathExecutable(name string) string {
 			continue
 		}
 		info, err := os.Stat(resolved)
-		if err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+		if err == nil && executableByCurrentUser(resolved, info) {
 			return resolved
 		}
 	}

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -1,0 +1,159 @@
+// Package gitexec is the single low-level boundary for production Git
+// subprocess execution. It owns process mechanics only; repository policy
+// such as locking, authentication, retries, and reconciliation belongs to
+// higher-level packages.
+package gitexec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const terminalPromptEnv = "GIT_TERMINAL_PROMPT=0"
+
+// Options configures one Git invocation.
+//
+// A nil Env inherits the current process environment. A non-nil Env, including
+// an empty slice, is used as the complete base environment. ExtraEnv overlays
+// either base, which supports inherited, augmented, and fully isolated
+// subprocess environments without changing the process environment.
+// GIT_TERMINAL_PROMPT=0 is applied last for every invocation.
+type Options struct {
+	Dir      string
+	Env      []string
+	ExtraEnv []string
+	Stdin    io.Reader
+}
+
+// Run executes Git for its side effects and returns a diagnostic error that
+// includes combined output on failure.
+func Run(ctx context.Context, opts Options, args ...string) error {
+	_, err := CombinedOutput(ctx, opts, args...)
+	return err
+}
+
+// Output executes Git and returns trimmed stdout. Failures include captured
+// stderr in the returned diagnostic error.
+func Output(ctx context.Context, opts Options, args ...string) (string, error) {
+	out, err := output(ctx, opts, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// RawOutput executes Git and returns stdout without trimming it. This is for
+// byte-sensitive output such as patches; most callers should use Output.
+func RawOutput(ctx context.Context, opts Options, args ...string) ([]byte, error) {
+	return output(ctx, opts, args...)
+}
+
+// CombinedOutput executes Git and returns raw interleaved stdout and stderr.
+// The output is returned even on failure so callers can classify Git errors.
+func CombinedOutput(ctx context.Context, opts Options, args ...string) ([]byte, error) {
+	cmd := command(ctx, opts, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, commandError(args, err, out)
+	}
+	return out, nil
+}
+
+// ExitCode returns the subprocess exit code contained in err. It understands
+// errors wrapped by this package; ok is false for start failures and errors
+// that do not originate from a completed subprocess.
+func ExitCode(err error) (code int, ok bool) {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return 0, false
+	}
+	return exitErr.ExitCode(), true
+}
+
+func output(ctx context.Context, opts Options, args ...string) ([]byte, error) {
+	cmd := command(ctx, opts, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		var detail []byte
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			detail = exitErr.Stderr
+		}
+		return out, commandError(args, err, detail)
+	}
+	return out, nil
+}
+
+func command(ctx context.Context, opts Options, args ...string) *exec.Cmd {
+	name := "git"
+	if path := usablePathExecutable(name); path != "" {
+		name = path
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = opts.Dir
+	cmd.Env = invocationEnv(opts)
+	cmd.Stdin = opts.Stdin
+	configureProcessGroupCancel(cmd)
+	return cmd
+}
+
+func invocationEnv(opts Options) []string {
+	var env []string
+	if opts.Env == nil {
+		env = append([]string(nil), os.Environ()...)
+	} else {
+		env = append([]string(nil), opts.Env...)
+	}
+	for _, entry := range opts.ExtraEnv {
+		env = overlayEnv(env, entry)
+	}
+	return overlayEnv(env, terminalPromptEnv)
+}
+
+func overlayEnv(env []string, entry string) []string {
+	key, _, ok := strings.Cut(entry, "=")
+	if !ok {
+		return append(env, entry)
+	}
+	out := env[:0]
+	for _, existing := range env {
+		existingKey, _, existingOK := strings.Cut(existing, "=")
+		if !existingOK || existingKey != key {
+			out = append(out, existing)
+		}
+	}
+	return append(out, entry)
+}
+
+func commandError(args []string, err error, output []byte) error {
+	detail := strings.TrimSpace(string(output))
+	if detail == "" {
+		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, detail)
+}
+
+// usablePathExecutable skips dangling or non-executable PATH entries instead
+// of accepting the first textual match. Long-lived Sybra processes can retain
+// a stale profile-manager shim after an upgrade while a usable system Git
+// remains later on PATH.
+func usablePathExecutable(name string) string {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		candidate := filepath.Join(dir, name)
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(resolved)
+		if err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+			return resolved
+		}
+	}
+	return ""
+}

--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -146,7 +146,11 @@ func commandError(args []string, err error, output []byte) error {
 func usablePathExecutable(name string) string {
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		candidate := filepath.Join(dir, name)
-		resolved, err := filepath.EvalSymlinks(candidate)
+		absolute, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(absolute)
 		if err != nil {
 			continue
 		}

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -175,6 +175,25 @@ func TestExecutableResolutionSkipsInaccessibleFile(t *testing.T) {
 	}
 }
 
+func TestExecutableResolutionMakesRelativePATHAbsoluteBeforeChangingDir(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	relativeBin := "relative-bin"
+	if err := os.Mkdir(relativeBin, 0o755); err != nil {
+		t.Fatalf("create relative bin: %v", err)
+	}
+	writeFakeGit(t, relativeBin, `printf 'relative-path-git\n'`)
+	t.Setenv("PATH", relativeBin)
+
+	got, err := Output(context.Background(), Options{Dir: t.TempDir()}, "version")
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if got != "relative-path-git" {
+		t.Fatalf("Output = %q, want relative-path-git", got)
+	}
+}
+
 func TestCancellationKillsProcessGroup(t *testing.T) {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 		t.Skip("process-group cancellation is supported on darwin and Linux")

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -154,6 +154,27 @@ func TestExecutableResolutionSkipsDanglingShim(t *testing.T) {
 	}
 }
 
+func TestExecutableResolutionSkipsInaccessibleFile(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("effective-user executable checks are supported on darwin and Linux")
+	}
+	badBin := t.TempDir()
+	goodBin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(badBin, "git"), []byte("not executable\n"), 0o010); err != nil {
+		t.Fatalf("write inaccessible git: %v", err)
+	}
+	writeFakeGit(t, goodBin, `printf 'usable\n'`)
+	t.Setenv("PATH", badBin+string(os.PathListSeparator)+goodBin)
+
+	got, err := Output(context.Background(), Options{}, "version")
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if got != "usable" {
+		t.Fatalf("Output = %q, want usable", got)
+	}
+}
+
 func TestCancellationKillsProcessGroup(t *testing.T) {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 		t.Skip("process-group cancellation is supported on darwin and Linux")

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -1,0 +1,220 @@
+package gitexec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEnvironmentModes(t *testing.T) {
+	bin := t.TempDir()
+	writeFakeGit(t, bin, `
+printf '%s|%s|%s\n' "${GITEXEC_AMBIENT-unset}" "${GITEXEC_VALUE-unset}" "$GIT_TERMINAL_PROMPT"
+`)
+	t.Setenv("PATH", bin)
+	t.Setenv("GITEXEC_AMBIENT", "inherited")
+	t.Setenv("GITEXEC_VALUE", "ambient")
+
+	tests := []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{
+			name: "inherited",
+			want: "inherited|ambient|0",
+		},
+		{
+			name: "augmented",
+			opts: Options{ExtraEnv: []string{"GITEXEC_VALUE=augmented", "GIT_TERMINAL_PROMPT=1"}},
+			want: "inherited|augmented|0",
+		},
+		{
+			name: "isolated",
+			opts: Options{Env: []string{"GITEXEC_VALUE=isolated"}},
+			want: "unset|isolated|0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Output(context.Background(), tt.opts, "environment")
+			if err != nil {
+				t.Fatalf("Output: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutputFormsAndWorkingDirectory(t *testing.T) {
+	bin := t.TempDir()
+	writeFakeGit(t, bin, `
+if [ "$1" = stdin ]; then
+  /bin/cat
+  exit
+fi
+printf '  %s  \n' "$PWD"
+`)
+	t.Setenv("PATH", bin)
+	dir := t.TempDir()
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+
+	got, err := Output(context.Background(), Options{Dir: dir}, "pwd")
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if got != resolvedDir {
+		t.Fatalf("Output = %q, want %q", got, resolvedDir)
+	}
+
+	raw, err := RawOutput(context.Background(), Options{Dir: dir}, "pwd")
+	if err != nil {
+		t.Fatalf("RawOutput: %v", err)
+	}
+	if want := "  " + resolvedDir + "  \n"; string(raw) != want {
+		t.Fatalf("RawOutput = %q, want %q", raw, want)
+	}
+
+	raw, err = RawOutput(context.Background(), Options{Stdin: strings.NewReader("patch\nbytes\n")}, "stdin")
+	if err != nil {
+		t.Fatalf("RawOutput with stdin: %v", err)
+	}
+	if string(raw) != "patch\nbytes\n" {
+		t.Fatalf("stdin output = %q", raw)
+	}
+}
+
+func TestNonZeroExitPreservesOutputAndCode(t *testing.T) {
+	bin := t.TempDir()
+	writeFakeGit(t, bin, `
+printf 'stdout detail\n'
+printf 'stderr detail\n' >&2
+exit 7
+`)
+	t.Setenv("PATH", bin)
+
+	out, err := CombinedOutput(context.Background(), Options{}, "failing", "argument")
+	if err == nil {
+		t.Fatal("CombinedOutput unexpectedly succeeded")
+	}
+	if got := string(out); !strings.Contains(got, "stdout detail") || !strings.Contains(got, "stderr detail") {
+		t.Fatalf("combined output = %q", got)
+	}
+	if got := err.Error(); !strings.Contains(got, "git failing argument") || !strings.Contains(got, "stdout detail") || !strings.Contains(got, "stderr detail") {
+		t.Fatalf("error = %q", got)
+	}
+	if code, ok := ExitCode(err); !ok || code != 7 {
+		t.Fatalf("ExitCode = (%d, %v), want (7, true)", code, ok)
+	}
+	if _, ok := ExitCode(errors.New("not an exit error")); ok {
+		t.Fatal("ExitCode reported a code for an unrelated error")
+	}
+}
+
+func TestOutputFailureIncludesStderr(t *testing.T) {
+	bin := t.TempDir()
+	writeFakeGit(t, bin, `
+printf 'specific stderr\n' >&2
+exit 3
+`)
+	t.Setenv("PATH", bin)
+
+	_, err := Output(context.Background(), Options{}, "bad-output")
+	if err == nil || !strings.Contains(err.Error(), "specific stderr") {
+		t.Fatalf("Output error = %v, want captured stderr", err)
+	}
+}
+
+func TestExecutableResolutionSkipsDanglingShim(t *testing.T) {
+	badBin := t.TempDir()
+	goodBin := t.TempDir()
+	if err := os.Symlink(filepath.Join(badBin, "missing-git"), filepath.Join(badBin, "git")); err != nil {
+		t.Fatalf("create dangling git shim: %v", err)
+	}
+	writeFakeGit(t, goodBin, `printf 'usable\n'`)
+	t.Setenv("PATH", badBin+string(os.PathListSeparator)+goodBin)
+
+	got, err := Output(context.Background(), Options{}, "version")
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	if got != "usable" {
+		t.Fatalf("Output = %q, want usable", got)
+	}
+}
+
+func TestCancellationKillsProcessGroup(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("process-group cancellation is supported on darwin and Linux")
+	}
+	bin := t.TempDir()
+	writeFakeGit(t, bin, `
+/bin/sleep 30 &
+child=$!
+printf '%s\n' "$child" > "$GITEXEC_PID_FILE"
+wait "$child"
+`)
+	t.Setenv("PATH", bin)
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Options{ExtraEnv: []string{"GITEXEC_PID_FILE=" + pidFile}}, "wait")
+	}()
+
+	pid := waitForChildPID(t, pidFile)
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run unexpectedly succeeded after cancellation")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Git process did not stop after cancellation")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for processExists(pid) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if processExists(pid) {
+		t.Fatalf("Git helper process %d survived context cancellation", pid)
+	}
+}
+
+func writeFakeGit(t *testing.T, dir, body string) {
+	t.Helper()
+	path := filepath.Join(dir, "git")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nset -eu\n"+body), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+}
+
+func waitForChildPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			var pid int
+			if _, scanErr := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &pid); scanErr == nil {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for child pid in %s", path)
+	return 0
+}

--- a/internal/gitexec/process_exists_other_test.go
+++ b/internal/gitexec/process_exists_other_test.go
@@ -1,0 +1,5 @@
+//go:build !darwin && !linux
+
+package gitexec
+
+func processExists(_ int) bool { return false }

--- a/internal/gitexec/process_exists_unix_test.go
+++ b/internal/gitexec/process_exists_unix_test.go
@@ -1,0 +1,13 @@
+//go:build darwin || linux
+
+package gitexec
+
+import (
+	"errors"
+	"syscall"
+)
+
+func processExists(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}


### PR DESCRIPTION
## Motivation

Centralize Git subprocess mechanics behind one narrow, reusable execution boundary so callers share PATH resolution, cancellation, environment, output, and diagnostic behavior.

## Implementation information

- add `internal/gitexec` with context-owned execution, working-directory and environment controls, non-interactive defaults, structured output helpers, and exit-code inspection
- kill whole Git process groups on cancellation and resolve stale, inaccessible, and relative PATH entries safely
- route Git calls in `internal/executil` through the shared boundary while retaining non-Git behavior
- cover environment modes, cancellation, output semantics, failures, executable resolution, and delegation with race-tested regression cases

Closes #3009

> Changelog: refactor(git): add shared Git execution boundary
