### PR TITLE
refactor(workflow): route Git execution through gitexec

### DIFF
--- a/internal/gitexec/gitexec.go
+++ b/internal/gitexec/gitexec.go
@@ -69,6 +69,20 @@ func RawOutput(ctx context.Context, opts Options, args ...string) ([]byte, error
 	return output(ctx, opts, args...)
 }
 
+// OutputWithStderr executes Git and returns raw stdout and stderr separately.
+// It is for callers that must inspect non-fatal stderr emitted by a successful
+// command while keeping stdout byte-exact.
+func OutputWithStderr(ctx context.Context, opts Options, args ...string) (stdoutBytes, stderrBytes []byte, runErr error) {
+	cmd := command(ctx, opts, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.Bytes(), stderr.Bytes(), commandError(args, err, stderr.Bytes())
+	}
+	return stdout.Bytes(), stderr.Bytes(), nil
+}
+
 // CombinedOutput executes Git and returns raw interleaved stdout and stderr.
 // The output is returned even on failure so callers can classify Git errors.
 func CombinedOutput(ctx context.Context, opts Options, args ...string) ([]byte, error) {

--- a/internal/gitexec/gitexec_test.go
+++ b/internal/gitexec/gitexec_test.go
@@ -162,6 +162,40 @@ exit 3
 	}
 }
 
+func TestOutputWithStderrKeepsStreamsSeparate(t *testing.T) {
+	bin := t.TempDir()
+	writeFakeGit(t, bin, `
+printf 'stdout bytes\n'
+printf 'stderr advisory\n' >&2
+if [ "$1" = fail ]; then
+  exit 4
+fi
+`)
+	t.Setenv("PATH", bin)
+
+	stdout, stderr, err := OutputWithStderr(context.Background(), Options{}, "success")
+	if err != nil {
+		t.Fatalf("OutputWithStderr success: %v", err)
+	}
+	if string(stdout) != "stdout bytes\n" || string(stderr) != "stderr advisory\n" {
+		t.Fatalf("OutputWithStderr = (%q, %q), want separate streams", stdout, stderr)
+	}
+
+	stdout, stderr, err = OutputWithStderr(context.Background(), Options{}, "fail")
+	if err == nil {
+		t.Fatal("OutputWithStderr failure unexpectedly succeeded")
+	}
+	if string(stdout) != "stdout bytes\n" || string(stderr) != "stderr advisory\n" {
+		t.Fatalf("failed OutputWithStderr = (%q, %q), want retained streams", stdout, stderr)
+	}
+	if got := err.Error(); !strings.Contains(got, "git fail") || !strings.Contains(got, "stderr advisory") {
+		t.Fatalf("OutputWithStderr error = %q, want command and stderr", got)
+	}
+	if code, ok := ExitCode(err); !ok || code != 4 {
+		t.Fatalf("ExitCode = (%d, %v), want (4, true)", code, ok)
+	}
+}
+
 func TestExecutableResolutionSkipsDanglingShim(t *testing.T) {
 	badBin := t.TempDir()
 	goodBin := t.TempDir()

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/project"
 )
 
@@ -559,7 +559,7 @@ func branchPatchAlreadyAppliedToBase(ctx context.Context, wtPath string) (bool, 
 	}
 
 	// Raw (untrimmed) patch bytes — fed verbatim into `git apply` stdin below.
-	patch, err := gitCmd(ctx, wtPath, "diff", "--binary", mergeBase+"..HEAD", "--").Output()
+	patch, err := gitexec.RawOutput(ctx, gitexec.Options{Dir: wtPath}, "diff", "--binary", mergeBase+"..HEAD", "--")
 	if err != nil {
 		return false, fmt.Errorf("git diff %s..HEAD: %w", mergeBase, err)
 	}
@@ -583,21 +583,15 @@ func branchPatchAlreadyAppliedToBase(ctx context.Context, wtPath string) (bool, 
 		_ = gitDo(cleanupCtx, wtPath, "worktree", "remove", "--force", baseTreeDir)
 	}()
 
