### PR TITLE
fix(provider): honor provider reset times

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -906,7 +906,7 @@ func (m *Manager) ProviderCanFailover(name string) bool {
 
 // ReportProviderSignal forwards a runner-side passive signal (rate-limit or
 // auth failure) to the health gate. Safe to call with a nil gate.
-func (m *Manager) ReportProviderSignal(name string, sig provider.Signal, reason string, retryAfter time.Duration) {
+func (m *Manager) ReportProviderSignal(name string, sig provider.Signal, reason string, retryAfter time.Duration, source provider.CooldownSource) {
 	m.mu.RLock()
 	g := m.gate
 	m.mu.RUnlock()
@@ -917,7 +917,7 @@ func (m *Manager) ReportProviderSignal(name string, sig provider.Signal, reason 
 	case provider.SignalAuthFailure:
 		g.ReportAuthFailure(name, reason)
 	case provider.SignalRateLimit:
-		g.ReportRateLimit(name, retryAfter, reason)
+		g.ReportRateLimit(name, retryAfter, reason, source)
 	case provider.SignalNone:
 		// no-op: caller decided not to escalate this run.
 	}

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -27,7 +27,7 @@ func (f *fakeGate) RateLimited(p string) bool     { return !f.healthy[p] }
 func (f *fakeGate) Failover(p string) string      { return f.failover[p] }
 func (f *fakeGate) Reason(p string) string        { return f.reasons[p] }
 func (f *fakeGate) ReportAuthFailure(p, _ string) { f.reportedAuth = append(f.reportedAuth, p) }
-func (f *fakeGate) ReportRateLimit(p string, d time.Duration, _ string) {
+func (f *fakeGate) ReportRateLimit(p string, d time.Duration, _ string, _ provider.CooldownSource) {
 	f.reportedRLName = append(f.reportedRLName, p)
 	f.reportedRLDelay = append(f.reportedRLDelay, d)
 }
@@ -606,8 +606,8 @@ func TestReportProviderSignal_DispatchesByKind(t *testing.T) {
 	m, _ := newTestManager(t)
 	fg := &fakeGate{healthy: map[string]bool{"claude": true}}
 	m.SetHealthGate(fg)
-	m.ReportProviderSignal("claude", provider.SignalAuthFailure, "logged_out", 0)
-	m.ReportProviderSignal("codex", provider.SignalRateLimit, "rate_limit_error", 30*time.Minute)
+	m.ReportProviderSignal("claude", provider.SignalAuthFailure, "logged_out", 0, provider.CooldownFromConfig)
+	m.ReportProviderSignal("codex", provider.SignalRateLimit, "rate_limit_error", 30*time.Minute, provider.CooldownFromConfig)
 	if len(fg.reportedAuth) != 1 || fg.reportedAuth[0] != "claude" {
 		t.Errorf("auth report missing: %+v", fg.reportedAuth)
 	}
@@ -622,7 +622,7 @@ func TestReportProviderSignal_DispatchesByKind(t *testing.T) {
 func TestReportProviderSignal_NilGateSafe(t *testing.T) {
 	m, _ := newTestManager(t)
 	// Do not call SetHealthGate.
-	m.ReportProviderSignal("claude", provider.SignalAuthFailure, "", 0)
+	m.ReportProviderSignal("claude", provider.SignalAuthFailure, "", 0, provider.CooldownFromConfig)
 }
 
 func TestReportProviderHealthSignal_CleanLimitResultMarksRateLimit(t *testing.T) {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/provider"
+
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/limits"
 )
@@ -704,12 +706,12 @@ func TestHasRunningAgentForTask(t *testing.T) {
 
 type stubGate struct{ rateLimited bool }
 
-func (s stubGate) IsHealthy(string) bool                         { return !s.rateLimited }
-func (s stubGate) RateLimited(string) bool                       { return s.rateLimited }
-func (s stubGate) Failover(string) string                        { return "" }
-func (s stubGate) Reason(string) string                          { return "" }
-func (s stubGate) ReportAuthFailure(string, string)              {}
-func (s stubGate) ReportRateLimit(string, time.Duration, string) {}
+func (s stubGate) IsHealthy(string) bool                                                  { return !s.rateLimited }
+func (s stubGate) RateLimited(string) bool                                                { return s.rateLimited }
+func (s stubGate) Failover(string) string                                                 { return "" }
+func (s stubGate) Reason(string) string                                                   { return "" }
+func (s stubGate) ReportAuthFailure(string, string)                                       {}
+func (s stubGate) ReportRateLimit(string, time.Duration, string, provider.CooldownSource) {}
 
 func TestProviderRateLimited(t *testing.T) {
 	m, _ := newTestManager(t)

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -30,7 +30,7 @@ type Provider interface {
 	// receipt must still be appended and verified for them.
 	EnforcesOutputSchema() bool
 	SessionFilePath(sessionID string) string
-	ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration)
+	ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource)
 	// HonorsAllowedTools reports whether this provider actually enforces
 	// RunConfig.AllowedTools on the spawned CLI. False means the list is
 	// silently ignored and the agent runs with the provider's own default

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -147,7 +147,7 @@ func (claudeProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
 	return claudeEventToStreamEvent(ce), nil
 }
 
-func (claudeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+func (claudeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
 	return providerpkg.ClassifyClaudeError(sample)
 }
 

--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -137,7 +137,7 @@ func (codexProvider) SessionFilePath(sessionID string) string {
 	return resolveCodexSessionFile(sessionID)
 }
 
-func (codexProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+func (codexProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
 	return providerpkg.ClassifyCodexError(sample)
 }
 

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -83,7 +83,7 @@ func (copilotProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
 	return copilotEventToStreamEvent(ce), nil
 }
 
-func (copilotProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+func (copilotProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
 	return providerpkg.ClassifyCopilotError(sample)
 }
 

--- a/internal/agent/provider_opencode.go
+++ b/internal/agent/provider_opencode.go
@@ -56,7 +56,7 @@ func (opencodeProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
 	return opencodeEventToStreamEvent(oe), nil
 }
 
-func (opencodeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+func (opencodeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
 	return providerpkg.ClassifyOpenCodeError(sample)
 }
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1162,7 +1162,7 @@ func (m *Manager) handleMalformedToolResults(a *Agent, event StreamEvent) {
 		reason := fmt.Sprintf("tool %s rejected malformed input: %s", toolName, truncatePromptField(diag.ValidationError))
 		a.NoteMalformedToolCall(event.toolResults[i].ToolUseID, toolName, malformedToolCallOutcomeUnrecoverable)
 		a.SetError(malformedToolCallErrorKind, reason)
-		m.ReportProviderSignal(a.GetProvider(), providerpkg.SignalRateLimit, malformedToolCallErrorKind, malformedToolFailoverCooldown)
+		m.ReportProviderSignal(a.GetProvider(), providerpkg.SignalRateLimit, malformedToolCallErrorKind, malformedToolFailoverCooldown, providerpkg.CooldownFromConfig)
 		m.logger.Warn("agent.headless.tool_call_malformed.unrecoverable",
 			"id", a.ID,
 			"provider", a.GetProvider(),

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -32,7 +32,7 @@ func (m *Manager) reportCleanProviderHealthSignal(a *Agent, stderrOut string, at
 }
 
 func (m *Manager) reportProviderHealthSample(a *Agent, sample provider.ErrorSample) provider.Signal {
-	sig, reason, retryAfter := classifyProviderError(a.Provider, sample)
+	sig, reason, retryAfter, src := classifyProviderError(a.Provider, sample)
 	if sig == provider.SignalNone {
 		if sample.ErrorType != "" || sample.ErrorStatus != 0 {
 			m.logger.Info("agent.provider.signal.unknown",
@@ -42,21 +42,21 @@ func (m *Manager) reportProviderHealthSample(a *Agent, sample provider.ErrorSamp
 		}
 		return sig
 	}
-	m.RecordProviderSignal(a, sig, reason, retryAfter)
+	m.RecordProviderSignal(a, sig, reason, retryAfter, src)
 	return sig
 }
 
 // RecordProviderSignal stores a provider-health classification on the agent
 // and forwards it to the shared health gate so all recovery paths maintain the
 // same "agent error kind + gate signal" invariant.
-func (m *Manager) RecordProviderSignal(a *Agent, sig provider.Signal, reason string, retryAfter time.Duration) {
+func (m *Manager) RecordProviderSignal(a *Agent, sig provider.Signal, reason string, retryAfter time.Duration, source provider.CooldownSource) {
 	if a == nil {
 		return
 	}
 	if kind := signalErrorKind(sig); kind != "" {
 		a.SetError(kind, reason)
 	}
-	m.ReportProviderSignal(a.Provider, sig, reason, retryAfter)
+	m.ReportProviderSignal(a.Provider, sig, reason, retryAfter, source)
 }
 
 // signalErrorKind maps a provider health signal to the short error-kind tag
@@ -94,10 +94,10 @@ func buildErrorSample(stderrOut string, attemptEvents []StreamEvent) provider.Er
 // classifyProviderError routes an error sample to the provider-appropriate
 // classifier. Without a copilot branch a logged-out / quota-exhausted copilot
 // would never be flagged, leaving the health gate routing failover work to it.
-func classifyProviderError(prov string, sample provider.ErrorSample) (provider.Signal, string, time.Duration) {
+func classifyProviderError(prov string, sample provider.ErrorSample) (provider.Signal, string, time.Duration, provider.CooldownSource) {
 	p, err := lookupProvider(prov)
 	if err != nil {
-		return provider.SignalNone, "", 0
+		return provider.SignalNone, "", 0, provider.CooldownFromConfig
 	}
 	return p.ClassifyError(sample)
 }

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -451,7 +451,7 @@ func TestClassifyProviderError_CodexConnectivityRoutesToRateLimit(t *testing.T) 
 	sample := provider.ErrorSample{
 		Stderr: "websocket connection refused: wss://chatgpt.com/backend-api/codex/responses",
 	}
-	sig, reason, _ := classifyProviderError("codex", sample)
+	sig, reason, _, _ := classifyProviderError("codex", sample)
 	if sig != provider.SignalRateLimit {
 		t.Fatalf("signal = %v, want SignalRateLimit", sig)
 	}

--- a/internal/learning/digest.go
+++ b/internal/learning/digest.go
@@ -370,9 +370,9 @@ func (g claudeOnlyGate) ReportAuthFailure(p, reason string) {
 	}
 }
 
-func (g claudeOnlyGate) ReportRateLimit(p string, retryAfter time.Duration, reason string) {
+func (g claudeOnlyGate) ReportRateLimit(p string, retryAfter time.Duration, reason string, source provider.CooldownSource) {
 	if g.base != nil && p == "claude" {
-		g.base.ReportRateLimit(p, retryAfter, reason)
+		g.base.ReportRateLimit(p, retryAfter, reason, source)
 	}
 }
 

--- a/internal/learning/digest_test.go
+++ b/internal/learning/digest_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/provider"
+
 	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
@@ -29,12 +31,12 @@ func (f fakeAudit) Read(audit.Query) ([]audit.Event, error) { return f.events, f
 // deterministic "summarizer unavailable" failure with no process spawned.
 type alwaysBlockGate struct{}
 
-func (alwaysBlockGate) IsHealthy(string) bool                         { return false }
-func (alwaysBlockGate) RateLimited(string) bool                       { return false }
-func (alwaysBlockGate) Failover(string) string                        { return "" }
-func (alwaysBlockGate) Reason(string) string                          { return "blocked for test" }
-func (alwaysBlockGate) ReportAuthFailure(string, string)              {}
-func (alwaysBlockGate) ReportRateLimit(string, time.Duration, string) {}
+func (alwaysBlockGate) IsHealthy(string) bool                                                  { return false }
+func (alwaysBlockGate) RateLimited(string) bool                                                { return false }
+func (alwaysBlockGate) Failover(string) string                                                 { return "" }
+func (alwaysBlockGate) Reason(string) string                                                   { return "blocked for test" }
+func (alwaysBlockGate) ReportAuthFailure(string, string)                                       {}
+func (alwaysBlockGate) ReportRateLimit(string, time.Duration, string, provider.CooldownSource) {}
 
 func newTestService(t *testing.T, d Deps) *Service {
 	t.Helper()

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -106,9 +106,9 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
 				continue
 			}
-			sig, reason, retryAfter := classifyError(p, stderrOut, string(raw))
+			sig, reason, retryAfter, src := classifyError(p, stderrOut, string(raw))
 			if sig != provider.SignalNone {
-				reportSignal(opts.Gate, p, sig, reason, retryAfter)
+				reportSignal(opts.Gate, p, sig, reason, retryAfter, src)
 				logFallback(opts.Logger, p, sig, reason)
 				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
 				continue
@@ -128,9 +128,9 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
 				continue
 			}
-			sig, reason, retryAfter := classifyError(p, stderrOut, string(raw))
+			sig, reason, retryAfter, src := classifyError(p, stderrOut, string(raw))
 			if sig != provider.SignalNone {
-				reportSignal(opts.Gate, p, sig, reason, retryAfter)
+				reportSignal(opts.Gate, p, sig, reason, retryAfter, src)
 				logFallback(opts.Logger, p, sig, reason)
 				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
 				continue
@@ -435,7 +435,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func classifyError(p, stderrOut, content string) (provider.Signal, string, time.Duration) {
+func classifyError(p, stderrOut, content string) (provider.Signal, string, time.Duration, provider.CooldownSource) {
 	sample := provider.ErrorSample{Stderr: stderrOut, Content: content}
 	switch p {
 	case "codex":
@@ -500,7 +500,7 @@ func containsAnyString(haystack string, needles ...string) bool {
 	return false
 }
 
-func reportSignal(g provider.HealthGate, p string, sig provider.Signal, reason string, retryAfter time.Duration) {
+func reportSignal(g provider.HealthGate, p string, sig provider.Signal, reason string, retryAfter time.Duration, source provider.CooldownSource) {
 	if g == nil {
 		return
 	}
@@ -508,7 +508,7 @@ func reportSignal(g provider.HealthGate, p string, sig provider.Signal, reason s
 	case provider.SignalAuthFailure:
 		g.ReportAuthFailure(p, reason)
 	case provider.SignalRateLimit:
-		g.ReportRateLimit(p, retryAfter, reason)
+		g.ReportRateLimit(p, retryAfter, reason, source)
 	case provider.SignalNone:
 	}
 }

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -266,9 +266,9 @@ func (g avoidingGate) ReportAuthFailure(providerName, reason string) {
 	}
 }
 
-func (g avoidingGate) ReportRateLimit(providerName string, retryAfter time.Duration, reason string) {
+func (g avoidingGate) ReportRateLimit(providerName string, retryAfter time.Duration, reason string, source provider.CooldownSource) {
 	if g.base != nil && providerName != g.avoid {
-		g.base.ReportRateLimit(providerName, retryAfter, reason)
+		g.base.ReportRateLimit(providerName, retryAfter, reason, source)
 	}
 }
 

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -59,7 +59,7 @@ type HealthGate interface {
 	Failover(unhealthy string) string
 	Reason(provider string) string
 	ReportAuthFailure(provider, reason string)
-	ReportRateLimit(provider string, retryAfter time.Duration, reason string)
+	ReportRateLimit(provider string, retryAfter time.Duration, reason string, source CooldownSource)
 }
 
 // HealthEvent is the payload emitted on state flips to the frontend.
@@ -594,7 +594,7 @@ func (c *Checker) ReportAuthFailure(provider, reason string) {
 
 // ReportRateLimit marks a provider as rate-limited. retryAfter zero falls back
 // to the per-provider configured cooldown.
-func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, reason string) {
+func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, reason string, source CooldownSource) {
 	// See ReportAuthFailure: the metric is a provider event and survives a nil
 	// checker; the cooldown it would record has nowhere to live without one.
 	metrics.ProviderRateLimit(provider)
@@ -631,7 +631,7 @@ func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, rea
 			"reason", reason,
 			"cooldown", cooldown.String(),
 			"until", until,
-			"source", parkSource(retryAfter))
+			"source", string(source))
 	}
 	c.setStatus(provider, Status{
 		Provider:         provider,
@@ -641,16 +641,6 @@ func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, rea
 		LastCheck:        c.now(),
 		RateLimitedUntil: until,
 	}, false)
-}
-
-// parkSource distinguishes a park the provider itself dated from one the
-// configured cooldown guessed at, so a surprising window can be traced to
-// whichever produced it.
-func parkSource(retryAfter time.Duration) string {
-	if retryAfter > 0 {
-		return "provider_hint"
-	}
-	return "configured_cooldown"
 }
 
 // Snapshot returns a copy of the current statuses for wails-bound read paths.

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -622,6 +622,17 @@ func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, rea
 		reason = RateLimitReason
 	}
 	until := c.now().Add(cooldown)
+	// Without this a 3-day park is byte-identical in the log to a 900s one:
+	// the health.flip line carries only provider/healthy/reason, so an
+	// over-long park would be undiagnosable in production.
+	if c.logger != nil {
+		c.logger.Info("provider.rate_limit.park",
+			"provider", provider,
+			"reason", reason,
+			"cooldown", cooldown.String(),
+			"until", until,
+			"source", parkSource(retryAfter))
+	}
 	c.setStatus(provider, Status{
 		Provider:         provider,
 		Healthy:          false,
@@ -630,6 +641,16 @@ func (c *Checker) ReportRateLimit(provider string, retryAfter time.Duration, rea
 		LastCheck:        c.now(),
 		RateLimitedUntil: until,
 	}, false)
+}
+
+// parkSource distinguishes a park the provider itself dated from one the
+// configured cooldown guessed at, so a surprising window can be traced to
+// whichever produced it.
+func parkSource(retryAfter time.Duration) string {
+	if retryAfter > 0 {
+		return "provider_hint"
+	}
+	return "configured_cooldown"
 }
 
 // Snapshot returns a copy of the current statuses for wails-bound read paths.

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -200,7 +200,7 @@ func TestClassifyClaudeError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, reason, retryAfter := ClassifyClaudeError(tc.in)
+			got, reason, retryAfter, _ := ClassifyClaudeError(tc.in)
 			if got != tc.want {
 				t.Errorf("signal: got %v want %v", got, tc.want)
 			}
@@ -283,7 +283,7 @@ func TestClassifyCodexError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, reason, retryAfter := ClassifyCodexError(tc.in)
+			got, reason, retryAfter, _ := ClassifyCodexError(tc.in)
 			if got != tc.want {
 				t.Errorf("signal: got %v want %v", got, tc.want)
 			}
@@ -312,7 +312,7 @@ func TestClassifyCopilotError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, _, _ := ClassifyCopilotError(tc.in)
+			got, _, _, _ := ClassifyCopilotError(tc.in)
 			if got != tc.want {
 				t.Errorf("got %v want %v", got, tc.want)
 			}
@@ -718,7 +718,7 @@ func TestChecker_LivenessOnlyProbeDoesNotClearPassiveAuthFailure(t *testing.T) {
 func TestChecker_RateLimitExpires(t *testing.T) {
 	c, _, clock := newTestChecker(t)
 	c.setStatus("claude", Status{Provider: "claude", Healthy: true, Reason: "ok"}, true)
-	c.ReportRateLimit("claude", 10*time.Minute, "rate_limit_error")
+	c.ReportRateLimit("claude", 10*time.Minute, "rate_limit_error", CooldownFromConfig)
 	if c.IsHealthy("claude") {
 		t.Fatalf("claude should be rate-limited")
 	}
@@ -795,7 +795,7 @@ func TestChecker_ProbeHealthyPreservesActiveRateLimit(t *testing.T) {
 	c.setStatus("claude", Status{Provider: "claude", Healthy: true, Reason: "ok"}, true)
 
 	// Mark rate-limited for 10m.
-	c.ReportRateLimit("claude", 10*time.Minute, "rate_limit_error")
+	c.ReportRateLimit("claude", 10*time.Minute, "rate_limit_error", CooldownFromConfig)
 	if c.IsHealthy("claude") {
 		t.Fatalf("claude should be rate-limited immediately after ReportRateLimit")
 	}
@@ -883,5 +883,5 @@ func TestNilChecker_IsAnAbsentGateNotAPanic(t *testing.T) {
 		t.Errorf("Failover = %q, want empty: an absent gate has no view to fail over with", got)
 	}
 	gate.ReportAuthFailure("codex", "logged_out")
-	gate.ReportRateLimit("codex", time.Minute, "429")
+	gate.ReportRateLimit("codex", time.Minute, "429", CooldownFromConfig)
 }

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -147,7 +147,20 @@ func TestProbeCodexOldCLIMarksProviderUnhealthy(t *testing.T) {
 	}
 }
 
+// classifierNow pins the classifier tests' clock a few days before the
+// "resets Jul 1 at 5pm" fixtures, so the parsed instant is a concrete
+// sub-clamp duration instead of depending on the wall clock.
+var classifierNow = time.Date(2026, time.June, 28, 12, 0, 0, 0, time.Local)
+
+// julyFirstReset is what the Jul 1 fixtures parse to under classifierNow.
+var julyFirstReset = time.Date(2026, time.July, 1, 17, 0, 0, 0, time.Local).Sub(classifierNow)
+
 func TestClassifyClaudeError(t *testing.T) {
+	// Pin the clock: several fixtures carry "resets Jul 1 at 5pm", which is now
+	// parsed into a concrete instant rather than falling back to the fixed
+	// cooldown. julyFirstReset is that instant relative to the pinned now.
+	pinNow(t, classifierNow)
+
 	cases := []struct {
 		name           string
 		in             ErrorSample
@@ -164,8 +177,8 @@ func TestClassifyClaudeError(t *testing.T) {
 		{"stderr_rate_limit", ErrorSample{Stderr: "rate limit exceeded"}, SignalRateLimit, "rate_limited", 0},
 		{"content_session_limit", ErrorSample{Content: "You've hit your session limit · resets 4:30pm"}, SignalRateLimit, "rate_limited", 0},
 		{"content_usage_limit", ErrorSample{Content: "usage limit reached for this period"}, SignalRateLimit, "rate_limited", 0},
-		{"content_weekly_limit", ErrorSample{Content: "You've hit your weekly limit · resets Jul 1 at 5pm"}, SignalRateLimit, "weekly_limit", weeklyLimitCooldown},
-		{"stderr_weekly_limit", ErrorSample{Stderr: "You've hit your weekly limit · resets Jul 1 at 5pm"}, SignalRateLimit, "weekly_limit", weeklyLimitCooldown},
+		{"content_weekly_limit", ErrorSample{Content: "You've hit your weekly limit · resets Jul 1 at 5pm"}, SignalRateLimit, "weekly_limit", julyFirstReset},
+		{"stderr_weekly_limit", ErrorSample{Stderr: "You've hit your weekly limit · resets Jul 1 at 5pm"}, SignalRateLimit, "weekly_limit", julyFirstReset},
 		{"weekly_word_without_specific_phrase_stays_rate_limited", ErrorSample{Content: "usage limit reached · resets weekly on Monday"}, SignalRateLimit, "rate_limited", 0},
 		{"clean_content_rate_limit_exceeded", ErrorSample{Content: "rate limit exceeded", ContentIsCleanResult: true}, SignalRateLimit, "rate_limited", 0},
 		{"clean_content_rate_limit_reached", ErrorSample{Content: "rate limit reached", ContentIsCleanResult: true}, SignalRateLimit, "rate_limited", 0},
@@ -177,7 +190,7 @@ func TestClassifyClaudeError(t *testing.T) {
 		{
 			"structured_429_with_weekly_content_stays_weekly",
 			ErrorSample{ErrorStatus: 429, Content: "You've hit your weekly limit · resets Jul 1 at 5pm"},
-			SignalRateLimit, "weekly_limit", weeklyLimitCooldown,
+			SignalRateLimit, "weekly_limit", julyFirstReset,
 		},
 		{
 			"structured_rate_limit_error_type_with_weekly_stderr_stays_weekly",
@@ -202,6 +215,11 @@ func TestClassifyClaudeError(t *testing.T) {
 }
 
 func TestClassifyCodexError(t *testing.T) {
+	// Pin the clock: several fixtures carry "resets Jul 1 at 5pm", which is now
+	// parsed into a concrete instant rather than falling back to the fixed
+	// cooldown. julyFirstReset is that instant relative to the pinned now.
+	pinNow(t, classifierNow)
+
 	cases := []struct {
 		name           string
 		in             ErrorSample
@@ -255,7 +273,7 @@ func TestClassifyCodexError(t *testing.T) {
 		{
 			"structured_429_with_weekly_content_stays_weekly",
 			ErrorSample{ErrorStatus: 429, Content: "You've hit your weekly limit · resets Jul 1 at 5pm"},
-			SignalRateLimit, "weekly_limit", weeklyLimitCooldown,
+			SignalRateLimit, "weekly_limit", julyFirstReset,
 		},
 		{
 			"structured_rate_limit_type_with_weekly_stderr_stays_weekly",

--- a/internal/provider/reset_hint.go
+++ b/internal/provider/reset_hint.go
@@ -1,0 +1,124 @@
+package provider
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// maxResetHint bounds how far out a parsed reset instant may park a provider.
+// A misparse would otherwise take it offline effectively forever, and a
+// too-long park costs the whole fleet while a too-short one costs one probe.
+const maxResetHint = 7 * 24 * time.Hour
+
+// nowFunc is the clock reset-hint parsing resolves relative dates against.
+// Overridden in tests; the classifiers are otherwise pure functions with no
+// clock of their own.
+var nowFunc = time.Now
+
+var (
+	// "try again at Aug 8th, 2026 9:41 AM" — the codex usage-limit message.
+	codexResetRe = regexp.MustCompile(`(?i)try again at\s+([a-z]{3,9})\.?\s+(\d{1,2})(?:st|nd|rd|th)?,?\s*(\d{4})?[,\s]+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?`)
+	// "resets Jul 1 at 5pm" / "resets Jul 1 at 17:00" — the claude message.
+	claudeResetRe = regexp.MustCompile(`(?i)resets?\s+(?:on\s+)?([a-z]{3,9})\.?\s+(\d{1,2})(?:st|nd|rd|th)?\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?`)
+)
+
+var monthByPrefix = map[string]time.Month{
+	"jan": time.January, "feb": time.February, "mar": time.March,
+	"apr": time.April, "may": time.May, "jun": time.June,
+	"jul": time.July, "aug": time.August, "sep": time.September,
+	"oct": time.October, "nov": time.November, "dec": time.December,
+}
+
+// parseResetHint extracts a provider-supplied reset instant from text and
+// returns how long from now that is.
+//
+// Providers state exactly when they will serve again — codex prints "try again
+// at Aug 8th, 2026 9:41 AM" — and without this the fixed cooldown retries every
+// 15 minutes for the three days until that instant, each retry burning a
+// dispatch. ok is false when nothing parses or when the instant is already
+// past, e.g. a stale message quoted from an earlier failure.
+//
+// Times are read in the local zone: providers print them in the account's zone
+// with no offset. A zone mismatch skews the park by hours at most, never
+// unbounded, since maxResetHint still applies.
+func parseResetHint(text string) (time.Duration, bool) {
+	if text == "" {
+		return 0, false
+	}
+	now := nowFunc()
+	for _, re := range []*regexp.Regexp{codexResetRe, claudeResetRe} {
+		m := re.FindStringSubmatch(text)
+		if m == nil {
+			continue
+		}
+		when, ok := resetInstant(re, m, now)
+		if !ok {
+			continue
+		}
+		d := when.Sub(now)
+		if d <= 0 {
+			continue
+		}
+		return min(d, maxResetHint), true
+	}
+	return 0, false
+}
+
+// resetInstant assembles the matched fields into a concrete instant. The two
+// expressions differ in whether a year group is present, so the year and time
+// groups are read positionally per pattern rather than by a shared index.
+func resetInstant(re *regexp.Regexp, m []string, now time.Time) (time.Time, bool) {
+	name := strings.ToLower(m[1])
+	month, ok := monthByPrefix[name[:min(3, len(name))]]
+	if !ok {
+		return time.Time{}, false
+	}
+	day, err := strconv.Atoi(m[2])
+	if err != nil || day < 1 || day > 31 {
+		return time.Time{}, false
+	}
+
+	var year int
+	hourIdx := 3
+	if re == codexResetRe {
+		hourIdx = 4
+		if m[3] != "" {
+			if year, err = strconv.Atoi(m[3]); err != nil {
+				return time.Time{}, false
+			}
+		}
+	}
+
+	hour, err := strconv.Atoi(m[hourIdx])
+	if err != nil || hour > 23 {
+		return time.Time{}, false
+	}
+	minute := 0
+	if v := m[hourIdx+1]; v != "" {
+		if minute, err = strconv.Atoi(v); err != nil || minute > 59 {
+			return time.Time{}, false
+		}
+	}
+	switch strings.ToLower(m[hourIdx+2]) {
+	case "pm":
+		if hour < 12 {
+			hour += 12
+		}
+	case "am":
+		if hour == 12 {
+			hour = 0
+		}
+	}
+
+	if year == 0 {
+		// A yearless "resets Jan 3" read in December means next January, not
+		// eleven months ago.
+		year = now.Year()
+		if time.Date(year, month, day, hour, minute, 0, 0, now.Location()).Before(now) {
+			year++
+		}
+	}
+	return time.Date(year, month, day, hour, minute, 0, 0, now.Location()), true
+}

--- a/internal/provider/reset_hint.go
+++ b/internal/provider/reset_hint.go
@@ -102,10 +102,12 @@ func parseResetHint(text string) (time.Duration, HintOutcome) {
 				continue
 			}
 			d := when.Sub(now)
-			if d <= 0 {
-				continue
-			}
-			if d > maxResetHint {
+			// Both out-of-range directions are rejections, not absences. A
+			// stale-but-parseable hint — a message quoted from an earlier
+			// failure, or a clock skew across the boundary — must stay
+			// distinguishable from text that never carried a date, or the
+			// park log cannot tell them apart.
+			if d <= 0 || d > maxResetHint {
 				rejected = true
 				continue
 			}
@@ -158,16 +160,19 @@ func resetInstant(re *regexp.Regexp, m []string, now time.Time) (time.Time, bool
 			return time.Time{}, false
 		}
 	}
+	// A 12-hour suffix constrains the hour to 1..12. The regex allows two
+	// digits, so without this "0pm" would resolve to a plausible-looking
+	// 12:00 and "13am" to 13:00 — malformed text turned into a valid instant.
 	switch strings.ToLower(m[hourIdx+2]) {
 	case "pm":
-		if hour > 12 {
+		if hour < 1 || hour > 12 {
 			return time.Time{}, false
 		}
 		if hour < 12 {
 			hour += 12
 		}
 	case "am":
-		if hour > 12 {
+		if hour < 1 || hour > 12 {
 			return time.Time{}, false
 		}
 		if hour == 12 {

--- a/internal/provider/reset_hint.go
+++ b/internal/provider/reset_hint.go
@@ -46,6 +46,23 @@ var monthByPrefix = map[string]time.Month{
 	"oct": time.October, "nov": time.November, "dec": time.December,
 }
 
+// HintOutcome distinguishes "the provider stated a time" from "nothing usable
+// was there" and from "something parsed but was out of range". The last case
+// must be visible: a rejected hint and an absent one produce identical parks,
+// so without this an over-long or nonsensical provider message is silently
+// indistinguishable from a message that never carried a date.
+type HintOutcome int
+
+const (
+	HintNone HintOutcome = iota
+	HintParsed
+	HintRejected
+)
+
+// ansiEscape matches SGR colour sequences, which would otherwise sit between
+// "try again at" and the month name and defeat the patterns.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
 // parseResetHint extracts a provider-supplied reset instant from text and
 // returns how long from now that is.
 //
@@ -54,38 +71,56 @@ var monthByPrefix = map[string]time.Month{
 // 15 minutes for the three days until that instant, each retry burning a
 // dispatch.
 //
-// ok is false whenever the result would be a guess: nothing parses, the
-// instant is already past, or it lands beyond maxResetHint. Every such case
-// falls back to the caller's configured cooldown, so this can only ever
-// shorten the gap between a park and the truth, never lengthen it past what
-// the provider itself stated.
+// The outcome is HintParsed only when a concrete, in-range, future instant was
+// found. Anything else falls back to the caller's configured cooldown, so this
+// can only shorten the gap between a park and the truth, never lengthen it
+// past what the provider itself stated.
 //
 // Times are read in the local zone: providers print them in the account's zone
 // with no offset. A zone mismatch skews the park by hours, and because an
 // over-long parse is rejected rather than capped, the skew cannot compound
 // into a multi-day park.
-func parseResetHint(text string) (time.Duration, bool) {
+func parseResetHint(text string) (time.Duration, HintOutcome) {
 	if text == "" {
-		return 0, false
+		return 0, HintNone
 	}
+	text = ansiEscape.ReplaceAllString(text, "")
 	now := nowFunc()
+
+	// The EARLIEST valid instant, not the first match. All matches are scanned
+	// because agent prose and tool output can carry a date-shaped fragment
+	// that would otherwise shadow the real hint — but a decoy that parses
+	// cleanly and sits further out would then over-park the provider, so the
+	// most conservative candidate wins.
+	var best time.Duration
+	found := false
+	rejected := false
 	for _, re := range []*regexp.Regexp{codexResetRe, claudeResetRe} {
-		// All matches, not just the first: agent prose and tool output can
-		// carry an earlier date-shaped fragment ("git reset origin 1 at 3pm")
-		// that would otherwise shadow or corrupt the real hint.
 		for _, m := range re.FindAllStringSubmatch(text, -1) {
 			when, ok := resetInstant(re, m, now)
 			if !ok {
 				continue
 			}
 			d := when.Sub(now)
-			if d <= 0 || d > maxResetHint {
+			if d <= 0 {
 				continue
 			}
-			return max(d, minResetHint), true
+			if d > maxResetHint {
+				rejected = true
+				continue
+			}
+			if !found || d < best {
+				best, found = d, true
+			}
 		}
 	}
-	return 0, false
+	if found {
+		return max(best, minResetHint), HintParsed
+	}
+	if rejected {
+		return 0, HintRejected
+	}
+	return 0, HintNone
 }
 
 // resetInstant assembles the matched fields into a concrete instant. The two

--- a/internal/provider/reset_hint.go
+++ b/internal/provider/reset_hint.go
@@ -7,10 +7,22 @@ import (
 	"time"
 )
 
-// maxResetHint bounds how far out a parsed reset instant may park a provider.
-// A misparse would otherwise take it offline effectively forever, and a
-// too-long park costs the whole fleet while a too-short one costs one probe.
+// maxResetHint bounds a parsed reset instant. Beyond it the parse is treated
+// as wrong and rejected outright rather than capped: capping would turn a
+// misparse into the worst possible park, while rejecting falls back to the
+// configured cooldown, which is never worse than today's behavior.
 const maxResetHint = 7 * 24 * time.Hour
+
+// minResetHint floors a parsed instant. A message classified moments before
+// its own reset yields a sub-second park, which buys one guaranteed-doomed
+// dispatch — the exact cost this parsing exists to remove.
+const minResetHint = 30 * time.Second
+
+// staleYearlessCutoff decides when a yearless date that already passed means
+// "next year" rather than "just now". "resets Jan 3" read in December is next
+// January; "resets Jul 1 at 5pm" read at 17:00:30 is a limit that has already
+// reset, not one eleven months out.
+const staleYearlessCutoff = 30 * 24 * time.Hour
 
 // nowFunc is the clock reset-hint parsing resolves relative dates against.
 // Overridden in tests; the classifiers are otherwise pure functions with no
@@ -19,9 +31,12 @@ var nowFunc = time.Now
 
 var (
 	// "try again at Aug 8th, 2026 9:41 AM" — the codex usage-limit message.
-	codexResetRe = regexp.MustCompile(`(?i)try again at\s+([a-z]{3,9})\.?\s+(\d{1,2})(?:st|nd|rd|th)?,?\s*(\d{4})?[,\s]+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?`)
+	// The year is \b-anchored and the time is trailed by \b so a malformed
+	// number ("20261") cannot have a two-digit prefix reinterpreted as the
+	// hour; the optional "at" covers the "<date> at <time>" phrasing.
+	codexResetRe = regexp.MustCompile(`(?i)try again at\s+([a-z]{3,9})\.?\s+(\d{1,2})(?:st|nd|rd|th)?,?\s*(?:(\d{4})\b)?[,\s]*(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b`)
 	// "resets Jul 1 at 5pm" / "resets Jul 1 at 17:00" — the claude message.
-	claudeResetRe = regexp.MustCompile(`(?i)resets?\s+(?:on\s+)?([a-z]{3,9})\.?\s+(\d{1,2})(?:st|nd|rd|th)?\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?`)
+	claudeResetRe = regexp.MustCompile(`(?i)resets?\s+(?:on\s+)?([a-z]{3,9})\.?\s+(\d{1,2})(?:st|nd|rd|th)?\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b`)
 )
 
 var monthByPrefix = map[string]time.Month{
@@ -37,31 +52,38 @@ var monthByPrefix = map[string]time.Month{
 // Providers state exactly when they will serve again — codex prints "try again
 // at Aug 8th, 2026 9:41 AM" — and without this the fixed cooldown retries every
 // 15 minutes for the three days until that instant, each retry burning a
-// dispatch. ok is false when nothing parses or when the instant is already
-// past, e.g. a stale message quoted from an earlier failure.
+// dispatch.
+//
+// ok is false whenever the result would be a guess: nothing parses, the
+// instant is already past, or it lands beyond maxResetHint. Every such case
+// falls back to the caller's configured cooldown, so this can only ever
+// shorten the gap between a park and the truth, never lengthen it past what
+// the provider itself stated.
 //
 // Times are read in the local zone: providers print them in the account's zone
-// with no offset. A zone mismatch skews the park by hours at most, never
-// unbounded, since maxResetHint still applies.
+// with no offset. A zone mismatch skews the park by hours, and because an
+// over-long parse is rejected rather than capped, the skew cannot compound
+// into a multi-day park.
 func parseResetHint(text string) (time.Duration, bool) {
 	if text == "" {
 		return 0, false
 	}
 	now := nowFunc()
 	for _, re := range []*regexp.Regexp{codexResetRe, claudeResetRe} {
-		m := re.FindStringSubmatch(text)
-		if m == nil {
-			continue
+		// All matches, not just the first: agent prose and tool output can
+		// carry an earlier date-shaped fragment ("git reset origin 1 at 3pm")
+		// that would otherwise shadow or corrupt the real hint.
+		for _, m := range re.FindAllStringSubmatch(text, -1) {
+			when, ok := resetInstant(re, m, now)
+			if !ok {
+				continue
+			}
+			d := when.Sub(now)
+			if d <= 0 || d > maxResetHint {
+				continue
+			}
+			return max(d, minResetHint), true
 		}
-		when, ok := resetInstant(re, m, now)
-		if !ok {
-			continue
-		}
-		d := when.Sub(now)
-		if d <= 0 {
-			continue
-		}
-		return min(d, maxResetHint), true
 	}
 	return 0, false
 }
@@ -71,7 +93,7 @@ func parseResetHint(text string) (time.Duration, bool) {
 // groups are read positionally per pattern rather than by a shared index.
 func resetInstant(re *regexp.Regexp, m []string, now time.Time) (time.Time, bool) {
 	name := strings.ToLower(m[1])
-	month, ok := monthByPrefix[name[:min(3, len(name))]]
+	month, ok := monthByPrefix[name[:3]]
 	if !ok {
 		return time.Time{}, false
 	}
@@ -103,20 +125,28 @@ func resetInstant(re *regexp.Regexp, m []string, now time.Time) (time.Time, bool
 	}
 	switch strings.ToLower(m[hourIdx+2]) {
 	case "pm":
+		if hour > 12 {
+			return time.Time{}, false
+		}
 		if hour < 12 {
 			hour += 12
 		}
 	case "am":
+		if hour > 12 {
+			return time.Time{}, false
+		}
 		if hour == 12 {
 			hour = 0
 		}
 	}
 
 	if year == 0 {
-		// A yearless "resets Jan 3" read in December means next January, not
-		// eleven months ago.
 		year = now.Year()
-		if time.Date(year, month, day, hour, minute, 0, 0, now.Location()).Before(now) {
+		candidate := time.Date(year, month, day, hour, minute, 0, 0, now.Location())
+		// Only a date far in the past means "next year". A few seconds or
+		// hours past means the limit has already reset, and rolling it
+		// forward would park the provider for a year.
+		if now.Sub(candidate) > staleYearlessCutoff {
 			year++
 		}
 	}

--- a/internal/provider/reset_hint_test.go
+++ b/internal/provider/reset_hint_test.go
@@ -221,12 +221,34 @@ func TestCleanResultContentNeverSuppliesAResetHint(t *testing.T) {
 	prose := "Done. I implemented the reset-hint parser for the case where codex says " +
 		"you've hit your usage limit and prints: try again at Aug 12th, 2026 9:00 AM."
 
-	_, _, after, src := ClassifyClaudeError(ErrorSample{Content: prose, ContentIsCleanResult: true})
-	if src == CooldownFromProvider {
-		t.Errorf("clean result content supplied a provider hint (%v); agent prose must never park its own provider", after)
+	// Every surface of a clean run, not just content. The first fix guarded
+	// content alone and the defect reproduced through stderr: an MCP warning
+	// or a fallback-model notice quoting a usage limit parked every enabled
+	// provider for 59 hours off runs that succeeded.
+	surfaces := map[string]ErrorSample{
+		"content": {Content: prose, ContentIsCleanResult: true},
+		"stderr": {
+			Stderr:               "[api] request failed: usage limit reached; try again at Aug 8th, 2026 9:41 AM",
+			Content:              "ok, done",
+			ContentIsCleanResult: true,
+		},
+		"mcp warning on stderr": {
+			Stderr:               `[warn] mcp server "notes" exited: You've hit your usage limit. Try again at Aug 8th, 2026 9:41 AM`,
+			Content:              "Task complete. All tests pass.",
+			ContentIsCleanResult: true,
+		},
 	}
-	if after > weeklyLimitCooldown {
-		t.Errorf("clean result content produced a %v park, longer than the fixed fallback %v", after, weeklyLimitCooldown)
+	for name, sample := range surfaces {
+		t.Run(name, func(t *testing.T) {
+			pinNow(t, now)
+			_, _, after, src := ClassifyClaudeError(sample)
+			if src == CooldownFromProvider {
+				t.Errorf("clean run supplied a provider hint (%v); a run the provider served states nothing about refusing", after)
+			}
+			if after > weeklyLimitCooldown {
+				t.Errorf("clean run produced a %v park, longer than the fixed fallback %v", after, weeklyLimitCooldown)
+			}
+		})
 	}
 }
 

--- a/internal/provider/reset_hint_test.go
+++ b/internal/provider/reset_hint_test.go
@@ -1,0 +1,165 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+// pinNow freezes the clock reset parsing resolves against, so yearless dates
+// and "already past" cases are deterministic rather than depending on when CI
+// happens to run.
+func pinNow(t *testing.T, when time.Time) {
+	t.Helper()
+	prev := nowFunc
+	nowFunc = func() time.Time { return when }
+	t.Cleanup(func() { nowFunc = prev })
+}
+
+func TestParseResetHint(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
+
+	tests := []struct {
+		name string
+		text string
+		want time.Duration
+		ok   bool
+	}{
+		{
+			// The exact string codex printed on the deploy host.
+			name: "codex usage limit with year",
+			text: "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 9:41 AM.",
+			want: time.Date(2026, time.August, 8, 9, 41, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{
+			name: "codex without year resolves to this year",
+			text: "try again at Aug 6, 9:41 AM",
+			want: time.Date(2026, time.August, 6, 9, 41, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{
+			name: "claude weekly limit",
+			text: "You've hit your weekly limit · resets Aug 7 at 5pm",
+			want: time.Date(2026, time.August, 7, 17, 0, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{
+			name: "claude 24-hour clock",
+			text: "resets Aug 7 at 17:30",
+			want: time.Date(2026, time.August, 7, 17, 30, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{
+			name: "midnight am is hour zero",
+			text: "resets Aug 6 at 12:00am",
+			want: time.Date(2026, time.August, 6, 0, 0, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{
+			name: "noon pm stays hour twelve",
+			text: "resets Aug 6 at 12:00pm",
+			want: time.Date(2026, time.August, 6, 12, 0, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{
+			// A yearless date already past this year rolls forward rather
+			// than producing a negative duration that would be discarded —
+			// and the clamp then caps the resulting months-long park.
+			name: "yearless date already past rolls forward then clamps",
+			text: "resets Jan 3 at 9am",
+			want: maxResetHint,
+			ok:   true,
+		},
+		{
+			// A stale message quoted from an earlier failure must not park
+			// the provider at all.
+			name: "explicit past instant is rejected",
+			text: "try again at Aug 1st, 2026 9:41 AM",
+			ok:   false,
+		},
+		{"no date at all", "You've hit your weekly limit", 0, false},
+		{"empty", "", 0, false},
+		{"garbage month", "try again at Foo 8th, 2026 9:41 AM", 0, false},
+		{"impossible day", "resets Aug 47 at 5pm", 0, false},
+		{"impossible minute", "resets Aug 6 at 9:99am", 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pinNow(t, now)
+			got, ok := parseResetHint(tc.text)
+			if ok != tc.ok {
+				t.Fatalf("parseResetHint(%q) ok = %v, want %v (got %v)", tc.text, ok, tc.ok, got)
+			}
+			if ok && got != tc.want {
+				t.Errorf("parseResetHint(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+// A wrong-century or otherwise absurd parse must not take the provider offline
+// for years.
+func TestParseResetHint_ClampsFarFutureInstant(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
+	pinNow(t, now)
+
+	got, ok := parseResetHint("try again at Aug 8th, 2099 9:41 AM")
+	if !ok {
+		t.Fatal("parseResetHint returned ok=false for a far-future instant, want clamped")
+	}
+	if got != maxResetHint {
+		t.Errorf("parseResetHint = %v, want clamp to %v", got, maxResetHint)
+	}
+}
+
+// The parsed instant must beat the fixed cooldown, which is the whole point:
+// a 15-minute default retried against a three-day window burns a dispatch
+// every cycle.
+func TestClassifiers_PreferProviderResetOverFixedCooldown(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
+	wantCodex := time.Date(2026, time.August, 8, 9, 41, 0, 0, time.Local).Sub(now)
+
+	t.Run("codex", func(t *testing.T) {
+		pinNow(t, now)
+		sig, reason, after := ClassifyCodexError(ErrorSample{
+			Stderr: "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 9:41 AM.",
+		})
+		if sig != SignalRateLimit {
+			t.Fatalf("signal = %v, want SignalRateLimit", sig)
+		}
+		if reason != "rate_limited" {
+			t.Errorf("reason = %q, want rate_limited", reason)
+		}
+		if after != wantCodex {
+			t.Errorf("retryAfter = %v, want %v", after, wantCodex)
+		}
+	})
+
+	t.Run("claude weekly limit overrides the hour default", func(t *testing.T) {
+		pinNow(t, now)
+		wantClaude := time.Date(2026, time.August, 7, 17, 0, 0, 0, time.Local).Sub(now)
+		sig, reason, after := ClassifyClaudeError(ErrorSample{
+			Stderr: "You've hit your weekly limit · resets Aug 7 at 5pm",
+		})
+		if sig != SignalRateLimit || reason != "weekly_limit" {
+			t.Fatalf("got (%v, %q), want (SignalRateLimit, weekly_limit)", sig, reason)
+		}
+		if after == weeklyLimitCooldown {
+			t.Fatalf("retryAfter fell back to the fixed %v instead of the parsed instant", weeklyLimitCooldown)
+		}
+		if after != wantClaude {
+			t.Errorf("retryAfter = %v, want %v", after, wantClaude)
+		}
+	})
+
+	t.Run("no parseable instant keeps the fixed cooldown", func(t *testing.T) {
+		pinNow(t, now)
+		_, reason, after := ClassifyClaudeError(ErrorSample{
+			Stderr: "You've hit your weekly limit",
+		})
+		if reason != "weekly_limit" || after != weeklyLimitCooldown {
+			t.Errorf("got (%q, %v), want (weekly_limit, %v)", reason, after, weeklyLimitCooldown)
+		}
+	})
+}

--- a/internal/provider/reset_hint_test.go
+++ b/internal/provider/reset_hint_test.go
@@ -112,6 +112,8 @@ func TestParseResetHint(t *testing.T) {
 			text: "try again at Aug 1st, 2026 9:41 AM",
 			ok:   false,
 		},
+		{"zero hour with pm is malformed", "resets Aug 6 at 0pm", 0, false},
+		{"thirteen with am is malformed", "resets Aug 6 at 13am", 0, false},
 		{"no date at all", "You've hit your weekly limit", 0, false},
 		{"empty", "", 0, false},
 		{"garbage month", "try again at Foo 8th, 2026 9:41 AM", 0, false},
@@ -303,6 +305,39 @@ func TestCooldownSourceIsHonest(t *testing.T) {
 		want := time.Date(2026, time.August, 8, 9, 41, 0, 0, time.Local).Sub(now)
 		if src != CooldownFromProvider || after != want {
 			t.Errorf("got (%v, %q), want (%v, %q)", after, src, want, CooldownFromProvider)
+		}
+	})
+}
+
+// A stale-but-parseable hint and text with no date produce the same park, so
+// the source must distinguish them or an operator cannot tell a provider whose
+// message was out of date from one that said nothing.
+func TestPastInstantIsReportedAsRejected(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
+
+	t.Run("past instant", func(t *testing.T) {
+		pinNow(t, now)
+		_, outcome := parseResetHint("try again at Aug 1st, 2026 9:41 AM")
+		if outcome != HintRejected {
+			t.Errorf("outcome = %v, want HintRejected for a stale instant", outcome)
+		}
+	})
+
+	t.Run("no date at all", func(t *testing.T) {
+		pinNow(t, now)
+		_, outcome := parseResetHint("You've hit your weekly limit")
+		if outcome != HintNone {
+			t.Errorf("outcome = %v, want HintNone when no date is present", outcome)
+		}
+	})
+
+	t.Run("surfaces through the classifier", func(t *testing.T) {
+		pinNow(t, now)
+		_, _, _, src := ClassifyCodexError(ErrorSample{
+			Stderr: "ERROR: usage limit. Please try again at Aug 1st, 2026 9:41 AM.",
+		})
+		if src != CooldownHintRejected {
+			t.Errorf("source = %q, want %q", src, CooldownHintRejected)
 		}
 	})
 }

--- a/internal/provider/reset_hint_test.go
+++ b/internal/provider/reset_hint_test.go
@@ -122,11 +122,11 @@ func TestParseResetHint(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			pinNow(t, now)
-			got, ok := parseResetHint(tc.text)
-			if ok != tc.ok {
-				t.Fatalf("parseResetHint(%q) ok = %v, want %v (got %v)", tc.text, ok, tc.ok, got)
+			got, outcome := parseResetHint(tc.text)
+			if parsed := outcome == HintParsed; parsed != tc.ok {
+				t.Fatalf("parseResetHint(%q) outcome = %v, want parsed=%v (got %v)", tc.text, outcome, tc.ok, got)
 			}
-			if ok && got != tc.want {
+			if outcome == HintParsed && got != tc.want {
 				t.Errorf("parseResetHint(%q) = %v, want %v", tc.text, got, tc.want)
 			}
 		})
@@ -139,8 +139,9 @@ func TestParseResetHint(t *testing.T) {
 func TestParseResetHint_RejectsFarFutureInstant(t *testing.T) {
 	pinNow(t, time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local))
 
-	if got, ok := parseResetHint("try again at Aug 8th, 2099 9:41 AM"); ok {
-		t.Errorf("parseResetHint = (%v, true), want rejection so the caller falls back", got)
+	got, outcome := parseResetHint("try again at Aug 8th, 2099 9:41 AM")
+	if outcome != HintRejected {
+		t.Errorf("parseResetHint = (%v, %v), want HintRejected so the caller falls back", got, outcome)
 	}
 }
 
@@ -149,9 +150,9 @@ func TestParseResetHint_RejectsFarFutureInstant(t *testing.T) {
 func TestParseResetHint_FloorsImminentInstant(t *testing.T) {
 	pinNow(t, time.Date(2026, time.August, 5, 16, 59, 59, 0, time.Local))
 
-	got, ok := parseResetHint("resets Aug 5 at 5pm")
-	if !ok {
-		t.Fatal("parseResetHint rejected an imminent future instant")
+	got, outcome := parseResetHint("resets Aug 5 at 5pm")
+	if outcome != HintParsed {
+		t.Fatalf("parseResetHint outcome = %v, want HintParsed", outcome)
 	}
 	if got != minResetHint {
 		t.Errorf("parseResetHint = %v, want floor of %v", got, minResetHint)
@@ -167,7 +168,7 @@ func TestClassifiers_PreferProviderResetOverFixedCooldown(t *testing.T) {
 
 	t.Run("codex", func(t *testing.T) {
 		pinNow(t, now)
-		sig, reason, after := ClassifyCodexError(ErrorSample{
+		sig, reason, after, _ := ClassifyCodexError(ErrorSample{
 			Stderr: "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 9:41 AM.",
 		})
 		if sig != SignalRateLimit {
@@ -184,7 +185,7 @@ func TestClassifiers_PreferProviderResetOverFixedCooldown(t *testing.T) {
 	t.Run("claude weekly limit overrides the hour default", func(t *testing.T) {
 		pinNow(t, now)
 		wantClaude := time.Date(2026, time.August, 7, 17, 0, 0, 0, time.Local).Sub(now)
-		sig, reason, after := ClassifyClaudeError(ErrorSample{
+		sig, reason, after, _ := ClassifyClaudeError(ErrorSample{
 			Stderr: "You've hit your weekly limit · resets Aug 7 at 5pm",
 		})
 		if sig != SignalRateLimit || reason != "weekly_limit" {
@@ -200,11 +201,86 @@ func TestClassifiers_PreferProviderResetOverFixedCooldown(t *testing.T) {
 
 	t.Run("no parseable instant keeps the fixed cooldown", func(t *testing.T) {
 		pinNow(t, now)
-		_, reason, after := ClassifyClaudeError(ErrorSample{
+		_, reason, after, _ := ClassifyClaudeError(ErrorSample{
 			Stderr: "You've hit your weekly limit",
 		})
 		if reason != "weekly_limit" || after != weeklyLimitCooldown {
 			t.Errorf("got (%q, %v), want (weekly_limit, %v)", reason, after, weeklyLimitCooldown)
+		}
+	})
+}
+
+// A clean, exit-0 run's content is the agent's own prose, which routinely
+// discusses rate limits and dates — the text below is close to what an agent
+// working on this very file would write. Parsing it let an agent park its own
+// provider for days off a successful run.
+func TestCleanResultContentNeverSuppliesAResetHint(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
+	pinNow(t, now)
+
+	prose := "Done. I implemented the reset-hint parser for the case where codex says " +
+		"you've hit your usage limit and prints: try again at Aug 12th, 2026 9:00 AM."
+
+	_, _, after, src := ClassifyClaudeError(ErrorSample{Content: prose, ContentIsCleanResult: true})
+	if src == CooldownFromProvider {
+		t.Errorf("clean result content supplied a provider hint (%v); agent prose must never park its own provider", after)
+	}
+	if after > weeklyLimitCooldown {
+		t.Errorf("clean result content produced a %v park, longer than the fixed fallback %v", after, weeklyLimitCooldown)
+	}
+}
+
+// A decoy that parses cleanly but sits further out must not beat the real
+// hint: the ceiling only bounds the damage, it does not prevent an over-park.
+func TestEarliestValidInstantWins(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
+	pinNow(t, now)
+
+	text := "INFO: scheduler note: try again at Aug 12th, 2026 9:00 AM if backoff persists\n" +
+		"ERROR: You've hit your usage limit. Please try again at Aug 8th, 2026 9:41 AM."
+	got, outcome := parseResetHint(text)
+	want := time.Date(2026, time.August, 8, 9, 41, 0, 0, time.Local).Sub(now)
+	if outcome != HintParsed || got != want {
+		t.Errorf("parseResetHint = (%v, %v), want (%v, HintParsed) — the earlier instant", got, outcome, want)
+	}
+}
+
+// A park whose duration came from a constant must not claim the provider
+// stated it, and a rejected hint must be distinguishable from no hint at all.
+func TestCooldownSourceIsHonest(t *testing.T) {
+	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
+
+	t.Run("constant fallback is not a provider hint", func(t *testing.T) {
+		pinNow(t, now)
+		_, reason, after, src := ClassifyCodexError(ErrorSample{
+			Stderr: "ERROR: You've hit your weekly limit. Please try again later.",
+		})
+		if reason != "weekly_limit" || after != weeklyLimitCooldown {
+			t.Fatalf("got (%q, %v), want the weekly constant", reason, after)
+		}
+		if src != CooldownFromConfig {
+			t.Errorf("source = %q, want %q — nothing was parsed from the provider", src, CooldownFromConfig)
+		}
+	})
+
+	t.Run("out-of-range hint is distinguishable from no hint", func(t *testing.T) {
+		pinNow(t, now)
+		_, _, _, src := ClassifyCodexError(ErrorSample{
+			Stderr: "ERROR: You've hit your usage limit. Please try again at Dec 25th, 2026 9:41 AM.",
+		})
+		if src != CooldownHintRejected {
+			t.Errorf("source = %q, want %q so an out-of-range parse leaves a trace", src, CooldownHintRejected)
+		}
+	})
+
+	t.Run("ansi coloured message still parses", func(t *testing.T) {
+		pinNow(t, now)
+		_, _, after, src := ClassifyCodexError(ErrorSample{
+			Stderr: "\x1b[1;31mERROR:\x1b[0m usage limit. Please try again at \x1b[1mAug 8th, 2026 9:41 AM\x1b[0m.",
+		})
+		want := time.Date(2026, time.August, 8, 9, 41, 0, 0, time.Local).Sub(now)
+		if src != CooldownFromProvider || after != want {
+			t.Errorf("got (%v, %q), want (%v, %q)", after, src, want, CooldownFromProvider)
 		}
 	})
 }

--- a/internal/provider/reset_hint_test.go
+++ b/internal/provider/reset_hint_test.go
@@ -62,14 +62,49 @@ func TestParseResetHint(t *testing.T) {
 			ok:   true,
 		},
 		{
-			// A yearless date already past this year rolls forward rather
-			// than producing a negative duration that would be discarded —
-			// and the clamp then caps the resulting months-long park.
-			name: "yearless date already past rolls forward then clamps",
+			// Barely past means the limit has already reset, not that it
+			// resets next year. Rolling forward here would park the provider
+			// for a week where the fixed cooldown parks it for an hour —
+			// strictly worse than doing nothing.
+			name: "yearless date barely past falls back",
+			text: "resets Aug 5 at 3pm",
+			ok:   false,
+		},
+		{
+			// Far past is genuinely next year, but that lands beyond the
+			// ceiling and is rejected rather than capped.
+			name: "yearless date far past exceeds the ceiling",
 			text: "resets Jan 3 at 9am",
-			want: maxResetHint,
+			ok:   false,
+		},
+		{
+			// A decoy date in agent prose or tool output must not shadow or
+			// corrupt the real hint that follows it.
+			name: "earlier date-shaped decoy does not win",
+			text: "tool output: git reset origin 1 at 3pm baseline\nYou've hit your weekly limit · resets Aug 7 at 5pm",
+			want: time.Date(2026, time.August, 7, 17, 0, 0, 0, time.Local).Sub(now),
 			ok:   true,
 		},
+		{
+			name: "past decoy does not win",
+			text: "note: reset May 1 at 9am was the last incident\nYou've hit your weekly limit · resets Aug 7 at 5pm",
+			want: time.Date(2026, time.August, 7, 17, 0, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{
+			// A malformed year must not have a two-digit prefix reinterpreted
+			// as the hour.
+			name: "malformed year does not become an hour",
+			text: "try again at Aug 8th, 20261 9:41 AM",
+			ok:   false,
+		},
+		{
+			name: "date-at-time phrasing parses",
+			text: "try again at Aug 6, 2026 at 9:41 AM",
+			want: time.Date(2026, time.August, 6, 9, 41, 0, 0, time.Local).Sub(now),
+			ok:   true,
+		},
+		{"impossible pm hour", "resets Aug 6 at 23pm", 0, false},
 		{
 			// A stale message quoted from an earlier failure must not park
 			// the provider at all.
@@ -98,18 +133,28 @@ func TestParseResetHint(t *testing.T) {
 	}
 }
 
-// A wrong-century or otherwise absurd parse must not take the provider offline
-// for years.
-func TestParseResetHint_ClampsFarFutureInstant(t *testing.T) {
-	now := time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local)
-	pinNow(t, now)
+// A wrong-century parse must fall back to the configured cooldown, not park
+// the provider for the ceiling. Capping a misparse turns it into the worst
+// available outcome; rejecting it is never worse than today.
+func TestParseResetHint_RejectsFarFutureInstant(t *testing.T) {
+	pinNow(t, time.Date(2026, time.August, 5, 15, 4, 0, 0, time.Local))
 
-	got, ok := parseResetHint("try again at Aug 8th, 2099 9:41 AM")
-	if !ok {
-		t.Fatal("parseResetHint returned ok=false for a far-future instant, want clamped")
+	if got, ok := parseResetHint("try again at Aug 8th, 2099 9:41 AM"); ok {
+		t.Errorf("parseResetHint = (%v, true), want rejection so the caller falls back", got)
 	}
-	if got != maxResetHint {
-		t.Errorf("parseResetHint = %v, want clamp to %v", got, maxResetHint)
+}
+
+// A hint parsed moments before its own instant must not produce a sub-second
+// park, which buys exactly one doomed dispatch.
+func TestParseResetHint_FloorsImminentInstant(t *testing.T) {
+	pinNow(t, time.Date(2026, time.August, 5, 16, 59, 59, 0, time.Local))
+
+	got, ok := parseResetHint("resets Aug 5 at 5pm")
+	if !ok {
+		t.Fatal("parseResetHint rejected an imminent future instant")
+	}
+	if got != minResetHint {
+		t.Errorf("parseResetHint = %v, want floor of %v", got, minResetHint)
 	}
 }
 

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -41,14 +41,23 @@ const (
 // caller's default. Parsing runs on the raw (non-lowercased) sample so month
 // names survive.
 //
-// Content is consulted ONLY for a non-clean result. A successful exit-0 run's
-// content is the agent's own prose, which routinely discusses rate limits and
-// dates — including the source of this very file. Parsing that would let an
-// agent talking about a usage limit park its own provider for days, turning a
-// pre-existing content false-positive worth 15 minutes into one worth a week.
+// A clean result supplies NO reset hint, from any surface. A successful exit-0
+// run's content is the agent's own prose, which routinely discusses rate limits
+// and dates — including the source of this very file. Its stderr is provider
+// and tool warnings: an MCP server or a fallback-model notice can quote a usage
+// limit while the run itself succeeded.
+//
+// Guarding content alone is not enough, and was not: the same defect
+// reproduced through stderr, parking every enabled provider for 59 hours off
+// two successful runs and leaving failover nowhere to go — against 15 minutes
+// before this parsing existed. If the provider served the run, it did not
+// refuse it, so nothing in that run states when it will serve again.
 func rateLimitCooldown(s ErrorSample, fallback time.Duration) (time.Duration, CooldownSource) {
+	if s.ContentIsCleanResult {
+		return fallback, CooldownFromConfig
+	}
 	d, outcome := parseResetHint(s.Stderr)
-	if outcome == HintNone && !s.ContentIsCleanResult {
+	if outcome == HintNone {
 		d, outcome = parseResetHint(s.Content)
 	}
 	switch outcome {

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -26,17 +26,39 @@ const connectivityCooldown = 60 * time.Second
 // would just churn retries against the same exhausted limit.
 const weeklyLimitCooldown = time.Hour
 
+// CooldownSource records where a park's duration came from, so an operator
+// tracing a surprising window can tell a provider-stated instant from a
+// configured guess — and from a provider message whose instant was rejected.
+type CooldownSource string
+
+const (
+	CooldownFromConfig   CooldownSource = "configured_cooldown"
+	CooldownFromProvider CooldownSource = "provider_hint"
+	CooldownHintRejected CooldownSource = "provider_hint_rejected"
+)
+
 // rateLimitCooldown prefers a provider-supplied reset instant over the
-// caller's default. Parsing runs on the raw (non-lowercased) sample so the
-// month names survive, and falls back silently when nothing parses.
-func rateLimitCooldown(s ErrorSample, fallback time.Duration) time.Duration {
-	if d, ok := parseResetHint(s.Stderr); ok {
-		return d
+// caller's default. Parsing runs on the raw (non-lowercased) sample so month
+// names survive.
+//
+// Content is consulted ONLY for a non-clean result. A successful exit-0 run's
+// content is the agent's own prose, which routinely discusses rate limits and
+// dates — including the source of this very file. Parsing that would let an
+// agent talking about a usage limit park its own provider for days, turning a
+// pre-existing content false-positive worth 15 minutes into one worth a week.
+func rateLimitCooldown(s ErrorSample, fallback time.Duration) (time.Duration, CooldownSource) {
+	d, outcome := parseResetHint(s.Stderr)
+	if outcome == HintNone && !s.ContentIsCleanResult {
+		d, outcome = parseResetHint(s.Content)
 	}
-	if d, ok := parseResetHint(s.Content); ok {
-		return d
+	switch outcome {
+	case HintParsed:
+		return d, CooldownFromProvider
+	case HintRejected:
+		return fallback, CooldownHintRejected
+	default:
+		return fallback, CooldownFromConfig
 	}
-	return fallback
 }
 
 // ErrorSample is the runner→classifier DTO. Using a plain struct (instead of
@@ -58,32 +80,35 @@ type ErrorSample struct {
 // 529/overloaded is intentionally NOT classified here — the retry path in
 // runner_headless.go already handles transient overload without marking the
 // provider unhealthy.
-func ClassifyClaudeError(s ErrorSample) (Signal, string, time.Duration) {
+func ClassifyClaudeError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
 	if s.ErrorStatus == 401 || s.ErrorType == "authentication_error" || s.ErrorType == "invalid_api_key" {
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	}
 	stderr := strings.ToLower(s.Stderr)
 	content := strings.ToLower(s.Content)
 	if containsAny(stderr, "not logged in", "please run claude auth login", "unauthorized") ||
 		containsAny(content, "not logged in", "please run claude auth login") {
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	}
 	// Weekly-limit phrasing is checked before the structured 429/rate_limit_error
 	// short-circuit below: providers can attach a generic rate-limit error code
 	// to a weekly-quota-exhaustion message, and the longer weeklyLimitCooldown
 	// park only applies if the text is inspected first.
 	if isWeeklyLimitText(stderr, content, s.ContentIsCleanResult) {
-		return SignalRateLimit, "weekly_limit", rateLimitCooldown(s, weeklyLimitCooldown)
+		cooldown, src := rateLimitCooldown(s, weeklyLimitCooldown)
+		return SignalRateLimit, "weekly_limit", cooldown, src
 	}
 	if s.ErrorStatus == 429 || s.ErrorType == "rate_limit_error" || s.ErrorType == "credit_balance_too_low" {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), rateLimitCooldown(s, 0)
+		cooldown, src := rateLimitCooldown(s, 0)
+		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), cooldown, src
 	}
 	if containsAny(stderr, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") ||
 		containsRateLimitContent(content, s.ContentIsCleanResult,
 			"rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") {
-		return SignalRateLimit, "rate_limited", rateLimitCooldown(s, 0)
+		cooldown, src := rateLimitCooldown(s, 0)
+		return SignalRateLimit, "rate_limited", cooldown, src
 	}
-	return SignalNone, "", 0
+	return SignalNone, "", 0, CooldownFromConfig
 }
 
 // isWeeklyLimit reports whether text contains a weekly-specific limit
@@ -142,22 +167,23 @@ func isCodexConnectivityText(text string) bool {
 // taxonomy is less well-known at design time, so we lean on substring matching
 // and let the runner log SignalNone cases with the raw strings for iterative
 // discovery.
-func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration) {
+func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
 	if s.ErrorStatus == 401 || strings.EqualFold(s.ErrorType, "unauthorized") {
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	}
 	stderr := strings.ToLower(s.Stderr)
 	content := strings.ToLower(s.Content)
 	if containsAny(stderr, "not logged in", "please run: codex login", "please run codex login", "unauthorized") ||
 		containsAny(content, "not logged in", "please run: codex login") {
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	}
 	// Weekly-limit phrasing is checked before the structured 429/rate_limit
 	// short-circuit below: providers can attach a generic rate-limit error
 	// code to a weekly-quota-exhaustion message, and the longer
 	// weeklyLimitCooldown park only applies if the text is inspected first.
 	if isWeeklyLimitText(stderr, content, s.ContentIsCleanResult) {
-		return SignalRateLimit, "weekly_limit", rateLimitCooldown(s, weeklyLimitCooldown)
+		cooldown, src := rateLimitCooldown(s, weeklyLimitCooldown)
+		return SignalRateLimit, "weekly_limit", cooldown, src
 	}
 	// Host-anchored: a bare "websocket connection" without the codex backend
 	// host must NOT match — it would false-positive on unrelated network
@@ -177,17 +203,19 @@ func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration) {
 	// itself hit a connectivity failure — see containsRateLimitContent for
 	// the same distinction on the rate-limit path.
 	if isCodexConnectivityText(stderr) || (!s.ContentIsCleanResult && isCodexConnectivityText(content)) {
-		return SignalRateLimit, "connectivity", connectivityCooldown
+		return SignalRateLimit, "connectivity", connectivityCooldown, CooldownFromConfig
 	}
 	if s.ErrorStatus == 429 || strings.EqualFold(s.ErrorType, "rate_limit") || strings.EqualFold(s.ErrorType, "insufficient_quota") {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), rateLimitCooldown(s, 0)
+		cooldown, src := rateLimitCooldown(s, 0)
+		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), cooldown, src
 	}
 	if containsAny(stderr, "rate_limit", "rate limit", "insufficient_quota", "quota exceeded", "usage limit", "weekly limit") ||
 		containsRateLimitContent(content, s.ContentIsCleanResult,
 			"rate_limit", "rate limit", "insufficient_quota", "quota exceeded", "usage limit", "weekly limit") {
-		return SignalRateLimit, "rate_limited", rateLimitCooldown(s, 0)
+		cooldown, src := rateLimitCooldown(s, 0)
+		return SignalRateLimit, "rate_limited", cooldown, src
 	}
-	return SignalNone, "", 0
+	return SignalNone, "", 0, CooldownFromConfig
 }
 
 // ClassifyCopilotError mirrors the other classifiers for GitHub Copilot CLI
@@ -196,37 +224,37 @@ func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration) {
 // (kept in sync with isLoggedOutStderr). Without a copilot-specific classifier
 // a logged-out/quota-exhausted copilot would return SignalNone and the health
 // gate would keep routing failover work to a dead provider.
-func ClassifyCopilotError(s ErrorSample) (Signal, string, time.Duration) {
+func ClassifyCopilotError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
 	if s.ErrorStatus == 401 || strings.EqualFold(s.ErrorType, "unauthorized") {
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	}
 	if s.ErrorStatus == 429 || strings.EqualFold(s.ErrorType, "rate_limit") || strings.EqualFold(s.ErrorType, "insufficient_quota") {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0
+		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0, CooldownFromConfig
 	}
 	stderr := strings.ToLower(s.Stderr)
 	content := strings.ToLower(s.Content)
 	authNeedles := []string{"not logged in", "not authenticated", "please run: copilot login", "run `copilot login`", "run 'copilot login'", "unauthorized"}
 	if containsAny(stderr, authNeedles...) || containsAny(content, authNeedles...) {
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	}
 	// Copilot meters usage in "premium requests"; an exhausted allowance is the
 	// copilot analogue of a rate limit.
 	quotaNeedles := []string{"rate_limit", "rate limit", "quota", "premium request", "usage limit", "monthly limit"}
 	if containsAny(stderr, quotaNeedles...) || containsRateLimitContent(content, s.ContentIsCleanResult, quotaNeedles...) {
-		return SignalRateLimit, "rate_limited", 0
+		return SignalRateLimit, "rate_limited", 0, CooldownFromConfig
 	}
-	return SignalNone, "", 0
+	return SignalNone, "", 0, CooldownFromConfig
 }
 
 // ClassifyOpenCodeError classifies OpenCode CLI failures. OpenCode can front
 // many providers, so keep the patterns generic and avoid provider-specific
 // assumptions beyond common HTTP/auth/rate-limit vocabulary.
-func ClassifyOpenCodeError(s ErrorSample) (Signal, string, time.Duration) {
+func ClassifyOpenCodeError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
 	if s.ErrorStatus == 401 || s.ErrorStatus == 403 {
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	}
 	if s.ErrorStatus == 429 {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0
+		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0, CooldownFromConfig
 	}
 	hay := strings.ToLower(strings.Join([]string{s.ErrorType, s.Stderr, s.Content}, "\n"))
 	switch {
@@ -235,15 +263,15 @@ func ClassifyOpenCodeError(s ErrorSample) (Signal, string, time.Duration) {
 		strings.Contains(hay, "unauthorized"),
 		strings.Contains(hay, "invalid api key"),
 		strings.Contains(hay, "missing api key"):
-		return SignalAuthFailure, "logged_out", 0
+		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
 	case strings.Contains(hay, "rate limit"),
 		strings.Contains(hay, "too many requests"),
 		strings.Contains(hay, "quota"),
 		strings.Contains(hay, "insufficient credits"),
 		strings.Contains(hay, "credit balance"):
-		return SignalRateLimit, "rate_limited", 0
+		return SignalRateLimit, "rate_limited", 0, CooldownFromConfig
 	}
-	return SignalNone, "", 0
+	return SignalNone, "", 0, CooldownFromConfig
 }
 
 func containsRateLimitContent(content string, cleanResult bool, broadNeedles ...string) bool {

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -26,6 +26,19 @@ const connectivityCooldown = 60 * time.Second
 // would just churn retries against the same exhausted limit.
 const weeklyLimitCooldown = time.Hour
 
+// rateLimitCooldown prefers a provider-supplied reset instant over the
+// caller's default. Parsing runs on the raw (non-lowercased) sample so the
+// month names survive, and falls back silently when nothing parses.
+func rateLimitCooldown(s ErrorSample, fallback time.Duration) time.Duration {
+	if d, ok := parseResetHint(s.Stderr); ok {
+		return d
+	}
+	if d, ok := parseResetHint(s.Content); ok {
+		return d
+	}
+	return fallback
+}
+
 // ErrorSample is the runner→classifier DTO. Using a plain struct (instead of
 // agent.StreamEvent directly) prevents an import cycle between internal/agent
 // and internal/provider.
@@ -60,15 +73,15 @@ func ClassifyClaudeError(s ErrorSample) (Signal, string, time.Duration) {
 	// to a weekly-quota-exhaustion message, and the longer weeklyLimitCooldown
 	// park only applies if the text is inspected first.
 	if isWeeklyLimitText(stderr, content, s.ContentIsCleanResult) {
-		return SignalRateLimit, "weekly_limit", weeklyLimitCooldown
+		return SignalRateLimit, "weekly_limit", rateLimitCooldown(s, weeklyLimitCooldown)
 	}
 	if s.ErrorStatus == 429 || s.ErrorType == "rate_limit_error" || s.ErrorType == "credit_balance_too_low" {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0
+		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), rateLimitCooldown(s, 0)
 	}
 	if containsAny(stderr, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") ||
 		containsRateLimitContent(content, s.ContentIsCleanResult,
 			"rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") {
-		return SignalRateLimit, "rate_limited", 0
+		return SignalRateLimit, "rate_limited", rateLimitCooldown(s, 0)
 	}
 	return SignalNone, "", 0
 }
@@ -144,7 +157,7 @@ func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration) {
 	// code to a weekly-quota-exhaustion message, and the longer
 	// weeklyLimitCooldown park only applies if the text is inspected first.
 	if isWeeklyLimitText(stderr, content, s.ContentIsCleanResult) {
-		return SignalRateLimit, "weekly_limit", weeklyLimitCooldown
+		return SignalRateLimit, "weekly_limit", rateLimitCooldown(s, weeklyLimitCooldown)
 	}
 	// Host-anchored: a bare "websocket connection" without the codex backend
 	// host must NOT match — it would false-positive on unrelated network
@@ -167,12 +180,12 @@ func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration) {
 		return SignalRateLimit, "connectivity", connectivityCooldown
 	}
 	if s.ErrorStatus == 429 || strings.EqualFold(s.ErrorType, "rate_limit") || strings.EqualFold(s.ErrorType, "insufficient_quota") {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0
+		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), rateLimitCooldown(s, 0)
 	}
 	if containsAny(stderr, "rate_limit", "rate limit", "insufficient_quota", "quota exceeded", "usage limit", "weekly limit") ||
 		containsRateLimitContent(content, s.ContentIsCleanResult,
 			"rate_limit", "rate limit", "insufficient_quota", "quota exceeded", "usage limit", "weekly limit") {
-		return SignalRateLimit, "rate_limited", 0
+		return SignalRateLimit, "rate_limited", rateLimitCooldown(s, 0)
 	}
 	return SignalNone, "", 0
 }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/provider"
+
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/blocker"
 	"github.com/Automaat/sybra/internal/logging"
@@ -78,8 +80,8 @@ func (f fakeGate) Reason(string) string {
 	}
 	return ""
 }
-func (f fakeGate) ReportAuthFailure(string, string)              {}
-func (f fakeGate) ReportRateLimit(string, time.Duration, string) {}
+func (f fakeGate) ReportAuthFailure(string, string)                                       {}
+func (f fakeGate) ReportRateLimit(string, time.Duration, string, provider.CooldownSource) {}
 
 // TestRunStartupCleanupEmpty verifies the boot pass is idempotent on a
 // fresh, empty store — no panics, no error returns, no spurious task

--- a/internal/selfmonitor/provider_feedback_test.go
+++ b/internal/selfmonitor/provider_feedback_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/provider"
+
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -28,8 +30,8 @@ func (s *stubProviderGate) RateLimited(_ string) bool     { return false }
 func (s *stubProviderGate) Failover(_ string) string      { return "" }
 func (s *stubProviderGate) Reason(_ string) string        { return "" }
 func (s *stubProviderGate) ReportAuthFailure(_, _ string) {}
-func (s *stubProviderGate) ReportRateLimit(provider string, after time.Duration, reason string) {
-	s.calls = append(s.calls, providerRateLimitCall{provider: provider, after: after, reason: reason})
+func (s *stubProviderGate) ReportRateLimit(name string, after time.Duration, reason string, _ provider.CooldownSource) {
+	s.calls = append(s.calls, providerRateLimitCall{provider: name, after: after, reason: reason})
 }
 
 // overloadedFixtureLines returns a Codex-format NDJSON stream that produces

--- a/internal/selfmonitor/service.go
+++ b/internal/selfmonitor/service.go
@@ -344,7 +344,7 @@ func (s *Service) reportProviderSignal(f *health.Finding, ls *LogSummary) {
 	for _, ec := range ls.ErrorClasses {
 		if ec.Class == "overloaded_error" || ec.Class == "rate_limit" {
 			s.deps.ProviderGate.ReportRateLimit(providerName, 15*time.Minute,
-				"selfmonitor: agent_retry_loop with "+ec.Class)
+				"selfmonitor: agent_retry_loop with "+ec.Class, provider.CooldownFromConfig)
 			s.deps.Logger.Info("selfmonitor.provider_signal",
 				"class", ec.Class, "task", f.TaskID, "provider", providerName)
 			return

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	synapsegithub "github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/sybra/completion"
 	"github.com/Automaat/sybra/internal/task"
@@ -4549,7 +4550,7 @@ func (g *scriptedGate) ReportAuthFailure(provider, reason string) {
 	g.reason[provider] = reason
 }
 
-func (g *scriptedGate) ReportRateLimit(provider string, retryAfter time.Duration, reason string) {
+func (g *scriptedGate) ReportRateLimit(provider string, retryAfter time.Duration, reason string, _ provider.CooldownSource) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.healthy[provider] = false
@@ -4608,7 +4609,7 @@ func (g *cooldownGate) ReportAuthFailure(provider, reason string) {
 	g.limitedTo[provider] = time.Now().Add(5 * time.Minute)
 }
 
-func (g *cooldownGate) ReportRateLimit(provider string, retryAfter time.Duration, reason string) {
+func (g *cooldownGate) ReportRateLimit(provider string, retryAfter time.Duration, reason string, _ provider.CooldownSource) {
 	if retryAfter <= 0 {
 		retryAfter = 200 * time.Millisecond
 	}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -6162,7 +6162,7 @@ func TestE2E_RateLimitCooldownWindowCorrectness(t *testing.T) {
 	env := setupE2EMultiProvider(t, "claude", []string{"success", "success"})
 	g := newCooldownGate()
 	env.agents.SetHealthGate(g)
-	g.ReportRateLimit("claude", 200*time.Millisecond, "rate_limited")
+	g.ReportRateLimit("claude", 200*time.Millisecond, "rate_limited", provider.CooldownFromConfig)
 
 	ag1, err := env.agents.Run(agent.RunConfig{
 		TaskID:   "cooldown-1",

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -218,7 +218,7 @@ type Watchdog struct {
 	// recordProviderSignal forwards a watchdog-detected provider signal through
 	// the same agent-manager helper the runner uses, so the agent error kind and
 	// provider health gate stay in sync across both paths.
-	recordProviderSignal func(*agent.Agent, provider.Signal, string, time.Duration)
+	recordProviderSignal func(*agent.Agent, provider.Signal, string, time.Duration, provider.CooldownSource)
 	// hasLiveHeadlessAgent reports whether a task has a registered live
 	// headless agent. checkDwell uses it to skip escalating a task whose
 	// headless run is mid-flight but hasn't touched the task file recently —
@@ -874,7 +874,7 @@ func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict age
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if w.recordProviderSignal != nil {
-		w.recordProviderSignal(ag, provider.SignalRateLimit, reason, 0)
+		w.recordProviderSignal(ag, provider.SignalRateLimit, reason, 0, provider.CooldownFromConfig)
 	}
 	if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
@@ -977,7 +977,7 @@ func (w *Watchdog) handleZeroOutputStall(ag *agent.Agent, stall, total time.Dura
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if w.recordProviderSignal != nil {
-		w.recordProviderSignal(ag, provider.SignalRateLimit, zeroOutputReason, 0)
+		w.recordProviderSignal(ag, provider.SignalRateLimit, zeroOutputReason, 0, provider.CooldownFromConfig)
 	}
 	if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1100,7 +1100,7 @@ func TestApplyVerdict_RateLimitStopReschedulesInsteadOfEscalating(t *testing.T) 
 				tasks:     tasks,
 				logger:    slog.New(slog.DiscardHandler),
 				stopAgent: func(string) error { stopped = true; return nil },
-				recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration) {
+				recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
 					ag.SetError("rate_limit", reason)
 					signaledName, signaledKind, signaledReason = ag.Provider, sig, reason
 				},
@@ -1147,7 +1147,7 @@ func TestApplyVerdict_RateLimitStopWithoutTaskStillSignalsAndStops(t *testing.T)
 	w := &Watchdog{
 		logger:    slog.New(slog.DiscardHandler),
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration) {
+		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
 			ag.SetError("rate_limit", reason)
 			signaledName, signaledKind = ag.Provider, sig
 			if reason == "" {
@@ -1191,7 +1191,7 @@ func TestHandleZeroOutputStall_SignalsProviderAndReschedulesInsteadOfEscalating(
 		tasks:     tasks,
 		logger:    slog.New(slog.DiscardHandler),
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration) {
+		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
 			ag.SetError("rate_limit", reason)
 			signaledName, signaledKind, signaledReason = ag.Provider, sig, reason
 		},
@@ -1229,7 +1229,7 @@ func TestHandleZeroOutputStall_NoTaskStillSignalsAndStops(t *testing.T) {
 	w := &Watchdog{
 		logger:               slog.New(slog.DiscardHandler),
 		stopAgent:            func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(*agent.Agent, provider.Signal, string, time.Duration) {},
+		recordProviderSignal: func(*agent.Agent, provider.Signal, string, time.Duration, provider.CooldownSource) {},
 	}
 
 	w.handleZeroOutputStall(&agent.Agent{ID: "a1", Provider: "claude"}, time.Hour, time.Hour, task.StatusInProgress)
@@ -1258,7 +1258,7 @@ func TestInspectHeadless_ZeroOutputStallSkipsJudge(t *testing.T) {
 			return agent.InspectorVerdict{Recommendation: "continue"}, nil
 		},
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration) {
+		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
 			ag.SetError("rate_limit", reason)
 			signaledReason = reason
 		},
@@ -1406,7 +1406,7 @@ func TestInspectHeadless_ReattachedSurvivorZeroOutputSkipsJudge(t *testing.T) {
 			return agent.InspectorVerdict{Recommendation: "continue"}, nil
 		},
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration) {
+		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
 			ag.SetError("rate_limit", reason)
 			signaledReason = reason
 		},


### PR DESCRIPTION
## Motivation

Providers state exactly when they will serve again. Codex, probed on the deploy
host, prints:

```
ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage
to purchase more credits or try again at Aug 8th, 2026 9:41 AM.
```

That is a three-day window, and the classifiers threw it away, returning a fixed
cooldown instead — one hour for a weekly limit, the configured 900s otherwise.
The result was a retry every fifteen minutes for three days, each one a wasted
dispatch that surfaced as a `monitor.dispatch.failed` charged against the task
rather than against the fleet.

> Changelog: fix(provider): honor provider-supplied reset times

## Implementation information

Parse the instant out of the error text and use it as the retry-after hint,
falling back to the configured cooldown whenever the result would be a guess.

- **Fail closed.** An instant that is already past, or beyond a seven-day
  ceiling, is rejected rather than capped, so every uncertain parse lands on the
  existing behaviour. Capping turns a misparse into the worst possible outcome;
  rejecting is never worse than today.
- **A served run supplies no hint.** If the provider served the run, it did not
  refuse it, so nothing in that run states when it will serve again. No surface
  of a clean result is parsed.
- **Earliest valid instant wins**, not the first match — agent prose and tool
  output carry date-shaped fragments, and a decoy that parses cleanly but sits
  further out would over-park while staying under the ceiling.
- ANSI sequences are stripped; the codex year is `\b`-anchored so a malformed
  number cannot have a two-digit prefix read as the hour; an imminent instant is
  floored so it cannot buy one guaranteed-doomed dispatch.
- Classifiers now return an explicit `CooldownSource`, threaded to the park log.
  Previously the source was inferred from any non-zero duration, so hard-coded
  constants were logged as provider-stated and a rejected hint was
  indistinguishable from no hint at all.

## Supporting documentation

Adversarial code review found the clamp was **worse than making no change**: a
yearless date whose this-year instance had just passed rolled forward a full
year and capped at the ceiling, parking a provider for a week where the old
fixed cooldown parked it for an hour. The same message carrying a year was
correctly rejected, so one instant had two opposite outcomes — and a test
asserted the week-long park as the intended contract.

Three rounds of adversarial manual testing against a live server:

1. A **successful exit-0 run** whose content mentioned a usage limit and a date
   parked the provider for 6.5 days, against 15 minutes on `main`. The trigger
   strings appear verbatim in this PR's own source, so an agent working on
   reset-hint parsing could park its own provider off a run that succeeded.
   Also found: first-match decoys, unhonest park sources, no clamp logging.
2. The fix for that guarded `Content` and left `Stderr` open, so the same defect
   reproduced through the other surface — claude parked 59h, failed over, and
   parked codex too. Every enabled provider down for 2.5 days off two runs that
   succeeded, with failover nowhere left to go: a 238x regression on an
   identical fixture. Fixed by guarding the run rather than the field.
3. PASS. Verified the round-1 and round-2 fixes hold on both the pipe and
   detached dispatch paths; that a genuinely failed run still honours the
   provider instant (~59h, `provider_hint`); that no third surface exists
   (`buildErrorSample` populates four fields, and `ErrorType`/`ErrorStatus`
   never reach a date parser); that a park survives an in-window healthy probe
   and lapses after expiry; and that failover still fires.

Two pre-existing defects found while testing are filed rather than fixed here:
#3066 (a clean run parking a provider for the fixed 15 minutes via
`containsRateLimitContent`) and #3067 (long parks flooding the debug log, and
the 30-minute effect lease being outlived by a multi-day park).

Closes #3043
