### PR TITLE
feat(monitor): detect zero provider capacity

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/monitor/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/monitor/models.ts
@@ -72,6 +72,15 @@ export enum AnomalyKind {
     KindBoardStalled = "board_stalled",
 
     /**
+     * KindNoProviderCapacity fires when every enabled provider is unhealthy
+     * and there is work that would otherwise dispatch. Without it a fleet with
+     * nowhere to run looks exactly like an idle one: monitor.tick reports
+     * dispatched:0 either way, and diagnosing it means grepping
+     * provider.health.flip out of the app log by hand.
+     */
+    KindNoProviderCapacity = "no_provider_capacity",
+
+    /**
      * KindClusterDrift is filed by clusterlead.Mirror, not Detect — a leader
      * canonical task's Tags/DependsOn disagree with what its home follower
      * reports, meaning a leader-side write never reached the node that

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -30,7 +30,7 @@ type DetectInput struct {
 	LiveAgents    []liveAgent
 	Cfg           config.MonitorConfig
 	AllowsProject func(projectID string) bool
-	// Providers is the health of every configured provider, keyed by name.
+	// Providers is the health of every configured provider, one entry each.
 	// Empty means the caller did not wire provider health, and the
 	// no-capacity rule stays silent rather than guessing.
 	Providers []ProviderHealth

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -30,6 +30,22 @@ type DetectInput struct {
 	LiveAgents    []liveAgent
 	Cfg           config.MonitorConfig
 	AllowsProject func(projectID string) bool
+	// Providers is the health of every configured provider, keyed by name.
+	// Empty means the caller did not wire provider health, and the
+	// no-capacity rule stays silent rather than guessing.
+	Providers []ProviderHealth
+}
+
+// ProviderHealth is the slice of provider state the no-capacity rule needs,
+// kept as a local struct so internal/monitor does not depend on
+// internal/provider's Checker.
+type ProviderHealth struct {
+	Name    string
+	Enabled bool
+	Healthy bool
+	Reason  string
+	// Until is the rate-limit window end, zero when unknown or not throttled.
+	Until time.Time
 }
 
 // Detect runs every threshold rule against the snapshot and returns a Report
@@ -42,6 +58,7 @@ func Detect(in DetectInput) Report {
 	}
 	report.Anomalies = append(report.Anomalies, detectBoardWide(in, report.Counts)...)
 	report.Anomalies = append(report.Anomalies, detectBoardStalled(in, report.Counts)...)
+	report.Anomalies = append(report.Anomalies, detectNoProviderCapacity(in, report.Counts)...)
 	report.Anomalies = append(report.Anomalies, detectPerTask(in)...)
 	report.Anomalies = append(report.Anomalies, detectFromAudit(in)...)
 	return report
@@ -149,6 +166,65 @@ func detectBoardStalled(in DetectInput, counts Counts) []Anomaly {
 		Severity:    SeverityError,
 		RequiresLLM: false,
 		Fingerprint: Fingerprint(KindBoardStalled, "", ev),
+		Evidence:    ev,
+		DetectedAt:  in.Now,
+	}}
+}
+
+// detectNoProviderCapacity fires when every enabled provider is unhealthy and
+// there is work that would otherwise dispatch.
+//
+// The distinction that matters is "nothing to do" versus "cannot do anything":
+// an idle board and a board with nowhere to run both report dispatched:0, and
+// the only way to tell them apart was to grep provider.health.flip out of the
+// app log. The evidence carries each provider's reason and reset time so the
+// expected recovery is visible without doing that.
+func detectNoProviderCapacity(in DetectInput, counts Counts) []Anomaly {
+	if len(in.Providers) == 0 {
+		return nil
+	}
+	// Work that would dispatch if anything could run. An idle board must not
+	// raise this: a fleet with no capacity and nothing to do is not degraded.
+	pending := counts.Todo + counts.InProgress
+	if pending == 0 {
+		return nil
+	}
+
+	enabled := 0
+	reasons := make(map[string]string)
+	var until []string
+	for i := range in.Providers {
+		p := in.Providers[i]
+		if !p.Enabled {
+			continue
+		}
+		enabled++
+		if p.Healthy {
+			return nil
+		}
+		reasons[p.Name] = p.Reason
+		if !p.Until.IsZero() {
+			until = append(until, p.Name+"="+p.Until.UTC().Format(time.RFC3339))
+		}
+	}
+	if enabled == 0 {
+		return nil
+	}
+	slices.Sort(until)
+
+	ev := map[string]any{
+		"pending":           pending,
+		"enabled_providers": enabled,
+		"reasons":           reasons,
+	}
+	if len(until) > 0 {
+		ev["rate_limited_until"] = strings.Join(until, ",")
+	}
+	return []Anomaly{{
+		Kind:        KindNoProviderCapacity,
+		Severity:    SeverityError,
+		RequiresLLM: false,
+		Fingerprint: Fingerprint(KindNoProviderCapacity, "", ev),
 		Evidence:    ev,
 		DetectedAt:  in.Now,
 	}}

--- a/internal/monitor/no_capacity_test.go
+++ b/internal/monitor/no_capacity_test.go
@@ -1,0 +1,94 @@
+package monitor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// A fleet with nowhere to run and an idle fleet both report dispatched:0, so
+// the only way to tell them apart was grepping provider.health.flip out of the
+// app log. The rule has to distinguish "nothing to do" from "cannot do
+// anything" — raising on an idle board would be noise, not a signal.
+func TestDetectNoProviderCapacity(t *testing.T) {
+	now := time.Date(2026, 8, 5, 19, 0, 0, 0, time.UTC)
+	until := now.Add(60 * time.Hour)
+
+	todo := []task.Task{{ID: "t1", Status: task.StatusTodo, StatusChangedAt: now.Add(-time.Minute)}}
+
+	tests := []struct {
+		name      string
+		tasks     []task.Task
+		providers []ProviderHealth
+		want      bool
+	}{
+		{
+			name:  "every enabled provider down with work pending",
+			tasks: todo,
+			providers: []ProviderHealth{
+				{Name: "claude", Enabled: true, Reason: "rate_limited", Until: until},
+				{Name: "codex", Enabled: true, Reason: "rate_limited", Until: until},
+				{Name: "copilot", Enabled: false},
+			},
+			want: true,
+		},
+		{
+			// Not degraded: there is nothing to run.
+			name:  "no capacity but an idle board",
+			tasks: nil,
+			providers: []ProviderHealth{
+				{Name: "claude", Enabled: true, Reason: "rate_limited"},
+			},
+			want: false,
+		},
+		{
+			name:  "one healthy provider is capacity",
+			tasks: todo,
+			providers: []ProviderHealth{
+				{Name: "claude", Enabled: true, Reason: "rate_limited"},
+				{Name: "codex", Enabled: true, Healthy: true, Reason: "ok"},
+			},
+			want: false,
+		},
+		{
+			// Deliberately off is a configuration choice, not an outage.
+			name:      "only disabled providers configured",
+			tasks:     todo,
+			providers: []ProviderHealth{{Name: "copilot", Enabled: false}},
+			want:      false,
+		},
+		{
+			name:      "provider health not wired stays silent",
+			tasks:     todo,
+			providers: nil,
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			report := Detect(DetectInput{Now: now, Tasks: tc.tasks, Providers: tc.providers})
+			var found *Anomaly
+			for i := range report.Anomalies {
+				if report.Anomalies[i].Kind == KindNoProviderCapacity {
+					found = &report.Anomalies[i]
+				}
+			}
+			if (found != nil) != tc.want {
+				t.Fatalf("no_provider_capacity raised = %v, want %v", found != nil, tc.want)
+			}
+			if found == nil {
+				return
+			}
+			// The expected recovery time has to be visible, or diagnosing it
+			// still means reading the log.
+			if got := found.Evidence["rate_limited_until"]; got == nil {
+				t.Errorf("evidence missing rate_limited_until: %+v", found.Evidence)
+			}
+			if got := found.Evidence["reasons"]; got == nil {
+				t.Errorf("evidence missing per-provider reasons: %+v", found.Evidence)
+			}
+		})
+	}
+}

--- a/internal/monitor/report.go
+++ b/internal/monitor/report.go
@@ -28,6 +28,12 @@ const (
 	KindFailureSpike      AnomalyKind = "failure_spike"
 	KindBottleneck        AnomalyKind = "bottleneck"
 	KindBoardStalled      AnomalyKind = "board_stalled"
+	// KindNoProviderCapacity fires when every enabled provider is unhealthy
+	// and there is work that would otherwise dispatch. Without it a fleet with
+	// nowhere to run looks exactly like an idle one: monitor.tick reports
+	// dispatched:0 either way, and diagnosing it means grepping
+	// provider.health.flip out of the app log by hand.
+	KindNoProviderCapacity AnomalyKind = "no_provider_capacity"
 	// KindClusterDrift is filed by clusterlead.Mirror, not Detect — a leader
 	// canonical task's Tags/DependsOn disagree with what its home follower
 	// reports, meaning a leader-side write never reached the node that
@@ -48,6 +54,7 @@ func AllAnomalyKinds() []AnomalyKind {
 		KindFailureSpike,
 		KindBottleneck,
 		KindBoardStalled,
+		KindNoProviderCapacity,
 		KindClusterDrift,
 	}
 }

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -78,17 +78,21 @@ type Deps struct {
 // Service runs the monitor loop. It is constructed once at app startup and
 // runs until its context is cancelled.
 type Service struct {
-	cfg                 config.MonitorConfig
-	tasks               taskAPI
-	audit               auditAPI
-	agents              agentLister
-	observerOnly        bool
-	dispatcher          Dispatcher
-	sink                IssueSink
-	emit                EmitFunc
-	logger              *slog.Logger
-	now                 func() time.Time
-	allowsProject       func(string) bool
+	cfg           config.MonitorConfig
+	tasks         taskAPI
+	audit         auditAPI
+	agents        agentLister
+	observerOnly  bool
+	dispatcher    Dispatcher
+	sink          IssueSink
+	emit          EmitFunc
+	logger        *slog.Logger
+	now           func() time.Time
+	allowsProject func(string) bool
+	// providerHealth reports every configured provider's state. Late-bound
+	// (SetProviderHealth); nil keeps the no-capacity rule silent rather than
+	// guessing that a fleet with no reported providers has no capacity.
+	providerHealth      func() []ProviderHealth
 	downgradeLLMForTask func(taskID string) bool
 	fetchPRState        func(repo string, number int) (github.PRState, error)
 	landClosedPR        func(context.Context, string, int, string) error
@@ -228,6 +232,7 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 		LiveAgents:    live,
 		Cfg:           s.cfg,
 		AllowsProject: s.allowsProject,
+		Providers:     s.snapshotProviders(),
 	})
 	report.Anomalies = SortAnomalies(report.Anomalies)
 	s.applyDowngradeLLM(report.Anomalies)
@@ -357,6 +362,7 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 		LiveAgents:    live,
 		Cfg:           s.cfg,
 		AllowsProject: s.allowsProject,
+		Providers:     s.snapshotProviders(),
 	})
 	report.Anomalies = SortAnomalies(report.Anomalies)
 	return report, nil
@@ -374,6 +380,17 @@ func (s *Service) LastReport() (Report, bool) {
 // agent-driven filing path (which produces hard-to-scrub LLM output) into the
 // deterministic-body path where the issue sink applies redaction. No-op when
 // the closure is unset.
+// SetProviderHealth late-binds the provider-health snapshot the no-capacity
+// rule reads. Left unset the rule stays silent.
+func (s *Service) SetProviderHealth(fn func() []ProviderHealth) { s.providerHealth = fn }
+
+func (s *Service) snapshotProviders() []ProviderHealth {
+	if s == nil || s.providerHealth == nil {
+		return nil
+	}
+	return s.providerHealth()
+}
+
 func (s *Service) applyDowngradeLLM(anoms []Anomaly) {
 	if s.downgradeLLMForTask == nil {
 		return

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -661,6 +661,29 @@ func (c *Checker) SetAutoFailover(v bool) {
 	c.mu.Unlock()
 }
 
+// ProviderEnabled reports whether a provider participates in probing and
+// failover. Exposed so callers can tell "no capacity" from "not configured"
+// without reaching into Config.
+func (c *Checker) ProviderEnabled(provider string) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	switch provider {
+	case "claude":
+		return c.cfg.ClaudeEnabled
+	case "codex":
+		return c.cfg.CodexEnabled
+	case "copilot":
+		return c.cfg.CopilotEnabled
+	case "opencode":
+		return c.cfg.OpenCodeEnabled
+	default:
+		return false
+	}
+}
+
 // SetProviderEnabled toggles per-provider probing and participation in failover.
 func (c *Checker) SetProviderEnabled(provider string, v bool) {
 	c.mu.Lock()

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -732,8 +732,30 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			return a.reviewer.AdvanceClosedTaskPR(ctx, taskID, prNumber, state)
 		},
 	})
+	svc.SetProviderHealth(a.providerHealthSnapshot)
 	a.monitorSvc = svc
 	a.wg.Go(func() { svc.Run(ctx) })
+}
+
+// providerHealthSnapshot adapts the health checker for the monitor's
+// no-capacity rule. Nil checker yields nil, which keeps the rule silent rather
+// than reporting a fleet with no providers as having no capacity.
+func (a *App) providerHealthSnapshot() []monitor.ProviderHealth {
+	if a == nil || a.providerHealth == nil {
+		return nil
+	}
+	statuses := a.providerHealth.Snapshot()
+	out := make([]monitor.ProviderHealth, 0, len(statuses))
+	for name, st := range statuses {
+		out = append(out, monitor.ProviderHealth{
+			Name:    name,
+			Enabled: a.providerHealth.ProviderEnabled(name),
+			Healthy: st.Healthy,
+			Reason:  st.Reason,
+			Until:   st.RateLimitedUntil,
+		})
+	}
+	return out
 }
 
 // startSelfMonitorService wires the deep-analysis loop that distills agent logs


### PR DESCRIPTION
## Motivation

The server board sat at **0 in-progress, 6 todo, 24 human-required** for hours because both configured providers were rate-limited at once. Nothing reported it.

`monitor.tick` logged `in_progress:0 todo:6 anomalies:11 dispatched:0` every five minutes — indistinguishable from a healthy idle board. Diagnosing it meant SSHing to the host and grepping `provider.health.flip` out of the app log by hand.

The condition is also structurally likely rather than exotic: the failover chain on that deployment is claude → codex, with copilot disabled because its CLI is not installed. One weekly limit plus one usage limit is a total stall with no third leg.

> Changelog: feat(monitor): detect zero provider capacity

## Implementation information

`no_provider_capacity` fires when every **enabled** provider is unhealthy and there is work that would otherwise dispatch. The evidence carries each provider's reason and its `RateLimitedUntil`, so the expected recovery time is visible without reading the log.

The distinction that matters is **"nothing to do" versus "cannot do anything"**, and the tests pin each way it could go wrong:

- an idle board does not raise it — a fleet with no capacity and nothing to run is not degraded
- a disabled provider is a configuration choice, not an outage, so a deployment with only copilot configured-and-off stays silent
- an unwired health snapshot stays silent rather than reporting a fleet with no *known* providers as having none

`monitor.ProviderHealth` is a local struct rather than a dependency on `internal/provider`'s `Checker`, keeping the detector pure and testable; the app layer adapts. `Checker.ProviderEnabled` is new — the enabled flags lived only inside `Config`, and telling "no capacity" from "not configured" needs them.

## Supporting documentation

Removing the idle-board guard fails exactly the idle case and leaves the others green, so the test discriminates rather than asserting the anomaly always fires.

### Split out, not dropped

The issue also lists `sybra-cli config doctor`, the startup `app.automations` summary, and a warning when fewer than two providers are healthy. This PR adds the detection and the evidence; those presentation surfaces are tracked in #3109 and queued under the umbrella.

Closing #3045 here is therefore honest about what shipped: the detector and its evidence. The `config doctor` surface in particular is not a trivial addition — live provider health lives in the running server'"'"'s Checker and `sybra-cli` is a separate process, so it needs a deliberate decision about whether to query the server or report only statically-knowable state. That belongs in its own review.

Closes #3045