### PR TITLE
fix(sandbox): migrate legacy Git objects safely

### DIFF
--- a/internal/agent/procsandbox_darwin_integration_test.go
+++ b/internal/agent/procsandbox_darwin_integration_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"compress/zlib"
 	"context"
 	"fmt"
 	"os"
@@ -93,7 +94,7 @@ func darwinEnvValue(env []string, key string) string {
 	return ""
 }
 
-func TestPrepareGitSandboxOverlay_DarwinPreservesLegacyObjects(t *testing.T) {
+func TestPrepareGitSandboxOverlay_DarwinRejectsInvalidLegacyObjects(t *testing.T) {
 	sandboxHome := t.TempDir()
 	legacy := filepath.Join(sandboxHome, ".sybra-git-overlay", "objects", "ab", "cdef")
 	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
@@ -104,11 +105,106 @@ func TestPrepareGitSandboxOverlay_DarwinPreservesLegacyObjects(t *testing.T) {
 	}
 
 	_, err := prepareGitSandboxOverlay(context.Background(), t.TempDir(), sandboxHome, gitSandboxRoots{objectDir: t.TempDir()})
-	if err == nil || !strings.Contains(err.Error(), "refusing to delete") {
-		t.Fatalf("prepareGitSandboxOverlay error = %v, want preserved legacy-object failure", err)
+	if err == nil || !strings.Contains(err.Error(), "unsupported legacy Git object payload") {
+		t.Fatalf("prepareGitSandboxOverlay error = %v, want invalid legacy-object failure", err)
 	}
 	if _, err := os.Stat(legacy); err != nil {
 		t.Fatalf("legacy object was not preserved: %v", err)
+	}
+}
+
+func TestPrepareGitSandboxOverlay_DarwinPreservesCorruptCanonicalLegacyObject(t *testing.T) {
+	sandboxHome := t.TempDir()
+	legacy := filepath.Join(sandboxHome, ".sybra-git-overlay", "objects", "ab", strings.Repeat("0", 38))
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacy, []byte("not a zlib Git object"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := prepareGitSandboxOverlay(context.Background(), t.TempDir(), sandboxHome, gitSandboxRoots{objectDir: t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "verify legacy object") {
+		t.Fatalf("prepareGitSandboxOverlay error = %v, want corrupt legacy-object failure", err)
+	}
+	if _, err := os.Stat(legacy); err != nil {
+		t.Fatalf("corrupt legacy object was not preserved: %v", err)
+	}
+}
+
+func TestVerifyLooseObject_RejectsOversizedObjectBeforeReadingBody(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zlib.NewWriter(file)
+	if _, err := fmt.Fprintf(zw, "blob %d\x00", int64(maxLegacyLooseObjectSize)+1); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	file, err = os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+
+	err = verifyLooseObject(file, strings.Repeat("0", 40))
+	if err == nil || !strings.Contains(err.Error(), "exceeds migration limit") {
+		t.Fatalf("verifyLooseObject error = %v, want migration-size limit", err)
+	}
+}
+
+func TestPrepareGitSandboxOverlay_DarwinMigratesLegacyObjectsBeforeReset(t *testing.T) {
+	bare, wt := setupLinkedWorktree(t)
+	sandboxHome := t.TempDir()
+	legacyObjects := filepath.Join(sandboxHome, ".sybra-git-overlay", "objects")
+	if err := os.MkdirAll(legacyObjects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sharedObjects := filepath.Join(bare, "objects")
+
+	if err := os.WriteFile(filepath.Join(wt, "legacy.txt"), []byte("preserved\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitOrFatal(t, wt, "add", "legacy.txt")
+	commit := exec.Command("git", "commit", "-q", "-m", "legacy overlay commit")
+	commit.Dir = wt
+	commit.Env = append(gitSandboxDiscoveryEnv(),
+		"GIT_OBJECT_DIRECTORY="+legacyObjects,
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES="+sharedObjects,
+	)
+	if out, err := commit.CombinedOutput(); err != nil {
+		t.Fatalf("create legacy-overlay commit: %v: %s", err, out)
+	}
+	head := strings.TrimSpace(runGitOutput(t, wt, "rev-parse", "HEAD"))
+	if _, err := os.Stat(filepath.Join(sharedObjects, head[:2], head[2:])); !os.IsNotExist(err) {
+		t.Fatalf("legacy commit unexpectedly present in shared store before migration: %v", err)
+	}
+
+	roots, err := resolveGitSandboxRoots(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("resolveGitSandboxRoots: %v", err)
+	}
+	if _, err := prepareGitSandboxOverlay(context.Background(), wt, sandboxHome, roots); err != nil {
+		t.Fatalf("prepareGitSandboxOverlay: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sharedObjects, head[:2], head[2:])); err != nil {
+		t.Fatalf("migrated commit missing from shared store: %v", err)
+	}
+	if _, err := os.Stat(legacyObjects); !os.IsNotExist(err) {
+		t.Fatalf("verified legacy object overlay was not reset: %v", err)
+	}
+	verify := exec.Command("git", "cat-file", "-e", head+"^{commit}")
+	verify.Dir = bare
+	verify.Env = gitSandboxDiscoveryEnv()
+	if out, err := verify.CombinedOutput(); err != nil {
+		t.Fatalf("migrated commit not independently readable: %v: %s", err, out)
 	}
 }
 
@@ -154,7 +250,7 @@ func TestPrepareGitSandboxOverlay_DarwinPreservesLegacyPack(t *testing.T) {
 	}
 
 	_, err := prepareGitSandboxOverlay(context.Background(), t.TempDir(), sandboxHome, gitSandboxRoots{objectDir: t.TempDir()})
-	if err == nil || !strings.Contains(err.Error(), "refusing to delete") {
+	if err == nil || !strings.Contains(err.Error(), "unsupported legacy Git object payload") {
 		t.Fatalf("prepareGitSandboxOverlay error = %v, want preserved legacy-pack failure", err)
 	}
 	if _, err := os.Stat(legacyPack); err != nil {
@@ -173,12 +269,24 @@ func TestPrepareGitSandboxOverlay_DarwinPreservesLegacyAlternates(t *testing.T) 
 	}
 
 	_, err := prepareGitSandboxOverlay(context.Background(), t.TempDir(), sandboxHome, gitSandboxRoots{objectDir: t.TempDir()})
-	if err == nil || !strings.Contains(err.Error(), "refusing to delete") {
+	if err == nil || !strings.Contains(err.Error(), "unsupported legacy Git object payload") {
 		t.Fatalf("prepareGitSandboxOverlay error = %v, want preserved legacy-alternates failure", err)
 	}
 	if _, err := os.Stat(legacyAlternates); err != nil {
 		t.Fatalf("legacy alternates file was not preserved: %v", err)
 	}
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitSandboxDiscoveryEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v (dir=%s): %v: %s", args, dir, err, out)
+	}
+	return string(out)
 }
 
 // runGitOrFatal runs a git command in dir, unsandboxed, for test setup.

--- a/internal/agent/procsandbox_git.go
+++ b/internal/agent/procsandbox_git.go
@@ -1,13 +1,20 @@
 package agent
 
 import (
+	"bufio"
+	"compress/zlib"
 	"context"
+	"crypto/sha1" // #nosec G505 -- Git's repository object format may be SHA-1.
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/gitexec"
@@ -203,12 +210,8 @@ func prepareGitSandboxOverlay(ctx context.Context, worktree, sandboxHome string,
 			return gitSandboxOverlay{}, err
 		}
 		legacyObjects := filepath.Join(base, "objects")
-		populated, err := gitObjectOverlayPopulated(legacyObjects)
-		if err != nil {
-			return gitSandboxOverlay{}, fmt.Errorf("inspect legacy git object overlay %s: %w", legacyObjects, err)
-		}
-		if populated {
-			return gitSandboxOverlay{}, fmt.Errorf("legacy git object overlay %s is not empty; refusing to delete objects that may be referenced by the task branch", legacyObjects)
+		if err := migrateLegacyGitObjectOverlay(ctx, worktree, legacyObjects, roots.objectDir); err != nil {
+			return gitSandboxOverlay{}, fmt.Errorf("migrate legacy git object overlay %s: %w", legacyObjects, err)
 		}
 	}
 	if err := os.RemoveAll(base); err != nil {
@@ -264,6 +267,233 @@ func prepareGitSandboxOverlay(ctx context.Context, worktree, sandboxHome string,
 	}
 	overlay.branchRefFile = canonRefFile
 	return overlay, nil
+}
+
+// migrateLegacyGitObjectOverlay publishes loose objects left by the former
+// Darwin object-overlay sandbox into the clone's durable object store. It is
+// deliberately conservative: every source object must be a canonical loose
+// object whose decompressed content hashes to its pathname, and an existing
+// destination must independently pass the same check. Pack files, alternates,
+// symlinks, and other payloads fail closed so os.RemoveAll cannot discard data
+// whose meaning Sybra has not proved.
+func migrateLegacyGitObjectOverlay(ctx context.Context, worktree, legacyObjects, sharedObjects string) error {
+	populated, err := gitObjectOverlayPopulated(legacyObjects)
+	if err != nil {
+		return err
+	}
+	if !populated {
+		return nil
+	}
+	if strings.TrimSpace(sharedObjects) == "" {
+		return errors.New("shared Git object directory is empty")
+	}
+
+	err = filepath.WalkDir(legacyObjects, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == legacyObjects || entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(legacyObjects, path)
+		if err != nil {
+			return err
+		}
+		if !isGitObjectPayloadPath(legacyObjects, path) {
+			return nil // derived commit-graph and info/packs metadata
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() {
+			return fmt.Errorf("unsupported legacy Git object entry %s", rel)
+		}
+		oid, ok := canonicalLooseObjectID(rel)
+		if !ok {
+			return fmt.Errorf("unsupported legacy Git object payload %s", rel)
+		}
+		return publishVerifiedLooseObject(path, filepath.Join(sharedObjects, rel), oid)
+	})
+	if err != nil {
+		return err
+	}
+
+	// A migrated commit is not useful if its tree or parents are still absent.
+	// Prove the task's entire HEAD graph resolves with only the shared store
+	// before the caller removes the legacy overlay.
+	out, err := gitexec.CombinedOutput(ctx, gitexec.Options{
+		Dir: worktree,
+		Env: append(stripEnvKeys(os.Environ(), "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"),
+			"GIT_OBJECT_DIRECTORY="+sharedObjects,
+			"GIT_ALTERNATE_OBJECT_DIRECTORIES=",
+		),
+	}, "rev-list", "--objects", "--missing=print", "HEAD")
+	if err != nil {
+		return fmt.Errorf("verify migrated HEAD reachability: %w", err)
+	}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if missing, ok := strings.CutPrefix(line, "?"); ok {
+			return fmt.Errorf("verify migrated HEAD reachability: missing object %s", missing)
+		}
+	}
+	return nil
+}
+
+func canonicalLooseObjectID(rel string) (string, bool) {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 2 || len(parts[0]) != 2 || (len(parts[1]) != 38 && len(parts[1]) != 62) {
+		return "", false
+	}
+	oid := parts[0] + parts[1]
+	if oid != strings.ToLower(oid) {
+		return "", false
+	}
+	_, err := hex.DecodeString(oid)
+	return oid, err == nil
+}
+
+func publishVerifiedLooseObject(src, dst, oid string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open legacy object %s: %w", oid, err)
+	}
+	defer func() { _ = source.Close() }()
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat legacy object %s: %w", oid, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("legacy object %s is not a regular file", oid)
+	}
+	if err := verifyLooseObject(source, oid); err != nil {
+		return fmt.Errorf("verify legacy object %s: %w", oid, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("prepare shared object fanout for %s: %w", oid, err)
+	}
+	if existing, err := os.Open(dst); err == nil {
+		defer func() { _ = existing.Close() }()
+		if err := verifyLooseObject(existing, oid); err != nil {
+			return fmt.Errorf("verify existing shared object %s: %w", oid, err)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect existing shared object %s: %w", oid, err)
+	}
+
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind legacy object %s: %w", oid, err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), "tmp_obj_migrate_")
+	if err != nil {
+		return fmt.Errorf("stage shared object %s: %w", oid, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := io.Copy(tmp, source); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("copy shared object %s: %w", oid, err)
+	}
+	if err := verifyLooseObject(tmp, oid); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("verify staged shared object %s: %w", oid, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync shared object %s: %w", oid, err)
+	}
+	if err := tmp.Chmod(0o444); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod shared object %s: %w", oid, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close shared object %s: %w", oid, err)
+	}
+	if err := os.Link(tmpName, dst); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("publish shared object %s: %w", oid, err)
+		}
+		existing, openErr := os.Open(dst)
+		if openErr != nil {
+			return fmt.Errorf("open concurrently published shared object %s: %w", oid, openErr)
+		}
+		defer func() { _ = existing.Close() }()
+		if verifyErr := verifyLooseObject(existing, oid); verifyErr != nil {
+			return fmt.Errorf("verify concurrently published shared object %s: %w", oid, verifyErr)
+		}
+	}
+	return nil
+}
+
+// GitHub rejects ordinary Git blobs above 100 MiB. Leave ample headroom for
+// non-GitHub repositories while bounding work on a provider-controlled legacy
+// overlay: validation runs in the trusted Sybra process, outside the provider
+// sandbox, so it must not stream an arbitrarily large zlib payload.
+const maxLegacyLooseObjectSize = 1 << 30
+const maxLegacyLooseObjectDiskSize = maxLegacyLooseObjectSize + 1<<20
+
+func verifyLooseObject(file *os.File, oid string) error {
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat compressed object: %w", err)
+	}
+	if info.Size() > maxLegacyLooseObjectDiskSize {
+		return fmt.Errorf("compressed object size %d exceeds migration limit %d", info.Size(), maxLegacyLooseObjectDiskSize)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	compressed := bufio.NewReader(file)
+	zr, err := zlib.NewReader(compressed)
+	if err != nil {
+		return fmt.Errorf("open zlib stream: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	var digest hash.Hash
+	switch len(oid) {
+	case sha1.Size * 2:
+		digest = sha1.New() // #nosec G401 -- required to verify SHA-1 Git object IDs.
+	case sha256.Size * 2:
+		digest = sha256.New()
+	default:
+		return fmt.Errorf("unsupported object ID length %d", len(oid))
+	}
+	reader := bufio.NewReader(io.TeeReader(zr, digest))
+	headerBytes := make([]byte, 0, 64)
+	for len(headerBytes) <= 128 {
+		char, err := reader.ReadByte()
+		if err != nil {
+			return fmt.Errorf("read object header: %w", err)
+		}
+		if char == 0 {
+			break
+		}
+		headerBytes = append(headerBytes, char)
+	}
+	if len(headerBytes) > 128 {
+		return errors.New("object header exceeds 128 bytes")
+	}
+	header := string(headerBytes)
+	typeName, sizeText, ok := strings.Cut(header, " ")
+	if !ok || (typeName != "blob" && typeName != "tree" && typeName != "commit" && typeName != "tag") {
+		return fmt.Errorf("invalid object header %q", header)
+	}
+	wantSize, err := strconv.ParseInt(sizeText, 10, 64)
+	if err != nil || wantSize < 0 {
+		return fmt.Errorf("invalid object size %q", sizeText)
+	}
+	if wantSize > maxLegacyLooseObjectSize {
+		return fmt.Errorf("object size %d exceeds migration limit %d", wantSize, maxLegacyLooseObjectSize)
+	}
+	gotSize, err := io.CopyN(io.Discard, reader, wantSize+1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("read object content: %w", err)
+	}
+	if gotSize != wantSize {
+		return fmt.Errorf("object size = %d, want %d", gotSize, wantSize)
+	}
+	if got := hex.EncodeToString(digest.Sum(nil)); got != oid {
+		return fmt.Errorf("object hash = %s, want %s", got, oid)
+	}
+	return nil
 }
 
 func prepareGitLooseObjectDirs(objectDir string) error {


### PR DESCRIPTION
## Summary

- migrate canonical loose objects left by the former Darwin Git overlay into the durable shared object store
- verify object hashes, publish collision-safely, and prove complete HEAD reachability before resetting the overlay
- fail closed for unsupported or corrupt payloads and bound validation work on provider-controlled data
- cover successful stranded-commit recovery plus malformed, corrupt, oversized, pack, and alternates cases

## Verification

- `mise run verify`
- adversarial review: clean after bounding compressed and decompressed validation input