### PR TITLE
fix(attachment): drop duplicate fsutil import

### DIFF
--- a/internal/attachment/store.go
+++ b/internal/attachment/store.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/google/uuid"
-
-	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 const metaFileName = "meta.json"


### PR DESCRIPTION
## Motivation

`main` does not build:

```
internal/attachment/store.go:18:2: fsutil redeclared in this block
	internal/attachment/store.go:15:2: other declaration of fsutil
```

Two PRs each added the `fsutil` import to this block for different reasons — #3117 for `AtomicWriteMode`, #3122 for `ValidateKey`/`SafeJoin` — and each was green against its own merge base. Squash-merging them in sequence left both lines, and Go rejects the redeclaration.

> Changelog: fix(attachment): drop duplicate fsutil import

## Implementation information

Removes the duplicate line. `go build ./internal/... ./cmd/...`, `go vet`, `golangci-lint` and the affected package tests are clean; `go vet` over the whole tree finds no other duplicate-import collision from the same batch.

## Supporting documentation

Worth noting for the next batch of parallel PRs: neither PR's merge check re-ran after the other landed, so nothing caught this between the two merges. GitHub evaluates the merge commit at check time, not at merge time, and both checks predated the other's merge. A required "branch up to date before merge" setting would close the window.

The breakage was invisible on both branches in isolation — it only exists in the combination.