-	cmd := gitCmd(ctx, baseTreeDir, "apply", "--check", "--reverse", "--whitespace=nowarn", "-")
-	cmd.Stdin = bytes.NewReader(patch)
-	out, err := cmd.CombinedOutput()
+	_, err = gitexec.CombinedOutput(ctx, gitexec.Options{Dir: baseTreeDir, Stdin: bytes.NewReader(patch)},
+		"apply", "--check", "--reverse", "--whitespace=nowarn", "-")
 	if err == nil {
 		return true, nil
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+	if code, ok := gitexec.ExitCode(err); ok && code == 1 {
 		return false, nil
 	}
-	detail := strings.TrimSpace(string(out))
-	if detail == "" {
-		return false, fmt.Errorf("git apply --reverse --check: %w", err)
-	}
-	return false, fmt.Errorf("git apply --reverse --check: %w: %s", err, detail)
+	return false, fmt.Errorf("git apply --reverse --check: %w", err)
 }
 
 // verifyPushedHead best-effort verifies the PR head now matches local HEAD

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/evidence"
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 // TamperBlessedTag short-circuits the detector: a human who has reviewed a
@@ -1196,11 +1197,11 @@ func pathIdenticalToUpstream(ctx context.Context, wtPath, upstream, path string)
 }
 
 // gitFilePatch and gitFileAtRef return raw (untrimmed) git output — the exact
