### PR TITLE
refactor(workflow): group the PR surface

### DIFF
--- a/internal/attachment/store.go
+++ b/internal/attachment/store.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/google/uuid"
-
-	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 const metaFileName = "meta.json"

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1272,17 +1272,8 @@ func (a *App) initWorkflowEngine() {
 		agentLauncher,
 		a.logger,
 	)
-	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
-	a.workflowEngine.SetPRStateFetcher(prStateFetcherAdapter{})
-	a.workflowEngine.SetPRHeadFetcher(prHeadFetcherAdapter{})
-	a.workflowEngine.SetPRCreator(prCreatorAdapter{})
-	a.workflowEngine.SetPRCloser(prCloserAdapter{})
-	a.workflowEngine.SetPRFinder(prFinderAdapter{})
-	a.workflowEngine.SetPRAnyStateFinder(prFinderAdapter{})
-	a.workflowEngine.SetPRExistenceChecker(prExistenceCheckerAdapter{})
-	a.workflowEngine.SetPRContentGenerator(prContentGeneratorAdapter{gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}})
+	a.wirePRSurface()
 	a.workflowEngine.SetTaskClassifier(a.newTaskClassifierAdapter())
-	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.wireWorktreeAccess()
 	a.workflowEngine.SetAttemptNoteAppender(&attemptNoteAppenderAdapter{})
 	a.workflowEngine.SetBranchSyncer(&branchSyncerAdapter{tasks: a.tasks, mgr: a.worktrees})
@@ -1662,4 +1653,27 @@ func (a *App) wireSidecarDir() {
 		return
 	}
 	a.workflowEngine.SetSidecarDirResolver(a.sandboxes.SybraHomeDir)
