### PR TITLE
fix(worktree): preserve live attempts

### DIFF
--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -171,7 +171,7 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 			// A live task agent protects canonical and attempt worktrees even if
 			// the task snapshot disappeared between List and this sweep.
 			continue
-		case isAttempt && inflightAttempts[name] && !task.IsTerminalStatus(t.Status):
+		case isAttempt && t != nil && inflightAttempts[name] && !task.IsTerminalStatus(t.Status):
 			// The parent task's status is not enough to identify a live fan-out:
 			// attempt agents can finish independently, leaving gaps where no
 			// agent is registered. The persisted attempt record is the durable

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/cleanup"
@@ -15,8 +16,9 @@ import (
 )
 
 var (
-	bareTaskIDRe   = regexp.MustCompile(`^[0-9a-f]{8}$`)
-	suffixTaskIDRe = regexp.MustCompile(`-([0-9a-f]{8})$`)
+	bareTaskIDRe    = regexp.MustCompile(`^[0-9a-f]{8}$`)
+	suffixTaskIDRe  = regexp.MustCompile(`-([0-9a-f]{8})$`)
+	attemptSuffixRe = regexp.MustCompile(`^attempt_[1-9]\d*$`)
 )
 
 const worktreeQuarantineDirName = ".quarantine"
@@ -25,6 +27,9 @@ const worktreeQuarantineDirName = ".quarantine"
 // name: task.Task.DirName() is either the bare 8-hex-char ID (no slug yet) or
 // "<slug>-<8hex-id>". Anything else returns "" (no match).
 func taskIDFromWorktreeDir(name string) string {
+	if idx := strings.LastIndex(name, "-"); idx >= 0 && attemptSuffixRe.MatchString(name[idx+1:]) {
+		name = name[:idx]
+	}
 	if bareTaskIDRe.MatchString(name) {
 		return name
 	}
@@ -32,6 +37,11 @@ func taskIDFromWorktreeDir(name string) string {
 		return m[1]
 	}
 	return ""
+}
+
+func isAttemptWorktreeDir(name string, t task.Task) bool {
+	prefix := t.DirName() + "-"
+	return strings.HasPrefix(name, prefix) && attemptSuffixRe.MatchString(strings.TrimPrefix(name, prefix))
 }
 
 // Remove cleans up the worktree for a task via git worktree remove.
@@ -103,8 +113,22 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 	}
 
 	active := make(map[string]*task.Task, len(tasks))
+	activeByID := make(map[string]*task.Task, len(tasks))
+	inflightAttempts := make(map[string]bool)
 	for i := range tasks {
 		active[tasks[i].DirName()] = &tasks[i]
+		activeByID[tasks[i].ID] = &tasks[i]
+		if tasks[i].Workflow == nil {
+			continue
+		}
+		for _, parent := range tasks[i].Workflow.BestOfNInflight {
+			if parent == nil {
+				continue
+			}
+			for attemptID := range parent.Attempts {
+				inflightAttempts[attemptDirName(tasks[i], attemptID)] = true
+			}
+		}
 	}
 	observedProtected := make(map[string]bool)
 
@@ -118,13 +142,33 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 		name := e.Name()
 		wtPath := filepath.Join(m.dir, name)
 
