### PR TITLE
refactor(project): route repository operations through gitexec

### DIFF
--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -5,6 +5,7 @@
 package gitexec
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -36,6 +37,20 @@ type Options struct {
 func Run(ctx context.Context, opts Options, args ...string) error {
 	_, err := CombinedOutput(ctx, opts, args...)
 	return err
+}
+
+// RunQuiet executes Git for side effects without retaining stdout. It is for
+// commands whose successful output can be large and is intentionally ignored;
+// stderr is still captured and included in failure diagnostics.
+func RunQuiet(ctx context.Context, opts Options, args ...string) error {
+	cmd := command(ctx, opts, args...)
+	cmd.Stdout = io.Discard
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return commandError(args, err, stderr.Bytes())
+	}
+	return nil
 }
 
 // Output executes Git and returns trimmed stdout. Failures include captured

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -122,6 +122,32 @@ exit 7
 	}
 }
 
+func TestRunQuietDiscardsStdoutAndPreservesStderr(t *testing.T) {
+	bin := t.TempDir()
+	writeFakeGit(t, bin, `
+printf 'discarded stdout\n'
+if [ "$1" = fail ]; then
+  printf 'useful stderr\n' >&2
+  exit 9
+fi
+`)
+	t.Setenv("PATH", bin)
+
+	if err := RunQuiet(context.Background(), Options{}, "success"); err != nil {
+		t.Fatalf("RunQuiet success: %v", err)
+	}
+	err := RunQuiet(context.Background(), Options{}, "fail")
+	if err == nil {
+		t.Fatal("RunQuiet failure unexpectedly succeeded")
+	}
+	if got := err.Error(); strings.Contains(got, "discarded stdout") || !strings.Contains(got, "useful stderr") {
+		t.Fatalf("RunQuiet error = %q, want stderr without stdout", got)
+	}
+	if code, ok := ExitCode(err); !ok || code != 9 {
+		t.Fatalf("ExitCode = (%d, %v), want (9, true)", code, ok)
+	}
+}
+
 func TestOutputFailureIncludesStderr(t *testing.T) {
 	bin := t.TempDir()
 	writeFakeGit(t, bin, `

--- a/internal/project/conflict_recovery.go
+++ b/internal/project/conflict_recovery.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 var conflictMarkerPrefixes = [][]byte{
@@ -69,15 +70,9 @@ func ResolvedUnmergedPaths(ctx context.Context, wtPath string) ([]string, error)
 	// staged deletion (an explicit, marker-free resolution with no working-tree
 	// file to inspect) apart from a staged add/modify whose file happens to be
 	// missing on disk.
-	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-status", "-z")
-	cmd.Dir = wtPath
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{Dir: wtPath}, "diff", "--cached", "--name-status", "-z")
 	if err != nil {
-		detail := strings.TrimSpace(string(out))
-		if detail == "" {
-			return nil, fmt.Errorf("git diff --cached --name-status -z: %w", err)
-		}
-		return nil, fmt.Errorf("git diff --cached --name-status -z: %w: %s", err, detail)
+		return nil, err
 	}
 
 	fields := bytes.Split(out, []byte{0})
@@ -143,15 +138,9 @@ func ResolvedUnmergedPaths(ctx context.Context, wtPath string) ([]string, error)
 // so a path with all three stages present would otherwise be reported three
 // times.
 func unmergedIndexPaths(ctx context.Context, wtPath string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "ls-files", "-u", "-z")
-	cmd.Dir = wtPath
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{Dir: wtPath}, "ls-files", "-u", "-z")
 	if err != nil {
-		detail := strings.TrimSpace(string(out))
-		if detail == "" {
-			return nil, fmt.Errorf("git ls-files -u -z: %w", err)
-		}
-		return nil, fmt.Errorf("git ls-files -u -z: %w: %s", err, detail)
+		return nil, err
 	}
 
 	seen := make(map[string]struct{})
@@ -175,15 +164,9 @@ func unmergedIndexPaths(ctx context.Context, wtPath string) ([]string, error) {
 }
 
 func mergeInProgress(ctx context.Context, wtPath string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-path", "MERGE_HEAD")
-	cmd.Dir = wtPath
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{Dir: wtPath}, "rev-parse", "--git-path", "MERGE_HEAD")
 	if err != nil {
-		detail := strings.TrimSpace(string(out))
-		if detail == "" {
-			return false, fmt.Errorf("git rev-parse --git-path MERGE_HEAD: %w", err)
-		}
-		return false, fmt.Errorf("git rev-parse --git-path MERGE_HEAD: %w: %s", err, detail)
+		return false, err
 	}
 	path := strings.TrimSpace(string(out))
 	if path == "" {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/Automaat/sybra/internal/executil"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 	"gopkg.in/yaml.v3"
 )
@@ -80,7 +79,7 @@ var networkGitTimeout = defaultNetworkGitTimeout
 // FetchRemoteBranch, FetchPRHead). Injecting fetchEnv() unconditionally is
 // harmless for the local ops — it only ever appends GH_TOKEN/GITHUB_TOKEN.
 func runBare(ctx context.Context, barePath string, args ...string) error {
-	return executil.RunEnv(ctx, barePath, fetchEnv(), "git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
+	return gitexec.Run(ctx, gitexec.Options{Dir: barePath, Env: fetchEnv()}, append([]string{"-c", "safe.bareRepository=all"}, args...)...)
 }
 
 func networkGitContext(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -90,7 +89,7 @@ func networkGitContext(ctx context.Context) (context.Context, context.CancelFunc
 func runNetworkGit(ctx context.Context, dir string, env []string, args ...string) error {
 	networkCtx, cancel := networkGitContext(ctx)
 	defer cancel()
-	return executil.RunEnv(networkCtx, dir, env, "git", args...)
+	return gitexec.Run(networkCtx, gitexec.Options{Dir: dir, Env: env}, args...)
 }
 
 func runBareFetch(ctx context.Context, barePath string, args ...string) error {
@@ -98,7 +97,7 @@ func runBareFetch(ctx context.Context, barePath string, args ...string) error {
 }
 
 func outputBare(ctx context.Context, barePath string, args ...string) (string, error) {
-	return executil.Output(ctx, barePath, "git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
+	return gitexec.Output(ctx, gitexec.Options{Dir: barePath}, append([]string{"-c", "safe.bareRepository=all"}, args...)...)
 }
 
 // LoadRepoConfig reads .sybra.yaml from the worktree root. Returns an empty
@@ -171,15 +170,12 @@ var errRefUnresolved = errors.New("ref does not resolve")
 // ref; any other failure (e.g. context cancellation) is returned as a plain
 // error so it propagates rather than triggering a fallback.
 func showFileAtRef(ctx context.Context, barePath, ref, path string) (data []byte, found bool, err error) {
-	cmd := exec.CommandContext(ctx, "git", "-c", "safe.bareRepository=all", "show", ref+":"+path)
-	cmd.Dir = barePath
-	out, runErr := cmd.Output()
+	out, runErr := gitexec.RawOutput(ctx, gitexec.Options{Dir: barePath}, "-c", "safe.bareRepository=all", "show", ref+":"+path)
 	if runErr == nil {
 		return out, true, nil
 	}
-	var exitErr *exec.ExitError
-	if errors.As(runErr, &exitErr) {
-		stderr := string(exitErr.Stderr)
+	if _, ok := gitexec.ExitCode(runErr); ok {
+		stderr := runErr.Error()
 		switch {
 		case strings.Contains(stderr, "does not exist in") || strings.Contains(stderr, "exists on disk, but not in"):
 			return nil, false, nil
@@ -200,13 +196,11 @@ func showFileAtRef(ctx context.Context, barePath, ref, path string) (data []byte
 // across concurrently-operating worktrees of one project rather than just
 // within a single worktree.
 func gitCommonDir(ctx context.Context, worktreePath string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
-	cmd.Dir = worktreePath
-	out, err := cmd.Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--git-common-dir")
 	if err != nil {
 		return "", fmt.Errorf("resolve git dir: %w", err)
 	}
-	gitDir := strings.TrimSpace(string(out))
+	gitDir := out
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(worktreePath, gitDir)
 	}
@@ -290,9 +284,7 @@ func InstallSignoffHook(ctx context.Context, worktreePath string) error {
 	if err := os.WriteFile(path, []byte(signoffHook), 0o755); err != nil {
 		return fmt.Errorf("write prepare-commit-msg hook: %w", err)
 	}
-	pin := exec.CommandContext(ctx, "git", "config", "core.hooksPath", hooksDir)
-	pin.Dir = worktreePath
-	if err := pin.Run(); err != nil {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "config", "core.hooksPath", hooksDir); err != nil {
 		return fmt.Errorf("pin core.hooksPath: %w", err)
 	}
 	return nil
@@ -431,7 +423,7 @@ func commitIdentity(ctx context.Context) (name, email string) {
 }
 
 func gitGlobalConfig(ctx context.Context, key string) string {
-	out, err := executil.Output(ctx, "", "git", "config", "--global", "--get", key)
+	out, err := gitexec.Output(ctx, gitexec.Options{}, "config", "--global", "--get", key)
 	if err != nil {
 		return ""
 	}
@@ -630,15 +622,11 @@ func resolveRef(ctx context.Context, barePath, ref string) (string, bool) {
 func AutoCommitUncommitted(ctx context.Context, wtPath, message string) bool {
 	restoreProtectedPaths(ctx, wtPath)
 	removeEmbeddedGitDirs(wtPath)
-	statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
-	statusCmd.Dir = wtPath
-	statusOut, err := statusCmd.Output()
-	if err != nil || len(strings.TrimSpace(string(statusOut))) == 0 {
+	statusOut, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "status", "--porcelain")
+	if err != nil || statusOut == "" {
 		return false
 	}
-	add := exec.CommandContext(ctx, "git", "add", "-A")
-	add.Dir = wtPath
-	if err := add.Run(); err != nil {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "add", "-A"); err != nil {
 		return false
 	}
 	return runRecoveryCommit(ctx, wtPath, message) == nil
@@ -654,9 +642,7 @@ func restoreProtectedPaths(ctx context.Context, wtPath string) {
 		if !isSafeProtectedPath(p) {
 			continue
 		}
-		restore := exec.CommandContext(ctx, "git", "checkout", "--", ":(literal)"+p)
-		restore.Dir = wtPath
-		_ = restore.Run()
+		_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "checkout", "--", ":(literal)"+p)
 	}
 }
 
@@ -720,20 +706,16 @@ func CheckpointCommit(ctx context.Context, wtPath, message string) (committed bo
 }
 
 func checkpointCommitOnce(ctx context.Context, wtPath, message string) (committed bool, err error) {
-	statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
-	statusCmd.Dir = wtPath
-	statusOut, err := statusCmd.CombinedOutput()
+	statusOut, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "status", "--porcelain")
 	if err != nil {
-		return false, fmt.Errorf("git status --porcelain: %w: %s", err, strings.TrimSpace(string(statusOut)))
+		return false, err
 	}
-	if len(strings.TrimSpace(string(statusOut))) == 0 {
+	if statusOut == "" {
 		return false, nil
 	}
 
-	add := exec.CommandContext(ctx, "git", "add", "-A")
-	add.Dir = wtPath
-	if out, err := add.CombinedOutput(); err != nil {
-		return false, fmt.Errorf("git add -A: %w: %s", err, strings.TrimSpace(string(out)))
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "add", "-A"); err != nil {
+		return false, err
 	}
 
 	if err := checkpointRunRecoveryCommit(ctx, wtPath, message); err != nil {
@@ -747,8 +729,8 @@ func repairCheckpointWorktree(ctx context.Context, wtPath string) error {
 	if err != nil {
 		return err
 	}
-	branchOut, _ := exec.CommandContext(ctx, "git", "-C", wtPath, "branch", "--show-current").Output()
-	_, err = RepairBareClone(ctx, commonDir, strings.TrimSpace(string(branchOut)))
+	branchOut, _ := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "branch", "--show-current")
+	_, err = RepairBareClone(ctx, commonDir, branchOut)
 	return err
 }
 
@@ -764,9 +746,7 @@ func SanitizeWorktree(ctx context.Context, wtPath string) error {
 	// Abort stuck merge if any. No harm running this when no merge is in
 	// progress — git just errors, which we ignore (best-effort, like the
 	// rebase abort above).
-	abort := exec.CommandContext(ctx, "git", "merge", "--abort")
-	abort.Dir = wtPath
-	_ = abort.Run()
+	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "merge", "--abort")
 
 	// Auto-commit any uncommitted changes before resetting. Agents are expected
 	// to commit before finishing, but if they forget this preserves their work
@@ -776,28 +756,20 @@ func SanitizeWorktree(ctx context.Context, wtPath string) error {
 	// Discard any remaining working-tree dirt (e.g. ignored files, failed
 	// commit) so the rebase can proceed cleanly. Committed work on the branch
 	// is preserved.
-	reset := exec.CommandContext(ctx, "git", "reset", "--hard", "HEAD")
-	reset.Dir = wtPath
-	_ = reset.Run()
-	clean := exec.CommandContext(ctx, "git", "clean", "-fd")
-	clean.Dir = wtPath
-	_ = clean.Run()
+	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "reset", "--hard", "HEAD")
+	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "clean", "-fd")
 
 	// Delete local branches that shadow remote tracking refs.
 	// A local branch named "origin/foo" shadows "refs/remotes/origin/foo".
-	listCmd := exec.CommandContext(ctx, "git", "branch", "--format=%(refname:short)")
-	listCmd.Dir = wtPath
-	branchOut, err := listCmd.Output()
+	branchOut, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "branch", "--format=%(refname:short)")
 	if err != nil {
 		return err
 	}
-	for line := range strings.SplitSeq(strings.TrimSpace(string(branchOut)), "\n") {
+	for line := range strings.SplitSeq(branchOut, "\n") {
 		if !strings.HasPrefix(line, "origin/") {
 			continue
 		}
-		del := exec.CommandContext(ctx, "git", "branch", "-D", line)
-		del.Dir = wtPath
-		_ = del.Run()
+		_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "branch", "-D", line)
 	}
 	return nil
 }
@@ -816,19 +788,13 @@ func ResetWorktreeForRetry(ctx context.Context, wtPath, ref string) error {
 		clearRebaseState(ctx, wtPath)
 	}
 
-	abort := exec.CommandContext(ctx, "git", "merge", "--abort")
-	abort.Dir = wtPath
-	_ = abort.Run()
+	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "merge", "--abort")
 
-	reset := exec.CommandContext(ctx, "git", "reset", "--hard", ref)
-	reset.Dir = wtPath
-	if out, err := reset.CombinedOutput(); err != nil {
-		return fmt.Errorf("reset worktree to %s: %w: %s", ref, err, strings.TrimSpace(string(out)))
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "reset", "--hard", ref); err != nil {
+		return fmt.Errorf("reset worktree to %s: %w", ref, err)
 	}
-	clean := exec.CommandContext(ctx, "git", "clean", "-fd")
-	clean.Dir = wtPath
-	if out, err := clean.CombinedOutput(); err != nil {
-		return fmt.Errorf("clean worktree: %w: %s", err, strings.TrimSpace(string(out)))
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "clean", "-fd"); err != nil {
+		return fmt.Errorf("clean worktree: %w", err)
 	}
 	return nil
 }
@@ -845,9 +811,7 @@ func clearRebaseState(ctx context.Context, wtPath string) {
 	dir := rebaseStateDir(ctx, wtPath)
 	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rebaseAbortTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(abortCtx, "git", "rebase", "--abort")
-	cmd.Dir = wtPath
-	if err := cmd.Run(); err != nil {
+	if err := gitexec.Run(abortCtx, gitexec.Options{Dir: wtPath}, "rebase", "--abort"); err != nil {
 		_ = os.RemoveAll(dir)
 	}
 }
@@ -856,13 +820,11 @@ func clearRebaseState(ctx context.Context, wtPath string) {
 func rebaseStateDir(ctx context.Context, wtPath string) string {
 	// git worktrees store rebase state inside the .git dir (which is a file
 	// pointing to the actual gitdir). Use rev-parse to resolve it.
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
-	cmd.Dir = wtPath
-	out, err := cmd.Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "rev-parse", "--git-dir")
 	if err != nil {
 		return filepath.Join(wtPath, ".git", "rebase-merge")
 	}
-	gitDir := strings.TrimSpace(string(out))
+	gitDir := out
 	// Check both rebase-merge (interactive) and rebase-apply (am-style).
 	for _, sub := range []string{"rebase-merge", "rebase-apply"} {
 		p := filepath.Join(gitDir, sub)
@@ -1005,7 +967,7 @@ func isSybraBranchPrefix(prefix string) bool {
 // the fork — and `gh pr create` therefore open cross-repo PRs — without a
 // project-level setting.
 func PushRemote(ctx context.Context, repoPath string) string {
-	if _, err := executil.Output(ctx, repoPath, "git", "config", "--get", "remote.fork.url"); err == nil {
+	if _, err := gitexec.Output(ctx, gitexec.Options{Dir: repoPath}, "config", "--get", "remote.fork.url"); err == nil {
 		return "fork"
 	}
 	return "origin"
@@ -1013,7 +975,7 @@ func PushRemote(ctx context.Context, repoPath string) string {
 
 // RemoteConfigured reports whether repoPath has a configured URL for remote.
 func RemoteConfigured(ctx context.Context, repoPath, remote string) bool {
-	_, err := executil.Output(ctx, repoPath, "git", "config", "--get", "remote."+remote+".url")
+	_, err := gitexec.Output(ctx, gitexec.Options{Dir: repoPath}, "config", "--get", "remote."+remote+".url")
 	return err == nil
 }
 
@@ -1028,10 +990,9 @@ const forkOnlyDisabledPushURL = "sybra-disabled-do-not-push-to-upstream-use-fork
 // intentionally not treated as Sybra's guard and must retain normal Git push
 // behavior.
 func OriginPushHasForkOnlyGuard(ctx context.Context, worktreePath string) (bool, error) {
-	pushURL, err := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote.origin.pushurl")
+	pushURL, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "config", "--get", "remote.origin.pushurl")
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		if code, ok := gitexec.ExitCode(err); ok && code == 1 {
 			return false, nil
 		}
 		return false, err
@@ -1049,14 +1010,14 @@ func OriginPushHasForkOnlyGuard(ctx context.Context, worktreePath string) (bool,
 // pushing to origin normally. Foreign pushurl values (set by the user) are
 // left untouched.
 func EnforceForkOnlyPush(ctx context.Context, worktreePath string) error {
-	if _, err := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote.fork.url"); err != nil {
-		current, getErr := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote.origin.pushurl")
+	if _, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "config", "--get", "remote.fork.url"); err != nil {
+		current, getErr := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "config", "--get", "remote.origin.pushurl")
 		if getErr == nil && strings.TrimSpace(current) == forkOnlyDisabledPushURL {
-			_ = executil.Run(ctx, worktreePath, "git", "config", "--unset", "remote.origin.pushurl")
+			_ = gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "config", "--unset", "remote.origin.pushurl")
 		}
 		return nil
 	}
-	return executil.Run(ctx, worktreePath, "git", "remote", "set-url", "--push", "origin", forkOnlyDisabledPushURL)
+	return gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "remote", "set-url", "--push", "origin", forkOnlyDisabledPushURL)
 }
 
 // ConfigureGitHubAuth removes any credentials embedded in the origin remote
@@ -1069,12 +1030,12 @@ func ConfigureGitHubAuth(ctx context.Context, worktreePath string) error {
 	if err := stripRemoteURLCredentials(ctx, worktreePath, "origin"); err != nil {
 		return err
 	}
-	return executil.Run(ctx, worktreePath, "git", "config",
+	return gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "config",
 		"credential.https://github.com.helper", "!gh auth git-credential")
 }
 
 func stripRemoteURLCredentials(ctx context.Context, worktreePath, remote string) error {
-	raw, err := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote."+remote+".url")
+	raw, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "config", "--get", "remote."+remote+".url")
 	if err != nil {
 		return fmt.Errorf("read %s remote url: %w", remote, err)
 	}
@@ -1082,7 +1043,7 @@ func stripRemoteURLCredentials(ctx context.Context, worktreePath, remote string)
 	if !changed {
 		return nil
 	}
-	return executil.Run(ctx, worktreePath, "git", "remote", "set-url", remote, cleaned)
+	return gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "remote", "set-url", remote, cleaned)
 }
 
 func stripHTTPSUserinfo(rawURL string) (string, bool) {
@@ -1196,11 +1157,8 @@ func DeleteBranch(ctx context.Context, barePath, branch string) error {
 // entire recreate path would only strand a task on a local-only cleanup.
 func DeleteUpstreamBranch(ctx context.Context, barePath, branch string) error {
 	remote := PushRemote(ctx, barePath)
-	cmd := exec.CommandContext(ctx, "git", "config", "--get", "remote."+remote+".url")
-	cmd.Dir = barePath
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: barePath}, "config", "--get", "remote."+remote+".url"); err != nil {
+		if code, ok := gitexec.ExitCode(err); ok && code == 1 {
 			return nil
 		}
 		return fmt.Errorf("resolve remote %s config: %w", remote, err)
@@ -1270,7 +1228,7 @@ func IsWorktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
 // rather than silently destroying possibly-unpushed work (see #2593, where a
 // completed implementation was lost this way).
 func HasUnpushedCommits(ctx context.Context, worktreePath string) bool {
-	out, err := executil.Output(ctx, worktreePath, "git", "rev-list", "--count", "HEAD", "--not", "--remotes")
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-list", "--count", "HEAD", "--not", "--remotes")
 	if err != nil {
 		return true
 	}
@@ -1282,7 +1240,7 @@ func HasUnpushedCommits(ctx context.Context, worktreePath string) bool {
 // promotion to materialize the canonical worktree at the winning attempt's
 // HEAD after SetBranchTo has already moved the shared branch ref.
 func HardResetWorktree(ctx context.Context, worktreePath, ref string) error {
-	return executil.Run(ctx, worktreePath, "git", "reset", "--hard", ref)
+	return gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "reset", "--hard", ref)
 }
 
 // HeadArg returns the `gh pr create --head` value for branch: a bare branch
@@ -1293,7 +1251,7 @@ func HeadArg(ctx context.Context, worktreePath, branch string) (string, error) {
 	if PushRemote(ctx, worktreePath) != "fork" {
 		return branch, nil
 	}
-	forkURL, err := executil.Output(ctx, worktreePath, "git", "config", "--get", "remote.fork.url")
+	forkURL, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "config", "--get", "remote.fork.url")
 	if err != nil {
 		return "", fmt.Errorf("resolve fork remote url: %w", err)
 	}
@@ -1306,7 +1264,7 @@ func HeadArg(ctx context.Context, worktreePath, branch string) (string, error) {
 
 // CurrentBranch returns the checked-out branch name for a worktree.
 func CurrentBranch(ctx context.Context, worktreePath string) (string, error) {
-	branch, err := executil.Output(ctx, worktreePath, "git", "branch", "--show-current")
+	branch, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "branch", "--show-current")
 	if err != nil {
 		return "", err
 	}
@@ -1315,7 +1273,7 @@ func CurrentBranch(ctx context.Context, worktreePath string) (string, error) {
 
 // CurrentCommit returns the full SHA of HEAD for a worktree.
 func CurrentCommit(ctx context.Context, worktreePath string) (string, error) {
-	sha, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "HEAD")
+	sha, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -1331,9 +1289,7 @@ func RemoteBranchHead(ctx context.Context, worktreePath, remote, branch string) 
 // isAncestor reports whether ancestor is reachable from descendant in the
 // worktree's history. Returns false when either ref is unknown.
 func isAncestor(ctx context.Context, worktreePath, ancestor, descendant string) bool {
-	cmd := exec.CommandContext(ctx, "git", "merge-base", "--is-ancestor", ancestor, descendant)
-	cmd.Dir = worktreePath
-	return cmd.Run() == nil
+	return gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "merge-base", "--is-ancestor", ancestor, descendant) == nil
 }
 
 // remoteBranchHead queries the live head SHA of branch on remote via ls-remote.
@@ -1343,14 +1299,11 @@ func remoteBranchHead(ctx context.Context, worktreePath, remote, branch string) 
 	err := withNetworkRetry(ctx, func() error {
 		networkCtx, cancel := networkGitContext(ctx)
 		defer cancel()
-		cmd := exec.CommandContext(networkCtx, "git", "ls-remote", remote, "refs/heads/"+branch)
-		cmd.Dir = worktreePath
-		cmd.Env = fetchEnv()
-		raw, runErr := cmd.CombinedOutput()
+		raw, runErr := gitexec.Output(networkCtx, gitexec.Options{Dir: worktreePath, Env: fetchEnv()}, "ls-remote", remote, "refs/heads/"+branch)
 		if runErr != nil {
-			return fmt.Errorf("git ls-remote %s refs/heads/%s: %w: %s", remote, branch, runErr, strings.TrimSpace(string(raw)))
+			return fmt.Errorf("resolve remote branch: %w", runErr)
 		}
-		out = strings.TrimSpace(string(raw))
+		out = raw
 		return nil
 	})
 	if err != nil {
@@ -1364,7 +1317,7 @@ func remoteBranchHead(ctx context.Context, worktreePath, remote, branch string) 
 }
 
 func remoteTrackingRef(ctx context.Context, worktreePath, remote, branch string) (string, bool) {
-	sha, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch)
+	sha, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch)
 	return sha, err == nil
 }
 
@@ -1408,7 +1361,7 @@ func refreshTrackingRefWithFetch(ctx context.Context, worktreePath, remote, bran
 }
 
 func reconcileWithTargetSHA(ctx context.Context, worktreePath, label, targetSHA string) error {
-	localSHA, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "HEAD")
+	localSHA, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return err
 	}
@@ -1426,7 +1379,7 @@ func reconcileWithTargetSHA(ctx context.Context, worktreePath, label, targetSHA 
 		if dirty {
 			return ErrDirtyWorktree
 		}
-		return executil.Run(ctx, worktreePath, "git", "merge", "--ff-only", targetSHA)
+		return gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "merge", "--ff-only", targetSHA)
 	}
 	return fmt.Errorf("%w: local %s vs %s %s", ErrBranchDiverged, localSHA[:min(7, len(localSHA))], label, targetSHA[:min(7, len(targetSHA))])
 }
@@ -1482,7 +1435,7 @@ func ReconcileWithNamedRemote(ctx context.Context, worktreePath, remote, branch 
 
 // ReconcileWithRef is ReconcileWithRemote for an already-fetched local ref.
 func ReconcileWithRef(ctx context.Context, worktreePath, ref string) error {
-	targetSHA, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", ref)
+	targetSHA, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--verify", ref)
 	if err != nil {
 		return fmt.Errorf("resolve %s: %w", ref, err)
 	}
@@ -1527,7 +1480,7 @@ func MergeDivergedRef(ctx context.Context, worktreePath, ref string) (bool, erro
 }
 
 func worktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
-	out, err := executil.Output(ctx, worktreePath, "git", "status", "--porcelain")
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "status", "--porcelain")
 	if err != nil {
 		return false, err
 	}
@@ -1558,7 +1511,7 @@ func PushSync(ctx context.Context, worktreePath, branch string) error {
 
 // RemoteURL returns a configured remote's fetch URL.
 func RemoteURL(ctx context.Context, worktreePath, remote string) (string, error) {
-	remoteURL, err := executil.Output(ctx, worktreePath, "git", "remote", "get-url", remote)
+	remoteURL, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "remote", "get-url", remote)
 	if err != nil {
 		return "", fmt.Errorf("resolve remote %s URL: %w", remote, err)
 	}
@@ -1587,9 +1540,8 @@ func PushSyncToPinnedRemote(ctx context.Context, worktreePath, branch, remote, e
 }
 
 func pushSyncToRemote(ctx context.Context, worktreePath, branch, remote, pinnedPushURL string) error {
-	if err := executil.Run(ctx, worktreePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
+		if code, ok := gitexec.ExitCode(err); ok && code == 1 {
 			return ErrBranchMissing
 		}
 		return err
@@ -1598,7 +1550,7 @@ func pushSyncToRemote(ctx context.Context, worktreePath, branch, remote, pinnedP
 	if !RemoteConfigured(ctx, worktreePath, remote) {
 		return fmt.Errorf("push remote %q is not configured", remote)
 	}
-	localSHA, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--verify", "refs/heads/"+branch)
+	localSHA, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--verify", "refs/heads/"+branch)
 	if err != nil {
 		return err
 	}
@@ -1702,7 +1654,7 @@ func SetPushAuthFailureHook(f func(err error)) {
 // hook (tests, lint) never fires on this credential-only probe.
 func PreflightPushCredentials(ctx context.Context, worktreePath string) error {
 	remote := PushRemote(ctx, worktreePath)
-	pushURL, err := executil.Output(ctx, worktreePath, "git", "remote", "get-url", "--push", remote)
+	pushURL, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "remote", "get-url", "--push", remote)
 	if err != nil {
 		return fmt.Errorf("resolve push remote %s: %w", remote, err)
 	}
@@ -1780,10 +1732,7 @@ var runGitPushProbe = execGitPushProbe
 func execGitPushProbe(ctx context.Context, dir string, env []string, args ...string) (string, error) {
 	networkCtx, cancel := networkGitContext(ctx)
 	defer cancel()
-	cmd := exec.CommandContext(networkCtx, "git", args...)
-	cmd.Dir = dir
-	cmd.Env = env
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(networkCtx, gitexec.Options{Dir: dir, Env: env}, args...)
 	return string(out), err
 }
 
@@ -1911,7 +1860,7 @@ func PruneWorktrees(ctx context.Context, barePath string) error {
 // path that no longer exists — the usual cause is a container redeploy that
 // changed the in-container mount point of the bare clone.
 func WorktreeHealthy(ctx context.Context, worktreePath string) bool {
-	_, err := executil.Output(ctx, worktreePath, "git", "rev-parse", "--git-dir")
+	_, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--git-dir")
 	return err == nil
 }
 
@@ -1952,9 +1901,9 @@ func RebaseOnto(ctx context.Context, worktreePath, ref string) error {
 	if isAncestor(ctx, worktreePath, ref, "HEAD") {
 		return nil
 	}
-	if err := executil.Run(ctx, worktreePath, "git", "rebase", ref); err != nil {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "rebase", ref); err != nil {
 		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rebaseAbortTimeout)
-		_ = executil.Run(abortCtx, worktreePath, "git", "rebase", "--abort")
+		_ = gitexec.Run(abortCtx, gitexec.Options{Dir: worktreePath}, "rebase", "--abort")
 		cancel()
 		return fmt.Errorf("rebase onto %s: %w", ref, err)
 	}
@@ -1974,13 +1923,13 @@ func RebaseOnto(ctx context.Context, worktreePath, ref string) error {
 // never configured one; --no-verify skips repo pre-commit hooks the same
 // way, so a failing hook can't defeat this recovery path.
 func MergeOnto(ctx context.Context, worktreePath, ref string) error {
-	if err := executil.Run(ctx, worktreePath, "git",
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: worktreePath},
 		"-c", "user.name=Sybra",
 		"-c", "user.email=sybra@localhost",
 		"-c", "commit.gpgsign=false",
 		"merge", "--no-edit", "--no-verify", "--signoff", ref); err != nil {
 		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rebaseAbortTimeout)
-		_ = executil.Run(abortCtx, worktreePath, "git", "merge", "--abort")
+		_ = gitexec.Run(abortCtx, gitexec.Options{Dir: worktreePath}, "merge", "--abort")
 		cancel()
 		return fmt.Errorf("merge %s: %w", ref, err)
 	}
@@ -2029,36 +1978,35 @@ func (r CleanMergeResult) String() string {
 // pre-merge HEAD plus `git clean -fd` so the caller's agent fallback always
 // starts from a clean tree.
 func TryCleanMerge(ctx context.Context, wtPath, baseRef string) (CleanMergeResult, error) {
-	if err := executil.Run(ctx, wtPath, "git", "rev-parse", "--verify", baseRef); err != nil {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "rev-parse", "--verify", baseRef); err != nil {
 		return CleanMergeConflict, fmt.Errorf("resolve base ref %s: %w", baseRef, err)
 	}
 
-	preMergeHEAD, err := executil.Output(ctx, wtPath, "git", "rev-parse", "--verify", "HEAD")
+	preMergeHEAD, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return CleanMergeConflict, fmt.Errorf("resolve pre-merge HEAD: %w", err)
 	}
 	preMergeHEAD = strings.TrimSpace(preMergeHEAD)
 
-	mergeErr := executil.Run(ctx, wtPath, "git",
+	mergeErr := gitexec.Run(ctx, gitexec.Options{Dir: wtPath},
 		"-c", "user.name=Sybra",
 		"-c", "user.email=sybra@localhost",
 		"-c", "commit.gpgsign=false",
 		"merge", "--no-edit", "--no-verify", "--signoff", baseRef)
 	if mergeErr != nil {
 		conflict := false
-		var exitErr *exec.ExitError
-		if errors.As(mergeErr, &exitErr) && exitErr.ExitCode() == 1 {
+		if code, ok := gitexec.ExitCode(mergeErr); ok && code == 1 {
 			conflict = true
 		}
 
 		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rebaseAbortTimeout)
 		defer cancel()
-		_ = executil.Run(abortCtx, wtPath, "git", "merge", "--abort")
+		_ = gitexec.Run(abortCtx, gitexec.Options{Dir: wtPath}, "merge", "--abort")
 
-		statusOut, statusErr := executil.Output(abortCtx, wtPath, "git", "status", "--porcelain")
+		statusOut, statusErr := gitexec.Output(abortCtx, gitexec.Options{Dir: wtPath}, "status", "--porcelain")
 		if statusErr != nil || strings.TrimSpace(statusOut) != "" {
-			_ = executil.Run(abortCtx, wtPath, "git", "reset", "--hard", preMergeHEAD)
-			_ = executil.Run(abortCtx, wtPath, "git", "clean", "-fd")
+			_ = gitexec.Run(abortCtx, gitexec.Options{Dir: wtPath}, "reset", "--hard", preMergeHEAD)
+			_ = gitexec.Run(abortCtx, gitexec.Options{Dir: wtPath}, "clean", "-fd")
 		}
 		if !conflict {
 			return CleanMergeConflict, fmt.Errorf("merge %s into worktree: %w", baseRef, mergeErr)
@@ -2066,7 +2014,7 @@ func TryCleanMerge(ctx context.Context, wtPath, baseRef string) (CleanMergeResul
 		return CleanMergeConflict, nil
 	}
 
-	postMergeHEAD, err := executil.Output(ctx, wtPath, "git", "rev-parse", "--verify", "HEAD")
+	postMergeHEAD, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return CleanMergeConflict, fmt.Errorf("resolve post-merge HEAD: %w", err)
 	}

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -746,7 +746,7 @@ func SanitizeWorktree(ctx context.Context, wtPath string) error {
 	// Abort stuck merge if any. No harm running this when no merge is in
 	// progress — git just errors, which we ignore (best-effort, like the
 	// rebase abort above).
-	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "merge", "--abort")
+	_ = gitexec.RunQuiet(ctx, gitexec.Options{Dir: wtPath}, "merge", "--abort")
 
 	// Auto-commit any uncommitted changes before resetting. Agents are expected
 	// to commit before finishing, but if they forget this preserves their work
@@ -756,8 +756,8 @@ func SanitizeWorktree(ctx context.Context, wtPath string) error {
 	// Discard any remaining working-tree dirt (e.g. ignored files, failed
 	// commit) so the rebase can proceed cleanly. Committed work on the branch
 	// is preserved.
-	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "reset", "--hard", "HEAD")
-	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "clean", "-fd")
+	_ = gitexec.RunQuiet(ctx, gitexec.Options{Dir: wtPath}, "reset", "--hard", "HEAD")
+	_ = gitexec.RunQuiet(ctx, gitexec.Options{Dir: wtPath}, "clean", "-fd")
 
 	// Delete local branches that shadow remote tracking refs.
 	// A local branch named "origin/foo" shadows "refs/remotes/origin/foo".
@@ -769,7 +769,7 @@ func SanitizeWorktree(ctx context.Context, wtPath string) error {
 		if !strings.HasPrefix(line, "origin/") {
 			continue
 		}
-		_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "branch", "-D", line)
+		_ = gitexec.RunQuiet(ctx, gitexec.Options{Dir: wtPath}, "branch", "-D", line)
 	}
 	return nil
 }
@@ -788,7 +788,7 @@ func ResetWorktreeForRetry(ctx context.Context, wtPath, ref string) error {
 		clearRebaseState(ctx, wtPath)
 	}
 
-	_ = gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "merge", "--abort")
+	_ = gitexec.RunQuiet(ctx, gitexec.Options{Dir: wtPath}, "merge", "--abort")
 
 	if err := gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, "reset", "--hard", ref); err != nil {
 		return fmt.Errorf("reset worktree to %s: %w", ref, err)
@@ -811,7 +811,7 @@ func clearRebaseState(ctx context.Context, wtPath string) {
 	dir := rebaseStateDir(ctx, wtPath)
 	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rebaseAbortTimeout)
 	defer cancel()
-	if err := gitexec.Run(abortCtx, gitexec.Options{Dir: wtPath}, "rebase", "--abort"); err != nil {
+	if err := gitexec.RunQuiet(abortCtx, gitexec.Options{Dir: wtPath}, "rebase", "--abort"); err != nil {
 		_ = os.RemoveAll(dir)
 	}
 }
@@ -1157,7 +1157,7 @@ func DeleteBranch(ctx context.Context, barePath, branch string) error {
 // entire recreate path would only strand a task on a local-only cleanup.
 func DeleteUpstreamBranch(ctx context.Context, barePath, branch string) error {
 	remote := PushRemote(ctx, barePath)
-	if err := gitexec.Run(ctx, gitexec.Options{Dir: barePath}, "config", "--get", "remote."+remote+".url"); err != nil {
+	if err := gitexec.RunQuiet(ctx, gitexec.Options{Dir: barePath}, "config", "--get", "remote."+remote+".url"); err != nil {
 		if code, ok := gitexec.ExitCode(err); ok && code == 1 {
 			return nil
 		}
@@ -1289,7 +1289,7 @@ func RemoteBranchHead(ctx context.Context, worktreePath, remote, branch string) 
 // isAncestor reports whether ancestor is reachable from descendant in the
 // worktree's history. Returns false when either ref is unknown.
 func isAncestor(ctx context.Context, worktreePath, ancestor, descendant string) bool {
-	return gitexec.Run(ctx, gitexec.Options{Dir: worktreePath}, "merge-base", "--is-ancestor", ancestor, descendant) == nil
+	return gitexec.RunQuiet(ctx, gitexec.Options{Dir: worktreePath}, "merge-base", "--is-ancestor", ancestor, descendant) == nil
 }
 
 // remoteBranchHead queries the live head SHA of branch on remote via ls-remote.

--- a/internal/project/recovery_commit.go
+++ b/internal/project/recovery_commit.go
@@ -3,16 +3,14 @@ package project
 import (
 	"context"
 	"fmt"
-	"os/exec"
-	"strings"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 func gitIdentityConfigured(ctx context.Context, wtPath string) bool {
 	for _, key := range []string{"user.name", "user.email"} {
-		cmd := exec.CommandContext(ctx, "git", "config", "--get", key)
-		cmd.Dir = wtPath
-		out, err := cmd.Output()
-		if err != nil || strings.TrimSpace(string(out)) == "" {
+		out, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "config", "--get", key)
+		if err != nil || out == "" {
 			return false
 		}
 	}
@@ -36,18 +34,16 @@ func recoveryCommitArgs(message string, hasIdentity, sign bool) []string {
 func runRecoveryCommit(ctx context.Context, wtPath, message string) error {
 	hasIdentity := gitIdentityConfigured(ctx, wtPath)
 	sign := GPGSigningAvailable(ctx)
-	out, err := gitCommitOutput(ctx, wtPath, recoveryCommitArgs(message, hasIdentity, sign))
+	err := gitCommit(ctx, wtPath, recoveryCommitArgs(message, hasIdentity, sign))
 	if err != nil && sign {
-		out, err = gitCommitOutput(ctx, wtPath, recoveryCommitArgs(message, hasIdentity, false))
+		err = gitCommit(ctx, wtPath, recoveryCommitArgs(message, hasIdentity, false))
 	}
 	if err != nil {
-		return fmt.Errorf("recovery commit: %w: %s", err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("recovery commit: %w", err)
 	}
 	return nil
 }
 
-func gitCommitOutput(ctx context.Context, wtPath string, args []string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = wtPath
-	return cmd.CombinedOutput()
+func gitCommit(ctx context.Context, wtPath string, args []string) error {
+	return gitexec.Run(ctx, gitexec.Options{Dir: wtPath}, args...)
 }

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -178,7 +178,7 @@ func indexUsable(ctx context.Context, checkoutPath string) error {
 // runQuietGit runs git in dir and discards successful output. On failure the
 // shared execution boundary includes Git's diagnostic output in the error.
 func runQuietGit(ctx context.Context, dir string, args ...string) error {
-	return gitexec.Run(ctx, gitexec.Options{Dir: dir}, args...)
+	return gitexec.RunQuiet(ctx, gitexec.Options{Dir: dir}, args...)
 }
 
 // bareRefTips lists the object ids every ref points at. They are the roots

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -333,7 +333,7 @@ func rebuildWorktreeIndexes(ctx context.Context, barePath string, report *Repair
 			continue
 		}
 		QuarantineRef(barePath, "worktrees/"+entry.Name()+"/index", quarantined)
-		if err := gitexec.Run(ctx, gitexec.Options{Dir: checkoutPath}, "reset", "--mixed", "HEAD"); err != nil {
+		if err := gitexec.RunQuiet(ctx, gitexec.Options{Dir: checkoutPath}, "reset", "--mixed", "HEAD"); err != nil {
 			_ = os.Rename(quarantined, indexPath)
 			continue
 		}

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -3,12 +3,12 @@ package project
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 type RepairReport struct {
@@ -175,18 +175,10 @@ func indexUsable(ctx context.Context, checkoutPath string) error {
 	return nil
 }
 
-// runQuietGit runs git in dir, discarding stdout and surfacing only stderr,
-// which is the part that explains a failure.
+// runQuietGit runs git in dir and discards successful output. On failure the
+// shared execution boundary includes Git's diagnostic output in the error.
 func runQuietGit(ctx context.Context, dir string, args ...string) error {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = dir
-	cmd.Stdout = io.Discard
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	return nil
+	return gitexec.Run(ctx, gitexec.Options{Dir: dir}, args...)
 }
 
 // bareRefTips lists the object ids every ref points at. They are the roots
@@ -341,10 +333,8 @@ func rebuildWorktreeIndexes(ctx context.Context, barePath string, report *Repair
 			continue
 		}
 		QuarantineRef(barePath, "worktrees/"+entry.Name()+"/index", quarantined)
-		cmd := exec.CommandContext(ctx, "git", "-C", checkoutPath, "reset", "--mixed", "HEAD")
-		if out, err := cmd.CombinedOutput(); err != nil {
+		if err := gitexec.Run(ctx, gitexec.Options{Dir: checkoutPath}, "reset", "--mixed", "HEAD"); err != nil {
 			_ = os.Rename(quarantined, indexPath)
-			_ = out
 			continue
 		}
 		report.RebuiltWorktreeIndexes = append(report.RebuiltWorktreeIndexes, "worktrees/"+entry.Name()+"/index")

--- a/internal/project/signing.go
+++ b/internal/project/signing.go
@@ -2,8 +2,8 @@ package project
 
 import (
 	"context"
-	"os/exec"
-	"strings"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 // GPGSigningAvailable reports whether this machine can GPG-sign commits, i.e.
@@ -13,11 +13,11 @@ import (
 // emit only -s there. DCO sign-off (-s) is guaranteed independently by the
 // prepare-commit-msg hook (see InstallSignoffHook).
 func GPGSigningAvailable(ctx context.Context) bool {
-	out, err := exec.CommandContext(ctx, "git", "config", "--global", "--get", "user.signingkey").Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{}, "config", "--global", "--get", "user.signingkey")
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(string(out)) != ""
+	return out != ""
 }
 
 // CommitSignFlags returns the git commit flags an agent should use on this

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -920,7 +920,7 @@ func (a *App) RegisterSpotlightHotkey() {
 		}()
 	})
 
-	if err := spotlight.Register(func() {
+	a.registerSpotlight(func() {
 		projectsJSON := "[]"
 		if projects, err := a.projectSvc.ListProjects(); err == nil {
 			if data, err := json.Marshal(projects); err == nil {
@@ -928,11 +928,7 @@ func (a *App) RegisterSpotlightHotkey() {
 			}
 		}
 		spotlight.ShowPanel(projectsJSON)
-	}); err != nil { //nolint:staticcheck,nolintlint // non-Darwin builds intentionally return an unsupported-platform error.
-		a.logger.Error("spotlight.register", "err", err)
-		return
-	}
-	a.logger.Info("spotlight.registered", "hotkey", "ctrl+space")
+	})
 }
 
 // Context returns the app's running context.

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -928,7 +928,7 @@ func (a *App) RegisterSpotlightHotkey() {
 			}
 		}
 		spotlight.ShowPanel(projectsJSON)
-	}); err != nil {
+	}); err != nil { //nolint:staticcheck,nolintlint // non-Darwin builds intentionally return an unsupported-platform error.
 		a.logger.Error("spotlight.register", "err", err)
 		return
 	}

--- a/internal/sybra/app_spotlight_darwin.go
+++ b/internal/sybra/app_spotlight_darwin.go
@@ -1,0 +1,11 @@
+package sybra
+
+import "github.com/Automaat/sybra/internal/spotlight"
+
+func (a *App) registerSpotlight(callback func()) {
+	if err := spotlight.Register(callback); err != nil {
+		a.logger.Error("spotlight.register", "err", err)
+		return
+	}
+	a.logger.Info("spotlight.registered", "hotkey", "ctrl+space")
+}

--- a/internal/sybra/app_spotlight_other.go
+++ b/internal/sybra/app_spotlight_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package sybra
+
+import "github.com/Automaat/sybra/internal/spotlight"
+
+func (a *App) registerSpotlight(callback func()) {
+	// The non-Darwin implementation always returns the platform support error.
+	// Logging it directly avoids a comparison that staticcheck can prove true.
+	a.logger.Error("spotlight.register", "err", spotlight.Register(callback))
+}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -288,7 +288,7 @@ func (a *App) healthPressureStatus() *health.PressureStatus {
 func (lm *LifecycleManager) StartWatchers(ctx context.Context) {
 	a := lm.app
 	cfgPath := filepath.Join(config.HomeDir(), "config.yaml")
-	cw := confighot.New(cfgPath, func() { //nolint:contextcheck // config reload emits process-global provider health UI events from a file watcher callback.
+	cw := confighot.New(cfgPath, func() { //nolint:contextcheck,nolintlint // contextcheck applies on Darwin; Linux must retain the shared suppression.
 		result, err := a.configSvc.ReloadFromDisk()
 		if err != nil {
 			a.logger.Error("config.reload.failed", "err", err)

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/blocker"
-	"github.com/Automaat/sybra/internal/executil"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/project"
@@ -1104,7 +1104,7 @@ func (r *Handler) autoResolveConflict(ctx context.Context, t task.Task, pr githu
 		return false
 	}
 
-	preMergeHead, err := executil.Output(ctx, dir, "git", "rev-parse", "--verify", "HEAD")
+	preMergeHead, err := gitexec.Output(ctx, gitexec.Options{Dir: dir}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		r.logger.Warn("pr-monitor.auto-resolve.pre-merge-head", "task_id", t.ID, "pr", pr.Number, "err", err)
 		return false
@@ -1112,7 +1112,7 @@ func (r *Handler) autoResolveConflict(ctx context.Context, t task.Task, pr githu
 	preMergeHead = strings.TrimSpace(preMergeHead)
 
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", base, base)
-	if err := executil.Run(ctx, dir, "git", "fetch", "origin", refspec); err != nil {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: dir}, "fetch", "origin", refspec); err != nil {
 		r.logger.Warn("pr-monitor.auto-resolve.fetch", "task_id", t.ID, "pr", pr.Number, "err", err)
 		return false
 	}
@@ -1130,7 +1130,7 @@ func (r *Handler) autoResolveConflict(ctx context.Context, t task.Task, pr githu
 		return false
 	}
 
-	mergedHead, err := executil.Output(ctx, dir, "git", "rev-parse", "--verify", "HEAD")
+	mergedHead, err := gitexec.Output(ctx, gitexec.Options{Dir: dir}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		r.logger.Warn("pr-monitor.auto-resolve.post-merge-head", "task_id", t.ID, "pr", pr.Number, "err", err)
 		r.rollbackAutoResolvedMerge(ctx, t.ID, pr.Number, dir, preMergeHead, "post-merge-head")
@@ -1179,7 +1179,7 @@ func resolveAutoResolveBase(ctx context.Context, dir string, pr github.PullReque
 	if base == "" {
 		return "", errors.New("base branch is empty")
 	}
-	if err := executil.Run(ctx, dir, "git", "check-ref-format", "--branch", base); err != nil {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: dir}, "check-ref-format", "--branch", base); err != nil {
 		return "", fmt.Errorf("validate base branch %q: %w", base, err)
 	}
 	return base, nil
@@ -1191,7 +1191,7 @@ func (r *Handler) rollbackAutoResolvedMerge(ctx context.Context, taskID string, 
 	}
 	resetCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 	defer cancel()
-	if err := executil.Run(resetCtx, dir, "git", "reset", "--hard", preMergeHead); err != nil {
+	if err := gitexec.Run(resetCtx, gitexec.Options{Dir: dir}, "reset", "--hard", preMergeHead); err != nil {
 		r.logger.Error("pr-monitor.auto-resolve.rollback-failed",
 			"task_id", taskID, "pr", prNumber, "reason", reason, "pre_merge_head", preMergeHead, "err", err)
 		return


### PR DESCRIPTION
## Motivation

Route the project repository layer through the shared Git execution boundary while keeping repository policy in `internal/project`.

## Implementation information

- migrate project Git calls and closely related review recovery calls to `internal/gitexec`
- preserve auth environment, network retry and timeout behavior, locking, push safety, divergence handling, repair, and cleanup policy
- add `RunQuiet` to preserve streaming and discard semantics for output-heavy maintenance paths
- retain exit-code classification and add regression coverage for quiet stdout and stderr behavior

Closes #3008

> Changelog: refactor(project): route repository operations through shared Git execution
