### PR TITLE
fix(agent): isolate judge working dir

### DIFF
--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -1077,6 +1077,9 @@ func (m *Manager) resolveSandboxReadRoots(cfg *RunConfig) []string {
 		}
 	}
 	add(cfg.sandbox.readOnlyDir)
+	for _, p := range cfg.ReadOnlyPaths {
+		add(p)
+	}
 	if cfg.Role == RoleMonitor {
 		add(config.HomeDir())
 	}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1963,7 +1963,10 @@ type RunConfig struct {
 	// source checkout when the task has no worktree of its own) so a live
 	// deploy/build checkout can never be written to by that run. Ignored
 	// outside sandbox enforce mode.
-	ReadOnlyDir        bool
+	ReadOnlyDir bool
+	// ReadOnlyPaths are explicit additional inspection roots for a read-only
+	// role (for example, the candidate worktrees a best-of-N judge compares).
+	ReadOnlyPaths      []string
 	Provider           string // "claude", "codex", or "copilot"
 	Model              string // requested model: tier alias or full provider model ID
 	ExperimentID       string

--- a/internal/agent/procsandbox_read_test.go
+++ b/internal/agent/procsandbox_read_test.go
@@ -108,6 +108,15 @@ func TestResolveSandboxReadRoots_GrantsReadOnlyDir(t *testing.T) {
 	}
 }
 
+func TestResolveSandboxReadRoots_GrantsExplicitReadOnlyPaths(t *testing.T) {
+	m := newReadModeManager("enforce")
+	attempt := t.TempDir()
+	cfg := &RunConfig{Role: RoleReview, ReadOnlyPaths: []string{attempt}, sandbox: specWithWriteRoots(t)}
+	if !slices.Contains(m.resolveSandboxReadRoots(cfg), attempt) {
+		t.Fatalf("explicit attempt root %q was not granted", attempt)
+	}
+}
+
 func TestApplySandboxReadMode_PostureGatesRestriction(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/blocker"
-	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/experience"
 	"github.com/Automaat/sybra/internal/pressure"
@@ -1020,7 +1019,8 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		// Verifier roles judge a worktree they must not alter. Enforced at the
 		// OS level rather than through the tool allowlist, which cannot express
 		// it — Bash reaches the same files (#2791).
-		ReadOnlyDir: r.JudgesWithoutWriting(),
+		ReadOnlyDir:   r.JudgesWithoutWriting(),
+		ReadOnlyPaths: assignment.ReadOnlyPaths,
 		// fork_subagent is a task-level opt-in, but must never reach a
 		// verifier role (review/test-runner/eval) — a forked subagent's own
 		// token spend would multiply on every independent check, and a
@@ -1043,12 +1043,16 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		}
 	}
 	if cfg.Dir == "" {
-		// System-role fallback (triage, plan, eval, …): no worktree required,
-		// but the agent process still needs an existing cwd. Use the sybra
-		// home dir rather than letting the process inherit Sybra's own cwd
-		// (which in dev mode would be the sybra source repo — the bug that
-		// caused branch changes on main).
-		cfg.Dir = config.HomeDir()
+		// A direct-dispatch role (notably a best-of-N judge) may deliberately
+		// have no worktree: it reads the candidate worktrees by absolute path.
+		// Give it an isolated temporary cwd rather than the operator's Sybra
+		// home. Besides keeping relative writes away from the board, this is a
+		// distinct ReadOnlyDir under enforce mode, so the sandbox can re-bind it
+		// read-only without also re-binding all of os.TempDir read-only.
+		cfg.Dir, err = fallbackAgentWorkingDir()
+		if err != nil {
+			return "", "", "", err
+		}
 	}
 
 	baselineRef = agentorch.CurrentWorktreeHead(context.Background(), cfg.Dir)
@@ -1064,6 +1068,21 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	}
 
 	return ag.ID, cfg.Dir, baselineRef, nil
