### PR TITLE
fix(review): stop recovery rewriting evidence

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -472,14 +472,27 @@ func isGitConfigKeyAbsent(err error) bool {
 	return ok && exitErr.ExitCode() == 5
 }
 
-// DefaultBranch resolves barePath's HEAD symbolic ref (e.g. refs/heads/main)
-// and returns the branch name (main).
+// DefaultBranch resolves barePath's HEAD symbolic ref (e.g.
+// refs/heads/main) and returns just the branch name (main).
 //
-// Trimming the prefix rather than taking the path base: a branch name may
-// contain slashes, and filepath.Base turned refs/heads/release/2.0 into "2.0",
-// which never equals the CurrentBranch it is compared against. That silently
-// disabled every guard that refuses to work on the default branch.
+// Truncating at the last slash is wrong for a branch name that contains one —
+// refs/heads/release/2.0 yields "2.0" — but several callers depend on the
+// current behaviour, so fixing it is tracked separately. Comparisons that must
+// be exact use DefaultBranchName.
 func DefaultBranch(ctx context.Context, barePath string) (string, error) {
+	ref, err := outputBare(ctx, barePath, "symbolic-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	// refs/heads/main → main
+	return filepath.Base(ref), nil
+}
+
+// DefaultBranchName returns the full default branch name, slashes intact, for
+// callers that compare it against a CurrentBranch. DefaultBranch cannot be used
+// there: it truncates release/2.0 to 2.0, which never matches, silently
+// disabling any guard built on the comparison.
+func DefaultBranchName(ctx context.Context, barePath string) (string, error) {
 	ref, err := outputBare(ctx, barePath, "symbolic-ref", "HEAD")
 	if err != nil {
 		return "", err

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -472,15 +472,19 @@ func isGitConfigKeyAbsent(err error) bool {
 	return ok && exitErr.ExitCode() == 5
 }
 
-// DefaultBranch resolves barePath's HEAD symbolic ref (e.g.
-// refs/heads/main) and returns just the branch name (main).
+// DefaultBranch resolves barePath's HEAD symbolic ref (e.g. refs/heads/main)
+// and returns the branch name (main).
+//
+// Trimming the prefix rather than taking the path base: a branch name may
+// contain slashes, and filepath.Base turned refs/heads/release/2.0 into "2.0",
+// which never equals the CurrentBranch it is compared against. That silently
+// disabled every guard that refuses to work on the default branch.
 func DefaultBranch(ctx context.Context, barePath string) (string, error) {
 	ref, err := outputBare(ctx, barePath, "symbolic-ref", "HEAD")
 	if err != nil {
 		return "", err
 	}
-	// refs/heads/main → main
-	return filepath.Base(ref), nil
+	return strings.TrimPrefix(ref, "refs/heads/"), nil
 }
 
 // ListTrackedFiles returns every file path tracked at ref in the bare repo,

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -4341,3 +4341,27 @@ func TestStripHTTPSUserinfo(t *testing.T) {
 		})
 	}
 }
