### PR TITLE
refactor(provider): return a classification value

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -906,18 +906,18 @@ func (m *Manager) ProviderCanFailover(name string) bool {
 
 // ReportProviderSignal forwards a runner-side passive signal (rate-limit or
 // auth failure) to the health gate. Safe to call with a nil gate.
-func (m *Manager) ReportProviderSignal(name string, sig provider.Signal, reason string, retryAfter time.Duration, source provider.CooldownSource) {
+func (m *Manager) ReportProviderSignal(name string, c provider.Classification) {
 	m.mu.RLock()
 	g := m.gate
 	m.mu.RUnlock()
 	if g == nil {
 		return
 	}
-	switch sig {
+	switch c.Signal {
 	case provider.SignalAuthFailure:
-		g.ReportAuthFailure(name, reason)
+		g.ReportAuthFailure(name, c.Reason)
 	case provider.SignalRateLimit:
-		g.ReportRateLimit(name, retryAfter, reason, source)
+		g.ReportRateLimit(name, c.RetryAfter, c.Reason, c.Source)
 	case provider.SignalNone:
 		// no-op: caller decided not to escalate this run.
 	}

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -606,8 +606,8 @@ func TestReportProviderSignal_DispatchesByKind(t *testing.T) {
 	m, _ := newTestManager(t)
 	fg := &fakeGate{healthy: map[string]bool{"claude": true}}
 	m.SetHealthGate(fg)
-	m.ReportProviderSignal("claude", provider.SignalAuthFailure, "logged_out", 0, provider.CooldownFromConfig)
-	m.ReportProviderSignal("codex", provider.SignalRateLimit, "rate_limit_error", 30*time.Minute, provider.CooldownFromConfig)
+	m.ReportProviderSignal("claude", provider.Classification{Signal: provider.SignalAuthFailure, Reason: "logged_out", Source: provider.CooldownFromConfig})
+	m.ReportProviderSignal("codex", provider.Classification{Signal: provider.SignalRateLimit, Reason: "rate_limit_error", RetryAfter: 30 * time.Minute, Source: provider.CooldownFromConfig})
 	if len(fg.reportedAuth) != 1 || fg.reportedAuth[0] != "claude" {
 		t.Errorf("auth report missing: %+v", fg.reportedAuth)
 	}
@@ -622,7 +622,7 @@ func TestReportProviderSignal_DispatchesByKind(t *testing.T) {
 func TestReportProviderSignal_NilGateSafe(t *testing.T) {
 	m, _ := newTestManager(t)
 	// Do not call SetHealthGate.
-	m.ReportProviderSignal("claude", provider.SignalAuthFailure, "", 0, provider.CooldownFromConfig)
+	m.ReportProviderSignal("claude", provider.Classification{Signal: provider.SignalAuthFailure, Reason: "", RetryAfter: 0, Source: provider.CooldownFromConfig})
 }
 
 func TestReportProviderHealthSignal_CleanLimitResultMarksRateLimit(t *testing.T) {

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	providerpkg "github.com/Automaat/sybra/internal/provider"
 )
@@ -30,7 +29,7 @@ type Provider interface {
 	// receipt must still be appended and verified for them.
 	EnforcesOutputSchema() bool
 	SessionFilePath(sessionID string) string
-	ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource)
+	ClassifyError(sample providerpkg.ErrorSample) providerpkg.Classification
 	// HonorsAllowedTools reports whether this provider actually enforces
 	// RunConfig.AllowedTools on the spawned CLI. False means the list is
 	// silently ignored and the agent runs with the provider's own default

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
@@ -147,7 +146,7 @@ func (claudeProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
 	return claudeEventToStreamEvent(ce), nil
 }
 
-func (claudeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
+func (claudeProvider) ClassifyError(sample providerpkg.ErrorSample) providerpkg.Classification {
 	return providerpkg.ClassifyClaudeError(sample)
 }
 

--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"os"
 	"strings"
-	"time"
 
 	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
@@ -137,7 +136,7 @@ func (codexProvider) SessionFilePath(sessionID string) string {
 	return resolveCodexSessionFile(sessionID)
 }
 
-func (codexProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
+func (codexProvider) ClassifyError(sample providerpkg.ErrorSample) providerpkg.Classification {
 	return providerpkg.ClassifyCodexError(sample)
 }
 

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"strings"
-	"time"
 
 	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
@@ -83,7 +82,7 @@ func (copilotProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
 	return copilotEventToStreamEvent(ce), nil
 }
 
-func (copilotProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
+func (copilotProvider) ClassifyError(sample providerpkg.ErrorSample) providerpkg.Classification {
 	return providerpkg.ClassifyCopilotError(sample)
 }
 

--- a/internal/agent/provider_opencode.go
+++ b/internal/agent/provider_opencode.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"strings"
-	"time"
 
 	"github.com/Automaat/sybra/internal/modeltier"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
@@ -56,7 +55,7 @@ func (opencodeProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
 	return opencodeEventToStreamEvent(oe), nil
 }
 
-func (opencodeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration, providerpkg.CooldownSource) {
+func (opencodeProvider) ClassifyError(sample providerpkg.ErrorSample) providerpkg.Classification {
 	return providerpkg.ClassifyOpenCodeError(sample)
 }
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1162,7 +1162,12 @@ func (m *Manager) handleMalformedToolResults(a *Agent, event StreamEvent) {
 		reason := fmt.Sprintf("tool %s rejected malformed input: %s", toolName, truncatePromptField(diag.ValidationError))
 		a.NoteMalformedToolCall(event.toolResults[i].ToolUseID, toolName, malformedToolCallOutcomeUnrecoverable)
 		a.SetError(malformedToolCallErrorKind, reason)
-		m.ReportProviderSignal(a.GetProvider(), providerpkg.SignalRateLimit, malformedToolCallErrorKind, malformedToolFailoverCooldown, providerpkg.CooldownFromConfig)
+		m.ReportProviderSignal(a.GetProvider(), providerpkg.Classification{
+			Signal:     providerpkg.SignalRateLimit,
+			Reason:     malformedToolCallErrorKind,
+			RetryAfter: malformedToolFailoverCooldown,
+			Source:     providerpkg.CooldownFromConfig,
+		})
 		m.logger.Warn("agent.headless.tool_call_malformed.unrecoverable",
 			"id", a.ID,
 			"provider", a.GetProvider(),

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/Automaat/sybra/internal/provider"
 )
@@ -32,31 +31,31 @@ func (m *Manager) reportCleanProviderHealthSignal(a *Agent, stderrOut string, at
 }
 
 func (m *Manager) reportProviderHealthSample(a *Agent, sample provider.ErrorSample) provider.Signal {
-	sig, reason, retryAfter, src := classifyProviderError(a.Provider, sample)
-	if sig == provider.SignalNone {
+	c := classifyProviderError(a.Provider, sample)
+	if c.Signal == provider.SignalNone {
 		if sample.ErrorType != "" || sample.ErrorStatus != 0 {
 			m.logger.Info("agent.provider.signal.unknown",
 				"provider", a.Provider,
 				"errorType", sample.ErrorType,
 				"errorStatus", sample.ErrorStatus)
 		}
-		return sig
+		return c.Signal
 	}
-	m.RecordProviderSignal(a, sig, reason, retryAfter, src)
-	return sig
+	m.RecordProviderSignal(a, c)
+	return c.Signal
 }
 
 // RecordProviderSignal stores a provider-health classification on the agent
 // and forwards it to the shared health gate so all recovery paths maintain the
 // same "agent error kind + gate signal" invariant.
-func (m *Manager) RecordProviderSignal(a *Agent, sig provider.Signal, reason string, retryAfter time.Duration, source provider.CooldownSource) {
+func (m *Manager) RecordProviderSignal(a *Agent, c provider.Classification) {
 	if a == nil {
 		return
 	}
-	if kind := signalErrorKind(sig); kind != "" {
-		a.SetError(kind, reason)
+	if kind := signalErrorKind(c.Signal); kind != "" {
+		a.SetError(kind, c.Reason)
 	}
-	m.ReportProviderSignal(a.Provider, sig, reason, retryAfter, source)
+	m.ReportProviderSignal(a.Provider, c)
 }
 
 // signalErrorKind maps a provider health signal to the short error-kind tag
@@ -94,10 +93,10 @@ func buildErrorSample(stderrOut string, attemptEvents []StreamEvent) provider.Er
 // classifyProviderError routes an error sample to the provider-appropriate
 // classifier. Without a copilot branch a logged-out / quota-exhausted copilot
 // would never be flagged, leaving the health gate routing failover work to it.
-func classifyProviderError(prov string, sample provider.ErrorSample) (provider.Signal, string, time.Duration, provider.CooldownSource) {
+func classifyProviderError(prov string, sample provider.ErrorSample) provider.Classification {
 	p, err := lookupProvider(prov)
 	if err != nil {
-		return provider.SignalNone, "", 0, provider.CooldownFromConfig
+		return provider.Classification{Signal: provider.SignalNone, Source: provider.CooldownFromConfig}
 	}
 	return p.ClassifyError(sample)
 }

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -451,7 +451,8 @@ func TestClassifyProviderError_CodexConnectivityRoutesToRateLimit(t *testing.T) 
 	sample := provider.ErrorSample{
 		Stderr: "websocket connection refused: wss://chatgpt.com/backend-api/codex/responses",
 	}
-	sig, reason, _, _ := classifyProviderError("codex", sample)
+	c := classifyProviderError("codex", sample)
+	sig, reason, _, _ := c.Signal, c.Reason, c.RetryAfter, c.Source
 	if sig != provider.SignalRateLimit {
 		t.Fatalf("signal = %v, want SignalRateLimit", sig)
 	}

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -106,11 +106,11 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
 				continue
 			}
-			sig, reason, retryAfter, src := classifyError(p, stderrOut, string(raw))
-			if sig != provider.SignalNone {
-				reportSignal(opts.Gate, p, sig, reason, retryAfter, src)
-				logFallback(opts.Logger, p, sig, reason)
-				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
+			c := classifyError(p, stderrOut, string(raw))
+			if c.Signal != provider.SignalNone {
+				reportSignal(opts.Gate, p, c)
+				logFallback(opts.Logger, p, c.Signal, c.Reason)
+				failures = append(failures, fmt.Sprintf("%s: %s", p, c.Reason))
 				continue
 			}
 			return Result{Provider: p}, providerError(p, err, stderrOut)
@@ -128,11 +128,11 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
 				continue
 			}
-			sig, reason, retryAfter, src := classifyError(p, stderrOut, string(raw))
-			if sig != provider.SignalNone {
-				reportSignal(opts.Gate, p, sig, reason, retryAfter, src)
-				logFallback(opts.Logger, p, sig, reason)
-				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
+			c := classifyError(p, stderrOut, string(raw))
+			if c.Signal != provider.SignalNone {
+				reportSignal(opts.Gate, p, c)
+				logFallback(opts.Logger, p, c.Signal, c.Reason)
+				failures = append(failures, fmt.Sprintf("%s: %s", p, c.Reason))
 				continue
 			}
 			return Result{Provider: p}, fmt.Errorf("%s output: %w", p, parseErr)
@@ -435,7 +435,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func classifyError(p, stderrOut, content string) (provider.Signal, string, time.Duration, provider.CooldownSource) {
+func classifyError(p, stderrOut, content string) provider.Classification {
 	sample := provider.ErrorSample{Stderr: stderrOut, Content: content}
 	switch p {
 	case "codex":
@@ -500,15 +500,15 @@ func containsAnyString(haystack string, needles ...string) bool {
 	return false
 }
 
-func reportSignal(g provider.HealthGate, p string, sig provider.Signal, reason string, retryAfter time.Duration, source provider.CooldownSource) {
+func reportSignal(g provider.HealthGate, p string, c provider.Classification) {
 	if g == nil {
 		return
 	}
-	switch sig {
+	switch c.Signal {
 	case provider.SignalAuthFailure:
-		g.ReportAuthFailure(p, reason)
+		g.ReportAuthFailure(p, c.Reason)
 	case provider.SignalRateLimit:
-		g.ReportRateLimit(p, retryAfter, reason, source)
+		g.ReportRateLimit(p, c.RetryAfter, c.Reason, c.Source)
 	case provider.SignalNone:
 	}
 }

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -200,7 +200,8 @@ func TestClassifyClaudeError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, reason, retryAfter, _ := ClassifyClaudeError(tc.in)
+			c := ClassifyClaudeError(tc.in)
+			got, reason, retryAfter, _ := c.Signal, c.Reason, c.RetryAfter, c.Source
 			if got != tc.want {
 				t.Errorf("signal: got %v want %v", got, tc.want)
 			}
@@ -283,7 +284,8 @@ func TestClassifyCodexError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, reason, retryAfter, _ := ClassifyCodexError(tc.in)
+			c := ClassifyCodexError(tc.in)
+			got, reason, retryAfter, _ := c.Signal, c.Reason, c.RetryAfter, c.Source
 			if got != tc.want {
 				t.Errorf("signal: got %v want %v", got, tc.want)
 			}
@@ -312,7 +314,8 @@ func TestClassifyCopilotError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, _, _, _ := ClassifyCopilotError(tc.in)
+			c := ClassifyCopilotError(tc.in)
+			got, _, _, _ := c.Signal, c.Reason, c.RetryAfter, c.Source
 			if got != tc.want {
 				t.Errorf("got %v want %v", got, tc.want)
 			}

--- a/internal/provider/reset_hint_test.go
+++ b/internal/provider/reset_hint_test.go
@@ -170,9 +170,10 @@ func TestClassifiers_PreferProviderResetOverFixedCooldown(t *testing.T) {
 
 	t.Run("codex", func(t *testing.T) {
 		pinNow(t, now)
-		sig, reason, after, _ := ClassifyCodexError(ErrorSample{
+		c := ClassifyCodexError(ErrorSample{
 			Stderr: "ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 9:41 AM.",
 		})
+		sig, reason, after, _ := c.Signal, c.Reason, c.RetryAfter, c.Source
 		if sig != SignalRateLimit {
 			t.Fatalf("signal = %v, want SignalRateLimit", sig)
 		}
@@ -187,9 +188,10 @@ func TestClassifiers_PreferProviderResetOverFixedCooldown(t *testing.T) {
 	t.Run("claude weekly limit overrides the hour default", func(t *testing.T) {
 		pinNow(t, now)
 		wantClaude := time.Date(2026, time.August, 7, 17, 0, 0, 0, time.Local).Sub(now)
-		sig, reason, after, _ := ClassifyClaudeError(ErrorSample{
+		c := ClassifyClaudeError(ErrorSample{
 			Stderr: "You've hit your weekly limit · resets Aug 7 at 5pm",
 		})
+		sig, reason, after, _ := c.Signal, c.Reason, c.RetryAfter, c.Source
 		if sig != SignalRateLimit || reason != "weekly_limit" {
 			t.Fatalf("got (%v, %q), want (SignalRateLimit, weekly_limit)", sig, reason)
 		}
@@ -203,9 +205,10 @@ func TestClassifiers_PreferProviderResetOverFixedCooldown(t *testing.T) {
 
 	t.Run("no parseable instant keeps the fixed cooldown", func(t *testing.T) {
 		pinNow(t, now)
-		_, reason, after, _ := ClassifyClaudeError(ErrorSample{
+		c := ClassifyClaudeError(ErrorSample{
 			Stderr: "You've hit your weekly limit",
 		})
+		_, reason, after, _ := c.Signal, c.Reason, c.RetryAfter, c.Source
 		if reason != "weekly_limit" || after != weeklyLimitCooldown {
 			t.Errorf("got (%q, %v), want (weekly_limit, %v)", reason, after, weeklyLimitCooldown)
 		}
@@ -243,7 +246,8 @@ func TestCleanResultContentNeverSuppliesAResetHint(t *testing.T) {
 	for name, sample := range surfaces {
 		t.Run(name, func(t *testing.T) {
 			pinNow(t, now)
-			_, _, after, src := ClassifyClaudeError(sample)
+			c := ClassifyClaudeError(sample)
+			_, _, after, src := c.Signal, c.Reason, c.RetryAfter, c.Source
 			if src == CooldownFromProvider {
 				t.Errorf("clean run supplied a provider hint (%v); a run the provider served states nothing about refusing", after)
 			}
@@ -276,9 +280,10 @@ func TestCooldownSourceIsHonest(t *testing.T) {
 
 	t.Run("constant fallback is not a provider hint", func(t *testing.T) {
 		pinNow(t, now)
-		_, reason, after, src := ClassifyCodexError(ErrorSample{
+		c := ClassifyCodexError(ErrorSample{
 			Stderr: "ERROR: You've hit your weekly limit. Please try again later.",
 		})
+		_, reason, after, src := c.Signal, c.Reason, c.RetryAfter, c.Source
 		if reason != "weekly_limit" || after != weeklyLimitCooldown {
 			t.Fatalf("got (%q, %v), want the weekly constant", reason, after)
 		}
@@ -289,9 +294,10 @@ func TestCooldownSourceIsHonest(t *testing.T) {
 
 	t.Run("out-of-range hint is distinguishable from no hint", func(t *testing.T) {
 		pinNow(t, now)
-		_, _, _, src := ClassifyCodexError(ErrorSample{
+		c := ClassifyCodexError(ErrorSample{
 			Stderr: "ERROR: You've hit your usage limit. Please try again at Dec 25th, 2026 9:41 AM.",
 		})
+		_, _, _, src := c.Signal, c.Reason, c.RetryAfter, c.Source
 		if src != CooldownHintRejected {
 			t.Errorf("source = %q, want %q so an out-of-range parse leaves a trace", src, CooldownHintRejected)
 		}
@@ -299,9 +305,10 @@ func TestCooldownSourceIsHonest(t *testing.T) {
 
 	t.Run("ansi coloured message still parses", func(t *testing.T) {
 		pinNow(t, now)
-		_, _, after, src := ClassifyCodexError(ErrorSample{
+		c := ClassifyCodexError(ErrorSample{
 			Stderr: "\x1b[1;31mERROR:\x1b[0m usage limit. Please try again at \x1b[1mAug 8th, 2026 9:41 AM\x1b[0m.",
 		})
+		_, _, after, src := c.Signal, c.Reason, c.RetryAfter, c.Source
 		want := time.Date(2026, time.August, 8, 9, 41, 0, 0, time.Local).Sub(now)
 		if src != CooldownFromProvider || after != want {
 			t.Errorf("got (%v, %q), want (%v, %q)", after, src, want, CooldownFromProvider)
@@ -333,9 +340,10 @@ func TestPastInstantIsReportedAsRejected(t *testing.T) {
 
 	t.Run("surfaces through the classifier", func(t *testing.T) {
 		pinNow(t, now)
-		_, _, _, src := ClassifyCodexError(ErrorSample{
+		c := ClassifyCodexError(ErrorSample{
 			Stderr: "ERROR: usage limit. Please try again at Aug 1st, 2026 9:41 AM.",
 		})
+		_, _, _, src := c.Signal, c.Reason, c.RetryAfter, c.Source
 		if src != CooldownHintRejected {
 			t.Errorf("source = %q, want %q", src, CooldownHintRejected)
 		}

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -70,6 +70,33 @@ func rateLimitCooldown(s ErrorSample, fallback time.Duration) (time.Duration, Co
 	}
 }
 
+// Classification is the result of inspecting a failed run: what it means for
+// provider health, why, how long to park, and where that duration came from.
+//
+// One value rather than a positional tuple. The tuple was re-declared at every
+// layer it crossed — the Provider interface, classifyProviderError,
+// llmexec.classifyError, RecordProviderSignal, ReportProviderSignal,
+// reportSignal, HealthGate.ReportRateLimit — plus every test fake. Adding the
+// CooldownSource field alone touched ~10 production files and ~40 call sites,
+// most of them carrying no information, and broke three test files in the
+// mechanical edit. A named value makes the next field additive.
+type Classification struct {
+	Signal Signal
+	// Reason is the short tag recorded on provider health and the agent.
+	Reason string
+	// RetryAfter is the park duration; zero means the caller's configured
+	// cooldown.
+	RetryAfter time.Duration
+	// Source records whether RetryAfter came from the provider, a configured
+	// default, or a provider hint that was rejected.
+	Source CooldownSource
+}
+
+// classified is shorthand for building a Classification at a return site.
+func classified(sig Signal, reason string, retryAfter time.Duration, src CooldownSource) Classification {
+	return Classification{Signal: sig, Reason: reason, RetryAfter: retryAfter, Source: src}
+}
+
 // ErrorSample is the runner→classifier DTO. Using a plain struct (instead of
 // agent.StreamEvent directly) prevents an import cycle between internal/agent
 // and internal/provider.
@@ -89,15 +116,15 @@ type ErrorSample struct {
 // 529/overloaded is intentionally NOT classified here — the retry path in
 // runner_headless.go already handles transient overload without marking the
 // provider unhealthy.
-func ClassifyClaudeError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
+func ClassifyClaudeError(s ErrorSample) Classification {
 	if s.ErrorStatus == 401 || s.ErrorType == "authentication_error" || s.ErrorType == "invalid_api_key" {
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	}
 	stderr := strings.ToLower(s.Stderr)
 	content := strings.ToLower(s.Content)
 	if containsAny(stderr, "not logged in", "please run claude auth login", "unauthorized") ||
 		containsAny(content, "not logged in", "please run claude auth login") {
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	}
 	// Weekly-limit phrasing is checked before the structured 429/rate_limit_error
 	// short-circuit below: providers can attach a generic rate-limit error code
@@ -105,19 +132,19 @@ func ClassifyClaudeError(s ErrorSample) (Signal, string, time.Duration, Cooldown
 	// park only applies if the text is inspected first.
 	if isWeeklyLimitText(stderr, content, s.ContentIsCleanResult) {
 		cooldown, src := rateLimitCooldown(s, weeklyLimitCooldown)
-		return SignalRateLimit, "weekly_limit", cooldown, src
+		return classified(SignalRateLimit, "weekly_limit", cooldown, src)
 	}
 	if s.ErrorStatus == 429 || s.ErrorType == "rate_limit_error" || s.ErrorType == "credit_balance_too_low" {
 		cooldown, src := rateLimitCooldown(s, 0)
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), cooldown, src
+		return classified(SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), cooldown, src)
 	}
 	if containsAny(stderr, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") ||
 		containsRateLimitContent(content, s.ContentIsCleanResult,
 			"rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") {
 		cooldown, src := rateLimitCooldown(s, 0)
-		return SignalRateLimit, "rate_limited", cooldown, src
+		return classified(SignalRateLimit, "rate_limited", cooldown, src)
 	}
-	return SignalNone, "", 0, CooldownFromConfig
+	return classified(SignalNone, "", 0, CooldownFromConfig)
 }
 
 // isWeeklyLimit reports whether text contains a weekly-specific limit
@@ -176,15 +203,15 @@ func isCodexConnectivityText(text string) bool {
 // taxonomy is less well-known at design time, so we lean on substring matching
 // and let the runner log SignalNone cases with the raw strings for iterative
 // discovery.
-func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
+func ClassifyCodexError(s ErrorSample) Classification {
 	if s.ErrorStatus == 401 || strings.EqualFold(s.ErrorType, "unauthorized") {
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	}
 	stderr := strings.ToLower(s.Stderr)
 	content := strings.ToLower(s.Content)
 	if containsAny(stderr, "not logged in", "please run: codex login", "please run codex login", "unauthorized") ||
 		containsAny(content, "not logged in", "please run: codex login") {
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	}
 	// Weekly-limit phrasing is checked before the structured 429/rate_limit
 	// short-circuit below: providers can attach a generic rate-limit error
@@ -192,7 +219,7 @@ func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration, CooldownS
 	// weeklyLimitCooldown park only applies if the text is inspected first.
 	if isWeeklyLimitText(stderr, content, s.ContentIsCleanResult) {
 		cooldown, src := rateLimitCooldown(s, weeklyLimitCooldown)
-		return SignalRateLimit, "weekly_limit", cooldown, src
+		return classified(SignalRateLimit, "weekly_limit", cooldown, src)
 	}
 	// Host-anchored: a bare "websocket connection" without the codex backend
 	// host must NOT match — it would false-positive on unrelated network
@@ -212,19 +239,19 @@ func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration, CooldownS
 	// itself hit a connectivity failure — see containsRateLimitContent for
 	// the same distinction on the rate-limit path.
 	if isCodexConnectivityText(stderr) || (!s.ContentIsCleanResult && isCodexConnectivityText(content)) {
-		return SignalRateLimit, "connectivity", connectivityCooldown, CooldownFromConfig
+		return classified(SignalRateLimit, "connectivity", connectivityCooldown, CooldownFromConfig)
 	}
 	if s.ErrorStatus == 429 || strings.EqualFold(s.ErrorType, "rate_limit") || strings.EqualFold(s.ErrorType, "insufficient_quota") {
 		cooldown, src := rateLimitCooldown(s, 0)
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), cooldown, src
+		return classified(SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), cooldown, src)
 	}
 	if containsAny(stderr, "rate_limit", "rate limit", "insufficient_quota", "quota exceeded", "usage limit", "weekly limit") ||
 		containsRateLimitContent(content, s.ContentIsCleanResult,
 			"rate_limit", "rate limit", "insufficient_quota", "quota exceeded", "usage limit", "weekly limit") {
 		cooldown, src := rateLimitCooldown(s, 0)
-		return SignalRateLimit, "rate_limited", cooldown, src
+		return classified(SignalRateLimit, "rate_limited", cooldown, src)
 	}
-	return SignalNone, "", 0, CooldownFromConfig
+	return classified(SignalNone, "", 0, CooldownFromConfig)
 }
 
 // ClassifyCopilotError mirrors the other classifiers for GitHub Copilot CLI
@@ -233,37 +260,37 @@ func ClassifyCodexError(s ErrorSample) (Signal, string, time.Duration, CooldownS
 // (kept in sync with isLoggedOutStderr). Without a copilot-specific classifier
 // a logged-out/quota-exhausted copilot would return SignalNone and the health
 // gate would keep routing failover work to a dead provider.
-func ClassifyCopilotError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
+func ClassifyCopilotError(s ErrorSample) Classification {
 	if s.ErrorStatus == 401 || strings.EqualFold(s.ErrorType, "unauthorized") {
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	}
 	if s.ErrorStatus == 429 || strings.EqualFold(s.ErrorType, "rate_limit") || strings.EqualFold(s.ErrorType, "insufficient_quota") {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0, CooldownFromConfig
+		return classified(SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0, CooldownFromConfig)
 	}
 	stderr := strings.ToLower(s.Stderr)
 	content := strings.ToLower(s.Content)
 	authNeedles := []string{"not logged in", "not authenticated", "please run: copilot login", "run `copilot login`", "run 'copilot login'", "unauthorized"}
 	if containsAny(stderr, authNeedles...) || containsAny(content, authNeedles...) {
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	}
 	// Copilot meters usage in "premium requests"; an exhausted allowance is the
 	// copilot analogue of a rate limit.
 	quotaNeedles := []string{"rate_limit", "rate limit", "quota", "premium request", "usage limit", "monthly limit"}
 	if containsAny(stderr, quotaNeedles...) || containsRateLimitContent(content, s.ContentIsCleanResult, quotaNeedles...) {
-		return SignalRateLimit, "rate_limited", 0, CooldownFromConfig
+		return classified(SignalRateLimit, "rate_limited", 0, CooldownFromConfig)
 	}
-	return SignalNone, "", 0, CooldownFromConfig
+	return classified(SignalNone, "", 0, CooldownFromConfig)
 }
 
 // ClassifyOpenCodeError classifies OpenCode CLI failures. OpenCode can front
 // many providers, so keep the patterns generic and avoid provider-specific
 // assumptions beyond common HTTP/auth/rate-limit vocabulary.
-func ClassifyOpenCodeError(s ErrorSample) (Signal, string, time.Duration, CooldownSource) {
+func ClassifyOpenCodeError(s ErrorSample) Classification {
 	if s.ErrorStatus == 401 || s.ErrorStatus == 403 {
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	}
 	if s.ErrorStatus == 429 {
-		return SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0, CooldownFromConfig
+		return classified(SignalRateLimit, reasonFromType(s.ErrorType, "rate_limited"), 0, CooldownFromConfig)
 	}
 	hay := strings.ToLower(strings.Join([]string{s.ErrorType, s.Stderr, s.Content}, "\n"))
 	switch {
@@ -272,15 +299,15 @@ func ClassifyOpenCodeError(s ErrorSample) (Signal, string, time.Duration, Cooldo
 		strings.Contains(hay, "unauthorized"),
 		strings.Contains(hay, "invalid api key"),
 		strings.Contains(hay, "missing api key"):
-		return SignalAuthFailure, "logged_out", 0, CooldownFromConfig
+		return classified(SignalAuthFailure, "logged_out", 0, CooldownFromConfig)
 	case strings.Contains(hay, "rate limit"),
 		strings.Contains(hay, "too many requests"),
 		strings.Contains(hay, "quota"),
 		strings.Contains(hay, "insufficient credits"),
 		strings.Contains(hay, "credit balance"):
-		return SignalRateLimit, "rate_limited", 0, CooldownFromConfig
+		return classified(SignalRateLimit, "rate_limited", 0, CooldownFromConfig)
 	}
-	return SignalNone, "", 0, CooldownFromConfig
+	return classified(SignalNone, "", 0, CooldownFromConfig)
 }
 
 func containsRateLimitContent(content string, cleanResult bool, broadNeedles ...string) bool {

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -109,9 +109,9 @@ type ErrorSample struct {
 }
 
 // ClassifyClaudeError decides whether a failed claude run should mark the
-// claude provider as rate-limited or logged-out. The third return is the
-// retry-after hint to use when setting a rate-limit cooldown; zero means the
-// checker should fall back to its configured default.
+// claude provider as rate-limited or logged-out. Classification.RetryAfter is
+// the hint to use when setting a rate-limit cooldown; zero means the checker
+// should fall back to its configured default.
 //
 // 529/overloaded is intentionally NOT classified here — the retry path in
 // runner_headless.go already handles transient overload without marking the

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -218,7 +218,7 @@ type Watchdog struct {
 	// recordProviderSignal forwards a watchdog-detected provider signal through
 	// the same agent-manager helper the runner uses, so the agent error kind and
 	// provider health gate stay in sync across both paths.
-	recordProviderSignal func(*agent.Agent, provider.Signal, string, time.Duration, provider.CooldownSource)
+	recordProviderSignal func(*agent.Agent, provider.Classification)
 	// hasLiveHeadlessAgent reports whether a task has a registered live
 	// headless agent. checkDwell uses it to skip escalating a task whose
 	// headless run is mid-flight but hasn't touched the task file recently —
@@ -874,7 +874,11 @@ func (w *Watchdog) stopForRateLimit(ag *agent.Agent, trigger string, verdict age
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if w.recordProviderSignal != nil {
-		w.recordProviderSignal(ag, provider.SignalRateLimit, reason, 0, provider.CooldownFromConfig)
+		w.recordProviderSignal(ag, provider.Classification{
+			Signal: provider.SignalRateLimit,
+			Reason: reason,
+			Source: provider.CooldownFromConfig,
+		})
 	}
 	if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
@@ -977,7 +981,11 @@ func (w *Watchdog) handleZeroOutputStall(ag *agent.Agent, stall, total time.Dura
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
 	if w.recordProviderSignal != nil {
-		w.recordProviderSignal(ag, provider.SignalRateLimit, zeroOutputReason, 0, provider.CooldownFromConfig)
+		w.recordProviderSignal(ag, provider.Classification{
+			Signal: provider.SignalRateLimit,
+			Reason: zeroOutputReason,
+			Source: provider.CooldownFromConfig,
+		})
 	}
 	if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1100,9 +1100,9 @@ func TestApplyVerdict_RateLimitStopReschedulesInsteadOfEscalating(t *testing.T) 
 				tasks:     tasks,
 				logger:    slog.New(slog.DiscardHandler),
 				stopAgent: func(string) error { stopped = true; return nil },
-				recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
-					ag.SetError("rate_limit", reason)
-					signaledName, signaledKind, signaledReason = ag.Provider, sig, reason
+				recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
+					ag.SetError("rate_limit", c.Reason)
+					signaledName, signaledKind, signaledReason = ag.Provider, c.Signal, c.Reason
 				},
 			}
 
@@ -1147,10 +1147,10 @@ func TestApplyVerdict_RateLimitStopWithoutTaskStillSignalsAndStops(t *testing.T)
 	w := &Watchdog{
 		logger:    slog.New(slog.DiscardHandler),
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
-			ag.SetError("rate_limit", reason)
-			signaledName, signaledKind = ag.Provider, sig
-			if reason == "" {
+		recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
+			ag.SetError("rate_limit", c.Reason)
+			signaledName, signaledKind = ag.Provider, c.Signal
+			if c.Reason == "" {
 				t.Fatal("reason should not be empty")
 			}
 		},
@@ -1191,9 +1191,9 @@ func TestHandleZeroOutputStall_SignalsProviderAndReschedulesInsteadOfEscalating(
 		tasks:     tasks,
 		logger:    slog.New(slog.DiscardHandler),
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
-			ag.SetError("rate_limit", reason)
-			signaledName, signaledKind, signaledReason = ag.Provider, sig, reason
+		recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
+			ag.SetError("rate_limit", c.Reason)
+			signaledName, signaledKind, signaledReason = ag.Provider, c.Signal, c.Reason
 		},
 	}
 
@@ -1229,7 +1229,7 @@ func TestHandleZeroOutputStall_NoTaskStillSignalsAndStops(t *testing.T) {
 	w := &Watchdog{
 		logger:               slog.New(slog.DiscardHandler),
 		stopAgent:            func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(*agent.Agent, provider.Signal, string, time.Duration, provider.CooldownSource) {},
+		recordProviderSignal: func(*agent.Agent, provider.Classification) {},
 	}
 
 	w.handleZeroOutputStall(&agent.Agent{ID: "a1", Provider: "claude"}, time.Hour, time.Hour, task.StatusInProgress)
@@ -1258,9 +1258,9 @@ func TestInspectHeadless_ZeroOutputStallSkipsJudge(t *testing.T) {
 			return agent.InspectorVerdict{Recommendation: "continue"}, nil
 		},
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
-			ag.SetError("rate_limit", reason)
-			signaledReason = reason
+		recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
+			ag.SetError("rate_limit", c.Reason)
+			signaledReason = c.Reason
 		},
 	}
 
@@ -1406,9 +1406,9 @@ func TestInspectHeadless_ReattachedSurvivorZeroOutputSkipsJudge(t *testing.T) {
 			return agent.InspectorVerdict{Recommendation: "continue"}, nil
 		},
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, sig provider.Signal, reason string, _ time.Duration, _ provider.CooldownSource) {
-			ag.SetError("rate_limit", reason)
-			signaledReason = reason
+		recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
+			ag.SetError("rate_limit", c.Reason)
+			signaledReason = c.Reason
 		},
 	}
 


### PR DESCRIPTION
## Motivation

Provider error classification crossed every layer as a widening positional tuple, re-declared at each one: the `Provider` interface's `ClassifyError`, `classifyProviderError`, `llmexec.classifyError`, `RecordProviderSignal`, `ReportProviderSignal`, `reportSignal`, and `HealthGate.ReportRateLimit` — plus every fake gate in the tests.

Adding a single field to it in #3043 (a `CooldownSource`, so the park log could stop claiming a provider stated a window it never stated) touched **~10 production files and ~40 call sites**, most of them mechanical re-declarations carrying no information. Three test files were broken during that edit by a regex that appended a named parameter to signatures whose existing parameters were unnamed.

The cost is not only the edit. `reportSignal(gate, p, sig, reason, retryAfter)` and `RecordProviderSignal(a, sig, reason, retryAfter)` differed in order and arity, and nothing but the compiler distinguished `reason` from any other string.

Second of the two Wave 0 structural items — see the ordering rationale on #3038.

> Changelog: refactor(provider): return a classification value

## Implementation information

`Classification` carries `Signal`, `Reason`, `RetryAfter` and `Source` as one named value, threaded through every layer above. A future field becomes a struct field and nothing else moves.

The two production `HealthGate` wrappers (`claudeOnlyGate` in `internal/learning`, `avoidingGate` in `internal/llmjob`) simply forward, so both got shorter, as did every test fake.

`HealthGate.ReportRateLimit` itself keeps its parameter list: it is the boundary where the value is consumed rather than passed on, and widening it would pull `internal/provider`'s vocabulary into every gate implementation for no gain.

## Supporting documentation

Behaviour-preserving. The classifier tests pass unchanged apart from constructing the value rather than destructuring a tuple, which is the point — if this had changed behaviour, those tests would have moved.

Verified with `go vet -tags e2e` across `./internal/... ./cmd/...` (the e2e suite is behind a build tag and does not compile under a plain `go test ./...`, which is how a signature change reached CI green-local last time), plus `internal/provider`, `internal/agent`, `internal/watchdog`, `internal/llmexec`, `internal/llmjob`, `internal/recovery`, `internal/learning` and `internal/selfmonitor`. Lint clean.

Closes #3070
