### PR TITLE
fix(worktree): serialize mutations per path

### DIFF
--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -1070,13 +1070,13 @@ func (o *Orchestrator) revertToTodoAfterGateBlock(taskID, logSuffix string) {
 }
 
 func (o *Orchestrator) resetWorktreeForCleanRetry(ctx context.Context, t task.Task, ref string) error {
-	reset, err := o.worktrees.ResetForRetry(ctx, t, "", ref)
+	target, reset, err := o.worktrees.ResetForRetry(ctx, t, "", ref)
 	if err != nil {
-		o.logger.Warn("worktree.clean-retry.reset", "task_id", t.ID, "ref", ref, "err", err)
+		o.logger.Warn("worktree.clean-retry.reset", "task_id", t.ID, "path", target, "ref", ref, "err", err)
 		return err
 	}
 	if reset {
-		o.logger.Info("worktree.clean-retry.reset", "task_id", t.ID, "ref", ref)
+		o.logger.Info("worktree.clean-retry.reset", "task_id", t.ID, "path", target, "ref", ref)
 	}
 	return nil
 }

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -1070,21 +1070,14 @@ func (o *Orchestrator) revertToTodoAfterGateBlock(taskID, logSuffix string) {
 }
 
 func (o *Orchestrator) resetWorktreeForCleanRetry(ctx context.Context, t task.Task, ref string) error {
-	resetDir := t.WorktreeDir
-	if resetDir == "" {
-		resetDir = o.worktrees.PathFor(t)
-	}
-	if _, statErr := os.Stat(resetDir); statErr != nil {
-		if os.IsNotExist(statErr) {
-			return nil
-		}
-		return fmt.Errorf("stat clean retry worktree: %w", statErr)
-	}
-	if err := project.ResetWorktreeForRetry(ctx, resetDir, ref); err != nil {
-		o.logger.Warn("worktree.clean-retry.reset", "task_id", t.ID, "path", resetDir, "ref", ref, "err", err)
+	reset, err := o.worktrees.ResetForRetry(ctx, t, "", ref)
+	if err != nil {
+		o.logger.Warn("worktree.clean-retry.reset", "task_id", t.ID, "ref", ref, "err", err)
 		return err
 	}
-	o.logger.Info("worktree.clean-retry.reset", "task_id", t.ID, "path", resetDir, "ref", ref)
+	if reset {
+		o.logger.Info("worktree.clean-retry.reset", "task_id", t.ID, "ref", ref)
+	}
 	return nil
 }
 

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -353,7 +353,9 @@ func (h *humanReviewHandler) dispatchDir(t task.Task) (dir string, readOnly, ret
 // read-only fallback is for a task that genuinely has no worktree, where
 // diagnosing Sybra itself is the whole job.
 func isRetryablePrepareError(err error) bool {
-	return errors.Is(err, worktree.ErrAgentRunning) || errors.Is(err, worktree.ErrTransientFetch)
+	return errors.Is(err, worktree.ErrAgentRunning) ||
+		errors.Is(err, worktree.ErrPreparationInFlight) ||
+		errors.Is(err, worktree.ErrTransientFetch)
 }
 
 // maybeSpawn is called from the status hook when a task lands in

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -197,6 +197,29 @@ func TestHumanReviewDispatchDir_PrepareFailureFallsBackReadOnly(t *testing.T) {
 	}
 }
 
+// TestHumanReviewDispatchDir_BusyPathRetriesInsteadOfReadOnly pins that a
+// preparation refused because another one owns the path is retried, not
+// answered with the read-only Sybra checkout. The claim-retry ladder is capped
+// under StaleDispatchClaimAge precisely so this handler meets a live
+// preparation; treating that refusal as permanent lands the recovery agent on
+// a tree it cannot write, which is the recoverable_action:none regression.
+func TestHumanReviewDispatchDir_BusyPathRetriesInsteadOfReadOnly(t *testing.T) {
+	h, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	h.prepareTaskWorktree = func(task.Task) (string, error) {
+		return "", fmt.Errorf("prepare worktree: %w", worktree.ErrPreparationInFlight)
+	}
+
+	dir, readOnly, retryable, _ := h.dispatchDir(task.Task{ID: "busy-task"})
+	if !retryable {
+		t.Error("retryable = false, want true")
+	}
+	if readOnly || dir == h.cfg.HumanReview.SybraRepoDir {
+		t.Errorf("fell back to the read-only Sybra checkout: dir=%q readOnly=%v", dir, readOnly)
+	}
+}
+
 func TestHumanReviewSpawn_HoldsDispatchClaimAcrossPreparationAndRun(t *testing.T) {
 	h, tasks, cleanup := newReviewTestEnv(t)
 	defer cleanup()

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -1315,32 +1315,18 @@ func (a *agentAdapter) classifyDirectDispatchWorktreeErr(taskID string, wtErr er
 }
 
 func (a *agentAdapter) resetWorktreeForRetry(t task.Task, dir, ref string) (bool, error) {
-	target := dir
-	if target == "" {
-		if t.WorktreeDir != "" {
-			target = t.WorktreeDir
-		} else {
-			target = a.agentOrch.Worktrees().PathFor(t)
-		}
-	}
-	if target == "" {
-		return false, nil
-	}
-	if _, err := os.Stat(target); err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("stat clean retry worktree: %w", err)
-	}
 	// context.Background(): StartAgent implements workflow.AgentDispatcher,
 	// a fixed interface signature with no ctx parameter (see the earlier
 	// comment on the PrepareForTask call in this file).
-	if err := project.ResetWorktreeForRetry(context.Background(), target, ref); err != nil {
-		a.agentOrch.Logger().Warn("worktree.clean-retry.reset", "task_id", t.ID, "path", target, "ref", ref, "err", err)
+	reset, err := a.agentOrch.Worktrees().ResetForRetry(context.Background(), t, dir, ref)
+	if err != nil {
+		a.agentOrch.Logger().Warn("worktree.clean-retry.reset", "task_id", t.ID, "path", dir, "ref", ref, "err", err)
 		return false, err
 	}
-	a.agentOrch.Logger().Info("worktree.clean-retry.reset", "task_id", t.ID, "path", target, "ref", ref)
-	return true, nil
+	if reset {
+		a.agentOrch.Logger().Info("worktree.clean-retry.reset", "task_id", t.ID, "ref", ref)
+	}
+	return reset, nil
 }
 
 func (a *agentAdapter) recordSystemAgentStart(taskID, role, mode string, cfg agent.RunConfig, ag *agent.Agent) error {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -1318,13 +1318,13 @@ func (a *agentAdapter) resetWorktreeForRetry(t task.Task, dir, ref string) (bool
 	// context.Background(): StartAgent implements workflow.AgentDispatcher,
 	// a fixed interface signature with no ctx parameter (see the earlier
 	// comment on the PrepareForTask call in this file).
-	reset, err := a.agentOrch.Worktrees().ResetForRetry(context.Background(), t, dir, ref)
+	target, reset, err := a.agentOrch.Worktrees().ResetForRetry(context.Background(), t, dir, ref)
 	if err != nil {
-		a.agentOrch.Logger().Warn("worktree.clean-retry.reset", "task_id", t.ID, "path", dir, "ref", ref, "err", err)
+		a.agentOrch.Logger().Warn("worktree.clean-retry.reset", "task_id", t.ID, "path", target, "ref", ref, "err", err)
 		return false, err
 	}
 	if reset {
-		a.agentOrch.Logger().Info("worktree.clean-retry.reset", "task_id", t.ID, "ref", ref)
+		a.agentOrch.Logger().Info("worktree.clean-retry.reset", "task_id", t.ID, "path", target, "ref", ref)
 	}
 	return reset, nil
 }

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -1157,7 +1157,7 @@ func (a *agentAdapter) reprepareProvidedWorktreeDir(t task.Task, taskID string, 
 	if err != nil {
 		return t, "", false, err
 	}
-	if rErr := project.RemoveWorktreeReconcile(context.Background(), proj.ClonePath, dir); rErr != nil {
+	if rErr := a.agentOrch.Worktrees().PruneMissingWorktree(context.Background(), proj.ClonePath, dir); rErr != nil {
 		return t, "", false, fmt.Errorf("reconcile missing worktree dir %s: %w", dir, rErr)
 	}
 	resolvedDir, cleanRetryReset, err = a.reprepareMissingWorktreeDir(t, taskID, role, dir, claim)

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1819,7 +1819,20 @@ func (r *Handler) parkOrEscalateBranchConflictDispatchFailure(taskID string, dis
 	return false
 }
 
+// worktreeBusyTransient reports whether a worktree entry point refused only
+// because something else currently owns the path — a live agent, or another
+// mutating operation mid-flight. Both clear on their own within one poll
+// interval, so neither may count toward the worktree-failure circuit breaker
+// (wtFailureLimit refusals escalate the task to human-required).
+func worktreeBusyTransient(err error) bool {
+	return errors.Is(err, worktree.ErrAgentRunning) || errors.Is(err, worktree.ErrPreparationInFlight)
+}
+
 func (r *Handler) parkOrEscalateBranchFixFailure(taskID string, wtErr error) bool {
+	if worktreeBusyTransient(wtErr) {
+		r.logger.Info("pr-monitor.branch-conflict.busy", "task_id", taskID, "err", wtErr)
+		return true
+	}
 	if r.dropTerminalWorktreeFailure(taskID, wtErr) {
 		return false
 	}
@@ -2072,8 +2085,8 @@ func (r *Handler) prepareWorktree(ctx context.Context, t task.Task, issue github
 		d, wtErr = r.worktrees.PrepareForTask(ctx, t, nil)
 	}
 	if wtErr != nil {
-		if errors.Is(wtErr, worktree.ErrAgentRunning) {
-			r.logger.Warn("pr-monitor.worktree.agent-running", "task_id", t.ID, "err", wtErr)
+		if worktreeBusyTransient(wtErr) {
+			r.logger.Warn("pr-monitor.worktree.busy", "task_id", t.ID, "err", wtErr)
 			return "", false
 		}
 		if errors.Is(wtErr, project.ErrBranchDiverged) {

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
 )
 
 func (r *Handler) createReviewTask(pr github.PullRequest, projectID string) {
@@ -200,9 +202,17 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 		// context.Background(): same dead end as StartFixReviewAgent above —
 		// reached from a Wails-bound service method with no ctx.
 		d, err := r.worktrees.PrepareForReview(context.Background(), current)
-		if err != nil {
+		switch {
+		case errors.Is(err, worktree.ErrPreparationInFlight):
+			// Never fall back to the operator's real Sybra home for a
+			// condition that clears on its own — the next tick prepares the
+			// task's own worktree instead of pointing a review agent at the
+			// live board (#1576).
+			r.logger.Info("review.worktree.busy", "task_id", current.ID, "err", err)
+			return nil
+		case err != nil:
 			r.logger.Error("review.worktree", "task_id", current.ID, "err", err)
-		} else {
+		default:
 			dir = d
 		}
 	}

--- a/internal/sybra/review/worktree_busy_test.go
+++ b/internal/sybra/review/worktree_busy_test.go
@@ -1,0 +1,58 @@
+package review
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+// TestParkOrEscalateBranchFixFailure_BusyPathDoesNotCountAsFailure pins that a
+// worktree refused only because another mutating operation owns the path never
+// reaches the worktree-failure circuit breaker. Without this, wtFailureLimit
+// polls against a task whose own preparation is still running escalate it to
+// human-required for a condition that clears by itself.
+func TestParkOrEscalateBranchFixFailure_BusyPathDoesNotCountAsFailure(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		wtErr error
+	}{
+		{"preparation in flight", fmt.Errorf("prepare: %w", worktree.ErrPreparationInFlight)},
+		{"agent running", fmt.Errorf("prepare: %w", worktree.ErrAgentRunning)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks, _, _ := newRebaseRecoveryDeps(t)
+			r := &Handler{
+				logger:     slog.New(slog.DiscardHandler),
+				tasks:      tasks,
+				wtFailures: make(map[string]int),
+			}
+			tk, err := tasks.Create("busy wt", "", task.AgentModeHeadless)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); err != nil {
+				t.Fatal(err)
+			}
+
+			for i := range wtFailureLimit + 2 {
+				if parked := r.parkOrEscalateBranchFixFailure(tk.ID, tt.wtErr); !parked {
+					t.Fatalf("attempt %d: parked = false, want true", i)
+				}
+			}
+
+			if n := r.wtFailures[tk.ID]; n != 0 {
+				t.Errorf("recorded worktree failures = %d, want 0", n)
+			}
+			got, err := tasks.Get(tk.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status == task.StatusHumanRequired {
+				t.Errorf("task escalated to human-required on a self-clearing refusal (reason %q)", got.StatusReason)
+			}
+		})
+	}
+}

--- a/internal/workflow/engine_bestofn_test.go
+++ b/internal/workflow/engine_bestofn_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/taskstatus"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 // --- fakes for CostBudgetChecker / AttemptWorktreeManager ---
@@ -628,6 +631,31 @@ func TestBestOfN_PromotionRefused_FailsClosedWithDistinctReason(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertHumanRequiredReason(t, tasks, reason)
+}
+
+// TestBestOfN_PromotionBusyPathDefersInsteadOfEscalating separates the two
+// kinds of promotion failure. The fail-closed reasons above are judgements a
+// human must make; a canonical path another mutating operation currently owns
+// is not one, and parking a human on it hands them a condition that is gone
+// before they read it.
+func TestBestOfN_PromotionBusyPathDefersInsteadOfEscalating(t *testing.T) {
+	engine, tasks, agents, attemptWt, _ := newBestOfNTestEngine(t, 2)
+	attemptWt.promoteErr = fmt.Errorf("promote: %w", worktreeerr.ErrPreparationInFlight)
+	setupTwoSuccessfulAttempts(t, engine, tasks)
+
+	judgeAgentID := agents.LastID()
+	out := `{"winner_attempt_id": "attempt_1", "rationale": "x"}`
+	if err := engine.AdvanceStep("t1", StepOutput{StepID: "judge", Status: "completed", AgentID: judgeAgentID, Output: out}); !errors.Is(err, worktreeerr.ErrPreparationInFlight) {
+		t.Fatalf("AdvanceStep err = %v, want ErrPreparationInFlight surfaced to the caller", err)
+	}
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Status == taskstatus.HumanRequired {
+		t.Errorf("task escalated to human-required on a self-clearing refusal (reason %q)", ti.StatusReason)
+	}
 }
 
 // --- resume-without-double-dispatch ---

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -614,6 +614,15 @@ func (e *Engine) execPromoteBestOfN(taskID string, step *Step) (StepOutput, erro
 
 	canonicalDir, promErr := e.attemptWorktrees.PromoteAttempt(taskID, winner.Dir, winner.Branch)
 	if promErr != nil {
+		// The fail-closed reasons above are all judgements a human must make.
+		// A canonical path another mutating operation currently owns is not
+		// one: it frees itself, and this step is resumable, so return the
+		// error and let the next tick re-enter rather than park a human on a
+		// condition that will be gone by the time they look.
+		if e.transientOrShutdownStartError(promErr) {
+			e.logger.Info("workflow.best-of-n.promote.deferred", "task_id", taskID, "step", step.ID, "err", promErr)
+			return StepOutput{}, promErr
+		}
 		return e.humanRequiredStepOutput(taskID, step, promErr.Error())
 	}
 	// Downstream steps (e.g. a shell step pushing the now-canonical branch)

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -114,6 +114,11 @@ func ClassifyAgentStartFailure(err error) AgentStartFailure {
 		// isDeferredNotFailed for why it still never feeds the breaker).
 		out.Reason = textutil.TruncateBytesTotal("work paused: machine under resource pressure — "+resourcePressureDetail(err), startReasonMaxLen, "...")
 		return out
+	case errors.Is(err, worktreeerr.ErrPreparationInFlight):
+		// Transient: another mutating worktree operation owns this path. It
+		// releases when it finishes and the next ResumeStalled tick redispatches
+		// — same treatment as ErrAgentRunning below, no reason, no escalation.
+		return out
 	case errors.Is(err, worktreeerr.ErrAgentRunning):
 		// Transient: PrepareForTask refused to rebase a worktree a tracked
 		// agent is still live in. The agent's own completion (or a later
@@ -234,6 +239,7 @@ func transientAgentStartError(err error) bool {
 		errors.Is(err, ErrResourcePressure) ||
 		errors.Is(err, worktreeerr.ErrTransientFetch) ||
 		errors.Is(err, worktreeerr.ErrAgentRunning) ||
+		errors.Is(err, worktreeerr.ErrPreparationInFlight) ||
 		errors.Is(err, provider.ErrProviderUnhealthy)
 }
 

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -192,6 +192,23 @@ func TestClassifyAgentStartError_AgentRunningSuppressed(t *testing.T) {
 	}
 }
 
+func TestClassifyAgentStartError_PreparationInFlightSuppressed(t *testing.T) {
+	// A worktree entry point refusing to run while another mutating operation
+	// owns the same path (sybra#3114) resolves the moment that one finishes.
+	// Escalating it would park a task on a condition no human can act on.
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrPreparationInFlight)
+	reason, permanent := ClassifyAgentStartError(wrapped)
+	if reason != "" {
+		t.Errorf("reason = %q, want empty", reason)
+	}
+	if permanent {
+		t.Error("preparation-in-flight must not be permanent")
+	}
+	if !transientAgentStartError(wrapped) {
+		t.Error("transientAgentStartError() = false, want true")
+	}
+}
+
 func TestSurfaceStartFailure_DispatchInFlightIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})

--- a/internal/worktree/attempt.go
+++ b/internal/worktree/attempt.go
@@ -61,6 +61,12 @@ func attemptBranchName(t task.Task, canonicalBranch, attemptID string) string {
 // recreated — a process restart mid-fan-out must not discard an attempt's
 // in-progress commits.
 func (m *Manager) PrepareAttempt(ctx context.Context, t task.Task, attemptID string) (dir, branch string, err error) {
+	release, err := m.lockPath(m.PathForAttempt(t, attemptID))
+	if err != nil {
+		return "", "", err
+	}
+	defer release()
+
 	proj, err := m.projects.Get(t.ProjectID)
 	if err != nil {
 		return "", "", fmt.Errorf("get project: %w", err)
@@ -134,6 +140,14 @@ func (m *Manager) PrepareAttempt(ctx context.Context, t task.Task, attemptID str
 //   - ErrPromotionDiverged: the canonical branch exists and is not an
 //     ancestor of the winner's HEAD (would discard non-attempt commits).
 func (m *Manager) PromoteAttempt(ctx context.Context, t task.Task, winnerDir, winnerBranch string) (canonicalDir string, err error) {
+	// Guards the canonical path this materializes, not the winner's attempt
+	// directory, which is only read here.
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	if t.PRNumber != 0 {
 		return "", fmt.Errorf("%w: PR #%d", ErrPromotionHasPR, t.PRNumber)
 	}

--- a/internal/worktree/attempt.go
+++ b/internal/worktree/attempt.go
@@ -243,24 +243,40 @@ func (m *Manager) CleanupAttempts(ctx context.Context, t task.Task, attemptIDs [
 		return
 	}
 	for _, attemptID := range attemptIDs {
-		wtPath := m.PathForAttempt(t, attemptID)
-		wtBranch := attemptBranchName(t, t.Branch, attemptID)
-		if _, statErr := os.Stat(wtPath); statErr == nil {
-			if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
-				m.logger.Warn("worktree.attempt.cleanup", "task_id", t.ID, "attempt", attemptID, "path", wtPath, "err", err)
-				continue
-			}
-			m.logger.Info("worktree.attempt.cleaned-up", "task_id", t.ID, "attempt", attemptID, "path", wtPath)
+		m.cleanupAttempt(ctx, t, proj, attemptID)
+	}
+}
+
+// cleanupAttempt removes one attempt's worktree and branch ref.
+func (m *Manager) cleanupAttempt(ctx context.Context, t task.Task, proj project.Project, attemptID string) {
+	wtPath := m.PathForAttempt(t, attemptID)
+	wtBranch := attemptBranchName(t, t.Branch, attemptID)
+
+	// PrepareAttempt locks this same key, and a failed attempt can be
+	// re-spawned into its own directory while loser cleanup runs. Removing the
+	// worktree under it is the hazard the lock exists for; cleanup is
+	// best-effort, so skip and let the next sweep take it.
+	release, lockErr := m.lockPath(wtPath)
+	if lockErr != nil {
+		m.logger.Info("worktree.attempt.cleanup.busy", "task_id", t.ID, "attempt", attemptID, "err", lockErr)
+		return
+	}
+	defer release()
+
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
+			m.logger.Warn("worktree.attempt.cleanup", "task_id", t.ID, "attempt", attemptID, "path", wtPath, "err", err)
+			return
 		}
-		// Delete the attempt's branch ref too: PrepareAttempt reuses an existing
-		// attempt branch verbatim, so a leftover ref would seed a later cycle's
-		// attempt from discarded (losing/already-judged) work instead of the
-		// intended base. The worktree above is removed first — a branch checked
-		// out in a live worktree cannot be deleted.
-		if project.BranchExists(ctx, proj.ClonePath, wtBranch) {
-			if err := project.DeleteBranch(ctx, proj.ClonePath, wtBranch); err != nil {
-				m.logger.Warn("worktree.attempt.cleanup.branch", "task_id", t.ID, "attempt", attemptID, "branch", wtBranch, "err", err)
-			}
+		m.logger.Info("worktree.attempt.cleaned-up", "task_id", t.ID, "attempt", attemptID, "path", wtPath)
+	}
+	// PrepareAttempt reuses an existing attempt branch verbatim, so a leftover
+	// ref would seed a later cycle from discarded (losing/already-judged) work
+	// instead of the intended base. Order matters: a branch checked out in a
+	// live worktree cannot be removed.
+	if project.BranchExists(ctx, proj.ClonePath, wtBranch) {
+		if err := project.DeleteBranch(ctx, proj.ClonePath, wtBranch); err != nil {
+			m.logger.Warn("worktree.attempt.cleanup.branch", "task_id", t.ID, "attempt", attemptID, "branch", wtBranch, "err", err)
 		}
 	}
 }

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -114,35 +114,22 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 		switch {
 		case !exists:
 			// Task deleted — remove worktree directory.
-		case t.Status != task.StatusDone:
+		case !task.IsTerminalStatus(t.Status):
 			continue
 		case m.hasAgent != nil && m.hasAgent(t.ID):
 			continue
 		}
 
-		if project.HasUnpushedCommits(ctx, wtPath) {
-			m.observeProtectedWorktree(ctx, wtPath, taskIDFromWorktreeDir(name), observedProtected)
+		// This sweep is the backstop for every worktree Remove skipped, so it
+		// must take the same per-path exclusion Remove does — otherwise the
+		// hazard is relocated here rather than avoided.
+		release, lockErr := m.lockPath(wtPath)
+		if lockErr != nil {
+			m.logger.Info("worktree.orphan-cleanup.busy", "path", wtPath, "err", lockErr)
 			continue
 		}
-
-		removed := false
-		if exists && t.ProjectID != "" {
-			if proj, perr := m.projects.Get(t.ProjectID); perr == nil {
-				if err := project.RemoveWorktree(ctx, proj.ClonePath, wtPath); err != nil {
-					m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
-				} else {
-					removed = true
-				}
-			}
-		}
-		if !removed {
-			// Task deleted or project lookup failed — force-remove and prune after.
-			if err := os.RemoveAll(wtPath); err != nil {
-				m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
-				continue
-			}
-		}
-		m.logger.Info("worktree.orphan-cleaned", "path", wtPath)
+		m.reapOrphanedWorktree(ctx, wtPath, name, t, exists, observedProtected)
+		release()
 	}
 	m.resolveProtectedWorktrees(observedProtected)
 
@@ -159,6 +146,34 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 			m.logger.Warn("worktree.prune", "project", projects[i].ID, "err", err)
 		}
 	}
+}
+
+// reapOrphanedWorktree removes one swept worktree directory. Caller holds the
+// path lock.
+func (m *Manager) reapOrphanedWorktree(ctx context.Context, wtPath, name string, t *task.Task, exists bool, observedProtected map[string]bool) {
+	if project.HasUnpushedCommits(ctx, wtPath) {
+		m.observeProtectedWorktree(ctx, wtPath, taskIDFromWorktreeDir(name), observedProtected)
+		return
+	}
+
+	removed := false
+	if exists && t.ProjectID != "" {
+		if proj, perr := m.projects.Get(t.ProjectID); perr == nil {
+			if err := project.RemoveWorktree(ctx, proj.ClonePath, wtPath); err != nil {
+				m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
+			} else {
+				removed = true
+			}
+		}
+	}
+	if !removed {
+		// Task deleted or project lookup failed — force-remove and prune after.
+		if err := os.RemoveAll(wtPath); err != nil {
+			m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
+			return
+		}
+	}
+	m.logger.Info("worktree.orphan-cleaned", "path", wtPath)
 }
 
 func (m *Manager) observeProtectedWorktree(ctx context.Context, path, taskID string, observed map[string]bool) {

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -128,7 +128,7 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 			m.logger.Info("worktree.orphan-cleanup.busy", "path", wtPath, "err", lockErr)
 			continue
 		}
-		m.reapOrphanedWorktree(ctx, wtPath, name, t, exists, observedProtected)
+		m.reapOrphanedWorktree(ctx, wtPath, name, t, observedProtected)
 		release()
 	}
 	m.resolveProtectedWorktrees(observedProtected)
@@ -149,15 +149,15 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 }
 
 // reapOrphanedWorktree removes one swept worktree directory. Caller holds the
-// path lock.
-func (m *Manager) reapOrphanedWorktree(ctx context.Context, wtPath, name string, t *task.Task, exists bool, observedProtected map[string]bool) {
+// path lock. A nil t is a directory whose task no longer exists.
+func (m *Manager) reapOrphanedWorktree(ctx context.Context, wtPath, name string, t *task.Task, observedProtected map[string]bool) {
 	if project.HasUnpushedCommits(ctx, wtPath) {
 		m.observeProtectedWorktree(ctx, wtPath, taskIDFromWorktreeDir(name), observedProtected)
 		return
 	}
 
 	removed := false
-	if exists && t.ProjectID != "" {
+	if t != nil && t.ProjectID != "" {
 		if proj, perr := m.projects.Get(t.ProjectID); perr == nil {
 			if err := project.RemoveWorktree(ctx, proj.ClonePath, wtPath); err != nil {
 				m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -50,6 +50,16 @@ func (m *Manager) Remove(ctx context.Context, taskID string) {
 	if _, err := os.Stat(wtPath); err != nil {
 		return
 	}
+	// A preparation is mid-flight on this exact directory. Deleting it out from
+	// under a `git worktree add`/rebase is the same hazard two concurrent
+	// preparations are (#3114). Cleanup is never urgent — CleanupOrphaned's
+	// periodic sweep reaps it later — so skip rather than wait.
+	release, lockErr := m.lockPath(wtPath)
+	if lockErr != nil {
+		m.logger.Info("worktree.cleanup.busy", "task_id", taskID, "err", lockErr)
+		return
+	}
+	defer release()
 	// Never reap a worktree whose completed work never reached origin — a task
 	// bounced to a terminal status (done/cancelled) after a failed push would
 	// otherwise lose its finished-but-unpushed diff right here, before the

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -68,6 +68,11 @@ type Manager struct {
 	hasLiveAgentOnly AgentChecker
 	misePath         string
 	protected        *cleanup.ProtectedStore
+	// paths serializes mutating operations per worktree directory. Not a
+	// Config field: it is process-internal state, and every Manager must have
+	// its own (a shared one would let two Managers over different worktree
+	// roots contend on identical relative paths).
+	paths pathLocks
 }
 
 func New(cfg Config) *Manager {

--- a/internal/worktree/prep_lock.go
+++ b/internal/worktree/prep_lock.go
@@ -1,0 +1,63 @@
+package worktree
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/worktreeerr"
+)
+
+// ErrPreparationInFlight indicates a mutating worktree operation was refused
+// because another one is already running against the same path. Alias of
+// worktreeerr.ErrPreparationInFlight for the same import-cycle reason as
+// ErrAgentRunning.
+var ErrPreparationInFlight = worktreeerr.ErrPreparationInFlight
+
+// pathLocks is the per-path exclusion that keeps two mutating operations off
+// one worktree directory.
+//
+// The dispatch claim (internal/agent.Manager.ClaimTaskDispatch) used to be the
+// only thing standing between two concurrent preparations of the same path,
+// and it is released on elapsed time alone: any claim older than
+// StaleDispatchClaimAge is deleted so a dispatcher that crashed mid-prepare
+// cannot wedge a task forever. Nothing bounds a live holder to that age —
+// PrepareForTask's fetch/rebase/push run on the caller's context, which on the
+// dispatch path has no deadline — so a preparation stalled against an
+// unresponsive remote outlives its own claim, and the next dispatcher is
+// granted the claim and starts a second `git worktree add`/rebase on the same
+// directory (#3114).
+//
+// Deliberately try-lock, not a blocking mutex: the losing caller is a
+// dispatcher, and every dispatcher already knows how to retry a transient
+// agent-start failure. Blocking would park a scheduler goroutine for as long
+// as the hung operation runs — the exact unbounded wait this is here to stop.
+type pathLocks struct {
+	mu   sync.Mutex
+	held map[string]time.Time
+}
+
+// lockPath reserves path for one mutating operation and returns its release
+// func. It never blocks: a path already reserved yields ErrPreparationInFlight
+// naming how long the incumbent has held it, so the log line distinguishes a
+// normal overlap from a wedged holder.
+func (m *Manager) lockPath(path string) (release func(), err error) {
+	key := filepath.Clean(path)
+
+	m.paths.mu.Lock()
+	defer m.paths.mu.Unlock()
+	if since, busy := m.paths.held[key]; busy {
+		return nil, fmt.Errorf("%w: %s (held %s)", ErrPreparationInFlight, key, time.Since(since).Round(time.Second))
+	}
+	if m.paths.held == nil {
+		m.paths.held = make(map[string]time.Time)
+	}
+	m.paths.held[key] = time.Now()
+
+	return func() {
+		m.paths.mu.Lock()
+		defer m.paths.mu.Unlock()
+		delete(m.paths.held, key)
+	}, nil
+}

--- a/internal/worktree/prep_lock_test.go
+++ b/internal/worktree/prep_lock_test.go
@@ -175,6 +175,9 @@ func TestLockedEntryPointsRefuseHeldPath(t *testing.T) {
 	if _, err := h.m.PrepareForFix(context.Background(), tk, 1); !errors.Is(err, ErrPreparationInFlight) {
 		t.Errorf("PrepareForFix err = %v, want ErrPreparationInFlight", err)
 	}
+	if err := h.m.PruneMissingWorktree(context.Background(), h.proj.ClonePath, h.m.PathFor(tk)); !errors.Is(err, ErrPreparationInFlight) {
+		t.Errorf("PruneMissingWorktree err = %v, want ErrPreparationInFlight", err)
+	}
 	if _, _, err := h.m.PrepareAttempt(context.Background(), tk, "att1"); err != nil {
 		t.Errorf("PrepareAttempt on a different path must not be refused: %v", err)
 	}

--- a/internal/worktree/prep_lock_test.go
+++ b/internal/worktree/prep_lock_test.go
@@ -1,0 +1,143 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestLockPath_SecondCallerIsRefused(t *testing.T) {
+	m := &Manager{dir: t.TempDir()}
+	path := filepath.Join(m.dir, "wt")
+
+	release, err := m.lockPath(path)
+	if err != nil {
+		t.Fatalf("first lockPath: %v", err)
+	}
+	if _, err := m.lockPath(path); !errors.Is(err, ErrPreparationInFlight) {
+		t.Fatalf("second lockPath err = %v, want ErrPreparationInFlight", err)
+	}
+
+	release()
+	release2, err := m.lockPath(path)
+	if err != nil {
+		t.Fatalf("lockPath after release: %v", err)
+	}
+	release2()
+	if n := len(m.paths.held); n != 0 {
+		t.Errorf("held entries after release = %d, want 0", n)
+	}
+}
+
+// TestLockPath_DistinctPathsAreIndependent pins that the exclusion is
+// per-directory: two best-of-N attempts of the same task prepare concurrently
+// by design and must not serialize against each other.
+func TestLockPath_DistinctPathsAreIndependent(t *testing.T) {
+	m := &Manager{dir: t.TempDir()}
+
+	releaseA, err := m.lockPath(filepath.Join(m.dir, "a"))
+	if err != nil {
+		t.Fatalf("lock a: %v", err)
+	}
+	defer releaseA()
+	releaseB, err := m.lockPath(filepath.Join(m.dir, "b"))
+	if err != nil {
+		t.Fatalf("lock b: %v", err)
+	}
+	releaseB()
+}
+
+// TestLockPath_NormalizesPath proves the key is the cleaned path, so the same
+// directory reached by two spellings is still one lock.
+func TestLockPath_NormalizesPath(t *testing.T) {
+	m := &Manager{dir: t.TempDir()}
+
+	release, err := m.lockPath(filepath.Join(m.dir, "wt"))
+	if err != nil {
+		t.Fatalf("lockPath: %v", err)
+	}
+	defer release()
+
+	if _, err := m.lockPath(filepath.Join(m.dir, "sub", "..", "wt")); !errors.Is(err, ErrPreparationInFlight) {
+		t.Fatalf("unnormalized path err = %v, want ErrPreparationInFlight", err)
+	}
+}
+
+// TestPrepareForTask_RefusesSecondConcurrentPreparation is the acceptance test
+// for #3114: a preparation that outlives the dispatch claim's age-based
+// release must not permit a second one on the same worktree. It holds the
+// first preparation open inside its setup batch — the same place a stalled
+// fetch/push would hold it — and asserts the second caller is refused rather
+// than allowed to run `git worktree add`/rebase over the top.
+func TestPrepareForTask_RefusesSecondConcurrentPreparation(t *testing.T) {
+	signals := t.TempDir()
+	started := filepath.Join(signals, "started")
+	unblock := filepath.Join(signals, "unblock")
+
+	h := prepareHarness(t, []string{
+		fmt.Sprintf("touch %s; while [ ! -f %s ]; do sleep 0.02; done", started, unblock),
+	}, 60*time.Second)
+
+	tk, err := h.tasks.Store().Create("concurrent prepare", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var firstErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, firstErr = h.m.PrepareForTask(context.Background(), tk, nil)
+	}()
+	// Unblocks and drains the incumbent however the test exits — a t.Fatalf
+	// below would otherwise leave the setup command spinning.
+	t.Cleanup(func() {
+		_ = os.WriteFile(unblock, nil, 0o600)
+		<-done
+	})
+
+	waitForFile(t, started)
+
+	if _, err := h.m.PrepareForTask(context.Background(), tk, nil); !errors.Is(err, ErrPreparationInFlight) {
+		t.Fatalf("second PrepareForTask err = %v, want ErrPreparationInFlight", err)
+	}
+
+	if err := os.WriteFile(unblock, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	<-done
+	if firstErr != nil {
+		t.Fatalf("first PrepareForTask: %v", firstErr)
+	}
+
+	// The path is released once the incumbent finishes, so the task is not
+	// wedged: the retry a dispatcher makes after the transient refusal works.
+	if _, err := h.m.PrepareForTask(context.Background(), tk, nil); err != nil {
+		t.Fatalf("PrepareForTask after release: %v", err)
+	}
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}

--- a/internal/worktree/prep_lock_test.go
+++ b/internal/worktree/prep_lock_test.go
@@ -130,6 +130,147 @@ func TestPrepareForTask_RefusesSecondConcurrentPreparation(t *testing.T) {
 	}
 }
 
+// TestLockedEntryPointsRefuseHeldPath sweeps the mutating entry points a
+// dispatcher can reach while another one owns the path. Each must refuse
+// rather than run its git operations over the top: ResetForRetry aborts an
+// in-progress rebase and hard-resets, RecreateFromBase deletes the directory
+// and its branch, and both are reached from re-dispatch paths that fire on
+// precisely the hung run that provokes the stale claim release.
+func TestLockedEntryPointsRefuseHeldPath(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("held path", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := h.m.lockPath(h.m.PathFor(tk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if _, err := h.m.ResetForRetry(context.Background(), tk, "", "HEAD"); !errors.Is(err, ErrPreparationInFlight) {
+		t.Errorf("ResetForRetry err = %v, want ErrPreparationInFlight", err)
+	}
+	if err := h.m.RecreateFromBase(context.Background(), tk); !errors.Is(err, ErrPreparationInFlight) {
+		t.Errorf("RecreateFromBase err = %v, want ErrPreparationInFlight", err)
+	}
+	if _, err := h.m.PrepareForReview(context.Background(), tk); !errors.Is(err, ErrPreparationInFlight) {
+		t.Errorf("PrepareForReview err = %v, want ErrPreparationInFlight", err)
+	}
+	if _, err := h.m.PrepareForBranchFix(context.Background(), tk); !errors.Is(err, ErrPreparationInFlight) {
+		t.Errorf("PrepareForBranchFix err = %v, want ErrPreparationInFlight", err)
+	}
+	if _, err := h.m.PrepareForBranchConflict(context.Background(), tk); !errors.Is(err, ErrPreparationInFlight) {
+		t.Errorf("PrepareForBranchConflict err = %v, want ErrPreparationInFlight", err)
+	}
+	if _, err := h.m.PrepareForFix(context.Background(), tk, 1); !errors.Is(err, ErrPreparationInFlight) {
+		t.Errorf("PrepareForFix err = %v, want ErrPreparationInFlight", err)
+	}
+	if _, _, err := h.m.PrepareAttempt(context.Background(), tk, "att1"); err != nil {
+		t.Errorf("PrepareAttempt on a different path must not be refused: %v", err)
+	}
+}
+
+// TestResetForRetry_ResetsWhenPathIsFree is the positive half: the refusal
+// above must come from the lock, not from ResetForRetry being broken.
+func TestResetForRetry_ResetsWhenPathIsFree(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("free path", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No worktree yet: nothing to reset, and that is not an error.
+	reset, err := h.m.ResetForRetry(context.Background(), tk, "", "HEAD")
+	if err != nil {
+		t.Fatalf("ResetForRetry with no worktree: %v", err)
+	}
+	if reset {
+		t.Error("reset = true with no worktree on disk, want false")
+	}
+
+	dir, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stray := filepath.Join(dir, "stray.txt")
+	if err := os.WriteFile(stray, []byte("partial work"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reset, err = h.m.ResetForRetry(context.Background(), tk, "", "HEAD")
+	if err != nil {
+		t.Fatalf("ResetForRetry: %v", err)
+	}
+	if !reset {
+		t.Error("reset = false on an existing worktree, want true")
+	}
+	if _, err := os.Stat(stray); !os.IsNotExist(err) {
+		t.Errorf("stray file survived the reset: %v", err)
+	}
+}
+
+// TestCleanup_SkipsHeldPathAndSweepsItLater covers the deletion half. Remove
+// declines a directory a preparation owns, and CleanupOrphaned — the sweep
+// Remove defers to — must both take the same lock and actually be able to reap
+// the deferred task, which for a cancelled one means looking past `done`.
+func TestCleanup_SkipsHeldPathAndSweepsItLater(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	m := New(Config{WorktreesDir: dir, Tasks: tasks, Logger: discardLogger()})
+
+	tk, err := store.Create("cancelled task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusCancelled)}); err != nil {
+		t.Fatal(err)
+	}
+	wtPath := filepath.Join(dir, tk.DirName())
+	makePushedGitDir(t, wtPath)
+
+	release, err := m.lockPath(wtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.Remove(context.Background(), tk.ID)
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("Remove deleted a worktree a preparation owns: %v", err)
+	}
+	m.CleanupOrphaned(context.Background())
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("CleanupOrphaned deleted a worktree a preparation owns: %v", err)
+	}
+
+	release()
+	m.CleanupOrphaned(context.Background())
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("cancelled task's worktree survived the sweep once the path was free: %v", err)
+	}
+}
+
 func waitForFile(t *testing.T, path string) {
 	t.Helper()
 	deadline := time.Now().Add(30 * time.Second)

--- a/internal/worktree/prep_lock_test.go
+++ b/internal/worktree/prep_lock_test.go
@@ -157,7 +157,7 @@ func TestLockedEntryPointsRefuseHeldPath(t *testing.T) {
 	}
 	defer release()
 
-	if _, err := h.m.ResetForRetry(context.Background(), tk, "", "HEAD"); !errors.Is(err, ErrPreparationInFlight) {
+	if _, _, err := h.m.ResetForRetry(context.Background(), tk, "", "HEAD"); !errors.Is(err, ErrPreparationInFlight) {
 		t.Errorf("ResetForRetry err = %v, want ErrPreparationInFlight", err)
 	}
 	if err := h.m.RecreateFromBase(context.Background(), tk); !errors.Is(err, ErrPreparationInFlight) {
@@ -200,13 +200,18 @@ func TestResetForRetry_ResetsWhenPathIsFree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// No worktree yet: nothing to reset, and that is not an error.
-	reset, err := h.m.ResetForRetry(context.Background(), tk, "", "HEAD")
+	// No worktree yet: nothing to reset, and that is not an error. The
+	// resolved path still comes back, since callers log it rather than the
+	// empty dir argument they passed.
+	target, reset, err := h.m.ResetForRetry(context.Background(), tk, "", "HEAD")
 	if err != nil {
 		t.Fatalf("ResetForRetry with no worktree: %v", err)
 	}
 	if reset {
 		t.Error("reset = true with no worktree on disk, want false")
+	}
+	if want := h.m.PathFor(tk); target != want {
+		t.Errorf("resolved path = %q, want %q", target, want)
 	}
 
 	dir, err := h.m.PrepareForTask(context.Background(), tk, nil)
@@ -218,12 +223,15 @@ func TestResetForRetry_ResetsWhenPathIsFree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reset, err = h.m.ResetForRetry(context.Background(), tk, "", "HEAD")
+	target, reset, err = h.m.ResetForRetry(context.Background(), tk, "", "HEAD")
 	if err != nil {
 		t.Fatalf("ResetForRetry: %v", err)
 	}
 	if !reset {
 		t.Error("reset = false on an existing worktree, want true")
+	}
+	if target != dir {
+		t.Errorf("resolved path = %q, want the prepared worktree %q", target, dir)
 	}
 	if _, err := os.Stat(stray); !os.IsNotExist(err) {
 		t.Errorf("stray file survived the reset: %v", err)

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -84,6 +84,15 @@ func (m *Manager) SyncTaskBranch(ctx context.Context, t task.Task) (SyncResult, 
 	if !m.Exists(t) {
 		return SyncSkipped, nil
 	}
+	// Another mutating operation owns this directory. This sync is
+	// opportunistic (see the doc above), so skip rather than fail — the next
+	// checkpoint retries once the directory is free.
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		m.logger.Info("worktree.sync-branch.busy", "task_id", t.ID, "err", err)
+		return SyncSkipped, nil
+	}
+	defer release()
 	// A tracked agent is still live in this worktree: rebasing here would
 	// corrupt its in-flight edits. This sync is opportunistic (never blocks
 	// workflow advancement per the doc above), so skip rather than fail —
@@ -152,6 +161,12 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 		}
 	}
 
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	// Adopt an externally-created worktree (e.g. one Orca already checked out)
 	// instead of creating a Sybra-managed one. Runs every agent in that
 	// directory as-is — no fetch/add/rebase/push-create/cleanup. This both
@@ -197,34 +212,10 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 
 	wtBranch = m.resolveTaskBranch(ctx, t, proj.ClonePath, wtPath, wtBranch)
 	if _, statErr := os.Stat(wtPath); statErr == nil {
-		callPhase(onPhase, "Checking worktree…")
-		usable, err := m.healOrRecreate(ctx, t.ID, proj.ClonePath, wtPath, wtBranch)
-		if err != nil {
-			return "", err
+		if dir, handled, err := m.reuseExistingWorktree(ctx, t, proj, wtPath, wtBranch, baseRef, onPhase); handled {
+			return dir, err
 		}
-		if usable {
-			if err := project.SanitizeWorktree(ctx, wtPath); err != nil {
-				m.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
-			}
-			if err := m.reconcileAndRebase(ctx, wtPath, wtBranch, baseRef, onPhase); err != nil {
-				return "", err
-			}
-			m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
-			// Sync remote after rebase. PushSync picks the minimum mode —
-			// no-op when local matches remote, regular push for
-			// fast-forward. On divergence it returns ErrDivergedNeedsResolve
-			// instead of force-pushing; callers here only log it (see
-			// logPushSync) because this is best-effort cleanup after the
-			// main reconcile/rebase path and the remote may have advanced
-			// again since that earlier fetch.
-			callPhase(onPhase, "Syncing upstream…")
-			m.logPushSync(t.ID, wtBranch, project.PushSync(ctx, wtPath, wtBranch))
-			if err := m.runPrepareSetup(ctx, t.ID, wtPath, proj, "reused worktree", onPhase); err != nil {
-				return "", err
-			}
-			return m.finalizeWorktree(ctx, t, wtPath, wtBranch, proj)
-		}
-		// Worktree was wiped — fall through to create paths below.
+		// Worktree was wiped — fall through to the create paths below.
 	}
 
 	// Branch may survive a prior worktree removal — check out existing branch
@@ -268,6 +259,38 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 	m.ensureBranch(t, wtBranch)
 	m.seedWorktree(ctx, t, wtPath, wtBranch)
 	return wtPath, nil
+}
+
+// reuseExistingWorktree rebases and finalizes an already-present worktree at
+// wtPath. handled=false means healOrRecreate wiped it as unusable and the
+// caller must fall through to its create paths; handled=true means this call
+// owns the outcome, error or not.
+func (m *Manager) reuseExistingWorktree(ctx context.Context, t task.Task, proj project.Project, wtPath, wtBranch, baseRef string, onPhase func(string)) (dir string, handled bool, err error) {
+	callPhase(onPhase, "Checking worktree…")
+	usable, err := m.healOrRecreate(ctx, t.ID, proj.ClonePath, wtPath, wtBranch)
+	if err != nil {
+		return "", true, err
+	}
+	if !usable {
+		return "", false, nil
+	}
+	if err := project.SanitizeWorktree(ctx, wtPath); err != nil {
+		m.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
+	}
+	if err := m.reconcileAndRebase(ctx, wtPath, wtBranch, baseRef, onPhase); err != nil {
+		return "", true, err
+	}
+	m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
+	// Best-effort cleanup after the main rebase: PushSync picks the minimum
+	// mode and reports divergence rather than force-pushing, and the remote may
+	// have advanced again since the earlier fetch, so only log the result.
+	callPhase(onPhase, "Syncing upstream…")
+	m.logPushSync(t.ID, wtBranch, project.PushSync(ctx, wtPath, wtBranch))
+	if err := m.runPrepareSetup(ctx, t.ID, wtPath, proj, "reused worktree", onPhase); err != nil {
+		return "", true, err
+	}
+	dir, err = m.finalizeWorktree(ctx, t, wtPath, wtBranch, proj)
+	return dir, true, err
 }
 
 func (m *Manager) resolveTaskBranch(ctx context.Context, t task.Task, clonePath, wtPath, wtBranch string) string {
@@ -595,6 +618,12 @@ func (m *Manager) finalizeWorktree(ctx context.Context, t task.Task, wtPath, wtB
 
 // PrepareForReview creates a detached-HEAD worktree for read-only PR review.
 func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, error) {
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	proj, err := m.projects.Get(t.ProjectID)
 	if err != nil {
 		return "", fmt.Errorf("get project: %w", err)
@@ -662,6 +691,12 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 // check out. Does not change PrepareForFix's behavior for its own PR-keyed
 // callers. Setup failures are non-gating, same rationale as PrepareForFix.
 func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string, error) {
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	// Adopt an externally-created worktree as-is, mirroring PrepareForFix.
 	if t.WorktreeDir != "" {
 		return m.adoptWorktree(ctx, t, nil)
@@ -762,6 +797,12 @@ func (m *Manager) PrepareForBranchConflict(ctx context.Context, t task.Task) (st
 // PrepareForBranchConflictFromRemote prepares a branch-conflict recovery
 // worktree whose remote side lives on remote, e.g. fork-backed PR heads.
 func (m *Manager) PrepareForBranchConflictFromRemote(ctx context.Context, t task.Task, remote string) (string, error) {
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	if t.WorktreeDir != "" {
 		return m.adoptWorktree(ctx, t, nil)
 	}
@@ -886,6 +927,12 @@ func (m *Manager) RecreateFromBase(ctx context.Context, t task.Task) error {
 // may exist precisely because that PR broke a gating setup command (e.g. a
 // build step), so refusing to create the worktree would deadlock the task.
 func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) (string, error) {
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
 	// Adopt an externally-created worktree (e.g. an Orca handoff) as-is instead
 	// of re-creating it. Without this guard PrepareForFix runs
 	// `git worktree add` at the adopted path, which fails ("already exists" /

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -894,33 +894,34 @@ func (m *Manager) PrepareForBranchConflictFromRemote(ctx context.Context, t task
 // tree the exclusion exists to prevent.
 //
 // dir overrides the task's own worktree path for callers that already resolved
-// one. Reports whether a reset ran; a directory that does not exist is not an
-// error.
-func (m *Manager) ResetForRetry(ctx context.Context, t task.Task, dir, ref string) (bool, error) {
-	target := dir
+// one. It returns the path it actually acted on — callers log that rather than
+// their own argument, which is empty whenever they left the resolution here —
+// and whether a reset ran; a directory that does not exist is not an error.
+func (m *Manager) ResetForRetry(ctx context.Context, t task.Task, dir, ref string) (target string, reset bool, err error) {
+	target = dir
 	if target == "" {
 		target = m.PathFor(t)
 	}
 	if target == "" {
-		return false, nil
+		return "", false, nil
 	}
 
 	release, err := m.lockPath(target)
 	if err != nil {
-		return false, err
+		return target, false, err
 	}
 	defer release()
 
 	if _, statErr := os.Stat(target); statErr != nil {
 		if os.IsNotExist(statErr) {
-			return false, nil
+			return target, false, nil
 		}
-		return false, fmt.Errorf("stat clean retry worktree: %w", statErr)
+		return target, false, fmt.Errorf("stat clean retry worktree: %w", statErr)
 	}
 	if err := project.ResetWorktreeForRetry(ctx, target, ref); err != nil {
-		return false, fmt.Errorf("reset worktree for retry: %w", err)
+		return target, false, fmt.Errorf("reset worktree for retry: %w", err)
 	}
-	return true, nil
+	return target, true, nil
 }
 
 // PruneMissingWorktree drops the bare repo's admin entry for a worktree path

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -887,6 +887,42 @@ func (m *Manager) PrepareForBranchConflictFromRemote(ctx context.Context, t task
 	return wtPath, nil
 }
 
+// ResetForRetry discards a killed or hung agent's partial work before a clean
+// retry, under the same per-path exclusion every Prepare* takes. It aborts an
+// in-progress rebase and hard-resets the tree, so running it against a
+// directory a live preparation is inside produces exactly the half-rebased
+// tree the exclusion exists to prevent.
+//
+// dir overrides the task's own worktree path for callers that already resolved
+// one. Reports whether a reset ran; a directory that does not exist is not an
+// error.
+func (m *Manager) ResetForRetry(ctx context.Context, t task.Task, dir, ref string) (bool, error) {
+	target := dir
+	if target == "" {
+		target = m.PathFor(t)
+	}
+	if target == "" {
+		return false, nil
+	}
+
+	release, err := m.lockPath(target)
+	if err != nil {
+		return false, err
+	}
+	defer release()
+
+	if _, statErr := os.Stat(target); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat clean retry worktree: %w", statErr)
+	}
+	if err := project.ResetWorktreeForRetry(ctx, target, ref); err != nil {
+		return false, fmt.Errorf("reset worktree for retry: %w", err)
+	}
+	return true, nil
+}
+
 // RecreateFromBase discards a task's diverged branch and its worktree so the
 // next PrepareForTask rebuilds it fresh off the project's base ref. The branch
 // tip is first backed up to refs/sybra-backup/<branch> (best-effort) so the
@@ -895,6 +931,12 @@ func (m *Manager) PrepareForBranchConflictFromRemote(ctx context.Context, t task
 // genuinely cannot be reconciled, so re-implementing from a clean base is the
 // only autonomous path left.
 func (m *Manager) RecreateFromBase(ctx context.Context, t task.Task) error {
+	release, err := m.lockPath(m.PathFor(t))
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	proj, err := m.projects.Get(t.ProjectID)
 	if err != nil {
 		return fmt.Errorf("get project: %w", err)

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -923,6 +923,21 @@ func (m *Manager) ResetForRetry(ctx context.Context, t task.Task, dir, ref strin
 	return true, nil
 }
 
+// PruneMissingWorktree drops the bare repo's admin entry for a worktree path
+// whose directory is gone from disk. Locked on that path: the directory can be
+// missing only because another preparation has not created it yet, and pruning
+// the registration mid `git worktree add` leaves a checkout git no longer
+// tracks.
+func (m *Manager) PruneMissingWorktree(ctx context.Context, clonePath, dir string) error {
+	release, err := m.lockPath(dir)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return project.RemoveWorktreeReconcile(ctx, clonePath, dir)
+}
+
 // RecreateFromBase discards a task's diverged branch and its worktree so the
 // next PrepareForTask rebuilds it fresh off the project's base ref. The branch
 // tip is first backed up to refs/sybra-backup/<branch> (best-effort) so the

--- a/internal/worktreeerr/worktreeerr.go
+++ b/internal/worktreeerr/worktreeerr.go
@@ -22,6 +22,16 @@ var ErrRebaseFailed = errors.New("worktree rebase failed")
 // rather than a real worktree conflict.
 var ErrAgentRunning = errors.New("worktree busy: agent still running for task")
 
+// ErrPreparationInFlight indicates a worktree entry point refused to run
+// because another goroutine is already inside a mutating operation on the very
+// same worktree path. The dispatch claim used to be the only thing serializing
+// those operations, and it is released on age alone (15m) — it cannot tell a
+// claim leaked by a crashed dispatcher from one a live holder is still inside,
+// so a preparation that outran the release age could be joined by a second one
+// on the same path. Callers must treat this exactly like ErrAgentRunning: a
+// transient "retry once the other one finishes" condition, never an escalation.
+var ErrPreparationInFlight = errors.New("worktree busy: preparation already in flight for this path")
+
 // RebaseBlockedReason is the human-facing status_reason written whenever
 // ErrRebaseFailed escalates a task to human-required. Shared between
 // internal/sybra's markRebaseBlocked and workflow.ClassifyAgentStartError so


### PR DESCRIPTION
## Motivation

The dispatch claim is what serializes worktree preparation, and it is released on elapsed time alone.

Any claim older than `StaleDispatchClaimAge` is deleted so a dispatcher that crashed mid-prepare cannot wedge a task forever. Nothing bounds a live holder to that age: `PrepareForTask`'s fetch, rebase and push run on the caller's context, which on the dispatch path has no deadline. A preparation stalled against an unresponsive remote therefore outlives its own claim, the next dispatcher is granted it, and two `git worktree add`/rebase runs land on one directory.

> Changelog: fix(worktree): serialize mutations per worktree path

## Implementation information

A per-path try-lock inside `worktree.Manager`, taken by every mutating entry point. The invariant no longer depends on each caller's retry window staying under the release age, which is all that avoided the hazard before (#3074 capped its ladder at 12m8s for exactly this reason, and nothing enforced that bound).

Try-lock, not a blocking mutex: the losing caller is a dispatcher, and every dispatcher already knows how to retry a transient agent-start failure. Blocking would park a scheduler goroutine for as long as the hung operation runs — the unbounded wait this exists to stop.

**The lock alone was not enough, and the gap was the interesting part.** Every re-dispatch path resets the worktree *before* it prepares one. `ResetWorktreeForRetry` aborts an in-progress rebase and hard-resets the tree, so replaying the issue's own sequence, the second dispatcher had already wrecked the first one's checkout by the time the lock refused it — "a half-rebased tree that the agent then runs in", reached by a different door. Both call sites now go through a locked `worktree.ResetForRetry`. Same omission in `RecreateFromBase`, `CleanupOrphaned`, `CleanupAttempts`, and the missing-worktree prune in `reprepareProvidedWorktreeDir`.

The refusal also had to be taught to four callers that never reach `ClassifyAgentStartFailure`:

- the PR monitor counted it toward the worktree-failure circuit breaker, so five polls against a task whose own preparation was still running escalated it to human-required;
- human-review treated it as a permanent prepare failure and dispatched the recovery agent into the read-only Sybra checkout — the `recoverable_action: none` regression its claim-retry cap was tuned to avoid;
- inbound review fell back to `config.HomeDir()`, the operator's live board;
- the best-of-n promote step turned every `PromoteAttempt` error into human-required, and that call is now lockable. Its other fail-closed reasons are judgements a human must make; this one is gone before they read it.

`CleanupOrphaned` only ever reaped tasks at `done`, so deferring a `cancelled` task's cleanup to it leaked that worktree forever. It now sweeps every terminal status.

`FixRenovateCI` has the same escalation shape and is deliberately left alone: the task it prepares is minted three lines above the call, so `PathFor` names a directory nothing else can hold. Neither adversarial pass could construct a reproduction.

## Supporting documentation

Adversarial review found the reset-before-prepare hole and the PR-monitor escalation as blockers; a manual pass against the real server found the promote step. Both are fixed here with regression tests.

Manual testing drove the acceptance criterion end to end against a running `sybra-server` in an isolated `SYBRA_HOME`, with a preparation stalled past the release age: at 15m01s the log showed `agent.dispatch-claim.stale-release`, the second dispatcher's preparation was refused, and `worktree.created` appears exactly once per path across the session. The task resumed on its own once the incumbent released. Zero refusals reached any task's `status_reason` across a full pipeline run, a best-of-n fan-out, cancel/reap, and repeat concurrent dispatch.

Two pre-existing defects surfaced during testing and are byte-identical on `main`, so they are not fixed here: `CleanupOrphaned` reaps live best-of-n attempt worktrees (`active` is keyed by `DirName()`, which never matches `<dirname>-attempt_N`, so the `hasAgent` guard is never consulted), and the best-of-n judge runs with cwd = `SYBRA_HOME`. Filed separately as #3149 and #3150.

Closes #3114
