### PR TITLE
build(deploy): preflight the CLI config too

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -59,6 +59,21 @@ func main() {
 	os.Exit(run(os.Args[1:]))
 }
 
+// runCheckConfigWithHome applies --home before validating, so the preflight
+// checks the home the caller named rather than whatever SYBRA_HOME happens to
+// hold.
+func runCheckConfigWithHome(homeOverride string, homeErr, jsonOut bool) int {
+	if homeErr {
+		return fatal(jsonOut, "--home requires a value")
+	}
+	if homeOverride != "" {
+		if err := os.Setenv("SYBRA_HOME", homeOverride); err != nil {
+			return fatal(jsonOut, "set SYBRA_HOME: %v", err)
+		}
+	}
+	return runCheckConfig()
+}
+
 // runCheckConfig mirrors sybra-server's -check-config so the deploy preflight
 // can assert both binaries accept the live config, not just the server.
 //
@@ -93,42 +108,55 @@ type homeResolution struct {
 	fromSybraHome   bool
 }
 
+// globalFlags are the flags accepted before, after, or around a subcommand.
+type globalFlags struct {
+	jsonOut      bool
+	checkConfig  bool
+	homeOverride string
+	homeErr      bool
+}
+
+// parseGlobalFlags strips the global flags from args wherever they appear and
+// returns the remainder as the subcommand and its arguments.
+func parseGlobalFlags(args []string) (flags globalFlags, rest []string) {
+	var g globalFlags
+	filtered := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--json":
+			g.jsonOut = true
+		case a == "--home":
+			// Take the tail as a slice rather than indexing: slicing at i+1 is
+			// always valid here, so the emptiness check is provably sufficient
+			// and the bounds analysis stays happy.
+			rest := args[i+1:]
+			if len(rest) == 0 {
+				g.homeErr = true
+				continue
+			}
+			g.homeOverride = rest[0]
+			i++
+		case strings.HasPrefix(a, "--home="):
+			g.homeOverride = strings.TrimPrefix(a, "--home=")
+		case a == "-check-config" || a == "--check-config":
+			g.checkConfig = true
+		default:
+			filtered = append(filtered, a)
+		}
+	}
+	return g, filtered
+}
+
 func run(args []string) int {
 	if len(args) == 0 {
 		usage()
 		return 1
 	}
 
-	// Extract global --json and --home flags before subcommand.
-	jsonOut := false
-	checkConfig := false
-	filtered := make([]string, 0, len(args))
-	homeOverride := ""
-	homeErr := false
-	for i := 0; i < len(args); i++ {
-		a := args[i]
-		switch {
-		case a == "--json":
-			jsonOut = true
-		case a == "--home":
-			// Take the tail as a slice rather than indexing: slicing at
-			// i+1 is always valid here, so the emptiness check below is
-			// provably sufficient and the bounds analysis stays happy.
-			rest := args[i+1:]
-			if len(rest) == 0 {
-				homeErr = true
-				continue
-			}
-			homeOverride = rest[0]
-			i++
-		case strings.HasPrefix(a, "--home="):
-			homeOverride = strings.TrimPrefix(a, "--home=")
-		case a == "-check-config" || a == "--check-config":
-			checkConfig = true
-		default:
-			filtered = append(filtered, a)
-		}
-	}
+	globals, filtered := parseGlobalFlags(args)
+	jsonOut, checkConfig := globals.jsonOut, globals.checkConfig
+	homeOverride, homeErr := globals.homeOverride, globals.homeErr
 
 	// After the global-flag pass, so position does not matter: the preflight is
 	// invoked as `sybra-cli -check-config` today, but `--home DIR
@@ -137,15 +165,7 @@ func run(args []string) int {
 	// runCheckConfig does its own strict load and must not inherit the
 	// task-store fallback that exists for ordinary commands.
 	if checkConfig {
-		if homeErr {
-			return fatal(jsonOut, "--home requires a value")
-		}
-		if homeOverride != "" {
-			if err := os.Setenv("SYBRA_HOME", homeOverride); err != nil {
-				return fatal(jsonOut, "set SYBRA_HOME: %v", err)
-			}
-		}
-		return runCheckConfig()
+		return runCheckConfigWithHome(homeOverride, homeErr, jsonOut)
 	}
 
 	// Detect the hook subcommand before config.Load can abort: codex lifecycle

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -98,12 +98,10 @@ func run(args []string) int {
 		usage()
 		return 1
 	}
-	if args[0] == "-check-config" || args[0] == "--check-config" {
-		return runCheckConfig()
-	}
 
 	// Extract global --json and --home flags before subcommand.
 	jsonOut := false
+	checkConfig := false
 	filtered := make([]string, 0, len(args))
 	homeOverride := ""
 	homeErr := false
@@ -125,9 +123,29 @@ func run(args []string) int {
 			i++
 		case strings.HasPrefix(a, "--home="):
 			homeOverride = strings.TrimPrefix(a, "--home=")
+		case a == "-check-config" || a == "--check-config":
+			checkConfig = true
 		default:
 			filtered = append(filtered, a)
 		}
+	}
+
+	// After the global-flag pass, so position does not matter: the preflight is
+	// invoked as `sybra-cli -check-config` today, but `--home DIR
+	// -check-config` must validate DIR rather than silently treating the flag
+	// as a subcommand. Handled before the home/config plumbing below because
+	// runCheckConfig does its own strict load and must not inherit the
+	// task-store fallback that exists for ordinary commands.
+	if checkConfig {
+		if homeErr {
+			return fatal(jsonOut, "--home requires a value")
+		}
+		if homeOverride != "" {
+			if err := os.Setenv("SYBRA_HOME", homeOverride); err != nil {
+				return fatal(jsonOut, "set SYBRA_HOME: %v", err)
+			}
+		}
+		return runCheckConfig()
 	}
 
 	// Detect the hook subcommand before config.Load can abort: codex lifecycle

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -59,6 +59,34 @@ func main() {
 	os.Exit(run(os.Args[1:]))
 }
 
+// runCheckConfig mirrors sybra-server's -check-config so the deploy preflight
+// can assert both binaries accept the live config, not just the server.
+//
+// They can disagree: the CLI tolerates a config it cannot parse by falling
+// back to a direct task store, so a key the server understands and the CLI
+// does not produces a warning on every invocation rather than a failure. That
+// is how a deployed CLI ended up warning "unknown config key
+// agent.sandbox_read_mode" on every call while the server ran happily — and
+// agents run sybra-cli from inside their worktrees to read and update task
+// state, so a CLI silently dropping the resolved config is a state-drift
+// hazard sitting in the middle of every workflow.
+//
+// LoadNoPersist, not Load, for the same reason the server uses it: a preflight
+// must never mutate the live config.yaml.
+func runCheckConfig() int {
+	cfg, err := config.LoadNoPersist()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "config: invalid:", err)
+		return 1
+	}
+	if err := cfg.ValidateCluster(); err != nil {
+		fmt.Fprintln(os.Stderr, "config: invalid:", err)
+		return 1
+	}
+	fmt.Println("config: ok")
+	return 0
+}
+
 type homeResolution struct {
 	effectiveHome   string
 	fromControlHome bool
@@ -69,6 +97,9 @@ func run(args []string) int {
 	if len(args) == 0 {
 		usage()
 		return 1
+	}
+	if args[0] == "-check-config" || args[0] == "--check-config" {
+		return runCheckConfig()
 	}
 
 	// Extract global --json and --home flags before subcommand.
@@ -82,12 +113,16 @@ func run(args []string) int {
 		case a == "--json":
 			jsonOut = true
 		case a == "--home":
-			if i+1 >= len(args) {
+			// Take the tail as a slice rather than indexing: slicing at
+			// i+1 is always valid here, so the emptiness check below is
+			// provably sufficient and the bounds analysis stays happy.
+			rest := args[i+1:]
+			if len(rest) == 0 {
 				homeErr = true
 				continue
 			}
+			homeOverride = rest[0]
 			i++
-			homeOverride = args[i]
 		case strings.HasPrefix(a, "--home="):
 			homeOverride = strings.TrimPrefix(a, "--home=")
 		default:

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -3136,4 +3136,35 @@ func TestRunCheckConfig(t *testing.T) {
 			}
 		}
 	})
+
+	// Position must not matter: the CLI already strips --json and --home
+	// wherever they appear, and a caller that puts one first would otherwise
+	// have -check-config treated as a subcommand and skip the preflight
+	// entirely.
+	t.Run("flag is routed after other global flags", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("SYBRA_HOME", home)
+		if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte("schema_version: 2\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if code := run([]string{"--json", "-check-config"}); code != 0 {
+			t.Errorf("run(--json -check-config) = %d, want 0", code)
+		}
+	})
+
+	// --home must select the home the preflight validates, not be ignored.
+	t.Run("home override targets the validated config", func(t *testing.T) {
+		good := t.TempDir()
+		bad := t.TempDir()
+		t.Setenv("SYBRA_HOME", good)
+		if err := os.WriteFile(filepath.Join(good, "config.yaml"), []byte("schema_version: 2\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(bad, "config.yaml"), []byte("this_key_does_not_exist: true\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if code := run([]string{"--home", bad, "-check-config"}); code != 1 {
+			t.Errorf("run(--home <invalid> -check-config) = %d, want 1 — the override was ignored", code)
+		}
+	})
 }

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -3080,3 +3080,60 @@ func TestHookCmd_FailsOpenOnBadConfig(t *testing.T) {
 		t.Errorf("hook must produce no stdout; got %q", out)
 	}
 }
