### PR TITLE
refactor(fsutil): reclaim keyed locks

### DIFF
--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/fsutil"
@@ -19,39 +18,18 @@ import (
 // Put uses atomic-rename for blobs; Append uses O_APPEND for streams.
 // Correctness never depends on index.json — List does a dir scan.
 //
-// Lock ordering: the Store's outer mu guards the locks map only. Per-task
-// mutexes (returned by lockFor) guard all I/O for that task. Nothing that
+// Per-task locks guard all I/O for that task. Nothing that
 // holds a per-task lock may call public methods that re-acquire the same lock.
 // Internal helpers that scan/write under an already-held per-task lock use
 // scanMetaLocked / rebuildIndexLocked directly.
 type Store struct {
 	root  string
-	mu    sync.Mutex // guards locks map only
-	locks map[string]*sync.Mutex
+	locks fsutil.KeyedLocker
 }
 
 // New creates a Store rooted at dir. The directory is created on first write.
 func New(dir string) *Store {
-	return &Store{root: dir, locks: make(map[string]*sync.Mutex)}
-}
-
-// lockFor returns the per-task mutex, creating it if absent.
-func (s *Store) lockFor(taskID string) *sync.Mutex {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	mu, ok := s.locks[taskID]
-	if !ok {
-		mu = &sync.Mutex{}
-		s.locks[taskID] = mu
-	}
-	return mu
-}
-
-// pruneLock removes the per-task lock entry. Call after Delete.
-func (s *Store) pruneLock(taskID string) {
-	s.mu.Lock()
-	delete(s.locks, taskID)
-	s.mu.Unlock()
+	return &Store{root: dir}
 }
 
 // taskDir returns the per-task directory, rejecting hostile IDs and verifying
@@ -127,9 +105,8 @@ func (s *Store) Put(taskID string, a Artifact) (Meta, error) {
 		return Meta{}, fmt.Errorf("artifact: marshal meta: %w", err)
 	}
 
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 
 	if err := fsutil.AtomicWrite(filepath.Join(dir, name), a.Content); err != nil {
 		return Meta{}, fmt.Errorf("artifact: write blob: %w", err)
@@ -163,9 +140,8 @@ func (s *Store) Append(taskID string, kind Kind, event any) error {
 	}
 	line = append(line, '\n')
 
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 
 	metaPath := filepath.Join(dir, name+".meta.json")
 	if _, statErr := os.Stat(metaPath); errors.Is(statErr, os.ErrNotExist) {
@@ -212,9 +188,8 @@ func (s *Store) List(taskID string) ([]Meta, error) {
 	if err != nil {
 		return nil, err
 	}
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 	return s.scanMetaLocked(taskID, dir)
 }
 
@@ -267,9 +242,8 @@ func (s *Store) Read(taskID, name string) ([]byte, Meta, error) {
 		return nil, Meta{}, err
 	}
 
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 
 	data, err := os.ReadFile(filepath.Join(dir, name))
 	if err != nil {
@@ -289,20 +263,18 @@ func (s *Store) Read(taskID, name string) ([]byte, Meta, error) {
 	return data, m, nil
 }
 
-// Delete removes all artifacts for a task and prunes the lock-map entry.
+// Delete removes all artifacts for a task.
 // Ignores a missing directory (idempotent).
 func (s *Store) Delete(taskID string) error {
 	dir, err := s.taskDir(taskID)
 	if err != nil {
 		return err
 	}
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 	if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("artifact: delete: %w", err)
 	}
-	s.pruneLock(taskID)
 	return nil
 }
 
@@ -316,9 +288,8 @@ func (s *Store) Reindex(taskID string) error {
 	if err != nil {
 		return err
 	}
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 	s.rebuildIndexLocked(taskID, dir)
 	return nil
 }

--- a/internal/artifact/store_test.go
+++ b/internal/artifact/store_test.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -53,6 +54,22 @@ func TestPutListRead(t *testing.T) {
 	}
 	if gotMeta.StepID != "plan" {
 		t.Errorf("StepID = %q, want plan", gotMeta.StepID)
+	}
+}
+
+func TestStoreLockTableReclaimsBurst(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	var wg sync.WaitGroup
+	for i := range 200 {
+		wg.Go(func() {
+			unlock := s.locks.LockLocal(fmt.Sprintf("task-%d", i))
+			unlock()
+		})
+	}
+	wg.Wait()
+	if got := s.locks.Len(); got != 0 {
+		t.Fatalf("lock entries = %d, want burst tasks reclaimed", got)
 	}
 }
 
@@ -197,11 +214,8 @@ func TestDelete(t *testing.T) {
 		t.Fatalf("second Delete: %v", err)
 	}
 
-	s.mu.Lock()
-	_, exists := s.locks["del-task"]
-	s.mu.Unlock()
-	if exists {
-		t.Error("lock entry not pruned after Delete")
+	if got := s.locks.Len(); got != 0 {
+		t.Errorf("lock entries = %d, want zero after Delete", got)
 	}
 
 	metas, err := s.List("del-task")

--- a/internal/attachment/store.go
+++ b/internal/attachment/store.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/fsutil"
@@ -22,7 +21,7 @@ const metaFileName = "meta.json"
 type Store struct {
 	root         string
 	maxSizeBytes int64
-	locks        sync.Map // taskID -> *sync.Mutex
+	locks        fsutil.KeyedLocker
 }
 
 // NewStore constructs a local attachment store rooted at dir.
@@ -56,9 +55,8 @@ func (s *Store) Put(taskID string, req UploadRequest) (Attachment, error) {
 		contentType = "application/octet-stream"
 	}
 
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 
 	id := "att_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	dir, err := s.attachmentDir(taskID, id)
@@ -123,9 +121,8 @@ func (s *Store) Import(taskID string, meta Attachment, data []byte) (Attachment,
 		createdAt = time.Now().UTC()
 	}
 
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 
 	dir, err := s.attachmentDir(taskID, meta.ID)
 	if err != nil {
@@ -234,9 +231,8 @@ func (s *Store) Delete(taskID, attachmentID string) error {
 	if err := fsutil.ValidateKey(attachmentID); err != nil {
 		return fmt.Errorf("attachment id: %w", err)
 	}
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 	dir, err := s.attachmentDir(taskID, attachmentID)
 	if err != nil {
 		return err
@@ -255,9 +251,8 @@ func (s *Store) DeleteTask(taskID string) error {
 	if err := fsutil.ValidateKey(taskID); err != nil {
 		return fmt.Errorf("task id: %w", err)
 	}
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.locks.LockLocal(taskID)
+	defer unlock()
 	dir, err := s.taskDir(taskID)
 	if err != nil {
 		return err
@@ -276,16 +271,6 @@ func (s *Store) validateSize(data []byte) error {
 		return fmt.Errorf("attachment exceeds max size of %d bytes", s.maxSizeBytes)
 	}
 	return nil
-}
-
-func (s *Store) lockFor(taskID string) *sync.Mutex {
-	existing, _ := s.locks.LoadOrStore(taskID, &sync.Mutex{})
-	if mu, ok := existing.(*sync.Mutex); ok {
-		return mu
-	}
-	mu := &sync.Mutex{}
-	s.locks.Store(taskID, mu)
-	return mu
 }
 
 func (s *Store) taskDir(taskID string) (string, error) {

--- a/internal/attachment/store_test.go
+++ b/internal/attachment/store_test.go
@@ -3,6 +3,7 @@ package attachment
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -55,6 +56,25 @@ func TestStorePutListPathDelete(t *testing.T) {
 	}
 	if _, err := store.Path("task-1", meta.ID); err == nil {
 		t.Fatal("Path after Delete returned nil error, want failure")
+	}
+}
+
+func TestStoreLockTableReclaimsBurst(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for i := range 200 {
+		wg.Go(func() {
+			unlock := store.locks.LockLocal(fmt.Sprintf("task-%d", i))
+			unlock()
+		})
+	}
+	wg.Wait()
+	if got := store.locks.Len(); got != 0 {
+		t.Fatalf("lock entries = %d, want burst tasks reclaimed", got)
 	}
 }
 

--- a/internal/fsutil/keyed_lock.go
+++ b/internal/fsutil/keyed_lock.go
@@ -9,10 +9,10 @@ import (
 )
 
 // KeyedLocker serializes read-modify-write critical sections keyed by an
-// arbitrary string (e.g. a task or project ID), both within this process (a
-// ref-counted semaphore per key) and across processes (an flock via
-// LockFile). Sidecar stores that do a Get-then-mutate-then-write should share
-// one KeyedLocker per store and hold it across the full critical section —
+// arbitrary string (e.g. a task or project ID). LockLocal/TryLockLocal provide
+// ref-counted in-process serialization; Lock/LockWithin add a cross-process
+// flock via LockFile. Sidecar stores that do a Get-then-mutate-then-write
+// should share one KeyedLocker per store and hold it across the full critical section —
 // not just the final write — or a concurrent writer can still interleave
 // between another caller's read and write and silently drop an update.
 //
@@ -36,6 +36,27 @@ func NewKeyedLocker() *KeyedLocker {
 	return &KeyedLocker{locks: map[string]*keyRefLock{}}
 }
 
+// LockLocal acquires the in-process lock for key and returns its release
+// function. The key remains retained while a caller holds or waits for the
+// lock and is removed after the last release.
+func (l *KeyedLocker) LockLocal(key string) func() {
+	lock := l.retain(key)
+	lock.acquire()
+	return l.localUnlockFunc(key, lock)
+}
+
+// TryLockLocal attempts to acquire key without blocking. A failed probe does
+// not leave a retained entry behind. This is the non-blocking counterpart to
+// LockLocal for callers that distinguish a busy key from an idle one.
+func (l *KeyedLocker) TryLockLocal(key string) (func(), bool) {
+	lock := l.retain(key)
+	if !lock.tryAcquire() {
+		l.releaseRef(key, lock)
+		return nil, false
+	}
+	return l.localUnlockFunc(key, lock), true
+}
+
 // Lock acquires the in-process lock for key, then the cross-process flock
 // on path (typically the record's own file path, or any stable synthetic
 // path if the record has no single backing file), and returns a func that
@@ -44,13 +65,7 @@ func NewKeyedLocker() *KeyedLocker {
 // never proceed holding only the in-process half, since that would silently
 // reintroduce the cross-process race this lock exists to close.
 func (l *KeyedLocker) Lock(key, path string) (func(), error) {
-	lock := l.retain(key)
-	lock.acquire()
-
-	releaseInProcess := func() {
-		lock.release()
-		l.releaseRef(key, lock)
-	}
+	releaseInProcess := l.LockLocal(key)
 
 	unlockFile, err := LockFile(path)
 	if err != nil {
@@ -59,6 +74,16 @@ func (l *KeyedLocker) Lock(key, path string) (func(), error) {
 	}
 
 	return l.unlockFunc(key, unlockFile, releaseInProcess), nil
+}
+
+func (l *KeyedLocker) localUnlockFunc(key string, lock *keyRefLock) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			lock.release()
+			l.releaseRef(key, lock)
+		})
+	}
 }
 
 // LockWithin is Lock with a bounded wait across both in-process and
@@ -128,6 +153,15 @@ func newKeyRefLock() *keyRefLock {
 
 func (l *keyRefLock) acquire() {
 	<-l.token
+}
+
+func (l *keyRefLock) tryAcquire() bool {
+	select {
+	case <-l.token:
+		return true
+	default:
+		return false
+	}
 }
 
 func (l *keyRefLock) acquireUntil(deadline time.Time) bool {

--- a/internal/fsutil/keyed_lock_test.go
+++ b/internal/fsutil/keyed_lock_test.go
@@ -2,6 +2,7 @@ package fsutil
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -39,5 +40,49 @@ func TestKeyedLockerLockWithin_TimesOutOnInProcessContention(t *testing.T) {
 	release()
 	if got := locker.Len(); got != 0 {
 		t.Fatalf("locker.Len() = %d, want timeout and release to reclaim key", got)
+	}
+}
+
+func TestKeyedLockerLocal_ReclaimsBurst(t *testing.T) {
+	t.Parallel()
+
+	locker := NewKeyedLocker()
+	const tasks = 200
+	var wg sync.WaitGroup
+	for i := range tasks {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock := locker.LockLocal(fmt.Sprintf("task-%d", i))
+			unlock()
+		}()
+	}
+	wg.Wait()
+	if got := locker.Len(); got != 0 {
+		t.Fatalf("locker.Len() = %d, want burst keys reclaimed", got)
+	}
+}
+
+func TestKeyedLockerTryLockLocal_ReportsBusyAndReclaimsProbe(t *testing.T) {
+	t.Parallel()
+
+	locker := NewKeyedLocker()
+	unlock := locker.LockLocal("task-a")
+	if probeUnlock, ok := locker.TryLockLocal("task-a"); ok {
+		probeUnlock()
+		t.Fatal("TryLockLocal succeeded while key was held")
+	}
+	if got := locker.Len(); got != 1 {
+		t.Fatalf("locker.Len() during hold = %d, want one retained key", got)
+	}
+	unlock()
+
+	probeUnlock, ok := locker.TryLockLocal("task-a")
+	if !ok {
+		t.Fatal("TryLockLocal failed for idle key")
+	}
+	probeUnlock()
+	if got := locker.Len(); got != 0 {
+		t.Fatalf("locker.Len() after probe = %d, want key reclaimed", got)
 	}
 }

--- a/internal/fsutil/keyed_lock_test.go
+++ b/internal/fsutil/keyed_lock_test.go
@@ -50,12 +50,10 @@ func TestKeyedLockerLocal_ReclaimsBurst(t *testing.T) {
 	const tasks = 200
 	var wg sync.WaitGroup
 	for i := range tasks {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			unlock := locker.LockLocal(fmt.Sprintf("task-%d", i))
 			unlock()
-		}()
+		})
 	}
 	wg.Wait()
 	if got := locker.Len(); got != 0 {

--- a/internal/project/git_lock.go
+++ b/internal/project/git_lock.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
 // bareRepoLocks serializes git mutations against a single bare clone within
@@ -13,12 +15,12 @@ import (
 // repo's shared lock files (e.g. .git/index.lock, ref locks). Keyed by the
 // cleaned clone path so callers passing equivalent-but-differently-formatted
 // paths still serialize against each other.
-var bareRepoLocks sync.Map // map[string]*sync.Mutex
+var bareRepoLocks fsutil.KeyedLocker
 
 // bareRepoPushLocks serializes `git push` invocations for worktrees sharing a
 // bare clone. Unlike bareRepoLocks, this lock may be held while pre-push hooks
 // run, so it must not gate fetch/worktree/ref plumbing for other agents.
-var bareRepoPushLocks sync.Map // map[string]*sync.Mutex
+var bareRepoPushLocks fsutil.KeyedLocker
 
 // withBareRepoLock runs fn while holding the mutex for barePath, blocking
 // concurrent git mutations against the same bare clone from other goroutines
@@ -36,7 +38,7 @@ func withBareRepoPushLock(barePath string, fn func() error) error {
 	return withPathLock(&bareRepoPushLocks, barePath, fn)
 }
 
-func withPathLock(locks *sync.Map, path string, fn func() error) error {
+func withPathLock(locks *fsutil.KeyedLocker, path string, fn func() error) error {
 	key := filepath.Clean(path)
 	// Git resolves macOS /var paths through the /private/var symlink when it
 	// reports a linked worktree's common directory. Canonicalize existing
@@ -46,14 +48,8 @@ func withPathLock(locks *sync.Map, path string, fn func() error) error {
 	if resolved, err := filepath.EvalSymlinks(key); err == nil {
 		key = filepath.Clean(resolved)
 	}
-	v, _ := locks.LoadOrStore(key, &sync.Mutex{})
-	mu, ok := v.(*sync.Mutex)
-	if !ok {
-		// Unreachable: these maps only ever store *sync.Mutex values.
-		mu = &sync.Mutex{}
-	}
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := locks.LockLocal(key)
+	defer unlock()
 	return fn()
 }
 

--- a/internal/project/git_lock_test.go
+++ b/internal/project/git_lock_test.go
@@ -52,6 +52,29 @@ func TestWithBareRepoLock_SerializesSameClonePath(t *testing.T) {
 	}
 }
 
+func TestBareRepoLockTablesReclaimBurst(t *testing.T) {
+	const paths = 200
+	var wg sync.WaitGroup
+	for i := range paths {
+		path := filepath.Join(t.TempDir(), fmt.Sprintf("repo-%d.git", i))
+		wg.Go(func() {
+			if err := withBareRepoLock(path, func() error { return nil }); err != nil {
+				t.Errorf("withBareRepoLock: %v", err)
+			}
+			if err := withBareRepoPushLock(path, func() error { return nil }); err != nil {
+				t.Errorf("withBareRepoPushLock: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+	if got := bareRepoLocks.Len(); got != 0 {
+		t.Fatalf("bare repo lock entries = %d, want burst paths reclaimed", got)
+	}
+	if got := bareRepoPushLocks.Len(); got != 0 {
+		t.Fatalf("bare repo push lock entries = %d, want burst paths reclaimed", got)
+	}
+}
+
 func TestWithBareRepoLock_DoesNotSerializeDifferentClonePaths(t *testing.T) {
 	t.Parallel()
 	bareA := filepath.Join(t.TempDir(), "a.git")

--- a/internal/sybra/clusterlead/ownership.go
+++ b/internal/sybra/clusterlead/ownership.go
@@ -1,19 +1,13 @@
 package clusterlead
 
-import "sync"
+import "github.com/Automaat/sybra/internal/fsutil"
 
 // taskOwnershipLocks serializes every operation that can observe or mutate a
 // task's follower ownership. It is deliberately package-wide: reconciliation
 // repairs run from Mirror while manual moves and leader edits run from
 // Assigner, and separate lock sets would let an old-node repair race a move.
-var taskOwnershipLocks sync.Map
+var taskOwnershipLocks fsutil.KeyedLocker
 
 func lockTaskOwnership(taskID string) func() {
-	v, _ := taskOwnershipLocks.LoadOrStore(taskID, &sync.Mutex{})
-	mu, ok := v.(*sync.Mutex)
-	if !ok {
-		panic("clusterlead: invalid ownership lock")
-	}
-	mu.Lock()
-	return mu.Unlock
+	return taskOwnershipLocks.LockLocal(taskID)
 }

--- a/internal/sybra/clusterlead/ownership_test.go
+++ b/internal/sybra/clusterlead/ownership_test.go
@@ -1,0 +1,21 @@
+package clusterlead
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestTaskOwnershipLocksReclaimBurst(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := range 200 {
+		wg.Go(func() {
+			unlock := lockTaskOwnership(fmt.Sprintf("task-%d", i))
+			unlock()
+		})
+	}
+	wg.Wait()
+	if got := taskOwnershipLocks.Len(); got != 0 {
+		t.Fatalf("ownership lock entries = %d, want burst tasks reclaimed", got)
+	}
+}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/metrics"
 )
 
@@ -40,7 +41,7 @@ type DeleteHook func(taskID string)
 type Manager struct {
 	store        *Store
 	emitter      EventEmitter
-	locks        sync.Map // string -> *sync.Mutex
+	locks        fsutil.KeyedLocker
 	onStatusHook StatusChangeHook
 	onDeleteHook []DeleteHook
 
@@ -117,24 +118,23 @@ func (m *Manager) OnExternalUpdate(path string) {
 		return
 	}
 
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 	// Only Status is needed here; use the parse-only read to avoid the
 	// per-call sidecar dir scan on every external file change.
 	t, err := m.store.read(id)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return
 	}
 	newStatus := string(t.Status)
 
 	prev, ok := m.lastFiredStatus(id)
 	if ok && prev == newStatus {
-		mu.Unlock()
+		unlock()
 		return
 	}
 	m.recordFiredStatus(id, newStatus)
-	mu.Unlock()
+	unlock()
 
 	m.onStatusHook(id, prev, newStatus)
 }
@@ -173,13 +173,8 @@ func (m *Manager) Plans() *PlanningSidecarStore { return m.store.Plans() }
 // PlanDrafts returns the underlying PlanDraftStore.
 func (m *Manager) PlanDrafts() *PlanDraftStore { return m.store.PlanDrafts() }
 
-func (m *Manager) lockFor(id string) *sync.Mutex {
-	existing, _ := m.locks.LoadOrStore(id, &sync.Mutex{})
-	mu, ok := existing.(*sync.Mutex)
-	if !ok {
-		mu = &sync.Mutex{}
-	}
-	return mu
+func (m *Manager) lock(id string) func() {
+	return m.locks.LockLocal(id)
 }
 
 // List returns all tasks (lock-free).
@@ -243,14 +238,13 @@ func (m *Manager) CreateWithStatus(title, body, mode string, status Status, extr
 // reports whether the task was newly created (vs an in-place update). See
 // Store.Put.
 func (m *Manager) Put(t Task) (Task, bool, error) {
-	mu := m.lockFor(t.ID)
-	mu.Lock()
+	unlock := m.lock(t.ID)
 
 	prev, getErr := m.store.read(t.ID)
 	existed := getErr == nil
 	saved, err := m.store.Put(t)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return saved, false, err
 	}
 
@@ -263,7 +257,7 @@ func (m *Manager) Put(t Task) (Task, bool, error) {
 	if fireHook {
 		m.recordFiredStatus(saved.ID, newStatus)
 	}
-	mu.Unlock()
+	unlock()
 
 	if existed {
 		metrics.TaskUpdated()
@@ -284,12 +278,11 @@ func (m *Manager) Put(t Task) (Task, bool, error) {
 // long-running operation with the latest leader-side edit immediately before
 // the write. It preserves Put's lifecycle events and status-hook behaviour.
 func (m *Manager) PutFn(id string, fn func(cur Task) (Task, error)) (Task, bool, error) {
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 
 	saved, prev, err := m.store.PutFn(id, fn)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return saved, false, err
 	}
 
@@ -299,7 +292,7 @@ func (m *Manager) PutFn(id string, fn func(cur Task) (Task, error)) (Task, bool,
 	if fireHook {
 		m.recordFiredStatus(saved.ID, newStatus)
 	}
-	mu.Unlock()
+	unlock()
 
 	metrics.TaskUpdated()
 	m.emitter.Emit(events.TaskUpdated, saved.FilePath)
@@ -326,23 +319,22 @@ func (m *Manager) Update(id string, u Update) (Task, error) {
 // tag merge gated on the current status) that would otherwise race with a
 // concurrent Update for the same id between their read and their write.
 func (m *Manager) UpdateFn(id string, fn func(cur Task) (Update, error)) (Task, error) {
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 
 	cur, err := m.store.Get(id)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return cur, err
 	}
 	u, err := fn(cur)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return cur, err
 	}
 
 	t, prev, err := m.store.UpdateWithPrev(id, u)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return t, err
 	}
 	var (
@@ -362,7 +354,7 @@ func (m *Manager) UpdateFn(id string, fn func(cur Task) (Update, error)) (Task, 
 	if fireHook {
 		m.recordFiredStatus(id, newStat)
 	}
-	mu.Unlock()
+	unlock()
 
 	if fireHook {
 		m.onStatusHook(id, prevStatus, newStat)
@@ -388,11 +380,10 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	if content == "" {
 		return m.Get(id)
 	}
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 	t, err := m.store.Get(id)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return Task{}, err
 	}
 	body := strings.TrimRight(t.Body, "\n")
@@ -401,7 +392,7 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	body += content + "\n"
 	t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
-	mu.Unlock()
+	unlock()
 	if err != nil {
 		return t, err
 	}
@@ -423,20 +414,18 @@ func (m *Manager) Touch(id string) (Task, error) {
 
 // Delete removes a task and emits task:deleted.
 func (m *Manager) Delete(id string) error {
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 	t, err := m.store.Get(id)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return err
 	}
 	if err := m.store.Delete(id); err != nil {
-		mu.Unlock()
+		unlock()
 		return err
 	}
-	m.locks.Delete(id)
 	m.forgetFiredStatus(id)
-	mu.Unlock()
+	unlock()
 	// Emit/hook after releasing the lock — see UpdateFn/AddRunWithStatus for
 	// why: this Manager is its own emitter's target (app.go routes
 	// task:updated back into OnExternalUpdate), so firing while still holding
@@ -454,10 +443,9 @@ func (m *Manager) Delete(id string) error {
 // Create does, so watchers (file watcher, workflow engine) treat it as a
 // new task rather than an update to one that "already existed".
 func (m *Manager) RestoreFromTrash(id string) (Task, error) {
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 	t, err := m.store.RestoreFromTrash(id)
-	mu.Unlock()
+	unlock()
 	if err != nil {
 		return Task{}, err
 	}
@@ -496,8 +484,7 @@ func (m *Manager) AddRun(taskID string, run AgentRun) error {
 
 // AddRunWithStatus appends an agent run and optionally changes task status in one write.
 func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) error {
-	mu := m.lockFor(taskID)
-	mu.Lock()
+	unlock := m.lock(taskID)
 	var prevStatus string
 	if status != nil {
 		if prev, getErr := m.store.Get(taskID); getErr == nil {
@@ -505,7 +492,7 @@ func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) 
 		}
 	}
 	if err := m.store.AddRunWithStatus(taskID, run, status); err != nil {
-		mu.Unlock()
+		unlock()
 		return err
 	}
 	t, err := m.store.Get(taskID)
@@ -522,7 +509,7 @@ func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) 
 	if fireHook {
 		m.recordFiredStatus(taskID, newStatus)
 	}
-	mu.Unlock()
+	unlock()
 	// Emit after releasing the lock, same as UpdateFn: OnExternalUpdate takes
 	// the same per-task lock, and this Manager is its own emitter's target
 	// (app.go routes task:updated back into OnExternalUpdate), so firing
@@ -539,14 +526,13 @@ func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) 
 
 // UpdateRun updates fields on a specific agent run and emits task:updated.
 func (m *Manager) UpdateRun(taskID, agentID string, patch RunPatch) error {
-	mu := m.lockFor(taskID)
-	mu.Lock()
+	unlock := m.lock(taskID)
 	if err := m.store.UpdateRun(taskID, agentID, patch); err != nil {
-		mu.Unlock()
+		unlock()
 		return err
 	}
 	t, err := m.store.Get(taskID)
-	mu.Unlock()
+	unlock()
 	// Emit after releasing the lock — see AddRunWithStatus for why.
 	if err == nil {
 		m.emitter.Emit(events.TaskUpdated, t.FilePath)

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -457,22 +458,17 @@ func TestManagerConcurrentDifferentIDsParallel(t *testing.T) {
 	}
 }
 
-func TestLockForTypeMismatchNoPanic(t *testing.T) {
+func TestManagerLocksReclaimedAfterBurst(t *testing.T) {
 	t.Parallel()
 	m, _ := newTestManager(t)
 
-	// Manually store a non-*sync.Mutex value to simulate type mismatch.
-	m.locks.Store("bad-id", "not-a-mutex")
-
-	// Must not panic; returned mutex must be usable.
-	mu := m.lockFor("bad-id")
-	if mu == nil {
-		t.Fatal("lockFor returned nil on type mismatch")
+	for i := range 200 {
+		unlock := m.lock(fmt.Sprintf("task-%d", i))
+		unlock()
 	}
-	func() {
-		mu.Lock()
-		defer mu.Unlock()
-	}()
+	if got := m.locks.Len(); got != 0 {
+		t.Fatalf("lock entries = %d, want burst keys reclaimed", got)
+	}
 }
 
 func TestNoopEmitter(t *testing.T) {
@@ -606,8 +602,7 @@ func TestManagerOnExternalUpdateWaitsForBusyWriterAndStillFires(t *testing.T) {
 		hookMu.Unlock()
 	})
 
-	mu := m.lockFor(task.ID)
-	mu.Lock()
+	unlock := m.lock(task.ID)
 
 	done := make(chan struct{})
 	go func() {
@@ -620,10 +615,10 @@ func TestManagerOnExternalUpdateWaitsForBusyWriterAndStillFires(t *testing.T) {
 		Status: Ptr(StatusInProgress),
 		Body:   &body,
 	}); err != nil {
-		mu.Unlock()
+		unlock()
 		t.Fatalf("UpdateWithPrev: %v", err)
 	}
-	mu.Unlock()
+	unlock()
 
 	select {
 	case <-done:

--- a/internal/task/transition.go
+++ b/internal/task/transition.go
@@ -138,17 +138,16 @@ func (m *Manager) Apply(intent TransitionIntent) (TransitionResult, error) {
 		return TransitionResult{}, fmt.Errorf("transition: intent.Extra.Status must be nil; set ToStatus instead")
 	}
 
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 
 	cur, err := m.store.Get(id)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return TransitionResult{}, err
 	}
 
 	outcome, err := m.applyLocked(cur, intent)
-	mu.Unlock()
+	unlock()
 	if err != nil {
 		return TransitionResult{}, err
 	}
@@ -171,23 +170,22 @@ func (m *Manager) ApplyFn(id string, fn func(cur Task) (TransitionIntent, error)
 		return TransitionResult{}, fmt.Errorf("transition: task id is required")
 	}
 
-	mu := m.lockFor(id)
-	mu.Lock()
+	unlock := m.lock(id)
 
 	cur, err := m.store.Get(id)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return TransitionResult{}, err
 	}
 	intent, err := fn(cur)
 	if err != nil {
-		mu.Unlock()
+		unlock()
 		return TransitionResult{}, err
 	}
 	intent.TaskID = id
 
 	outcome, err := m.applyLocked(cur, intent)
-	mu.Unlock()
+	unlock()
 	if err != nil {
 		return TransitionResult{}, err
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/blocker"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evidence"
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/project"
@@ -472,8 +473,8 @@ type Engine struct {
 	ctx              context.Context
 	drainCtx         context.Context
 	mu               sync.Mutex
-	inflightMutexes  map[string]*sync.Mutex     // taskID → advance serializer (parallel-aware)
-	routeMutexes     map[string]*sync.Mutex     // taskID → serialize run_agent route publication vs completion reads
+	inflightLocks    fsutil.KeyedLocker         // taskID → advance serializer (parallel-aware)
+	routeLocks       fsutil.KeyedLocker         // taskID → serialize run_agent route publication vs completion reads
 	dispatching      map[string]struct{}        // taskID → workflow-engine dispatch/resume attempt in progress before StartAgent owns the shared manager claim
 	starting         map[string]struct{}        // taskID → StartWorkflowWithVars in progress
 	humanAction      map[string]struct{}        // taskID → HandleHumanAction in progress
@@ -587,8 +588,6 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		now:              func() time.Time { return time.Now().UTC() },
 		logger:           logger,
 		ctx:              context.Background(),
-		inflightMutexes:  make(map[string]*sync.Mutex),
-		routeMutexes:     make(map[string]*sync.Mutex),
 		dispatching:      make(map[string]struct{}),
 		starting:         make(map[string]struct{}),
 		humanAction:      make(map[string]struct{}),

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/blocker"
@@ -28,7 +27,7 @@ const triageRetryableStatusReasonPrefix = "triage retryable: "
 // double-delivered callback — from triggering "step not found" errors that
 // would otherwise spam the log and re-persist the task file on every hit.
 func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
-	e.acquireInflight(taskID) // blocks until any concurrent advance releases
+	unlockInflight := e.acquireInflight(taskID) // blocks until any concurrent advance releases
 
 	// Use an idempotent release so we can unlock before executeSteps while
 	// still having a defer as a safety net for early-return paths. Releasing
@@ -40,7 +39,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	release := func() {
 		if !released {
 			released = true
-			e.releaseInflight(taskID)
+			unlockInflight()
 		}
 	}
 	defer release()
@@ -314,47 +313,13 @@ func (e *Engine) executeNextSteps(taskID string, def *Definition, step *Step, wf
 // acquireInflight serializes AdvanceStep for a task. Blocks (rather than
 // returning false) so simultaneous parallel-child completions from
 // different agent goroutines are processed sequentially instead of one
-// silently being dropped. Always returns true; the bool return is kept
-// so callers can preserve the "skip on already-advancing" log line.
+// silently being dropped. It returns the release function for that hold.
 //
 // Re-entry within the same goroutine is not supported — every AdvanceStep
-// path defers releaseInflight before any callback that could re-enter.
-func (e *Engine) acquireInflight(taskID string) bool {
-	mu := e.taskInflightMutex(taskID)
-	mu.Lock()
-	return true
-}
-
-// releaseInflight unlocks the per-task advance mutex.
-func (e *Engine) releaseInflight(taskID string) {
-	mu := e.taskInflightMutex(taskID)
-	mu.Unlock()
-}
-
-// taskInflightMutex returns the lazily-initialized per-task mutex used by
-// acquire/releaseInflight. Old taskInflightMutex entries linger for the
-// life of the process; tasks with hundreds of millions of IDs would leak
-// memory, but task IDs are bounded by the human workload so this is fine.
-func (e *Engine) taskInflightMutex(taskID string) *sync.Mutex {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	mu, ok := e.inflightMutexes[taskID]
-	if !ok {
-		mu = &sync.Mutex{}
-		e.inflightMutexes[taskID] = mu
-	}
-	return mu
-}
-
-func (e *Engine) taskRouteMutex(taskID string) *sync.Mutex {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	mu, ok := e.routeMutexes[taskID]
-	if !ok {
-		mu = &sync.Mutex{}
-		e.routeMutexes[taskID] = mu
-	}
-	return mu
+// path defers the returned release function before any callback that could
+// re-enter.
+func (e *Engine) acquireInflight(taskID string) func() {
+	return e.inflightLocks.LockLocal(taskID)
 }
 
 // advanceContext bundles everything AdvanceStep needs to act on a single

--- a/internal/workflow/engine_events_agents.go
+++ b/internal/workflow/engine_events_agents.go
@@ -14,19 +14,18 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	// task's still-legitimate routes mid-completion.
 	defer e.enterCompletion(taskID)()
 
-	routeMu := e.taskRouteMutex(taskID)
-	routeMu.Lock()
+	unlockRoute := e.routeLocks.LockLocal(taskID)
 	e.mu.Lock()
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
 		e.mu.Unlock()
-		routeMu.Unlock()
+		unlockRoute()
 		e.logger.Error("workflow.agent-complete.get", "task_id", taskID, "err", err)
 		return
 	}
 	spawnedStep, routeStatus := e.resolveCompletionRouteLocked(t, c)
 	e.mu.Unlock()
-	routeMu.Unlock()
+	unlockRoute()
 	if e.handleAgentCompleteInitialBail(taskID, t, c) {
 		e.clearAgentStep(taskID, c.AgentID)
 		return
@@ -569,13 +568,13 @@ func (e *Engine) rescheduleRunAgent(taskID, agentID string, step *Step, t TaskIn
 			"task_id", taskID, "reason", "other-agent-running", "step", step.ID)
 		return
 	}
-	mu := e.taskInflightMutex(taskID)
-	if !mu.TryLock() {
+	probeUnlock, ok := e.inflightLocks.TryLockLocal(taskID)
+	if !ok {
 		e.logger.Debug(logPrefix+".skip",
 			"task_id", taskID, "reason", "inflight", "step", step.ID)
 		return
 	}
-	mu.Unlock()
+	probeUnlock()
 
 	if !e.tryMarkRescheduleDispatching(taskID, step, logPrefix) {
 		return
@@ -754,8 +753,8 @@ func (e *Engine) handleCheckpointReschedule(taskID string, t *TaskInfo, step *St
 }
 
 func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, parent, child *Step, t TaskInfo) {
-	e.acquireInflight(taskID)
-	defer e.releaseInflight(taskID)
+	unlockInflight := e.acquireInflight(taskID)
+	defer unlockInflight()
 
 	fresh, err := e.tasks.GetTask(taskID)
 	_, skip := resumeSkipReasonForStatus(fresh.Status)

--- a/internal/workflow/engine_events_resume.go
+++ b/internal/workflow/engine_events_resume.go
@@ -39,12 +39,12 @@ func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason str
 	// during which no agent is yet registered — without this guard the ticker
 	// would spawn a duplicate and the second agent's completion would corrupt
 	// the workflow at the wait_human gate.
-	// inflightMutexes is a non-blocking probe: TryLock distinguishes "another
+	// inflightLocks is a non-blocking probe: TryLock distinguishes "another
 	// goroutine currently holds the advance lock" from "free".
-	mu := e.taskInflightMutex(taskID)
-	advancing := !mu.TryLock()
+	probeUnlock, idle := e.inflightLocks.TryLockLocal(taskID)
+	advancing := !idle
 	if !advancing {
-		mu.Unlock()
+		probeUnlock()
 	}
 
 	// Retire orphaned routes before interpreting them as "agent still pending"

--- a/internal/workflow/engine_skill_receipt.go
+++ b/internal/workflow/engine_skill_receipt.go
@@ -207,8 +207,8 @@ func taskSidecarContent(t TaskInfo, kind string) string {
 }
 
 func (e *Engine) rescheduleSkillReceiptParallelChild(taskID string, parent, child *Step) {
-	e.acquireInflight(taskID)
-	defer e.releaseInflight(taskID)
+	unlockInflight := e.acquireInflight(taskID)
+	defer unlockInflight()
 
 	fresh, err := e.tasks.GetTask(taskID)
 	_, skip := resumeSkipReasonForStatus(fresh.Status)

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -209,9 +209,8 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		}
 		ctx.Vars[WorkflowVarSidecarDir] = sidecar
 	}
-	routeMu := e.taskRouteMutex(taskID)
-	routeMu.Lock()
-	defer routeMu.Unlock()
+	unlockRoute := e.routeLocks.LockLocal(taskID)
+	defer unlockRoute()
 
 	mode := resolveRunAgentMode(step.Config.Mode, ctx)
 	if admit, reason := e.agents.AdmitDispatch(taskID, step.Config.Role, mode); !admit {

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -120,8 +120,7 @@ func (e *Engine) execBestOfN(taskID string, def *Definition, step *Step, wfExec 
 	// Released before finalizeBestOfNParent (which may recurse into
 	// executeSteps/StopAgentsForTask) so it cannot deadlock the way holding
 	// this lock through execRunAgent's StopAgentsForTask would.
-	inflight := e.taskInflightMutex(taskID)
-	inflight.Lock()
+	unlockInflight := e.acquireInflight(taskID)
 	for i := 1; i <= n; i++ {
 		id := bestOfNAttemptID(i)
 		status := rec.Attempts[id]
@@ -154,7 +153,7 @@ func (e *Engine) execBestOfN(taskID string, def *Definition, step *Step, wfExec 
 	if !allDone {
 		persistErr = e.tasks.SetWorkflow(taskID, wfExec)
 	}
-	inflight.Unlock()
+	unlockInflight()
 	if persistErr != nil {
 		return nil, persistErr
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5197,10 +5197,9 @@ func TestRescheduleRateLimitedAgent_SkippedInflightDoesNotConsumeWatchdogRetry(t
 	})
 	setWorkflowAgentRoute(t, tasks, "t1", "limited-agent", "implement")
 
-	mu := engine.taskInflightMutex("t1")
-	mu.Lock()
+	unlockInflight := engine.acquireInflight("t1")
 	engine.RescheduleRateLimitedAgent("t1", "limited-agent")
-	mu.Unlock()
+	unlockInflight()
 
 	if got := agents.CallCount(); got != 0 {
 		t.Fatalf("unexpected replacement agent starts = %d, want 0", got)
@@ -9287,8 +9286,7 @@ func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
 	// Simulate the original dispatch being mid-flight inside AdvanceStep —
 	// the per-task advance mutex is held, no agent registered yet (worktree
 	// still being created in the real system, fake-claude hasn't started).
-	heldMu := engine.taskInflightMutex("t1")
-	heldMu.Lock()
+	unlockInflight := engine.acquireInflight("t1")
 
 	before := agents.CallCount()
 	engine.ResumeStalled()
@@ -9299,11 +9297,33 @@ func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
 
 	// Once the original dispatch finishes and releases the advance mutex,
 	// a subsequent tick is allowed to resume — that's the real recovery path.
-	heldMu.Unlock()
+	unlockInflight()
 
 	engine.ResumeStalled()
 	if got := agents.CallCount(); got != before+1 {
 		t.Errorf("ResumeStalled after inflight cleared: calls %d → %d (want +1)", before, got)
+	}
+}
+
+func TestEngineKeyedLocksReclaimBurst(t *testing.T) {
+	t.Parallel()
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	var wg sync.WaitGroup
+	for i := range 200 {
+		wg.Go(func() {
+			key := fmt.Sprintf("task-%d", i)
+			unlockInflight := engine.inflightLocks.LockLocal(key)
+			unlockInflight()
+			unlockRoute := engine.routeLocks.LockLocal(key)
+			unlockRoute()
+		})
+	}
+	wg.Wait()
+	if got := engine.inflightLocks.Len(); got != 0 {
+		t.Fatalf("inflight lock entries = %d, want burst tasks reclaimed", got)
+	}
+	if got := engine.routeLocks.Len(); got != 0 {
+		t.Fatalf("route lock entries = %d, want burst tasks reclaimed", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add reclaiming process-local lock and nonblocking probe APIs to fsutil.KeyedLocker
- migrate every hand-rolled keyed mutex table to the shared primitive
- preserve workflow advance and route serialization while reclaiming idle keys
- add burst reclamation and contention coverage for all migrated tables

## Verification

- focused ordinary and race suites for all affected packages
- adversarial review: clean
- independent adversarial stress: pass, including 3,000 holder/waiter rounds and repeated workflow probes
- full ordinary race suite passed
- isolated workflow E2E regression test passed under the race detector
- full tagged E2E suite reached its 10-minute local timeout under concurrent stress; GitHub CI will run it in a clean environment

Closes #3140