### PR TITLE
refactor(workflow): inject clock into timing decisions

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/clock"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/fsutil"
@@ -468,7 +469,7 @@ type Engine struct {
 	dispatchDisabled atomic.Bool
 	ownerID          string
 	effectLeaseTTL   time.Duration
-	now              func() time.Time
+	clock            clock.Clock
 	logger           *slog.Logger
 	ctx              context.Context
 	drainCtx         context.Context
@@ -585,7 +586,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		agents:           agents,
 		ownerID:          newEffectOwnerID(),
 		effectLeaseTTL:   defaultEffectLeaseTTL,
-		now:              func() time.Time { return time.Now().UTC() },
+		clock:            clock.System{},
 		logger:           logger,
 		ctx:              context.Background(),
 		dispatching:      make(map[string]struct{}),
@@ -608,6 +609,12 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 func newEffectOwnerID() string {
 	return fmt.Sprintf("workflow-engine-%d-%d", time.Now().UTC().UnixNano(), effectOwnerSeq.Add(1))
 }
+
+// SetClock binds the clock used by workflow control-flow decisions. Record
+// timestamps that do not influence control flow continue to use time.Now.
+func (e *Engine) SetClock(c clock.Clock) { e.clock = clock.Or(c) }
+
+func (e *Engine) now() time.Time { return clock.Or(e.clock).Now().UTC() }
 
 // SetContext binds a parent context to the engine. Shell steps use
 // context.WithTimeout(parent, shellTimeout) so they are cancelled when

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -469,6 +469,7 @@ type Engine struct {
 	dispatchDisabled atomic.Bool
 	ownerID          string
 	effectLeaseTTL   time.Duration
+	clockMu          sync.RWMutex
 	clock            clock.Clock
 	logger           *slog.Logger
 	ctx              context.Context
@@ -610,11 +611,21 @@ func newEffectOwnerID() string {
 	return fmt.Sprintf("workflow-engine-%d-%d", time.Now().UTC().UnixNano(), effectOwnerSeq.Add(1))
 }
 
-// SetClock binds the clock used by workflow control-flow decisions. Record
-// timestamps that do not influence control flow continue to use time.Now.
-func (e *Engine) SetClock(c clock.Clock) { e.clock = clock.Or(c) }
+// SetClock binds the clock used by workflow control-flow decisions. It is safe
+// to replace while the engine is running. Record timestamps that do not
+// influence control flow continue to use time.Now.
+func (e *Engine) SetClock(c clock.Clock) {
+	e.clockMu.Lock()
+	e.clock = clock.Or(c)
+	e.clockMu.Unlock()
+}
 
-func (e *Engine) now() time.Time { return clock.Or(e.clock).Now().UTC() }
+func (e *Engine) now() time.Time {
+	e.clockMu.RLock()
+	c := e.clock
+	e.clockMu.RUnlock()
+	return clock.Or(c).Now().UTC()
+}
 
 // SetContext binds a parent context to the engine. Shell steps use
 // context.WithTimeout(parent, shellTimeout) so they are cancelled when

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -877,7 +877,7 @@ func (e *Engine) reviewBudgetExhaustion(t TaskInfo) (hourly, lifetime bool) {
 	for i := range t.AgentRuns {
 		runs[i] = reviewbudget.Run{Role: t.AgentRuns[i].Role, StartedAt: t.AgentRuns[i].StartedAt}
 	}
-	now := time.Now()
+	now := e.now()
 	return budget.HourlyExceeded(runs, now), budget.LifetimeExceeded(runs)
 }
 

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -132,7 +132,7 @@ func (e *Engine) startWorkflowCore(taskID, workflowID, startStepID string, vars 
 		CurrentStep: start.ID,
 		State:       ExecRunning,
 		Variables:   variables,
-		StartedAt:   time.Now().UTC(),
+		StartedAt:   e.now(),
 	}
 
 	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {

--- a/internal/workflow/engine_events_resume.go
+++ b/internal/workflow/engine_events_resume.go
@@ -256,7 +256,7 @@ func (e *Engine) resumeStalledTask(t *TaskInfo) {
 }
 
 func (e *Engine) resumePreflightConsumesTick(t *TaskInfo, step *Step, logEvent string) bool {
-	if retryAt, ok := workflowRetryAfter(t.Workflow); ok && time.Now().Before(retryAt) {
+	if retryAt, ok := workflowRetryAfter(t.Workflow); ok && e.now().Before(retryAt) {
 		retryAtStr := retryAt.Format(time.RFC3339)
 		e.resumeSkip.Log(e.logger, logEvent, t.ID,
 			"retry_after|"+step.ID+"|"+retryAtStr,

--- a/internal/workflow/engine_events_startfail.go
+++ b/internal/workflow/engine_events_startfail.go
@@ -147,7 +147,7 @@ func (e *Engine) surfaceStartFailureClassified(taskID string, currentStatus task
 	// surface a status_reason (unlike the fully-silent transient sentinels)
 	// but must never accumulate toward the breaker.
 	if wf != nil && stepID != "" && !isTransientCapacityError(err) && !isDeferredNotFailed(err) {
-		attempts, trip := recordCircuitBreakerFailure(wf, stepID, time.Now())
+		attempts, trip := recordCircuitBreakerFailure(wf, stepID, e.now())
 		if trip {
 			// The status skip in resumeSkipReasonForStatus alone is not a
 			// sufficient backstop against a flapping loop: it only stops

--- a/internal/workflow/engine_events_watchdog.go
+++ b/internal/workflow/engine_events_watchdog.go
@@ -432,7 +432,7 @@ func (e *Engine) watchdogRateLimitRecoverySpec() watchdogRecoverySpec {
 				retryKey := watchdogRateLimitRetryKey(step.ID)
 				freshKey := watchdogZeroOutputFreshRetryKey(step.ID)
 				if watchdogreason.IsSilentHang(t.StatusReason) && parseWorkflowInt(t.Workflow.Variables[freshKey]) == 0 {
-					t.Workflow.StartedAt = time.Now().UTC()
+					t.Workflow.StartedAt = e.now()
 					t.Workflow.SetVar(freshKey, "1")
 					t.Workflow.SetVar(retryKey, "0")
 					if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
@@ -445,7 +445,7 @@ func (e *Engine) watchdogRateLimitRecoverySpec() watchdogRecoverySpec {
 				targetStatus, reason, terminalState := watchdogRateLimitExhaustionResolution(*t, step, attempts)
 				t.Workflow.State = terminalState
 				if watchdogreason.IsSilentHang(t.StatusReason) {
-					t.Workflow.StartedAt = time.Now().UTC()
+					t.Workflow.StartedAt = e.now()
 				}
 				if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
 					e.logger.Error("workflow.watchdog-rate-limit.persist", "task_id", t.ID, "step", step.ID, "err", err)

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -240,7 +240,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 func (e *Engine) parkStepForRetry(taskID string, wfExec *Execution, t TaskInfo, stepID, statusReason, logEvent string, logAttrs ...any) (StepOutput, error) {
 	wfExec.CurrentStep = stepID
 	wfExec.State = ExecWaiting
-	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
+	wfExec.SetVar(workflowRetryAfterVar, e.now().Add(prCreateRetryBackoff).Format(time.RFC3339))
 	if err := e.tasks.SetStatusAndWorkflow(taskID, string(t.Status), statusReason, wfExec); err != nil {
 		return StepOutput{}, err
 	}
@@ -275,7 +275,7 @@ func (e *Engine) maybeParkImplementGitHubRetry(taskID string, step *Step, wfExec
 	wfExec.CurrentStep = step.ID
 	wfExec.State = ExecWaiting
 	wfExec.SetVar(implementPushAttemptsVar, strconv.Itoa(attempts+1))
-	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
+	wfExec.SetVar(workflowRetryAfterVar, e.now().Add(prCreateRetryBackoff).Format(time.RFC3339))
 	if err := e.tasks.SetStatusAndWorkflow(taskID, "in-progress", implementPushRetryStatusReason, wfExec); err != nil {
 		return false, err
 	}

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -527,7 +527,7 @@ func (e *Engine) rearmNoCommitAuthorRun(taskID string, wfExec *Execution, t Task
 	}
 	wfExec.SetVar(counterKey, "1")
 	wfExec.SetVar(verifyReaskNoteVar, noCommitReaskNote(run))
-	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(verifyChecksAutoFixBackoff).Format(time.RFC3339))
+	wfExec.SetVar(workflowRetryAfterVar, e.now().Add(verifyChecksAutoFixBackoff).Format(time.RFC3339))
 	wfExec.ClearStepRecords(stepID)
 	wfExec.CurrentStep = stepID
 	wfExec.State = ExecWaiting

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -301,7 +301,7 @@ func (e *Engine) acquireVerifyChecksSlot(slot chan struct{}) (release func(), ok
 func (e *Engine) parkVerifyChecksForBackpressure(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
 	wfExec.CurrentStep = step.ID
 	wfExec.State = ExecWaiting
-	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(verifyChecksBackoff).Format(time.RFC3339))
+	wfExec.SetVar(workflowRetryAfterVar, e.now().Add(verifyChecksBackoff).Format(time.RFC3339))
 	if err := e.tasks.SetStatusAndWorkflow(taskID, string(t.Status), verifyChecksBusyReason, wfExec); err != nil {
 		return StepOutput{}, err
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -5796,7 +5796,7 @@ func TestResumeStalled_SkipsWorkflowRetryUntil(t *testing.T) {
 		t.Fatalf("agent starts before retry window = %d, want 0", agents.CallCount())
 	}
 
-	fakeClock.Advance(time.Hour)
+	fakeClock.Advance(time.Hour + time.Second)
 	tasks.Put(TaskInfo{
 		ID:        "t1",
 		Status:    "in-progress",
@@ -5808,6 +5808,38 @@ func TestResumeStalled_SkipsWorkflowRetryUntil(t *testing.T) {
 	if agents.CallCount() != 1 {
 		t.Fatalf("agent starts after retry window = %d, want 1", agents.CallCount())
 	}
+}
+
+func TestEngineClockCanBeReplacedWhileRunning(t *testing.T) {
+	t.Parallel()
+
+	e := &Engine{}
+	first := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
+	second := clock.NewFake(first.Now().Add(time.Hour))
+	var wg sync.WaitGroup
+	wg.Add(5)
+	go func() {
+		defer wg.Done()
+		for i := range 1_000 {
+			if i%2 == 0 {
+				e.SetClock(first)
+			} else {
+				e.SetClock(second)
+			}
+		}
+	}()
+	for range 4 {
+		go func() {
+			defer wg.Done()
+			for range 1_000 {
+				if got := e.now(); got.IsZero() {
+					t.Error("now returned the zero time during concurrent clock replacement")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // TestResumeStalled_SkipLogsPromotedToThrottledInfo proves ResumeStalled's

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/attribution"
 	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/clock"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/dispatchorder"
 	"github.com/Automaat/sybra/internal/metrics"
@@ -5772,13 +5773,15 @@ func TestResumeStalled_SkipsWorkflowRetryUntil(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	engine := NewEngine(store, tasks, agents, discardLogger())
+	fakeClock := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
+	engine.SetClock(fakeClock)
 
 	wf := &Execution{
 		WorkflowID:  "test-simple",
 		CurrentStep: "implement",
 		State:       ExecWaiting,
 		Variables: map[string]string{
-			workflowRetryAfterVar: time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+			workflowRetryAfterVar: fakeClock.Now().Add(time.Hour).Format(time.RFC3339),
 		},
 	}
 	tasks.Put(TaskInfo{
@@ -5793,7 +5796,7 @@ func TestResumeStalled_SkipsWorkflowRetryUntil(t *testing.T) {
 		t.Fatalf("agent starts before retry window = %d, want 0", agents.CallCount())
 	}
 
-	wf.Variables[workflowRetryAfterVar] = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	fakeClock.Advance(time.Hour)
 	tasks.Put(TaskInfo{
 		ID:        "t1",
 		Status:    "in-progress",

--- a/internal/workflow/rewind_retry.go
+++ b/internal/workflow/rewind_retry.go
@@ -110,7 +110,7 @@ func (e *Engine) rewindRetry(taskID string, wfExec *Execution, t TaskInfo, p rew
 		wfExec.SetVar(fpKey, p.fingerprint)
 		wfExec.SetVar(fpCountKey, strconv.Itoa(count))
 	}
-	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(p.backoff(attempts)).Format(time.RFC3339))
+	wfExec.SetVar(workflowRetryAfterVar, e.now().Add(p.backoff(attempts)).Format(time.RFC3339))
 	if p.onArm != nil {
 		p.onArm(wfExec, attempt)
 	}

--- a/internal/workflow/rewind_retry_test.go
+++ b/internal/workflow/rewind_retry_test.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/clock"
 )
 
 // TestRewindRetry_PolicyMatrix exercises rewindRetry's shared shape in
@@ -28,6 +30,8 @@ func TestRewindRetry_PolicyMatrix(t *testing.T) {
 	t.Run("under cap arms and rewinds", func(t *testing.T) {
 		tasks := newMemTasks()
 		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		fakeClock := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
+		engine.SetClock(fakeClock)
 		wf := newExec("")
 		ti := TaskInfo{ID: "t1", Status: "in-progress", Workflow: wf}
 		tasks.Put(ti)
@@ -65,6 +69,9 @@ func TestRewindRetry_PolicyMatrix(t *testing.T) {
 		}
 		if wf.Variables[workflowRetryAfterVar] == "" {
 			t.Fatal("retry-after not set")
+		}
+		if got, ok := workflowRetryAfter(wf); !ok || !got.Equal(fakeClock.Now().Add(time.Minute)) {
+			t.Fatalf("retry-after = %v, %t; want %v from injected clock", got, ok, fakeClock.Now().Add(time.Minute))
 		}
 		if wf.CurrentStep != "implement" {
 			t.Fatalf("CurrentStep = %q, want implement", wf.CurrentStep)

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/clock"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/worktreeerr"
@@ -607,9 +608,11 @@ func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	fakeClock := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
+	engine.SetClock(fakeClock)
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
-	old := time.Now().Add(-2 * circuitBreakerWindow).Format(time.RFC3339)
+	old := fakeClock.Now().Format(time.RFC3339)
 	wf := &Execution{
 		CurrentStep: "run_test",
 		State:       ExecRunning,
@@ -619,6 +622,7 @@ func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 		},
 	}
 
+	fakeClock.Advance(2 * circuitBreakerWindow)
 	engine.surfaceStartFailure("t1", "todo", wrapped, wf, "run_test")
 
 	if wf.State == ExecFailed {

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -612,12 +612,12 @@ func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 	engine.SetClock(fakeClock)
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
-	old := fakeClock.Now().Format(time.RFC3339)
+	firstFailureAt := fakeClock.Now().Format(time.RFC3339)
 	wf := &Execution{
 		CurrentStep: "run_test",
 		State:       ExecRunning,
 		Variables: map[string]string{
-			circuitBreakerFirstKey("run_test"):   old,
+			circuitBreakerFirstKey("run_test"):   firstFailureAt,
 			circuitBreakerFailureKey("run_test"): strconv.Itoa(maxCircuitBreakerFailures),
 		},
 	}

--- a/internal/workflow/triage_review_test.go
+++ b/internal/workflow/triage_review_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/clock"
 	"github.com/Automaat/sybra/internal/config"
 )
 
@@ -1240,8 +1241,10 @@ func TestEngineReviewBudgetExceededTransition(t *testing.T) {
 	e := &Engine{logger: slog.New(slog.DiscardHandler), tasks: mt}
 	e.SetReviewUntilClean(true)
 	e.SetReviewRoundsPerHour(2)
+	fakeClock := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
+	e.SetClock(fakeClock)
 
-	now := time.Now()
+	now := fakeClock.Now()
 	task := TaskInfo{
 		ID:     "t1",
 		Status: "testing",
@@ -1256,6 +1259,15 @@ func TestEngineReviewBudgetExceededTransition(t *testing.T) {
 	}
 	if next == nil || next.ID != "park" {
 		t.Fatalf("resolveNext routed to %v, want park", next)
+	}
+
+	fakeClock.Advance(time.Hour)
+	next, _, err = e.resolveNext("t1", def, &def.Steps[0], &Execution{Variables: map[string]string{}}, task)
+	if err != nil {
+		t.Fatalf("resolveNext after advancing clock: %v", err)
+	}
+	if next == nil || next.ID != "loop" {
+		t.Fatalf("resolveNext after advancing clock routed to %v, want loop", next)
 	}
 }
 


### PR DESCRIPTION
Closes #3142

## Summary
- bind the shared injectable clock to workflow-engine control-flow decisions
- route retry deadlines, resume gates, circuit-breaker windows, review budgets, and watchdog/session starts through it
- keep pure record, completion, evidence, and identity timestamps on wall time
- convert retry, backoff, staleness, and park-window tests to advance a fake clock

## Verification
- `go test -race ./internal/workflow`
- `go test -race ./...`
- `mise exec -- golangci-lint run ./...`
- `mise run verify` passed every gate through frontend coverage/API sync; local repository-hygiene stopped only on pre-existing tracked `.claude/skills` files matched by this worktree's `.git/info/exclude` (branch does not modify them)
- independent adversarial review: CLEAN
- independent real-server adversarial test: PASS (`/health`, authenticated task listing, 20x race boundary probes)