+
+// The CLI must reject a config the server would reject, rather than tolerating
+// it. Its normal path falls back to a direct task store on a load failure, so
+// a key the server understands and the CLI does not is a per-invocation
+// warning instead of a failure — that is how a deployed CLI warned "unknown
+// config key agent.sandbox_read_mode" on every call while the server ran fine.
+// The deploy preflight runs this against the live config for exactly that
+// reason.
+func TestRunCheckConfig(t *testing.T) {
+	t.Run("valid config accepted", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("SYBRA_HOME", home)
+		if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte("schema_version: 2\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if code := runCheckConfig(); code != 0 {
+			t.Fatalf("runCheckConfig() = %d, want 0 for a valid config", code)
+		}
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("SYBRA_HOME", home)
+		configPath := filepath.Join(home, "config.yaml")
+		if err := os.WriteFile(configPath, []byte("this_key_does_not_exist: true\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if code := runCheckConfig(); code != 1 {
+			t.Fatalf("runCheckConfig() = %d, want 1 for an unknown config key", code)
+		}
+		// LoadNoPersist, not Load: a preflight must never rewrite the live
+		// config.yaml it is validating.
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "this_key_does_not_exist: true\n" {
+			t.Fatalf("runCheckConfig must not rewrite an invalid config.yaml, got %q", data)
+		}
+	})
+
+	// Assert the SUCCESS case through run(): an unrecognised flag also exits
+	// 1 as an unknown command, so asserting the failure path here would pass
+	// whether or not the flag is wired at all.
+	t.Run("flag is routed by run", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("SYBRA_HOME", home)
+		if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte("schema_version: 2\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		for _, flag := range []string{"-check-config", "--check-config"} {
+			if code := run([]string{flag}); code != 0 {
+				t.Errorf("run(%s) = %d, want 0 — the flag is not routed", flag, code)
+			}
+		}
+	})
+}

