### PR TITLE
fix(workflow): count fix attempts by evidence

### DIFF
--- a/internal/workflow/engine_steps_focused_checks.go
+++ b/internal/workflow/engine_steps_focused_checks.go
@@ -393,6 +393,7 @@ func (e *Engine) reaskFocusedChecks(taskID string, step *Step, wfExec *Execution
 		// One prior identical occurrence means this is repeat #2. Re-running
 		// the same deterministic failure again only spends another author run.
 		maxSameFingerprintRuns: 1,
+		attemptProducedWork:    lastAuthorRunProducedWork,
 		onArm: func(wfExec *Execution, attempt int) {
 			wfExec.SetVar(focusedChecksReaskNoteVar, buildFocusedChecksReaskNote(selected, changedFiles, failedCmd, output))
 			wfExec.SetVar(verifyRetryModelVar, "expensive")

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -852,6 +852,7 @@ func (e *Engine) autoFixOrFlagVerifyChecks(taskID string, step *Step, wfExec *Ex
 		// second occurrence proves the repair made no progress and must stop
 		// the loop immediately.
 		maxSameFingerprintRuns: 1,
+		attemptProducedWork:    lastAuthorRunProducedWork,
 		onArm: func(wfExec *Execution, attempt int) {
 			wfExec.SetVar(verifyReaskNoteVar, buildVerifyReaskNote(failedCmd, output))
 			wfExec.SetVar(verifyRetryModelVar, "expensive")

--- a/internal/workflow/evidence_attempts_test.go
+++ b/internal/workflow/evidence_attempts_test.go
@@ -11,7 +11,12 @@ import (
 // budget just the same, so a trivially fixable finding escalated on an attempt
 // that never happened.
 func TestRewindRetry_FingerprintNotChargedWithoutCommits(t *testing.T) {
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	tasks := newMemTasks()
+	// Seed the provider: rewindRetry persists via SetWorkflow and
+	// UpdateTaskStatus, and against an unseeded store both error — the test
+	// would then pass without exercising the path it claims to.
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	policy := func(ti TaskInfo) rewindRetryPolicy {
 		return rewindRetryPolicy{
@@ -31,10 +36,18 @@ func TestRewindRetry_FingerprintNotChargedWithoutCommits(t *testing.T) {
 		ti := TaskInfo{ID: "t1", Status: "in-progress", AgentRuns: []AgentRunInfo{
 			{AgentID: "a1", Role: "implementation", HeadSHA: "deadbeef"},
 		}}
-		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); !armed {
+		armed, _, err := engine.rewindRetry("t1", wfExec, ti, policy(ti))
+		if err != nil {
+			t.Fatalf("first arm: %v", err)
+		}
+		if !armed {
 			t.Fatal("first arm should be allowed")
 		}
-		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); armed {
+		armed, _, err = engine.rewindRetry("t1", wfExec, ti, policy(ti))
+		if err != nil {
+			t.Fatalf("second arm: %v", err)
+		}
+		if armed {
 			t.Error("a committed attempt must spend the same-fingerprint budget")
 		}
 	})
@@ -44,10 +57,18 @@ func TestRewindRetry_FingerprintNotChargedWithoutCommits(t *testing.T) {
 		ti := TaskInfo{ID: "t1", Status: "in-progress", AgentRuns: []AgentRunInfo{
 			{AgentID: "a1", Role: "implementation"},
 		}}
-		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); !armed {
+		armed, _, err := engine.rewindRetry("t1", wfExec, ti, policy(ti))
+		if err != nil {
+			t.Fatalf("first arm: %v", err)
+		}
+		if !armed {
 			t.Fatal("first arm should be allowed")
 		}
-		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); !armed {
+		armed, _, err = engine.rewindRetry("t1", wfExec, ti, policy(ti))
+		if err != nil {
+			t.Fatalf("second arm: %v", err)
+		}
+		if !armed {
 			t.Error("a run that never committed did not attempt the fix; it must not spend the budget")
 		}
 	})
@@ -63,7 +84,11 @@ func TestRewindRetry_FingerprintNotChargedWithoutCommits(t *testing.T) {
 		p.max = 3
 		armedCount := 0
 		for range 10 {
-			if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, p); armed {
+			armed, _, err := engine.rewindRetry("t1", wfExec, ti, p)
+			if err != nil {
+				t.Fatalf("rewindRetry: %v", err)
+			}
+			if armed {
 				armedCount++
 			}
 		}

--- a/internal/workflow/evidence_attempts_test.go
+++ b/internal/workflow/evidence_attempts_test.go
@@ -1,0 +1,106 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+)
+
+// The same-fingerprint cap exists to stop a repair loop that makes no
+// progress. It could not tell "the agent tried and failed" from "the agent
+// never touched the file": a run that ended without committing spent the
+// budget just the same, so a trivially fixable finding escalated on an attempt
+// that never happened.
+func TestRewindRetry_FingerprintNotChargedWithoutCommits(t *testing.T) {
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+
+	policy := func(ti TaskInfo) rewindRetryPolicy {
+		return rewindRetryPolicy{
+			counterKey:             "step.verify.auto_fix",
+			max:                    5,
+			rewindStep:             "implement",
+			backoff:                func(int) time.Duration { return 0 },
+			fingerprint:            "fp-unused-funcs",
+			maxSameFingerprintRuns: 1,
+			attemptProducedWork:    lastAuthorRunProducedWork,
+			reason:                 func(int) string { return "retry" },
+		}
+	}
+
+	t.Run("run that committed charges the occurrence", func(t *testing.T) {
+		wfExec := &Execution{Variables: map[string]string{}}
+		ti := TaskInfo{ID: "t1", Status: "in-progress", AgentRuns: []AgentRunInfo{
+			{AgentID: "a1", Role: "implementation", HeadSHA: "deadbeef"},
+		}}
+		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); !armed {
+			t.Fatal("first arm should be allowed")
+		}
+		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); armed {
+			t.Error("a committed attempt must spend the same-fingerprint budget")
+		}
+	})
+
+	t.Run("run that committed nothing does not", func(t *testing.T) {
+		wfExec := &Execution{Variables: map[string]string{}}
+		ti := TaskInfo{ID: "t1", Status: "in-progress", AgentRuns: []AgentRunInfo{
+			{AgentID: "a1", Role: "implementation"},
+		}}
+		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); !armed {
+			t.Fatal("first arm should be allowed")
+		}
+		if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, policy(ti)); !armed {
+			t.Error("a run that never committed did not attempt the fix; it must not spend the budget")
+		}
+	})
+
+	// The generic ceiling still terminates a run that never commits, so the
+	// evidence gate cannot spin forever.
+	t.Run("absolute ceiling still bounds the loop", func(t *testing.T) {
+		wfExec := &Execution{Variables: map[string]string{}}
+		ti := TaskInfo{ID: "t1", Status: "in-progress", AgentRuns: []AgentRunInfo{
+			{AgentID: "a1", Role: "implementation"},
+		}}
+		p := policy(ti)
+		p.max = 3
+		armedCount := 0
+		for range 10 {
+			if armed, _, _ := engine.rewindRetry("t1", wfExec, ti, p); armed {
+				armedCount++
+			}
+		}
+		if armedCount != 3 {
+			t.Errorf("armed %d times, want exactly the ceiling of 3", armedCount)
+		}
+	})
+}
+
+func TestLastAuthorRunProducedWork(t *testing.T) {
+	tests := []struct {
+		name string
+		runs []AgentRunInfo
+		want bool
+	}{
+		{"no runs at all charges the occurrence", nil, true},
+		{"author run with a head sha", []AgentRunInfo{{Role: "implementation", HeadSHA: "abc"}}, true},
+		{"author run with a commit source", []AgentRunInfo{{Role: "implementation", FinalCommitSource: "agent"}}, true},
+		{"author run with neither", []AgentRunInfo{{Role: "implementation"}}, false},
+		{
+			// Verifier roles produce no commit by design and must not be read
+			// as the failed attempt.
+			name: "verifier run is skipped in favour of the author run",
+			runs: []AgentRunInfo{{Role: "implementation", HeadSHA: "abc"}, {Role: "review"}},
+			want: true,
+		},
+		{
+			name: "most recent author run wins",
+			runs: []AgentRunInfo{{Role: "implementation", HeadSHA: "abc"}, {Role: "implementation"}},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lastAuthorRunProducedWork(TaskInfo{AgentRuns: tc.runs}); got != tc.want {
+				t.Errorf("lastAuthorRunProducedWork = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/rewind_retry.go
+++ b/internal/workflow/rewind_retry.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"slices"
 	"strconv"
 	"time"
 )
@@ -32,12 +33,40 @@ type rewindRetryPolicy struct {
 	// identical failures can exhaust earlier than the generic attempt ceiling.
 	fingerprint            string
 	maxSameFingerprintRuns int
+	// attemptProducedWork reports whether the run this policy is retrying
+	// actually changed anything. The same-fingerprint cap exists to stop a
+	// repair loop that makes no progress, but it could not tell "the agent
+	// tried and failed" from "the agent never touched the file" — a run that
+	// aborted, or ended without committing, spent the budget just the same.
+	// Nil keeps the occurrence charged unconditionally.
+	attemptProducedWork func(TaskInfo) bool
 	// onArm sets any additional workflow variables the rewound step's prompt
 	// needs (reask note, cleared verdict vars) once the counter has been
 	// bumped to `attempt`, before the workflow is persisted. Optional.
 	onArm func(wfExec *Execution, attempt int)
 	// reason builds the task status-reason recorded alongside the rewind.
 	reason func(attempt int) string
+}
+
+// lastAuthorRunProducedWork reports whether the most recent code-author run on
+// the task committed anything.
+//
+// HeadSHA and FinalCommitSource are recorded only once a run's commit is
+// observed, so their absence on a code-author run is the same evidence
+// verify_commits acts on: nothing was produced. Verifier roles are ignored —
+// producing no commit is what they are for.
+func lastAuthorRunProducedWork(t TaskInfo) bool {
+	// Index rather than value-range: AgentRunInfo is large enough that a
+	// per-iteration copy is flagged.
+	for i := range slices.Backward(t.AgentRuns) {
+		if !isCodeAuthorRun(t.AgentRuns[i]) {
+			continue
+		}
+		return t.AgentRuns[i].HeadSHA != "" || t.AgentRuns[i].FinalCommitSource != ""
+	}
+	// No code-author run recorded at all: charge the occurrence rather than
+	// looping, since there is no evidence either way.
+	return true
 }
 
 // rewindRetry applies a rewindRetryPolicy. armed=true means the counter was
@@ -57,7 +86,15 @@ func (e *Engine) rewindRetry(taskID string, wfExec *Execution, t TaskInfo, p rew
 		fpKey := p.counterKey + ".fingerprint"
 		fpCountKey := p.counterKey + ".fingerprint_count"
 		if wfExec.Variables[fpKey] == p.fingerprint && parseWorkflowInt(wfExec.Variables[fpCountKey]) >= p.maxSameFingerprintRuns {
-			return false, attempts, nil
+			if p.attemptProducedWork == nil || p.attemptProducedWork(t) {
+				return false, attempts, nil
+			}
+			// The previous run left no commit, so it was not an attempt at
+			// this failure. Give the occurrence back rather than escalating on
+			// work that never happened. The generic attempt ceiling above
+			// still bounds the loop, so a run that never commits cannot spin
+			// here forever.
+			wfExec.SetVar(fpCountKey, strconv.Itoa(parseWorkflowInt(wfExec.Variables[fpCountKey])-1))
 		}
 	}
 


### PR DESCRIPTION
## Motivation

`autoFixOrFlagVerifyChecks` sets `maxSameFingerprintRuns: 1`. If the identical failing command and excerpt survive one code-author run, the loop stops and the task escalates to `human-required`.

The intent is right — do not loop forever on a repair that makes no progress. The effect was wrong, because **nothing distinguished "the agent tried and could not fix it" from "the agent never attempted the fix"**.

Task `cd7f0957` escalated on two unused functions in `internal/sybra/app_init.go` after a repair run that never touched that file. The fingerprint was charged an attempt for work that did not happen, and a finding worth two deleted lines became a multi-day human-required park.

> Changelog: fix(workflow): count fix attempts by evidence

## Implementation information

An occurrence is charged only when the most recent code-author run left a commit.

`HeadSHA` and `FinalCommitSource` are recorded once a run's commit is observed, so their absence on a code-author run is the same evidence `verify_commits` already acts on when it rewinds a no-commit run. Verifier roles are skipped — producing no commit is what review, test-runner and eval are *for*.

The generic attempt ceiling (`verifyChecksAutoFixCeiling`) is untouched and checked first, so only the same-fingerprint fast path becomes evidence-gated. A run that never commits therefore cannot spin here; it exhausts the ceiling instead. There is a test for exactly that, because it is the obvious way this change could go wrong.

Applied to both callers of the policy — verify-checks and focused-checks — since they share the shape.

## Supporting documentation

Reverting the gate fails two of the three subtests: the no-commit case and the ceiling case. The committed-attempt case stays green, so the test discriminates rather than just asserting that retries happen.

Builds on #3040, which landed the related half: a no-commit code-author run is now also *recorded* `incomplete` rather than `success`.

Closes #3042
