### PR TITLE
ci(git): enforce the gitexec boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       - name: Check for direct production Git subprocess spawns outside gitexec
         run: |
           bash scripts/check-git-exec-gate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,17 @@ jobs:
       - name: Check for direct gh subprocess spawns outside github.Run/RunWithEnv
         run: bash scripts/check-gh-exec-gate.sh
 
+  check-git-exec-gate:
+    name: Git Calls Routed Through gitexec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check for direct production Git subprocess spawns outside gitexec
+        run: |
+          bash scripts/check-git-exec-gate.sh
+          bash scripts/check-git-exec-gate.test.sh
+
   check-no-direct-status-write:
     name: No Direct Task-Status Writes
     runs-on: ubuntu-latest

--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -76,6 +76,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 // scenarioFileLockSuffix is appended to FAKE_CLAUDE_SCENARIO_FILE to derive a
@@ -329,10 +331,8 @@ func runBestOfNJudge() {
 }
 
 func runGitIn(dir string, args ...string) {
-	cmd := exec.CommandContext(context.Background(), "git", args...)
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		emitResult("best_of_n_attempt: git " + strings.Join(args, " ") + " failed: " + err.Error() + ": " + string(out))
+	if _, err := gitexec.CombinedOutput(context.Background(), gitexec.Options{Dir: dir}, args...); err != nil {
+		emitResult("best_of_n_attempt: " + err.Error())
 		os.Exit(1)
 	}
 }
@@ -483,13 +483,7 @@ git push origin "HEAD:refs/heads/$branch" >/dev/null 2>&1
 }
 
 func gitOutput(dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(context.Background(), "git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
-	}
-	return strings.TrimSpace(string(out)), nil
+	return gitexec.Output(context.Background(), gitexec.Options{Dir: dir}, args...)
 }
 
 func runEvaluate(taskID string) {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"math"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
@@ -27,6 +26,7 @@ import (
 	"github.com/Automaat/sybra/internal/codexhook"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evaluation"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/issueref"
 	"github.com/Automaat/sybra/internal/modeltier"
@@ -262,11 +262,11 @@ func currentWorktreeRevision() string {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "git", "-C", wd, "rev-parse", "HEAD").Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: wd}, "rev-parse", "HEAD")
 	if err != nil {
 		return ""
 	}