--- a/deploy/bin/sybra-build.sh
+++ b/deploy/bin/sybra-build.sh
@@ -47,7 +47,7 @@ BUILD_RETRY_THRESHOLD="${SYBRA_BUILD_RETRY_THRESHOLD:-3}"
 # phase depends on transient host/network/toolchain state.
 is_deterministic_phase() {
   case "$1" in
-    config-preflight) return 0 ;;
+    config-preflight | config-preflight-cli) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -176,9 +176,18 @@ main() {
   # exact live config before it is ever activated. Deterministic given an
   # unchanged sha+config, so a failure here is quarantined immediately rather
   # than retried — see the acceptance bar in issue #2729.
-  log "preflight: validating live config (fingerprint=$(config_fingerprint)) against candidate binary"
+  log "preflight: validating live config (fingerprint=$(config_fingerprint)) against candidate binaries"
   "$CANDIDATE_DIR/sybra-server" -check-config >"$(detail_log_path "$ID" config-preflight)" 2>&1 \
-    || reject_candidate "config-preflight" "candidate binary rejected the live config; see $(detail_log_path "$ID" config-preflight) on this host for detail"
+    || reject_candidate "config-preflight" "candidate server rejected the live config; see $(detail_log_path "$ID" config-preflight) on this host for detail"
+
+  # The CLI too, not just the server. The CLI tolerates a config it cannot
+  # parse by falling back to a direct task store, so a schema disagreement is a
+  # warning on every invocation instead of a failure — and agents run
+  # sybra-cli from inside their worktrees to read and update task state. A
+  # build that ships a CLI which cannot parse the config the server runs on is
+  # not a good build.
+  "$CANDIDATE_DIR/sybra-cli" -check-config >"$(detail_log_path "$ID" config-preflight-cli)" 2>&1 \
+    || reject_candidate "config-preflight-cli" "candidate CLI rejected the live config the server accepted; see $(detail_log_path "$ID" config-preflight-cli) on this host for detail"
 
   activate_candidate
   prune_releases

--- a/deploy/tests/deploy_integration_test.sh
+++ b/deploy/tests/deploy_integration_test.sh
@@ -76,7 +76,7 @@ new_env() {
   cp -a "$FIXTURE_SRC" "$root/src"
   ( cd "$root/src" && git init -q && git config user.email t@t.com && git config user.name t && git add -A && git commit -q -m init )
 
-  unset FAKE_CHECK_CONFIG FAKE_NPM_FAIL FAKE_SANDBOX_SMOKE_FAIL FAKE_HEALTH_MODE FAKE_LISTEN_ADDR
+  unset FAKE_CHECK_CONFIG FAKE_CHECK_CONFIG_CLI FAKE_NPM_FAIL FAKE_SANDBOX_SMOKE_FAIL FAKE_HEALTH_MODE FAKE_LISTEN_ADDR
   unset SYBRA_HEALTH_URL SYBRA_HEALTH_QUARANTINE_THRESHOLD SYBRA_DEPLOY_LOCK_WAIT_SEC
   unset SYBRA_HEALTH_TIMEOUT_SEC SYBRA_HEALTH_INTERVAL_SEC
 
@@ -158,6 +158,42 @@ seed_last_good() {
   run_healthcheck >"$root/seed-health.log" 2>&1
   stop_fake_server "$srv"
   echo "$rel"
+}
+
+# The CLI can disagree with the server about the same config: it tolerates a
+# config it cannot parse by falling back to a direct task store, so a schema
+# drift is a per-invocation warning rather than a failure. Agents run sybra-cli
+# from inside their worktrees to read and update task state, so a CLI silently
+# dropping the resolved config is a state-drift hazard in the middle of every
+# workflow — the preflight must reject that build, not ship it.
+scenario_cli_config_incompatibility() {
+  local root="$1"
+  new_env "$root"
+
+  local seeded; seeded="$(seed_last_good "$root")"
+  assert_eq "cli-config-incompat: seed promoted to last-good" "$seeded" "$(last_good_target)"
+
+  bump_commit "$root" "cli-rejects-config"
+  export FAKE_CHECK_CONFIG=ok
+  export FAKE_CHECK_CONFIG_CLI=fail
+  run_build >"$root/build-cli.log" 2>&1
+  assert_eq "cli-config-incompat: rejected candidate still exits 0" "0" "$?"
+  assert_eq "cli-config-incompat: current unchanged when only the CLI rejects" "$seeded" "$(current_target)"
+  assert_contains "cli-config-incompat: logs the CLI preflight rejection" "$(cat "$root/build-cli.log")" "config-preflight-cli"
+
+  # Deterministic, so the next attempt short-circuits rather than rebuilding.
+  run_build >"$root/build-cli2.log" 2>&1
+  assert_eq "cli-config-incompat: quarantined retry exits 0" "0" "$?"
+  assert_contains "cli-config-incompat: quarantined retry skips rebuild" "$(cat "$root/build-cli2.log")" "Skipping rebuild"
+
+  export FAKE_CHECK_CONFIG_CLI=ok
+  mkdir -p "$SYBRA_HOME"
+  echo "marker: cli-fixed" >"$SYBRA_HOME/config.yaml"
+  run_build >"$root/build-cli3.log" 2>&1
+  assert_eq "cli-config-incompat: activates once the CLI accepts" "0" "$?"
+  if [[ "$(current_target)" == "$seeded" ]]; then
+    fail "cli-config-incompat: current should advance after the CLI accepts the config"
+  fi
 }
 
 scenario_config_incompatibility() {
@@ -397,6 +433,7 @@ main() {
   echo "test root: $TMPBASE"
 
   scenario_config_incompatibility "$TMPBASE/config-incompat"
+  scenario_cli_config_incompatibility "$TMPBASE/cli-config-incompat"
   scenario_build_failure "$TMPBASE/build-failure"
   scenario_build_failure_persistent "$TMPBASE/build-failure-persistent"
   scenario_lock_contention "$TMPBASE/lock-contention"

--- a/deploy/tests/fixtures/fake-src/cmd/sybra-cli/main.go
+++ b/deploy/tests/fixtures/fake-src/cmd/sybra-cli/main.go
@@ -1,5 +1,30 @@
 // Stand-in for cmd/sybra-cli used only by deploy/tests — see cmd/sybra-server
 // in this fixture for why a trimmed-down module exists at all.
+//
+// It implements -check-config because the deploy preflight validates the live
+// config against BOTH binaries. FAKE_CHECK_CONFIG_CLI is separate from
+// FAKE_CHECK_CONFIG so a scenario can make the server accept a config the CLI
+// rejects — the drift this preflight exists to catch, where the real CLI
+// tolerated an unknown key by falling back to a direct task store while the
+// server ran happily on it.
 package main
 
-func main() {}
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	checkConfig := flag.Bool("check-config", false, "")
+	flag.Parse()
+
+	if *checkConfig {
+		if os.Getenv("FAKE_CHECK_CONFIG_CLI") == "fail" {
+			fmt.Fprintln(os.Stderr, "config: invalid: fake CLI rejected key")
+			os.Exit(1)
+		}
+		fmt.Println("config: ok")
+		return
+	}
+}


### PR DESCRIPTION
## Motivation

Every `sybra-cli` invocation on the deploy host printed:

```
warning: load config: unknown config key "agent.sandbox_read_mode";
falling back to direct task store at /home/sybra/.sybra/tasks for `list`
```

The running server accepted that key — its log carries `agent.sandbox.read.report` lines — so the CLI and the server disagreed on the config schema despite being built from the same checkout into the same `/opt/sybra/build`.

The deploy preflight did not catch it because it validates the live config against the **server** candidate only. And the CLI does not fail on a config it cannot parse: it falls back to a direct task store, so a schema disagreement is a per-invocation warning rather than a rejected build.

That matters beyond the noise. **Agents run `sybra-cli` from inside their worktrees** to read and update task state, so a CLI silently dropping the resolved config is a state-drift hazard sitting in the middle of every workflow.

> Changelog: build(deploy): preflight the CLI config too

## Implementation information

- Give `sybra-cli` the same `-check-config` entry point `sybra-server` has: `LoadNoPersist` + `ValidateCluster`, exit 0 or 1, never mutating the live `config.yaml`. It short-circuits before the fallback task store, which is the whole point.
- Run it in `sybra-build.sh` alongside the server check.
- Classify `config-preflight-cli` as a deterministic phase, so a disagreement quarantines the sha+config combo immediately rather than being retried — its outcome depends only on source and config, exactly like the server check.
- The fake CLI fixture gains `-check-config`, gated on a separate `FAKE_CHECK_CONFIG_CLI` so a scenario can make the server accept what the CLI rejects.

## Supporting documentation

The new integration scenario drives precisely the case this issue describes: server accepts, CLI rejects, candidate is not activated, retry short-circuits as quarantined, and activation resumes once the CLI accepts.

The Go test asserts the **success** path through `run()`. Asserting the failure path would pass whether or not the flag is wired at all, since an unrecognised flag also exits 1 as an unknown command — I confirmed that by deleting the flag handling and watching the first version of the test stay green.

Two notes for the reviewer:

- `deploy/tests/deploy_integration_test.sh` cannot pass on macOS: it needs `flock`, which is Linux-only. Baseline `main` fails 17 assertions on this host and this branch fails 20, all lock-contention rather than assertion failures. The three from the new scenario are in that set. CI runs it on Linux.
- Reading `--home`'s value now slices the tail instead of indexing after an increment. The two-step form defeated gosec's bounds analysis once the early return above it existed and reported a false out-of-range on untouched code; `main` is clean, so this keeps it that way without a suppression.

Closes #3046