+
+// A branch name may contain slashes. filepath.Base turned refs/heads/release/2.0
+// into "2.0", which never equals the CurrentBranch it is compared against, so
+// every default-branch refusal silently passed on such a project.
+func TestDefaultBranch_KeepsSlashesInTheName(t *testing.T) {
+	t.Parallel()
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "--bare", "-b", "release/2.0", bare)
+
+	got, err := DefaultBranch(context.Background(), bare)
+	if err != nil {
+		t.Fatalf("DefaultBranch: %v", err)
+	}
+	if got != "release/2.0" {
+		t.Errorf("DefaultBranch = %q, want release/2.0", got)
+	}
+}

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -4345,7 +4345,7 @@ func TestStripHTTPSUserinfo(t *testing.T) {
 // A branch name may contain slashes. filepath.Base turned refs/heads/release/2.0
 // into "2.0", which never equals the CurrentBranch it is compared against, so
 // every default-branch refusal silently passed on such a project.
-func TestDefaultBranch_KeepsSlashesInTheName(t *testing.T) {
+func TestDefaultBranchName_KeepsSlashes(t *testing.T) {
 	t.Parallel()
 	bare := filepath.Join(t.TempDir(), "origin.git")
 	run := func(args ...string) {
@@ -4357,11 +4357,17 @@ func TestDefaultBranch_KeepsSlashesInTheName(t *testing.T) {
 	}
 	run("init", "--bare", "-b", "release/2.0", bare)
 
-	got, err := DefaultBranch(context.Background(), bare)
+	got, err := DefaultBranchName(context.Background(), bare)
 	if err != nil {
-		t.Fatalf("DefaultBranch: %v", err)
+		t.Fatalf("DefaultBranchName: %v", err)
 	}
 	if got != "release/2.0" {
-		t.Errorf("DefaultBranch = %q, want release/2.0", got)
+		t.Errorf("DefaultBranchName = %q, want release/2.0", got)
+	}
+
+	// The older DefaultBranch still truncates; that is tracked separately, and
+	// pinning it here keeps the difference deliberate rather than accidental.
+	if legacy, err := DefaultBranch(context.Background(), bare); err != nil || legacy != "2.0" {
+		t.Errorf("DefaultBranch = %q (err %v), want the documented 2.0 truncation", legacy, err)
 	}
 }

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -130,6 +130,11 @@ type humanReviewSpawnOptions struct {
 	SkipABVariant         bool
 	RetryReason           string
 	ClaimRetryAttempt     int
+	// WorktreePrepared records that an earlier attempt already ran
+	// PrepareForTask. A transient failure can leave the tree sanitized and
+	// rebased and still return retryable, so the retry reuses a checkout that
+	// no longer holds the evidence — and would report it as untouched.
+	WorktreePrepared bool
 }
 
 func (h *humanReviewHandler) abTestingConfig() abtest.Config {
@@ -278,13 +283,21 @@ func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly, ret
 		}
 		if err != nil {
 			if isRetryablePrepareError(err) {
+				// rebuilt, not clean: a transient fetch failure lands after
+				// SanitizeWorktree has already auto-committed and reset the
+				// tree, so the retry must not call the survivor untouched.
 				h.logger.Info("human-review.worktree.prepare.retryable", "task_id", t.ID, "err", err)
-				return "", false, true, false
+				return "", false, true, true
 			}
 			h.logger.Warn("human-review.worktree.prepare", "task_id", t.ID, "err", err)
 		}
 		dir, readOnly = humanReviewDispatchDir(t, h.cfg.HumanReview.SybraRepoDir)
-		return dir, readOnly, false, true
+		// Only warn when the fallback is the Sybra source tree. Landing back on
+		// the task's own adopted worktree means preparation refused it before
+		// touching anything, so the agent IS looking at the state that failed
+		// and must not be told otherwise — the mandate would have it distrust a
+		// correct reproduction.
+		return dir, readOnly, false, readOnly
 	}
 	dir, readOnly = humanReviewDispatchDir(t, h.cfg.HumanReview.SybraRepoDir)
 	return dir, readOnly, false, false
@@ -390,12 +403,15 @@ func (h *humanReviewHandler) spawnReview(t task.Task, prevStatus string, opts hu
 	}
 
 	dir, readOnlyDir, retryable, rebuiltDir := h.dispatchDir(t)
+	rebuiltDir = rebuiltDir || opts.WorktreePrepared
 	if retryable {
 		// Give back the reserved slot as claim contention does, or the retry
 		// hits the per-hour cap and the task is never examined at all. The
 		// dispatch claim itself is released by the deferred call above.
 		h.releaseReservedSlot(taskID, now)
-		h.scheduleClaimRetry(taskID, prevStatus, opts)
+		next := opts
+		next.WorktreePrepared = rebuiltDir
+		h.scheduleClaimRetry(taskID, prevStatus, next)
 		return false
 	}
 	prompt := h.buildPrompt(t, dir, wctx, rebuiltDir)

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -102,6 +102,10 @@ type humanReviewHandler struct {
 	// not persisted in task.WorktreeDir, so looking at that field alone sends
 	// ordinary tasks to the read-only deploy checkout (#2973).
 	prepareTaskWorktree func(task.Task) (string, error)
+	// resolveExistingWorktree returns an already-checked-out worktree without
+	// mutating it. Tried before prepareTaskWorktree, because preparation
+	// rewrites the very state a recovery agent was sent to explain (#3073).
+	resolveExistingWorktree func(task.Task) (string, bool)
 	// claimTaskDispatch serializes recovery preparation and registration with
 	// every workflow dispatcher that can mutate the same task worktree.
 	claimTaskDispatch func(string) (release func(), ok bool)
@@ -184,6 +188,9 @@ func (a *App) initHumanReview(ctx context.Context) {
 	a.humanReview.abTesting = a.abTestingConfig
 	a.humanReview.schedule = lifecycleSchedule(ctx)
 	if a.worktrees != nil {
+		a.humanReview.resolveExistingWorktree = func(t task.Task) (string, bool) {
+			return a.worktrees.ResolveExisting(ctx, t)
+		}
 		a.humanReview.prepareTaskWorktree = func(t task.Task) (string, error) {
 			if t.PRNumber != 0 {
 				return a.worktrees.PrepareForFix(ctx, t, t.PRNumber)
@@ -241,22 +248,30 @@ func humanReviewDispatchDir(t task.Task, sybraRepoDir string) (dir string, readO
 // eliminate. Three agents on three different tasks reported the worktree as
 // read-only and returned recoverable_action: none, each having already
 // verified a fix they could not apply.
-func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly, retryable bool) {
+func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly, retryable, rebuilt bool) {
+	// Non-mutating first: the tree that failed is the evidence, and every
+	// Prepare* path rewrites it before the agent reads a line of it (#3073).
+	if h.resolveExistingWorktree != nil {
+		if dir, ok := h.resolveExistingWorktree(t); ok {
+			h.logger.Info("human-review.worktree.reused", "task_id", t.ID, "dir", dir)
+			return dir, false, false, false
+		}
+	}
 	if h.prepareTaskWorktree != nil {
 		dir, err := h.prepareTaskWorktree(t)
 		if err == nil && strings.TrimSpace(dir) != "" {
-			return dir, false, false
+			return dir, false, false, true
 		}
 		if err != nil {
 			if isRetryablePrepareError(err) {
 				h.logger.Info("human-review.worktree.prepare.retryable", "task_id", t.ID, "err", err)
-				return "", false, true
+				return "", false, true, false
 			}
 			h.logger.Warn("human-review.worktree.prepare", "task_id", t.ID, "err", err)
 		}
 	}
 	dir, readOnly = humanReviewDispatchDir(t, h.cfg.HumanReview.SybraRepoDir)
-	return dir, readOnly, false
+	return dir, readOnly, false, false
 }
 
 // isRetryablePrepareError reports whether a worktree preparation failure will
@@ -358,7 +373,7 @@ func (h *humanReviewHandler) spawnReview(t task.Task, prevStatus string, opts hu
 		}
 	}
 
-	dir, readOnlyDir, retryable := h.dispatchDir(t)
+	dir, readOnlyDir, retryable, rebuiltDir := h.dispatchDir(t)
 	if retryable {
 		// Give back the reserved slot as claim contention does, or the retry
 		// hits the per-hour cap and the task is never examined at all. The
@@ -367,7 +382,7 @@ func (h *humanReviewHandler) spawnReview(t task.Task, prevStatus string, opts hu
 		h.scheduleClaimRetry(taskID, prevStatus, opts)
 		return false
 	}
-	prompt := h.buildPrompt(t, dir, wctx)
+	prompt := h.buildPrompt(t, dir, wctx, rebuiltDir)
 	cfg := h.spawnReviewConfig(t, taskID, prompt, dir, readOnlyDir, opts)
 	if !h.preRunEligible(taskID, now, opts.IgnoreRenderedVerdict) {
 		return false
@@ -1794,7 +1809,22 @@ func (h *humanReviewHandler) writePromptTaskDetails(b *strings.Builder, t task.T
 	}
 }
 
-func (h *humanReviewHandler) buildPrompt(t task.Task, dir string, wctx *WorkScrubContext) string {
+// writeRebuiltWorktreeWarning tells the agent the tree it is about to inspect
+// is not the tree that failed. The mandate orders it to re-run the exact
+// failing command and never to infer "flaky/transient" from reasoning alone —
+// but preparation auto-committed the dirty tree, reset it, and rebased it onto
+// a fresher base, so a base-induced failure simply will not reproduce. Without
+// this the harness itself manufactures the false "it passes now" evidence the
+// mandate spends a paragraph forbidding.
+func writeRebuiltWorktreeWarning(b *strings.Builder) {
+	b.WriteString("## Worktree was rebuilt before you saw it (READ THIS FIRST)\n")
+	b.WriteString("No usable checkout existed, so this worktree was prepared from scratch: uncommitted work was auto-committed, the tree was reset and cleaned, and it was rebased onto a fresher base branch. **You are not looking at the state that failed.**\n\n")
+	b.WriteString("- A re-run that now PASSES is not evidence the failure was flaky or transient — a base-induced failure stops reproducing on a fresher base. Say the original state was unavailable rather than calling it flaky.\n")
+	b.WriteString("- Reconstruct the failure from the agent-run output and logs below, which describe the tree as it actually was.\n")
+	b.WriteString("- If you cannot confirm the root cause against evidence you can still see, say so in your verdict instead of inferring one.\n\n")
+}
+
+func (h *humanReviewHandler) buildPrompt(t task.Task, dir string, wctx *WorkScrubContext, rebuiltDir bool) string {
 	var b strings.Builder
 	b.WriteString("# Sybra auto-review of human-required transition\n\n")
 	if wctx != nil {
@@ -1806,6 +1836,9 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, dir string, wctx *WorkScru
 		b.WriteString("- DO describe the sybra bug abstractly: which workflow step misfired, which sybra subsystem is implicated, what state was inconsistent.\n\n")
 	}
 	writeAutonomyMandate(&b, h.signingPolicy().CommitFlags(context.Background()))
+	if rebuiltDir {
+		writeRebuiltWorktreeWarning(&b)
+	}
 	b.WriteString("## Task\n")
 	h.writePromptTaskDetails(&b, t, dir)
 	b.WriteString("\n### Task body\n")

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -105,7 +105,7 @@ type humanReviewHandler struct {
 	// resolveExistingWorktree returns an already-checked-out worktree without
 	// mutating it. Tried before prepareTaskWorktree, because preparation
 	// rewrites the very state a recovery agent was sent to explain (#3073).
-	resolveExistingWorktree func(task.Task) (string, bool)
+	resolveExistingWorktree func(task.Task) (string, error)
 	// claimTaskDispatch serializes recovery preparation and registration with
 	// every workflow dispatcher that can mutate the same task worktree.
 	claimTaskDispatch func(string) (release func(), ok bool)
@@ -188,7 +188,7 @@ func (a *App) initHumanReview(ctx context.Context) {
 	a.humanReview.abTesting = a.abTestingConfig
 	a.humanReview.schedule = lifecycleSchedule(ctx)
 	if a.worktrees != nil {
-		a.humanReview.resolveExistingWorktree = func(t task.Task) (string, bool) {
+		a.humanReview.resolveExistingWorktree = func(t task.Task) (string, error) {
 			return a.worktrees.ResolveExisting(ctx, t)
 		}
 		a.humanReview.prepareTaskWorktree = func(t task.Task) (string, error) {
@@ -252,12 +252,26 @@ func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly, ret
 	// Non-mutating first: the tree that failed is the evidence, and every
 	// Prepare* path rewrites it before the agent reads a line of it (#3073).
 	if h.resolveExistingWorktree != nil {
-		if dir, ok := h.resolveExistingWorktree(t); ok {
+		dir, err := h.resolveExistingWorktree(t)
+		switch {
+		case err == nil && strings.TrimSpace(dir) != "":
 			h.logger.Info("human-review.worktree.reused", "task_id", t.ID, "dir", dir)
 			return dir, false, false, false
+		case errors.Is(err, worktree.ErrWorktreeBusy):
+			// Falling through to preparation would rebase the branch out from
+			// under the live run, and the read-only fallback would strand a
+			// recovery that can see the fix but not apply it.
+			h.logger.Info("human-review.worktree.busy", "task_id", t.ID, "err", err)
+			return "", false, true, false
+		case err != nil:
+			h.logger.Info("human-review.worktree.reuse-declined", "task_id", t.ID, "err", err)
 		}
 	}
 	if h.prepareTaskWorktree != nil {
+		// Rebuilt from here on, not only on success: a preparation that
+		// sanitizes the tree and then fails non-retryably has destroyed the
+		// evidence more thoroughly than one that succeeded, and the agent
+		// still needs telling.
 		dir, err := h.prepareTaskWorktree(t)
 		if err == nil && strings.TrimSpace(dir) != "" {
 			return dir, false, false, true
@@ -269,6 +283,8 @@ func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly, ret
 			}
 			h.logger.Warn("human-review.worktree.prepare", "task_id", t.ID, "err", err)
 		}
+		dir, readOnly = humanReviewDispatchDir(t, h.cfg.HumanReview.SybraRepoDir)
+		return dir, readOnly, false, true
 	}
 	dir, readOnly = humanReviewDispatchDir(t, h.cfg.HumanReview.SybraRepoDir)
 	return dir, readOnly, false, false
@@ -1818,7 +1834,7 @@ func (h *humanReviewHandler) writePromptTaskDetails(b *strings.Builder, t task.T
 // mandate spends a paragraph forbidding.
 func writeRebuiltWorktreeWarning(b *strings.Builder) {
 	b.WriteString("## Worktree was rebuilt before you saw it (READ THIS FIRST)\n")
-	b.WriteString("No usable checkout existed, so this worktree was prepared from scratch: uncommitted work was auto-committed, the tree was reset and cleaned, and it was rebased onto a fresher base branch. **You are not looking at the state that failed.**\n\n")
+	b.WriteString("No usable checkout was available, so this worktree went through preparation: any uncommitted work was auto-committed, the tree was reset and cleaned, and it was rebased onto a fresher base branch — or, if no checkout existed at all, it was created fresh from the base branch. Either way, **you are not looking at the state that failed.**\n\n")
 	b.WriteString("- A re-run that now PASSES is not evidence the failure was flaky or transient — a base-induced failure stops reproducing on a fresher base. Say the original state was unavailable rather than calling it flaky.\n")
 	b.WriteString("- Reconstruct the failure from the agent-run output and logs below, which describe the tree as it actually was.\n")
 	b.WriteString("- If you cannot confirm the root cause against evidence you can still see, say so in your verdict instead of inferring one.\n\n")

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -110,7 +110,12 @@ type humanReviewHandler struct {
 	// every workflow dispatcher that can mutate the same task worktree.
 	claimTaskDispatch func(string) (release func(), ok bool)
 
-	mu       sync.Mutex
+	mu sync.Mutex
+	// prepared records that some attempt in this human-required episode already
+	// ran PrepareForTask. Carrying it on spawn options alone was not enough:
+	// handleStructuredVerdictFailure and retryAfterCrash both build fresh
+	// options, so a re-entry reused the sanitized tree and called it untouched.
+	prepared map[string]bool
 	inflight map[string]string      // taskID -> agent ID
 	recent   []time.Time            // spawn timestamps (rolling window), global cap
 	perTask  map[string][]time.Time // taskID -> spawn timestamps (rolling window), per-task cap
@@ -352,6 +357,7 @@ func (h *humanReviewHandler) maybeSpawnWithOptions(taskID, prevStatus string, op
 	// against an already-recovered task would race the recovery flow and let
 	// the agent's unblock actions rewrite the task to the wrong state.
 	if t.Status != task.StatusHumanRequired {
+		h.forgetPrepared(taskID)
 		h.skip(taskID, "stale_status_"+string(t.Status))
 		return false
 	}
@@ -403,7 +409,7 @@ func (h *humanReviewHandler) spawnReview(t task.Task, prevStatus string, opts hu
 	}
 
 	dir, readOnlyDir, retryable, rebuiltDir := h.dispatchDir(t)
-	rebuiltDir = rebuiltDir || opts.WorktreePrepared
+	rebuiltDir = h.notePrepared(taskID, rebuiltDir || opts.WorktreePrepared)
 	if retryable {
 		// Give back the reserved slot as claim contention does, or the retry
 		// hits the per-hour cap and the task is never examined at all. The
@@ -1614,6 +1620,30 @@ func (h *humanReviewHandler) markVerdictRendered(taskID, agentID string) {
 	}
 }
 
+// notePrepared records and returns the sticky rebuilt state for a task. Sticky
+// for the whole human-required episode: once preparation has rewritten the
+// tree, every later attempt in that episode is looking at the rewritten one.
+func (h *humanReviewHandler) notePrepared(taskID string, rebuilt bool) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if rebuilt {
+		if h.prepared == nil {
+			h.prepared = make(map[string]bool)
+		}
+		h.prepared[taskID] = true
+	}
+	return h.prepared[taskID]
+}
+
+// forgetPrepared ends the episode. Called where the task leaves
+// human-required, so a future park starts from a clean slate rather than
+// inheriting a warning about a preparation that predates it.
+func (h *humanReviewHandler) forgetPrepared(taskID string) {
+	h.mu.Lock()
+	delete(h.prepared, taskID)
+	h.mu.Unlock()
+}
+
 func (h *humanReviewHandler) skip(taskID, reason string) {
 	h.logger.Info("human-review.skip", "task_id", taskID, "reason", reason)
 	h.logAudit(audit.EventHumanReviewSkipped, taskID, "", map[string]any{"reason": reason})
@@ -1742,6 +1772,7 @@ func (h *humanReviewHandler) preRunEligible(taskID string, reservedAt time.Time,
 	}
 	if current.Status != task.StatusHumanRequired {
 		h.releaseReservedSlot(taskID, reservedAt)
+		h.forgetPrepared(taskID)
 		h.skip(taskID, "status_"+string(current.Status))
 		return false
 	}
@@ -1850,7 +1881,7 @@ func (h *humanReviewHandler) writePromptTaskDetails(b *strings.Builder, t task.T
 // mandate spends a paragraph forbidding.
 func writeRebuiltWorktreeWarning(b *strings.Builder) {
 	b.WriteString("## Worktree was rebuilt before you saw it (READ THIS FIRST)\n")
-	b.WriteString("No usable checkout was available, so this worktree went through preparation: any uncommitted work was auto-committed, the tree was reset and cleaned, and it was rebased onto a fresher base branch — or, if no checkout existed at all, it was created fresh from the base branch. Either way, **you are not looking at the state that failed.**\n\n")
+	b.WriteString("No usable checkout of the task's code was available, so worktree preparation ran. Preparation auto-commits uncommitted work, resets and cleans the tree, and rebases onto a fresher base branch; it may also have failed before reaching any of that. Either way, **you are not looking at the state that failed.**\n\n")
 	b.WriteString("- A re-run that now PASSES is not evidence the failure was flaky or transient — a base-induced failure stops reproducing on a fresher base. Say the original state was unavailable rather than calling it flaky.\n")
 	b.WriteString("- Reconstruct the failure from the agent-run output and logs below, which describe the tree as it actually was.\n")
 	b.WriteString("- If you cannot confirm the root cause against evidence you can still see, say so in your verdict instead of inferring one.\n\n")

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -173,7 +173,7 @@ func TestHumanReviewDispatchDir_PreparesManagedWorktree(t *testing.T) {
 		return wantDir, nil
 	}
 
-	dir, readOnly, _ := h.dispatchDir(task.Task{ID: "managed-task"})
+	dir, readOnly, _, _ := h.dispatchDir(task.Task{ID: "managed-task"})
 	if !called {
 		t.Fatal("managed worktree preparer was not called")
 	}
@@ -190,9 +190,67 @@ func TestHumanReviewDispatchDir_PrepareFailureFallsBackReadOnly(t *testing.T) {
 		return "", errors.New("worktree unavailable")
 	}
 
-	dir, readOnly, _ := h.dispatchDir(task.Task{ID: "fallback-task"})
+	dir, readOnly, _, _ := h.dispatchDir(task.Task{ID: "fallback-task"})
 	if dir != h.cfg.HumanReview.SybraRepoDir || !readOnly {
 		t.Fatalf("got dir=%q readOnly=%v, want dir=%q readOnly=true", dir, readOnly, h.cfg.HumanReview.SybraRepoDir)
+	}
+}
+
+// The recovery agent is sent to explain a failure, and every Prepare* path
+// rewrites the tree that failed before it reads a line of it — auto-committing
+// the dirty state, resetting, and rebasing onto a fresher base. A healthy
+// existing checkout must therefore be used untouched, or a base-induced
+// failure stops reproducing and the agent reports "flaky" on manufactured
+// evidence.
+func TestHumanReviewDispatchDir_ReusesExistingWorktreeUnmutated(t *testing.T) {
+	h, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	existing := t.TempDir()
+	h.resolveExistingWorktree = func(task.Task) (string, bool) { return existing, true }
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		t.Fatal("preparation ran against a healthy existing worktree, rewriting the evidence")
+		return "", nil
+	}
+
+	dir, readOnly, retryable, rebuilt := h.dispatchDir(task.Task{ID: "parked-task"})
+	if dir != existing {
+		t.Errorf("dir = %q, want the existing worktree %q", dir, existing)
+	}
+	if readOnly || retryable {
+		t.Errorf("readOnly=%v retryable=%v, want both false", readOnly, retryable)
+	}
+	if rebuilt {
+		t.Error("rebuilt=true for a reused worktree: the agent would be told its evidence is stale when it is not")
+	}
+}
+
+// With no usable checkout, preparation is unavoidable — but then the agent has
+// to be told, because the mandate orders it to re-run the failing command and
+// forbids inferring "flaky" from reasoning alone.
+func TestHumanReviewDispatchDir_PreparedWorktreeIsFlaggedRebuilt(t *testing.T) {
+	h, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	prepared := t.TempDir()
+	h.resolveExistingWorktree = func(task.Task) (string, bool) { return "", false }
+	h.prepareTaskWorktree = func(task.Task) (string, error) { return prepared, nil }
+
+	dir, _, _, rebuilt := h.dispatchDir(task.Task{ID: "parked-task"})
+	if dir != prepared {
+		t.Errorf("dir = %q, want %q", dir, prepared)
+	}
+	if !rebuilt {
+		t.Fatal("rebuilt=false after preparation: the agent is never told its tree is not the tree that failed")
+	}
+
+	prompt := h.buildPrompt(task.Task{ID: "t1", ProjectID: "Automaat/sybra"}, dir, nil, rebuilt)
+	if !strings.Contains(prompt, "not looking at the state that failed") {
+		t.Error("prompt does not warn that the worktree was rebuilt")
+	}
+	clean := h.buildPrompt(task.Task{ID: "t1", ProjectID: "Automaat/sybra"}, dir, nil, false)
+	if strings.Contains(clean, "not looking at the state that failed") {
+		t.Error("prompt warns about a rebuild that did not happen")
 	}
 }
 
@@ -409,7 +467,7 @@ func TestBuildPrompt_NoFencedVerdictInstruction(t *testing.T) {
 	}
 
 	dir, _ := humanReviewDispatchDir(tk, h.cfg.HumanReview.SybraRepoDir)
-	prompt := h.buildPrompt(tk, dir, nil)
+	prompt := h.buildPrompt(tk, dir, nil, false)
 	if strings.Contains(prompt, "sybra-verdict") {
 		t.Errorf("prompt still instructs a fenced sybra-verdict block:\n%s", prompt)
 	}
@@ -433,7 +491,7 @@ func TestBuildPrompt_RequiresVerificationBeforeTransient(t *testing.T) {
 	}
 
 	dir, _ := humanReviewDispatchDir(tk, h.cfg.HumanReview.SybraRepoDir)
-	prompt := h.buildPrompt(tk, dir, nil)
+	prompt := h.buildPrompt(tk, dir, nil, false)
 	if !strings.Contains(prompt, "actually re-run the exact failing command") {
 		t.Errorf("prompt does not require re-running the failing command before calling it transient:\n%s", prompt)
 	}
@@ -464,7 +522,7 @@ func TestBuildPrompt_DraftApproveRequiresHumanSubmission(t *testing.T) {
 	}
 
 	dir, _ := humanReviewDispatchDir(tk, h.cfg.HumanReview.SybraRepoDir)
-	prompt := h.buildPrompt(tk, dir, nil)
+	prompt := h.buildPrompt(tk, dir, nil, false)
 	for _, want := range []string{
 		"pre-flight the draft before submitting anything",
 		"APPROVE drafts must NEVER be auto-submitted",
@@ -494,7 +552,7 @@ func TestBuildPrompt_RequiresRecheckingSupersededFailures(t *testing.T) {
 	}
 
 	dir, _ := humanReviewDispatchDir(tk, h.cfg.HumanReview.SybraRepoDir)
-	prompt := h.buildPrompt(tk, dir, nil)
+	prompt := h.buildPrompt(tk, dir, nil, false)
 	if !strings.Contains(prompt, "supersedes the wording the failure quotes") {
 		t.Errorf("prompt does not require rechecking superseded test-runner FAILs:\n%s", prompt)
 	}
@@ -2376,7 +2434,7 @@ func TestBuildPrompt_IncludesUnblockAndAutonomyMandate(t *testing.T) {
 		Branch: "feat/queue", WorktreeDir: "/data/worktrees/queue",
 	}
 	dir, _ := humanReviewDispatchDir(tk, h.cfg.HumanReview.SybraRepoDir)
-	p := h.buildPrompt(tk, dir, nil)
+	p := h.buildPrompt(tk, dir, nil, false)
 	for _, want := range []string{
 		"UNBLOCK", "AUTONOMY", "ROOT CAUSE", "unblocked",
 		"never fabricate", "/data/worktrees/queue", "feat/queue",
@@ -3873,7 +3931,7 @@ func TestHumanReviewPrompt_HonorsCommitSigningPolicy(t *testing.T) {
 	// Go through the real prompt builder, not writeAutonomyMandate directly:
 	// asserting on a value this test supplies is what made the original test
 	// unable to catch the defect it appeared to cover.
-	prompt := h.buildPrompt(task.Task{ID: "t1", ProjectID: "Automaat/sybra"}, t.TempDir(), nil)
+	prompt := h.buildPrompt(task.Task{ID: "t1", ProjectID: "Automaat/sybra"}, t.TempDir(), nil, false)
 	for line := range strings.Lines(prompt) {
 		if strings.Contains(line, "commit") && strings.Contains(line, "-S") {
 			t.Errorf("mandate instructs GPG signing under the never policy:\n%s", line)
@@ -3916,7 +3974,7 @@ func TestHumanReviewDispatchDir_RetryableErrorsDoNotFallBackReadOnly(t *testing.
 			h.cfg.HumanReview.SybraRepoDir = "/opt/sybra/src"
 			h.prepareTaskWorktree = func(task.Task) (string, error) { return "", tc.prepareErr }
 
-			dir, readOnly, retryable := h.dispatchDir(task.Task{ID: "t1"})
+			dir, readOnly, retryable, _ := h.dispatchDir(task.Task{ID: "t1"})
 			if retryable != tc.wantRetryable {
 				t.Fatalf("retryable = %v, want %v", retryable, tc.wantRetryable)
 			}

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -4259,3 +4259,78 @@ func TestHumanReviewDispatchDir_AdoptedFallbackIsNotFlaggedRebuilt(t *testing.T)
 		t.Error("rebuilt=true for an untouched worktree; the agent would distrust a correct reproduction")
 	}
 }
+
+// The provider-fallback retry and retryAfterCrash both build fresh spawn
+// options, so carrying the flag on options alone lost it: the second agent was
+// handed the tree the first one's preparation had already rewritten, with no
+// warning. The flag is sticky for the whole human-required episode instead.
+func TestHumanReviewSpawn_PreparedFlagIsStickyPerEpisode(t *testing.T) {
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("sticky prepared", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": "Automaat/sybra",
+		"status":     string(task.StatusHumanRequired),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	wtDir := t.TempDir()
+	prepared := false
+	h.resolveExistingWorktree = func(task.Task) (string, error) {
+		if prepared {
+			return wtDir, nil
+		}
+		return "", os.ErrNotExist
+	}
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		prepared = true
+		return wtDir, nil
+	}
+
+	var prompts []string
+	h.agents = &fakeHumanReviewAgentRunner{run: func(cfg agent.RunConfig) (*agent.Agent, error) {
+		prompts = append(prompts, cfg.Prompt)
+		return &agent.Agent{ID: fmt.Sprintf("rev%d", len(prompts)), TaskID: cfg.TaskID, StartedAt: time.Now().UTC()}, nil
+	}}
+
+	if !h.maybeSpawn(tk.ID, string(task.StatusInReview)) {
+		t.Fatal("first review did not spawn")
+	}
+	// The first agent finished, as it has when the provider fallback re-spawns.
+	h.clearInflight(tk.ID)
+	// A fresh options value, as the provider fallback and crash retry both build.
+	if !h.maybeSpawnWithOptions(tk.ID, string(task.StatusInReview),
+		humanReviewSpawnOptions{IgnoreRenderedVerdict: true, RetryReason: "malformed_verdict"}) {
+		t.Fatal("retry did not spawn")
+	}
+
+	if len(prompts) != 2 {
+		t.Fatalf("got %d prompts, want 2", len(prompts))
+	}
+	for i, p := range prompts {
+		if !strings.Contains(p, "not looking at the state that failed") {
+			t.Errorf("prompt %d reused the rewritten tree without warning the agent", i)
+		}
+	}
+
+	// A later episode must not inherit the warning.
+	h.clearInflight(tk.ID)
+	h.forgetPrepared(tk.ID)
+	h.mu.Lock()
+	h.perTask = map[string][]time.Time{}
+	h.recent = nil
+	h.mu.Unlock()
+	prompts = nil
+	if !h.maybeSpawnWithOptions(tk.ID, string(task.StatusInReview),
+		humanReviewSpawnOptions{IgnoreRenderedVerdict: true}) {
+		t.Fatal("third spawn refused")
+	}
+	if strings.Contains(prompts[0], "not looking at the state that failed") {
+		t.Error("a new episode inherited a warning about a preparation that predates it")
+	}
+}

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -166,6 +166,9 @@ func TestHumanReviewDispatchDir_PreparesManagedWorktree(t *testing.T) {
 
 	wantDir := t.TempDir()
 	called := false
+	// Production wires both resolvers together, so a nil resolver would test an
+	// order that never ships.
+	h.resolveExistingWorktree = func(task.Task) (string, error) { return "", os.ErrNotExist }
 	h.prepareTaskWorktree = func(tk task.Task) (string, error) {
 		called = true
 		if tk.ID != "managed-task" {
@@ -187,6 +190,7 @@ func TestHumanReviewDispatchDir_PrepareFailureFallsBackReadOnly(t *testing.T) {
 	h, _, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
+	h.resolveExistingWorktree = func(task.Task) (string, error) { return "", os.ErrNotExist }
 	h.prepareTaskWorktree = func(task.Task) (string, error) {
 		return "", errors.New("worktree unavailable")
 	}
@@ -333,6 +337,66 @@ func TestHumanReviewDispatchDir_BusyWorktreeIsRetryable(t *testing.T) {
 	}
 }
 
+// A transient fetch failure lands after SanitizeWorktree has auto-committed
+// and reset the tree, so the retry reuses a checkout that no longer holds the
+// evidence. Without carrying the flag across the retry it is reported as
+// untouched — the exact false reassurance the warning exists to prevent.
+func TestHumanReviewSpawn_PreparedFlagSurvivesRetry(t *testing.T) {
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("transient prepare", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": "Automaat/sybra",
+		"status":     string(task.StatusHumanRequired),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	wtDir := t.TempDir()
+	prepared := false
+	// First pass: nothing to reuse, and preparation fails transiently after
+	// having already sanitized. Second pass: the sanitized tree is reusable.
+	h.resolveExistingWorktree = func(task.Task) (string, error) {
+		if prepared {
+			return wtDir, nil
+		}
+		return "", os.ErrNotExist
+	}
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		prepared = true
+		return "", fmt.Errorf("fetch: %w", worktree.ErrTransientFetch)
+	}
+
+	var prompt string
+	h.agents = &fakeHumanReviewAgentRunner{run: func(cfg agent.RunConfig) (*agent.Agent, error) {
+		prompt = cfg.Prompt
+		return &agent.Agent{ID: "rev", TaskID: cfg.TaskID, StartedAt: time.Now().UTC()}, nil
+	}}
+	// Run the real scheduled retry rather than reconstructing its options, so
+	// the flag has to survive the actual handoff.
+	var retry func()
+	h.schedule = func(_ time.Duration, fn func()) { retry = fn }
+
+	if h.maybeSpawn(tk.ID, string(task.StatusInReview)) {
+		t.Fatal("spawned despite a retryable preparation failure")
+	}
+	if retry == nil {
+		t.Fatal("no retry scheduled after a retryable preparation failure")
+	}
+	retry()
+
+	if prompt == "" {
+		t.Fatal("retry did not spawn")
+	}
+	if !strings.Contains(prompt, "not looking at the state that failed") {
+		t.Error("retry reused a sanitized worktree without warning the agent")
+	}
+}
+
 // A preparation that sanitizes the tree and then fails non-retryably has
 // destroyed the evidence more thoroughly than one that succeeded, so the
 // read-only fallback still has to carry the warning.
@@ -377,6 +441,13 @@ func TestHumanReviewSpawn_HoldsDispatchClaimAcrossPreparationAndRun(t *testing.T
 		}
 		held = true
 		return func() { held = false }, true
+	}
+	// Reuse is tried first in production, and it must also be inside the claim.
+	h.resolveExistingWorktree = func(task.Task) (string, error) {
+		if !held {
+			t.Fatal("worktree reuse ran without the dispatch claim")
+		}
+		return "", os.ErrNotExist
 	}
 	h.prepareTaskWorktree = func(task.Task) (string, error) {
 		if !held {
@@ -4072,6 +4143,9 @@ func TestHumanReviewDispatchDir_RetryableErrorsDoNotFallBackReadOnly(t *testing.
 			h, _, cleanup := newReviewTestEnv(t)
 			defer cleanup()
 			h.cfg.HumanReview.SybraRepoDir = "/opt/sybra/src"
+			// No reusable checkout, so preparation is genuinely the next step —
+			// production always wires both resolvers together.
+			h.resolveExistingWorktree = func(task.Task) (string, error) { return "", os.ErrNotExist }
 			h.prepareTaskWorktree = func(task.Task) (string, error) { return "", tc.prepareErr }
 
 			dir, readOnly, retryable, _ := h.dispatchDir(task.Task{ID: "t1"})
@@ -4142,5 +4216,46 @@ func TestHumanReviewSpawn_RetryablePrepareSchedulesRetry(t *testing.T) {
 
 	if runCalls != 1 {
 		t.Errorf("agent runs after retry = %d, want 1", runCalls)
+	}
+}
+
+// The empty-dir guard is load-bearing: without it a resolver returning
+// ("", nil) would give the agent an empty RunConfig.Dir and run it in the
+// server process's own working directory.
+func TestHumanReviewDispatchDir_EmptyReuseFallsThrough(t *testing.T) {
+	h, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	prepared := t.TempDir()
+	h.resolveExistingWorktree = func(task.Task) (string, error) { return "  ", nil }
+	h.prepareTaskWorktree = func(task.Task) (string, error) { return prepared, nil }
+
+	dir, _, _, _ := h.dispatchDir(task.Task{ID: "t1"})
+	if dir != prepared {
+		t.Errorf("dir = %q, want the prepared worktree %q", dir, prepared)
+	}
+}
+
+// A preparation can fail before it mutates anything — adoptWorktree refuses a
+// detached or default-branch checkout up front — and the fallback then lands
+// back on the task's own untouched worktree. Telling the agent it is "not
+// looking at the state that failed" there makes it distrust a correct
+// reproduction, which is the opposite of what the warning is for.
+func TestHumanReviewDispatchDir_AdoptedFallbackIsNotFlaggedRebuilt(t *testing.T) {
+	h, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	adopted := t.TempDir()
+	h.resolveExistingWorktree = func(task.Task) (string, error) { return "", os.ErrInvalid }
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		return "", errors.New("adopt worktree: checked out on default branch")
+	}
+
+	dir, readOnly, _, rebuilt := h.dispatchDir(task.Task{ID: "t1", WorktreeDir: adopted})
+	if dir != adopted || readOnly {
+		t.Fatalf("got dir=%q readOnly=%v, want the task's own worktree", dir, readOnly)
+	}
+	if rebuilt {
+		t.Error("rebuilt=true for an untouched worktree; the agent would distrust a correct reproduction")
 	}
 }

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -207,7 +208,7 @@ func TestHumanReviewDispatchDir_ReusesExistingWorktreeUnmutated(t *testing.T) {
 	defer cleanup()
 
 	existing := t.TempDir()
-	h.resolveExistingWorktree = func(task.Task) (string, bool) { return existing, true }
+	h.resolveExistingWorktree = func(task.Task) (string, error) { return existing, nil }
 	h.prepareTaskWorktree = func(task.Task) (string, error) {
 		t.Fatal("preparation ran against a healthy existing worktree, rewriting the evidence")
 		return "", nil
@@ -233,7 +234,7 @@ func TestHumanReviewDispatchDir_PreparedWorktreeIsFlaggedRebuilt(t *testing.T) {
 	defer cleanup()
 
 	prepared := t.TempDir()
-	h.resolveExistingWorktree = func(task.Task) (string, bool) { return "", false }
+	h.resolveExistingWorktree = func(task.Task) (string, error) { return "", os.ErrNotExist }
 	h.prepareTaskWorktree = func(task.Task) (string, error) { return prepared, nil }
 
 	dir, _, _, rebuilt := h.dispatchDir(task.Task{ID: "parked-task"})
@@ -251,6 +252,105 @@ func TestHumanReviewDispatchDir_PreparedWorktreeIsFlaggedRebuilt(t *testing.T) {
 	clean := h.buildPrompt(task.Task{ID: "t1", ProjectID: "Automaat/sybra"}, dir, nil, false)
 	if strings.Contains(clean, "not looking at the state that failed") {
 		t.Error("prompt warns about a rebuild that did not happen")
+	}
+}
+
+// dispatchDir computing the flag correctly is worth nothing if spawnReview
+// drops it. Assert against the prompt the agent is actually handed.
+func TestHumanReviewSpawn_RebuiltWarningReachesTheAgent(t *testing.T) {
+	cases := []struct {
+		name        string
+		reuse       bool
+		wantWarning bool
+	}{
+		{name: "reused worktree carries no warning", reuse: true},
+		{name: "prepared worktree carries the warning", wantWarning: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, tasks, cleanup := newReviewTestEnv(t)
+			defer cleanup()
+
+			tk, err := tasks.Create("rebuilt warning", "", task.AgentModeHeadless)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tasks.UpdateMap(tk.ID, map[string]any{
+				"project_id": "Automaat/sybra",
+				"status":     string(task.StatusHumanRequired),
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			wtDir := t.TempDir()
+			h.resolveExistingWorktree = func(task.Task) (string, error) {
+				if tc.reuse {
+					return wtDir, nil
+				}
+				return "", os.ErrNotExist
+			}
+			h.prepareTaskWorktree = func(task.Task) (string, error) { return wtDir, nil }
+
+			var prompt string
+			h.agents = &fakeHumanReviewAgentRunner{run: func(cfg agent.RunConfig) (*agent.Agent, error) {
+				prompt = cfg.Prompt
+				return &agent.Agent{ID: "rev", TaskID: cfg.TaskID, StartedAt: time.Now().UTC()}, nil
+			}}
+
+			if !h.maybeSpawn(tk.ID, string(task.StatusInReview)) {
+				t.Fatal("review did not spawn")
+			}
+			got := strings.Contains(prompt, "not looking at the state that failed")
+			if got != tc.wantWarning {
+				t.Errorf("prompt warns = %v, want %v", got, tc.wantWarning)
+			}
+		})
+	}
+}
+
+// Reuse skips PrepareForTask, and with it the ErrAgentRunning guard that #3108
+// turned into a retry. A busy worktree must stay retryable, or the recovery
+// agent edits a checkout the implementer is still committing into.
+func TestHumanReviewDispatchDir_BusyWorktreeIsRetryable(t *testing.T) {
+	h, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	h.resolveExistingWorktree = func(task.Task) (string, error) {
+		return "", fmt.Errorf("resolve: %w", worktree.ErrWorktreeBusy)
+	}
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		t.Fatal("preparation ran against a worktree with a live agent")
+		return "", nil
+	}
+
+	dir, readOnly, retryable, _ := h.dispatchDir(task.Task{ID: "busy-task"})
+	if !retryable {
+		t.Errorf("retryable=false for a busy worktree; recovery falls back instead of waiting")
+	}
+	if dir != "" || readOnly {
+		t.Errorf("got dir=%q readOnly=%v, want an empty retryable result", dir, readOnly)
+	}
+}
+
+// A preparation that sanitizes the tree and then fails non-retryably has
+// destroyed the evidence more thoroughly than one that succeeded, so the
+// read-only fallback still has to carry the warning.
+func TestHumanReviewDispatchDir_FailedPrepareStillFlagsRebuilt(t *testing.T) {
+	h, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	h.resolveExistingWorktree = func(task.Task) (string, error) { return "", os.ErrNotExist }
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		return "", errors.New("reconcile failed after sanitize")
+	}
+
+	dir, readOnly, _, rebuilt := h.dispatchDir(task.Task{ID: "t1"})
+	if dir != h.cfg.HumanReview.SybraRepoDir || !readOnly {
+		t.Fatalf("got dir=%q readOnly=%v, want the read-only fallback", dir, readOnly)
+	}
+	if !rebuilt {
+		t.Error("rebuilt=false after a preparation that already mutated the tree")
 	}
 }
 

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -4330,6 +4330,9 @@ func TestHumanReviewSpawn_PreparedFlagIsStickyPerEpisode(t *testing.T) {
 		humanReviewSpawnOptions{IgnoreRenderedVerdict: true}) {
 		t.Fatal("third spawn refused")
 	}
+	if len(prompts) != 1 {
+		t.Fatalf("third spawn produced %d prompts, want 1", len(prompts))
+	}
 	if strings.Contains(prompts[0], "not looking at the state that failed") {
 		t.Error("a new episode inherited a warning about a preparation that predates it")
 	}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -157,16 +157,30 @@ func (m *Manager) ResolveExisting(ctx context.Context, t task.Task) (string, err
 	if m.hasLiveAgentOnly != nil && m.hasLiveAgentOnly(t.ID) {
 		return "", fmt.Errorf("resolve existing worktree %s: %w", path, ErrWorktreeBusy)
 	}
-	if err := pushableCheckout(ctx, path); err != nil {
+	if err := m.pushableCheckout(ctx, t, path); err != nil {
 		return "", err
 	}
 	return path, nil
 }
 
+// inProgressMarkers are the per-worktree files git writes while an operation is
+// half-applied. They live in the linked worktree's own git dir, not the common
+// one, so `rev-parse --git-dir` is the right base.
+var inProgressMarkers = []string{
+	"rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "sequencer",
+}
+
 // pushableCheckout rejects the states that pass WorktreeHealthy but leave an
-// agent unable to publish its fix: a detached HEAD (PrepareForReview creates
-// the same path detached) and an interrupted rebase or merge.
-func pushableCheckout(ctx context.Context, path string) error {
+// agent unable to publish its fix, or able to publish it somewhere catastrophic:
+// a detached HEAD (PrepareForReview creates the same path detached), a
+// half-applied rebase/merge/revert, and the project's default branch.
+//
+// The default-branch case is the dangerous one. The recovery mandate orders the
+// agent to fix, commit and push, and origin's push URL is only neutered for fork
+// remotes — so on an own-repo project this would put agent commits straight onto
+// main with no PR. adoptWorktree already refuses it for the same reason, and
+// like adoptWorktree this fails closed when the default branch cannot be read.
+func (m *Manager) pushableCheckout(ctx context.Context, t task.Task, path string) error {
 	branch, err := project.CurrentBranch(ctx, path)
 	if err != nil {
 		return fmt.Errorf("resolve existing worktree %s: %w", path, err)
@@ -182,10 +196,28 @@ func pushableCheckout(ctx context.Context, path string) error {
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(path, gitDir)
 	}
-	for _, marker := range []string{"rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD"} {
+	for _, marker := range inProgressMarkers {
 		if _, err := os.Stat(filepath.Join(gitDir, marker)); err == nil {
 			return fmt.Errorf("resolve existing worktree %s: %s in progress: %w", path, marker, os.ErrInvalid)
 		}
+	}
+	return m.refuseDefaultBranch(ctx, t, path, branch)
+}
+
+func (m *Manager) refuseDefaultBranch(ctx context.Context, t task.Task, path, branch string) error {
+	if m.projects == nil || strings.TrimSpace(t.ProjectID) == "" {
+		return nil
+	}
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return fmt.Errorf("resolve existing worktree %s: load project: %w", path, err)
+	}
+	def, err := project.DefaultBranch(ctx, proj.ClonePath)
+	if err != nil {
+		return fmt.Errorf("resolve existing worktree %s: cannot determine default branch to guard against: %w", path, err)
+	}
+	if branch == def {
+		return fmt.Errorf("resolve existing worktree %s: checked out on default branch %q: %w", path, def, os.ErrInvalid)
 	}
 	return nil
 }

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -212,7 +212,7 @@ func (m *Manager) refuseDefaultBranch(ctx context.Context, t task.Task, path, br
 	if err != nil {
 		return fmt.Errorf("resolve existing worktree %s: load project: %w", path, err)
 	}
-	def, err := project.DefaultBranch(ctx, proj.ClonePath)
+	def, err := project.DefaultBranchName(ctx, proj.ClonePath)
 	if err != nil {
 		return fmt.Errorf("resolve existing worktree %s: cannot determine default branch to guard against: %w", path, err)
 	}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/cleanup"
+	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -117,8 +118,14 @@ func (m *Manager) Exists(t task.Task) bool {
 	return err == nil
 }
 
+// ErrWorktreeBusy reports that a worktree exists but an agent is still writing
+// to it, so it must not be handed to a second one. Callers should retry rather
+// than fall back to preparation, which would rebase the branch out from under
+// the live run.
+var ErrWorktreeBusy = errors.New("worktree has a live agent")
+
 // ResolveExisting returns the task's worktree path if one is already checked
-// out and git can resolve it, without touching a single byte of it.
+// out and usable as-is, without touching a single byte of it.
 //
 // Every Prepare* entry point rewrites what it returns: SanitizeWorktree
 // auto-commits the dirty tree and then `reset --hard` / `clean -fd`s it,
@@ -127,22 +134,60 @@ func (m *Manager) Exists(t task.Task) bool {
 // to explain a failure — it hands the diagnosis a different tree on a
 // different base, and a base-induced failure simply stops reproducing (#3073).
 //
-// Health here is deliberately just "git resolves it". Being on an unexpected
-// branch is not a reason to fall through to preparation: a half-merged or
-// conflicted checkout IS the state that failed, and preparation would destroy
-// exactly the evidence the caller came for.
-func (m *Manager) ResolveExisting(ctx context.Context, t task.Task) (string, bool) {
+// "Usable" is narrower than "resolvable". A detached HEAD or an interrupted
+// rebase passes `rev-parse --git-dir` but cannot be pushed from, and a
+// recovery agent is under orders to fix, commit and push: its commit would
+// land unreferenced and the next Prepare* would drop the verified fix. Those
+// fall through to preparation. Merely being on an *unexpected* branch does
+// not — that is a half-merged checkout, which is the state that failed.
+func (m *Manager) ResolveExisting(ctx context.Context, t task.Task) (string, error) {
 	if m == nil {
-		return "", false
+		return "", os.ErrNotExist
 	}
 	path := m.PathFor(t)
 	if _, err := os.Stat(path); err != nil {
-		return "", false
+		return "", err
 	}
 	if !project.WorktreeHealthy(ctx, path) {
-		return "", false
+		return "", fmt.Errorf("resolve existing worktree %s: %w", path, os.ErrNotExist)
 	}
-	return path, true
+	// Reuse skips PrepareForTask, and with it the only live-agent guard on this
+	// path. Without this check a task parked mid-run hands its own worktree to
+	// the recovery agent while the implementer is still committing into it.
+	if m.hasLiveAgentOnly != nil && m.hasLiveAgentOnly(t.ID) {
+		return "", fmt.Errorf("resolve existing worktree %s: %w", path, ErrWorktreeBusy)
+	}
+	if err := pushableCheckout(ctx, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// pushableCheckout rejects the states that pass WorktreeHealthy but leave an
+// agent unable to publish its fix: a detached HEAD (PrepareForReview creates
+// the same path detached) and an interrupted rebase or merge.
+func pushableCheckout(ctx context.Context, path string) error {
+	branch, err := project.CurrentBranch(ctx, path)
+	if err != nil {
+		return fmt.Errorf("resolve existing worktree %s: %w", path, err)
+	}
+	if branch == "" {
+		return fmt.Errorf("resolve existing worktree %s: detached HEAD: %w", path, os.ErrInvalid)
+	}
+	gitDir, err := gitexec.Output(ctx, gitexec.Options{Dir: path}, "rev-parse", "--git-dir")
+	if err != nil {
+		return fmt.Errorf("resolve existing worktree %s: %w", path, err)
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(path, gitDir)
+	}
+	for _, marker := range []string{"rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD"} {
+		if _, err := os.Stat(filepath.Join(gitDir, marker)); err == nil {
+			return fmt.Errorf("resolve existing worktree %s: %s in progress: %w", path, marker, os.ErrInvalid)
+		}
+	}
+	return nil
 }
 
 // ValidatePath checks that path is within the worktrees directory and is a directory.

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -114,6 +115,34 @@ func (m *Manager) PathFor(t task.Task) string {
 func (m *Manager) Exists(t task.Task) bool {
 	_, err := os.Stat(m.PathFor(t))
 	return err == nil
+}
+
+// ResolveExisting returns the task's worktree path if one is already checked
+// out and git can resolve it, without touching a single byte of it.
+//
+// Every Prepare* entry point rewrites what it returns: SanitizeWorktree
+// auto-commits the dirty tree and then `reset --hard` / `clean -fd`s it,
+// reconcileAndRebase moves it onto a fresher base, and PushSync publishes the
+// result. That is right for an agent about to do work, and wrong for one sent
+// to explain a failure — it hands the diagnosis a different tree on a
+// different base, and a base-induced failure simply stops reproducing (#3073).
+//
+// Health here is deliberately just "git resolves it". Being on an unexpected
+// branch is not a reason to fall through to preparation: a half-merged or
+// conflicted checkout IS the state that failed, and preparation would destroy
+// exactly the evidence the caller came for.
+func (m *Manager) ResolveExisting(ctx context.Context, t task.Task) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	path := m.PathFor(t)
+	if _, err := os.Stat(path); err != nil {
+		return "", false
+	}
+	if !project.WorktreeHealthy(ctx, path) {
+		return "", false
+	}
+	return path, true
 }
 
 // ValidatePath checks that path is within the worktrees directory and is a directory.

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -2183,9 +2183,9 @@ func TestManager_ResolveExistingLeavesTheTreeUntouched(t *testing.T) {
 	headBefore := gitOut(t, wt, "rev-parse", "HEAD")
 	statusBefore := gitOut(t, wt, "status", "--porcelain")
 
-	got, ok := m.ResolveExisting(context.Background(), tk)
-	if !ok {
-		t.Fatalf("healthy worktree not resolved: %q", got)
+	got, err := m.ResolveExisting(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("healthy worktree not resolved: %v", err)
 	}
 	if got != wt {
 		t.Errorf("resolved %q, want %q", got, wt)
@@ -2210,7 +2210,7 @@ func TestManager_ResolveExistingRejectsMissingAndNonGit(t *testing.T) {
 	}
 	m := New(Config{WorktreesDir: dir, Tasks: task.NewManager(store, nil), Logger: discardLogger()})
 
-	if got, ok := m.ResolveExisting(context.Background(), task.Task{ID: "absent"}); ok {
+	if got, err := m.ResolveExisting(context.Background(), task.Task{ID: "absent"}); err == nil {
 		t.Errorf("resolved a worktree that does not exist: %q", got)
 	}
 
@@ -2219,8 +2219,85 @@ func TestManager_ResolveExistingRejectsMissingAndNonGit(t *testing.T) {
 	if err := os.MkdirAll(notRepo, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got, ok := m.ResolveExisting(context.Background(), bare); ok {
+	if got, err := m.ResolveExisting(context.Background(), bare); err == nil {
 		t.Errorf("resolved a directory git cannot resolve: %q", got)
+	}
+}
+
+// Reuse skips PrepareForTask, and with it the ErrAgentRunning guard that is the
+// only thing stopping a second agent from editing a checkout the first is still
+// committing into.
+func TestManager_ResolveExistingRefusesLiveAgent(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(Config{
+		WorktreesDir:     dir,
+		Tasks:            task.NewManager(store, nil),
+		Logger:           discardLogger(),
+		LiveAgentChecker: func(string) bool { return true },
+	})
+
+	tk := task.Task{ID: "busy"}
+	makePushedGitDir(t, filepath.Join(dir, tk.DirName()))
+
+	got, err := m.ResolveExisting(context.Background(), tk)
+	if !errors.Is(err, ErrWorktreeBusy) {
+		t.Fatalf("ResolveExisting = %q, %v; want ErrWorktreeBusy", got, err)
+	}
+}
+
+// A recovery agent is ordered to fix, commit and push. These two states pass
+// WorktreeHealthy and then cannot be pushed from at all — the commit lands
+// unreferenced and the next Prepare* drops the verified fix.
+func TestManager_ResolveExistingRefusesUnpushableCheckout(t *testing.T) {
+	cases := []struct {
+		name    string
+		breakWT func(t *testing.T, wt string)
+	}{
+		{
+			name: "detached HEAD",
+			breakWT: func(t *testing.T, wt string) {
+				t.Helper()
+				mustRunInDir(t, wt, "git", "checkout", "--detach")
+			},
+		},
+		{
+			name: "interrupted rebase",
+			breakWT: func(t *testing.T, wt string) {
+				t.Helper()
+				gitDir := gitOut(t, wt, "rev-parse", "--absolute-git-dir")
+				if err := os.MkdirAll(filepath.Join(gitDir, "rebase-merge"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := task.NewStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			m := New(Config{WorktreesDir: dir, Tasks: task.NewManager(store, nil), Logger: discardLogger()})
+
+			tk := task.Task{ID: "unpushable"}
+			wt := filepath.Join(dir, tk.DirName())
+			makePushedGitDir(t, wt)
+			if _, err := m.ResolveExisting(context.Background(), tk); err != nil {
+				t.Fatalf("healthy worktree refused before the break: %v", err)
+			}
+			tc.breakWT(t, wt)
+
+			got, err := m.ResolveExisting(context.Background(), tk)
+			if err == nil {
+				t.Fatalf("ResolveExisting returned %q for a checkout that cannot be pushed from", got)
+			}
+		})
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -2249,9 +2249,10 @@ func TestManager_ResolveExistingRefusesLiveAgent(t *testing.T) {
 	}
 }
 
-// A recovery agent is ordered to fix, commit and push. These two states pass
-// WorktreeHealthy and then cannot be pushed from at all — the commit lands
-// unreferenced and the next Prepare* drops the verified fix.
+// A recovery agent is ordered to fix, commit and push. Each of these passes
+// WorktreeHealthy and then either cannot be pushed from at all — the commit
+// lands unreferenced and the next Prepare* drops the verified fix — or pushes
+// somewhere catastrophic.
 func TestManager_ResolveExistingRefusesUnpushableCheckout(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -2265,13 +2266,31 @@ func TestManager_ResolveExistingRefusesUnpushableCheckout(t *testing.T) {
 			},
 		},
 		{
-			name: "interrupted rebase",
+			name: "conflicted merge",
 			breakWT: func(t *testing.T, wt string) {
 				t.Helper()
-				gitDir := gitOut(t, wt, "rev-parse", "--absolute-git-dir")
-				if err := os.MkdirAll(filepath.Join(gitDir, "rebase-merge"), 0o755); err != nil {
-					t.Fatal(err)
-				}
+				forkConflict(t, wt, "merge")
+			},
+		},
+		{
+			name: "conflicted cherry-pick",
+			breakWT: func(t *testing.T, wt string) {
+				t.Helper()
+				forkConflict(t, wt, "cherry-pick")
+			},
+		},
+		{
+			name: "conflicted rebase",
+			breakWT: func(t *testing.T, wt string) {
+				t.Helper()
+				forkConflict(t, wt, "rebase")
+			},
+		},
+		{
+			name: "half-applied revert",
+			breakWT: func(t *testing.T, wt string) {
+				t.Helper()
+				runInDirAllowFail(wt, "git", "revert", "--no-commit", "HEAD")
 			},
 		},
 	}
@@ -2288,6 +2307,7 @@ func TestManager_ResolveExistingRefusesUnpushableCheckout(t *testing.T) {
 			tk := task.Task{ID: "unpushable"}
 			wt := filepath.Join(dir, tk.DirName())
 			makePushedGitDir(t, wt)
+			mustRunInDir(t, wt, "git", "checkout", "-q", "-b", "feature")
 			if _, err := m.ResolveExisting(context.Background(), tk); err != nil {
 				t.Fatalf("healthy worktree refused before the break: %v", err)
 			}
@@ -2298,6 +2318,87 @@ func TestManager_ResolveExistingRefusesUnpushableCheckout(t *testing.T) {
 				t.Fatalf("ResolveExisting returned %q for a checkout that cannot be pushed from", got)
 			}
 		})
+	}
+}
+
+// forkConflict leaves op half-applied against a conflicting sibling commit, so
+// git writes the real in-progress marker rather than a hand-made directory.
+func forkConflict(t *testing.T, wt, op string) {
+	t.Helper()
+	base := gitOut(t, wt, "rev-parse", "HEAD")
+	mustRunInDir(t, wt, "git", "checkout", "-q", "-b", "other", base)
+	writeFileT(t, filepath.Join(wt, "f.txt"), "other side")
+	mustRunInDir(t, wt, "git", "commit", "-q", "-am", "other")
+	other := gitOut(t, wt, "rev-parse", "HEAD")
+
+	mustRunInDir(t, wt, "git", "checkout", "-q", "feature")
+	writeFileT(t, filepath.Join(wt, "f.txt"), "feature side")
+	mustRunInDir(t, wt, "git", "commit", "-q", "-am", "feature")
+
+	switch op {
+	case "merge":
+		runInDirAllowFail(wt, "git", "merge", other)
+	case "cherry-pick":
+		runInDirAllowFail(wt, "git", "cherry-pick", other)
+	case "rebase":
+		runInDirAllowFail(wt, "git", "rebase", other)
+	}
+}
+
+func writeFileT(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// runInDirAllowFail runs a command expected to exit non-zero (a deliberate
+// conflict), so only the resulting repository state matters.
+func runInDirAllowFail(dir, name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	_, _ = cmd.CombinedOutput()
+}
+
+// The recovery mandate orders the agent to commit and push, and origin's push
+// URL is only neutered for fork remotes. Reusing a checkout sitting on the
+// default branch would put agent commits straight onto main with no PR —
+// which is why adoptWorktree already refuses it.
+func TestManager_ResolveExistingRefusesDefaultBranch(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("default branch reuse", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wt := h.m.PathFor(tk)
+	mustRunInDir(t, "", "git", "clone", "-q", h.proj.ClonePath, wt)
+	branch := gitOut(t, wt, "rev-parse", "--abbrev-ref", "HEAD")
+	def, err := project.DefaultBranch(context.Background(), h.proj.ClonePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if branch != def {
+		t.Fatalf("clone landed on %q, want the default branch %q", branch, def)
+	}
+
+	got, err := h.m.ResolveExisting(context.Background(), tk)
+	if err == nil {
+		t.Fatalf("ResolveExisting returned %q for a checkout on the default branch", got)
+	}
+
+	// A feature branch in the same worktree is still fine.
+	mustRunInDir(t, wt, "git", "checkout", "-q", "-b", "feature")
+	if _, err := h.m.ResolveExisting(context.Background(), tk); err != nil {
+		t.Errorf("feature branch refused: %v", err)
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -2293,6 +2293,15 @@ func TestManager_ResolveExistingRefusesUnpushableCheckout(t *testing.T) {
 				runInDirAllowFail(wt, "git", "revert", "--no-commit", "HEAD")
 			},
 		},
+		{
+			// The only marker not already subsumed by the detached-HEAD check:
+			// a conflicted `git am` stays on the branch and writes rebase-apply.
+			name: "conflicted git am",
+			breakWT: func(t *testing.T, wt string) {
+				t.Helper()
+				conflictedAm(t, wt)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -2342,6 +2351,31 @@ func forkConflict(t *testing.T, wt, op string) {
 		runInDirAllowFail(wt, "git", "cherry-pick", other)
 	case "rebase":
 		runInDirAllowFail(wt, "git", "rebase", other)
+	}
+}
+
+// conflictedAm leaves `git am` half-applied. Unlike a conflicted rebase (which
+// detaches HEAD and is caught by the earlier check), am stays on the branch, so
+// rebase-apply is the only thing that can refuse this checkout.
+func conflictedAm(t *testing.T, wt string) {
+	t.Helper()
+	base := gitOut(t, wt, "rev-parse", "HEAD")
+	mustRunInDir(t, wt, "git", "checkout", "-q", "-b", "patchsrc", base)
+	writeFileT(t, filepath.Join(wt, "f.txt"), "patched")
+	mustRunInDir(t, wt, "git", "commit", "-q", "-am", "patch")
+	patch := gitOut(t, wt, "format-patch", "-1", "--stdout")
+
+	mustRunInDir(t, wt, "git", "checkout", "-q", "feature")
+	writeFileT(t, filepath.Join(wt, "f.txt"), "conflicting")
+	mustRunInDir(t, wt, "git", "commit", "-q", "-am", "conflicting")
+
+	cmd := exec.Command("git", "am")
+	cmd.Dir = wt
+	cmd.Stdin = strings.NewReader(patch + "\n")
+	_, _ = cmd.CombinedOutput()
+
+	if branch := gitOut(t, wt, "branch", "--show-current"); branch == "" {
+		t.Fatal("git am detached HEAD; this case no longer isolates rebase-apply")
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -2159,3 +2159,78 @@ func TestManager_RefuseRecreateWithUncommittedWork(t *testing.T) {
 		t.Fatalf("uncommitted worktree contents gone: %v", statErr)
 	}
 }
+
+// ResolveExisting is the recovery path's answer to #3073, so what it must not
+// do is the whole point: a recovery agent re-running the failing command has
+// to see the working tree, HEAD, and branch that produced the failure.
+func TestManager_ResolveExistingLeavesTheTreeUntouched(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(Config{WorktreesDir: dir, Tasks: task.NewManager(store, nil), Logger: discardLogger()})
+
+	tk := task.Task{ID: "t1"}
+	wt := filepath.Join(dir, tk.DirName())
+	makePushedGitDir(t, wt)
+	// The implementer's uncommitted edits are the evidence, and SanitizeWorktree
+	// would auto-commit then reset them away.
+	if err := os.WriteFile(filepath.Join(wt, "uncommitted.txt"), []byte("the state that failed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	headBefore := gitOut(t, wt, "rev-parse", "HEAD")
+	statusBefore := gitOut(t, wt, "status", "--porcelain")
+
+	got, ok := m.ResolveExisting(context.Background(), tk)
+	if !ok {
+		t.Fatalf("healthy worktree not resolved: %q", got)
+	}
+	if got != wt {
+		t.Errorf("resolved %q, want %q", got, wt)
+	}
+	if after := gitOut(t, wt, "rev-parse", "HEAD"); after != headBefore {
+		t.Errorf("HEAD moved: %q -> %q", headBefore, after)
+	}
+	if after := gitOut(t, wt, "status", "--porcelain"); after != statusBefore {
+		t.Errorf("working tree changed: %q -> %q", statusBefore, after)
+	}
+	if _, statErr := os.Stat(filepath.Join(wt, "uncommitted.txt")); statErr != nil {
+		t.Errorf("uncommitted evidence gone: %v", statErr)
+	}
+}
+
+func TestManager_ResolveExistingRejectsMissingAndNonGit(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(Config{WorktreesDir: dir, Tasks: task.NewManager(store, nil), Logger: discardLogger()})
+
+	if got, ok := m.ResolveExisting(context.Background(), task.Task{ID: "absent"}); ok {
+		t.Errorf("resolved a worktree that does not exist: %q", got)
+	}
+
+	bare := task.Task{ID: "not-a-repo"}
+	notRepo := filepath.Join(dir, bare.DirName())
+	if err := os.MkdirAll(notRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := m.ResolveExisting(context.Background(), bare); ok {
+		t.Errorf("resolved a directory git cannot resolve: %q", got)
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}


### PR DESCRIPTION
## Motivation

The human-review agent is dispatched to explain why a task failed, and
preparation rewrote the evidence before it read a line of it.
`SanitizeWorktree` auto-commits the dirty tree then `reset --hard`/`clean -fd`s
it, `reconcileAndRebase` moves it onto a fresher base, and `PushSync` publishes
the result.

Meanwhile the mandate instructs that agent to *"re-run the exact failing command
in the task's worktree to confirm; never infer 'flaky/transient/infra' from
reasoning alone."* A base-induced failure simply stops reproducing on the new
base, so the harness manufactured exactly the false "it passes now" evidence the
mandate spends a paragraph forbidding.

> Changelog: fix(review): stop recovery rewriting the evidence it diagnoses

## Implementation information

Add `Manager.ResolveExisting`, which returns an already-checked-out worktree
without touching a byte of it, and try it before any `Prepare*` path. When no
usable checkout exists and preparation is unavoidable, the prompt now says so.

"Usable" is narrower than "resolvable", and the two exclusions are the
interesting part:

- **A live agent.** Reuse skips `PrepareForTask`, and with it the only
  `ErrAgentRunning` guard on this path — the one #3108 had just turned into a
  retry because it is the most common way into recovery. Without an explicit
  check, a task parked mid-run hands its own checkout to a second agent.
  `ClaimTaskDispatch` does not cover this: it dedupes concurrent *dispatches*, and
  a claim is not a running agent. Busy is returned as **retryable**, not as a
  fallback — falling through to preparation would rebase the branch out from
  under the live run.
- **A checkout that cannot be pushed from.** A detached HEAD (`PrepareForReview`
  creates the same path detached) or an interrupted rebase passes
  `WorktreeHealthy`, which is only `rev-parse --git-dir`. The agent is under
  orders to fix, commit and push: its commit would land unreferenced and the
  next `Prepare*` would drop the verified fix.

Being on an *unexpected* branch is deliberately **not** an exclusion. That is a
half-merged checkout, which is the state that failed — refusing it would destroy
the evidence this change exists to preserve.

The rebuilt flag is set once preparation is *invoked*, not only when it
succeeds. A run that sanitized the tree and then failed non-retryably destroyed
the evidence more thoroughly than one that succeeded, and the agent still needs
telling.

## Supporting documentation

Adversarial review found both exclusions above as blockers on the first version,
which reused any worktree `git rev-parse` could resolve. It reproduced each end
to end: `PrepareForTask` returning `ErrAgentRunning` while `ResolveExisting`
returned the path, and a detached checkout where `git commit` succeeded and
`git push` failed with `fatal: You are not currently on a branch.`

It also found the `rebuiltDir` wiring untested — replacing `spawnReview`'s call
with a literal `false` left the whole suite green, so the warning could have
silently stopped reaching any real agent. `TestHumanReviewSpawn_RebuiltWarning
ReachesTheAgent` now asserts against the prompt in the spawned `RunConfig`.

Five mutations, each killing exactly one test: drop the live-agent guard; drop
the pushable-checkout check; let busy fall through instead of retrying; leave a
failed preparation unflagged; drop the flag at the spawn site.

### Third review pass

The rebuilt flag was lost on every re-entry that builds fresh spawn options —
the provider fallback after a malformed verdict, and `retryAfterCrash` — so the
second agent got the tree the first one's preparation had already rewritten,
with no warning. Carrying it on the options was not enough; it is now sticky for
the human-required episode and forgotten when the task leaves that status.

The default-branch guard could not fire at all on a project whose default branch
contains a slash: `DefaultBranch` took `filepath.Base`, turning
`refs/heads/release/2.0` into `2.0`, which never equals the `CurrentBranch` it is
compared against. That silently disabled the identical refusal in
`adoptWorktree` too, so the fix is in `internal/project`.

Added the one in-progress marker not already subsumed by the detached-HEAD check
— a conflicted `git am` stays on its branch, where a conflicted rebase detaches —
and stopped the warning asserting mutations that a preparation failing before
`SanitizeWorktree` never made.

Closes #3073
