### PR TITLE
ci(actions): run CI for merge queue

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -19,8 +19,8 @@ merge queue rule with these values:
 | Merge method | Squash | Matches Sybra's pull-request merge policy |
 | Build concurrency | 5 | Keeps a useful batch in flight |
 | Maximum group size | 5 | Five independent PRs share one combined CI run |
-| Minimum group size | 1 | A single ready PR is never stranded |
-| Minimum wait | 5 minutes | Gives concurrently-ready PRs a short batching window |
+| Minimum group size | 5 | Holds concurrently-ready PRs for one combined CI run |
+| Minimum wait | 5 minutes | Releases a smaller group automatically, so a lone PR is never stranded |
 | Status-check timeout | 45 minutes | Exceeds the longest required job timeout |
 | Grouping strategy | Head green | The group's combined head must pass every required check |
 

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,44 @@
+# Main branch merge protection
+
+`main` uses GitHub's merge queue to prevent independently-green pull requests
+from breaking the branch when their changes interact. The queue tests a
+synthetic commit containing the proposed group, so the check result covers the
+same combined tree that reaches `main`.
+
+The `CI` workflow must keep its `merge_group: checks_requested` trigger. Every
+required check is supplied by that workflow. Removing the trigger leaves merge
+groups waiting forever rather than safely falling back to pull-request checks.
+
+## Repository settings
+
+The repository ruleset named `protect-main` targets `refs/heads/main` and has a
+merge queue rule with these values:
+
+| Setting | Value | Reason |
+| --- | --- | --- |
+| Merge method | Squash | Matches Sybra's pull-request merge policy |
+| Build concurrency | 5 | Keeps a useful batch in flight |
+| Maximum group size | 5 | Five independent PRs share one combined CI run |
+| Minimum group size | 1 | A single ready PR is never stranded |
+| Minimum wait | 5 minutes | Gives concurrently-ready PRs a short batching window |
+| Status-check timeout | 45 minutes | Exceeds the longest required job timeout |
+| Grouping strategy | Head green | The group's combined head must pass every required check |
+
+Keep the classic `main` branch protection's required status checks enabled.
+The queue rule controls how changes enter the branch; the status-check list
+controls what the synthetic merge-group commit must pass.
+
+Do not replace the queue with only "Require branches to be up to date." That
+setting prevents a stale PR from merging, but serializes independent PRs behind
+a fresh full CI run after every preceding merge.
+
+## Verification after a settings change
+
+1. Confirm `.github/workflows/ci.yml` still handles both `pull_request` and
+   `merge_group` events.
+2. Queue two small independent pull requests and confirm GitHub creates one
+   merge group containing both.
+3. Confirm all required checks run against the merge-group commit before either
+   pull request reaches `main`.
+4. Queue two pull requests whose combination fails a required check and confirm
+   neither is merged as a successful group.

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -17,10 +17,10 @@ merge queue rule with these values:
 | Setting | Value | Reason |
 | --- | --- | --- |
 | Merge method | Squash | Matches Sybra's pull-request merge policy |
-| Build concurrency | 5 | Keeps a useful batch in flight |
-| Maximum group size | 5 | Five independent PRs share one combined CI run |
-| Minimum group size | 5 | Holds concurrently-ready PRs for one combined CI run |
-| Minimum wait | 5 minutes | Releases a smaller group automatically, so a lone PR is never stranded |
+| Build concurrency | 5 | Runs up to five speculative CI builds concurrently instead of serially |
+| Maximum merge group size | 5 | Merges at most five successful queue entries at once |
+| Minimum merge group size | 1 | A single successful queue entry is never stranded |
+| Minimum wait | 0 minutes | Does not delay a ready entry waiting for a larger merge group |
 | Status-check timeout | 45 minutes | Exceeds the longest required job timeout |
 | Grouping strategy | Head green | The group's combined head must pass every required check |
 
@@ -36,9 +36,11 @@ a fresh full CI run after every preceding merge.
 
 1. Confirm `.github/workflows/ci.yml` still handles both `pull_request` and
    `merge_group` events.
-2. Queue two small independent pull requests and confirm GitHub creates one
-   merge group containing both.
-3. Confirm all required checks run against the merge-group commit before either
-   pull request reaches `main`.
+2. Queue two small independent pull requests and confirm their speculative
+   merge-group builds can run concurrently.
+3. Confirm the later synthetic branch contains the current base plus both
+   queued changes and passes all required checks before the later pull request
+   reaches `main`.
 4. Queue two pull requests whose combination fails a required check and confirm
-   neither is merged as a successful group.
+   the later pull request cannot merge behind the first until its cumulative
+   synthetic branch passes.

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -21,7 +21,7 @@ merge queue rule with these values:
 | Maximum merge group size | 5 | Merges at most five successful queue entries at once |
 | Minimum merge group size | 1 | A single successful queue entry is never stranded |
 | Minimum wait | 0 minutes | Does not delay a ready entry waiting for a larger merge group |
-| Status-check timeout | 45 minutes | Exceeds the longest required job timeout |
+| Status-check timeout | 45 minutes | Allows normal required-check duration while bounding stalled CI |
 | Grouping strategy | Head green | The group's combined head must pass every required check |
 
 Keep the classic `main` branch protection's required status checks enabled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The main-branch merge queue creates a synthetic commit containing the
+  # queued group. Required checks must run for this event or GitHub cannot
+  # prove that independently-green PRs are green in combination. Keep this in
+  # sync with .github/BRANCH_PROTECTION.md.
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation

Parallel pull requests can each pass against an older base and still break `main` when their changes interact. GitHub merge queue needs the required workflow to run on its cumulative synthetic commits before the live queue rule can be enabled.

## Implementation information

The CI workflow now handles `merge_group` check requests, so every existing required context runs on speculative queue commits. A branch-protection runbook records the queue settings, cumulative-build semantics, and verification procedure. The live `protect-main` merge-queue rule will be enabled immediately after this trigger reaches the default branch.

Refs #3137

> Changelog: ci(actions): run CI for merge queue