### PR TITLE
refactor(backoff): unify exponential retry windows

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -1,0 +1,115 @@
+// Package backoff provides the shared bounded exponential retry policy.
+package backoff
+
+import (
+	"math/rand/v2"
+	"strings"
+	"time"
+)
+
+// Result is the delay selected for an attempt and whether the unjittered
+// exponential schedule has reached its ceiling.
+type Result struct {
+	Delay     time.Duration
+	AtCeiling bool
+}
+
+// StepsResult is the discrete counterpart of Result for schedulers whose wait
+// is measured in whole ticks rather than wall-clock time.
+type StepsResult struct {
+	Steps     int
+	AtCeiling bool
+}
+
+// ForAttempt returns a bounded exponential delay with equal jitter. Attempts
+// are one-based: attempt 1 uses base, attempt 2 uses 2*base, and so on. Equal
+// jitter selects uniformly from the upper half of the computed window, which
+// keeps retries spread out even after the exponential schedule reaches its
+// ceiling.
+func ForAttempt(attempt int, base, ceiling time.Duration) Result {
+	return forAttempt(attempt, base, ceiling, rand.Int64N)
+}
+
+// StepsForAttempt returns a bounded exponential whole-step wait with equal
+// jitter. Sampling in the discrete domain keeps short schedules spread out;
+// converting a continuous duration to ticks would collapse most values onto
+// the same rounded tick.
+func StepsForAttempt(attempt, base, ceiling int) StepsResult {
+	return stepsForAttempt(attempt, base, ceiling, rand.IntN)
+}
+
+// WithoutJitter returns the exact bounded exponential delay. Callers must
+// state why synchronized retries are safe; this makes every opt-out visible at
+// the call site during review.
+func WithoutJitter(attempt int, base, ceiling time.Duration, reason string) Result {
+	if strings.TrimSpace(reason) == "" {
+		panic("backoff: no-jitter reason is required")
+	}
+	nominal, atCeiling := exponential(attempt, base, ceiling)
+	return Result{Delay: nominal, AtCeiling: atCeiling}
+}
+
+func forAttempt(attempt int, base, ceiling time.Duration, int64n func(int64) int64) Result {
+	nominal, atCeiling := exponential(attempt, base, ceiling)
+	if nominal <= 1 {
+		return Result{Delay: nominal, AtCeiling: atCeiling}
+	}
+	minimum := nominal/2 + nominal%2
+	span := int64(nominal-minimum) + 1
+	return Result{
+		Delay:     minimum + time.Duration(int64n(span)),
+		AtCeiling: atCeiling,
+	}
+}
+
+func stepsForAttempt(attempt, base, ceiling int, intn func(int) int) StepsResult {
+	nominal, atCeiling := exponentialSteps(attempt, base, ceiling)
+	if nominal <= 1 {
+		return StepsResult{Steps: nominal, AtCeiling: atCeiling}
+	}
+	minimum := nominal/2 + nominal%2
+	return StepsResult{
+		Steps:     minimum + intn(nominal-minimum+1),
+		AtCeiling: atCeiling,
+	}
+}
+
+func exponential(attempt int, base, ceiling time.Duration) (time.Duration, bool) {
+	if attempt <= 0 || base <= 0 || ceiling <= 0 {
+		return 0, false
+	}
+	if base >= ceiling {
+		return ceiling, true
+	}
+	delay := base
+	for i := 1; i < attempt; i++ {
+		if delay > ceiling/2 {
+			return ceiling, true
+		}
+		delay *= 2
+		if delay >= ceiling {
+			return ceiling, true
+		}
+	}
+	return delay, false
+}
+
+func exponentialSteps(attempt, base, ceiling int) (int, bool) {
+	if attempt <= 0 || base <= 0 || ceiling <= 0 {
+		return 0, false
+	}
+	if base >= ceiling {
+		return ceiling, true
+	}
+	steps := base
+	for i := 1; i < attempt; i++ {
+		if steps > ceiling/2 {
+			return ceiling, true
+		}
+		steps *= 2
+		if steps >= ceiling {
+			return ceiling, true
+		}
+	}
+	return steps, false
+}

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -1,0 +1,94 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestForAttemptBoundsAndCeiling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		attempt   int
+		base      time.Duration
+		ceiling   time.Duration
+		wantMin   time.Duration
+		wantMax   time.Duration
+		atCeiling bool
+	}{
+		{name: "disabled attempt", attempt: 0, base: time.Second, ceiling: time.Minute},
+		{name: "first", attempt: 1, base: time.Second, ceiling: time.Minute, wantMin: 500 * time.Millisecond, wantMax: time.Second},
+		{name: "doubles", attempt: 3, base: time.Second, ceiling: time.Minute, wantMin: 2 * time.Second, wantMax: 4 * time.Second},
+		{name: "caps", attempt: 20, base: time.Second, ceiling: time.Minute, wantMin: 30 * time.Second, wantMax: time.Minute, atCeiling: true},
+		{name: "base above cap", attempt: 1, base: 2 * time.Minute, ceiling: time.Minute, wantMin: 30 * time.Second, wantMax: time.Minute, atCeiling: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ForAttempt(tt.attempt, tt.base, tt.ceiling)
+			if got.Delay < tt.wantMin || got.Delay > tt.wantMax {
+				t.Fatalf("ForAttempt delay = %v, want [%v, %v]", got.Delay, tt.wantMin, tt.wantMax)
+			}
+			if got.AtCeiling != tt.atCeiling {
+				t.Fatalf("ForAttempt AtCeiling = %v, want %v", got.AtCeiling, tt.atCeiling)
+			}
+		})
+	}
+}
+
+func TestForAttemptJitterEndpoints(t *testing.T) {
+	t.Parallel()
+
+	low := forAttempt(3, time.Second, time.Minute, func(int64) int64 { return 0 })
+	high := forAttempt(3, time.Second, time.Minute, func(n int64) int64 { return n - 1 })
+	if low.Delay != 2*time.Second || high.Delay != 4*time.Second {
+		t.Fatalf("jitter endpoints = [%v, %v], want [2s, 4s]", low.Delay, high.Delay)
+	}
+
+	oddLow := forAttempt(1, 3*time.Nanosecond, time.Second, func(int64) int64 { return 0 })
+	if oddLow.Delay != 2*time.Nanosecond {
+		t.Fatalf("odd jitter minimum = %v, want ceiling-half 2ns", oddLow.Delay)
+	}
+}
+
+func TestStepsForAttemptJittersInWholeSteps(t *testing.T) {
+	t.Parallel()
+
+	low := stepsForAttempt(2, 1, 8, func(int) int { return 0 })
+	high := stepsForAttempt(2, 1, 8, func(n int) int { return n - 1 })
+	if low.Steps != 1 || high.Steps != 2 {
+		t.Fatalf("step jitter endpoints = [%d, %d], want [1, 2]", low.Steps, high.Steps)
+	}
+	oddLow := stepsForAttempt(1, 3, 10, func(int) int { return 0 })
+	if oddLow.Steps != 2 {
+		t.Fatalf("odd step jitter minimum = %d, want ceiling-half 2", oddLow.Steps)
+	}
+
+	maxInt := int(^uint(0) >> 1)
+	capped := StepsForAttempt(100, 1, maxInt)
+	if capped.Steps < maxInt/2 || capped.Steps > maxInt || !capped.AtCeiling {
+		t.Fatalf("large capped step result = %+v, want [%d, %d] at ceiling", capped, maxInt/2, maxInt)
+	}
+}
+
+func TestWithoutJitter(t *testing.T) {
+	t.Parallel()
+
+	got := WithoutJitter(4, time.Second, 5*time.Second, "deterministic protocol deadline")
+	if got.Delay != 5*time.Second || !got.AtCeiling {
+		t.Fatalf("WithoutJitter = %+v, want delay 5s at ceiling", got)
+	}
+}
+
+func TestWithoutJitterRequiresReason(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("WithoutJitter did not panic for an empty reason")
+		}
+	}()
+	WithoutJitter(1, time.Second, time.Minute, "  ")
+}

