### PR TITLE
refactor(git): migrate specialized consumers to gitexec

### DIFF
--- a/internal/agent/k8s_job_runner.go
+++ b/internal/agent/k8s_job_runner.go
@@ -12,12 +12,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/project"
 )
 
@@ -566,10 +566,9 @@ func syncK8sGitWorkspace(ctx context.Context, dir string) error {
 }
 
 func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{Dir: dir}, args...)
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/agent/k8s_job_runner_test.go
+++ b/internal/agent/k8s_job_runner_test.go
@@ -6,9 +6,41 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestGitOutputUsesWorkspaceDirectoryAndDisablesPrompts(t *testing.T) {
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nprintf '%s\\n%s\\n' \"$PWD\" \"$GIT_TERMINAL_PROMPT\"\n"), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	workspace := t.TempDir()
+	out, err := gitOutput(t.Context(), workspace, "status", "--short")
+	if err != nil {
+		t.Fatalf("gitOutput: %v", err)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 || lines[1] != "0" {
+		t.Fatalf("git environment = %q, want working directory and prompt=0", out)
+	}
+	actualInfo, err := os.Stat(lines[0])
+	if err != nil {
+		t.Fatalf("stat actual working directory: %v", err)
+	}
+	wantInfo, err := os.Stat(workspace)
+	if err != nil {
+		t.Fatalf("stat expected working directory: %v", err)
+	}
+	if !os.SameFile(actualInfo, wantInfo) {
+		t.Fatalf("working directory = %q, want %q", lines[0], workspace)
+	}
+}
 
 func TestK8sName(t *testing.T) {
 	got := k8sName("Sybra Agent_BAD.ID/With Stuff")

--- a/internal/agent/procsandbox_git.go
+++ b/internal/agent/procsandbox_git.go
@@ -7,9 +7,10 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 var errGitSandboxNotRepo = errors.New("sandbox git roots: worktree is not a git repository")
@@ -396,16 +397,12 @@ func copyGitOverlayFile(src, dst string, mode fs.FileMode) error {
 }
 
 func gitHeadCommit(ctx context.Context, worktree string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "HEAD")
-	cmd.Dir = worktree
-	cmd.Env = gitSandboxDiscoveryEnv()
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{
+		Dir: worktree,
+		Env: gitSandboxDiscoveryEnv(),
+	}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg == "" {
-			return "", fmt.Errorf("git rev-parse --verify HEAD: %w", err)
-		}
-		return "", fmt.Errorf("git rev-parse --verify HEAD: %w: %s", err, msg)
+		return "", fmt.Errorf("git rev-parse --verify HEAD: %w", err)
 	}
 	head := strings.TrimSpace(string(out))
 	if head == "" {
@@ -428,19 +425,16 @@ func gitPath(ctx context.Context, worktree string, args ...string) (string, erro
 
 func gitPathRaw(ctx context.Context, worktree string, args ...string) (string, error) {
 	cmdArgs := append([]string{"rev-parse"}, args...)
-	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
-	cmd.Dir = worktree
-	cmd.Env = gitSandboxDiscoveryEnv()
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{
+		Dir: worktree,
+		Env: gitSandboxDiscoveryEnv(),
+	}, cmdArgs...)
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if looksLikeNotGitRepo(msg) {
 			return "", errGitSandboxNotRepo
 		}
-		if msg == "" {
-			return "", fmt.Errorf("git %s: %w", strings.Join(cmdArgs, " "), err)
-		}
-		return "", fmt.Errorf("git %s: %w: %s", strings.Join(cmdArgs, " "), err, msg)
+		return "", fmt.Errorf("git %s: %w", strings.Join(cmdArgs, " "), err)
 	}
 	path := strings.TrimSpace(string(out))
 	if path == "" {
@@ -455,9 +449,8 @@ func gitPathRaw(ctx context.Context, worktree string, args ...string) (string, e
 // gitExitCode reports a git process exit code, or -1 when err is not an exit
 // failure (spawn error, context cancellation).
 func gitExitCode(err error) int {
-	var ee *exec.ExitError
-	if errors.As(err, &ee) {
-		return ee.ExitCode()
+	if code, ok := gitexec.ExitCode(err); ok {
+		return code
 	}
 	return -1
 }
@@ -480,19 +473,16 @@ func gitRevParsePath(ctx context.Context, worktree, arg string) (string, error) 
 // empty output, while a real failure (not a repository, unreadable HEAD)
 // exits 128 and prints. Only the first is swallowed.
 func gitSymbolicRef(ctx context.Context, worktree string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
-	cmd.Dir = worktree
-	cmd.Env = gitSandboxDiscoveryEnv()
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{
+		Dir: worktree,
+		Env: gitSandboxDiscoveryEnv(),
+	}, "symbolic-ref", "-q", "HEAD")
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if msg == "" && gitExitCode(err) == 1 {
 			return "", nil
 		}
-		if msg == "" {
-			return "", fmt.Errorf("git symbolic-ref -q HEAD: %w", err)
-		}
-		return "", fmt.Errorf("git symbolic-ref -q HEAD: %w: %s", err, msg)
+		return "", fmt.Errorf("git symbolic-ref -q HEAD: %w", err)
 	}
 	// Exit 0 with no ref is not a state git produces; treat it as a real fault
 	// rather than silently reporting "detached".

--- a/internal/agent/procsandbox_git.go
+++ b/internal/agent/procsandbox_git.go
@@ -402,7 +402,7 @@ func gitHeadCommit(ctx context.Context, worktree string) (string, error) {
 		Env: gitSandboxDiscoveryEnv(),
 	}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("git rev-parse --verify HEAD: %w", err)
+		return "", err
 	}
 	head := strings.TrimSpace(string(out))
 	if head == "" {
@@ -434,7 +434,7 @@ func gitPathRaw(ctx context.Context, worktree string, args ...string) (string, e
 		if looksLikeNotGitRepo(msg) {
 			return "", errGitSandboxNotRepo
 		}
-		return "", fmt.Errorf("git %s: %w", strings.Join(cmdArgs, " "), err)
+		return "", err
 	}
 	path := strings.TrimSpace(string(out))
 	if path == "" {
@@ -482,7 +482,7 @@ func gitSymbolicRef(ctx context.Context, worktree string) (string, error) {
 		if msg == "" && gitExitCode(err) == 1 {
 			return "", nil
 		}
-		return "", fmt.Errorf("git symbolic-ref -q HEAD: %w", err)
+		return "", err
 	}
 	// Exit 0 with no ref is not a state git produces; treat it as a real fault
 	// rather than silently reporting "detached".

--- a/internal/agent/procsandbox_git_test.go
+++ b/internal/agent/procsandbox_git_test.go
@@ -2,10 +2,70 @@ package agent
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
+
+func TestGitHeadCommitPassesScrubbedDiscoveryEnvironment(t *testing.T) {
+	binDir := t.TempDir()
+	capture := filepath.Join(t.TempDir(), "capture")
+	fakeGit := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+printf 'pwd=%s\nprompt=%s\nobjects=%s\nalternates=%s\n' \
+  "$PWD" "$GIT_TERMINAL_PROMPT" "${GIT_OBJECT_DIRECTORY-unset}" \
+  "${GIT_ALTERNATE_OBJECT_DIRECTORIES-unset}" > "$SYBRA_TEST_CAPTURE"
+printf 'abc123\n'
+`
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("SYBRA_TEST_CAPTURE", capture)
+	t.Setenv("GIT_OBJECT_DIRECTORY", "/attacker/objects")
+	t.Setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/attacker/alternates")
+
+	worktree := t.TempDir()
+	head, err := gitHeadCommit(t.Context(), worktree)
+	if err != nil {
+		t.Fatalf("gitHeadCommit: %v", err)
+	}
+	if head != "abc123" {
+		t.Fatalf("head = %q, want abc123", head)
+	}
+	raw, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	got := string(raw)
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) != 4 || !strings.HasPrefix(lines[0], "pwd=") {
+		t.Fatalf("unexpected capture:\n%s", got)
+	}
+	actualInfo, err := os.Stat(strings.TrimPrefix(lines[0], "pwd="))
+	if err != nil {
+		t.Fatalf("stat captured worktree: %v", err)
+	}
+	wantInfo, err := os.Stat(worktree)
+	if err != nil {
+		t.Fatalf("stat expected worktree: %v", err)
+	}
+	if !os.SameFile(actualInfo, wantInfo) {
+		t.Fatalf("captured worktree = %q, want %q", lines[0], worktree)
+	}
+	for _, want := range []string{
+		"prompt=0",
+		"objects=unset",
+		"alternates=unset",
+	} {
+		if !strings.Contains(got, want+"\n") {
+			t.Errorf("capture missing %q:\n%s", want, got)
+		}
+	}
+}
 
 func TestDedupeRoots_DropsEmptyAndDuplicate(t *testing.T) {
 	got := dedupeRoots("/a", "/a", "", "/b", "  ", "/a")

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 )
 
@@ -630,12 +630,9 @@ func gitRun(ctx context.Context, dir, name string, args ...string) error {
 }
 
 func git(ctx context.Context, dir, name string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", append([]string{name}, args...)...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	out, err := cmd.CombinedOutput()
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{Dir: dir}, append([]string{name}, args...)...)
 	if err != nil {
-		return "", fmt.Errorf("git %s %s: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -13,6 +13,36 @@ import (
 	"github.com/Automaat/sybra/internal/github"
 )
 
+func TestGitUsesWorkingDirectoryAndDisablesPrompts(t *testing.T) {
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nprintf '%s\\n%s\\n' \"$PWD\" \"$GIT_TERMINAL_PROMPT\"\n"), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	repoDir := t.TempDir()
+	out, err := git(t.Context(), repoDir, "status", "--short")
+	if err != nil {
+		t.Fatalf("git: %v", err)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 || lines[1] != "0" {
+		t.Fatalf("git environment = %q, want working directory and prompt=0", out)
+	}
+	actualInfo, err := os.Stat(lines[0])
+	if err != nil {
+		t.Fatalf("stat actual working directory: %v", err)
+	}
+	wantInfo, err := os.Stat(repoDir)
+	if err != nil {
+		t.Fatalf("stat expected working directory: %v", err)
+	}
+	if !os.SameFile(actualInfo, wantInfo) {
+		t.Fatalf("working directory = %q, want %q", lines[0], repoDir)
+	}
+}
+
 func TestCheckAndApplyAutoModeFastForwards(t *testing.T) {
 	ctx := t.Context()
 	upstream, work := seedRepos(t)

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -13,7 +13,6 @@
 package cleanup
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/fs"
@@ -28,6 +27,7 @@ import (
 	"github.com/Automaat/sybra/internal/buildcache"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -305,11 +305,11 @@ func goBuildCacheDir() string {
 func gitStatusClean(path string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "git", "-C", path, "status", "--porcelain").Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: path}, "status", "--porcelain")
 	if err != nil {
 		return false
 	}
-	return len(bytes.TrimSpace(out)) == 0
+	return out == ""
 }
 
 // hasUnpushedCommits reports whether the worktree at path holds commits not

--- a/internal/cleanup/protected.go
+++ b/internal/cleanup/protected.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -454,13 +454,13 @@ func rescueWorktree(path, ref, bundlePath string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := exec.CommandContext(ctx, "git", "-C", path, "update-ref", ref, "HEAD").Run(); err != nil {
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: path}, "update-ref", ref, "HEAD"); err != nil {
 		return fmt.Errorf("create rescue ref: %w", err)
 	}
-	if out, err := exec.CommandContext(ctx, "git", "-C", path, "bundle", "create", bundlePath, "HEAD").CombinedOutput(); err != nil {
-		return fmt.Errorf("create rescue bundle: %w: %s", err, strings.TrimSpace(string(out)))
+	if _, err := gitexec.CombinedOutput(ctx, gitexec.Options{Dir: path}, "bundle", "create", bundlePath, "HEAD"); err != nil {
+		return fmt.Errorf("create rescue bundle: %w", err)
 	}
-	if out, err := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "--verify", ref).CombinedOutput(); err != nil || strings.TrimSpace(string(out)) == "" {
+	if out, err := gitexec.Output(ctx, gitexec.Options{Dir: path}, "rev-parse", "--verify", ref); err != nil || out == "" {
 		if err == nil {
 			err = errors.New("empty rescue ref")
 		}

--- a/internal/cleanup/protected_test.go
+++ b/internal/cleanup/protected_test.go
@@ -261,6 +261,37 @@ func TestProtectedStoreRescueFailureLeavesFindingOpen(t *testing.T) {
 	}
 }
 
+func TestRescueWorktreeCreatesRefAndBundle(t *testing.T) {
+	worktree := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "test@example.invalid"},
+		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
+		{"commit", "-q", "--allow-empty", "-m", "seed"},
+	} {
+		cmd := exec.CommandContext(t.Context(), "git", args...)
+		cmd.Dir = worktree
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	ref := "refs/sybra/rescue/test"
+	bundle := filepath.Join(t.TempDir(), "rescue.bundle")
+	if err := rescueWorktree(worktree, ref, bundle); err != nil {
+		t.Fatalf("rescueWorktree: %v", err)
+	}
+	if info, err := os.Stat(bundle); err != nil || info.Size() == 0 {
+		t.Fatalf("bundle stat: info=%v err=%v", info, err)
+	}
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "--verify", ref)
+	cmd.Dir = worktree
+	if out, err := cmd.CombinedOutput(); err != nil || strings.TrimSpace(string(out)) == "" {
+		t.Fatalf("verify rescue ref: %v: %s", err, out)
+	}
+}
+
 func TestProtectedEvidenceLogPathsIncludesReattachedFinding(t *testing.T) {
 	t.Parallel()
 	store := newProtectedStore(t)

--- a/internal/tasksnapshot/snapshotter.go
+++ b/internal/tasksnapshot/snapshotter.go
@@ -7,16 +7,14 @@
 // -A`, and if the index is dirty, commit. Polling — not event subscription
 // — is the trigger, so a raw external `rm` is captured for free (`git add
 // -A` is its own change detector). All git operations run against a
-// dedicated GIT_DIR/GIT_WORK_TREE pair via direct exec.CommandContext argv
+// dedicated GIT_DIR/GIT_WORK_TREE pair via the shared git execution boundary
 // (no shell, no remotes, no network) under a per-op timeout, and every
 // error is logged and swallowed by the production entry points so task CRUD
 // can never be broken by a snapshotting failure.
 package tasksnapshot
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -26,6 +24,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 // opTimeout bounds every individual git invocation.
@@ -96,15 +96,9 @@ func BuildEnv(gitDir, workTree string) []string {
 func (s *Snapshotter) run(ctx context.Context, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, opTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = BuildEnv(s.gitDir, s.workTree)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
-	}
-	return strings.TrimSpace(stdout.String()), nil
+	return gitexec.Output(ctx, gitexec.Options{
+		Env: BuildEnv(s.gitDir, s.workTree),
+	}, args...)
 }
 
 // hasStagedChanges reports whether the index differs from HEAD, using the
@@ -113,14 +107,13 @@ func (s *Snapshotter) run(ctx context.Context, args ...string) (string, error) {
 func (s *Snapshotter) hasStagedChanges(ctx context.Context) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, opTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--quiet")
-	cmd.Env = BuildEnv(s.gitDir, s.workTree)
-	err := cmd.Run()
+	err := gitexec.RunQuiet(ctx, gitexec.Options{
+		Env: BuildEnv(s.gitDir, s.workTree),
+	}, "diff", "--cached", "--quiet")
 	if err == nil {
 		return false, nil
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+	if code, ok := gitexec.ExitCode(err); ok && code == 1 {
 		return true, nil
 	}
 	return false, err

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/cleanup"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -196,11 +195,11 @@ func (m *Manager) resolveProtectedWorktrees(observed map[string]bool) {
 func worktreeHead(ctx context.Context, path string) string {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "HEAD").Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: path}, "rev-parse", "HEAD")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return out
 }
 
 func worktreeObservedState(ctx context.Context, path string) string {

--- a/internal/worktree/context.go
+++ b/internal/worktree/context.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -104,13 +104,11 @@ func renderContextFile(t task.Task, wtPath, branch string) string {
 // SanitizeWorktree's `git add -A` auto-commit and pushed to the PR. The
 // "already present" case returns nil.
 func addToInfoExclude(ctx context.Context, wtPath, entry string) error {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-path", "info/exclude")
-	cmd.Dir = wtPath
-	out, err := cmd.Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: wtPath}, "rev-parse", "--git-path", "info/exclude")
 	if err != nil {
 		return fmt.Errorf("resolve info/exclude: %w", err)
 	}
-	excludePath := strings.TrimSpace(string(out))
+	excludePath := out
 	if !filepath.IsAbs(excludePath) {
 		excludePath = filepath.Join(wtPath, excludePath)
 	}


### PR DESCRIPTION
## Summary
- route task snapshots, auto-update, Kubernetes sync, cleanup/recovery, worktree helpers, and process-sandbox Git metadata through `internal/gitexec`
- preserve subsystem-local timeouts, isolated Git environments, prompt suppression, diagnostics, and rescue safety checks
- add focused regressions for working-directory/environment options and rescue bundle creation

## Verification
- `mise run verify`
- independent adversarial code review: PASS
- independent adversarial manual testing: PASS

Closes #3010