### PR TITLE
fix(workflow): keep the diagnostic on escalation

### DIFF
--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -829,6 +829,62 @@ func autoFixBackoff(attempts int) time.Duration {
 	return backoff
 }
 
+// verifyDiagnosticName is the sidecar a verify escalation leaves behind.
+const verifyDiagnosticName = ".sybra-verify-%s.md"
+
+// writeVerifyDiagnostic persists the failing command and the highest-signal
+// excerpt, returning the path it wrote or "".
+//
+// status_reason records the command trimmed to a single line and drops the
+// diagnostic entirely, so whoever picks the task up next — a human, or the
+// human-review autonomy agent whose mandate tells it to "re-run the exact
+// failing command" — gets a command but not the finding, and has to re-run a
+// multi-minute suite to learn what it already said. The re-ask path has built
+// this excerpt all along; only the escalation threw it away.
+//
+// Best-effort: a task that cannot be escalated because a sidecar would not
+// write is strictly worse than one escalated without it.
+func (e *Engine) writeVerifyDiagnostic(taskID, failedCmd, output string) string {
+	dir := e.resolveSidecarDir(taskID)
+	if dir == "" || taskID == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("# Verify failure — task ")
+	b.WriteString(taskID)
+	b.WriteString("\n\n## Failing command\n\n```\n")
+	b.WriteString(failedCmd)
+	b.WriteString("\n```\n")
+	if excerpt := highestSignalVerifyFailureExcerpt(failedCmd, output); excerpt != "" {
+		b.WriteString("\n## Highest-signal failure excerpt\n\n```\n")
+		b.WriteString(excerpt)
+		b.WriteString("\n```\n")
+	}
+	// The structured excerpt only covers frontend commands, so a Go lint or
+	// test failure — the majority of what escalates — would otherwise record
+	// nothing but the command. Mirror buildVerifyReaskNote and keep the tail.
+	if tail := tailString(strings.TrimSpace(output), 3000); tail != "" {
+		b.WriteString("\n## Output tail\n\n```\n")
+		b.WriteString(tail)
+		b.WriteString("\n```\n")
+	}
+	path := filepath.Join(dir, fmt.Sprintf(verifyDiagnosticName, taskID))
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		e.logger.Warn("workflow.verify-checks.diagnostic", "task_id", taskID, "err", err)
+		return ""
+	}
+	return path
+}
+
+// withDiagnostic appends a pointer to the sidecar so status_reason stays short
+// while still leading somewhere with the actual finding.
+func withDiagnostic(reason, path string) string {
+	if path == "" {
+		return reason
+	}
+	return reason + " — diagnostic: " + path
+}
+
 // autoFixOrFlagVerifyChecks rewinds the workflow to the implementation step and
 // re-asks the agent to fix a code-fixable verify failure at its root cause,
 // looping instead of escalating an ordinary lint/test failure the agent can fix
