### PR TITLE
fix(review): retry prepare instead of read-only

### DIFF
--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -363,7 +363,6 @@ func (h *humanReviewHandler) spawnReview(t task.Task, prevStatus string, opts hu
 		// hits the per-hour cap and the task is never examined at all. The
 		// dispatch claim itself is released by the deferred call above.
 		h.releaseReservedSlot(taskID, now)
-		h.clearInflight(taskID)
 		h.scheduleClaimRetry(taskID, prevStatus, opts)
 		return false
 	}

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/verdict"
 	"github.com/Automaat/sybra/internal/workflow"
+	"github.com/Automaat/sybra/internal/worktree"
 )
 
 // humanReviewPromptHeadTail bounds how many lines of the host log file are
@@ -227,17 +228,42 @@ func humanReviewDispatchDir(t task.Task, sybraRepoDir string) (dir string, readO
 	return sybraRepoDir, true
 }
 
-func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly bool) {
+// dispatchDir resolves where the recovery agent runs. retryable means
+// preparation failed for a reason that clears on its own, so the caller should
+// wait rather than dispatch.
+//
+// Collapsing every prepare error into the read-only Sybra-source fallback made
+// the most common entry path silently degrade: the human-required status hook
+// spawns while the agent that just failed is still winding down in the
+// registry, so PrepareForTask returns ErrAgentRunning and recovery landed on a
+// read-only dir — the exact condition writable recovery worktrees exist to
+// eliminate. Three agents on three different tasks reported the worktree as
+// read-only and returned recoverable_action: none, each having already
+// verified a fix they could not apply.
+func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly, retryable bool) {
 	if h.prepareTaskWorktree != nil {
 		dir, err := h.prepareTaskWorktree(t)
 		if err == nil && strings.TrimSpace(dir) != "" {
-			return dir, false
+			return dir, false, false
 		}
 		if err != nil {
+			if isRetryablePrepareError(err) {
+				h.logger.Info("human-review.worktree.prepare.retryable", "task_id", t.ID, "err", err)
+				return "", false, true
+			}
 			h.logger.Warn("human-review.worktree.prepare", "task_id", t.ID, "err", err)
 		}
 	}
-	return humanReviewDispatchDir(t, h.cfg.HumanReview.SybraRepoDir)
+	dir, readOnly = humanReviewDispatchDir(t, h.cfg.HumanReview.SybraRepoDir)
+	return dir, readOnly, false
+}
+
+// isRetryablePrepareError reports whether a worktree preparation failure will
+// clear without intervention. A live agent finishes; a fetch blip passes. The
+// read-only fallback is for a task that genuinely has no worktree, where
+// diagnosing Sybra itself is the whole job.
+func isRetryablePrepareError(err error) bool {
+	return errors.Is(err, worktree.ErrAgentRunning) || errors.Is(err, worktree.ErrTransientFetch)
 }
 
 // maybeSpawn is called from the status hook when a task lands in
@@ -331,7 +357,16 @@ func (h *humanReviewHandler) spawnReview(t task.Task, prevStatus string, opts hu
 		}
 	}
 
-	dir, readOnlyDir := h.dispatchDir(t)
+	dir, readOnlyDir, retryable := h.dispatchDir(t)
+	if retryable {
+		// Give back the reserved slot as claim contention does, or the retry
+		// hits the per-hour cap and the task is never examined at all. The
+		// dispatch claim itself is released by the deferred call above.
+		h.releaseReservedSlot(taskID, now)
+		h.clearInflight(taskID)
+		h.scheduleClaimRetry(taskID, prevStatus, opts)
+		return false
+	}
 	prompt := h.buildPrompt(t, dir, wctx)
 	cfg := h.spawnReviewConfig(t, taskID, prompt, dir, readOnlyDir, opts)
 	if !h.preRunEligible(taskID, now, opts.IgnoreRenderedVerdict) {

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/verdict"
 	"github.com/Automaat/sybra/internal/workflow"
+	"github.com/Automaat/sybra/internal/worktree"
 )
 
 // setupUnblockedRecoveryWorktree creates a clone checked out on branch, with
@@ -172,7 +173,7 @@ func TestHumanReviewDispatchDir_PreparesManagedWorktree(t *testing.T) {
 		return wantDir, nil
 	}
 
-	dir, readOnly := h.dispatchDir(task.Task{ID: "managed-task"})
+	dir, readOnly, _ := h.dispatchDir(task.Task{ID: "managed-task"})
 	if !called {
 		t.Fatal("managed worktree preparer was not called")
 	}
@@ -189,7 +190,7 @@ func TestHumanReviewDispatchDir_PrepareFailureFallsBackReadOnly(t *testing.T) {
 		return "", errors.New("worktree unavailable")
 	}
 
-	dir, readOnly := h.dispatchDir(task.Task{ID: "fallback-task"})
+	dir, readOnly, _ := h.dispatchDir(task.Task{ID: "fallback-task"})
 	if dir != h.cfg.HumanReview.SybraRepoDir || !readOnly {
 		t.Fatalf("got dir=%q readOnly=%v, want dir=%q readOnly=true", dir, readOnly, h.cfg.HumanReview.SybraRepoDir)
 	}
