### PR TITLE
fix(textutil): stop truncation corrupting UTF-8

### DIFF
--- a/cmd/sybra-cli/triage.go
+++ b/cmd/sybra-cli/triage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/triage"
 )
 
@@ -190,8 +191,6 @@ func triageRetryableReason(err error) string {
 	}
 	detail = strings.Join(strings.Fields(detail), " ")
 	const maxDetailLen = 500
-	if len(detail) > maxDetailLen {
-		detail = detail[:maxDetailLen] + "..."
-	}
+	detail = textutil.TruncateBytes(detail, maxDetailLen, "...")
 	return triageRetryableStatusReasonPrefix + "classifier failed: " + detail
 }

--- a/internal/agent/event_convo.go
+++ b/internal/agent/event_convo.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/limits"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // claudeEventToConvoEvent converts a shared ClaudeEvent into a ConvoEvent for
@@ -30,9 +31,7 @@ func claudeEventToConvoEvent(e ClaudeEvent) ConvoEvent {
 			results := make([]ToolResultBlock, len(e.Message.ToolResults))
 			copy(results, e.Message.ToolResults)
 			for i := range results {
-				if len(results[i].Content) > 2000 {
-					results[i].Content = results[i].Content[:2000] + "..."
-				}
+				results[i].Content = textutil.TruncateBytes(results[i].Content, 2000, "...")
 			}
 			ev.ToolResults = results
 		}

