### PR TITLE
fix(cli): report an unknown config key

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1879,7 +1879,7 @@ func printJSON(v any) int {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(v); err != nil {
-		fmt.Fprintf(os.Stderr, `{"error":"%v"}`+"\n", err)
+		writeJSONError(err.Error())
 		return 1
 	}
 	return 0
@@ -1888,11 +1888,23 @@ func printJSON(v any) int {
 func fatal(jsonOut bool, format string, args ...any) int {
 	msg := fmt.Sprintf(format, args...)
 	if jsonOut {
-		fmt.Fprintf(os.Stderr, `{"error":"%s"}`+"\n", msg)
+		writeJSONError(msg)
 	} else {
 		fmt.Fprintf(os.Stderr, "error: %s\n", msg)
 	}
 	return 1
+}
+
+// writeJSONError marshals rather than interpolating: several messages quote a
+// config key or a path, and a raw double quote inside the string literal makes
+// the object unparseable for the agents that run this with --json.
+func writeJSONError(msg string) {
+	encoded, err := json.Marshal(map[string]string{"error": msg})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", msg)
+		return
+	}
+	fmt.Fprintln(os.Stderr, string(encoded))
 }
 
 func filterProject(tasks []task.Task, projectID string) []task.Task {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -49,11 +49,11 @@ import (
 var hookTaskIDRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 
 var (
-	loadCLIConfig          = config.Load
-	loadCLIConfigNoPersist = config.LoadNoPersist
-	enableCLIAppAuth       = github.EnableAppAuth
-	refreshCLIAppToken     = github.RefreshAppToken
-	currentCLIAppToken     = github.CurrentAppToken
+	loadCLIConfig        = config.Load
+	loadCLIConfigLenient = config.LoadLenient
+	enableCLIAppAuth     = github.EnableAppAuth
+	refreshCLIAppToken   = github.RefreshAppToken
+	currentCLIAppToken   = github.CurrentAppToken
 )
 
 func main() {
@@ -212,11 +212,18 @@ func run(args []string) int {
 	}
 
 	if isReadOnlyConfigCommand(cmd) {
-		cfg, err := loadCLIConfigNoPersist()
+		cfg, schemaErr, err := loadCLIConfigLenient()
 		if err != nil {
 			return fatal(jsonOut, "load config: %v", err)
 		}
-		return cmdConfig(cfg, rest, jsonOut, allowHTTPForHome(homeOverride, home))
+		// Only `config doctor` survives a bad key. It is the command an
+		// operator reaches for once the config stops loading, so dying on that
+		// key leaves them with nothing; it reports the key as a finding
+		// instead, beside every other check. The rest still fail closed.
+		if schemaErr != nil && !isConfigDoctor(rest) {
+			return fatal(jsonOut, "load config: %v", schemaErr)
+		}
+		return cmdConfig(cfg, rest, jsonOut, allowHTTPForHome(homeOverride, home), schemaErr)
 	}
 
 	cfg, err := loadCLIConfig()
@@ -261,6 +268,10 @@ func allowHTTPForHome(homeOverride string, home homeResolution) bool {
 
 func isReadOnlyConfigCommand(cmd string) bool {
 	return cmd == "config"
+}
+
+func isConfigDoctor(args []string) bool {
+	return len(args) > 0 && args[0] == "doctor"
 }
 
 func resolveHome(homeOverride string) homeResolution {
@@ -419,7 +430,7 @@ func dispatch(cmd string, rest []string, cfg *config.Config, store *task.Manager
 	case "progress":
 		return cmdProgress(store, projStore, rest, jsonOut)
 	case "config":
-		return cmdConfig(cfg, rest, jsonOut, allowHTTP)
+		return cmdConfig(cfg, rest, jsonOut, allowHTTP, nil)
 	case "doctor":
 		return cmdDoctor(cfg, store, rest, jsonOut)
 	case "trash":
@@ -477,6 +488,15 @@ func cmdGithubAppToken(cfg *config.Config, jsonOut bool) int {
 
 func dispatchTaskStoreFallback(cmd string, rest []string, jsonOut bool, loadErr error) (code int, handled bool) {
 	if !supportsTaskStoreFallback(cmd) {
+		return 0, false
+	}
+	// An unknown key says nothing about whether the server is reachable, so
+	// the fallback's premise does not hold. Its write path is also the one an
+	// agent cannot use: agents run `sybra-cli update` from inside a sandboxed
+	// worktree where the task store is read-only. Failing here names the key;
+	// falling back turned one stale key into agents that could not update
+	// their own tasks.
+	if errors.Is(loadErr, config.ErrUnknownConfigKey) {
 		return 0, false
 	}
 	store, tasksDir, err := openFallbackTaskStore()
@@ -3096,7 +3116,7 @@ func cmdTasksHistory(cfg *config.Config, args []string, jsonOut bool) int {
 	return 0
 }
 
-func cmdConfig(cfg *config.Config, args []string, jsonOut, allowHTTP bool) int {
+func cmdConfig(cfg *config.Config, args []string, jsonOut, allowHTTP bool, schemaErr error) int {
 	if len(args) == 0 {
 		return fatal(jsonOut, "usage: config <dump|explain|doctor|migrate>")
 	}
@@ -3106,7 +3126,7 @@ func cmdConfig(cfg *config.Config, args []string, jsonOut, allowHTTP bool) int {
 	case "explain":
 		return cmdConfigExplain(cfg, args[1:], jsonOut)
 	case "doctor":
-		return cmdConfigDoctor(cfg, jsonOut, allowHTTP)
+		return cmdConfigDoctor(cfg, jsonOut, allowHTTP, schemaErr)
 	case "migrate":
 		return cmdConfigMigrate(args[1:], jsonOut)
 	default:
@@ -3395,12 +3415,18 @@ func resolveCapacity(cfg *config.Config, allowHTTP bool) *doctorCapacityReport {
 	return buildCapacityReport(cfg, api, time.Now())
 }
 
-func cmdConfigDoctor(cfg *config.Config, jsonOut, allowHTTP bool) int {
+func cmdConfigDoctor(cfg *config.Config, jsonOut, allowHTTP bool, schemaErr error) int {
 	var findings []configDoctorFinding
 	add := func(severity, format string, a ...any) {
 		findings = append(findings, configDoctorFinding{Severity: severity, Message: fmt.Sprintf(format, a...)})
 	}
 	routing := config.BuildRoutingSummary(cfg)
+
+	// Reported first: it is the reason every other command is failing, and the
+	// values below were resolved without it.
+	if schemaErr != nil {
+		add("error", "config schema: %v (this key is ignored; remove it from config.yaml)", schemaErr)
+	}
 
 	addConfigPermFindings(add)
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -371,7 +371,10 @@ func TestCLIWorksWithV2ObservabilityConfig(t *testing.T) {
 func TestCLIGetAndUpdateFallbackWhenConfigLoadFails(t *testing.T) {
 	dir := setupStore(t)
 	t.Setenv("SYBRA_TASKS_DIR", "")
-	if err := os.WriteFile(config.ConfigPath(), []byte("future_namespace:\n  enabled: true\n"), 0o644); err != nil {
+	// Unparseable, not merely unknown: a schema error deliberately no longer
+	// reaches the fallback (#3133), since it says nothing about whether the
+	// server is up and its write path is denied to the agents that hit it.
+	if err := os.WriteFile(config.ConfigPath(), []byte("::not yaml at all\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -432,7 +435,10 @@ func TestCLIFallbackSupportsBroadenedTaskStoreCommands(t *testing.T) {
 		t.Fatalf("seed delete task: %v", err)
 	}
 
-	if err := os.WriteFile(config.ConfigPath(), []byte("future_namespace:\n  enabled: true\n"), 0o644); err != nil {
+	// Unparseable, not merely unknown: a schema error deliberately no longer
+	// reaches the fallback (#3133), since it says nothing about whether the
+	// server is up and its write path is denied to the agents that hit it.
+	if err := os.WriteFile(config.ConfigPath(), []byte("::not yaml at all\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -876,7 +882,7 @@ func TestConfigDoctorJSONReturnsNonZeroForErrors(t *testing.T) {
 	cfg.Agent.Provider = "nope"
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code == 0 {
 		t.Fatalf("expected non-zero exit for JSON doctor errors, output:\n%s", out)
@@ -899,7 +905,7 @@ func TestConfigDoctorJSONReportsGitHubPollingStates(t *testing.T) {
 	cfg.GitHub.Polling.AssignedPRs.Enabled = false
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected status-only doctor to stay non-fatal, got %d:\n%s", code, out)
@@ -934,7 +940,7 @@ func TestConfigDoctorJSONWarnsOnHarnessEvolutionWithoutSelfMonitor(t *testing.T)
 	}
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected the warning to stay non-fatal, got %d:\n%s", code, out)
@@ -958,7 +964,7 @@ func TestConfigDoctorJSONNoWarningWhenSelfMonitorEnabled(t *testing.T) {
 	cfg.SelfMonitor.Enabled = true
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected doctor to stay non-fatal, got %d:\n%s", code, out)
@@ -980,7 +986,7 @@ func TestConfigDoctorJSONReportsSandboxModeErrors(t *testing.T) {
 	cfg.Agent.SandboxMode = "definitely-not-valid"
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code == 0 {
 		t.Fatalf("expected non-zero exit for JSON doctor errors, output:\n%s", out)
@@ -1006,7 +1012,7 @@ func TestConfigDoctorJSONReportsIncompleteK8sSecretEnv(t *testing.T) {
 	}
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code == 0 {
 		t.Fatalf("expected non-zero exit for an incomplete secret_env entry, output:\n%s", out)
@@ -1032,7 +1038,7 @@ func TestConfigDoctorJSONReportsAllMissingK8sSecretEnvFields(t *testing.T) {
 	}
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code == 0 {
 		t.Fatalf("expected non-zero exit for an empty secret_env entry, output:\n%s", out)
@@ -1062,7 +1068,7 @@ func TestConfigDoctorJSONAcceptsCompleteK8sSecretEnv(t *testing.T) {
 	}
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected a complete secret_env entry to stay non-fatal, got %d:\n%s", code, out)
@@ -1093,7 +1099,7 @@ func TestConfigDoctorJSONValidatesK8sSecretEnvRegardlessOfMode(t *testing.T) {
 	}
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code == 0 {
 		t.Fatalf("expected mode: fake to still validate secret_env, output:\n%s", out)
@@ -1109,7 +1115,7 @@ func TestConfigDoctorJSONWarnsOnLowTTLWithDifferingFailedTTL(t *testing.T) {
 	cfg.Agent.K8sJobs.FailedTTL = 86400
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected a warning-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1133,7 +1139,7 @@ func TestConfigDoctorJSONAcceptsTypicalTTLDefaults(t *testing.T) {
 	cfg.Agent.K8sJobs.FailedTTL = 86400
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected typical TTL defaults to stay clean, got %d:\n%s", code, out)
@@ -1159,7 +1165,7 @@ func TestConfigDoctorJSONReportsWhitespaceOnlyK8sSecretEnvFields(t *testing.T) {
 	}
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code == 0 {
 		t.Fatalf("expected a whitespace-only secret_key to be treated as missing, output:\n%s", out)
@@ -1181,7 +1187,7 @@ func TestConfigDoctorJSONAcceptsSupportedEnforceHosts(t *testing.T) {
 	cfg.Agent.SandboxMode = "enforce"
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected supported-host enforce config to stay non-fatal, got %d:\n%s", code, out)
@@ -1208,7 +1214,7 @@ func TestConfigDoctorJSONReportsConfigPermissionWarnings(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1238,7 +1244,7 @@ func TestConfigDoctorJSONAcceptsStricterConfigPermissions(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1274,7 +1280,7 @@ func TestConfigDoctorJSONReportsRoutingSummaryAndWarnings(t *testing.T) {
 	}}
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only routing doctor to exit zero, got %d:\n%s", code, out)
@@ -1322,7 +1328,7 @@ func TestConfigDoctorWarnsOnNonRemappableConcreteFailoverModel(t *testing.T) {
 	cfg.Monitor.Model = "claude-fable-5"
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1351,7 +1357,7 @@ func TestConfigDoctorJSONWarnsOnABTestingWithoutEvaluation(t *testing.T) {
 	cfg.Evaluation.Enabled = false
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1375,7 +1381,7 @@ func TestConfigDoctorJSONWarnsOnRoutingWithoutEvaluation(t *testing.T) {
 	cfg.Evaluation.Enabled = false
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1405,7 +1411,7 @@ func TestConfigDoctorJSONNoExperimentEvaluationWarningWhenEvaluationEnabled(t *t
 	cfg.Evaluation.Enabled = true
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1434,7 +1440,7 @@ func TestConfigDoctorJSONWarnsOnStaleEvaluationReport(t *testing.T) {
 	cfg.Evaluation.Enabled = true
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -1464,7 +1470,7 @@ func TestConfigDoctorJSONWarnsOnMissingEvaluationReport(t *testing.T) {
 	cfg.Evaluation.Enabled = true
 
 	code, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 	if code != 0 {
 		t.Fatalf("expected warnings-only doctor to exit zero, got %d:\n%s", code, out)
@@ -3277,7 +3283,7 @@ func TestConfigDoctorReportsCapacity(t *testing.T) {
 	cfg.Providers.OpenCode.Enabled = false
 
 	_, out := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, true, false)
+		return cmdConfigDoctor(cfg, true, false, nil)
 	})
 
 	var report configDoctorReport
@@ -3295,7 +3301,7 @@ func TestConfigDoctorReportsCapacity(t *testing.T) {
 	}
 
 	_, human := captureStdout(t, func() int {
-		return cmdConfigDoctor(cfg, false, false)
+		return cmdConfigDoctor(cfg, false, false, nil)
 	})
 	if !strings.Contains(human, "provider capacity enabled: claude") {
 		t.Errorf("human output omits the capacity section:\n%s", human)

--- a/cmd/sybra-cli/unknown_key_test.go
+++ b/cmd/sybra-cli/unknown_key_test.go
@@ -8,15 +8,36 @@ import (
 	"testing"
 )
 
-const staleKeyConfig = "schema_version: 2\nagent:\n  sandbox_read_policy: strict\n"
+// staleKeyShapes covers every position an unknown key can sit in, because they
+// are rejected by two different passes: a key inside a schema v2 namespace is
+// refused by the document normalizer, and everything else by the schema walk.
+// A fixture that only exercises one pass reports green while the other still
+// kills the CLI outright.
+var staleKeyShapes = []struct {
+	name string
+	yaml string
+	key  string
+}{
+	{"top level", "schema_version: 2\nfuture_namespace:\n  enabled: true\n", "future_namespace"},
+	{"execution namespace", "schema_version: 2\nexecution:\n  bogus:\n    enabled: true\n", "execution.bogus"},
+	{"workflow namespace", "schema_version: 2\nworkflow:\n  bogus:\n    enabled: true\n", "workflow.bogus"},
+	{"integrations namespace", "schema_version: 2\nintegrations:\n  slack:\n    enabled: true\n", "integrations.slack"},
+	{"supervision namespace", "schema_version: 2\nsupervision:\n  bogus:\n    enabled: true\n", "supervision.bogus"},
+	{"observability namespace", "schema_version: 2\nobservability:\n  bogus:\n    enabled: true\n", "observability.bogus"},
+	{"storage namespace", "schema_version: 2\nstorage:\n  bogus:\n    enabled: true\n", "storage.bogus"},
+	{"storage paths namespace", "schema_version: 2\nstorage:\n  paths:\n    bogus: /tmp/x\n", "storage.paths.bogus"},
+	{"instance namespace", "schema_version: 2\ninstance:\n  bogus: true\n", "instance.bogus"},
+	{"legacy flat key", "schema_version: 2\nagent:\n  sandbox_read_policy: strict\n", "agent.sandbox_read_policy"},
+	{"nested under a known key", "schema_version: 2\nexecution:\n  agent:\n    sandbox_read_policy: strict\n", "agent.sandbox_read_policy"},
+}
 
-// writeStaleKeyConfig seeds an isolated home with a config carrying a key this
-// build no longer knows — the state a rendered config lands in when a key is
-// removed from the schema and the template still ships it.
-func writeStaleKeyConfig(t *testing.T) string {
+// writeStaleKeyConfigYAML seeds an isolated home with a config carrying a key
+// this build no longer knows — the state a rendered config lands in when a key
+// is removed from the schema and the template still ships it.
+func writeStaleKeyConfigYAML(t *testing.T, contents string) string {
 	t.Helper()
 	home := setupStore(t)
-	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(staleKeyConfig), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return home
@@ -27,32 +48,63 @@ func writeStaleKeyConfig(t *testing.T) string {
 // exists to explain, and taking the provider capacity report with it. It must
 // report the key as a finding and still perform every other check.
 func TestConfigDoctorReportsUnknownKey(t *testing.T) {
-	writeStaleKeyConfig(t)
+	for _, shape := range staleKeyShapes {
+		t.Run(shape.name, func(t *testing.T) {
+			writeStaleKeyConfigYAML(t, shape.yaml)
 
-	code, stdout, stderr := runCLIWithStderr(t, "--json", "config", "doctor")
-	if code != 1 {
-		t.Errorf("exit = %d, want 1 (an unknown key is still an error)", code)
+			code, stdout, stderr := runCLIWithStderr(t, "--json", "config", "doctor")
+			if code != 1 {
+				t.Errorf("exit = %d, want 1 (an unknown key is still an error)", code)
+			}
+
+			var report configDoctorReport
+			if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+				t.Fatalf("config doctor produced no report: %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+			}
+
+			var named bool
+			for _, f := range report.Findings {
+				if f.Severity == "error" && strings.Contains(f.Message, shape.key) {
+					named = true
+				}
+			}
+			if !named {
+				t.Errorf("no error finding names %q; findings=%+v", shape.key, report.Findings)
+			}
+			if report.Routing.ProviderPreference == "" {
+				t.Error("routing summary is empty — doctor stopped at the bad key instead of resolving the rest")
+			}
+			if len(report.Findings) < 2 {
+				t.Errorf("only the schema finding was produced, so no other check ran: %+v", report.Findings)
+			}
+		})
 	}
+}
 
+// TestConfigDoctorReportsEveryUnknownKey pins the one-pass contract: template
+// drift leaves several stale keys at once, and reporting one per run turns a
+// single fix into a sequence of them.
+func TestConfigDoctorReportsEveryUnknownKey(t *testing.T) {
+	writeStaleKeyConfigYAML(t, "schema_version: 2\nintegrations:\n  slack:\n    enabled: true\nstorage:\n  bogus: true\nfuture_namespace:\n  enabled: true\n")
+
+	code, stdout, _ := runCLIWithStderr(t, "--json", "config", "doctor")
+	if code != 1 {
+		t.Errorf("exit = %d, want 1", code)
+	}
 	var report configDoctorReport
 	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
-		t.Fatalf("config doctor produced no report: %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+		t.Fatalf("config doctor produced no report: %v", err)
 	}
-
-	var named bool
-	for _, f := range report.Findings {
-		if f.Severity == "error" && strings.Contains(f.Message, "agent.sandbox_read_policy") {
-			named = true
+	for _, key := range []string{"integrations.slack", "storage.bogus", "future_namespace"} {
+		var named bool
+		for _, f := range report.Findings {
+			if f.Severity == "error" && strings.Contains(f.Message, key) {
+				named = true
+			}
 		}
-	}
-	if !named {
-		t.Errorf("no error finding names the unknown key; findings=%+v", report.Findings)
-	}
-	if report.Routing.ProviderPreference == "" {
-		t.Error("routing summary is empty — doctor stopped at the bad key instead of resolving the rest")
-	}
-	if len(report.Findings) < 2 {
-		t.Errorf("only the schema finding was produced, so no other check ran: %+v", report.Findings)
+		if !named {
+			t.Errorf("no error finding names %q; findings=%+v", key, report.Findings)
+		}
 	}
 }
 
@@ -61,21 +113,23 @@ func TestConfigDoctorReportsUnknownKey(t *testing.T) {
 // to a caller still refuses, since the key is silently dropped from it.
 func TestConfigSubcommandsStillFailClosedOnUnknownKey(t *testing.T) {
 	for _, sub := range []string{"dump", "explain"} {
-		t.Run(sub, func(t *testing.T) {
-			writeStaleKeyConfig(t)
+		for _, shape := range staleKeyShapes {
+			t.Run(sub+"/"+shape.name, func(t *testing.T) {
+				writeStaleKeyConfigYAML(t, shape.yaml)
 
-			args := []string{"config", sub}
-			if sub == "explain" {
-				args = append(args, "agent.provider")
-			}
-			code, _, stderr := runCLIWithStderr(t, args...)
-			if code == 0 {
-				t.Fatalf("config %s exited 0 on an unknown config key", sub)
-			}
-			if !strings.Contains(stderr, "agent.sandbox_read_policy") {
-				t.Errorf("stderr does not name the offending key: %q", stderr)
-			}
-		})
+				args := []string{"config", sub}
+				if sub == "explain" {
+					args = append(args, "agent.provider")
+				}
+				code, _, stderr := runCLIWithStderr(t, args...)
+				if code == 0 {
+					t.Fatalf("config %s exited 0 on an unknown config key", sub)
+				}
+				if !strings.Contains(stderr, shape.key) {
+					t.Errorf("stderr does not name the offending key: %q", stderr)
+				}
+			})
+		}
 	}
 }
 
@@ -86,24 +140,26 @@ func TestConfigSubcommandsStillFailClosedOnUnknownKey(t *testing.T) {
 // key became agents that could not update their own tasks.
 func TestUnknownKeyDoesNotRedirectTaskWrites(t *testing.T) {
 	for _, cmd := range []string{"list", "update"} {
-		t.Run(cmd, func(t *testing.T) {
-			writeStaleKeyConfig(t)
+		for _, shape := range staleKeyShapes {
+			t.Run(cmd+"/"+shape.name, func(t *testing.T) {
+				writeStaleKeyConfigYAML(t, shape.yaml)
 
-			args := []string{cmd}
-			if cmd == "update" {
-				args = append(args, "abc12345", "--status", "done")
-			}
-			code, _, stderr := runCLIWithStderr(t, args...)
-			if code == 0 {
-				t.Fatalf("`%s` exited 0 on an unknown config key", cmd)
-			}
-			if strings.Contains(stderr, "falling back to direct task store") {
-				t.Errorf("`%s` fell back to the direct task store on a schema error: %q", cmd, stderr)
-			}
-			if !strings.Contains(stderr, "agent.sandbox_read_policy") {
-				t.Errorf("stderr does not name the offending key: %q", stderr)
-			}
-		})
+				args := []string{cmd}
+				if cmd == "update" {
+					args = append(args, "abc12345", "--status", "done")
+				}
+				code, _, stderr := runCLIWithStderr(t, args...)
+				if code == 0 {
+					t.Fatalf("`%s` exited 0 on an unknown config key", cmd)
+				}
+				if strings.Contains(stderr, "falling back to direct task store") {
+					t.Errorf("`%s` fell back to the direct task store on a schema error: %q", cmd, stderr)
+				}
+				if !strings.Contains(stderr, shape.key) {
+					t.Errorf("stderr does not name the offending key: %q", stderr)
+				}
+			})
+		}
 	}
 }
 
@@ -122,5 +178,23 @@ func TestUnreachableConfigStillFallsBack(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "falling back to direct task store") {
 		t.Errorf("no fallback warning for an unparseable config: %q", stderr)
+	}
+}
+
+// TestJSONErrorIsParseable pins that --json failures stay machine-readable.
+// Agents run `sybra-cli --json update` per the sybra-tasks skill, and the
+// unknown-key messages this change routes to them quote the offending key —
+// interpolating that into a JSON string literal produced output no agent could
+// parse.
+func TestJSONErrorIsParseable(t *testing.T) {
+	writeStaleKeyConfigYAML(t, staleKeyShapes[0].yaml)
+
+	_, _, stderr := runCLIWithStderr(t, "--json", "update", "abc12345", "--status", "done")
+	var got map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stderr)), &got); err != nil {
+		t.Fatalf("--json error is not parseable JSON: %v\nstderr=%q", err, stderr)
+	}
+	if !strings.Contains(got["error"], staleKeyShapes[0].key) {
+		t.Errorf("error field = %q, want it to name the offending key", got["error"])
 	}
 }

--- a/cmd/sybra-cli/unknown_key_test.go
+++ b/cmd/sybra-cli/unknown_key_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const staleKeyConfig = "schema_version: 2\nagent:\n  sandbox_read_policy: strict\n"
+
+// writeStaleKeyConfig seeds an isolated home with a config carrying a key this
+// build no longer knows — the state a rendered config lands in when a key is
+// removed from the schema and the template still ships it.
+func writeStaleKeyConfig(t *testing.T) string {
+	t.Helper()
+	home := setupStore(t)
+	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(staleKeyConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// TestConfigDoctorReportsUnknownKey is the acceptance test for #3133. `config
+// doctor` used to refuse to run on an unknown key — dying on the one input it
+// exists to explain, and taking the provider capacity report with it. It must
+// report the key as a finding and still perform every other check.
+func TestConfigDoctorReportsUnknownKey(t *testing.T) {
+	writeStaleKeyConfig(t)
+
+	code, stdout, stderr := runCLIWithStderr(t, "--json", "config", "doctor")
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 (an unknown key is still an error)", code)
+	}
+
+	var report configDoctorReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("config doctor produced no report: %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+
+	var named bool
+	for _, f := range report.Findings {
+		if f.Severity == "error" && strings.Contains(f.Message, "agent.sandbox_read_policy") {
+			named = true
+		}
+	}
+	if !named {
+		t.Errorf("no error finding names the unknown key; findings=%+v", report.Findings)
+	}
+	if report.Routing.ProviderPreference == "" {
+		t.Error("routing summary is empty — doctor stopped at the bad key instead of resolving the rest")
+	}
+	if len(report.Findings) < 2 {
+		t.Errorf("only the schema finding was produced, so no other check ran: %+v", report.Findings)
+	}
+}
+
+// TestConfigSubcommandsStillFailClosedOnUnknownKey pins the other half: only
+// the diagnostic tolerates a bad key. Anything that hands the resolved config
+// to a caller still refuses, since the key is silently dropped from it.
+func TestConfigSubcommandsStillFailClosedOnUnknownKey(t *testing.T) {
+	for _, sub := range []string{"dump", "explain"} {
+		t.Run(sub, func(t *testing.T) {
+			writeStaleKeyConfig(t)
+
+			args := []string{"config", sub}
+			if sub == "explain" {
+				args = append(args, "agent.provider")
+			}
+			code, _, stderr := runCLIWithStderr(t, args...)
+			if code == 0 {
+				t.Fatalf("config %s exited 0 on an unknown config key", sub)
+			}
+			if !strings.Contains(stderr, "agent.sandbox_read_policy") {
+				t.Errorf("stderr does not name the offending key: %q", stderr)
+			}
+		})
+	}
+}
+
+// TestUnknownKeyDoesNotRedirectTaskWrites pins the second acceptance criterion.
+// A schema error used to drop the CLI into its direct task-store fallback,
+// which is exactly the path an agent cannot take: agents run `sybra-cli update`
+// from inside a sandboxed worktree where that store is read-only, so one stale
+// key became agents that could not update their own tasks.
+func TestUnknownKeyDoesNotRedirectTaskWrites(t *testing.T) {
+	for _, cmd := range []string{"list", "update"} {
+		t.Run(cmd, func(t *testing.T) {
+			writeStaleKeyConfig(t)
+
+			args := []string{cmd}
+			if cmd == "update" {
+				args = append(args, "abc12345", "--status", "done")
+			}
+			code, _, stderr := runCLIWithStderr(t, args...)
+			if code == 0 {
+				t.Fatalf("`%s` exited 0 on an unknown config key", cmd)
+			}
+			if strings.Contains(stderr, "falling back to direct task store") {
+				t.Errorf("`%s` fell back to the direct task store on a schema error: %q", cmd, stderr)
+			}
+			if !strings.Contains(stderr, "agent.sandbox_read_policy") {
+				t.Errorf("stderr does not name the offending key: %q", stderr)
+			}
+		})
+	}
+}
+
+// TestUnreachableConfigStillFallsBack keeps the fallback alive for what it was
+// built for: a config that cannot be read at all, where nothing is known about
+// the server and a local task store is the best available answer.
+func TestUnreachableConfigStillFallsBack(t *testing.T) {
+	home := setupStore(t)
+	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte("::not yaml at all\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := runCLIWithStderr(t, "list")
+	if code != 0 {
+		t.Fatalf("`list` exited %d; the fallback must still cover an unparseable config: %q", code, stderr)
+	}
+	if !strings.Contains(stderr, "falling back to direct task store") {
+		t.Errorf("no fallback warning for an unparseable config: %q", stderr)
+	}
+}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -966,7 +967,7 @@ func (c *Config) InterventionsDir() string {
 
 func Load() (*ResolvedConfig, error) {
 	cfg, _, err := load(loadOptions{persistLoadReconciles: true})
-	return cfg, err
+	return requireResolved(cfg, err)
 }
 
 // LoadNoPersist reads config.yaml and applies in-memory defaults/reconciles
@@ -974,7 +975,20 @@ func Load() (*ResolvedConfig, error) {
 // their read-only contract and to preserve raw-editor formatting/comments.
 func LoadNoPersist() (*ResolvedConfig, error) {
 	cfg, _, err := load(loadOptions{})
-	return cfg, err
+	return requireResolved(cfg, err)
+}
+
+// requireResolved turns "no error but no config" into an error, so callers
+// that dereference the result do not have to prove the combination is
+// impossible.
+func requireResolved(cfg *ResolvedConfig, err error) (*ResolvedConfig, error) {
+	switch {
+	case err != nil:
+		return nil, err
+	case cfg == nil:
+		return nil, errors.New("load config: no configuration resolved")
+	}
+	return cfg, nil
 }
 
 // LoadLenient resolves config.yaml without failing on an unknown key, and

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -965,30 +965,48 @@ func (c *Config) InterventionsDir() string {
 }
 
 func Load() (*ResolvedConfig, error) {
-	return load(loadOptions{persistLoadReconciles: true})
+	cfg, _, err := load(loadOptions{persistLoadReconciles: true})
+	return cfg, err
 }
 
 // LoadNoPersist reads config.yaml and applies in-memory defaults/reconciles
 // without writing any migration back to disk. Reload paths use this to keep
 // their read-only contract and to preserve raw-editor formatting/comments.
 func LoadNoPersist() (*ResolvedConfig, error) {
-	return load(loadOptions{})
+	cfg, _, err := load(loadOptions{})
+	return cfg, err
+}
+
+// LoadLenient resolves config.yaml without failing on an unknown key, and
+// returns that key's error alongside the config rather than instead of it.
+//
+// Only a diagnostic may use this. `config doctor` exists to explain a config
+// an operator cannot get past, and refusing to run on one bad key made it
+// useless in exactly that case — reporting the key as a finding, next to every
+// other check, is the whole point. Everything that acts on the config still
+// fails closed via Load/LoadNoPersist.
+func LoadLenient() (cfg *ResolvedConfig, schemaErr, err error) {
+	return load(loadOptions{lenient: true})
 }
 
 type loadOptions struct {
 	persistLoadReconciles bool
+	lenient               bool
 }
 
-func load(opts loadOptions) (*ResolvedConfig, error) {
+func load(opts loadOptions) (resolvedCfg *ResolvedConfig, schemaErr, err error) {
 	path := configPath()
 	data, err := os.ReadFile(path)
 	existingFile := err == nil
 	var fileCfg *FileConfig
 	switch {
 	case existingFile:
-		fileCfg, err = ParseFileConfig(data)
+		fileCfg, schemaErr, err = parseFileConfigLenient(data)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
+		}
+		if schemaErr != nil && !opts.lenient {
+			return nil, nil, schemaErr
 		}
 		for _, warning := range fileCfg.Warnings() {
 			slog.Warn("config: deprecated schema v2 alias", "warning", warning)
@@ -996,11 +1014,11 @@ func load(opts loadOptions) (*ResolvedConfig, error) {
 	case os.IsNotExist(err):
 		if opts.persistLoadReconciles {
 			if writeErr := writeDefaultConfig(path); writeErr != nil {
-				return nil, writeErr
+				return nil, nil, writeErr
 			}
 		}
 	default:
-		return nil, err
+		return nil, nil, err
 	}
 	if opts.persistLoadReconciles {
 		tightenConfigPerms(path, existingFile)
@@ -1010,13 +1028,13 @@ func load(opts loadOptions) (*ResolvedConfig, error) {
 		ExistingFile:    existingFile,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := ValidateUnattendedPosture(resolved.Config); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	ensureServerAuthToken(resolved.Config, opts.persistLoadReconciles)
-	return resolved.Config, nil
+	return resolved.Config, schemaErr, nil
 }
 
 // AuthTokenPath is where sybra-server's generated bearer token is persisted

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -1000,7 +1000,9 @@ func requireResolved(cfg *ResolvedConfig, err error) (*ResolvedConfig, error) {
 // other check, is the whole point. Everything that acts on the config still
 // fails closed via Load/LoadNoPersist.
 func LoadLenient() (cfg *ResolvedConfig, schemaErr, err error) {
-	return load(loadOptions{lenient: true})
+	cfg, schemaErr, err = load(loadOptions{lenient: true})
+	cfg, err = requireResolved(cfg, err)
+	return cfg, schemaErr, err
 }
 
 type loadOptions struct {

--- a/internal/config/config_migration.go
+++ b/internal/config/config_migration.go
@@ -124,15 +124,42 @@ func CanonicalFilePathForLegacy(path string) (string, bool) {
 	return "", false
 }
 
+// unknownKeySink decides what a namespace does with a key this build does not
+// know. A strict caller gets an error and stops; a diagnostic collects the
+// path and skips the key, so the rest of the document still resolves and every
+// stale key is reported in one pass rather than one per run.
+type unknownKeySink struct {
+	lenient   bool
+	collected []string
+}
+
+func (s *unknownKeySink) reject(path string) error {
+	if s == nil || !s.lenient {
+		return fmt.Errorf("%w %q", ErrUnknownConfigKey, path)
+	}
+	s.collected = append(s.collected, path)
+	return nil
+}
+
+// NormalizeV2Document rewrites a schema v2 document into the flat internal
+// shape, failing on any key it does not know.
 func NormalizeV2Document(root *yaml.Node) (*yaml.Node, []string, error) {
+	doc, warnings, _, err := normalizeV2Document(root, &unknownKeySink{})
+	return doc, warnings, err
+}
+
+// normalizeV2Document returns the unknown keys it skipped alongside the
+// document, so a lenient caller can report them without losing everything
+// else in the file.
+func normalizeV2Document(root *yaml.Node, sink *unknownKeySink) (doc *yaml.Node, warnings, unknown []string, err error) {
 	builder := newFlatConfigBuilder()
-	warnings := []string{}
+	warnings = []string{}
 	top, ok := yamlDocumentMapping(root)
 	if !ok {
 		if root == nil || root.Kind == 0 {
-			return root, nil, nil
+			return root, nil, nil, nil
 		}
-		return nil, nil, fmt.Errorf("config root must be a mapping")
+		return nil, nil, nil, fmt.Errorf("config root must be a mapping")
 	}
 	for i := 0; i+1 < len(top.Content); i += 2 {
 		keyNode := top.Content[i]
@@ -147,38 +174,38 @@ func NormalizeV2Document(root *yaml.Node) (*yaml.Node, []string, error) {
 				warnings = append(warnings, warn)
 			}
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			continue
 		}
 		switch key {
 		case "instance":
-			if err := normalizeInstanceNamespace(builder, valueNode); err != nil {
-				return nil, nil, err
+			if err := normalizeInstanceNamespace(builder, valueNode, sink); err != nil {
+				return nil, nil, nil, err
 			}
 		case "execution":
-			if err := normalizeSimpleNamespace(builder, valueNode, map[string]string{
+			if err := normalizeSimpleNamespaceSink(builder, valueNode, sink, map[string]string{
 				"agent":     "agent",
 				"providers": "providers",
 			}, "execution"); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		case "workflow":
-			if err := normalizeSimpleNamespace(builder, valueNode, map[string]string{
+			if err := normalizeSimpleNamespaceSink(builder, valueNode, sink, map[string]string{
 				"orchestrator": "orchestrator",
 				"testing":      "testing",
 				"triage":       "triage",
 				"umbrella":     "umbrella",
 				"admission":    "admission",
 			}, "workflow"); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		case "integrations":
-			if err := normalizeIntegrationsNamespace(builder, valueNode); err != nil {
-				return nil, nil, err
+			if err := normalizeIntegrationsNamespace(builder, valueNode, sink); err != nil {
+				return nil, nil, nil, err
 			}
 		case "supervision":
-			if err := normalizeSimpleNamespace(builder, valueNode, map[string]string{
+			if err := normalizeSimpleNamespaceSink(builder, valueNode, sink, map[string]string{
 				"human_review":      "human_review",
 				"monitor":           "monitor",
 				"watchdog":          "watchdog",
@@ -188,14 +215,14 @@ func NormalizeV2Document(root *yaml.Node) (*yaml.Node, []string, error) {
 				"harness_evolution": "harness_evolution",
 				"prompt_lab":        "prompt_lab",
 			}, "supervision"); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		case "storage":
-			if err := normalizeStorageNamespace(builder, valueNode); err != nil {
-				return nil, nil, err
+			if err := normalizeStorageNamespace(builder, valueNode, sink); err != nil {
+				return nil, nil, nil, err
 			}
 		case "observability":
-			if err := normalizeSimpleNamespace(builder, valueNode, map[string]string{
+			if err := normalizeSimpleNamespaceSink(builder, valueNode, sink, map[string]string{
 				"logging":      "logging",
 				"audit":        "audit",
 				"metrics":      "metrics",
@@ -203,17 +230,19 @@ func NormalizeV2Document(root *yaml.Node) (*yaml.Node, []string, error) {
 				"intervention": "intervention",
 				"ab_testing":   "ab_testing",
 			}, "observability"); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		case "routing", "server", "cluster", "auto_update", "webhook":
 			if err := builder.setTopLevel(key, valueNode, key); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		default:
-			return nil, nil, fmt.Errorf("unknown config key %q", key)
+			if err := sink.reject(key); err != nil {
+				return nil, nil, nil, err
+			}
 		}
 	}
-	return builder.document(), warnings, nil
+	return builder.document(), warnings, sink.collected, nil
 }
 
 func MigrateRawConfig(raw []byte, toVersion int) (*MigrationResult, error) {
@@ -632,7 +661,7 @@ func normalizeLegacyTopLevel(builder *flatConfigBuilder, key string, value *yaml
 	return false, "", nil
 }
 
-func normalizeSimpleNamespace(builder *flatConfigBuilder, node *yaml.Node, allowed map[string]string, prefix string) error {
+func normalizeSimpleNamespaceSink(builder *flatConfigBuilder, node *yaml.Node, sink *unknownKeySink, allowed map[string]string, prefix string) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("%s must be a mapping", prefix)
 	}
@@ -640,7 +669,10 @@ func normalizeSimpleNamespace(builder *flatConfigBuilder, node *yaml.Node, allow
 		key := node.Content[i].Value
 		dest, ok := allowed[key]
 		if !ok {
-			return fmt.Errorf("unknown config key %q", prefix+"."+key)
+			if err := sink.reject(prefix + "." + key); err != nil {
+				return err
+			}
+			continue
 		}
 		if err := builder.setTopLevel(dest, node.Content[i+1], prefix+"."+key); err != nil {
 			return err
@@ -649,11 +681,11 @@ func normalizeSimpleNamespace(builder *flatConfigBuilder, node *yaml.Node, allow
 	return nil
 }
 
-func normalizeInstanceNamespace(builder *flatConfigBuilder, node *yaml.Node) error {
-	return normalizeSimpleNamespace(builder, node, map[string]string{"project_types": "project_types"}, "instance")
+func normalizeInstanceNamespace(builder *flatConfigBuilder, node *yaml.Node, sink *unknownKeySink) error {
+	return normalizeSimpleNamespaceSink(builder, node, sink, map[string]string{"project_types": "project_types"}, "instance")
 }
 
-func normalizeIntegrationsNamespace(builder *flatConfigBuilder, node *yaml.Node) error {
+func normalizeIntegrationsNamespace(builder *flatConfigBuilder, node *yaml.Node, sink *unknownKeySink) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("integrations must be a mapping")
 	}
@@ -670,7 +702,9 @@ func normalizeIntegrationsNamespace(builder *flatConfigBuilder, node *yaml.Node)
 				return err
 			}
 		default:
-			return fmt.Errorf("unknown config key %q", "integrations."+key)
+			if err := sink.reject("integrations." + key); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -704,7 +738,7 @@ func normalizeGitHubNamespace(builder *flatConfigBuilder, node *yaml.Node) error
 	return nil
 }
 
-func normalizeStorageNamespace(builder *flatConfigBuilder, node *yaml.Node) error {
+func normalizeStorageNamespace(builder *flatConfigBuilder, node *yaml.Node, sink *unknownKeySink) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("storage must be a mapping")
 	}
@@ -729,18 +763,20 @@ func normalizeStorageNamespace(builder *flatConfigBuilder, node *yaml.Node) erro
 				return err
 			}
 		case "paths":
-			if err := normalizeStoragePathsNamespace(builder, value); err != nil {
+			if err := normalizeStoragePathsNamespace(builder, value, sink); err != nil {
 				return err
 			}
 		default:
-			return fmt.Errorf("unknown config key %q", "storage."+key)
+			if err := sink.reject("storage." + key); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
-func normalizeStoragePathsNamespace(builder *flatConfigBuilder, node *yaml.Node) error {
-	return normalizeSimpleNamespace(builder, node, map[string]string{
+func normalizeStoragePathsNamespace(builder *flatConfigBuilder, node *yaml.Node, sink *unknownKeySink) error {
+	return normalizeSimpleNamespaceSink(builder, node, sink, map[string]string{
 		"tasks":       "tasks_dir",
 		"skills":      "skills_dir",
 		"repo":        "repo_dir",

--- a/internal/config/file_config.go
+++ b/internal/config/file_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -14,6 +15,14 @@ const (
 	LegacySchemaVersion  = 1
 	CurrentSchemaVersion = 2
 )
+
+// ErrUnknownConfigKey marks a config.yaml that is valid YAML but names a key
+// this build does not know — typically a key removed by an upgrade, left
+// behind in an externally-rendered file. It is a statement about the schema
+// and nothing else, so callers must not read it as "the config is
+// unreadable": a diagnostic can still resolve every other value, and a client
+// can still reach the server.
+var ErrUnknownConfigKey = errors.New("unknown config key")
 
 // FileConfig preserves what the operator wrote, including whether a key was
 // omitted entirely. Resolve consumes it to produce a concrete ResolvedConfig.
@@ -119,19 +128,34 @@ func yamlNodeAt(node *yaml.Node, path ...string) (*yaml.Node, bool) {
 	return node, true
 }
 
+// ParseFileConfig parses config.yaml and fails on any unknown key.
 func ParseFileConfig(data []byte) (*FileConfig, error) {
+	cfg, schemaErr, err := parseFileConfigLenient(data)
+	if err != nil {
+		return nil, err
+	}
+	if schemaErr != nil {
+		return nil, schemaErr
+	}
+	return cfg, nil
+}
+
+// parseFileConfigLenient returns the parsed config and the unknown-key error
+// separately, so a diagnostic can report the bad key and still read every
+// other value. err is reserved for input this cannot parse at all.
+func parseFileConfigLenient(data []byte) (parsed *FileConfig, schemaErr, err error) {
 	var root yaml.Node
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	cfg := &FileConfig{root: &root, data: append([]byte(nil), data...)}
 	if root.Kind == 0 {
 		cfg.schemaVersion = LegacySchemaVersion
-		return cfg, nil
+		return cfg, nil, nil
 	}
 	schemaVersion, hasVersion, err := parseSchemaVersion(&root)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	cfg.schemaVersion = schemaVersion
 	cfg.hasSchemaVersion = hasVersion
@@ -139,21 +163,18 @@ func ParseFileConfig(data []byte) (*FileConfig, error) {
 	if cfg.schemaVersion >= CurrentSchemaVersion {
 		normalized, warnings, err := NormalizeV2Document(&root)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		cfg.normalizedRoot = normalized
 		cfg.warnings = warnings
 		cfg.normalizedData, err = marshalYAMLDocument(normalized)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		validateRoot = normalized
 		cfg.warnings = append(cfg.warnings, legacyFieldAliasWarnings(normalized)...)
 	}
-	if err := validateKnownConfigKeys(validateRoot, cfg.schemaVersion); err != nil {
-		return nil, err
-	}
-	return cfg, nil
+	return cfg, validateKnownConfigKeys(validateRoot, cfg.schemaVersion), nil
 }
 
 func parseSchemaVersion(root *yaml.Node) (version int, hasVersion bool, err error) {
@@ -471,11 +492,11 @@ func validateNodeAgainstType(node *yaml.Node, typ reflect.Type, path []string, a
 				continue
 			}
 			suggestion := nearestKey(key, knownKeys(fields, allowedAliases, allowedFieldAliases))
-			msg := fmt.Sprintf("unknown config key %q", joinPath(append(path, key)))
+			msg := fmt.Sprintf("%q", joinPath(append(path, key)))
 			if suggestion != "" {
 				msg += fmt.Sprintf(" (did you mean %q?)", suggestion)
 			}
-			return fmt.Errorf("%s", msg)
+			return fmt.Errorf("%w %s", ErrUnknownConfigKey, msg)
 		}
 	case reflect.Slice, reflect.Array:
 		if node.Kind != yaml.SequenceNode {

--- a/internal/config/file_config.go
+++ b/internal/config/file_config.go
@@ -137,6 +137,9 @@ func ParseFileConfig(data []byte) (*FileConfig, error) {
 	case schemaErr != nil:
 		return nil, schemaErr
 	case cfg == nil:
+		// parseFileConfigLenient never returns this combination. Stating it
+		// anyway is what lets the static analysis prove every caller's
+		// dereference safe, rather than leaving it to be inferred.
 		return nil, errors.New("parse config: no document")
 	}
 	return cfg, nil
@@ -162,11 +165,18 @@ func parseFileConfigLenient(data []byte) (parsed *FileConfig, schemaErr, err err
 	cfg.schemaVersion = schemaVersion
 	cfg.hasSchemaVersion = hasVersion
 	validateRoot := &root
+	var skipped []string
 	if cfg.schemaVersion >= CurrentSchemaVersion {
-		normalized, warnings, err := NormalizeV2Document(&root)
+		// Lenient: an unknown key at a namespace boundary is rejected here
+		// rather than by validateKnownConfigKeys below, so a strict normalizer
+		// would abort before the caller ever sees a schema error it could
+		// report. Collect and skip; the strict wrapper turns the same keys
+		// back into a hard failure.
+		normalized, warnings, unknown, err := normalizeV2Document(&root, &unknownKeySink{lenient: true})
 		if err != nil {
 			return nil, nil, err
 		}
+		skipped = unknown
 		cfg.normalizedRoot = normalized
 		cfg.warnings = warnings
 		cfg.normalizedData, err = marshalYAMLDocument(normalized)
@@ -176,7 +186,27 @@ func parseFileConfigLenient(data []byte) (parsed *FileConfig, schemaErr, err err
 		validateRoot = normalized
 		cfg.warnings = append(cfg.warnings, legacyFieldAliasWarnings(normalized)...)
 	}
-	return cfg, validateKnownConfigKeys(validateRoot, cfg.schemaVersion), nil
+	return cfg, unknownKeyError(skipped, validateKnownConfigKeys(validateRoot, cfg.schemaVersion)), nil
+}
+
+// unknownKeyError merges the keys the normalizer skipped with the one the
+// schema walk rejected into a single sentinel-matching error. Reporting every
+// stale key at once matters for the case this exists for: a rendered config
+// left behind by an upgrade usually carries several, and one-per-run turns a
+// single fix into a sequence of them.
+func unknownKeyError(skipped []string, validateErr error) error {
+	if len(skipped) == 0 {
+		return validateErr
+	}
+	quoted := make([]string, 0, len(skipped))
+	for _, key := range skipped {
+		quoted = append(quoted, fmt.Sprintf("%q", key))
+	}
+	msg := strings.Join(quoted, ", ")
+	if validateErr != nil {
+		msg += ", " + strings.TrimPrefix(validateErr.Error(), ErrUnknownConfigKey.Error()+" ")
+	}
+	return fmt.Errorf("%w %s", ErrUnknownConfigKey, msg)
 }
 
 func parseSchemaVersion(root *yaml.Node) (version int, hasVersion bool, err error) {

--- a/internal/config/file_config.go
+++ b/internal/config/file_config.go
@@ -131,11 +131,13 @@ func yamlNodeAt(node *yaml.Node, path ...string) (*yaml.Node, bool) {
 // ParseFileConfig parses config.yaml and fails on any unknown key.
 func ParseFileConfig(data []byte) (*FileConfig, error) {
 	cfg, schemaErr, err := parseFileConfigLenient(data)
-	if err != nil {
+	switch {
+	case err != nil:
 		return nil, err
-	}
-	if schemaErr != nil {
+	case schemaErr != nil:
 		return nil, schemaErr
+	case cfg == nil:
+		return nil, errors.New("parse config: no document")
 	}
 	return cfg, nil
 }

--- a/internal/config/lenient_parse_test.go
+++ b/internal/config/lenient_parse_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseFileConfigLenient covers the split the CLI depends on: a schema
+// error must come back beside a usable config, never instead of it, and it
+// must carry ErrUnknownConfigKey so a caller can tell "this key is stale" from
+// "this file is unreadable". The two rejection passes disagree about which
+// keys they own — a namespace key is refused by the document normalizer and
+// everything else by the schema walk — so both are covered here.
+func TestParseFileConfigLenient(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		yaml string
+		key  string
+	}{
+		{"top level", "schema_version: 2\nfuture_namespace:\n  enabled: true\n", "future_namespace"},
+		{"execution namespace", "schema_version: 2\nexecution:\n  bogus:\n    enabled: true\n", "execution.bogus"},
+		{"integrations namespace", "schema_version: 2\nintegrations:\n  slack:\n    enabled: true\n", "integrations.slack"},
+		{"storage paths namespace", "schema_version: 2\nstorage:\n  paths:\n    bogus: /tmp/x\n", "storage.paths.bogus"},
+		{"instance namespace", "schema_version: 2\ninstance:\n  bogus: true\n", "instance.bogus"},
+		{"nested field", "schema_version: 2\nexecution:\n  agent:\n    bogus_field: 1\n", "agent.bogus_field"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, schemaErr, err := parseFileConfigLenient([]byte(tt.yaml))
+			if err != nil {
+				t.Fatalf("err = %v, want nil (a stale key is not unparseable input)", err)
+			}
+			if cfg == nil {
+				t.Fatal("config = nil; a lenient parse must still return the document")
+			}
+			if schemaErr == nil {
+				t.Fatalf("schemaErr = nil for %q", tt.key)
+			}
+			if !errors.Is(schemaErr, ErrUnknownConfigKey) {
+				t.Errorf("schemaErr = %v, does not match ErrUnknownConfigKey", schemaErr)
+			}
+			if !strings.Contains(schemaErr.Error(), tt.key) {
+				t.Errorf("schemaErr = %q, want it to name %q", schemaErr, tt.key)
+			}
+
+			// The strict wrapper must still refuse the same input.
+			if _, strictErr := ParseFileConfig([]byte(tt.yaml)); strictErr == nil {
+				t.Error("ParseFileConfig accepted a config with an unknown key")
+			}
+		})
+	}
+}
+
+// TestParseFileConfigLenient_ReportsEveryUnknownKey pins the one-pass
+// contract, so an operator clearing template drift is not handed one key per
+// run.
+func TestParseFileConfigLenient_ReportsEveryUnknownKey(t *testing.T) {
+	t.Parallel()
+	const doc = "schema_version: 2\nintegrations:\n  slack:\n    enabled: true\nstorage:\n  bogus: true\nfuture_namespace:\n  enabled: true\n"
+
+	_, schemaErr, err := parseFileConfigLenient([]byte(doc))
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if schemaErr == nil {
+		t.Fatal("schemaErr = nil")
+	}
+	for _, key := range []string{"integrations.slack", "storage.bogus", "future_namespace"} {
+		if !strings.Contains(schemaErr.Error(), key) {
+			t.Errorf("schemaErr = %q, want it to name %q", schemaErr, key)
+		}
+	}
+}
+
+// TestParseFileConfigLenient_CleanConfig proves the lenient path is not simply
+// swallowing everything: a valid document reports no schema error, and an
+// unparseable one is still a hard failure rather than a tolerated key.
+func TestParseFileConfigLenient_CleanConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg, schemaErr, err := parseFileConfigLenient([]byte("schema_version: 2\nexecution:\n  agent:\n    provider: claude\n"))
+	if err != nil || schemaErr != nil {
+		t.Fatalf("clean config: err=%v schemaErr=%v, want both nil", err, schemaErr)
+	}
+	if cfg == nil {
+		t.Fatal("config = nil for a clean document")
+	}
+
+	if _, _, err := parseFileConfigLenient([]byte("::not yaml at all\n")); err == nil {
+		t.Error("unparseable input produced no error")
+	}
+}
+
+// TestNormalizeV2DocumentStaysStrict guards the exported wrapper: only the
+// unexported lenient path may skip a key, since every migration and save path
+// goes through this one.
+func TestNormalizeV2DocumentStaysStrict(t *testing.T) {
+	t.Parallel()
+	cfg, _, err := parseFileConfigLenient([]byte("schema_version: 2\nintegrations:\n  slack:\n    enabled: true\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := NormalizeV2Document(cfg.root); err == nil {
+		t.Fatal("NormalizeV2Document accepted an unknown namespace key")
+	} else if !errors.Is(err, ErrUnknownConfigKey) {
+		t.Errorf("err = %v, does not match ErrUnknownConfigKey", err)
+	}
+}

--- a/internal/config/lenient_parse_test.go
+++ b/internal/config/lenient_parse_test.go
@@ -102,6 +102,9 @@ func TestNormalizeV2DocumentStaysStrict(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if cfg == nil {
+		t.Fatal("config = nil")
+	}
 	if _, _, err := NormalizeV2Document(cfg.root); err == nil {
 		t.Fatal("NormalizeV2Document accepted an unknown namespace key")
 	} else if !errors.Is(err, ErrUnknownConfigKey) {


### PR DESCRIPTION
## Motivation

One key `config.yaml` names but this build does not know did three things, in ascending order of harm.

It killed `sybra-cli config doctor` — the command an operator reaches for once the config stops loading, dying on the one input it exists to explain, and taking the provider capacity report from #3109 with it. It dropped task commands into the direct task-store fallback. That fallback then broke agent task updates, because agents run `sybra-cli` from inside a sandboxed worktree where the task store is read-only, so a single stale key became agents that could not update their own tasks.

> Changelog: fix(cli): report unknown config keys instead of failing closed

## Implementation information

The schema error gets its own sentinel, `config.ErrUnknownConfigKey`, and a lenient load that returns it *beside* the resolved config rather than instead of it.

`config doctor` uses that load and reports each stale key as an `error` finding next to every other check, still exiting non-zero. Every other config subcommand, the server, and `-check-config` still fail closed — the leniency has exactly one caller, and it never persists.

The fallback no longer fires for a schema error. An unknown key says nothing about whether the server is reachable, and the fallback's write path is the one denied to the caller most likely to hit it, so the command now fails naming the key. A config that cannot be parsed at all still falls back, which is what the fallback was built for.

**Unknown keys are rejected by two different passes, and the first version of this change only covered one.** A key inside a schema v2 namespace — `integrations.slack`, `execution.bogus`, `storage.paths.bogus` — is refused by the document normalizer, which returned a hard error before the lenient path was ever consulted. Both symptoms still reproduced for the canonical v2 shape. The normalizer now takes a sink: strict callers get the error, the diagnostic collects the path and skips the key so the rest of the document resolves. Skipping a key does not cost its valid siblings.

Every stale key is now reported in one pass. Template drift usually leaves several at once, and one-per-run turns a single fix into a sequence of them.

`--json` errors are marshalled rather than interpolated into a string literal. These messages quote the offending key, and a raw double quote made the object unparseable — for the exact caller this change routes them to, since agents run `sybra-cli --json update`.

## Supporting documentation

Adversarial review found the namespace gap as a blocker: the original fixture used the deprecated flat alias, so the suite was green while every canonical v2 config still died. It also found the `--json` escaping defect. Both are fixed here, and the fixture is now table-driven over eleven key positions — reverting the sink fails nine of them.

Manual testing built both binaries and drove 19 stale-key shapes against a running `sybra-server` in an isolated `SYBRA_HOME`, with a `main`-built CLI for contrast. Each shape: doctor runs, exits 1, names the key, and still emits the routing summary, the directory checks and live provider capacity from the server. The original harm was reproduced directly — same home, same key, tasks directory read-only — where `main` warns about the fallback and then fails on a permission-denied lock file, and this branch fails naming the key. `grep "falling back to direct task store"` across every run: zero hits. Every `--json` failure parses, including one on a key carrying an embedded quote and newline, which `main` emits as invalid JSON.

Three residual behaviours were checked and are identical on `main`, so they are not addressed here: a config-shape error that is not an unknown key (a namespace whose value is not a mapping, or a legacy key duplicated by its v2 form) still stops doctor and still reaches the fallback; an invalid *value* alongside an unknown key aborts on the value; and doctor names a v2-nested key by its normalized flat path rather than the path the operator wrote.

Note that `agent.sandbox_read_mode`, the key the issue names from the deploy host, is still live in this build, so the tests and manual runs use keys that are genuinely absent.

Closes #3133
