### PR TITLE
fix(provider): stop clean runs parking on prose

### DIFF
--- a/internal/provider/clean_result_test.go
+++ b/internal/provider/clean_result_test.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// A provider usage cap arrives on a subtype:"success" result with the limit
+// text as essentially the whole content, so clean-result classification has to
+// stay. What it must not do is fire on an agent's own answer that discusses
+// limits — which is exactly what an agent working on this file writes.
+func TestCleanResultContent_DistinguishesProviderCapFromAgentProse(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    Signal
+	}{
+		{
+			// The real shape: short, and the message is the whole result.
+			name:    "provider cap notice is still classified",
+			content: "You've hit your usage limit. Your limit will reset at 5pm.",
+			want:    SignalRateLimit,
+		},
+		{
+			name:    "session limit notice is still classified",
+			content: "You've hit your session limit · resets 4:30pm",
+			want:    SignalRateLimit,
+		},
+		{
+			// An agent reporting on work it did in this area. Long, with the
+			// phrase incidental.
+			name: "agent prose about limits is not a rate limit",
+			content: "Done. I implemented the reset-hint parser for the case where codex says " +
+				"you've hit your usage limit and prints a reset time. The parser now rejects " +
+				"out-of-range instants rather than clamping them, because clamping turned a " +
+				"misparse into the worst possible park. I also added regression tests covering " +
+				"the decoy case, the malformed-year case, and the ANSI-wrapped form, and checked " +
+				"each by reverting the fix to confirm the test fails.",
+			want: SignalNone,
+		},
+		{
+			// Long output that merely quotes a limit line, e.g. a tool result
+			// echoed back inside a longer answer.
+			name:    "long answer quoting a limit line is not a rate limit",
+			content: strings.Repeat("analysis of the failing verify suite. ", 20) + "rate limit exceeded",
+			want:    SignalNone,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyClaudeError(ErrorSample{Content: tc.content, ContentIsCleanResult: true})
+			if got.Signal != tc.want {
+				t.Errorf("signal = %v, want %v (content %d chars)", got.Signal, tc.want, len(tc.content))
+			}
+		})
+	}
+}
+
+// A non-clean result is a run that actually failed, so its content keeps the
+// broad needle matching regardless of length.
+func TestNonCleanResultContent_UnaffectedByLengthBudget(t *testing.T) {
+	long := strings.Repeat("stack trace line\n", 50) + "rate limit exceeded"
+	got := ClassifyClaudeError(ErrorSample{Content: long})
+	if got.Signal != SignalRateLimit {
+		t.Errorf("signal = %v, want SignalRateLimit — a failed run's content is still evidence", got.Signal)
+	}
+}

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -310,9 +310,27 @@ func ClassifyOpenCodeError(s ErrorSample) Classification {
 	return classified(SignalNone, "", 0, CooldownFromConfig)
 }
 
+// cleanResultLimitBudget bounds how long a clean run's content may be and
+// still be read as a provider limit notice.
+//
+// A provider usage cap arrives on a subtype:"success" result with the limit
+// text as essentially the whole content — see buildErrorSample, which captures
+// the terminal result regardless of subtype precisely for that case. An
+// agent's answer that happens to discuss rate limits is a full response with
+// the phrase somewhere inside it. Length is what separates them: the needle
+// list alone cannot, because "hit your usage limit" and "rate limit exceeded"
+// are exactly what an agent writes when it works on this area of the codebase.
+//
+// Without this, a successful exit-0 run parked its own provider for the
+// configured cooldown off its own prose.
+const cleanResultLimitBudget = 400
+
 func containsRateLimitContent(content string, cleanResult bool, broadNeedles ...string) bool {
 	if !cleanResult {
 		return containsAny(content, broadNeedles...)
+	}
+	if len(strings.TrimSpace(content)) > cleanResultLimitBudget {
+		return false
 	}
 	return containsAny(content,
 		"you've hit your session limit",


### PR DESCRIPTION
## Motivation

A **successful, exit-0** agent run could park its own provider, because `buildErrorSample` feeds the terminal result's `Content` — the agent's own final answer — into the rate-limit classifiers, and the clean-result needle list still matches phrases an agent legitimately writes.

Reproduced on `main` with a fake claude CLI exiting 0 whose result text was ordinary prose about this area of the codebase:

```
{'provider': 'claude', 'healthy': False, 'reason': 'rate_limited',
 'ratelimitedUntil': '2026-08-05T21:48:50+02:00'}
```

15 minutes of lost capacity from a run that succeeded. Found while manually testing #3043, which removed the *amplified* form (agent prose could supply a parsed reset instant and park for days) but deliberately left this underlying case alone.

> Changelog: fix(provider): stop clean runs parking on prose

## Implementation information

The issue — which I wrote — proposed "consider not classifying clean results at all: if the run exited 0 and produced a terminal result, the provider served it."

**That would have regressed real detection.** `buildErrorSample` carries an explicit comment for exactly this:

> Capture the terminal result regardless of subtype. A provider usage cap (e.g. a five-hour session limit) is reported on a `subtype:"success"` result with the limit text in Content — not a structured error envelope — so a `subtype=="error"` filter would miss it.

So clean-result classification has to stay. The needle list cannot separate the two cases, because `"hit your usage limit"` and `"rate limit exceeded"` are precisely what an agent writes when working on this code.

Length can. A provider cap notice is essentially the whole result — short, and the message *is* the content. An agent's answer is a full response with the phrase somewhere inside it. A clean result longer than the budget no longer matches.

A non-clean result is untouched: that content is a failed run's output, which is evidence.

## Supporting documentation

The table pins both directions — a real cap notice and a session-limit notice still classify; agent prose and a long answer quoting a limit line do not. Removing the budget fails exactly the two prose cases and leaves the cap cases green, so the test discriminates rather than just asserting one side.

## Open question

The 400-character budget is a judgement call, not a measured threshold. It comfortably fits the cap notices I have seen (`"You've hit your usage limit. Your limit will reset at 5pm."` is 58) and comfortably excludes agent answers. If anyone has a real provider cap message longer than that, it should move — the constant is named and documented so it can.

Closes #3066
