### PR TITLE
fix(project): keep slashes in the default branch

### DIFF
--- a/cmd/sybra-cli/feature_branch_test.go
+++ b/cmd/sybra-cli/feature_branch_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/project"
+)
+
+// TestAssertFeatureBranch is the handoff-side half of the default-branch guard
+// (#3129). It compares the worktree's branch against project.DefaultBranch, so
+// while that truncated refs/heads/release/2.0 to "2.0" the comparison never
+// matched and a handoff from a checkout on the default branch was accepted.
+func TestAssertFeatureBranch(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		defaultBranch string
+		checkout      string
+		wantErr       string
+	}{
+		{name: "slashed default refused", defaultBranch: "release/2.0", checkout: "release/2.0", wantErr: `on the default branch "release/2.0"`},
+		{name: "plain default refused", defaultBranch: "main", checkout: "main", wantErr: `on the default branch "main"`},
+		{name: "feature branch accepted", defaultBranch: "release/2.0", checkout: "feat/work"},
+		{name: "branch sharing the default's last segment accepted", defaultBranch: "release/2.0", checkout: "hotfix/2.0"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tmp := t.TempDir()
+			clone := filepath.Join(tmp, "clone.git")
+			work := filepath.Join(tmp, "work")
+
+			runGit(t, "", "init", "-b", tt.defaultBranch, work)
+			runGit(t, work, "config", "user.email", "test@test.com")
+			runGit(t, work, "config", "user.name", "Test")
+			runGit(t, work, "config", "commit.gpgsign", "false")
+			if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("x\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, work, "add", ".")
+			runGit(t, work, "commit", "-m", "init")
+			runGit(t, "", "clone", "--bare", work, clone)
+			if tt.checkout != tt.defaultBranch {
+				runGit(t, work, "checkout", "-b", tt.checkout)
+			}
+
+			proj := project.Project{ID: "owner/repo", ClonePath: clone}
+			err := assertFeatureBranch(work, proj)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("assertFeatureBranch on %q: %v", tt.checkout, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("handoff accepted a worktree on the default branch %q", tt.defaultBranch)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestAssertFeatureBranch_NoClonePathFailsClosed pins the fail-closed contract:
+// a project record with no clone path must be a diagnosable refusal. Left to
+// git, an empty path runs in the CLI's own cwd, so the guard would compare the
+// worktree's branch against whatever branch that checkout happens to be on.
+func TestAssertFeatureBranch_NoClonePathFailsClosed(t *testing.T) {
+	t.Parallel()
+	work := t.TempDir()
+	runGit(t, "", "init", "-b", "main", work)
+	runGit(t, work, "checkout", "-b", "feat/work")
+
+	err := assertFeatureBranch(work, project.Project{ID: "owner/repo"})
+	if err == nil {
+		t.Fatal("handoff accepted a project with no clone path")
+	}
+	if !strings.Contains(err.Error(), "clone path") {
+		t.Errorf("error = %q, want it to name the missing clone path", err)
+	}
+}

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -480,7 +480,7 @@ func DefaultBranch(ctx context.Context, barePath string) (string, error) {
 	// to a guard, so a project record with no clone_path would compare a real
 	// branch against an unrelated repository's instead of failing.
 	if strings.TrimSpace(barePath) == "" {
-		return "", errors.New("resolve default branch: project has no clone path")
+		return "", errors.New("project has no clone path")
 	}
 	ref, err := outputBare(ctx, barePath, "symbolic-ref", "HEAD")
 	if err != nil {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -472,31 +472,16 @@ func isGitConfigKeyAbsent(err error) bool {
 	return ok && exitErr.ExitCode() == 5
 }
 
-// DefaultBranch resolves barePath's HEAD symbolic ref (e.g.
-// refs/heads/main) and returns just the branch name (main).
-//
-// Truncating at the last slash is wrong for a branch name that contains one —
-// refs/heads/release/2.0 yields "2.0" — but several callers depend on the
-// current behaviour, so fixing it is tracked separately. Comparisons that must
-// be exact use DefaultBranchName.
+// DefaultBranch resolves barePath's HEAD symbolic ref (e.g. refs/heads/main)
+// and returns the branch name it points at (main), slashes intact.
 func DefaultBranch(ctx context.Context, barePath string) (string, error) {
 	ref, err := outputBare(ctx, barePath, "symbolic-ref", "HEAD")
 	if err != nil {
 		return "", err
 	}
-	// refs/heads/main → main
-	return filepath.Base(ref), nil
-}
-
-// DefaultBranchName returns the full default branch name, slashes intact, for
-// callers that compare it against a CurrentBranch. DefaultBranch cannot be used
-// there: it truncates release/2.0 to 2.0, which never matches, silently
-// disabling any guard built on the comparison.
-func DefaultBranchName(ctx context.Context, barePath string) (string, error) {
-	ref, err := outputBare(ctx, barePath, "symbolic-ref", "HEAD")
-	if err != nil {
-		return "", err
-	}
+	// refs/heads/release/2.0 → release/2.0, never "2.0": a truncated name
+	// matches no branch and resolves to no ref, so every guard and base-ref
+	// built on it fails open rather than loudly.
 	return strings.TrimPrefix(ref, "refs/heads/"), nil
 }
 

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -475,6 +475,13 @@ func isGitConfigKeyAbsent(err error) bool {
 // DefaultBranch resolves barePath's HEAD symbolic ref (e.g. refs/heads/main)
 // and returns the branch name it points at (main), slashes intact.
 func DefaultBranch(ctx context.Context, barePath string) (string, error) {
+	// An empty path leaves git in the Sybra process's own cwd, which answers
+	// with whatever branch that checkout is on. Every caller feeds the answer
+	// to a guard, so a project record with no clone_path would compare a real
+	// branch against an unrelated repository's instead of failing.
+	if strings.TrimSpace(barePath) == "" {
+		return "", errors.New("resolve default branch: project has no clone path")
+	}
 	ref, err := outputBare(ctx, barePath, "symbolic-ref", "HEAD")
 	if err != nil {
 		return "", err

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -4344,30 +4344,33 @@ func TestStripHTTPSUserinfo(t *testing.T) {
 
 // A branch name may contain slashes. filepath.Base turned refs/heads/release/2.0
 // into "2.0", which never equals the CurrentBranch it is compared against, so
-// every default-branch refusal silently passed on such a project.
-func TestDefaultBranchName_KeepsSlashes(t *testing.T) {
+// every default-branch refusal silently passed on such a project — and every
+// base ref built from it named a branch that does not exist.
+func TestDefaultBranch_KeepsSlashes(t *testing.T) {
 	t.Parallel()
-	bare := filepath.Join(t.TempDir(), "origin.git")
-	run := func(args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v: %s", args, err, out)
-		}
-	}
-	run("init", "--bare", "-b", "release/2.0", bare)
+	for _, tt := range []struct {
+		name    string
+		initial string
+	}{
+		{"slashed", "release/2.0"},
+		{"plain", "main"},
+		{"two slashes", "team/release/2.0"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			bare := filepath.Join(t.TempDir(), "origin.git")
+			cmd := exec.Command("git", "init", "--bare", "-b", tt.initial, bare)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git init: %v: %s", err, out)
+			}
 
-	got, err := DefaultBranchName(context.Background(), bare)
-	if err != nil {
-		t.Fatalf("DefaultBranchName: %v", err)
-	}
-	if got != "release/2.0" {
-		t.Errorf("DefaultBranchName = %q, want release/2.0", got)
-	}
-
-	// The older DefaultBranch still truncates; that is tracked separately, and
-	// pinning it here keeps the difference deliberate rather than accidental.
-	if legacy, err := DefaultBranch(context.Background(), bare); err != nil || legacy != "2.0" {
-		t.Errorf("DefaultBranch = %q (err %v), want the documented 2.0 truncation", legacy, err)
+			got, err := DefaultBranch(context.Background(), bare)
+			if err != nil {
+				t.Fatalf("DefaultBranch: %v", err)
+			}
+			if got != tt.initial {
+				t.Errorf("DefaultBranch = %q, want %q", got, tt.initial)
+			}
+		})
 	}
 }

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -284,7 +284,7 @@ func setupRebaseRecoveryHandler(t *testing.T, withConflictWorkflow bool) (*Handl
 	// feature/recover against itself.
 	clone := filepath.Join(tmp, "clone.git")
 	runGit(t, "", "clone", "--bare", repo, clone)
-	runGit(t, clone, "symbolic-ref", "HEAD", "refs/heads/main")
+	runGit(t, clone, "-c", "safe.bareRepository=all", "symbolic-ref", "HEAD", "refs/heads/main")
 
 	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
 	if err != nil {

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -278,6 +278,14 @@ func setupRebaseRecoveryHandler(t *testing.T, withConflictWorkflow bool) (*Handl
 	runGit(t, repo, "commit", "-m", "initial")
 	runGit(t, repo, "checkout", "-b", "feature/recover")
 
+	// ClonePath is a bare clone whose HEAD names the project's default branch;
+	// the task's checkout is a separate directory on its feature branch.
+	// Pointing both at `repo` left the default-branch adoption guard checking
+	// feature/recover against itself.
+	clone := filepath.Join(tmp, "clone.git")
+	runGit(t, "", "clone", "--bare", repo, clone)
+	runGit(t, clone, "symbolic-ref", "HEAD", "refs/heads/main")
+
 	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
 	if err != nil {
 		t.Fatal(err)
@@ -288,7 +296,7 @@ func setupRebaseRecoveryHandler(t *testing.T, withConflictWorkflow bool) (*Handl
 		Owner:     "owner",
 		Repo:      "repo",
 		URL:       "https://github.com/owner/repo",
-		ClonePath: repo,
+		ClonePath: clone,
 		Type:      project.ProjectTypePet,
 	})
 

--- a/internal/worktree/default_branch_slash_test.go
+++ b/internal/worktree/default_branch_slash_test.go
@@ -29,8 +29,12 @@ func TestAdoptRefusesSlashedDefaultBranch(t *testing.T) {
 			if err == nil {
 				t.Fatal("adopted a worktree sitting on the default branch")
 			}
-			if !strings.Contains(err.Error(), defaultBranch) {
-				t.Errorf("refusal %q does not name the default branch %q", err, defaultBranch)
+			// The full phrase, not just the branch name: the name alone also
+			// appears in the temp-dir path every adoption error carries, so a
+			// substring check passes on any failure at all.
+			want := `checked out on default branch "` + defaultBranch + `"`
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("refusal %q is not the default-branch refusal for %q", err, defaultBranch)
 			}
 
 			// Control: the refusal must come from the branch being the default

--- a/internal/worktree/default_branch_slash_test.go
+++ b/internal/worktree/default_branch_slash_test.go
@@ -1,0 +1,109 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestAdoptRefusesSlashedDefaultBranch is the acceptance test for #3129. The
+// guard that stops an agent pushing straight to the default branch with no PR
+// compares CurrentBranch against DefaultBranch, and DefaultBranch used to
+// truncate at the last slash — so on a project whose default is release/2.0 it
+// returned "2.0", the comparison never matched, and the guard passed a worktree
+// sitting on the branch it exists to refuse.
+func TestAdoptRefusesSlashedDefaultBranch(t *testing.T) {
+	for _, defaultBranch := range []string{"release/2.0", "main"} {
+		t.Run(defaultBranch, func(t *testing.T) {
+			h := slashDefaultHarness(t, defaultBranch)
+
+			onDefault := filepath.Join(t.TempDir(), "adopted-on-default")
+			mustGit(t, h.proj.ClonePath, "worktree", "add", onDefault, defaultBranch)
+			tk := task.Task{ID: "slash001", Title: "adopt default", ProjectID: h.proj.ID, WorktreeDir: onDefault}
+			_, err := h.m.PrepareForTask(context.Background(), tk, nil)
+			if err == nil {
+				t.Fatal("adopted a worktree sitting on the default branch")
+			}
+			if !strings.Contains(err.Error(), defaultBranch) {
+				t.Errorf("refusal %q does not name the default branch %q", err, defaultBranch)
+			}
+
+			// Control: the refusal must come from the branch being the default
+			// one, not from every adoption failing.
+			onFeature := filepath.Join(t.TempDir(), "adopted-on-feature")
+			mustGit(t, h.proj.ClonePath, "worktree", "add", "-b", "feat/work", onFeature, defaultBranch)
+			feat := task.Task{ID: "slash002", Title: "adopt feature", ProjectID: h.proj.ID, WorktreeDir: onFeature}
+			if _, err := h.m.PrepareForTask(context.Background(), feat, nil); err != nil {
+				t.Fatalf("adopting a feature-branch worktree: %v", err)
+			}
+		})
+	}
+}
+
+// TestPrepareForTask_SlashedDefaultBranchBaseRef pins the other half: the base
+// ref new worktrees branch from is built by concatenating the default branch
+// name, so a truncated name names a ref that does not exist and worktree
+// creation fails outright.
+func TestPrepareForTask_SlashedDefaultBranchBaseRef(t *testing.T) {
+	h := slashDefaultHarness(t, "release/2.0")
+
+	tk, err := h.tasks.Store().Create("slashed base", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("PrepareForTask on a slashed default branch: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "README.md")); err != nil {
+		t.Errorf("worktree was not branched off the default branch's content: %v", err)
+	}
+}
+
+// slashDefaultHarness builds a preparedHarness whose project default branch is
+// defaultBranch, which prepareHarness hardcodes to main.
+func slashDefaultHarness(t *testing.T, defaultBranch string) preparedHarness {
+	t.Helper()
+	h := prepareHarness(t, nil, 0)
+
+	mustGit(t, h.src, "branch", "-m", "main", defaultBranch)
+	mustGit(t, h.proj.ClonePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	mustGit(t, h.proj.ClonePath, "fetch", "origin", "+refs/heads/*:refs/heads/*")
+	mustGit(t, h.proj.ClonePath, "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch)
+	if defaultBranch != "main" {
+		mustGit(t, h.proj.ClonePath, "branch", "-D", "main")
+		mustGit(t, h.proj.ClonePath, "update-ref", "-d", "refs/remotes/origin/main")
+	}
+
+	// Asserted through git, not through project.DefaultBranch: a regression
+	// there must fail at the guard it breaks, not at this setup check.
+	out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", h.proj.ClonePath, "symbolic-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git symbolic-ref: %v: %s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "refs/heads/"+defaultBranch {
+		t.Fatalf("harness HEAD = %q, want refs/heads/%s", got, defaultBranch)
+	}
+	return h
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := append([]string{"-c", "safe.bareRepository=all", "-C", dir}, args...)
+	if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -217,7 +217,7 @@ func (m *Manager) refuseDefaultBranch(ctx context.Context, t task.Task, path, br
 	if err != nil {
 		return fmt.Errorf("resolve existing worktree %s: load project: %w", path, err)
 	}
-	def, err := project.DefaultBranchName(ctx, proj.ClonePath)
+	def, err := project.DefaultBranch(ctx, proj.ClonePath)
 	if err != nil {
 		return fmt.Errorf("resolve existing worktree %s: cannot determine default branch to guard against: %w", path, err)
 	}


### PR DESCRIPTION
## Motivation

`project.DefaultBranch` resolved `symbolic-ref HEAD` and returned `filepath.Base(ref)`, so `refs/heads/release/2.0` came back as `"2.0"`.

That name matches no branch and resolves to no ref, so everything built on it failed open rather than loudly. The guard that refuses a worktree checked out on the default branch compares against `project.CurrentBranch`, which returns `release/2.0` — the comparison never matched, and the guard passed a checkout it exists to refuse. `sybra-cli handoff` compares the same way. Every base ref built by concatenation named `origin/2.0`, a branch that does not exist, so worktree creation failed outright and `LoadRepoConfigAtDefaultBranch` could not read the repo's own `setup:` block.

> Changelog: fix(project): resolve default branch names containing slashes

## Implementation information

`DefaultBranch` returns the name with slashes intact, and `DefaultBranchName` — added by #3121 as a narrow workaround for one comparison — folds back into it.

All ten non-test callers were audited, and every one wants the untruncated name: each either compares for exact equality against `CurrentBranch` (already slash-preserving) or concatenates onto `refs/heads/` or `refs/remotes/origin/`. None builds a path segment, directory name, or display label from it.

The three review-recovery tests that made the straightforward fix look like a regression were the reason it was deferred, and they were wrong rather than protective. They pointed a project's `ClonePath` and its task's `WorktreeDir` at one non-bare repo sitting on `feature/recover`, so the adoption guard was comparing that branch against a mangled copy of itself and could never fire. They now get a bare clone whose HEAD names the default branch, which is what a project record actually holds.

`DefaultBranch` also now rejects an empty clone path. `gitexec` maps that to `cmd.Dir = ""`, so git ran in the Sybra process's own working directory and answered with whatever branch *that* checkout was on — and the untruncated name made that answer start matching. A project record with no `clone_path` is a state two other production sites already guard for, so the guards now fail closed on a diagnosable error instead of on a branch read out of an unrelated repository.

## Supporting documentation

Every new test was mutation-checked. Reverting to `filepath.Base` fails the adoption guard, the base-ref path, and the handoff guard; removing the empty-path check fails the fail-closed test.

Adversarial review found the empty-clone-path defect and that `assertFeatureBranch` — the second guard the issue names — had no test at all and stayed green under the revert. Both are fixed here.

Manual testing drove a running `sybra-server` in an isolated `SYBRA_HOME` against projects whose defaults were `release/2.0`, `team/release/2.0` and `main`. Worktrees branched off the real slashed ref (merge-base equals `origin/release/2.0`), all three default-branch guards refused live on each shape, and a branch literally named `2.0` under a `release/2.0` default was correctly accepted — the old false positive is gone. A repo `setup:` block was read from a slashed default branch, which the truncated name could not resolve at all.

One pre-existing defect surfaced during testing and is not fixed here: `verify_commits` ref recovery deletes `refs/remotes/origin/<base>` before fetching and never restores it when the fetch fails. It reproduces identically on a plain `main` project, so it is independent of this change. Filed separately.

Closes #3129
