### PR TITLE
refactor(workflow): require grouped engine dependencies

### DIFF
--- a/internal/sybra/app_dispatch_gate_test.go
+++ b/internal/sybra/app_dispatch_gate_test.go
@@ -23,7 +23,7 @@ import (
 func TestDispatchTaskCreatedWorkflow_RefusesDuringStartupRecovery(t *testing.T) {
 	app := setupApp(t)
 	launcher := &recordingAgentLauncher{}
-	app.workflowEngine = workflow.NewEngine(
+	app.workflowEngine = workflow.NewTestEngine(
 		mustWorkflowStoreWithTestSimple(t, t.TempDir()),
 		&taskAdapter{tasks: app.tasks},
 		launcher,
@@ -91,7 +91,7 @@ steps:
 		t.Fatal(err)
 	}
 
-	engine := workflow.NewEngine(wfStore, &taskAdapter{tasks: taskMgr}, &recordingAgentLauncher{}, discardLogger())
+	engine := workflow.NewTestEngine(wfStore, &taskAdapter{tasks: taskMgr}, &recordingAgentLauncher{}, discardLogger())
 	app := &App{tasks: taskMgr, workflowEngine: engine, logger: discardLogger()}
 
 	app.startupRecoveryPending.Store(true)
@@ -136,7 +136,7 @@ func TestStatusHook_WaitForStatus_RefusesDuringStartupRecovery(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(wfDir, "test-status-hook.yaml"), []byte(waitForStatusWorkflowYAML), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: app.tasks},
 		&agentAdapter{agents: app.agents, agentOrch: app.agentOrch, tasks: app.tasks},
@@ -229,7 +229,7 @@ func TestReplayDeferredStatusChanges_UsesCurrentStatus(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(wfDir, "test-status-hook.yaml"), []byte(waitForStatusWorkflowYAML), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	app.workflowEngine = workflow.NewEngine(
+	app.workflowEngine = workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: app.tasks},
 		&agentAdapter{agents: app.agents, agentOrch: app.agentOrch, tasks: app.tasks},
@@ -289,7 +289,7 @@ func TestReplayDeferredStatusChanges_DispatchesHumanReview(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app.workflowEngine = workflow.NewEngine(
+	app.workflowEngine = workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: app.tasks},
 		&agentAdapter{agents: app.agents, agentOrch: app.agentOrch, tasks: app.tasks},

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1301,21 +1301,19 @@ func (a *App) initWorkflowEngine() {
 		a.logger.Error("workflow.sync-builtins", "err", syncErr)
 	}
 	agentLauncher := a.newWorkflowAgentLauncher()
-	a.workflowEngine = workflow.NewEngine(
+	if a.sandboxes == nil {
+		panic("wire workflow engine: sandbox manager is nil")
+	}
+	a.workflowEngine, err = workflow.NewEngine(
 		wfStore,
 		&taskAdapter{tasks: a.tasks, projects: a.projects},
 		agentLauncher,
 		a.logger,
+		a.workflowDependencies(agentLauncher),
 	)
-	a.wirePRSurface()
-	a.workflowEngine.SetTaskClassifier(a.newTaskClassifierAdapter())
-	a.wireWorktreeAccess()
-	a.workflowEngine.SetAttemptNoteAppender(&attemptNoteAppenderAdapter{})
-	a.workflowEngine.SetBranchSyncer(&branchSyncerAdapter{tasks: a.tasks, mgr: a.worktrees})
-	a.workflowEngine.SetCheckConfigGetter(&checkConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
-	a.workflowEngine.SetCostBudgetChecker(agentLauncher)
-	a.workflowEngine.SetAttemptWorktreeManager(&attemptWorktreeAdapter{tasks: a.tasks, mgr: a.worktrees})
-	a.workflowEngine.SetManualTestConfigGetter(&manualTestConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
+	if err != nil {
+		panic("wire workflow engine: " + err.Error())
+	}
 	a.configureWorkflowPolicies()
 	if a.cfg.Evaluation.Offline.Enabled {
 		gate := prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline)
@@ -1398,6 +1396,34 @@ func (a *App) initWorkflowEngine() {
 	}
 	// Workflow completion moves to wireServices so the callback closure binds
 	// to the completion.Handler constructed there.
+}
+
+func (a *App) workflowDependencies(agentLauncher *agentAdapter) workflow.Dependencies {
+	return workflow.Dependencies{
+		PR: workflow.PRSurface{
+			Linker:           workflowpr.LinkerAdapter{},
+			ReviewRequester:  workflowpr.ReviewRequesterAdapter{},
+			StateFetcher:     workflowpr.StateFetcherAdapter{},
+			HeadFetcher:      workflowpr.HeadFetcherAdapter{},
+			Creator:          workflowpr.CreatorAdapter{},
+			Closer:           workflowpr.CloserAdapter{},
+			Finder:           workflowpr.FinderAdapter{},
+			AnyStateFinder:   workflowpr.FinderAdapter{},
+			ExistenceChecker: workflowpr.ExistenceCheckerAdapter{},
+			ContentGenerator: workflowpr.ContentGeneratorAdapter{Gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}},
+		},
+		Execution: workflow.ExecutionSurface{
+			Worktrees:        &worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees},
+			SidecarDir:       a.sandboxes.SybraHomeDir,
+			AttemptNotes:     &attemptNoteAppenderAdapter{},
+			BranchSyncer:     &branchSyncerAdapter{tasks: a.tasks, mgr: a.worktrees},
+			Checks:           &checkConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees},
+			ManualTests:      &manualTestConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees},
+			Classifier:       a.newTaskClassifierAdapter(),
+			CostBudget:       agentLauncher,
+			AttemptWorktrees: &attemptWorktreeAdapter{tasks: a.tasks, mgr: a.worktrees},
+		},
+	}
 }
 
 func (a *App) configureWorkflowPolicies() {
@@ -1667,49 +1693,4 @@ func (a *App) syncSkillsBundle(signing project.SigningPolicy) {
 		UserHomeDir:          userHome,
 		DowngradeCommitFlags: !signing.SignsCommits(context.Background()),
 	})
-}
-
-// wireWorktreeAccess gives the engine both halves of a task's filesystem: the
-// worktree it operates in, and the writable scratch dir used when that
-// worktree is read-only.
-func (a *App) wireWorktreeAccess() {
-	if a == nil || a.workflowEngine == nil {
-		return
-	}
-	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
-	a.wireSidecarDir()
-}
-
-// wireSidecarDir points workflow scratch output at the per-task sandbox home.
-// Verifier roles run against a read-only worktree, so their own output has to
-// land somewhere still writable; that home is already an allowed write root
-// under the OS sandbox, so this needs no new hole.
-func (a *App) wireSidecarDir() {
-	if a == nil || a.workflowEngine == nil || a.sandboxes == nil {
-		return
-	}
-	a.workflowEngine.SetSidecarDirResolver(a.sandboxes.SybraHomeDir)
-}
-
-// wirePRSurface wires the engine's pull-request dependency group. Split out of
-// initWorkflowEngine both to keep that function within the length gate and
-// because the group is the unit that must stay complete.
-func (a *App) wirePRSurface() {
-	if err := a.workflowEngine.SetPRSurface(workflow.PRSurface{
-		Linker:           workflowpr.LinkerAdapter{},
-		ReviewRequester:  workflowpr.ReviewRequesterAdapter{},
-		StateFetcher:     workflowpr.StateFetcherAdapter{},
-		HeadFetcher:      workflowpr.HeadFetcherAdapter{},
-		Creator:          workflowpr.CreatorAdapter{},
-		Closer:           workflowpr.CloserAdapter{},
-		Finder:           workflowpr.FinderAdapter{},
-		AnyStateFinder:   workflowpr.FinderAdapter{},
-		ExistenceChecker: workflowpr.ExistenceCheckerAdapter{},
-		ContentGenerator: workflowpr.ContentGeneratorAdapter{Gen: &prcontent.FallbackGenerator{Logger: a.logger, Gate: a.providerHealth}},
-	}); err != nil {
-		// Only reachable by forgetting a field here — a programming error, so
-		// fail at boot rather than let a PR step no-op in production. Same
-		// posture as buildPlanSchema's static-marshal panic.
-		panic("wire workflow PR surface: " + err.Error())
-	}
 }

--- a/internal/sybra/app_instance_role_test.go
+++ b/internal/sybra/app_instance_role_test.go
@@ -178,7 +178,7 @@ steps:
 			}
 			ta := &taskAdapter{tasks: a.tasks}
 			aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-			a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+			a.workflowEngine = workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 			a.applyInstanceRole()
 			a.initStatusHook()
 
@@ -246,7 +246,7 @@ steps:
 			}
 			ta := &taskAdapter{tasks: a.tasks}
 			aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-			a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+			a.workflowEngine = workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 			a.applyInstanceRole()
 
 			created, err := a.tasks.Create("todo plan-contract probe", "", "headless")
@@ -325,7 +325,7 @@ steps:
 				}
 				ta := &taskAdapter{tasks: a.tasks}
 				aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-				a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+				a.workflowEngine = workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 				a.applyInstanceRole()
 
 				created, err := a.tasks.Create("dispatch sink probe", "", "headless")

--- a/internal/sybra/app_queue_order_test.go
+++ b/internal/sybra/app_queue_order_test.go
@@ -64,7 +64,7 @@ func TestInitWorkflowEngine_QueueComparatorPrefersQueuedTask(t *testing.T) {
 	}
 	launcher := &recordingAgentLauncher{}
 
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		mustWorkflowStoreWithTestSimple(t, home),
 		&taskAdapter{tasks: taskMgr},
 		launcher,

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -316,7 +316,7 @@ steps:
 		t.Fatal(err)
 	}
 
-	engine := workflow.NewEngine(wfStore, &taskAdapter{tasks: taskMgr}, &recordingAgentLauncher{}, discardLogger())
+	engine := workflow.NewTestEngine(wfStore, &taskAdapter{tasks: taskMgr}, &recordingAgentLauncher{}, discardLogger())
 	app := &App{
 		cfg:            config.DefaultConfig(),
 		workflowEngine: engine,

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -282,7 +282,7 @@ func setupTaskService(t *testing.T) (*TaskService, *App) {
 	}
 	ta := &taskAdapter{tasks: a.tasks}
 	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-	engine := workflow.NewEngine(wfStore, ta, aa, a.logger)
+	engine := workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 	// Bind the test context so a background workflow (spawned by CreateTask)
 	// unwinds when the test ends — otherwise classify_task's retry backoff can
 	// outlive the task dir's cleanup and leak a sleeping goroutine.

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -55,7 +55,7 @@ func TestApp_WatcherStatusHook_AdvancesWorkflow(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(wfDir, "test-status-hook.yaml"), []byte(waitForStatusWorkflowYAML), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: app.tasks},
 		&agentAdapter{agents: app.agents, agentOrch: app.agentOrch, tasks: app.tasks},
@@ -190,7 +190,7 @@ steps:
 		t.Fatal(err)
 	}
 
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: a.tasks},
 		&fakeAgentLauncher{tasks: a.tasks},
@@ -393,7 +393,7 @@ steps:
 
 	ta := &taskAdapter{tasks: a.tasks}
 	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-	a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+	a.workflowEngine = workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 	a.initStatusHook()
 
 	created, err := a.tasks.Create("ready-review dispatch", "", "headless")
@@ -467,7 +467,7 @@ steps:
 
 	ta := &taskAdapter{tasks: a.tasks}
 	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-	a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+	a.workflowEngine = workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 	a.initStatusHook()
 
 	created, err := a.tasks.Create("testing dispatch", "", "headless")
@@ -543,7 +543,7 @@ steps:
 
 	ta := &taskAdapter{tasks: a.tasks}
 	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-	a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+	a.workflowEngine = workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 	a.initStatusHook()
 
 	created, err := a.tasks.Create("ready-pr dispatch", "", "headless")
@@ -621,7 +621,7 @@ steps:
 
 	ta := &taskAdapter{tasks: a.tasks}
 	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
-	a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+	a.workflowEngine = workflow.NewTestEngine(wfStore, ta, aa, a.logger)
 	a.initStatusHook()
 
 	created, err := a.tasks.Create("umbrella tracker", "", "headless")

--- a/internal/sybra/e2e_bestofn_test.go
+++ b/internal/sybra/e2e_bestofn_test.go
@@ -252,7 +252,7 @@ func TestE2E_BestOfN_PromotesWinnerCleansUpLosers(t *testing.T) {
 	awa := &attemptWorktreeAdapter{tasks: taskMgr, mgr: wm}
 	ara := &artifactRecorderAdapter{store: artifactStore}
 
-	engine = workflow.NewEngine(wfStore, ta, aa, logger)
+	engine = workflow.NewTestEngine(wfStore, ta, aa, logger)
 	engine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: taskMgr, mgr: wm})
 	engine.SetAttemptWorktreeManager(awa)
 	engine.SetCostBudgetChecker(aa)

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -389,7 +389,7 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 
 	ta := &taskAdapter{tasks: taskMgr}
 	aa := &agentAdapter{agents: agentMgr, agentOrch: agentOrch, tasks: taskMgr}
-	engine = workflow.NewEngine(wfStore, ta, aa, logger)
+	engine = workflow.NewTestEngine(wfStore, ta, aa, logger)
 	engine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: taskMgr, mgr: wm})
 	classifier := newE2EFakeClassifier()
 	engine.SetTaskClassifier(&taskClassifierAdapter{tasks: taskMgr, classifier: classifier})
