### PR TITLE
fix(monitor): do not charge outages to anomalies

### DIFF
--- a/internal/monitor/capacity_dispatch_test.go
+++ b/internal/monitor/capacity_dispatch_test.go
@@ -1,0 +1,93 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/provider"
+)
+
+// A dispatch refused for want of provider capacity never ran, so it must not
+// consume the anomaly's cooldown. canDispatch reserves the window before the
+// attempt — necessary so two ticks cannot both fire — which meant a fleet-wide
+// rate limit left every anomaly unexamined for a full cooldown afterwards.
+func TestCanDispatch_ReleasedWhenNoProviderCapacity(t *testing.T) {
+	st := newRunState()
+	now := time.Now()
+	const fp = "stuck_human_blocked:abc123"
+	const cooldown = 30 * time.Minute
+
+	if !st.canDispatch(fp, now, cooldown) {
+		t.Fatal("precondition: first dispatch should be allowed")
+	}
+	if st.canDispatch(fp, now.Add(time.Minute), cooldown) {
+		t.Fatal("precondition: the reservation should block a second attempt")
+	}
+
+	st.releaseDispatch(fp)
+
+	if !st.canDispatch(fp, now.Add(time.Minute), cooldown) {
+		t.Error("after release the anomaly is still on cooldown; the outage was charged to it")
+	}
+}
+
+type capacityDispatcher struct {
+	err   error
+	calls int
+}
+
+func (d *capacityDispatcher) Dispatchable(Anomaly) (ok bool, skipReason string) { return true, "" }
+
+func (d *capacityDispatcher) Dispatch(context.Context, Anomaly) (string, error) {
+	d.calls++
+	return "", d.err
+}
+
+// The service must distinguish "no capacity" from "this dispatch failed".
+func TestDispatchLLMAnomalies_CapacityFailureRetriesNextTick(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantRetried bool
+	}{
+		{
+			name:        "provider unhealthy releases the reservation",
+			err:         &provider.UnhealthyError{Provider: "codex", Reason: "rate_limited", RateLimited: true},
+			wantRetried: true,
+		},
+		{
+			// A real dispatch failure did consume an attempt and must stay on
+			// cooldown, or a broken anomaly re-fires every tick.
+			name:        "ordinary failure keeps the cooldown",
+			err:         errors.New("worktree prepare failed"),
+			wantRetried: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &capacityDispatcher{err: tc.err}
+			svc := &Service{
+				dispatcher: d,
+				state:      newRunState(),
+				logger:     slog.New(slog.DiscardHandler),
+				cfg:        config.MonitorConfig{IssueCooldownMinutes: 30},
+			}
+			anoms := []Anomaly{{Kind: "stuck_human_blocked", TaskID: "t1", Fingerprint: "fp1", RequiresLLM: true}}
+
+			svc.dispatchLLMAnomalies(context.Background(), time.Now(), anoms)
+			svc.dispatchLLMAnomalies(context.Background(), time.Now().Add(time.Minute), anoms)
+
+			wantCalls := 1
+			if tc.wantRetried {
+				wantCalls = 2
+			}
+			if d.calls != wantCalls {
+				t.Errorf("dispatch attempts = %d, want %d", d.calls, wantCalls)
+			}
+		})
+	}
+}