--- a/internal/github/authhealth.go
+++ b/internal/github/authhealth.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/backoff"
 	"github.com/Automaat/sybra/internal/errclass"
 
 	"github.com/Automaat/sybra/internal/clock"
@@ -260,14 +261,8 @@ func (t *authHealthTracker) observeFailure(state AuthState, reason string) {
 func (t *authHealthTracker) applyFailureBackoffLocked() {
 	t.hadFailure = true
 	t.consecutiveFailures++
-	backoff := authCircuitBaseBackoff
-	for i := 1; i < t.consecutiveFailures && backoff < authCircuitMaxBackoff; i++ {
-		backoff *= 2
-	}
-	if backoff > authCircuitMaxBackoff {
-		backoff = authCircuitMaxBackoff
-	}
-	t.nextAttempt = t.now().Add(backoff)
+	delay := backoff.ForAttempt(t.consecutiveFailures, authCircuitBaseBackoff, authCircuitMaxBackoff).Delay
+	t.nextAttempt = t.now().Add(delay)
 }
 
 // isAuthErrorMsg is IsAuthError's message-matching core, factored out so

--- a/internal/github/authhealth_clock_test.go
+++ b/internal/github/authhealth_clock_test.go
@@ -38,13 +38,14 @@ func TestAuthCircuitBackoffScheduleWithoutSleeping(t *testing.T) {
 			if !open {
 				t.Fatal("circuit should be open right after a failure")
 			}
-			if got := retryAfter.Sub(fake.Now()); got != tt.wantBackoff {
-				t.Fatalf("retryAfter is %v out, want %v", got, tt.wantBackoff)
+			gotBackoff := retryAfter.Sub(fake.Now())
+			if gotBackoff < tt.wantBackoff/2 || gotBackoff > tt.wantBackoff {
+				t.Fatalf("retryAfter is %v out, want jittered window [%v, %v]", gotBackoff, tt.wantBackoff/2, tt.wantBackoff)
 			}
 
 			// One tick short of the window the circuit is still open; one tick
 			// past it, closed — the boundary a sleep-based test cannot pin.
-			fake.Advance(tt.wantBackoff - time.Nanosecond)
+			fake.Advance(gotBackoff - time.Nanosecond)
 			if open, _ := AuthCircuitOpen(); !open {
 				t.Error("circuit closed one nanosecond early")
 			}
@@ -79,7 +80,7 @@ func TestAuthCircuitBackoffStopsAtTheCeiling(t *testing.T) {
 	ObserveCallResult([]byte("Bad credentials"), authFail)
 
 	_, retryAfter := AuthCircuitOpen()
-	if got := retryAfter.Sub(fake.Now()); got != authCircuitMaxBackoff {
-		t.Errorf("backoff after 20 failures = %v, want the %v ceiling", got, authCircuitMaxBackoff)
+	if got := retryAfter.Sub(fake.Now()); got < authCircuitMaxBackoff/2 || got > authCircuitMaxBackoff {
+		t.Errorf("backoff after 20 failures = %v, want capped jitter window [%v, %v]", got, authCircuitMaxBackoff/2, authCircuitMaxBackoff)
 	}
 }

--- a/internal/github/automerge_backoff.go
+++ b/internal/github/automerge_backoff.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/sybra/internal/backoff"
 )
 
 // MergeErrorClass classifies a failed auto-merge attempt so AutoMergeBackoff
@@ -163,10 +165,10 @@ func (b *AutoMergeBackoff) RecordFailure(repo string, number int, headSHA, state
 	}
 	entry.attempts++
 	base, ceiling := mergeBackoffWindow(class)
-	delay := expoBackoff(base, entry.attempts, ceiling)
-	entry.nextTry = b.now().Add(delay)
+	computed := backoff.ForAttempt(entry.attempts, base, ceiling)
+	entry.nextTry = b.now().Add(computed.Delay)
 	b.entries[key] = entry
-	return delay >= ceiling
+	return computed.AtCeiling
 }
 
 // Clear drops backoff state for repo#number, reporting whether an entry
@@ -196,18 +198,4 @@ func (b *AutoMergeBackoff) Class(repo string, number int) MergeErrorClass {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.entries[autoMergeBackoffKey(repo, number)].class
-}
-
-func expoBackoff(base time.Duration, attempts int, ceiling time.Duration) time.Duration {
-	d := base
-	for i := 1; i < attempts; i++ {
-		d *= 2
-		if d >= ceiling {
-			return ceiling
-		}
-	}
-	if d > ceiling {
-		return ceiling
-	}
-	return d
 }

--- a/internal/github/automerge_backoff_test.go
+++ b/internal/github/automerge_backoff_test.go
@@ -95,8 +95,13 @@ func TestAutoMergeBackoff_ExponentialGrowthAndCeiling(t *testing.T) {
 
 	// One more failure at the ceiling must not exceed it.
 	b.RecordFailure("owner/repo", 5, "sha1", "state1", MergeErrorBlocked)
-	// nextTry - now should be capped at ceiling; verify indirectly via ShouldAttempt.
-	now = now.Add(ceiling - time.Second)
+	nextDelay := b.entries[autoMergeBackoffKey("owner/repo", 5)].nextTry.Sub(now)
+	if nextDelay < ceiling/2 || nextDelay > ceiling {
+		t.Fatalf("capped jitter delay = %v, want [%v, %v]", nextDelay, ceiling/2, ceiling)
+	}
+	// Verify the actual jittered boundary rather than assuming every capped
+	// retry lands exactly on the ceiling.
+	now = now.Add(nextDelay - time.Second)
 	if b.ShouldAttempt("owner/repo", 5, "sha1", "state1") {
 		t.Fatal("expected still suppressed just before the ceiling elapses")
 	}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/attachment"
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/backoff"
 	"github.com/Automaat/sybra/internal/bgop"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/diskreclaim"
@@ -132,10 +133,10 @@ func (s *liveLimitPollState) recordResult(now time.Time, result limits.LiveRefre
 			logger.Warn("limits.live_poll.invalidate", "provider", limits.ProviderClaude, "err", err)
 		}
 		s.claudeAuthFailures++
-		backoff := liveLimitAuthBackoff(s.claudeAuthFailures)
-		s.next[limits.ProviderClaude] = now.Add(backoff)
+		retryDelay := liveLimitAuthBackoff(s.claudeAuthFailures)
+		s.next[limits.ProviderClaude] = now.Add(retryDelay)
 		if !s.claudeAuthOpen {
-			logger.Warn("limits.live_poll.claude_auth", "backoff", backoff, "err", claude.Err)
+			logger.Warn("limits.live_poll.claude_auth", "backoff", retryDelay, "err", claude.Err)
 			s.claudeAuthOpen = true
 		}
 		return
@@ -149,20 +150,7 @@ func (s *liveLimitPollState) recordResult(now time.Time, result limits.LiveRefre
 }
 
 func liveLimitAuthBackoff(failures int) time.Duration {
-	if failures <= 1 {
-		return liveLimitPollInterval
-	}
-	backoff := liveLimitPollInterval
-	for range failures - 1 {
-		if backoff >= liveLimitPollAuthBackoffMax {
-			return liveLimitPollAuthBackoffMax
-		}
-		backoff *= 2
-	}
-	if backoff > liveLimitPollAuthBackoffMax {
-		return liveLimitPollAuthBackoffMax
-	}
-	return backoff
+	return backoff.ForAttempt(max(failures, 1), liveLimitPollInterval, liveLimitPollAuthBackoffMax).Delay
 }
 
 func liveLimitProviderEnabled(policy limits.Policy, providerName string) bool {

--- a/internal/sybra/app_live_limits_test.go
+++ b/internal/sybra/app_live_limits_test.go
@@ -45,8 +45,8 @@ func TestLiveLimitPollState_ClaudeAuthBackoffAndRecovery(t *testing.T) {
 	if !state.claudeAuthOpen || state.claudeAuthFailures != 1 {
 		t.Fatalf("auth state after first failure = open:%v failures:%d", state.claudeAuthOpen, state.claudeAuthFailures)
 	}
-	if got := state.next[limits.ProviderClaude]; !got.Equal(now.Add(liveLimitPollInterval)) {
-		t.Fatalf("first backoff next poll = %v, want %v", got, now.Add(liveLimitPollInterval))
+	if got := state.next[limits.ProviderClaude]; got.Before(now.Add(liveLimitPollInterval/2)) || got.After(now.Add(liveLimitPollInterval)) {
+		t.Fatalf("first backoff next poll = %v, want jittered window [%v, %v]", got, now.Add(liveLimitPollInterval/2), now.Add(liveLimitPollInterval))
 	}
 	snap, ok := limitStore.Snapshot(limits.ProviderClaude)
 	if !ok || snap.Confidence != limits.ConfidenceEstimated {
@@ -63,8 +63,8 @@ func TestLiveLimitPollState_ClaudeAuthBackoffAndRecovery(t *testing.T) {
 	if state.claudeAuthFailures != 2 {
 		t.Fatalf("auth failures after second failure = %d, want 2", state.claudeAuthFailures)
 	}
-	if got := state.next[limits.ProviderClaude]; !got.Equal(secondNow.Add(2 * liveLimitPollInterval)) {
-		t.Fatalf("second backoff next poll = %v, want %v", got, secondNow.Add(2*liveLimitPollInterval))
+	if got := state.next[limits.ProviderClaude]; got.Before(secondNow.Add(liveLimitPollInterval)) || got.After(secondNow.Add(2*liveLimitPollInterval)) {
+		t.Fatalf("second backoff next poll = %v, want jittered window [%v, %v]", got, secondNow.Add(liveLimitPollInterval), secondNow.Add(2*liveLimitPollInterval))
 	}
 	if got := countLogMessage(records, "limits.live_poll.claude_auth"); got != 1 {
 		t.Fatalf("auth warning count = %d, want 1 deduped log", got)
@@ -89,14 +89,14 @@ func TestLiveLimitPollState_ClaudeAuthBackoffAndRecovery(t *testing.T) {
 }
 
 func TestLiveLimitAuthBackoff_Bounded(t *testing.T) {
-	if got := liveLimitAuthBackoff(1); got != liveLimitPollInterval {
-		t.Fatalf("backoff(1) = %v, want %v", got, liveLimitPollInterval)
+	if got := liveLimitAuthBackoff(1); got < liveLimitPollInterval/2 || got > liveLimitPollInterval {
+		t.Fatalf("backoff(1) = %v, want [%v, %v]", got, liveLimitPollInterval/2, liveLimitPollInterval)
 	}
-	if got := liveLimitAuthBackoff(2); got != 2*liveLimitPollInterval {
-		t.Fatalf("backoff(2) = %v, want %v", got, 2*liveLimitPollInterval)
+	if got := liveLimitAuthBackoff(2); got < liveLimitPollInterval || got > 2*liveLimitPollInterval {
+		t.Fatalf("backoff(2) = %v, want [%v, %v]", got, liveLimitPollInterval, 2*liveLimitPollInterval)
 	}
-	if got := liveLimitAuthBackoff(6); got != liveLimitPollAuthBackoffMax {
-		t.Fatalf("backoff(6) = %v, want max %v", got, liveLimitPollAuthBackoffMax)
+	if got := liveLimitAuthBackoff(6); got < liveLimitPollAuthBackoffMax/2 || got > liveLimitPollAuthBackoffMax {
+		t.Fatalf("backoff(6) = %v, want capped jitter window [%v, %v]", got, liveLimitPollAuthBackoffMax/2, liveLimitPollAuthBackoffMax)
 	}
 }
 

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/backoff"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/gitexec"
@@ -273,8 +274,8 @@ func (h *Handler) OnComplete(ag *agent.Agent) {
 }
 
 func (h *Handler) retryUpdateRunCompletion(ag *agent.Agent, runUpdates task.RunPatch, resultContent string, exitErr error) {
-	delay := completionUpdateRunRetryInitialDelay
-	for {
+	for attempt := 1; ; attempt++ {
+		delay := backoff.ForAttempt(attempt, completionUpdateRunRetryInitialDelay, completionUpdateRunRetryMaxDelay).Delay
 		time.Sleep(delay)
 		err := h.tasks.UpdateRun(ag.TaskID, ag.ID, runUpdates)
 		if err == nil {
@@ -287,10 +288,6 @@ func (h *Handler) retryUpdateRunCompletion(ag *agent.Agent, runUpdates task.RunP
 			return
 		}
 		h.logger.Warn("task.update-run.deferred.retry", "task_id", ag.TaskID, "agent_id", ag.ID, "delay", delay, "err", err)
-		delay *= 2
-		if delay > completionUpdateRunRetryMaxDelay {
-			delay = completionUpdateRunRetryMaxDelay
-		}
 	}
 }
 

--- a/internal/sybra/review/pr_poll_sched.go
+++ b/internal/sybra/review/pr_poll_sched.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"slices"
 
+	"github.com/Automaat/sybra/internal/backoff"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
@@ -26,14 +27,7 @@ func expBackoff(streak, maxTicks int) int {
 	if streak <= 0 || maxTicks <= 0 {
 		return 0
 	}
-	skip := 1
-	for i := 1; i < streak && skip < maxTicks; i++ {
-		skip *= 2
-		if skip >= maxTicks {
-			return maxTicks
-		}
-	}
-	return skip
+	return backoff.StepsForAttempt(streak, 1, maxTicks).Steps
 }
 
 func (r *Handler) selectKnownPRPoll(ctx context.Context, tasks []task.Task) knownPRPollSelection {

--- a/internal/sybra/review/pr_poll_sched_test.go
+++ b/internal/sybra/review/pr_poll_sched_test.go
@@ -19,21 +19,22 @@ func TestExpBackoff(t *testing.T) {
 		name     string
 		streak   int
 		maxTicks int
-		want     int
+		wantMin  int
+		wantMax  int
 	}{
-		{name: "non-positive streak", streak: 0, maxTicks: 8, want: 0},
-		{name: "first stable poll", streak: 1, maxTicks: 8, want: 1},
-		{name: "second stable poll", streak: 2, maxTicks: 8, want: 2},
-		{name: "third stable poll", streak: 3, maxTicks: 8, want: 4},
-		{name: "clamps to max", streak: 5, maxTicks: 8, want: 8},
-		{name: "disabled when max non-positive", streak: 3, maxTicks: 0, want: 0},
+		{name: "non-positive streak", streak: 0, maxTicks: 8},
+		{name: "first stable poll", streak: 1, maxTicks: 8, wantMin: 1, wantMax: 1},
+		{name: "second stable poll", streak: 2, maxTicks: 8, wantMin: 1, wantMax: 2},
+		{name: "third stable poll", streak: 3, maxTicks: 8, wantMin: 2, wantMax: 4},
+		{name: "clamps to max", streak: 5, maxTicks: 8, wantMin: 4, wantMax: 8},
+		{name: "disabled when max non-positive", streak: 3, maxTicks: 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := expBackoff(tt.streak, tt.maxTicks); got != tt.want {
-				t.Fatalf("expBackoff(%d, %d) = %d, want %d", tt.streak, tt.maxTicks, got, tt.want)
+			if got := expBackoff(tt.streak, tt.maxTicks); got < tt.wantMin || got > tt.wantMax {
+				t.Fatalf("expBackoff(%d, %d) = %d, want [%d, %d]", tt.streak, tt.maxTicks, got, tt.wantMin, tt.wantMax)
 			}
 		})
 	}
@@ -419,11 +420,11 @@ func TestSelectKnownPRPoll(t *testing.T) {
 
 		stablePR := github.PullRequest{HeadSHA: "sha-1", UpdatedAt: "2026-07-13T12:00:00Z"}
 		r.noteKnownPRResult("owner/repo", 42, stablePR)
-		wantSkips := []int{1, 2, 4, 8}
+		wantSkips := [][2]int{{1, 1}, {1, 2}, {2, 4}, {4, 8}}
 		for i, want := range wantSkips {
 			r.noteKnownPRResult("owner/repo", 42, stablePR)
-			if _, _, got, _ := r.prSnapshots.Backoff("owner/repo#42"); got != want {
-				t.Fatalf("stable round %d skipTicks = %d, want %d", i+1, got, want)
+			if _, _, got, _ := r.prSnapshots.Backoff("owner/repo#42"); got < want[0] || got > want[1] {
+				t.Fatalf("stable round %d skipTicks = %d, want [%d, %d]", i+1, got, want[0], want[1])
 			}
 		}
 

--- a/internal/umbrella/tags.go
+++ b/internal/umbrella/tags.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/backoff"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -254,16 +255,7 @@ func HasRecoverExhaustedTag(tags []string) bool {
 // given the failure count after the attempt that just failed (1 for the
 // first failure). Doubles per failure from a 1 hour base, capped at 24 hours.
 func RecoverBackoff(failCount int) time.Duration {
-	if failCount < 1 {
-		failCount = 1
-	}
-	shift := failCount - 1
-	const maxShift = 10 // 1h<<10 already exceeds the 24h cap; bounds the shift against overflow
-	if shift > maxShift {
-		shift = maxShift
-	}
-	d := recoverBackoffBase * time.Duration(1<<uint(shift))
-	return min(d, recoverBackoffMax)
+	return backoff.ForAttempt(max(failCount, 1), recoverBackoffBase, recoverBackoffMax).Delay
 }
 
 // ReplaceTagPrefix returns tags with every entry sharing prefix removed and

--- a/internal/umbrella/tags_test.go
+++ b/internal/umbrella/tags_test.go
@@ -120,19 +120,20 @@ func TestRecoverBackoff(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		failCount int
-		want      time.Duration
+		wantMin   time.Duration
+		wantMax   time.Duration
 	}{
-		{0, time.Hour}, // treated as 1
-		{1, time.Hour},
-		{2, 2 * time.Hour},
-		{3, 4 * time.Hour},
-		{5, 16 * time.Hour},
-		{6, 24 * time.Hour}, // 32h would exceed the cap
-		{100, 24 * time.Hour},
+		{0, 30 * time.Minute, time.Hour}, // treated as 1
+		{1, 30 * time.Minute, time.Hour},
+		{2, time.Hour, 2 * time.Hour},
+		{3, 2 * time.Hour, 4 * time.Hour},
+		{5, 8 * time.Hour, 16 * time.Hour},
+		{6, 12 * time.Hour, 24 * time.Hour}, // nominal 32h is capped before jitter
+		{100, 12 * time.Hour, 24 * time.Hour},
 	}
 	for _, c := range cases {
-		if got := RecoverBackoff(c.failCount); got != c.want {
-			t.Errorf("RecoverBackoff(%d) = %v, want %v", c.failCount, got, c.want)
+		if got := RecoverBackoff(c.failCount); got < c.wantMin || got > c.wantMax {
+			t.Errorf("RecoverBackoff(%d) = %v, want [%v, %v]", c.failCount, got, c.wantMin, c.wantMax)
 		}
 	}
 }

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/backoff"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/pressure"
@@ -165,20 +166,7 @@ func (s *state) deferForPressure(id string, now time.Time) (deadline time.Time, 
 }
 
 func pressureInspectBackoff(defers int) time.Duration {
-	if defers <= 1 {
-		return 2 * time.Minute
-	}
-	backoff := 2 * time.Minute
-	for range defers - 1 {
-		if backoff >= maxPressureInspectBackoff {
-			return maxPressureInspectBackoff
-		}
-		backoff *= 2
-	}
-	if backoff > maxPressureInspectBackoff {
-		return maxPressureInspectBackoff
-	}
-	return backoff
+	return backoff.ForAttempt(max(defers, 1), 2*time.Minute, maxPressureInspectBackoff).Delay
 }
 
 // Watchdog monitors headless agents for stalls, budget overruns, and tool-call

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -138,8 +138,9 @@ func TestInspectHeadless_DefersAndBacksOffUnderPressure(t *testing.T) {
 	if inspectCalled {
 		t.Fatal("inspectAgent called under machine pressure")
 	}
-	if s.ready(ag.ID, now.Add(90*time.Second)) {
-		t.Fatal("first pressure backoff expired too early")
+	firstDeadline := s.nextEligibleAt[ag.ID]
+	if delay := firstDeadline.Sub(now); delay < time.Minute || delay > 2*time.Minute {
+		t.Fatalf("first pressure backoff = %v, want jittered window [1m, 2m]", delay)
 	}
 
 	secondAttempt := now.Add(2 * time.Minute)
@@ -147,11 +148,9 @@ func TestInspectHeadless_DefersAndBacksOffUnderPressure(t *testing.T) {
 	if inspectCalled {
 		t.Fatal("inspectAgent called during second pressure defer")
 	}
-	if s.ready(ag.ID, secondAttempt.Add(3*time.Minute+30*time.Second)) {
-		t.Fatal("second pressure backoff expired too early")
-	}
-	if !s.ready(ag.ID, secondAttempt.Add(4*time.Minute)) {
-		t.Fatal("second pressure backoff did not expand to four minutes")
+	secondDeadline := s.nextEligibleAt[ag.ID]
+	if delay := secondDeadline.Sub(secondAttempt); delay < 2*time.Minute || delay > 4*time.Minute {
+		t.Fatalf("second pressure backoff = %v, want jittered window [2m, 4m]", delay)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add one bounded exponential backoff policy with equal jitter for durations and discrete scheduler ticks
- require a source-visible reason for any no-jitter opt-out
- migrate GitHub auth and auto-merge, live limits, completion persistence, PR polling, watchdog pressure, and umbrella recovery schedules
- preserve each caller’s nominal base, ceiling, and one-based attempt semantics
- cover odd windows, capped jitter, overflow, discrete distribution, and concurrent sampling

## Verification

- full affected-package race suite
- 100 randomized repetitions of migrated schedules
- adversarial review: clean after fixing discrete rounding, missed umbrella recovery, overflow, and odd-window bounds
- independent sybra-test: pass, including real isolated server health and authenticated API probe
- full repository build, Go race, tagged E2E, frontend check/test, and lint gates passed; local repo-hygiene stopped only on worktree-excluded tracked skill files unchanged by this branch

Closes #3141