### PR TITLE
fix(workflow): reclaim orphaned effect leases

### DIFF
--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -46,6 +46,10 @@ type WorkflowRestarter interface {
 	HandleAgentComplete(taskID string, completion workflow.AgentCompletion)
 	ReplayPersistedEffects()
 	ReplayPersistedEffectsForTask(taskID string) bool
+	// ReclaimOrphanedEffectLeases must run before the two replay paths above:
+	// both claim effects, and a lease held by the previous engine instance
+	// fences them for the rest of its TTL.
+	ReclaimOrphanedEffectLeases() int
 }
 
 // PRResolver resolves the GitHub PR a task lost track of when its pr_number was
@@ -133,6 +137,10 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 	r.cleanStaleRuns()
 	r.pruneAgentLogs()
 	if r.WorkflowEngine != nil {
+		// Ordered ahead of the replay: reattach above has established which
+		// steps are genuinely still running, and both replay paths below claim
+		// effects that a dead instance's lease would otherwise fence.
+		r.WorkflowEngine.ReclaimOrphanedEffectLeases()
 		r.WorkflowEngine.ReplayPersistedEffects()
 	}
 	r.RestartStaleInProgress(ctx)

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -166,8 +166,10 @@ func TestRunStartupCleanup_ReplaysEffectsBeforeStaleRestart(t *testing.T) {
 	r.RunStartupCleanup(context.Background())
 	wg.Wait()
 
-	if !slices.Equal(order, []string{"replay", "replay:" + created.ID, "restart"}) {
-		t.Fatalf("startup order = %v, want [replay replay:%s restart]", order, created.ID)
+	// Reclaim must lead: both replay paths claim effects, and a lease held by
+	// the previous engine instance fences them for the rest of its TTL.
+	if !slices.Equal(order, []string{"reclaim", "replay", "replay:" + created.ID, "restart"}) {
+		t.Fatalf("startup order = %v, want [reclaim replay replay:%s restart]", order, created.ID)
 	}
 }
 
@@ -1233,10 +1235,11 @@ type stubWorkflowEngine struct {
 	startWorkflowErr   error
 	completions        []workflow.AgentCompletion
 
-	replayCalls int
-	callOrder   *[]string
-	replayTasks []string
-	replayTask  bool
+	replayCalls  int
+	reclaimCalls int
+	callOrder    *[]string
+	replayTasks  []string
+	replayTask   bool
 
 	dispatchEventCalls  []map[string]string
 	dispatchEventResult string
@@ -1256,6 +1259,14 @@ func (s *stubWorkflowEngine) DispatchEvent(_, _ string, extraFields, _ map[strin
 
 func (s *stubWorkflowEngine) HandleAgentComplete(_ string, c workflow.AgentCompletion) {
 	s.completions = append(s.completions, c)
+}
+
+func (s *stubWorkflowEngine) ReclaimOrphanedEffectLeases() int {
+	s.reclaimCalls++
+	if s.callOrder != nil {
+		*s.callOrder = append(*s.callOrder, "reclaim")
+	}
+	return 0
 }
 
 func (s *stubWorkflowEngine) ReplayPersistedEffects() {
@@ -2153,6 +2164,8 @@ func (s *recordingWorkflowStub) HandleAgentComplete(taskID string, _ workflow.Ag
 }
 
 func (*recordingWorkflowStub) ReplayPersistedEffects() {}
+
+func (*recordingWorkflowStub) ReclaimOrphanedEffectLeases() int { return 0 }
 
 func (*recordingWorkflowStub) ReplayPersistedEffectsForTask(string) bool { return false }
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -442,12 +442,6 @@ func (a *App) startLifecycle(schedulerCtx, watcherCtx context.Context, emit func
 		if a.humanReview != nil {
 			a.humanReview.recoverStrandedUnblockedTasks() //nolint:contextcheck // handler bounds its git/PR checks with dedicated timeouts, matching live completion.
 		}
-		// After reattach, so a survive-restart agent's own claim is seen as live
-		// and left alone; before dispatch is armed, so the first sweep is not
-		// fenced by the previous instance's leases.
-		if a.workflowEngine != nil {
-			a.workflowEngine.ReclaimOrphanedEffectLeases()
-		}
 		// Arm dispatch now that reattach/replay/restart-stale have run, then
 		// nudge so any task that changed status during the window (buffered,
 		// not dispatched — see startupRecoveryPending) is picked up by the

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -442,6 +442,12 @@ func (a *App) startLifecycle(schedulerCtx, watcherCtx context.Context, emit func
 		if a.humanReview != nil {
 			a.humanReview.recoverStrandedUnblockedTasks() //nolint:contextcheck // handler bounds its git/PR checks with dedicated timeouts, matching live completion.
 		}
+		// After reattach, so a survive-restart agent's own claim is seen as live
+		// and left alone; before dispatch is armed, so the first sweep is not
+		// fenced by the previous instance's leases.
+		if a.workflowEngine != nil {
+			a.workflowEngine.ReclaimOrphanedEffectLeases()
+		}
 		// Arm dispatch now that reattach/replay/restart-stale have run, then
 		// nudge so any task that changed status during the window (buffered,
 		// not dispatched — see startupRecoveryPending) is picked up by the

--- a/internal/workflow/effect_reclaim.go
+++ b/internal/workflow/effect_reclaim.go
@@ -66,8 +66,9 @@ func (e *Engine) reclaimEligible(t *TaskInfo) bool {
 	return true
 }
 
-// orphanedLeaseSteps nils the lease on every record this engine may reclaim and
-// returns their step ids for logging. A lapsed lease already fences nobody, so
+// orphanedLeaseSteps nils the lease on every record this engine may reclaim,
+// reporting "<effect-id>=<stale-owner>" so a reclaim names the exact record it
+// freed rather than an ambiguous step. A lapsed lease already fences nobody, so
 // rewriting it would bump the task generation for no gain — and a generation
 // bump re-opens status-effect dedupe, which keys on exactly one generation back.
 func (e *Engine) orphanedLeaseSteps(wf *Execution) []string {
@@ -83,7 +84,7 @@ func (e *Engine) orphanedLeaseSteps(wf *Execution) []string {
 			continue
 		}
 		rec.LeaseExpiresAt = nil
-		steps = append(steps, rec.ID.StepID+"="+rec.Owner)
+		steps = append(steps, rec.ID.String()+"="+rec.Owner)
 	}
 	return steps
 }

--- a/internal/workflow/effect_reclaim.go
+++ b/internal/workflow/effect_reclaim.go
@@ -1,0 +1,85 @@
+package workflow
+
+// ReclaimOrphanedEffectLeases releases in-flight effect claims left behind by a
+// previous engine instance.
+//
+// An effect lease has no heartbeat, so its TTL is deliberately generous
+// (defaultEffectLeaseTTL) to avoid reclaiming a step that is merely slow. That
+// reasoning only holds while the owner is alive. A restart mints a fresh owner
+// id, so every claim the previous instance held becomes unreclaimable by the
+// live engine for the remainder of its TTL: `ClaimEffect` takes the
+// owner-mismatch branch and `resume-stalled` re-fences the same step every tick
+// until the lease lapses. A process that no longer exists cannot be mid-step,
+// so at boot those claims can be expired outright.
+//
+// Call once at startup, after agent reattach and before dispatch is armed.
+// Reattach matters: a survive-restart agent outlives the engine that spawned
+// it, and its step's claim is exactly the kind this would otherwise reclaim.
+// Releasing it would let a second agent start for a step that is still running,
+// so any task with a live agent is skipped and left to the TTL.
+func (e *Engine) ReclaimOrphanedEffectLeases() int {
+	if e == nil || e.tasks == nil {
+		return 0
+	}
+	tasks, err := e.tasks.ListTasks()
+	if err != nil {
+		e.logger.Error("workflow.effect.reclaim.list", "err", err)
+		return 0
+	}
+	reclaimed := 0
+	for i := range tasks {
+		reclaimed += e.reclaimTaskEffectLeases(&tasks[i])
+	}
+	if reclaimed > 0 {
+		e.logger.Info("workflow.effect.reclaim", "effects", reclaimed, "owner", e.ownerID)
+	}
+	return reclaimed
+}
+
+func (e *Engine) reclaimTaskEffectLeases(t *TaskInfo) int {
+	if t.Workflow == nil || len(t.Workflow.EffectLog) == 0 {
+		return 0
+	}
+	if e.agents != nil && (e.agents.HasRunningAgent(t.ID) || e.agents.IsDispatching(t.ID)) {
+		return 0
+	}
+	next := t.Workflow.Clone()
+	if next == nil {
+		return 0
+	}
+	orphans := 0
+	for i := range next.EffectLog {
+		rec := &next.EffectLog[i]
+		if rec.CompletedAt != nil || rec.LeaseExpiresAt == nil {
+			continue
+		}
+		if rec.Owner == "" || rec.Owner == e.ownerID {
+			continue
+		}
+		e.logger.Info("workflow.effect.reclaim.orphan",
+			"task_id", t.ID, "step", rec.ID.StepID, "effect", rec.ID.String(), "stale_owner", rec.Owner)
+		rec.LeaseExpiresAt = nil
+		orphans++
+	}
+	if orphans == 0 {
+		return 0
+	}
+	applied, err := e.tasks.SetWorkflowIf(t.ID, WorkflowWriteFence{
+		Generation:   t.Generation,
+		Status:       t.Status,
+		StatusReason: t.StatusReason,
+		WorkflowID:   t.Workflow.WorkflowID,
+		CurrentStep:  t.Workflow.CurrentStep,
+		State:        t.Workflow.State,
+	}, next)
+	if err != nil {
+		e.logger.Error("workflow.effect.reclaim.persist", "task_id", t.ID, "err", err)
+		return 0
+	}
+	if !applied {
+		e.logger.Info("workflow.effect.reclaim.stale", "task_id", t.ID)
+		return 0
+	}
+	t.Workflow = next
+	return orphans
+}

--- a/internal/workflow/effect_reclaim.go
+++ b/internal/workflow/effect_reclaim.go
@@ -1,5 +1,11 @@
 package workflow
 
+// reclaimFenceRetries bounds re-reads when a concurrent boot write invalidates
+// the fence. Reattach and restart-stale keep writing tasks while this sweep
+// runs, and a lost fence would otherwise restore the full-TTL stall until the
+// next process start — this sweep is boot-only, nothing retries it later.
+const reclaimFenceRetries = 2
+
 // ReclaimOrphanedEffectLeases releases in-flight effect claims left behind by a
 // previous engine instance.
 //
@@ -12,13 +18,18 @@ package workflow
 // until the lease lapses. A process that no longer exists cannot be mid-step,
 // so at boot those claims can be expired outright.
 //
-// Call once at startup, after agent reattach and before dispatch is armed.
+// Call once at startup, after agent reattach and before effect replay.
 // Reattach matters: a survive-restart agent outlives the engine that spawned
 // it, and its step's claim is exactly the kind this would otherwise reclaim.
 // Releasing it would let a second agent start for a step that is still running,
-// so any task with a live agent is skipped and left to the TTL.
+// so any task with a live or dispatching agent is skipped and left to the TTL.
 func (e *Engine) ReclaimOrphanedEffectLeases() int {
 	if e == nil || e.tasks == nil {
+		return 0
+	}
+	// On a leader mirroring a follower's execution, "owner is not mine" means
+	// the peer still running the step, not an orphan.
+	if e.dispatchDisabled.Load() {
 		return 0
 	}
 	tasks, err := e.tasks.ListTasks()
@@ -36,50 +47,84 @@ func (e *Engine) ReclaimOrphanedEffectLeases() int {
 	return reclaimed
 }
 
-func (e *Engine) reclaimTaskEffectLeases(t *TaskInfo) int {
+// reclaimEligible reports whether this task is one this instance may rewrite at
+// all. Tasks homed on a remote follower, terminal workflows, and tasks with a
+// live agent are all left alone.
+func (e *Engine) reclaimEligible(t *TaskInfo) bool {
 	if t.Workflow == nil || len(t.Workflow.EffectLog) == 0 {
-		return 0
+		return false
+	}
+	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
+		return false
+	}
+	if e.dispatchGate != nil && !e.dispatchGate(*t) {
+		return false
 	}
 	if e.agents != nil && (e.agents.HasRunningAgent(t.ID) || e.agents.IsDispatching(t.ID)) {
-		return 0
+		return false
 	}
-	next := t.Workflow.Clone()
-	if next == nil {
-		return 0
-	}
-	orphans := 0
-	for i := range next.EffectLog {
-		rec := &next.EffectLog[i]
-		if rec.CompletedAt != nil || rec.LeaseExpiresAt == nil {
+	return true
+}
+
+// orphanedLeaseSteps nils the lease on every record this engine may reclaim and
+// returns their step ids for logging. A lapsed lease already fences nobody, so
+// rewriting it would bump the task generation for no gain — and a generation
+// bump re-opens status-effect dedupe, which keys on exactly one generation back.
+func (e *Engine) orphanedLeaseSteps(wf *Execution) []string {
+	now := e.now()
+	var steps []string
+	for i := range wf.EffectLog {
+		rec := &wf.EffectLog[i]
+		switch {
+		case rec.CompletedAt != nil,
+			rec.Owner == "",
+			rec.Owner == e.ownerID,
+			!rec.leaseActiveAt(now):
 			continue
 		}
-		if rec.Owner == "" || rec.Owner == e.ownerID {
-			continue
-		}
-		e.logger.Info("workflow.effect.reclaim.orphan",
-			"task_id", t.ID, "step", rec.ID.StepID, "effect", rec.ID.String(), "stale_owner", rec.Owner)
 		rec.LeaseExpiresAt = nil
-		orphans++
+		steps = append(steps, rec.ID.StepID+"="+rec.Owner)
 	}
-	if orphans == 0 {
-		return 0
+	return steps
+}
+
+func (e *Engine) reclaimTaskEffectLeases(t *TaskInfo) int {
+	for attempt := range reclaimFenceRetries {
+		if !e.reclaimEligible(t) {
+			return 0
+		}
+		next := t.Workflow.Clone()
+		if next == nil {
+			return 0
+		}
+		steps := e.orphanedLeaseSteps(next)
+		if len(steps) == 0 {
+			return 0
+		}
+		applied, err := e.tasks.SetWorkflowIf(t.ID, WorkflowWriteFence{
+			Generation:   t.Generation,
+			Status:       t.Status,
+			StatusReason: t.StatusReason,
+			WorkflowID:   t.Workflow.WorkflowID,
+			CurrentStep:  t.Workflow.CurrentStep,
+			State:        t.Workflow.State,
+		}, next)
+		if err != nil {
+			e.logger.Error("workflow.effect.reclaim.persist", "task_id", t.ID, "err", err)
+			return 0
+		}
+		if applied {
+			t.Workflow = next
+			e.logger.Info("workflow.effect.reclaim.orphan",
+				"task_id", t.ID, "effects", len(steps), "stale", steps)
+			return len(steps)
+		}
+		fresh, freshErr := e.tasks.GetTask(t.ID)
+		if freshErr != nil || attempt == reclaimFenceRetries-1 {
+			e.logger.Info("workflow.effect.reclaim.stale", "task_id", t.ID, "attempts", attempt+1)
+			return 0
+		}
+		*t = fresh
 	}
-	applied, err := e.tasks.SetWorkflowIf(t.ID, WorkflowWriteFence{
-		Generation:   t.Generation,
-		Status:       t.Status,
-		StatusReason: t.StatusReason,
-		WorkflowID:   t.Workflow.WorkflowID,
-		CurrentStep:  t.Workflow.CurrentStep,
-		State:        t.Workflow.State,
-	}, next)
-	if err != nil {
-		e.logger.Error("workflow.effect.reclaim.persist", "task_id", t.ID, "err", err)
-		return 0
-	}
-	if !applied {
-		e.logger.Info("workflow.effect.reclaim.stale", "task_id", t.ID)
-		return 0
-	}
-	t.Workflow = next
-	return orphans
+	return 0
 }

--- a/internal/workflow/effect_reclaim_test.go
+++ b/internal/workflow/effect_reclaim_test.go
@@ -85,28 +85,81 @@ func TestReclaimOrphanedEffectLeases_SkipsTaskWithLiveAgent(t *testing.T) {
 	}
 }
 
-func TestReclaimOrphanedEffectLeases_LeavesOwnAndCompletedClaims(t *testing.T) {
+func TestReclaimOrphanedEffectLeases_LeavesClaimsItMustNotTouch(t *testing.T) {
+	past := time.Now().UTC().Add(-20 * time.Minute)
+	future := time.Now().UTC().Add(20 * time.Minute)
+
 	tests := []struct {
-		name      string
-		owner     func(e *Engine) string
-		completed bool
+		name    string
+		owner   func(e *Engine) string
+		expires time.Time
+		arrange func(e *Engine, agents *mockAgents, tk *TaskInfo)
 	}{
-		{name: "own live claim", owner: func(e *Engine) string { return e.ownerID }},
-		{name: "completed claim", owner: func(*Engine) string { return "workflow-engine-1-1" }, completed: true},
+		{
+			name:    "own live claim",
+			owner:   func(e *Engine) string { return e.ownerID },
+			expires: future,
+		},
+		{
+			name:    "completed claim",
+			owner:   func(*Engine) string { return "workflow-engine-1-1" },
+			expires: future,
+			arrange: func(_ *Engine, _ *mockAgents, tk *TaskInfo) {
+				done := time.Now().UTC()
+				tk.Workflow.EffectLog[0].CompletedAt = &done
+			},
+		},
+		{
+			// Intent-only: fences nobody, so rewriting only bumps generation.
+			name:    "ownerless claim",
+			owner:   func(*Engine) string { return "" },
+			expires: future,
+		},
+		{
+			// Already lapsed — ClaimEffect takes it over without help.
+			name:    "expired lease",
+			owner:   func(*Engine) string { return "workflow-engine-1-1" },
+			expires: past,
+		},
+		{
+			// Claimed before the agent registers, so HasRunningAgent misses it.
+			name:    "task mid-dispatch",
+			owner:   func(*Engine) string { return "workflow-engine-1-1" },
+			expires: future,
+			arrange: func(_ *Engine, agents *mockAgents, _ *TaskInfo) {
+				agents.dispatchClaimed = map[string]bool{"t1": true}
+			},
+		},
+		{
+			name:    "terminal workflow",
+			owner:   func(*Engine) string { return "workflow-engine-1-1" },
+			expires: future,
+			arrange: func(_ *Engine, _ *mockAgents, tk *TaskInfo) {
+				tk.Workflow.State = ExecCompleted
+			},
+		},
+		{
+			// Homed on a follower: that owner is a live peer, not an orphan.
+			name:    "task the dispatch gate rejects",
+			owner:   func(*Engine) string { return "workflow-engine-1-1" },
+			expires: future,
+			arrange: func(e *Engine, _ *mockAgents, _ *TaskInfo) {
+				e.SetDispatchGate(func(TaskInfo) bool { return false })
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tasks := newMemTasks()
-			engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
+			agents := newMockAgents()
+			engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
 
-			future := time.Now().UTC().Add(20 * time.Minute)
-			var completed *time.Time
-			if tc.completed {
-				done := time.Now().UTC()
-				completed = &done
+			tk := orphanedLeaseTask("t1", tc.owner(engine), tc.expires, nil)
+			if tc.arrange != nil {
+				tc.arrange(engine, agents, &tk)
 			}
-			tasks.Put(orphanedLeaseTask("t1", tc.owner(engine), future, completed))
+			tasks.Put(tk)
 
 			if got := engine.ReclaimOrphanedEffectLeases(); got != 0 {
 				t.Fatalf("ReclaimOrphanedEffectLeases() = %d, want 0", got)
@@ -115,6 +168,22 @@ func TestReclaimOrphanedEffectLeases_LeavesOwnAndCompletedClaims(t *testing.T) {
 				t.Fatal("LeaseExpiresAt = nil, want the claim left intact")
 			}
 		})
+	}
+}
+
+// An instance that never dispatches must not rewrite the board's effect log.
+func TestReclaimOrphanedEffectLeases_NoopWhenDispatchDisabled(t *testing.T) {
+	tasks := newMemTasks()
+	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
+	engine.SetAutoDispatch(false)
+
+	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", time.Now().UTC().Add(20*time.Minute), nil))
+
+	if got := engine.ReclaimOrphanedEffectLeases(); got != 0 {
+		t.Fatalf("ReclaimOrphanedEffectLeases() = %d, want 0 with dispatch disabled", got)
+	}
+	if lease := leaseFor(t, tasks, "t1"); lease == nil {
+		t.Fatal("LeaseExpiresAt = nil, want the claim left intact")
 	}
 }
 

--- a/internal/workflow/effect_reclaim_test.go
+++ b/internal/workflow/effect_reclaim_test.go
@@ -1,0 +1,145 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+)
+
+const noopWorkflowYAML = `id: noop
+name: Noop
+trigger:
+  on: task.created
+steps:
+  - id: plan
+    name: Plan
+    type: set_status
+    config:
+      status: planning
+`
+
+func orphanedLeaseTask(id, owner string, expiresAt time.Time, completed *time.Time) TaskInfo {
+	return TaskInfo{
+		ID:     id,
+		Status: "planning",
+		Workflow: &Execution{
+			WorkflowID:  "simple-task-plan",
+			CurrentStep: "plan",
+			State:       ExecRunning,
+			EffectLog: []EffectRecord{{
+				ID:             EffectID{Generation: 17, StepSeq: 1, StepID: "plan", Pos: 0},
+				IntentAt:       expiresAt.Add(-30 * time.Minute),
+				Owner:          owner,
+				LeaseExpiresAt: &expiresAt,
+				CompletedAt:    completed,
+			}},
+		},
+	}
+}
+
+func leaseFor(t *testing.T, tasks *memTasks, id string) *time.Time {
+	t.Helper()
+	got, err := tasks.GetTask(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Workflow.EffectLog) != 1 {
+		t.Fatalf("EffectLog = %+v, want exactly one record", got.Workflow.EffectLog)
+	}
+	return got.Workflow.EffectLog[0].LeaseExpiresAt
+}
+
+// A restart mints a fresh owner id, so the previous instance's still-valid
+// lease fences the live engine out of its own step until the TTL lapses.
+func TestReclaimOrphanedEffectLeases_ReleasesDeadOwnersClaim(t *testing.T) {
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
+
+	future := time.Now().UTC().Add(20 * time.Minute)
+	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", future, nil))
+
+	if got := engine.ReclaimOrphanedEffectLeases(); got != 1 {
+		t.Fatalf("ReclaimOrphanedEffectLeases() = %d, want 1", got)
+	}
+	if lease := leaseFor(t, tasks, "t1"); lease != nil {
+		t.Fatalf("LeaseExpiresAt = %v, want nil so the live engine can claim", lease)
+	}
+}
+
+// A survive-restart agent outlives the engine that spawned it. Releasing its
+// step's claim would let a second agent start for work already in flight.
+func TestReclaimOrphanedEffectLeases_SkipsTaskWithLiveAgent(t *testing.T) {
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
+
+	future := time.Now().UTC().Add(20 * time.Minute)
+	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", future, nil))
+	agents.running["t1"] = "reattached-agent"
+
+	if got := engine.ReclaimOrphanedEffectLeases(); got != 0 {
+		t.Fatalf("ReclaimOrphanedEffectLeases() = %d, want 0 while an agent is live", got)
+	}
+	if lease := leaseFor(t, tasks, "t1"); lease == nil {
+		t.Fatal("LeaseExpiresAt = nil, want the reattached agent's claim left intact")
+	}
+}
+
+func TestReclaimOrphanedEffectLeases_LeavesOwnAndCompletedClaims(t *testing.T) {
+	tests := []struct {
+		name      string
+		owner     func(e *Engine) string
+		completed bool
+	}{
+		{name: "own live claim", owner: func(e *Engine) string { return e.ownerID }},
+		{name: "completed claim", owner: func(*Engine) string { return "workflow-engine-1-1" }, completed: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks := newMemTasks()
+			engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
+
+			future := time.Now().UTC().Add(20 * time.Minute)
+			var completed *time.Time
+			if tc.completed {
+				done := time.Now().UTC()
+				completed = &done
+			}
+			tasks.Put(orphanedLeaseTask("t1", tc.owner(engine), future, completed))
+
+			if got := engine.ReclaimOrphanedEffectLeases(); got != 0 {
+				t.Fatalf("ReclaimOrphanedEffectLeases() = %d, want 0", got)
+			}
+			if lease := leaseFor(t, tasks, "t1"); lease == nil {
+				t.Fatal("LeaseExpiresAt = nil, want the claim left intact")
+			}
+		})
+	}
+}
+
+// End-to-end: the fenced ClaimEffect that produced the stall must succeed once
+// the orphan is reclaimed.
+func TestReclaimOrphanedEffectLeases_UnfencesSubsequentClaim(t *testing.T) {
+	tasks := newMemTasks()
+	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
+
+	future := time.Now().UTC().Add(20 * time.Minute)
+	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", future, nil))
+
+	claim := EffectClaim{
+		EffectID: EffectID{Generation: 17, StepSeq: 1, StepID: "plan", Pos: 0},
+		Owner:    engine.ownerID,
+		LeaseTTL: 30 * time.Minute,
+		Now:      time.Now().UTC(),
+	}
+	if _, err := tasks.ClaimWorkflowEffect("t1", claim); err == nil {
+		t.Fatal("ClaimWorkflowEffect succeeded before reclaim, want a fence conflict")
+	}
+
+	engine.ReclaimOrphanedEffectLeases()
+
+	if _, err := tasks.ClaimWorkflowEffect("t1", claim); err != nil {
+		t.Fatalf("ClaimWorkflowEffect after reclaim: %v, want success", err)
+	}
+}


### PR DESCRIPTION
## Motivation

A task sat at `planning` doing nothing for 30 minutes, logging the same pair every tick:

```
workflow.resume-stalled  task_id=... step=plan
workflow.effect.fenced   effect=g17:s1:plan:0 err="workflow effect is claimed by another owner"
```

Its `plan` effect was claimed at `18:24:09Z` with `lease_expires_at 19:13:43Z` and no `completed_at`. The owner id encodes the engine's start time; decoding it gave a process that two subsequent restarts had already replaced. Effect leases have no heartbeat, so `defaultEffectLeaseTTL` is deliberately long to avoid reclaiming a merely slow step — sound while the owner is alive, wrong once it is gone. A process that no longer exists cannot be mid-step.

Closes #3060

> Changelog: fix(workflow): reclaim orphaned effect leases

## Implementation information

`Engine.ReclaimOrphanedEffectLeases` nils `LeaseExpiresAt` on incomplete effect records owned by a different engine instance, called once from `Recovery.RunStartupCleanup` between agent reattach and `ReplayPersistedEffects`.

Placement is the whole design. **After reattach**, because a survive-restart agent outlives the engine that spawned it and its step's claim is exactly the kind this would otherwise release — freeing it would let a second agent start on work already in flight. `ReattachAllContext` registers survivors synchronously before returning, so `HasRunningAgent` is a sound liveness proxy by then. **Before replay**, because `ReplayPersistedEffects` and `RestartStaleInProgress` both claim effects and are precisely the callers a stale lease fences; running the reclaim after them (my first attempt) left the boot emitting the same `workflow.effect.fenced` line the issue is about.

The sweep skips, in order: instances with dispatch disabled; tasks the dispatch gate rejects; terminal workflows; tasks with a live or dispatching agent; and records that are completed, ownerless, this engine's own, or whose lease has already lapsed.

Four of those guards came out of the adversarial review, which caught the first pass being too eager:

- **Neither dispatch gate was honoured**, unlike every other board-wide sweep (`replayPersistedEffectsTask` checks both). On a cluster leader, `clusterlead.Merge` copies a follower's execution wholesale into the leader's store, so the leader's `ListTasks` returns tasks whose effect log carries a *live remote* engine's owner and an unexpired lease — with the agent on the follower host, both liveness checks read false and the leader would have nilled a running peer's lease. An agent-only instance (`SetAutoDispatch(false)`) would likewise have rewritten a board it never dispatches from.
- **Lapsed leases were rewritten pointlessly.** Measured against this board: 21 tasks carry 65 incomplete-with-lease records and *none* are still active. Each write goes through `UpdateWithPrev`, which bumps `Generation` — and status-effect dedupe keys on exactly one generation back (`internal/task/transition.go`), so the rewrite would make the last poller/watchdog effect on those tasks re-appliable. 9 of the 21 are `done`/`cancelled`.
- **A lost fence had no retry.** The sweep is boot-only; reattach and restart-stale keep writing tasks while it runs, and any of those writes invalidates the fence. It now re-reads and retries, bounded.
- **The orphan log line fired before the write**, so a fenced task logged N orphans for 0 reclaims — a false positive against the issue's own acceptance criterion. It now logs only once the write lands.

## Supporting documentation

Every guard mutation-verified — removing it individually makes a named subtest fail:

| removed guard | failing coverage |
|---|---|
| `dispatchDisabled` | `NoopWhenDispatchDisabled` |
| `dispatchGate` | `task the dispatch gate rejects` |
| terminal workflow | `terminal workflow` |
| `IsDispatching` | `task mid-dispatch` |
| ownerless record | `ownerless claim` |
| `leaseActiveAt` | `expired lease` |
| the `LeaseExpiresAt = nil` write itself | `ReleasesDeadOwnersClaim`, `UnfencesSubsequentClaim` |

`UnfencesSubsequentClaim` is the end-to-end one: it asserts `ClaimWorkflowEffect` fails with a fence conflict before the reclaim and succeeds after. The startup ordering is pinned by extending the existing `RunStartupCleanup` order assertion to `[reclaim replay replay:<id> restart]`; dropping the call makes it fail.

Gates: `go build ./...`, `go vet`, `go test ./internal/... ./cmd/...`, `golangci-lint run` (0 issues), `go test -race -tags e2e -short ./internal/sybra/...` — all green.

Not done: no live restart-with-orphan-lease was staged against a running instance; evidence is unit/e2e plus the production log that motivated the issue.