@@ -838,7 +894,8 @@ func autoFixBackoff(attempts int) time.Duration {
 // ran), escalates to human-required.
 func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Execution, t TaskInfo, reason, failedCmd, output string) (StepOutput, error) {
 	if wfExec == nil || wfExec.CountStep(verifyChecksImplStepID) == 0 {
-		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
+		diag := e.writeVerifyDiagnostic(taskID, failedCmd, output)
+		return e.flagVerifyChecks(taskID, step, withDiagnostic(reason, diag), failedCmd)
 	}
 	fingerprint := autoFixFailureFingerprint(failedCmd, output)
 	armed, attempt, err := e.rewindRetry(taskID, wfExec, t, rewindRetryPolicy{
@@ -866,7 +923,8 @@ func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Ex
 	if !armed {
 		exhausted := fmt.Sprintf("%s — escalating after repeated identical auto-fix failures or %d attempts without passing",
 			reason, verifyChecksAutoFixCeiling)
-		return e.flagVerifyChecks(taskID, step, exhausted, "auto-fix-exhausted: "+trimDiffLine(failedCmd))
+		diag := e.writeVerifyDiagnostic(taskID, failedCmd, output)
+		return e.flagVerifyChecks(taskID, step, withDiagnostic(exhausted, diag), "auto-fix-exhausted: "+trimDiffLine(failedCmd))
 	}
 	e.logger.Info("workflow.verify-checks.auto-fix",
 		"task_id", taskID, "attempt", attempt, "cmd", trimDiffLine(failedCmd))

--- a/internal/workflow/verify_diagnostic_test.go
+++ b/internal/workflow/verify_diagnostic_test.go
@@ -1,0 +1,64 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// status_reason records the failing command trimmed to one line and drops the
+// diagnostic, so whoever picks the task up next gets a command but not the
+// finding. The re-ask path has always built this excerpt; only the escalation
+// threw it away.
+func TestWriteVerifyDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.SetSidecarDirResolver(func(string) (string, error) { return dir, nil })
+
+	const cmd = `GOLANGCI_LINT_CACHE="${TMPDIR:-/tmp}/golangci-lint" mise exec -- golangci-lint run ./internal/...`
+	output := strings.Join([]string{
+		"some preamble that is not the finding",
+		"internal/sybra/app_init.go:1613:15: func (*App).wireWorktreeAccess is unused (unused)",
+		"2 issues:",
+	}, "\n")
+
+	path := engine.writeVerifyDiagnostic("t1", cmd, output)
+	if path == "" {
+		t.Fatal("writeVerifyDiagnostic returned no path")
+	}
+	if got, want := filepath.Dir(path), dir; got != want {
+		t.Errorf("wrote to %q, want inside %q", got, want)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read diagnostic: %v", err)
+	}
+	if !strings.Contains(string(body), cmd) {
+		t.Errorf("diagnostic missing the failing command:\n%s", body)
+	}
+	// The whole point: the finding itself, not just the command.
+	if !strings.Contains(string(body), "wireWorktreeAccess is unused") {
+		t.Errorf("diagnostic missing the failure excerpt:\n%s", body)
+	}
+}
+
+// Without a sidecar dir there is nowhere to write; escalation must still
+// proceed rather than being blocked on bookkeeping.
+func TestWriteVerifyDiagnostic_NoSidecarDirIsNotFatal(t *testing.T) {
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	if got := engine.writeVerifyDiagnostic("t1", "cmd", "output"); got != "" {
+		t.Errorf("path = %q, want empty when no sidecar dir is resolvable", got)
+	}
+}
+
+func TestWithDiagnostic(t *testing.T) {
+	if got := withDiagnostic("verify failed", ""); got != "verify failed" {
+		t.Errorf("with no path = %q, want the reason unchanged", got)
+	}
+	got := withDiagnostic("verify failed", "/s/.sybra-verify-t1.md")
+	if !strings.Contains(got, "/s/.sybra-verify-t1.md") || !strings.HasPrefix(got, "verify failed") {
+		t.Errorf("with a path = %q, want the reason plus a pointer", got)
+	}
+}


### PR DESCRIPTION
## Motivation

Every task parked on a failed verify suite carried a `status_reason` of this shape:

```
verify suite failed on changed Go file `internal/sybra/app_init.go` in
GOLANGCI_LINT_CACHE="${TMPDIR:-/tmp}/golangci-lint-$(basename "$(pwd)")"
mise exec -- golangci-lint run ./internal/... .… — deterministic lint finding;
re-ask implementation to fix the code without weakening the check
```

The command, trimmed to `.…`. **The failure itself was not recorded at all.**

Whoever picked the task up next got a command but not the finding — including the human-review autonomy agent, whose mandate explicitly tells it to "re-run the exact failing command in the task's worktree to confirm". So it paid for a multi-minute suite to learn something the escalation already knew. On `cd7f0957` the answer was two unused functions.

> Changelog: fix(workflow): keep the diagnostic on escalation

## Implementation information

Write the failing command and the failure to `.sybra-verify-<task-id>.md` in the task's sidecar dir, and append a pointer to `status_reason`. The reason itself stays short — it is frontmatter, not a log.

One thing worth flagging for the reviewer, because it changes what this is worth: `highestSignalVerifyFailureExcerpt` only extracts a structured excerpt for **frontend** commands. For a Go lint or test failure — the majority of what escalates — it returns `""`. So the sidecar also carries the output tail, mirroring what `buildVerifyReaskNote` already does for the re-ask path. Without that this would have written a file containing only the command the reason already had.

Best-effort by design: a task that could not be escalated because a sidecar would not write is strictly worse than one escalated without it, so a write failure logs and continues.

## Supporting documentation

Three tests, checked by reverting: removing the output-tail block fails `TestWriteVerifyDiagnostic` with "diagnostic missing the failure excerpt", which is the case that matters for Go failures. The no-sidecar-dir path and the reason-formatting helper are pinned separately.

Full `internal/workflow` suite passes; `go vet -tags e2e` clean across `./internal/... ./cmd/...`.

Closes #3041
