### PR TITLE
fix(agent): retry transient runs off the budget

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -165,6 +165,12 @@ export class AgentRun {
      */
     "zeroOutputStall"?: boolean;
 
+    /**
+     * TurnCount is zero when the child produced nothing, so the run holds no
+     * evidence about its instructions and must not spend a conformance budget.
+     */
+    "turnCount"?: number;
+
     /** Creates a new AgentRun instance. */
     constructor($$source: Partial<AgentRun> = {}) {
         if (!("agentId" in $$source)) {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -34,6 +34,9 @@ type State string
 const (
 	ErrorKindToolUseAborted  = "tool_use_aborted"
 	ErrorKindUserInterrupted = "user_interrupted"
+	// ErrorKindPromptUndelivered: the child never received the prompt, so the run
+	// carries no verdict and must be re-dispatched instead of counted as a try.
+	ErrorKindPromptUndelivered = "prompt_undelivered"
 )
 
 const (

--- a/internal/agent/prompt_undelivered_test.go
+++ b/internal/agent/prompt_undelivered_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// handleError re-classifies every fatal error from scratch, so the kind stamped
+// at the delivery site only survives if classifyAgentError recognises it too.
+// Without that, an undelivered prompt lands in the generic "crash" bucket and
+// completion counts it as a real verdict.
+func TestClassifyAgentError_PromptUndelivered(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered,
+		errors.New("write stdin: timed out after 2m0s, pipe closed"))
+
+	if got := classifyAgentError(wrapped); got != ErrorKindPromptUndelivered {
+		t.Fatalf("classifyAgentError(delivery failure) = %q, want %q", got, ErrorKindPromptUndelivered)
+	}
+}
+
+// The wrapped error text contains "i/o timeout"-adjacent wording that the
+// substring table would otherwise classify as a git/network failure.
+func TestClassifyAgentError_PromptUndeliveredBeatsSubstringTable(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered,
+		errors.New("write stdin: i/o timeout"))
+
+	if got := classifyAgentError(wrapped); got != ErrorKindPromptUndelivered {
+		t.Fatalf("classifyAgentError(i/o timeout delivery failure) = %q, want %q", got, ErrorKindPromptUndelivered)
+	}
+}
+
+func TestHandleError_PreservesPromptUndeliveredKind(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "a1"}
+	wrapped := fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered,
+		errors.New("write stdin: timed out after 2m0s, pipe closed"))
+
+	m.handleError(t.Context(), a, wrapped)
+
+	if got := a.GetErrorKind(); got != ErrorKindPromptUndelivered {
+		t.Fatalf("GetErrorKind() after handleError = %q, want %q", got, ErrorKindPromptUndelivered)
+	}
+}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -321,12 +321,13 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 		if writeErr := m.writeUserMessageTimeout(a, cfg.Prompt, stdinInitialWriteTimeout); writeErr != nil {
 			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
 			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
+			a.SetExitErr(fmt.Errorf("%w: %w", errPromptUndelivered, writeErr))
 			a.convo.closeStdinPipe()
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
 			_ = cmd.Wait()
-			return false, fmt.Errorf("deliver initial prompt: %w", writeErr)
+			return false, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
 		}
 	} else if promptStdin != nil {
 		m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt)
@@ -511,6 +512,7 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 		if writeErr := m.writeUserMessageTimeout(a, cfg.Prompt, stdinInitialWriteTimeout); writeErr != nil {
 			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
 			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
+			a.SetExitErr(fmt.Errorf("%w: %w", errPromptUndelivered, writeErr))
 			a.convo.closeStdinPipe()
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
@@ -520,7 +522,7 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 				// pipe variant's kill path.
 				_ = cmd.Wait()
 			}
-			return nil, fmt.Errorf("deliver initial prompt: %w", writeErr)
+			return nil, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
 		}
 	} else if promptStdin != nil {
 		m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt)
