### PR TITLE
fix(watchdog): stop hangs parking the provider

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -162,7 +162,7 @@ export class AgentRun {
 
     /**
      * ResumeZeroOutputStall marks a run whose zero-output watchdog stall fired
-     * (errorKind "rate_limit" + errorMsg watchdogreason.ZeroOutputBeforeStartup).
+     * (errorKind "silent_hang" + errorMsg watchdogreason.ZeroOutputBeforeStartup).
      * It is the durable poison signal agentorch.PickImplementationResumeSession
      * counts to detect a session stuck in a resume-stall loop.
      */

--- a/frontend/src/components/AgentErrorBanner.svelte
+++ b/frontend/src/components/AgentErrorBanner.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Component } from 'svelte'
-  import { ArrowUpDown, Cloud, Ban, Clock, AlertTriangle, RotateCcw, ChevronRight } from '@lucide/svelte'
+  import { ArrowUpDown, Cloud, Ban, Clock, EyeOff, AlertTriangle, RotateCcw, ChevronRight } from '@lucide/svelte'
   import { agentStore } from '../stores/agents.svelte.js'
 
   interface ErrorEvent {
@@ -58,6 +58,14 @@
       icon: Clock,
       what: 'The API provider rate limit was reached.',
       todo: 'Wait a few minutes and retry, or check provider health.',
+      color: 'bg-warning-50 border-warning-400 dark:bg-warning-950 dark:border-warning-600',
+      iconColor: 'text-warning-500',
+    },
+    silent_hang: {
+      label: 'No output from agent',
+      icon: EyeOff,
+      what: 'The agent process started but produced no output before the startup timeout, so the watchdog stopped it.',
+      todo: 'The task is rescheduled automatically. Provider quota is not the cause — read the run log for what the process was doing.',
       color: 'bg-warning-50 border-warning-400 dark:bg-warning-950 dark:border-warning-600',
       iconColor: 'text-warning-500',
     },

--- a/frontend/src/components/AgentErrorBanner.svelte.test.ts
+++ b/frontend/src/components/AgentErrorBanner.svelte.test.ts
@@ -38,6 +38,15 @@ describe('AgentErrorBanner', () => {
     expect(screen.getByText('Git / network error')).toBeDefined()
   })
 
