### PR TITLE
refactor(llmjob): unify LLM JSON extraction

### DIFF
--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -178,7 +178,7 @@ func parseInspectorOutput(raw []byte) (InspectorVerdict, error) {
 		}
 		text = *envelope.Result
 	}
-	jsonStr := extractLastJSONObject(text)
+	jsonStr := llmjob.ExtractLastJSONObject(text)
 	if jsonStr == "" {
 		return InspectorVerdict{}, fmt.Errorf("no JSON object in result: %q", text)
 	}
@@ -192,58 +192,4 @@ func parseInspectorOutput(raw []byte) (InspectorVerdict, error) {
 		return InspectorVerdict{}, fmt.Errorf("invalid recommendation: %q", v.Recommendation)
 	}
 	return v, nil
-}
-
-// extractLastJSONObject returns the last balanced {...} substring in s, or "".
-// It tracks JSON string-literal state so that braces inside string values
-// are not counted toward depth.
-func extractLastJSONObject(s string) string {
-	s = strings.TrimSpace(s)
-	var (
-		inString  bool
-		escape    bool
-		depth     int
-		objStart  = -1
-		lastStart = -1
-		lastEnd   = -1
-	)
-	for i := range len(s) {
-		c := s[i]
-		if escape {
-			escape = false
-			continue
-		}
-		if inString {
-			switch c {
-			case '\\':
-				escape = true
-			case '"':
-				inString = false
-			}
-			continue
-		}
-		switch c {
-		case '"':
-			inString = true
-		case '{':
-			if depth == 0 {
-				objStart = i
-			}
-			depth++
-		case '}':
-			if depth == 0 {
-				continue
-			}
-			depth--
-			if depth == 0 && objStart >= 0 {
-				lastStart = objStart
-				lastEnd = i
-				objStart = -1
-			}
-		}
-	}
-	if lastStart < 0 {
-		return ""
-	}
-	return s[lastStart : lastEnd+1]
 }

--- a/internal/agent/inspector_test.go
+++ b/internal/agent/inspector_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 // TestInspectorVerdictSchemaIsCodexStrict asserts inspectorVerdictSchema is a
@@ -146,60 +144,29 @@ func TestParseInspectorOutput(t *testing.T) {
 	}
 }
 
