### PR TITLE
refactor(errclass): co-locate error phrase tables

### DIFF
--- a/internal/agent/errclass_sites_test.go
+++ b/internal/agent/errclass_sites_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestClassifyAgentError_PinsRateLimitLiterals pins the rate_limit arm, which
+// had no test of any kind.
+//
+// Its label reaches completion.isRateLimitedRun, which reports the run as
+// stalled and re-dispatches it. Losing a phrase here turns that run into a
+// crash instead, which burns workflow retry budget and ends at human-required.
+func TestClassifyAgentError_PinsRateLimitLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		msg  string
+		want string
+	}{
+		{msg: "You have exceeded your premium request rate limit", want: "rate_limit"},
+		{msg: "rate_limit_error: this request would exceed your rate limit", want: "rate_limit"},
+		{msg: "HTTP 429 Too Many Requests", want: "rate_limit"},
+		{msg: "the model is overloaded, try again", want: "rate_limit"},
+
+		{msg: "fatal: could not resolve host: github.com", want: "git_clone"},
+		{msg: "worktree is already checked out", want: "worktree_conflict"},
+		{msg: "open /var/log: permission denied", want: "permission_denied"},
+		{msg: "the flux capacitor is misaligned", want: "crash"},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			if got := classifyAgentError(errors.New(tc.msg)); got != tc.want {
+				t.Fatalf("classifyAgentError(%q) = %q, want %q", tc.msg, got, tc.want)
+			}
+		})
+	}
+	if got := classifyAgentError(nil); got != "crash" {
+		t.Fatalf("classifyAgentError(nil) = %q, want crash", got)
+	}
+}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1715,7 +1715,7 @@ func classifyAgentError(err error) string {
 		strings.Contains(msg, "eacces") ||
 		strings.Contains(msg, "operation not permitted"):
 		return "permission_denied"
-	case errclass.IsRateLimit(msg) || strings.Contains(msg, "429") || strings.Contains(msg, "overloaded"):
+	case errclass.Matches(msg, errclass.AgentRateLimitPhrases):
 		return "rate_limit"
 	default:
 		return "crash"

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
+
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/project"
@@ -1713,7 +1715,7 @@ func classifyAgentError(err error) string {
 		strings.Contains(msg, "eacces") ||
 		strings.Contains(msg, "operation not permitted"):
 		return "permission_denied"
-	case strings.Contains(msg, "rate limit") || strings.Contains(msg, "429") || strings.Contains(msg, "overloaded"):
+	case errclass.IsRateLimit(msg) || strings.Contains(msg, "429") || strings.Contains(msg, "overloaded"):
 		return "rate_limit"
 	default:
 		return "crash"

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -15,7 +15,7 @@
 // with no human told; and the workflow tables read agent prose rather than a
 // transport error. Merging the answers changes retry and escalation behaviour
 // at every one of those sites and needs per-site judgement. See the follow-up
-// issue linked from #3139.
+// issue #3162.
 //
 // It is a leaf on purpose. internal/github depends on internal/clock alone, so
 // anything heavier here would cycle.

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -1,0 +1,200 @@
+// Package errclass is the one home for deciding whether an error is
+// transient, rate limited, an auth failure, or permanent.
+//
+// The phrases used to live in twelve packages and drifted apart: "context
+// deadline exceeded" was transient to internal/github and unknown to
+// internal/project, a bare "tls handshake" was transient to two sites and not
+// to two others, and internal/monitor matched GitHub's rate-limit text without
+// lowercasing it first, so "Secondary rate limit" read as an ordinary failure
+// and retried against an exhausted token.
+//
+// It is a leaf on purpose. internal/github depends on internal/clock alone, so
+// anything heavier here would cycle.
+package errclass
+
+import "strings"
+
+// Class is what a caller acts on. Unknown means the tables do not recognize
+// the text, and callers must fail closed rather than assume permanence.
+type Class string
+
+const (
+	Transient   Class = "transient"
+	RateLimited Class = "rate_limited"
+	Auth        Class = "auth"
+	Permanent   Class = "permanent"
+	Unknown     Class = "unknown"
+)
+
+// Phrase families. Each is the union of what the sites that were merged into
+// this package used to match, so a caller composes the families its scope
+// needs instead of carrying its own literals. Every entry is lowercase;
+// matching lowercases the input once.
+var (
+	// NetworkPhrases are transport failures that resolve on their own.
+	NetworkPhrases = []string{
+		"dial tcp",
+		"i/o timeout",
+		"context deadline exceeded",
+		"deadline exceeded",
+		"connection reset",
+		"connection refused",
+		"timed out",
+		"no route to host",
+		"network is unreachable",
+		"failed to connect",
+		"couldn't connect to server",
+		"empty reply from server",
+		"recv failure",
+	}
+
+	// StreamPhrases are truncated-response failures. Kept out of
+	// NetworkPhrases because they also appear in a genuine parse defect
+	// ("parse graphql response: unexpected EOF"), which must escalate rather
+	// than retry, so only callers reading raw transport output want them.
+	StreamPhrases = []string{
+		"stream error",
+		"unexpected eof",
+	}
+
+	// DNSPhrases are name-resolution failures.
+	DNSPhrases = []string{
+		"could not resolve host",
+		"couldn't resolve host",
+		"no such host",
+		"temporary failure in name resolution",
+	}
+
+	// TLSPhrases cover both the bare handshake failure and the timeout. Two
+	// of the merged sites required " timeout" and two did not, so a
+	// "tls: handshake failure" was transient to half the tree.
+	TLSPhrases = []string{
+		"tls handshake",
+		"tls handshake timeout",
+		"tls:",
+	}
+
+	// GatewayPhrases are the 5xx responses worth retrying. A plain 500 is
+	// deliberately absent: it is usually a real server-side bug rather than
+	// a blip, which is the narrower of the two answers the merged sites gave.
+	GatewayPhrases = []string{
+		"http 502",
+		"http 503",
+		"http 504",
+	}
+
+	// RateLimitPhrases are GitHub and provider backpressure.
+	RateLimitPhrases = []string{
+		"secondary rate limit",
+		"api rate limit exceeded",
+		"rate limit exceeded",
+		"rate limit",
+		"too many requests",
+	}
+
+	// AuthPhrases are credential failures. Unlike a rate limit these do not
+	// self-heal, so callers bound their retries before escalating.
+	AuthPhrases = []string{
+		"http 401",
+		"401 unauthorized",
+		"bad credentials",
+		"authentication failed",
+		"failed to log in",
+		"gh auth",
+		"gh_token environment variable",
+		"gh_token is invalid",
+		"github_token is invalid",
+		"token has expired",
+		"could not read username for 'https://github.com'",
+	}
+
+	// GitTransportPhrases are git-remote transport failures with no
+	// equivalent outside a fetch or push.
+	GitTransportPhrases = []string{
+		"ssh: connect to host",
+		"early eof",
+		"unexpected disconnect while reading sideband packet",
+	}
+)
+
+// IsNetwork reports a transport or name-resolution failure.
+func IsNetwork(text string) bool {
+	return matches(text, NetworkPhrases, DNSPhrases, TLSPhrases)
+}
+
+// IsGitTransport reports a git-remote transport failure, including the
+// generic network families.
+func IsGitTransport(text string) bool {
+	return matches(text, NetworkPhrases, DNSPhrases, TLSPhrases, GitTransportPhrases)
+}
+
+// IsGateway reports a retryable 5xx gateway response.
+func IsGateway(text string) bool {
+	return matches(text, GatewayPhrases)
+}
+
+// IsRateLimit reports provider or forge backpressure.
+func IsRateLimit(text string) bool {
+	return matches(text, RateLimitPhrases)
+}
+
+// IsAuth reports a credential failure.
+func IsAuth(text string) bool {
+	return matches(text, AuthPhrases)
+}
+
+// Classify answers the four-way question for callers that want one verdict.
+//
+// Auth outranks rate limit, which outranks transient: a 401 that also mentions
+// a retry budget is still a credential problem, and a rate limit needs a
+// cooldown rather than an immediate retry. Text the tables do not recognize is
+// Unknown, never Permanent — a caller that cannot tell must fail closed rather
+// than swallow a retryable failure.
+func Classify(text string) Class {
+	switch {
+	case IsAuth(text):
+		return Auth
+	case IsRateLimit(text):
+		return RateLimited
+	case IsGitTransport(text), IsGateway(text):
+		return Transient
+	default:
+		return Unknown
+	}
+}
+
+// ClassifyErr is Classify over an error. A nil error is Unknown, since there
+// is nothing to classify.
+func ClassifyErr(err error) Class {
+	if err == nil {
+		return Unknown
+	}
+	return Classify(err.Error())
+}
+
+// Matches reports whether text contains any phrase in families. Exported for
+// callers whose scope is narrower than any single predicate here.
+func Matches(text string, families ...[]string) bool {
+	return matches(text, families...)
+}
+
+func matches(text string, families ...[]string) bool {
+	if text == "" {
+		return false
+	}
+	lower := strings.ToLower(text)
+	for _, family := range families {
+		for _, phrase := range family {
+			if strings.Contains(lower, phrase) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Is reports whether err classifies as c. Kept so a caller reads as a question
+// about one class rather than a switch.
+func Is(err error, c Class) bool {
+	return ClassifyErr(err) == c
+}

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -23,11 +23,10 @@ package errclass
 
 import "strings"
 
-// Tables shared by more than one caller. Adding a phrase to one of these
-// changes every caller that composes it.
+// The one genuinely shared table, reached through IsBadRef.
 var (
 	// The twelve needles internal/project and internal/workflow each carried byte-identically.
-	BadRefPhrases = []string{
+	badRefPhrases = []string{
 		"bad object head",
 		"fatal: bad object",
 		"not a valid object name",
@@ -173,5 +172,5 @@ func Matches(text string, families ...[]string) bool {
 
 // IsBadRef reports a corrupt or unresolvable git object or ref.
 func IsBadRef(text string) bool {
-	return Matches(text, BadRefPhrases)
+	return Matches(text, badRefPhrases)
 }

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -108,6 +108,24 @@ var (
 		"could not read username for 'https://github.com'",
 	}
 
+	// BadRefPhrases are corrupt or unresolvable git object/ref errors, which
+	// clear on a re-fetch. The same twelve lived byte-identically in
+	// internal/project and internal/workflow.
+	BadRefPhrases = []string{
+		"bad object head",
+		"fatal: bad object",
+		"not a valid object name",
+		"invalid object",
+		"invalid revision range",
+		"missing object",
+		"unable to read sha1 file",
+		"object file",
+		"loose object",
+		"unknown revision",
+		"ambiguous argument",
+		"reference broken",
+	}
+
 	// GitTransportPhrases are git-remote transport failures with no
 	// equivalent outside a fetch or push.
 	GitTransportPhrases = []string{
@@ -126,6 +144,11 @@ func IsNetwork(text string) bool {
 // generic network families.
 func IsGitTransport(text string) bool {
 	return matches(text, NetworkPhrases, DNSPhrases, TLSPhrases, GitTransportPhrases)
+}
+
+// IsBadRef reports a corrupt or unresolvable git object or ref.
+func IsBadRef(text string) bool {
+	return matches(text, BadRefPhrases)
 }
 
 // IsGateway reports a retryable 5xx gateway response.

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -1,19 +1,21 @@
-// Package errclass is the one home for the phrases that decide whether an
-// error is transient, rate limited, or an auth failure.
+// Package errclass holds every phrase table used to decide whether an error
+// is transient, rate limited, or an auth failure.
 //
-// The tables used to live in a dozen packages and drifted apart. "context
-// deadline exceeded" was transient to internal/github and unrecognized by
-// internal/project. internal/monitor knew two of the four rate-limit phrases
-// internal/github knew, so a gate-suppressed call retried as an ordinary
-// failure. The twelve bad-ref needles existed byte-identically in
-// internal/project and internal/workflow, free to diverge.
+// The tables used to live in a dozen packages, where they drifted apart
+// unseen. The twelve bad-ref needles existed byte-identically in
+// internal/project and internal/workflow. internal/monitor knew two of the
+// four rate-limit phrases internal/github knew. Nothing made a reader of one
+// table aware of the others.
 //
-// Families are deliberately narrow, and a caller composes the ones its scope
-// needs plus any literal only it uses. A broad family is not free: a bare
-// "timed out" in the network family reclassified a permanently blocked merge
-// as transient and cut its backoff ceiling from two hours to ten minutes, and
-// a bare "tls:" made an x509 certificate failure look like a network blip that
-// retries forever instead of reaching a human.
+// This package co-locates them and does not merge them. Each caller keeps the
+// exact set it had, because the sets differ for good reasons: IsTransientError
+// gates poller escalation, where under-reporting transience escalates the
+// whole board; IsTransientNetworkError becomes worktree.ErrTransientFetch,
+// which callers must never escalate, so over-reporting there retries forever
+// with no human told; and the workflow tables read agent prose rather than a
+// transport error. Merging the answers changes retry and escalation behaviour
+// at every one of those sites and needs per-site judgement. See the follow-up
+// issue linked from #3139.
 //
 // It is a leaf on purpose. internal/github depends on internal/clock alone, so
 // anything heavier here would cycle.
@@ -21,88 +23,10 @@ package errclass
 
 import "strings"
 
-// Class is the answer a caller acts on. Unknown means the tables do not
-// recognize the text; callers fail closed rather than assume permanence.
-type Class string
-
-const (
-	Transient   Class = "transient"
-	RateLimited Class = "rate_limited"
-	Auth        Class = "auth"
-	Unknown     Class = "unknown"
-)
-
-// Phrase families. Every entry is lowercase; matching lowercases the input
-// once. A phrase belongs here only when two or more callers used it; one used
-// by a single caller stays with that caller.
+// Tables shared by more than one caller. Adding a phrase to one of these
+// changes every caller that composes it.
 var (
-	// Every timeout entry is qualified: a bare "timed out" also matches a blocked merge waiting on a status check.
-	NetworkPhrases = []string{
-		"dial tcp",
-		"i/o timeout",
-		"context deadline exceeded",
-		"connection reset",
-		"connection refused",
-		"connection timed out",
-		"operation timed out",
-		"no route to host",
-		"network is unreachable",
-		"failed to connect",
-		"couldn't connect to server",
-		"empty reply from server",
-		"recv failure",
-	}
-
-	DNSPhrases = []string{
-		"could not resolve host",
-		"couldn't resolve host",
-		"no such host",
-		"temporary failure in name resolution",
-	}
-
-	// A bare "tls:" is excluded: it also matches x509 verification failures, which never self-heal.
-	TLSPhrases = []string{
-		"tls handshake",
-	}
-
-	// A plain 500 is absent because it is usually a real server-side bug rather than a blip.
-	GatewayPhrases = []string{
-		"http 502",
-		"http 503",
-		"http 504",
-	}
-
-	RateLimitPhrases = []string{
-		"secondary rate limit",
-		"rate limit exceeded",
-	}
-
-	// These do not self-heal, so callers bound their retries before escalating.
-	AuthPhrases = []string{
-		"http 401",
-		"401 unauthorized",
-		"bad credentials",
-		"authentication failed",
-		"failed to log in",
-		"token has expired",
-		"gh_token is invalid",
-		"github_token is invalid",
-		"could not read username for 'https://github.com'",
-	}
-
-	// Outside NetworkPhrases because a GraphQL parse defect reads the same and must escalate rather than retry.
-	StreamPhrases = []string{
-		"stream error",
-		"unexpected eof",
-	}
-
-	GitTransportPhrases = []string{
-		"ssh: connect to host",
-		"early eof",
-		"unexpected disconnect while reading sideband packet",
-	}
-
-	// Corrupt or unresolvable git objects and refs, which clear on a re-fetch.
+	// The twelve needles internal/project and internal/workflow each carried byte-identically.
 	BadRefPhrases = []string{
 		"bad object head",
 		"fatal: bad object",
@@ -119,69 +43,120 @@ var (
 	}
 )
 
-// IsNetwork reports a transport, name-resolution, or TLS-handshake failure.
-func IsNetwork(text string) bool {
-	return matches(text, NetworkPhrases, DNSPhrases, TLSPhrases)
-}
-
-// IsGitTransport is IsNetwork plus the git-remote-only failures.
-func IsGitTransport(text string) bool {
-	return matches(text, NetworkPhrases, DNSPhrases, TLSPhrases, GitTransportPhrases)
-}
-
-// IsGateway reports a retryable 5xx gateway response.
-func IsGateway(text string) bool {
-	return matches(text, GatewayPhrases)
-}
-
-// IsRateLimit reports forge backpressure.
-func IsRateLimit(text string) bool {
-	return matches(text, RateLimitPhrases)
-}
-
-// IsAuth reports a credential failure.
-func IsAuth(text string) bool {
-	return matches(text, AuthPhrases)
-}
-
-// IsBadRef reports a corrupt or unresolvable git object or ref.
-func IsBadRef(text string) bool {
-	return matches(text, BadRefPhrases)
-}
-
-// Classify answers the three-way question, plus Unknown.
-//
-// Auth outranks rate limit, which outranks transient. A 401 that also mentions
-// a retry budget is still a credential problem, and a rate limit needs a
-// cooldown rather than an immediate retry.
-func Classify(text string) Class {
-	switch {
-	case IsAuth(text):
-		return Auth
-	case IsRateLimit(text):
-		return RateLimited
-	case IsGitTransport(text), IsGateway(text):
-		return Transient
-	default:
-		return Unknown
+// Tables owned by a single caller. They live here so a reader sees all of
+// them at once and can tell which phrase one table knows and another misses.
+var (
+	// github.IsTransientError, whose false answer escalates a poller.
+	GitHubTransientPhrases = []string{
+		"dial tcp",
+		"i/o timeout",
+		"context deadline exceeded",
+		"connection reset",
+		"connection refused",
+		"tls handshake timeout",
+		"no route to host",
 	}
-}
 
-// ClassifyErr is Classify over an error. A nil error is Unknown.
-func ClassifyErr(err error) Class {
-	if err == nil {
-		return Unknown
+	// github.isTransientGHError, which reads raw gh output rather than a wrapped error.
+	GHOutputTransientPhrases = []string{
+		"http 502",
+		"http 503",
+		"http 504",
+		"operation timed out",
+		"i/o timeout",
+		"deadline exceeded",
+		"connection reset",
+		"connection refused",
+		"stream error",
+		"unexpected eof",
+		"tls handshake",
 	}
-	return Classify(err.Error())
-}
 
-// Matches reports whether text contains any phrase in families. A caller whose
-// scope is narrower than a predicate here composes families with it.
+	// github.isRateLimitedMessage.
+	GitHubRateLimitPhrases = []string{
+		"secondary rate limit",
+		"api rate limit exceeded",
+		"rate limit exceeded",
+	}
+
+	// github.isAuthErrorMsg. "gh auth login" stays narrow: the bare prefix also
+	// matches gh's missing-scope hint, which would hold the shared circuit open.
+	GitHubAuthPhrases = []string{
+		"http 401",
+		"bad credentials",
+		"gh auth login",
+		"gh_token environment variable",
+	}
+
+	// monitor.classifyGHError, which knows fewer phrases than github does.
+	MonitorRateLimitPhrases = []string{
+		"api rate limit exceeded",
+		"secondary rate limit",
+	}
+
+	// project.IsTransientNetworkError, whose true answer must never escalate.
+	GitTransportPhrases = []string{
+		"connection refused",
+		"connection reset",
+		"connection timed out",
+		"failed to connect",
+		"couldn't connect to server",
+		"could not resolve host",
+		"couldn't resolve host",
+		"network is unreachable",
+		"operation timed out",
+		"temporary failure in name resolution",
+		"no route to host",
+		"ssh: connect to host",
+		"recv failure",
+		"tls handshake timeout",
+		"empty reply from server",
+		"early eof",
+		"unexpected disconnect while reading sideband packet",
+	}
+
+	// workflow.looksLikeTransientGitHub, which reads agent prose, so a bare
+	// "timed out" and "tls:" are reachability signals rather than merge state.
+	WorkflowTransientPhrases = []string{
+		"connection refused",
+		"connection reset",
+		"could not resolve host",
+		"no such host",
+		"no route to host",
+		"network is unreachable",
+		"temporary failure in name resolution",
+		"i/o timeout",
+		"timed out",
+		"context deadline exceeded",
+		"tls handshake",
+		"tls:",
+	}
+
+	// workflow.looksLikeAuthFailure, whose "gh auth" is broader than github's
+	// because an echoed command is this site's usual credential signal.
+	WorkflowAuthPhrases = []string{
+		"bad credentials",
+		"authentication failed",
+		"failed to log in",
+		"gh auth",
+		"gh_token is invalid",
+		"github_token is invalid",
+		"token has expired",
+		"could not read username for 'https://github.com'",
+		"401 unauthorized",
+	}
+
+	// agent.classifyAgentError's rate_limit bucket.
+	AgentRateLimitPhrases = []string{
+		"rate limit",
+		"429",
+		"overloaded",
+	}
+)
+
+// Matches reports whether text contains any phrase in families, comparing
+// case-insensitively. Every table entry is lowercase for that reason.
 func Matches(text string, families ...[]string) bool {
-	return matches(text, families...)
-}
-
-func matches(text string, families ...[]string) bool {
 	if text == "" {
 		return false
 	}
@@ -194,4 +169,9 @@ func matches(text string, families ...[]string) bool {
 		}
 	}
 	return false
+}
+
+// IsBadRef reports a corrupt or unresolvable git object or ref.
+func IsBadRef(text string) bool {
+	return Matches(text, BadRefPhrases)
 }

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -1,12 +1,19 @@
-// Package errclass is the one home for deciding whether an error is
-// transient, rate limited, an auth failure, or permanent.
+// Package errclass is the one home for the phrases that decide whether an
+// error is transient, rate limited, or an auth failure.
 //
-// The phrases used to live in twelve packages and drifted apart: "context
-// deadline exceeded" was transient to internal/github and unknown to
-// internal/project, a bare "tls handshake" was transient to two sites and not
-// to two others, and internal/monitor matched GitHub's rate-limit text without
-// lowercasing it first, so "Secondary rate limit" read as an ordinary failure
-// and retried against an exhausted token.
+// The tables used to live in a dozen packages and drifted apart. "context
+// deadline exceeded" was transient to internal/github and unrecognized by
+// internal/project. internal/monitor knew two of the four rate-limit phrases
+// internal/github knew, so a gate-suppressed call retried as an ordinary
+// failure. The twelve bad-ref needles existed byte-identically in
+// internal/project and internal/workflow, free to diverge.
+//
+// Families are deliberately narrow, and a caller composes the ones its scope
+// needs plus any literal only it uses. A broad family is not free: a bare
+// "timed out" in the network family reclassified a permanently blocked merge
+// as transient and cut its backoff ceiling from two hours to ten minutes, and
+// a bare "tls:" made an x509 certificate failure look like a network blip that
+// retries forever instead of reaching a human.
 //
 // It is a leaf on purpose. internal/github depends on internal/clock alone, so
 // anything heavier here would cycle.
@@ -14,32 +21,30 @@ package errclass
 
 import "strings"
 
-// Class is what a caller acts on. Unknown means the tables do not recognize
-// the text, and callers must fail closed rather than assume permanence.
+// Class is the answer a caller acts on. Unknown means the tables do not
+// recognize the text; callers fail closed rather than assume permanence.
 type Class string
 
 const (
 	Transient   Class = "transient"
 	RateLimited Class = "rate_limited"
 	Auth        Class = "auth"
-	Permanent   Class = "permanent"
 	Unknown     Class = "unknown"
 )
 
-// Phrase families. Each is the union of what the sites that were merged into
-// this package used to match, so a caller composes the families its scope
-// needs instead of carrying its own literals. Every entry is lowercase;
-// matching lowercases the input once.
+// Phrase families. Every entry is lowercase; matching lowercases the input
+// once. A phrase belongs here only when two or more callers used it; one used
+// by a single caller stays with that caller.
 var (
-	// NetworkPhrases are transport failures that resolve on their own.
+	// Every timeout entry is qualified: a bare "timed out" also matches a blocked merge waiting on a status check.
 	NetworkPhrases = []string{
 		"dial tcp",
 		"i/o timeout",
 		"context deadline exceeded",
-		"deadline exceeded",
 		"connection reset",
 		"connection refused",
-		"timed out",
+		"connection timed out",
+		"operation timed out",
 		"no route to host",
 		"network is unreachable",
 		"failed to connect",
@@ -48,16 +53,6 @@ var (
 		"recv failure",
 	}
 
-	// StreamPhrases are truncated-response failures. Kept out of
-	// NetworkPhrases because they also appear in a genuine parse defect
-	// ("parse graphql response: unexpected EOF"), which must escalate rather
-	// than retry, so only callers reading raw transport output want them.
-	StreamPhrases = []string{
-		"stream error",
-		"unexpected eof",
-	}
-
-	// DNSPhrases are name-resolution failures.
 	DNSPhrases = []string{
 		"could not resolve host",
 		"couldn't resolve host",
@@ -65,52 +60,49 @@ var (
 		"temporary failure in name resolution",
 	}
 
-	// TLSPhrases cover both the bare handshake failure and the timeout. Two
-	// of the merged sites required " timeout" and two did not, so a
-	// "tls: handshake failure" was transient to half the tree.
+	// A bare "tls:" is excluded: it also matches x509 verification failures, which never self-heal.
 	TLSPhrases = []string{
 		"tls handshake",
-		"tls handshake timeout",
-		"tls:",
 	}
 
-	// GatewayPhrases are the 5xx responses worth retrying. A plain 500 is
-	// deliberately absent: it is usually a real server-side bug rather than
-	// a blip, which is the narrower of the two answers the merged sites gave.
+	// A plain 500 is absent because it is usually a real server-side bug rather than a blip.
 	GatewayPhrases = []string{
 		"http 502",
 		"http 503",
 		"http 504",
 	}
 
-	// RateLimitPhrases are GitHub and provider backpressure.
 	RateLimitPhrases = []string{
 		"secondary rate limit",
-		"api rate limit exceeded",
 		"rate limit exceeded",
-		"rate limit",
-		"too many requests",
 	}
 
-	// AuthPhrases are credential failures. Unlike a rate limit these do not
-	// self-heal, so callers bound their retries before escalating.
+	// These do not self-heal, so callers bound their retries before escalating.
 	AuthPhrases = []string{
 		"http 401",
 		"401 unauthorized",
 		"bad credentials",
 		"authentication failed",
 		"failed to log in",
-		"gh auth",
-		"gh_token environment variable",
+		"token has expired",
 		"gh_token is invalid",
 		"github_token is invalid",
-		"token has expired",
 		"could not read username for 'https://github.com'",
 	}
 
-	// BadRefPhrases are corrupt or unresolvable git object/ref errors, which
-	// clear on a re-fetch. The same twelve lived byte-identically in
-	// internal/project and internal/workflow.
+	// Outside NetworkPhrases because a GraphQL parse defect reads the same and must escalate rather than retry.
+	StreamPhrases = []string{
+		"stream error",
+		"unexpected eof",
+	}
+
+	GitTransportPhrases = []string{
+		"ssh: connect to host",
+		"early eof",
+		"unexpected disconnect while reading sideband packet",
+	}
+
+	// Corrupt or unresolvable git objects and refs, which clear on a re-fetch.
 	BadRefPhrases = []string{
 		"bad object head",
 		"fatal: bad object",
@@ -125,30 +117,16 @@ var (
 		"ambiguous argument",
 		"reference broken",
 	}
-
-	// GitTransportPhrases are git-remote transport failures with no
-	// equivalent outside a fetch or push.
-	GitTransportPhrases = []string{
-		"ssh: connect to host",
-		"early eof",
-		"unexpected disconnect while reading sideband packet",
-	}
 )
 
-// IsNetwork reports a transport or name-resolution failure.
+// IsNetwork reports a transport, name-resolution, or TLS-handshake failure.
 func IsNetwork(text string) bool {
 	return matches(text, NetworkPhrases, DNSPhrases, TLSPhrases)
 }
 
-// IsGitTransport reports a git-remote transport failure, including the
-// generic network families.
+// IsGitTransport is IsNetwork plus the git-remote-only failures.
 func IsGitTransport(text string) bool {
 	return matches(text, NetworkPhrases, DNSPhrases, TLSPhrases, GitTransportPhrases)
-}
-
-// IsBadRef reports a corrupt or unresolvable git object or ref.
-func IsBadRef(text string) bool {
-	return matches(text, BadRefPhrases)
 }
 
 // IsGateway reports a retryable 5xx gateway response.
@@ -156,7 +134,7 @@ func IsGateway(text string) bool {
 	return matches(text, GatewayPhrases)
 }
 
-// IsRateLimit reports provider or forge backpressure.
+// IsRateLimit reports forge backpressure.
 func IsRateLimit(text string) bool {
 	return matches(text, RateLimitPhrases)
 }
@@ -166,13 +144,16 @@ func IsAuth(text string) bool {
 	return matches(text, AuthPhrases)
 }
 
-// Classify answers the four-way question for callers that want one verdict.
+// IsBadRef reports a corrupt or unresolvable git object or ref.
+func IsBadRef(text string) bool {
+	return matches(text, BadRefPhrases)
+}
+
+// Classify answers the three-way question, plus Unknown.
 //
-// Auth outranks rate limit, which outranks transient: a 401 that also mentions
+// Auth outranks rate limit, which outranks transient. A 401 that also mentions
 // a retry budget is still a credential problem, and a rate limit needs a
-// cooldown rather than an immediate retry. Text the tables do not recognize is
-// Unknown, never Permanent — a caller that cannot tell must fail closed rather
-// than swallow a retryable failure.
+// cooldown rather than an immediate retry.
 func Classify(text string) Class {
 	switch {
 	case IsAuth(text):
@@ -186,8 +167,7 @@ func Classify(text string) Class {
 	}
 }
 
-// ClassifyErr is Classify over an error. A nil error is Unknown, since there
-// is nothing to classify.
+// ClassifyErr is Classify over an error. A nil error is Unknown.
 func ClassifyErr(err error) Class {
 	if err == nil {
 		return Unknown
@@ -195,8 +175,8 @@ func ClassifyErr(err error) Class {
 	return Classify(err.Error())
 }
 
-// Matches reports whether text contains any phrase in families. Exported for
-// callers whose scope is narrower than any single predicate here.
+// Matches reports whether text contains any phrase in families. A caller whose
+// scope is narrower than a predicate here composes families with it.
 func Matches(text string, families ...[]string) bool {
 	return matches(text, families...)
 }
@@ -214,10 +194,4 @@ func matches(text string, families ...[]string) bool {
 		}
 	}
 	return false
-}
-
-// Is reports whether err classifies as c. Kept so a caller reads as a question
-// about one class rather than a switch.
-func Is(err error, c Class) bool {
-	return ClassifyErr(err) == c
 }

--- a/internal/errclass/errclass_test.go
+++ b/internal/errclass/errclass_test.go
@@ -1,84 +1,6 @@
 package errclass
 
-import (
-	"errors"
-	"testing"
-)
-
-func TestClassify(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		text string
-		want Class
-	}{
-		{name: "empty", text: "", want: Unknown},
-		{name: "unrecognized fails closed to unknown", text: "the flux capacitor is misaligned", want: Unknown},
-
-		{name: "dial tcp", text: "Get \"https://api.github.com\": dial tcp 140.82.121.6:443: connect: connection refused", want: Transient},
-		{name: "i/o timeout", text: "read tcp: i/o timeout", want: Transient},
-		{name: "context deadline exceeded", text: "context deadline exceeded", want: Transient},
-		{name: "dns", text: "fatal: could not resolve host: github.com", want: Transient},
-		{name: "gateway 502", text: "gh: HTTP 502", want: Transient},
-		{name: "gateway 503", text: "gh: HTTP 503 Service Unavailable", want: Transient},
-		{name: "git sideband", text: "fatal: unexpected disconnect while reading sideband packet", want: Transient},
-		{name: "blocked merge timeout is not transient", text: "required status check timed out", want: Unknown},
-
-		{name: "secondary rate limit", text: "You have exceeded a secondary rate limit", want: RateLimited},
-		{name: "api rate limit exceeded", text: "API rate limit exceeded for user ID 1", want: RateLimited},
-
-		{name: "bad credentials", text: "gh: Bad credentials (HTTP 401)", want: Auth},
-		{name: "http 401", text: "gh: HTTP 401", want: Auth},
-		{name: "401 unauthorized", text: "remote: 401 Unauthorized", want: Auth},
-		{name: "token expired", text: "the token has expired", want: Auth},
-
-		{name: "auth outranks rate limit", text: "Bad credentials; also rate limit exceeded", want: Auth},
-		{name: "rate limit outranks transient", text: "connection reset; api rate limit exceeded", want: RateLimited},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := Classify(tc.text); got != tc.want {
-				t.Fatalf("Classify(%q) = %q, want %q", tc.text, got, tc.want)
-			}
-		})
-	}
-}
-
-// TestClassifyIsCaseInsensitive pins the defect that made internal/monitor
-// miss GitHub's own capitalization and retry against an exhausted token.
-func TestClassifyIsCaseInsensitive(t *testing.T) {
-	for _, text := range []string{
-		"Secondary rate limit",
-		"SECONDARY RATE LIMIT",
-		"API rate limit exceeded",
-		"api rate limit exceeded",
-	} {
-		if got := Classify(text); got != RateLimited {
-			t.Fatalf("Classify(%q) = %q, want %q", text, got, RateLimited)
-		}
-	}
-}
-
-// TestStreamPhrasesAreNotNetwork pins why truncated-response phrases sit in
-// their own family: a GraphQL parse defect must escalate, not retry.
-func TestStreamPhrasesAreNotNetwork(t *testing.T) {
-	const parseDefect = "parse graphql response: unexpected EOF"
-	if IsNetwork(parseDefect) {
-		t.Fatal("IsNetwork matched a parse defect, which would stop it escalating")
-	}
-	if Classify(parseDefect) != Unknown {
-		t.Fatalf("Classify(%q) = %q, want %q", parseDefect, Classify(parseDefect), Unknown)
-	}
-	if !Matches(parseDefect, StreamPhrases) {
-		t.Fatal("StreamPhrases should still match for callers reading raw transport output")
-	}
-}
-
-// TestPlainHTTP500IsNotGateway pins the narrower of the two answers the merged
-// sites gave: a bare 500 is usually a real server-side bug.
-func TestPlainHTTP500IsNotGateway(t *testing.T) {
-	if IsGateway("gh: HTTP 500") {
-		t.Fatal("IsGateway matched a plain 500")
-	}
-}
+import "testing"
 
 // TestIsBadRef pins the twelve needles that lived byte-identically in
 // internal/project and internal/workflow.
@@ -86,7 +8,7 @@ func TestIsBadRef(t *testing.T) {
 	for _, text := range []string{
 		"fatal: bad object HEAD",
 		"error: object file .git/objects/ab/cdef is empty",
-		"fatal: ambiguous argument 'origin/main...HEAD': unknown revision or path not in the working tree",
+		"fatal: ambiguous argument 'origin/main...HEAD': unknown revision",
 		"fatal: Invalid revision range origin/main...HEAD",
 	} {
 		if !IsBadRef(text) {
@@ -96,16 +18,16 @@ func TestIsBadRef(t *testing.T) {
 	if IsBadRef("connection refused") {
 		t.Fatal("IsBadRef matched a network error")
 	}
+	if IsBadRef("") {
+		t.Fatal("IsBadRef matched empty input")
+	}
 }
 
-func TestClassifyErr(t *testing.T) {
-	if got := ClassifyErr(nil); got != Unknown {
-		t.Fatalf("ClassifyErr(nil) = %q, want %q", got, Unknown)
+func TestMatchesIsCaseInsensitive(t *testing.T) {
+	if !Matches("FATAL: BAD OBJECT HEAD", BadRefPhrases) {
+		t.Fatal("Matches should lowercase the input")
 	}
-	if got := ClassifyErr(errors.New("connection refused")); got != Transient {
-		t.Fatalf("ClassifyErr = %q, want %q", got, Transient)
-	}
-	if got := ClassifyErr(errors.New("Bad credentials")); got != Auth {
-		t.Fatalf("ClassifyErr = %q, want %q", got, Auth)
+	if Matches("anything", nil) {
+		t.Fatal("Matches with no families should be false")
 	}
 }

--- a/internal/errclass/errclass_test.go
+++ b/internal/errclass/errclass_test.go
@@ -24,7 +24,7 @@ func TestIsBadRef(t *testing.T) {
 }
 
 func TestMatchesIsCaseInsensitive(t *testing.T) {
-	if !Matches("FATAL: BAD OBJECT HEAD", BadRefPhrases) {
+	if !Matches("FATAL: BAD OBJECT HEAD", badRefPhrases) {
 		t.Fatal("Matches should lowercase the input")
 	}
 	if Matches("anything", nil) {

--- a/internal/errclass/errclass_test.go
+++ b/internal/errclass/errclass_test.go
@@ -1,0 +1,128 @@
+package errclass
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+		want Class
+	}{
+		{name: "empty", text: "", want: Unknown},
+		{name: "unrecognized fails closed to unknown", text: "the flux capacitor is misaligned", want: Unknown},
+
+		{name: "dial tcp", text: "Get \"https://api.github.com\": dial tcp 140.82.121.6:443: connect: connection refused", want: Transient},
+		{name: "i/o timeout", text: "read tcp: i/o timeout", want: Transient},
+		{name: "context deadline exceeded", text: "context deadline exceeded", want: Transient},
+		{name: "dns", text: "fatal: could not resolve host: github.com", want: Transient},
+		{name: "gateway 502", text: "gh: HTTP 502", want: Transient},
+		{name: "gateway 503", text: "gh: HTTP 503 Service Unavailable", want: Transient},
+		{name: "git sideband", text: "fatal: unexpected disconnect while reading sideband packet", want: Transient},
+
+		{name: "secondary rate limit", text: "You have exceeded a secondary rate limit", want: RateLimited},
+		{name: "api rate limit exceeded", text: "API rate limit exceeded for user", want: RateLimited},
+		{name: "too many requests", text: "HTTP 429: Too Many Requests", want: RateLimited},
+
+		{name: "bad credentials", text: "gh: Bad credentials (HTTP 401)", want: Auth},
+		{name: "http 401", text: "gh: HTTP 401", want: Auth},
+		{name: "401 unauthorized", text: "remote: 401 Unauthorized", want: Auth},
+		{name: "token expired", text: "the token has expired", want: Auth},
+
+		{name: "auth outranks rate limit", text: "Bad credentials; also rate limit exceeded", want: Auth},
+		{name: "rate limit outranks transient", text: "connection reset; api rate limit exceeded", want: RateLimited},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Classify(tc.text); got != tc.want {
+				t.Fatalf("Classify(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyIsCaseInsensitive pins the defect that made internal/monitor
+// miss GitHub's own capitalization and retry against an exhausted token.
+func TestClassifyIsCaseInsensitive(t *testing.T) {
+	for _, text := range []string{
+		"Secondary rate limit",
+		"SECONDARY RATE LIMIT",
+		"API rate limit exceeded",
+		"api rate limit exceeded",
+	} {
+		if got := Classify(text); got != RateLimited {
+			t.Fatalf("Classify(%q) = %q, want %q", text, got, RateLimited)
+		}
+	}
+}
+
+// TestStreamPhrasesAreNotNetwork pins why truncated-response phrases sit in
+// their own family: a GraphQL parse defect must escalate, not retry.
+func TestStreamPhrasesAreNotNetwork(t *testing.T) {
+	const parseDefect = "parse graphql response: unexpected EOF"
+	if IsNetwork(parseDefect) {
+		t.Fatal("IsNetwork matched a parse defect, which would stop it escalating")
+	}
+	if Classify(parseDefect) != Unknown {
+		t.Fatalf("Classify(%q) = %q, want %q", parseDefect, Classify(parseDefect), Unknown)
+	}
+	if !Matches(parseDefect, StreamPhrases) {
+		t.Fatal("StreamPhrases should still match for callers reading raw transport output")
+	}
+}
+
+// TestPlainHTTP500IsNotGateway pins the narrower of the two answers the merged
+// sites gave: a bare 500 is usually a real server-side bug.
+func TestPlainHTTP500IsNotGateway(t *testing.T) {
+	if IsGateway("gh: HTTP 500") {
+		t.Fatal("IsGateway matched a plain 500")
+	}
+}
+
+func TestClassifyErr(t *testing.T) {
+	if got := ClassifyErr(nil); got != Unknown {
+		t.Fatalf("ClassifyErr(nil) = %q, want %q", got, Unknown)
+	}
+	if got := ClassifyErr(errors.New("connection refused")); got != Transient {
+		t.Fatalf("ClassifyErr = %q, want %q", got, Transient)
+	}
+	if !Is(errors.New("Bad credentials"), Auth) {
+		t.Fatal("Is(auth error, Auth) = false")
+	}
+}
+
+// TestFamiliesAreLowercase guards the tables themselves: an uppercase entry
+// can never match, since matching lowercases the input.
+func TestFamiliesAreLowercase(t *testing.T) {
+	families := map[string][]string{
+		"NetworkPhrases":      NetworkPhrases,
+		"DNSPhrases":          DNSPhrases,
+		"TLSPhrases":          TLSPhrases,
+		"GatewayPhrases":      GatewayPhrases,
+		"RateLimitPhrases":    RateLimitPhrases,
+		"AuthPhrases":         AuthPhrases,
+		"GitTransportPhrases": GitTransportPhrases,
+		"StreamPhrases":       StreamPhrases,
+	}
+	for name, family := range families {
+		for _, phrase := range family {
+			if phrase != lower(phrase) {
+				t.Errorf("%s contains %q, which is not lowercase and can never match", name, phrase)
+			}
+			if phrase == "" {
+				t.Errorf("%s contains an empty phrase, which matches everything", name)
+			}
+		}
+	}
+}
+
+func lower(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/errclass/errclass_test.go
+++ b/internal/errclass/errclass_test.go
@@ -80,6 +80,24 @@ func TestPlainHTTP500IsNotGateway(t *testing.T) {
 	}
 }
 
+// TestIsBadRef pins the twelve needles that lived byte-identically in
+// internal/project and internal/workflow.
+func TestIsBadRef(t *testing.T) {
+	for _, text := range []string{
+		"fatal: bad object HEAD",
+		"error: object file .git/objects/ab/cdef is empty",
+		"fatal: ambiguous argument 'origin/main...HEAD': unknown revision or path not in the working tree",
+		"fatal: Invalid revision range origin/main...HEAD",
+	} {
+		if !IsBadRef(text) {
+			t.Fatalf("IsBadRef(%q) = false, want true", text)
+		}
+	}
+	if IsBadRef("connection refused") {
+		t.Fatal("IsBadRef matched a network error")
+	}
+}
+
 func TestClassifyErr(t *testing.T) {
 	if got := ClassifyErr(nil); got != Unknown {
 		t.Fatalf("ClassifyErr(nil) = %q, want %q", got, Unknown)
@@ -103,6 +121,7 @@ func TestFamiliesAreLowercase(t *testing.T) {
 		"RateLimitPhrases":    RateLimitPhrases,
 		"AuthPhrases":         AuthPhrases,
 		"GitTransportPhrases": GitTransportPhrases,
+		"BadRefPhrases":       BadRefPhrases,
 		"StreamPhrases":       StreamPhrases,
 	}
 	for name, family := range families {

--- a/internal/errclass/errclass_test.go
+++ b/internal/errclass/errclass_test.go
@@ -21,10 +21,10 @@ func TestClassify(t *testing.T) {
 		{name: "gateway 502", text: "gh: HTTP 502", want: Transient},
 		{name: "gateway 503", text: "gh: HTTP 503 Service Unavailable", want: Transient},
 		{name: "git sideband", text: "fatal: unexpected disconnect while reading sideband packet", want: Transient},
+		{name: "blocked merge timeout is not transient", text: "required status check timed out", want: Unknown},
 
 		{name: "secondary rate limit", text: "You have exceeded a secondary rate limit", want: RateLimited},
-		{name: "api rate limit exceeded", text: "API rate limit exceeded for user", want: RateLimited},
-		{name: "too many requests", text: "HTTP 429: Too Many Requests", want: RateLimited},
+		{name: "api rate limit exceeded", text: "API rate limit exceeded for user ID 1", want: RateLimited},
 
 		{name: "bad credentials", text: "gh: Bad credentials (HTTP 401)", want: Auth},
 		{name: "http 401", text: "gh: HTTP 401", want: Auth},
@@ -105,43 +105,7 @@ func TestClassifyErr(t *testing.T) {
 	if got := ClassifyErr(errors.New("connection refused")); got != Transient {
 		t.Fatalf("ClassifyErr = %q, want %q", got, Transient)
 	}
-	if !Is(errors.New("Bad credentials"), Auth) {
-		t.Fatal("Is(auth error, Auth) = false")
+	if got := ClassifyErr(errors.New("Bad credentials")); got != Auth {
+		t.Fatalf("ClassifyErr = %q, want %q", got, Auth)
 	}
-}
-
-// TestFamiliesAreLowercase guards the tables themselves: an uppercase entry
-// can never match, since matching lowercases the input.
-func TestFamiliesAreLowercase(t *testing.T) {
-	families := map[string][]string{
-		"NetworkPhrases":      NetworkPhrases,
-		"DNSPhrases":          DNSPhrases,
-		"TLSPhrases":          TLSPhrases,
-		"GatewayPhrases":      GatewayPhrases,
-		"RateLimitPhrases":    RateLimitPhrases,
-		"AuthPhrases":         AuthPhrases,
-		"GitTransportPhrases": GitTransportPhrases,
-		"BadRefPhrases":       BadRefPhrases,
-		"StreamPhrases":       StreamPhrases,
-	}
-	for name, family := range families {
-		for _, phrase := range family {
-			if phrase != lower(phrase) {
-				t.Errorf("%s contains %q, which is not lowercase and can never match", name, phrase)
-			}
-			if phrase == "" {
-				t.Errorf("%s contains an empty phrase, which matches everything", name)
-			}
-		}
-	}
-}
-
-func lower(s string) string {
-	b := []byte(s)
-	for i := range b {
-		if b[i] >= 'A' && b[i] <= 'Z' {
-			b[i] += 'a' - 'A'
-		}
-	}
-	return string(b)
 }

--- a/internal/errclass/families_test.go
+++ b/internal/errclass/families_test.go
@@ -7,38 +7,16 @@ import (
 
 func allFamilies() map[string][]string {
 	return map[string][]string{
-		"NetworkPhrases":      NetworkPhrases,
-		"DNSPhrases":          DNSPhrases,
-		"TLSPhrases":          TLSPhrases,
-		"GatewayPhrases":      GatewayPhrases,
-		"RateLimitPhrases":    RateLimitPhrases,
-		"AuthPhrases":         AuthPhrases,
-		"StreamPhrases":       StreamPhrases,
-		"GitTransportPhrases": GitTransportPhrases,
-		"BadRefPhrases":       BadRefPhrases,
-	}
-}
-
-// TestNoPhraseSubsumesAnother catches the dead weight a substring-matched
-// table accumulates: an entry contained in another entry can never be the
-// reason a match happened, so a test naming it proves nothing.
-func TestNoPhraseSubsumesAnother(t *testing.T) {
-	type entry struct{ family, phrase string }
-	var all []entry
-	for family, phrases := range allFamilies() {
-		for _, p := range phrases {
-			all = append(all, entry{family, p})
-		}
-	}
-	for _, a := range all {
-		for _, b := range all {
-			if a == b || a.phrase == b.phrase {
-				continue
-			}
-			if strings.Contains(a.phrase, b.phrase) {
-				t.Errorf("%s %q contains %s %q, so the longer entry is unreachable", a.family, a.phrase, b.family, b.phrase)
-			}
-		}
+		"BadRefPhrases":            BadRefPhrases,
+		"GitHubTransientPhrases":   GitHubTransientPhrases,
+		"GHOutputTransientPhrases": GHOutputTransientPhrases,
+		"GitHubRateLimitPhrases":   GitHubRateLimitPhrases,
+		"GitHubAuthPhrases":        GitHubAuthPhrases,
+		"MonitorRateLimitPhrases":  MonitorRateLimitPhrases,
+		"GitTransportPhrases":      GitTransportPhrases,
+		"WorkflowTransientPhrases": WorkflowTransientPhrases,
+		"WorkflowAuthPhrases":      WorkflowAuthPhrases,
+		"AgentRateLimitPhrases":    AgentRateLimitPhrases,
 	}
 }
 
@@ -70,48 +48,5 @@ func TestEveryPhraseIsReachable(t *testing.T) {
 				t.Errorf("%s %q does not match itself", name, phrase)
 			}
 		}
-	}
-}
-
-// TestPermanentTLSFailureIsNotTransient pins the defect that made an x509
-// failure retry forever without ever reaching a human.
-func TestPermanentTLSFailureIsNotTransient(t *testing.T) {
-	const x509 = `Get "https://api.github.com/repos/o/r": tls: failed to verify certificate: x509: certificate signed by unknown authority`
-	if IsNetwork(x509) {
-		t.Fatal("IsNetwork matched an x509 verification failure")
-	}
-	if IsGitTransport(x509) {
-		t.Fatal("IsGitTransport matched an x509 verification failure")
-	}
-	if got := Classify(x509); got != Unknown {
-		t.Fatalf("Classify(x509) = %q, want %q", got, Unknown)
-	}
-	if !IsNetwork("net/http: TLS handshake timeout") {
-		t.Fatal("a real handshake timeout should still be transient")
-	}
-}
-
-// TestBlockedMergeIsNotTransient pins the defect that cut a blocked merge's
-// backoff ceiling from two hours to ten minutes.
-func TestBlockedMergeIsNotTransient(t *testing.T) {
-	for _, text := range []string{
-		`Pull request is not mergeable: required status check "e2e" timed out`,
-		"base branch policy prohibits the merge; the required status check timed out",
-	} {
-		if IsNetwork(text) {
-			t.Errorf("IsNetwork(%q) = true, want false", text)
-		}
-		if got := Classify(text); got != Unknown {
-			t.Errorf("Classify(%q) = %q, want %q", text, got, Unknown)
-		}
-	}
-}
-
-// TestScopeHintIsNotAuth pins the defect that would have held the shared auth
-// circuit open on a missing-scope error.
-func TestScopeHintIsNotAuth(t *testing.T) {
-	const scopeHint = "gh: Your token has not been granted the required scopes. To request it, run: gh auth refresh -s read:org"
-	if IsAuth(scopeHint) {
-		t.Fatal("IsAuth matched a missing-scope hint, which never self-heals")
 	}
 }

--- a/internal/errclass/families_test.go
+++ b/internal/errclass/families_test.go
@@ -7,7 +7,7 @@ import (
 
 func allFamilies() map[string][]string {
 	return map[string][]string{
-		"BadRefPhrases":            BadRefPhrases,
+		"badRefPhrases":            badRefPhrases,
 		"GitHubTransientPhrases":   GitHubTransientPhrases,
 		"GHOutputTransientPhrases": GHOutputTransientPhrases,
 		"GitHubRateLimitPhrases":   GitHubRateLimitPhrases,
@@ -34,18 +34,6 @@ func TestFamiliesAreUsableLowercase(t *testing.T) {
 			}
 			if strings.TrimSpace(phrase) != phrase {
 				t.Errorf("%s has %q with surrounding whitespace", name, phrase)
-			}
-		}
-	}
-}
-
-// TestEveryPhraseIsReachable proves each entry is load-bearing: the phrase on
-// its own classifies, so deleting it would change an answer.
-func TestEveryPhraseIsReachable(t *testing.T) {
-	for name, family := range allFamilies() {
-		for _, phrase := range family {
-			if !Matches(phrase, family) {
-				t.Errorf("%s %q does not match itself", name, phrase)
 			}
 		}
 	}

--- a/internal/errclass/families_test.go
+++ b/internal/errclass/families_test.go
@@ -1,0 +1,117 @@
+package errclass
+
+import (
+	"strings"
+	"testing"
+)
+
+func allFamilies() map[string][]string {
+	return map[string][]string{
+		"NetworkPhrases":      NetworkPhrases,
+		"DNSPhrases":          DNSPhrases,
+		"TLSPhrases":          TLSPhrases,
+		"GatewayPhrases":      GatewayPhrases,
+		"RateLimitPhrases":    RateLimitPhrases,
+		"AuthPhrases":         AuthPhrases,
+		"StreamPhrases":       StreamPhrases,
+		"GitTransportPhrases": GitTransportPhrases,
+		"BadRefPhrases":       BadRefPhrases,
+	}
+}
+
+// TestNoPhraseSubsumesAnother catches the dead weight a substring-matched
+// table accumulates: an entry contained in another entry can never be the
+// reason a match happened, so a test naming it proves nothing.
+func TestNoPhraseSubsumesAnother(t *testing.T) {
+	type entry struct{ family, phrase string }
+	var all []entry
+	for family, phrases := range allFamilies() {
+		for _, p := range phrases {
+			all = append(all, entry{family, p})
+		}
+	}
+	for _, a := range all {
+		for _, b := range all {
+			if a == b || a.phrase == b.phrase {
+				continue
+			}
+			if strings.Contains(a.phrase, b.phrase) {
+				t.Errorf("%s %q contains %s %q, so the longer entry is unreachable", a.family, a.phrase, b.family, b.phrase)
+			}
+		}
+	}
+}
+
+func TestFamiliesAreUsableLowercase(t *testing.T) {
+	for name, family := range allFamilies() {
+		if len(family) == 0 {
+			t.Errorf("%s is empty", name)
+		}
+		for _, phrase := range family {
+			if phrase == "" {
+				t.Errorf("%s has an empty phrase, which matches everything", name)
+			}
+			if phrase != strings.ToLower(phrase) {
+				t.Errorf("%s has %q, which is not lowercase and can never match", name, phrase)
+			}
+			if strings.TrimSpace(phrase) != phrase {
+				t.Errorf("%s has %q with surrounding whitespace", name, phrase)
+			}
+		}
+	}
+}
+
+// TestEveryPhraseIsReachable proves each entry is load-bearing: the phrase on
+// its own classifies, so deleting it would change an answer.
+func TestEveryPhraseIsReachable(t *testing.T) {
+	for name, family := range allFamilies() {
+		for _, phrase := range family {
+			if !Matches(phrase, family) {
+				t.Errorf("%s %q does not match itself", name, phrase)
+			}
+		}
+	}
+}
+
+// TestPermanentTLSFailureIsNotTransient pins the defect that made an x509
+// failure retry forever without ever reaching a human.
+func TestPermanentTLSFailureIsNotTransient(t *testing.T) {
+	const x509 = `Get "https://api.github.com/repos/o/r": tls: failed to verify certificate: x509: certificate signed by unknown authority`
+	if IsNetwork(x509) {
+		t.Fatal("IsNetwork matched an x509 verification failure")
+	}
+	if IsGitTransport(x509) {
+		t.Fatal("IsGitTransport matched an x509 verification failure")
+	}
+	if got := Classify(x509); got != Unknown {
+		t.Fatalf("Classify(x509) = %q, want %q", got, Unknown)
+	}
+	if !IsNetwork("net/http: TLS handshake timeout") {
+		t.Fatal("a real handshake timeout should still be transient")
+	}
+}
+
+// TestBlockedMergeIsNotTransient pins the defect that cut a blocked merge's
+// backoff ceiling from two hours to ten minutes.
+func TestBlockedMergeIsNotTransient(t *testing.T) {
+	for _, text := range []string{
+		`Pull request is not mergeable: required status check "e2e" timed out`,
+		"base branch policy prohibits the merge; the required status check timed out",
+	} {
+		if IsNetwork(text) {
+			t.Errorf("IsNetwork(%q) = true, want false", text)
+		}
+		if got := Classify(text); got != Unknown {
+			t.Errorf("Classify(%q) = %q, want %q", text, got, Unknown)
+		}
+	}
+}
+
+// TestScopeHintIsNotAuth pins the defect that would have held the shared auth
+// circuit open on a missing-scope error.
+func TestScopeHintIsNotAuth(t *testing.T) {
+	const scopeHint = "gh: Your token has not been granted the required scopes. To request it, run: gh auth refresh -s read:org"
+	if IsAuth(scopeHint) {
+		t.Fatal("IsAuth matched a missing-scope hint, which never self-heals")
+	}
+}

--- a/internal/github/authhealth.go
+++ b/internal/github/authhealth.go
@@ -274,14 +274,8 @@ func (t *authHealthTracker) applyFailureBackoffLocked() {
 // ObserveCallResult can classify a combined stdout+stderr blob the same way
 // IsAuthError classifies a wrapped error.
 func isAuthErrorMsg(msg string) bool {
-	lower := strings.ToLower(msg)
-	// "gh auth login" stays narrow here: the bare "gh auth" prefix also matches
-	// gh's missing-scope hint, which never self-heals and would hold the shared
-	// auth circuit open across every call.
-	return strings.Contains(lower, authCircuitOpenMarker) ||
-		strings.Contains(lower, "gh auth login") ||
-		strings.Contains(lower, "gh_token environment variable") ||
-		errclass.IsAuth(msg)
+	return strings.Contains(strings.ToLower(msg), authCircuitOpenMarker) ||
+		errclass.Matches(msg, errclass.GitHubAuthPhrases)
 }
 
 // authCircuitOpenMarker tags the synthetic error returned while the circuit

--- a/internal/github/authhealth.go
+++ b/internal/github/authhealth.go
@@ -274,7 +274,13 @@ func (t *authHealthTracker) applyFailureBackoffLocked() {
 // ObserveCallResult can classify a combined stdout+stderr blob the same way
 // IsAuthError classifies a wrapped error.
 func isAuthErrorMsg(msg string) bool {
-	return strings.Contains(strings.ToLower(msg), authCircuitOpenMarker) ||
+	lower := strings.ToLower(msg)
+	// "gh auth login" stays narrow here: the bare "gh auth" prefix also matches
+	// gh's missing-scope hint, which never self-heals and would hold the shared
+	// auth circuit open across every call.
+	return strings.Contains(lower, authCircuitOpenMarker) ||
+		strings.Contains(lower, "gh auth login") ||
+		strings.Contains(lower, "gh_token environment variable") ||
 		errclass.IsAuth(msg)
 }
 

--- a/internal/github/authhealth.go
+++ b/internal/github/authhealth.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
+
 	"github.com/Automaat/sybra/internal/clock"
 )
 
@@ -272,12 +274,8 @@ func (t *authHealthTracker) applyFailureBackoffLocked() {
 // ObserveCallResult can classify a combined stdout+stderr blob the same way
 // IsAuthError classifies a wrapped error.
 func isAuthErrorMsg(msg string) bool {
-	msg = strings.ToLower(msg)
-	return strings.Contains(msg, "http 401") ||
-		strings.Contains(msg, "bad credentials") ||
-		strings.Contains(msg, "gh auth login") ||
-		strings.Contains(msg, "gh_token environment variable") ||
-		strings.Contains(msg, authCircuitOpenMarker)
+	return strings.Contains(strings.ToLower(msg), authCircuitOpenMarker) ||
+		errclass.IsAuth(msg)
 }
 
 // authCircuitOpenMarker tags the synthetic error returned while the circuit

--- a/internal/github/automerge_backoff.go
+++ b/internal/github/automerge_backoff.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/sybra/internal/errclass"
 )
 
 // MergeErrorClass classifies a failed auto-merge attempt so AutoMergeBackoff
@@ -46,6 +48,9 @@ func ClassifyMergeError(err error) MergeErrorClass {
 	if err == nil {
 		return ""
 	}
+	// Auth and rate limit are asked first, matching errclass.Classify's own
+	// precedence; IsTransientError stays broader than errclass.Transient here
+	// because a poller that under-reports transience escalates the whole board.
 	switch {
 	case IsAuthError(err):
 		return MergeErrorAuth
@@ -55,6 +60,8 @@ func ClassifyMergeError(err error) MergeErrorClass {
 		return MergeErrorTransient
 	case isMergeBlockedMessage(err.Error()):
 		return MergeErrorBlocked
+	case errclass.Classify(err.Error()) == errclass.Transient:
+		return MergeErrorTransient
 	default:
 		return MergeErrorUnknown
 	}

--- a/internal/github/automerge_backoff.go
+++ b/internal/github/automerge_backoff.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/Automaat/sybra/internal/errclass"
 )
 
 // MergeErrorClass classifies a failed auto-merge attempt so AutoMergeBackoff
@@ -48,9 +46,6 @@ func ClassifyMergeError(err error) MergeErrorClass {
 	if err == nil {
 		return ""
 	}
-	// Auth and rate limit are asked first, matching errclass.Classify's own
-	// precedence; IsTransientError stays broader than errclass.Transient here
-	// because a poller that under-reports transience escalates the whole board.
 	switch {
 	case IsAuthError(err):
 		return MergeErrorAuth
@@ -60,8 +55,6 @@ func ClassifyMergeError(err error) MergeErrorClass {
 		return MergeErrorTransient
 	case isMergeBlockedMessage(err.Error()):
 		return MergeErrorBlocked
-	case errclass.Classify(err.Error()) == errclass.Transient:
-		return MergeErrorTransient
 	default:
 		return MergeErrorUnknown
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -717,7 +717,7 @@ func IsTransientError(err error) bool {
 	if isRateLimitedMessage(msg) {
 		return true
 	}
-	return errclass.IsNetwork(msg)
+	return errclass.Matches(msg, errclass.GitHubTransientPhrases)
 }
 
 // IsAuthError reports whether err is a GitHub authentication failure — an

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/sybra/internal/errclass"
 )
 
 // execer abstracts command execution for testing.
@@ -704,7 +706,10 @@ func IsTransientError(err error) bool {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
-	// HTTP 5xx: sanitized gh output produces "gh: http 5xx"
+	// HTTP 5xx: sanitized gh output produces "gh: http 5xx". Kept broader than
+	// errclass.IsGateway on purpose — this predicate gates poller escalation,
+	// where treating a 500 as transient costs one retry and treating it as
+	// permanent costs a board-wide escalation storm.
 	if strings.Contains(msg, "http 5") {
 		return true
 	}
@@ -712,13 +717,7 @@ func IsTransientError(err error) bool {
 	if isRateLimitedMessage(msg) {
 		return true
 	}
-	return strings.Contains(msg, "dial tcp") ||
-		strings.Contains(msg, "i/o timeout") ||
-		strings.Contains(msg, "context deadline exceeded") ||
-		strings.Contains(msg, "connection reset") ||
-		strings.Contains(msg, "connection refused") ||
-		strings.Contains(msg, "tls handshake timeout") ||
-		strings.Contains(msg, "no route to host")
+	return errclass.IsNetwork(msg)
 }
 
 // IsAuthError reports whether err is a GitHub authentication failure — an

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -706,10 +706,9 @@ func IsTransientError(err error) bool {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
-	// HTTP 5xx: sanitized gh output produces "gh: http 5xx". Kept broader than
-	// errclass.IsGateway on purpose — this predicate gates poller escalation,
-	// where treating a 500 as transient costs one retry and treating it as
-	// permanent costs a board-wide escalation storm.
+	// HTTP 5xx: sanitized gh output produces "gh: http 5xx". Broader than the
+	// gateway-only list gh output uses, because this predicate gates poller
+	// escalation: a 500 read as permanent costs a board-wide escalation storm.
 	if strings.Contains(msg, "http 5") {
 		return true
 	}

--- a/internal/github/errclass_sites_test.go
+++ b/internal/github/errclass_sites_test.go
@@ -25,6 +25,7 @@ func TestIsTransientGHError_PinsLiterals(t *testing.T) {
 		{out: "http2: stream error", want: true},
 		{out: "unexpected EOF", want: true},
 		{out: "net/http: TLS handshake timeout", want: true},
+		{out: "tls: first record does not look like a TLS handshake", want: true},
 
 		{out: "gh: HTTP 500", want: false},
 		{out: "gh: HTTP 404", want: false},
@@ -51,6 +52,7 @@ func TestIsRateLimitedMessage_PinsLiterals(t *testing.T) {
 		{msg: "API rate limit exceeded for user ID 1", want: true},
 		{msg: "rate limit exceeded", want: true},
 		{msg: rateLimitWallMarker, want: true},
+		{msg: "API rate limit exceeded", want: true},
 		{msg: "SECONDARY RATE LIMIT", want: true},
 
 		{msg: "connection refused", want: false},
@@ -82,6 +84,8 @@ func TestIsAuthErrorMsg_PinsLiterals(t *testing.T) {
 		// A missing-scope hint never self-heals; treating it as an auth error
 		// would hold the shared circuit open across every gh call.
 		{msg: "gh: Your token has not been granted the required scopes. To request it, run: gh auth refresh -s read:org", want: false},
+		{msg: "fatal: Authentication failed for 'https://github.com/o/r.git/'", want: false},
+		{msg: "remote: 401 Unauthorized", want: false},
 		{msg: "connection refused", want: false},
 		{msg: "", want: false},
 	} {
@@ -100,6 +104,7 @@ func TestClassifyMergeError_BlockedStaysBlocked(t *testing.T) {
 	for _, msg := range []string{
 		`Pull request is not mergeable: required status check "e2e" timed out`,
 		"base branch policy prohibits the merge; the required status check timed out",
+		"blocked by a policy: waiting for status checks; the connection timed out earlier but has recovered",
 		"gh: not mergeable: waiting for status checks",
 	} {
 		if got := ClassifyMergeError(errors.New(msg)); got != MergeErrorBlocked {

--- a/internal/github/errclass_sites_test.go
+++ b/internal/github/errclass_sites_test.go
@@ -1,0 +1,109 @@
+package github
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestIsTransientGHError_PinsLiterals pins the literal set isTransientGHError
+// matched before it moved onto errclass. StreamPhrases in particular had no
+// test outside the new package, so its retry was unguarded.
+func TestIsTransientGHError_PinsLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{out: "gh: HTTP 502", want: true},
+		{out: "gh: HTTP 503", want: true},
+		{out: "gh: HTTP 504", want: true},
+		{out: "operation timed out", want: true},
+		{out: "read tcp: i/o timeout", want: true},
+		{out: "context deadline exceeded", want: true},
+		{out: "deadline exceeded", want: true},
+		{out: "connection reset by peer", want: true},
+		{out: "connect: connection refused", want: true},
+		{out: "http2: stream error", want: true},
+		{out: "unexpected EOF", want: true},
+		{out: "net/http: TLS handshake timeout", want: true},
+
+		{out: "gh: HTTP 500", want: false},
+		{out: "gh: HTTP 404", want: false},
+		{out: "gh: Bad credentials", want: false},
+		{out: "", want: false},
+	} {
+		t.Run(tc.out, func(t *testing.T) {
+			got := isTransientGHError([]byte(tc.out), errors.New(tc.out))
+			if got != tc.want {
+				t.Fatalf("isTransientGHError(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsRateLimitedMessage_PinsLiterals pins the four phrases this predicate
+// recognized before the move.
+func TestIsRateLimitedMessage_PinsLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		msg  string
+		want bool
+	}{
+		{msg: "You have exceeded a secondary rate limit", want: true},
+		{msg: "API rate limit exceeded for user ID 1", want: true},
+		{msg: "rate limit exceeded", want: true},
+		{msg: rateLimitWallMarker, want: true},
+		{msg: "SECONDARY RATE LIMIT", want: true},
+
+		{msg: "connection refused", want: false},
+		{msg: "Bad credentials", want: false},
+		{msg: "", want: false},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			if got := isRateLimitedMessage(tc.msg); got != tc.want {
+				t.Fatalf("isRateLimitedMessage(%q) = %v, want %v", tc.msg, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsAuthErrorMsg_PinsLiterals pins the credential phrases, including the
+// two that stay local to this package: the narrow "gh auth login" and the
+// GH_TOKEN hint.
+func TestIsAuthErrorMsg_PinsLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		msg  string
+		want bool
+	}{
+		{msg: "gh: HTTP 401", want: true},
+		{msg: "gh: Bad credentials", want: true},
+		{msg: "To get started with GitHub CLI, please run: gh auth login", want: true},
+		{msg: "the GH_TOKEN environment variable is not set", want: true},
+		{msg: authCircuitOpenMarker, want: true},
+
+		// A missing-scope hint never self-heals; treating it as an auth error
+		// would hold the shared circuit open across every gh call.
+		{msg: "gh: Your token has not been granted the required scopes. To request it, run: gh auth refresh -s read:org", want: false},
+		{msg: "connection refused", want: false},
+		{msg: "", want: false},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			if got := isAuthErrorMsg(tc.msg); got != tc.want {
+				t.Fatalf("isAuthErrorMsg(%q) = %v, want %v", tc.msg, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyMergeError_BlockedStaysBlocked pins the backoff-collapse defect:
+// a blocked merge whose text mentions a timed-out check must not read as
+// transient, or its ceiling drops from two hours to ten minutes.
+func TestClassifyMergeError_BlockedStaysBlocked(t *testing.T) {
+	for _, msg := range []string{
+		`Pull request is not mergeable: required status check "e2e" timed out`,
+		"base branch policy prohibits the merge; the required status check timed out",
+		"gh: not mergeable: waiting for status checks",
+	} {
+		if got := ClassifyMergeError(errors.New(msg)); got != MergeErrorBlocked {
+			t.Errorf("ClassifyMergeError(%q) = %q, want %q", msg, got, MergeErrorBlocked)
+		}
+	}
+}

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -56,7 +56,10 @@ func isTransientGHError(out []byte, err error) bool {
 		return false
 	}
 	msg := string(out)
-	return errclass.IsGateway(msg) || errclass.IsNetwork(msg) || errclass.Matches(msg, errclass.StreamPhrases)
+	return errclass.IsGateway(msg) ||
+		errclass.IsNetwork(msg) ||
+		errclass.Matches(msg, errclass.StreamPhrases) ||
+		strings.Contains(strings.ToLower(msg), "deadline exceeded")
 }
 
 type ttlCache[T any] struct {

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -56,10 +56,7 @@ func isTransientGHError(out []byte, err error) bool {
 		return false
 	}
 	msg := string(out)
-	return errclass.IsGateway(msg) ||
-		errclass.IsNetwork(msg) ||
-		errclass.Matches(msg, errclass.StreamPhrases) ||
-		strings.Contains(strings.ToLower(msg), "deadline exceeded")
+	return errclass.Matches(msg, errclass.GHOutputTransientPhrases)
 }
 
 type ttlCache[T any] struct {
@@ -427,7 +424,7 @@ func (g *ghRequestGate) pressure() (fraction float64, known bool) {
 
 func isRateLimitedMessage(msg string) bool {
 	return strings.Contains(strings.ToLower(msg), rateLimitWallMarker) ||
-		errclass.IsRateLimit(msg)
+		errclass.Matches(msg, errclass.GitHubRateLimitPhrases)
 }
 
 func isGraphQLRateLimitBody(body []byte) bool {

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/sybra/internal/errclass"
 )
 
 const (
@@ -53,18 +55,8 @@ func isTransientGHError(out []byte, err error) bool {
 	if err == nil || isRateLimitedResponse(resp) {
 		return false
 	}
-	msg := strings.ToLower(string(out))
-	for _, sig := range []string{
-		"http 502", "http 503", "http 504",
-		"operation timed out", "i/o timeout", "deadline exceeded",
-		"connection reset", "connection refused",
-		"stream error", "unexpected eof", "tls handshake",
-	} {
-		if strings.Contains(msg, sig) {
-			return true
-		}
-	}
-	return false
+	msg := string(out)
+	return errclass.IsGateway(msg) || errclass.IsNetwork(msg) || errclass.Matches(msg, errclass.StreamPhrases)
 }
 
 type ttlCache[T any] struct {
@@ -431,11 +423,8 @@ func (g *ghRequestGate) pressure() (fraction float64, known bool) {
 }
 
 func isRateLimitedMessage(msg string) bool {
-	lower := strings.ToLower(msg)
-	return strings.Contains(lower, rateLimitWallMarker) ||
-		strings.Contains(lower, "secondary rate limit") ||
-		strings.Contains(lower, "api rate limit exceeded") ||
-		strings.Contains(lower, "rate limit exceeded")
+	return strings.Contains(strings.ToLower(msg), rateLimitWallMarker) ||
+		errclass.IsRateLimit(msg)
 }
 
 func isGraphQLRateLimitBody(body []byte) bool {

--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -314,7 +314,7 @@ func classifyGHError(op string, out []byte, err error) error {
 	}
 	out = redactSecrets(out)
 	msg := err.Error() + "\n" + string(out)
-	if errclass.IsRateLimit(msg) {
+	if errclass.Matches(msg, errclass.MonitorRateLimitPhrases) {
 		return ErrGHRateLimit
 	}
 	if detail := sanitizeGHOutput(out); detail != "" {

--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Automaat/sybra/internal/errclass"
+
 	"github.com/Automaat/sybra/internal/attribution"
 	"github.com/Automaat/sybra/internal/github"
 )
@@ -312,7 +314,7 @@ func classifyGHError(op string, out []byte, err error) error {
 	}
 	out = redactSecrets(out)
 	msg := err.Error() + "\n" + string(out)
-	if strings.Contains(msg, "API rate limit exceeded") || strings.Contains(msg, "secondary rate limit") {
+	if errclass.IsRateLimit(msg) {
 		return ErrGHRateLimit
 	}
 	if detail := sanitizeGHOutput(out); detail != "" {

--- a/internal/project/errclass_sites_test.go
+++ b/internal/project/errclass_sites_test.go
@@ -1,0 +1,81 @@
+package project
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestIsTransientNetworkError_PinsLiterals pins the transport phrases this
+// predicate matched before it moved onto errclass.
+//
+// It gates branch-conflict recovery, and worktree treats its true answer as
+// ErrTransientFetch, which callers must never escalate to human-required. A
+// phrase that is permanent but reads as transient here therefore retries
+// forever with no human ever told.
+func TestIsTransientNetworkError_PinsLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		msg  string
+		want bool
+	}{
+		{msg: "connect: connection refused", want: true},
+		{msg: "connection reset by peer", want: true},
+		{msg: "connection timed out", want: true},
+		{msg: "failed to connect to github.com", want: true},
+		{msg: "couldn't connect to server", want: true},
+		{msg: "fatal: could not resolve host: github.com", want: true},
+		{msg: "couldn't resolve host name", want: true},
+		{msg: "network is unreachable", want: true},
+		{msg: "operation timed out", want: true},
+		{msg: "temporary failure in name resolution", want: true},
+		{msg: "no route to host", want: true},
+		{msg: "ssh: connect to host github.com port 22: Connection timed out", want: true},
+		{msg: "recv failure: Connection reset by peer", want: true},
+		{msg: "net/http: TLS handshake timeout", want: true},
+		{msg: "empty reply from server", want: true},
+		{msg: "early EOF", want: true},
+		{msg: "fatal: unexpected disconnect while reading sideband packet", want: true},
+
+		// An x509 failure never self-heals, so a true answer here would loop without ever reaching a human.
+		{msg: `tls: failed to verify certificate: x509: certificate signed by unknown authority`, want: false},
+		{msg: "CONFLICT (content): Merge conflict in main.go", want: false},
+		{msg: "Authentication failed for 'https://github.com/o/r.git/'", want: false},
+		{msg: "", want: false},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			if got := IsTransientNetworkError(errors.New(tc.msg)); got != tc.want {
+				t.Fatalf("IsTransientNetworkError(%q) = %v, want %v", tc.msg, got, tc.want)
+			}
+		})
+	}
+	if IsTransientNetworkError(nil) {
+		t.Fatal("IsTransientNetworkError(nil) = true")
+	}
+}
+
+// TestIsBadRefError_PinsLiterals pins the twelve needles that lived
+// byte-identically here and in internal/workflow.
+func TestIsBadRefError_PinsLiterals(t *testing.T) {
+	for _, msg := range []string{
+		"bad object HEAD",
+		"fatal: bad object abc123",
+		"not a valid object name",
+		"invalid object",
+		"fatal: Invalid revision range origin/main...HEAD",
+		"missing object",
+		"unable to read sha1 file",
+		"error: object file .git/objects/ab/cdef is empty",
+		"loose object",
+		"unknown revision",
+		"fatal: ambiguous argument 'origin/main'",
+		"reference broken",
+	} {
+		if !IsBadRefError(errors.New(msg)) {
+			t.Errorf("IsBadRefError(%q) = false, want true", msg)
+		}
+	}
+	for _, msg := range []string{"connection refused", "Bad credentials", ""} {
+		if IsBadRefError(errors.New(msg)) {
+			t.Errorf("IsBadRefError(%q) = true, want false", msg)
+		}
+	}
+}

--- a/internal/project/errclass_sites_test.go
+++ b/internal/project/errclass_sites_test.go
@@ -31,6 +31,7 @@ func TestIsTransientNetworkError_PinsLiterals(t *testing.T) {
 		{msg: "ssh: connect to host github.com port 22: Connection timed out", want: true},
 		{msg: "recv failure: Connection reset by peer", want: true},
 		{msg: "net/http: TLS handshake timeout", want: true},
+		{msg: "tls: first record does not look like a TLS handshake", want: false},
 		{msg: "empty reply from server", want: true},
 		{msg: "early EOF", want: true},
 		{msg: "fatal: unexpected disconnect while reading sideband packet", want: true},

--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -2,8 +2,9 @@ package project
 
 import (
 	"context"
-	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/errclass"
 )
 
 // transientNetworkMarkers are substrings of git/ssh/curl transport failures
@@ -13,25 +14,6 @@ import (
 // delay reporting) a permanent failure, but a false negative would wrongly
 // classify a transient outage as a content conflict and escalate a task to
 // human-required on a perfectly clean branch.
-var transientNetworkMarkers = []string{
-	"connection refused",
-	"connection reset",
-	"connection timed out",
-	"failed to connect",
-	"couldn't connect to server",
-	"could not resolve host",
-	"couldn't resolve host",
-	"network is unreachable",
-	"operation timed out",
-	"temporary failure in name resolution",
-	"no route to host",
-	"ssh: connect to host",
-	"recv failure",
-	"tls handshake timeout",
-	"empty reply from server",
-	"early eof",
-	"unexpected disconnect while reading sideband packet",
-}
 
 var gitOpRetrySleepContext = sleepWithContext
 
@@ -42,13 +24,7 @@ func IsTransientNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
-	for _, marker := range transientNetworkMarkers {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
+	return errclass.IsGitTransport(err.Error())
 }
 
 // withNetworkRetry runs fn, retrying on gitOpRetryBackoffs when the failure

--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -16,7 +16,7 @@ func IsTransientNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errclass.IsGitTransport(err.Error())
+	return errclass.Matches(err.Error(), errclass.GitTransportPhrases)
 }
 
 // withNetworkRetry runs fn, retrying on gitOpRetryBackoffs when the failure

--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -7,14 +7,6 @@ import (
 	"github.com/Automaat/sybra/internal/errclass"
 )
 
-// transientNetworkMarkers are substrings of git/ssh/curl transport failures
-// that indicate a connectivity blip (DNS, refused/reset connection, timeout)
-// rather than a genuine content conflict or an auth/config problem. Matching
-// is deliberately narrow — a false positive here would retry (and briefly
-// delay reporting) a permanent failure, but a false negative would wrongly
-// classify a transient outage as a content conflict and escalate a task to
-// human-required on a perfectly clean branch.
-
 var gitOpRetrySleepContext = sleepWithContext
 
 // IsTransientNetworkError reports whether err looks like a transient

--- a/internal/project/repair.go
+++ b/internal/project/repair.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
+
 	"github.com/Automaat/sybra/internal/gitexec"
 )
 
@@ -25,32 +27,11 @@ var QuarantineDir string
 // It is configured by the app alongside QuarantineDir.
 var WorktreesDir string
 
-var badRefMarkers = []string{
-	"fatal: bad object",
-	"bad object head",
-	"not a valid object name",
-	"invalid object",
-	"invalid revision range",
-	"missing object",
-	"unable to read sha1 file",
-	"object file",
-	"loose object",
-	"unknown revision",
-	"ambiguous argument",
-	"reference broken",
-}
-
 func IsBadRefError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
-	for _, marker := range badRefMarkers {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
+	return errclass.IsBadRef(err.Error())
 }
 
 // fsckRefBatch bounds how many ref tips are passed to one `git fsck`

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -313,10 +313,7 @@ func isPRCreationStep(stepID string) bool {
 
 func looksLikeGitHubRateLimit(output string) bool {
 	lower := strings.ToLower(output)
-	// A bare "rate limit" is this site's own: it reads agent prose, where
-	// "rate limit exhausted" is as common as GitHub's own wording, and the
-	// corroborator below is what keeps it from matching unrelated text.
-	if !errclass.IsRateLimit(output) && !strings.Contains(lower, "rate limit") {
+	if !strings.Contains(lower, "rate limit") {
 		return false
 	}
 	return strings.Contains(lower, "github") ||
@@ -333,16 +330,8 @@ func looksLikeGitHubRateLimit(output string) bool {
 // looksLikeGitHubRateLimit (requires "rate limit") and looksLikeAuthFailure
 // (credential problems, which are not naturally time-bounded).
 func looksLikeTransientGitHub(output string) bool {
-	if errclass.IsNetwork(output) {
-		return true
-	}
-	lower := strings.ToLower(output)
-	// Only this site reads agent prose, where a bare "timed out" or "tls:" is
-	// still a GitHub-reachability failure rather than a blocked merge.
-	if strings.Contains(lower, "timed out") || strings.Contains(lower, "tls:") {
-		return true
-	}
-	return looksLikeGatewayStatus(lower)
+	return errclass.Matches(output, errclass.WorkflowTransientPhrases) ||
+		looksLikeGatewayStatus(strings.ToLower(output))
 }
 
 // looksLikeGatewayStatus matches HTTP 502/503 responses regardless of how the
@@ -385,7 +374,5 @@ func isStatusBoundary(b byte) bool {
 // limits or network blips, a broken token does not self-heal, so callers must
 // bound how many times they retry before escalating to a human.
 func looksLikeAuthFailure(output string) bool {
-	// "gh auth" is broader than the shared family on purpose: this site reads
-	// agent output, where the echoed command is the usual credential signal.
-	return errclass.IsAuth(output) || strings.Contains(strings.ToLower(output), "gh auth")
+	return errclass.Matches(output, errclass.WorkflowAuthPhrases)
 }

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
+
 	"github.com/Automaat/sybra/internal/taskstatus"
 	"github.com/Automaat/sybra/internal/textutil"
 )
@@ -310,10 +312,10 @@ func isPRCreationStep(stepID string) bool {
 }
 
 func looksLikeGitHubRateLimit(output string) bool {
-	lower := strings.ToLower(output)
-	if !strings.Contains(lower, "rate limit") {
+	if !errclass.IsRateLimit(output) {
 		return false
 	}
+	lower := strings.ToLower(output)
 	return strings.Contains(lower, "github") ||
 		strings.Contains(lower, "graphql") ||
 		strings.Contains(lower, "gh ") ||
@@ -328,27 +330,7 @@ func looksLikeGitHubRateLimit(output string) bool {
 // looksLikeGitHubRateLimit (requires "rate limit") and looksLikeAuthFailure
 // (credential problems, which are not naturally time-bounded).
 func looksLikeTransientGitHub(output string) bool {
-	lower := strings.ToLower(output)
-	patterns := []string{
-		"connection refused",
-		"connection reset",
-		"could not resolve host",
-		"no such host",
-		"no route to host",
-		"network is unreachable",
-		"temporary failure in name resolution",
-		"i/o timeout",
-		"timed out",
-		"context deadline exceeded",
-		"tls handshake",
-		"tls:",
-	}
-	for _, p := range patterns {
-		if strings.Contains(lower, p) {
-			return true
-		}
-	}
-	return looksLikeGatewayStatus(lower)
+	return errclass.IsNetwork(output) || looksLikeGatewayStatus(strings.ToLower(output))
 }
 
 // looksLikeGatewayStatus matches HTTP 502/503 responses regardless of how the
@@ -391,22 +373,5 @@ func isStatusBoundary(b byte) bool {
 // limits or network blips, a broken token does not self-heal, so callers must
 // bound how many times they retry before escalating to a human.
 func looksLikeAuthFailure(output string) bool {
-	lower := strings.ToLower(output)
-	patterns := []string{
-		"bad credentials",
-		"authentication failed",
-		"failed to log in",
-		"gh auth",
-		"gh_token is invalid",
-		"github_token is invalid",
-		"token has expired",
-		"could not read username for 'https://github.com'",
-		"401 unauthorized",
-	}
-	for _, p := range patterns {
-		if strings.Contains(lower, p) {
-			return true
-		}
-	}
-	return false
+	return errclass.IsAuth(output)
 }

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -312,10 +312,13 @@ func isPRCreationStep(stepID string) bool {
 }
 
 func looksLikeGitHubRateLimit(output string) bool {
-	if !errclass.IsRateLimit(output) {
+	lower := strings.ToLower(output)
+	// A bare "rate limit" is this site's own: it reads agent prose, where
+	// "rate limit exhausted" is as common as GitHub's own wording, and the
+	// corroborator below is what keeps it from matching unrelated text.
+	if !errclass.IsRateLimit(output) && !strings.Contains(lower, "rate limit") {
 		return false
 	}
-	lower := strings.ToLower(output)
 	return strings.Contains(lower, "github") ||
 		strings.Contains(lower, "graphql") ||
 		strings.Contains(lower, "gh ") ||
@@ -330,7 +333,16 @@ func looksLikeGitHubRateLimit(output string) bool {
 // looksLikeGitHubRateLimit (requires "rate limit") and looksLikeAuthFailure
 // (credential problems, which are not naturally time-bounded).
 func looksLikeTransientGitHub(output string) bool {
-	return errclass.IsNetwork(output) || looksLikeGatewayStatus(strings.ToLower(output))
+	if errclass.IsNetwork(output) {
+		return true
+	}
+	lower := strings.ToLower(output)
+	// Only this site reads agent prose, where a bare "timed out" or "tls:" is
+	// still a GitHub-reachability failure rather than a blocked merge.
+	if strings.Contains(lower, "timed out") || strings.Contains(lower, "tls:") {
+		return true
+	}
+	return looksLikeGatewayStatus(lower)
 }
 
 // looksLikeGatewayStatus matches HTTP 502/503 responses regardless of how the
@@ -373,5 +385,7 @@ func isStatusBoundary(b byte) bool {
 // limits or network blips, a broken token does not self-heal, so callers must
 // bound how many times they retry before escalating to a human.
 func looksLikeAuthFailure(output string) bool {
-	return errclass.IsAuth(output)
+	// "gh auth" is broader than the shared family on purpose: this site reads
+	// agent output, where the echoed command is the usual credential signal.
+	return errclass.IsAuth(output) || strings.Contains(strings.ToLower(output), "gh auth")
 }

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
+
 	"github.com/Automaat/sybra/internal/attribution"
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/gitexec"
@@ -726,26 +728,7 @@ func shouldRetryVerifyCommitsGitError(err error, output []byte) bool {
 	if err == nil {
 		return false
 	}
-	text := strings.ToLower(err.Error() + "\n" + string(output))
-	for _, needle := range []string{
-		"bad object head",
-		"fatal: bad object",
-		"not a valid object name",
-		"invalid object",
-		"invalid revision range",
-		"missing object",
-		"unable to read sha1 file",
-		"object file",
-		"loose object",
-		"unknown revision",
-		"ambiguous argument",
-		"reference broken",
-	} {
-		if strings.Contains(text, needle) {
-			return true
-		}
-	}
-	return false
+	return errclass.IsBadRef(err.Error() + "\n" + string(output))
 }
 
 func (e *Engine) recoverVerifyCommitsRefs(taskID, wtPath string, t TaskInfo) bool {

--- a/internal/workflow/errclass_sites_test.go
+++ b/internal/workflow/errclass_sites_test.go
@@ -1,0 +1,131 @@
+package workflow
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestShouldRetryVerifyCommitsGitError_PinsLiterals pins the twelve bad-ref
+// needles this predicate carried before it moved onto errclass. It had no test
+// of any kind, so the whole list was free to drift from internal/project's
+// byte-identical copy.
+func TestShouldRetryVerifyCommitsGitError_PinsLiterals(t *testing.T) {
+	for _, msg := range []string{
+		"bad object HEAD",
+		"fatal: bad object abc123",
+		"not a valid object name",
+		"invalid object",
+		"fatal: Invalid revision range origin/main...HEAD",
+		"missing object",
+		"unable to read sha1 file",
+		"error: object file .git/objects/ab/cdef is empty",
+		"loose object",
+		"unknown revision",
+		"fatal: ambiguous argument 'origin/main'",
+		"reference broken",
+	} {
+		if !shouldRetryVerifyCommitsGitError(errors.New(msg), nil) {
+			t.Errorf("shouldRetryVerifyCommitsGitError(%q) = false, want true", msg)
+		}
+	}
+	if !shouldRetryVerifyCommitsGitError(errors.New("exit 128"), []byte("fatal: bad object HEAD")) {
+		t.Error("the git output should be read alongside the error")
+	}
+	for _, msg := range []string{"connection refused", "Bad credentials"} {
+		if shouldRetryVerifyCommitsGitError(errors.New(msg), nil) {
+			t.Errorf("shouldRetryVerifyCommitsGitError(%q) = true, want false", msg)
+		}
+	}
+	if shouldRetryVerifyCommitsGitError(nil, []byte("fatal: bad object HEAD")) {
+		t.Error("a nil error should never retry")
+	}
+}
+
+// TestLooksLikeTransientGitHub_PinsLiterals pins the reachability phrases,
+// including the bare "timed out" and "tls:" this site keeps locally because it
+// reads agent prose rather than a transport error.
+func TestLooksLikeTransientGitHub_PinsLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{out: "connection refused", want: true},
+		{out: "connection reset by peer", want: true},
+		{out: "could not resolve host: github.com", want: true},
+		{out: "no such host", want: true},
+		{out: "no route to host", want: true},
+		{out: "network is unreachable", want: true},
+		{out: "temporary failure in name resolution", want: true},
+		{out: "read tcp: i/o timeout", want: true},
+		{out: "the request timed out", want: true},
+		{out: "context deadline exceeded", want: true},
+		{out: "net/http: TLS handshake timeout", want: true},
+		{out: "tls: bad record MAC", want: true},
+		{out: "HTTP 502 Bad Gateway", want: true},
+		{out: "503 Service Unavailable", want: true},
+
+		{out: "gh: Bad credentials", want: false},
+		{out: "API rate limit exceeded", want: false},
+		{out: "", want: false},
+	} {
+		t.Run(tc.out, func(t *testing.T) {
+			if got := looksLikeTransientGitHub(tc.out); got != tc.want {
+				t.Fatalf("looksLikeTransientGitHub(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLooksLikeAuthFailure_PinsLiterals pins the credential phrases, including
+// the broad "gh auth" this site keeps locally because an echoed command is its
+// usual signal.
+func TestLooksLikeAuthFailure_PinsLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{out: "gh: Bad credentials", want: true},
+		{out: "Authentication failed for 'https://github.com/o/r.git/'", want: true},
+		{out: "failed to log in", want: true},
+		{out: "run: gh auth status", want: true},
+		{out: "GH_TOKEN is invalid", want: true},
+		{out: "GITHUB_TOKEN is invalid", want: true},
+		{out: "the token has expired", want: true},
+		{out: "could not read Username for 'https://github.com'", want: true},
+		{out: "remote: 401 Unauthorized", want: true},
+
+		{out: "connection refused", want: false},
+		{out: "API rate limit exceeded", want: false},
+		{out: "", want: false},
+	} {
+		t.Run(tc.out, func(t *testing.T) {
+			if got := looksLikeAuthFailure(tc.out); got != tc.want {
+				t.Fatalf("looksLikeAuthFailure(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLooksLikeGitHubRateLimit_PinsLiterals pins that this site still requires
+// a GitHub-shaped corroborator alongside the rate-limit phrase.
+func TestLooksLikeGitHubRateLimit_PinsLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{out: "github: API rate limit exceeded", want: true},
+		{out: "graphql: rate limit exceeded", want: true},
+		{out: "gh api: secondary rate limit", want: true},
+		{out: "GitHub GraphQL rate limit exhausted; I will wait for reset.", want: true},
+
+		{out: "the build rate limit exceeded our budget", want: false},
+		{out: "connection refused", want: false},
+		{out: "", want: false},
+	} {
+		t.Run(tc.out, func(t *testing.T) {
+			if got := looksLikeGitHubRateLimit(tc.out); got != tc.want {
+				t.Fatalf("looksLikeGitHubRateLimit(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

The phrases that decide whether an error is transient, rate limited, or an auth failure lived in a dozen packages. Nothing made a reader of one table aware of the others, so they drifted. The twelve bad-ref needles existed byte-identically in `internal/project` and `internal/workflow`, each free to change alone. `internal/monitor` knew two of the four rate-limit phrases `internal/github` knew. #3139.

> Changelog: refactor(errclass): co-locate the error phrase tables

## Implementation information

`internal/errclass` now holds every table in one file. It is a leaf with no internal imports, which `internal/github` forces: that package depends on `internal/clock` alone, so anything heavier would cycle.

**It co-locates the tables and does not merge them, and that is the main decision in this PR.** Each caller keeps the exact set it had. Only the bad-ref table is genuinely shared, because its two owners already held identical copies.

The issue asks both for one package to answer the question and for behaviour on every phrase handled today to stay unchanged. Those conflict, and the evidence for that is not an opinion. Merging the sets was implemented first, and adversarial testing over a real corpus found **204 differing answers across ten of fourteen predicates**, three of them defects:

- `agent.classifyAgentError` stopped recognising eleven rate-limit phrasings. That label reaches `completion.isRateLimitedRun`, so a run that should be reported stalled and re-dispatched became a crash that burns workflow retry budget and ends at human-required.
- A bare `"tls handshake"` made `tls: first record does not look like a TLS handshake` transient. That condition is permanent, and `project.IsTransientNetworkError`'s true answer becomes `worktree.ErrTransientFetch`, which callers must never escalate. It would have retried forever with no human told.
- `"connection timed out"` in a shared family let a blocked merge read as transient, cutting its backoff ceiling from two hours to ten minutes against unchanged PR state.

The sets differ because the callers differ. `IsTransientError` gates poller escalation, where under-reporting transience escalates the whole board. `IsTransientNetworkError` must never over-report. The workflow tables read agent prose rather than a transport error, which is why a bare `"timed out"` and `"tls:"` belong there and nowhere else. Merging the answers is real work that needs per-site judgement, so it gets its own issue rather than riding along here.

## Supporting documentation

**One intentional behaviour change.** `monitor.classifyGHError` now matches case-insensitively, with the same two phrases it had. Every sibling already did. Real GitHub bodies use the exact casing the pre-image matched, so this only widens on text GitHub does not emit.

**Everything else is proven unchanged.** A differential harness ran each pre-image predicate, transcribed verbatim from `main`, against the new one over 18,242 inputs: every pre-image literal fed standalone in nine casing and token-embedding variants, real gh/git/ssh/curl/Go-transport text, GitHub error bodies, Unicode casefold inputs, and 20k seeded-random phrase concatenations. Roughly 440k comparisons, **zero differences** in all thirteen other predicates, including the nil-error and sentinel paths. Set equality was also checked directly, table against pre-image list, in both directions.

**Coverage is mutation-proven.** Sentinelling each table one at a time now fails tests in the packages that own it. `AgentRateLimitPhrases` was the last unguarded one: its `rate_limit` arm had no test of any kind, so this adds one.

Closes #3139