-		t, exists := active[name]
+		t := active[name]
+		ownerID := taskIDFromWorktreeDir(name)
+		isAttempt := false
+		if t == nil {
+			if owner := activeByID[ownerID]; owner != nil && isAttemptWorktreeDir(name, *owner) {
+				t = owner
+				isAttempt = true
+			}
+		}
 		switch {
-		case !exists:
+		case isAttempt && inflightAttempts[name]:
+			// The parent task's status is not enough to identify a live fan-out:
+			// attempt agents can finish independently, leaving gaps where no
+			// agent is registered. The persisted attempt record is the durable
+			// ownership signal across those gaps and process restarts.
+			continue
+		case ownerID != "" && m.hasAgent != nil && m.hasAgent(ownerID):
+			// A live task agent protects canonical and attempt worktrees even if
+			// the task snapshot disappeared between List and this sweep.
+			continue
+		case isAttempt:
+			// The task still exists but no fan-out owns this attempt anymore.
+			// CleanupAttempts normally removes it after promotion/failure; this
+			// sweep remains the backstop when that best-effort cleanup lost a race.
+		case t == nil:
 			// Task deleted — remove worktree directory.
 		case !task.IsTerminalStatus(t.Status):
-			continue
-		case m.hasAgent != nil && m.hasAgent(t.ID):
 			continue
 		}
 

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -27,7 +27,7 @@ const worktreeQuarantineDirName = ".quarantine"
 // name: task.Task.DirName() is either the bare 8-hex-char ID (no slug yet) or
 // "<slug>-<8hex-id>". Anything else returns "" (no match).
 func taskIDFromWorktreeDir(name string) string {
-	if idx := strings.LastIndex(name, "-"); idx >= 0 && attemptSuffixRe.MatchString(name[idx+1:]) {
+	if idx := strings.LastIndex(name, "-"); idx >= 0 && isAttemptSuffix(name[idx+1:]) {
 		name = name[:idx]
 	}
 	if bareTaskIDRe.MatchString(name) {
@@ -39,9 +39,13 @@ func taskIDFromWorktreeDir(name string) string {
 	return ""
 }
 
-func isAttemptWorktreeDir(name string, t task.Task) bool {
-	prefix := t.DirName() + "-"
-	return strings.HasPrefix(name, prefix) && attemptSuffixRe.MatchString(strings.TrimPrefix(name, prefix))
+func isAttemptSuffix(name string) bool {
+	return attemptSuffixRe.MatchString(name)
+}
+
+func isAttemptWorktreeDir(name string) bool {
+	idx := strings.LastIndex(name, "-")
+	return idx >= 0 && isAttemptSuffix(name[idx+1:])
 }
 
 // Remove cleans up the worktree for a task via git worktree remove.
@@ -125,8 +129,19 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 			if parent == nil {
 				continue
 			}
-			for attemptID := range parent.Attempts {
+			for attemptID, attempt := range parent.Attempts {
+				// The computed name protects the prepare-before-persist window. The
+				// persisted path remains authoritative after a task slug changes.
 				inflightAttempts[attemptDirName(tasks[i], attemptID)] = true
+				if attempt == nil || attempt.Dir == "" {
+					continue
+				}
+				cleanDir := filepath.Clean(attempt.Dir)
+				name := filepath.Base(cleanDir)
+				if filepath.Clean(filepath.Dir(cleanDir)) == filepath.Clean(m.dir) &&
+					taskIDFromWorktreeDir(name) == tasks[i].ID && isAttemptWorktreeDir(name) {
+					inflightAttempts[name] = true
+				}
 			}
 		}
 	}
@@ -146,21 +161,21 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 		ownerID := taskIDFromWorktreeDir(name)
 		isAttempt := false
 		if t == nil {
-			if owner := activeByID[ownerID]; owner != nil && isAttemptWorktreeDir(name, *owner) {
+			if owner := activeByID[ownerID]; owner != nil && isAttemptWorktreeDir(name) {
 				t = owner
 				isAttempt = true
 			}
 		}
 		switch {
-		case isAttempt && inflightAttempts[name]:
+		case ownerID != "" && m.hasAgent != nil && m.hasAgent(ownerID):
+			// A live task agent protects canonical and attempt worktrees even if
+			// the task snapshot disappeared between List and this sweep.
+			continue
+		case isAttempt && inflightAttempts[name] && !task.IsTerminalStatus(t.Status):
 			// The parent task's status is not enough to identify a live fan-out:
 			// attempt agents can finish independently, leaving gaps where no
 			// agent is registered. The persisted attempt record is the durable
 			// ownership signal across those gaps and process restarts.
-			continue
-		case ownerID != "" && m.hasAgent != nil && m.hasAgent(ownerID):
-			// A live task agent protects canonical and attempt worktrees even if
-			// the task snapshot disappeared between List and this sweep.
 			continue
 		case isAttempt:
 			// The task still exists but no fan-out owns this attempt anymore.

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/prepstate"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // initBareWithCommit creates a bare repo containing a single commit on
@@ -359,6 +360,85 @@ func TestCleanupOrphaned(t *testing.T) {
 	// Active task's dir should remain
 	if _, err := os.Stat(filepath.Join(dir, tk.DirName())); err != nil {
 		t.Error("active task dir should remain")
+	}
+}
+
+func TestCleanupOrphaned_PreservesInflightAttemptAndReapsFinishedAttempt(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+	tk, err := store.Create("best of n task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf := &workflow.Execution{BestOfNInflight: map[string]*workflow.BestOfNInflight{
+		"attempts": {
+			ParentStepID: "attempts",
+			Attempts: map[string]*workflow.AttemptStatus{
+				"attempt_1": {AttemptID: "attempt_1", Status: "pending"},
+			},
+		},
+	}}
+	if _, err := store.Update(tk.ID, task.Update{Workflow: &wf}); err != nil {
+		t.Fatal(err)
+	}
+
+	inflightDir := filepath.Join(dir, attemptDirName(tk, "attempt_1"))
+	finishedDir := filepath.Join(dir, attemptDirName(tk, "attempt_2"))
+	makePushedGitDir(t, inflightDir)
+	makePushedGitDir(t, finishedDir)
+
+	m := New(Config{WorktreesDir: dir, Tasks: taskMgr, Logger: discardLogger()})
+	m.CleanupOrphaned(context.Background())
+
+	if _, err := os.Stat(inflightDir); err != nil {
+		t.Fatalf("in-flight attempt removed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(finishedDir); !os.IsNotExist(err) {
+		t.Fatalf("finished attempt still exists after cleanup: %v", err)
+	}
+}
+
+func TestCleanupOrphaned_PreservesDeletedTaskAttemptWithLiveAgent(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+	tk, err := store.Create("deleted best of n task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attemptDir := filepath.Join(dir, attemptDirName(tk, "attempt_1"))
+	makePushedGitDir(t, attemptDir)
+	if err := taskMgr.Delete(tk.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	live := true
+	m := New(Config{
+		WorktreesDir: dir,
+		Tasks:        taskMgr,
+		Logger:       discardLogger(),
+		AgentChecker: func(taskID string) bool { return live && taskID == tk.ID },
+	})
+	m.CleanupOrphaned(context.Background())
+	if _, err := os.Stat(attemptDir); err != nil {
+		t.Fatalf("deleted task's live attempt removed unexpectedly: %v", err)
+	}
+
+	live = false
+	m.CleanupOrphaned(context.Background())
+	if _, err := os.Stat(attemptDir); !os.IsNotExist(err) {
+		t.Fatalf("deleted task's finished attempt still exists after cleanup: %v", err)
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -442,6 +442,78 @@ func TestCleanupOrphaned_PreservesDeletedTaskAttemptWithLiveAgent(t *testing.T) 
 	}
 }
 
+func TestCleanupOrphaned_ReapsTerminalTaskAttemptWithStaleInflightRecord(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+	tk, err := store.Create("terminal best of n task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf := &workflow.Execution{BestOfNInflight: map[string]*workflow.BestOfNInflight{
+		"attempts": {
+			ParentStepID: "attempts",
+			Attempts: map[string]*workflow.AttemptStatus{
+				"attempt_1": {AttemptID: "attempt_1", Status: "completed"},
+			},
+		},
+	}}
+	done := task.StatusDone
+	if _, err := store.Update(tk.ID, task.Update{Workflow: &wf, Status: &done}); err != nil {
+		t.Fatal(err)
+	}
+	attemptDir := filepath.Join(dir, attemptDirName(tk, "attempt_1"))
+	makePushedGitDir(t, attemptDir)
+
+	m := New(Config{WorktreesDir: dir, Tasks: taskMgr, Logger: discardLogger()})
+	m.CleanupOrphaned(context.Background())
+
+	if _, err := os.Stat(attemptDir); !os.IsNotExist(err) {
+		t.Fatalf("terminal task's stale attempt still exists after cleanup: %v", err)
+	}
+}
+
+func TestCleanupOrphaned_PreservesInflightAttemptAfterSlugChange(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+	tk, err := store.Create("old slug", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attemptDir := filepath.Join(dir, attemptDirName(tk, "attempt_1"))
+	wf := &workflow.Execution{BestOfNInflight: map[string]*workflow.BestOfNInflight{
+		"attempts": {
+			ParentStepID: "attempts",
+			Attempts: map[string]*workflow.AttemptStatus{
+				"attempt_1": {AttemptID: "attempt_1", Dir: attemptDir, Status: "pending"},
+			},
+		},
+	}}
+	newSlug := "new-slug"
+	if _, err := store.Update(tk.ID, task.Update{Workflow: &wf, Slug: &newSlug}); err != nil {
+		t.Fatal(err)
+	}
+	makePushedGitDir(t, attemptDir)
+
+	m := New(Config{WorktreesDir: dir, Tasks: taskMgr, Logger: discardLogger()})
+	m.CleanupOrphaned(context.Background())
+
+	if _, err := os.Stat(attemptDir); err != nil {
+		t.Fatalf("renamed task's in-flight attempt removed unexpectedly: %v", err)
+	}
+}
+
 // TestManager_HasUnpushedCommits proves the resolver sandbox cleanup relies
 // on (#2593): it locates taskID's own worktree by ID and reports whether it
 // holds commits not on origin, and fails safe (false — nothing to protect)


### PR DESCRIPTION
## Motivation

The periodic orphan sweep treated best-of-N attempt directories as deleted-task worktrees, allowing it to remove live fan-out checkouts before judging and promotion.

## Implementation information

Classify attempt directories by their immutable task ID and persisted best-of-N ownership. Live agents and non-terminal inflight records protect attempts across registration gaps and slug changes, while terminal, deleted, and finished-fan-out attempts remain eligible for cleanup. Regression coverage exercises inflight, deleted, terminal, renamed, and eventual-cleanup states.

## Validation

- `go test -race ./internal/worktree -run "TestCleanupOrphaned|TestTaskIDFromWorktreeDir" -count=1 -v`
- `go test -tags e2e -timeout 90s ./internal/sybra -run "^TestE2E_BestOfN_PromotesWinnerCleansUpLosers$" -count=1 -v`
- `golangci-lint run ./internal/worktree/...`

Closes #3149

> Changelog: fix(worktree): preserve live best-of-N attempts during orphan cleanup