-func TestExtractLastJSONObject(t *testing.T) {
-	tests := []struct {
-		in, want string
-	}{
-		{`{"a":1}`, `{"a":1}`},
-		{`noise {"a":1} more {"b":2}`, `{"b":2}`},
-		{`{"outer":{"inner":1}}`, `{"outer":{"inner":1}}`},
-		{`no braces`, ``},
-		{`{unbalanced`, ``},
-	}
-	for _, tc := range tests {
-		if got := llmjob.ExtractLastJSONObject(tc.in); got != tc.want {
-			t.Errorf("llmjob.ExtractLastJSONObject(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
-// TestExtractLastJSONObject_BraceInsideString demonstrates that the
-// brace-counting walker in extractLastJSONObject does not understand JSON
-// string literals — it counts every `{` and `}` byte regardless of whether
-// it sits inside a quoted string. A perfectly valid JSON object whose
-// string value contains a `{` or `}` character is therefore mis-parsed:
-// the walker sees an unbalanced brace and either truncates the result or
-// returns an empty string.
-//
-// This matters because parseInspectorOutput feeds the inspector model's
-// `result` text through this function. If the model writes a reason like
-// `"saw a stray ) {"`, the verdict is silently lost and the watchdog
-// fails to act on a stuck agent.
-//
-// Fix: parse the result as JSON (or use a real tokenizer that knows about
-// string literals) instead of brace counting on raw bytes.
-func TestExtractLastJSONObject_BraceInsideString(t *testing.T) {
+// The inspector model wraps its verdict in prose, so this call site depends on
+// the shared scanner's two hard cases: a brace inside a string value (the model
+// quotes code in its reason) and a decoy object before the want answer.
+func TestParseInspectorOutputResolvesTheRealObject(t *testing.T) {
+	want := `{"recommendation":"continue","reason":"looks fine"}`
 	tests := []struct {
 		name string
-		in   string
-		want string
+		raw  string
 	}{
-		{
-			name: "open brace inside string value",
-			in:   `{"reason": "if (x) {"}`,
-			want: `{"reason": "if (x) {"}`,
-		},
-		{
-			name: "close brace inside string value",
-			in:   `{"reason": "saw }"}`,
-			want: `{"reason": "saw }"}`,
-		},
+		{name: "prose around", raw: "My read:\n" + want + "\ndone."},
+		{name: "fenced", raw: "```json\n" + want + "\n```"},
+		{name: "open brace inside a string value", raw: `{"recommendation":"stop","reason":"if (x) {"}` + "\nrevised:\n" + want},
+		{name: "close brace inside a string value", raw: `{"recommendation":"stop","reason":"saw }"}` + "\nrevised:\n" + want},
+		{name: "decoy object first", raw: `{"recommendation":"stop","reason":"draft"}` + "\nOn reflection:\n" + want},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := llmjob.ExtractLastJSONObject(tc.in)
-			if got != tc.want {
-				t.Errorf("llmjob.ExtractLastJSONObject(%q) = %q, want %q (brace inside string literal mis-parsed)", tc.in, got, tc.want)
+			got, err := parseInspectorOutput([]byte(tc.raw))
+			if err != nil {
+				t.Fatalf("parseInspectorOutput: %v", err)
+			}
+			if got.Recommendation != "continue" || got.Reason != "looks fine" {
+				t.Errorf("resolved the wrong object: %+v", got)
 			}
 		})
 	}

--- a/internal/agent/inspector_test.go
+++ b/internal/agent/inspector_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 // TestInspectorVerdictSchemaIsCodexStrict asserts inspectorVerdictSchema is a
@@ -155,8 +157,8 @@ func TestExtractLastJSONObject(t *testing.T) {
 		{`{unbalanced`, ``},
 	}
 	for _, tc := range tests {
-		if got := extractLastJSONObject(tc.in); got != tc.want {
-			t.Errorf("extractLastJSONObject(%q) = %q, want %q", tc.in, got, tc.want)
+		if got := llmjob.ExtractLastJSONObject(tc.in); got != tc.want {
+			t.Errorf("llmjob.ExtractLastJSONObject(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }
@@ -195,9 +197,9 @@ func TestExtractLastJSONObject_BraceInsideString(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := extractLastJSONObject(tc.in)
+			got := llmjob.ExtractLastJSONObject(tc.in)
 			if got != tc.want {
-				t.Errorf("extractLastJSONObject(%q) = %q, want %q (brace inside string literal mis-parsed)", tc.in, got, tc.want)
+				t.Errorf("llmjob.ExtractLastJSONObject(%q) = %q, want %q (brace inside string literal mis-parsed)", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/internal/evaluation/judge.go
+++ b/internal/evaluation/judge.go
@@ -171,7 +171,7 @@ func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
 		}
 		text = *envelope.Result
 	}
-	jsonStr := judgeExtractLastJSON(text)
+	jsonStr := llmjob.ExtractLastJSONObject(text)
 	if jsonStr == "" {
 		return QualityVerdict{}, fmt.Errorf("no JSON object in result: %q", text)
 	}
@@ -226,59 +226,6 @@ func AgreesWithOutcome(v QualityVerdict, outcome string, threshold float64) bool
 	default:
 		return true
 	}
-}
-
-// judgeExtractLastJSON returns the last balanced {...} substring in s, or "".
-// The model may prepend prose before the final JSON object.
-func judgeExtractLastJSON(s string) string {
-	s = strings.TrimSpace(s)
-	var (
-		inString  bool
-		escape    bool
-		depth     int
-		objStart  = -1
-		lastStart = -1
-		lastEnd   = -1
-	)
-	for i := range len(s) {
-		c := s[i]
-		if escape {
-			escape = false
-			continue
-		}
-		if inString {
-			switch c {
-			case '\\':
-				escape = true
-			case '"':
-				inString = false
-			}
-			continue
-		}
-		switch c {
-		case '"':
-			inString = true
-		case '{':
-			if depth == 0 {
-				objStart = i
-			}
-			depth++
-		case '}':
-			if depth == 0 {
-				continue
-			}
-			depth--
-			if depth == 0 && objStart >= 0 {
-				lastStart = objStart
-				lastEnd = i
-				objStart = -1
-			}
-		}
-	}
-	if lastStart < 0 {
-		return ""
-	}
-	return s[lastStart : lastEnd+1]
 }
 
 func clampScore(s int) int {

--- a/internal/evaluation/judge_parse_test.go
+++ b/internal/evaluation/judge_parse_test.go
@@ -1,0 +1,48 @@
+package evaluation
+
+import "testing"
+
+// The judge's JSON arrives wrapped in prose and sometimes inside the claude
+// `--output-format json` envelope, so this call site depends on the shared
+// scanner's two hard cases: a brace inside a string value, and a decoy object
+// emitted before the want answer.
+func TestParseQualityVerdictResolvesTheRealObject(t *testing.T) {
+	t.Parallel()
+	want := `{"overall":8,"dimensions":{"correctness":{"score":8},"code_quality":{"score":8},"scope_discipline":{"score":8},"test_coverage":{"score":8},"review_worthiness":{"score":8}},"summary":"solid"}`
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "bare object", raw: want},
+		{name: "prose around", raw: "My verdict:\n" + want + "\nend."},
+		{name: "fenced", raw: "```json\n" + want + "\n```"},
+		{
+			name: "close brace inside a string value",
+			raw:  `{"overall":1,"dimensions":{"correctness":{"score":8},"code_quality":{"score":8},"scope_discipline":{"score":8},"test_coverage":{"score":8},"review_worthiness":{"score":8}},"summary":"a } in the diff"}` + "\nrevised:\n" + want,
+		},
+		{
+			name: "decoy object first",
+			raw:  `{"overall":1,"dimensions":{"correctness":{"score":8},"code_quality":{"score":8},"scope_discipline":{"score":8},"test_coverage":{"score":8},"review_worthiness":{"score":8}},"summary":"draft"}` + "\nOn reflection:\n" + want,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseQualityVerdict([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("parseQualityVerdict: %v", err)
+			}
+			if got.Overall != 8 || got.Summary != "solid" {
+				t.Errorf("resolved the wrong object: %+v", got)
+			}
+		})
+	}
+}
+
+func TestParseQualityVerdictRejectsOutputWithNoObject(t *testing.T) {
+	t.Parallel()
+	if _, err := parseQualityVerdict([]byte("the judge refused")); err == nil {
+		t.Error("expected an error on output containing no JSON object")
+	}
+}

--- a/internal/learning/digest_parse_test.go
+++ b/internal/learning/digest_parse_test.go
@@ -1,0 +1,50 @@
+package learning
+
+import "testing"
+
+// The summarizer wraps its JSON in prose, so this call site depends on the
+// shared scanner's two hard cases: a brace inside a string value, and a decoy
+// object emitted before the want answer.
+func TestParseDigestJSONResolvesTheRealObject(t *testing.T) {
+	t.Parallel()
+	want := `{"since":"2026-01-01","until":"2026-01-07","worked":["shipped the gate"]}`
+
+	tests := []struct {
+		name string
+		text string
+	}{
+		{name: "bare object", text: want},
+		{name: "prose around", text: "Here is the digest:\n" + want + "\ndone."},
+		{name: "fenced", text: "```json\n" + want + "\n```"},
+		{
+			name: "close brace inside a string value",
+			text: `{"since":"x","until":"y","worked":["a } in the diff"]}` + "\nrevised:\n" + want,
+		},
+		{
+			name: "decoy object first",
+			text: `{"since":"draft","until":"draft","worked":["wrong"]}` + "\nOn reflection:\n" + want,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseDigestJSON(tt.text)
+			if err != nil {
+				t.Fatalf("parseDigestJSON: %v", err)
+			}
+			if got.Since != "2026-01-01" || got.Until != "2026-01-07" {
+				t.Errorf("resolved the wrong object: %+v", got)
+			}
+			if len(got.Worked) != 1 || got.Worked[0] != "shipped the gate" {
+				t.Errorf("worked = %v, want the want object's entry", got.Worked)
+			}
+		})
+	}
+}
+
+func TestParseDigestJSONRejectsOutputWithNoObject(t *testing.T) {
+	t.Parallel()
+	if _, err := parseDigestJSON("the summarizer refused"); err == nil {
+		t.Error("expected an error on output containing no JSON object")
+	}
+}

--- a/internal/learning/validate.go
+++ b/internal/learning/validate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/textutil"
 )
 
@@ -43,7 +44,7 @@ type rawDigest struct {
 // parseDigestJSON extracts the last balanced JSON object from the
 // summarizer's free-form output and unmarshals it into a rawDigest.
 func parseDigestJSON(text string) (rawDigest, error) {
-	jsonStr := extractLastJSON(text)
+	jsonStr := llmjob.ExtractLastJSONObject(text)
 	if jsonStr == "" {
 		return rawDigest{}, fmt.Errorf("no JSON object in summarizer output: %q", textutil.TruncateBytes(text, 200, "…"))
 	}
@@ -159,59 +160,4 @@ func mentionsLowSample(text string) bool {
 		}
 	}
 	return false
-}
-
-// extractLastJSON returns the last balanced {...} substring in s, or "".
-// Mirrors evaluation.judgeExtractLastJSON / selfmonitor.judgeExtractLastJSON —
-// each LLM-output-parsing package keeps its own copy rather than sharing a
-// dependency across otherwise-independent judge/summarizer packages.
-func extractLastJSON(s string) string {
-	s = strings.TrimSpace(s)
-	var (
-		inString  bool
-		escape    bool
-		depth     int
-		objStart  = -1
-		lastStart = -1
-		lastEnd   = -1
-	)
-	for i := range len(s) {
-		c := s[i]
-		if escape {
-			escape = false
-			continue
-		}
-		if inString {
-			switch c {
-			case '\\':
-				escape = true
-			case '"':
-				inString = false
-			}
-			continue
-		}
-		switch c {
-		case '"':
-			inString = true
-		case '{':
-			if depth == 0 {
-				objStart = i
-			}
-			depth++
-		case '}':
-			if depth == 0 {
-				continue
-			}
-			depth--
-			if depth == 0 && objStart >= 0 {
-				lastStart = objStart
-				lastEnd = i
-				objStart = -1
-			}
-		}
-	}
-	if lastStart < 0 {
-		return ""
-	}
-	return s[lastStart : lastEnd+1]
 }

--- a/internal/llmjob/extract_test.go
+++ b/internal/llmjob/extract_test.go
@@ -1,0 +1,38 @@
+package llmjob
+
+import "testing"
+
+func TestExtractLastJSONObject(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain object", in: `{"a":1}`, want: `{"a":1}`},
+		{name: "prose around", in: "sure:\n{\"a\":1}\ndone", want: `{"a":1}`},
+		{name: "fenced code block", in: "```json\n{\"a\":1}\n```", want: `{"a":1}`},
+		{name: "nested objects", in: `{"a":{"b":2}}`, want: `{"a":{"b":2}}`},
+		{name: "no object", in: "no json here", want: ""},
+		{name: "unclosed object", in: `prose {"a":1`, want: ""},
+
+		// A naive first-brace/last-brace scan mis-slices these. Both shapes
+		// come out of real judge and planner runs.
+		{name: "close brace inside a string value", in: `{"a":"}"}`, want: `{"a":"}"}`},
+		{name: "escaped quote before a brace", in: `{"a":"x\"}y"}`, want: `{"a":"x\"}y"}`},
+		{name: "open brace inside a string value", in: `{"a":"{"}`, want: `{"a":"{"}`},
+		{name: "prose containing braces", in: `use { and } freely {"a":1}`, want: `{"a":1}`},
+
+		// A model that reasons before answering emits its real answer last.
+		{name: "decoy object first", in: `{"draft":true}` + "\nactually:\n" + `{"final":true}`, want: `{"final":true}`},
+		{name: "decoy inside a fence", in: "```\n{\"draft\":1}\n```\nfinal answer:\n{\"final\":2}", want: `{"final":2}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ExtractLastJSONObject(tt.in); got != tt.want {
+				t.Errorf("ExtractLastJSONObject(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -97,7 +97,7 @@ func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options
 		}
 		lastProvider = res.Provider
 		var out T
-		jsonText := extractLastJSONObject(res.Text)
+		jsonText := ExtractLastJSONObject(res.Text)
 		if jsonText == "" {
 			lastErr = fmt.Errorf("parse JSON: no JSON object in result: %q", res.Text)
 		} else if err := json.Unmarshal([]byte(jsonText), &out); err != nil {
@@ -144,9 +144,12 @@ func mergeModels(defaults, explicit map[string]string) map[string]string {
 	return out
 }
 
-// extractLastJSONObject returns the last balanced {...} substring in s, or "".
-// It tolerates common provider wrappers such as prose and fenced code blocks.
-func extractLastJSONObject(s string) string {
+// ExtractLastJSONObject returns the last balanced {...} substring in s, or "".
+// It tolerates common provider wrappers — prose, reasoning, fenced code blocks
+// — and tracks string-literal state so a brace inside a JSON string value does
+// not count toward depth. Last, not first: a model that reasons before
+// answering often emits a JSON-ish block ahead of its real answer.
+func ExtractLastJSONObject(s string) string {
 	s = strings.TrimSpace(s)
 	var (
 		inString  bool

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -145,10 +145,15 @@ func mergeModels(defaults, explicit map[string]string) map[string]string {
 }
 
 // ExtractLastJSONObject returns the last balanced {...} substring in s, or "".
-// It tolerates common provider wrappers — prose, reasoning, fenced code blocks
-// — and tracks string-literal state so a brace inside a JSON string value does
-// not count toward depth. Last, not first: a model that reasons before
-// answering often emits a JSON-ish block ahead of its real answer.
+// It tolerates the usual provider wrappers — prose, reasoning, fenced code
+// blocks — and tracks string-literal state so a brace inside a JSON string
+// value does not count toward depth. Last, not first: a model that reasons
+// before answering often emits a JSON-ish block ahead of its real answer.
+//
+// Tracking string state has a cost: an unpaired ASCII quote in the surrounding
+// prose (`a 6" margin`) flips that state and hides the object entirely,
+// returning "". A caller that cannot afford to lose the object should fall
+// back to an outermost-brace span and let json.Unmarshal reject it.
 func ExtractLastJSONObject(s string) string {
 	s = strings.TrimSpace(s)
 	var (

--- a/internal/selfmonitor/judge.go
+++ b/internal/selfmonitor/judge.go
@@ -154,7 +154,7 @@ func parseJudgeVerdict(raw []byte) (Verdict, error) {
 		}
 		text = *envelope.Result
 	}
-	jsonStr := judgeExtractLastJSON(text)
+	jsonStr := llmjob.ExtractLastJSONObject(text)
 	if jsonStr == "" {
 		return Verdict{}, fmt.Errorf("no JSON object in result: %q", text)
 	}
@@ -164,57 +164,4 @@ func parseJudgeVerdict(raw []byte) (Verdict, error) {
 	}
 	_ = validateJudgeVerdict(&v)
 	return v, nil
-}
-
-// judgeExtractLastJSON returns the last balanced {...} substring in s, or "".
-// Mirrors triage.extractLastJSONObject and internal/agent/inspector.go.
-func judgeExtractLastJSON(s string) string {
-	s = strings.TrimSpace(s)
-	var (
-		inString  bool
-		escape    bool
-		depth     int
-		objStart  = -1
-		lastStart = -1
-		lastEnd   = -1
-	)
-	for i := range len(s) {
-		c := s[i]
-		if escape {
-			escape = false
-			continue
-		}
-		if inString {
-			switch c {
-			case '\\':
-				escape = true
-			case '"':
-				inString = false
-			}
-			continue
-		}
-		switch c {
-		case '"':
-			inString = true
-		case '{':
-			if depth == 0 {
-				objStart = i
-			}
-			depth++
-		case '}':
-			if depth == 0 {
-				continue
-			}
-			depth--
-			if depth == 0 && objStart >= 0 {
-				lastStart = objStart
-				lastEnd = i
-				objStart = -1
-			}
-		}
-	}
-	if lastStart < 0 {
-		return ""
-	}
-	return s[lastStart : lastEnd+1]
 }

--- a/internal/selfmonitor/judge_test.go
+++ b/internal/selfmonitor/judge_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/task"
+
+	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 func TestJudgeJobSpecBoundsEachProviderAttempt(t *testing.T) {
@@ -237,9 +239,9 @@ func TestJudgeExtractLastJSON_ReturnsLastObject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := judgeExtractLastJSON(tt.input)
+			got := llmjob.ExtractLastJSONObject(tt.input)
 			if got != tt.want {
-				t.Errorf("judgeExtractLastJSON(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("llmjob.ExtractLastJSONObject(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/selfmonitor/judge_test.go
+++ b/internal/selfmonitor/judge_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/task"
-
-	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 func TestJudgeJobSpecBoundsEachProviderAttempt(t *testing.T) {
@@ -199,49 +197,6 @@ func TestParseJudgeVerdict_ExtractsLastJSONObject(t *testing.T) {
 			}
 			if v.RootCause != tt.wantRootCause {
 				t.Errorf("RootCause = %q, want %q", v.RootCause, tt.wantRootCause)
-			}
-		})
-	}
-}
-
-func TestJudgeExtractLastJSON_ReturnsLastObject(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "single object",
-			input: `{"a":"b"}`,
-			want:  `{"a":"b"}`,
-		},
-		{
-			name:  "prose then object",
-			input: `some text {"classification":"confirmed"}`,
-			want:  `{"classification":"confirmed"}`,
-		},
-		{
-			name:  "two objects, returns last",
-			input: `{"first":1} more text {"second":2}`,
-			want:  `{"second":2}`,
-		},
-		{
-			name:  "no object",
-			input: `plain text only`,
-			want:  "",
-		},
-		{
-			name:  "nested object",
-			input: `{"outer":{"inner":1}}`,
-			want:  `{"outer":{"inner":1}}`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := llmjob.ExtractLastJSONObject(tt.input)
-			if got != tt.want {
-				t.Errorf("llmjob.ExtractLastJSONObject(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 // DefaultMaxParallel bounds how many children of one umbrella run at once when
@@ -474,7 +476,8 @@ func buildPlanSchema(subs []SubIssue) string {
 
 // ParsePlan extracts a Plan from a model's raw stdout. It tolerates the claude
 // `--output-format json` envelope ({"result":"..."}) and a surrounding code
-// fence or prose by extracting the first balanced JSON object.
+// fence or prose by extracting the last balanced JSON object — a model that
+// reasons before answering emits its real plan last.
 func ParsePlan(raw string) (Plan, error) {
 	text := raw
 	var env struct {
@@ -484,8 +487,8 @@ func ParsePlan(raw string) (Plan, error) {
 		text = env.Result
 	}
 
-	obj, ok := firstJSONObject(text)
-	if !ok {
+	obj := llmjob.ExtractLastJSONObject(text)
+	if obj == "" {
 		return Plan{}, fmt.Errorf("planner output contains no JSON object")
 	}
 	var plan Plan
@@ -493,39 +496,6 @@ func ParsePlan(raw string) (Plan, error) {
 		return Plan{}, fmt.Errorf("parse planner JSON: %w", err)
 	}
 	return plan, nil
-}
-
-// firstJSONObject returns the first brace-balanced JSON object substring in s,
-// ignoring braces inside string literals. ok is false when none is found.
-func firstJSONObject(s string) (string, bool) {
-	start := strings.IndexByte(s, '{')
-	if start < 0 {
-		return "", false
-	}
-	depth := 0
-	inStr := false
-	escaped := false
-	for i := start; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case escaped:
-			escaped = false
-		case c == '\\' && inStr:
-			escaped = true
-		case c == '"':
-			inStr = !inStr
-		case inStr:
-			// skip
-		case c == '{':
-			depth++
-		case c == '}':
-			depth--
-			if depth == 0 {
-				return s[start : i+1], true
-			}
-		}
-	}
-	return "", false
 }
 
 // resolve rewrites every child and dependency ref to its canonical sub-issue

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -239,31 +239,6 @@ func TestAdversarialSchemaRejectsDuplicateCoverage(t *testing.T) {
 	}
 }
 
-func TestFirstJSONObject(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name, in, want string
-		ok             bool
-	}{
-		{"plain", `{"a":1}`, `{"a":1}`, true},
-		{"prose around", "sure:\n{\"a\":1}\ndone", `{"a":1}`, true},
-		{"code fence", "```json\n{\"a\":1}\n```", `{"a":1}`, true},
-		{"nested", `{"a":{"b":2}}`, `{"a":{"b":2}}`, true},
-		{"brace in string", `{"a":"}"}`, `{"a":"}"}`, true},
-		{"escaped quote in string", `{"a":"x\"}y"}`, `{"a":"x\"}y"}`, true},
-		{"none", "no json here", "", false},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			got, ok := firstJSONObject(c.in)
-			if ok != c.ok || got != c.want {
-				t.Fatalf("firstJSONObject(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.ok)
-			}
-		})
-	}
-}
-
 func TestParsePlan(t *testing.T) {
 	t.Parallel()
 	want := `{"children":[{"issue":"o/r#1","dependsOn":[]}],"maxParallel":3}`
@@ -273,6 +248,10 @@ func TestParsePlan(t *testing.T) {
 		{"plain json", want},
 		{"claude envelope", `{"type":"result","result":"` + strings.ReplaceAll(want, `"`, `\"`) + `"}`},
 		{"fenced in prose", "Here is the plan:\n```json\n" + want + "\n```"},
+		// A reasoning model emits a decoy object before its real answer, so
+		// the last balanced object is the plan — not the first.
+		{"decoy object first", `{"children":[{"issue":"o/r#99","dependsOn":[]}],"maxParallel":1}` + "\nOn reflection:\n" + want},
+		{"brace inside a string value", `{"note":"} not a close"}` + "\n" + want},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -494,6 +494,13 @@ type judgeScore struct {
 
 // extractJudgeJSON parses a judgeVerdict out of a judge agent's raw output,
 // tolerating surrounding prose and code fences.
+//
+// Failing to parse costs every attempt in the round, so it tries both
+// heuristics: the shared scanner first, then the outermost brace span. They
+// fail on disjoint inputs — the scanner is defeated by an odd ASCII quote in
+// the prose ("a 6\" margin"), which flips its string-literal state and hides
+// the object, while the span is defeated by a brace inside a string value.
+// json.Unmarshal validates whichever one produced a candidate.
 func extractJudgeJSON(output string) (judgeVerdict, error) {
 	trimmed := strings.TrimSpace(output)
 	var v judgeVerdict
@@ -502,12 +509,26 @@ func extractJudgeJSON(output string) (judgeVerdict, error) {
 	}
 	obj := llmjob.ExtractLastJSONObject(trimmed)
 	if obj == "" {
+		obj = outermostBraceSpan(trimmed)
+	}
+	if obj == "" {
 		return judgeVerdict{}, fmt.Errorf("no JSON object found in judge output")
 	}
 	if err := json.Unmarshal([]byte(obj), &v); err != nil {
 		return judgeVerdict{}, fmt.Errorf("malformed judge JSON: %w", err)
 	}
 	return v, nil
+}
+
+// outermostBraceSpan returns the first `{` through the last `}`, ignoring
+// quote state. Only a fallback for output the balanced scanner cannot read.
+func outermostBraceSpan(s string) string {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end <= start {
+		return ""
+	}
+	return s[start : end+1]
 }
 
 // humanRequiredStepOutput flips the task to human-required with reason and

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/textutil"
 )
 
@@ -492,20 +493,18 @@ type judgeScore struct {
 }
 
 // extractJudgeJSON parses a judgeVerdict out of a judge agent's raw output,
-// tolerating surrounding prose by falling back to the outermost {...} span
-// when the whole trimmed output isn't valid JSON on its own.
+// tolerating surrounding prose and code fences.
 func extractJudgeJSON(output string) (judgeVerdict, error) {
 	trimmed := strings.TrimSpace(output)
 	var v judgeVerdict
 	if err := json.Unmarshal([]byte(trimmed), &v); err == nil {
 		return v, nil
 	}
-	start := strings.IndexByte(trimmed, '{')
-	end := strings.LastIndexByte(trimmed, '}')
-	if start < 0 || end <= start {
+	obj := llmjob.ExtractLastJSONObject(trimmed)
+	if obj == "" {
 		return judgeVerdict{}, fmt.Errorf("no JSON object found in judge output")
 	}
-	if err := json.Unmarshal([]byte(trimmed[start:end+1]), &v); err != nil {
+	if err := json.Unmarshal([]byte(obj), &v); err != nil {
 		return judgeVerdict{}, fmt.Errorf("malformed judge JSON: %w", err)
 	}
 	return v, nil

--- a/internal/workflow/engine_steps_bestofn_judge_test.go
+++ b/internal/workflow/engine_steps_bestofn_judge_test.go
@@ -28,6 +28,19 @@ func TestExtractJudgeJSONToleratesBracesAndProse(t *testing.T) {
 			wantWinner: "a1",
 		},
 		{
+			// An odd ASCII quote in the prose flips the balanced scanner's
+			// string-literal state and hides the object entirely. Losing this
+			// discards every attempt in the round.
+			name:       "odd quote in the prose",
+			output:     "Attempt a2 hardcodes a 6\" margin.\n" + `{"winner_attempt_id":"a1","scores":[],"rationale":"ok"}`,
+			wantWinner: "a1",
+		},
+		{
+			name:       "unterminated string literal mentioned in prose",
+			output:     "a2 leaves an unterminated string literal (\") in parser.go.\n" + `{"winner_attempt_id":"a1","scores":[],"rationale":"ok"}`,
+			wantWinner: "a1",
+		},
+		{
 			name:       "decoy verdict before the real one",
 			output:     `{"winner_attempt_id":"a2","scores":[]}` + "\nOn reflection:\n" + `{"winner_attempt_id":"a1","scores":[],"rationale":"revised"}`,
 			wantWinner: "a1",

--- a/internal/workflow/engine_steps_bestofn_judge_test.go
+++ b/internal/workflow/engine_steps_bestofn_judge_test.go
@@ -1,0 +1,53 @@
+package workflow
+
+import "testing"
+
+// The judge parser used to scan from the first `{` to the last `}` with no
+// string-literal tracking, so a brace inside a rationale — which is prose the
+// model writes about code — sliced a malformed span and failed the step on
+// output the shared scanner reads fine.
+func TestExtractJudgeJSONToleratesBracesAndProse(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantWinner string
+	}{
+		{
+			name:       "bare object",
+			output:     `{"winner_attempt_id":"a1","scores":[{"attempt_id":"a1","score":0.9}],"rationale":"clean"}`,
+			wantWinner: "a1",
+		},
+		{
+			name:       "close brace inside the rationale",
+			output:     `{"winner_attempt_id":"a1","scores":[],"rationale":"a2 leaves a stray } in the diff"}`,
+			wantWinner: "a1",
+		},
+		{
+			name:       "prose with braces around the object",
+			output:     "The blocks `{` and `}` are unbalanced in a2.\n```json\n" + `{"winner_attempt_id":"a1","scores":[],"rationale":"ok"}` + "\n```",
+			wantWinner: "a1",
+		},
+		{
+			name:       "decoy verdict before the real one",
+			output:     `{"winner_attempt_id":"a2","scores":[]}` + "\nOn reflection:\n" + `{"winner_attempt_id":"a1","scores":[],"rationale":"revised"}`,
+			wantWinner: "a1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractJudgeJSON(tt.output)
+			if err != nil {
+				t.Fatalf("extractJudgeJSON: %v", err)
+			}
+			if got.WinnerAttemptID != tt.wantWinner {
+				t.Errorf("winner = %q, want %q", got.WinnerAttemptID, tt.wantWinner)
+			}
+		})
+	}
+}
+
+func TestExtractJudgeJSONRejectsOutputWithNoObject(t *testing.T) {
+	if _, err := extractJudgeJSON("the judge refused to answer"); err == nil {
+		t.Error("expected an error on output containing no JSON object")
+	}
+}


### PR DESCRIPTION
## Motivation

`internal/llmjob` already held the correct string-literal-aware balanced-brace scanner, in the package built for exactly this job. Four other packages carried byte-identical copies under four different names, with comments rationalizing the duplication. #3079.

Two further sites then drifted, which is the cost that rationale did not price in. The best-of-N judge scanned first-brace to last-brace with no string tracking, so a `}` inside a rationale — prose the model writes about code — sliced a malformed span and failed the step on output the shared scanner reads fine. The umbrella planner took the *first* object rather than the last, so a model that reasons before answering handed it a decoy plan.

> Changelog: refactor(llmjob): unify LLM JSON extraction

## Implementation information

Exports `llmjob.ExtractLastJSONObject` and points all six sites at it. I verified the four copies really were byte-identical to `llmjob`'s before deleting them, so those call sites cannot have changed behaviour. No consumer gains a dependency — every one already reached `llmjob`'s deps transitively; `internal/workflow` gains only `llmjob` itself.

Last-object semantics turned out not to be load-bearing for the planner: no test distinguished first from last, and the planner constrains output with a JSON schema. Where it could in principle pick a wrong object, the result fails `(*Plan).validate` on coverage and falls into the corrective retry, never a silently wrong DAG.

### The judge site keeps both heuristics

Moving the judge onto the shared scanner alone would have been a regression. The scanner tracks string-literal state, so an unpaired ASCII quote in the surrounding prose — `a 6" margin` — flips that state and hides the object entirely; the naive span tolerated exactly that. Parsing nothing there discards every attempt in the round and parks the task.

The two heuristics fail on disjoint inputs, so `extractJudgeJSON` tries the scanner first and falls back to the outermost span, letting `json.Unmarshal` reject whichever candidate is malformed. Both shapes are covered by tests, and I confirmed by mutation that removing the fallback fails them.

`ExtractLastJSONObject`'s doc now states the unpaired-quote limitation rather than claiming it tolerates any prose.

## Supporting documentation

Adds call-site tests at the two sites that had none — `learning.parseDigestJSON` and `evaluation.parseQualityVerdict` — where mutating the scanner previously stayed green. Two tests that had been retargeted to call the shared scanner directly were replaced with production call-site tests; they read as call-site coverage while providing none.

Closes #3079