+}
+
+// fallbackAgentWorkingDir creates an otherwise empty, per-run cwd for a
+// direct-dispatch agent that intentionally has no task worktree. It must be a
+// child of the OS temp directory rather than os.TempDir itself: read-only
+// judge runs re-bind their cwd after the sandbox's broad tmp write root, and
+// locking the whole tmp root would break provider scratch files. The OS temp
+// cleaner reclaims these directories if a stopped/crashed process leaves one
+// behind.
+func fallbackAgentWorkingDir() (string, error) {
+	dir, err := os.MkdirTemp("", "sybra-agent-cwd-")
+	if err != nil {
+		return "", fmt.Errorf("create fallback agent working directory: %w", err)
+	}
+	return dir, nil
 }
 
 // ensureWorktreeDir resolves the cwd a direct-dispatch agent should run in.

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -452,6 +452,32 @@ func TestAgentAdapterStartAgentSystemRoleHonorsDispatchClaim(t *testing.T) {
 	}
 }
 
+// TestFallbackAgentWorkingDir pins the no-worktree dispatch path used by the
+// best-of-N judge. A judge intentionally reads candidate worktrees by their
+// absolute paths, so it must not be given a task worktree merely to obtain a
+// cwd; in particular it must never fall back to the operator's Sybra home.
+func TestFallbackAgentWorkingDir(t *testing.T) {
+	dir, err := fallbackAgentWorkingDir()
+	if err != nil {
+		t.Fatalf("fallbackAgentWorkingDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat fallback cwd: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("fallback cwd %q is not a directory", dir)
+	}
+	if dir == config.HomeDir() {
+		t.Fatalf("fallback cwd = Sybra home %q", dir)
+	}
+	if filepath.Clean(filepath.Dir(dir)) != filepath.Clean(os.TempDir()) {
+		t.Fatalf("fallback cwd parent = %q, want OS temp directory %q", filepath.Dir(dir), os.TempDir())
+	}
+}
+
 // conflictRecoveryHarness bundles the real-git fixture used to drive a
 // direct-dispatch StartAgent into a rebase-blocked worktree-prep error and its
 // synchronous conflict-recovery callback.

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -110,6 +110,9 @@ type AgentAssignment struct {
 	ReasoningEffort string
 	PromptTransform *PromptTransform
 	SkillAliases    map[string]string
+	// ReadOnlyPaths are additional paths a diagnostic agent may inspect under
+	// the deny-by-default sandbox read posture. They never grant write access.
+	ReadOnlyPaths []string
 	// ForceInjectedSkill forces provider prep to inject the resolved skill
 	// instructions instead of relying on native visibility. Used by the
 	// automatic retry after a missing mandatory-skill receipt.

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -434,16 +434,26 @@ func bestOfNAttemptReadRoots(wfExec *Execution) []string {
 		return nil
 	}
 	var roots []string
+	seen := make(map[string]struct{})
 	for _, parent := range wfExec.BestOfNInflight {
 		if parent == nil {
 			continue
 		}
 		for _, attempt := range parent.Attempts {
-			if attempt != nil && attempt.Status == "completed" && strings.TrimSpace(attempt.Dir) != "" {
-				roots = append(roots, attempt.Dir)
+			if attempt == nil || attempt.Status != "completed" {
+				continue
+			}
+			dir := strings.TrimSpace(attempt.Dir)
+			if dir == "" {
+				continue
+			}
+			if _, ok := seen[dir]; !ok {
+				seen[dir] = struct{}{}
+				roots = append(roots, dir)
 			}
 		}
 	}
+	slices.Sort(roots)
 	return roots
 }
 

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -365,6 +365,9 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		return err
 	}
 	applySkillReceiptRecoveryAssignment(step.ID, wfExec, &assignment)
+	if step.Config.Role == "review" && wfExec.Variables["bestofn.attempts.manifest"] != "" {
+		assignment.ReadOnlyPaths = bestOfNAttemptReadRoots(wfExec)
+	}
 
 	prompt, err := e.renderAssignedPrompt(taskID, step, ctx, assignment, "workflow.consume-steer")
 	if err != nil {
@@ -424,6 +427,24 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	}
 	agentStarted = true
 	return e.persistStartedAgent(taskID, step, wfExec, agentID, provider, startedDir, baselineRef, cleanRetryKey, cleanRetryRef, dir)
+}
+
+func bestOfNAttemptReadRoots(wfExec *Execution) []string {
+	if wfExec == nil {
+		return nil
+	}
+	var roots []string
+	for _, parent := range wfExec.BestOfNInflight {
+		if parent == nil {
+			continue
+		}
+		for _, attempt := range parent.Attempts {
+			if attempt != nil && attempt.Status == "completed" && strings.TrimSpace(attempt.Dir) != "" {
+				roots = append(roots, attempt.Dir)
+			}
+		}
+	}
+	return roots
 }
 
 func resolveRunAgentMode(mode string, ctx TemplateContext) string {

--- a/internal/workflow/engine_steps_bestofn_judge_test.go
+++ b/internal/workflow/engine_steps_bestofn_judge_test.go
@@ -8,12 +8,14 @@ import (
 func TestBestOfNAttemptReadRoots_CompletedOnly(t *testing.T) {
 	wf := &Execution{BestOfNInflight: map[string]*BestOfNInflight{
 		"attempts": {Attempts: map[string]*AttemptStatus{
-			"a1": {Status: "completed", Dir: "/tmp/attempt-a1"},
+			"a1": {Status: "completed", Dir: " /tmp/attempt-a1 "},
 			"a2": {Status: "pending", Dir: "/tmp/attempt-a2"},
-			"a3": {Status: "completed"},
+			"a3": {Status: "completed", Dir: "/tmp/attempt-b"},
+			"a4": {Status: "completed", Dir: "/tmp/attempt-a1"},
+			"a5": {Status: "completed"},
 		}},
 	}}
-	if got := bestOfNAttemptReadRoots(wf); !slices.Equal(got, []string{"/tmp/attempt-a1"}) {
+	if got := bestOfNAttemptReadRoots(wf); !slices.Equal(got, []string{"/tmp/attempt-a1", "/tmp/attempt-b"}) {
 		t.Fatalf("bestOfNAttemptReadRoots() = %v", got)
 	}
 }

--- a/internal/workflow/engine_steps_bestofn_judge_test.go
+++ b/internal/workflow/engine_steps_bestofn_judge_test.go
@@ -1,6 +1,22 @@
 package workflow
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
+
+func TestBestOfNAttemptReadRoots_CompletedOnly(t *testing.T) {
+	wf := &Execution{BestOfNInflight: map[string]*BestOfNInflight{
+		"attempts": {Attempts: map[string]*AttemptStatus{
+			"a1": {Status: "completed", Dir: "/tmp/attempt-a1"},
+			"a2": {Status: "pending", Dir: "/tmp/attempt-a2"},
+			"a3": {Status: "completed"},
+		}},
+	}}
+	if got := bestOfNAttemptReadRoots(wf); !slices.Equal(got, []string{"/tmp/attempt-a1"}) {
+		t.Fatalf("bestOfNAttemptReadRoots() = %v", got)
+	}
+}
 
 // The judge parser used to scan from the first `{` to the last `}` with no
 // string-literal tracking, so a brace inside a rationale — which is prose the


### PR DESCRIPTION
## Motivation

Best-of-N judges previously fell back to the Sybra home as their working directory, placing the operator board in their immediate write path.

## Implementation information

Direct no-worktree agents now receive an isolated temporary cwd. Best-of-N judges additionally receive only completed attempt worktrees as read-only sandbox roots, preserving absolute-path inspection with the deny-by-default read posture enabled.

Closes #3150

> Changelog: fix(agent): isolate judge working dir