--- a/internal/monitor/capacity_dispatch_test.go
+++ b/internal/monitor/capacity_dispatch_test.go
@@ -55,9 +55,16 @@ func TestDispatchLLMAnomalies_CapacityFailureRetriesNextTick(t *testing.T) {
 		wantRetried bool
 	}{
 		{
-			name:        "provider unhealthy releases the reservation",
-			err:         &provider.UnhealthyError{Provider: "codex", Reason: "rate_limited", RateLimited: true},
+			name:        "rate-limited provider releases the reservation",
+			err:         &provider.UnhealthyError{Provider: "codex", Reason: provider.RateLimitReason, RateLimited: true},
 			wantRetried: true,
+		},
+		{
+			// A permanent refusal does not self-heal, so releasing would retry
+			// it every tick until a human logs the provider back in.
+			name:        "logged-out provider keeps the cooldown",
+			err:         &provider.UnhealthyError{Provider: "codex", Reason: "logged_out"},
+			wantRetried: false,
 		},
 		{
 			// A real dispatch failure did consume an attempt and must stay on

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -430,6 +431,16 @@ func (s *Service) dispatchLLMAnomalies(ctx context.Context, now time.Time, anoms
 		}
 		agentID, err := s.dispatcher.Dispatch(ctx, a)
 		if err != nil {
+			// A dispatch refused for want of provider capacity never ran, so
+			// it must not consume the anomaly's cooldown. Charging the fleet's
+			// outage to the task is what leaves an anomaly unexamined for a
+			// full cooldown window after every rate limit.
+			if errors.Is(err, provider.ErrProviderUnhealthy) {
+				s.state.releaseDispatch(a.Fingerprint)
+				s.logger.Warn("monitor.dispatch.no-capacity",
+					"kind", a.Kind, "fingerprint", a.Fingerprint, "err", err)
+				continue
+			}
 			s.logger.Warn("monitor.dispatch.failed", "kind", a.Kind, "fingerprint", a.Fingerprint, "err", err)
 			continue
 		}

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -411,6 +411,19 @@ func (s *Service) applyRemediations(ctx context.Context, anoms []Anomaly) remedi
 	return res
 }
 
+// isTransientCapacityRefusal reports whether a dispatch failure was a
+// self-healing capacity throttle rather than a refusal that needs a human.
+// UnhealthyError.RateLimited is the reliable signal — a rate limit is not
+// always tagged with Until, so a zero Until would otherwise read as "not a
+// rate limit".
+func isTransientCapacityRefusal(err error) bool {
+	var unhealthy *provider.UnhealthyError
+	if errors.As(err, &unhealthy) {
+		return unhealthy.RateLimited
+	}
+	return false
+}
+
 func (s *Service) dispatchLLMAnomalies(ctx context.Context, now time.Time, anoms []Anomaly) []string {
 	cooldown := time.Duration(s.cfg.IssueCooldownMinutes) * time.Minute
 	var out []string
@@ -435,7 +448,12 @@ func (s *Service) dispatchLLMAnomalies(ctx context.Context, now time.Time, anoms
 			// it must not consume the anomaly's cooldown. Charging the fleet's
 			// outage to the task is what leaves an anomaly unexamined for a
 			// full cooldown window after every rate limit.
-			if errors.Is(err, provider.ErrProviderUnhealthy) {
+			//
+			// Only a transient throttle, not every unhealthy provider: a
+			// permanent refusal (logged out, disabled in config) does not
+			// self-heal, so releasing there would retry it every tick until a
+			// human intervenes.
+			if isTransientCapacityRefusal(err) {
 				s.state.releaseDispatch(a.Fingerprint)
 				s.logger.Warn("monitor.dispatch.no-capacity",
 					"kind", a.Kind, "fingerprint", a.Fingerprint, "err", err)

--- a/internal/monitor/state.go
+++ b/internal/monitor/state.go
@@ -160,6 +160,20 @@ func (s *runState) canDispatch(fp string, now time.Time, cooldown time.Duration)
 	return true
 }
 
+// releaseDispatch undoes the cooldown canDispatch reserved, so the anomaly is
+// eligible again on the next tick.
+//
+// canDispatch has to record before the dispatch is attempted — two ticks must
+// not both fire for one fingerprint. But that means a dispatch which never
+// started, because no provider had capacity, burns the whole cooldown window
+// and charges the fleet's outage to the anomaly. Releasing keeps the reservation
+// honest: it is spent only when work actually began.
+func (s *runState) releaseDispatch(fp string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.lastDispatchAt, fp)
+}
+
 // recordReport stores the most recent finished report so Wails callers can
 // fetch it without waiting for the next tick.
 func (s *runState) recordReport(r Report, at time.Time) {


### PR DESCRIPTION
## Motivation

When every provider is rate-limited, the monitor's recovery dispatches all fail the same way:

```
WARN monitor.dispatch.failed kind=stuck_human_blocked fingerprint=stuck_human_blocked:09b7a3b6
     err="dispatch stuck_human_blocked: provider codex unhealthy (provider reports rate limit reached)"
```

Nine anomalies, twice within an hour, then nothing.

`runState.canDispatch` reserves the anomaly's cooldown *before* the dispatch is attempted, which it must — two ticks cannot both fire for one fingerprint. But a dispatch that never ran, because no provider had capacity, burned the whole window anyway. Each refusal bought a full `IssueCooldownMinutes` of silence on a task whose only problem was that the fleet had none.

That is the fleet's outage charged to the task.

> Changelog: fix(monitor): do not charge outages to anomalies

## Implementation information

`releaseDispatch` undoes the reservation when the refusal is `provider.ErrProviderUnhealthy`, so the anomaly is eligible again on the next tick. The sentinel already exists and `UnhealthyError` already distinguishes a transient capacity throttle from a permanent refusal, so no new classification was needed.

An ordinary dispatch failure still consumes the window. That one really did attempt work, and re-firing it every tick is precisely what the cooldown exists to prevent — the table test pins both directions.

### Scope note

The issue also proposes a deferred-intent queue that re-fires on `ProviderHealthEvent` rather than waiting for the next monitor tick. That is a larger change and not required for the defect described here: with the reservation released, the next tick already retries, and the tick interval bounds the delay. I have left it out rather than bundling a speculative queue into a correctness fix. Worth reconsidering once #3045 (detect zero provider capacity) lands, since the two would share the health-event subscription.

## Supporting documentation

Both tests were checked by reverting: removing only the `releaseDispatch` call fails with `dispatch attempts = 1, want 2`, and the ordinary-failure case stays green, so the test distinguishes the two paths rather than just asserting a retry happens.

Closes #3044
