### PR TITLE
refactor(fsutil): unify path containment checks

### DIFF
--- a/internal/agentqueue/queue.go
+++ b/internal/agentqueue/queue.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -146,7 +147,7 @@ func (q *Queue) Restore(it Item) bool {
 }
 
 func (q *Queue) offer(it Item, restore bool) bool {
-	if !safeTaskID(it.TaskID) {
+	if fsutil.ValidateKey(it.TaskID) != nil {
 		q.log.Warn("agentqueue.offer.unsafe-task-id", "task_id", it.TaskID)
 		return false
 	}
@@ -192,7 +193,7 @@ func earliestEnqueued(existing, incoming time.Time) time.Time {
 // Remove drops taskID from the queue and its store file, if present. An
 // unsafe or absent TaskID is a no-op.
 func (q *Queue) Remove(taskID string) {
-	if !safeTaskID(taskID) {
+	if fsutil.ValidateKey(taskID) != nil {
 		return
 	}
 

--- a/internal/agentqueue/store.go
+++ b/internal/agentqueue/store.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/task"
@@ -28,28 +27,12 @@ func newStore(dir string) (*store, error) {
 	return &store{dir: dir}, nil
 }
 
-// safeTaskID reports whether id is safe to use as a filename component: it
-// must be non-empty, contain no path separators or "..", and equal its own
-// filepath.Base (rejecting anything that could escape dir).
-func safeTaskID(id string) bool {
-	if id == "" {
-		return false
-	}
-	if strings.ContainsAny(id, "/\\") {
-		return false
-	}
-	if strings.Contains(id, "..") {
-		return false
-	}
-	return filepath.Base(id) == id
-}
-
 func (s *store) filePath(taskID string) string {
 	return filepath.Join(s.dir, taskID+".yaml")
 }
 
 func (s *store) put(it Item) error {
-	if !safeTaskID(it.TaskID) {
+	if fsutil.ValidateKey(it.TaskID) != nil {
 		return fmt.Errorf("agentqueue: unsafe task id %q", it.TaskID)
 	}
 	data, err := yaml.Marshal(it)
@@ -60,7 +43,7 @@ func (s *store) put(it Item) error {
 }
 
 func (s *store) del(taskID string) error {
-	if !safeTaskID(taskID) {
+	if fsutil.ValidateKey(taskID) != nil {
 		return fmt.Errorf("agentqueue: unsafe task id %q", taskID)
 	}
 	if err := os.Remove(s.filePath(taskID)); err != nil && !os.IsNotExist(err) {

--- a/internal/agentqueue/store_test.go
+++ b/internal/agentqueue/store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -243,7 +244,7 @@ func TestStore_SafeTaskID(t *testing.T) {
 		{".hidden", true},
 	}
 	for _, tt := range tests {
-		if got := safeTaskID(tt.id); got != tt.want {
+		if got := fsutil.ValidateKey(tt.id) == nil; got != tt.want {
 			t.Errorf("safeTaskID(%q) = %v, want %v", tt.id, got, tt.want)
 		}
 	}

--- a/internal/attachment/store.go
+++ b/internal/attachment/store.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/google/uuid"
 )
 
@@ -37,7 +38,7 @@ func (s *Store) Put(taskID string, req UploadRequest) (Attachment, error) {
 	if s == nil {
 		return Attachment{}, errors.New("attachment store is not configured")
 	}
-	if err := validateTaskKey(taskID); err != nil {
+	if err := fsutil.ValidateKey(taskID); err != nil {
 		return Attachment{}, err
 	}
 	if err := s.validateSize(req.Data); err != nil {
@@ -97,10 +98,10 @@ func (s *Store) Import(taskID string, meta Attachment, data []byte) (Attachment,
 	if s == nil {
 		return Attachment{}, errors.New("attachment store is not configured")
 	}
-	if err := validateTaskKey(taskID); err != nil {
+	if err := fsutil.ValidateKey(taskID); err != nil {
 		return Attachment{}, err
 	}
-	if err := validateTaskKey(meta.ID); err != nil {
+	if err := fsutil.ValidateKey(meta.ID); err != nil {
 		return Attachment{}, err
 	}
 	if err := s.validateSize(data); err != nil {
@@ -166,7 +167,7 @@ func (s *Store) List(taskID string) ([]Attachment, error) {
 	if s == nil {
 		return nil, errors.New("attachment store is not configured")
 	}
-	if err := validateTaskKey(taskID); err != nil {
+	if err := fsutil.ValidateKey(taskID); err != nil {
 		return nil, err
 	}
 	taskDir, err := s.taskDir(taskID)
@@ -213,7 +214,7 @@ func (s *Store) Path(taskID, attachmentID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if !withinDir(dir, meta.Path) {
+	if !fsutil.Within(dir, meta.Path) {
 		return "", fmt.Errorf("attachment path escapes task dir: %s", attachmentID)
 	}
 	if _, err := os.Stat(meta.Path); err != nil {
@@ -227,10 +228,10 @@ func (s *Store) Delete(taskID, attachmentID string) error {
 	if s == nil {
 		return errors.New("attachment store is not configured")
 	}
-	if err := validateTaskKey(taskID); err != nil {
+	if err := fsutil.ValidateKey(taskID); err != nil {
 		return err
 	}
-	if err := validateTaskKey(attachmentID); err != nil {
+	if err := fsutil.ValidateKey(attachmentID); err != nil {
 		return err
 	}
 	mu := s.lockFor(taskID)
@@ -251,7 +252,7 @@ func (s *Store) DeleteTask(taskID string) error {
 	if s == nil {
 		return errors.New("attachment store is not configured")
 	}
-	if err := validateTaskKey(taskID); err != nil {
+	if err := fsutil.ValidateKey(taskID); err != nil {
 		return err
 	}
 	mu := s.lockFor(taskID)
@@ -288,18 +289,18 @@ func (s *Store) lockFor(taskID string) *sync.Mutex {
 }
 
 func (s *Store) taskDir(taskID string) (string, error) {
-	return safeJoin(s.root, taskID)
+	return fsutil.SafeJoin(s.root, taskID)
 }
 
 func (s *Store) attachmentDir(taskID, attachmentID string) (string, error) {
-	if err := validateTaskKey(attachmentID); err != nil {
+	if err := fsutil.ValidateKey(attachmentID); err != nil {
 		return "", err
 	}
 	taskDir, err := s.taskDir(taskID)
 	if err != nil {
 		return "", err
 	}
-	return safeJoin(taskDir, attachmentID)
+	return fsutil.SafeJoin(taskDir, attachmentID)
 }
 
 func (s *Store) readMeta(dir string) (Attachment, error) {
@@ -312,37 +313,6 @@ func (s *Store) readMeta(dir string) (Attachment, error) {
 		return Attachment{}, fmt.Errorf("decode attachment metadata: %w", err)
 	}
 	return meta, nil
-}
-
-func validateTaskKey(v string) error {
-	if strings.TrimSpace(v) == "" {
-		return errors.New("attachment key is required")
-	}
-	if strings.Contains(v, string(filepath.Separator)) || strings.Contains(v, "/") || strings.Contains(v, "\\") {
-		return fmt.Errorf("attachment key %q contains path separators", v)
-	}
-	if v == "." || v == ".." {
-		return fmt.Errorf("attachment key %q is invalid", v)
-	}
-	return nil
-}
-
-func safeJoin(root string, parts ...string) (string, error) {
-	base := filepath.Clean(root)
-	candidate := filepath.Join(append([]string{base}, parts...)...)
-	if !withinDir(base, candidate) && filepath.Clean(candidate) != base {
-		return "", fmt.Errorf("path escapes root: %s", candidate)
-	}
-	return candidate, nil
-}
-
-func withinDir(root, path string) bool {
-	root = filepath.Clean(root)
-	path = filepath.Clean(path)
-	if path == root {
-		return true
-	}
-	return strings.HasPrefix(path, root+string(filepath.Separator))
 }
 
 func sanitizeFileName(name string) string {

--- a/internal/attachment/store.go
+++ b/internal/attachment/store.go
@@ -39,7 +39,7 @@ func (s *Store) Put(taskID string, req UploadRequest) (Attachment, error) {
 		return Attachment{}, errors.New("attachment store is not configured")
 	}
 	if err := fsutil.ValidateKey(taskID); err != nil {
-		return Attachment{}, err
+		return Attachment{}, fmt.Errorf("task id: %w", err)
 	}
 	if err := s.validateSize(req.Data); err != nil {
 		return Attachment{}, err
@@ -99,10 +99,10 @@ func (s *Store) Import(taskID string, meta Attachment, data []byte) (Attachment,
 		return Attachment{}, errors.New("attachment store is not configured")
 	}
 	if err := fsutil.ValidateKey(taskID); err != nil {
-		return Attachment{}, err
+		return Attachment{}, fmt.Errorf("task id: %w", err)
 	}
 	if err := fsutil.ValidateKey(meta.ID); err != nil {
-		return Attachment{}, err
+		return Attachment{}, fmt.Errorf("attachment id: %w", err)
 	}
 	if err := s.validateSize(data); err != nil {
 		return Attachment{}, err
@@ -168,7 +168,7 @@ func (s *Store) List(taskID string) ([]Attachment, error) {
 		return nil, errors.New("attachment store is not configured")
 	}
 	if err := fsutil.ValidateKey(taskID); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("task id: %w", err)
 	}
 	taskDir, err := s.taskDir(taskID)
 	if err != nil {
@@ -229,10 +229,10 @@ func (s *Store) Delete(taskID, attachmentID string) error {
 		return errors.New("attachment store is not configured")
 	}
 	if err := fsutil.ValidateKey(taskID); err != nil {
-		return err
+		return fmt.Errorf("task id: %w", err)
 	}
 	if err := fsutil.ValidateKey(attachmentID); err != nil {
-		return err
+		return fmt.Errorf("attachment id: %w", err)
 	}
 	mu := s.lockFor(taskID)
 	mu.Lock()
@@ -253,7 +253,7 @@ func (s *Store) DeleteTask(taskID string) error {
 		return errors.New("attachment store is not configured")
 	}
 	if err := fsutil.ValidateKey(taskID); err != nil {
-		return err
+		return fmt.Errorf("task id: %w", err)
 	}
 	mu := s.lockFor(taskID)
 	mu.Lock()
@@ -294,7 +294,7 @@ func (s *Store) taskDir(taskID string) (string, error) {
 
 func (s *Store) attachmentDir(taskID, attachmentID string) (string, error) {
 	if err := fsutil.ValidateKey(attachmentID); err != nil {
-		return "", err
+		return "", fmt.Errorf("attachment id: %w", err)
 	}
 	taskDir, err := s.taskDir(taskID)
 	if err != nil {

--- a/internal/experience/store.go
+++ b/internal/experience/store.go
@@ -1,13 +1,14 @@
 package experience
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 const defaultMaxPerProject = 50
@@ -105,7 +106,7 @@ func (s *Store) Delete(projectID string) error {
 }
 
 func (s *Store) projectDir(projectID string) (string, error) {
-	safe, err := sanitizeProjectID(projectID)
+	safe, err := fsutil.ProjectKeyDir(projectID)
 	if err != nil {
 		return "", err
 	}
@@ -177,40 +178,6 @@ func sortRecords(records []Record) {
 		}
 		return records[i].TaskID < records[j].TaskID
 	})
-}
-
-func sanitizeProjectID(projectID string) (string, error) {
-	id := strings.TrimSpace(projectID)
-	if id == "" {
-		return "", fmt.Errorf("project id is empty")
-	}
-	if isOpaqueWorkProjectKey(id) {
-		return id, nil
-	}
-	if filepath.Clean(id) != id || strings.Contains(id, `\`) {
-		return "", fmt.Errorf("invalid project id %q", projectID)
-	}
-	owner, repo, ok := strings.Cut(id, "/")
-	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
-		return "", fmt.Errorf("invalid project id %q", projectID)
-	}
-	if owner == "." || owner == ".." || repo == "." || repo == ".." {
-		return "", fmt.Errorf("invalid project id %q", projectID)
-	}
-	return "gh-" + hex.EncodeToString([]byte(owner)) + "-" + hex.EncodeToString([]byte(repo)), nil
-}
-
-func isOpaqueWorkProjectKey(id string) bool {
-	const prefix = "work-"
-	if !strings.HasPrefix(id, prefix) || len(id) != len(prefix)+64 {
-		return false
-	}
-	for _, r := range id[len(prefix):] {
-		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
-			return false
-		}
-	}
-	return true
 }
 
 func sanitizeRecordID(recordID string) (string, error) {

--- a/internal/experience/store_test.go
+++ b/internal/experience/store_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 func TestStoreProjectScopingIdempotencyOrderingAndLimit(t *testing.T) {
@@ -92,16 +94,16 @@ func TestStoreRejectsUnsafeIDsAndDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, id := range []string{"", "../repo", "owner/../repo", "owner/repo/extra", "owner\\repo", "work-zzzz"} {
-		if _, err := sanitizeProjectID(id); err == nil {
-			t.Fatalf("sanitizeProjectID(%q) succeeded, want error", id)
+		if _, err := fsutil.ProjectKeyDir(id); err == nil {
+			t.Fatalf("fsutil.ProjectKeyDir(%q) succeeded, want error", id)
 		}
 	}
-	if got, err := sanitizeProjectID("owner/repo"); err != nil || got != "gh-6f776e6572-7265706f" {
-		t.Fatalf("sanitizeProjectID(owner/repo) = %q, %v; want encoded key", got, err)
+	if got, err := fsutil.ProjectKeyDir("owner/repo"); err != nil || got != "gh-6f776e6572-7265706f" {
+		t.Fatalf("fsutil.ProjectKeyDir(owner/repo) = %q, %v; want encoded key", got, err)
 	}
 	opaqueKey := "work-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-	if got, err := sanitizeProjectID(opaqueKey); err != nil || got != opaqueKey {
-		t.Fatalf("sanitizeProjectID(opaque work key) = %q, %v; want same key", got, err)
+	if got, err := fsutil.ProjectKeyDir(opaqueKey); err != nil || got != opaqueKey {
+		t.Fatalf("fsutil.ProjectKeyDir(opaque work key) = %q, %v; want same key", got, err)
 	}
 	if err := store.Put("owner/repo", Record{TaskID: "task-1", CreatedAt: time.Now().UTC()}); err != nil {
 		t.Fatal(err)

--- a/internal/fsutil/contain.go
+++ b/internal/fsutil/contain.go
@@ -1,0 +1,106 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrEscapesRoot reports a path that resolves outside the root it was joined
+// under.
+var ErrEscapesRoot = errors.New("path escapes root")
+
+// ValidateKey rejects a string used as a single path component: the shape that
+// a store derives a filename from. Callers pass externally-supplied keys —
+// task ids pushed by a cluster peer, attachment names from an upload — so
+// this rejects rather than sanitizes. Silently rewriting a hostile key hides
+// the attempt and can still collide with a legitimate file.
+func ValidateKey(v string) error {
+	if strings.TrimSpace(v) == "" {
+		return errors.New("key must not be empty")
+	}
+	if v == "." || v == ".." {
+		return fmt.Errorf("key %q is a path traversal", v)
+	}
+	if strings.ContainsRune(v, 0) {
+		return fmt.Errorf("key %q contains a NUL byte", v)
+	}
+	// Both separators, on every OS: a key crossing machines must not become
+	// traversable only on the platform that treats "\" as a separator.
+	if strings.ContainsAny(v, `/\`) || strings.ContainsRune(v, filepath.Separator) {
+		return fmt.Errorf("key %q contains a path separator", v)
+	}
+	if filepath.IsAbs(v) || filepath.Base(v) != v {
+		return fmt.Errorf("key %q is not a single path component", v)
+	}
+	return nil
+}
+
+// SafeJoin joins parts under root and returns the result only when it stays
+// inside root. Every part must be a single component (see ValidateKey), so
+// traversal is impossible by construction rather than caught after the fact
+// by a string comparison on the joined path.
+//
+// When root exists, containment is re-checked through os.Root, which resolves
+// each component against the real filesystem and so refuses a symlink that
+// points outside — something neither a prefix test nor filepath.Rel can see.
+func SafeJoin(root string, parts ...string) (string, error) {
+	if root == "" {
+		return "", errors.New("root must not be empty")
+	}
+	for _, p := range parts {
+		if err := ValidateKey(p); err != nil {
+			return "", err
+		}
+	}
+	base := filepath.Clean(root)
+	joined := filepath.Join(append([]string{base}, parts...)...)
+
+	r, err := os.OpenRoot(base)
+	if err != nil {
+		// A not-yet-created root cannot host a symlink, and the components are
+		// already validated, so the lexical join is sound. Any other error is
+		// the caller's to see.
+		if os.IsNotExist(err) {
+			return joined, nil
+		}
+		return "", err
+	}
+	defer func() { _ = r.Close() }()
+
+	rel, err := filepath.Rel(base, joined)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrEscapesRoot, joined)
+	}
+	// Stat resolves the whole chain against the real filesystem, so a
+	// component that is a symlink out of the root fails here. A path that
+	// simply does not exist yet is fine — callers are usually about to create
+	// it. Note os.Root also refuses an absolute symlink target even when it
+	// points back inside, which is stricter than containment requires but is
+	// the safe direction.
+	if _, err := r.Stat(rel); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("%w: %s: %w", ErrEscapesRoot, joined, err)
+	}
+	return joined, nil
+}
+
+// Within reports whether path resolves inside root. Prefer SafeJoin when you
+// are building the path; this is for checking one you were handed.
+//
+// Purely lexical: it answers for the strings, not the filesystem, so it cannot
+// see a symlink pointing out of root. Use it to reject obviously-escaping
+// input, not as the only barrier around a hostile path.
+func Within(root, path string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if path == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/fsutil/contain_test.go
+++ b/internal/fsutil/contain_test.go
@@ -1,0 +1,237 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		key  string
+		ok   bool
+	}{
+		{name: "plain id", key: "task-abc123", ok: true},
+		{name: "dots inside a name", key: "report.v2.json", ok: true},
+		{name: "unicode name", key: "café-résumé", ok: true},
+
+		{name: "empty", key: ""},
+		{name: "whitespace only", key: "   "},
+		{name: "current dir", key: "."},
+		{name: "parent dir", key: ".."},
+		{name: "traversal prefix", key: "../etc"},
+		{name: "traversal suffix", key: "a/.."},
+		{name: "forward slash", key: "a/b"},
+		{name: "backslash", key: `a\b`},
+		{name: "absolute path", key: "/etc/passwd"},
+		{name: "absolute traversal", key: "/../../etc/passwd"},
+		{name: "nul byte", key: "a\x00b"},
+		{name: "trailing separator", key: "dir/"},
+
+		// A lookalike is not a separator, so it stays a legal single component
+		// — the point is that filepath cannot mistake it for one.
+		{name: "fullwidth solidus lookalike", key: "a／b", ok: true},
+		{name: "division slash lookalike", key: "a∕b", ok: true},
+		{name: "fullwidth full stops", key: "．．", ok: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateKey(tt.key)
+			if tt.ok && err != nil {
+				t.Errorf("ValidateKey(%q) = %v, want nil", tt.key, err)
+			}
+			if !tt.ok && err == nil {
+				t.Errorf("ValidateKey(%q) = nil, want an error", tt.key)
+			}
+		})
+	}
+}
+
+// A key that ValidateKey accepts must never produce a path outside the root,
+// which is the property the per-package copies were each hand-rolling.
+func TestValidateKeyAcceptedKeysStayInsideTheRoot(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for _, key := range []string{"task-abc", "report.v2.json", "café", "a／b", "．．"} {
+		if err := ValidateKey(key); err != nil {
+			continue
+		}
+		joined := filepath.Join(root, key)
+		if !Within(root, joined) {
+			t.Errorf("ValidateKey accepted %q but %q escapes %q", key, joined, root)
+		}
+	}
+}
+
+func TestSafeJoin(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	if got, err := SafeJoin(root, "a", "b"); err != nil {
+		t.Errorf("SafeJoin(root, a, b) = %v", err)
+	} else if got != filepath.Join(root, "a", "b") {
+		t.Errorf("SafeJoin = %q, want %q", got, filepath.Join(root, "a", "b"))
+	}
+
+	for _, parts := range [][]string{
+		{".."}, {"..", ".."}, {"a", ".."}, {"a/b"}, {`a\b`}, {"/etc"}, {""}, {"."},
+	} {
+		if _, err := SafeJoin(root, parts...); err == nil {
+			t.Errorf("SafeJoin(root, %q) = nil, want an error", parts)
+		}
+	}
+
+	if _, err := SafeJoin("", "a"); err == nil {
+		t.Error("SafeJoin with an empty root should fail")
+	}
+
+	// A root that does not exist yet cannot host a symlink, so the validated components make the lexical join sound.
+	missing := filepath.Join(root, "not-created-yet")
+	if got, err := SafeJoin(missing, "a"); err != nil {
+		t.Errorf("SafeJoin under a missing root = %v", err)
+	} else if got != filepath.Join(missing, "a") {
+		t.Errorf("SafeJoin = %q, want %q", got, filepath.Join(missing, "a"))
+	}
+}
+
+// The reason SafeJoin resolves through os.Root rather than comparing strings:
+// a component can be a symlink whose target is outside the root, which every
+// lexical check in this repo used to miss.
+func TestSafeJoinRefusesASymlinkOutOfTheRoot(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on windows")
+	}
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	outside := filepath.Join(base, "outside")
+	for _, d := range []string{root, outside} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	secret := filepath.Join(outside, "secret")
+	if err := os.WriteFile(secret, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := SafeJoin(root, "escape"); err == nil {
+		t.Error("SafeJoin followed a symlink pointing out of the root")
+	}
+
+	// Relative target: os.Root refuses an absolute symlink target outright,
+	// even one pointing back inside, so only a relative link can be accepted.
+	if err := os.MkdirAll(filepath.Join(root, "real"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(root, "ok")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SafeJoin(root, "ok"); err != nil {
+		t.Errorf("SafeJoin refused a relative symlink that stays inside the root: %v", err)
+	}
+}
+
+func TestWithin(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		root string
+		path string
+		want bool
+	}{
+		{name: "same path", root: "/a/b", path: "/a/b", want: true},
+		{name: "child", root: "/a/b", path: "/a/b/c", want: true},
+		{name: "deep child", root: "/a/b", path: "/a/b/c/d", want: true},
+		{name: "unclean child", root: "/a/b", path: "/a/b/c/../d", want: true},
+		{name: "parent", root: "/a/b", path: "/a"},
+		{name: "sibling", root: "/a/b", path: "/a/bc"},
+		{name: "escaping traversal", root: "/a/b", path: "/a/b/../../c"},
+		{name: "unrelated", root: "/a/b", path: "/x/y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Within(tt.root, tt.path); got != tt.want {
+				t.Errorf("Within(%q, %q) = %v, want %v", tt.root, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// The sibling-prefix case is why Within uses filepath.Rel rather than
+// strings.HasPrefix: "/a/bc" starts with "/a/b" but is not inside it.
+func TestWithinRejectsASiblingSharingThePrefix(t *testing.T) {
+	t.Parallel()
+	if Within("/data/sybra", "/data/sybra-backup/secret") {
+		t.Error("Within accepted a sibling directory sharing the root's prefix")
+	}
+}
+
+func TestProjectKeyDir(t *testing.T) {
+	t.Parallel()
+	opaque := "work-" + strings.Repeat("a", 64)
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "owner and repo", id: "Automaat/sybra", want: "gh-4175746f6d616174-7379627261"},
+		{name: "opaque work key passes through", id: opaque, want: opaque},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ProjectKeyDir(tt.id)
+			if err != nil {
+				t.Fatalf("ProjectKeyDir(%q) = %v", tt.id, err)
+			}
+			if got != tt.want {
+				t.Errorf("ProjectKeyDir(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+			if err := ValidateKey(got); err != nil {
+				t.Errorf("ProjectKeyDir(%q) produced an unusable component: %v", tt.id, err)
+			}
+		})
+	}
+
+	for _, id := range []string{"", "   ", "..", "../etc", "owner", "owner/", "/repo", "a/b/c", `a\b`, "./a/b", "../a/b"} {
+		if _, err := ProjectKeyDir(id); err == nil {
+			t.Errorf("ProjectKeyDir(%q) = nil, want an error", id)
+		}
+	}
+}
+
+func TestIsOpaqueWorkProjectKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "64 hex digits", id: "work-" + strings.Repeat("a", 64), want: true},
+		{name: "mixed hex", id: "work-" + strings.Repeat("0f", 32), want: true},
+		{name: "too short", id: "work-" + strings.Repeat("a", 63)},
+		{name: "too long", id: "work-" + strings.Repeat("a", 65)},
+		{name: "uppercase hex", id: "work-" + strings.Repeat("A", 64)},
+		{name: "non-hex", id: "work-" + strings.Repeat("z", 64)},
+		{name: "no prefix", id: strings.Repeat("a", 64)},
+		{name: "empty", id: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsOpaqueWorkProjectKey(tt.id); got != tt.want {
+				t.Errorf("IsOpaqueWorkProjectKey(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/fsutil/projectkey.go
+++ b/internal/fsutil/projectkey.go
@@ -1,0 +1,54 @@
+package fsutil
+
+import (
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ProjectKeyDir maps a project id ("owner/repo") to one filesystem-safe
+// directory name. The owner and repo are hex-encoded rather than sanitized so
+// that two distinct projects can never collide on the same directory — a
+// character-stripping sanitizer would map "a/b-c" and "a/b_c" together.
+//
+// Work-project keys arrive already opaque (see IsOpaqueWorkProjectKey) and are
+// passed through: they are a hash, so they carry no path structure and must
+// not be re-encoded, or the record written under one name is read under
+// another.
+func ProjectKeyDir(projectID string) (string, error) {
+	id := strings.TrimSpace(projectID)
+	if id == "" {
+		return "", fmt.Errorf("project id is empty")
+	}
+	if IsOpaqueWorkProjectKey(id) {
+		return id, nil
+	}
+	if filepath.Clean(id) != id || strings.Contains(id, `\`) {
+		return "", fmt.Errorf("invalid project id %q", projectID)
+	}
+	owner, repo, ok := strings.Cut(id, "/")
+	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
+		return "", fmt.Errorf("invalid project id %q", projectID)
+	}
+	if owner == "." || owner == ".." || repo == "." || repo == ".." {
+		return "", fmt.Errorf("invalid project id %q", projectID)
+	}
+	return "gh-" + hex.EncodeToString([]byte(owner)) + "-" + hex.EncodeToString([]byte(repo)), nil
+}
+
+// IsOpaqueWorkProjectKey reports whether id is a scrubbed work-project key:
+// "work-" followed by 64 lowercase hex digits. Work project ids are hashed
+// before they reach disk so a work repo's owner/name never lands in a path.
+func IsOpaqueWorkProjectKey(id string) bool {
+	const prefix = "work-"
+	if !strings.HasPrefix(id, prefix) || len(id) != len(prefix)+64 {
+		return false
+	}
+	for _, r := range id[len(prefix):] {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/intervention/store.go
+++ b/internal/intervention/store.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 // Store is a project-partitioned, fingerprint-deduplicated, filesystem-backed
@@ -160,49 +162,11 @@ func readRecord(path string) (Record, error) {
 }
 
 func (s *Store) projectDir(projectKey string) (string, error) {
-	safe, err := sanitizeProjectKey(projectKey)
+	safe, err := fsutil.ProjectKeyDir(projectKey)
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(s.dir, safe), nil
-}
-
-// sanitizeProjectKey validates projectKey is either an opaque work-project
-// hash (see ProjectKey) or an "owner/repo" shape, then maps it to a
-// filesystem-safe directory name. Mirrors
-// internal/experience/store.go:sanitizeProjectID.
-func sanitizeProjectKey(projectKey string) (string, error) {
-	id := strings.TrimSpace(projectKey)
-	if id == "" {
-		return "", fmt.Errorf("project key is empty")
-	}
-	if isOpaqueWorkProjectKey(id) {
-		return id, nil
-	}
-	if filepath.Clean(id) != id || strings.Contains(id, `\`) {
-		return "", fmt.Errorf("invalid project key %q", projectKey)
-	}
-	owner, repo, ok := strings.Cut(id, "/")
-	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
-		return "", fmt.Errorf("invalid project key %q", projectKey)
-	}
-	if owner == "." || owner == ".." || repo == "." || repo == ".." {
-		return "", fmt.Errorf("invalid project key %q", projectKey)
-	}
-	return "gh-" + hex.EncodeToString([]byte(owner)) + "-" + hex.EncodeToString([]byte(repo)), nil
-}
-
-func isOpaqueWorkProjectKey(id string) bool {
-	const prefix = "work-"
-	if !strings.HasPrefix(id, prefix) || len(id) != len(prefix)+64 {
-		return false
-	}
-	for _, r := range id[len(prefix):] {
-		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
-			return false
-		}
-	}
-	return true
 }
 
 // fingerprintFileName maps an arbitrary fingerprint string to a

--- a/internal/prompteval/store.go
+++ b/internal/prompteval/store.go
@@ -34,13 +34,10 @@ func New(dir string) *Store {
 // validateKey rejects a variantID/digest that is empty, contains a path
 // separator, "..", or any character outside [A-Za-z0-9._-].
 func validateKey(key string) error {
-	if key == "" {
-		return fmt.Errorf("prompteval: key must not be empty")
+	if err := fsutil.ValidateKey(key); err != nil {
+		return fmt.Errorf("prompteval: %w", err)
 	}
 	if !validKey.MatchString(key) {
-		return fmt.Errorf("prompteval: invalid key %q", key)
-	}
-	if key == "." || key == ".." {
 		return fmt.Errorf("prompteval: invalid key %q", key)
 	}
 	return nil

--- a/internal/sybra/clusterlead/mirror.go
+++ b/internal/sybra/clusterlead/mirror.go
@@ -292,6 +292,14 @@ func (m *Mirror) applyFollowerTask(node string, follower task.Task) bool {
 }
 
 func (m *Mirror) applyFollowerTaskWithContext(ctx context.Context, node string, follower task.Task) bool {
+	// Validate on ingest, not at Put: the id arrives from a peer over HTTP and
+	// reaches writeSidecars — which builds eight paths from it — before Put's
+	// own ValidateID runs. Rejecting here means a hostile id writes nothing.
+	if err := task.ValidateID(follower.ID); err != nil {
+		m.logger.Warn("cluster.mirror.reject.invalid_task_id", "node", node, "task", follower.ID, "err", err)
+		return false
+	}
+
 	m.applyMu.Lock()
 	defer m.applyMu.Unlock()
 

--- a/internal/sybra/clusterlead/mirror_task_id_test.go
+++ b/internal/sybra/clusterlead/mirror_task_id_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"slices"
+
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -48,10 +50,10 @@ func TestApplyFollowerTaskRejectsUnsafeIDsWithoutWriting(t *testing.T) {
 				t.Fatalf("applyFollowerTask accepted id %q", tt.id)
 			}
 
-			after := treeSnapshot(t, dir)
-			if len(after) != len(before) {
-				t.Fatalf("id %q wrote %d new paths under the tasks dir:\nbefore=%v\nafter=%v",
-					tt.id, len(after)-len(before), before, after)
+			// Compare the whole listing, not its length: a regression that
+			// removed one path and added another would balance out.
+			if after := treeSnapshot(t, dir); !slices.Equal(after, before) {
+				t.Fatalf("id %q changed the tasks tree:\nbefore=%v\nafter=%v", tt.id, before, after)
 			}
 		})
 	}

--- a/internal/sybra/clusterlead/mirror_task_id_test.go
+++ b/internal/sybra/clusterlead/mirror_task_id_test.go
@@ -1,0 +1,94 @@
+package clusterlead
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// A follower's task id reaches writeSidecars — which builds eight paths from
+// it — before Put's own ValidateID runs, and followers are peers reachable
+// over HTTP. Rejecting on ingest is what makes a hostile id write nothing.
+func TestApplyFollowerTaskRejectsUnsafeIDsWithoutWriting(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{name: "parent traversal", id: "../escape"},
+		{name: "nested traversal", id: "../../etc/passwd"},
+		{name: "forward separator", id: "a/b"},
+		{name: "backslash separator", id: `a\b`},
+		{name: "absolute path", id: "/etc/passwd"},
+		{name: "empty", id: ""},
+		{name: "dot", id: "."},
+		{name: "dot dot", id: ".."},
+		{name: "leading dash", id: "-rf"},
+		{name: "over the length cap", id: strings.Repeat("a", 65)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := leaderConfig("http://unused", []string{"owner/pet"})
+			roster, _ := NewRoster(cfg, nil)
+			mgr := newManager(t)
+			dir := mgr.Store().Dir()
+			mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+			before := treeSnapshot(t, dir)
+
+			if mirror.applyFollowerTask("pet-box", task.Task{
+				ID: tt.id, Title: "hostile", Status: task.StatusTodo,
+				ProjectID: "owner/pet", UpdatedAt: t0,
+				Plan: "plan body", CodeReview: "review body",
+			}) {
+				t.Fatalf("applyFollowerTask accepted id %q", tt.id)
+			}
+
+			after := treeSnapshot(t, dir)
+			if len(after) != len(before) {
+				t.Fatalf("id %q wrote %d new paths under the tasks dir:\nbefore=%v\nafter=%v",
+					tt.id, len(after)-len(before), before, after)
+			}
+		})
+	}
+}
+
+// A well-formed id still applies, so the guard is a filter and not a wall.
+func TestApplyFollowerTaskStillAdoptsValidIDs(t *testing.T) {
+	cfg := leaderConfig("http://unused", []string{"owner/pet"})
+	roster, _ := NewRoster(cfg, nil)
+	mgr := newManager(t)
+	mirror := NewMirror(cfg, mgr, roster, nil, time.Second)
+
+	if !mirror.applyFollowerTask("pet-box", task.Task{
+		ID: "task-abc123", Title: "legit", Status: task.StatusTodo,
+		ProjectID: "owner/pet", UpdatedAt: time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC),
+	}) {
+		t.Fatal("a valid follower task must still adopt")
+	}
+	if _, err := mgr.Get("task-abc123"); err != nil {
+		t.Fatalf("adopted task not readable: %v", err)
+	}
+}
+
+// treeSnapshot lists every path under the tasks dir and its parent, so a write
+// that escapes upward is visible rather than silently outside the walk.
+func treeSnapshot(t *testing.T, dir string) []string {
+	t.Helper()
+	var out []string
+	root := filepath.Dir(dir)
+	if err := filepath.WalkDir(root, func(p string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		out = append(out, p)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/internal/task/planning_sidecar.go
+++ b/internal/task/planning_sidecar.go
@@ -21,13 +21,24 @@ func NewPlanningSidecarStore(dir, suffix, label string) *PlanningSidecarStore {
 	return &PlanningSidecarStore{dir: dir, suffix: suffix, label: label}
 }
 
-func (s *PlanningSidecarStore) sidecarPath(taskID string) string {
-	return filepath.Join(s.dir, taskID+s.suffix)
+// sidecarPath validates the id before joining. Nine sidecar stores used to
+// join an unchecked id, and ids arrive from outside this process — a cluster
+// peer pushes one over HTTP — so the check belongs here, at the one place
+// every sidecar path is now built, rather than in each caller.
+func (s *PlanningSidecarStore) sidecarPath(taskID string) (string, error) {
+	if err := ValidateID(taskID); err != nil {
+		return "", fmt.Errorf("%s: %w", s.label, err)
+	}
+	return filepath.Join(s.dir, taskID+s.suffix), nil
 }
 
 // Read returns the sidecar content for a task. Returns ("", nil) when missing.
 func (s *PlanningSidecarStore) Read(taskID string) (string, error) {
-	data, err := os.ReadFile(s.sidecarPath(taskID))
+	path, err := s.sidecarPath(taskID)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return "", nil
 	}
@@ -42,7 +53,11 @@ func (s *PlanningSidecarStore) Write(taskID, content string) error {
 	if content == "" {
 		return s.Delete(taskID)
 	}
-	if err := fsutil.AtomicWrite(s.sidecarPath(taskID), []byte(content)); err != nil {
+	path, err := s.sidecarPath(taskID)
+	if err != nil {
+		return err
+	}
+	if err := fsutil.AtomicWrite(path, []byte(content)); err != nil {
 		return fmt.Errorf("write %s: %w", s.label, err)
 	}
 	return nil
@@ -50,7 +65,11 @@ func (s *PlanningSidecarStore) Write(taskID, content string) error {
 
 // Delete removes the sidecar. Missing files are ignored.
 func (s *PlanningSidecarStore) Delete(taskID string) error {
-	if err := os.Remove(s.sidecarPath(taskID)); err != nil && !os.IsNotExist(err) {
+	path, err := s.sidecarPath(taskID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete %s: %w", s.label, err)
 	}
 	return nil


### PR DESCRIPTION
## Motivation

Path containment and key sanitization were reimplemented about eleven times, each slightly different. The gap that left is concrete rather than stylistic: none of the sidecar stores validated a task id before joining it into a path. #3082.

`task.ValidateID` already existed, and its doc comment names the exact threat — an externally-supplied id, "notably a leader-pushed task in cluster mode" — but it ran only at `Store.Put`. `adoptFollowerTask` calls `writeSidecars` *first*, and that builds eight paths from an id a peer supplied over HTTP.

> Changelog: refactor(fsutil): unify path containment checks

## Implementation information

Two layers close it. The shared sidecar store validates before every join, so all nine sidecars are covered at the one place they now have in common (the consolidation from #3077 is what made a single place exist). The mirror also rejects on ingest, so a hostile id fails fast and is logged rather than surfacing as a confusing sidecar write error.

Consolidates the helpers into `fsutil.ValidateKey` / `SafeJoin` / `Within` and deletes the per-package copies, including the verbatim duplicate of `isOpaqueWorkProjectKey` shared by `experience` and `intervention`.

`SafeJoin` resolves through `os.Root` rather than comparing strings. A component can be a symlink whose target is outside the root, which neither a prefix test nor `filepath.Rel` can see — and every containment check in this repo was one or the other. Worth knowing for future callers: `os.Root` refuses *any* absolute symlink target, even one pointing back inside, which is stricter than containment strictly requires but errs the safe way.

`ValidateKey` rejects rather than sanitizes. Silently rewriting a hostile key hides the attempt and can still collide with a legitimate file.

## Supporting documentation

The vulnerability is real, not theoretical. Removing both new guards and replaying this branch's own test shows ids of `..`, `.` and `a\b` each writing two files under the tasks dir; with either guard in place, nothing is written. That is the mutation check behind `TestApplyFollowerTaskRejectsUnsafeIDsWithoutWriting`, which snapshots the tasks dir *and its parent* so an upward escape is visible rather than silently outside the walk.

The containment table covers `..`, absolute paths, both separators, NUL, trailing separators, and unicode lookalikes (a fullwidth solidus is not a separator, so it stays a legal component — the point is that `filepath` cannot mistake it for one), plus a real symlink pointing out of the root.

Closes #3082