### PR TITLE
test(agent): assert the sandbox ref contract

### DIFF
--- a/internal/agent/procsandbox_linux_integration_test.go
+++ b/internal/agent/procsandbox_linux_integration_test.go
@@ -512,8 +512,19 @@ func newSandboxGitHarness(t *testing.T) sandboxGitHarness {
 	// there is inside a sandbox write root, which inverts every assertion in
 	// this file about writes being blocked. A checkout under /tmp reintroduces
 	// that silently, so say so instead of failing two unrelated tests.
-	if tmpRoot := os.TempDir(); strings.HasPrefix(base, tmpRoot+string(filepath.Separator)) {
-		t.Skipf("checkout lives under the sandbox tmp write root %s; run the suite from another path", tmpRoot)
+	tmpRoot, err := canonicalizeRoot(os.TempDir())
+	if err != nil {
+		t.Fatalf("canonicalize temp root: %v", err)
+	}
+	canonBase, err := canonicalizeRoot(base)
+	if err != nil {
+		t.Fatalf("canonicalize harness base: %v", err)
+	}
+	// Canonicalized on both sides, the way enforceSpec resolves the write
+	// root: a symlinked temp dir compares unequal as a raw string and would
+	// skip the skip.
+	if canonBase == tmpRoot || strings.HasPrefix(canonBase, tmpRoot+string(filepath.Separator)) {
+		t.Skipf("checkout lives under the sandbox temp write root %s; run the suite from another path", tmpRoot)
 	}
 
 	h := sandboxGitHarness{

--- a/internal/agent/procsandbox_linux_integration_test.go
+++ b/internal/agent/procsandbox_linux_integration_test.go
@@ -356,7 +356,21 @@ func TestSandboxEnforce_LargeFetchUnpacksLooseObjects(t *testing.T) {
 	if after := linuxRepoWideMaintenanceState(t, h.sybraBare); after != before {
 		t.Fatalf("large fetch wrote shared pack/info state instead of loose objects\nbefore: %s\nafter: %s", before, after)
 	}
-	h.git(t, h.taskWt, "cat-file", "-e", "refs/remotes/origin/main^{commit}")
+	// Proves the fetch actually landed its ref, which is what makes the
+	// loose-object assertion above mean anything — checked inside the same
+	// sandbox, since refs/remotes is bound to a per-run overlay (#2054) and a
+	// task-scoped fetch is not allowed to publish into the shared clone.
+	inSandbox := newProviderCmd(context.Background(), &cfg, false, "git", "cat-file", "-e", "refs/remotes/origin/main^{commit}")
+	inSandbox.Dir = h.taskWt
+	inSandbox.Env = append(os.Environ(), cfg.ExtraEnv...)
+	if out, err := inSandbox.CombinedOutput(); err != nil {
+		t.Fatalf("fetched ref not visible to the sandboxed run that fetched it: %v: %s", err, out)
+	}
+	// The other half of the same contract: the ref must not reach the shared
+	// clone, where every sibling worktree would read it.
+	if h.gitShowRefExists(t, h.sybraBare, "refs/remotes/origin/main") {
+		t.Fatal("sandboxed fetch published refs/remotes/origin/main into the shared clone")
+	}
 }
 
 func linuxMaintenanceState(t *testing.T, bare string) string {

--- a/internal/agent/procsandbox_linux_integration_test.go
+++ b/internal/agent/procsandbox_linux_integration_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -332,6 +333,7 @@ func TestSandboxEnforce_LargeFetchUnpacksLooseObjects(t *testing.T) {
 	h.gitRaw(t, h.src, "add", "bulk")
 	h.gitRaw(t, h.src, "commit", "-m", "large upstream change")
 	h.gitRaw(t, h.src, "push", "origin", "main")
+	upstreamHead := strings.TrimSpace(h.gitRaw(t, h.src, "rev-parse", "HEAD"))
 
 	m, _ := newTestManager(t, ManagerConfig{
 		SandboxHome: func(string) (string, error) { return h.sandboxHome, nil },
@@ -356,10 +358,21 @@ func TestSandboxEnforce_LargeFetchUnpacksLooseObjects(t *testing.T) {
 	if after := linuxRepoWideMaintenanceState(t, h.sybraBare); after != before {
 		t.Fatalf("large fetch wrote shared pack/info state instead of loose objects\nbefore: %s\nafter: %s", before, after)
 	}
+	// The fetched history itself must reach the shared clone, as loose
+	// objects: the maintenance snapshot above only watches pack/ and info/, so
+	// without this a publish regression (an empty object overlay, a fanout
+	// glob that stops matching) leaves every assertion here green while the
+	// fetch is discarded by the next run's overlay reset.
+	if !h.gitShowRefExists(t, h.sybraBare, "refs/heads/main") {
+		t.Fatal("harness lost refs/heads/main in the shared clone")
+	}
+	h.gitBare(t, h.sybraBare, "cat-file", "-e", upstreamHead+"^{commit}")
 	// Proves the fetch actually landed its ref, which is what makes the
 	// loose-object assertion above mean anything — checked inside the same
-	// sandbox, since refs/remotes is bound to a per-run overlay (#2054) and a
-	// task-scoped fetch is not allowed to publish into the shared clone.
+	// sandbox, because on Linux refs/remotes is bound to a per-run overlay
+	// (#2054) so a task-scoped fetch cannot publish it. Darwin grants the
+	// shared ref dir directly (sandboxUsesGitObjectOverlay is false there) and
+	// its twin test asserts the host-visible form instead.
 	inSandbox := newProviderCmd(context.Background(), &cfg, false, "git", "cat-file", "-e", "refs/remotes/origin/main^{commit}")
 	inSandbox.Dir = h.taskWt
 	inSandbox.Env = append(os.Environ(), cfg.ExtraEnv...)
@@ -494,6 +507,15 @@ func newSandboxGitHarness(t *testing.T) sandboxGitHarness {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(base) })
 
+	// The harness roots its clone at the working directory, not t.TempDir(),
+	// because enforceSpec binds os.TempDir() writable: a shared clone living
+	// there is inside a sandbox write root, which inverts every assertion in
+	// this file about writes being blocked. A checkout under /tmp reintroduces
+	// that silently, so say so instead of failing two unrelated tests.
+	if tmpRoot := os.TempDir(); strings.HasPrefix(base, tmpRoot+string(filepath.Separator)) {
+		t.Skipf("checkout lives under the sandbox tmp write root %s; run the suite from another path", tmpRoot)
+	}
+
 	h := sandboxGitHarness{
 		base:        base,
 		sandboxHome: t.TempDir(),
@@ -581,7 +603,17 @@ func (h sandboxGitHarness) gitShowRefExists(t *testing.T, gitDir, ref string) bo
 	t.Helper()
 	cmd := exec.Command("git", "-c", "safe.bareRepository=all", "--git-dir="+gitDir, "show-ref", "--verify", "--quiet", ref)
 	err := cmd.Run()
-	return err == nil
+	if err == nil {
+		return true
+	}
+	// Exit 1 is "no such ref"; anything else (dubious ownership, a mistyped
+	// git-dir, no git on PATH) would otherwise read as absence and quietly
+	// satisfy a containment assertion for the wrong reason.
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("show-ref %s in %s: %v", ref, gitDir, err)
+	}
+	return false
 }
 
 func (h sandboxGitHarness) writeLooseObject(t *testing.T, gitDir, body string) string {


### PR DESCRIPTION
## Motivation

`TestSandboxEnforce_LargeFetchUnpacksLooseObjects` failed deterministically on the deploy host, and because the project's verify gate is the whole-repo test suite, **every task on that host failed verify regardless of what it changed**. The board filled with tasks parked on an identical "implementation does not pass the project verify suite" reason that had nothing to do with their own diffs.

The test ended by asserting, from outside the sandbox, that a sandboxed `git fetch origin` had published `refs/remotes/origin/main` into the shared clone:

```go
h.git(t, h.taskWt, "cat-file", "-e", "refs/remotes/origin/main^{commit}")
```

On Linux a task-scoped run binds `refs/remotes` to a per-run overlay precisely so it cannot do that (#2054, "isolate task-scoped git metadata writes"). The assertion contradicted the containment it was written next to. It arrived three weeks later in #3028 and has never executed in CI: the test skips where `bwrap` is absent, which is every GitHub runner.

So the sandbox was right and the test was wrong, and nothing in CI could see it.

> Changelog: test(agent): assert the sandbox ref contract instead of its opposite

## Implementation information

Assert both halves of the contract the sandbox actually implements:

- the fetched ref is visible to the run that fetched it, checked inside the same sandbox;
- it does not reach the shared clone, where every sibling worktree would read it;
- the fetched *objects* do reach the shared clone as loose objects.

That third assertion is not redundant. Removing the host-side check took away the only guarantee that the fetch was published at all — the maintenance snapshot above it watches `objects/pack` and `objects/info`, so an object-publish regression would have left every other assertion green while the fetch was discarded by the next run's overlay reset.

Two supporting fixes came out of the same review:

`gitShowRefExists` treated any non-zero exit as "ref absent", so dubious ownership, a mistyped git-dir, or a missing `git` would satisfy a containment assertion for the wrong reason. Only exit 1 means absence now; anything else fails the test.

The harness deliberately roots its clone at the working directory rather than `t.TempDir()`, because `enforceSpec` binds the system temp root writable — a shared clone living there sits *inside* a sandbox write root and inverts every "this write is blocked" assertion in the file. Running the suite from a checkout under that root silently fails two unrelated tests (`LinkedWorktreeGitOps`, `BlocksSharedCloneMaintenance`). It now skips with the reason instead, which is how this was diagnosed.

## Supporting documentation

Verified on the deploy host (`bubblewrap 0.9.0`, `git 2.43.0`), as the unprivileged service user, from a checkout outside the temp root:

- old test on clean `main`: fails 3/3;
- fixed test: passes 3/3; whole `internal/agent` package `ok`; full `go test ./internal/... ./cmd/...` passes.

Both halves are mutation-checked. Dropping the `gitOverlayRemoteRefDir` bind fails with `sandboxed fetch published refs/remotes/origin/main into the shared clone`. Breaking the object sync's fanout glob fails on the new `cat-file` for the fetched commit.

Adversarial review raised one further concern — that a second sandboxed invocation would re-run the post-command object sync and hit `EACCES` copying onto git's `0444` loose objects, so the in-sandbox assertion would only pass as root. Not reproducible here: five runs as uid 1000 pass, and the run that produced the green results was already under `sudo -u sybra`. Worth knowing the sync does re-run, so if that failure mode ever appears the fix is to fold the check into the fetch's own invocation rather than spawn a second one.

Note the darwin twin of this test asserts the host-visible form and is correct to: `sandboxUsesGitObjectOverlay()` is false there and Seatbelt grants the shared ref dir directly, so containment of `refs/remotes/*` is a Linux property. The comment says so rather than stating an unqualified contract.
