### PR TITLE
fix(workflow): record no-commit runs honestly

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -310,6 +310,14 @@ func (a *taskAdapter) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerpr
 	return a.tasks.UpdateRun(taskID, agentID, patch)
 }
 
+// MarkAgentRunOutcome corrects a run's recorded outcome after the fact. The
+// completion handler derives success from a clean exit alone, which it must:
+// whether a code-author run produced commits is only known later, once the
+// branch is inspected.
+func (a *taskAdapter) MarkAgentRunIncomplete(taskID, agentID string) error {
+	return a.tasks.UpdateRun(taskID, agentID, task.RunPatch{Outcome: task.Ptr(task.RunOutcomeIncomplete)})
+}
+
 func (a *taskAdapter) RecordAgentRunFinalCommit(taskID, agentID, headSHA, source string) error {
 	patch := task.RunPatch{}
 	if headSHA != "" {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -310,7 +310,7 @@ func (a *taskAdapter) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerpr
 	return a.tasks.UpdateRun(taskID, agentID, patch)
 }
 
-// MarkAgentRunOutcome corrects a run's recorded outcome after the fact. The
+// MarkAgentRunIncomplete corrects a run's recorded outcome after the fact. The
 // completion handler derives success from a clean exit alone, which it must:
 // whether a code-author run produced commits is only known later, once the
 // branch is inspected.

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -123,6 +123,10 @@ func (a *taskAdapter) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerpr
 	return a.tasks.UpdateRun(taskID, agentID, patch)
 }
 
+func (a *taskAdapter) MarkAgentRunIncomplete(taskID, agentID string) error {
+	return a.tasks.UpdateRun(taskID, agentID, task.RunPatch{Outcome: task.Ptr(task.RunOutcomeIncomplete)})
+}
+
 func (a *taskAdapter) RecordAgentRunFinalCommit(taskID, agentID, headSHA, source string) error {
 	patch := task.RunPatch{}
 	if headSHA != "" {

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -207,6 +207,13 @@ func ValidateAgentProvider(s string) (string, error) {
 const (
 	RunOutcomeSuccess = "success"
 	RunOutcomeFailure = "failure"
+	// RunOutcomeIncomplete marks a code-author run that exited cleanly but
+	// produced nothing. A clean exit is not evidence of work: an agent that
+	// delegates to a subagent and ends its turn waiting for it exits 0 with no
+	// commit, and recording that as success let one task accumulate 18 runs
+	// over 4 days while every downstream consumer believed the implementation
+	// had landed.
+	RunOutcomeIncomplete = "incomplete"
 )
 
 // AgentRun records one dispatch of an agent process against a task: what was

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -137,6 +137,11 @@ type TaskProvider interface {
 	MarkAgentRunProtocolViolation(taskID, agentID, violation string) error
 	MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint string) error
 	RecordAgentRunFinalCommit(taskID, agentID, headSHA, source string) error
+	// MarkAgentRunIncomplete downgrades a clean-exit code-author run that
+	// produced no commits. Named rather than taking an outcome string because
+	// internal/workflow cannot import internal/task (cycle via
+	// internal/agent), so the vocabulary stays on the far side of the adapter.
+	MarkAgentRunIncomplete(taskID, agentID string) error
 	AppendTaskBody(id, content string) error
 	// ReplaceTaskBody overwrites the task's full body. Used by the test-route
 	// step to archive/strip a stale "## Test Failures" section before

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -487,6 +487,18 @@ func (e *Engine) verifyCommitsHandleEmptyOutput(taskID string, step *Step, wfExe
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "no commits: flipped to human-required"}, nil
 }
 
+// markRunIncomplete downgrades a clean-exit code-author run that produced
+// nothing. Best-effort: the retry it accompanies matters more than the
+// bookkeeping, so a patch failure is logged rather than aborting the rearm.
+func (e *Engine) markRunIncomplete(taskID, agentID string) {
+	if agentID == "" {
+		return
+	}
+	if err := e.tasks.MarkAgentRunIncomplete(taskID, agentID); err != nil {
+		e.logger.Error("workflow.verify-commits.mark-incomplete", "task_id", taskID, "agent_id", agentID, "err", err)
+	}
+}
+
 func (e *Engine) rearmNoCommitAuthorRun(taskID string, wfExec *Execution, t TaskInfo) bool {
 	if wfExec == nil {
 		return false
@@ -496,6 +508,12 @@ func (e *Engine) rearmNoCommitAuthorRun(taskID string, wfExec *Execution, t Task
 	if !ok || !isCodeAuthorRun(run) {
 		return false
 	}
+	// Correct the record before retrying. The completion handler derives
+	// success from a clean exit, which is all it can see — but a code-author
+	// run that produced no commit did not succeed, and every consumer of
+	// Outcome (stats, evaluation, the human-review verdict gate, stale-run
+	// recovery) otherwise believes the implementation landed.
+	e.markRunIncomplete(taskID, agentID)
 	stepID := wfExec.LastAgentStepID()
 	if stepID == "" {
 		return false

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -566,6 +566,7 @@ type memTasks struct {
 	failGet          bool
 	failSetWorkflow  bool
 	failSetWorkflowN int
+	incompleteRuns   []string
 }
 
 func newMemTasks() *memTasks {
@@ -765,6 +766,19 @@ func (m *memTasks) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint
 		}
 	}
 	return fmt.Errorf("agent run %s not found for task %s", agentID, taskID)
+}
+
+func (m *memTasks) IncompleteRuns() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.incompleteRuns...)
+}
+
+func (m *memTasks) MarkAgentRunIncomplete(taskID, agentID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.incompleteRuns = append(m.incompleteRuns, taskID+"/"+agentID)
+	return nil
 }
 
 func (m *memTasks) RecordAgentRunFinalCommit(taskID, agentID, headSHA, source string) error {
@@ -11585,5 +11599,63 @@ func TestStartWorkflow_ConcurrentSameTaskSingleWinner(t *testing.T) {
 	}
 	if ti.Workflow == nil || ti.Workflow.WorkflowID != "test-simple" {
 		t.Errorf("task workflow not set correctly: %+v", ti.Workflow)
+	}
+}
+
+// A code-author run that exits cleanly but produces no commits is not a
+// success, and the completion handler cannot know that — it derives the
+// outcome from the exit alone. Leaving the record at "success" is what let one
+// task accumulate 18 runs over 4 days: an agent delegated to a subagent, ended
+// its turn with "I'll just wait for the notification instead", exited 0, and
+// every downstream consumer of Outcome believed the implementation had landed.
+func TestExecVerifyCommits_NoCommitAuthorRunMarkedIncomplete(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wtDir := makeGitRepo(t, false /* HEAD == origin/main, so no commits */)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	wfExec := &Execution{Variables: map[string]string{}}
+	wfExec.RecordStep(StepRecord{StepID: "implement", Status: "completed", AgentID: "a1", Provider: "claude"})
+	ti := TaskInfo{
+		ID: "t1", Status: "in-progress",
+		AgentRuns: []AgentRunInfo{{AgentID: "a1", Role: "implementation"}},
+	}
+
+	if _, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, ti); !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+
+	if got := tasks.IncompleteRuns(); len(got) != 1 || got[0] != "t1/a1" {
+		t.Errorf("incomplete runs = %v, want [t1/a1] — the success record was left uncorrected", got)
+	}
+}
+
+// A verifier role that produces no commits is doing its job; only code-author
+// roles are downgraded.
+func TestExecVerifyCommits_VerifierRunNotMarkedIncomplete(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wtDir := makeGitRepo(t, false)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	wfExec := &Execution{Variables: map[string]string{}}
+	wfExec.RecordStep(StepRecord{StepID: "review", Status: "completed", AgentID: "a1", Provider: "claude"})
+	ti := TaskInfo{
+		ID: "t1", Status: "in-progress",
+		AgentRuns: []AgentRunInfo{{AgentID: "a1", Role: "review"}},
+	}
+
+	_, _ = engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, ti)
+
+	if got := tasks.IncompleteRuns(); len(got) != 0 {
+		t.Errorf("incomplete runs = %v, want none for a verifier role", got)
 	}
 }