+  it('shows silent_hang as a hang, not as a rate limit', () => {
+    render(AgentErrorBanner, {
+      props: { agentId: 'a1', error: { kind: 'silent_hang', msg: 'zero output before startup timeout' } },
+    })
+    expect(screen.getByText('No output from agent')).toBeDefined()
+    expect(screen.queryByText('API rate limited')).toBeNull()
+    expect(screen.queryByText(/Wait a few minutes and retry, or check provider health/)).toBeNull()
+  })
+
   it('shows rate_limit error label', () => {
     render(AgentErrorBanner, {
       props: { agentId: 'a1', error: { kind: 'rate_limit', msg: '' } },

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -38,6 +38,11 @@ const (
 	// ErrorKindPromptUndelivered: the child never received the prompt, so the run
 	// carries no verdict and must be re-dispatched instead of counted as a try.
 	ErrorKindPromptUndelivered = "prompt_undelivered"
+	// ErrorKindSilentHang: the child produced no output at all before the
+	// watchdog's startup timeout. Distinct from "rate_limit", which this case
+	// borrowed until the borrowed kind started parking healthy providers and
+	// telling operators to go check a quota that was fine.
+	ErrorKindSilentHang = "silent_hang"
 )
 
 const (
@@ -2163,9 +2168,9 @@ func (a *Agent) SetError(kind, msg string) {
 }
 
 // GetErrorKind returns the classified error kind recorded on the agent
-// ("rate_limit", "auth", or ""). The runner sets it when a run is classified
-// against the provider health gate, letting the completion handler tell a
-// transient provider limit apart from a real crash.
+// ("rate_limit", "auth", "silent_hang", or ""). The runner sets it when a run
+// is classified against the provider health gate, letting the completion
+// handler tell a transient provider limit apart from a real crash.
 func (a *Agent) GetErrorKind() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -2168,9 +2168,10 @@ func (a *Agent) SetError(kind, msg string) {
 }
 
 // GetErrorKind returns the classified error kind recorded on the agent
-// ("rate_limit", "auth", "silent_hang", or ""). The runner sets it when a run
-// is classified against the provider health gate, letting the completion
-// handler tell a transient provider limit apart from a real crash.
+// ("rate_limit", "auth", "silent_hang", or ""). The runner sets the first two
+// when a run is classified against the provider health gate; the watchdog sets
+// silent_hang without consulting the gate at all. Either way the completion
+// handler uses it to tell a run worth re-dispatching from a real crash.
 func (a *Agent) GetErrorKind() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
@@ -2179,7 +2180,7 @@ func (a *Agent) GetErrorKind() string {
 
 // GetErrorMsg returns the classified error message recorded alongside
 // GetErrorKind, e.g. watchdogreason.ZeroOutputBeforeStartup for a zero-output
-// stall reported via RecordProviderSignal.
+// stall recorded by the watchdog.
 func (a *Agent) GetErrorMsg() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -1308,10 +1308,14 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 	}
 
 	if parseErr != nil {
-		if ag.GetErrorKind() == "rate_limit" {
+		if kind := ag.GetErrorKind(); kind == "rate_limit" || kind == agent.ErrorKindSilentHang {
+			deferReason := "provider_rate_limited"
+			if kind == agent.ErrorKindSilentHang {
+				deferReason = "agent_silent_hang"
+			}
 			h.logger.Warn("human-review.verdict.deferred",
-				"task_id", taskID, "agent_id", ag.ID, "reason", "provider_rate_limited")
-			h.logAudit(audit.EventHumanReviewSkipped, taskID, ag.ID, map[string]any{"reason": "provider_rate_limited"})
+				"task_id", taskID, "agent_id", ag.ID, "reason", deferReason)
+			h.logAudit(audit.EventHumanReviewSkipped, taskID, ag.ID, map[string]any{"reason": deferReason})
 			return
 		}
 		// Without the zero-tool-calls check, a run that did real diagnostic

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/verdict"
+	"github.com/Automaat/sybra/internal/watchdogreason"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
@@ -3072,6 +3073,46 @@ func TestOnComplete_RateLimitedVerdictDoesNotRenderNoise(t *testing.T) {
 	for _, run := range got.AgentRuns {
 		if run.AgentID == "hr1" && run.VerdictRendered {
 			t.Fatal("rate-limited human-review must not mark verdict_rendered")
+		}
+	}
+}
+
+// TestOnComplete_SilentHangVerdictDoesNotRenderNoise mirrors the rate-limited
+// case for a review agent the watchdog killed for producing nothing. It has no
+// output at all, so without an explicit defer it reads as an unparseable
+// verdict, gets a "crashed before producing a verdict" note appended, and
+// latches verdict_rendered — retiring the review permanently over a hang that
+// is about to be re-dispatched.
+func TestOnComplete_SilentHangVerdictDoesNotRenderNoise(t *testing.T) {
+	t.Parallel()
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Silent review", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{AgentID: "hr1", Role: string(agent.RoleHumanReview)}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	ag := &agent.Agent{ID: "hr1", TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.SetError(agent.ErrorKindSilentHang, watchdogreason.ZeroOutputBeforeStartup)
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if strings.Contains(got.Body, "unparseable verdict") || strings.Contains(got.Body, "crashed before producing a verdict") {
+		t.Errorf("silently-hung human-review should not append verdict noise; got:\n%s", got.Body)
+	}
+	for _, run := range got.AgentRuns {
+		if run.AgentID == "hr1" && run.VerdictRendered {
+			t.Fatal("silently-hung human-review must not mark verdict_rendered")
 		}
 	}
 }

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -533,16 +533,16 @@ func (h *Handler) buildRunPatch(ag *agent.Agent, state agent.State, cost, premiu
 	if sha := h.captureHeadSHA(ag.TaskID); sha != "" {
 		runUpdates.HeadSHA = task.Ptr(sha)
 	}
-	// Watchdog.handleZeroOutputStall reports the signal with the bare
-	// zeroOutputReason constant (internal/watchdog/agent.go), not the
-	// "watchdog: rate limit: ..." string watchdogreason.RateLimit wraps it in
-	// for the task's StatusReason — RecordProviderSignal persists exactly the
-	// reason string it is handed, so ag.GetErrorMsg() here is the bare
-	// constant. Comparing directly against it (not via
-	// watchdogreason.IsZeroOutputRateLimit, which checks the wrapped form)
-	// is intentional.
+	// Watchdog.handleZeroOutputStall records the bare zeroOutputReason constant
+	// (internal/watchdog/agent.go), not the "watchdog: silent hang: ..." string
+	// watchdogreason.SilentHang wraps it in for the task's StatusReason, so
+	// ag.GetErrorMsg() here is the bare constant. Comparing directly against it
+	// (not via watchdogreason.IsSilentHang, which checks the wrapped form) is
+	// intentional. The "rate_limit" kind is still accepted because a run that
+	// stalled before this build shipped carries the kind this case borrowed
+	// then, and its resume must still be recognized.
 	errKind, errMsg := ag.GetError()
-	if errKind == "rate_limit" && errMsg == watchdogreason.ZeroOutputBeforeStartup {
+	if (errKind == agent.ErrorKindSilentHang || errKind == "rate_limit") && errMsg == watchdogreason.ZeroOutputBeforeStartup {
 		runUpdates.ResumeZeroOutputStall = task.Ptr(true)
 	}
 	return runUpdates
@@ -550,9 +550,9 @@ func (h *Handler) buildRunPatch(ag *agent.Agent, state agent.State, cost, premiu
 
 // notifyWorkflowEngine advances the workflow engine for a completed agent.
 // Returns false if the caller should return immediately. Signal kills and
-// Sybra-initiated stops stall for recovery; rate limits, malformed tool calls,
-// and rejected-tool/user interruptions immediately re-drive the same step so
-// provider failover can choose a healthy peer. Auth failures fall through
+// Sybra-initiated stops stall for recovery; rate limits, silent hangs,
+// malformed tool calls, and rejected-tool/user interruptions immediately
+// re-drive the same step so provider failover can choose a healthy peer. Auth failures fall through
 // (need human login) and take the normal failed path.
 //
 // Load-bearing: PR #722's SIGINT-first path lets default Go binaries (e.g.
@@ -574,7 +574,7 @@ func (h *Handler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, ex
 	if stall.Stalled {
 		h.logger.Warn("agent.completion.stall",
 			"task_id", ag.TaskID, "agent_id", ag.ID,
-			"signaled", isSignalKill(exitErr), "stopped", stall.StopStalled, "rate_limited", stall.RateLimited, "malformed_tool", stall.MalformedTool, "tool_use_aborted", stall.ToolUseAborted, "user_interrupted", stall.UserInterrupted, "checkpoint", stall.CheckpointStopped, "prompt_undelivered", stall.PromptUndelivered)
+			"signaled", isSignalKill(exitErr), "stopped", stall.StopStalled, "rate_limited", stall.RateLimited, "silent_hang", stall.SilentHang, "malformed_tool", stall.MalformedTool, "tool_use_aborted", stall.ToolUseAborted, "user_interrupted", stall.UserInterrupted, "checkpoint", stall.CheckpointStopped, "prompt_undelivered", stall.PromptUndelivered)
 		switch {
 		case stall.CheckpointStopped:
 			h.workflowEngine.RescheduleCheckpointedAgent(ag.TaskID, ag.ID)
@@ -582,7 +582,7 @@ func (h *Handler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, ex
 			h.workflowEngine.RescheduleInterruptedAgent(ag.TaskID, ag.ID)
 		case stall.PromptUndelivered:
 			h.workflowEngine.ReschedulePromptUndeliveredAgent(ag.TaskID, ag.ID)
-		case stall.RateLimited || stall.MalformedTool:
+		case stall.RateLimited || stall.SilentHang || stall.MalformedTool:
 			h.workflowEngine.RescheduleRateLimitedAgent(ag.TaskID, ag.ID)
 		default:
 			h.workflowEngine.ClearAgentStep(ag.TaskID, ag.ID)
@@ -610,6 +610,7 @@ func (h *Handler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, ex
 type stallDisposition struct {
 	Stalled           bool
 	RateLimited       bool
+	SilentHang        bool
 	MalformedTool     bool
 	ToolUseAborted    bool
 	UserInterrupted   bool
@@ -621,6 +622,7 @@ type stallDisposition struct {
 func classifyStall(ag *agent.Agent, exitErr error) stallDisposition {
 	out := stallDisposition{
 		RateLimited:       isRateLimitedRun(ag, exitErr),
+		SilentHang:        isSilentHangRun(ag),
 		MalformedTool:     ag.GetErrorKind() == "malformed_tool_call",
 		ToolUseAborted:    isToolUseAbortedRun(ag),
 		UserInterrupted:   isUserInterruptedRun(ag),
@@ -636,7 +638,7 @@ func classifyStall(ag *agent.Agent, exitErr error) stallDisposition {
 	checkpointFailed := ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpointFailed
 	out.CheckpointStopped = ag.WasStopped() && ag.GetEscalationReason() == agent.EscalationReasonCheckpoint
 	out.StopStalled = ag.WasStopped() && !ag.WasCompletedByResult() && !costStopped && !subagentTurnsStopped && !checkpointFailed && !out.CheckpointStopped
-	out.Stalled = isSignalKill(exitErr) || out.StopStalled || out.RateLimited || out.MalformedTool || out.ToolUseAborted || out.UserInterrupted || out.CheckpointStopped || out.PromptUndelivered
+	out.Stalled = isSignalKill(exitErr) || out.StopStalled || out.RateLimited || out.SilentHang || out.MalformedTool || out.ToolUseAborted || out.UserInterrupted || out.CheckpointStopped || out.PromptUndelivered
 	return out
 }
 
@@ -1021,6 +1023,14 @@ func estimatedRunCost(ag *agent.Agent, cost, premiumRequests float64) float64 {
 // as an exit-0 result, so the agent error kind is authoritative.
 func isRateLimitedRun(ag *agent.Agent, exitErr error) bool {
 	return ag.GetErrorKind() == "rate_limit"
+}
+
+// isSilentHangRun reports whether the watchdog killed this run for producing no
+// output at all. It shares the rate-limited run's immediate-reschedule branch
+// (neither carries a verdict, and both re-drive the same step) without sharing
+// its provider-health verdict.
+func isSilentHangRun(ag *agent.Agent) bool {
+	return ag.GetErrorKind() == agent.ErrorKindSilentHang
 }
 
 func isToolUseAbortedRun(ag *agent.Agent) bool {

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -552,8 +552,9 @@ func (h *Handler) buildRunPatch(ag *agent.Agent, state agent.State, cost, premiu
 // Returns false if the caller should return immediately. Signal kills and
 // Sybra-initiated stops stall for recovery; rate limits, silent hangs,
 // malformed tool calls, and rejected-tool/user interruptions immediately
-// re-drive the same step so provider failover can choose a healthy peer. Auth failures fall through
-// (need human login) and take the normal failed path.
+// re-drive the same step, where a rate limit fails over on the health gate and
+// a silent hang is routed around its provider by the engine. Auth failures
+// fall through (need human login) and take the normal failed path.
 //
 // Load-bearing: PR #722's SIGINT-first path lets default Go binaries (e.g.
 // fake-claude in tests) exit with code 2 (NOT WaitStatus.Signaled), so

--- a/internal/sybra/completion/completion_test.go
+++ b/internal/sybra/completion/completion_test.go
@@ -316,6 +316,46 @@ func TestBuildRunPatchMarksResumeZeroOutputStall(t *testing.T) {
 	})
 }
 
+// TestOnComplete_SilentHangReschedulesInsteadOfClearing pins the routing the
+// whole reschedule contract rests on. The disposition alone proves nothing:
+// a silent hang that reaches the default branch still reads as "stalled", it
+// just quietly loses its same-tick re-dispatch and waits for a later sweep.
+func TestOnComplete_SilentHangReschedulesInsteadOfClearing(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	wm := worktree.New(worktree.Config{WorktreesDir: t.TempDir(), Tasks: tasks, Logger: logger})
+	wf := &recordingWorkflow{}
+
+	created, err := tasks.CreateWithStatus("hung task", "body", "headless", task.StatusInProgress, task.Update{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.AddRun(created.ID, task.AgentRun{AgentID: "ag-1", Role: "implementation", Mode: "headless"}); err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &agent.Agent{ID: "ag-1", TaskID: created.ID, Mode: "headless", Provider: "claude"}
+	ag.SetError(agent.ErrorKindSilentHang, watchdogreason.ZeroOutputBeforeStartup)
+	ag.MarkStopped()
+
+	h := New(Config{Logger: logger, Tasks: tasks, Worktrees: wm, WorkflowEngine: wf})
+	h.OnComplete(ag)
+
+	if len(wf.rateLimited) != 1 || wf.rateLimited[0] != "ag-1" {
+		t.Fatalf("RescheduleRateLimitedAgent calls = %v, want [ag-1] (a silent hang must re-drive its step now)", wf.rateLimited)
+	}
+	if len(wf.completed) != 0 {
+		t.Fatalf("HandleAgentComplete called %d times, want 0 (a silent run carries no verdict)", len(wf.completed))
+	}
+	if len(wf.cleared) != 0 {
+		t.Fatalf("ClearAgentStep called %d times, want 0 (clearing drops the immediate re-dispatch)", len(wf.cleared))
+	}
+}
+
 // TestBuildRunPatchDowngradesConformanceWhenReceiptMissing covers #2009: a
 // process can exit cleanly and produce a plausible result without the
 // mandatory workflow skill's transcript ever proving it was followed. The

--- a/internal/sybra/completion/completion_test.go
+++ b/internal/sybra/completion/completion_test.go
@@ -258,6 +258,18 @@ func TestBuildRunPatchMarksResumeZeroOutputStall(t *testing.T) {
 	t.Run("zero-output stall sets the marker", func(t *testing.T) {
 		t.Parallel()
 		ag := &agent.Agent{ID: "ag-1", TaskID: "task-1"}
+		ag.SetError(agent.ErrorKindSilentHang, watchdogreason.ZeroOutputBeforeStartup)
+
+		patch := (&Handler{}).buildRunPatch(ag, agent.StateStopped, 0, 0, "", nil)
+
+		if patch.ResumeZeroOutputStall == nil || !*patch.ResumeZeroOutputStall {
+			t.Fatalf("ResumeZeroOutputStall = %v, want true", patch.ResumeZeroOutputStall)
+		}
+	})
+
+	t.Run("legacy rate_limit kind from an in-flight run still sets the marker", func(t *testing.T) {
+		t.Parallel()
+		ag := &agent.Agent{ID: "ag-1b", TaskID: "task-1"}
 		ag.SetError("rate_limit", watchdogreason.ZeroOutputBeforeStartup)
 
 		patch := (&Handler{}).buildRunPatch(ag, agent.StateStopped, 0, 0, "", nil)
@@ -586,6 +598,21 @@ func TestClassifyStall_CheckpointDisposition(t *testing.T) {
 		if !stall.Stalled || stall.RateLimited || !stall.MalformedTool || stall.ToolUseAborted || stall.StopStalled || stall.CheckpointStopped {
 			t.Fatalf("classifyStall(malformed_tool_call) = stalled=%v rateLimited=%v malformedTool=%v toolUseAborted=%v stopStalled=%v checkpointStopped=%v",
 				stall.Stalled, stall.RateLimited, stall.MalformedTool, stall.ToolUseAborted, stall.StopStalled, stall.CheckpointStopped)
+		}
+	})
+
+	// A silent hang carries no verdict either, and the watchdog no longer
+	// borrows the rate-limit kind to reach this branch (#3154), so the
+	// disposition has to recognize it on its own or the run stops being
+	// re-dispatched at all.
+	t.Run("silent hang stalls for retry without claiming a rate limit", func(t *testing.T) {
+		ag := &agent.Agent{}
+		ag.SetError(agent.ErrorKindSilentHang, watchdogreason.ZeroOutputBeforeStartup)
+
+		stall := classifyStall(ag, nil)
+		if !stall.Stalled || !stall.SilentHang || stall.RateLimited || stall.MalformedTool || stall.ToolUseAborted || stall.CheckpointStopped {
+			t.Fatalf("classifyStall(silent_hang) = stalled=%v silentHang=%v rateLimited=%v malformedTool=%v toolUseAborted=%v checkpointStopped=%v",
+				stall.Stalled, stall.SilentHang, stall.RateLimited, stall.MalformedTool, stall.ToolUseAborted, stall.CheckpointStopped)
 		}
 	})
 

--- a/internal/sybra/completion/parked_adoption_test.go
+++ b/internal/sybra/completion/parked_adoption_test.go
@@ -14,8 +14,9 @@ import (
 // recordingWorkflow captures the workflow.CompletionWorkflow calls OnComplete
 // makes, so a test can assert on advancement vs. suppression.
 type recordingWorkflow struct {
-	completed []workflow.AgentCompletion
-	cleared   []string
+	completed   []workflow.AgentCompletion
+	cleared     []string
+	rateLimited []string
 }
 
 func (r *recordingWorkflow) HandleAgentComplete(_ string, c workflow.AgentCompletion) {
@@ -28,7 +29,9 @@ func (r *recordingWorkflow) ClearAgentStep(_, agentID string) {
 
 func (r *recordingWorkflow) RescheduleInterruptedAgent(_, _ string) {}
 
-func (r *recordingWorkflow) RescheduleRateLimitedAgent(_, _ string) {}
+func (r *recordingWorkflow) RescheduleRateLimitedAgent(_, agentID string) {
+	r.rateLimited = append(r.rateLimited, agentID)
+}
 
 func (r *recordingWorkflow) RescheduleCheckpointedAgent(_, _ string) {}
 

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -284,7 +284,7 @@ type AgentRun struct {
 	// fan-out counting existed.
 	SubagentCallCount int `json:"subagentCallCount,omitempty"`
 	// ResumeZeroOutputStall marks a run whose zero-output watchdog stall fired
-	// (errorKind "rate_limit" + errorMsg watchdogreason.ZeroOutputBeforeStartup).
+	// (errorKind "silent_hang" + errorMsg watchdogreason.ZeroOutputBeforeStartup).
 	// It is the durable poison signal agentorch.PickImplementationResumeSession
 	// counts to detect a session stuck in a resume-stall loop.
 	ResumeZeroOutputStall bool `json:"zeroOutputStall,omitempty"`

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -954,39 +954,37 @@ func (w *Watchdog) stopForRewardHackingRetry(ag *agent.Agent, verdict agent.Insp
 	w.logger.Info("agent.watchdog.reward_hacking.retry", "id", ag.ID, "task_id", ag.TaskID, "reason", verdict.Reason)
 }
 
-// zeroOutputReason is the provider-health detail recorded for a zero-output
-// startup hang (see inspectHeadless). Kept distinct from the generic
-// "rate_limited" reason so provider health status/logs can tell the two
-// apart even though both share the SignalRateLimit health-gate bucket.
+// zeroOutputReason is the detail recorded on the task and the agent for a
+// zero-output startup hang (see inspectHeadless).
 const zeroOutputReason = watchdogreason.ZeroOutputBeforeStartup
 
 // handleZeroOutputStall handles a "stall" trigger on a headless agent that
-// never produced any output at all. This reuses stopForRateLimit's recovery
-// machinery: mark the task retryable (not human-required), report a
-// provider-health signal so the health gate parks this provider for its
-// cooldown and the next dispatch can fail over to a healthy peer, and stop
-// the hung process. Reusing the "rate_limit" signal/error-kind is what makes
-// the completion handler's isRateLimitedRun check reschedule the run
-// immediately (RescheduleRateLimitedAgent) instead of leaving it for the
-// same-provider "watchdog hang" retry budget that #1913 exhausted for
-// nothing.
+// never produced any output at all: mark the task retryable (not
+// human-required), tag the agent so the completion handler re-dispatches the
+// run immediately, and stop the hung process.
+//
+// The agent gets ErrorKindSilentHang rather than a provider-health signal. The
+// two used to be one call: this path reported provider.SignalRateLimit purely
+// to reach the completion handler's reschedule branch and skip the
+// same-provider "watchdog hang" retry budget that #1913 exhausted for nothing.
+// That borrowed signal also parked the whole provider for its rate-limit
+// cooldown, so one task hanging three times in a morning made a healthy
+// provider unavailable to every other task for 45 minutes, and with the peer
+// provider genuinely capped there was nowhere left to fail over (#3154). A
+// silent child says nothing about the provider's quota, so nothing here
+// touches provider health; the reschedule is preserved by the error kind
+// instead.
 func (w *Watchdog) handleZeroOutputStall(ag *agent.Agent, stall, total time.Duration, expectedStatus task.Status) {
 	w.logger.Warn("agent.watchdog.zero_output_stall",
 		"id", ag.ID, "task_id", ag.TaskID, "provider", ag.Provider,
 		"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
-	reason := watchdogreason.RateLimit(zeroOutputReason)
+	reason := watchdogreason.SilentHang(zeroOutputReason)
 	if ag.TaskID == "" {
 		w.logger.Warn("agent.watchdog.zero_output_stall.untracked", "id", ag.ID, "provider", ag.Provider)
 	} else if err := w.applyStatusEffect(ag.TaskID, "watchdog.agent.zero-output-stall", task.StatusInProgress, expectedStatus, reason); err != nil {
 		w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 	}
-	if w.recordProviderSignal != nil {
-		w.recordProviderSignal(ag, provider.Classification{
-			Signal: provider.SignalRateLimit,
-			Reason: zeroOutputReason,
-			Source: provider.CooldownFromConfig,
-		})
-	}
+	ag.SetError(agent.ErrorKindSilentHang, zeroOutputReason)
 	if err := w.stopAgent(ag.ID); err != nil {
 		w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
 	}

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -403,10 +403,12 @@ func (w *Watchdog) inspectHeadless(ctx context.Context, s *state, now time.Time,
 	// crossed an app restart still classifies correctly: fromRecord bumps
 	// LastEventAt to reattach wall-clock, so an empty-log survivor would no
 	// longer satisfy the timestamp equality even though it has produced nothing.
-	// Route it through the provider-health signal path instead, exactly like
-	// stopForRateLimit: this marks the provider unhealthy for its cooldown
-	// window so the reschedule can fail over to a working peer, rather than
-	// retrying the identical broken provider.
+	// Route it through handleZeroOutputStall instead, which tags the run so the
+	// completion handler re-dispatches it at once, and leaves provider health
+	// alone: a child that said nothing is no evidence about the account's
+	// quota. The re-dispatch still routes around the provider that went silent
+	// (workflow.routeAroundSilentHang), so a wedged CLI does not get handed the
+	// same run again.
 	if trigger == "stall" && ag.OutputLen() == 0 {
 		w.handleZeroOutputStall(ag, stall, total, t.Status)
 		return

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1175,25 +1175,25 @@ func TestApplyVerdict_RateLimitStopWithoutTaskStillSignalsAndStops(t *testing.T)
 	}
 }
 
-// TestHandleZeroOutputStall_SignalsProviderAndReschedulesInsteadOfEscalating
-// covers #1913: a headless agent that never produced a single byte of
-// output (NDJSON or stderr) since launch must be treated as a provider
-// startup failure — provider-health signal + retryable in-progress status —
-// not a generic watchdog hang that would exhaust its same-provider retry
-// budget and strand the task (and its umbrella parent) in human-required.
-func TestHandleZeroOutputStall_SignalsProviderAndReschedulesInsteadOfEscalating(t *testing.T) {
+// TestHandleZeroOutputStall_ReschedulesWithoutParkingProvider covers #1913 and
+// #3154 together: a headless agent that never produced a single byte of output
+// (NDJSON or stderr) since launch keeps its retryable in-progress status and
+// its silent-hang error kind, so the completion handler re-dispatches it
+// instead of exhausting the same-provider retry budget and stranding the task
+// (and its umbrella parent) in human-required. What it must NOT do is report
+// provider health: the silent child is no evidence about the account's quota,
+// and reporting it parked a healthy provider for every other task.
+func TestHandleZeroOutputStall_ReschedulesWithoutParkingProvider(t *testing.T) {
 	tasks, tk := newTestTasks(t)
 
 	stopped := false
-	var signaledName, signaledReason string
-	var signaledKind provider.Signal
+	signaled := false
 	w := &Watchdog{
 		tasks:     tasks,
 		logger:    slog.New(slog.DiscardHandler),
 		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
-			ag.SetError("rate_limit", c.Reason)
-			signaledName, signaledKind, signaledReason = ag.Provider, c.Signal, c.Reason
+		recordProviderSignal: func(*agent.Agent, provider.Classification) {
+			signaled = true
 		},
 	}
 
@@ -1210,32 +1210,48 @@ func TestHandleZeroOutputStall_SignalsProviderAndReschedulesInsteadOfEscalating(
 	if !strings.Contains(got.StatusReason, zeroOutputReason) {
 		t.Fatalf("status_reason = %q, want it to include %q", got.StatusReason, zeroOutputReason)
 	}
+	if !watchdogreason.IsSilentHang(got.StatusReason) {
+		t.Fatalf("status_reason = %q, want a silent-hang reason the workflow recovery recognizes", got.StatusReason)
+	}
+	if watchdogreason.IsRateLimit(got.StatusReason) {
+		t.Fatalf("status_reason = %q, want it to stop claiming a rate limit", got.StatusReason)
+	}
 	if !stopped {
 		t.Fatal("stopAgent not called on zero-output stall")
 	}
-	if ag.GetErrorKind() != "rate_limit" {
-		t.Fatalf("agent error kind = %q, want %q (so the completion handler reschedules it)", ag.GetErrorKind(), "rate_limit")
+	if ag.GetErrorKind() != agent.ErrorKindSilentHang {
+		t.Fatalf("agent error kind = %q, want %q (so the completion handler reschedules it)", ag.GetErrorKind(), agent.ErrorKindSilentHang)
 	}
-	if signaledName != "claude" || signaledKind != provider.SignalRateLimit {
-		t.Fatalf("recordProviderSignal(provider=%q, sig=%v), want (claude, SignalRateLimit)", signaledName, signaledKind)
+	if ag.GetErrorMsg() != zeroOutputReason {
+		t.Fatalf("agent error msg = %q, want %q", ag.GetErrorMsg(), zeroOutputReason)
 	}
-	if signaledReason != zeroOutputReason {
-		t.Fatalf("signaled reason = %q, want %q", signaledReason, zeroOutputReason)
+	if signaled {
+		t.Fatal("provider health signalled for a silent child; a hung agent must not park the provider for every other task")
 	}
 }
 
-func TestHandleZeroOutputStall_NoTaskStillSignalsAndStops(t *testing.T) {
+func TestHandleZeroOutputStall_NoTaskStillStops(t *testing.T) {
 	stopped := false
+	signaled := false
 	w := &Watchdog{
-		logger:               slog.New(slog.DiscardHandler),
-		stopAgent:            func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(*agent.Agent, provider.Classification) {},
+		logger:    slog.New(slog.DiscardHandler),
+		stopAgent: func(string) error { stopped = true; return nil },
+		recordProviderSignal: func(*agent.Agent, provider.Classification) {
+			signaled = true
+		},
 	}
 
-	w.handleZeroOutputStall(&agent.Agent{ID: "a1", Provider: "claude"}, time.Hour, time.Hour, task.StatusInProgress)
+	ag := &agent.Agent{ID: "a1", Provider: "claude"}
+	w.handleZeroOutputStall(ag, time.Hour, time.Hour, task.StatusInProgress)
 
 	if !stopped {
 		t.Fatal("stopAgent not called on taskless zero-output stall")
+	}
+	if signaled {
+		t.Fatal("provider health signalled for a taskless silent child")
+	}
+	if ag.GetErrorKind() != agent.ErrorKindSilentHang {
+		t.Fatalf("agent error kind = %q, want %q", ag.GetErrorKind(), agent.ErrorKindSilentHang)
 	}
 }
 
@@ -1248,7 +1264,6 @@ func TestInspectHeadless_ZeroOutputStallSkipsJudge(t *testing.T) {
 
 	judgeCalled := false
 	stopped := false
-	var signaledReason string
 	w := &Watchdog{
 		tasks:  tasks,
 		logger: slog.New(slog.DiscardHandler),
@@ -1257,11 +1272,8 @@ func TestInspectHeadless_ZeroOutputStallSkipsJudge(t *testing.T) {
 			judgeCalled = true
 			return agent.InspectorVerdict{Recommendation: "continue"}, nil
 		},
-		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
-			ag.SetError("rate_limit", c.Reason)
-			signaledReason = c.Reason
-		},
+		stopAgent:            func(string) error { stopped = true; return nil },
+		recordProviderSignal: func(*agent.Agent, provider.Classification) {},
 	}
 
 	started := time.Now().Add(-20 * time.Minute)
@@ -1290,8 +1302,8 @@ func TestInspectHeadless_ZeroOutputStallSkipsJudge(t *testing.T) {
 	if got.Status != task.StatusInProgress {
 		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
 	}
-	if signaledReason != zeroOutputReason {
-		t.Fatalf("signaled reason = %q, want %q", signaledReason, zeroOutputReason)
+	if ag.GetErrorKind() != agent.ErrorKindSilentHang {
+		t.Fatalf("agent error kind = %q, want %q", ag.GetErrorKind(), agent.ErrorKindSilentHang)
 	}
 }
 
@@ -1396,7 +1408,6 @@ func TestInspectHeadless_ReattachedSurvivorZeroOutputSkipsJudge(t *testing.T) {
 
 	judgeCalled := false
 	stopped := false
-	var signaledReason string
 	w := &Watchdog{
 		tasks:  tasks,
 		logger: slog.New(slog.DiscardHandler),
@@ -1405,11 +1416,8 @@ func TestInspectHeadless_ReattachedSurvivorZeroOutputSkipsJudge(t *testing.T) {
 			judgeCalled = true
 			return agent.InspectorVerdict{Recommendation: "continue"}, nil
 		},
-		stopAgent: func(string) error { stopped = true; return nil },
-		recordProviderSignal: func(ag *agent.Agent, c provider.Classification) {
-			ag.SetError("rate_limit", c.Reason)
-			signaledReason = c.Reason
-		},
+		stopAgent:            func(string) error { stopped = true; return nil },
+		recordProviderSignal: func(*agent.Agent, provider.Classification) {},
 	}
 
 	// Empty log, StartedAt well in the past, LastEventAt set to reattach time —
@@ -1433,8 +1441,8 @@ func TestInspectHeadless_ReattachedSurvivorZeroOutputSkipsJudge(t *testing.T) {
 	if !stopped {
 		t.Fatal("stopAgent not called on reattached zero-output stall")
 	}
-	if signaledReason != zeroOutputReason {
-		t.Fatalf("signaled reason = %q, want %q", signaledReason, zeroOutputReason)
+	if ag.GetErrorKind() != agent.ErrorKindSilentHang {
+		t.Fatalf("agent error kind = %q, want %q", ag.GetErrorKind(), agent.ErrorKindSilentHang)
 	}
 }
 

--- a/internal/watchdogreason/reason.go
+++ b/internal/watchdogreason/reason.go
@@ -10,6 +10,7 @@ const (
 	loopStopPrefix             = "watchdog: loop stop"
 	budgetStopPrefix           = "watchdog: budget stop"
 	rateLimitPrefix            = "watchdog: rate limit"
+	silentHangPrefix           = "watchdog: silent hang"
 	rewardHackingPrefix        = "watchdog: reward_hacking"
 	rewardHackingRetryPrefix   = "watchdog: reward-hacking retry"
 	verifyFailedPrefix         = "watchdog: verify suite still fails after loop stop:"
@@ -24,6 +25,7 @@ const (
 	KindLoopStop           Kind = "loop_stop"
 	KindBudgetStop         Kind = "budget_stop"
 	KindRateLimit          Kind = "rate_limit"
+	KindSilentHang         Kind = "silent_hang"
 	KindRewardHacking      Kind = "reward_hacking"
 	KindRewardHackingRetry Kind = "reward_hacking_retry"
 	KindVerifyFailed       Kind = "verify_failed"
@@ -58,6 +60,10 @@ func Parse(reason string) Parsed {
 		return Parsed{Kind: KindRateLimit}
 	case strings.HasPrefix(reason, rateLimitPrefix+":"):
 		return Parsed{Kind: KindRateLimit, Detail: strings.TrimSpace(strings.TrimPrefix(reason, rateLimitPrefix+":"))}
+	case reason == silentHangPrefix:
+		return Parsed{Kind: KindSilentHang}
+	case strings.HasPrefix(reason, silentHangPrefix+":"):
+		return Parsed{Kind: KindSilentHang, Detail: strings.TrimSpace(strings.TrimPrefix(reason, silentHangPrefix+":"))}
 	case reason == rewardHackingPrefix:
 		return Parsed{Kind: KindRewardHacking}
 	case strings.HasPrefix(reason, rewardHackingPrefix+":"):
@@ -89,8 +95,19 @@ func IsRewardHackingRetry(reason string) bool {
 	return Parse(reason).Kind == KindRewardHackingRetry
 }
 
-func IsZeroOutputRateLimit(reason string) bool {
+// IsSilentHang reports whether reason marks a run that produced no output at
+// all before the startup timeout.
+//
+// Two forms match. The current one is KindSilentHang. The second is the legacy
+// rate-limit wrapping this case used before it got its own kind: tasks parked
+// under the old form are already persisted on disk, and their recovery keys off
+// this predicate, so dropping the legacy match would strand every one of them
+// on the next upgrade.
+func IsSilentHang(reason string) bool {
 	parsed := Parse(reason)
+	if parsed.Kind == KindSilentHang {
+		return true
+	}
 	return parsed.Kind == KindRateLimit && parsed.Detail == ZeroOutputBeforeStartup
 }
 
@@ -125,6 +142,10 @@ func RateLimit(reason string) string {
 	return withDetail(rateLimitPrefix, reason)
 }
 
+func SilentHang(reason string) string {
+	return withDetail(silentHangPrefix, reason)
+}
+
 // IsRetryableStop reports whether a human-required watchdog stop is a
 // recoverable loop/stop verdict rather than a verified blocker. This is the
 // class ResumeStalled may safely re-dispatch for workflow-owned implementation
@@ -144,6 +165,7 @@ func isLegacyRetryableStop(reason string) bool {
 	for _, prefix := range []string{
 		budgetStopPrefix,
 		rateLimitPrefix,
+		silentHangPrefix,
 		rewardHackingPrefix,
 		rewardHackingRetryPrefix,
 		verifyFailedPrefix,

--- a/internal/watchdogreason/reason_test.go
+++ b/internal/watchdogreason/reason_test.go
@@ -32,12 +32,38 @@ func TestIsRetryableStop(t *testing.T) {
 	}
 }
 
-func TestIsZeroOutputRateLimit(t *testing.T) {
-	if !IsZeroOutputRateLimit(RateLimit(ZeroOutputBeforeStartup)) {
-		t.Fatalf("expected zero-output watchdog rate limit to match")
+func TestIsSilentHang(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{"current form", SilentHang(ZeroOutputBeforeStartup), true},
+		{"bare prefix", SilentHang(""), true},
+		{"legacy rate-limit wrapping already on disk", RateLimit(ZeroOutputBeforeStartup), true},
+		{"real rate limit", RateLimit("org-level quota exhausted"), false},
+		{"hang", Hang("no stream activity"), false},
+		{"empty", "", false},
 	}
-	if IsZeroOutputRateLimit(RateLimit("org-level quota exhausted")) {
-		t.Fatalf("non-zero-output rate limit must not match")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSilentHang(tc.reason); got != tc.want {
+				t.Fatalf("IsSilentHang(%q) = %v, want %v", tc.reason, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSilentHangIsNotARateLimit pins the split the whole fix rests on: an
+// operator (and every consumer keying off IsRateLimit) must be able to tell a
+// hung child from an exhausted quota by the reason alone.
+func TestSilentHangIsNotARateLimit(t *testing.T) {
+	reason := SilentHang(ZeroOutputBeforeStartup)
+	if IsRateLimit(reason) {
+		t.Fatalf("IsRateLimit(%q) = true, want false", reason)
+	}
+	if got := Parse(reason); got.Kind != KindSilentHang || got.Detail != ZeroOutputBeforeStartup {
+		t.Fatalf("Parse(%q) = %+v, want kind %q with the zero-output detail", reason, got, KindSilentHang)
 	}
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -19,10 +19,17 @@ const (
 	// (2026-07-23 board freeze). We fence, reset the budget, retry fresh once,
 	// and only park blocked if the fresh round also exhausts.
 	watchdogZeroOutputFreshRetryVarPrefix = "watchdog.rate_limit_fresh_retry."
-	watchdogRewardHackingRetryVarPrefix   = "watchdog.reward_hacking_retry."
-	maxWatchdogRewardHackingRetries       = 1
-	transientFetchRetryVarPrefix          = "transient_fetch.retry."
-	maxTransientFetchRetries              = 2
+	// watchdogSilentHangAvoidVarPrefix names the provider whose child went
+	// silent on this step, so the very next dispatch of that step routes around
+	// it. A silent hang used to park the provider on the health gate, and the
+	// park is what pushed the retry onto a peer; dropping the park to keep the
+	// provider available to other tasks would otherwise pin this run to the
+	// provider that just produced nothing. Consumed once, by the next dispatch.
+	watchdogSilentHangAvoidVarPrefix    = "watchdog.silent_hang_avoid."
+	watchdogRewardHackingRetryVarPrefix = "watchdog.reward_hacking_retry."
+	maxWatchdogRewardHackingRetries     = 1
+	transientFetchRetryVarPrefix        = "transient_fetch.retry."
+	maxTransientFetchRetries            = 2
 	// worktreeRepairRetryVarPrefix/maxWorktreeRepairRetries bound the automated
 	// retry budget for tasks parked blocked with blocker.KindWorktreeRepair
 	// (disk-space exhaustion or a failed rebase — see start_error.go). These

--- a/internal/workflow/engine_events_agents.go
+++ b/internal/workflow/engine_events_agents.go
@@ -457,6 +457,7 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 }
 
 func (e *Engine) rescheduleRateLimitedRunAgent(taskID, agentID string, step *Step, t TaskInfo, def *Definition) {
+	e.markSilentHangProvider(&t, step, agentID)
 	if e.shouldSkipResumeForRateLimitedProvider(&t, step, "workflow.rate-limit-reschedule.park") {
 		// Provider is still inside its rate-limit cooldown and no healthy peer is
 		// available to fail over to. Park the task without consuming a watchdog
@@ -776,6 +777,7 @@ func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, pare
 	e.clearAgentStep(taskID, agentID)
 	clearAgentRouteFromWorkflow(wfExec, agentID)
 
+	e.markSilentHangProvider(&fresh, child, agentID)
 	if e.shouldSkipResumeForRateLimitedProvider(&fresh, child, "workflow.rate-limit-reschedule.park") {
 		// See RescheduleRateLimitedAgent: park rather than burn a retry budget or
 		// trip the breaker while this child's provider is rate-limited with no

--- a/internal/workflow/engine_events_watchdog.go
+++ b/internal/workflow/engine_events_watchdog.go
@@ -260,12 +260,17 @@ func (e *Engine) handleWatchdogRateLimitRetry(t *TaskInfo, step *Step) bool {
 	return e.handleWatchdogRecoveryRetry(watchdogRecoveryRateLimit, t, step)
 }
 
+// isWatchdogRateLimitReason gates the bounded retry policy that re-dispatches
+// a parked run. Silent hangs are recovered by the same policy (including its
+// fresh-session escape hatch below) even though they no longer claim the
+// provider was rate-limited, so both reasons have to match here or a hung task
+// parks forever with nothing to pick it back up.
 func isWatchdogRateLimitReason(reason string) bool {
-	return watchdogreason.IsRateLimit(reason)
+	return watchdogreason.IsRateLimit(reason) || watchdogreason.IsSilentHang(reason)
 }
 
 func watchdogRateLimitExhaustionResolution(t TaskInfo, _ *Step, attempts int) (status taskstatus.Status, reason string, terminalState ExecState) {
-	if watchdogreason.IsZeroOutputRateLimit(t.StatusReason) {
+	if watchdogreason.IsSilentHang(t.StatusReason) {
 		return taskstatus.Blocked, fmt.Sprintf("watchdog: zero-output startup retry budget exhausted after %d identical attempts", attempts+1), ExecFailed
 	}
 	return taskstatus.HumanRequired, fmt.Sprintf("watchdog: rate limit retry budget exhausted after %d clean re-dispatches", attempts), ExecFailed
@@ -425,7 +430,7 @@ func (e *Engine) watchdogRateLimitRecoverySpec() watchdogRecoverySpec {
 			onExhausted: func(e *Engine, t *TaskInfo, step *Step, attempts int) {
 				retryKey := watchdogRateLimitRetryKey(step.ID)
 				freshKey := watchdogZeroOutputFreshRetryKey(step.ID)
-				if watchdogreason.IsZeroOutputRateLimit(t.StatusReason) && parseWorkflowInt(t.Workflow.Variables[freshKey]) == 0 {
+				if watchdogreason.IsSilentHang(t.StatusReason) && parseWorkflowInt(t.Workflow.Variables[freshKey]) == 0 {
 					t.Workflow.StartedAt = time.Now().UTC()
 					t.Workflow.SetVar(freshKey, "1")
 					t.Workflow.SetVar(retryKey, "0")
@@ -438,7 +443,7 @@ func (e *Engine) watchdogRateLimitRecoverySpec() watchdogRecoverySpec {
 				}
 				targetStatus, reason, terminalState := watchdogRateLimitExhaustionResolution(*t, step, attempts)
 				t.Workflow.State = terminalState
-				if watchdogreason.IsZeroOutputRateLimit(t.StatusReason) {
+				if watchdogreason.IsSilentHang(t.StatusReason) {
 					t.Workflow.StartedAt = time.Now().UTC()
 				}
 				if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {

--- a/internal/workflow/engine_events_watchdog.go
+++ b/internal/workflow/engine_events_watchdog.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -658,6 +659,41 @@ func watchdogRateLimitRetryKey(stepID string) string {
 
 func watchdogZeroOutputFreshRetryKey(stepID string) string {
 	return watchdogZeroOutputFreshRetryVarPrefix + stepID
+}
+
+func watchdogSilentHangAvoidKey(stepID string) string {
+	return watchdogSilentHangAvoidVarPrefix + stepID
+}
+
+// markSilentHangProvider records the provider of a run the watchdog killed for
+// producing no output, so the next dispatch of the same step routes around it.
+// Called before the retry gate clears the status reason, which is the only
+// evidence at this point that the stop was a silent hang rather than a real
+// rate limit.
+func (e *Engine) markSilentHangProvider(t *TaskInfo, step *Step, agentID string) {
+	if t == nil || t.Workflow == nil || step == nil || !watchdogreason.IsSilentHang(t.StatusReason) {
+		return
+	}
+	prov := runProviderByAgentID(t.AgentRuns, agentID)
+	if prov == "" {
+		return
+	}
+	t.Workflow.SetVar(watchdogSilentHangAvoidKey(step.ID), prov)
+	if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
+		e.logger.Error("workflow.silent-hang.avoid-persist", "task_id", t.ID, "step", step.ID, "err", err)
+	}
+}
+
+func runProviderByAgentID(runs []AgentRunInfo, agentID string) string {
+	if agentID == "" {
+		return ""
+	}
+	for i := range slices.Backward(runs) {
+		if runs[i].AgentID == agentID {
+			return normalizeExplicitWorkflowProvider(runs[i].Provider)
+		}
+	}
+	return ""
 }
 
 func worktreeRepairRetryKey(stepID string) string {

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -587,6 +587,10 @@ func (e *Engine) resolveAgentVariant(t TaskInfo, step *Step, wfExec *Execution, 
 			}
 		}
 	}
+	if routed, ok := e.routeAroundSilentHang(t, step, wfExec, provider); ok {
+		provider = routed
+		assignment.RoutingReason = "silent_hang_avoid"
+	}
 	if provider != "" && !providerAvailable(provider) {
 		e.logger.Warn(fallbackLog, "wanted", provider, "reason", "CLI not found")
 		return "", defaultModel, AgentAssignment{}, nil
@@ -595,6 +599,37 @@ func (e *Engine) resolveAgentVariant(t TaskInfo, step *Step, wfExec *Execution, 
 		assignment.RoutingReason = "cross"
 	}
 	return provider, resolvedModel, assignment, nil
+}
+
+// routeAroundSilentHang moves this one dispatch off the provider whose last run
+// on this step went silent, and consumes the hint so the step returns to normal
+// routing afterwards. The provider stays healthy for every other task, which is
+// the whole point of not reporting a silent child to the health gate — but the
+// run that just watched it produce nothing should not be handed straight back
+// to it.
+func (e *Engine) routeAroundSilentHang(t TaskInfo, step *Step, wfExec *Execution, provider string) (string, bool) {
+	if wfExec == nil || step == nil {
+		return "", false
+	}
+	avoid := wfExec.Variables[watchdogSilentHangAvoidKey(step.ID)]
+	if avoid == "" {
+		return "", false
+	}
+	wfExec.SetVar(watchdogSilentHangAvoidKey(step.ID), "")
+	effective := provider
+	if effective == "" {
+		effective = e.agents.DefaultProvider()
+	}
+	if effective != avoid {
+		return "", false
+	}
+	alt := crossProvider(effective)
+	if alt == "" || alt == avoid || !providerAvailable(alt) {
+		return "", false
+	}
+	e.logger.Info("workflow.silent-hang.reroute",
+		"task_id", t.ID, "step", step.ID, "from", avoid, "to", alt)
+	return alt, true
 }
 
 // resolveProvider resolves the step-level provider string.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4714,6 +4714,100 @@ func TestResumeStalled_SilentHangReasonRecovers(t *testing.T) {
 	}
 }
 
+// TestRescheduleRateLimitedAgent_SilentHangRoutesAroundTheProvider pins the
+// failover the health-gate park used to buy for the hung run itself. Parking
+// the provider is what pushed the retry onto a peer; now that a silent child
+// leaves provider health alone (so other tasks keep dispatching), this run has
+// to route around the provider that produced nothing, or it just hands the
+// same wedged CLI another 15 minutes.
+func TestRescheduleRateLimitedAgent_SilentHangRoutesAroundTheProvider(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.defaultProvider = "claude"
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: watchdogreason.SilentHang(watchdogreason.ZeroOutputBeforeStartup),
+		AgentMode:    "headless",
+		AgentRuns: []AgentRunInfo{
+			{AgentID: "hung-agent", Role: "implementation", Provider: "claude"},
+		},
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+	setWorkflowAgentRoute(t, tasks, "t1", "hung-agent", "implement")
+
+	engine.RescheduleRateLimitedAgent("t1", "hung-agent")
+
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("replacement agent starts = %d, want 1", got)
+	}
+	if p := agents.LastCall().Provider; p == "claude" || p == "" {
+		t.Fatalf("re-dispatched provider = %q, want a peer of the provider that went silent", p)
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if v := got.Workflow.Variables[watchdogSilentHangAvoidKey("implement")]; v != "" {
+		t.Fatalf("avoid var = %q, want it consumed by the dispatch it steered", v)
+	}
+}
+
+// TestRescheduleRateLimitedAgent_RealRateLimitKeepsItsProvider guards the other
+// side: a genuine rate limit is already handled by the health gate's failover,
+// so it must not pick up the silent-hang reroute and start crossing providers
+// on its own.
+func TestRescheduleRateLimitedAgent_RealRateLimitKeepsItsProvider(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.defaultProvider = "claude"
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: watchdogreason.RateLimit("org-level quota exhausted"),
+		AgentMode:    "headless",
+		AgentRuns: []AgentRunInfo{
+			{AgentID: "limited-agent", Role: "implementation", Provider: "claude"},
+		},
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+	setWorkflowAgentRoute(t, tasks, "t1", "limited-agent", "implement")
+
+	engine.RescheduleRateLimitedAgent("t1", "limited-agent")
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if v := got.Workflow.Variables[watchdogSilentHangAvoidKey("implement")]; v != "" {
+		t.Fatalf("avoid var = %q, want empty for a real rate limit", v)
+	}
+}
+
 func TestIsWatchdogRateLimitReason_CoversBothParkedForms(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4672,6 +4672,71 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 	}
 }
 
+// TestResumeStalled_SilentHangReasonRecovers pins the reason rename (#3154):
+// the watchdog now parks a zero-output run under the silent-hang reason instead
+// of a borrowed rate-limit one, and the shared retry policy has to keep picking
+// it up. Without this the fix would trade a parked provider for a parked task
+// that nothing re-dispatches. The sibling tests above still drive the legacy
+// wrapped reason, which is what tasks parked before the upgrade carry on disk.
+func TestResumeStalled_SilentHangReasonRecovers(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: watchdogreason.SilentHang(watchdogreason.ZeroOutputBeforeStartup),
+		AgentMode:    "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{watchdogRateLimitRetryKey("implement"): "1"},
+		},
+	})
+
+	engine.ResumeStalled()
+
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("replacement agent starts = %d, want 1", got)
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != "in-progress" || got.StatusReason != "" {
+		t.Fatalf("status/reason = %q/%q, want in-progress with the reason cleared", got.Status, got.StatusReason)
+	}
+	if got.Workflow.Variables[watchdogRateLimitRetryKey("implement")] != "2" {
+		t.Fatalf("retry var = %q, want 2", got.Workflow.Variables[watchdogRateLimitRetryKey("implement")])
+	}
+}
+
+func TestIsWatchdogRateLimitReason_CoversBothParkedForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{"silent hang", watchdogreason.SilentHang(watchdogreason.ZeroOutputBeforeStartup), true},
+		{"legacy wrapped zero output", watchdogreason.RateLimit(watchdogreason.ZeroOutputBeforeStartup), true},
+		{"real rate limit", watchdogreason.RateLimit("org-level quota exhausted"), true},
+		{"hang", watchdogreason.Hang("no stream activity"), false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWatchdogRateLimitReason(tc.reason); got != tc.want {
+				t.Fatalf("isWatchdogRateLimitReason(%q) = %v, want %v", tc.reason, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestResumeStalled_WatchdogZeroOutputFreshRoundDispatches proves the deadlock
 // break end-to-end: a poisoned resume that has exhausted its resume budget is
 // granted a fresh round (tick 1 consumed, fenced) and then actually


### PR DESCRIPTION
## Motivation

A headless agent that produced no output for its whole startup window was reported to the shared provider health gate as a rate limit. The gate then parked the provider for a full cooldown, so every unrelated task that would have dispatched to it failed with "provider unhealthy (rate_limited)" while the account itself sat at 29 percent of its weekly window. One task that hung three times in a morning made a healthy provider unavailable for roughly 45 minutes, and with the peer provider genuinely capped there was nowhere to fail over, so the board stopped. The agent view compounded it by labelling the run "API rate limited" and sending the operator to check a quota that was fine.

> Changelog: fix(watchdog): stop a silent hang parking the provider

Closes #3154

## Implementation information

The borrowed rate-limit signal was doing two jobs. It reached the completion handler's immediate-reschedule branch, which is worth keeping, and it parked the provider, which is the bug. Those are now separate: the watchdog records `ErrorKindSilentHang` on the agent and a `watchdog: silent hang: ...` reason on the task, and reports nothing to the health gate. `classifyStall` recognises the new kind and routes it down the same reschedule branch as before, so the run stays off the same-provider hang retry budget.

Parking the provider also, as a side effect, pushed the hung run's retry onto a peer. Dropping the park without replacing that would pin the run to the CLI that just produced nothing, so the engine now records which provider went silent on that step and routes the next dispatch of it around that provider once. Provider health stays untouched, so every other task keeps dispatching to it.

Both the new reason and the legacy wrapped form match everywhere recovery keys off them, because tasks parked before this change are already on disk and must still recover. The frontend gets its own `silent_hang` banner instead of the rate-limit one, and the comments that described the deleted health-gate hop were corrected rather than left to drift.

Alternatives considered: leaving the reason string alone and changing only the health-gate call. That keeps the blast radius smaller but leaves the task reason and the agent banner both claiming a rate limit, which is half the reported problem.

## Supporting documentation

Verified by running the real server, not only by tests. Three isolated instances (own `SYBRA_HOME`, own `HOME`, own random port, fake provider CLIs on `PATH`), 7 tasks and 8 silent hangs over ~35 minutes of real wall clock:

- Silent hang on claude: `agent.watchdog.zero_output_stall` then `silent_hang:true`, `workflow.rate-limit-reschedule`, `workflow.silent-hang.reroute from=claude to=codex`; the retried run succeeded on codex and the task reached `done`.
- `GetProviderHealth` reported claude `healthy:true` throughout, with zero `provider.rate_limit.park` and zero `provider.health.flip` lines across all 8 hangs.
- A second task dispatched during the hang ran on the same provider and succeeded, including on the instance where claude was the only provider available.
- Task reason read exactly `watchdog: silent hang: zero output before startup timeout`, and the live agent state served to the agent view carried `errorKind: silent_hang`.
- A genuine rate limit still parked claude for its cooldown, flipped health to unhealthy, and failed over to codex.

Mutation checks: reverting the reschedule branch, or the reroute, leaves the new tests failing, so neither is tautological.