@@ -3883,5 +3884,105 @@ func TestHumanReviewPrompt_HonorsCommitSigningPolicy(t *testing.T) {
 	h.SetSigningPolicy(project.SigningRequire)
 	if got := h.signingPolicy().CommitFlags(context.Background()); got != "-s -S" {
 		t.Errorf("after reload to require, flags = %q, want -s -S", got)
+	}
+}
+
+// The human-required status hook spawns while the agent that just failed is
+// still winding down in the registry, so PrepareForTask returns
+// ErrAgentRunning on the most common entry path into recovery. Falling back to
+// the read-only Sybra source there is the exact condition writable recovery
+// worktrees exist to eliminate — three agents on three tasks each verified a
+// fix and then reported they could not apply it.
+func TestHumanReviewDispatchDir_RetryableErrorsDoNotFallBackReadOnly(t *testing.T) {
+	tests := []struct {
+		name          string
+		prepareErr    error
+		wantRetryable bool
+	}{
+		{"live agent still winding down", worktree.ErrAgentRunning, true},
+		{"transient fetch blip", worktree.ErrTransientFetch, true},
+		{
+			// A task that genuinely has no worktree is what the read-only
+			// fallback is for: diagnosing Sybra itself.
+			name:          "permanent failure still falls back",
+			prepareErr:    errors.New("no worktree and no branch"),
+			wantRetryable: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, cleanup := newReviewTestEnv(t)
+			defer cleanup()
+			h.cfg.HumanReview.SybraRepoDir = "/opt/sybra/src"
+			h.prepareTaskWorktree = func(task.Task) (string, error) { return "", tc.prepareErr }
+
+			dir, readOnly, retryable := h.dispatchDir(task.Task{ID: "t1"})
+			if retryable != tc.wantRetryable {
+				t.Fatalf("retryable = %v, want %v", retryable, tc.wantRetryable)
+			}
+			if tc.wantRetryable {
+				if dir != "" || readOnly {
+					t.Errorf("retryable prepare returned dir=%q readOnly=%v, want no dispatch", dir, readOnly)
+				}
+				return
+			}
+			if dir != "/opt/sybra/src" || !readOnly {
+				t.Errorf("permanent failure gave dir=%q readOnly=%v, want the read-only fallback", dir, readOnly)
+			}
+		})
+	}
+}
+
+// Classifying the error is not enough: the spawn path must actually wait
+// instead of dispatching. Without this the agent still runs, just against the
+// read-only fallback.
+func TestHumanReviewSpawn_RetryablePrepareSchedulesRetry(t *testing.T) {
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("retryable prepare", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": "Automaat/sybra",
+		"status":     string(task.StatusHumanRequired),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prepareCalls := 0
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		prepareCalls++
+		if prepareCalls == 1 {
+			return "", worktree.ErrAgentRunning
+		}
+		return t.TempDir(), nil
+	}
+	var scheduled func()
+	h.schedule = func(_ time.Duration, fn func()) { scheduled = fn }
+	runCalls := 0
+	h.agents = &fakeHumanReviewAgentRunner{run: func(cfg agent.RunConfig) (*agent.Agent, error) {
+		runCalls++
+		if cfg.ReadOnlyDir {
+			t.Error("dispatched read-only after a retryable prepare failure")
+		}
+		return &agent.Agent{ID: "recovered", TaskID: cfg.TaskID, StartedAt: time.Now().UTC()}, nil
+	}}
+
+	if h.maybeSpawn(tk.ID, string(task.StatusInReview)) {
+		t.Fatal("spawned despite a retryable prepare failure")
+	}
+	if runCalls != 0 {
+		t.Fatalf("agent ran %d times before the retry", runCalls)
+	}
+	if scheduled == nil {
+		t.Fatal("retryable prepare did not schedule a retry")
+	}
+
+	scheduled()
+
+	if runCalls != 1 {
+		t.Errorf("agent runs after retry = %d, want 1", runCalls)
 	}
 }


### PR DESCRIPTION
## Motivation

`humanReviewHandler.dispatchDir` collapsed **every** `prepareTaskWorktree` error into the read-only Sybra-source fallback, including the two that are explicitly retryable.

`worktree.ErrAgentRunning` is returned whenever `hasLiveAgentOnly(t.ID)` is true. The human-required status hook fires `go a.humanReview.maybeSpawn` while the agent that just failed is still winding down in the registry — so the single most common entry path into recovery silently degraded to exactly the read-only dispatch that writable recovery worktrees (#2973) exist to eliminate. It was logged only as `human-review.worktree.prepare` at Warn.

That is the failure mode observed on the live server: three recovery agents on three different tasks each returned `decision: sybra_bug, recoverable_action: none`, reporting that the worktree was read-only and they could not apply a fix they had already verified.

`ErrTransientFetch` — a DNS or SSH blip — did the same.

> Changelog: fix(review): retry prepare instead of read-only

## Implementation information

`dispatchDir` now reports retryability, and the spawn path schedules a retry rather than dispatching. A permanent failure still falls back: a task with genuinely no worktree is what the read-only dispatch is *for*, where diagnosing Sybra itself is the whole job.

One thing worth the reviewer's attention: the retry also has to hand back the slot `reserveSpawn` took, exactly as the claim-contention path does. Without that the per-hour cap eats the retry and the task is never examined at all — a strictly worse outcome than the read-only dispatch this replaces.

**The classifier test alone would not have caught that.** It passed while the spawn-path test failed with `agent runs after retry = 0, want 1`. Testing the machinery rather than just the predicate is what surfaced it.

## Supporting documentation

Two mutations, both checked: removing the slot release fails the spawn-path test, and making `isRetryablePrepareError` always false fails both retryable classifier cases and the spawn test, while leaving the permanent-failure case green.

Interacts with #3074 — the retry ladder is currently 1s/4s/9s, which may be shorter than a live agent takes to wind down. That is tracked separately rather than widened here.

Closes #3075
