### PR TITLE
fix(workflow): declare only through the reason

### DIFF
--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -121,13 +121,14 @@ steps:
         then:
 
         ```sybra-recovery
-        {"decision": "already-fixed-on-main", "reason": "<one sentence>"}
+        {"decision": "<already-fixed-on-main|none>", "reason": "<one sentence>"}
         ```
 
-        Emit that block only when you made no commits and the change is
-        genuinely already on the base branch. In every other case either omit
-        the block or emit `{"decision": "none"}`. Describing the situation in
-        prose alone is not a declaration and will leave the task for a human.
+        Replace both placeholders; a verbatim copy of the line above is
+        rejected. Declare already-fixed-on-main only when you made no commits
+        and the change is genuinely already on the base branch. In every other
+        case either omit the block or declare none. Describing the situation in
+        prose alone is not a declaration and leaves the task for a human.
         {{- if .Task.PlanContract}}
 
         ## Executable Plan Contract

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -114,6 +114,20 @@ steps:
 
         Before finishing, re-check your change against a short checklist:
         tests updated, edge cases covered, no leftover debug code.
+
+        If you conclude the requested change is already present on the base
+        branch and this task is a duplicate that needs no PR, say so in a
+        machine-readable block at the end of your final response, and only
+        then:
+
+        ```sybra-recovery
+        {"decision": "already-fixed-on-main", "reason": "<one sentence>"}
+        ```
+
+        Emit that block only when you made no commits and the change is
+        genuinely already on the base branch. In every other case either omit
+        the block or emit `{"decision": "none"}`. Describing the situation in
+        prose alone is not a declaration and will leave the task for a human.
         {{- if .Task.PlanContract}}
 
         ## Executable Plan Contract

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -120,7 +120,7 @@ steps:
         declare it by setting the task's status reason to exactly one JSON
         object and nothing else:
 
-            sybra-cli update <task-id> --status human-required \
+            sybra-cli update {{.Task.ID}} --status human-required \
               --status-reason '{"decision":"already-fixed-on-main","reason":"<one sentence>"}'
 
         Only that exact call counts as a declaration. Writing the same JSON in

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -115,20 +115,19 @@ steps:
         Before finishing, re-check your change against a short checklist:
         tests updated, edge cases covered, no leftover debug code.
 
-        If you conclude the requested change is already present on the base
-        branch and this task is a duplicate that needs no PR, say so in a
-        machine-readable block at the end of your final response, and only
-        then:
+        If you made no commits because the requested change is already present
+        on the base branch, so this task is a duplicate that needs no PR,
+        declare it by setting the task's status reason to exactly one JSON
+        object and nothing else:
 
-        ```sybra-recovery
-        {"decision": "<already-fixed-on-main|none>", "reason": "<one sentence>"}
-        ```
+            sybra-cli update <task-id> --status human-required \
+              --status-reason '{"decision":"already-fixed-on-main","reason":"<one sentence>"}'
 
-        Replace both placeholders; a verbatim copy of the line above is
-        rejected. Declare already-fixed-on-main only when you made no commits
-        and the change is genuinely already on the base branch. In every other
-        case either omit the block or declare none. Describing the situation in
-        prose alone is not a declaration and leaves the task for a human.
+        Only that exact call counts as a declaration. Writing the same JSON in
+        your response, quoting it, or describing the situation in prose does
+        not, and leaves the task for a human. Declare it only when you made no
+        commits and the change is genuinely already on the base branch; in
+        every other case park with an ordinary prose reason instead.
         {{- if .Task.PlanContract}}
 
         ## Executable Plan Contract

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -236,7 +236,10 @@ func (e *Engine) reloadTaskAndCheckImplementRetry(taskID string, currentStep *St
 		return t, parked, nil, err
 	}
 	var recovered bool
-	comp, recovered, err = e.maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID, currentStep, wfExec, t, output, output.Output)
+	// t was reloaded above, so its reason is the one this run set when it
+	// self-escalated. The run's own response text is deliberately not a
+	// declaration channel — see maybeRecoverHumanRequiredAlreadyFixedOnMain.
+	comp, recovered, err = e.maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID, currentStep, wfExec, t, output, t.StatusReason)
 	if recovered || err != nil {
 		return t, false, comp, err
 	}