-// patch/file bytes matter to the tamper regex scanners below, so they use
-// gitCmd directly rather than the output-trimming gitOutput helper.
+// patch/file bytes matter to the tamper regex scanners below, so they use the
+// shared runner's raw-output operation rather than the trimming helper.
 
 func gitFilePatch(ctx context.Context, wtPath, rangeSpec, path string) (string, error) {
-	out, err := gitCmd(ctx, wtPath, "-c", "core.quotePath=false", "diff", rangeSpec, "--", path).Output()
+	out, err := gitexec.RawOutput(ctx, gitexec.Options{Dir: wtPath}, "-c", "core.quotePath=false", "diff", rangeSpec, "--", path)
 	if err != nil {
 		return "", err
 	}
@@ -1212,7 +1213,7 @@ func gitFilePatch(ctx context.Context, wtPath, rangeSpec, path string) (string, 
 // newly added file — which callers treat as "no base content" rather than a
 // hard failure.
 func gitFileAtRef(ctx context.Context, wtPath, ref, path string) (string, error) {
-	out, err := gitCmd(ctx, wtPath, "show", ref+":"+path).Output()
+	out, err := gitexec.RawOutput(ctx, gitexec.Options{Dir: wtPath}, "show", ref+":"+path)
 	if err != nil {
 		return "", err
 	}

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1,13 +1,11 @@
 package workflow
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
@@ -16,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/evidence"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/workflow/failureclassify"
 )
 
@@ -2519,21 +2518,17 @@ func (e *Engine) attemptDiffStat(ctx context.Context, wtPath string) string {
 	defer cancel()
 
 	base := resolveOriginBase(diffCtx, wtPath)
-	cmd := exec.CommandContext(diffCtx, "git", "diff", "--stat", base+"...HEAD")
-	cmd.Dir = wtPath
 	// Capture stderr separately so git's non-fatal advisories (safe.directory,
 	// advice.* hints) — which it can emit while still exiting 0 — never leak into
 	// the note's fenced diff-stat block presented as if part of the diff.
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
+	out, stderr, err := gitexec.OutputWithStderr(diffCtx, gitexec.Options{Dir: wtPath}, "diff", "--stat", base+"...HEAD")
 	if err != nil {
-		diag := singleLineDiagnostic(err, stderr.String())
+		diag := singleLineDiagnostic(err, string(stderr))
 		e.logger.Warn("workflow.test.reimplement-note", "worktree", wtPath, "base", base, "err", err, "phase", "diff-stat")
 		return "(diff unavailable: " + diag + ")"
 	}
-	if stderr.Len() > 0 {
-		e.logger.Warn("workflow.test.reimplement-note", "worktree", wtPath, "base", base, "phase", "diff-stat", "stderr", singleLineDiagnostic(nil, stderr.String()))
+	if len(stderr) > 0 {
+		e.logger.Warn("workflow.test.reimplement-note", "worktree", wtPath, "base", base, "phase", "diff-stat", "stderr", singleLineDiagnostic(nil, string(stderr)))
 	}
 	diff := capPriorAttemptDiffStat(string(out))
 	if diff == "" {

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/attribution"
 	"github.com/Automaat/sybra/internal/evidence"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
 )
@@ -836,16 +836,16 @@ func currentWorktreeTree(ctx context.Context, wtPath string) (string, error) {
 	_ = tmpIndex.Close()
 	defer func() { _ = os.Remove(path) }()
 
-	env := append(os.Environ(), "GIT_INDEX_FILE="+path)
-	if out, err := gitCmdEnv(ctx, wtPath, env, "read-tree", "HEAD").CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git read-tree HEAD: %w: %s", err, strings.TrimSpace(string(out)))
+	opts := gitexec.Options{Dir: wtPath, ExtraEnv: []string{"GIT_INDEX_FILE=" + path}}
+	if _, err := gitexec.CombinedOutput(ctx, opts, "read-tree", "HEAD"); err != nil {
+		return "", err
 	}
-	if out, err := gitCmdEnv(ctx, wtPath, env, "add", "-A").CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git add -A: %w: %s", err, strings.TrimSpace(string(out)))
+	if _, err := gitexec.CombinedOutput(ctx, opts, "add", "-A"); err != nil {
+		return "", err
 	}
-	out, err := gitCmdEnv(ctx, wtPath, env, "write-tree").CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, opts, "write-tree")
 	if err != nil {
-		return "", fmt.Errorf("git write-tree: %w: %s", err, strings.TrimSpace(string(out)))
+		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -861,12 +861,11 @@ func fastForwardToRef(ctx context.Context, wtPath, ref string) error {
 }
 
 func isAncestorCommit(ctx context.Context, wtPath, ancestor, ref string) (bool, error) {
-	err := gitCmd(ctx, wtPath, "merge-base", "--is-ancestor", ancestor, ref).Run()
+	err := gitexec.RunQuiet(ctx, gitexec.Options{Dir: wtPath}, "merge-base", "--is-ancestor", ancestor, ref)
 	if err == nil {
 		return true, nil
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+	if code, ok := gitexec.ExitCode(err); ok && code == 1 {
 		return false, nil
 	}
 	return false, err
@@ -881,7 +880,7 @@ func diagnoseWorktreeState(parentCtx context.Context, wtPath string) string {
 	ctx, cancel := context.WithTimeout(parentCtx, shellTimeout)
 	defer cancel()
 
-	out, err := gitCmd(ctx, wtPath, "status", "--porcelain").CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{Dir: wtPath}, "status", "--porcelain")
 	if err != nil {
 		first, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
 		first = strings.TrimSpace(first)

--- a/internal/workflow/git_runner.go
+++ b/internal/workflow/git_runner.go
@@ -2,114 +2,31 @@ package workflow
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"os/exec"
-	"strings"
-	"syscall"
-	"time"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
-// gitCmd builds a git subprocess bound to ctx and rooted at dir, with the
-// same forceful-cancel wiring every workflow git call needs (see
-// configureWorkflowGitCancel). Every git invocation in this package goes
-// through this constructor (directly or via gitStdout/gitCombinedOutput/
-// gitDo/gitOK) so that wiring can never be forgotten on a new call site —
-// before this, only one of ~40 call sites applied it.
-func gitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = dir
-	configureWorkflowGitCancel(cmd)
-	return cmd
-}
-
-// gitCmdEnv is gitCmd for the rare call site that must override the
-// subprocess environment (e.g. a scratch GIT_INDEX_FILE for a throwaway tree
-// build) rather than inheriting the caller's.
-func gitCmdEnv(ctx context.Context, dir string, env []string, args ...string) *exec.Cmd {
-	cmd := gitCmd(ctx, dir, args...)
-	cmd.Env = env
-	return cmd
-}
-
-// configureWorkflowGitCancel makes a git subprocess's context cancellation
-// SIGKILL the whole process group instead of relying on the default
-// os.Process.Kill (which only signals the direct child): git can spawn
-// helper processes (e.g. a credential helper) that would otherwise survive
-// a canceled ctx and keep the worktree locked.
-func configureWorkflowGitCancel(cmd *exec.Cmd) {
-	if cmd == nil {
-		return
-	}
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	cmd.SysProcAttr.Setpgid = true
-	cmd.WaitDelay = time.Second
-	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
-			if errors.Is(err, syscall.ESRCH) {
-				return nil
-			}
-			return err
-		}
-		return nil
-	}
-}
-
-// gitStdout runs a git command and returns its trimmed stdout. The wrapped
-// error includes stderr (exec.Cmd.Output captures it into the ExitError when
-// Stderr is unset) so callers get the same diagnostic detail a
-// CombinedOutput call would.
+// gitStdout runs a Git command and returns its trimmed stdout. Process-group
+// cancellation and failure diagnostics are provided by the shared boundary.
 func gitStdout(ctx context.Context, dir string, args ...string) (string, error) {
-	out, err := gitCmd(ctx, dir, args...).Output()
-	if err != nil {
-		return "", wrapGitOutputErr(args, err)
-	}
-	return strings.TrimSpace(string(out)), nil
+	return gitexec.Output(ctx, gitexec.Options{Dir: dir}, args...)
 }
 
-func wrapGitOutputErr(args []string, err error) error {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		if detail := strings.TrimSpace(string(exitErr.Stderr)); detail != "" {
-			return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, detail)
-		}
-	}
-	return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
-}
-
-// gitCombinedOutput runs a git command and returns the raw combined
-// stdout+stderr bytes alongside a wrapped error, for callers that must
-// inspect output text even on failure (e.g. flake/retry classification).
+// gitCombinedOutput returns raw interleaved stdout and stderr, including the
+// output on failure for workflow retry and failure classification.
 func gitCombinedOutput(ctx context.Context, dir string, args ...string) ([]byte, error) {
-	out, err := gitCmd(ctx, dir, args...).CombinedOutput()
-	if err != nil {
-		detail := strings.TrimSpace(string(out))
-		if detail == "" {
-			return out, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
-		}
-		return out, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, detail)
-	}
-	return out, nil
+	return gitexec.CombinedOutput(ctx, gitexec.Options{Dir: dir}, args...)
 }
 
-// gitDo runs a git command for its exit code/side effect only, wrapping any
-// failure with its combined output. A best-effort caller that doesn't care
-// about the outcome discards the error explicitly (`_ = gitDo(...)`).
+// gitDo runs a Git command for its side effect and preserves combined failure
+// diagnostics. Best-effort callers discard the returned error explicitly.
 func gitDo(ctx context.Context, dir string, args ...string) error {
-	_, err := gitCombinedOutput(ctx, dir, args...)
-	return err
+	return gitexec.Run(ctx, gitexec.Options{Dir: dir}, args...)
 }
 
-// gitOK runs a git command and reports only whether it exited zero, for
-// git's own boolean-by-exit-code checks (ref verify, is-ancestor, diff
-// --quiet) where the caller has no use for stdout/stderr.
+// gitOK reports only whether Git exited zero for boolean-by-exit-code checks.
 func gitOK(ctx context.Context, dir string, args ...string) bool {
-	return gitCmd(ctx, dir, args...).Run() == nil
+	return gitexec.RunQuiet(ctx, gitexec.Options{Dir: dir}, args...) == nil
 }
 
 // gitRevParseVerify resolves rev via `git rev-parse --verify` and reports
@@ -120,9 +37,7 @@ func gitRevParseVerify(ctx context.Context, dir, rev string) (sha string, ok boo
 }
 
 // gitIsAncestor reports whether ancestor is reachable from descendant, per
-// `git merge-base --is-ancestor`'s exit-code contract (0 = yes, 1 = no). A
-// caller that must distinguish "no" from a genuine command failure (e.g. an
-// unresolvable ref) should use gitCmd directly instead.
+// `git merge-base --is-ancestor`'s exit-code contract (0 = yes, 1 = no).
 func gitIsAncestor(ctx context.Context, dir, ancestor, descendant string) bool {
 	return gitOK(ctx, dir, "merge-base", "--is-ancestor", ancestor, descendant)
 }

--- a/internal/workflow/git_runner_cancel_unix_test.go
+++ b/internal/workflow/git_runner_cancel_unix_test.go
@@ -36,12 +36,13 @@ esac
 	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
-	t.Setenv("PATH", bin)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	pidFile := filepath.Join(t.TempDir(), "helper.pid")
 	t.Setenv("WORKFLOW_GIT_HELPER_PID", pidFile)
 	wtPath := t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan error, 1)
 	go func() {
 		done <- gitDo(ctx, wtPath, "hold")

--- a/internal/workflow/git_runner_cancel_unix_test.go
+++ b/internal/workflow/git_runner_cancel_unix_test.go
@@ -1,0 +1,85 @@
+//go:build darwin || linux
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWorkflowGitCancellationKillsHelperBeforeWorktreeReuse(t *testing.T) {
+	bin := t.TempDir()
+	gitPath := filepath.Join(bin, "git")
+	script := `#!/bin/sh
+set -eu
+case "$1" in
+  hold)
+    /bin/sleep 30 &
+    child=$!
+    printf '%s\n' "$child" > "$WORKFLOW_GIT_HELPER_PID"
+    wait "$child"
+    ;;
+  probe)
+    child="$(/bin/cat "$WORKFLOW_GIT_HELPER_PID")"
+    if kill -0 "$child" 2>/dev/null; then
+      printf 'helper still retains the worktree\n' >&2
+      exit 73
+    fi
+    ;;
+esac
+`
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", bin)
+	pidFile := filepath.Join(t.TempDir(), "helper.pid")
+	t.Setenv("WORKFLOW_GIT_HELPER_PID", pidFile)
+	wtPath := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- gitDo(ctx, wtPath, "hold")
+	}()
+
+	waitForWorkflowGitHelperPID(t, pidFile)
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("gitDo unexpectedly succeeded after cancellation")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("workflow Git command did not stop after cancellation")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for !gitOK(context.Background(), wtPath, "probe") && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !gitOK(context.Background(), wtPath, "probe") {
+		t.Fatal("Git helper survived cancellation and retained the worktree")
+	}
+}
+
+func waitForWorkflowGitHelperPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			var pid int
+			if _, scanErr := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &pid); scanErr == nil {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for Git helper PID in %s", path)
+	return 0
+}


### PR DESCRIPTION
## Motivation

Route workflow Git subprocesses through the shared execution boundary while retaining workflow-specific convenience helpers and gate policy.

## Implementation information

- reduce the workflow Git runner to domain helpers that delegate to `internal/gitexec`
- preserve raw, combined, split-stream, stdin, scratch-index, and boolean exit-code semantics
- migrate the direct prior-attempt diff-stat outlier and specialized raw/apply paths
- add explicit workflow cancellation coverage proving helper death before worktree reuse

Closes #3011

> Changelog: refactor(workflow): route Git execution through shared Git boundary