@@ -1681,6 +1683,11 @@ func (m *Manager) handleError(ctx context.Context, a *Agent, err error) {
 func classifyAgentError(err error) string {
 	if err == nil {
 		return "crash"
+	}
+	// Ahead of the substring table, which reads this as a bare i/o timeout and
+	// mislabels it git_clone.
+	if errors.Is(err, errPromptUndelivered) {
+		return ErrorKindPromptUndelivered
 	}
 	msg := strings.ToLower(err.Error())
 	switch {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -320,6 +320,7 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 		// attempt instead of pressing on as if delivery succeeded.
 		if writeErr := m.writeUserMessageTimeout(a, cfg.Prompt, stdinInitialWriteTimeout); writeErr != nil {
 			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
+			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
 			a.convo.closeStdinPipe()
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
@@ -509,6 +510,7 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 		// Fail the attempt instead of pressing on as if delivery succeeded.
 		if writeErr := m.writeUserMessageTimeout(a, cfg.Prompt, stdinInitialWriteTimeout); writeErr != nil {
 			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
+			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
 			a.convo.closeStdinPipe()
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -12,6 +12,11 @@ import (
 
 var errProviderRateLimited = errors.New("provider rate-limited")
 
+// errPromptUndelivered tags an attempt that died before the child could read
+// its prompt, so classifyAgentError can keep it out of the "crash" bucket that
+// completion counts as a real verdict.
+var errPromptUndelivered = errors.New("prompt undelivered")
+
 // reportProviderHealthSignal classifies the final error surface of a failed
 // run and forwards rate-limit / auth failures to the provider health gate so
 // the next scheduling attempt can fail over to a peer.

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -563,6 +563,7 @@ func toRunInfos(runs []task.AgentRun) []workflow.AgentRunInfo {
 			HeadSHA:                runs[i].HeadSHA,
 			FinalCommitSource:      runs[i].FinalCommitSource,
 			SubagentCallCount:      runs[i].SubagentCallCount,
+			TurnCount:              runs[i].TurnCount,
 		}
 	}
 	return out

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -582,6 +582,8 @@ func (h *Handler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, ex
 			h.workflowEngine.RescheduleCheckpointedAgent(ag.TaskID, ag.ID)
 		case stall.ToolUseAborted || stall.UserInterrupted:
 			h.workflowEngine.RescheduleInterruptedAgent(ag.TaskID, ag.ID)
+		case stall.PromptUndelivered:
+			h.workflowEngine.ReschedulePromptUndeliveredAgent(ag.TaskID, ag.ID)
 		case stall.RateLimited || stall.MalformedTool:
 			h.workflowEngine.RescheduleRateLimitedAgent(ag.TaskID, ag.ID)
 		default:

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -474,6 +474,7 @@ func addRunMetadata(updates *task.RunPatch, ag *agent.Agent) {
 		updates.SkillConformance = task.Ptr(ag.SkillConformance)
 	}
 	updates.SubagentCallCount = task.Ptr(ag.GetSubagentCallCount())
+	updates.TurnCount = task.Ptr(ag.GetTurnCount())
 }
 
 func (h *Handler) buildRunPatch(ag *agent.Agent, state agent.State, cost, premiumRequests float64, resultContent string, exitErr error) task.RunPatch {
@@ -575,7 +576,7 @@ func (h *Handler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, ex
 	if stall.Stalled {
 		h.logger.Warn("agent.completion.stall",
 			"task_id", ag.TaskID, "agent_id", ag.ID,
-			"signaled", isSignalKill(exitErr), "stopped", stall.StopStalled, "rate_limited", stall.RateLimited, "malformed_tool", stall.MalformedTool, "tool_use_aborted", stall.ToolUseAborted, "user_interrupted", stall.UserInterrupted, "checkpoint", stall.CheckpointStopped)
+			"signaled", isSignalKill(exitErr), "stopped", stall.StopStalled, "rate_limited", stall.RateLimited, "malformed_tool", stall.MalformedTool, "tool_use_aborted", stall.ToolUseAborted, "user_interrupted", stall.UserInterrupted, "checkpoint", stall.CheckpointStopped, "prompt_undelivered", stall.PromptUndelivered)
 		switch {
 		case stall.CheckpointStopped:
 			h.workflowEngine.RescheduleCheckpointedAgent(ag.TaskID, ag.ID)
@@ -599,8 +600,9 @@ func (h *Handler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, ex
 }
 
 // classifyStall reports whether a completion is a retryable stall: signal
-// kill, stop-before-result, provider rate limit, malformed tool call, or
-// rejected-tool interruption rather than the agent's actual terminal outcome.
+// kill, stop-before-result, provider rate limit, malformed tool call,
+// rejected-tool interruption, or an undelivered prompt rather than the agent's
+// actual terminal outcome.
 // buildRunPatch and
 // notifyWorkflowEngine both key off this so the persisted AgentRun.Outcome and
 // the workflow's Success signal can never diverge: a stalled run is retried,
@@ -611,16 +613,18 @@ type stallDisposition struct {
 	MalformedTool     bool
 	ToolUseAborted    bool
 	UserInterrupted   bool
+	PromptUndelivered bool
 	StopStalled       bool
 	CheckpointStopped bool
 }
 
 func classifyStall(ag *agent.Agent, exitErr error) stallDisposition {
 	out := stallDisposition{
-		RateLimited:     isRateLimitedRun(ag, exitErr),
-		MalformedTool:   ag.GetErrorKind() == "malformed_tool_call",
-		ToolUseAborted:  isToolUseAbortedRun(ag),
-		UserInterrupted: isUserInterruptedRun(ag),
+		RateLimited:       isRateLimitedRun(ag, exitErr),
+		MalformedTool:     ag.GetErrorKind() == "malformed_tool_call",
+		ToolUseAborted:    isToolUseAbortedRun(ag),
+		UserInterrupted:   isUserInterruptedRun(ag),
+		PromptUndelivered: ag.GetErrorKind() == agent.ErrorKindPromptUndelivered,
 	}
 	// Cost and forked-subagent-turn guardrails intentionally hard-stop the
 	// subprocess, but they are a budget/runaway failure, not an infra stall.
@@ -632,7 +636,7 @@ func classifyStall(ag *agent.Agent, exitErr error) stallDisposition {
 	checkpointFailed := ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpointFailed
 	out.CheckpointStopped = ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpoint
 	out.StopStalled = ag.WasStopped() && !ag.WasCompletedByResult() && !costStopped && !subagentTurnsStopped && !checkpointFailed && !out.CheckpointStopped
-	out.Stalled = isSignalKill(exitErr) || out.StopStalled || out.RateLimited || out.MalformedTool || out.ToolUseAborted || out.UserInterrupted || out.CheckpointStopped
+	out.Stalled = isSignalKill(exitErr) || out.StopStalled || out.RateLimited || out.MalformedTool || out.ToolUseAborted || out.UserInterrupted || out.CheckpointStopped || out.PromptUndelivered
 	return out
 }
 

--- a/internal/sybra/completion/completion_test.go
+++ b/internal/sybra/completion/completion_test.go
@@ -589,6 +589,28 @@ func TestClassifyStall_CheckpointDisposition(t *testing.T) {
 		}
 	})
 
+	// An initial prompt that never reached the child leaves a run holding no
+	// verdict about anything, so it must be re-dispatched rather than counted.
+	t.Run("undelivered prompt stalls for retry", func(t *testing.T) {
+		ag := &agent.Agent{}
+		ag.SetError(agent.ErrorKindPromptUndelivered, "write stdin: timed out after 2m0s, pipe closed")
+
+		stall := classifyStall(ag, errors.New("deliver initial prompt: write stdin: timed out after 2m0s, pipe closed"))
+		if !stall.Stalled || !stall.PromptUndelivered || stall.RateLimited || stall.MalformedTool || stall.ToolUseAborted || stall.CheckpointStopped {
+			t.Fatalf("classifyStall(prompt_undelivered) = stalled=%v promptUndelivered=%v rateLimited=%v malformedTool=%v toolUseAborted=%v checkpointStopped=%v",
+				stall.Stalled, stall.PromptUndelivered, stall.RateLimited, stall.MalformedTool, stall.ToolUseAborted, stall.CheckpointStopped)
+		}
+	})
+
+	t.Run("undelivered prompt is not a definitive outcome", func(t *testing.T) {
+		ag := &agent.Agent{}
+		ag.SetError(agent.ErrorKindPromptUndelivered, "write stdin: timed out after 2m0s, pipe closed")
+
+		if got := runTerminalOutcome(ag, errors.New("deliver initial prompt: timed out")); got != "" {
+			t.Fatalf("runTerminalOutcome(prompt_undelivered) = %q, want empty", got)
+		}
+	})
+
 	t.Run("tool use aborted stalls for retry", func(t *testing.T) {
 		ag := &agent.Agent{}
 		ag.SetError(agent.ErrorKindToolUseAborted, "provider run aborted after tool use was rejected")

--- a/internal/sybra/completion/parked_adoption_test.go
+++ b/internal/sybra/completion/parked_adoption_test.go
@@ -32,6 +32,8 @@ func (r *recordingWorkflow) RescheduleRateLimitedAgent(_, _ string) {}
 
 func (r *recordingWorkflow) RescheduleCheckpointedAgent(_, _ string) {}
 
+func (r *recordingWorkflow) ReschedulePromptUndeliveredAgent(_, _ string) {}
+
 func (r *recordingWorkflow) DispatchEvent(_, _ string, _, _ map[string]string) (string, error) {
 	return "", nil
 }

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -427,7 +427,7 @@ func (r *Handler) pollKnownTaskPRs(ctx context.Context) time.Duration {
 		fetchMatchers = append(fetchMatchers, reconcileMatchers...)
 	}
 	fetchMatchers = append(fetchMatchers, r.settledImplementationFetchMatchers(ctx, selection.tasks)...)
-	monitoredPRs := r.fetchKnownTaskPRs(fetchMatchers)
+	monitoredPRs := r.fetchKnownTaskPRs(fetchMatchers, selection.retainKeys)
 	// fetchKnownTaskPRs records auth failures on the shared circuit. Once it
 	// trips, back off like pollAndMonitorPRs instead of re-hammering a dead
 	// token every cycle (#1516) — the next cycle re-probes and closes on
@@ -723,7 +723,7 @@ func (r *Handler) handleKnownPRConflictsViaREST(ctx context.Context, tasks []tas
 
 	fetchMatchers := append([]github.TaskMatcher{}, matchers...)
 	fetchMatchers = append(fetchMatchers, settledImplementMatchers...)
-	monitoredPRs := r.fetchKnownTaskPRs(fetchMatchers)
+	monitoredPRs := r.fetchKnownTaskPRs(fetchMatchers, selection.retainKeys)
 	if len(matchers) > 0 {
 		var handled []github.PRIssue
 		matched := github.MatchTaskPRs(monitoredPRs, matchers)
@@ -949,7 +949,10 @@ func prRefCacheKey(repo string, number int) string {
 // status/check event at the same head, e.g. a re-run CI job failing), or a
 // failed probe evicts the cache entry and falls back to a full fetch, so a
 // stale ready-state is never reused.
-func (r *Handler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []github.PullRequest {
+// retain lists PR keys this tick skipped on purpose (backoff-deferred or
+// per-tick-capped). They are not fetched, but their snapshots must survive the
+// prune below or their skip counters die with them.
+func (r *Handler) fetchKnownTaskPRs(matchers []github.TaskMatcher, retain []string) []github.PullRequest {
 	fetchFn := github.FetchPRsForMonitor
 	if r.fetchKnownPRsFn != nil {
 		fetchFn = r.fetchKnownPRsFn
@@ -986,7 +989,12 @@ func (r *Handler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []github.Pull
 	}
 
 	// Drop cache entries for PRs no longer linked to a monitored task.
-	r.prSnapshots.Prune(seen)
+	keep := make(map[string]struct{}, len(seen)+len(retain))
+	maps.Copy(keep, seen)
+	for _, key := range retain {
+		keep[key] = struct{}{}
+	}
+	r.prSnapshots.Prune(keep)
 
 	if len(refs) == 0 {
 		return prs
@@ -1739,7 +1747,7 @@ func (r *Handler) includeKnownTaskPRs(ctx context.Context, tasks []task.Task, mo
 		return monitoredPRs
 	}
 
-	knownPRs := r.fetchKnownTaskPRs(matchers)
+	knownPRs := r.fetchKnownTaskPRs(matchers, selection.retainKeys)
 	if len(knownPRs) == 0 {
 		return monitoredPRs
 	}

--- a/internal/sybra/review/pr_poll_sched.go
+++ b/internal/sybra/review/pr_poll_sched.go
@@ -15,6 +15,11 @@ type knownPRPollSelection struct {
 	selectedPRs int
 	deferredPRs int
 	cappedPRs   int
+	// retainKeys are the PRs this tick deliberately skipped (deferred by
+	// backoff or cut by the per-tick cap). They are absent from `tasks`, so
+	// without listing them here Prune would delete the very skip counters that
+	// deferred them and the backoff could never last more than one tick.
+	retainKeys []string
 }
 
 func expBackoff(streak, maxTicks int) int {
@@ -35,6 +40,7 @@ func (r *Handler) selectKnownPRPoll(ctx context.Context, tasks []task.Task) know
 	active := make([]task.Task, 0, len(tasks))
 	passthrough := make([]task.Task, 0, len(tasks))
 	candidates := make([]task.Task, 0, len(tasks))
+	var retainKeys []string
 	activePRs := 0
 	deferred := 0
 
@@ -61,6 +67,7 @@ func (r *Handler) selectKnownPRPoll(ctx context.Context, tasks []task.Task) know
 		if skipTicks > 0 {
 			if r.knownPRStillStableDuringBackoff(&tk, key) {
 				deferred++
+				retainKeys = append(retainKeys, key)
 				continue
 			}
 		}
@@ -85,9 +92,14 @@ func (r *Handler) selectKnownPRPoll(ctx context.Context, tasks []task.Task) know
 	selected = append(selected, active...)
 	selected = append(selected, passthrough...)
 	selected = append(selected, candidates[:budget]...)
+	for i := range candidates[budget:] {
+		capped := &candidates[budget+i]
+		retainKeys = append(retainKeys, prRefCacheKey(capped.ProjectID, capped.PRNumber))
+	}
 
 	return knownPRPollSelection{
 		tasks:       selected,
+		retainKeys:  retainKeys,
 		selectedPRs: activePRs + budget,
 		deferredPRs: deferred,
 		cappedPRs:   len(candidates) - budget,

--- a/internal/sybra/review/pr_poll_sched.go
+++ b/internal/sybra/review/pr_poll_sched.go
@@ -54,12 +54,17 @@ func (r *Handler) selectKnownPRPoll(ctx context.Context, tasks []task.Task) know
 
 		key := prRefCacheKey(tk.ProjectID, tk.PRNumber)
 		_, _, skipTicks, _ := r.prSnapshots.Backoff(key)
+		if r.prSnapshots.TaskStatusAdvancedSince(key, tk.StatusChangedAt) {
+			r.prSnapshots.ResetBackoff(key)
+			skipTicks = 0
+		}
 		if skipTicks > 0 {
 			if r.knownPRStillStableDuringBackoff(&tk, key) {
 				deferred++
 				continue
 			}
 		}
+		r.prSnapshots.NoteTaskStatus(key, tk.StatusChangedAt)
 		candidates = append(candidates, tk)
 	}
 

--- a/internal/sybra/review/pr_poll_sched_test.go
+++ b/internal/sybra/review/pr_poll_sched_test.go
@@ -218,6 +218,79 @@ func TestSelectKnownPRPoll(t *testing.T) {
 		}
 	})
 
+	// A deferred PR is absent from the selection, so it is also absent from the
+	// `seen` set Prune keeps — its skip counters must be retained explicitly or
+	// the backoff can never survive past the tick that armed it.
+	t.Run("deferred and capped keys are retained for pruning", func(t *testing.T) {
+		t.Parallel()
+
+		r := &Handler{
+			cfg:         &config.Config{GitHub: config.GitHubConfig{ReviewsMaxPRsPerTick: 1}},
+			prSnapshots: PRSnapshotStore{entries: map[string]prSnapshot{"owner/repo#7": {skipTicks: 2}}},
+		}
+		deferredTask := newTask("deferred", 7, base)
+		cappedA := newTask("capped-a", 8, base.Add(time.Hour))
+		cappedB := newTask("capped-b", 9, base)
+
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{deferredTask, cappedA, cappedB})
+		if sel.deferredPRs != 1 || sel.cappedPRs != 1 {
+			t.Fatalf("selection stats = %+v, want deferred=1 capped=1", sel)
+		}
+		want := map[string]bool{"owner/repo#7": true, "owner/repo#9": true}
+		if len(sel.retainKeys) != len(want) {
+			t.Fatalf("retainKeys = %v, want the deferred and capped keys", sel.retainKeys)
+		}
+		for _, key := range sel.retainKeys {
+			if !want[key] {
+				t.Fatalf("retainKeys = %v, unexpected key %q", sel.retainKeys, key)
+			}
+		}
+	})
+
+	// An older sibling task must not rewind the PR-keyed stamp, or the newer
+	// one reads as "advanced" forever and the PR loses its request pacing.
+	t.Run("older sibling task cannot rewind the status stamp", func(t *testing.T) {
+		t.Parallel()
+
+		probes := 0
+		r := &Handler{
+			prSnapshots: PRSnapshotStore{entries: map[string]prSnapshot{
+				"owner/repo#7": {
+					headSHA:         "sha-1",
+					updatedAt:       "2026-07-13T12:00:00Z",
+					skipTicks:       2,
+					statusChangedAt: base,
+				},
+			}},
+			fetchHeadStateFn: func(string, int) (string, bool, string, error) {
+				probes++
+				return "sha-1", true, "2026-07-13T12:00:00Z", nil
+			},
+		}
+		newer := newTask("newer", 7, base.Add(2*time.Hour))
+		newer.StatusChangedAt = base.Add(2 * time.Hour)
+		older := newTask("older", 7, base.Add(time.Hour))
+		older.StatusChangedAt = base.Add(time.Hour)
+
+		if sel := r.selectKnownPRPoll(context.Background(), []task.Task{newer, older}); len(sel.tasks) != 2 {
+			t.Fatalf("first tick selected = %v, want both tasks after the status change", taskIDs(sel.tasks))
+		}
+		if got := r.prSnapshots.entries["owner/repo#7"].statusChangedAt; !got.Equal(newer.StatusChangedAt) {
+			t.Fatalf("stamp after tick 1 = %v, want the newer task's %v", got, newer.StatusChangedAt)
+		}
+
+		// Re-arm only the skip counter, leaving whatever stamp tick 1 wrote, so
+		// a rewound stamp shows up as a PR that never backs off again.
+		armed := r.prSnapshots.entries["owner/repo#7"]
+		armed.skipTicks = 2
+		r.prSnapshots.set("owner/repo#7", armed)
+
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{newer, older})
+		if len(sel.tasks) != 0 {
+			t.Fatalf("second tick selected = %v, want none — the stamp must not rewind", taskIDs(sel.tasks))
+		}
+	})
+
 	t.Run("updatedAt change breaks stable backoff", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/sybra/review/pr_poll_sched_test.go
+++ b/internal/sybra/review/pr_poll_sched_test.go
@@ -166,6 +166,58 @@ func TestSelectKnownPRPoll(t *testing.T) {
 		}
 	})
 
+	// Backoff is keyed on the PR, so a task unblocked back into a fixable lane
+	// would otherwise serve out a streak the PR earned while it was parked.
+	t.Run("task status change breaks stable backoff", func(t *testing.T) {
+		t.Parallel()
+
+		unblockedAt := base.Add(time.Hour)
+		probes := 0
+		r := &Handler{
+			prSnapshots: PRSnapshotStore{entries: map[string]prSnapshot{
+				"owner/repo#7": {
+					headSHA:         "sha-1",
+					updatedAt:       "2026-07-13T12:00:00Z",
+					stableStreak:    3,
+					skipTicks:       4,
+					statusChangedAt: base,
+				},
+			}},
+			fetchHeadStateFn: func(string, int) (string, bool, string, error) {
+				probes++
+				return "sha-1", true, "2026-07-13T12:00:00Z", nil
+			},
+		}
+		tk := newTask("unblocked", 7, unblockedAt)
+		tk.StatusChangedAt = unblockedAt
+
+		sel := r.selectKnownPRPoll(context.Background(), []task.Task{tk})
+		if probes != 0 {
+			t.Fatalf("fetchHeadStateFn calls = %d, want 0 — a status change selects without probing", probes)
+		}
+		if got := taskIDs(sel.tasks); len(got) != 1 || got[0] != "unblocked" {
+			t.Fatalf("selected ids = %v, want [unblocked] on the tick after a status change", got)
+		}
+		if sel.deferredPRs != 0 {
+			t.Fatalf("deferredPRs = %d, want 0", sel.deferredPRs)
+		}
+		if _, _, got, _ := r.prSnapshots.Backoff("owner/repo#7"); got != 0 {
+			t.Fatalf("skipTicks = %d, want reset to 0", got)
+		}
+
+		// The same status must not keep bypassing the backoff on later ticks.
+		r.prSnapshots.set("owner/repo#7", prSnapshot{
+			headSHA:         "sha-1",
+			updatedAt:       "2026-07-13T12:00:00Z",
+			skipTicks:       2,
+			statusChangedAt: unblockedAt,
+		})
+		sel = r.selectKnownPRPoll(context.Background(), []task.Task{tk})
+		if len(sel.tasks) != 0 || sel.deferredPRs != 1 {
+			t.Fatalf("second tick selected=%v deferred=%d, want none selected and 1 deferred", taskIDs(sel.tasks), sel.deferredPRs)
+		}
+	})
+
 	t.Run("updatedAt change breaks stable backoff", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/sybra/review/pr_snapshot.go
+++ b/internal/sybra/review/pr_snapshot.go
@@ -1,6 +1,10 @@
 package review
 
-import "github.com/Automaat/sybra/internal/github"
+import (
+	"time"
+
+	"github.com/Automaat/sybra/internal/github"
+)
 
 // prSnapshot is one linked PR's cross-poll-cycle bookkeeping, keyed by
 // "repo#number" (prRefCacheKey). It replaces two previously separate caches —
@@ -19,6 +23,11 @@ type prSnapshot struct {
 	ready        *github.PullRequest
 	stableStreak int
 	skipTicks    int
+	// statusChangedAt is the linked task's StatusChangedAt as of the last tick
+	// that selected this PR. Backoff is keyed on the PR, so without this a task
+	// re-entering a fixable lane would keep serving out a streak the PR earned
+	// while the task was parked and unfixable.
+	statusChangedAt time.Time
 }
 
 // PRSnapshotStore is the single owner of per-PR ("repo#number") poll-cycle
@@ -74,6 +83,24 @@ func (s *PRSnapshotStore) ClearReady(key string) {
 func (s *PRSnapshotStore) Backoff(key string) (headSHA, updatedAt string, skipTicks, stableStreak int) {
 	e := s.entries[key]
 	return e.headSHA, e.updatedAt, e.skipTicks, e.stableStreak
+}
+
+// TaskStatusAdvancedSince reports whether the linked task changed status after
+// the last tick that selected key. A task moving back into a fixable lane must
+// be re-probed immediately rather than waiting out the PR's stable streak.
+func (s *PRSnapshotStore) TaskStatusAdvancedSince(key string, statusChangedAt time.Time) bool {
+	e, ok := s.entries[key]
+	if !ok {
+		return true
+	}
+	return statusChangedAt.After(e.statusChangedAt)
+}
+
+// NoteTaskStatus stamps the linked task's StatusChangedAt onto key.
+func (s *PRSnapshotStore) NoteTaskStatus(key string, statusChangedAt time.Time) {
+	e := s.get(key)
+	e.statusChangedAt = statusChangedAt
+	s.set(key, e)
 }
 
 // DecrementSkipTicks consumes one skip-tick for key, leaving every other

--- a/internal/sybra/review/pr_snapshot.go
+++ b/internal/sybra/review/pr_snapshot.go
@@ -96,9 +96,15 @@ func (s *PRSnapshotStore) TaskStatusAdvancedSince(key string, statusChangedAt ti
 	return statusChangedAt.After(e.statusChangedAt)
 }
 
-// NoteTaskStatus stamps the linked task's StatusChangedAt onto key.
+// NoteTaskStatus advances key's stamp to statusChangedAt. The stamp only ever
+// moves forward: several tasks can share one PR, and letting an older task's
+// timestamp overwrite a newer one would leave the newer task permanently
+// "advanced" and strip the PR of its backoff for good.
 func (s *PRSnapshotStore) NoteTaskStatus(key string, statusChangedAt time.Time) {
 	e := s.get(key)
+	if !statusChangedAt.After(e.statusChangedAt) {
+		return
+	}
 	e.statusChangedAt = statusChangedAt
 	s.set(key, e)
 }

--- a/internal/sybra/review/readycache_test.go
+++ b/internal/sybra/review/readycache_test.go
@@ -41,7 +41,7 @@ func TestFetchKnownTaskPRs_SkipsFullFetchForKnownReadyPR(t *testing.T) {
 
 	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
 
-	first := r.fetchKnownTaskPRs(matchers)
+	first := r.fetchKnownTaskPRs(matchers, nil)
 	if len(first) != 1 || first[0].Number != 50 {
 		t.Fatalf("first cycle: got %+v, want [readyPR]", first)
 	}
@@ -49,7 +49,7 @@ func TestFetchKnownTaskPRs_SkipsFullFetchForKnownReadyPR(t *testing.T) {
 		t.Fatalf("full fetches after first cycle = %d, want 1", fullFetches)
 	}
 
-	second := r.fetchKnownTaskPRs(matchers)
+	second := r.fetchKnownTaskPRs(matchers, nil)
 	if len(second) != 1 || second[0].Number != 50 {
 		t.Fatalf("second cycle: got %+v, want [readyPR]", second)
 	}
@@ -98,7 +98,7 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 
 	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
 
-	if got := r.fetchKnownTaskPRs(matchers); len(got) != 1 || got[0].HeadSHA != "sha50" {
+	if got := r.fetchKnownTaskPRs(matchers, nil); len(got) != 1 || got[0].HeadSHA != "sha50" {
 		t.Fatalf("first cycle: got %+v", got)
 	}
 	if fullFetches != 1 {
@@ -109,7 +109,7 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 	currentHeadSHA = "sha-forced"
 	currentUpdatedAt = "2026-07-02T11:00:00Z"
 
-	got := r.fetchKnownTaskPRs(matchers)
+	got := r.fetchKnownTaskPRs(matchers, nil)
 	if len(got) != 1 || got[0].HeadSHA != "sha-forced" {
 		t.Fatalf("second cycle: got %+v, want fresh forced-push snapshot", got)
 	}
@@ -124,7 +124,7 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 	// full fetch — but only if the new state was itself ready; here it isn't
 	// (RESTApproved=false), so the cache should stay empty and every
 	// subsequent cycle keeps re-fetching until re-approved.
-	third := r.fetchKnownTaskPRs(matchers)
+	third := r.fetchKnownTaskPRs(matchers, nil)
 	if fullFetches != 3 {
 		t.Fatalf("full fetches after third cycle = %d, want 3 (not-ready state must never be cached)", fullFetches)
 	}
@@ -173,7 +173,7 @@ func TestFetchKnownTaskPRs_ClosedAtSameHeadInvalidatesReadyCache(t *testing.T) {
 
 	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
 
-	got := r.fetchKnownTaskPRs(matchers)
+	got := r.fetchKnownTaskPRs(matchers, nil)
 	if len(got) != 0 {
 		t.Fatalf("got %+v, want no open PRs (the cached PR is now closed)", got)
 	}
@@ -231,7 +231,7 @@ func TestFetchKnownTaskPRs_StatusEventInvalidatesReadyCacheAtSameHead(t *testing
 
 	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
 
-	if got := r.fetchKnownTaskPRs(matchers); len(got) != 1 || got[0].CIStatus != "SUCCESS" {
+	if got := r.fetchKnownTaskPRs(matchers, nil); len(got) != 1 || got[0].CIStatus != "SUCCESS" {
 		t.Fatalf("first cycle: got %+v, want cached ready PR", got)
 	}
 	if fullFetches != 1 {
@@ -241,7 +241,7 @@ func TestFetchKnownTaskPRs_StatusEventInvalidatesReadyCacheAtSameHead(t *testing
 	// Simulate a same-head CI/status event: updatedAt moves, head SHA doesn't.
 	currentUpdatedAt = failedCIPR.UpdatedAt
 
-	got := r.fetchKnownTaskPRs(matchers)
+	got := r.fetchKnownTaskPRs(matchers, nil)
 	if fullFetches != 2 {
 		t.Fatalf("full fetches after same-head status event = %d, want 2 (updatedAt change must invalidate the cache)", fullFetches)
 	}

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -2652,13 +2652,13 @@ func TestFetchKnownTaskPRs_CircuitBreaksOnRepeatedAuthFailure(t *testing.T) {
 	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
 
 	for i := range poll.AuthFailureThreshold - 1 {
-		r.fetchKnownTaskPRs(matchers)
+		r.fetchKnownTaskPRs(matchers, nil)
 		if r.AuthCircuitOpen() {
 			t.Fatalf("circuit opened after %d fetches, want threshold %d", i+1, poll.AuthFailureThreshold)
 		}
 	}
 
-	r.fetchKnownTaskPRs(matchers)
+	r.fetchKnownTaskPRs(matchers, nil)
 	if !r.AuthCircuitOpen() {
 		t.Fatalf("circuit did not open after %d consecutive auth failures", poll.AuthFailureThreshold)
 	}
@@ -2671,7 +2671,7 @@ func TestFetchKnownTaskPRs_CircuitBreaksOnRepeatedAuthFailure(t *testing.T) {
 		}
 		return results
 	}
-	r.fetchKnownTaskPRs(matchers)
+	r.fetchKnownTaskPRs(matchers, nil)
 	if r.AuthCircuitOpen() {
 		t.Error("circuit stayed open after a successful fetch")
 	}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -304,6 +304,9 @@ type AgentRun struct {
 	// It is the durable poison signal agentorch.PickImplementationResumeSession
 	// counts to detect a session stuck in a resume-stall loop.
 	ResumeZeroOutputStall bool `json:"zeroOutputStall,omitempty"`
+	// TurnCount is zero when the child produced nothing, so the run holds no
+	// evidence about its instructions and must not spend a conformance budget.
+	TurnCount int `json:"turnCount,omitempty"`
 }
 
 // Attachment re-exports the persisted task attachment metadata type.

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -111,6 +111,7 @@ type agentRunRecord struct {
 	FinalCommitSource       string    `yaml:"final_commit_source,omitempty"`
 	SubagentCallCount       int       `yaml:"subagent_call_count,omitempty"`
 	ResumeZeroOutputStall   bool      `yaml:"zero_output_stall,omitempty"`
+	TurnCount               int       `yaml:"turn_count,omitempty"`
 }
 
 // taskFromFrontmatter rebuilds the persisted task fields. Store loading

--- a/internal/task/store_runpatch.go
+++ b/internal/task/store_runpatch.go
@@ -126,6 +126,7 @@ type RunPatch struct {
 	SkillConformance        *string
 	SessionID               *string
 	SubagentCallCount       *int
+	TurnCount               *int
 }
 
 func applyRunLifecycle(run *AgentRun, p RunPatch) {
@@ -227,6 +228,9 @@ func applyRunIdentity(run *AgentRun, p RunPatch) {
 	}
 	if p.SubagentCallCount != nil {
 		run.SubagentCallCount = *p.SubagentCallCount
+	}
+	if p.TurnCount != nil {
+		run.TurnCount = *p.TurnCount
 	}
 }
 

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1123,6 +1123,7 @@ func TestStoreUpdateRunPayloadRoundTrip(t *testing.T) {
 		FinalCommitSource:       Ptr("fallback"),
 		SubagentCallCount:       Ptr(3),
 		ResumeZeroOutputStall:   Ptr(true),
+		TurnCount:               Ptr(17),
 	}
 	assertRunPatchCoversEveryField(t, patch)
 
@@ -1176,6 +1177,7 @@ func TestStoreUpdateRunPayloadRoundTrip(t *testing.T) {
 		FinalCommitSource:       "fallback",
 		SubagentCallCount:       3,
 		ResumeZeroOutputStall:   true,
+		TurnCount:               17,
 	})
 }
 
@@ -1285,6 +1287,9 @@ func assertAgentRunPayload(t *testing.T, got, want AgentRun) {
 	}
 	if got.ResumeZeroOutputStall != want.ResumeZeroOutputStall {
 		t.Errorf("ResumeZeroOutputStall = %t, want %t", got.ResumeZeroOutputStall, want.ResumeZeroOutputStall)
+	}
+	if got.TurnCount != want.TurnCount {
+		t.Errorf("TurnCount = %d, want %d", got.TurnCount, want.TurnCount)
 	}
 }
 

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -25,6 +25,7 @@ type CompletionWorkflow interface {
 	RescheduleInterruptedAgent(taskID, agentID string)
 	RescheduleRateLimitedAgent(taskID, agentID string)
 	RescheduleCheckpointedAgent(taskID, agentID string)
+	ReschedulePromptUndeliveredAgent(taskID, agentID string)
 	DispatchEvent(taskID, event string, extra map[string]string, vars map[string]string) (string, error)
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -117,6 +117,9 @@ type AgentRunInfo struct {
 	// no-op run apart from one that delegated to a background subagent and
 	// ended before that delegation produced any commits.
 	SubagentCallCount int
+	// TurnCount is zero when the provider child emitted nothing, marking a run
+	// that never saw its instructions rather than one that defied them.
+	TurnCount int
 }
 
 // TaskProvider reads and updates tasks.

--- a/internal/workflow/engine_events_agents.go
+++ b/internal/workflow/engine_events_agents.go
@@ -641,6 +641,80 @@ func (e *Engine) checkpointRescheduleKey(stepID string) string {
 	return "step." + stepID + ".checkpoint_count"
 }
 
+// maxPromptUndeliveredRetries bounds re-dispatches for runs whose prompt never
+// reached the provider child. The stall lane skips HandleAgentComplete, so
+// nothing else counts these — without a ceiling a wedged CLI would burn a
+// two-minute write timeout per tick forever instead of reaching a human.
+const maxPromptUndeliveredRetries = 3
+
+func promptUndeliveredKey(stepID string) string {
+	return "step." + stepID + ".prompt_undelivered"
+}
+
+func (e *Engine) handlePromptUndeliveredReschedule(taskID string, t *TaskInfo, step *Step) bool {
+	if t.Workflow == nil {
+		return true
+	}
+	return e.boundedRetry(t, step, boundedRetryPolicy{
+		name:       "prompt-undelivered-reschedule",
+		applies:    func(*Engine, *TaskInfo, *Step) bool { return true },
+		counterKey: promptUndeliveredKey,
+		max:        maxPromptUndeliveredRetries,
+		onExhausted: func(e *Engine, t *TaskInfo, step *Step, attempts int) {
+			reason := fmt.Sprintf("provider never accepted the prompt across %d attempts — the agent CLI is not reading stdin on this host", attempts+1)
+			if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+				e.resumeError.Log(e.logger, "workflow.prompt-undelivered-reschedule.human-required", taskID, err, "task_id", taskID)
+			}
+		},
+	})
+}
+
+// ReschedulePromptUndeliveredAgent re-drives a run_agent step whose provider
+// child never read the prompt, charging each attempt against a per-step budget
+// so a persistently wedged CLI escalates instead of looping.
+func (e *Engine) ReschedulePromptUndeliveredAgent(taskID, agentID string) {
+	if taskID == "" {
+		e.clearAgentStep(taskID, agentID)
+		e.logger.Warn("workflow.prompt-undelivered-reschedule.untracked", "agent_id", agentID)
+		return
+	}
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil || t.Workflow == nil || t.Workflow.CurrentStep == "" {
+		e.clearAgentStep(taskID, agentID)
+		return
+	}
+	if _, skip := resumeSkipReasonForStatus(t.Status); t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed || skip {
+		e.clearAgentStep(taskID, agentID)
+		return
+	}
+	def, err := e.store.Get(t.Workflow.WorkflowID)
+	if err != nil {
+		e.clearAgentStep(taskID, agentID)
+		return
+	}
+	step := def.StepByID(t.Workflow.CurrentStep)
+	if step == nil {
+		e.clearAgentStep(taskID, agentID)
+		return
+	}
+	spawnedStep, tracked := e.lookupAgentStep(taskID, agentID)
+	if step.Type != StepRunAgent || (tracked && spawnedStep != step.ID) {
+		// Block attempts still charge the budget so a wedged CLI cannot loop
+		// inside a parallel/best-of-n child; ResumeStalled respawns the attempt.
+		e.clearAgentStep(taskID, agentID)
+		clearAgentRouteFromWorkflow(t.Workflow, agentID)
+		if tracked {
+			e.handlePromptUndeliveredReschedule(taskID, &t, step)
+		}
+		return
+	}
+	e.clearAgentStep(taskID, agentID)
+	clearAgentRouteFromWorkflow(t.Workflow, agentID)
+	e.rescheduleRunAgent(taskID, agentID, step, t, &def, "workflow.prompt-undelivered-reschedule", func(t *TaskInfo, step *Step) bool {
+		return e.handlePromptUndeliveredReschedule(taskID, t, step)
+	})
+}
+
 func (e *Engine) effectiveMaxCheckpoints() int {
 	if e.maxCheckpoints > 0 {
 		return e.maxCheckpoints

--- a/internal/workflow/engine_prompt_undelivered_test.go
+++ b/internal/workflow/engine_prompt_undelivered_test.go
@@ -1,0 +1,95 @@
+package workflow
+
+import "testing"
+
+// The stall lane never reaches HandleAgentComplete, so the skill-receipt
+// ceilings cannot see these runs. Without a budget of its own a wedged CLI
+// re-dispatches forever, burning a write timeout per tick and never escalating.
+func promptUndeliveredStore(t *testing.T) *Store {
+	t.Helper()
+	return newInlineTestStore(t, "prompt-undelivered", `id: prompt-undelivered
+name: Prompt Undelivered
+trigger:
+  on: task.created
+steps:
+  - id: run
+    name: Run
+    type: run_agent
+    config:
+      role: pr-fix
+      mode: headless
+      provider: claude
+      prompt: "Fix the PR."
+    next:
+      - goto: done
+  - id: done
+    name: Done
+    type: set_status
+    config:
+      status: done
+`)
+}
+
+func promptUndeliveredTask(t *testing.T, spent string) TaskInfo {
+	t.Helper()
+	vars := map[string]string{WorkflowVarDir: t.TempDir()}
+	if spent != "" {
+		vars[promptUndeliveredKey("run")] = spent
+	}
+	return TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow: &Execution{
+			WorkflowID:  "prompt-undelivered",
+			CurrentStep: "run",
+			State:       ExecWaiting,
+			Variables:   vars,
+			AgentRoutes: map[string]string{"agent-1": "run"},
+		},
+	}
+}
+
+func TestReschedulePromptUndeliveredAgent_ChargesItsOwnBudget(t *testing.T) {
+	store := promptUndeliveredStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(promptUndeliveredTask(t, ""))
+
+	engine.ReschedulePromptUndeliveredAgent("t1", "agent-1")
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ti.Workflow.Variables[promptUndeliveredKey("run")]; got != "1" {
+		t.Fatalf("prompt-undelivered counter = %q, want 1", got)
+	}
+	if ti.Status == "human-required" {
+		t.Fatal("first undelivered prompt parked the task instead of retrying")
+	}
+}
+
+func TestReschedulePromptUndeliveredAgent_EscalatesWhenBudgetSpent(t *testing.T) {
+	store := promptUndeliveredStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(promptUndeliveredTask(t, "3"))
+
+	engine.ReschedulePromptUndeliveredAgent("t1", "agent-1")
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Status != "human-required" {
+		t.Fatalf("Status = %q, want human-required once the budget is spent", ti.Status)
+	}
+	if len(agents.calls) != 0 {
+		t.Fatalf("StartAgent calls = %d, want none after escalation", len(agents.calls))
+	}
+}

--- a/internal/workflow/engine_skill_receipt.go
+++ b/internal/workflow/engine_skill_receipt.go
@@ -13,8 +13,18 @@ import (
 
 const maxSkillReceiptRecoveryAttempts = 1
 
+// maxSkillReceiptZeroOutputRetries bounds re-dispatches for runs that produced
+// no turns at all. They are kept off the conformance budget — a child that
+// emitted nothing never saw the skill — but still need a ceiling so a provider
+// failing to start in a loop reaches a human instead of spinning forever.
+const maxSkillReceiptZeroOutputRetries = 3
+
 func skillReceiptRecoveryKey(stepID string) string {
 	return "step." + stepID + ".skill_receipt_retry"
+}
+
+func skillReceiptZeroOutputKey(stepID string) string {
+	return "step." + stepID + ".skill_receipt_zero_output"
 }
 
 func applySkillReceiptRecoveryAssignment(stepID string, wfExec *Execution, assignment *AgentAssignment) {
@@ -26,6 +36,24 @@ func applySkillReceiptRecoveryAssignment(stepID string, wfExec *Execution, assig
 	}
 	assignment.ForceInjectedSkill = true
 	assignment.SkillRecoveryAttempt = true
+}
+
+// clearSkillReceiptCounters drops both receipt-retry counters once a run finally
+// produces a conformance receipt, so a later unrelated miss starts from zero.
+func (e *Engine) clearSkillReceiptCounters(taskID, spawnedStep string, fresh TaskInfo) {
+	cleared := false
+	for _, key := range []string{skillReceiptRecoveryKey(spawnedStep), skillReceiptZeroOutputKey(spawnedStep)} {
+		if parseWorkflowInt(fresh.Workflow.Variables[key]) > 0 {
+			delete(fresh.Workflow.Variables, key)
+			cleared = true
+		}
+	}
+	if !cleared {
+		return
+	}
+	if err := e.tasks.SetWorkflow(taskID, fresh.Workflow); err != nil {
+		e.logger.Warn("workflow.skill-receipt.clear", "task_id", taskID, "step", spawnedStep, "err", err)
+	}
 }
 
 func agentRunInfoByID(runs []AgentRunInfo, agentID string) (AgentRunInfo, bool) {
@@ -52,21 +80,24 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 	if !ok {
 		return false
 	}
+	// No turns means the child never saw the instructions, so the missing
+	// receipt indicts the spawn rather than the agent's conformance.
+	zeroOutput := run.TurnCount == 0
 	retryKey := skillReceiptRecoveryKey(spawnedStep)
+	maxAttempts := maxSkillReceiptRecoveryAttempts
+	if zeroOutput {
+		retryKey = skillReceiptZeroOutputKey(spawnedStep)
+		maxAttempts = maxSkillReceiptZeroOutputRetries
+	}
 	retries := parseWorkflowInt(fresh.Workflow.Variables[retryKey])
 	if run.RequestedSkill == "" {
 		return false
 	}
 	if run.SkillConformance != skillattr.ConformanceUnverified {
-		if retries > 0 {
-			delete(fresh.Workflow.Variables, retryKey)
-			if err := e.tasks.SetWorkflow(taskID, fresh.Workflow); err != nil {
-				e.logger.Warn("workflow.skill-receipt.clear", "task_id", taskID, "step", spawnedStep, "err", err)
-			}
-		}
+		e.clearSkillReceiptCounters(taskID, spawnedStep, fresh)
 		return false
 	}
-	if retries >= maxSkillReceiptRecoveryAttempts {
+	if retries >= maxAttempts {
 		if present, kind := importedSidecarPresentForStep(currentStep, fresh); present {
 			delete(fresh.Workflow.Variables, retryKey)
 			if err := e.tasks.SetWorkflow(taskID, fresh.Workflow); err != nil {
@@ -94,13 +125,16 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 		}
 		summary := skillReceiptExhaustionSummary(output)
 		reason := fmt.Sprintf("mandatory workflow skill %q produced no conformance receipt after automatic recovery retry", run.RequestedSkill)
+		if zeroOutput {
+			reason = fmt.Sprintf("provider produced no output across %d attempts, so mandatory workflow skill %q never ran", maxAttempts, run.RequestedSkill)
+		}
 		if summary != "" {
 			reason += ": " + summary
 		}
 		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
 			e.logger.Error("workflow.skill-receipt.human-required", "task_id", taskID, "step", spawnedStep, "err", statusErr)
 		}
-		e.logger.Warn("workflow.skill-receipt.exhausted", "task_id", taskID, "step", spawnedStep, "skill", run.RequestedSkill, "summary", summary)
+		e.logger.Warn("workflow.skill-receipt.exhausted", "task_id", taskID, "step", spawnedStep, "skill", run.RequestedSkill, "zero_output", zeroOutput, "summary", summary)
 		e.fireComplete(&CompletionInfo{
 			TaskID:     taskID,
 			WorkflowID: fresh.Workflow.WorkflowID,
@@ -116,7 +150,7 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 	}
 	switch {
 	case currentStep.Type == StepRunAgent && currentStep.ID == spawnedStep:
-		e.logger.Warn("workflow.skill-receipt.retry", "task_id", taskID, "step", spawnedStep, "skill", run.RequestedSkill)
+		e.logger.Warn("workflow.skill-receipt.retry", "task_id", taskID, "step", spawnedStep, "skill", run.RequestedSkill, "zero_output", zeroOutput)
 		e.clearAgentStep(taskID, agentID)
 		clearAgentRouteFromWorkflow(fresh.Workflow, agentID)
 		e.rescheduleRunAgent(taskID, agentID, currentStep, fresh, def, "workflow.skill-receipt-reschedule", nil)
@@ -126,7 +160,7 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 		if child == nil || child.Type != StepRunAgent {
 			return false
 		}
-		e.logger.Warn("workflow.skill-receipt.retry", "task_id", taskID, "parent", currentStep.ID, "child", spawnedStep, "skill", run.RequestedSkill)
+		e.logger.Warn("workflow.skill-receipt.retry", "task_id", taskID, "parent", currentStep.ID, "child", spawnedStep, "skill", run.RequestedSkill, "zero_output", zeroOutput)
 		e.clearAgentStep(taskID, agentID)
 		clearAgentRouteFromWorkflow(fresh.Workflow, agentID)
 		e.rescheduleSkillReceiptParallelChild(taskID, currentStep, child)

--- a/internal/workflow/engine_skill_receipt.go
+++ b/internal/workflow/engine_skill_receipt.go
@@ -126,7 +126,7 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 		summary := skillReceiptExhaustionSummary(output)
 		reason := fmt.Sprintf("mandatory workflow skill %q produced no conformance receipt after automatic recovery retry", run.RequestedSkill)
 		if zeroOutput {
-			reason = fmt.Sprintf("provider produced no output across %d attempts, so mandatory workflow skill %q never ran", maxAttempts, run.RequestedSkill)
+			reason = fmt.Sprintf("provider produced no output across %d attempts, so mandatory workflow skill %q never ran", maxAttempts+1, run.RequestedSkill)
 		}
 		if summary != "" {
 			reason += ": " + summary

--- a/internal/workflow/engine_skill_receipt_zero_output_test.go
+++ b/internal/workflow/engine_skill_receipt_zero_output_test.go
@@ -1,0 +1,113 @@
+package workflow
+
+import (
+	"maps"
+	"testing"
+)
+
+// A provider child that emitted no turns never saw the skill instructions, so
+// its missing receipt must not spend the conformance budget that exists to
+// catch an agent ignoring a mandatory skill.
+func zeroOutputSkillReceiptStore(t *testing.T) *Store {
+	t.Helper()
+	return newInlineTestStore(t, "skill-receipt", `id: skill-receipt
+name: Skill Receipt
+trigger:
+  on: task.created
+steps:
+  - id: run
+    name: Run
+    type: run_agent
+    config:
+      role: pr-fix
+      mode: headless
+      provider: claude
+      prompt: "Run /fix-review now."
+    next:
+      - goto: done
+  - id: done
+    name: Done
+    type: set_status
+    config:
+      status: done
+`)
+}
+
+func zeroOutputSkillReceiptTask(t *testing.T, agentID string, vars map[string]string) TaskInfo {
+	t.Helper()
+	variables := map[string]string{WorkflowVarDir: t.TempDir()}
+	maps.Copy(variables, vars)
+	return TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow: &Execution{
+			WorkflowID:  "skill-receipt",
+			CurrentStep: "run",
+			State:       ExecWaiting,
+			Variables:   variables,
+		},
+		AgentRuns: []AgentRunInfo{{
+			AgentID:            agentID,
+			Role:               "pr-fix",
+			Provider:           "claude",
+			RequestedSkill:     "fix-review",
+			SkillExecutionMode: "injected",
+			SkillConformance:   "unverified",
+			TurnCount:          0,
+		}},
+	}
+}
+
+func TestHandleAgentComplete_ZeroOutputRunSparesConformanceBudget(t *testing.T) {
+	store := zeroOutputSkillReceiptStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(zeroOutputSkillReceiptTask(t, "agent-1", nil))
+
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "agent-1", Result: "", Success: false})
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ti.Workflow.Variables[skillReceiptRecoveryKey("run")]; got != "" {
+		t.Fatalf("conformance retry var = %q, want unset for a zero-output run", got)
+	}
+	if got := ti.Workflow.Variables[skillReceiptZeroOutputKey("run")]; got != "1" {
+		t.Fatalf("zero-output retry var = %q, want 1", got)
+	}
+	if ti.Status == "human-required" {
+		t.Fatal("zero-output run parked the task instead of re-dispatching")
+	}
+	if len(agents.calls) != 1 {
+		t.Fatalf("StartAgent calls = %d, want 1 retry", len(agents.calls))
+	}
+}
+
+func TestHandleAgentComplete_ZeroOutputRunsEscalateAfterOwnCeiling(t *testing.T) {
+	store := zeroOutputSkillReceiptStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	spent := map[string]string{
+		skillReceiptZeroOutputKey("run"): "3",
+	}
+	tasks.Put(zeroOutputSkillReceiptTask(t, "agent-1", spent))
+
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "agent-1", Result: "", Success: false})
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Status != "human-required" {
+		t.Fatalf("Status = %q, want human-required once the zero-output ceiling is spent", ti.Status)
+	}
+	if len(agents.calls) != 0 {
+		t.Fatalf("StartAgent calls = %d, want no further retry", len(agents.calls))
+	}
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -7046,6 +7046,7 @@ steps:
 			RequestedSkill:     "sybra-test",
 			SkillExecutionMode: "native",
 			SkillConformance:   "unverified",
+			TurnCount:          7,
 		}},
 	})
 
@@ -7135,6 +7136,7 @@ steps:
 			RequestedSkill:     "sybra-test",
 			SkillExecutionMode: "injected",
 			SkillConformance:   "unverified",
+			TurnCount:          7,
 		}},
 	})
 
@@ -7243,6 +7245,7 @@ steps:
 			RequestedSkill:     "adversarial-review",
 			SkillExecutionMode: "injected",
 			SkillConformance:   "unverified",
+			TurnCount:          7,
 		}},
 	})
 
@@ -7322,6 +7325,7 @@ steps:
 			RequestedSkill:     "sybra-test",
 			SkillExecutionMode: "injected",
 			SkillConformance:   "unverified",
+			TurnCount:          7,
 		}},
 	})
 


### PR DESCRIPTION
## Motivation

A PR-fix dispatch parked its task at `human-required` after three agents that never did any work: one codex run rate-limited (handled correctly), then two claude runs that crashed with `deliver initial prompt: write stdin: timed out after 2m0s, pipe closed` — zero turns, zero tool calls, $0, empty stream logs. The child never drained stdin, so neither agent ever saw its prompt, yet both were recorded as ordinary completions and spent the mandatory-skill conformance budget. `agent.headless.initial-prompt` timeouts appear 44 times in the app log over three days, across tasks.

Closes #3037

> Changelog: fix(agent): retry transient runs off the budget

## Implementation information

Three defects, all "a transient infrastructure failure counted as a real agent verdict".

**1. Prompt-delivery failure is now a stall.** Both delivery sites (pipe and detached/survive) wrap the error with a new `errPromptUndelivered` sentinel and stamp `ErrorKindPromptUndelivered`. `classifyAgentError` recognises the sentinel *before* its substring table — the wrapped text reads as a bare i/o timeout and would otherwise classify as `git_clone`. `classifyStall` gains a `PromptUndelivered` disposition, so the run is retried rather than persisted as a definitive outcome.

The sentinel check in `classifyAgentError` is load-bearing rather than belt-and-braces: `handleError` re-classifies every fatal error from scratch, so a kind stamped only at the delivery site is overwritten with `"crash"` before completion ever sees it. Caught by the adversarial review — the first pass was inert without it.

**2. Zero-turn runs get their own budget.** `maybeRecoverUnverifiedSkillRun` billed any `SkillConformance == unverified` run against a 1-attempt conformance budget. A run that emitted no turns never saw the skill instructions, so its missing receipt indicts the spawn, not the agent. Those now spend `step.<id>.skill_receipt_zero_output` (ceiling 3) instead. This needed `TurnCount` plumbed from `agent.Agent` through `task.RunPatch` / `task.AgentRun` (persisted as `turn_count`) to `workflow.AgentRunInfo`.

Because the stall lane in (1) never reaches `HandleAgentComplete`, prompt-undelivered runs would bypass every ceiling and re-dispatch forever, burning a two-minute write timeout per tick. They now route through `ReschedulePromptUndeliveredAgent`, a bounded lane built on the existing `boundedRetry` policy shape, which escalates to `human-required` after 3 attempts.

**3. Unblocking a task resets its PR poll backoff.** `selectKnownPRPoll` defers a PR on a streak keyed by `(project, PR number)`, so a task moved from `human-required` back into `in-review` kept serving out a streak the PR earned while it was parked and unfixable. `prSnapshot` gains a `statusChangedAt` stamp; a task whose `StatusChangedAt` is newer resets the backoff and is selected without a probe. The stamp only moves forward — several tasks can share one PR, and an older sibling rewinding it would leave the newer one permanently "advanced" and strip the PR of its request pacing.

While verifying that premise, the adversarial review surfaced an adjacent pre-existing bug: deferred and capped PRs are absent from the selection, hence from the `seen` set `Prune` keeps, so the prune deleted the very skip counters that deferred them and no backoff could survive the tick that armed it. The selection now carries `retainKeys` for those PRs.

`StatusChangedAt` is used rather than `UpdatedAt` deliberately: any task write bumps `UpdatedAt`, so keying on it would let the poll's own writes defeat the backoff entirely.

## Supporting documentation

Regression tests for each behaviour, every one mutation-verified to fail with its production change reverted:

- `classifyAgentError` maps the sentinel, beats the substring table (`git_clone` without the ordering), and survives `handleError`
- `classifyStall` reports the stall, and `runTerminalOutcome` returns no definitive outcome
- a zero-turn run leaves the conformance counter untouched and escalates only after its own ceiling
- the prompt-undelivered lane charges its budget and escalates when spent
- a status change selects without probing; an older sibling cannot rewind the stamp; deferred and capped keys are retained

Four existing `TestHandleAgentComplete_UnverifiedSkill*` fixtures gained a non-zero `TurnCount` — they model an agent that ran and skipped the skill, which now requires turns to say so.

Gates: `go build ./...`, `go vet`, `go test ./internal/... ./cmd/...`, `golangci-lint run` (0 issues), and `go test -race -tags e2e -short ./internal/sybra/...` all green. One full-suite run showed four `internal/sybra` runtime-probe failures plus a git-cancellation test; all use wall-clock `context.WithTimeout` (2s), all passed isolated and on a clean re-run, and they were load-induced by a concurrent suite plus the live agent fleet.

Not done: the adversarial manual-test pass was skipped at the author's direction, so there is no live end-to-end run of the wedged-CLI path behind this — the evidence above is unit/e2e level only.