+}
+
+// wirePRSurface wires the engine's pull-request dependency group. Split out of
+// initWorkflowEngine both to keep that function within the length gate and
+// because the group is the unit that must stay complete.
+func (a *App) wirePRSurface() {
+	if err := a.workflowEngine.SetPRSurface(workflow.PRSurface{
+		Linker:           prLinkerAdapter{},
+		ReviewRequester:  prReviewRequesterAdapter{},
+		StateFetcher:     prStateFetcherAdapter{},
+		HeadFetcher:      prHeadFetcherAdapter{},
+		Creator:          prCreatorAdapter{},
+		Closer:           prCloserAdapter{},
+		Finder:           prFinderAdapter{},
+		AnyStateFinder:   prFinderAdapter{},
+		ExistenceChecker: prExistenceCheckerAdapter{},
+		ContentGenerator: prContentGeneratorAdapter{gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}},
+	}); err != nil {
+		// Only reachable by forgetting a field here — a programming error, so
+		// fail at boot rather than let a PR step no-op in production. Same
+		// posture as buildPlanSchema's static-marshal panic.
+		panic("wire workflow PR surface: " + err.Error())
+	}
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -680,20 +680,91 @@ func (e *Engine) SetAdmissionDecisionHook(hook func(TaskInfo, AdmissionDecision)
 // Defs returns the workflow definition store.
 func (e *Engine) Defs() *Store { return e.store }
 
+// PRSurface is the pull-request dependency group: every collaborator the
+// engine needs to open, find, link, close and re-review a PR.
+//
+// It exists because the engine is constructed empty and assembled through 46
+// Set* calls, so a dependency the wiring forgot is not a compile error or a
+// startup failure — it is a nil field that turns a step into a silently
+// skipped branch, weeks later and far from the omission. Grouping the surface
+// lets SetPRSurface reject a partial wiring at startup, where it is
+// attributable.
+//
+// The individual setters below survive as test seams: tests legitimately wire
+// one collaborator and leave the rest nil, so the per-field nil guards must
+// stay until a group has no seam left.
+type PRSurface struct {
+	Linker           PRLinker
+	ReviewRequester  PRReviewRequester
+	StateFetcher     PRStateFetcher
+	HeadFetcher      PRHeadFetcher
+	Creator          PRCreator
+	Closer           PRCloser
+	Finder           PRFinder
+	AnyStateFinder   PRAnyStateFinder
+	ExistenceChecker PRExistenceChecker
+	ContentGenerator PRContentGenerator
+}
+
+// SetPRSurface wires the whole PR dependency group and reports every missing
+// member at once, so a wiring omission surfaces at startup rather than as a
+// step that quietly does nothing. Production must use this; the per-field
+// setters are for tests.
+func (e *Engine) SetPRSurface(s PRSurface) error {
+	var missing []string
+	for _, dep := range []struct {
+		name  string
+		isNil bool
+	}{
+		{"Linker", s.Linker == nil},
+		{"ReviewRequester", s.ReviewRequester == nil},
+		{"StateFetcher", s.StateFetcher == nil},
+		{"HeadFetcher", s.HeadFetcher == nil},
+		{"Creator", s.Creator == nil},
+		{"Closer", s.Closer == nil},
+		{"Finder", s.Finder == nil},
+		{"AnyStateFinder", s.AnyStateFinder == nil},
+		{"ExistenceChecker", s.ExistenceChecker == nil},
+		{"ContentGenerator", s.ContentGenerator == nil},
+	} {
+		if dep.isNil {
+			missing = append(missing, dep.name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("workflow: PR surface missing %s", strings.Join(missing, ", "))
+	}
+	e.prLinker = s.Linker
+	e.prReviewers = s.ReviewRequester
+	e.prStates = s.StateFetcher
+	e.prHeads = s.HeadFetcher
+	e.prCreator = s.Creator
+	e.prCloser = s.Closer
+	e.prFinder = s.Finder
+	e.prAnyStateFinder = s.AnyStateFinder
+	e.prExistence = s.ExistenceChecker
+	e.prContentGen = s.ContentGenerator
+	return nil
+}
+
 // SetPRLinker wires an implementation of PRLinker used by the
 // `ensure_pr_closes_issue` step. Leaving it unset makes the step a no-op.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRLinker(l PRLinker) { e.prLinker = l }
 
 // SetPRReviewRequester wires an implementation used by rerequest_review.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRReviewRequester(r PRReviewRequester) { e.prReviewers = r }
 
 // SetPRStateFetcher wires an implementation used by `route_pr_fix_result` to
 // re-probe the live PR before parking human-required. Leaving it unset skips
 // the re-probe and trusts the agent's sentinel as-is.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRStateFetcher(f PRStateFetcher) { e.prStates = f }
 
 // SetPRHeadFetcher wires an implementation used by `push_branch` to verify a
 // push landed. Leaving it unset skips the verification.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRHeadFetcher(f PRHeadFetcher) { e.prHeads = f }
 
 // SetPushCredentialPreflighter wires the push-auth preflight used before
@@ -706,28 +777,34 @@ func (e *Engine) SetPushCredentialPreflighter(p PushCredentialPreflighter) {
 // SetPRCreator wires an implementation of `gh pr create` used by the
 // `create_pr` step. Leaving it unset flips the task to human-required when
 // create_pr is reached, since a PR cannot be opened without it.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRCreator(c PRCreator) { e.prCreator = c }
 
 // SetPRCloser wires best-effort cleanup for superseded PRs after a task is
 // relinked to a replacement PR.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRCloser(c PRCloser) { e.prCloser = c }
 
 // SetPRFinder wires the open-PR-by-branch lookup used by create_pr's
 // idempotency guard. Leaving it unset skips the guard.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRFinder(f PRFinder) { e.prFinder = f }
 
 // SetPRAnyStateFinder wires the all-state branch lookup used by create_pr's
 // squash-merge duplicate guard. Leaving it unset skips the guard.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRAnyStateFinder(f PRAnyStateFinder) { e.prAnyStateFinder = f }
 
 // SetPRExistenceChecker wires the pr_number-belongs-to-repo verification used
 // by link_pr_and_review's Path 1. Leaving it unset skips the check and
 // trusts task.pr_number outright, matching the engine's pre-existing
 // behavior.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRExistenceChecker(c PRExistenceChecker) { e.prExistence = c }
 
 // SetPRContentGenerator wires the LLM-backed title/body drafter used by the
 // `create_pr` step. Leaving it unset falls back to a templated title/body.
+// Test seam: production wires this through SetPRSurface.
 func (e *Engine) SetPRContentGenerator(g PRContentGenerator) { e.prContentGen = g }
 
 // SetWorktreeGetter wires a WorktreeGetter used by steps that need the task's

--- a/internal/workflow/pr_surface_test.go
+++ b/internal/workflow/pr_surface_test.go
@@ -1,0 +1,121 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/github"
+)
+
+// The point of the group is that a forgotten member is caught at wiring time.
+// Before it, an omission left a nil field that turned the corresponding step
+// into a silently skipped branch, discovered far from the omission.
+func TestSetPRSurfaceNamesEveryMissingMember(t *testing.T) {
+	t.Parallel()
+	e := &Engine{}
+
+	err := e.SetPRSurface(PRSurface{})
+	if err == nil {
+		t.Fatal("SetPRSurface accepted an entirely empty surface")
+	}
+	for _, want := range []string{
+		"Linker", "ReviewRequester", "StateFetcher", "HeadFetcher", "Creator",
+		"Closer", "Finder", "AnyStateFinder", "ExistenceChecker", "ContentGenerator",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name the missing %s", err, want)
+		}
+	}
+}
+
+// A partial surface is the realistic bug — one member forgotten among ten —
+// so it must be rejected just as firmly as an empty one.
+func TestSetPRSurfaceRejectsAPartialWiring(t *testing.T) {
+	t.Parallel()
+	full := completePRSurface()
+	partial := full
+	partial.Finder = nil
+
+	err := (&Engine{}).SetPRSurface(partial)
+	if err == nil {
+		t.Fatal("SetPRSurface accepted a surface missing Finder")
+	}
+	if !strings.Contains(err.Error(), "Finder") {
+		t.Errorf("error %q does not name Finder", err)
+	}
+	if strings.Contains(err.Error(), "Linker") {
+		t.Errorf("error %q names Linker, which was supplied", err)
+	}
+}
+
+func TestSetPRSurfaceWiresEveryField(t *testing.T) {
+	t.Parallel()
+	e := &Engine{}
+	if err := e.SetPRSurface(completePRSurface()); err != nil {
+		t.Fatalf("SetPRSurface(complete) = %v", err)
+	}
+	for name, got := range map[string]any{
+		"prLinker":         e.prLinker,
+		"prReviewers":      e.prReviewers,
+		"prStates":         e.prStates,
+		"prHeads":          e.prHeads,
+		"prCreator":        e.prCreator,
+		"prCloser":         e.prCloser,
+		"prFinder":         e.prFinder,
+		"prAnyStateFinder": e.prAnyStateFinder,
+		"prExistence":      e.prExistence,
+		"prContentGen":     e.prContentGen,
+	} {
+		if got == nil {
+			t.Errorf("%s is still nil after a complete SetPRSurface", name)
+		}
+	}
+}
+
+// stubPRSurface satisfies every PR interface with a do-nothing implementation.
+// The group test cares only that a member is present, not what it returns.
+type stubPRSurface struct{}
+
+func (stubPRSurface) GetClosingIssues(string, int) (issues []int, body string, err error) {
+	return nil, "", nil
+}
+func (stubPRSurface) EditBody(string, int, string) error                          { return nil }
+func (stubPRSurface) RerequestReview(string, int) (reviewers []string, err error) { return nil, nil }
+func (stubPRSurface) RequestCopilotReview(context.Context, string, int) error {
+	return nil
+}
+func (stubPRSurface) FetchPRState(string, int) (github.PRState, error) { return github.PRState{}, nil }
+func (stubPRSurface) FetchPRHeadSHA(context.Context, string, int) (string, error) {
+	return "", nil
+}
+func (stubPRSurface) CreatePR(context.Context, string, PRCreateRequest) (number int, headSHA string, err error) {
+	return 0, "", nil
+}
+func (stubPRSurface) ClosePR(context.Context, string, int, string) error { return nil }
+func (stubPRSurface) FindPRForBranch(context.Context, string, string) (number int, found bool, err error) {
+	return 0, false, nil
+}
+func (stubPRSurface) FindPRForBranchAnyState(context.Context, string, string) (number int, state string, found bool, err error) {
+	return 0, "", false, nil
+}
+func (stubPRSurface) PRExists(context.Context, string, int) (bool, error) { return false, nil }
+func (stubPRSurface) GeneratePRContent(context.Context, string, string, []string) (title, body string, err error) {
+	return "", "", nil
+}
+
+func completePRSurface() PRSurface {
+	s := stubPRSurface{}
+	return PRSurface{
+		Linker:           s,
+		ReviewRequester:  s,
+		StateFetcher:     s,
+		HeadFetcher:      s,
+		Creator:          s,
+		Closer:           s,
+		Finder:           s,
+		AnyStateFinder:   s,
+		ExistenceChecker: s,
+		ContentGenerator: s,
+	}
+}


### PR DESCRIPTION
## Motivation

`workflow.Engine` is constructed empty and assembled through 46 `Set*` calls, 41 of them from `app_init.go`. At three to five dependencies that pattern is right; at 46 it has inverted into the cost it was meant to avoid. A dependency the wiring forgets is not a compile error or a startup failure — it is a nil field that turns a step into a silently skipped branch, discovered weeks later and far from the omission. #3085.

> Changelog: refactor(workflow): group the PR surface

## Implementation information

The issue is explicit that this lands incrementally and that each group can be its own PR. This is group one, and the one with the clearest boundary: the ten collaborators needed to open, find, link, close and re-review a PR.

`app_init` wired them one call at a time. It now passes a `PRSurface`, and `SetPRSurface` reports *every* missing member at once rather than the first — a wiring omission is usually one field among ten, and naming only the first would send the next person round the loop again. Production PR wiring drops from ten calls to one.

Incomplete wiring **panics at boot**. That is only reachable by forgetting a field in this one literal, so it is a programming error rather than a runtime condition, and it matches the posture `buildPlanSchema` already takes for its static-marshal. The alternative — logging and continuing — is the silent-skip failure this issue exists to remove.

## Supporting documentation

**What this does not do, and why.** The acceptance asks for required dependencies as constructor arguments and for nil guards to be deleted. Neither is reachable for this group yet, and the reason is worth recording rather than glossing:

- All ten per-field setters are used by tests — 77 call sites that wire one collaborator and leave the rest nil. That is legitimate: a test exercising `create_pr` has no business supplying a review requester. So the setters survive, each now carrying a `Test seam: production wires this through SetPRSurface` note, which is exactly the escape hatch the issue's step 3 allows.
- Because the seams can still leave a field nil, the per-field nil guards are still reachable and must stay. Guard deletion becomes safe once a group has no seam left, which is why the issue sequences it after grouping rather than alongside.

`NewEngine`'s signature is untouched: it has 482 call sites, all but one in tests, and widening it would have been churn without a guarantee, since those tests genuinely do not need a PR surface.

The three new tests cover the empty surface, the realistic partial one, and that a complete surface actually populates every field.

Closes #3085