-	return string(out)
+	return out
 }
 
 func shortRevision(rev string) string {
@@ -1119,11 +1119,11 @@ func printHandoffStatusResult(t task.Task, status task.Status, projectID, dir st
 // deriveProjectID reads the origin remote of a git worktree and converts it to
 // a Sybra project id (owner/repo).
 func deriveProjectID(dir string) (string, error) {
-	out, err := exec.CommandContext(context.Background(), "git", "-C", dir, "remote", "get-url", "origin").Output()
+	out, err := gitexec.Output(context.Background(), gitexec.Options{Dir: dir}, "remote", "get-url", "origin")
 	if err != nil {
 		return "", fmt.Errorf("git remote get-url origin: %w", err)
 	}
-	owner, repo, err := project.ParseGitHubURL(strings.TrimSpace(string(out)))
+	owner, repo, err := project.ParseGitHubURL(out)
 	if err != nil {
 		return "", err
 	}
@@ -2972,31 +2972,24 @@ func cmdTasksHistory(cfg *config.Config, args []string, jsonOut bool) int {
 	// the read-only commands below but must be set consistently.
 	env := tasksnapshot.BuildEnv(gitDir, cfg.TasksDir)
 
-	verify := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
-	verify.Env = env
-	if err := verify.Run(); err != nil {
+	opts := gitexec.Options{Env: env}
+	if err := gitexec.Run(ctx, opts, "rev-parse", "--git-dir"); err != nil {
 		return fatal(jsonOut, "tasks snapshot history unavailable — snapshotting is disabled or has not run yet (%v)", err)
 	}
 
 	// Detect an empty repo by HEAD resolvability, not a locale-dependent
 	// stderr string: `rev-parse --verify --quiet HEAD` exits non-zero with no
 	// output when no commits exist yet, which is a valid empty history.
-	head := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "--quiet", "HEAD")
-	head.Env = env
-	hasCommits := head.Run() == nil
+	hasCommits := gitexec.RunQuiet(ctx, opts, "rev-parse", "--verify", "--quiet", "HEAD") == nil
 
 	var entries []taskHistoryEntry
 	if hasCommits {
 		const sep = "\x1f"
-		logCmd := exec.CommandContext(ctx, "git", "log", "--date=iso-strict", "--pretty=format:%h"+sep+"%ad"+sep+"%s", fmt.Sprintf("-n%d", *limit))
-		logCmd.Env = env
-		var stdout, stderr bytes.Buffer
-		logCmd.Stdout = &stdout
-		logCmd.Stderr = &stderr
-		if err := logCmd.Run(); err != nil {
-			return fatal(jsonOut, "tasks snapshot history unavailable: %v: %s", err, strings.TrimSpace(stderr.String()))
+		stdout, err := gitexec.RawOutput(ctx, opts, "log", "--date=iso-strict", "--pretty=format:%h"+sep+"%ad"+sep+"%s", fmt.Sprintf("-n%d", *limit))
+		if err != nil {
+			return fatal(jsonOut, "tasks snapshot history unavailable: %v", err)
 		}
-		for line := range strings.SplitSeq(strings.TrimRight(stdout.String(), "\n"), "\n") {
+		for line := range strings.SplitSeq(strings.TrimRight(string(stdout), "\n"), "\n") {
 			if line == "" {
 				continue
 			}

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -1,12 +1,7 @@
 package executil
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
 	"strings"
-
-	"github.com/Automaat/sybra/internal/gitexec"
 )
 
 // EscapeAppleScript escapes a string for safe embedding inside an AppleScript
@@ -15,45 +10,4 @@ func EscapeAppleScript(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	return s
-}
-
-// Run executes a command in dir, returning a formatted error with stderr on failure.
-func Run(ctx context.Context, dir, name string, args ...string) error {
-	return RunEnv(ctx, dir, nil, name, args...)
-}
-
-// RunEnv executes a command in dir with an explicit environment, returning a
-// formatted error with stderr on failure. A nil env means "inherit the
-// current process environment", matching exec.Cmd's own zero-value behavior
-// and Run's default. Git delegates to gitexec, which additionally enforces its
-// non-interactive subprocess environment.
-func RunEnv(ctx context.Context, dir string, env []string, name string, args ...string) error {
-	if name == "git" {
-		return gitexec.Run(ctx, gitexec.Options{Dir: dir, Env: env}, args...)
-	}
-	cmd := commandContext(ctx, name, args...)
-	cmd.Dir = dir
-	cmd.Env = env
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, string(out))
-	}
-	return nil
-}
-
-// Output executes a command in dir and returns its trimmed stdout.
-func Output(ctx context.Context, dir, name string, args ...string) (string, error) {
-	if name == "git" {
-		return gitexec.Output(ctx, gitexec.Options{Dir: dir}, args...)
-	}
-	cmd := commandContext(ctx, name, args...)
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-func commandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, name, args...)
 }

--- a/internal/executil/executil_test.go
+++ b/internal/executil/executil_test.go
@@ -1,9 +1,6 @@
 package executil
 
 import (
-	"context"
-	"os"
-	"strings"
 	"testing"
 )
 
@@ -29,37 +26,5 @@ func TestEscapeAppleScript(t *testing.T) {
 				t.Errorf("EscapeAppleScript(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
-	}
-}
-
-func TestRunEnv_NilEnvInheritsProcess(t *testing.T) {
-	t.Setenv("EXECUTIL_TEST_MARKER", "inherited")
-	if err := RunEnv(context.Background(), "", nil, "sh", "-c", `test "$EXECUTIL_TEST_MARKER" = "inherited"`); err != nil {
-		t.Fatalf("RunEnv with nil env should inherit the process environment: %v", err)
-	}
-}
-
-func TestRunEnv_ExplicitEnvOverridesProcess(t *testing.T) {
-	t.Setenv("EXECUTIL_TEST_MARKER", "ambient")
-	env := append(os.Environ(), "EXECUTIL_TEST_MARKER=overridden")
-	if err := RunEnv(context.Background(), "", env, "sh", "-c", `test "$EXECUTIL_TEST_MARKER" = "overridden"`); err != nil {
-		t.Fatalf("RunEnv should use the explicit env: %v", err)
-	}
-}
-
-func TestRunEnv_ReturnsStderrOnFailure(t *testing.T) {
-	err := RunEnv(context.Background(), "", nil, "sh", "-c", "echo boom 1>&2; exit 1")
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "boom") {
-		t.Fatalf("error = %v, want it to contain stderr output", err)
-	}
-}
-
-func TestRun_DelegatesToRunEnvWithNilEnv(t *testing.T) {
-	t.Setenv("EXECUTIL_TEST_MARKER", "inherited")
-	if err := Run(context.Background(), "", "sh", "-c", `test "$EXECUTIL_TEST_MARKER" = "inherited"`); err != nil {
-		t.Fatalf("Run should behave like RunEnv with a nil env: %v", err)
 	}
 }

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -20,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/bgop"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evaluation"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/pressure"
 	"github.com/Automaat/sybra/internal/project"
@@ -1521,13 +1521,11 @@ func CurrentWorktreeHead(ctx context.Context, dir string) string {
 	if dir == "" {
 		return ""
 	}
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", "HEAD")
-	cmd.Dir = dir
-	out, err := cmd.Output()
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: dir}, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return out
 }
 
 // FirstNonEmpty returns the first non-empty string among vals, or "" if all

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/loopagent"
@@ -795,11 +796,11 @@ func (h *Handler) captureHeadSHA(taskID string) string {
 	if err != nil || !h.worktrees.Exists(t) {
 		return ""
 	}
-	out, err := exec.CommandContext(context.Background(), "git", "-C", h.worktrees.PathFor(t), "rev-parse", "HEAD").Output()
+	out, err := gitexec.Output(context.Background(), gitexec.Options{Dir: h.worktrees.PathFor(t)}, "rev-parse", "HEAD")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return out
 }
 
 // runOutcome derives the stats.RunRecord outcome for a completed agent run.

--- a/internal/sybra/svc_agents.go
+++ b/internal/sybra/svc_agents.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/sysopen"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/worktree"
@@ -186,21 +186,14 @@ func (s *AgentService) GetAgentDiff(taskID string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_PAGER=cat")
-
-	diffCmd := exec.CommandContext(ctx, "git", "diff", "HEAD", "--patch", "-M", "--no-color")
-	diffCmd.Dir = dir
-	diffCmd.Env = env
-	diffOut, err := diffCmd.Output()
+	opts := gitexec.Options{Dir: dir, ExtraEnv: []string{"GIT_PAGER=cat"}}
+	diffOut, err := gitexec.RawOutput(ctx, opts, "diff", "HEAD", "--patch", "-M", "--no-color")
 	if err != nil {
 		s.logger.Warn("agent.diff.git-diff-failed", "task_id", taskID, "err", err)
 		return "", nil
 	}
 
-	lsCmd := exec.CommandContext(ctx, "git", "ls-files", "--others", "--exclude-standard")
-	lsCmd.Dir = dir
-	lsCmd.Env = env
-	lsOut, err := lsCmd.Output()
+	lsOut, err := gitexec.RawOutput(ctx, opts, "ls-files", "--others", "--exclude-standard")
 	if err != nil {
 		s.logger.Warn("agent.diff.ls-files-failed", "task_id", taskID, "err", err)
 		return string(diffOut), nil

--- a/mise.toml
+++ b/mise.toml
@@ -79,6 +79,8 @@ run = [
   "bash scripts/check-no-home-fallback.sh",
   "bash scripts/check-no-viewer-user-endpoint.sh",
   "bash scripts/check-gh-exec-gate.sh",
+  "bash scripts/check-git-exec-gate.sh",
+  "bash scripts/check-git-exec-gate.test.sh",
   "bash scripts/check-no-direct-status-write.sh",
   "bash scripts/check-autonomy-slo.sh",
   "bash scripts/resolve-release-version.test.sh",
@@ -87,7 +89,7 @@ run = [
   "wails3 generate bindings -ts -clean -d frontend/bindings ./... && git diff --exit-code frontend/bindings/",
   "hadolint Dockerfile",
 ]
-description = "Run every deterministic CI-aligned gate (go build+mod+tidy+tests+e2e, golangci-lint, frontend check+build:web+tests+oxlint+pins, api-shim sync, no-home-fallback, no-direct-status-write, autonomy SLO gate, bindings sync, hadolint). Run before committing. Excludes nilaway/security/playwright — CI owns those."
+description = "Run every deterministic CI-aligned gate (go build+mod+tidy+tests+e2e, golangci-lint, frontend check+build:web+tests+oxlint+pins, api-shim sync, no-home-fallback, Git/GitHub execution boundaries, no-direct-status-write, autonomy SLO gate, bindings sync, hadolint). Run before committing. Excludes nilaway/security/playwright — CI owns those."
 
 [tasks."build:frontend:desktop"]
 run = "cd frontend && npm run build:desktop"

--- a/scripts/check-git-exec-gate.sh
+++ b/scripts/check-git-exec-gate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Keep internal/gitexec as the single production boundary for Git subprocesses.
+# Domain packages own policy (locks, timeouts, recovery, authentication), while
+# gitexec owns process construction, non-interactive defaults, diagnostics, and
+# cancellation. A direct spawn outside that boundary silently loses those
+# mechanics and recreates the fragmentation tracked by #3006.
+#
+# Test files may execute Git directly to construct real repository fixtures.
+# The fake-provider binaries are test infrastructure too, but their Go-level
+# Git calls still use gitexec; shell-embedded Git in fake scenarios is outside
+# this Go constructor check and must remain confined to cmd/fake-*.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# The sole production package allowed to construct a Git process. Its current
+# implementation resolves the executable through a variable, but keeping the
+# boundary explicitly allowlisted makes the architectural exception clear if
+# its constructor later uses the literal again.
+ALLOWLIST=(
+  "internal/gitexec/gitexec.go"
+)
+
+is_allowlisted() {
+  local file="$1"
+  for allowed in "${ALLOWLIST[@]}"; do
+    [[ "${file}" == "${allowed}" ]] && return 0
+  done
+  return 1
+}
+
+files=()
+while IFS= read -r -d '' file; do
+  case "${file}" in
+    *_test.go)
+      ;;
+    *.go)
+      files+=("${file}")
+      ;;
+  esac
+done < <(git ls-files -z --cached --others --exclude-standard)
+
+# Detect both exec.Command("git", ...) and
+# exec.CommandContext(ctx, "git", ...). The optional leading argument is the
+# context expression; [^,]+ intentionally accepts selectors and calls such as
+# context.Background(). This is a deterministic literal guard, not a Go AST or
+# data-flow analysis, so indirection through a binary-name variable is reviewed
+# separately rather than pretending this grep proves more than it does.
+PATTERN='exec\.Command(Context)?\(([^,]+,[[:space:]]*)?"git"([[:space:]]*,|\))'
+
+fail=0
+if ((${#files[@]} > 0)); then
+  while IFS= read -r hit; do
+    [[ -z "${hit}" ]] && continue
+    file="${hit%%:*}"
+    if is_allowlisted "${file}"; then
+      continue
+    fi
+    if ((fail == 0)); then
+      echo "ERROR: production Git subprocess spawn outside internal/gitexec." >&2
+      echo "Route the operation through gitexec and keep only domain policy at the caller." >&2
+      echo >&2
+    fi
+    fail=1
+    echo "  ${hit}" >&2
+  done < <(grep -nHE "${PATTERN}" "${files[@]}" 2>/dev/null | sed 's#^\./##' || true)
+fi
+
+if ((fail != 0)); then
+  exit 1
+fi
+
+echo "check-git-exec-gate: ok"

--- a/scripts/check-git-exec-gate.sh
+++ b/scripts/check-git-exec-gate.sh
@@ -14,22 +14,6 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# The sole production package allowed to construct a Git process. Its current
-# implementation resolves the executable through a variable, but keeping the
-# boundary explicitly allowlisted makes the architectural exception clear if
-# its constructor later uses the literal again.
-ALLOWLIST=(
-  "internal/gitexec/gitexec.go"
-)
-
-is_allowlisted() {
-  local file="$1"
-  for allowed in "${ALLOWLIST[@]}"; do
-    [[ "${file}" == "${allowed}" ]] && return 0
-  done
-  return 1
-}
-
 files=()
 while IFS= read -r -d '' file; do
   case "${file}" in
@@ -41,34 +25,8 @@ while IFS= read -r -d '' file; do
   esac
 done < <(git ls-files -z --cached --others --exclude-standard)
 
-# Detect both exec.Command("git", ...) and
-# exec.CommandContext(ctx, "git", ...). The optional leading argument is the
-# context expression; [^,]+ intentionally accepts selectors and calls such as
-# context.Background(). This is a deterministic literal guard, not a Go AST or
-# data-flow analysis, so indirection through a binary-name variable is reviewed
-# separately rather than pretending this grep proves more than it does.
-PATTERN='exec\.Command(Context)?\(([^,]+,[[:space:]]*)?"git"([[:space:]]*,|\))'
-
-fail=0
 if ((${#files[@]} > 0)); then
-  while IFS= read -r hit; do
-    [[ -z "${hit}" ]] && continue
-    file="${hit%%:*}"
-    if is_allowlisted "${file}"; then
-      continue
-    fi
-    if ((fail == 0)); then
-      echo "ERROR: production Git subprocess spawn outside internal/gitexec." >&2
-      echo "Route the operation through gitexec and keep only domain policy at the caller." >&2
-      echo >&2
-    fi
-    fail=1
-    echo "  ${hit}" >&2
-  done < <(grep -nHE "${PATTERN}" "${files[@]}" 2>/dev/null | sed 's#^\./##' || true)
-fi
-
-if ((fail != 0)); then
-  exit 1
+  go run ./scripts/checkgitexec "${files[@]}"
 fi
 
 echo "check-git-exec-gate: ok"

--- a/scripts/check-git-exec-gate.test.sh
+++ b/scripts/check-git-exec-gate.test.sh
@@ -31,6 +31,9 @@ assert_rejected() {
 assert_rejected command 'package fixture; import "os/exec"; func f() { _ = exec.Command("git", "status") }'
 assert_rejected command_context 'package fixture; import ("context"; "os/exec"); func f(ctx context.Context) { _ = exec.CommandContext(ctx, "git", "status") }'
 assert_rejected command_background 'package fixture; import ("context"; "os/exec"); func f() { _ = exec.CommandContext(context.Background(), "git", "status") }'
+assert_rejected multiline_command $'package fixture\nimport "os/exec"\nfunc f() {\n\t_ = exec.Command(\n\t\t"git",\n\t\t"status",\n\t)\n}'
+assert_rejected multiline_command_context $'package fixture\nimport ("context"; "os/exec")\nfunc f(ctx context.Context) {\n\t_ = exec.CommandContext(\n\t\tctx,\n\t\t"git",\n\t\t"status",\n\t)\n}'
+assert_rejected aliased_import 'package fixture; import command "os/exec"; func f() { _ = command.Command("git", "status") }'
 
 # Direct Git in test fixtures is deliberately allowed.
 printf '%s\n' 'package fixture; import "os/exec"; func f() { _ = exec.Command("git", "status") }' > "${fixture_dir}/fixture_test.go"

--- a/scripts/check-git-exec-gate.test.sh
+++ b/scripts/check-git-exec-gate.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fixture_dir="$(mktemp -d .git-exec-gate-test.XXXXXX)"
+cleanup() {
+  rm -rf -- "${fixture_dir}"
+}
+trap cleanup EXIT
+
+assert_rejected() {
+  local name="$1"
+  local source="$2"
+  local file="${fixture_dir}/${name}.go"
+  local output
+
+  printf '%s\n' "${source}" > "${file}"
+  if output="$(bash scripts/check-git-exec-gate.sh 2>&1)"; then
+    echo "ERROR: gate accepted ${name}" >&2
+    exit 1
+  fi
+  if ! grep -Fq "${file}" <<<"${output}"; then
+    echo "ERROR: gate rejected ${name} without identifying ${file}" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+  rm -f -- "${file}"
+}
+
+assert_rejected command 'package fixture; import "os/exec"; func f() { _ = exec.Command("git", "status") }'
+assert_rejected command_context 'package fixture; import ("context"; "os/exec"); func f(ctx context.Context) { _ = exec.CommandContext(ctx, "git", "status") }'
+assert_rejected command_background 'package fixture; import ("context"; "os/exec"); func f() { _ = exec.CommandContext(context.Background(), "git", "status") }'
+
+# Direct Git in test fixtures is deliberately allowed.
+printf '%s\n' 'package fixture; import "os/exec"; func f() { _ = exec.Command("git", "status") }' > "${fixture_dir}/fixture_test.go"
+bash scripts/check-git-exec-gate.sh >/dev/null
+
+echo "check-git-exec-gate.test: all tests passed"

--- a/scripts/checkgitexec/main.go
+++ b/scripts/checkgitexec/main.go
@@ -1,0 +1,119 @@
+// Command checkgitexec rejects production Go code that constructs Git
+// subprocesses outside internal/gitexec. Syntax-aware inspection keeps the
+// boundary effective across multiline formatting and os/exec import aliases.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+var allowlist = map[string]struct{}{
+	"internal/gitexec/gitexec.go": {},
+}
+
+func main() {
+	fset := token.NewFileSet()
+	failed := false
+	for _, path := range os.Args[1:] {
+		path = filepath.ToSlash(path)
+		if _, ok := allowlist[path]; ok {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "check-git-exec-gate: parse %s: %v\n", path, err)
+			failed = true
+			continue
+		}
+
+		execNames, dotImported := osExecImports(file)
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			command, ok := osExecCommand(call.Fun, execNames, dotImported)
+			if !ok {
+				return true
+			}
+			arg := 0
+			if command == "CommandContext" {
+				arg = 1
+			}
+			if len(call.Args) <= arg || !isGitLiteral(call.Args[arg]) {
+				return true
+			}
+			if !failed {
+				fmt.Fprintln(os.Stderr, "ERROR: production Git subprocess spawn outside internal/gitexec.")
+				fmt.Fprintln(os.Stderr, "Route the operation through gitexec and keep only domain policy at the caller.")
+				fmt.Fprintln(os.Stderr)
+			}
+			failed = true
+			pos := fset.Position(call.Pos())
+			fmt.Fprintf(os.Stderr, "  %s:%d:%d: os/exec.%s constructs git\n", path, pos.Line, pos.Column, command)
+			return true
+		})
+	}
+	if failed {
+		os.Exit(1)
+	}
+}
+
+func osExecImports(file *ast.File) (map[string]struct{}, bool) {
+	names := make(map[string]struct{})
+	dotImported := false
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || path != "os/exec" {
+			continue
+		}
+		if spec.Name == nil {
+			names["exec"] = struct{}{}
+			continue
+		}
+		switch spec.Name.Name {
+		case ".":
+			dotImported = true
+		case "_":
+		default:
+			names[spec.Name.Name] = struct{}{}
+		}
+	}
+	return names, dotImported
+}
+
+func osExecCommand(expr ast.Expr, names map[string]struct{}, dotImported bool) (string, bool) {
+	switch fun := expr.(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := fun.X.(*ast.Ident)
+		if !ok {
+			return "", false
+		}
+		if _, ok := names[pkg.Name]; !ok {
+			return "", false
+		}
+		if fun.Sel.Name == "Command" || fun.Sel.Name == "CommandContext" {
+			return fun.Sel.Name, true
+		}
+	case *ast.Ident:
+		if dotImported && (fun.Name == "Command" || fun.Name == "CommandContext") {
+			return fun.Name, true
+		}
+	}
+	return "", false
+}
+
+func isGitLiteral(expr ast.Expr) bool {
+	literal, ok := expr.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	return err == nil && value == "git"
+}


### PR DESCRIPTION
Closes #3007

## Summary
- route the remaining production Git subprocess consumers through `internal/gitexec`
- remove obsolete generic command helpers from `internal/executil`
- add a syntax-aware repository gate and CI job that reject direct production `os/exec` Git constructors, including multiline and aliased imports
- retain the narrow exception for Git-backed test fixtures and document fake-provider shell infrastructure

## Verification
- `env TZ=UTC mise run verify`
- independent adversarial code review: PASS after resolving a multiline detection finding
- independent adversarial runtime/CLI test: PASS
- post-rebase boundary self-tests and affected Go package tests: PASS