--- a/internal/agent/malformed_tool_call.go
+++ b/internal/agent/malformed_tool_call.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const (
@@ -84,17 +86,9 @@ Previous input:
 %s
 Reissue exactly one corrected %s tool call next. No explanation. No other tool first.`,
 		tool,
-		truncatePromptField(diag.ValidationError),
-		truncatePromptField(diag.ExpectedSchema),
-		truncatePromptField(inputJSON),
+		textutil.TruncateBytesTrimmed(strings.TrimSpace(diag.ValidationError), malformedToolPromptFieldLimit, "\n... (truncated)"),
+		textutil.TruncateBytesTrimmed(strings.TrimSpace(diag.ExpectedSchema), malformedToolPromptFieldLimit, "\n... (truncated)"),
+		textutil.TruncateBytesTrimmed(strings.TrimSpace(inputJSON), malformedToolPromptFieldLimit, "\n... (truncated)"),
 		tool,
 	))
-}
-
-func truncatePromptField(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) <= malformedToolPromptFieldLimit {
-		return s
-	}
-	return strings.TrimSpace(s[:malformedToolPromptFieldLimit]) + "\n... (truncated)"
 }

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/project"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // errSurviveShutdown is returned by a detached headless attempt when the
@@ -1159,7 +1160,7 @@ func (m *Manager) handleMalformedToolResults(a *Agent, event StreamEvent) {
 				return
 			}
 		}
-		reason := fmt.Sprintf("tool %s rejected malformed input: %s", toolName, truncatePromptField(diag.ValidationError))
+		reason := fmt.Sprintf("tool %s rejected malformed input: %s", toolName, textutil.TruncateBytesTrimmed(strings.TrimSpace(diag.ValidationError), malformedToolPromptFieldLimit, "\n... (truncated)"))
 		a.NoteMalformedToolCall(event.toolResults[i].ToolUseID, toolName, malformedToolCallOutcomeUnrecoverable)
 		a.SetError(malformedToolCallErrorKind, reason)
 		m.ReportProviderSignal(a.GetProvider(), providerpkg.SignalRateLimit, malformedToolCallErrorKind, malformedToolFailoverCooldown)

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -422,17 +422,23 @@ func TestManagerRunPersistsAndReattachesLiveHeadlessAgent(t *testing.T) {
 	t.Cleanup(func() { reattachPIDPoll.Store(prev) })
 
 	binDir := t.TempDir()
+	// The child must still be alive when ReattachAll runs. Staying up for a
+	// fixed span raced a loaded runner — the process exited first and
+	// reattach correctly found nothing — so it blocks on a sentinel the test
+	// writes once it is done with the live process. The iteration cap only
+	// stops a leak if the test dies before releasing it.
+	releaseFile := filepath.Join(t.TempDir(), "release")
 	fakeClaude := filepath.Join(binDir, "claude")
-	if err := os.WriteFile(fakeClaude, []byte(`#!/bin/sh
+	if err := os.WriteFile(fakeClaude, fmt.Appendf(nil, `#!/bin/sh
 trap 'exit 130' INT TERM
-printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-lifecycle"}'
+printf '%%s\n' '{"type":"system","subtype":"init","session_id":"sess-lifecycle"}'
 i=0
-while [ "$i" -lt 5 ]; do
-  sleep 0.1
+while [ ! -f %q ] && [ "$i" -lt 1200 ]; do
+  sleep 0.05
   i=$((i + 1))
 done
-printf '%s\n' '{"type":"result","result":"done","session_id":"sess-lifecycle","total_cost_usd":0}'
-`), 0o755); err != nil {
+printf '%%s\n' '{"type":"result","result":"done","session_id":"sess-lifecycle","total_cost_usd":0}'
+`, releaseFile), 0o755); err != nil {
 		t.Fatalf("write fake claude: %v", err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -499,7 +505,10 @@ printf '%s\n' '{"type":"result","result":"done","session_id":"sess-lifecycle","t
 		t.Fatal("expected reattached agent to rehydrate output from log")
 	}
 
-	waitForAgentDone(t, got, 5*time.Second)
+	if err := os.WriteFile(releaseFile, nil, 0o644); err != nil {
+		t.Fatalf("release fake claude: %v", err)
+	}
+	waitForAgentDone(t, got, 15*time.Second)
 	if got.GetState() != StateStopped {
 		t.Fatalf("completed reattached state = %s, want %s", got.GetState(), StateStopped)
 	}

--- a/internal/agent/tool_failure.go
+++ b/internal/agent/tool_failure.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const (
@@ -59,9 +61,9 @@ func (m *Manager) recordToolCallFailure(a *Agent, rec ToolCallFailureRecord) {
 			}
 		}
 	}
-	rec.ToolInputSummary = truncateToolFailureField(rec.ToolInputSummary)
-	rec.Reason = truncateToolFailureField(rec.Reason)
-	rec.ForegroundCommand = truncateToolFailureField(rec.ForegroundCommand)
+	rec.ToolInputSummary = textutil.TruncateBytes(rec.ToolInputSummary, toolFailureMaxField, "...[truncated]")
+	rec.Reason = textutil.TruncateBytes(rec.Reason, toolFailureMaxField, "...[truncated]")
+	rec.ForegroundCommand = textutil.TruncateBytes(rec.ForegroundCommand, toolFailureMaxField, "...[truncated]")
 
 	m.logger.Warn("agent.tool_failure",
 		"id", rec.AgentID,
@@ -156,22 +158,15 @@ func summarizeToolInput(input map[string]any) string {
 	for _, key := range []string{"command", "file_path", "path", "description", "url"} {
 		if v, ok := input[key]; ok {
 			if s := strings.TrimSpace(fmt.Sprint(v)); s != "" {
-				return truncateToolFailureField(s)
+				return textutil.TruncateBytes(s, toolFailureMaxField, "...[truncated]")
 			}
 		}
 	}
 	data, err := json.Marshal(input)
 	if err != nil {
-		return truncateToolFailureField(fmt.Sprint(input))
+		return textutil.TruncateBytes(fmt.Sprint(input), toolFailureMaxField, "...[truncated]")
 	}
-	return truncateToolFailureField(string(data))
-}
-
-func truncateToolFailureField(s string) string {
-	if len(s) <= toolFailureMaxField {
-		return s
-	}
-	return s[:toolFailureMaxField] + "...[truncated]"
+	return textutil.TruncateBytes(string(data), toolFailureMaxField, "...[truncated]")
 }
 
 func logApprovalToolFailure(logger *slog.Logger, agentID, toolName, toolUseID, source, reason string) {

--- a/internal/agent/tool_result_bound.go
+++ b/internal/agent/tool_result_bound.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/artifact"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const (
@@ -95,7 +95,7 @@ func bindToolResultContent(taskID, producerRole string, store *artifact.Store, t
 	}
 	b.WriteString("\n")
 	b.WriteString(summary)
-	return truncateUTF8(b.String(), toolResultSummaryMaxBytes)
+	return textutil.TruncateBytesTotal(b.String(), toolResultSummaryMaxBytes, "...")
 }
 
 func persistToolResultArtifact(taskID, producerRole string, store *artifact.Store, tr ToolResultBlock) toolResultArtifactRef {
@@ -147,7 +147,7 @@ func summarizeToolResult(content string, isError bool) string {
 		if tailStart := max(0, len(lines)-toolResultTailLines); tailStart > 0 {
 			sections = append(sections, fmt.Sprintf("tail lines %d-%d:\n%s", tailStart+1, len(lines), strings.Join(lines[tailStart:], "\n")))
 		}
-		return truncateUTF8(strings.Join(sections, "\n\n"), toolResultSummaryMaxBytes)
+		return textutil.TruncateBytesTotal(strings.Join(sections, "\n\n"), toolResultSummaryMaxBytes, "...")
 	}
 
 	headEnd := min(len(lines), toolResultHeadLines)
@@ -161,7 +161,7 @@ func summarizeToolResult(content string, isError bool) string {
 			sections = append(sections, fmt.Sprintf("tail lines %d-%d:\n%s", tailStart+1, len(lines), strings.Join(lines[tailStart:], "\n")))
 		}
 	}
-	return truncateUTF8(strings.Join(sections, "\n\n"), toolResultSummaryMaxBytes)
+	return textutil.TruncateBytesTotal(strings.Join(sections, "\n\n"), toolResultSummaryMaxBytes, "...")
 }
 
 func interestingToolResultWindows(lines []string, isError bool) []lineWindow {
@@ -302,20 +302,6 @@ func sanitizeArtifactToken(s string) string {
 		return "tool"
 	}
 	return out
-}
-
-func truncateUTF8(s string, maxBytes int) string {
-	if maxBytes <= 0 || len(s) <= maxBytes {
-		return s
-	}
-	if maxBytes <= 3 {
-		return s[:maxBytes]
-	}
-	cut := maxBytes - 3
-	for cut > 0 && !utf8.RuneStart(s[cut]) {
-		cut--
-	}
-	return s[:cut] + "..."
 }
 
 func windowCovered(w lineWindow, sections, lines []string) bool {

--- a/internal/evaluation/judge.go
+++ b/internal/evaluation/judge.go
@@ -8,11 +8,11 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/llmexec"
 	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // defaultJudgeModel is a capable model for nuanced code-quality judgment.
@@ -128,14 +128,14 @@ func buildQualityPrompt(req JudgeRequest, dims []RubricDimension) string {
 	b.WriteString("Score each dimension 0–10 (10 = excellent). Output ONLY a single JSON object on the final line.\n\n")
 
 	fmt.Fprintf(&b, "Task: %s\n", req.Title)
-	if body := truncate(req.Body, 800); body != "" {
+	if body := textutil.TruncateBytes(req.Body, 800, "\n…(truncated)"); body != "" {
 		fmt.Fprintf(&b, "Task details: %s\n", body)
 	}
 	if req.Trajectory != "" {
 		fmt.Fprintf(&b, "How the agent worked: %s\n", req.Trajectory)
 	}
 	b.WriteString("\nDiff (may be truncated):\n")
-	b.WriteString(truncate(req.Diff, maxDiffChars))
+	b.WriteString(textutil.TruncateBytes(req.Diff, maxDiffChars, "\n…(truncated)"))
 	b.WriteString("\n\nScore these dimensions:\n")
 	for _, d := range dims {
 		fmt.Fprintf(&b, "- %s: %s\n", d.Key, d.Question)
@@ -289,15 +289,4 @@ func clampScore(s int) int {
 		return 10
 	}
 	return s
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	// Back up to a rune boundary so the cut never splits a multibyte character.
-	for n > 0 && !utf8.RuneStart(s[n]) {
-		n--
-	}
-	return s[:n] + "\n…(truncated)"
 }

--- a/internal/experience/record.go
+++ b/internal/experience/record.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const (
@@ -47,7 +48,7 @@ func FromTask(t task.Task, proj project.Project) Record {
 		CreatedAt:      recordCreatedAt(t),
 		ProjectID:      proj.ID,
 		ProjectType:    string(proj.Type),
-		Title:          truncateText(t.Title, storedTextMaxRunes),
+		Title:          textutil.TruncateRunesTotal(strings.TrimSpace(t.Title), storedTextMaxRunes, "..."),
 		Tags:           boundedStrings(t.Tags, storedSliceMaxItems, storedSliceMaxRunes),
 		Size:           taskSize(t),
 		Type:           string(t.TaskType),
@@ -56,9 +57,9 @@ func FromTask(t task.Task, proj project.Project) Record {
 		Outcome:        t.Outcome,
 		Attempts:       len(t.AgentRuns),
 		FailureModes:   boundedStrings(failureModes(t), storedSliceMaxItems, storedSliceMaxRunes),
-		Strategy:       truncateText(firstNonEmpty(t.PlanBrief, t.Plan, t.Body), storedTextMaxRunes),
+		Strategy:       textutil.TruncateRunesTotal(strings.TrimSpace(firstNonEmpty(t.PlanBrief, t.Plan, t.Body)), storedTextMaxRunes, "..."),
 		VerifyCommands: boundedStrings(verifyCommands(proj), storedSliceMaxItems, storedSliceMaxRunes),
-		Caution:        truncateText(caution(t), storedTextMaxRunes),
+		Caution:        textutil.TruncateRunesTotal(strings.TrimSpace(caution(t)), storedTextMaxRunes, "..."),
 	}
 }
 
@@ -223,7 +224,7 @@ func singleLine(s string) string {
 }
 
 func promptText(s string) string {
-	return truncateText(singleLine(s), promptFieldMaxRunes)
+	return textutil.TruncateRunesTotal(strings.TrimSpace(singleLine(s)), promptFieldMaxRunes, "...")
 }
 
 func promptStrings(values []string) string {
@@ -243,22 +244,7 @@ func boundedStrings(values []string, maxItems, maxRunes int) []string {
 		if v == "" {
 			continue
 		}
-		out = append(out, truncateText(v, maxRunes))
+		out = append(out, textutil.TruncateRunesTotal(strings.TrimSpace(v), maxRunes, "..."))
 	}
 	return out
-}
-
-func truncateText(s string, maxRunes int) string {
-	s = strings.TrimSpace(s)
-	if maxRunes <= 0 {
-		return ""
-	}
-	runes := []rune(s)
-	if len(runes) <= maxRunes {
-		return s
-	}
-	if maxRunes <= 3 {
-		return string(runes[:maxRunes])
-	}
-	return string(runes[:maxRunes-3]) + "..."
 }

--- a/internal/harnessevolution/propose.go
+++ b/internal/harnessevolution/propose.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 func Propose(clusters []Cluster, now time.Time) []Proposal {
@@ -76,10 +78,7 @@ func proposalTitle(kind ProposalKind, c Cluster) string {
 	if c.AffectedStep != "" {
 		base += " at " + c.AffectedStep
 	}
-	if len(base) <= 80 {
-		return base
-	}
-	return base[:77] + "..."
+	return textutil.TruncateBytesTotal(base, 80, "...")
 }
 
 func expectedImpact(c Cluster) string {

--- a/internal/learning/validate.go
+++ b/internal/learning/validate.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // maxBucketItems and maxItemChars bound every free-text bucket so a digest
@@ -43,7 +45,7 @@ type rawDigest struct {
 func parseDigestJSON(text string) (rawDigest, error) {
 	jsonStr := extractLastJSON(text)
 	if jsonStr == "" {
-		return rawDigest{}, fmt.Errorf("no JSON object in summarizer output: %q", truncateForError(text))
+		return rawDigest{}, fmt.Errorf("no JSON object in summarizer output: %q", textutil.TruncateBytes(text, 200, "…"))
 	}
 	var rd rawDigest
 	if err := json.Unmarshal([]byte(jsonStr), &rd); err != nil {
@@ -157,14 +159,6 @@ func mentionsLowSample(text string) bool {
 		}
 	}
 	return false
-}
-
-func truncateForError(s string) string {
-	const maxChars = 200
-	if len(s) <= maxChars {
-		return s
-	}
-	return s[:maxChars] + "…"
 }
 
 // extractLastJSON returns the last balanced {...} substring in s, or "".

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -16,7 +16,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode/utf8"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // FileName is the scratchpad's name at the worktree root.
@@ -113,30 +114,7 @@ func clampNotes(body string) (string, bool) {
 	if len(body) <= seedMaxBytes {
 		return body, false
 	}
-	head := trimToRuneBoundaryEnd(body[:seedHeadBytes])
-	tail := trimToRuneBoundaryStart(body[len(body)-(seedMaxBytes-seedHeadBytes):])
+	head := textutil.TrimPartialRuneSuffix(body[:seedHeadBytes])
+	tail := textutil.TrimPartialRunePrefix(body[len(body)-(seedMaxBytes-seedHeadBytes):])
 	return head + elisionMarker + tail, true
-}
-
-// trimToRuneBoundaryStart drops a leading partial rune so s begins on a rune
-// boundary. A valid UTF-8 string with no leading continuation byte is returned
-// unchanged.
-func trimToRuneBoundaryStart(s string) string {
-	for len(s) > 0 && !utf8.RuneStart(s[0]) {
-		s = s[1:]
-	}
-	return s
-}
-
-// trimToRuneBoundaryEnd drops a trailing partial rune so s ends on a rune
-// boundary. Only an invalid encoding (RuneError with size 1) is trimmed; a
-// legitimately-present U+FFFD (size 3) is kept.
-func trimToRuneBoundaryEnd(s string) string {
-	for len(s) > 0 {
-		if r, size := utf8.DecodeLastRuneInString(s); r != utf8.RuneError || size > 1 {
-			break
-		}
-		s = s[:len(s)-1]
-	}
-	return s
 }

--- a/internal/promptlab/propose.go
+++ b/internal/promptlab/propose.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // candidateIntents are the directions promptlab may scaffold from a weak
@@ -67,10 +68,7 @@ func buildProposal(s WeakSubject, intent string, now time.Time) Proposal {
 
 func proposalTitle(s WeakSubject, intent string) string {
 	base := fmt.Sprintf("Prompt Lab: %s for role %s", strings.ReplaceAll(intent, "-", " "), s.Role)
-	if len(base) <= 80 {
-		return base
-	}
-	return base[:77] + "..."
+	return textutil.TruncateBytesTotal(base, 80, "...")
 }
 
 func expectedImpact(s WeakSubject, intent string) string {

--- a/internal/selfmonitor/judge.go
+++ b/internal/selfmonitor/judge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // judgeAttemptTimeout bounds each provider invocation, including llmjob repair
@@ -119,10 +120,7 @@ func buildJudgePrompt(f health.Finding, ls *LogSummary, t *task.Task) string {
 
 	if t != nil {
 		fmt.Fprintf(&b, "Task: %s\n", t.Title)
-		body := t.Body
-		if len(body) > 500 {
-			body = body[:500] + "…"
-		}
+		body := textutil.TruncateBytes(t.Body, 500, "…")
 		if body != "" {
 			fmt.Fprintf(&b, "Body: %s\n", body)
 		}

--- a/internal/selfmonitor/loganalyzer.go
+++ b/internal/selfmonitor/loganalyzer.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // LogSummarySchemaVersion is bumped whenever the shape of LogSummary changes
@@ -330,7 +331,7 @@ func (st *analyzerState) onUser(ev *agent.ClaudeEvent) {
 		return
 	}
 	for _, r := range ev.Message.ToolResults {
-		excerpt := truncate(r.Content, 400)
+		excerpt := textutil.TruncateBytes(r.Content, 400, "…")
 		if call, ok := st.byUseID[r.ToolUseID]; ok {
 			call.trace.ResultExcerpt = excerpt
 			call.trace.IsError = r.IsError
@@ -368,7 +369,7 @@ func (st *analyzerState) onResult(ev *agent.ClaudeEvent) {
 	class := classifyResultError(ev.Result.ErrorType, ev.Result.ErrorStatus, ev.Result.Text)
 	st.errorClassCounts[class]++
 	if _, ok := st.errorClassSamples[class]; !ok {
-		st.errorClassSamples[class] = truncate(ev.Result.Text, 400)
+		st.errorClassSamples[class] = textutil.TruncateBytes(ev.Result.Text, 400, "…")
 	}
 	if class != "" {
 		st.summary.FinalError = class
@@ -564,13 +565,6 @@ func classifyByText(text string) string {
 		return "network"
 	}
 	return "unknown"
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "…"
 }
 
 func itoa(n int) string {

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/scrub"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/verdict"
 	"github.com/Automaat/sybra/internal/workflow"
 )
@@ -1673,10 +1674,7 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, dir string, wctx *WorkScru
 					defaultStr(r.ProtocolViolation, "(none)"), defaultStr(r.TestOutcome, "(none)"), defaultStr(r.TestFailureFingerprint, "(none)"))
 			}
 			if r.Result != "" {
-				res := r.Result
-				if len(res) > humanReviewMaxAgentResult {
-					res = res[:humanReviewMaxAgentResult] + "\n... (truncated)"
-				}
+				res := textutil.TruncateBytes(r.Result, humanReviewMaxAgentResult, "\n... (truncated)")
 				b.WriteString("Result:\n```\n")
 				b.WriteString(strings.TrimSpace(res))
 				b.WriteString("\n```\n")

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Automaat/sybra/internal/skillattr"
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/verdict"
 	"github.com/Automaat/sybra/internal/watchdogreason"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -498,10 +499,7 @@ func (h *Handler) buildRunPatch(ag *agent.Agent, state agent.State, cost, premiu
 			ag.SkillConformance = skillattr.ConformanceRecovered
 		}
 	}
-	truncated := resultContent
-	if len(truncated) > maxResultLen {
-		truncated = truncated[:maxResultLen] + "\n... (truncated)"
-	}
+	truncated := textutil.TruncateBytes(resultContent, maxResultLen, "\n... (truncated)")
 	runUpdates := task.RunPatch{
 		State:           task.Ptr(string(state)),
 		CostUSD:         task.Ptr(cost),
@@ -720,11 +718,7 @@ func interruptedReviewAssistantTranscript(ag *agent.Agent) string {
 	if b.Len() == 0 {
 		return ""
 	}
-	transcript := b.String()
-	if len(transcript) > interruptedReviewMaxLen {
-		transcript = transcript[:interruptedReviewMaxLen] + "\n\n... (truncated)"
-	}
-	return transcript
+	return textutil.TruncateBytes(b.String(), interruptedReviewMaxLen, "\n\n... (truncated)")
 }
 
 // handleFixReviewCompletion routes a finished manual fix-review agent. Without

--- a/internal/sybra/completion/result_utf8_test.go
+++ b/internal/sybra/completion/result_utf8_test.go
@@ -1,0 +1,47 @@
+package completion
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/agent"
+)
+
+// Every completed run's final result is truncated into AgentRun.Result, which
+// internal/task persists as YAML frontmatter (`yaml:"result,omitempty"`). This
+// is the highest-volume raw-agent-output-to-YAML path in the system, so a cut
+// landing inside a multibyte rune turns the run record into an unreadable
+// !!binary base64 block rather than corrupting one status reason.
+func TestBuildRunPatchResultSurvivesMultibyteAgentOutput(t *testing.T) {
+	for name, result := range map[string]string{
+		"ellipsis run":       strings.Repeat("…", 1000),
+		"arrow run":          strings.Repeat("→", 1000),
+		"emoji run":          strings.Repeat("🚀", 800),
+		"box-drawing border": strings.Repeat("│─", 1000),
+	} {
+		t.Run(name, func(t *testing.T) {
+			patch := (&Handler{}).buildRunPatch(&agent.Agent{}, agent.StateStopped, 0, 0, result, nil)
+
+			if patch.Result == nil {
+				t.Fatal("Result not set on the run patch")
+			}
+			if !utf8.ValidString(*patch.Result) {
+				t.Fatalf("run result is not valid UTF-8: %q", *patch.Result)
+			}
+			if !strings.HasSuffix(*patch.Result, "\n... (truncated)") {
+				t.Fatalf("run result = %q, want the truncation marker", *patch.Result)
+			}
+
+			data, err := yaml.Marshal(map[string]string{"result": *patch.Result})
+			if err != nil {
+				t.Fatalf("yaml.Marshal: %v", err)
+			}
+			if strings.Contains(string(data), "!!binary") {
+				t.Fatalf("run result marshalled as a binary block:\n%s", data)
+			}
+		})
+	}
+}

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -969,13 +969,21 @@ func prHasCurrentApproval(pr github.PullRequest) bool {
 	return pr.ReviewDecision == "APPROVED" || pr.RESTApproved
 }
 
+// pushPreflightFailureReason builds the status_reason for a failed credential
+// preflight. git surfaces remote output verbatim, so err can carry raw bytes
+// in whatever encoding the remote used — sanitize before it reaches YAML.
+func pushPreflightFailureReason(err error) string {
+	return "GitHub push credential preflight failed before starting PR fix: " +
+		textutil.TruncateBytesTrimmed(strings.ToValidUTF8(err.Error(), ""), 240, "...")
+}
+
 func (r *Handler) preflightPushCredentials(ctx context.Context, taskID, dir string) (admit, handled bool) {
 	preflight := r.pushPreflightFn
 	if preflight == nil {
 		preflight = project.PreflightPushCredentials
 	}
 	if err := preflight(ctx, dir); err != nil {
-		reason := "GitHub push credential preflight failed before starting PR fix: " + textutil.TruncateBytesTrimmed(strings.ToValidUTF8(err.Error(), ""), 240, "...")
+		reason := pushPreflightFailureReason(err)
 		if _, updateErr := r.tasks.Apply(task.TransitionIntent{
 			TaskID:   taskID,
 			ToStatus: task.StatusHumanRequired,

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/blocker"
@@ -21,6 +20,7 @@ import (
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
@@ -975,7 +975,7 @@ func (r *Handler) preflightPushCredentials(ctx context.Context, taskID, dir stri
 		preflight = project.PreflightPushCredentials
 	}
 	if err := preflight(ctx, dir); err != nil {
-		reason := "GitHub push credential preflight failed before starting PR fix: " + truncatePushPreflightReason(err.Error(), 240)
+		reason := "GitHub push credential preflight failed before starting PR fix: " + textutil.TruncateBytesTrimmed(strings.ToValidUTF8(err.Error(), ""), 240, "...")
 		if _, updateErr := r.tasks.Apply(task.TransitionIntent{
 			TaskID:   taskID,
 			ToStatus: task.StatusHumanRequired,
@@ -991,21 +991,6 @@ func (r *Handler) preflightPushCredentials(ctx context.Context, taskID, dir stri
 		return false, true
 	}
 	return true, false
-}
-
-func truncatePushPreflightReason(s string, limit int) string {
-	s = strings.ToValidUTF8(s, "")
-	if limit <= 0 || len(s) <= limit {
-		return s
-	}
-	var b strings.Builder
-	for _, r := range s {
-		if b.Len()+utf8.RuneLen(r) > limit {
-			break
-		}
-		b.WriteRune(r)
-	}
-	return strings.TrimSpace(b.String()) + "..."
 }
 
 // A rerun re-runs jobs the repo already ran and sends no content anywhere, so the work/pet split does not apply. EXC:FILE011:load-bearing-invariant

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -389,9 +389,11 @@ func assertPRFixPromptUsesResolvedPushRemote(t *testing.T, prompt, branch string
 }
 
 func TestPushPreflightFailureReasonKeepsValidUTF8(t *testing.T) {
-	// Long enough to force a cut, multibyte at the cut point, and a raw
-	// invalid byte of the kind a remote's own error output can carry.
-	detail := strings.Repeat("remote rejected ", 20) + "\xff café… suffix"
+	// The multibyte and invalid bytes must sit BEFORE the 240-byte cut, or
+	// the test passes without exercising either the boundary walk or the
+	// sanitisation — git surfaces remote bytes verbatim, so both can land
+	// anywhere in the string.
+	detail := "\xff café… " + strings.Repeat("remote rejected …", 30)
 	got := pushPreflightFailureReason(errors.New(detail))
 
 	if !utf8.ValidString(got) {

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
-	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
@@ -389,13 +388,20 @@ func assertPRFixPromptUsesResolvedPushRemote(t *testing.T, prompt, branch string
 	}
 }
 
-func TestTruncatePushPreflightReasonKeepsValidUTF8(t *testing.T) {
-	got := textutil.TruncateBytesTrimmed(strings.ToValidUTF8("prefix \xff café suffix", ""), 12, "...")
+func TestPushPreflightFailureReasonKeepsValidUTF8(t *testing.T) {
+	// Long enough to force a cut, multibyte at the cut point, and a raw
+	// invalid byte of the kind a remote's own error output can carry.
+	detail := strings.Repeat("remote rejected ", 20) + "\xff café… suffix"
+	got := pushPreflightFailureReason(errors.New(detail))
+
 	if !utf8.ValidString(got) {
-		t.Fatalf("truncated reason is invalid UTF-8: %q", got)
+		t.Fatalf("preflight reason is invalid UTF-8: %q", got)
 	}
 	if !strings.HasSuffix(got, "...") {
-		t.Fatalf("truncated reason = %q, want ellipsis", got)
+		t.Fatalf("preflight reason = %q, want ellipsis", got)
+	}
+	if !strings.HasPrefix(got, "GitHub push credential preflight failed") {
+		t.Fatalf("preflight reason = %q, want the classified prefix", got)
 	}
 }
 

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
@@ -389,7 +390,7 @@ func assertPRFixPromptUsesResolvedPushRemote(t *testing.T, prompt, branch string
 }
 
 func TestTruncatePushPreflightReasonKeepsValidUTF8(t *testing.T) {
-	got := truncatePushPreflightReason("prefix \xff café suffix", 12)
+	got := textutil.TruncateBytesTrimmed(strings.ToValidUTF8("prefix \xff café suffix", ""), 12, "...")
 	if !utf8.ValidString(got) {
 		t.Fatalf("truncated reason is invalid UTF-8: %q", got)
 	}

--- a/internal/sybra/svc_info_runtimes.go
+++ b/internal/sybra/svc_info_runtimes.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const (
@@ -125,23 +127,9 @@ func formatRuntimeProbeError(ctx context.Context, err error, output []byte, time
 	}
 	msg = strings.Join(strings.Fields(msg), " ")
 	if len(msg) > runtimeProbeErrorMax {
-		msg = truncateRuntimeProbeError(msg)
+		msg = textutil.TruncateBytesTotal(msg, runtimeProbeErrorMax, "...")
 	}
 	return msg
-}
-
-func truncateRuntimeProbeError(msg string) string {
-	const suffix = "..."
-	limit := runtimeProbeErrorMax - len(suffix)
-	var b strings.Builder
-	for _, r := range msg {
-		next := string(r)
-		if b.Len()+len(next) > limit {
-			break
-		}
-		b.WriteString(next)
-	}
-	return b.String() + suffix
 }
 
 func probeRuntimeTextCapability(path string, probe *runtimeTextProbe, timeout time.Duration) string {

--- a/internal/sybra/svc_info_runtimes.go
+++ b/internal/sybra/svc_info_runtimes.go
@@ -127,7 +127,7 @@ func formatRuntimeProbeError(ctx context.Context, err error, output []byte, time
 	}
 	msg = strings.Join(strings.Fields(msg), " ")
 	if len(msg) > runtimeProbeErrorMax {
-		msg = textutil.TruncateBytesTotal(msg, runtimeProbeErrorMax, "...")
+		msg = textutil.TruncateBytesTotal(strings.ToValidUTF8(msg, "\uFFFD"), runtimeProbeErrorMax, "...")
 	}
 	return msg
 }

--- a/internal/sybra/svc_info_runtimes_test.go
+++ b/internal/sybra/svc_info_runtimes_test.go
@@ -1,14 +1,14 @@
 package sybra
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
-
-	"github.com/Automaat/sybra/internal/textutil"
 )
 
 func TestDetectAvailableRuntimes(t *testing.T) {
@@ -134,16 +134,24 @@ func TestRuntimeProbeTimeout(t *testing.T) {
 }
 
 func TestRuntimeProbeErrorTruncationStaysWithinByteLimit(t *testing.T) {
-	longErr := strings.Repeat("failure ", 40) + "ą"
-	got := textutil.TruncateBytesTotal(longErr, runtimeProbeErrorMax, "...")
-	if len(got) > runtimeProbeErrorMax {
-		t.Fatalf("truncated error length = %d, want <= %d", len(got), runtimeProbeErrorMax)
-	}
-	if !strings.HasSuffix(got, "...") {
-		t.Fatalf("truncated error = %q, want ASCII suffix", got)
-	}
-	if !utf8.ValidString(got) {
-		t.Fatalf("truncated error is not valid UTF-8: %q", got)
+	// A probe binary's stderr is whatever the binary wrote: latin-1 bytes and
+	// multibyte runes both reach this path, which is why the field is capped
+	// in bytes rather than runes.
+	for name, output := range map[string]string{
+		"multibyte at the cut": strings.Repeat("failure ", 40) + "ą",
+		"invalid latin-1 byte": strings.Repeat("failure ", 20) + " caf\xe9 \xff\xfe " + strings.Repeat("b", 60),
+		"ellipsis run":         strings.Repeat("…", 200),
+	} {
+		got := formatRuntimeProbeError(context.Background(), errors.New("probe failed"), []byte(output), time.Second)
+		if len(got) > runtimeProbeErrorMax {
+			t.Errorf("%s: length = %d, want <= %d", name, len(got), runtimeProbeErrorMax)
+		}
+		if !strings.HasSuffix(got, "...") {
+			t.Errorf("%s: got %q, want ASCII suffix", name, got)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("%s: got %q, which is not valid UTF-8", name, got)
+		}
 	}
 }
 

--- a/internal/sybra/svc_info_runtimes_test.go
+++ b/internal/sybra/svc_info_runtimes_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 func TestDetectAvailableRuntimes(t *testing.T) {
@@ -133,7 +135,7 @@ func TestRuntimeProbeTimeout(t *testing.T) {
 
 func TestRuntimeProbeErrorTruncationStaysWithinByteLimit(t *testing.T) {
 	longErr := strings.Repeat("failure ", 40) + "ą"
-	got := truncateRuntimeProbeError(longErr)
+	got := textutil.TruncateBytesTotal(longErr, runtimeProbeErrorMax, "...")
 	if len(got) > runtimeProbeErrorMax {
 		t.Fatalf("truncated error length = %d, want <= %d", len(got), runtimeProbeErrorMax)
 	}

--- a/internal/task/status_reason_utf8_test.go
+++ b/internal/task/status_reason_utf8_test.go
@@ -1,0 +1,48 @@
+package task
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/Automaat/sybra/internal/textutil"
+)
+
+// A status reason is built by truncating raw agent output, then persisted as
+// YAML frontmatter. A cut landing inside a multibyte rune used to leave
+// invalid UTF-8, which yaml.v3 re-encodes as an unreadable !!binary block —
+// the task file and the board then show base64 instead of the reason.
+func TestStatusReasonFromTruncatedAgentOutputMarshalsAsPlainYAML(t *testing.T) {
+	t.Parallel()
+	output := "planning failed " + strings.Repeat("…", 400) // ellipses put the 500-byte cut mid-rune
+
+	reason := "planning plan retry budget exhausted after 3 attempt(s): " +
+		textutil.TruncateBytes(strings.TrimSpace(output), 500, "\n... (truncated)")
+
+	if !utf8.ValidString(reason) {
+		t.Fatalf("truncated status reason is not valid UTF-8: %q", reason)
+	}
+
+	task := Task{
+		ID:           "task-utf8",
+		Title:        "utf8 reason",
+		Status:       StatusHumanRequired,
+		AgentMode:    AgentModeHeadless,
+		StatusReason: reason,
+	}
+	data, err := Marshal(task)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "!!binary") {
+		t.Fatalf("status reason marshalled as a binary block:\n%s", data)
+	}
+
+	parsed, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if parsed.StatusReason != reason {
+		t.Errorf("StatusReason did not round-trip:\ngot  %q\nwant %q", parsed.StatusReason, reason)
+	}
+}

--- a/internal/textutil/truncate.go
+++ b/internal/textutil/truncate.go
@@ -1,0 +1,108 @@
+// Package textutil holds the one rune-safe truncation implementation.
+//
+// Every cut lands on a UTF-8 rune boundary. Slicing raw bytes instead splits
+// multibyte runes in agent output — `…`, `→`, box-drawing borders, emoji are
+// ordinary there — and the invalid UTF-8 that produces is not inert: yaml.v3
+// re-encodes it as an unreadable `!!binary` block in the task file, and
+// encoding/json silently swaps in U+FFFD.
+package textutil
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// TruncateBytes keeps at most limit bytes of s and appends suffix when it
+// cuts, so the result can exceed limit by len(suffix). Callers that need the
+// whole result bounded want TruncateBytesTotal.
+func TruncateBytes(s string, limit int, suffix string) string {
+	if len(s) <= limit {
+		return s
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	return s[:runeBoundaryAtOrBefore(s, limit)] + suffix
+}
+
+// TruncateBytesTotal bounds the whole result — content plus suffix — to limit
+// bytes. A limit too small for the suffix yields the suffix alone, itself cut
+// on a rune boundary.
+func TruncateBytesTotal(s string, limit int, suffix string) string {
+	if len(s) <= limit {
+		return s
+	}
+	if limit <= len(suffix) {
+		return suffix[:runeBoundaryAtOrBefore(suffix, max(limit, 0))]
+	}
+	return TruncateBytes(s, limit-len(suffix), suffix)
+}
+
+// TruncateRunesTotal bounds the whole result to limit runes. Use it for
+// budgets a human reads as a character count; the byte variants are for
+// storage and protocol limits.
+func TruncateRunesTotal(s string, limit int, suffix string) string {
+	if limit <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= limit {
+		return s
+	}
+	suffixRunes := []rune(suffix)
+	if limit <= len(suffixRunes) {
+		return string(suffixRunes[:limit])
+	}
+	return string([]rune(s)[:limit-len(suffixRunes)]) + suffix
+}
+
+// TruncateMiddle keeps the head and tail of s and replaces the middle with
+// marker, bounding the whole result to limit bytes. Prefer it when the end of
+// the text carries the signal — a stack trace's innermost frame, a command's
+// exit status — and a head-only cut would drop it.
+func TruncateMiddle(s string, limit int, marker string) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(s) <= limit {
+		return s
+	}
+	if limit <= len(marker)+2 {
+		return s[:runeBoundaryAtOrBefore(s, limit)]
+	}
+	keep := limit - len(marker)
+	head := runeBoundaryAtOrBefore(s, keep/2)
+	tail := runeBoundaryAtOrAfter(s, len(s)-(keep-keep/2))
+	return s[:head] + marker + s[tail:]
+}
+
+// TruncateBytesTrimmed is TruncateBytes with surrounding whitespace stripped
+// from the cut content, so a cut landing mid-indentation does not leave the
+// suffix dangling off a run of spaces.
+func TruncateBytesTrimmed(s string, limit int, suffix string) string {
+	if len(s) <= limit {
+		return s
+	}
+	return strings.TrimSpace(TruncateBytes(s, limit, "")) + suffix
+}
+
+// runeBoundaryAtOrBefore returns the largest index <= i that starts a rune.
+func runeBoundaryAtOrBefore(s string, i int) int {
+	if i >= len(s) {
+		return len(s)
+	}
+	for i > 0 && !utf8.RuneStart(s[i]) {
+		i--
+	}
+	return i
+}
+
+// runeBoundaryAtOrAfter returns the smallest index >= i that starts a rune.
+func runeBoundaryAtOrAfter(s string, i int) int {
+	if i < 0 {
+		return 0
+	}
+	for i < len(s) && !utf8.RuneStart(s[i]) {
+		i++
+	}
+	return i
+}

--- a/internal/textutil/truncate.go
+++ b/internal/textutil/truncate.go
@@ -85,6 +85,26 @@ func TruncateBytesTrimmed(s string, limit int, suffix string) string {
 	return strings.TrimSpace(TruncateBytes(s, limit, "")) + suffix
 }
 
+// TrimPartialRunePrefix drops a leading partial rune so s begins on a rune
+// boundary. Use it when slicing from the middle of a buffer, where the cut
+// point is not under your control.
+func TrimPartialRunePrefix(s string) string {
+	return s[runeBoundaryAtOrAfter(s, 0):]
+}
+
+// TrimPartialRuneSuffix drops a trailing partial rune so s ends on a rune
+// boundary. A legitimately-present U+FFFD is kept — only a 1-byte RuneError,
+// which can only come from a broken encoding, is trimmed.
+func TrimPartialRuneSuffix(s string) string {
+	for len(s) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(s); r != utf8.RuneError || size > 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
 // runeBoundaryAtOrBefore returns the largest index <= i that starts a rune.
 func runeBoundaryAtOrBefore(s string, i int) int {
 	if i >= len(s) {

--- a/internal/textutil/truncate.go
+++ b/internal/textutil/truncate.go
@@ -25,6 +25,15 @@ func TruncateBytes(s string, limit int, suffix string) string {
 	return s[:runeBoundaryAtOrBefore(s, limit)] + suffix
 }
 
+// TruncateBytesValid caps s like TruncateBytes and additionally guarantees the
+// whole result is valid UTF-8, repairing malformed bytes anywhere in the
+// retained text rather than only aligning the cut. Reach for it when the text
+// comes from outside the process — tool output, remote stderr, file contents —
+// where a bad byte can sit well before the cut point.
+func TruncateBytesValid(s string, limit int, suffix string) string {
+	return TruncateBytes(strings.ToValidUTF8(s, "\uFFFD"), limit, suffix)
+}
+
 // TruncateBytesTotal bounds the whole result — content plus suffix — to limit
 // bytes. A limit too small for the suffix yields the suffix alone, itself cut
 // on a rune boundary.
@@ -82,7 +91,7 @@ func TruncateBytesTrimmed(s string, limit int, suffix string) string {
 	if len(s) <= limit {
 		return s
 	}
-	return strings.TrimSpace(TruncateBytes(s, limit, "")) + suffix
+	return strings.TrimSpace(TruncateBytesValid(s, limit, "")) + suffix
 }
 
 // TrimPartialRunePrefix drops a leading partial rune so s begins on a rune

--- a/internal/textutil/truncate_test.go
+++ b/internal/textutil/truncate_test.go
@@ -152,11 +152,11 @@ func TestEveryCutPointStaysValidUTF8(t *testing.T) {
 	for limit := -2; limit <= len(s)+2; limit++ {
 		for _, suffix := range []string{"...", "…", "\n... (truncated)", ""} {
 			for name, got := range map[string]string{
-				"TruncateBytes":       TruncateBytes(s, limit, suffix),
-				"TruncateBytesTotal":  TruncateBytesTotal(s, limit, suffix),
-				"TruncateRunesTotal":  TruncateRunesTotal(s, limit, suffix),
-				"TruncateMiddle":      TruncateMiddle(s, limit, suffix),
-				"TruncateBytesTrimed": TruncateBytesTrimmed(s, limit, suffix),
+				"TruncateBytes":        TruncateBytes(s, limit, suffix),
+				"TruncateBytesTotal":   TruncateBytesTotal(s, limit, suffix),
+				"TruncateRunesTotal":   TruncateRunesTotal(s, limit, suffix),
+				"TruncateMiddle":       TruncateMiddle(s, limit, suffix),
+				"TruncateBytesTrimmed": TruncateBytesTrimmed(s, limit, suffix),
 			} {
 				if !utf8.ValidString(got) {
 					t.Errorf("%s(%q, %d, %q) = %q: invalid UTF-8", name, s, limit, suffix, got)

--- a/internal/textutil/truncate_test.go
+++ b/internal/textutil/truncate_test.go
@@ -1,0 +1,167 @@
+package textutil
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// multibyte spells out the runes that actually appear in agent output and
+// caused the corruption: ellipsis, arrow, box-drawing border, emoji.
+const multibyte = "…→│🚀"
+
+func TestTruncateBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		s      string
+		limit  int
+		suffix string
+		want   string
+	}{
+		{name: "under limit is untouched", s: "abc", limit: 10, suffix: "…", want: "abc"},
+		{name: "exactly at limit is untouched", s: "abc", limit: 3, suffix: "…", want: "abc"},
+		{name: "ascii cut appends suffix", s: "abcdef", limit: 3, suffix: "...", want: "abc..."},
+		{name: "cut inside a rune backs up", s: "a" + multibyte, limit: 2, suffix: "!", want: "a!"},
+		{name: "cut on a rune boundary keeps the rune", s: "a" + multibyte, limit: 4, suffix: "!", want: "a…!"},
+		{name: "zero limit yields the suffix alone", s: "abc", limit: 0, suffix: "...", want: "..."},
+		{name: "negative limit yields the suffix alone", s: "abc", limit: -5, suffix: "...", want: "..."},
+		{name: "empty input is untouched", s: "", limit: 5, suffix: "...", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := TruncateBytes(tt.s, tt.limit, tt.suffix); got != tt.want {
+				t.Errorf("TruncateBytes(%q, %d, %q) = %q, want %q", tt.s, tt.limit, tt.suffix, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateBytesTotal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		s      string
+		limit  int
+		suffix string
+		want   string
+	}{
+		{name: "under limit is untouched", s: "abc", limit: 10, suffix: "...", want: "abc"},
+		{name: "result fits the limit", s: "abcdefghij", limit: 6, suffix: "...", want: "abc..."},
+		{name: "cut inside a rune backs up", s: "ab" + multibyte, limit: 6, suffix: "...", want: "ab..."},
+		{name: "limit equal to the suffix drops content", s: "abcdef", limit: 3, suffix: "...", want: "..."},
+		{name: "limit below the suffix cuts the suffix", s: "abcdef", limit: 2, suffix: "...", want: ".."},
+		{name: "limit splitting a multibyte suffix yields nothing", s: "abcdef", limit: 2, suffix: "…", want: ""},
+		{name: "zero limit yields nothing", s: "abc", limit: 0, suffix: "...", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := TruncateBytesTotal(tt.s, tt.limit, tt.suffix)
+			if got != tt.want {
+				t.Errorf("TruncateBytesTotal(%q, %d, %q) = %q, want %q", tt.s, tt.limit, tt.suffix, got, tt.want)
+			}
+			if len(got) > max(tt.limit, 0) && len(tt.s) > tt.limit {
+				t.Errorf("result %q is %d bytes, over the %d limit", got, len(got), tt.limit)
+			}
+		})
+	}
+}
+
+func TestTruncateRunesTotal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		s      string
+		limit  int
+		suffix string
+		want   string
+	}{
+		{name: "under limit is untouched", s: multibyte, limit: 10, suffix: "...", want: multibyte},
+		{name: "counts runes not bytes", s: multibyte, limit: 4, suffix: "...", want: multibyte},
+		{name: "cut leaves room for the suffix", s: multibyte, limit: 3, suffix: "...", want: "..."},
+		{name: "ascii cut", s: "abcdefgh", limit: 6, suffix: "...", want: "abc..."},
+		{name: "limit below the suffix cuts the suffix", s: "abcdef", limit: 2, suffix: "...", want: ".."},
+		{name: "zero limit yields nothing", s: "abc", limit: 0, suffix: "...", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := TruncateRunesTotal(tt.s, tt.limit, tt.suffix)
+			if got != tt.want {
+				t.Errorf("TruncateRunesTotal(%q, %d, %q) = %q, want %q", tt.s, tt.limit, tt.suffix, got, tt.want)
+			}
+			if n := utf8.RuneCountInString(got); n > max(tt.limit, 0) {
+				t.Errorf("result %q is %d runes, over the %d limit", got, n, tt.limit)
+			}
+		})
+	}
+}
+
+func TestTruncateMiddle(t *testing.T) {
+	t.Parallel()
+	const marker = "..."
+	tests := []struct {
+		name  string
+		s     string
+		limit int
+		want  string
+	}{
+		{name: "under limit is untouched", s: "abc", limit: 10, want: "abc"},
+		{name: "keeps head and tail", s: "abcdefghij", limit: 7, want: "ab...ij"},
+		{name: "limit too small for the marker cuts the head", s: "abcdefghij", limit: 4, want: "abcd"},
+		{name: "zero limit yields nothing", s: "abcdef", limit: 0, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := TruncateMiddle(tt.s, tt.limit, marker)
+			if got != tt.want {
+				t.Errorf("TruncateMiddle(%q, %d, %q) = %q, want %q", tt.s, tt.limit, marker, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateMiddleKeepsTheTail(t *testing.T) {
+	t.Parallel()
+	s := strings.Repeat("x", 200) + "EXIT_STATUS=1"
+	got := TruncateMiddle(s, 60, "\n... (truncated) ...\n")
+	if !strings.HasSuffix(got, "EXIT_STATUS=1") {
+		t.Errorf("middle truncation dropped the tail: %q", got)
+	}
+}
+
+func TestTruncateBytesTrimmed(t *testing.T) {
+	t.Parallel()
+	if got := TruncateBytesTrimmed("abc   def", 6, "..."); got != "abc..." {
+		t.Errorf("TruncateBytesTrimmed = %q, want %q", got, "abc...")
+	}
+	if got := TruncateBytesTrimmed("abc", 10, "..."); got != "abc" {
+		t.Errorf("under-limit input was modified: %q", got)
+	}
+}
+
+// Every function must return valid UTF-8 at every possible cut point. This is
+// the invariant the six byte-slicing helpers this package replaced all missed.
+func TestEveryCutPointStaysValidUTF8(t *testing.T) {
+	t.Parallel()
+	// Mixed-width runes so some limits necessarily land mid-rune.
+	s := "ok " + multibyte + " tail " + multibyte
+	for limit := -2; limit <= len(s)+2; limit++ {
+		for _, suffix := range []string{"...", "…", "\n... (truncated)", ""} {
+			for name, got := range map[string]string{
+				"TruncateBytes":       TruncateBytes(s, limit, suffix),
+				"TruncateBytesTotal":  TruncateBytesTotal(s, limit, suffix),
+				"TruncateRunesTotal":  TruncateRunesTotal(s, limit, suffix),
+				"TruncateMiddle":      TruncateMiddle(s, limit, suffix),
+				"TruncateBytesTrimed": TruncateBytesTrimmed(s, limit, suffix),
+			} {
+				if !utf8.ValidString(got) {
+					t.Errorf("%s(%q, %d, %q) = %q: invalid UTF-8", name, s, limit, suffix, got)
+				}
+			}
+		}
+	}
+}

--- a/internal/umbrella/recover.go
+++ b/internal/umbrella/recover.go
@@ -8,11 +8,11 @@ import (
 	"slices"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/scrub"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // RecoveryOutcome classifies how a RecoverDegraded run concluded.
@@ -565,7 +565,7 @@ func safeRecoveryFailureReason(cause error) string {
 	reason := cause.Error()
 	reason, _ = scrub.Scrub(reason, nil)
 	reason = stripRecoveryPayloads(reason)
-	return truncateUTF8(reason, 160)
+	return textutil.TruncateBytesTotal(reason, 160, "...")
 }
 
 func stripRecoveryPayloads(reason string) string {
@@ -608,20 +608,5 @@ func stripDelimitedPayloads(s string, open, closing rune) string {
 func formatRecoveryFailureReason(count int, reason string) string {
 	reason = fmt.Sprintf("%s%d): %s", RecoveryFailureReasonPrefix, count, reason)
 	const maxLen = 200
-	return truncateUTF8(reason, maxLen)
-}
-
-func truncateUTF8(s string, maxLen int) string {
-	if maxLen <= 0 || len(s) <= maxLen {
-		return s
-	}
-	const tail = "..."
-	if maxLen <= len(tail) {
-		return tail[:maxLen]
-	}
-	cut := maxLen - len(tail)
-	for cut > 0 && !utf8.RuneStart(s[cut]) {
-		cut--
-	}
-	return s[:cut] + tail
+	return textutil.TruncateBytesTotal(reason, maxLen, "...")
 }

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/reviewbudget"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const triageRetryableStatusReasonPrefix = "triage retryable: "
@@ -68,7 +69,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	wfExec.RecordStep(StepRecord{
 		StepID:    output.StepID,
 		Status:    output.Status,
-		Output:    truncate(output.Output, 4000),
+		Output:    textutil.TruncateBytes(output.Output, 4000, "\n... (truncated)"),
 		AgentID:   output.AgentID,
 		Provider:  output.Provider,
 		StartedAt: now,
@@ -100,7 +101,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		clearWatchdogRetryCounters(wfExec, output.StepID)
 	}
 	if output.Output != "" {
-		wfExec.SetVar("step."+output.StepID+".output", truncate(output.Output, 2000))
+		wfExec.SetVar("step."+output.StepID+".output", textutil.TruncateBytes(output.Output, 2000, "\n... (truncated)"))
 		// Extract the adversarial test verdict from the UNtruncated output and
 		// stash it in a tiny dedicated var. The verdict marker sits on the final
 		// line and would otherwise be lost to the 2000-byte prefix truncation
@@ -663,12 +664,12 @@ func (e *Engine) recordSyncStepOutput(taskID string, step *Step, wfExec *Executi
 	wfExec.RecordStep(StepRecord{
 		StepID:    step.ID,
 		Status:    output.Status,
-		Output:    truncate(output.Output, 4000),
+		Output:    textutil.TruncateBytes(output.Output, 4000, "\n... (truncated)"),
 		StartedAt: now,
 		EndedAt:   now,
 	})
 	if output.Output != "" {
-		wfExec.SetVar("step."+step.ID+".output", truncate(output.Output, 2000))
+		wfExec.SetVar("step."+step.ID+".output", textutil.TruncateBytes(output.Output, 2000, "\n... (truncated)"))
 	}
 
 	// Re-read task for latest state (set_status changes task).
@@ -1037,7 +1038,7 @@ func (e *Engine) blockRetryExhaustedPlanningIfNeeded(taskID string, def *Definit
 	role := step.Config.Role
 	reason := fmt.Sprintf("planning %s retry budget exhausted after %d attempt(s)", role, attempts)
 	if trimmed := strings.TrimSpace(output); trimmed != "" {
-		reason += ": " + truncate(trimmed, 500)
+		reason += ": " + textutil.TruncateBytes(trimmed, 500, "\n... (truncated)")
 	}
 	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 		return true, err
@@ -1047,11 +1048,4 @@ func (e *Engine) blockRetryExhaustedPlanningIfNeeded(taskID string, def *Definit
 	wfExec.CompletedAt = &now
 	wfExec.CurrentStep = ""
 	return true, e.tasks.SetWorkflow(taskID, wfExec)
-}
-
-func truncate(s string, limit int) string {
-	if len(s) <= limit {
-		return s
-	}
-	return s[:limit] + "\n... (truncated)"
 }

--- a/internal/workflow/engine_skill_receipt_summary.go
+++ b/internal/workflow/engine_skill_receipt_summary.go
@@ -239,7 +239,10 @@ func trimReceiptSummary(s string) string {
 	if !isUsefulReceiptDetail(s) {
 		return ""
 	}
-	return textutil.TruncateBytesTrimmed(s, 160, "...")
+	if len(s) <= 160 {
+		return s
+	}
+	return textutil.TruncateBytesTrimmed(s, 157, "...")
 }
 
 func isUsefulReceiptDetail(s string) bool {

--- a/internal/workflow/engine_skill_receipt_summary.go
+++ b/internal/workflow/engine_skill_receipt_summary.go
@@ -235,7 +235,10 @@ func trimReceiptSummary(s string) string {
 	if s == "" {
 		return ""
 	}
-	s = strings.Join(strings.Fields(s), " ")
+	// Sanitize whether or not the cut fires: this reaches a persisted YAML
+	// status_reason, so a short line carrying a malformed byte serializes as
+	// an unreadable !!binary block just as a truncated one does.
+	s = strings.ToValidUTF8(strings.Join(strings.Fields(s), " "), "\uFFFD")
 	if !isUsefulReceiptDetail(s) {
 		return ""
 	}

--- a/internal/workflow/engine_skill_receipt_summary.go
+++ b/internal/workflow/engine_skill_receipt_summary.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // skillReceiptExhaustionSummary condenses the last failed skill output into a
@@ -237,10 +239,7 @@ func trimReceiptSummary(s string) string {
 	if !isUsefulReceiptDetail(s) {
 		return ""
 	}
-	if len(s) > 160 {
-		return strings.TrimSpace(trimUTF8ToBytes(s, 157)) + "..."
-	}
-	return s
+	return textutil.TruncateBytesTrimmed(s, 160, "...")
 }
 
 func isUsefulReceiptDetail(s string) bool {

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 var errBestOfNParked = errors.New("best-of-n parked waiting for attempt completion")
@@ -273,7 +275,7 @@ func (e *Engine) advanceBestOfNAttempt(taskID string, def *Definition, parent *S
 	status.AgentID = output.AgentID
 	status.Provider = output.Provider
 	status.Status = output.Status
-	status.Output = truncate(output.Output, 4000)
+	status.Output = textutil.TruncateBytes(output.Output, 4000, "\n... (truncated)")
 
 	if !rec.AllAttemptsDone() {
 		e.logger.Debug("workflow.best-of-n.attempt-done",
@@ -327,11 +329,11 @@ func (e *Engine) finalizeBestOfNParent(taskID string, def *Definition, parent *S
 	wfExec.RecordStep(StepRecord{
 		StepID:    parent.ID,
 		Status:    "completed",
-		Output:    truncate(parentOutput, 4000),
+		Output:    textutil.TruncateBytes(parentOutput, 4000, "\n... (truncated)"),
 		StartedAt: rec.StartedAt,
 		EndedAt:   now,
 	})
-	wfExec.SetVar("step."+parent.ID+".output", truncate(parentOutput, 2000))
+	wfExec.SetVar("step."+parent.ID+".output", textutil.TruncateBytes(parentOutput, 2000, "\n... (truncated)"))
 
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
@@ -465,7 +467,7 @@ func buildBestOfNManifest(stepID string, rec *BestOfNInflight) string {
 			Provider:  a.Provider,
 			Branch:    a.Branch,
 			Dir:       a.Dir,
-			Output:    truncate(a.Output, 500),
+			Output:    textutil.TruncateBytes(a.Output, 500, "\n... (truncated)"),
 		})
 	}
 	b, mErr := json.Marshal(m)

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 var prURLRe = regexp.MustCompile(`github\.com/[^/\s]+/[^/\s]+/pull/(\d+)`)
@@ -124,7 +126,7 @@ func (e *Engine) execLinkPRAndReview(taskID string, step *Step, wfExec *Executio
 			if jsonErr != nil {
 				// gh --json returned malformed output. Don't mask the upstream
 				// failure as "no pr found" — log so operators can diagnose.
-				e.logger.Warn("workflow.link-pr.gh-list.parse", "task_id", taskID, "err", jsonErr, "raw", truncate(string(out), 200))
+				e.logger.Warn("workflow.link-pr.gh-list.parse", "task_id", taskID, "err", jsonErr, "raw", textutil.TruncateBytes(string(out), 200, "\n... (truncated)"))
 			}
 		}
 	}
@@ -166,7 +168,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 				return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
 			}
 			if jsonErr != nil {
-				e.logger.Warn("workflow.evaluate.gh-list.parse", "task_id", taskID, "err", jsonErr, "raw", truncate(string(out), 200))
+				e.logger.Warn("workflow.evaluate.gh-list.parse", "task_id", taskID, "err", jsonErr, "raw", textutil.TruncateBytes(string(out), 200, "\n... (truncated)"))
 			}
 		}
 	}

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // execParallel spawns every child of a `parallel` block concurrently, all
@@ -225,7 +227,7 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 	status.AgentID = output.AgentID
 	status.Provider = output.Provider
 	status.Status = output.Status
-	status.Output = truncate(output.Output, 4000)
+	status.Output = textutil.TruncateBytes(output.Output, 4000, "\n... (truncated)")
 
 	// Wait for the rest of the cohort.
 	if !rec.AllChildrenDone() {
@@ -272,12 +274,12 @@ func (e *Engine) finalizeParallelParent(taskID string, def *Definition, parent *
 	wfExec.RecordStep(StepRecord{
 		StepID:    parent.ID,
 		Status:    parentStatus,
-		Output:    truncate(parentOutput, 4000),
+		Output:    textutil.TruncateBytes(parentOutput, 4000, "\n... (truncated)"),
 		StartedAt: rec.StartedAt,
 		EndedAt:   now,
 	})
 	if parentOutput != "" {
-		wfExec.SetVar("step."+parent.ID+".output", truncate(parentOutput, 2000))
+		wfExec.SetVar("step."+parent.ID+".output", textutil.TruncateBytes(parentOutput, 2000, "\n... (truncated)"))
 	}
 
 	t, err := e.tasks.GetTask(taskID)

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // execPushBranch deterministically pushes the task's worktree branch to its
@@ -479,24 +480,7 @@ func prRetryReason(base, detail string) string {
 	if detail == "" {
 		return base
 	}
-	return base + ": " + truncateMiddle(detail, 240)
-}
-
-func truncateMiddle(s string, limit int) string {
-	if limit <= 0 {
-		return ""
-	}
-	if len(s) <= limit {
-		return s
-	}
-	marker := "\n... (truncated) ...\n"
-	if limit <= len(marker)+2 {
-		return s[:limit]
-	}
-	keep := limit - len(marker)
-	head := keep / 2
-	tail := keep - head
-	return s[:head] + marker + s[len(s)-tail:]
+	return base + ": " + textutil.TruncateMiddle(detail, 240, "\n... (truncated) ...\n")
 }
 
 // findExistingPRForBranch checks for a PR already open on branch, mirroring

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/project"
-	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // newPRWorktree sets up a bare "origin" clone plus a worktree checked out on
@@ -1189,11 +1189,20 @@ func TestPRRetryReasonPreservesTailForLongHookOutput(t *testing.T) {
 	}
 }
 
-func TestTruncateMiddleHonorsSmallLimit(t *testing.T) {
-	for _, limit := range []int{-1, 0, 1, 5, 20} {
-		got := textutil.TruncateMiddle("abcdefghijklmnopqrstuvwxyz", limit, "\n... (truncated) ...\n")
-		if len(got) > max(0, limit) {
-			t.Fatalf("limit %d: len(%q) = %d, want <= %d", limit, got, len(got), max(0, limit))
+// prRetryReason feeds a status_reason persisted as YAML, and hook output is
+// exactly where box-drawing table borders and arrows show up.
+func TestPRRetryReasonKeepsValidUTF8OnMultibyteHookOutput(t *testing.T) {
+	for name, detail := range map[string]string{
+		"box-drawing":  strings.Repeat("│─", 400),
+		"ellipsis run": strings.Repeat("…", 400),
+		"emoji run":    strings.Repeat("🚀", 300),
+	} {
+		got := prRetryReason(prPushRetryStatusReason, detail)
+		if !utf8.ValidString(got) {
+			t.Errorf("%s: reason is not valid UTF-8: %q", name, got)
+		}
+		if !strings.HasPrefix(got, prPushRetryStatusReason+": ") {
+			t.Errorf("%s: reason = %q, want base prefix", name, got)
 		}
 	}
 }

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // newPRWorktree sets up a bare "origin" clone plus a worktree checked out on
@@ -1190,7 +1191,7 @@ func TestPRRetryReasonPreservesTailForLongHookOutput(t *testing.T) {
 
 func TestTruncateMiddleHonorsSmallLimit(t *testing.T) {
 	for _, limit := range []int{-1, 0, 1, 5, 20} {
-		got := truncateMiddle("abcdefghijklmnopqrstuvwxyz", limit)
+		got := textutil.TruncateMiddle("abcdefghijklmnopqrstuvwxyz", limit, "\n... (truncated) ...\n")
 		if len(got) > max(0, limit) {
 			t.Fatalf("limit %d: len(%q) = %d, want <= %d", limit, got, len(got), max(0, limit))
 		}

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/gitexec"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // TamperBlessedTag short-circuits the detector: a human who has reviewed a
@@ -1277,12 +1278,8 @@ func tamperReason(r tamperReport) string {
 // trimDiffLine normalizes a diff content line for inclusion in a finding:
 // trimmed and capped to a sane length.
 func trimDiffLine(s string) string {
-	s = strings.TrimSpace(s)
 	const maxLen = 120
-	if len(s) > maxLen {
-		return s[:maxLen] + "…"
-	}
-	return s
+	return textutil.TruncateBytes(strings.TrimSpace(s), maxLen, "…")
 }
 
 // documentedDeletionAllowlist extracts explicitly documented file deletions

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -731,7 +731,7 @@ func capTextBlock(text string, maxLines, maxBytes int, suffix string, preserveLa
 		limit -= len(suffix)
 	}
 	if len(text) > limit {
-		text = textutil.TruncateBytes(text, limit, "")
+		text = textutil.TruncateBytesValid(text, limit, "")
 		truncated = true
 	}
 	text = strings.TrimRight(text, "\n")
@@ -2550,7 +2550,7 @@ func singleLineDiagnostic(err error, output string) string {
 	if text == "" {
 		return "unknown error"
 	}
-	return textutil.TruncateBytes(text, 300, "")
+	return textutil.TruncateBytesValid(text, 300, "")
 }
 
 // recurringProductBugFingerprints returns the distinct product-bug failure

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/gitexec"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/workflow/failureclassify"
 )
 
@@ -731,7 +731,7 @@ func capTextBlock(text string, maxLines, maxBytes int, suffix string, preserveLa
 		limit -= len(suffix)
 	}
 	if len(text) > limit {
-		text = trimUTF8ToBytes(text, limit)
+		text = textutil.TruncateBytes(text, limit, "")
 		truncated = true
 	}
 	text = strings.TrimRight(text, "\n")
@@ -764,25 +764,6 @@ func normalizeAcceptanceLedgerReport(report string) string {
 		}
 	}
 	return strings.TrimSpace(strings.Join(lines, "\n"))
-}
-
-func trimUTF8ToBytes(s string, limit int) string {
-	if limit <= 0 {
-		return ""
-	}
-	if len(s) <= limit {
-		return s
-	}
-	s = s[:limit]
-	for len(s) > 0 && !utf8.ValidString(s) {
-		_, size := utf8.DecodeLastRuneInString(s)
-		if size <= 1 {
-			s = s[:len(s)-1]
-			continue
-		}
-		s = s[:len(s)-size]
-	}
-	return s
 }
 
 func upsertAcceptanceLedger(body, fingerprint, report string) (nextBody string, changed bool) {
@@ -2569,7 +2550,7 @@ func singleLineDiagnostic(err error, output string) string {
 	if text == "" {
 		return "unknown error"
 	}
-	return trimUTF8ToBytes(text, 300)
+	return textutil.TruncateBytes(text, 300, "")
 }
 
 // recurringProductBugFingerprints returns the distinct product-bug failure

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/prompteval"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
-	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/watchdogreason"
 	"github.com/Automaat/sybra/internal/worktreeerr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -7414,28 +7413,6 @@ func TestAdvanceStep_FailedWorkflowIsNoop(t *testing.T) {
 	}
 	if agents.CallCount() != 0 {
 		t.Errorf("agents.CallCount = %d, want 0 — failed workflow must not spawn", agents.CallCount())
-	}
-}
-
-func TestTruncate(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		limit int
-		want  string
-	}{
-		{"under limit", "short", 100, "short"},
-		{"at limit", "exact", 5, "exact"},
-		{"over limit", "this is too long", 7, "this is\n... (truncated)"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := textutil.TruncateBytes(tt.input, tt.limit, "\n... (truncated)")
-			if got != tt.want {
-				t.Errorf("TruncateBytes(%q, %d) = %q, want %q", tt.input, tt.limit, got, tt.want)
-			}
-		})
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/prompteval"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/watchdogreason"
 	"github.com/Automaat/sybra/internal/worktreeerr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -7430,9 +7431,9 @@ func TestTruncate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncate(tt.input, tt.limit)
+			got := textutil.TruncateBytes(tt.input, tt.limit, "\n... (truncated)")
 			if got != tt.want {
-				t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.limit, got, tt.want)
+				t.Errorf("TruncateBytes(%q, %d) = %q, want %q", tt.input, tt.limit, got, tt.want)
 			}
 		})
 	}

--- a/internal/workflow/engine_validate_plan_contract.go
+++ b/internal/workflow/engine_validate_plan_contract.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const maxPlanContractBytes = 64 * 1024
@@ -358,10 +360,7 @@ func normalizeCriterionWhitespace(s string) string {
 }
 
 func quoteProblem(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) > 140 {
-		s = s[:137] + "..."
-	}
+	s = textutil.TruncateBytesTotal(strings.TrimSpace(s), 140, "...")
 	return fmt.Sprintf("%q", s)
 }
 

--- a/internal/workflow/receipt_summary_utf8_test.go
+++ b/internal/workflow/receipt_summary_utf8_test.go
@@ -1,0 +1,74 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+// These three cap arbitrary tool and test-runner output, where a malformed byte
+// can sit anywhere in the text rather than only at the cut. Aligning the cut is
+// not enough for them: trimReceiptSummary feeds a persisted YAML status_reason,
+// and the capTextBlock pair feeds the task body and agent prompts, which reach
+// the frontend as JSON.
+func TestOutputCapsRepairInvalidBytesBeforeTheCut(t *testing.T) {
+	dirty := strings.Repeat("ok ", 30) + "\xff\xfe" + strings.Repeat("tail … ", 900)
+
+	for name, got := range map[string]string{
+		"trimReceiptSummary":   trimReceiptSummary(dirty),
+		"singleLineDiagnostic": singleLineDiagnostic(nil, dirty),
+		"capLedgerRepro":       capLedgerRepro(dirty),
+		"capPriorDiffStat":     capPriorAttemptDiffStat(dirty),
+		"capPriorAttemptText":  capPriorAttemptText(dirty),
+	} {
+		if !utf8.ValidString(got) {
+			t.Errorf("%s returned invalid UTF-8: %q", name, got)
+		}
+	}
+}
+
+// trimReceiptSummary's result is persisted as YAML frontmatter, so an invalid
+// byte anywhere in it turns the whole reason into an unreadable !!binary block.
+func TestReceiptSummaryMarshalsAsPlainYAML(t *testing.T) {
+	detail := "## Test Failures\nObserved output: assertion failed caf\xe9 mismatch \xff\xfe " +
+		strings.Repeat("expected vs actual … ", 20)
+
+	summary := trimReceiptSummary(detail)
+	if !utf8.ValidString(summary) {
+		t.Fatalf("receipt summary is not valid UTF-8: %q", summary)
+	}
+
+	data, err := yaml.Marshal(map[string]string{"status_reason": summary})
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "!!binary") {
+		t.Fatalf("receipt summary marshalled as a binary block:\n%s", data)
+	}
+}
+
+// The pre-refactor helper capped content at 157 bytes and only truncated past
+// 160, so a string between the two came back whole. Persisted text must not
+// churn on a refactor.
+func TestReceiptSummaryKeepsItsOriginalLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		length  int
+		wantLen int
+	}{
+		{name: "at the truncation threshold", length: 160, wantLen: 160},
+		{name: "one byte over", length: 161, wantLen: 160},
+		{name: "far over", length: 4000, wantLen: 160},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trimReceiptSummary(strings.Repeat("a", tt.length))
+			if len(got) != tt.wantLen {
+				t.Errorf("len(trimReceiptSummary(%d bytes)) = %d, want %d: %q",
+					tt.length, len(got), tt.wantLen, got)
+			}
+		})
+	}
+}

--- a/internal/workflow/receipt_summary_utf8_test.go
+++ b/internal/workflow/receipt_summary_utf8_test.go
@@ -32,20 +32,27 @@ func TestOutputCapsRepairInvalidBytesBeforeTheCut(t *testing.T) {
 // trimReceiptSummary's result is persisted as YAML frontmatter, so an invalid
 // byte anywhere in it turns the whole reason into an unreadable !!binary block.
 func TestReceiptSummaryMarshalsAsPlainYAML(t *testing.T) {
-	detail := "## Test Failures\nObserved output: assertion failed caf\xe9 mismatch \xff\xfe " +
-		strings.Repeat("expected vs actual … ", 20)
+	// Both branches matter: a malformed byte corrupts the frontmatter whether
+	// or not the line was long enough to be cut.
+	for name, detail := range map[string]string{
+		"truncated": "## Test Failures\nObserved output: assertion failed caf\xe9 mismatch \xff\xfe " +
+			strings.Repeat("expected vs actual … ", 20),
+		"under the cut": "## Test Failures\nObserved output: assertion failed caf\xe9 \xff\xfe mismatch",
+	} {
+		t.Run(name, func(t *testing.T) {
+			summary := trimReceiptSummary(detail)
+			if !utf8.ValidString(summary) {
+				t.Fatalf("receipt summary is not valid UTF-8: %q", summary)
+			}
 
-	summary := trimReceiptSummary(detail)
-	if !utf8.ValidString(summary) {
-		t.Fatalf("receipt summary is not valid UTF-8: %q", summary)
-	}
-
-	data, err := yaml.Marshal(map[string]string{"status_reason": summary})
-	if err != nil {
-		t.Fatalf("yaml.Marshal: %v", err)
-	}
-	if strings.Contains(string(data), "!!binary") {
-		t.Fatalf("receipt summary marshalled as a binary block:\n%s", data)
+			data, err := yaml.Marshal(map[string]string{"status_reason": summary})
+			if err != nil {
+				t.Fatalf("yaml.Marshal: %v", err)
+			}
+			if strings.Contains(string(data), "!!binary") {
+				t.Fatalf("receipt summary marshalled as a binary block:\n%s", data)
+			}
+		})
 	}
 }
 

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Automaat/sybra/internal/blocker"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
@@ -111,7 +112,7 @@ func ClassifyAgentStartFailure(err error) AgentStartFailure {
 		// dispatch-plumbing sentinels above, this names an operator-visible
 		// machine condition, so it DOES surface a status_reason (see
 		// isDeferredNotFailed for why it still never feeds the breaker).
-		out.Reason = truncateReason("work paused: machine under resource pressure — " + resourcePressureDetail(err))
+		out.Reason = textutil.TruncateBytesTotal("work paused: machine under resource pressure — "+resourcePressureDetail(err), startReasonMaxLen, "...")
 		return out
 	case errors.Is(err, worktreeerr.ErrAgentRunning):
 		// Transient: PrepareForTask refused to rebase a worktree a tracked
@@ -204,7 +205,7 @@ func ClassifyAgentStartFailure(err error) AgentStartFailure {
 	default:
 		out.Reason = "agent start failed: " + err.Error()
 	}
-	out.Reason = truncateReason(out.Reason)
+	out.Reason = textutil.TruncateBytesTotal(out.Reason, startReasonMaxLen, "...")
 	return out
 }
 
@@ -266,18 +267,6 @@ func resourcePressureDetail(err error) string {
 		return "local resource pressure"
 	}
 	return detail
-}
-
-// truncateReason caps a status_reason to startReasonMaxLen bytes with an
-// ASCII ellipsis so the UI banner stays one line. Byte (not rune) bound so
-// the caller can compare against len(reason) without surprises from
-// multi-byte runes.
-func truncateReason(s string) string {
-	if len(s) <= startReasonMaxLen {
-		return s
-	}
-	const tail = "..."
-	return s[:startReasonMaxLen-len(tail)] + tail
 }
 
 // FormatStartFailure is a tiny helper for callers that want to log the same

--- a/internal/workflow/status_reason_utf8_test.go
+++ b/internal/workflow/status_reason_utf8_test.go
@@ -1,0 +1,128 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The engine truncates raw agent output into a status_reason, which internal/task
+// persists as YAML frontmatter (`yaml:"status_reason,omitempty"`). A cut landing
+// inside a multibyte rune leaves invalid UTF-8, and yaml.v3 then re-encodes the
+// whole field as an unreadable !!binary base64 block in the task file and on the
+// board. Agent output routinely carries ellipses, arrows and emoji, so this
+// drives the real engine path rather than the truncation helper alone.
+func TestPlanningRetryStatusReasonSurvivesMultibyteAgentOutput(t *testing.T) {
+	for name, output := range map[string]string{
+		"ellipsis run":       strings.Repeat("…", 400),
+		"arrow run":          strings.Repeat("→", 400),
+		"emoji run":          strings.Repeat("🚀", 300),
+		"box-drawing border": strings.Repeat("│─", 400),
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := newInlineTestStore(t, "simple-task-plan", `
+id: simple-task-plan
+name: test planning retry
+trigger:
+  on: task.created
+steps:
+  - id: plan
+    type: run_agent
+    config:
+      role: plan
+      max_retries: 1
+    next:
+      - goto: done
+  - id: done
+    type: set_status
+    config:
+      status: todo
+`)
+			tasks := newMemTasks()
+			agents := newMockAgents()
+			engine := NewEngine(store, tasks, agents, discardLogger())
+
+			tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "headless"})
+			if err := engine.StartWorkflowFromStepWithVars("t1", "simple-task-plan", "plan", nil); err != nil {
+				t.Fatal(err)
+			}
+			for range 2 {
+				agents.SimulateComplete("t1")
+				if err := engine.AdvanceStep("t1", StepOutput{StepID: "plan", Status: "failed", Output: output}); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ti, _ := tasks.GetTask("t1")
+			if ti.Status != "human-required" {
+				t.Fatalf("status = %q, want human-required", ti.Status)
+			}
+			if !utf8.ValidString(ti.StatusReason) {
+				t.Fatalf("status_reason is not valid UTF-8: %q", ti.StatusReason)
+			}
+
+			data, err := yaml.Marshal(map[string]string{"status_reason": ti.StatusReason})
+			if err != nil {
+				t.Fatalf("yaml.Marshal: %v", err)
+			}
+			if strings.Contains(string(data), "!!binary") {
+				t.Fatalf("status_reason marshalled as a binary block:\n%s", data)
+			}
+		})
+	}
+}
+
+// Step output is also published as a workflow variable that reaches the frontend
+// as JSON, where invalid UTF-8 is silently replaced by U+FFFD instead of failing.
+func TestStepOutputVariableSurvivesMultibyteAgentOutput(t *testing.T) {
+	store := newInlineTestStore(t, "test-simple", `
+id: test-simple
+name: test
+trigger:
+  on: task.created
+steps:
+  - id: triage
+    type: run_agent
+    config:
+      role: implementation
+    next:
+      - goto: done
+  - id: done
+    type: set_status
+    config:
+      status: todo
+`)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	if err := engine.StartWorkflowFromStepWithVars("t1", "test-simple", "triage", nil); err != nil {
+		t.Fatal(err)
+	}
+	agents.SimulateComplete("t1")
+	if err := engine.AdvanceStep("t1", StepOutput{
+		StepID: "triage",
+		Status: "completed",
+		Output: strings.Repeat("…", 2000),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow == nil {
+		t.Fatal("workflow missing after advance")
+	}
+	got := ti.Workflow.Variables["step.triage.output"]
+	if got == "" {
+		t.Fatal("step output variable was not published")
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("step output variable is not valid UTF-8: %q", got)
+	}
+	if strings.ContainsRune(got, utf8.RuneError) {
+		t.Fatalf("step output variable contains U+FFFD replacement runes: %q", got)
+	}
+}


### PR DESCRIPTION
## Motivation

Fifteen hand-rolled truncation helpers disagreed on limit units, on the ellipsis, and on whether they respected UTF-8 boundaries. Six sliced raw bytes and could cut a multibyte rune in half. #3078.

That is live corruption, not a corner case. A truncated status reason is persisted as YAML frontmatter, and an invalid-UTF-8 cut makes `yaml.v3` re-encode the whole field as an unreadable `!!binary` base64 block in the task file and on the board. The same text feeds workflow step-output variables, where `encoding/json` silently substitutes U+FFFD instead. Agent output routinely carries `…`, `→`, box-drawing borders and emoji, so the cut landing mid-rune is ordinary input.

> Changelog: fix(textutil): stop truncation corrupting UTF-8

## Implementation information

Adds `internal/textutil` with one rune-safe implementation, split by what the limit bounds rather than by caller: content bytes, total bytes, total runes, and a middle-keeping variant for text whose tail carries the signal. `TruncateBytesValid` additionally repairs malformed bytes anywhere in the retained text, for input from outside the process where a bad byte can sit well before the cut. Every call site keeps its existing limit and ellipsis so persisted text does not churn.

Two things the issue's own list did not name turned up while sweeping:

- `completion.buildRunPatch` raw-slices **every** completed run's result into `AgentRun.Result`, also YAML frontmatter. That is the highest-volume corruption path in the system, well above the status reason the issue leads with.
- Eight further sites byte-sliced text — human-review agent results, tool-result content, tamper-finding diff lines, proposal titles, plan-contract quotes, interrupted-review transcripts, selfmonitor task bodies, CLI triage reasons.

`notes.clampNotes` keeps its asymmetric head+tail window but now calls the shared rune-boundary walk, so that logic lives in one place. The only surviving `truncate*` functions are non-text: `procstat`'s `[]Process` slicer, a token-based command-family trimmer, and numeric clamps.

### On the tests

Asserting the library with a call site's arguments inlined proves nothing about the call site. The first version of these tests did exactly that, and reverting `engine_advance.go` to the pre-fix byte slice left the whole suite green. Every truncation test now drives a real engine, handler or CLI path, and each one was confirmed to fail against its reverted production call site.

## Supporting documentation

Verified by differential run against `origin/main`: the original corruption reproduces on the base build and does not on this branch, and every migrated site produces byte-identical output for realistic input apart from the intended UTF-8 fix. `mise run verify` passes.

Two regressions this PR introduced were caught by that differential harness and fixed here: three sites migrated off a helper that guaranteed whole-string validity and briefly lost it, and `formatRuntimeProbeError` stopped sanitizing the arbitrary bytes a probe binary can write to stderr.

Closes #3078