### PR TITLE
fix(workflow): recover PR-tail worktrees

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -886,6 +886,10 @@ func (a *worktreeGetterAdapter) GetWorktreePath(taskID string) (string, bool) {
 	return path, ok
 }
 
+func (a *worktreeGetterAdapter) ResolvePRWorktree(ctx context.Context, taskID string) (path string, found bool, err error) {
+	return ensureReadyPRWorktree(ctx, a.tasks, a.mgr, taskID)
+}
+
 func (*attemptNoteAppenderAdapter) AppendReimplementNote(ctx context.Context, _, wtPath, marker, note string) error {
 	return worktree.AppendNote(ctx, wtPath, marker, note)
 }

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -362,6 +362,27 @@ func TestWorktreeGetterAdapter_GetWorktreePath_RecoversReadyPRWorktree(t *testin
 	}
 }
 
+func TestWorktreeGetterAdapter_ResolvePRWorktree_RecoversRemoteBranch(t *testing.T) {
+	t.Parallel()
+
+	h := newReadyPRRecoveryHarness(t)
+	adapter := &worktreeGetterAdapter{tasks: h.tasks, mgr: h.mgr}
+
+	path, ok, err := adapter.ResolvePRWorktree(context.Background(), h.task.ID)
+	if err != nil {
+		t.Fatalf("ResolvePRWorktree: %v", err)
+	}
+	if !ok {
+		t.Fatal("ResolvePRWorktree() = false, want recovered worktree")
+	}
+	if path != h.mgr.PathFor(h.task) {
+		t.Fatalf("path = %q, want %q", path, h.mgr.PathFor(h.task))
+	}
+	if _, err := os.Stat(filepath.Join(path, "fix.txt")); err != nil {
+		t.Fatalf("recovered worktree missing remote branch content: %v", err)
+	}
+}
+
 func TestBranchSyncerAdapter_SyncTaskBranch_RecoversMissingReadyPRWorktree(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -188,6 +188,13 @@ type WorktreeGetter interface {
 	GetWorktreePath(taskID string) (string, bool)
 }
 
+// PRWorktreeResolver resolves or reconstructs the implementation worktree for
+// deterministic PR-tail steps. It is optional so lightweight Engine users and
+// tests can keep providing a read-only WorktreeGetter.
+type PRWorktreeResolver interface {
+	ResolvePRWorktree(ctx context.Context, taskID string) (path string, found bool, err error)
+}
+
 // AttemptNoteAppender persists re-implementation context into a task's local
 // NOTES.md scratchpad. Engine passes the already-resolved worktree path so the
 // adapter can reuse the same path for both diff inspection and the append.

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -19,9 +19,9 @@ import (
 // maybe_create_pr retry path in simple-task-pr). Replaces the push-branch
 // agent role: no LLM/agent involved, only git plumbing.
 func (e *Engine) execPushBranch(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
-	wtPath, branch, out, done := e.prWorktreeAndBranch(taskID, step, t)
+	wtPath, branch, out, done, err := e.prWorktreeAndBranch(taskID, step, t)
 	if done {
-		return out, nil
+		return out, err
 	}
 
 	if out, err, ok := e.pushTaskBranch(taskID, step, wfExec, t, wtPath, branch); !ok {
@@ -48,9 +48,9 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 		return e.humanRequiredPR(taskID, step, "task has no project — cannot open a PR")
 	}
 
-	wtPath, branch, out, done := e.prWorktreeAndBranch(taskID, step, t)
+	wtPath, branch, out, done, err := e.prWorktreeAndBranch(taskID, step, t)
 	if done {
-		return out, nil
+		return out, err
 	}
 
 	headArg, err := func() (string, error) {
@@ -174,10 +174,10 @@ func (e *Engine) linkTaskPR(taskID string, t TaskInfo, newPR int) error {
 // push_branch/create_pr. A production WorktreeGetter may also implement
 // PRWorktreeResolver, allowing one reconstruction attempt before a genuinely
 // unrecoverable setup problem is escalated to human-required.
-func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtPath, branch string, out StepOutput, done bool) {
+func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtPath, branch string, out StepOutput, done bool, stepErr error) {
 	if e.worktrees == nil {
-		out, _ = e.humanRequiredPR(taskID, step, "no worktree getter configured")
-		return "", "", out, true
+		out, stepErr = e.humanRequiredPR(taskID, step, "no worktree getter configured")
+		return "", "", out, true, stepErr
 	}
 	var (
 		ok  bool
@@ -191,12 +191,12 @@ func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtP
 		wtPath, ok = e.worktrees.GetWorktreePath(taskID)
 	}
 	if err != nil {
-		out, _ = e.humanRequiredPR(taskID, step, "could not prepare worktree: "+err.Error())
-		return "", "", out, true
+		out, stepErr = e.humanRequiredPR(taskID, step, "could not prepare worktree: "+err.Error())
+		return "", "", out, true, stepErr
 	}
 	if !ok {
-		out, _ = e.humanRequiredPR(taskID, step, "no worktree found for task")
-		return "", "", out, true
+		out, stepErr = e.humanRequiredPR(taskID, step, "no worktree found for task")
+		return "", "", out, true, stepErr
 	}
 	branch = t.Branch
 	if branch == "" {
@@ -208,12 +208,12 @@ func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtP
 			if err != nil {
 				reason += ": " + err.Error()
 			}
-			out, _ = e.humanRequiredPR(taskID, step, reason)
-			return "", "", out, true
+			out, stepErr = e.humanRequiredPR(taskID, step, reason)
+			return "", "", out, true, stepErr
 		}
 		branch = resolved
 	}
-	return wtPath, branch, StepOutput{}, false
+	return wtPath, branch, StepOutput{}, false, nil
 }
 
 // humanRequiredPR flips the task to human-required with reason and returns a

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -171,16 +171,29 @@ func (e *Engine) linkTaskPR(taskID string, t TaskInfo, newPR int) error {
 }
 
 // prWorktreeAndBranch resolves the on-disk worktree and branch used by
-// push_branch/create_pr. These steps run only after implementation/review has
-// already produced a worktree, so a missing WorktreeGetter or worktree is an
-// unrecoverable setup problem, not a transient one, and flips straight to
-// human-required.
+// push_branch/create_pr. A production WorktreeGetter may also implement
+// PRWorktreeResolver, allowing one reconstruction attempt before a genuinely
+// unrecoverable setup problem is escalated to human-required.
 func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtPath, branch string, out StepOutput, done bool) {
 	if e.worktrees == nil {
 		out, _ = e.humanRequiredPR(taskID, step, "no worktree getter configured")
 		return "", "", out, true
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	var (
+		ok  bool
+		err error
+	)
+	if resolver, resolves := e.worktrees.(PRWorktreeResolver); resolves {
+		ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+		defer cancel()
+		wtPath, ok, err = resolver.ResolvePRWorktree(ctx, taskID)
+	} else {
+		wtPath, ok = e.worktrees.GetWorktreePath(taskID)
+	}
+	if err != nil {
+		out, _ = e.humanRequiredPR(taskID, step, "could not prepare worktree: "+err.Error())
+		return "", "", out, true
+	}
 	if !ok {
 		out, _ = e.humanRequiredPR(taskID, step, "no worktree found for task")
 		return "", "", out, true

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -175,6 +175,15 @@ type fakePRWorktreeResolver struct {
 	getCalls     int
 }
 
+type failStatusTaskProvider struct {
+	*memTasks
+	err error
+}
+
+func (f *failStatusTaskProvider) UpdateTaskStatus(string, string, string) error {
+	return f.err
+}
+
 func (f *fakePRWorktreeResolver) GetWorktreePath(string) (string, bool) {
 	f.getCalls++
 	return "", false
@@ -230,6 +239,34 @@ func TestExecCreatePR_WorktreeRecoveryErrorIsPrecise(t *testing.T) {
 	}
 	if reason := tasks.Reason("t1"); reason != out.Output {
 		t.Fatalf("status reason = %q, want %q", reason, out.Output)
+	}
+}
+
+func TestExecCreatePR_WorktreeRecoveryPropagatesStatusFailure(t *testing.T) {
+	baseTasks := newMemTasks()
+	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets"}
+	baseTasks.Put(task)
+	tasks := &failStatusTaskProvider{memTasks: baseTasks, err: errors.New("persist status: disk full")}
+	resolver := &fakePRWorktreeResolver{err: errors.New("prepare branch: remote ref missing")}
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(resolver)
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err == nil || !strings.Contains(err.Error(), "persist status: disk full") {
+		t.Fatalf("err = %v, want status persistence failure", err)
+	}
+	if out != (StepOutput{}) {
+		t.Fatalf("output = %+v, want zero output on status persistence failure", out)
+	}
+	if resolver.resolveCalls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", resolver.resolveCalls)
+	}
+	stored, getErr := baseTasks.GetTask("t1")
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if stored.Status != "ready-pr" {
+		t.Fatalf("status = %q, want unchanged ready-pr", stored.Status)
 	}
 }
 

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -168,6 +168,71 @@ func (f *fakePushPreflighter) PreflightPushCredentials(_ context.Context, wtPath
 	return f.err
 }
 
+type fakePRWorktreeResolver struct {
+	path         string
+	err          error
+	resolveCalls int
+	getCalls     int
+}
+
+func (f *fakePRWorktreeResolver) GetWorktreePath(string) (string, bool) {
+	f.getCalls++
+	return "", false
+}
+
+func (f *fakePRWorktreeResolver) ResolvePRWorktree(context.Context, string) (path string, found bool, err error) {
+	f.resolveCalls++
+	return f.path, f.path != "", f.err
+}
+
+func TestExecPushBranch_RecoversMissingWorktreeOnce(t *testing.T) {
+	_, wtPath := newPRWorktree(t, "feat/existing-pr")
+	commitFile(t, wtPath, "change.txt", "feat: task work")
+	local := headSHA(t, wtPath)
+
+	tasks := newMemTasks()
+	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"}
+	tasks.Put(task)
+	resolver := &fakePRWorktreeResolver{path: wtPath}
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(resolver)
+	engine.SetPRHeadFetcher(&fakePRHeadFetcher{sha: local})
+
+	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execPushBranch: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, want completed", out.Status)
+	}
+	if resolver.resolveCalls != 1 || resolver.getCalls != 0 {
+		t.Fatalf("resolver calls = %d, getter calls = %d; want one resolve and no fallback get", resolver.resolveCalls, resolver.getCalls)
+	}
+}
+
+func TestExecCreatePR_WorktreeRecoveryErrorIsPrecise(t *testing.T) {
+	tasks := newMemTasks()
+	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets"}
+	tasks.Put(task)
+	resolver := &fakePRWorktreeResolver{err: errors.New("prepare branch: remote ref missing")}
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(resolver)
+
+	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("execCreatePR: %v", err)
+	}
+	if resolver.resolveCalls != 1 || resolver.getCalls != 0 {
+		t.Fatalf("resolver calls = %d, getter calls = %d; want one resolve and no fallback get", resolver.resolveCalls, resolver.getCalls)
+	}
+	if !strings.Contains(out.Output, "could not prepare worktree: prepare branch: remote ref missing") {
+		t.Fatalf("output = %q, want underlying prepare error", out.Output)
+	}
+	if reason := tasks.Reason("t1"); reason != out.Output {
+		t.Fatalf("status reason = %q, want %q", reason, out.Output)
+	}
+}
+
 func TestExecPushBranch_Success(t *testing.T) {
 	_, wtPath := newPRWorktree(t, "feat/existing-pr")
 	commitFile(t, wtPath, "change.txt", "feat: task work")


### PR DESCRIPTION
## Motivation

Deterministic PR-tail steps escalated a missing checkout without exposing the worktree manager's existing remote-branch recovery or its precise errors. Closes #3015.

## Implementation

- add an optional PR-tail worktree resolver that can reconstruct a missing ready-PR checkout once
- wire the production adapter to the existing branch-fix preparation path
- preserve detailed prepare failures and propagate failed human-required status writes
- keep read-only worktree getters compatible for lightweight engine users
- cover successful continuation, one-attempt behavior, real remote-branch recreation, and failure propagation

## Verification

- `mise run verify`
- independent adversarial code review: clean after status-error propagation fix
- independent Sybra server test: missing checkout recreated, deterministic push completed, local and remote SHAs matched
- existing checkout inode remained unchanged; nonexistent branch retained its underlying prepare error

> Changelog: fix(workflow): recreate missing PR-tail worktrees from remote task branches