### PR DESCRIPTION
## Motivation

Task `cd7f0957` accumulated **18 agent runs over 4 days** and stayed parked, blocked on two unused functions. Its first implementation run explains the rest. The recorded result is, verbatim:

```
I'll just wait for the notification instead — no need to actively poll.

(waiting for the exploration agent to finish)
```

`outcome: success`, `cost_usd: 0.99`, `subagent_call_count: 1`. The agent delegated to a subagent, ended its turn waiting for it, exited 0, and Sybra banked the run as a successful implementation.

A clean exit is not evidence of work. `runTerminalOutcome` derives success from `exitErr == nil`, which is all the completion handler can see — whether a code-author run produced commits is only knowable later, once the branch is inspected.

> Changelog: fix(workflow): record no-commit runs honestly

## Implementation information

The engine already detects this case at `verify_commits` and retries the step once (`rearmNoCommitAuthorRun`, from #f884134e). What it did not do was correct the record, so every consumer of `Outcome` went on believing the implementation had landed:

- `internal/stats` and the evaluation scorecard count it as a successful run
- `internal/recovery/stale.go` branches on `Outcome == RunOutcomeSuccess`
- `app_human_review.go` gates its verdict handling on `Outcome != "success"`

This adds `RunOutcomeIncomplete` and sets it where the no-commit case is already detected.

The engine cannot name the constant directly: `internal/workflow` importing `internal/task` is a cycle through `internal/agent`. So the capability is a named `MarkAgentRunIncomplete(taskID, agentID)` on the task provider, and the outcome vocabulary stays on the far side of the adapter — the same shape as the existing `MarkAgentRunTestOutcome` and `RecordAgentRunFinalCommit`.

Verifier roles are deliberately untouched: producing no commits is what review, test-runner and eval are *for*. `isCodeAuthorRun` already gates this, and there is a test pinning it.

## Supporting documentation

Both tests were checked by reverting the fix — removing the downgrade fails the code-author test and leaves the verifier test green.

Two scope notes:

- The retry half of #3040 already shipped in `f884134e`; this PR is the record-correctness half. I found that while reading the code rather than assuming the issue was fully open.
- The issue also proposes that an `incomplete` run should not consume the auto-fix same-fingerprint budget. `rearmNoCommitAuthorRun` already keeps its own separate counter (`step.verify_commits.no_commit_retry`), so that concern does not arise on this path. The general evidence-based attempt counting stays with #3042, which shares the "did this run actually do anything" predicate and should build on this.

Closes #3040