@@ -4688,7 +4688,7 @@ func rebuildEngineFromEnv(t *testing.T, env *e2eEnv) *workflow.Engine {
 
 	ta := &taskAdapter{tasks: taskMgr}
 	aa := &agentAdapter{agents: agentMgr, agentOrch: agentOrch, tasks: taskMgr}
-	engine = workflow.NewEngine(env.wfStore, ta, aa, e2eLogger(t))
+	engine = workflow.NewTestEngine(env.wfStore, ta, aa, e2eLogger(t))
 	engine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: taskMgr, mgr: wm})
 	engine.SetPRLinker(nil)
 	if env.classifier != nil {

--- a/internal/sybra/review/automerge_test.go
+++ b/internal/sybra/review/automerge_test.go
@@ -1535,7 +1535,7 @@ func TestHandleTaskPRIssues_ExhaustedRetryParksOnlyWhenNoSiblingHandleable(t *te
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
@@ -1617,7 +1617,7 @@ func TestHandleTaskPRIssues_CancelsStalePlanWorkflowForLinkedPR(t *testing.T) {
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
@@ -1702,7 +1702,7 @@ func TestHandleKnownPRConflictsViaREST_SkipsCommentsWithoutGraphQLThreadData(t *
 			t.Fatal(err)
 		}
 		agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-		engine := workflow.NewEngine(
+		engine := workflow.NewTestEngine(
 			wfStore,
 			&taskAdapter{tasks: tasks},
 			&agentAdapter{agents: agentMgr, tasks: tasks},

--- a/internal/sybra/review/autoresolve_test.go
+++ b/internal/sybra/review/autoresolve_test.go
@@ -117,7 +117,7 @@ func newAutoResolveHarness(t *testing.T, autoResolveEnabled bool) *autoResolveHa
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, filepath.Join(tmp, "logs"))
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},

--- a/internal/sybra/review/ci_failure_dispatch_test.go
+++ b/internal/sybra/review/ci_failure_dispatch_test.go
@@ -47,7 +47,7 @@ func buildPRFixHandler(t *testing.T, tasks *task.Manager, fetchReviewsFn func() 
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},

--- a/internal/sybra/review/coalesce_test.go
+++ b/internal/sybra/review/coalesce_test.go
@@ -121,7 +121,7 @@ func TestDispatchFixIssues_ReviewHoldSetsParkVar(t *testing.T) {
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
@@ -220,7 +220,7 @@ func TestHandleMatchedPRIssues_CoalescesFixIssues(t *testing.T) {
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},

--- a/internal/sybra/review/fix_dispatch_test.go
+++ b/internal/sybra/review/fix_dispatch_test.go
@@ -79,7 +79,7 @@ func TestDispatchPRIssueWithOptions_RecoversRetryableHumanRequiredPRFix(t *testi
 	launcher := &countingFailingAgentLauncher{
 		err: &provider.UnhealthyError{Provider: "claude", Reason: provider.RateLimitReason, RateLimited: true},
 	}
-	engine := workflow.NewEngine(wfStore, &taskAdapter{tasks: tasks}, launcher, slog.New(slog.DiscardHandler))
+	engine := workflow.NewTestEngine(wfStore, &taskAdapter{tasks: tasks}, launcher, slog.New(slog.DiscardHandler))
 	handler := &Handler{
 		logger:         slog.New(slog.DiscardHandler),
 		emit:           func(string, any) {},
@@ -184,7 +184,7 @@ func TestDispatchPRIssueWithOptions_DoesNotRewritePermanentFailure(t *testing.T)
 	}
 
 	launcher := &countingFailingAgentLauncher{err: workflow.ErrNoProjectAssigned}
-	engine := workflow.NewEngine(wfStore, &taskAdapter{tasks: tasks}, launcher, slog.New(slog.DiscardHandler))
+	engine := workflow.NewTestEngine(wfStore, &taskAdapter{tasks: tasks}, launcher, slog.New(slog.DiscardHandler))
 	handler := &Handler{
 		logger:         slog.New(slog.DiscardHandler),
 		emit:           func(string, any) {},

--- a/internal/sybra/review/outbound_test.go
+++ b/internal/sybra/review/outbound_test.go
@@ -64,7 +64,7 @@ func newOutboundWorkflowTestHandler(t *testing.T) (*Handler, *task.Manager) {
 	if _, err := projects.CreateMeta("https://github.com/Automaat/sybra", project.ProjectTypePet); err != nil {
 		t.Fatal(err)
 	}
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agents, tasks: tasks},
 		logger,

--- a/internal/sybra/review/rebase_recover_test.go
+++ b/internal/sybra/review/rebase_recover_test.go
@@ -339,7 +339,7 @@ func setupRebaseRecoveryHandler(t *testing.T, withConflictWorkflow bool) (*Handl
 		}
 	}
 
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agents, tasks: tasks},
 		logger,
@@ -577,7 +577,7 @@ func setupBranchConflictNoPRHandler(t *testing.T, initialStatus task.Status, pri
 		t.Fatal(err)
 	}
 
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agents, tasks: tasks},
 		logger,
@@ -808,7 +808,7 @@ func TestRecoverBranchConflictNoPR_DispatchFailureRestoresPriorWorkflow(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	r.WorkflowEngine = workflow.NewEngine(emptyStore, &taskAdapter{tasks: r.tasks}, &agentAdapter{agents: r.agents, tasks: r.tasks}, slog.New(slog.DiscardHandler))
+	r.WorkflowEngine = workflow.NewTestEngine(emptyStore, &taskAdapter{tasks: r.tasks}, &agentAdapter{agents: r.agents, tasks: r.tasks}, slog.New(slog.DiscardHandler))
 
 	if r.RecoverStaleBranchConflict(tk.ID) {
 		t.Fatal("recoverBranchConflictNoPR returned true despite dispatch failure")
@@ -942,7 +942,7 @@ func TestDispatchBranchConflictRecovery_QueuesRetryInsteadOfGivingUpWhenMarkerHe
 	}
 
 	launcher := &blockingAgentLauncher{entryCh: make(chan struct{}), releaseCh: make(chan struct{})}
-	engine := workflow.NewEngine(wfStore, &taskAdapter{tasks: tasks}, launcher, logger)
+	engine := workflow.NewTestEngine(wfStore, &taskAdapter{tasks: tasks}, launcher, logger)
 	r := &Handler{
 		logger: logger, emit: func(string, any) {},
 		tasks: tasks, prTracker: github.NewIssueTracker(0),
@@ -1151,7 +1151,7 @@ func newDispatchFailureHandler(t *testing.T, launchErr error) (*Handler, task.Ta
 		t.Fatal(err)
 	}
 
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&failingAgentLauncher{err: launchErr},
 		logger,

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -1425,7 +1425,7 @@ func TestCancelResolvedPRFixWorkflows(t *testing.T) {
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,
@@ -1540,7 +1540,7 @@ func TestCancelResolvedPRFixWorkflows_CoalescedSiblingStillLive(t *testing.T) {
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,
@@ -2759,7 +2759,7 @@ func TestAdvanceClosedTaskPRs_CancelsStaleWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,
@@ -3187,7 +3187,7 @@ func TestCancelResolvedPRFixWorkflows_DefersWhileChecksPending(t *testing.T) {
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,
@@ -3258,7 +3258,7 @@ func TestCancelResolvedPRFixWorkflows_CancelsCommentsWorkflowThenDispatchesCIFai
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,
@@ -3343,7 +3343,7 @@ func TestCancelResolvedPRFixWorkflows_CancelsCommentsWorkflowWhenRemainingCIIsFl
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,
@@ -3415,7 +3415,7 @@ func TestCancelResolvedPRFixWorkflows_DefersCommentsWorkflowWhileChecksPending(t
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,
@@ -3483,7 +3483,7 @@ func TestCancelResolvedPRFixWorkflows_CancelsWhenChecksSettleGreen(t *testing.T)
 		t.Fatal(err)
 	}
 	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
-	engine := workflow.NewEngine(wfStore,
+	engine := workflow.NewTestEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
 		logger,

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -195,7 +195,7 @@ func TestReloadFromDisk_Guardrails(t *testing.T) {
 
 func TestReloadFromDisk_WorkflowReviewGuardrails(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)
-	svc.workflowEngine = workflow.NewEngine(nil, nil, nil, slog.New(slog.DiscardHandler))
+	svc.workflowEngine = workflow.NewTestEngine(nil, nil, nil, slog.New(slog.DiscardHandler))
 	svc.applyWorkflowGuardrails(*svc.cfg)
 
 	next := *svc.cfg
@@ -229,7 +229,7 @@ func TestReloadFromDisk_WorkflowReviewGuardrails(t *testing.T) {
 // around it.
 func TestApplyWorkflowGuardrails_WiresReviewRoundsPerHour(t *testing.T) {
 	svc, _ := setupConfigSvc(t)
-	svc.workflowEngine = workflow.NewEngine(nil, nil, nil, slog.New(slog.DiscardHandler))
+	svc.workflowEngine = workflow.NewTestEngine(nil, nil, nil, slog.New(slog.DiscardHandler))
 
 	cfg := *svc.cfg
 	cfg.Agent.ReviewRoundsPerHour = 7

--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -958,7 +958,7 @@ func TestApp_StatusHook_AdvancesWorkflow(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(wfDir, "test-status-hook.yaml"), []byte(waitForStatusWorkflowYAML), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: app.tasks},
 		&agentAdapter{agents: app.agents, agentOrch: app.agentOrch, tasks: app.tasks},

--- a/internal/sybra/svc_promptlab_test.go
+++ b/internal/sybra/svc_promptlab_test.go
@@ -33,7 +33,7 @@ func setupPromptLabService(t *testing.T) *PromptLabService {
 	if err := workflow.SyncBuiltins(wfStore); err != nil {
 		t.Fatal(err)
 	}
-	engine := workflow.NewEngine(
+	engine := workflow.NewTestEngine(
 		wfStore,
 		&taskAdapter{tasks: a.tasks},
 		parkedAgentLauncher{&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}},

--- a/internal/sybra/svc_tasks_dispatch_test.go
+++ b/internal/sybra/svc_tasks_dispatch_test.go
@@ -85,7 +85,7 @@ func setupDispatchTestService(t *testing.T, launcher *fakeAgentLauncher) (*TaskS
 	svc, a := setupTaskService(t)
 	launcher.tasks = a.tasks
 	ta := &taskAdapter{tasks: a.tasks}
-	svc.workflowEngine = workflow.NewEngine(mustWorkflowStore(t), ta, launcher, a.logger)
+	svc.workflowEngine = workflow.NewTestEngine(mustWorkflowStore(t), ta, launcher, a.logger)
 	return svc, a
 }
 
@@ -1190,7 +1190,7 @@ func TestDispatchFromHumanRequired_FailsClosedOnNoMatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	svc.workflowEngine = workflow.NewEngine(emptyStore, ta, launcher, a.logger)
+	svc.workflowEngine = workflow.NewTestEngine(emptyStore, ta, launcher, a.logger)
 	tk := newHumanRequiredTask(t, a, 0)
 
 	_, err = svc.DispatchFromHumanRequired(tk.ID, "in-progress", "retry please")
@@ -1218,7 +1218,7 @@ func TestDispatchFromHumanRequired_ReadyPRAuthorStillFailsClosedOnNoMatch(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	svc.workflowEngine = workflow.NewEngine(emptyStore, ta, launcher, a.logger)
+	svc.workflowEngine = workflow.NewTestEngine(emptyStore, ta, launcher, a.logger)
 	tk := newHumanRequiredTask(t, a, 42)
 	_, err = a.tasks.Update(tk.ID, task.Update{RunRole: task.Ptr(string(agent.RoleImplementation))})
 	if err != nil {

--- a/internal/workflow/atomic_status_workflow_test.go
+++ b/internal/workflow/atomic_status_workflow_test.go
@@ -15,7 +15,7 @@ func TestFinishTerminalStepOutput_PersistFailureLeavesTaskUnchanged(t *testing.T
 	wf := &Execution{WorkflowID: "test-simple", State: ExecRunning, CurrentStep: "step1", Variables: map[string]string{}}
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", Workflow: wf})
 
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	tasks.failSetWorkflow = true
 	clone := wf.Clone()

--- a/internal/workflow/bounded_retry_test.go
+++ b/internal/workflow/bounded_retry_test.go
@@ -31,7 +31,7 @@ func TestBoundedRetry_PolicyMatrix(t *testing.T) {
 
 	t.Run("applies false is a no-op", func(t *testing.T) {
 		tasks := newMemTasks()
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		ti, step := newTaskStep("")
 		tasks.Put(*ti)
 
@@ -51,7 +51,7 @@ func TestBoundedRetry_PolicyMatrix(t *testing.T) {
 
 	t.Run("busy skips without consuming budget", func(t *testing.T) {
 		tasks := newMemTasks()
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		ti, step := newTaskStep("")
 		tasks.Put(*ti)
 
@@ -72,7 +72,7 @@ func TestBoundedRetry_PolicyMatrix(t *testing.T) {
 
 	t.Run("under cap arms a retry", func(t *testing.T) {
 		tasks := newMemTasks()
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		ti, step := newTaskStep("")
 		tasks.Put(*ti)
 
@@ -111,7 +111,7 @@ func TestBoundedRetry_PolicyMatrix(t *testing.T) {
 
 	t.Run("at cap escalates via onExhausted and never arms", func(t *testing.T) {
 		tasks := newMemTasks()
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		ti, step := newTaskStep("2")
 		tasks.Put(*ti)
 
@@ -149,7 +149,7 @@ func TestBoundedRetry_PolicyMatrix(t *testing.T) {
 	t.Run("persist error uses onPersistError override instead of the default log", func(t *testing.T) {
 		tasks := newMemTasks()
 		tasks.failSetWorkflow = true
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		ti, step := newTaskStep("")
 		tasks.Put(*ti)
 
@@ -173,7 +173,7 @@ func TestBoundedRetry_PolicyMatrix(t *testing.T) {
 
 	t.Run("onArmed error is reported as handled without a retry log", func(t *testing.T) {
 		tasks := newMemTasks()
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		ti, step := newTaskStep("")
 		tasks.Put(*ti)
 

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -1739,7 +1739,7 @@ func TestBuiltinBestOfN_OptInTriggerPriority(t *testing.T) {
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	untagged := TaskInfo{ID: "t1", Status: "in-progress", Tags: []string{"backend"}}
 	if got := engine.MatchWorkflow(untagged, "task.status_changed"); got == nil || got.ID != "simple-task-implement" {
@@ -1773,7 +1773,7 @@ func TestSimpleTaskReview_DoesNotMatchLinkedPRTask(t *testing.T) {
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	prePR := TaskInfo{ID: "pre-pr", Status: "ready-review"}
 	if got := engine.MatchWorkflow(prePR, "task.status_changed"); got == nil || got.ID != "simple-task-review" {
@@ -1803,7 +1803,7 @@ func TestSimpleTaskPR_SkipsReviewOnlyRoles(t *testing.T) {
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	codeAuthor := TaskInfo{ID: "code-author", Status: "ready-pr"}
 	if got := engine.MatchWorkflow(codeAuthor, "task.status_changed"); got == nil || got.ID != "simple-task-pr" {

--- a/internal/workflow/effect_reclaim_test.go
+++ b/internal/workflow/effect_reclaim_test.go
@@ -53,7 +53,7 @@ func leaseFor(t *testing.T, tasks *memTasks, id string) *time.Time {
 func TestReclaimOrphanedEffectLeases_ReleasesDeadOwnersClaim(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
+	engine := NewTestEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
 
 	future := time.Now().UTC().Add(20 * time.Minute)
 	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", future, nil))
@@ -71,7 +71,7 @@ func TestReclaimOrphanedEffectLeases_ReleasesDeadOwnersClaim(t *testing.T) {
 func TestReclaimOrphanedEffectLeases_SkipsTaskWithLiveAgent(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
+	engine := NewTestEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
 
 	future := time.Now().UTC().Add(20 * time.Minute)
 	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", future, nil))
@@ -153,7 +153,7 @@ func TestReclaimOrphanedEffectLeases_LeavesClaimsItMustNotTouch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
+			engine := NewTestEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, agents, discardLogger())
 
 			tk := orphanedLeaseTask("t1", tc.owner(engine), tc.expires, nil)
 			if tc.arrange != nil {
@@ -174,7 +174,7 @@ func TestReclaimOrphanedEffectLeases_LeavesClaimsItMustNotTouch(t *testing.T) {
 // An instance that never dispatches must not rewrite the board's effect log.
 func TestReclaimOrphanedEffectLeases_NoopWhenDispatchDisabled(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
 	engine.SetAutoDispatch(false)
 
 	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", time.Now().UTC().Add(20*time.Minute), nil))
@@ -191,7 +191,7 @@ func TestReclaimOrphanedEffectLeases_NoopWhenDispatchDisabled(t *testing.T) {
 // the orphan is reclaimed.
 func TestReclaimOrphanedEffectLeases_UnfencesSubsequentClaim(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newInlineTestStore(t, "noop", noopWorkflowYAML), tasks, newMockAgents(), discardLogger())
 
 	future := time.Now().UTC().Add(20 * time.Minute)
 	tasks.Put(orphanedLeaseTask("t1", "workflow-engine-1-1", future, nil))

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -433,34 +434,16 @@ type Engine struct {
 	store            *Store
 	tasks            TaskProvider
 	agents           AgentLauncher
-	prLinker         PRLinker
-	prReviewers      PRReviewRequester
-	prStates         PRStateFetcher
-	prHeads          PRHeadFetcher
-	pushPreflight    PushCredentialPreflighter
-	prCreator        PRCreator
-	prCloser         PRCloser
-	prFinder         PRFinder
-	prAnyStateFinder PRAnyStateFinder
-	prExistence      PRExistenceChecker
-	prContentGen     PRContentGenerator
-	worktrees        WorktreeGetter
-	sidecarDir       SidecarDirResolver
-	attemptNotes     AttemptNoteAppender
-	branchSyncer     BranchSyncer
-	checks           CheckConfigGetter
-	manualTests      ManualTestConfigGetter
-	classifier       TaskClassifier
+	pr               PRSurface
+	execution        ExecutionSurface
 	recorder         ArtifactRecorder
 	evidenceRecorder EvidenceRecorder
 	// evidence configures the require_evidence step (zero-value Enabled=false
 	// matches config.EvidenceConfig's own default — see SetEvidenceConfig).
-	evidence         config.EvidenceConfig
-	evidenceHook     func(TaskInfo, EvidenceDecision)
-	costBudget       CostBudgetChecker
-	attemptWorktrees AttemptWorktreeManager
-	onComplete       func(CompletionInfo)
-	dispatchGate     func(TaskInfo) bool
+	evidence     config.EvidenceConfig
+	evidenceHook func(TaskInfo, EvidenceDecision)
+	onComplete   func(CompletionInfo)
+	dispatchGate func(TaskInfo) bool
 	// dispatchDisabled is stored negated so the zero value keeps a
 	// struct-literal Engine dispatching, matching its behavior before this
 	// gate existed. atomic.Bool because SetAutoDispatch (config/lifecycle
@@ -581,12 +564,53 @@ const defaultTestAttempts = config.DefaultTestingMaxAttempts
 // SetMaxCheckpoints was never called. Mirrors config.DefaultMaxCheckpoints.
 const defaultMaxCheckpoints = config.DefaultMaxCheckpoints
 
-// NewEngine creates a workflow engine.
-func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {
+// Dependencies contains the collaborators required by a production Engine.
+// Keeping them in cohesive groups makes construction atomic: adding a new
+// required collaborator changes this value and its validation instead of
+// adding another order-dependent Set* call in the application wiring.
+type Dependencies struct {
+	PR        PRSurface
+	Execution ExecutionSurface
+}
+
+// NewEngine creates a production workflow engine. Every collaborator whose
+// absence would skip or disable workflow behavior is validated before the
+// engine is returned.
+func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger, deps Dependencies) (*Engine, error) {
+	missing := missingDependencyNames(
+		namedDependency{"Store", store},
+		namedDependency{"Tasks", tasks},
+		namedDependency{"Agents", agents},
+		namedDependency{"Logger", logger},
+	)
+	missing = append(missing, deps.missing()...)
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("workflow: engine dependencies missing %s", strings.Join(missing, ", "))
+	}
+	return newEngine(store, tasks, agents, logger, deps), nil
+}
+
+// NewTestEngine creates a deliberately partial engine for focused tests. Tests
+// can bind only the collaborators they exercise through the documented test
+// seams; production must use NewEngine so missing dependencies fail at startup.
+func NewTestEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {
+	return newEngine(store, tasks, agents, logger, Dependencies{
+		Execution: ExecutionSurface{
+			BranchSyncer: skippedBranchSyncer{},
+			Checks:       emptyCheckConfigGetter{},
+			ManualTests:  emptyManualTestConfigGetter{},
+			CostBudget:   unlimitedCostBudgetChecker{},
+		},
+	})
+}
+
+func newEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger, deps Dependencies) *Engine {
 	e := &Engine{
 		store:            store,
 		tasks:            tasks,
 		agents:           agents,
+		pr:               deps.PR,
+		execution:        deps.Execution,
 		ownerID:          newEffectOwnerID(),
 		effectLeaseTTL:   defaultEffectLeaseTTL,
 		clock:            clock.System{},
@@ -717,23 +741,14 @@ func (e *Engine) SetAdmissionDecisionHook(hook func(TaskInfo, AdmissionDecision)
 func (e *Engine) Defs() *Store { return e.store }
 
 // PRSurface is the pull-request dependency group: every collaborator the
-// engine needs to open, find, link, close and re-review a PR.
-//
-// It exists because the engine is constructed empty and assembled through 46
-// Set* calls, so a dependency the wiring forgot is not a compile error or a
-// startup failure — it is a nil field that turns a step into a silently
-// skipped branch, weeks later and far from the omission. Grouping the surface
-// lets SetPRSurface reject a partial wiring at startup, where it is
-// attributable.
-//
-// The individual setters below survive as test seams: tests legitimately wire
-// one collaborator and leave the rest nil, so the per-field nil guards must
-// stay until a group has no seam left.
+// engine needs to open, find, link, close and re-review a PR. NewEngine
+// validates the required members together before publishing an Engine.
 type PRSurface struct {
 	Linker           PRLinker
 	ReviewRequester  PRReviewRequester
 	StateFetcher     PRStateFetcher
 	HeadFetcher      PRHeadFetcher
+	PushPreflighter  PushCredentialPreflighter
 	Creator          PRCreator
 	Closer           PRCloser
 	Finder           PRFinder
@@ -742,124 +757,161 @@ type PRSurface struct {
 	ContentGenerator PRContentGenerator
 }
 
-// SetPRSurface wires the whole PR dependency group and reports every missing
-// member at once, so a wiring omission surfaces at startup rather than as a
-// step that quietly does nothing. Production must use this; the per-field
-// setters are for tests.
-func (e *Engine) SetPRSurface(s PRSurface) error {
+// ExecutionSurface groups the non-PR collaborators used to inspect and
+// mutate a task checkout and to run deterministic workflow steps.
+type ExecutionSurface struct {
+	Worktrees        WorktreeGetter
+	SidecarDir       SidecarDirResolver
+	AttemptNotes     AttemptNoteAppender
+	BranchSyncer     BranchSyncer
+	Checks           CheckConfigGetter
+	ManualTests      ManualTestConfigGetter
+	Classifier       TaskClassifier
+	CostBudget       CostBudgetChecker
+	AttemptWorktrees AttemptWorktreeManager
+}
+
+func (d Dependencies) missing() []string {
+	missing := d.PR.missing()
+	missing = append(missing, missingDependencyNames(
+		namedDependency{"Execution.Worktrees", d.Execution.Worktrees},
+		namedDependency{"Execution.SidecarDir", d.Execution.SidecarDir},
+		namedDependency{"Execution.AttemptNotes", d.Execution.AttemptNotes},
+		namedDependency{"Execution.BranchSyncer", d.Execution.BranchSyncer},
+		namedDependency{"Execution.Checks", d.Execution.Checks},
+		namedDependency{"Execution.ManualTests", d.Execution.ManualTests},
+		namedDependency{"Execution.Classifier", d.Execution.Classifier},
+		namedDependency{"Execution.CostBudget", d.Execution.CostBudget},
+		namedDependency{"Execution.AttemptWorktrees", d.Execution.AttemptWorktrees},
+	)...)
+	return missing
+}
+
+func (s PRSurface) missing() []string {
+	return missingDependencyNames(
+		namedDependency{"PR.Linker", s.Linker},
+		namedDependency{"PR.ReviewRequester", s.ReviewRequester},
+		namedDependency{"PR.StateFetcher", s.StateFetcher},
+		namedDependency{"PR.HeadFetcher", s.HeadFetcher},
+		namedDependency{"PR.Creator", s.Creator},
+		namedDependency{"PR.Closer", s.Closer},
+		namedDependency{"PR.Finder", s.Finder},
+		namedDependency{"PR.AnyStateFinder", s.AnyStateFinder},
+		namedDependency{"PR.ExistenceChecker", s.ExistenceChecker},
+		namedDependency{"PR.ContentGenerator", s.ContentGenerator},
+	)
+}
+
+type namedDependency struct {
+	name  string
+	value any
+}
+
+func missingDependencyNames(deps ...namedDependency) []string {
 	var missing []string
-	for _, dep := range []struct {
-		name  string
-		isNil bool
-	}{
-		{"Linker", s.Linker == nil},
-		{"ReviewRequester", s.ReviewRequester == nil},
-		{"StateFetcher", s.StateFetcher == nil},
-		{"HeadFetcher", s.HeadFetcher == nil},
-		{"Creator", s.Creator == nil},
-		{"Closer", s.Closer == nil},
-		{"Finder", s.Finder == nil},
-		{"AnyStateFinder", s.AnyStateFinder == nil},
-		{"ExistenceChecker", s.ExistenceChecker == nil},
-		{"ContentGenerator", s.ContentGenerator == nil},
-	} {
-		if dep.isNil {
+	for _, dep := range deps {
+		if isNilDependency(dep.value) {
 			missing = append(missing, dep.name)
 		}
 	}
+	return missing
+}
+
+func isNilDependency(value any) bool {
+	if value == nil {
+		return true
+	}
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+// setPRSurfaceForTest validates and replaces the PR group in focused tests.
+func (e *Engine) setPRSurfaceForTest(s PRSurface) error {
+	missing := s.missing()
 	if len(missing) > 0 {
 		return fmt.Errorf("workflow: PR surface missing %s", strings.Join(missing, ", "))
 	}
-	e.prLinker = s.Linker
-	e.prReviewers = s.ReviewRequester
-	e.prStates = s.StateFetcher
-	e.prHeads = s.HeadFetcher
-	e.prCreator = s.Creator
-	e.prCloser = s.Closer
-	e.prFinder = s.Finder
-	e.prAnyStateFinder = s.AnyStateFinder
-	e.prExistence = s.ExistenceChecker
-	e.prContentGen = s.ContentGenerator
+	e.pr = s
 	return nil
 }
 
-// SetPRLinker wires an implementation of PRLinker used by the
-// `ensure_pr_closes_issue` step. Leaving it unset makes the step a no-op.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRLinker(l PRLinker) { e.prLinker = l }
+// SetPRLinker is a test seam for packages that exercise PR linking through the
+// public Engine API. Production supplies the complete PRSurface to NewEngine.
+func (e *Engine) SetPRLinker(l PRLinker) { e.pr.Linker = l }
 
-// SetPRReviewRequester wires an implementation used by rerequest_review.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRReviewRequester(r PRReviewRequester) { e.prReviewers = r }
+// setPRReviewRequesterForTest wires an implementation used by rerequest_review.
+// Test seam: production wires this through setPRSurfaceForTest.
+func (e *Engine) setPRReviewRequesterForTest(r PRReviewRequester) { e.pr.ReviewRequester = r }
 
-// SetPRStateFetcher wires an implementation used by `route_pr_fix_result` to
+// setPRStateFetcherForTest wires an implementation used by `route_pr_fix_result` to
 // re-probe the live PR before parking human-required. Leaving it unset skips
 // the re-probe and trusts the agent's sentinel as-is.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRStateFetcher(f PRStateFetcher) { e.prStates = f }
+// Test seam: production wires this through setPRSurfaceForTest.
+func (e *Engine) setPRStateFetcherForTest(f PRStateFetcher) { e.pr.StateFetcher = f }
 
-// SetPRHeadFetcher wires an implementation used by `push_branch` to verify a
+// setPRHeadFetcherForTest wires an implementation used by `push_branch` to verify a
 // push landed. Leaving it unset skips the verification.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRHeadFetcher(f PRHeadFetcher) { e.prHeads = f }
+// Test seam: production wires this through setPRSurfaceForTest.
+func (e *Engine) setPRHeadFetcherForTest(f PRHeadFetcher) { e.pr.HeadFetcher = f }
 
-// SetPushCredentialPreflighter wires the push-auth preflight used before
+// setPushCredentialPreflighterForTest wires the push-auth preflight used before
 // `push_branch` and `create_pr` attempt a real git push. Leaving it unset uses
 // project.PreflightPushCredentials.
-func (e *Engine) SetPushCredentialPreflighter(p PushCredentialPreflighter) {
-	e.pushPreflight = p
+func (e *Engine) setPushCredentialPreflighterForTest(p PushCredentialPreflighter) {
+	e.pr.PushPreflighter = p
 }
 
-// SetPRCreator wires an implementation of `gh pr create` used by the
-// `create_pr` step. Leaving it unset flips the task to human-required when
-// create_pr is reached, since a PR cannot be opened without it.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRCreator(c PRCreator) { e.prCreator = c }
+// SetPRCreator is a test seam for deterministic PR-creation scenarios.
+// Production supplies the complete PRSurface to NewEngine.
+func (e *Engine) SetPRCreator(c PRCreator) { e.pr.Creator = c }
 
-// SetPRCloser wires best-effort cleanup for superseded PRs after a task is
+// setPRCloserForTest wires best-effort cleanup for superseded PRs after a task is
 // relinked to a replacement PR.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRCloser(c PRCloser) { e.prCloser = c }
+// Test seam: production wires this through setPRSurfaceForTest.
+func (e *Engine) setPRCloserForTest(c PRCloser) { e.pr.Closer = c }
 
-// SetPRFinder wires the open-PR-by-branch lookup used by create_pr's
-// idempotency guard. Leaving it unset skips the guard.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRFinder(f PRFinder) { e.prFinder = f }
+// SetPRFinder is a test seam for create_pr idempotency scenarios. Production
+// supplies the complete PRSurface to NewEngine.
+func (e *Engine) SetPRFinder(f PRFinder) { e.pr.Finder = f }
 
-// SetPRAnyStateFinder wires the all-state branch lookup used by create_pr's
+// setPRAnyStateFinderForTest wires the all-state branch lookup used by create_pr's
 // squash-merge duplicate guard. Leaving it unset skips the guard.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRAnyStateFinder(f PRAnyStateFinder) { e.prAnyStateFinder = f }
+// Test seam: production wires this through setPRSurfaceForTest.
+func (e *Engine) setPRAnyStateFinderForTest(f PRAnyStateFinder) { e.pr.AnyStateFinder = f }
 
-// SetPRExistenceChecker wires the pr_number-belongs-to-repo verification used
+// setPRExistenceCheckerForTest wires the pr_number-belongs-to-repo verification used
 // by link_pr_and_review's Path 1. Leaving it unset skips the check and
 // trusts task.pr_number outright, matching the engine's pre-existing
 // behavior.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRExistenceChecker(c PRExistenceChecker) { e.prExistence = c }
+// Test seam: production wires this through setPRSurfaceForTest.
+func (e *Engine) setPRExistenceCheckerForTest(c PRExistenceChecker) { e.pr.ExistenceChecker = c }
 
-// SetPRContentGenerator wires the LLM-backed title/body drafter used by the
+// setPRContentGeneratorForTest wires the LLM-backed title/body drafter used by the
 // `create_pr` step. Leaving it unset falls back to a templated title/body.
-// Test seam: production wires this through SetPRSurface.
-func (e *Engine) SetPRContentGenerator(g PRContentGenerator) { e.prContentGen = g }
+// Test seam: production wires this through setPRSurfaceForTest.
+func (e *Engine) setPRContentGeneratorForTest(g PRContentGenerator) { e.pr.ContentGenerator = g }
 
-// SetWorktreeGetter wires a WorktreeGetter used by steps that need the task's
-// live git checkout (verify_commits, re-implementation note seeding). Leaving
-// it unset makes those worktree-dependent paths no-op.
-func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.worktrees = g }
+// SetWorktreeGetter is a test seam for steps that inspect a task checkout.
+// Production supplies Worktrees through ExecutionSurface at construction.
+func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.execution.Worktrees = g }
 
-// SetSidecarDirResolver late-binds the writable scratch directory used by
+// setSidecarDirResolverForTest late-binds the writable scratch directory used by
 // verifier roles whose worktree is read-only.
-func (e *Engine) SetSidecarDirResolver(r SidecarDirResolver) { e.sidecarDir = r }
+func (e *Engine) setSidecarDirResolverForTest(r SidecarDirResolver) { e.execution.SidecarDir = r }
 
 // resolveSidecarDir returns the writable scratch dir for taskID, or "" when no
 // resolver is wired or it fails. Callers fall back to the worktree, which is
 // the pre-#2791 behaviour, so a missing resolver degrades rather than breaks.
 func (e *Engine) resolveSidecarDir(taskID string) string {
-	if e == nil || e.sidecarDir == nil {
+	if e == nil || e.execution.SidecarDir == nil {
 		return ""
 	}
-	dir, err := e.sidecarDir(taskID)
+	dir, err := e.execution.SidecarDir(taskID)
 	if err != nil {
 		e.logger.Warn("workflow.sidecar-dir.resolve", "task_id", taskID, "err", err)
 		return ""
@@ -867,22 +919,24 @@ func (e *Engine) resolveSidecarDir(taskID string) string {
 	return strings.TrimSpace(dir)
 }
 
-// SetAttemptNoteAppender wires the local NOTES.md writer used when testing
+// setAttemptNoteAppenderForTest wires the local NOTES.md writer used when testing
 // routes a task back to implementation. Leaving it unset disables note seeding.
-func (e *Engine) SetAttemptNoteAppender(a AttemptNoteAppender) { e.attemptNotes = a }
+func (e *Engine) setAttemptNoteAppenderForTest(a AttemptNoteAppender) { e.execution.AttemptNotes = a }
 
-// SetBranchSyncer wires a BranchSyncer used by the `sync_branch` step.
+// setBranchSyncerForTest wires a BranchSyncer used by the `sync_branch` step.
 // Leaving it unset makes the step a no-op (skipped outcome).
-func (e *Engine) SetBranchSyncer(s BranchSyncer) { e.branchSyncer = s }
+func (e *Engine) setBranchSyncerForTest(s BranchSyncer) { e.execution.BranchSyncer = s }
 
-// SetCheckConfigGetter wires the project codegen/verify resolver used by the
+// setCheckConfigGetterForTest wires the project codegen/verify resolver used by the
 // `codegen_gate` and `verify_checks` steps. Leaving it unset makes those steps
 // no-ops.
-func (e *Engine) SetCheckConfigGetter(g CheckConfigGetter) { e.checks = g }
+func (e *Engine) setCheckConfigGetterForTest(g CheckConfigGetter) { e.execution.Checks = g }
 
-// SetManualTestConfigGetter wires the manual-test surface resolver used by
+// setManualTestConfigGetterForTest wires the manual-test surface resolver used by
 // testing prompts. Leaving it unset makes the prompt rely on repo discovery.
-func (e *Engine) SetManualTestConfigGetter(g ManualTestConfigGetter) { e.manualTests = g }
+func (e *Engine) setManualTestConfigGetterForTest(g ManualTestConfigGetter) {
+	e.execution.ManualTests = g
+}
 
 // SetVerifyTimeout overrides the verify_checks time budget. Zero keeps the
 // default (verifyChecksDefaultTimeout). Used by tests for a short budget.
@@ -903,10 +957,9 @@ func (e *Engine) SetVerifyChecksMaxConcurrent(n int) {
 	e.verifyChecksMaxConcurrent = n
 }
 
-// SetTaskClassifier wires the deterministic Go triage classifier used by the
-// `classify_task` step. Leaving it unset flips the task to human-required
-// when classify_task is reached, since a task cannot be routed without it.
-func (e *Engine) SetTaskClassifier(c TaskClassifier) { e.classifier = c }
+// SetTaskClassifier is a test seam for deterministic classification paths.
+// Production supplies Classifier through ExecutionSurface at construction.
+func (e *Engine) SetTaskClassifier(c TaskClassifier) { e.execution.Classifier = c }
 
 // SetArtifactRecorder wires an ArtifactRecorder that captures per-task
 // workflow artifacts (plan snapshots, trace events). Leaving it unset
@@ -933,16 +986,16 @@ func (e *Engine) SetEvidenceDecisionHook(hook func(TaskInfo, EvidenceDecision)) 
 	e.evidenceHook = hook
 }
 
-// SetCostBudgetChecker wires the cumulative task cost-budget preflight used
-// by the `best_of_n` step (fan-out) and its judge run_agent step. Leaving it
-// unset skips the preflight — see CostBudgetChecker's doc comment.
-func (e *Engine) SetCostBudgetChecker(c CostBudgetChecker) { e.costBudget = c }
+// SetCostBudgetChecker is a test seam for best-of-N budget paths. Production
+// supplies CostBudget through ExecutionSurface at construction.
+func (e *Engine) SetCostBudgetChecker(c CostBudgetChecker) { e.execution.CostBudget = c }
 
-// SetAttemptWorktreeManager wires the isolated per-attempt worktree
-// lifecycle used by `best_of_n`/`promote_best_of_n`. Leaving it unset fails
-// those steps closed to human-required — see AttemptWorktreeManager's doc
-// comment.
-func (e *Engine) SetAttemptWorktreeManager(m AttemptWorktreeManager) { e.attemptWorktrees = m }
+// SetAttemptWorktreeManager is a test seam for best-of-N worktree paths.
+// Production supplies AttemptWorktrees through ExecutionSurface at
+// construction.
+func (e *Engine) SetAttemptWorktreeManager(m AttemptWorktreeManager) {
+	e.execution.AttemptWorktrees = m
+}
 
 // SetOnComplete registers a callback fired when a workflow reaches the
 // completed state. Used to clear external debounce trackers.
@@ -1060,9 +1113,9 @@ func (e *Engine) SetQueueReconciler(fn func()) {
 }
 
 func (e *Engine) withManualTestConfig(t TaskInfo) TaskInfo {
-	if e.manualTests == nil || t.ID == "" {
+	if t.ID == "" {
 		return t
 	}
-	t.ManualTest = e.manualTests.ManualTestConfig(t.ID)
+	t.ManualTest = e.execution.ManualTests.ManualTestConfig(t.ID)
 	return t
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -742,7 +742,8 @@ func (e *Engine) Defs() *Store { return e.store }
 
 // PRSurface is the pull-request dependency group: every collaborator the
 // engine needs to open, find, link, close and re-review a PR. NewEngine
-// validates the required members together before publishing an Engine.
+// validates the required members together before publishing an Engine;
+// PushPreflighter is the sole optional member and retains its runtime fallback.
 type PRSurface struct {
 	Linker           PRLinker
 	ReviewRequester  PRReviewRequester

--- a/internal/workflow/engine_agent_route_race_test.go
+++ b/internal/workflow/engine_agent_route_race_test.go
@@ -11,7 +11,7 @@ func TestHandleAgentComplete_WaitsForRunAgentRoutePublication(t *testing.T) {
 	agents := newMockAgents()
 	agents.startEntered = make(chan struct{}, 1)
 	agents.startGate = make(chan struct{})
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 
@@ -62,7 +62,7 @@ func TestHandleAgentComplete_AfterRoutePersistFailureStillAdvances(t *testing.T)
 	agents := newMockAgents()
 	agents.startEntered = make(chan struct{}, 1)
 	agents.startGate = make(chan struct{})
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 
@@ -119,7 +119,7 @@ func TestPersistStartedAgent_ClearsStalePendingRouteOnSuccessfulPersist(t *testi
 	}
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless", Workflow: wfExec})
 
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.setPendingAgentStep("t1", "agent-1", "implement")
 
 	if err := engine.persistStartedAgent("t1", step, wfExec, "agent-1", "claude", "", "", "", "", ""); err != nil {

--- a/internal/workflow/engine_autodispatch_test.go
+++ b/internal/workflow/engine_autodispatch_test.go
@@ -90,5 +90,5 @@ func newAutoDispatchEngine(t *testing.T) (*Engine, *mockAgents) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
-	return NewEngine(store, tasks, agents, discardLogger()), agents
+	return NewTestEngine(store, tasks, agents, discardLogger()), agents
 }

--- a/internal/workflow/engine_bench_test.go
+++ b/internal/workflow/engine_bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkStartWorkflow(b *testing.B) {
 	store := newBenchStore(b)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	b.ResetTimer()
 	for i := range b.N {
@@ -51,7 +51,7 @@ func BenchmarkAdvanceStep_ToImplement(b *testing.B) {
 	store := newBenchStore(b)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	b.ResetTimer()
 	for i := range b.N {
@@ -76,7 +76,7 @@ func BenchmarkAdvanceStep_Retry(b *testing.B) {
 	store := newBenchStore(b)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	b.ResetTimer()
 	for i := range b.N {
@@ -103,7 +103,7 @@ func BenchmarkResumeStalled(b *testing.B) {
 	store := newBenchStore(b)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	for i := range taskCount {
 		id := fmt.Sprintf("stalled-%d", i)
@@ -127,7 +127,7 @@ func BenchmarkConcurrentAdvance_DistinctTasks(b *testing.B) {
 	store := newBenchStore(b)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	var counter atomic.Int64
 	b.ResetTimer()

--- a/internal/workflow/engine_bestofn_test.go
+++ b/internal/workflow/engine_bestofn_test.go
@@ -169,7 +169,7 @@ func newBestOfNTestEngine(t *testing.T, attempts int) (*Engine, *memTasks, *mock
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	attemptWorktrees := newFakeAttemptWorktrees()
 	costBudget := &fakeCostBudget{}
 	engine.SetAttemptWorktreeManager(attemptWorktrees)

--- a/internal/workflow/engine_cascade_test.go
+++ b/internal/workflow/engine_cascade_test.go
@@ -68,7 +68,7 @@ func TestCascade_SynchronousWorkflowChainsToSuccessor(t *testing.T) {
 		store := newTestStoreWith(t)
 		tasks := newMemTasks()
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 		engine.SetOnComplete(cascadeOnComplete(engine, tasks))
 
 		addStatusWorkflow(t, store, "kickoff", "task.created", "", "in-progress")
@@ -92,7 +92,7 @@ func TestCascade_SynchronousWorkflowChainsToSuccessor(t *testing.T) {
 		store := newTestStoreWith(t)
 		tasks := newMemTasks()
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 		engine.SetOnComplete(cascadeOnComplete(engine, tasks))
 
 		addStatusWorkflow(t, store, "kickoff", "task.created", "", "in-progress")
@@ -129,7 +129,7 @@ func TestCascade_ParallelTerminalStepCascades(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.failSpawn = errors.New("spawn boom") // force all parallel children to fail at spawn
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetOnComplete(cascadeOnComplete(engine, tasks))
 
 	// kickoff ends on a parallel block (no set_status), so it leaves the task
@@ -178,7 +178,7 @@ func TestCascade_DepthGuardStopsRunawayChain(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	var logBuf bytes.Buffer
-	engine := NewEngine(store, tasks, agents, slog.New(slog.NewTextHandler(&logBuf, nil)))
+	engine := NewTestEngine(store, tasks, agents, slog.New(slog.NewTextHandler(&logBuf, nil)))
 	engine.SetOnComplete(cascadeOnComplete(engine, tasks))
 
 	// Ping-pong between two real non-terminal statuses (definition validation

--- a/internal/workflow/engine_dependencies_test.go
+++ b/internal/workflow/engine_dependencies_test.go
@@ -1,0 +1,118 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/project"
+)
+
+func TestNewEngineRejectsIncompleteDependencies(t *testing.T) {
+	t.Parallel()
+
+	engine, err := NewEngine(nil, nil, nil, nil, Dependencies{})
+	if engine != nil {
+		t.Fatal("NewEngine returned an engine for incomplete dependencies")
+	}
+	if err == nil {
+		t.Fatal("NewEngine accepted incomplete dependencies")
+	}
+	for _, want := range []string{
+		"Store", "Tasks", "Agents", "Logger", "PR.Linker",
+		"Execution.Worktrees", "Execution.Classifier", "Execution.AttemptWorktrees",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name missing %s", err, want)
+		}
+	}
+}
+
+func TestNewEngineAcceptsCompleteDependencies(t *testing.T) {
+	t.Parallel()
+
+	engine, err := NewEngine(
+		newTestStore(t),
+		newMemTasks(),
+		newMockAgents(),
+		discardLogger(),
+		completeDependencies(),
+	)
+	if err != nil {
+		t.Fatalf("NewEngine(complete) = %v", err)
+	}
+	if engine == nil {
+		t.Fatal("NewEngine(complete) returned nil")
+	}
+}
+
+func TestNewEngineRejectsTypedNilDependency(t *testing.T) {
+	t.Parallel()
+
+	deps := completeDependencies()
+	var classifier *stubExecutionSurface
+	deps.Execution.Classifier = classifier
+
+	engine, err := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger(), deps)
+	if engine != nil || err == nil {
+		t.Fatalf("NewEngine(typed nil classifier) = (%v, %v), want (nil, error)", engine, err)
+	}
+	if !strings.Contains(err.Error(), "Execution.Classifier") {
+		t.Fatalf("error %q does not name typed-nil classifier", err)
+	}
+}
+
+func TestNewTestEngineAllowsFocusedCollaborators(t *testing.T) {
+	t.Parallel()
+
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	worktrees := stubExecutionSurface{}
+	engine.SetWorktreeGetter(worktrees)
+	if engine.execution.Worktrees != worktrees {
+		t.Fatal("focused test collaborator was not installed")
+	}
+}
+
+type stubExecutionSurface struct{}
+
+func (stubExecutionSurface) GetWorktreePath(string) (string, bool) { return "", false }
+func (stubExecutionSurface) AppendReimplementNote(context.Context, string, string, string, string) error {
+	return nil
+}
+func (stubExecutionSurface) SyncTaskBranch(context.Context, string) (string, error) {
+	return "noop", nil
+}
+func (stubExecutionSurface) CodegenCommands(context.Context, string) []string { return nil }
+func (stubExecutionSurface) VerifyCommands(context.Context, string) []string  { return nil }
+func (stubExecutionSurface) SetupCommands(context.Context, string) []string   { return nil }
+func (stubExecutionSurface) FocusedChecks(context.Context, string) []project.FocusedCheck {
+	return nil
+}
+func (stubExecutionSurface) ManualTestConfig(string) ManualTestInfo     { return ManualTestInfo{} }
+func (stubExecutionSurface) ClassifyTask(context.Context, string) error { return nil }
+func (stubExecutionSurface) CheckTaskCostBudget(string) error           { return nil }
+func (stubExecutionSurface) PrepareAttempt(string, string) (dir, branch string, err error) {
+	return "", "", nil
+}
+func (stubExecutionSurface) PromoteAttempt(string, string, string) (string, error) {
+	return "", nil
+}
+func (stubExecutionSurface) CleanupAttempts(string, []string) {}
+
+func completeDependencies() Dependencies {
+	execution := stubExecutionSurface{}
+	return Dependencies{
+		PR: completePRSurface(),
+		Execution: ExecutionSurface{
+			Worktrees:        execution,
+			SidecarDir:       func(string) (string, error) { return "", nil },
+			AttemptNotes:     execution,
+			BranchSyncer:     execution,
+			Checks:           execution,
+			ManualTests:      execution,
+			Classifier:       execution,
+			CostBudget:       execution,
+			AttemptWorktrees: execution,
+		},
+	}
+}

--- a/internal/workflow/engine_dispatch_test.go
+++ b/internal/workflow/engine_dispatch_test.go
@@ -27,7 +27,7 @@ func TestExecPushBranch_DivergedRecovery_NestedStartWorkflowFails(t *testing.T) 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr"})
 	store := newTestStoreWith(t, "test-push-first.yaml", "test-recovery-target.yaml")
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 
 	var nestedErr error
@@ -62,7 +62,7 @@ func TestExecPushBranch_DivergedRecovery_ReplaceWorkflowSucceeds(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr"})
 	store := newTestStoreWith(t, "test-push-first.yaml", "test-recovery-target.yaml")
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 
 	var replaceErr error

--- a/internal/workflow/engine_drain_test.go
+++ b/internal/workflow/engine_drain_test.go
@@ -42,7 +42,7 @@ func TestExecClassifyTask_BackoffAbandonsOnDrain(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetTaskClassifier(&ctxCancelClassifier{})
 
 	engineCtx, cancelEngine := context.WithCancel(t.Context())

--- a/internal/workflow/engine_events_watchdog.go
+++ b/internal/workflow/engine_events_watchdog.go
@@ -59,7 +59,7 @@ func (e *Engine) handleWatchdogHangRetry(t *TaskInfo, step *Step) bool {
 }
 
 func (e *Engine) handleWatchdogHangReadyPR(t *TaskInfo, step *Step) bool {
-	if e.prStates == nil || t == nil || t.Workflow == nil || step == nil {
+	if e.pr.StateFetcher == nil || t == nil || t.Workflow == nil || step == nil {
 		return false
 	}
 	if t.ProjectID == "" || t.PRNumber <= 0 {
@@ -68,7 +68,7 @@ func (e *Engine) handleWatchdogHangReadyPR(t *TaskInfo, step *Step) bool {
 	if t.Workflow.WorkflowID != "simple-task-implement" || step.ID != "implement" {
 		return false
 	}
-	state, err := e.prStates.FetchPRState(t.ProjectID, t.PRNumber)
+	state, err := e.pr.StateFetcher.FetchPRState(t.ProjectID, t.PRNumber)
 	if err != nil {
 		e.logger.Warn("workflow.watchdog-hang.ready-pr.fetch", "task_id", t.ID, "pr", t.PRNumber, "err", err)
 		return false

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -20,7 +20,7 @@ func runWatchdogRecoveryAssertion(t *testing.T, assert watchdogRecoveryAssertion
 func TestHandleWatchdogHangRetry_SetsReaskNoteOnRetry(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "test-simple",
 		CurrentStep: "implement",
@@ -164,7 +164,7 @@ func TestHandleWatchdogRecoveryRetry_TableDrivenKinds(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tasks := newMemTasks()
-			engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+			engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 			wf := &Execution{
 				WorkflowID:  "test-simple",
 				CurrentStep: tc.step.ID,
@@ -190,7 +190,7 @@ func TestResumeStalled_WatchdogHangRunTestRendersTestingReaskNote(t *testing.T) 
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{
 		ID:           "t1",
 		Status:       "testing",
@@ -234,14 +234,14 @@ func (f fakeManualTestConfigGetter) ManualTestConfig(taskID string) ManualTestIn
 func TestHandleWatchdogHangRetry_RunTestPrioritizesManualTestSurface(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	manualTest := ManualTestInfo{
 		Kind:          "server",
 		Command:       "go run ./cmd/sybra-server",
 		HealthURL:     "http://127.0.0.1:8080/health",
 		ProbeCommands: []string{"curl -fsS http://127.0.0.1:8080/health"},
 	}
-	engine.SetManualTestConfigGetter(fakeManualTestConfigGetter{"t1": manualTest})
+	engine.setManualTestConfigGetterForTest(fakeManualTestConfigGetter{"t1": manualTest})
 	wf := &Execution{
 		WorkflowID:  "testing-task",
 		CurrentStep: testVerdictSourceStep,
@@ -291,7 +291,7 @@ func TestHandleWatchdogHangRetry_RunTestPrioritizesManualTestSurface(t *testing.
 func TestHandleWatchdogStopRetry_TestRunnerUsesTestingGuidance(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(newTestStore(t), tasks, agents, discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, agents, discardLogger())
 	wf := &Execution{WorkflowID: "testing-task", CurrentStep: "run_test", State: ExecWaiting, Variables: map[string]string{}, StartedAt: time.Now().UTC()}
 	tasks.Put(TaskInfo{ID: "t1", Status: "human-required", StatusReason: "watchdog: loop stop: repeated test", AgentMode: "headless", Workflow: wf})
 	ti := TaskInfo{ID: "t1", Status: "human-required", StatusReason: "watchdog: loop stop: repeated test", AgentMode: "headless", Workflow: wf}
@@ -309,8 +309,8 @@ func TestHandleWatchdogStopRetry_TestRunnerUsesTestingGuidance(t *testing.T) {
 func TestHandleWatchdogHangRetry_NonReadyPRStillRetries(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
-	engine.SetPRStateFetcher(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "CONFLICTING"}})
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine.setPRStateFetcherForTest(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "CONFLICTING"}})
 	wf := &Execution{
 		WorkflowID:  "simple-task-implement",
 		CurrentStep: "implement",
@@ -347,7 +347,7 @@ func TestHandleWatchdogHangRetry_NonReadyPRStillRetries(t *testing.T) {
 func TestHandleWatchdogHangRetry_RunTestExhaustionOpensPRGate(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "testing-task",
 		CurrentStep: testVerdictSourceStep,
@@ -392,8 +392,8 @@ func TestResumeStalled_WatchdogHangReadyPRSkipsRedispatch(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(newStoreWithBuiltin(t, "simple-task-implement"), tasks, agents, discardLogger())
-	engine.SetPRStateFetcher(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
+	engine := NewTestEngine(newStoreWithBuiltin(t, "simple-task-implement"), tasks, agents, discardLogger())
+	engine.setPRStateFetcherForTest(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
 	wf := &Execution{
 		WorkflowID:  "simple-task-implement",
 		CurrentStep: "implement",
@@ -460,7 +460,7 @@ func TestBuildWatchdogReaskNote_AttemptCount(t *testing.T) {
 func TestHandleWatchdogRewardHackingRetry_SetsReaskNoteOnRetry(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "test-simple",
 		CurrentStep: "fix_review",
@@ -514,7 +514,7 @@ func TestHandleWatchdogRewardHackingRetry_SetsReaskNoteOnRetry(t *testing.T) {
 func TestHandleWatchdogRewardHackingRetry_ImplementationUsesImplementationBudget(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "simple-task-implement",
 		CurrentStep: "implement",
@@ -551,7 +551,7 @@ func TestHandleWatchdogRewardHackingRetry_ImplementationUsesImplementationBudget
 func TestHandleWatchdogRewardHackingRetry_ExhaustedBudgetEscalates(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "test-simple",
 		CurrentStep: "fix_review",
@@ -600,7 +600,7 @@ func TestBuildRewardHackingFixReviewReaskNote_AttemptCount(t *testing.T) {
 
 func TestResumePreflight_TerminalizesNonRetryableRewardHackingPark(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",
 		CurrentStep: "fix",
@@ -639,7 +639,7 @@ func TestResumePreflight_TerminalizesNonRetryableRewardHackingPark(t *testing.T)
 
 func TestResumePreflight_DoesNotTerminalizeOrdinaryHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",
 		CurrentStep: "fix",
@@ -669,7 +669,7 @@ func TestResumePreflight_DoesNotTerminalizeOrdinaryHumanRequired(t *testing.T) {
 
 func TestResumePreflight_DoesNotOverwriteReplacementWorkflow(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	staleWorkflow := &Execution{
 		WorkflowID:  "branch-conflict-fix",
 		CurrentStep: "fix",
@@ -717,7 +717,7 @@ func TestResumeStalled_WatchdogRewardHackingPlanCriticRendersRetryNote(t *testin
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{
 		ID:           "t1",
 		Status:       "planning",
@@ -775,7 +775,7 @@ steps:
 	store := newInlineTestStore(t, "test-fixreview-reset", yaml)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wf := &Execution{
 		WorkflowID:  "test-fixreview-reset",
@@ -829,7 +829,7 @@ steps:
 func TestClearWatchdogReaskNote(t *testing.T) {
 	t.Parallel()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID: "test-simple",
 		Variables:  map[string]string{watchdogReaskNoteVar: "stale hang guidance"},

--- a/internal/workflow/engine_import_sidecar_test.go
+++ b/internal/workflow/engine_import_sidecar_test.go
@@ -26,7 +26,7 @@ func importSidecarFixture(t *testing.T, fixturePath string) (*Engine, *memTasks)
 		},
 	})
 	agents := newMockAgents()
-	return NewEngine(store, tasks, agents, discardLogger()), tasks
+	return NewTestEngine(store, tasks, agents, discardLogger()), tasks
 }
 
 func TestImportSidecar_WritesContentFromFile(t *testing.T) {
@@ -72,7 +72,7 @@ func TestImportSidecar_RequiredMissingFileFlipsHumanRequired(t *testing.T) {
 			Variables:   map[string]string{"contract_path": filepath.Join(t.TempDir(), "missing.json")},
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "plan", info)
@@ -104,7 +104,7 @@ func TestImportSidecar_EmptyDirVarDistinguishedFromMissing(t *testing.T) {
 			Variables:   map[string]string{}, // _dir never set
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "review", info)
@@ -139,7 +139,7 @@ func TestImportSidecar_EmptyDirVarRecoversViaWorktreeGetter(t *testing.T) {
 			Variables:   map[string]string{}, // lost during restart/reattach
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: worktree, ok: true})
 
 	info, _ := tasks.GetTask("t1")
@@ -211,7 +211,7 @@ func TestImportSidecars_RecoveredDirMakesLaterMissingArtifactPlainMissing(t *tes
 			Variables:   map[string]string{},
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: worktree, ok: true})
 
 	info, _ := tasks.GetTask("t1")
@@ -248,7 +248,7 @@ func TestImportSidecar_MissingFileWithDirSetStillReportsMissing(t *testing.T) {
 			Variables:   map[string]string{"_dir": t.TempDir()},
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "review", info)
@@ -288,7 +288,7 @@ func TestImportSidecar_RecoversFromTaskWorktreeWhenDirVarEmpty(t *testing.T) {
 			Variables:   map[string]string{}, // _dir never set
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
 
 	info, _ := tasks.GetTask("t1")
@@ -322,7 +322,7 @@ func TestImportSidecar_RecoveryStillEscalatesWhenFileAlsoMissingInWorktree(t *te
 			Variables:   map[string]string{}, // _dir never set
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true}) // no review.md written here
 
 	info, _ := tasks.GetTask("t1")
@@ -350,7 +350,7 @@ func TestImportSidecar_NonReservedDirTemplateStillReportsMissing(t *testing.T) {
 			Variables:   map[string]string{},
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "review", info)
@@ -378,7 +378,7 @@ func TestImportSidecar_NoConfigIsNoop(t *testing.T) {
 			CurrentStep: "implement",
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "implement", info)
@@ -392,7 +392,7 @@ func TestImportSidecar_NoConfigIsNoop(t *testing.T) {
 func TestImportSidecar_NoWorkflowIsNoop(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1"}) // no Workflow attached
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "review", info) // must not panic
@@ -414,7 +414,7 @@ func TestImportSidecar_UnknownKindLogsAndDoesNotWrite(t *testing.T) {
 			Variables:   map[string]string{"sidecar_path": path},
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "review", info) // must not panic
@@ -457,7 +457,7 @@ func TestImportSidecars_WritesMultiplePlanningArtifacts(t *testing.T) {
 			},
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	info, _ := tasks.GetTask("t1")
 	engine.importSidecarIfConfigured("t1", "plan", info)
@@ -509,7 +509,7 @@ func newImportSidecarsFixture(t *testing.T, files map[string]string) (*Engine, *
 			Variables:   vars,
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	return engine, tasks, dir
 }
 

--- a/internal/workflow/engine_missing_step_test.go
+++ b/internal/workflow/engine_missing_step_test.go
@@ -44,7 +44,7 @@ func TestResumeStalled_MissingStepEscalatesOnce(t *testing.T) {
 		},
 	})
 
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.ResumeStalled()
 
 	ti, _ := tasks.GetTask("t1")
@@ -90,7 +90,7 @@ func TestResumeStalled_MissingStepRetriesAfterPersistFailure(t *testing.T) {
 		},
 	})
 
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	tasks.failSetWorkflow = true
 	engine.ResumeStalled()
@@ -150,7 +150,7 @@ func TestResumeStalled_MissingStepSkipsQuietCases(t *testing.T) {
 				agents.running["t1"] = "agent-1"
 			}
 
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			engine.ResumeStalled()
 
 			ti, _ := tasks.GetTask("t1")

--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -177,7 +177,7 @@ func TestParallel_DispatchesAllChildren(t *testing.T) {
 	store := newTestStoreWith(t, "test-parallel.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
 	if err := engine.StartWorkflow("t1", "test-parallel"); err != nil {
@@ -242,7 +242,7 @@ func TestParallel_AppliesABAssignmentToAuthorChildren(t *testing.T) {
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
 		ID:             "exp",
@@ -288,7 +288,7 @@ func TestParallel_AppliesPromptAndSkillVariantPayloads(t *testing.T) {
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
 		ID:             "payload-exp",
@@ -327,7 +327,7 @@ func TestParallel_AllCompleteAdvancesParent(t *testing.T) {
 	store := newTestStoreWith(t, "test-parallel.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
 	if err := engine.StartWorkflow("t1", "test-parallel"); err != nil {
@@ -377,7 +377,7 @@ func TestParallel_ChildFailRetryThenSucceed(t *testing.T) {
 	store := newTestStoreWith(t, "test-parallel.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
 	if err := engine.StartWorkflow("t1", "test-parallel"); err != nil {
@@ -430,7 +430,7 @@ func TestParallel_ChildFailExhaustedFailsParent(t *testing.T) {
 	store := newTestStoreWith(t, "test-parallel.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
 	if err := engine.StartWorkflow("t1", "test-parallel"); err != nil {
@@ -467,7 +467,7 @@ func TestParallel_AllSpawnsFail_AdvancesParent(t *testing.T) {
 	store := newTestStoreWith(t, "test-parallel-terminal.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
 	agents.SetFailSpawn(errors.New("project not registered locally"))
@@ -510,7 +510,7 @@ func TestParallel_ShutdownCancellationDuringSpawnDoesNotFailParent(t *testing.T)
 	store := newTestStoreWith(t, "test-parallel-terminal.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
 	shutdownCtx, cancel := context.WithCancel(context.Background())
@@ -544,7 +544,7 @@ func TestParallel_PlanDraftSidecarKeyedByStepID(t *testing.T) {
 	store := newTestStoreWith(t, "test-parallel.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
 	if err := engine.StartWorkflow("t1", "test-parallel"); err != nil {
@@ -589,7 +589,7 @@ func TestParallel_CompletionRoutesViaPendingAgentStepAfterPersistFailure(t *test
 	store := newTestStoreWith(t, "test-parallel.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wfExec := &Execution{
 		WorkflowID:  "test-parallel",

--- a/internal/workflow/engine_pr_recovery.go
+++ b/internal/workflow/engine_pr_recovery.go
@@ -55,10 +55,10 @@ func (e *Engine) maybeRecoverHumanRequiredAlreadyFixedOnMain(taskID string, curr
 	if !declared || !alreadyFixed {
 		return nil, false, nil
 	}
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return nil, false, nil
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok || wtPath == "" {
 		return nil, false, nil
 	}
@@ -102,10 +102,10 @@ func (e *Engine) maybeRecoverHumanRequiredByOpeningPR(taskID string, currentStep
 	if !isMissingLivePRVerificationBlocker(t.StatusReason + "\n" + output.Output) {
 		return nil, false, nil
 	}
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return nil, false, nil
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok || wtPath == "" {
 		return nil, false, nil
 	}

--- a/internal/workflow/engine_prompt_undelivered_test.go
+++ b/internal/workflow/engine_prompt_undelivered_test.go
@@ -54,7 +54,7 @@ func TestReschedulePromptUndeliveredAgent_ChargesItsOwnBudget(t *testing.T) {
 	store := promptUndeliveredStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(promptUndeliveredTask(t, ""))
 
@@ -76,7 +76,7 @@ func TestReschedulePromptUndeliveredAgent_EscalatesWhenBudgetSpent(t *testing.T)
 	store := promptUndeliveredStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(promptUndeliveredTask(t, "3"))
 

--- a/internal/workflow/engine_resume_pr_steps_test.go
+++ b/internal/workflow/engine_resume_pr_steps_test.go
@@ -56,11 +56,11 @@ func TestResumeStalled_ResumesParkedCreatePR(t *testing.T) {
 		},
 	})
 
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	creator := &fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)}
 	engine.SetPRCreator(creator)
-	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
+	engine.setPRContentGeneratorForTest(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
 
 	engine.ResumeStalled()
 
@@ -140,9 +140,9 @@ func TestResumeStalled_ResumesParkedPushBranch(t *testing.T) {
 		},
 	})
 
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetPRHeadFetcher(&fakePRHeadFetcher{sha: local})
+	engine.setPRHeadFetcherForTest(&fakePRHeadFetcher{sha: local})
 
 	engine.ResumeStalled()
 
@@ -182,7 +182,7 @@ func TestResumeStalled_ResumesParkedAdmissionPreflight(t *testing.T) {
 		},
 	})
 
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
 
 	engine.ResumeStalled()

--- a/internal/workflow/engine_skill_receipt_zero_output_test.go
+++ b/internal/workflow/engine_skill_receipt_zero_output_test.go
@@ -63,7 +63,7 @@ func TestHandleAgentComplete_ZeroOutputRunSparesConformanceBudget(t *testing.T) 
 	store := zeroOutputSkillReceiptStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(zeroOutputSkillReceiptTask(t, "agent-1", nil))
 
@@ -91,7 +91,7 @@ func TestHandleAgentComplete_ZeroOutputRunsEscalateAfterOwnCeiling(t *testing.T)
 	store := zeroOutputSkillReceiptStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	spent := map[string]string{
 		skillReceiptZeroOutputKey("run"): "3",

--- a/internal/workflow/engine_stale_route_test.go
+++ b/internal/workflow/engine_stale_route_test.go
@@ -40,7 +40,7 @@ func staleRouteEngine(t *testing.T, logger *slog.Logger, routes map[string]strin
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	wf := &Execution{
 		WorkflowID:  "test-simple",
@@ -222,7 +222,7 @@ func TestResumeStalled_StaleRoutePrunerSparesMidAdvanceCompletion(t *testing.T) 
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	recorder := newGatedRecorder()
 	engine.SetArtifactRecorder(recorder)

--- a/internal/workflow/engine_steps_admission.go
+++ b/internal/workflow/engine_steps_admission.go
@@ -135,10 +135,10 @@ func (e *Engine) checkAdmissionOversize(raw string) string {
 // transient vs permanent. A not-yet-existing worktree is not a failure here —
 // see the doc comment on execAdmissionPreflight.
 func (e *Engine) checkAdmissionCredentials(taskID string) error {
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return nil
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return nil
 	}

--- a/internal/workflow/engine_steps_admission_test.go
+++ b/internal/workflow/engine_steps_admission_test.go
@@ -218,7 +218,7 @@ func TestExecAdmissionPreflight_NoWorktreeSkipsCredentialCheck(t *testing.T) {
 	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
 	preflight := &fakePushPreflighter{err: errors.New("should never be called")}
-	engine.SetPushCredentialPreflighter(preflight)
+	engine.setPushCredentialPreflighterForTest(preflight)
 
 	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
@@ -240,7 +240,7 @@ func TestExecAdmissionPreflight_MissingCredentialsBlockAsCredentialRequired(t *t
 	engine.SetAdmissionConfig(config.AdmissionConfig{Enabled: true})
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: "/tmp/wt", ok: true})
 	preflight := &fakePushPreflighter{err: errors.New("gh auth status: Bad credentials")}
-	engine.SetPushCredentialPreflighter(preflight)
+	engine.setPushCredentialPreflighterForTest(preflight)
 
 	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), newAdmissionExec(),
 		TaskInfo{ID: "fa6919fc", PlanContract: validPlanContract("fa6919fc")})
@@ -277,7 +277,7 @@ func TestExecAdmissionPreflight_TransientCredentialErrorParksForRetry(t *testing
 	// A rate-limited/transient preflight hit must self-heal via a bounded
 	// retry, not permanently strand a re-dispatched task at human-required.
 	preflight := &fakePushPreflighter{err: errors.New("gh: API rate limit exceeded for GitHub")}
-	engine.SetPushCredentialPreflighter(preflight)
+	engine.setPushCredentialPreflighterForTest(preflight)
 
 	wfExec := newAdmissionExec()
 	out, err := engine.execAdmissionPreflight("fa6919fc", newAdmissionPreflightStep(), wfExec,

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -227,10 +227,10 @@ func (e *Engine) importOneSidecar(taskID, stepID string, step *Step, info TaskIn
 // or the file still doesn't exist at the recovered path — callers fall
 // through to the ordinary escalation path in that case.
 func (e *Engine) recoverSidecarFromTaskWorktree(taskID, stepID string, step *Step, info TaskInfo, cfg ImportSidecar) (path string, content []byte, ok bool) {
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return "", nil, false
 	}
-	wtPath, found := e.worktrees.GetWorktreePath(taskID)
+	wtPath, found := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !found || strings.TrimSpace(wtPath) == "" {
 		return "", nil, false
 	}

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -64,16 +64,14 @@ func bestOfNSuccessfulVar(stepID string) string { return "bestofn." + stepID + "
 // budget, so this preflights it explicitly and fails closed on
 // ErrTaskCostExceeded.
 func (e *Engine) execBestOfN(taskID string, def *Definition, step *Step, wfExec *Execution, ctx TemplateContext) (*CompletionInfo, error) {
-	if e.costBudget != nil {
-		if err := e.costBudget.CheckTaskCostBudget(taskID); err != nil {
-			if errors.Is(err, ErrTaskCostExceeded) {
-				return e.failStepClosed(taskID, def, step, wfExec,
-					"best-of-n: cost budget exceeded before attempts started: "+err.Error())
-			}
-			return nil, err
+	if err := e.execution.CostBudget.CheckTaskCostBudget(taskID); err != nil {
+		if errors.Is(err, ErrTaskCostExceeded) {
+			return e.failStepClosed(taskID, def, step, wfExec,
+				"best-of-n: cost budget exceeded before attempts started: "+err.Error())
 		}
+		return nil, err
 	}
-	if e.attemptWorktrees == nil {
+	if e.execution.AttemptWorktrees == nil {
 		return e.failStepClosed(taskID, def, step, wfExec,
 			"best-of-n: no attempt worktree manager configured")
 	}
@@ -179,7 +177,7 @@ func (e *Engine) spawnBestOfNAttempt(taskID string, step *Step, wfExec *Executio
 	if admit, reason := e.agents.AdmitDispatch(taskID, step.Config.Role, mode); !admit {
 		return fmt.Errorf("%w: %s", ErrResourcePressure, reason)
 	}
-	dir, branch, err := e.attemptWorktrees.PrepareAttempt(taskID, attemptID)
+	dir, branch, err := e.execution.AttemptWorktrees.PrepareAttempt(taskID, attemptID)
 	if err != nil {
 		return fmt.Errorf("prepare attempt worktree: %w", err)
 	}
@@ -359,7 +357,7 @@ func (e *Engine) finalizeBestOfNParent(taskID string, def *Definition, parent *S
 // on the success path, so a block that never reaches promotion doesn't leak
 // attempt directories on disk indefinitely.
 func (e *Engine) cleanupAllBestOfNAttempts(taskID string, rec *BestOfNInflight) {
-	if e.attemptWorktrees == nil || rec == nil {
+	if e.execution.AttemptWorktrees == nil || rec == nil {
 		return
 	}
 	ids := make([]string, 0, len(rec.Attempts))
@@ -370,7 +368,7 @@ func (e *Engine) cleanupAllBestOfNAttempts(taskID string, rec *BestOfNInflight) 
 		return
 	}
 	sort.Strings(ids)
-	e.attemptWorktrees.CleanupAttempts(taskID, ids)
+	e.execution.AttemptWorktrees.CleanupAttempts(taskID, ids)
 }
 
 // preflightRunAgentBudget enforces the cumulative task cost budget BEFORE a
@@ -385,10 +383,10 @@ func (e *Engine) cleanupAllBestOfNAttempts(taskID string, rec *BestOfNInflight) 
 // flips the task to human-required and ends the workflow via the same
 // declarative Next path as every other mechanical gate.
 func (e *Engine) preflightRunAgentBudget(taskID string, def *Definition, step *Step, wfExec *Execution) (comp *CompletionInfo, handled bool, err error) {
-	if !step.Config.BudgetPreflight || e.costBudget == nil {
+	if !step.Config.BudgetPreflight {
 		return nil, false, nil
 	}
-	cErr := e.costBudget.CheckTaskCostBudget(taskID)
+	cErr := e.execution.CostBudget.CheckTaskCostBudget(taskID)
 	if cErr == nil {
 		return nil, false, nil
 	}
@@ -592,16 +590,14 @@ func (e *Engine) execPromoteBestOfN(taskID string, step *Step) (StepOutput, erro
 		return e.humanRequiredStepOutput(taskID, step, "best-of-n promotion: judge named a non-successful attempt "+winnerID)
 	}
 
-	if e.costBudget != nil {
-		if cErr := e.costBudget.CheckTaskCostBudget(taskID); cErr != nil {
-			if errors.Is(cErr, ErrTaskCostExceeded) {
-				return e.humanRequiredStepOutput(taskID, step, "best-of-n promotion: cost budget exceeded before promotion: "+cErr.Error())
-			}
-			return StepOutput{}, cErr
+	if cErr := e.execution.CostBudget.CheckTaskCostBudget(taskID); cErr != nil {
+		if errors.Is(cErr, ErrTaskCostExceeded) {
+			return e.humanRequiredStepOutput(taskID, step, "best-of-n promotion: cost budget exceeded before promotion: "+cErr.Error())
 		}
+		return StepOutput{}, cErr
 	}
 
-	if e.attemptWorktrees == nil {
+	if e.execution.AttemptWorktrees == nil {
 		return e.humanRequiredStepOutput(taskID, step, "best-of-n promotion: no attempt worktree manager configured")
 	}
 
@@ -611,7 +607,7 @@ func (e *Engine) execPromoteBestOfN(taskID string, step *Step) (StepOutput, erro
 		}
 	}
 
-	canonicalDir, promErr := e.attemptWorktrees.PromoteAttempt(taskID, winner.Dir, winner.Branch)
+	canonicalDir, promErr := e.execution.AttemptWorktrees.PromoteAttempt(taskID, winner.Dir, winner.Branch)
 	if promErr != nil {
 		// The fail-closed reasons above are all judgements a human must make.
 		// A canonical path another mutating operation currently owns is not
@@ -642,7 +638,7 @@ func (e *Engine) execPromoteBestOfN(taskID string, step *Step) (StepOutput, erro
 	}
 	sort.Strings(allAttempts)
 	if len(allAttempts) > 0 {
-		e.attemptWorktrees.CleanupAttempts(taskID, allAttempts)
+		e.execution.AttemptWorktrees.CleanupAttempts(taskID, allAttempts)
 	}
 
 	// Persist the loser cleanup + inflight teardown against the CURRENT

--- a/internal/workflow/engine_steps_classify.go
+++ b/internal/workflow/engine_steps_classify.go
@@ -21,7 +21,7 @@ const classifyTaskTimeout = 2 * time.Minute
 // /sybra-triage skill around the same classifier, which was a second LLM
 // call for no benefit.
 func (e *Engine) execClassifyTask(taskID string, step *Step, wfExec *Execution) (StepOutput, error) {
-	if e.classifier == nil {
+	if e.execution.Classifier == nil {
 		return e.humanRequiredClassify(taskID, step, "no task classifier configured")
 	}
 
@@ -39,7 +39,7 @@ func (e *Engine) execClassifyTask(taskID string, step *Step, wfExec *Execution) 
 	var err error
 	for attempt := 0; ; attempt++ {
 		attemptCtx, cancel := context.WithTimeout(e.ctx, classifyTaskTimeout)
-		err = e.classifier.ClassifyTask(attemptCtx, taskID)
+		err = e.execution.Classifier.ClassifyTask(attemptCtx, taskID)
 		cancel()
 		if err == nil {
 			e.logger.Info("workflow.classify-task", "task_id", taskID, "step", step.ID)

--- a/internal/workflow/engine_steps_classify_test.go
+++ b/internal/workflow/engine_steps_classify_test.go
@@ -27,7 +27,7 @@ func TestExecClassifyTask_Success(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	classifier := &fakeTaskClassifier{}
 	engine.SetTaskClassifier(classifier)
 
@@ -52,7 +52,7 @@ func TestExecClassifyTask_NilClassifier(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	// No SetTaskClassifier call — engine must flip to human-required.
 
 	out, err := engine.execClassifyTask("t1", newClassifyTaskStep(), &Execution{})
@@ -88,7 +88,7 @@ func TestExecClassifyTask_RetriesTransientFailure(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	classifier := &failNTimesClassifier{failFirst: 2}
 	engine.SetTaskClassifier(classifier)
 
@@ -122,7 +122,7 @@ func TestExecClassifyTask_ContextCanceledParksInsteadOfCompleting(t *testing.T) 
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	classifier := &ctxCancelClassifier{}
 	engine.SetTaskClassifier(classifier)
 
@@ -156,7 +156,7 @@ func TestExecClassifyTask_ClassifierError(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetTaskClassifier(&fakeTaskClassifier{err: errors.New("provider unavailable")})
 
 	out, err := engine.execClassifyTask("t1", newClassifyTaskStep(), &Execution{})

--- a/internal/workflow/engine_steps_clear_test.go
+++ b/internal/workflow/engine_steps_clear_test.go
@@ -41,7 +41,7 @@ func writeCycle1Artifacts(t *testing.T, dir string) {
 func clearTestEnv(t *testing.T, dir string) (*Engine, *memTasks, TaskInfo) {
 	t.Helper()
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	info := TaskInfo{
 		ID:            "t1",
 		Plan:          "cycle 1 plan",
@@ -137,7 +137,7 @@ func TestClearPlanArtifacts_LeavesUnrelatedWorktreeFilesAlone(t *testing.T) {
 // affirmation reaches a human gate that then auto-approves it.
 func TestClearPlanArtifacts_UnknownWorktreeEscalatesRatherThanReplanning(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	info := TaskInfo{
 		ID:       "t1",
 		Plan:     "cycle 1 plan",
@@ -220,7 +220,7 @@ func TestClearPlanArtifacts_UnreadableWorktreeEscalates(t *testing.T) {
 // halt the workflow with a hard error instead of quietly reporting completed.
 func TestClearPlanArtifacts_StatusUpdateFailureIsHardError(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	// The task is never Put, so UpdateTaskStatus fails with "not found" —
 	// standing in for a store write failure at exactly the point it matters.
 	info := TaskInfo{

--- a/internal/workflow/engine_steps_codegen.go
+++ b/internal/workflow/engine_steps_codegen.go
@@ -22,19 +22,15 @@ type codegenGateReport struct {
 }
 
 func (e *Engine) execCodegenGate(taskID string, step *Step) (StepOutput, error) {
-	if e.checks == nil {
-		return stepDone(step, "skipped: no check config getter")
-	}
-
 	timeout := resolveWorkflowCheckTimeout(e.verifyTimeout)
-	cmds := e.checks.CodegenCommands(e.ctx, taskID)
+	cmds := e.execution.Checks.CodegenCommands(e.ctx, taskID)
 	if len(cmds) == 0 {
 		return stepDone(step, "skipped: no codegen commands configured")
 	}
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return stepDone(step, "skipped: no worktree getter configured")
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return stepDone(step, "skipped: no worktree for task")
 	}

--- a/internal/workflow/engine_steps_codegen_test.go
+++ b/internal/workflow/engine_steps_codegen_test.go
@@ -16,9 +16,9 @@ func newCodegenGateStep() *Step { return &Step{ID: "codegen_gate", Type: StepCod
 
 func newCodegenGateEngine(t *testing.T, wt string, cmds []string) (*Engine, *memTasks) {
 	t.Helper()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{codegen: cmds})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{codegen: cmds})
 	return engine, engine.tasks.(*memTasks)
 }
 
@@ -33,17 +33,17 @@ func codegenGitOutput(t *testing.T, dir string, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func TestExecCodegenGate_NoGetterSkips(t *testing.T) {
+func TestExecCodegenGate_DefaultGetterSkips(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
 
 	out, err := engine.execCodegenGate("t1", newCodegenGateStep())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if out.Output != "skipped: no check config getter" {
-		t.Fatalf("Output = %q, want no-getter skip", out.Output)
+	if out.Output != "skipped: no codegen commands configured" {
+		t.Fatalf("Output = %q, want no-commands skip", out.Output)
 	}
 }
 
@@ -63,8 +63,8 @@ func TestExecCodegenGate_NoCommandsSkips(t *testing.T) {
 
 func TestExecCodegenGate_NoWorktreeGetterSkips(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.SetCheckConfigGetter(&fakeCheckGetter{codegen: []string{"true"}})
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{codegen: []string{"true"}})
 
 	out, err := engine.execCodegenGate("t1", newCodegenGateStep())
 	if err != nil {
@@ -77,8 +77,8 @@ func TestExecCodegenGate_NoWorktreeGetterSkips(t *testing.T) {
 
 func TestExecCodegenGate_NoWorktreeForTaskSkips(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.SetCheckConfigGetter(&fakeCheckGetter{codegen: []string{"true"}})
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{codegen: []string{"true"}})
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
 
 	out, err := engine.execCodegenGate("t1", newCodegenGateStep())

--- a/internal/workflow/engine_steps_evidence.go
+++ b/internal/workflow/engine_steps_evidence.go
@@ -54,10 +54,10 @@ var freshnessExemptCriteria = map[string]bool{
 // caller) so producers can pass raw report/output text without duplicating
 // evidence.Digest at every call site.
 func (e *Engine) recordEvidence(taskID, stepID, criterion string, proofType evidence.ProofType, exitStatus int, command, result string) {
-	if e.evidenceRecorder == nil || e.worktrees == nil {
+	if e.evidenceRecorder == nil || e.execution.Worktrees == nil {
 		return
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return
 	}
@@ -90,10 +90,10 @@ func (e *Engine) recordEvidence(taskID, stepID, criterion string, proofType evid
 // re-executing the suite. A failing run keeps using plain recordEvidence
 // (unstamped), which is correct: failures are never memoized.
 func (e *Engine) recordVerifyChecksEvidence(taskID, stepID, command, result, treeSHA, checksHash string) {
-	if e.evidenceRecorder == nil || e.worktrees == nil {
+	if e.evidenceRecorder == nil || e.execution.Worktrees == nil {
 		return
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return
 	}
@@ -136,7 +136,7 @@ func (e *Engine) recordVerifyChecksEvidence(taskID, stepID, command, result, tre
 // re-records fresh evidence on its own, so callers gate this to the single-pass
 // route.
 func (e *Engine) refreshReviewEvidenceFreshness(taskID string) {
-	if e.evidenceRecorder == nil || e.worktrees == nil {
+	if e.evidenceRecorder == nil || e.execution.Worktrees == nil {
 		return
 	}
 	ce, err := e.evidenceRecorder.Evidence(taskID)
@@ -147,7 +147,7 @@ func (e *Engine) refreshReviewEvidenceFreshness(taskID string) {
 	if !ok {
 		return
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return
 	}
@@ -180,12 +180,12 @@ func evidenceBackendIdentity() string {
 // place.
 func (e *Engine) requiredEvidenceCriteria(taskID string, t TaskInfo) []string {
 	var required []string
-	if e.worktrees != nil {
-		if _, ok := e.worktrees.GetWorktreePath(taskID); ok {
+	if e.execution.Worktrees != nil {
+		if _, ok := e.execution.Worktrees.GetWorktreePath(taskID); ok {
 			required = append(required, evidenceCriterionVerifyCommits, evidenceCriterionDetectTampering)
 		}
 	}
-	if e.checks != nil && len(e.checks.VerifyCommands(e.ctx, taskID)) > 0 {
+	if len(e.execution.Checks.VerifyCommands(e.ctx, taskID)) > 0 {
 		required = append(required, evidenceCriterionVerifyChecks)
 	}
 	if taskWasTested(t.AgentRuns) {
@@ -304,10 +304,10 @@ func (e *Engine) fireEvidenceDecision(t TaskInfo, d EvidenceDecision) {
 // currentHeadSHA resolves the task worktree's current HEAD commit. Empty when
 // no WorktreeGetter is wired or the task has no worktree.
 func (e *Engine) currentHeadSHA(taskID string) string {
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return ""
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return ""
 	}

--- a/internal/workflow/engine_steps_evidence_test.go
+++ b/internal/workflow/engine_steps_evidence_test.go
@@ -78,7 +78,7 @@ func newRequireEvidenceStep() *Step { return &Step{ID: "require_evidence", Type:
 
 func newRequireEvidenceEngine(t *testing.T, wt string) (*Engine, *memTasks, *fakeEvidenceRecorder) {
 	t.Helper()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
 	rec := newFakeEvidenceRecorder()
 	engine.SetEvidenceRecorder(rec)
@@ -172,7 +172,7 @@ func TestExecRequireEvidence_CompleteAndFreshLands(t *testing.T) {
 	wt := makeGitRepo(t, true)
 	head := headSHAForTest(t, wt)
 	engine, tasks, rec := newRequireEvidenceEngine(t, wt)
-	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: []string{"true"}})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{cmds: []string{"true"}})
 	rec.Set("t1", evidence.CompletionEvidence{Criteria: []evidence.CriterionEvidence{
 		{Criterion: evidenceCriterionVerifyCommits, ExitStatus: 0, FinalRev: head},
 		{Criterion: evidenceCriterionDetectTampering, ExitStatus: 0, FinalRev: head},
@@ -197,7 +197,7 @@ func TestExecRequireEvidence_MissingCriterionBlocks(t *testing.T) {
 	wt := makeGitRepo(t, true)
 	head := headSHAForTest(t, wt)
 	engine, tasks, rec := newRequireEvidenceEngine(t, wt)
-	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: []string{"true"}})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{cmds: []string{"true"}})
 	// verify_checks omitted entirely, even though a verify suite is configured.
 	rec.Set("t1", evidence.CompletionEvidence{Criteria: []evidence.CriterionEvidence{
 		{Criterion: evidenceCriterionVerifyCommits, ExitStatus: 0, FinalRev: head},

--- a/internal/workflow/engine_steps_focused_checks.go
+++ b/internal/workflow/engine_steps_focused_checks.go
@@ -37,17 +37,14 @@ type selectedFocusedCheck struct {
 }
 
 func (e *Engine) execFocusedChecks(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
-	if e.checks == nil {
-		return stepDone(step, "skipped: no check config getter")
-	}
-	focused := e.checks.FocusedChecks(e.ctx, taskID)
+	focused := e.execution.Checks.FocusedChecks(e.ctx, taskID)
 	if len(focused) == 0 {
 		return stepDone(step, "skipped: no focused checks configured")
 	}
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return stepDone(step, "skipped: no worktree getter configured")
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return stepDone(step, "skipped: no worktree for task")
 	}
@@ -119,7 +116,7 @@ type worktreeBaseRefGetter interface {
 }
 
 func (e *Engine) focusedChecksBaseRef(taskID string) string {
-	if getter, ok := e.checks.(worktreeBaseRefGetter); ok {
+	if getter, ok := e.execution.Checks.(worktreeBaseRefGetter); ok {
 		return getter.WorktreeBaseRef(e.ctx, taskID)
 	}
 	return project.WorktreeBaseRefFresh

--- a/internal/workflow/engine_steps_focused_checks_test.go
+++ b/internal/workflow/engine_steps_focused_checks_test.go
@@ -18,9 +18,9 @@ func newFocusedChecksStep() *Step { return &Step{ID: "focused_checks", Type: Ste
 
 func newFocusedChecksEngine(t *testing.T, wt string, focused []project.FocusedCheck, verify []string) (*Engine, *memTasks, *recordingArtifactRecorder) {
 	t.Helper()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: focused, cmds: verify})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: focused, cmds: verify})
 	rec := &recordingArtifactRecorder{}
 	engine.SetArtifactRecorder(rec)
 	return engine, engine.tasks.(*memTasks), rec
@@ -222,7 +222,7 @@ func TestExecFocusedChecks_HeadBaseExcludesLocalDefaultBranchChanges(t *testing.
 			Commands: []string{"true"},
 		},
 	}, nil)
-	engine.checks.(*fakeCheckGetter).worktreeBaseRef = project.WorktreeBaseRefHead
+	engine.execution.Checks.(*fakeCheckGetter).worktreeBaseRef = project.WorktreeBaseRefHead
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", ProjectID: "owner/repo"})
 
 	out, err := engine.execFocusedChecks("t1", newFocusedChecksStep(), nil, TaskInfo{ID: "t1", Status: "in-progress", ProjectID: "owner/repo"})

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -69,11 +69,11 @@ func (e *Engine) execLinkPRAndReview(taskID string, step *Step, wfExec *Executio
 	// silently flip the task to in-review against a PR nobody but the agent
 	// will ever look at.
 	if t.PRNumber > 0 {
-		if t.ProjectID == "" || e.prExistence == nil {
+		if t.ProjectID == "" || e.pr.ExistenceChecker == nil {
 			return setInReview(t.PRNumber, "task.pr_number")
 		}
 		ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
-		exists, verifyErr := e.prExistence.PRExists(ctx, t.ProjectID, t.PRNumber)
+		exists, verifyErr := e.pr.ExistenceChecker.PRExists(ctx, t.ProjectID, t.PRNumber)
 		cancel()
 		switch {
 		case exists:

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -35,7 +35,7 @@ func (e *Engine) execPushBranch(taskID string, step *Step, wfExec *Execution, t 
 	// (propagation lag, or a race with another pusher) is logged, not fatal —
 	// link_pr_and_review still finds task.pr_number regardless, and a stale
 	// head would surface as a failing PR check rather than a silent miss.
-	if e.prHeads != nil && t.PRNumber > 0 && t.ProjectID != "" {
+	if e.pr.HeadFetcher != nil && t.PRNumber > 0 && t.ProjectID != "" {
 		e.verifyPushedHead(taskID, wtPath, t)
 	}
 
@@ -87,13 +87,13 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 
 	title, body := e.generatePRContent(taskID, wtPath, t)
 
-	if e.prCreator == nil {
+	if e.pr.Creator == nil {
 		return e.humanRequiredPR(taskID, step, "no PR creator configured")
 	}
 
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
-	number, headSHA, createErr := e.prCreator.CreatePR(ctx, wtPath, PRCreateRequest{
+	number, headSHA, createErr := e.pr.Creator.CreatePR(ctx, wtPath, PRCreateRequest{
 		Repo:  t.ProjectID,
 		Head:  headArg,
 		Draft: t.ProjectType != "pet",
@@ -119,12 +119,12 @@ func (e *Engine) execCreatePR(taskID string, step *Step, wfExec *Execution, t Ta
 }
 
 func (e *Engine) requestCopilotReview(taskID, repo string, prNumber int) {
-	if repo == "" || prNumber <= 0 || e.prReviewers == nil {
+	if repo == "" || prNumber <= 0 || e.pr.ReviewRequester == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
-	if err := e.prReviewers.RequestCopilotReview(ctx, repo, prNumber); err != nil {
+	if err := e.pr.ReviewRequester.RequestCopilotReview(ctx, repo, prNumber); err != nil {
 		e.logger.Warn("workflow.create-pr.copilot-review.failed", "task_id", taskID, "repo", repo, "pr", prNumber, "err", err)
 		return
 	}
@@ -158,13 +158,13 @@ func (e *Engine) linkTaskPR(taskID string, t TaskInfo, newPR int) error {
 	if err := e.tasks.UpdateTaskPR(taskID, newPR); err != nil {
 		return err
 	}
-	if oldPR == 0 || oldPR == newPR || t.ProjectID == "" || e.prCloser == nil {
+	if oldPR == 0 || oldPR == newPR || t.ProjectID == "" || e.pr.Closer == nil {
 		return nil
 	}
 	comment := fmt.Sprintf("Superseded by #%d for Sybra task %s.", newPR, taskID)
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
-	if err := e.prCloser.ClosePR(ctx, t.ProjectID, oldPR, comment); err != nil {
+	if err := e.pr.Closer.ClosePR(ctx, t.ProjectID, oldPR, comment); err != nil {
 		e.logger.Warn("workflow.pr.superseded-close", "task_id", taskID, "old_pr", oldPR, "new_pr", newPR, "err", err)
 		return nil
 	}
@@ -177,7 +177,7 @@ func (e *Engine) linkTaskPR(taskID string, t TaskInfo, newPR int) error {
 // PRWorktreeResolver, allowing one reconstruction attempt before a genuinely
 // unrecoverable setup problem is escalated to human-required.
 func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtPath, branch string, out StepOutput, done bool, stepErr error) {
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		out, stepErr = e.humanRequiredPR(taskID, step, "no worktree getter configured")
 		return "", "", out, true, stepErr
 	}
@@ -185,12 +185,12 @@ func (e *Engine) prWorktreeAndBranch(taskID string, step *Step, t TaskInfo) (wtP
 		ok  bool
 		err error
 	)
-	if resolver, resolves := e.worktrees.(PRWorktreeResolver); resolves {
+	if resolver, resolves := e.execution.Worktrees.(PRWorktreeResolver); resolves {
 		ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 		defer cancel()
 		wtPath, ok, err = resolver.ResolvePRWorktree(ctx, taskID)
 	} else {
-		wtPath, ok = e.worktrees.GetWorktreePath(taskID)
+		wtPath, ok = e.execution.Worktrees.GetWorktreePath(taskID)
 	}
 	if err != nil {
 		out, stepErr = e.humanRequiredPR(taskID, step, "could not prepare worktree: "+err.Error())
@@ -314,8 +314,8 @@ func (e *Engine) pushTaskBranch(taskID string, step *Step, wfExec *Execution, t 
 }
 
 func (e *Engine) preflightPushCredentials(ctx context.Context, wtPath string) error {
-	if e.pushPreflight != nil {
-		return e.pushPreflight.PreflightPushCredentials(ctx, wtPath)
+	if e.pr.PushPreflighter != nil {
+		return e.pr.PushPreflighter.PreflightPushCredentials(ctx, wtPath)
 	}
 	return project.PreflightPushCredentials(ctx, wtPath)
 }
@@ -492,12 +492,12 @@ func prRetryReason(base, detail string) string {
 // lookup failure is treated as "no PR found" so create_pr proceeds rather than
 // getting stuck.
 func (e *Engine) findExistingPRForBranch(repo, branch string) (number int, ok bool) {
-	if e.prFinder == nil {
+	if e.pr.Finder == nil {
 		return 0, false
 	}
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
-	num, found, err := e.prFinder.FindPRForBranch(ctx, repo, branch)
+	num, found, err := e.pr.Finder.FindPRForBranch(ctx, repo, branch)
 	if err != nil {
 		e.logger.Warn("workflow.create-pr.find-existing", "repo", repo, "head", branch, "err", err)
 		return 0, false
@@ -506,12 +506,12 @@ func (e *Engine) findExistingPRForBranch(repo, branch string) (number int, ok bo
 }
 
 func (e *Engine) handleExistingAnyStatePRForBranch(taskID string, step *Step, wtPath string, t TaskInfo, headArg string) (StepOutput, bool) {
-	if e.prAnyStateFinder == nil {
+	if e.pr.AnyStateFinder == nil {
 		return StepOutput{}, false
 	}
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
-	num, state, found, err := e.prAnyStateFinder.FindPRForBranchAnyState(ctx, t.ProjectID, headArg)
+	num, state, found, err := e.pr.AnyStateFinder.FindPRForBranchAnyState(ctx, t.ProjectID, headArg)
 	if err != nil {
 		e.logger.Warn("workflow.create-pr.find-any-state", "task_id", taskID, "repo", t.ProjectID, "head", headArg, "err", err)
 		return StepOutput{}, false
@@ -610,7 +610,7 @@ func (e *Engine) verifyPushedHead(taskID, wtPath string, t TaskInfo) {
 		}
 		shaCtx, shaCancel := context.WithTimeout(e.ctx, shellTimeout)
 		var shaErr error
-		remoteSHA, shaErr = e.prHeads.FetchPRHeadSHA(shaCtx, t.ProjectID, t.PRNumber)
+		remoteSHA, shaErr = e.pr.HeadFetcher.FetchPRHeadSHA(shaCtx, t.ProjectID, t.PRNumber)
 		shaCancel()
 		if shaErr == nil && remoteSHA == localSHA {
 			return
@@ -619,21 +619,21 @@ func (e *Engine) verifyPushedHead(taskID, wtPath string, t TaskInfo) {
 	e.logger.Warn("workflow.push-branch.head-mismatch", "task_id", taskID, "pr", t.PRNumber, "local", localSHA, "remote", remoteSHA)
 }
 
-// generatePRContent drafts a PR title/body via e.prContentGen, falling back
+// generatePRContent drafts a PR title/body via e.pr.ContentGenerator, falling back
 // to a minimal templated title/body (task title verbatim, task body under a
 // Motivation heading) when no generator is wired or the generation failed —
 // so create_pr always has something valid to hand `gh pr create`.
 func (e *Engine) generatePRContent(taskID, wtPath string, t TaskInfo) (title, body string) {
 	fallbackTitle := t.Title
 	fallbackBody := "## Motivation\n\n" + strings.TrimSpace(t.Body) + "\n\n## Implementation information\n\nSee commit history for " + t.Title + "."
-	if e.prContentGen == nil {
+	if e.pr.ContentGenerator == nil {
 		return fallbackTitle, fallbackBody
 	}
 
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
 	subjects := commitSubjects(ctx, wtPath)
-	genTitle, genBody, genErr := e.prContentGen.GeneratePRContent(ctx, t.Title, t.Body, subjects)
+	genTitle, genBody, genErr := e.pr.ContentGenerator.GeneratePRContent(ctx, t.Title, t.Body, subjects)
 	if genErr != nil || strings.TrimSpace(genTitle) == "" || strings.TrimSpace(genBody) == "" {
 		e.logger.Warn("workflow.create-pr.content-fallback", "task_id", taskID, "err", genErr)
 		return fallbackTitle, fallbackBody

--- a/internal/workflow/engine_steps_pr_test.go
+++ b/internal/workflow/engine_steps_pr_test.go
@@ -205,9 +205,9 @@ func TestExecPushBranch_RecoversMissingWorktreeOnce(t *testing.T) {
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"}
 	tasks.Put(task)
 	resolver := &fakePRWorktreeResolver{path: wtPath}
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(resolver)
-	engine.SetPRHeadFetcher(&fakePRHeadFetcher{sha: local})
+	engine.setPRHeadFetcherForTest(&fakePRHeadFetcher{sha: local})
 
 	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, task)
 	if err != nil {
@@ -226,7 +226,7 @@ func TestExecCreatePR_WorktreeRecoveryErrorIsPrecise(t *testing.T) {
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets"}
 	tasks.Put(task)
 	resolver := &fakePRWorktreeResolver{err: errors.New("prepare branch: remote ref missing")}
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(resolver)
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
@@ -250,7 +250,7 @@ func TestExecCreatePR_WorktreeRecoveryPropagatesStatusFailure(t *testing.T) {
 	baseTasks.Put(task)
 	tasks := &failStatusTaskProvider{memTasks: baseTasks, err: errors.New("persist status: disk full")}
 	resolver := &fakePRWorktreeResolver{err: errors.New("prepare branch: remote ref missing")}
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(resolver)
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
@@ -279,9 +279,9 @@ func TestExecPushBranch_Success(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetPRHeadFetcher(&fakePRHeadFetcher{sha: local})
+	engine.setPRHeadFetcherForTest(&fakePRHeadFetcher{sha: local})
 
 	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
 	if err != nil {
@@ -313,9 +313,9 @@ func TestExecPushBranch_BranchConflictUsesTrustedSelectedRemote(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
+	engine.setPushCredentialPreflighterForTest(&fakePushPreflighter{})
 
 	wfExec := &Execution{WorkflowID: "branch-conflict-fix", Variables: map[string]string{
 		WorkflowVarBranchConflictPushRemote: "origin",
@@ -344,10 +344,10 @@ func TestExecPushBranch_PreflightFailureFallsThroughToSuccessfulPush(t *testing.
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	preflight := &fakePushPreflighter{err: errors.New("github push credential preflight failed: gh auth status: Bad credentials")}
-	engine.SetPushCredentialPreflighter(preflight)
+	engine.setPushCredentialPreflighterForTest(preflight)
 
 	wfExec := &Execution{Variables: map[string]string{}}
 	out, err := engine.execPushBranch("t1", newPushBranchStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
@@ -387,10 +387,10 @@ func TestExecPushBranch_PreflightAndPushBothFailParksForRetry(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	preflight := &fakePushPreflighter{err: errors.New("github push credential preflight failed: gh auth status: Bad credentials")}
-	engine.SetPushCredentialPreflighter(preflight)
+	engine.setPushCredentialPreflighterForTest(preflight)
 
 	wfExec := &Execution{Variables: map[string]string{}}
 	_, err := engine.execPushBranch("t1", newPushBranchStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5, ProjectID: "acme/widgets"})
@@ -421,7 +421,7 @@ func TestExecPushBranch_PreflightAndPushBothFailParksForRetry(t *testing.T) {
 func TestExecPushBranch_NoWorktreeFlipsHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "main", PRNumber: 5})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
 
 	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "main", PRNumber: 5})
@@ -456,7 +456,7 @@ func TestExecPushBranch_DivergedFlipsHumanRequired(t *testing.T) {
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 
 	out, err := engine.execPushBranch("t1", newPushBranchStep(), &Execution{Variables: map[string]string{}}, TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
@@ -487,7 +487,7 @@ func TestExecPushBranch_DivergedRecoveredParksInsteadOfHumanRequired(t *testing.
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 
 	var recoveredTaskID string
@@ -524,7 +524,7 @@ func TestExecPushBranch_DivergedRecoveryDeclinesFallsBackToHumanRequired(t *test
 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/existing-pr", PRNumber: 5})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	engine.SetConflictRecovery(func(string) bool { return false })
 
@@ -550,7 +550,7 @@ func TestExecPushBranch_DivergedRecoveryDeclinesFallsBackToHumanRequired(t *test
 func TestConflictRecovery_DeferredWhileMarkerHeld(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	var calls int
 	engine.SetConflictRecovery(func(string) bool { calls++; return true })
@@ -596,7 +596,7 @@ func TestDrainPendingConflictRecovery_DeclineEscalates(t *testing.T) {
 			State:       ExecRunning,
 		},
 	})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetConflictRecovery(func(string) bool { return false })
 
 	engine.mu.Lock()
@@ -625,7 +625,7 @@ func TestDrainPendingConflictRecovery_DeclineEscalates(t *testing.T) {
 func TestTryConflictRecovery_ExportedWrapperQueuesWhileMarkerHeld(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	var calls int
 	engine.SetConflictRecovery(func(string) bool { calls++; return true })
@@ -670,7 +670,7 @@ func TestTryConflictRecovery_NilSafe(t *testing.T) {
 func TestTryConflictRecovery_NoRecoveryWiredReturnsFalse(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	if engine.TryConflictRecovery("t1") {
 		t.Fatal("TryConflictRecovery with no recovery wired = true, want false")
@@ -688,7 +688,7 @@ func TestTryConflictRecovery_NoRecoveryWiredReturnsFalse(t *testing.T) {
 func TestQueueConflictRecoveryRetry_DrainedByLaterMarkerRelease(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	var calls int
 	engine.SetConflictRecovery(func(string) bool { calls++; return true })
@@ -720,13 +720,13 @@ func TestExecCreatePR_Success(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	creator := &fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)}
 	engine.SetPRCreator(creator)
 	reviewer := &fakePRReviewRequester{}
-	engine.SetPRReviewRequester(reviewer)
-	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
+	engine.setPRReviewRequesterForTest(reviewer)
+	engine.setPRContentGeneratorForTest(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
 	if err != nil {
@@ -766,10 +766,10 @@ func TestExecCreatePR_CopilotReviewFailureDoesNotBlockPR(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	engine.SetPRCreator(&fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)})
-	engine.SetPRReviewRequester(&fakePRReviewRequester{copilotErr: errors.New("copilot unavailable")})
+	engine.setPRReviewRequesterForTest(&fakePRReviewRequester{copilotErr: errors.New("copilot unavailable")})
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
 	if err != nil {
@@ -803,11 +803,11 @@ func TestExecCreatePR_ClosesSupersededLinkedPR(t *testing.T) {
 		Body:        "body",
 	}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	engine.SetPRCreator(&fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)})
 	closer := &fakePRCloser{}
-	engine.SetPRCloser(closer)
+	engine.setPRCloserForTest(closer)
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
 	if err != nil {
@@ -847,10 +847,10 @@ func TestExecCreatePR_SupersededCloseFailureDoesNotBlockRelink(t *testing.T) {
 		Body:        "body",
 	}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	engine.SetPRCreator(&fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)})
-	engine.SetPRCloser(&fakePRCloser{err: errors.New("github unavailable")})
+	engine.setPRCloserForTest(&fakePRCloser{err: errors.New("github unavailable")})
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
 	if err != nil {
@@ -872,7 +872,7 @@ func TestExecCreatePR_ExistingPRShortCircuitsWithoutCreating(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	finder := &fakePRFinder{number: 77, found: true}
 	engine.SetPRFinder(finder)
@@ -925,10 +925,10 @@ func TestExecCreatePR_MergedSameBranchWithAppliedPatchMarksDoneWithoutCreating(t
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	anyState := &fakePRAnyStateFinder{number: 77, state: "MERGED", found: true}
-	engine.SetPRAnyStateFinder(anyState)
+	engine.setPRAnyStateFinderForTest(anyState)
 	creator := &fakePRCreator{number: 999, headSHA: headSHA(t, wtPath)}
 	engine.SetPRCreator(creator)
 
@@ -964,9 +964,9 @@ func TestExecCreatePR_MergedSameBranchWithRemainingPatchStillCreates(t *testing.
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetPRAnyStateFinder(&fakePRAnyStateFinder{number: 77, state: "MERGED", found: true})
+	engine.setPRAnyStateFinderForTest(&fakePRAnyStateFinder{number: 77, state: "MERGED", found: true})
 	creator := &fakePRCreator{number: 42, headSHA: headSHA(t, wtPath)}
 	engine.SetPRCreator(creator)
 
@@ -996,7 +996,7 @@ func TestExecCreatePR_FinderErrorFallsThroughToCreate(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	// A lookup failure must be treated as "no PR found" so create_pr proceeds
 	// rather than getting stuck — matching the best-effort docstring.
@@ -1027,11 +1027,11 @@ func TestExecCreatePR_DraftForNonPetProject(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "work", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	creator := &fakePRCreator{number: 7, headSHA: headSHA(t, wtPath)}
 	engine.SetPRCreator(creator)
-	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
+	engine.setPRContentGeneratorForTest(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
 
 	if _, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task); err != nil {
 		t.Fatalf("execCreatePR: %v", err)
@@ -1048,11 +1048,11 @@ func TestExecCreatePR_ContentFallbackWhenGeneratorUnset(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body text"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	creator := &fakePRCreator{number: 9, headSHA: headSHA(t, wtPath)}
 	engine.SetPRCreator(creator)
-	// No SetPRContentGenerator call — engine must fall back.
+	// No setPRContentGeneratorForTest call — engine must fall back.
 
 	if _, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task); err != nil {
 		t.Fatalf("execCreatePR: %v", err)
@@ -1072,7 +1072,7 @@ func TestExecCreatePR_NoCreatorFlipsHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	// No PRCreator wired.
 
@@ -1089,7 +1089,7 @@ func TestExecCreatePR_NoProjectFlipsHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	if _, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task); err != nil {
 		t.Fatalf("execCreatePR: %v", err)
@@ -1107,10 +1107,10 @@ func TestExecCreatePR_CreateErrorRateLimitParksForRetry(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	engine.SetPRCreator(&fakePRCreator{err: errors.New("GitHub API rate limit exceeded")})
-	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "t", body: "## Motivation\n\n## Implementation information\n"})
+	engine.setPRContentGeneratorForTest(&fakePRContentGenerator{title: "t", body: "## Motivation\n\n## Implementation information\n"})
 
 	wfExec := &Execution{Variables: map[string]string{}}
 	_, err := engine.execCreatePR("t1", newCreatePRStep(), wfExec, task)
@@ -1126,7 +1126,7 @@ func TestExecCreatePR_CreateErrorRateLimitParksForRetry(t *testing.T) {
 func TestClassifyPRGitError_AuthFailureEscalatesAfterMaxRetries(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	step := newCreatePRStep()
 	task := TaskInfo{ID: "t1", Status: "ready-pr"}
 
@@ -1150,7 +1150,7 @@ func TestClassifyPRGitError_AuthFailureEscalatesAfterMaxRetries(t *testing.T) {
 func TestClassifyPRGitError_GitHTTPSUsernamePromptIsAuthFailure(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	step := newCreatePRStep()
 	task := TaskInfo{ID: "t1", Status: "ready-pr"}
 	wfExec := &Execution{Variables: map[string]string{}}
@@ -1216,7 +1216,7 @@ func TestPRRetryReasonKeepsValidUTF8OnMultibyteHookOutput(t *testing.T) {
 func TestClassifyPRGitError_UnclassifiedFailureParksOnceThenEscalates(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	step := newPushBranchStep()
 	task := TaskInfo{ID: "t1", Status: "ready-pr"}
 
@@ -1261,11 +1261,11 @@ func TestExecCreatePR_AdoptsExistingPROnAlreadyExistsConflict(t *testing.T) {
 	tasks := newMemTasks()
 	task := TaskInfo{ID: "t1", Status: "ready-pr", Branch: "feat/my-branch", ProjectID: "acme/widgets", ProjectType: "pet", Title: "feat(x): y", Body: "body"}
 	tasks.Put(task)
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	engine.SetPRFinder(&raceThenFoundFinder{})
 	engine.SetPRCreator(&fakePRCreator{err: errors.New(`a pull request for branch "acme:feat/my-branch" into branch "main" already exists: https://github.com/acme/widgets/pull/55`)})
-	engine.SetPRContentGenerator(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
+	engine.setPRContentGeneratorForTest(&fakePRContentGenerator{title: "feat(x): y", body: "## Motivation\n\nz\n\n## Implementation information\n\nw"})
 
 	out, err := engine.execCreatePR("t1", newCreatePRStep(), &Execution{Variables: map[string]string{}}, task)
 	if err != nil {

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -227,20 +227,16 @@ func prFixAllowsResolvedMergeRecovery(reason string) bool {
 }
 
 func (e *Engine) tryRecoverResolvedMerge(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error, bool) {
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return StepOutput{}, nil, false
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return StepOutput{}, nil, false
 	}
 	if wfExec != nil && wfExec.Variables[resolvedMergeCheckpointVar(step.ID)] == "true" {
 		return e.pushRecoveredResolvedMergeCommit(taskID, step, wfExec, t, wtPath)
 	}
-	if e.checks == nil {
-		return StepOutput{}, nil, false
-	}
-
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
 	resolved, err := project.ResolvedUnmergedPaths(ctx, wtPath)
@@ -336,7 +332,7 @@ func (e *Engine) pushRecoveredResolvedMergeCommit(taskID string, step *Step, wfE
 	if out, err, ok := e.pushTaskBranch(taskID, step, wfExec, t, wtPath, branch); !ok {
 		return out, err, true
 	}
-	if e.prHeads != nil && t.PRNumber > 0 && t.ProjectID != "" {
+	if e.pr.HeadFetcher != nil && t.PRNumber > 0 && t.ProjectID != "" {
 		e.verifyPushedHead(taskID, wtPath, t)
 	}
 	e.logger.Info("workflow.pr-fix.recovered-resolved-merge", "task_id", taskID, "branch", branch)
@@ -372,7 +368,7 @@ func (e *Engine) resolvedMergeFocusedCommands(ctx context.Context, taskID, wtPat
 			files = append(files, file)
 		}
 	}
-	_, commands = selectFocusedChecks(e.checks.FocusedChecks(ctx, taskID), files)
+	_, commands = selectFocusedChecks(e.execution.Checks.FocusedChecks(ctx, taskID), files)
 	return commands, files, nil
 }
 
@@ -445,10 +441,10 @@ func cleanGitRelPath(file string) (string, bool) {
 // must never count as resolved, so any fetch error falls through to the
 // normal human-required park.
 func (e *Engine) checkPRAlreadyResolved(taskID string, t TaskInfo, agentReason string) (msg string, resolved bool) {
-	if e.prStates == nil || t.ProjectID == "" || t.PRNumber <= 0 {
+	if e.pr.StateFetcher == nil || t.ProjectID == "" || t.PRNumber <= 0 {
 		return "", false
 	}
-	state, err := e.prStates.FetchPRState(t.ProjectID, t.PRNumber)
+	state, err := e.pr.StateFetcher.FetchPRState(t.ProjectID, t.PRNumber)
 	if err != nil {
 		e.logger.Warn("workflow.pr-fix.resolved-probe-failed", "task_id", taskID, "pr", t.PRNumber, "err", err)
 		return "", false

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -258,7 +258,7 @@ func TestExecRoutePRFixResult_HumanRequiredStopsBeforeRelink(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -304,14 +304,14 @@ func TestExecRoutePRFixResult_RecoversResolvedUnmergedConflict(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: []project.FocusedCheck{{
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: []project.FocusedCheck{{
 		Name:     "workflow",
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
 	}}})
-	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
+	engine.setPushCredentialPreflighterForTest(&fakePushPreflighter{})
 
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
@@ -399,14 +399,14 @@ func TestExecRoutePRFixResult_RecoversResolvedButUnstagedConflict(t *testing.T) 
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: []project.FocusedCheck{{
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: []project.FocusedCheck{{
 		Name:     "workflow",
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
 	}}})
-	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
+	engine.setPushCredentialPreflighterForTest(&fakePushPreflighter{})
 
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
@@ -494,15 +494,15 @@ func TestExecRoutePRFixResult_ResolvedMergePushRetryKeepsCheckpointContext(t *te
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: []project.FocusedCheck{{
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: []project.FocusedCheck{{
 		Name:     "workflow",
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
 	}}})
 	preflight := &fakePushPreflighter{}
-	engine.SetPushCredentialPreflighter(preflight)
+	engine.setPushCredentialPreflighterForTest(preflight)
 
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
@@ -580,14 +580,14 @@ func TestExecRoutePRFixResult_ResolvedMergeRejectsUnexpectedDirtyPath(t *testing
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: []project.FocusedCheck{{
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: []project.FocusedCheck{{
 		Name:     "workflow",
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
 	}}})
-	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
+	engine.setPushCredentialPreflighterForTest(&fakePushPreflighter{})
 
 	beforeSHA := headSHA(t, wtPath)
 	wf := &Execution{
@@ -650,14 +650,14 @@ func TestExecRoutePRFixResult_HumanRequiredApprovalStopSkipsResolvedMergeRecover
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: []project.FocusedCheck{{
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: []project.FocusedCheck{{
 		Name:     "workflow",
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
 	}}})
-	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
+	engine.setPushCredentialPreflighterForTest(&fakePushPreflighter{})
 
 	beforeSHA := headSHA(t, wtPath)
 	wf := &Execution{
@@ -720,14 +720,14 @@ func TestExecRoutePRFixResult_ResolvedUnmergedWithFailingTestsRoutesToTestFix(t 
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: []project.FocusedCheck{{
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: []project.FocusedCheck{{
 		Name:     "workflow",
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
 	}}})
-	engine.SetPushCredentialPreflighter(&fakePushPreflighter{})
+	engine.setPushCredentialPreflighterForTest(&fakePushPreflighter{})
 
 	beforeSHA := headSHA(t, wtPath)
 	wf := &Execution{
@@ -779,8 +779,8 @@ func TestExecRoutePRFixResult_ResolvedUnmergedWithFailingTestsRoutesToTestFix(t 
 func TestResolvedMergeFocusedCommandsReturnsChangedFilesError(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.SetCheckConfigGetter(&fakeCheckGetter{focused: []project.FocusedCheck{{
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{focused: []project.FocusedCheck{{
 		Name:     "workflow",
 		Paths:    []string{"internal/workflow/**"},
 		Commands: []string{"true"},
@@ -861,7 +861,7 @@ func TestExecRoutePRFixResult_HumanRequiredWithFailingTestsRoutesToTestFix(t *te
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -908,7 +908,7 @@ func TestExecRoutePRFixResult_TestFixOwnHumanRequiredParksImmediately(t *testing
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_test_fix_result",
@@ -955,7 +955,7 @@ func TestExecRoutePRFixResult_HumanRequiredWithoutFailingTestsNoNote(t *testing.
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -988,7 +988,7 @@ func TestExecRoutePRFixResult_NoPRRemoteOutageResumesRecovery(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",
 		CurrentStep: "route_result",
@@ -1037,7 +1037,7 @@ func TestExecRoutePRFixResult_FlakeRoutesToInReviewWithoutCommit(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -1078,7 +1078,7 @@ func TestExecRoutePRFixResult_ReviewHoldParkBeatsFlake(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -1116,8 +1116,8 @@ func TestExecRoutePRFixResult_ReProbesResolvedRemotePR(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
-	engine.SetPRStateFetcher(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.setPRStateFetcherForTest(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -1157,8 +1157,8 @@ func TestExecRoutePRFixResult_ReviewHoldParkIgnoresResolvedRemotePR(t *testing.T
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
-	engine.SetPRStateFetcher(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.setPRStateFetcherForTest(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -1195,7 +1195,7 @@ func TestExecRoutePRFixResult_ReviewHoldParkWinsOverContinue(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	// The agent pushed in review-hold push mode and reported `continue`; the
 	// deterministic park var must still route the task to human-required so the
 	// drafted pending review isn't silently left unsubmitted.
@@ -1239,7 +1239,7 @@ func TestExecRoutePRFixResult_ReviewHoldParkIgnoresFailingTestLines(t *testing.T
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	wf := &Execution{
 		WorkflowID:  "pr-fix",
 		CurrentStep: "route_pr_fix_result",
@@ -1391,7 +1391,7 @@ func TestAdvanceStep_PRFixHumanRequiredUsesUntruncatedOutput(t *testing.T) {
 
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	if err := engine.StartWorkflow("t1", "pr-fix-route-test"); err != nil {
 		t.Fatalf("start workflow: %v", err)
@@ -1466,7 +1466,7 @@ func TestAdvanceStep_TestFixHumanRequiredUsesUntruncatedOutput(t *testing.T) {
 
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	if err := engine.StartWorkflow("t1", "test-fix-route-test"); err != nil {
 		t.Fatalf("start workflow: %v", err)

--- a/internal/workflow/engine_steps_resume_test.go
+++ b/internal/workflow/engine_steps_resume_test.go
@@ -43,7 +43,7 @@ func TestExecResumeWorkflow_ResumesCapturedTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",
@@ -98,7 +98,7 @@ func TestExecResumeWorkflow_NoTargetCompletesNormally(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",
@@ -155,7 +155,7 @@ func TestExecResumeWorkflow_SkipsStaleRebaseHumanRequired(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",
@@ -206,7 +206,7 @@ func TestExecResumeWorkflow_RestoresUnrelatedHumanRequired(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",
@@ -272,7 +272,7 @@ func TestExecResumeWorkflow_SkipsStaleRebaseHumanRequiredWithResumeTarget(t *tes
 		t.Fatal(err)
 	}
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wf := &Execution{
 		WorkflowID:  "branch-conflict-fix",

--- a/internal/workflow/engine_steps_sync.go
+++ b/internal/workflow/engine_steps_sync.go
@@ -26,7 +26,7 @@ type syncBranchReport struct {
 
 // execSyncBranch runs a proactive, best-effort sync of the task's worktree
 // branch against the project's default branch. It never blocks workflow
-// advancement: a nil BranchSyncer, a missing worktree, a sync error, or even
+// advancement: a skipped sync, a missing worktree, a sync error, or even
 // a panic inside the syncer all resolve to a completed step with the outcome
 // recorded in the step output and (when a recorder is wired) a generic
 // artifact — never an error return, and never a task status change.
@@ -38,14 +38,10 @@ func (e *Engine) execSyncBranch(taskID string, step *Step) (out StepOutput, err 
 		}
 	}()
 
-	if e.branchSyncer == nil {
-		return e.recordSyncBranch(taskID, step, syncResultSkipped, "no branch syncer configured")
-	}
-
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
 
-	result, syncErr := e.branchSyncer.SyncTaskBranch(ctx, taskID)
+	result, syncErr := e.execution.BranchSyncer.SyncTaskBranch(ctx, taskID)
 	if syncErr != nil {
 		e.logger.Warn("workflow.sync-branch.result", "task_id", taskID, "result", result, "err", syncErr)
 		return e.recordSyncBranch(taskID, step, result, syncErr.Error())

--- a/internal/workflow/engine_steps_sync_test.go
+++ b/internal/workflow/engine_steps_sync_test.go
@@ -39,7 +39,7 @@ func newSyncBranchStep() *Step { return &Step{ID: "sync_branch", Type: StepSyncB
 
 func newSyncBranchEngine(t *testing.T) (*Engine, *memTasks) {
 	t.Helper()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	return engine, engine.tasks.(*memTasks)
 }
 
@@ -67,7 +67,7 @@ func TestExecSyncBranch_Success(t *testing.T) {
 	t.Parallel()
 	engine, tasks := newSyncBranchEngine(t)
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine.SetBranchSyncer(&fakeBranchSyncer{result: "synced"})
+	engine.setBranchSyncerForTest(&fakeBranchSyncer{result: "synced"})
 
 	out, err := engine.execSyncBranch("t1", newSyncBranchStep())
 	if err != nil {
@@ -85,7 +85,7 @@ func TestExecSyncBranch_NoopIsCompleted(t *testing.T) {
 	t.Parallel()
 	engine, tasks := newSyncBranchEngine(t)
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine.SetBranchSyncer(&fakeBranchSyncer{result: "noop"})
+	engine.setBranchSyncerForTest(&fakeBranchSyncer{result: "noop"})
 
 	out, err := engine.execSyncBranch("t1", newSyncBranchStep())
 	if err != nil {
@@ -100,7 +100,7 @@ func TestExecSyncBranch_ConflictDoesNotBlock(t *testing.T) {
 	t.Parallel()
 	engine, tasks := newSyncBranchEngine(t)
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine.SetBranchSyncer(&fakeBranchSyncer{result: "conflict", err: errors.New("rebase conflict")})
+	engine.setBranchSyncerForTest(&fakeBranchSyncer{result: "conflict", err: errors.New("rebase conflict")})
 
 	out, err := engine.execSyncBranch("t1", newSyncBranchStep())
 	if err != nil {
@@ -121,7 +121,7 @@ func TestExecSyncBranch_FailedDoesNotBlock(t *testing.T) {
 	t.Parallel()
 	engine, tasks := newSyncBranchEngine(t)
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine.SetBranchSyncer(&fakeBranchSyncer{result: "failed", err: errors.New("network timeout")})
+	engine.setBranchSyncerForTest(&fakeBranchSyncer{result: "failed", err: errors.New("network timeout")})
 
 	out, err := engine.execSyncBranch("t1", newSyncBranchStep())
 	if err != nil {
@@ -140,7 +140,7 @@ func TestExecSyncBranch_UsesShellTimeout(t *testing.T) {
 	engine, tasks := newSyncBranchEngine(t)
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
 	syncer := &deadlineCapturingSyncer{}
-	engine.SetBranchSyncer(syncer)
+	engine.setBranchSyncerForTest(syncer)
 
 	out, err := engine.execSyncBranch("t1", newSyncBranchStep())
 	if err != nil {
@@ -161,7 +161,7 @@ func TestExecSyncBranch_PanicIsContained(t *testing.T) {
 	t.Parallel()
 	engine, tasks := newSyncBranchEngine(t)
 	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
-	engine.SetBranchSyncer(&fakeBranchSyncer{panics: true})
+	engine.setBranchSyncerForTest(&fakeBranchSyncer{panics: true})
 
 	out, err := engine.execSyncBranch("t1", newSyncBranchStep())
 	if err != nil {

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -895,10 +895,10 @@ func (e *Engine) execDetectTampering(taskID string, step *Step, t TaskInfo) (Ste
 			0, "human bless ("+TamperBlessedTag+" tag)", "blessed")
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "blessed"}, nil
 	}
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree for task"}, nil
 	}

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -1003,7 +1003,7 @@ func newTamperEngine(t *testing.T, wt string) (*Engine, *memTasks) {
 	t.Helper()
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
 	return engine, tasks
 }
@@ -1012,7 +1012,7 @@ func TestExecDetectTampering_NoWorktreeSkips(t *testing.T) {
 	t.Parallel()
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
 	if err != nil {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -2457,10 +2457,10 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 }
 
 func (e *Engine) seedReimplementNote(ctx context.Context, wfExec *Execution, taskID string, attempts int, t TaskInfo) {
-	if e.attemptNotes == nil || e.worktrees == nil {
+	if e.execution.AttemptNotes == nil || e.execution.Worktrees == nil {
 		return
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return
 	}
@@ -2488,7 +2488,7 @@ func (e *Engine) seedReimplementNote(ctx context.Context, wfExec *Execution, tas
 			"Latest rejection reason:\n\n%s\n",
 		attempts, marker, diffStat, quoteMarkdownBlock(reason),
 	)
-	if err := e.attemptNotes.AppendReimplementNote(ctx, taskID, wtPath, marker, section); err != nil {
+	if err := e.execution.AttemptNotes.AppendReimplementNote(ctx, taskID, wtPath, marker, section); err != nil {
 		e.logger.Warn("workflow.test.reimplement-note", "task_id", taskID, "worktree", wtPath, "attempts", attempts, "err", err)
 		return
 	}

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1696,7 +1696,7 @@ func makeTestEngine(t *testing.T) (*Engine, *memTasks) {
 	t.Helper()
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetTestingMaxAttempts(3)
 	return engine, tasks
 }
@@ -1791,7 +1791,7 @@ func makeTestingTaskEngine(t *testing.T) (*Engine, *memTasks, *mockAgents) {
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	return engine, tasks, agents
 }
 
@@ -2909,7 +2909,7 @@ func TestExecRouteTestResult_ReimplementSeedsNote(t *testing.T) {
 	wtPath := makeGitRepo(t, true)
 	e.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	appender := &recordingAttemptNoteAppender{}
-	e.SetAttemptNoteAppender(appender)
+	e.setAttemptNoteAppenderForTest(appender)
 
 	now := time.Now().UTC()
 	var report strings.Builder
@@ -3003,7 +3003,7 @@ func TestExecRouteTestResult_ReimplementNoteIdempotent(t *testing.T) {
 	wtPath := makeGitRepo(t, true)
 	e.SetWorktreeGetter(&fakeWorktreeGetter{path: wtPath, ok: true})
 	appender := &recordingAttemptNoteAppender{}
-	e.SetAttemptNoteAppender(appender)
+	e.setAttemptNoteAppenderForTest(appender)
 
 	now := time.Now().UTC()
 	taskID := "t-reimplement-idem"
@@ -3061,7 +3061,7 @@ func TestExecRouteTestResult_AppenderErrorFailsOpen(t *testing.T) {
 	e, tasks := makeTestEngine(t)
 	e.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, true), ok: true})
 	appender := &recordingAttemptNoteAppender{err: errors.New("disk full")}
-	e.SetAttemptNoteAppender(appender)
+	e.setAttemptNoteAppenderForTest(appender)
 
 	now := time.Now().UTC()
 	taskID := "t-reimplement-appender-error"
@@ -3144,7 +3144,7 @@ func TestExecRouteTestResult_NonReimplementRoutesDoNotSeedNote(t *testing.T) {
 			e, tasks := makeTestEngine(t)
 			e.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, true), ok: true})
 			appender := &recordingAttemptNoteAppender{}
-			e.SetAttemptNoteAppender(appender)
+			e.setAttemptNoteAppenderForTest(appender)
 			tasks.Put(tt.task)
 
 			out, err := e.execRouteTestResult(tt.taskID, &Step{ID: "route_test"}, tt.wf, mustGetTaskInfo(t, tasks, tt.taskID))

--- a/internal/workflow/engine_steps_triage.go
+++ b/internal/workflow/engine_steps_triage.go
@@ -256,8 +256,8 @@ func (e *Engine) execTriageReview(taskID string, step *Step, t TaskInfo) (StepOu
 // triage heuristic. Tries the worktree first, falls back to gh pr diff when
 // the task has a PR but no worktree (e.g. the standalone pr-review workflow).
 func (e *Engine) collectTriageDiff(taskID string, t TaskInfo) (files []string, insertions, deletions int, source string, err error) {
-	if e.worktrees != nil {
-		if wtPath, ok := e.worktrees.GetWorktreePath(taskID); ok {
+	if e.execution.Worktrees != nil {
+		if wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID); ok {
 			files, insertions, deletions, err = e.gitTriageDiff(wtPath)
 			if err == nil {
 				return files, insertions, deletions, "worktree", nil

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -39,11 +39,11 @@ const (
 // human can fix the linkage manually.
 //
 // The step is a no-op when any of these are missing: task.Issue,
-// task.PRNumber, task.ProjectID, engine.prLinker. It also skips when
+// task.PRNumber, task.ProjectID, engine.pr.Linker. It also skips when
 // the issue lives in a different repo than the PR (cross-repo linking
 // needs explicit support GitHub handles but this check does not).
 func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
-	if e.prLinker == nil {
+	if e.pr.Linker == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no pr linker configured"}, nil
 	}
 	if t.Issue == "" || t.PRNumber == 0 || t.ProjectID == "" {
@@ -58,7 +58,7 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: cross-repo issue link"}, nil
 	}
 
-	issues, body, err := e.prLinker.GetClosingIssues(t.ProjectID, t.PRNumber)
+	issues, body, err := e.pr.Linker.GetClosingIssues(t.ProjectID, t.PRNumber)
 	if err != nil {
 		e.logger.Error("workflow.pr-close.fetch", "task_id", taskID, "err", err)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "fetch failed: " + err.Error()}, nil
@@ -72,7 +72,7 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 		newBody += "\n\n"
 	}
 	newBody += "Closes " + t.Issue
-	if editErr := e.prLinker.EditBody(t.ProjectID, t.PRNumber, newBody); editErr != nil {
+	if editErr := e.pr.Linker.EditBody(t.ProjectID, t.PRNumber, newBody); editErr != nil {
 		e.logger.Error("workflow.pr-close.edit", "task_id", taskID, "err", editErr)
 		if statusErr := e.tasks.UpdateTaskStatus(taskID, taskstatus.HumanRequired, "PR does not close linked issue and auto-fix failed: "+editErr.Error()); statusErr != nil {
 			e.logger.Error("workflow.pr-close.status", "task_id", taskID, "err", statusErr)
@@ -92,7 +92,7 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 			prVerifySleep(prVerifyBackoffs[attempt-1])
 		}
 		var verified []int
-		verified, _, verifyErr = e.prLinker.GetClosingIssues(t.ProjectID, t.PRNumber)
+		verified, _, verifyErr = e.pr.Linker.GetClosingIssues(t.ProjectID, t.PRNumber)
 		if verifyErr == nil && slices.Contains(verified, issueNum) {
 			e.logger.Info("workflow.pr-close.linked", "task_id", taskID, "pr", t.PRNumber, "issue", issueNum, "attempt", attempt)
 			return StepOutput{StepID: step.ID, Status: "completed", Output: fmt.Sprintf("linked issue #%d", issueNum)}, nil
@@ -120,14 +120,14 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 // no-op when the PR linker is unset or the task carries no PR/project, and it
 // never blocks the workflow — a fetch/edit failure is logged and completed.
 func (e *Engine) execStampPRAttribution(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
-	if e.prLinker == nil {
+	if e.pr.Linker == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no pr linker configured"}, nil
 	}
 	if t.PRNumber == 0 || t.ProjectID == "" {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: missing pr or project"}, nil
 	}
 
-	_, body, err := e.prLinker.GetClosingIssues(t.ProjectID, t.PRNumber)
+	_, body, err := e.pr.Linker.GetClosingIssues(t.ProjectID, t.PRNumber)
 	if err != nil {
 		e.logger.Error("workflow.pr-attribution.fetch", "task_id", taskID, "err", err)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "fetch failed: " + err.Error()}, nil
@@ -140,7 +140,7 @@ func (e *Engine) execStampPRAttribution(taskID string, step *Step, t TaskInfo) (
 		}
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "already stamped"}, nil
 	}
-	if editErr := e.prLinker.EditBody(t.ProjectID, t.PRNumber, stamped); editErr != nil {
+	if editErr := e.pr.Linker.EditBody(t.ProjectID, t.PRNumber, stamped); editErr != nil {
 		e.logger.Error("workflow.pr-attribution.edit", "task_id", taskID, "err", editErr)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "edit failed: " + editErr.Error()}, nil
 	}
@@ -149,14 +149,14 @@ func (e *Engine) execStampPRAttribution(taskID string, step *Step, t TaskInfo) (
 }
 
 func (e *Engine) execRerequestReview(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
-	if e.prReviewers == nil {
+	if e.pr.ReviewRequester == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no pr review requester configured"}, nil
 	}
 	if t.PRNumber == 0 || t.ProjectID == "" {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: missing pr or project"}, nil
 	}
 
-	reviewers, err := e.prReviewers.RerequestReview(t.ProjectID, t.PRNumber)
+	reviewers, err := e.pr.ReviewRequester.RerequestReview(t.ProjectID, t.PRNumber)
 	if err != nil {
 		e.logger.Warn("workflow.rerequest-review.failed", "task_id", taskID, "pr", t.PRNumber, "err", err)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "request failed: " + err.Error()}, nil
@@ -273,10 +273,10 @@ func originBaseCandidates(ctx context.Context, wtPath string) []string {
 }
 
 func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree for task"}, nil
 	}

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -314,19 +314,16 @@ func (e *Engine) verifyChecksCacheHit(taskID string, step *Step, wtPath, treeSHA
 }
 
 func (e *Engine) loadVerifyChecksInputs(taskID string) (cmds []string, wtPath string, timeout time.Duration, skip string) {
-	if e.checks == nil {
-		return nil, "", 0, "skipped: no check config getter"
-	}
 	timeout = resolveWorkflowCheckTimeout(e.verifyTimeout)
-	cmds = e.checks.VerifyCommands(e.ctx, taskID)
+	cmds = e.execution.Checks.VerifyCommands(e.ctx, taskID)
 	if len(cmds) == 0 {
 		return nil, "", 0, "skipped: no verify commands configured"
 	}
-	if e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return nil, "", 0, "skipped: no worktree getter configured"
 	}
 	var ok bool
-	wtPath, ok = e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok = e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return nil, "", 0, "skipped: no worktree for task"
 	}
@@ -389,14 +386,14 @@ func (e *Engine) parkVerifyChecksForBackpressure(taskID string, step *Step, wfEx
 // must treat that the same as "could not verify" and fall back to their own
 // default behavior rather than treat it as a pass.
 func (e *Engine) VerifyTaskNow(ctx context.Context, taskID string) (verified, passed bool, failedCmd, output string, err error) {
-	if e.checks == nil || e.worktrees == nil {
+	if e.execution.Worktrees == nil {
 		return false, false, "", "", nil
 	}
-	cmds := e.checks.VerifyCommands(ctx, taskID)
+	cmds := e.execution.Checks.VerifyCommands(ctx, taskID)
 	if len(cmds) == 0 {
 		return false, false, "", "", nil
 	}
-	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	wtPath, ok := e.execution.Worktrees.GetWorktreePath(taskID)
 	if !ok {
 		return false, false, "", "", nil
 	}
@@ -445,7 +442,7 @@ func (e *Engine) runVerifySuiteWithRetry(parent context.Context, taskID, wtPath 
 
 func (e *Engine) healToolchainAndRetry(taskID, wtPath string, cmds []string, timeout time.Duration, stepID string) (attempted bool, failedCmd, output string, runErr error) {
 	setupCtx, cancel := context.WithTimeout(e.ctx, timeout)
-	setup := e.checks.SetupCommands(setupCtx, taskID)
+	setup := e.execution.Checks.SetupCommands(setupCtx, taskID)
 	if len(setup) == 0 {
 		cancel()
 		return false, "", "", nil

--- a/internal/workflow/engine_steps_verify_checks_autofix_test.go
+++ b/internal/workflow/engine_steps_verify_checks_autofix_test.go
@@ -529,9 +529,9 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: []string{lintVerifyCommand("internal/foo/foo.go")}})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{cmds: []string{lintVerifyCommand("internal/foo/foo.go")}})
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 
 	if err := engine.StartWorkflow("t1", "verify-lint-repair"); err != nil {

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -49,22 +49,22 @@ func newVerifyChecksStep() *Step { return &Step{ID: "verify_checks", Type: StepV
 
 func newVerifyChecksEngine(t *testing.T, wt string, cmds []string) (*Engine, *memTasks) {
 	t.Helper()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: cmds})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{cmds: cmds})
 	return engine, engine.tasks.(*memTasks)
 }
 
-func TestExecVerifyChecks_NoGetterSkips(t *testing.T) {
+func TestExecVerifyChecks_DefaultGetterSkips(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
 
 	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), nil, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if out.Output != "skipped: no check config getter" {
+	if out.Output != "skipped: no verify commands configured" {
 		t.Errorf("Output = %q, want skip", out.Output)
 	}
 }
@@ -85,7 +85,7 @@ func TestExecVerifyChecks_NoCommandsSkips(t *testing.T) {
 
 func TestVerifyTaskNow_NoGetterNotVerified(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
 
 	verified, passed, _, _, err := engine.VerifyTaskNow(t.Context(), "t1")
@@ -112,9 +112,9 @@ func TestVerifyTaskNow_NoCommandsNotVerified(t *testing.T) {
 
 func TestVerifyTaskNow_NoWorktreeNotVerified(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: []string{"true"}})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{cmds: []string{"true"}})
 
 	verified, passed, _, _, err := engine.VerifyTaskNow(t.Context(), "t1")
 	if err != nil {
@@ -363,10 +363,10 @@ func TestExecVerifyChecks_CommandChangeForcesRerun(t *testing.T) {
 
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
 	getter := &fakeCheckGetter{cmds: []string{"echo run >> " + counter}}
-	engine.SetCheckConfigGetter(getter)
+	engine.setCheckConfigGetterForTest(getter)
 	engine.SetEvidenceRecorder(newFakeEvidenceRecorder())
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 
@@ -623,7 +623,7 @@ func TestExecVerifyChecks_BackpressureParksWhilePeerVerifyInFlight(t *testing.T)
 		t.Fatal(err)
 	}
 	var logs bytes.Buffer
-	engine := NewEngine(store, newMemTasks(), newMockAgents(), slog.New(slog.NewTextHandler(&logs, nil)))
+	engine := NewTestEngine(store, newMemTasks(), newMockAgents(), slog.New(slog.NewTextHandler(&logs, nil)))
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{
 		ok: true,
 		paths: map[string]string{
@@ -631,7 +631,7 @@ func TestExecVerifyChecks_BackpressureParksWhilePeerVerifyInFlight(t *testing.T)
 			"t2": wt2,
 		},
 	})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{cmdsByTask: map[string][]string{
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{cmdsByTask: map[string][]string{
 		"t1": {blocking},
 		"t2": {"true"},
 	}})
@@ -735,9 +735,9 @@ func TestExecVerifyChecks_BackpressureParksWhilePeerVerifyInFlight(t *testing.T)
 
 func newVerifyChecksEngineWithSetup(t *testing.T, wt string, cmds, setup []string) (*Engine, *memTasks) {
 	t.Helper()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
-	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: cmds, setup: setup})
+	engine.setCheckConfigGetterForTest(&fakeCheckGetter{cmds: cmds, setup: setup})
 	return engine, engine.tasks.(*memTasks)
 }
 
@@ -965,7 +965,7 @@ func TestRunVerifyCommands_DeadlineReturnsCtxErr(t *testing.T) {
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	failed, _, err := engine.runVerifyCommands(ctx, "t1", wt, []string{"sleep 20"})
 	if err == nil {
 		t.Fatal("expected a context error on deadline, got nil")
@@ -981,7 +981,7 @@ func TestRunVerifyCommands_DeadlineReturnsCtxErr(t *testing.T) {
 func TestRunVerifyCommands_GOCACHEIsPerTaskWhileGOMODCACHEStaysShared(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	ctx := context.Background()
 	cmd := `printf '%s|%s' "$GOCACHE" "$GOMODCACHE"`
 
@@ -1266,7 +1266,7 @@ func TestEnsureNodeToolchain_RepairsCorruptBin(t *testing.T) {
 
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", dir, "npm run build:web", tail)
 
@@ -1286,7 +1286,7 @@ func TestEnsureNodeToolchain_RepairsMissingBin(t *testing.T) {
 
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", dir, "npm run build:web", tail)
 
@@ -1306,7 +1306,7 @@ func TestEnsureNodeToolchain_IntactBinSkipsRepair(t *testing.T) {
 
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", dir, "npm run build:web", tail)
 
@@ -1330,7 +1330,7 @@ func TestEnsureNodeToolchain_ResolvesCdPrefix(t *testing.T) {
 
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", root, "(cd frontend && mise exec -- npm run build:web)", tail)
 
@@ -1351,7 +1351,7 @@ func TestEnsureNodeToolchain_CdSubstringIsNotAFalseMatch(t *testing.T) {
 	writeTestFile(t, filepath.Join(binDir, "vite"), "#!/bin/sh\necho vite\n") // intact
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", root, "npm run test:cd main", tail)
 
@@ -1374,7 +1374,7 @@ func TestEnsureNodeToolchain_QuotedDirWithSpace(t *testing.T) {
 	writeTestFile(t, filepath.Join(binDir, "vite"), "") // corrupt
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", root, `cd "my dir" && npm run build`, tail)
 
@@ -1396,7 +1396,7 @@ func TestEnsureNodeToolchain_ChainedCdRepairsEachLeg(t *testing.T) {
 	// Shared fake npm on PATH; it drops the marker in whichever cwd it runs.
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", root,
 		"(cd frontend && npm run build) && (cd backend && npm test)", tail)
@@ -1423,7 +1423,7 @@ func TestEnsureNodeToolchain_TraversalIsRejected(t *testing.T) {
 	if err := os.MkdirAll(wt, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", wt, "cd ../outside && npm run build", tail)
 
@@ -1436,7 +1436,7 @@ func TestEnsureNodeToolchain_NonNodeDirSkips(t *testing.T) {
 	dir := t.TempDir() // no package.json
 	fakeNPM(t, "marker-npm-ci-ran")
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	tail := &boundedTail{max: 4096}
 	engine.ensureNodeToolchain(context.Background(), "t1", dir, "go test ./...", tail)
 
@@ -1649,7 +1649,7 @@ func TestRepairCorruptedNodeModules_RepairsPartialInstall(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairCorruptedNodeModules(context.Background(), "t1", wt)
 
 	if _, err := os.Stat(filepath.Join(nm, ".bin")); err != nil {
@@ -1753,7 +1753,7 @@ func TestRepairCorruptedNodeModules_UsesSubdirMiseConfig(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	if failed := engine.repairCorruptedNodeModules(context.Background(), "t1", wt); failed {
 		t.Fatal("repairCorruptedNodeModules reported failure; want subdir mise config to drive npm repair")
 	}
@@ -1782,7 +1782,7 @@ func TestRepairCorruptedNodeModules_LeavesHealthyInstallAlone(t *testing.T) {
 	// No fake npm on PATH — if the engine tried to repair a healthy install
 	// it would fail loudly (npm ci would error or hit the network); a
 	// successful, silent no-op proves the healthy install was left alone.
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairCorruptedNodeModules(context.Background(), "t1", wt)
 }
 
@@ -1811,7 +1811,7 @@ func TestRepairCorruptedNodeModules_SkipsPnpmWorkspace(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairCorruptedNodeModules(context.Background(), "t1", wt)
 
 	if _, err := os.Stat(filepath.Join(frontend, "invoked")); err == nil {
@@ -2028,7 +2028,7 @@ func TestRepairTornNodeModules_RepairsWhenTorn(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "marker")
 	fakeNpmOnPath(t, marker)
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	out, err := os.ReadFile(marker)
@@ -2056,7 +2056,7 @@ func TestRepairTornNodeModules_RepairsRootProject(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "marker")
 	fakeNpmOnPath(t, marker)
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	out, err := os.ReadFile(marker)
@@ -2081,7 +2081,7 @@ func TestRepairTornNodeModules_SkipsWithoutLockfile(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "marker")
 	fakeNpmOnPath(t, marker)
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
@@ -2112,7 +2112,7 @@ func TestRepairTornNodeModules_LogsRepairFailure(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), logger)
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), logger)
 	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if !strings.Contains(logBuf.String(), "workflow.verify-checks.npm-repair-failed") {
@@ -2154,7 +2154,7 @@ esac
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if _, err := os.Stat(lifecycleMarker); !os.IsNotExist(err) {
@@ -2182,7 +2182,7 @@ func TestRepairTornNodeModules_SkipsWhenHealthy(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "marker")
 	fakeNpmOnPath(t, marker)
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	engine.repairTornNodeModules(t.Context(), "t1", wt)
 
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -156,7 +156,7 @@ func TestReplayPersistedEffects(t *testing.T) {
 			},
 		}, gets: map[string]int{}}
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 		engine.ReplayPersistedEffects()
 
@@ -201,7 +201,7 @@ func TestReplayPersistedEffects(t *testing.T) {
 			},
 		}, gets: map[string]int{}}
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 		engine.ReplayPersistedEffects()
 
@@ -265,7 +265,7 @@ steps:
 			},
 		}, gets: map[string]int{}}
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 		engine.ReplayPersistedEffects()
 
@@ -322,7 +322,7 @@ steps:
 			},
 		}, gets: map[string]int{}}
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 		engine.ReplayPersistedEffects()
 
@@ -374,7 +374,7 @@ steps:
 			},
 		}, gets: map[string]int{}}
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 		if handled := engine.ReplayPersistedEffectsForTask("t2"); !handled {
 			t.Fatal("ReplayPersistedEffectsForTask returned false, want true")
@@ -421,7 +421,7 @@ steps:
 		}, gets: map[string]int{}}
 		agents := newMockAgents()
 		agents.SetProviderRateLimited(true)
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 		engine.ReplayPersistedEffects()
 
@@ -459,7 +459,7 @@ steps:
 			},
 		}, gets: map[string]int{}}
 		agents := newMockAgents()
-		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 		engine.ReplayPersistedEffects()
 
@@ -508,7 +508,7 @@ func TestResumeStalled_RecordsFallbackMetric(t *testing.T) {
 		},
 	}, gets: map[string]int{}}
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	engine.ResumeStalled()
 
@@ -1408,7 +1408,7 @@ func TestFullLifecycle_DirectImplement(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 
@@ -1468,7 +1468,7 @@ func TestOneShot_ComputedFromStepConfig(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Legacy interactive-mode task forces the templated implement step into
 	// interactive mode via {{.Task.AgentMode}}, exercising the coercion path.
@@ -1535,7 +1535,7 @@ func TestFullLifecycle_PlanPath(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 
@@ -1607,7 +1607,7 @@ func TestPlanReject_ThenApprove(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -1656,7 +1656,7 @@ func TestTriageRetry_Success(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -1699,7 +1699,7 @@ func TestTriageRetry_Exhausted(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -1742,7 +1742,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "headless"})
 	if err := engine.StartWorkflowFromStepWithVars("t1", "simple-task-plan", "plan", nil); err != nil {
@@ -1802,7 +1802,7 @@ func TestResumeStalled_WatchdogHangRetriesThenEscalates(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			vars := map[string]string{}
 			if tc.retries != "" {
 				vars[watchdogHangRetryKey("implement")] = tc.retries
@@ -1901,7 +1901,7 @@ func TestResumeStalled_WatchdogStopImplementationRetriesThenEscalates(t *testing
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			vars := map[string]string{}
 			if tc.retries != "" {
 				vars[watchdogStopRetryKey("implement")] = tc.retries
@@ -2012,7 +2012,7 @@ func TestResumeStalled_WatchdogRewardHackingRetriesThenEscalates(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			vars := map[string]string{}
 			if tc.retries != "" {
 				vars[watchdogRewardHackingRetryKey(tc.stepID)] = tc.retries
@@ -2095,7 +2095,7 @@ func TestResumeStalled_WorktreeRepairRetriesThenExhausts(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			vars := map[string]string{}
 			if tc.attempts != "" {
 				vars[worktreeRepairRetryKey("implement")] = tc.attempts
@@ -2149,7 +2149,7 @@ func TestResumeStalled_WatchdogStopVerifiedFailureDoesNotRetry(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{
 		ID:           "t1",
 		Status:       "human-required",
@@ -2185,7 +2185,7 @@ func TestResumeStalled_WatchdogStopRateLimitedProviderKeepsHumanRequired(t *test
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimited(true)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{
 		ID:           "t1",
 		Status:       "human-required",
@@ -2230,7 +2230,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
 	tasks.Put(TaskInfo{
@@ -2289,7 +2289,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetOpenPROnUnrunnableGate(false)
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
@@ -2331,7 +2331,7 @@ func TestResumeStalled_TransientFetchRetriesThenEscalates(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetFailSpawn(worktreeerr.ErrTransientFetch)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -2386,7 +2386,7 @@ func TestResumeStalled_WatchdogHangDoesNotBurnBudgetWhileAgentRunning(t *testing
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{
 		ID:           "t1",
 		Status:       "in-progress",
@@ -2530,7 +2530,7 @@ func startTestSimpleImplement(t *testing.T) (*Store, *memTasks, *mockAgents, *En
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -2586,7 +2586,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
 
@@ -2675,7 +2675,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false), ok: true})
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
@@ -2830,7 +2830,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false), ok: true})
 
 	tasks.Put(TaskInfo{
@@ -2902,7 +2902,7 @@ steps:
 `)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false), ok: true})
 
 			tasks.Put(TaskInfo{
@@ -2977,7 +2977,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false), ok: true})
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
@@ -3046,7 +3046,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false), ok: true})
 
 	tasks.Put(TaskInfo{
@@ -3120,7 +3120,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
 
@@ -3207,7 +3207,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
 
@@ -3284,7 +3284,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) { completed = append(completed, info) })
 
@@ -3346,7 +3346,7 @@ func TestRetry_SupersededAgentLateCompletionDropped(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -3411,7 +3411,7 @@ func TestTriageRetryableReasonTreatsCompletedRunAsFailed(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -3452,7 +3452,7 @@ func TestTriageRetryableExhaustionBlocksNonHuman(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -3492,7 +3492,7 @@ func TestMatchWorkflow_ReviewTag(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Task WITH review tag should NOT match test-simple.
 	review := TaskInfo{ID: "t1", Tags: []string{"review"}}
@@ -3511,7 +3511,7 @@ func TestMatchWorkflow_NoMatch(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Wrong event type.
 	normal := TaskInfo{ID: "t1"}
@@ -3560,7 +3560,7 @@ func TestDispatchEvent_MatchesAndStarts(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	addPREventWorkflow(t, store, "pr-fix-test", 0, "ci_failure")
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-review", AgentMode: "headless"})
@@ -3586,7 +3586,7 @@ func TestDispatchEvent_NoMatchReturnsEmpty(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	addPREventWorkflow(t, store, "pr-fix-test", 0, "ci_failure")
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-review"})
@@ -3609,7 +3609,7 @@ func TestDispatchEvent_AlreadyActiveRejected(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	addPREventWorkflow(t, store, "pr-fix-test", 0, "ci_failure")
 	tasks.Put(TaskInfo{
@@ -3637,7 +3637,7 @@ func TestDispatchEvent_TerminalWorkflowReplaced(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	addPREventWorkflow(t, store, "pr-fix-test", 0, "ci_failure")
 	tasks.Put(TaskInfo{
@@ -3670,7 +3670,7 @@ func TestHasActiveWorkflow(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "no-wf", Status: "todo"})
 	tasks.Put(TaskInfo{
@@ -3716,7 +3716,7 @@ func TestCancelWorkflow(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID: "active", Status: "in-progress",
@@ -3781,7 +3781,7 @@ func TestStartWorkflowRejectsTamperFlaggedRestart(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	originalWorkflow := &Execution{
 		WorkflowID: "simple-task-implement",
@@ -3819,7 +3819,7 @@ func TestStartWorkflowAllowsNonTamperHumanRequiredRestart(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "human",
@@ -3840,7 +3840,7 @@ func TestMatchWorkflow_PriorityTieBreak(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Two workflows match the same event + field — higher priority wins.
 	addPREventWorkflow(t, store, "pr-fix-generic", 0, "ci_failure")
@@ -3863,7 +3863,7 @@ func TestMatchWorkflow_EqualPriorityDeterministic(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Two workflows with equal priority — alphabetical (store order) wins.
 	addPREventWorkflow(t, store, "pr-fix-zebra", 5, "ci_failure")
@@ -3886,7 +3886,7 @@ func TestNoWorkflowField(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"}) // no Workflow
 
@@ -3922,7 +3922,7 @@ func TestResumeStalled_PrioritizesReviewOverNewWork(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	parked := func(id string, status taskstatus.Status) TaskInfo {
 		return TaskInfo{
@@ -3961,7 +3961,7 @@ func TestResumeStalled_DispatchComparatorOverridesDefaultOrder(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	parked := func(id string, status taskstatus.Status) TaskInfo {
 		return TaskInfo{
@@ -4007,7 +4007,7 @@ func TestResumeStalled_QueueReconcilerInvokedBeforeDispatch(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:     "t1",
@@ -4061,7 +4061,7 @@ func TestResumeStalled_ReconcilesWaitHumanStatus(t *testing.T) {
 	}
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:     "t1",
@@ -4105,7 +4105,7 @@ func TestResumeStalled_WaitHumanStatusRespectsSkipStatuses(t *testing.T) {
 	for _, keep := range []taskstatus.Status{"cancelled", "done", "human-required"} {
 		t.Run(string(keep), func(t *testing.T) {
 			tasks := newMemTasks()
-			engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+			engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 			tasks.Put(TaskInfo{
 				ID:     "t1",
 				Status: keep,
@@ -4158,7 +4158,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	now := time.Now().UTC()
 	tasks.Put(TaskInfo{
 		ID:     "t1",
@@ -4262,7 +4262,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	now := time.Now().UTC()
 	tasks.Put(TaskInfo{
 		ID: "t1", Status: "planning", Tags: []string{"nocritic"},
@@ -4325,7 +4325,7 @@ steps:
       status: plan-review
 `)
 	tasks := newMemTasks()
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	now := time.Now().UTC()
 	stale := TaskInfo{
 		ID: "t1", Status: "planning", Tags: []string{"nocritic"},
@@ -4373,7 +4373,7 @@ func TestResumeStalled_RunAgent(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Simulate a task stuck at "implement" step with no running agent.
 	tasks.Put(TaskInfo{
@@ -4403,7 +4403,7 @@ func TestResumeStalled_RunAgentAfterCompletedDispatchEffect(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	completedAt := time.Now().UTC()
 	tasks.Put(TaskInfo{
@@ -4452,7 +4452,7 @@ func TestResumeStalled_DispatchesRateLimitedProviderForFailover(t *testing.T) {
 	agents := newMockAgents()
 	agents.SetProviderRateLimited(true)
 	agents.SetProviderFailover(true)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -4477,7 +4477,7 @@ func TestRescheduleRateLimitedAgent_RerunsCurrentStep(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -4506,7 +4506,7 @@ func TestRescheduleInterruptedAgent_UnparksHumanRequiredCurrentStep(t *testing.T
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -4547,7 +4547,7 @@ func TestRescheduleInterruptedAgent_SkipsBlockedAndTerminalStatuses(t *testing.T
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			tasks.Put(TaskInfo{
 				ID:        "t1",
@@ -4625,7 +4625,7 @@ func TestRescheduleRateLimitedAgent_WatchdogRetriesThenEscalates(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			vars := map[string]string{}
 			if tc.retries != "" {
@@ -4722,7 +4722,7 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			vars := map[string]string{}
 			if tc.retries != "" {
@@ -4791,7 +4791,7 @@ func TestResumeStalled_SilentHangReasonRecovers(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -4838,7 +4838,7 @@ func TestRescheduleRateLimitedAgent_SilentHangRoutesAroundTheProvider(t *testing
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.defaultProvider = "claude"
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -4887,7 +4887,7 @@ func TestRescheduleRateLimitedAgent_RealRateLimitKeepsItsProvider(t *testing.T) 
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.defaultProvider = "claude"
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -4950,7 +4950,7 @@ func TestResumeStalled_WatchdogZeroOutputFreshRoundDispatches(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -5001,7 +5001,7 @@ func TestResumeStalled_WatchdogRateLimitPoolBusyDoesNotBurnRetryBudget(t *testin
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetFailSpawn(ErrAgentPoolBusy)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -5045,7 +5045,7 @@ func TestResumeStalled_WatchdogHangPoolBusyRetainsReaskNote(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetFailSpawn(ErrAgentPoolBusy)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{
 		ID: "t1", Status: "in-progress", StatusReason: "watchdog hang: no stream activity", AgentMode: "headless",
 		Workflow: &Execution{WorkflowID: "test-simple", CurrentStep: "implement", State: ExecWaiting, Variables: map[string]string{}, StartedAt: time.Now().UTC()},
@@ -5068,7 +5068,7 @@ func TestResumeStalled_WatchdogRateLimitDoesNotClearConcurrentFailure(t *testing
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -5121,7 +5121,7 @@ func TestRescheduleRateLimitedAgent_ParksWhileProviderRateLimitedNoFailover(t *t
 			agents := newMockAgents()
 			// Provider throttled, no peer to fail over to → must park and wait.
 			agents.SetProviderRateLimited(true)
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			vars := map[string]string{}
 			if tc.retries != "" {
@@ -5172,7 +5172,7 @@ func TestRescheduleRateLimitedAgent_EmptyTaskIDClearsTrackedAgent(t *testing.T) 
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{
 		ID:        "t1",
 		Status:    "in-progress",
@@ -5200,7 +5200,7 @@ func TestRescheduleRateLimitedAgent_SkippedInflightDoesNotConsumeWatchdogRetry(t
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -5244,7 +5244,7 @@ func TestRescheduleRateLimitedAgent_SkippedSharedClaimDoesNotConsumeWatchdogRetr
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -5287,7 +5287,7 @@ func TestRescheduleRateLimitedAgent_SkipsBlockedStatus(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -5334,7 +5334,7 @@ func TestRescheduleRateLimitedAgent_HoldsDispatchClaimAcrossRescheduleAttempt(t 
 	agents := newMockAgents()
 	agents.startEntered = make(chan struct{}, 1)
 	agents.startGate = make(chan struct{})
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -5386,7 +5386,7 @@ func TestRescheduleCheckpointedAgent_RerunsCurrentStepSameWorktree(t *testing.T)
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.claimInsideStart = true
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetMaxCheckpoints(3)
 
 	const worktreeDir = "/tmp/checkpoint-worktree"
@@ -5434,7 +5434,7 @@ func TestRescheduleCheckpointedAgent_RetriesGhostDispatchPark(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.failSpawnOnce = ErrDispatchInFlight
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetMaxCheckpoints(3)
 
 	tasks.Put(TaskInfo{
@@ -5464,7 +5464,7 @@ func TestRescheduleCheckpointedAgent_ParksAtCap(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetMaxCheckpoints(2)
 
 	tasks.Put(TaskInfo{
@@ -5503,7 +5503,7 @@ func TestHandleAgentComplete_CheckpointFailedParksWithoutRetry(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -5560,7 +5560,7 @@ func TestRescheduleRateLimitedAgent_RerunsParallelChild(t *testing.T) {
 	store := newTestStoreWith(t, "test-parallel.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -5649,7 +5649,7 @@ func TestRescheduleRateLimitedAgent_ParallelChildWatchdogRetriesThenEscalates(t 
 			store := newTestStoreWith(t, "test-parallel.yaml")
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			vars := map[string]string{}
 			if tc.retries != "" {
@@ -5708,7 +5708,7 @@ func TestResumeStalled_ParallelProviderUnhealthyLeavesChildPending(t *testing.T)
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetFailSpawn(&providerpkg.UnhealthyError{Provider: "claude", Reason: "rate_limited"})
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -5767,7 +5767,7 @@ func TestResumeStalled_FailoversRateLimitedProvider(t *testing.T) {
 	agents := newMockAgents()
 	agents.SetProviderRateLimited(true)
 	agents.SetProviderFailover(true)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -5792,7 +5792,7 @@ func TestResumeStalled_SkipsWorkflowRetryUntil(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	fakeClock := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
 	engine.SetClock(fakeClock)
 
@@ -5876,7 +5876,7 @@ func TestResumeStalled_SkipLogsPromotedToThrottledInfo(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	retryAt := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 	wf := &Execution{
@@ -5940,7 +5940,7 @@ func TestResumeStalled_RateLimitedProviderSkipIsThrottled(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimited(true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	for _, id := range []string{"t1", "t2"} {
 		tasks.Put(TaskInfo{
@@ -6007,7 +6007,7 @@ func TestResumeStalled_LaterParkIsLoggedAgain(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimitedFor("claude", true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -6065,7 +6065,7 @@ func TestResumeStalled_SkipWaitHuman(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Task at wait_human step.
 	tasks.Put(TaskInfo{
@@ -6095,7 +6095,7 @@ func TestResumeStalled_SkipsHumanRequired(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Simulate a review task whose pr-review workflow is at the implement
 	// (run_agent) step but whose status was flipped to human-required before
@@ -6125,7 +6125,7 @@ func TestResumeStalled_SkipsBlockedStatus(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:           "t1",
@@ -6153,7 +6153,7 @@ func TestResumeStalled_SkipsDoneStatus(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Simulate a task whose PR merged (flipping Status to done) while its
 	// workflow was still paused Running/Waiting at an earlier step — e.g.
@@ -6193,7 +6193,7 @@ func TestResumeStalled_SkipsTerminalStatusAfterFreshRead(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			tasks.Put(TaskInfo{
 				ID:        "t1",
@@ -6241,7 +6241,7 @@ func TestRescheduleRateLimitedAgent_ParallelChildSkipsTerminalStatusAfterFreshRe
 			store := newTestStoreWith(t, "test-parallel.yaml")
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			tasks.Put(TaskInfo{
 				ID:        "t1",
@@ -6293,7 +6293,7 @@ func TestHandleHumanAction_NotWaiting(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:     "t1",
@@ -6323,7 +6323,7 @@ func TestHandleHumanAction_InvalidActionAlreadyWaitingDoesNotMutate(t *testing.T
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:     "t1",
@@ -6374,7 +6374,7 @@ func TestConcurrentAdvance(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -6410,7 +6410,7 @@ func TestStartWorkflow_InvalidWorkflowID(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
@@ -6424,7 +6424,7 @@ func TestAdvanceStep_UnknownStepID(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -6458,7 +6458,7 @@ func TestAdvanceStep_TaskWithoutWorkflow(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
 
@@ -6472,7 +6472,7 @@ func TestResumeStalled_SkipsTaskWithRunningAgent(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -6500,7 +6500,7 @@ func TestResumeStalled_SkipsCompletedWorkflow(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	now := time.Now().UTC()
 	tasks.Put(TaskInfo{
@@ -6527,7 +6527,7 @@ func TestShellStep_ExecutesCommand(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	step := &Step{
 		ID:   "shell1",
@@ -6568,7 +6568,7 @@ func TestShellStep_StdinReaderExitsOnEOF(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	step := &Step{
 		ID:   "stdin-reader",
@@ -6614,7 +6614,7 @@ func TestShellStep_ContextCancelKillsCommand(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	parentCtx, cancel := context.WithCancel(context.Background())
 	engine.SetContext(parentCtx)
@@ -6659,7 +6659,7 @@ func TestShellStep_FailingCommandSetsStatusFailed(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	step := &Step{
 		ID:   "shell1",
@@ -6688,7 +6688,7 @@ func TestShellStep_EmptyRenderedDirFailsClosed(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	step := &Step{
 		ID:   "shell-empty-dir",
@@ -6718,7 +6718,7 @@ func TestExecRunAgent_DefaultModeAndModel(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 
@@ -6785,7 +6785,7 @@ func TestExecRunAgent_PersistsPreparedWorktreeDir(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
 	step := &Step{
@@ -6822,7 +6822,7 @@ func TestExecRunAgent_UsesConfiguredScratchDirForPlan(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	scratchDir := t.TempDir()
 	tasks.Put(TaskInfo{ID: "t1", Status: "plan-needed", AgentMode: "headless"})
@@ -6873,7 +6873,7 @@ func TestExecRunAgent_ABTestingOverridesProviderModel(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{
 		Enabled: &enabled,
@@ -6922,7 +6922,7 @@ func TestExecRunAgent_DefaultProviderPathWinsWhenABTestingOmitted(t *testing.T) 
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetABTestingConfig(abtest.DefaultConfig())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	step := &Step{
@@ -6960,7 +6960,7 @@ func TestExecRunAgentVariantPrompt(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
 		ID:             "prompt-exp",
@@ -7015,7 +7015,7 @@ func TestExecRunAgent_EvalGateBlocksFailingDigestedVariant(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetEvalGate(prompteval.NewGate(evalStore, config.OfflineEvalConfig{}))
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
@@ -7049,7 +7049,7 @@ func TestExecRunAgentSkillAlias(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
 		ID:             "skill-exp",
@@ -7114,7 +7114,7 @@ func TestExecRunAgentVariantSubjectMismatchDoesNotApplyPayload(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			enabled := true
 			engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
 				ID:             "subject-exp",
@@ -7154,7 +7154,7 @@ func TestExecRunAgentReuseAgentSkillAlias(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
 		ID:             "skill-exp",
@@ -7192,7 +7192,7 @@ func TestSelectABVariantPropagatesExperimentKind(t *testing.T) {
 	providerAvailable = func(string) bool { return true }
 	t.Cleanup(func() { providerAvailable = prev })
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{
 		Enabled: &enabled,
@@ -7232,7 +7232,7 @@ func TestExecRunAgent_ABTestingSkipsRateLimitedProvider(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimitedFor("codex", true)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{
 		Enabled: &enabled,
@@ -7283,7 +7283,7 @@ func TestExecRunAgent_ABTestingSkipsConfigDisabledProvider(t *testing.T) {
 	// unhealthy. selectABVariant must not deterministically wedge every
 	// task on this step onto a provider that will always fail to start.
 	agents.SetProviderUnhealthy("copilot", true)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{
 		Enabled: &enabled,
@@ -7364,7 +7364,7 @@ func TestExecRunAgent_ProviderDemotionEmitsThrottledSignal(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimitedFor("codex", true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 	enabled := true
 	// codex carries almost all the weight so the unfiltered ("wanted")
 	// selection is codex with overwhelming probability for any task ID,
@@ -7466,7 +7466,7 @@ func TestExecRunAgent_ProviderShutoutEmitsSignal(t *testing.T) {
 	// Every variant is on codex, and codex is rate-limited — provider
 	// filtering zeroes out the whole experiment, forcing the fallback.
 	agents.SetProviderRateLimitedFor("codex", true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 	enabled := true
 	engine.SetABTestingConfig(abtest.Config{
 		Enabled: &enabled,
@@ -7518,7 +7518,7 @@ func TestHandleAgentComplete_CompletedWorkflowIsNoop(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -7570,7 +7570,7 @@ func TestHandleAgentComplete_UntrackedRoleMismatchDoesNotAdvanceCurrentStep(t *t
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -7632,7 +7632,7 @@ steps:
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	recorder := &recordingArtifactRecorder{}
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetArtifactRecorder(recorder)
 
 	tasks.Put(TaskInfo{
@@ -7720,7 +7720,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	var completed []CompletionInfo
 	engine.SetOnComplete(func(info CompletionInfo) {
 		completed = append(completed, info)
@@ -7828,7 +7828,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".sybra-review-t1.md"), []byte("Review Verdict: CLEAN\n\nNo findings.\n"), 0o644); err != nil {
@@ -7913,7 +7913,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -7965,7 +7965,7 @@ func TestAdvanceStep_EmptyStepIDIsNoop(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -8003,7 +8003,7 @@ func TestAdvanceStep_FailedWorkflowIsNoop(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:     "t1",
@@ -8029,7 +8029,7 @@ func TestAgentModeTemplate(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -8065,7 +8065,7 @@ func startPlanReuseAtReviewPlan(t *testing.T) (*Engine, *memTasks, *mockAgents) 
 	store := newTestStoreWith(t, "test-plan-reuse.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "interactive"})
 	if err := engine.StartWorkflow("t1", "test-plan-reuse"); err != nil {
@@ -8095,7 +8095,7 @@ func TestHandleStatusChange_AdvancesRunAgentWhenWaitForStatusMatches(t *testing.
 	store := newTestStoreWith(t, "test-plan-reuse.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "interactive"})
 	if err := engine.StartWorkflow("t1", "test-plan-reuse"); err != nil {
@@ -8168,7 +8168,7 @@ func TestHandleStatusChange_NoOp(t *testing.T) {
 			store := newTestStoreWith(t, "test-plan-reuse.yaml")
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "interactive"})
 			if err := engine.StartWorkflow("t1", "test-plan-reuse"); err != nil {
@@ -8204,7 +8204,7 @@ func TestHandleStatusChange_UnknownTaskDoesNotPanic(t *testing.T) {
 	store := newTestStoreWith(t, "test-plan-reuse.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Act — must not panic even though the task was never registered.
 	engine.HandleStatusChange("ghost", "plan-review")
@@ -8446,7 +8446,7 @@ func startAutoApprovePlanReview(t *testing.T, task TaskInfo) (*Engine, *memTasks
 	}
 	tasks := newMemTasks()
 	tasks.Put(task)
-	return NewEngine(store, tasks, newMockAgents(), discardLogger()), tasks
+	return NewTestEngine(store, tasks, newMockAgents(), discardLogger()), tasks
 }
 
 func autoApproveReviewStep() *Step {
@@ -8493,7 +8493,7 @@ func TestPlanReuse_ApproveRepairsMissedWaitForStatus(t *testing.T) {
 	store := newTestStoreWith(t, "test-plan-reuse.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "interactive"})
 	if err := engine.StartWorkflow("t1", "test-plan-reuse"); err != nil {
@@ -8598,7 +8598,7 @@ func TestExecRerequestReview_NoRequesterSkips(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}
 	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), ti)
@@ -8614,9 +8614,9 @@ func TestExecRerequestReview_MissingFieldsSkip(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	requester := &fakePRReviewRequester{}
-	engine.SetPRReviewRequester(requester)
+	engine.setPRReviewRequesterForTest(requester)
 
 	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), TaskInfo{ID: "t1", ProjectID: "owner/repo"})
 	if err != nil {
@@ -8634,9 +8634,9 @@ func TestExecRerequestReview_RequestsReviewers(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	requester := &fakePRReviewRequester{reviewers: []string{"alice", "bob"}}
-	engine.SetPRReviewRequester(requester)
+	engine.setPRReviewRequesterForTest(requester)
 
 	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}
 	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), ti)
@@ -8655,8 +8655,8 @@ func TestExecRerequestReview_ErrorIsNonFatal(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
-	engine.SetPRReviewRequester(&fakePRReviewRequester{err: fmt.Errorf("boom")})
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
+	engine.setPRReviewRequesterForTest(&fakePRReviewRequester{err: fmt.Errorf("boom")})
 
 	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}
 	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), ti)
@@ -8672,7 +8672,7 @@ func TestExecEnsurePRClosesIssue_NoLinkerSkips(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5, Issue: "https://github.com/owner/repo/issues/7"}
 	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
@@ -8701,7 +8701,7 @@ func TestExecEnsurePRClosesIssue_MissingFieldsSkip(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			engine.SetPRLinker(&fakePRLinker{})
 
 			out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), tt.ti)
@@ -8722,7 +8722,7 @@ func TestExecEnsurePRClosesIssue_CrossRepoSkips(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{}
 	engine.SetPRLinker(linker)
 
@@ -8748,7 +8748,7 @@ func TestExecEnsurePRClosesIssue_AlreadyLinkedNoEdit(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{{issues: []int{7}, body: "original"}},
 	}
@@ -8774,7 +8774,7 @@ func TestExecEnsurePRClosesIssue_EditAppendsAndVerifies(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{
 			{issues: nil, body: "Implements the feature."},
@@ -8814,7 +8814,7 @@ func TestExecEnsurePRClosesIssue_EmptyBodyNoLeadingNewlines(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{
 			{issues: nil, body: ""},
@@ -8839,7 +8839,7 @@ func TestExecEnsurePRClosesIssue_EditFailureFlipsHumanRequired(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{{issues: nil, body: "body"}},
 		editErr:  fmt.Errorf("403 forbidden"),
@@ -8873,7 +8873,7 @@ func TestExecEnsurePRClosesIssue_VerifyLagTrustsBody(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{
 			// 1 pre-check + 4 verify attempts, all miss.
@@ -8918,7 +8918,7 @@ func TestExecEnsurePRClosesIssue_VerifyRetrySucceeds(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{
 			{issues: nil, body: "body"},                    // pre-check miss → triggers edit
@@ -8952,7 +8952,7 @@ func TestExecEnsurePRClosesIssue_VerifyErrorTrustsBody(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{
 			{issues: nil, body: "body"},
@@ -8990,7 +8990,7 @@ func TestExecEnsurePRClosesIssue_FetchErrorIsSoftFail(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{{err: errors.New("network timeout")}},
 	}
@@ -9026,7 +9026,7 @@ func TestExecStampPRAttribution_NoLinkerSkips(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}
 	out, err := engine.execStampPRAttribution("t1", newStampPRStep(), ti)
@@ -9051,7 +9051,7 @@ func TestExecStampPRAttribution_MissingFieldsSkip(t *testing.T) {
 			store := newTestStore(t)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 			linker := &fakePRLinker{}
 			engine.SetPRLinker(linker)
 
@@ -9073,7 +9073,7 @@ func TestExecStampPRAttribution_AppendsFooter(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{{body: "## Motivation\nfix it\n\nCloses https://github.com/owner/repo/issues/7"}},
 	}
@@ -9099,7 +9099,7 @@ func TestExecStampPRAttribution_EmptyBodySkips(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{{body: "   \n\t"}},
 	}
@@ -9122,7 +9122,7 @@ func TestExecStampPRAttribution_IdempotentNoEdit(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{{body: "## Motivation\nfix it\n\n" + attribution.Footer}},
 	}
@@ -9145,7 +9145,7 @@ func TestExecStampPRAttribution_FetchErrorIsSoftFail(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{getQueue: []getResult{{err: errors.New("network timeout")}}}
 	engine.SetPRLinker(linker)
 
@@ -9163,7 +9163,7 @@ func TestExecStampPRAttribution_EditErrorIsSoftFail(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{{body: "body without footer"}},
 		editErr:  errors.New("gh edit failed"),
@@ -9196,7 +9196,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "interactive"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -9274,7 +9274,7 @@ func TestHandleAgentComplete_WaitHumanWithoutActionIsNoop(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Put a task directly at the wait_human step with no agent tracked.
 	tasks.Put(TaskInfo{
@@ -9322,7 +9322,7 @@ func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Task sitting at an interactive run_agent step with no running agent —
 	// the shape ResumeStalled normally resumes.
@@ -9362,7 +9362,7 @@ func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
 
 func TestEngineKeyedLocksReclaimBurst(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	var wg sync.WaitGroup
 	for i := range 200 {
 		wg.Go(func() {
@@ -9394,7 +9394,7 @@ func TestResumeStalled_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -9441,7 +9441,7 @@ func TestResumeStalled_ConcurrentCallsReserveDispatchWindow(t *testing.T) {
 	agents := newMockAgents()
 	agents.startGate = make(chan struct{})
 	agents.startEntered = make(chan struct{}, 2)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -9491,7 +9491,7 @@ func TestDispatchEvent_SkipsClaimHeldByOutOfBandDispatcher(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "new"})
 	agents.SetDispatchClaimed("t1", true)
@@ -9511,7 +9511,7 @@ func TestExecRunAgent_ConsumesSupervisorSteer(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
 	tasks.SetSteer("t1", "stop retrying the failing command")
@@ -9547,7 +9547,7 @@ func TestExecRunAgent_ResourcePressureParksWithoutConsumingSteer(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
 	tasks.SetSteer("t1", "keep this steer")
@@ -9594,7 +9594,7 @@ func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "interactive"})
 
@@ -9640,7 +9640,7 @@ func TestExecuteSteps_CycleDetection(t *testing.T) {
 	store := newTestStoreWith(t, "test-cycle.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "cycle1", Status: "todo", AgentMode: "headless"})
 
@@ -9829,7 +9829,7 @@ func TestExecRunAgent_DispatchInFlightWaits(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	agents := newMockAgents()
 	agents.SetFailSpawn(ErrDispatchInFlight)
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
 		t.Fatalf("StartWorkflow returned error, want nil (dispatch-in-flight is benign): %v", err)
@@ -9852,7 +9852,7 @@ func TestExecRunAgent_PanicClearsDispatchingClaim(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	agents := &panicStartAgents{mockAgents: newMockAgents()}
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	var recovered any
 	func() {
@@ -9871,7 +9871,7 @@ func TestExecRunAgent_PanicClearsDispatchingClaim(t *testing.T) {
 
 func TestExecRunAgent_PreStartFailureReleasesClaimedEffect(t *testing.T) {
 	tasks := newMemTasks()
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 	step := &Step{
 		ID:   "implement",
 		Type: StepRunAgent,
@@ -9933,7 +9933,7 @@ func TestExecRunAgent_RealSpawnErrorPropagates(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	agents := newMockAgents()
 	agents.SetFailSpawn(errors.New("worktree boom"))
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	if err := engine.StartWorkflow("t1", "test-simple"); err == nil {
 		t.Fatal("StartWorkflow should propagate a real spawn error")
@@ -9954,7 +9954,7 @@ func TestStartWorkflow_InitialDispatchFailure_EscalatesPermanentError(t *testing
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	agents := newMockAgents()
 	agents.SetFailSpawn(fmt.Errorf("task t1 has no project_id: refusing to start triage agent without isolated worktree: %w", ErrNoProjectAssigned))
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	if err := engine.StartWorkflow("t1", "test-simple"); err == nil {
 		t.Fatal("StartWorkflow should propagate the spawn error")
@@ -9983,7 +9983,7 @@ func TestSurfaceInitialDispatchFailure_ReadFailureDoesNotWriteEmptyStatus(t *tes
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	tasks.SetFailGet(true)
 	wf := &Execution{WorkflowID: "x", CurrentStep: "run_agent", State: ExecRunning}
@@ -10016,7 +10016,7 @@ func TestExecVerifyCommits_ParksWhileSiblingRunning(t *testing.T) {
 	agents.mu.Lock()
 	agents.running["t1"] = "sibling" // a different agent than the completer
 	agents.mu.Unlock()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false /* no commits */), ok: true})
 
 	wfExec := &Execution{WorkflowID: "x", CurrentStep: "verify_commits", State: ExecRunning}
@@ -10049,7 +10049,7 @@ func TestExecVerifyCommits_ExcludesCompletingAgent(t *testing.T) {
 	agents.mu.Lock()
 	agents.running["t1"] = "completer" // the same agent whose completion drives this step
 	agents.mu.Unlock()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false /* no commits */), ok: true})
 
 	wfExec := &Execution{}
@@ -10103,7 +10103,7 @@ func TestExecuteSteps_VerifyCommitsParkDoesNotComplete(t *testing.T) {
 	agents.mu.Lock()
 	agents.running["t1"] = "sibling"
 	agents.mu.Unlock()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false /* no commits */), ok: true})
 
 	wf := &Execution{WorkflowID: "simple-task-implement", CurrentStep: "verify_commits", State: ExecRunning}
@@ -10133,7 +10133,7 @@ func TestExecVerifyCommits_NoGetterSkips(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	// worktrees nil by default
 
 	ti := TaskInfo{ID: "t1"}
@@ -10154,7 +10154,7 @@ func TestExecVerifyCommits_NoWorktreeSkips(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
@@ -10174,7 +10174,7 @@ func TestExecVerifyCommits_WithCommitsVerified(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wtDir := makeGitRepo(t, true /* withExtraCommit */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -10201,7 +10201,7 @@ func TestExecVerifyCommits_GitErrorFlipsHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Path exists but is not a git repo — git log returns non-zero,
 	// simulating the broken-worktree scenario from the synapse→sybra rename.
@@ -10231,7 +10231,7 @@ func TestExecVerifyCommits_GitErrorReasonContainsDiagnosis(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Path exists but is not a git repo — `git log` and `git status`
 	// both fail with the same fatal so diagnosis surfaces it.
@@ -10276,7 +10276,7 @@ func TestExecVerifyCommits_RetriesAfterTransientFailure(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
 	// First call may or may not actually be blocked by the lock depending
@@ -10327,7 +10327,7 @@ exec "{{REAL_GIT}}" "$@"
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
@@ -10376,7 +10376,7 @@ exec "{{REAL_GIT}}" "$@"
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
@@ -10456,7 +10456,7 @@ func TestExecVerifyCommits_FetchesMissingLocalHeadObject(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", Branch: "fix/missing-object"})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1", Branch: "fix/missing-object"})
@@ -10492,7 +10492,7 @@ func TestExecVerifyCommits_BranchAtBaseFlipsHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -10521,7 +10521,7 @@ func TestExecVerifyCommits_NoCommitAuthorRunRetriesOnce(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -10567,7 +10567,7 @@ func TestExecVerifyCommits_NoCommitAuthorRunRetryPersistFailureDoesNotPartiallyR
 			Variables:   map[string]string{},
 		},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -10605,7 +10605,7 @@ func TestExecVerifyCommits_NoCommitAuthorRunRetriesOnceWithSubagentDiagnosis(t *
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -10634,7 +10634,7 @@ func TestExecVerifyCommits_NoCommitAuthorRunEscalatesAfterRetry(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -10675,7 +10675,7 @@ func TestExecVerifyCommits_BranchAncestorOfBaseFlipsHumanRequired(t *testing.T) 
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wtDir := makeGitRepoBehindOrigin(t)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -10707,7 +10707,7 @@ func TestExecVerifyCommits_AgentFailedFlipsHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// Same git state as TestExecVerifyCommits_BranchAtBaseFlipsHumanRequired:
 	// HEAD == origin/main.
@@ -10748,7 +10748,7 @@ func TestExecVerifyCommits_AutoCommitsUncommittedWork(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	// HEAD == origin/main (no commits ahead), but leave uncommitted work
 	// sitting dirty in the worktree.
@@ -10815,7 +10815,7 @@ exec "{{REAL_GIT}}" "$@"
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wtDir := makeGitRepo(t, false /* no extra commit */)
 	if err := os.WriteFile(filepath.Join(wtDir, "uncommitted.txt"), []byte("finished work\n"), 0o644); err != nil {
@@ -10896,7 +10896,7 @@ func TestExecVerifyCommits_AutoCommitAdoptsEquivalentRemoteCommitAfterRetry(t *t
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1", Branch: branch})
@@ -10956,7 +10956,7 @@ func TestExecVerifyCommits_EmptyRemoteBranchFlipsHumanRequired(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1", Branch: branch})
@@ -10980,7 +10980,7 @@ func TestRecordFinalCommitState_ContextCancelDoesNotHang(t *testing.T) {
 		Status:    "in-progress",
 		AgentRuns: []AgentRunInfo{{AgentID: "a1"}},
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	wtDir := makeGitRepo(t, true /* withExtraCommit */)
 	withFakeGit(t, `#!/bin/sh
@@ -11458,7 +11458,7 @@ func TestAdvanceStep_ImplementHumanRequiredGitHubAuthParksForRetry(t *testing.T)
 		AgentMode:    "headless",
 		Workflow:     wf,
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	err := engine.AdvanceStep("t1", StepOutput{
 		StepID:  "implement",
@@ -11515,7 +11515,7 @@ func TestAdvanceStep_ImplementGitHubAuthRetryCapFallsThroughToHumanRequired(t *t
 		AgentMode:    "headless",
 		Workflow:     wf,
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	err := engine.AdvanceStep("t1", StepOutput{
 		StepID:  "implement",
@@ -11558,7 +11558,7 @@ func TestAdvanceStep_ImplementNonGitHubAuthHumanRequiredFallsThrough(t *testing.
 		AgentMode:    "headless",
 		Workflow:     wf,
 	})
-	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, tasks, newMockAgents(), discardLogger())
 
 	err := engine.AdvanceStep("t1", StepOutput{
 		StepID:  "implement",
@@ -11607,7 +11607,7 @@ func newEngineForEval(t *testing.T, tasks *memTasks) *Engine {
 	t.Helper()
 	store := newTestStore(t)
 	agents := newMockAgents()
-	return NewEngine(store, tasks, agents, discardLogger())
+	return NewTestEngine(store, tasks, agents, discardLogger())
 }
 
 func TestExecEvaluate_LastAgentFailedFlipsHumanRequired(t *testing.T) {
@@ -11997,7 +11997,7 @@ func TestExecLinkPRAndReview_PRNumberNotInRepoFallsThrough(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", PRNumber: 8, ProjectID: "kumahq/kuma"})
 	engine := newEngineForEval(t, tasks)
-	engine.SetPRExistenceChecker(fakePRExistenceChecker{exists: false})
+	engine.setPRExistenceCheckerForTest(fakePRExistenceChecker{exists: false})
 	wfExec := &Execution{
 		StepHistory: []StepRecord{
 			{StepID: "implement", Status: "completed", AgentID: "a1", Output: "changes pushed"},
@@ -12024,7 +12024,7 @@ func TestExecLinkPRAndReview_PRNumberUnverifiedFallsThrough(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", PRNumber: 8, ProjectID: "kumahq/kuma"})
 	engine := newEngineForEval(t, tasks)
-	engine.SetPRExistenceChecker(fakePRExistenceChecker{err: errors.New("gh: authentication failed")})
+	engine.setPRExistenceCheckerForTest(fakePRExistenceChecker{err: errors.New("gh: authentication failed")})
 
 	out, err := engine.execLinkPRAndReview("t1", newLinkPRStep(), &Execution{}, TaskInfo{ID: "t1", PRNumber: 8, ProjectID: "kumahq/kuma"})
 	if err != nil {
@@ -12043,7 +12043,7 @@ func TestExecLinkPRAndReview_PRNumberVerifiedInRepoTrusted(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", PRNumber: 8, ProjectID: "kumahq/kuma"})
 	engine := newEngineForEval(t, tasks)
-	engine.SetPRExistenceChecker(fakePRExistenceChecker{exists: true})
+	engine.setPRExistenceCheckerForTest(fakePRExistenceChecker{exists: true})
 
 	out, err := engine.execLinkPRAndReview("t1", newLinkPRStep(), &Execution{}, TaskInfo{ID: "t1", PRNumber: 8, ProjectID: "kumahq/kuma"})
 	if err != nil {
@@ -12169,7 +12169,7 @@ func TestAdvanceStep_MarkReviewedAfterReviewRole(t *testing.T) {
 	store := newTestStoreWith(t, "test-review-fix.yaml")
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-review-fix"); err != nil {
@@ -12209,7 +12209,7 @@ func TestAdvanceStep_WorkflowDefinitionDeletedMidRun(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -12250,7 +12250,7 @@ func TestStartWorkflow_ConcurrentSameTaskSingleWinner(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 
@@ -12308,7 +12308,7 @@ func TestStartWorkflow_ConcurrentSameTaskSingleWinner(t *testing.T) {
 // exercised here. Run under -race; plain fields fail.
 func TestEngineGuardrails_ConcurrentSetAndRead(t *testing.T) {
 	store := newTestStore(t)
-	engine := NewEngine(store, newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, newMemTasks(), newMockAgents(), discardLogger())
 
 	var wg sync.WaitGroup
 	for i := range 8 {
@@ -12338,7 +12338,7 @@ func TestEngineGuardrails_ConcurrentSetAndRead(t *testing.T) {
 // stored explicitly — dropping that flips behaviour silently.
 func TestNewEngine_OpenPROnUnrunnableGateDefaultsTrue(t *testing.T) {
 	store := newTestStore(t)
-	engine := NewEngine(store, newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(store, newMemTasks(), newMockAgents(), discardLogger())
 	if !engine.openPROnUnrunnableGate.Load() {
 		t.Error("openPROnUnrunnableGate = false, want the documented default of true")
 	}
@@ -12355,7 +12355,7 @@ func TestExecVerifyCommits_NoCommitAuthorRunMarkedIncomplete(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wtDir := makeGitRepo(t, false /* HEAD == origin/main, so no commits */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -12383,7 +12383,7 @@ func TestExecVerifyCommits_VerifierRunNotMarkedIncomplete(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wtDir := makeGitRepo(t, false)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
@@ -12414,7 +12414,7 @@ func TestResumeStalled_ClaimedElsewhereDoesNotReArmEveryTick(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetDispatchClaimed("t1", true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	tasks.Put(TaskInfo{
 		ID:        "t1",
@@ -12453,7 +12453,7 @@ func TestReplayPersistedEffects_NoopIsThrottled(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	completed := time.Now().UTC()
 	tasks.Put(TaskInfo{
@@ -12528,7 +12528,7 @@ func TestResumeStalled_ParkMovingProviderReArms(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimitedFor("claude", true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	put := func() {
 		tasks.Put(TaskInfo{
@@ -12580,7 +12580,7 @@ func TestRescheduleRateLimitedAgent_LaterParkIsLoggedAgain(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimitedFor("claude", true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	park := func(agentID string) {
 		tasks.Put(TaskInfo{
@@ -12639,7 +12639,7 @@ func TestReplayPersistedEffects_DispatchReArmsThePark(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimited(true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	put := func() {
 		tasks.Put(TaskInfo{
@@ -12700,7 +12700,7 @@ func TestResumeStalled_ParkOnAnotherStepIsLogged(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetProviderRateLimited(true)
-	engine := NewEngine(store, tasks, agents, logger)
+	engine := NewTestEngine(store, tasks, agents, logger)
 
 	put := func(step string) {
 		tasks.Put(TaskInfo{

--- a/internal/workflow/engine_test_defaults.go
+++ b/internal/workflow/engine_test_defaults.go
@@ -1,0 +1,35 @@
+package workflow
+
+import (
+	"context"
+
+	"github.com/Automaat/sybra/internal/project"
+)
+
+// These neutral collaborators preserve the historical partial-engine behavior
+// for NewTestEngine without forcing production code to retain nil branches for
+// dependencies that NewEngine guarantees.
+type skippedBranchSyncer struct{}
+
+func (skippedBranchSyncer) SyncTaskBranch(context.Context, string) (string, error) {
+	return syncResultSkipped, nil
+}
+
+type emptyCheckConfigGetter struct{}
+
+func (emptyCheckConfigGetter) CodegenCommands(context.Context, string) []string { return nil }
+func (emptyCheckConfigGetter) VerifyCommands(context.Context, string) []string  { return nil }
+func (emptyCheckConfigGetter) SetupCommands(context.Context, string) []string   { return nil }
+func (emptyCheckConfigGetter) FocusedChecks(context.Context, string) []project.FocusedCheck {
+	return nil
+}
+
+type emptyManualTestConfigGetter struct{}
+
+func (emptyManualTestConfigGetter) ManualTestConfig(string) ManualTestInfo {
+	return ManualTestInfo{}
+}
+
+type unlimitedCostBudgetChecker struct{}
+
+func (unlimitedCostBudgetChecker) CheckTaskCostBudget(string) error { return nil }

--- a/internal/workflow/evidence_attempts_test.go
+++ b/internal/workflow/evidence_attempts_test.go
@@ -16,7 +16,7 @@ func TestRewindRetry_FingerprintNotChargedWithoutCommits(t *testing.T) {
 	// UpdateTaskStatus, and against an unseeded store both error — the test
 	// would then pass without exercising the path it claims to.
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 
 	policy := func(ti TaskInfo) rewindRetryPolicy {
 		return rewindRetryPolicy{

--- a/internal/workflow/permutation_contract_test.go
+++ b/internal/workflow/permutation_contract_test.go
@@ -124,7 +124,7 @@ func newWorkflowPermutationScenario(t *testing.T) *workflowPermutationScenario {
 	store := newInlineTestStore(t, "permutation-contract", workflowPermutationContractYAML)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "permutation-contract"); err != nil {
 		t.Fatalf("StartWorkflow: %v", err)
@@ -157,7 +157,7 @@ func (s *workflowPermutationScenario) restart() {
 		clonedTasks.Put(cloneWorkflowPermutationTask(tasks[i]))
 	}
 	clonedAgents := cloneWorkflowPermutationAgents(s.agents)
-	clonedEngine := NewEngine(s.store, clonedTasks, clonedAgents, discardLogger())
+	clonedEngine := NewTestEngine(s.store, clonedTasks, clonedAgents, discardLogger())
 	rehydrateWorkflowPermutationRoutes(clonedEngine, clonedTasks)
 	s.tasks = clonedTasks
 	s.agents = clonedAgents

--- a/internal/workflow/pr_surface_test.go
+++ b/internal/workflow/pr_surface_test.go
@@ -15,9 +15,9 @@ func TestSetPRSurfaceNamesEveryMissingMember(t *testing.T) {
 	t.Parallel()
 	e := &Engine{}
 
-	err := e.SetPRSurface(PRSurface{})
+	err := e.setPRSurfaceForTest(PRSurface{})
 	if err == nil {
-		t.Fatal("SetPRSurface accepted an entirely empty surface")
+		t.Fatal("setPRSurfaceForTest accepted an entirely empty surface")
 	}
 	for _, want := range []string{
 		"Linker", "ReviewRequester", "StateFetcher", "HeadFetcher", "Creator",
@@ -37,9 +37,9 @@ func TestSetPRSurfaceRejectsAPartialWiring(t *testing.T) {
 	partial := full
 	partial.Finder = nil
 
-	err := (&Engine{}).SetPRSurface(partial)
+	err := (&Engine{}).setPRSurfaceForTest(partial)
 	if err == nil {
-		t.Fatal("SetPRSurface accepted a surface missing Finder")
+		t.Fatal("setPRSurfaceForTest accepted a surface missing Finder")
 	}
 	if !strings.Contains(err.Error(), "Finder") {
 		t.Errorf("error %q does not name Finder", err)
@@ -52,23 +52,23 @@ func TestSetPRSurfaceRejectsAPartialWiring(t *testing.T) {
 func TestSetPRSurfaceWiresEveryField(t *testing.T) {
 	t.Parallel()
 	e := &Engine{}
-	if err := e.SetPRSurface(completePRSurface()); err != nil {
-		t.Fatalf("SetPRSurface(complete) = %v", err)
+	if err := e.setPRSurfaceForTest(completePRSurface()); err != nil {
+		t.Fatalf("setPRSurfaceForTest(complete) = %v", err)
 	}
 	for name, got := range map[string]any{
-		"prLinker":         e.prLinker,
-		"prReviewers":      e.prReviewers,
-		"prStates":         e.prStates,
-		"prHeads":          e.prHeads,
-		"prCreator":        e.prCreator,
-		"prCloser":         e.prCloser,
-		"prFinder":         e.prFinder,
-		"prAnyStateFinder": e.prAnyStateFinder,
-		"prExistence":      e.prExistence,
-		"prContentGen":     e.prContentGen,
+		"prLinker":         e.pr.Linker,
+		"prReviewers":      e.pr.ReviewRequester,
+		"prStates":         e.pr.StateFetcher,
+		"prHeads":          e.pr.HeadFetcher,
+		"prCreator":        e.pr.Creator,
+		"prCloser":         e.pr.Closer,
+		"prFinder":         e.pr.Finder,
+		"prAnyStateFinder": e.pr.AnyStateFinder,
+		"prExistence":      e.pr.ExistenceChecker,
+		"prContentGen":     e.pr.ContentGenerator,
 	} {
 		if got == nil {
-			t.Errorf("%s is still nil after a complete SetPRSurface", name)
+			t.Errorf("%s is still nil after a complete setPRSurfaceForTest", name)
 		}
 	}
 }

--- a/internal/workflow/rewind_retry_test.go
+++ b/internal/workflow/rewind_retry_test.go
@@ -29,7 +29,7 @@ func TestRewindRetry_PolicyMatrix(t *testing.T) {
 
 	t.Run("under cap arms and rewinds", func(t *testing.T) {
 		tasks := newMemTasks()
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		fakeClock := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
 		engine.SetClock(fakeClock)
 		wf := newExec("")
@@ -93,7 +93,7 @@ func TestRewindRetry_PolicyMatrix(t *testing.T) {
 
 	t.Run("at cap does not arm and leaves counter untouched", func(t *testing.T) {
 		tasks := newMemTasks()
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		wf := newExec("2")
 		ti := TaskInfo{ID: "t1", Status: "in-progress", Workflow: wf}
 		tasks.Put(ti)
@@ -130,7 +130,7 @@ func TestRewindRetry_PolicyMatrix(t *testing.T) {
 	t.Run("persist failure reports armed with error", func(t *testing.T) {
 		tasks := newMemTasks()
 		tasks.failSetWorkflow = true
-		engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+		engine := NewTestEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
 		wf := newExec("")
 		ti := TaskInfo{ID: "t1", Status: "in-progress", Workflow: wf}
 		tasks.Put(ti)

--- a/internal/workflow/sidecar_seed_test.go
+++ b/internal/workflow/sidecar_seed_test.go
@@ -17,8 +17,8 @@ func TestExecRunAgentSeedsSidecarDirBeforeRendering(t *testing.T) {
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	agents.SetAdmitDispatch("pool busy")
-	engine := NewEngine(newTestStore(t), tasks, agents, discardLogger())
-	engine.SetSidecarDirResolver(func(string) (string, error) { return "/sandbox/t1", nil })
+	engine := NewTestEngine(newTestStore(t), tasks, agents, discardLogger())
+	engine.setSidecarDirResolverForTest(func(string) (string, error) { return "/sandbox/t1", nil })
 
 	step := &Step{ID: "review", Type: StepRunAgent}
 	wfExec := &Execution{

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -213,7 +213,7 @@ func TestClassifyAgentStartError_PreparationInFlightSuppressed(t *testing.T) {
 func TestSurfaceStartFailure_DispatchInFlightIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	engine.surfaceStartFailure("t1", "in-progress", ErrDispatchInFlight, nil, "")
 
@@ -229,7 +229,7 @@ func TestSurfaceStartFailure_DispatchInFlightIsNoOp(t *testing.T) {
 func TestSurfaceStartFailure_TransientKeepsStatus(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	engine.surfaceStartFailure("t1", "in-progress", errors.New("git fetch: timeout"), nil, "")
 
@@ -250,7 +250,7 @@ func TestSurfaceStartFailure_TransientFetchKeepsStatus(t *testing.T) {
 	// retry once connectivity recovers.
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrTransientFetch)
 	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
@@ -278,7 +278,7 @@ func TestIsTransientFetchReason(t *testing.T) {
 func TestSurfaceStartFailure_PermanentFlipsToHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("worktree required: %w", project.ErrProjectNotRegistered)
 	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
@@ -305,7 +305,7 @@ func TestSurfaceStartFailure_RebaseFailedFlipsToBlocked(t *testing.T) {
 	// internal/recovery/recovery_test.go.
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
 	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
@@ -331,7 +331,7 @@ func TestSurfaceStartFailure_RebaseFailedFlipsToBlocked(t *testing.T) {
 func TestSurfaceStartFailure_DiskSpaceErrorSkipsConflictRecovery(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	var recoveryCalled bool
 	engine.SetConflictRecovery(func(string) bool {
@@ -370,7 +370,7 @@ func TestSurfaceStartFailure_DiskSpaceErrorSkipsConflictRecovery(t *testing.T) {
 func TestSurfaceStartFailure_RebaseFailedRecoversInsteadOfHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	var recoveredTaskID string
 	engine.SetConflictRecovery(func(taskID string) bool {
@@ -401,7 +401,7 @@ func TestSurfaceStartFailure_RebaseFailedRecoversInsteadOfHumanRequired(t *testi
 func TestSurfaceStartFailure_RebaseFailedRecoveryDeclinesFallsBackToBlocked(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 	engine.SetConflictRecovery(func(string) bool { return false })
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
@@ -426,7 +426,7 @@ func TestSurfaceStartFailure_RebaseFailedRecoveryDeclinesFallsBackToBlocked(t *t
 func TestSurfaceStartFailure_RebaseFailedRecoveryDeferredWhileMarkerHeld(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	var calls int
 	engine.SetConflictRecovery(func(string) bool { calls++; return true })
@@ -472,7 +472,7 @@ func TestSurfaceStartFailure_RebaseFailedDeferredDeclineKeepsOriginalReason(t *t
 			Variables:   map[string]string{},
 		},
 	})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 	engine.SetConflictRecovery(func(string) bool { return false })
 
 	engine.mu.Lock()
@@ -507,7 +507,7 @@ func TestSurfaceStartFailure_RebaseFailedDeferredDeclineKeepsOriginalReason(t *t
 func TestSurfaceStartFailure_NilErrIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	engine.surfaceStartFailure("t1", "in-progress", nil, nil, "")
 
@@ -525,7 +525,7 @@ func TestSurfaceStartFailure_CircuitBreakerTripsAfterRepeatedFailures(t *testing
 	// forever.
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
 	wf := &Execution{CurrentStep: "run_test", State: ExecRunning, Variables: map[string]string{}}
@@ -558,7 +558,7 @@ func TestSurfaceStartFailure_CircuitBreakerTripsAfterRepeatedFailures(t *testing
 func TestSurfaceStartFailure_TransientRateLimitDoesNotTripBreaker(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	rateLimited := &provider.UnhealthyError{Provider: "claude", Reason: provider.RateLimitReason}
 	wf := &Execution{CurrentStep: "implement", State: ExecRunning, Variables: map[string]string{}}
@@ -581,7 +581,7 @@ func TestSurfaceStartFailure_TransientRateLimitDoesNotTripBreaker(t *testing.T) 
 func TestSurfaceStartFailure_QuotaRateLimitDoesNotTripBreaker(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	quotaLimited := &provider.UnhealthyError{
 		Provider:    "codex",
@@ -607,7 +607,7 @@ func TestSurfaceStartFailure_QuotaRateLimitDoesNotTripBreaker(t *testing.T) {
 func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 	fakeClock := clock.NewFake(time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC))
 	engine.SetClock(fakeClock)
 
@@ -647,7 +647,7 @@ func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 func TestSurfaceStartFailure_ShutdownCancellationDoesNotTripBreaker(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 	shutdownCtx, cancel := context.WithCancel(context.Background())
 	cancel() // simulate the app context already cancelled by graceful shutdown
 	engine.SetContext(shutdownCtx)
@@ -690,7 +690,7 @@ func TestSurfaceStartFailure_ShutdownCancellationDoesNotTripBreaker(t *testing.T
 func TestSurfaceStartFailure_ShutdownCancellationSkipsConflictRecoveryToo(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 	shutdownCtx, cancel := context.WithCancel(context.Background())
 	cancel() // simulate the app context already cancelled by graceful shutdown
 	engine.SetContext(shutdownCtx)
@@ -729,7 +729,7 @@ func TestSurfaceStartFailure_ShutdownCancellationSkipsConflictRecoveryToo(t *tes
 func TestSurfaceStartFailure_ContextCanceledStillTripsBreakerWhenNotShuttingDown(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 	engine.SetContext(context.Background()) // healthy, not cancelled
 
 	wrapped := fmt.Errorf("fetch origin: %w", context.Canceled)
@@ -763,7 +763,7 @@ func TestHandleAgentComplete_CircuitBreakerAttributesNextStepNotCompletedStep(t 
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
@@ -795,7 +795,7 @@ func TestHandleAgentComplete_CircuitBreakerAttributesNextStepNotCompletedStep(t 
 func TestSurfaceStartFailure_AlreadyHumanRequiredIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "human-required", StatusReason: "existing reason"})
-	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+	engine := NewTestEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
 	engine.surfaceStartFailure("t1", "human-required", wrapped, nil, "")

--- a/internal/workflow/status_reason_utf8_test.go
+++ b/internal/workflow/status_reason_utf8_test.go
@@ -42,7 +42,7 @@ steps:
 `)
 			tasks := newMemTasks()
 			agents := newMockAgents()
-			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 			tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "headless"})
 			if err := engine.StartWorkflowFromStepWithVars("t1", "simple-task-plan", "plan", nil); err != nil {
@@ -96,7 +96,7 @@ steps:
 `)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
 	if err := engine.StartWorkflowFromStepWithVars("t1", "test-simple", "triage", nil); err != nil {

--- a/internal/workflow/triage_review_test.go
+++ b/internal/workflow/triage_review_test.go
@@ -437,7 +437,7 @@ func TestExecTriageReview_NoWorktreeNoPRReturnsStaff(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	out, err := engine.execTriageReview("t1", newTriageStep(), TaskInfo{ID: "t1"})
 	if err != nil {
@@ -456,7 +456,7 @@ func TestExecTriageReview_BrokenWorktreeReturnsStaff(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 	// Path exists but is not a git repo.
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
 
@@ -474,7 +474,7 @@ func TestExecTriageReview_TinyDocChangeReturnsSimple(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wt := makeGitRepo(t, false /* extra commit added below */)
 	// Add one tiny doc change.
@@ -500,7 +500,7 @@ func TestExecTriageReview_RiskyPathReturnsStaff(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wt := makeGitRepo(t, false)
 	// Touch a workflow-internal file — only one line, but risky path.
@@ -530,7 +530,7 @@ func TestExecTriageReview_LargeChangeReturnsStaff(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine := NewTestEngine(store, tasks, agents, discardLogger())
 
 	wt := makeGitRepo(t, false)
 	// Write a single non-risky, non-trivial file but with > line limit

--- a/internal/workflow/verify_diagnostic_test.go
+++ b/internal/workflow/verify_diagnostic_test.go
@@ -13,8 +13,8 @@ import (
 // threw it away.
 func TestWriteVerifyDiagnostic(t *testing.T) {
 	dir := t.TempDir()
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
-	engine.SetSidecarDirResolver(func(string) (string, error) { return dir, nil })
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.setSidecarDirResolverForTest(func(string) (string, error) { return dir, nil })
 
 	const cmd = `GOLANGCI_LINT_CACHE="${TMPDIR:-/tmp}/golangci-lint" mise exec -- golangci-lint run ./internal/...`
 	output := strings.Join([]string{
@@ -47,7 +47,7 @@ func TestWriteVerifyDiagnostic(t *testing.T) {
 // Without a sidecar dir there is nowhere to write; escalation must still
 // proceed rather than being blocked on bookkeeping.
 func TestWriteVerifyDiagnostic_NoSidecarDirIsNotFatal(t *testing.T) {
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	if got := engine.writeVerifyDiagnostic("t1", "cmd", "output"); got != "" {
 		t.Errorf("path = %q, want empty when no sidecar dir is resolvable", got)
 	}


### PR DESCRIPTION
Closes #3143

## Summary
- require validated PR and execution dependency groups at production Engine construction
- keep a deliberately partial NewTestEngine so focused tests only bind the collaborators they exercise
- collapse Engine fields from 69 to 51, exported Set methods from 49 to 35, app-init setter calls to 22, and non-test workflow nil guards from 1,062 to 1,043
- preserve neutral test behavior for checks, branch sync, manual-test hints, and cost budgets

## Verification
- go test ./...
- mise exec -- golangci-lint run ./...
- mise run verify: all substantive gates passed, including ordinary race and tagged E2E; local-only tracked .claude/skills ignore mismatch stopped the final repository-hygiene step
- independent adversarial review: CLEAN
- independent sybra-test: PASS, including 19 missing-dependency cases and typed-nil cases under race