--- a/internal/workflow/engine_pr_recovery.go
+++ b/internal/workflow/engine_pr_recovery.go
@@ -11,7 +11,7 @@ import (
 
 const readyPRRecoveryReason = "manual verification requires a live PR and the branch is already pushed — routing to PR flow instead of parking human-required"
 const alreadyFixedOnMainRecoveryReason = "requested change already satisfies origin base and the task branch has no remaining diff — closing duplicate task as done"
-const unreadableRecoveryVerdictReason = "run emitted an unreadable sybra-recovery declaration — staying parked rather than inferring the outcome from its prose"
+const unreadableRecoveryVerdictReason = "run emitted an unreadable recovery declaration — staying parked rather than inferring the outcome from its prose"
 
 // maybeRecoverHumanRequiredAlreadyFixedOnMain rewrites a narrow duplicate-task
 // class: an implementation step parked the task at human-required after
@@ -19,9 +19,9 @@ const unreadableRecoveryVerdictReason = "run emitted an unreadable sybra-recover
 // still clean with no commits ahead of the origin base. In that case Sybra has
 // enough deterministic proof to close the task itself instead of parking it.
 //
-// The trigger is the run's own structured sybra-recovery declaration. On
-// agent-completion recovery it must come from the current run's output, not a
-// stale task status_reason from an older human-required park.
+// The trigger is the run's own structured declaration, set as the task's
+// whole status reason. On agent-completion recovery it must come from the
+// current run, not a stale status_reason from an older human-required park.
 //
 // The repo-state proof that follows (no commits ahead, no uncommitted diff,
 // HEAD reachable from the origin base) is necessary but not sufficient: it is

--- a/internal/workflow/engine_pr_recovery.go
+++ b/internal/workflow/engine_pr_recovery.go
@@ -7,10 +7,16 @@ import (
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/taskstatus"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const readyPRRecoveryReason = "manual verification requires a live PR and the branch is already pushed — routing to PR flow instead of parking human-required"
 const alreadyFixedOnMainRecoveryReason = "requested change already satisfies origin base and the task branch has no remaining diff — closing duplicate task as done"
+
+// maxDeclaredReasonBytes bounds the agent's own text before it reaches the
+// task's YAML frontmatter.
+const maxDeclaredReasonBytes = 400
+
 const unreadableRecoveryVerdictReason = "run emitted an unreadable recovery declaration — staying parked rather than inferring the outcome from its prose"
 
 // maybeRecoverHumanRequiredAlreadyFixedOnMain rewrites a narrow duplicate-task
@@ -19,9 +25,10 @@ const unreadableRecoveryVerdictReason = "run emitted an unreadable recovery decl
 // still clean with no commits ahead of the origin base. In that case Sybra has
 // enough deterministic proof to close the task itself instead of parking it.
 //
-// The trigger is the run's own structured declaration, set as the task's
-// whole status reason. On agent-completion recovery it must come from the
-// current run, not a stale status_reason from an older human-required park.
+// The trigger is the run's structured declaration, set as the task's whole
+// status reason through the CLI. The run's response text is not a channel:
+// accepting it there let a response that was only the JSON object close a
+// task whose reason explicitly refused to declare one.
 //
 // The repo-state proof that follows (no commits ahead, no uncommitted diff,
 // HEAD reachable from the origin base) is necessary but not sufficient: it is
@@ -65,7 +72,7 @@ func (e *Engine) maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID string, curr
 	}
 	reason := alreadyFixedOnMainRecoveryReason
 	if declaredReason := recoveryVerdictReason(duplicateSignal); declaredReason != "" {
-		reason += " — agent declared: " + declaredReason
+		reason += " — agent declared: " + textutil.TruncateBytes(declaredReason, maxDeclaredReasonBytes, "…")
 	}
 	if err := e.tasks.UpdateTaskStatus(taskID, taskstatus.Done, reason); err != nil {
 		return nil, false, err

--- a/internal/workflow/engine_pr_recovery.go
+++ b/internal/workflow/engine_pr_recovery.go
@@ -33,7 +33,13 @@ func (e *Engine) maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID string, curr
 	if wfExec != nil && wfExec.LastAgentStepFailed() {
 		return nil, false, nil
 	}
-	if !looksLikeAlreadyFixedOnMainVerdict(duplicateSignal) {
+	alreadyFixed, err := declaresAlreadyFixedOnMain(duplicateSignal)
+	if err != nil {
+		// Stay parked: guessing from the prose of a run that already failed to declare is the behaviour this replaces.
+		e.logger.Warn("workflow.human-required.duplicate-recovery.unreadable-verdict", "task_id", taskID, "err", err)
+		return nil, false, nil
+	}
+	if !alreadyFixed {
 		return nil, false, nil
 	}
 	if e.worktrees == nil {
@@ -164,29 +170,6 @@ func isMissingLivePRVerificationBlocker(reason string) bool {
 		strings.Contains(r, "required live") ||
 		strings.Contains(r, "live pr-monitor") ||
 		strings.Contains(r, "live proof")
-}
-
-func looksLikeAlreadyFixedOnMainVerdict(reason string) bool {
-	lower := strings.ToLower(strings.TrimSpace(reason))
-	if lower == "" {
-		return false
-	}
-	fixedSignal := strings.Contains(lower, "already fixed") ||
-		strings.Contains(lower, "already on main") ||
-		strings.Contains(lower, "already merged") ||
-		strings.Contains(lower, "already landed") ||
-		strings.Contains(lower, "already satisfied") ||
-		strings.Contains(lower, "duplicate task")
-	mainSignal := strings.Contains(lower, "main") ||
-		strings.Contains(lower, "origin/main") ||
-		strings.Contains(lower, "upstream") ||
-		strings.Contains(lower, "origin")
-	closeSignal := strings.Contains(lower, "no pr needed") ||
-		strings.Contains(lower, "no pr required") ||
-		strings.Contains(lower, "safe to close") ||
-		strings.Contains(lower, "mark done") ||
-		strings.Contains(lower, "mark as done")
-	return fixedSignal && (mainSignal || closeSignal)
 }
 
 func (e *Engine) branchAlreadySatisfiedOnMain(taskID, wtPath string, t TaskInfo) (bool, error) {

--- a/internal/workflow/engine_pr_recovery.go
+++ b/internal/workflow/engine_pr_recovery.go
@@ -11,6 +11,7 @@ import (
 
 const readyPRRecoveryReason = "manual verification requires a live PR and the branch is already pushed — routing to PR flow instead of parking human-required"
 const alreadyFixedOnMainRecoveryReason = "requested change already satisfies origin base and the task branch has no remaining diff — closing duplicate task as done"
+const unreadableRecoveryVerdictReason = "run emitted an unreadable sybra-recovery declaration — staying parked rather than inferring the outcome from its prose"
 
 // maybeRecoverHumanRequiredAlreadyFixedOnMain rewrites a narrow duplicate-task
 // class: an implementation step parked the task at human-required after
@@ -18,11 +19,14 @@ const alreadyFixedOnMainRecoveryReason = "requested change already satisfies ori
 // still clean with no commits ahead of the origin base. In that case Sybra has
 // enough deterministic proof to close the task itself instead of parking it.
 //
-// Agent text is only a trigger hint here. On agent-completion recovery the hint
-// must come from the current run's output, not a stale task status_reason from
-// an older human-required park. The close decision itself still requires
-// repo-state proof: no commits ahead, no uncommitted diff, and HEAD reachable
-// from the origin base.
+// The trigger is the run's own structured sybra-recovery declaration. On
+// agent-completion recovery it must come from the current run's output, not a
+// stale task status_reason from an older human-required park.
+//
+// The repo-state proof that follows (no commits ahead, no uncommitted diff,
+// HEAD reachable from the origin base) is necessary but not sufficient: it is
+// trivially true for a branch the agent never committed to, which is why the
+// declaration carries the decision.
 func (e *Engine) maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID string, currentStep *Step, wfExec *Execution, t TaskInfo, output StepOutput, duplicateSignal string) (*CompletionInfo, bool, error) {
 	if currentStep == nil || currentStep.Type != StepRunAgent || currentStep.Config.Role != "implementation" || output.Status != "completed" {
 		return nil, false, nil
@@ -33,13 +37,15 @@ func (e *Engine) maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID string, curr
 	if wfExec != nil && wfExec.LastAgentStepFailed() {
 		return nil, false, nil
 	}
-	alreadyFixed, err := declaresAlreadyFixedOnMain(duplicateSignal)
+	alreadyFixed, declared, err := declaresAlreadyFixedOnMain(duplicateSignal)
 	if err != nil {
-		// Stay parked: guessing from the prose of a run that already failed to declare is the behaviour this replaces.
 		e.logger.Warn("workflow.human-required.duplicate-recovery.unreadable-verdict", "task_id", taskID, "err", err)
+		if uerr := e.tasks.UpdateTaskStatus(taskID, taskstatus.HumanRequired, unreadableRecoveryVerdictReason); uerr != nil {
+			return nil, false, uerr
+		}
 		return nil, false, nil
 	}
-	if !alreadyFixed {
+	if !declared || !alreadyFixed {
 		return nil, false, nil
 	}
 	if e.worktrees == nil {
@@ -57,7 +63,11 @@ func (e *Engine) maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID string, curr
 	if !clean {
 		return nil, false, nil
 	}
-	if err := e.tasks.UpdateTaskStatus(taskID, taskstatus.Done, alreadyFixedOnMainRecoveryReason); err != nil {
+	reason := alreadyFixedOnMainRecoveryReason
+	if declaredReason := recoveryVerdictReason(duplicateSignal); declaredReason != "" {
+		reason += " — agent declared: " + declaredReason
+	}
+	if err := e.tasks.UpdateTaskStatus(taskID, taskstatus.Done, reason); err != nil {
 		return nil, false, err
 	}
 	e.logger.Info("workflow.human-required.duplicate-recovery", "task_id", taskID)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2626,6 +2626,7 @@ func TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired(t *testing.T
 		{name: "negated prose", output: "I checked whether this was already fixed on main; it is NOT. Ran out of context before committing, parking for a human."},
 		{name: "incidental main.go mention", output: "Already fixed the nil deref in main.go but could not push."},
 		{name: "verdict json quoted inside prose", output: `Per the contract I would emit {"decision": "already-fixed-on-main", "reason": "change already on base"} only if the work were landed. It is not, so I am NOT declaring that. No commits were made.`},
+		{name: "verdict fence quoted and disclaimed", output: quotedFenceDisclaimed},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tasks, ti := runAlreadyFixedOnMainRecovery(t, tc.output)
@@ -2644,7 +2645,7 @@ func TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired(t *testing.T
 // the run that tried to declare and produced something unparseable: it stays
 // parked, and the board says why rather than only the app log.
 func TestAdvanceStep_AlreadyFixedOnMainUnreadableDeclarationRecordsReason(t *testing.T) {
-	_, ti := runAlreadyFixedOnMainRecovery(t, "```sybra-recovery\n{\"decision\":\"close-it\"}\n```")
+	_, ti := runAlreadyFixedOnMainRecovery(t, `{"decision":"close-it"}`)
 	if ti.Status != "human-required" {
 		t.Fatalf("status = %q, want human-required", ti.Status)
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2438,7 +2438,13 @@ func startTestSimpleImplement(t *testing.T) (*Store, *memTasks, *mockAgents, *En
 }
 
 const missingLivePRProofReason = "manual verification blocker: no current open PR could be verified as allFlaky for the required live pr-monitor proof"
-const alreadyFixedOnMainVerdict = "Already fixed on main; no PR needed. Duplicate task, safe to close/mark done."
+const alreadyFixedOnMainVerdict = `{"decision":"already-fixed-on-main","reason":"landed in an earlier PR"}`
+
+// alreadyFixedOnMainProse is the shape recovery used to act on. It must never
+// close a task on its own now that a declaration is required.
+const alreadyFixedOnMainProse = "Already fixed on main; no PR needed. Duplicate task, safe to close/mark done."
+
+const alreadyFixedOnMainDeclaredReason = alreadyFixedOnMainRecoveryReason + " — agent declared: landed in an earlier PR"
 
 func TestAdvanceStep_ManualVerificationBlockerRoutesToReadyPR(t *testing.T) {
 	store := newInlineTestStore(t, "pr-recovery", `
@@ -2597,8 +2603,8 @@ steps:
 	if ti.Status != "done" {
 		t.Fatalf("status = %q, want done", ti.Status)
 	}
-	if ti.StatusReason != alreadyFixedOnMainRecoveryReason {
-		t.Fatalf("status reason = %q, want %q", ti.StatusReason, alreadyFixedOnMainRecoveryReason)
+	if ti.StatusReason != alreadyFixedOnMainDeclaredReason {
+		t.Fatalf("status reason = %q, want %q", ti.StatusReason, alreadyFixedOnMainDeclaredReason)
 	}
 	if ti.Workflow == nil || ti.Workflow.State != ExecCompleted || ti.Workflow.CurrentStep != "" {
 		t.Fatalf("workflow = %+v, want completed terminal workflow", ti.Workflow)
@@ -2606,6 +2612,111 @@ steps:
 	if len(completed) != 1 || completed[0].WorkflowID != "pr-recovery" {
 		t.Fatalf("completions = %+v, want one pr-recovery completion", completed)
 	}
+}
+
+// TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired pins the
+// defect this recovery was rebuilt for: prose alone, affirmative or negated,
+// must never close a task. The old scan closed on all three of these.
+func TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{name: "affirmative prose", output: alreadyFixedOnMainProse},
+		{name: "negated prose", output: "I checked whether this was already fixed on main; it is NOT. Ran out of context before committing, parking for a human."},
+		{name: "incidental main.go mention", output: "Already fixed the nil deref in main.go but could not push."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks, ti := runAlreadyFixedOnMainRecovery(t, tc.output)
+			if ti.Status != "human-required" {
+				t.Fatalf("status = %q, want human-required", ti.Status)
+			}
+			if ti.StatusReason != alreadyFixedOnMainVerdict {
+				t.Fatalf("status reason = %q, want the stale park reason preserved", ti.StatusReason)
+			}
+			_ = tasks
+		})
+	}
+}
+
+// TestAdvanceStep_AlreadyFixedOnMainUnreadableDeclarationRecordsReason covers
+// the run that tried to declare and produced something unparseable: it stays
+// parked, and the board says why rather than only the app log.
+func TestAdvanceStep_AlreadyFixedOnMainUnreadableDeclarationRecordsReason(t *testing.T) {
+	_, ti := runAlreadyFixedOnMainRecovery(t, "```sybra-recovery\n{\"decision\":\"close-it\"}\n```")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+	if ti.StatusReason != unreadableRecoveryVerdictReason {
+		t.Fatalf("status reason = %q, want %q", ti.StatusReason, unreadableRecoveryVerdictReason)
+	}
+}
+
+// runAlreadyFixedOnMainRecovery drives one implementation run to completion
+// with output and returns the task as recovery left it.
+func runAlreadyFixedOnMainRecovery(t *testing.T, output string) (*memTasks, TaskInfo) {
+	t.Helper()
+	store := newInlineTestStore(t, "pr-recovery", `
+id: pr-recovery
+name: PR Recovery
+trigger:
+  on: task.created
+steps:
+  - id: implement
+    name: Implement
+    type: run_agent
+    config:
+      role: implementation
+      mode: headless
+      prompt: "implement"
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: verify
+  - id: verify
+    name: Verify
+    type: set_status
+    config:
+      status: done
+    next:
+      - goto: ""
+`)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false), ok: true})
+
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		ProjectID: "acme/widgets",
+	})
+	if err := engine.StartWorkflow("t1", "pr-recovery"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.UpdateTaskStatus("t1", "human-required", alreadyFixedOnMainVerdict); err != nil {
+		t.Fatal(err)
+	}
+
+	agentID := agents.LastID()
+	agents.SimulateComplete("t1")
+	if err := engine.AdvanceStep("t1", StepOutput{
+		StepID:  "implement",
+		AgentID: agentID,
+		Status:  "completed",
+		Output:  output,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tasks, ti
 }
 
 func TestAdvanceStep_AlreadyFixedOnMainEmptyOutputStaysHumanRequired(t *testing.T) {
@@ -2749,8 +2860,8 @@ steps:
 	if ti.Status != "done" {
 		t.Fatalf("status = %q, want done", ti.Status)
 	}
-	if ti.StatusReason != alreadyFixedOnMainRecoveryReason {
-		t.Fatalf("status reason = %q, want %q", ti.StatusReason, alreadyFixedOnMainRecoveryReason)
+	if ti.StatusReason != alreadyFixedOnMainDeclaredReason {
+		t.Fatalf("status reason = %q, want %q", ti.StatusReason, alreadyFixedOnMainDeclaredReason)
 	}
 	if ti.Workflow == nil || ti.Workflow.State != ExecCompleted || ti.Workflow.CurrentStep != "" {
 		t.Fatalf("workflow = %+v, want completed terminal workflow", ti.Workflow)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2625,6 +2625,7 @@ func TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired(t *testing.T
 		{name: "affirmative prose", output: alreadyFixedOnMainProse},
 		{name: "negated prose", output: "I checked whether this was already fixed on main; it is NOT. Ran out of context before committing, parking for a human."},
 		{name: "incidental main.go mention", output: "Already fixed the nil deref in main.go but could not push."},
+		{name: "verdict json quoted inside prose", output: `Per the contract I would emit {"decision": "already-fixed-on-main", "reason": "change already on base"} only if the work were landed. It is not, so I am NOT declaring that. No commits were made.`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tasks, ti := runAlreadyFixedOnMainRecovery(t, tc.output)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2633,11 +2633,37 @@ func TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired(t *testing.T
 			if ti.Status != "human-required" {
 				t.Fatalf("status = %q, want human-required", ti.Status)
 			}
-			if ti.StatusReason != alreadyFixedOnMainVerdict {
-				t.Fatalf("status reason = %q, want the stale park reason preserved", ti.StatusReason)
+			if ti.StatusReason != alreadyFixedOnMainProse {
+				t.Fatalf("status reason = %q, want the park reason preserved", ti.StatusReason)
 			}
 			_ = tasks
 		})
+	}
+}
+
+// TestAdvanceStep_AlreadyFixedOnMainResponseTextIsNotAChannel pins the channel
+// split: only the status reason declares. A response that is nothing but the
+// JSON object used to close a task whose reason refused to declare one.
+func TestAdvanceStep_AlreadyFixedOnMainResponseTextIsNotAChannel(t *testing.T) {
+	_, ti := runAlreadyFixedOnMainRecoveryWithReason(t,
+		alreadyFixedOnMainVerdict,
+		"I am NOT declaring a recovery verdict. I made no commits and a human must review this.")
+	if ti.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", ti.Status)
+	}
+}
+
+// TestAdvanceStep_AlreadyFixedOnMainLongDeclaredReasonIsBounded keeps an
+// agent-authored reason out of the task frontmatter at full length.
+func TestAdvanceStep_AlreadyFixedOnMainLongDeclaredReasonIsBounded(t *testing.T) {
+	long := strings.Repeat("x", 5000)
+	_, ti := runAlreadyFixedOnMainRecoveryWithReason(t, "",
+		`{"decision":"already-fixed-on-main","reason":"`+long+`"}`)
+	if ti.Status != "done" {
+		t.Fatalf("status = %q, want done", ti.Status)
+	}
+	if len(ti.StatusReason) > len(alreadyFixedOnMainRecoveryReason)+maxDeclaredReasonBytes+64 {
+		t.Fatalf("status reason is %d bytes, want the declared reason bounded", len(ti.StatusReason))
 	}
 }
 
@@ -2645,7 +2671,7 @@ func TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired(t *testing.T
 // the run that tried to declare and produced something unparseable: it stays
 // parked, and the board says why rather than only the app log.
 func TestAdvanceStep_AlreadyFixedOnMainUnreadableDeclarationRecordsReason(t *testing.T) {
-	_, ti := runAlreadyFixedOnMainRecovery(t, `{"decision":"close-it"}`)
+	_, ti := runAlreadyFixedOnMainRecoveryWithReason(t, "", `{"decision":"close-it"}`)
 	if ti.Status != "human-required" {
 		t.Fatalf("status = %q, want human-required", ti.Status)
 	}
@@ -2657,6 +2683,13 @@ func TestAdvanceStep_AlreadyFixedOnMainUnreadableDeclarationRecordsReason(t *tes
 // runAlreadyFixedOnMainRecovery drives one implementation run to completion
 // with output and returns the task as recovery left it.
 func runAlreadyFixedOnMainRecovery(t *testing.T, output string) (*memTasks, TaskInfo) {
+	t.Helper()
+	return runAlreadyFixedOnMainRecoveryWithReason(t, output, alreadyFixedOnMainProse)
+}
+
+// runAlreadyFixedOnMainRecoveryWithReason drives one implementation run whose
+// response text is output and whose park reason is parkReason.
+func runAlreadyFixedOnMainRecoveryWithReason(t *testing.T, output, parkReason string) (*memTasks, TaskInfo) {
 	t.Helper()
 	store := newInlineTestStore(t, "pr-recovery", `
 id: pr-recovery
@@ -2700,7 +2733,7 @@ steps:
 	if err := engine.StartWorkflow("t1", "pr-recovery"); err != nil {
 		t.Fatal(err)
 	}
-	if err := tasks.UpdateTaskStatus("t1", "human-required", alreadyFixedOnMainVerdict); err != nil {
+	if err := tasks.UpdateTaskStatus("t1", "human-required", parkReason); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2772,7 +2805,7 @@ steps:
 			if err := engine.StartWorkflow("t1", "pr-recovery"); err != nil {
 				t.Fatal(err)
 			}
-			if err := tasks.UpdateTaskStatus("t1", "human-required", alreadyFixedOnMainVerdict); err != nil {
+			if err := tasks.UpdateTaskStatus("t1", "human-required", alreadyFixedOnMainProse); err != nil {
 				t.Fatal(err)
 			}
 
@@ -2794,8 +2827,8 @@ steps:
 			if ti.Status != "human-required" {
 				t.Fatalf("status = %q, want human-required", ti.Status)
 			}
-			if ti.StatusReason != alreadyFixedOnMainVerdict {
-				t.Fatalf("status reason = %q, want stale human-required reason preserved", ti.StatusReason)
+			if ti.StatusReason != alreadyFixedOnMainProse {
+				t.Fatalf("status reason = %q, want the park reason preserved", ti.StatusReason)
 			}
 			if ti.Workflow == nil || ti.Workflow.State != ExecCompleted || ti.Workflow.CurrentStep != "" {
 				t.Fatalf("workflow = %+v, want completed terminal workflow", ti.Workflow)

--- a/internal/workflow/recovery_verdict.go
+++ b/internal/workflow/recovery_verdict.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 // Decisions an implementation agent may declare about closing its task
@@ -16,79 +18,97 @@ const (
 )
 
 // recoveryVerdict is the implementation role's structured statement about
-// whether Sybra may close the task as an already-landed duplicate. It exists
-// so the close decision reads a value the agent declared rather than a
-// substring of whatever prose the run happened to emit.
+// whether Sybra may close the task as an already-landed duplicate.
+//
+// Recovery reads this and nothing else. The predecessor scanned the run's
+// prose for phrases like "already fixed" plus a word containing "main", which
+// matched "main.go", "func main()" and "remaining", and had no notion of
+// negation: a run reporting it had checked and the change was NOT on main
+// closed the task as done.
 type recoveryVerdict struct {
 	Decision string `json:"decision"`
 	Reason   string `json:"reason,omitempty"`
 }
 
-var recoveryFenceRe = regexp.MustCompile("(?s)```\\s*sybra-recovery\\s*\\n(.*?)\\n```")
+// recoveryFenceRe tolerates up to three leading spaces on the fence so a
+// declaration nested in a list item or blockquote still parses.
+var recoveryFenceRe = regexp.MustCompile("(?ms)^[ \\t]{0,3}```[ \\t]*sybra-recovery[ \\t]*\\n(.*?)\\n[ \\t]{0,3}```")
 
-// Legacy prose signals, kept for agents whose prompt predates the declaration
-// block. Every branch token is word-anchored: an unanchored "main" also
-// matches "remaining", "maintain" and "domain", which made the old base-branch
-// signal true for almost any English sentence and left the phrase set below as
-// the only real gate.
-var (
-	fixedPhraseRe = regexp.MustCompile(`already (fixed|on main|merged|landed|satisfied)|duplicate task`)
-	basePhraseRe  = regexp.MustCompile(`\b(main|upstream|origin)\b`)
-	closePhraseRe = regexp.MustCompile(`no pr (needed|required)|safe to close|mark (as )?done`)
-)
+// errNoRecoveryDeclaration means the run declared nothing. Recovery treats it
+// as "leave the task parked", not as an error worth reporting.
+var errNoRecoveryDeclaration = errors.New("recovery verdict: no declaration")
 
-// parseRecoveryVerdict returns the verdict an implementation agent declared in
-// a fenced ```sybra-recovery``` block. declared=false means the run made no
-// declaration at all, which is the normal case for an agent on an older
-// prompt. A block that is present but unreadable returns an error instead:
-// once an agent has tried to declare and failed, falling back to guessing from
-// its prose is the behaviour this replaces.
-func parseRecoveryVerdict(text string) (v recoveryVerdict, declared bool, err error) {
-	m := recoveryFenceRe.FindStringSubmatch(text)
-	if len(m) < 2 {
-		return recoveryVerdict{}, false, nil
+// parseRecoveryVerdict reads the verdict an implementation agent declared,
+// either as a fenced sybra-recovery block or, on the status-reason path where
+// the reason is a single-line CLI argument, as a bare JSON object.
+//
+// The last fenced block wins: the prompt asks for the declaration at the end
+// of the response, and an agent that quotes the contract before answering
+// would otherwise have its quotation read as the verdict.
+func parseRecoveryVerdict(text string) (recoveryVerdict, error) {
+	if payload, ok := lastFencedRecoveryPayload(text); ok {
+		return decodeRecoveryVerdict(payload)
 	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(m[1])), &v); err != nil {
-		return recoveryVerdict{}, false, fmt.Errorf("recovery verdict: malformed json: %w", err)
+	if obj := llmjob.ExtractLastJSONObject(text); obj != "" {
+		var probe struct {
+			Decision string `json:"decision"`
+		}
+		if err := json.Unmarshal([]byte(obj), &probe); err == nil && strings.TrimSpace(probe.Decision) != "" {
+			return decodeRecoveryVerdict(obj)
+		}
+	}
+	return recoveryVerdict{}, errNoRecoveryDeclaration
+}
+
+func lastFencedRecoveryPayload(text string) (string, bool) {
+	matches := recoveryFenceRe.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return "", false
+	}
+	return matches[len(matches)-1][1], true
+}
+
+func decodeRecoveryVerdict(payload string) (recoveryVerdict, error) {
+	var v recoveryVerdict
+	if err := json.Unmarshal([]byte(strings.TrimSpace(payload)), &v); err != nil {
+		return recoveryVerdict{}, fmt.Errorf("recovery verdict: malformed json: %w", err)
 	}
 	v.Decision = strings.ToLower(strings.TrimSpace(v.Decision))
 	v.Reason = strings.TrimSpace(v.Reason)
 	switch v.Decision {
 	case recoveryDecisionAlreadyFixed, recoveryDecisionNone:
-		return v, true, nil
+		return v, nil
 	case "":
-		return recoveryVerdict{}, false, errors.New("recovery verdict: missing decision")
+		return recoveryVerdict{}, errors.New("recovery verdict: missing decision")
 	default:
-		return recoveryVerdict{}, false, fmt.Errorf("recovery verdict: unknown decision %q", v.Decision)
+		return recoveryVerdict{}, fmt.Errorf("recovery verdict: unknown decision %q", v.Decision)
 	}
 }
 
-// declaresAlreadyFixedOnMain reports whether signal says the requested change
-// is already on the base branch. A structured declaration is authoritative. In
-// its absence the legacy prose match decides, and an unreadable declaration
-// decides nothing at all, so the caller leaves the task parked.
-func declaresAlreadyFixedOnMain(signal string) (bool, error) {
-	v, declared, err := parseRecoveryVerdict(signal)
+// declaresAlreadyFixedOnMain reports whether the run declared that the
+// requested change is already on the base branch.
+//
+// ok=false with a nil error means no declaration was made, so the task stays
+// parked for a human. A non-nil error means a declaration was present and
+// unreadable, which the caller records on the task.
+func declaresAlreadyFixedOnMain(signal string) (alreadyFixed, ok bool, err error) {
+	v, err := parseRecoveryVerdict(signal)
+	if errors.Is(err, errNoRecoveryDeclaration) {
+		return false, false, nil
+	}
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	if declared {
-		return v.Decision == recoveryDecisionAlreadyFixed, nil
-	}
-	return looksLikeAlreadyFixedOnMainProse(signal), nil
+	return v.Decision == recoveryDecisionAlreadyFixed, true, nil
 }
 
-// looksLikeAlreadyFixedOnMainProse is the legacy heuristic: an explicit
-// already-landed phrase, corroborated by either a base-branch mention or an
-// explicit request to close. It is deliberately narrower than a bare keyword
-// scan and is only reached when the run declared nothing.
-func looksLikeAlreadyFixedOnMainProse(signal string) bool {
-	lower := strings.ToLower(strings.TrimSpace(signal))
-	if lower == "" {
-		return false
+// recoveryVerdictReason returns the agent's own justification for a declared
+// verdict, so a task closed as a duplicate records why rather than only that
+// it happened.
+func recoveryVerdictReason(signal string) string {
+	v, err := parseRecoveryVerdict(signal)
+	if err != nil {
+		return ""
 	}
-	if !fixedPhraseRe.MatchString(lower) {
-		return false
-	}
-	return basePhraseRe.MatchString(lower) || closePhraseRe.MatchString(lower)
+	return v.Reason
 }

--- a/internal/workflow/recovery_verdict.go
+++ b/internal/workflow/recovery_verdict.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 // Decisions an implementation agent may declare about closing its task
@@ -49,15 +47,27 @@ func parseRecoveryVerdict(text string) (recoveryVerdict, error) {
 	if payload, ok := lastFencedRecoveryPayload(text); ok {
 		return decodeRecoveryVerdict(payload)
 	}
-	if obj := llmjob.ExtractLastJSONObject(text); obj != "" {
-		var probe struct {
-			Decision string `json:"decision"`
-		}
-		if err := json.Unmarshal([]byte(obj), &probe); err == nil && strings.TrimSpace(probe.Decision) != "" {
-			return decodeRecoveryVerdict(obj)
-		}
+	// Whole-string JSON only. An object lifted out of surrounding prose is the
+	// old substring bug again: an agent that quotes the contract to say it is
+	// NOT declaring one would otherwise declare it.
+	trimmed := strings.TrimSpace(text)
+	if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") && carriesDecision(trimmed) {
+		return decodeRecoveryVerdict(trimmed)
 	}
 	return recoveryVerdict{}, errNoRecoveryDeclaration
+}
+
+// carriesDecision reports whether payload is an object with a decision key, so
+// unrelated JSON on the status-reason path reads as no declaration rather than
+// as an unreadable one.
+func carriesDecision(payload string) bool {
+	var probe struct {
+		Decision string `json:"decision"`
+	}
+	if err := json.Unmarshal([]byte(payload), &probe); err != nil {
+		return false
+	}
+	return strings.TrimSpace(probe.Decision) != ""
 }
 
 func lastFencedRecoveryPayload(text string) (string, bool) {

--- a/internal/workflow/recovery_verdict.go
+++ b/internal/workflow/recovery_verdict.go
@@ -1,0 +1,94 @@
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Decisions an implementation agent may declare about closing its task
+// without a PR.
+const (
+	recoveryDecisionAlreadyFixed = "already-fixed-on-main"
+	recoveryDecisionNone         = "none"
+)
+
+// recoveryVerdict is the implementation role's structured statement about
+// whether Sybra may close the task as an already-landed duplicate. It exists
+// so the close decision reads a value the agent declared rather than a
+// substring of whatever prose the run happened to emit.
+type recoveryVerdict struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+var recoveryFenceRe = regexp.MustCompile("(?s)```\\s*sybra-recovery\\s*\\n(.*?)\\n```")
+
+// Legacy prose signals, kept for agents whose prompt predates the declaration
+// block. Every branch token is word-anchored: an unanchored "main" also
+// matches "remaining", "maintain" and "domain", which made the old base-branch
+// signal true for almost any English sentence and left the phrase set below as
+// the only real gate.
+var (
+	fixedPhraseRe = regexp.MustCompile(`already (fixed|on main|merged|landed|satisfied)|duplicate task`)
+	basePhraseRe  = regexp.MustCompile(`\b(main|upstream|origin)\b`)
+	closePhraseRe = regexp.MustCompile(`no pr (needed|required)|safe to close|mark (as )?done`)
+)
+
+// parseRecoveryVerdict returns the verdict an implementation agent declared in
+// a fenced ```sybra-recovery``` block. declared=false means the run made no
+// declaration at all, which is the normal case for an agent on an older
+// prompt. A block that is present but unreadable returns an error instead:
+// once an agent has tried to declare and failed, falling back to guessing from
+// its prose is the behaviour this replaces.
+func parseRecoveryVerdict(text string) (v recoveryVerdict, declared bool, err error) {
+	m := recoveryFenceRe.FindStringSubmatch(text)
+	if len(m) < 2 {
+		return recoveryVerdict{}, false, nil
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(m[1])), &v); err != nil {
+		return recoveryVerdict{}, false, fmt.Errorf("recovery verdict: malformed json: %w", err)
+	}
+	v.Decision = strings.ToLower(strings.TrimSpace(v.Decision))
+	v.Reason = strings.TrimSpace(v.Reason)
+	switch v.Decision {
+	case recoveryDecisionAlreadyFixed, recoveryDecisionNone:
+		return v, true, nil
+	case "":
+		return recoveryVerdict{}, false, errors.New("recovery verdict: missing decision")
+	default:
+		return recoveryVerdict{}, false, fmt.Errorf("recovery verdict: unknown decision %q", v.Decision)
+	}
+}
+
+// declaresAlreadyFixedOnMain reports whether signal says the requested change
+// is already on the base branch. A structured declaration is authoritative. In
+// its absence the legacy prose match decides, and an unreadable declaration
+// decides nothing at all, so the caller leaves the task parked.
+func declaresAlreadyFixedOnMain(signal string) (bool, error) {
+	v, declared, err := parseRecoveryVerdict(signal)
+	if err != nil {
+		return false, err
+	}
+	if declared {
+		return v.Decision == recoveryDecisionAlreadyFixed, nil
+	}
+	return looksLikeAlreadyFixedOnMainProse(signal), nil
+}
+
+// looksLikeAlreadyFixedOnMainProse is the legacy heuristic: an explicit
+// already-landed phrase, corroborated by either a base-branch mention or an
+// explicit request to close. It is deliberately narrower than a bare keyword
+// scan and is only reached when the run declared nothing.
+func looksLikeAlreadyFixedOnMainProse(signal string) bool {
+	lower := strings.ToLower(strings.TrimSpace(signal))
+	if lower == "" {
+		return false
+	}
+	if !fixedPhraseRe.MatchString(lower) {
+		return false
+	}
+	return basePhraseRe.MatchString(lower) || closePhraseRe.MatchString(lower)
+}

--- a/internal/workflow/recovery_verdict.go
+++ b/internal/workflow/recovery_verdict.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 )
 
@@ -23,59 +22,42 @@ const (
 // matched "main.go", "func main()" and "remaining", and had no notion of
 // negation: a run reporting it had checked and the change was NOT on main
 // closed the task as done.
+//
+// The agent declares it by setting the task's status reason to exactly this
+// object, so a declaration costs a deliberate CLI call that narration cannot
+// imitate.
 type recoveryVerdict struct {
 	Decision string `json:"decision"`
 	Reason   string `json:"reason,omitempty"`
 }
 
-// recoveryFenceRe tolerates up to three leading spaces on the fence so a
-// declaration nested in a list item or blockquote still parses.
-var recoveryFenceRe = regexp.MustCompile("(?ms)^[ \\t]{0,3}```[ \\t]*sybra-recovery[ \\t]*\\n(.*?)\\n[ \\t]{0,3}```")
-
 // errNoRecoveryDeclaration means the run declared nothing. Recovery treats it
 // as "leave the task parked", not as an error worth reporting.
 var errNoRecoveryDeclaration = errors.New("recovery verdict: no declaration")
 
-// parseRecoveryVerdict reads the verdict an implementation agent declared,
-// either as a fenced sybra-recovery block or, on the status-reason path where
-// the reason is a single-line CLI argument, as a bare JSON object.
+// parseRecoveryVerdict reads the verdict only when the whole signal is the
+// declaration, which in practice means the agent set it as the task's status
+// reason through the CLI.
 //
-// The last fenced block wins: the prompt asks for the declaration at the end
-// of the response, and an agent that quotes the contract before answering
-// would otherwise have its quotation read as the verdict.
+// Nothing is extracted from a larger body of text. Every attempt to lift a
+// declaration out of prose reopened the bug this replaces: an agent that
+// quotes the contract to say it is NOT declaring a verdict had the quotation
+// read as one, whether the quote was inline JSON, a fenced block, a markdown
+// table, or an indented fence. Requiring the whole string removes the class
+// rather than the last shape someone thought of.
 func parseRecoveryVerdict(text string) (recoveryVerdict, error) {
-	if payload, ok := lastFencedRecoveryPayload(text); ok {
-		return decodeRecoveryVerdict(payload)
-	}
-	// Whole-string JSON only. An object lifted out of surrounding prose is the
-	// old substring bug again: an agent that quotes the contract to say it is
-	// NOT declaring one would otherwise declare it.
 	trimmed := strings.TrimSpace(text)
-	if strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}") && carriesDecision(trimmed) {
-		return decodeRecoveryVerdict(trimmed)
+	if !strings.HasPrefix(trimmed, "{") || !strings.HasSuffix(trimmed, "}") {
+		return recoveryVerdict{}, errNoRecoveryDeclaration
 	}
-	return recoveryVerdict{}, errNoRecoveryDeclaration
-}
-
-// carriesDecision reports whether payload is an object with a decision key, so
-// unrelated JSON on the status-reason path reads as no declaration rather than
-// as an unreadable one.
-func carriesDecision(payload string) bool {
-	var probe struct {
-		Decision string `json:"decision"`
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &probe); err != nil {
+		return recoveryVerdict{}, fmt.Errorf("recovery verdict: malformed json: %w", err)
 	}
-	if err := json.Unmarshal([]byte(payload), &probe); err != nil {
-		return false
+	if _, ok := probe["decision"]; !ok {
+		return recoveryVerdict{}, errNoRecoveryDeclaration
 	}
-	return strings.TrimSpace(probe.Decision) != ""
-}
-
-func lastFencedRecoveryPayload(text string) (string, bool) {
-	matches := recoveryFenceRe.FindAllStringSubmatch(text, -1)
-	if len(matches) == 0 {
-		return "", false
-	}
-	return matches[len(matches)-1][1], true
+	return decodeRecoveryVerdict(trimmed)
 }
 
 func decodeRecoveryVerdict(payload string) (recoveryVerdict, error) {

--- a/internal/workflow/recovery_verdict_test.go
+++ b/internal/workflow/recovery_verdict_test.go
@@ -2,6 +2,13 @@ package workflow
 
 import "testing"
 
+// quotedFenceDisclaimed is the shape that defeated every extraction-based
+// attempt: the agent echoes a filled-in declaration from the task body and
+// then says in prose that it is not making one.
+const quotedFenceDisclaimed = "I read the task body, which contains the contract example:\n\n" +
+	"```sybra-recovery\n{\"decision\": \"already-fixed-on-main\", \"reason\": \"the change is already on the base branch\"}\n```\n\n" +
+	"I am NOT declaring that. I made no commits and the change is NOT on main."
+
 func TestDeclaresAlreadyFixedOnMain(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
@@ -10,38 +17,26 @@ func TestDeclaresAlreadyFixedOnMain(t *testing.T) {
 		wantDeclared     bool
 	}{
 		{
-			name:             "fenced already fixed",
-			signal:           "Checked the base branch.\n\n```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"landed in an earlier PR\"}\n```",
+			name:             "whole-string declaration",
+			signal:           `{"decision":"already-fixed-on-main","reason":"landed in an earlier PR"}`,
 			wantAlreadyFixed: true,
 			wantDeclared:     true,
 		},
 		{
-			name:             "fenced none",
-			signal:           "```sybra-recovery\n{\"decision\":\"none\"}\n```",
+			name:             "whole-string declaration with surrounding whitespace",
+			signal:           "  \n{\"decision\":\"already-fixed-on-main\",\"reason\":\"landed earlier\"}\n ",
+			wantAlreadyFixed: true,
+			wantDeclared:     true,
+		},
+		{
+			name:             "whole-string none",
+			signal:           `{"decision":"none"}`,
 			wantAlreadyFixed: false,
-			wantDeclared:     true,
-		},
-		{
-			name:             "last fenced block wins over a quoted contract",
-			signal:           "The contract asks for:\n\n```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"example\"}\n```\n\nI made no such finding:\n\n```sybra-recovery\n{\"decision\":\"none\"}\n```",
-			wantAlreadyFixed: false,
-			wantDeclared:     true,
-		},
-		{
-			name:             "indented fence still parses",
-			signal:           "  ```sybra-recovery\n  {\"decision\":\"already-fixed-on-main\",\"reason\":\"already on base\"}\n  ```",
-			wantAlreadyFixed: true,
-			wantDeclared:     true,
-		},
-		{
-			name:             "bare json object on the status-reason path",
-			signal:           `{"decision":"already-fixed-on-main","reason":"duplicate of an earlier task"}`,
-			wantAlreadyFixed: true,
 			wantDeclared:     true,
 		},
 		{
 			name:             "affirmative prose is not a declaration",
-			signal:           "Already fixed on main; no PR needed. Duplicate task, safe to close/mark done.",
+			signal:           alreadyFixedOnMainProse,
 			wantAlreadyFixed: false,
 			wantDeclared:     false,
 		},
@@ -58,12 +53,6 @@ func TestDeclaresAlreadyFixedOnMain(t *testing.T) {
 			wantDeclared:     false,
 		},
 		{
-			name:             "unrelated json is not a declaration",
-			signal:           "Ran the checks and got {\"passed\": true, \"failed\": 0}.",
-			wantAlreadyFixed: false,
-			wantDeclared:     false,
-		},
-		{
 			name:             "json quoted inside prose is not a declaration",
 			signal:           `Per the contract I would emit {"decision": "already-fixed-on-main", "reason": "change already on base"} only if the work were already landed. It is not landed, so I am NOT declaring that.`,
 			wantAlreadyFixed: false,
@@ -72,6 +61,30 @@ func TestDeclaresAlreadyFixedOnMain(t *testing.T) {
 		{
 			name:             "json trailing a prose summary is not a declaration",
 			signal:           "I could not implement the change and made no commits.\n\n{\"decision\": \"already-fixed-on-main\", \"reason\": \"example I am NOT making\"}",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
+		},
+		{
+			name:             "quoted fence disclaimed in prose is not a declaration",
+			signal:           quotedFenceDisclaimed,
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
+		},
+		{
+			name:             "fenced block alone is not a declaration",
+			signal:           "```sybra-recovery\n{\"decision\":\"already-fixed-on-main\"}\n```",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
+		},
+		{
+			name:             "json fence is not a declaration",
+			signal:           "```json\n{\"decision\":\"already-fixed-on-main\"}\n```",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
+		},
+		{
+			name:             "markdown table mentioning the decision is not a declaration",
+			signal:           "| field | value |\n|---|---|\n| decision | already-fixed-on-main |",
 			wantAlreadyFixed: false,
 			wantDeclared:     false,
 		},
@@ -116,23 +129,23 @@ func TestDeclaresAlreadyFixedOnMainUnreadableDeclaration(t *testing.T) {
 	}{
 		{
 			name:   "malformed json",
-			signal: "```sybra-recovery\n{\"decision\": already-fixed-on-main}\n```",
+			signal: `{"decision": already-fixed-on-main}`,
 		},
 		{
 			name:   "unknown decision",
-			signal: "```sybra-recovery\n{\"decision\":\"close-it\"}\n```",
+			signal: `{"decision":"close-it"}`,
 		},
 		{
-			name:   "missing decision",
-			signal: "```sybra-recovery\n{\"reason\":\"it is a duplicate\"}\n```",
+			name:   "empty decision",
+			signal: `{"decision":""}`,
+		},
+		{
+			name:   "unicode lookalike hyphens",
+			signal: `{"decision":"already‑fixed‑on‑main"}`,
 		},
 		{
 			name:   "verbatim prompt placeholder is rejected",
-			signal: "```sybra-recovery\n{\"decision\": \"<already-fixed-on-main|none>\", \"reason\": \"<one sentence>\"}\n```",
-		},
-		{
-			name:   "unreadable declaration outranks corroborating prose",
-			signal: "Already fixed on main, safe to close.\n\n```sybra-recovery\n{\"decision\":\n```",
+			signal: `{"decision": "<already-fixed-on-main|none>", "reason": "<one sentence>"}`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -148,7 +161,7 @@ func TestDeclaresAlreadyFixedOnMainUnreadableDeclaration(t *testing.T) {
 }
 
 func TestRecoveryVerdictReason(t *testing.T) {
-	signal := "```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"landed in an earlier PR\"}\n```"
+	signal := `{"decision":"already-fixed-on-main","reason":"landed in an earlier PR"}`
 	if got := recoveryVerdictReason(signal); got != "landed in an earlier PR" {
 		t.Fatalf("recoveryVerdictReason = %q, want %q", got, "landed in an earlier PR")
 	}

--- a/internal/workflow/recovery_verdict_test.go
+++ b/internal/workflow/recovery_verdict_test.go
@@ -64,6 +64,24 @@ func TestDeclaresAlreadyFixedOnMain(t *testing.T) {
 			wantDeclared:     false,
 		},
 		{
+			name:             "json quoted inside prose is not a declaration",
+			signal:           `Per the contract I would emit {"decision": "already-fixed-on-main", "reason": "change already on base"} only if the work were already landed. It is not landed, so I am NOT declaring that.`,
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
+		},
+		{
+			name:             "json trailing a prose summary is not a declaration",
+			signal:           "I could not implement the change and made no commits.\n\n{\"decision\": \"already-fixed-on-main\", \"reason\": \"example I am NOT making\"}",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
+		},
+		{
+			name:             "unrelated whole-string json is not a declaration",
+			signal:           `{"passed": true, "failed": 0}`,
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
+		},
+		{
 			name:             "empty",
 			signal:           "",
 			wantAlreadyFixed: false,

--- a/internal/workflow/recovery_verdict_test.go
+++ b/internal/workflow/recovery_verdict_test.go
@@ -1,0 +1,111 @@
+package workflow
+
+import "testing"
+
+func TestDeclaresAlreadyFixedOnMain(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		signal string
+		want   bool
+	}{
+		{
+			name:   "structured already fixed",
+			signal: "Checked the base branch.\n\n```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"landed in an earlier PR\"}\n```",
+			want:   true,
+		},
+		{
+			name:   "structured none",
+			signal: "```sybra-recovery\n{\"decision\":\"none\"}\n```",
+			want:   false,
+		},
+		{
+			name:   "structured none wins over prose",
+			signal: "This is a duplicate task, already fixed on main.\n\n```sybra-recovery\n{\"decision\":\"none\"}\n```",
+			want:   false,
+		},
+		{
+			name:   "legacy prose already fixed plus base branch",
+			signal: "Already fixed on main; nothing left to do.",
+			want:   true,
+		},
+		{
+			name:   "legacy prose duplicate plus close request",
+			signal: "Duplicate task, safe to close.",
+			want:   true,
+		},
+		{
+			name:   "remaining does not corroborate",
+			signal: "Already fixed the remaining lint errors in the helper.",
+			want:   false,
+		},
+		{
+			name:   "maintain does not corroborate",
+			signal: "Already fixed the parser so we can maintain one code path.",
+			want:   false,
+		},
+		{
+			name:   "domain does not corroborate",
+			signal: "Already fixed the domain model validation.",
+			want:   false,
+		},
+		{
+			name:   "base branch mention without an already-landed phrase",
+			signal: "Rebased onto origin/main and pushed the branch.",
+			want:   false,
+		},
+		{
+			name:   "empty",
+			signal: "",
+			want:   false,
+		},
+		{
+			name:   "whitespace",
+			signal: " \n\t ",
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := declaresAlreadyFixedOnMain(tc.signal)
+			if err != nil {
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) returned error: %v", tc.signal, err)
+			}
+			if got != tc.want {
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) = %v, want %v", tc.signal, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeclaresAlreadyFixedOnMainUnreadableBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		signal string
+	}{
+		{
+			name:   "malformed json",
+			signal: "```sybra-recovery\n{\"decision\": already-fixed-on-main}\n```",
+		},
+		{
+			name:   "unknown decision",
+			signal: "```sybra-recovery\n{\"decision\":\"close-it\"}\n```",
+		},
+		{
+			name:   "missing decision",
+			signal: "```sybra-recovery\n{\"reason\":\"it is a duplicate\"}\n```",
+		},
+		{
+			name:   "unreadable block outranks corroborating prose",
+			signal: "Already fixed on main, safe to close.\n\n```sybra-recovery\n{\"decision\":\n```",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := declaresAlreadyFixedOnMain(tc.signal)
+			if err == nil {
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) = %v, want an error", tc.signal, got)
+			}
+			if got {
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) = true on error, want false", tc.signal)
+			}
+		})
+	}
+}

--- a/internal/workflow/recovery_verdict_test.go
+++ b/internal/workflow/recovery_verdict_test.go
@@ -4,79 +4,94 @@ import "testing"
 
 func TestDeclaresAlreadyFixedOnMain(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		signal string
-		want   bool
+		name             string
+		signal           string
+		wantAlreadyFixed bool
+		wantDeclared     bool
 	}{
 		{
-			name:   "structured already fixed",
-			signal: "Checked the base branch.\n\n```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"landed in an earlier PR\"}\n```",
-			want:   true,
+			name:             "fenced already fixed",
+			signal:           "Checked the base branch.\n\n```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"landed in an earlier PR\"}\n```",
+			wantAlreadyFixed: true,
+			wantDeclared:     true,
 		},
 		{
-			name:   "structured none",
-			signal: "```sybra-recovery\n{\"decision\":\"none\"}\n```",
-			want:   false,
+			name:             "fenced none",
+			signal:           "```sybra-recovery\n{\"decision\":\"none\"}\n```",
+			wantAlreadyFixed: false,
+			wantDeclared:     true,
 		},
 		{
-			name:   "structured none wins over prose",
-			signal: "This is a duplicate task, already fixed on main.\n\n```sybra-recovery\n{\"decision\":\"none\"}\n```",
-			want:   false,
+			name:             "last fenced block wins over a quoted contract",
+			signal:           "The contract asks for:\n\n```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"example\"}\n```\n\nI made no such finding:\n\n```sybra-recovery\n{\"decision\":\"none\"}\n```",
+			wantAlreadyFixed: false,
+			wantDeclared:     true,
 		},
 		{
-			name:   "legacy prose already fixed plus base branch",
-			signal: "Already fixed on main; nothing left to do.",
-			want:   true,
+			name:             "indented fence still parses",
+			signal:           "  ```sybra-recovery\n  {\"decision\":\"already-fixed-on-main\",\"reason\":\"already on base\"}\n  ```",
+			wantAlreadyFixed: true,
+			wantDeclared:     true,
 		},
 		{
-			name:   "legacy prose duplicate plus close request",
-			signal: "Duplicate task, safe to close.",
-			want:   true,
+			name:             "bare json object on the status-reason path",
+			signal:           `{"decision":"already-fixed-on-main","reason":"duplicate of an earlier task"}`,
+			wantAlreadyFixed: true,
+			wantDeclared:     true,
 		},
 		{
-			name:   "remaining does not corroborate",
-			signal: "Already fixed the remaining lint errors in the helper.",
-			want:   false,
+			name:             "affirmative prose is not a declaration",
+			signal:           "Already fixed on main; no PR needed. Duplicate task, safe to close/mark done.",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
 		},
 		{
-			name:   "maintain does not corroborate",
-			signal: "Already fixed the parser so we can maintain one code path.",
-			want:   false,
+			name:             "negated prose is not a declaration",
+			signal:           "I checked whether this was already fixed on main; it is NOT. Ran out of context before committing, parking for a human.",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
 		},
 		{
-			name:   "domain does not corroborate",
-			signal: "Already fixed the domain model validation.",
-			want:   false,
+			name:             "incidental main.go mention is not a declaration",
+			signal:           "Already fixed the nil deref in main.go and pushed the branch.",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
 		},
 		{
-			name:   "base branch mention without an already-landed phrase",
-			signal: "Rebased onto origin/main and pushed the branch.",
-			want:   false,
+			name:             "unrelated json is not a declaration",
+			signal:           "Ran the checks and got {\"passed\": true, \"failed\": 0}.",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
 		},
 		{
-			name:   "empty",
-			signal: "",
-			want:   false,
+			name:             "empty",
+			signal:           "",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
 		},
 		{
-			name:   "whitespace",
-			signal: " \n\t ",
-			want:   false,
+			name:             "whitespace",
+			signal:           " \n\t ",
+			wantAlreadyFixed: false,
+			wantDeclared:     false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := declaresAlreadyFixedOnMain(tc.signal)
+			alreadyFixed, declared, err := declaresAlreadyFixedOnMain(tc.signal)
 			if err != nil {
 				t.Fatalf("declaresAlreadyFixedOnMain(%q) returned error: %v", tc.signal, err)
 			}
-			if got != tc.want {
-				t.Fatalf("declaresAlreadyFixedOnMain(%q) = %v, want %v", tc.signal, got, tc.want)
+			if declared != tc.wantDeclared {
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) declared = %v, want %v", tc.signal, declared, tc.wantDeclared)
+			}
+			if alreadyFixed != tc.wantAlreadyFixed {
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) alreadyFixed = %v, want %v", tc.signal, alreadyFixed, tc.wantAlreadyFixed)
 			}
 		})
 	}
 }
 
-func TestDeclaresAlreadyFixedOnMainUnreadableBlock(t *testing.T) {
+func TestDeclaresAlreadyFixedOnMainUnreadableDeclaration(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		signal string
@@ -94,18 +109,32 @@ func TestDeclaresAlreadyFixedOnMainUnreadableBlock(t *testing.T) {
 			signal: "```sybra-recovery\n{\"reason\":\"it is a duplicate\"}\n```",
 		},
 		{
-			name:   "unreadable block outranks corroborating prose",
+			name:   "verbatim prompt placeholder is rejected",
+			signal: "```sybra-recovery\n{\"decision\": \"<already-fixed-on-main|none>\", \"reason\": \"<one sentence>\"}\n```",
+		},
+		{
+			name:   "unreadable declaration outranks corroborating prose",
 			signal: "Already fixed on main, safe to close.\n\n```sybra-recovery\n{\"decision\":\n```",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := declaresAlreadyFixedOnMain(tc.signal)
+			alreadyFixed, declared, err := declaresAlreadyFixedOnMain(tc.signal)
 			if err == nil {
-				t.Fatalf("declaresAlreadyFixedOnMain(%q) = %v, want an error", tc.signal, got)
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) = (%v, %v), want an error", tc.signal, alreadyFixed, declared)
 			}
-			if got {
-				t.Fatalf("declaresAlreadyFixedOnMain(%q) = true on error, want false", tc.signal)
+			if alreadyFixed || declared {
+				t.Fatalf("declaresAlreadyFixedOnMain(%q) = (%v, %v) on error, want (false, false)", tc.signal, alreadyFixed, declared)
 			}
 		})
+	}
+}
+
+func TestRecoveryVerdictReason(t *testing.T) {
+	signal := "```sybra-recovery\n{\"decision\":\"already-fixed-on-main\",\"reason\":\"landed in an earlier PR\"}\n```"
+	if got := recoveryVerdictReason(signal); got != "landed in an earlier PR" {
+		t.Fatalf("recoveryVerdictReason = %q, want %q", got, "landed in an earlier PR")
+	}
+	if got := recoveryVerdictReason("no declaration here"); got != "" {
+		t.Fatalf("recoveryVerdictReason = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Motivation

The already-fixed-on-main recovery closed a task as `done` based on a substring scan of whatever prose the run emitted. Its base-branch signal was an unanchored `main`, which matches `main.go`, `func main()`, `remaining`, `maintain` and `domain`, so it was true for almost any sentence and the phrase set was the only real gate. The scan had no notion of negation either: a run reporting that it had checked and the change was **not** on main satisfied both halves and closed the task.

The repo-state proof behind it does not save the situation. No commits ahead, a clean tree, and HEAD reachable from the origin base are all trivially true for a branch the agent never committed to, which is exactly the state a run that gave up leaves behind. Text was the only thing standing between "the agent did nothing" and "task closed as done". #3138.

> Changelog: fix(workflow): declare only through the reason

## Implementation information

A task now closes as an already-landed duplicate only when its entire status reason is a JSON object declaring it, which the agent sets with a deliberate `sybra-cli update --status-reason` call. Nothing is extracted from a larger body of text and the run's response is not a channel at all. The repo-state proof still has to hold on top of the declaration, and a run that declares nothing, or declares something unreadable, stays parked with the reason recorded on the task rather than only in the log.

The prose heuristic is deleted rather than narrowed, and so is every intermediate design this PR went through. That history is the argument for the final shape, so it is worth stating plainly: word-anchoring the base-branch signal still closed on `"I checked whether this was already fixed on main; it is NOT"`; accepting a fenced `sybra-recovery` block still closed when an agent echoed a filled-in block from the task body and disclaimed it in prose; accepting a whole-string object from the run's response still closed a task whose status reason explicitly refused to declare one. Each fix removed one shape and the class survived. Requiring the whole status reason removes the class, because a quotation inside prose is never the whole string and narration cannot invoke the CLI.

The declared reason is bounded with `textutil` before it reaches task frontmatter. A 20,000-character reason previously landed verbatim in the task file.

## Supporting documentation

**Behaviour change worth calling out.** The issue asks both for "never a substring of prose" and for tasks that recovery resolves correctly today to keep resolving. Those conflict and this PR takes the first. Until the new prompt reaches running agents, a duplicate task that would previously have auto-closed on prose now parks for a human. That is the issue's own stated preference for a run it cannot classify, and parking a real duplicate is the cheaper error than closing a task where nothing shipped.

`prompt-lab-author.yaml` also runs `role: implementation` without the declaration contract, so its runs no longer auto-recover. Left deliberately: that workflow authors prompts rather than landing changes.

**Verification.** Every finding above came from adversarial review and from adversarial manual testing against a real `sybra-server` in an isolated `SYBRA_HOME` with fake provider CLIs, not from reading the diff. The final run drove 39 tasks through the recovery; exactly two reached `done`, both intended. The eight response-channel false closes from the previous run are fixed, and a declaration on a branch that does have commits still parks.

Coverage is mutation-checked in both directions. Restoring the prose scan turns `TestAdvanceStep_AlreadyFixedOnMainUndeclaredStaysHumanRequired` red on all five inputs; restoring the response text as a channel turns `TestAdvanceStep_AlreadyFixedOnMainResponseTextIsNotAChannel` red. Before this PR the equivalent engine tests survived the first mutation, which is why the engine-level pins were added next to the pure-function table.

**One thing found and deliberately not fixed here.** `route_pr_fix_result` writes a pr-fix agent's `SYBRA_PR_FIX_REASON` sentinel verbatim as the whole status reason, so an agent can get a syntactically valid declaration into a reason without the CLI call. Testing confirmed it cannot reach `done` three ways: the recovery requires `role: implementation`, no shipped workflow routes a pr-fix human-required park into an implementation step, and every transition into human-required clears the reason. It is a laundering surface with no current exit, so it belongs in its own issue rather than widening this diff.

Closes #3138
