### PR TITLE
ci(actions): gate the consolidated primitives against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,17 @@ jobs:
       - name: Check the gate itself still catches drift
         run: bash scripts/check-atomic-writes.test.sh
 
+  check-consolidated-primitives:
+    name: Consolidated Primitive Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Check truncation, JSON extraction, task status, and provider boundaries
+        run: bash scripts/check-consolidated-primitives.sh
+
   check-no-viewer-user-endpoint:
     name: No /user Identity Lookups
     runs-on: ubuntu-latest

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -974,7 +974,7 @@ func resolveHandoffMode(fs *flag.FlagSet, stage, rawStatus string, pr int) (cfg 
 		}
 		return handoffStageConfig{}, "", false, handoffStageUsageError(stage)
 	}
-	if pr > 0 && stageCfg.name != "ready-pr" {
+	if pr > 0 && stageCfg.name != string(task.StatusReadyPR) {
 		return handoffStageConfig{}, "", false, fmt.Errorf("--pr is only valid with --stage ready-pr so the PR stays linked to an internal Sybra task")
 	}
 	return stageCfg, "", false, nil
@@ -1031,16 +1031,16 @@ type handoffStageDef struct {
 
 var handoffStageRegistry = []handoffStageDef{
 	// implement: simple-task-handoff → in-progress → implement → review → testing → PR
-	{name: "implement", aliases: []string{"", "in-progress"}, tags: []string{"handoff"},
+	{name: "implement", aliases: []string{"", string(task.StatusInProgress)}, tags: []string{"handoff"},
 		usage: "have a plan -> Sybra implements, reviews, tests, opens the PR"},
 	// review: simple-task-handoff-review → ready-review → review → testing → PR
-	{name: "review", aliases: []string{"ready-review", "agentic-review"}, tags: []string{"handoff", "handoff-review"},
+	{name: "review", aliases: []string{string(task.StatusReadyReview), "agentic-review"}, tags: []string{"handoff", "handoff-review"},
 		usage: "implemented locally -> Sybra enters agentic review", requiresSource: true},
 	// testing: simple-task-handoff-testing → testing → adversarial test → PR
-	{name: "testing", aliases: []string{"test"}, tags: []string{"handoff", "handoff-testing"},
+	{name: string(task.StatusTesting), aliases: []string{"test"}, tags: []string{"handoff", "handoff-testing"},
 		usage: "reviewed locally -> Sybra tests, then opens the PR", requiresSource: true},
 	// ready-pr: simple-task-handoff-ready-pr → ready-pr → open/update PR
-	{name: "ready-pr", aliases: []string{"open-pr", "create-pr"}, tags: []string{"handoff", "handoff-ready-pr"},
+	{name: string(task.StatusReadyPR), aliases: []string{"open-pr", "create-pr"}, tags: []string{"handoff", "handoff-ready-pr"},
 		usage: "tested locally -> Sybra opens or updates the PR; pass --pr N\n" +
 			strings.Repeat(" ", 19) + "only to link an existing same-branch PR"},
 }
@@ -1077,7 +1077,7 @@ func handoffStageUsageError(stage string) error {
 
 func isExternalPRHandoffStage(stage string) bool {
 	switch strings.ToLower(strings.TrimSpace(stage)) {
-	case "pr", "in-review", "pull-request", "pull_request":
+	case "pr", string(task.StatusInReview), "pull-request", "pull_request":
 		return true
 	default:
 		return false
@@ -1206,10 +1206,10 @@ func printHandoffResult(t task.Task, stage, projectID, dir string) {
 	case "review":
 		fmt.Printf("  worktree: %s\n", dir)
 		fmt.Println("  Sybra will skip to review and open the PR from this worktree.")
-	case "testing":
+	case string(task.StatusTesting):
 		fmt.Printf("  worktree: %s\n", dir)
 		fmt.Println("  Sybra will skip straight to adversarial testing of this worktree.")
-	case "ready-pr":
+	case string(task.StatusReadyPR):
 		fmt.Printf("  worktree: %s\n", dir)
 		fmt.Println("  Sybra will skip straight to opening or updating the PR from this worktree.")
 	default:

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/events"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 // errReattachedGone marks a reattached agent whose process exited without
@@ -580,7 +581,8 @@ func (m *Manager) reattachDecide(r Record, now time.Time) reattachDecision {
 // set.
 func ParksLiveAgent(status string) bool {
 	switch status {
-	case "todo", "new", "human-required", "blocked", "done", "cancelled":
+	case string(taskstatus.Todo), string(taskstatus.New), string(taskstatus.HumanRequired),
+		string(taskstatus.Blocked), string(taskstatus.Done), string(taskstatus.Cancelled):
 		return true
 	default:
 		return false

--- a/internal/audit/summary.go
+++ b/internal/audit/summary.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/runacct"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 type Summary struct {
@@ -57,7 +58,7 @@ func Summarize(events []Event, since, until time.Time) Summary {
 			}
 			statusEntered[e.TaskID] = e.Timestamp
 
-			if to == "done" {
+			if to == string(taskstatus.Done) {
 				s.TasksCompleted++
 				if created, ok := taskCreated[e.TaskID]; ok {
 					cycleTimes = append(cycleTimes, e.Timestamp.Sub(created).Hours())

--- a/internal/blocker/blocker.go
+++ b/internal/blocker/blocker.go
@@ -3,6 +3,8 @@ package blocker
 import (
 	"fmt"
 	"time"
+
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 // Kind classifies why a task is parked or retrying.
@@ -76,7 +78,7 @@ func ValidateStatus(status string, state State) error {
 	if state.IsZero() {
 		return nil
 	}
-	if status == "human-required" && !AllowsHumanRequired(state.Kind) {
+	if status == string(taskstatus.HumanRequired) && !AllowsHumanRequired(state.Kind) {
 		return fmt.Errorf("blocker kind %q cannot transition to human-required", state.Kind)
 	}
 	return nil

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/taskstatus"
 	"gopkg.in/yaml.v3"
 
 	"github.com/Automaat/sybra/internal/fsutil"
@@ -1831,14 +1832,14 @@ func applyMonitorDefaults(cfg *Config, file *FileConfig) {
 	if cfg.Monitor.BottleneckHours == nil {
 		cfg.Monitor.BottleneckHours = map[string]float64{}
 	}
-	if _, ok := cfg.Monitor.BottleneckHours["plan-review"]; !ok {
-		cfg.Monitor.BottleneckHours["plan-review"] = 4
+	if _, ok := cfg.Monitor.BottleneckHours[string(taskstatus.PlanReview)]; !ok {
+		cfg.Monitor.BottleneckHours[string(taskstatus.PlanReview)] = 4
 	}
-	if _, ok := cfg.Monitor.BottleneckHours["human-required"]; !ok {
-		cfg.Monitor.BottleneckHours["human-required"] = 8
+	if _, ok := cfg.Monitor.BottleneckHours[string(taskstatus.HumanRequired)]; !ok {
+		cfg.Monitor.BottleneckHours[string(taskstatus.HumanRequired)] = 8
 	}
-	if _, ok := cfg.Monitor.BottleneckHours["in-progress"]; !ok {
-		cfg.Monitor.BottleneckHours["in-progress"] = 6
+	if _, ok := cfg.Monitor.BottleneckHours[string(taskstatus.InProgress)]; !ok {
+		cfg.Monitor.BottleneckHours[string(taskstatus.InProgress)] = 6
 	}
 	if _, ok := cfg.Monitor.BottleneckHours["default"]; !ok {
 		cfg.Monitor.BottleneckHours["default"] = 12

--- a/internal/dispatchorder/dispatchorder.go
+++ b/internal/dispatchorder/dispatchorder.go
@@ -7,17 +7,19 @@
 // take the typed value directly.
 package dispatchorder
 
+import "github.com/Automaat/sybra/internal/taskstatus"
+
 // Rank ranks a task's pipeline status for dispatch ordering: lower ranks are
 // dispatched sooner. Unknown statuses rank last (4).
 func Rank(status string) int {
 	switch status {
-	case "in-review", "ready-pr":
+	case string(taskstatus.InReview), string(taskstatus.ReadyPR):
 		return 0
-	case "ready-review", "testing":
+	case string(taskstatus.ReadyReview), string(taskstatus.Testing):
 		return 1
-	case "in-progress":
+	case string(taskstatus.InProgress):
 		return 2
-	case "planning", "plan-review":
+	case string(taskstatus.Planning), string(taskstatus.PlanReview):
 		return 3
 	default:
 		return 4

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/runacct"
 	"github.com/Automaat/sybra/internal/skillattr"
 	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 // Skill-conformance cohort buckets. See skillConformanceBucket.
@@ -577,7 +578,7 @@ func scanTaskSignals(events []audit.Event) map[string]*taskSignals {
 		switch e.Type {
 		case audit.EventTaskStatusChanged:
 			s := sig(e.TaskID)
-			if strVal(e.Data, "to") == "human-required" {
+			if strVal(e.Data, "to") == string(taskstatus.HumanRequired) {
 				// A request for intervention, not evidence one happened —
 				// see EventInterventionRecorded/EventPlanApproved below for
 				// the actual resolution provenance (issue #2727).

--- a/internal/evaluation/slo.go
+++ b/internal/evaluation/slo.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/runoutcome"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 // SLOTargets is the rolling autonomy/reliability target set (#2441). Defined
@@ -240,11 +241,11 @@ func scanRestartCadence(events []audit.Event, since, until time.Time) float64 {
 		if e.Type != audit.EventTaskStatusChanged || e.Timestamp.Before(since) || e.Timestamp.After(until) {
 			continue
 		}
-		if strVal(e.Data, "from") != "human-required" {
+		if strVal(e.Data, "from") != string(taskstatus.HumanRequired) {
 			continue
 		}
 		to := strVal(e.Data, "to")
-		if to != "in-progress" && to != "in-review" {
+		if to != string(taskstatus.InProgress) && to != string(taskstatus.InReview) {
 			continue
 		}
 		if manuallyDispatchedNear(e.TaskID, e.Timestamp) {

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/runacct"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 // costThresholds per agent role. Empty string key covers implementation agents.
@@ -199,7 +200,7 @@ func checkStatusBounce(events []audit.Event, now time.Time) []Finding {
 		if from == "" || to == "" {
 			continue
 		}
-		if to == "human-required" && isExpectedHumanRequired(e) {
+		if to == string(taskstatus.HumanRequired) && isExpectedHumanRequired(e) {
 			continue
 		}
 

--- a/internal/health/checks_extra.go
+++ b/internal/health/checks_extra.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/runacct"
 	"github.com/Automaat/sybra/internal/runoutcome"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 const (
@@ -18,12 +19,12 @@ const (
 // statusDwellThresholds maps task status → max acceptable hours in that status
 // before flagging a bottleneck. Statuses absent from the map are not checked.
 var statusDwellThresholds = map[string]float64{
-	"plan-review":    12,
-	"in-review":      24,
-	"testing":        12,
-	"ready-pr":       2, // transient (PR opens in seconds); flag fast if PR-open stalls
-	"human-required": 24,
-	"todo":           24,
+	string(taskstatus.PlanReview):    12,
+	string(taskstatus.InReview):      24,
+	string(taskstatus.Testing):       12,
+	string(taskstatus.ReadyPR):       2, // transient (PR opens in seconds); flag fast if PR-open stalls
+	string(taskstatus.HumanRequired): 24,
+	string(taskstatus.Todo):          24,
 }
 
 // isAgentFailure classifies an audit event as a failed agent run. Production
@@ -93,7 +94,7 @@ func checkTriageMismatch(events []audit.Event, now time.Time) []Finding {
 			continue
 		}
 		to, _ := e.Data["to"].(string)
-		if to == "human-required" && classifiedHeadless[e.TaskID] {
+		if to == string(taskstatus.HumanRequired) && classifiedHeadless[e.TaskID] {
 			if isExpectedHumanRequired(e) {
 				continue
 			}
@@ -111,7 +112,7 @@ func checkTriageMismatch(events []audit.Event, now time.Time) []Finding {
 			TaskID:      taskID,
 			Evidence: map[string]any{
 				"classified_mode": "headless",
-				"final_status":    "human-required",
+				"final_status":    string(taskstatus.HumanRequired),
 			},
 			DetectedAt: now,
 		})

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -114,7 +114,7 @@ func clampNotes(body string) (string, bool) {
 	if len(body) <= seedMaxBytes {
 		return body, false
 	}
-	head := textutil.TrimPartialRuneSuffix(body[:seedHeadBytes])
-	tail := textutil.TrimPartialRunePrefix(body[len(body)-(seedMaxBytes-seedHeadBytes):])
+	head := textutil.TruncateBytes(body, seedHeadBytes, "")
+	tail := textutil.TailBytes(body, seedMaxBytes-seedHeadBytes)
 	return head + elisionMarker + tail, true
 }

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -677,13 +677,13 @@ func (c *Checker) ProviderEnabled(provider string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	switch provider {
-	case "claude":
+	case providerid.Claude:
 		return c.cfg.ClaudeEnabled
-	case "codex":
+	case providerid.Codex:
 		return c.cfg.CodexEnabled
-	case "copilot":
+	case providerid.Copilot:
 		return c.cfg.CopilotEnabled
-	case "opencode":
+	case providerid.OpenCode:
 		return c.cfg.OpenCodeEnabled
 	default:
 		return false

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -1244,17 +1244,17 @@ func (h *humanReviewHandler) verifyUnblocked(t task.Task) bool {
 
 func safeHumanReviewRecoveryStatus(action string) (task.Status, bool) {
 	switch strings.TrimSpace(action) {
-	case "in-progress":
+	case string(task.StatusInProgress):
 		return task.StatusInProgress, true
-	case "ready-review":
+	case string(task.StatusReadyReview):
 		return task.StatusReadyReview, true
-	case "in-review":
+	case string(task.StatusInReview):
 		return task.StatusInReview, true
-	case "testing":
+	case string(task.StatusTesting):
 		return task.StatusTesting, true
-	case "ready-pr":
+	case string(task.StatusReadyPR):
 		return task.StatusReadyPR, true
-	case "done":
+	case string(task.StatusDone):
 		return task.StatusDone, true
 	default:
 		return "", false
@@ -1912,7 +1912,7 @@ func (h *humanReviewHandler) retryAfterCrash(taskID string) bool {
 	h.mu.Lock()
 	delete(h.inflight, taskID)
 	h.mu.Unlock()
-	return h.maybeSpawn(h.ctx(), taskID, "human-required")
+	return h.maybeSpawn(h.ctx(), taskID, string(task.StatusHumanRequired))
 }
 
 func (h *humanReviewHandler) logAudit(evt, taskID, agentID string, data map[string]any) {

--- a/internal/textutil/truncate.go
+++ b/internal/textutil/truncate.go
@@ -114,6 +114,19 @@ func TrimPartialRuneSuffix(s string) string {
 	return s
 }
 
+// TailBytes keeps at most the last limit bytes of s and starts at a UTF-8 rune
+// boundary. Use it when the end carries the useful signal, such as the final
+// lines of a command log.
+func TailBytes(s string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(s) <= limit {
+		return s
+	}
+	return s[runeBoundaryAtOrAfter(s, len(s)-limit):]
+}
+
 // runeBoundaryAtOrBefore returns the largest index <= i that starts a rune.
 func runeBoundaryAtOrBefore(s string, i int) int {
 	if i >= len(s) {

--- a/internal/textutil/truncate_test.go
+++ b/internal/textutil/truncate_test.go
@@ -133,6 +133,31 @@ func TestTruncateMiddleKeepsTheTail(t *testing.T) {
 	}
 }
 
+func TestTailBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		s     string
+		limit int
+		want  string
+	}{
+		{name: "under limit is untouched", s: "abc", limit: 10, want: "abc"},
+		{name: "ascii tail", s: "abcdef", limit: 3, want: "def"},
+		{name: "cut inside a rune advances", s: "a…tail", limit: 6, want: "tail"},
+		{name: "cut on a rune boundary keeps the rune", s: "a…tail", limit: 7, want: "…tail"},
+		{name: "zero limit yields nothing", s: "abc", limit: 0, want: ""},
+		{name: "negative limit yields nothing", s: "abc", limit: -1, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := TailBytes(tt.s, tt.limit); got != tt.want {
+				t.Errorf("TailBytes(%q, %d) = %q, want %q", tt.s, tt.limit, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTruncateBytesTrimmed(t *testing.T) {
 	t.Parallel()
 	if got := TruncateBytesTrimmed("abc   def", 6, "..."); got != "abc..." {
@@ -162,6 +187,9 @@ func TestEveryCutPointStaysValidUTF8(t *testing.T) {
 					t.Errorf("%s(%q, %d, %q) = %q: invalid UTF-8", name, s, limit, suffix, got)
 				}
 			}
+		}
+		if got := TailBytes(s, limit); !utf8.ValidString(got) {
+			t.Errorf("TailBytes(%q, %d) = %q: invalid UTF-8", s, limit, got)
 		}
 	}
 }

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 // expandIssueLocker serializes one umbrella's critical section across both
@@ -951,11 +952,8 @@ func clearExpandFailure(tasks *task.Manager, trackerID string) error {
 func formatExpandFailureReason(count int, cause error) string {
 	reason := fmt.Sprintf("umbrella expansion failed (attempt %d): %v", count, cause)
 	const maxLen = 200
-	if len(reason) <= maxLen {
-		return reason
-	}
 	const tail = "..."
-	return reason[:maxLen-len(tail)] + tail
+	return textutil.TruncateBytesTotal(reason, maxLen, tail)
 }
 
 // childProjectID returns the repo a child should be worked in: the sub-issue's

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 // Decision is the agent's structured verdict output.
@@ -139,13 +141,13 @@ func normalize(v Decision, src Source) (Decision, Source, error) {
 }
 
 var validRecoverableActions = map[string]bool{
-	"none":         true,
-	"in-progress":  true,
-	"ready-review": true,
-	"in-review":    true,
-	"testing":      true,
-	"ready-pr":     true,
-	"done":         true,
+	"none":                         true,
+	string(taskstatus.InProgress):  true,
+	string(taskstatus.ReadyReview): true,
+	string(taskstatus.InReview):    true,
+	string(taskstatus.Testing):     true,
+	string(taskstatus.ReadyPR):     true,
+	string(taskstatus.Done):        true,
 }
 
 var validConfidence = map[string]bool{

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Automaat/sybra/internal/pressure"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/watchdogreason"
 )
 
@@ -837,7 +838,7 @@ func (w *Watchdog) verdictStatusFromVerify(ctx context.Context, taskID, judgeRea
 func trimTail(failedCmd, output string, n int) string {
 	tail := output
 	if len(tail) > n {
-		tail = "…" + strings.ToValidUTF8(tail[len(tail)-n:], "")
+		tail = "…" + strings.ToValidUTF8(textutil.TailBytes(tail, n), "")
 	}
 	if tail == "" {
 		return failedCmd

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -985,7 +985,7 @@ func (e *Engine) blockRetryExhaustedTriageIfNeeded(taskID string, step *Step, wf
 	wfExec.State = ExecFailed
 	wfExec.CompletedAt = &now
 	wfExec.CurrentStep = ""
-	return true, e.tasks.SetBlockerAndWorkflow(taskID, "blocked", reason, blocker.State{
+	return true, e.tasks.SetBlockerAndWorkflow(taskID, string(taskstatus.Blocked), reason, blocker.State{
 		Kind:       blocker.KindTriageRetryExhausted,
 		Actor:      blocker.ActorWorkflow,
 		Code:       "triage_retryable",
@@ -1007,5 +1007,5 @@ func (e *Engine) blockRetryExhaustedPlanningIfNeeded(taskID string, def *Definit
 	wfExec.State = ExecFailed
 	wfExec.CompletedAt = &now
 	wfExec.CurrentStep = ""
-	return true, e.tasks.SetStatusAndWorkflow(taskID, "human-required", reason, wfExec)
+	return true, e.tasks.SetStatusAndWorkflow(taskID, string(taskstatus.HumanRequired), reason, wfExec)
 }

--- a/internal/workflow/engine_events_resume.go
+++ b/internal/workflow/engine_events_resume.go
@@ -16,7 +16,7 @@ func resumeSkipReasonForStatus(status taskstatus.Status) (reason string, skip bo
 	case taskstatus.HumanRequired:
 		return "human_required", true
 	case taskstatus.Blocked:
-		return "blocked", true
+		return string(taskstatus.Blocked), true
 	case taskstatus.Done, taskstatus.Cancelled:
 		return "terminal_status", true
 	default:
@@ -128,7 +128,7 @@ func (e *Engine) escalateMissingStep(taskID string, wf *Execution) {
 		" planning to re-plan against the current workflow."
 	failed := *wf
 	failed.State = ExecFailed
-	if err := e.tasks.SetStatusAndWorkflow(taskID, "human-required", reason, &failed); err != nil {
+	if err := e.tasks.SetStatusAndWorkflow(taskID, string(taskstatus.HumanRequired), reason, &failed); err != nil {
 		e.logger.Warn("workflow.resume-stalled.step-missing.escalate", "task_id", taskID, "err", err)
 		return
 	}
@@ -271,7 +271,7 @@ func (e *Engine) resumePreflightConsumesTick(t *TaskInfo, step *Step, logEvent s
 	retryableWorktreeRepair := e.canRetryWorktreeRepair(t, step)
 	if reason, skip := resumeSkipReasonForStatus(t.Status); skip &&
 		(reason != "human_required" || !retryableWatchdogStop) &&
-		(reason != "blocked" || !retryableWorktreeRepair) {
+		(reason != string(taskstatus.Blocked) || !retryableWorktreeRepair) {
 		e.resumeSkip.Log(e.logger, logEvent, t.ID,
 			reason+"|"+string(t.Status)+"|"+step.ID,
 			"task_id", t.ID, "reason", reason, "status", t.Status, "step", step.ID)

--- a/internal/workflow/engine_skill_receipt.go
+++ b/internal/workflow/engine_skill_receipt.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/skillattr"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 const maxSkillReceiptRecoveryAttempts = 1
@@ -128,7 +129,7 @@ func (e *Engine) maybeRecoverUnverifiedSkillRun(taskID, agentID, spawnedStep, ou
 		if summary != "" {
 			reason += ": " + summary
 		}
-		if err := e.tasks.SetStatusAndWorkflow(taskID, "human-required", reason, fresh.Workflow); err != nil {
+		if err := e.tasks.SetStatusAndWorkflow(taskID, string(taskstatus.HumanRequired), reason, fresh.Workflow); err != nil {
 			e.logger.Error("workflow.skill-receipt.human-required", "task_id", taskID, "step", spawnedStep, "err", err)
 		}
 		e.logger.Warn("workflow.skill-receipt.exhausted", "task_id", taskID, "step", spawnedStep, "skill", run.RequestedSkill, "zero_output", zeroOutput, "summary", summary)

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -276,7 +276,7 @@ func (e *Engine) maybeParkImplementGitHubRetry(taskID string, step *Step, wfExec
 	wfExec.State = ExecWaiting
 	wfExec.SetVar(implementPushAttemptsVar, strconv.Itoa(attempts+1))
 	wfExec.SetVar(workflowRetryAfterVar, e.now().Add(prCreateRetryBackoff).Format(time.RFC3339))
-	if err := e.tasks.SetStatusAndWorkflow(taskID, "in-progress", implementPushRetryStatusReason, wfExec); err != nil {
+	if err := e.tasks.SetStatusAndWorkflow(taskID, string(taskstatus.InProgress), implementPushRetryStatusReason, wfExec); err != nil {
 		return false, err
 	}
 	e.logger.Warn("workflow.implement-push-retry.parked",

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/gitexec"
@@ -714,9 +713,9 @@ func capHeadTailText(text string, maxBytes int, elision string) string {
 	if headBytes <= 0 {
 		headBytes = maxBytes / 2
 	}
-	head := trimUTF8ToBytes(text, headBytes)
+	head := textutil.TruncateBytes(text, headBytes, "")
 	tailBudget := max(0, maxBytes-len(elision)-len(head))
-	tail := trimUTF8ToBytesFromEnd(text, tailBudget)
+	tail := textutil.TailBytes(text, tailBudget)
 	return strings.TrimRight(head, "\n") + elision + strings.TrimLeft(tail, "\n")
 }
 
@@ -742,41 +741,6 @@ func normalizeAcceptanceLedgerReport(report string) string {
 	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
-func trimUTF8ToBytes(s string, limit int) string {
-	if limit <= 0 {
-		return ""
-	}
-	if len(s) <= limit {
-		return s
-	}
-	s = s[:limit]
-	for len(s) > 0 && !utf8.ValidString(s) {
-		_, size := utf8.DecodeLastRuneInString(s)
-		if size <= 1 {
-			s = s[:len(s)-1]
-			continue
-		}
-		s = s[:len(s)-size]
-	}
-	return s
-}
-
-func trimUTF8ToBytesFromEnd(s string, limit int) string {
-	if limit <= 0 {
-		return ""
-	}
-	if len(s) <= limit {
-		return s
-	}
-	s = s[len(s)-limit:]
-	for len(s) > 0 && !utf8.ValidString(s) {
-		if utf8.RuneStart(s[0]) {
-			break
-		}
-		s = s[1:]
-	}
-	return s
-}
 func upsertAcceptanceLedger(body, fingerprint, report string) (nextBody string, changed bool) {
 	if fingerprint == "" || report == "" {
 		return body, false

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/taskstatus"
+	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/workflow/failureclassify"
 )
 
@@ -1505,10 +1506,10 @@ func (b *boundedTail) String() string {
 }
 
 // tailString returns the last n bytes of s, prefixed with an elision marker
-// when truncated. Debug output — not rune-aligned at the cut.
+// when truncated. The shared helper keeps the cut rune-aligned.
 func tailString(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
-	return "…(truncated)…\n" + s[len(s)-n:]
+	return "…(truncated)…\n" + textutil.TailBytes(s, n)
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4726,7 +4726,7 @@ func TestResumeStalled_WatchdogZeroOutputUsesSharedRetryBudget(t *testing.T) {
 			freshUsed:        true,
 			since:            time.Now().Add(-1 * time.Hour),
 			wantStarts:       0,
-			wantStatus:       "in-progress",
+			wantStatus:       taskstatus.InProgress,
 			wantReason:       watchdogreason.RateLimit(watchdogreason.ZeroOutputBeforeStartup),
 			wantRetry:        "0",
 			wantFresh:        "1",

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -9839,7 +9839,7 @@ fi
 exec "{{REAL_GIT}}" "$@"
 `)
 
-	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine := NewTestEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
 	if recovered := engine.recoverVerifyCommitsRefs("t1", wtPath, TaskInfo{Branch: "fix/not-pushed"}); recovered {
 		t.Fatal("recoverVerifyCommitsRefs() = true, want false after failed fetch")
 	}

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"text/template"
-	"unicode/utf8"
+
+	"github.com/Automaat/sybra/internal/textutil"
 )
 
 const (
@@ -205,26 +206,9 @@ func clampPromptInline(body string) string {
 	if len(body) <= promptInlineMaxBytes {
 		return body
 	}
-	head := trimPromptRuneBoundaryEnd(body[:promptInlineHeadBytes])
-	tail := trimPromptRuneBoundaryStart(body[len(body)-(promptInlineMaxBytes-promptInlineHeadBytes):])
+	head := textutil.TruncateBytes(body, promptInlineHeadBytes, "")
+	tail := textutil.TailBytes(body, promptInlineMaxBytes-promptInlineHeadBytes)
 	return head + promptInlineElision + tail
-}
-
-func trimPromptRuneBoundaryStart(s string) string {
-	for len(s) > 0 && !utf8.RuneStart(s[0]) {
-		s = s[1:]
-	}
-	return s
-}
-
-func trimPromptRuneBoundaryEnd(s string) string {
-	for len(s) > 0 {
-		if r, size := utf8.DecodeLastRuneInString(s); r != utf8.RuneError || size > 1 {
-			break
-		}
-		s = s[:len(s)-1]
-	}
-	return s
 }
 
 // DefaultCommitSignFlags reports the configured fallback. Exported for the

--- a/mise.toml
+++ b/mise.toml
@@ -80,6 +80,7 @@ run = [
   "bash scripts/check-no-home-fallback.sh",
   "bash scripts/check-atomic-writes.sh",
   "bash scripts/check-atomic-writes.test.sh",
+  "bash scripts/check-consolidated-primitives.sh",
   "bash scripts/check-no-viewer-user-endpoint.sh",
   "bash scripts/check-gh-exec-gate.sh",
   "bash scripts/check-git-exec-gate.sh",
@@ -93,7 +94,7 @@ run = [
   "wails3 generate bindings -ts -clean -d frontend/bindings ./... && git diff --exit-code frontend/bindings/",
   "hadolint Dockerfile",
 ]
-description = "Run every deterministic CI-aligned gate (go build+mod+tidy+tests+e2e, golangci-lint, frontend check+build:web+tests+oxlint+pins, api-shim sync, no-home-fallback, Git/GitHub execution boundaries, no-direct-status-write, no-direct-workflow-write, autonomy SLO gate, bindings sync, hadolint). Run before committing. Excludes nilaway/security/playwright — CI owns those."
+description = "Run every deterministic CI-aligned gate (go build+mod+tidy+tests+e2e, golangci-lint, frontend check+build:web+tests+oxlint+pins, api-shim sync, no-home-fallback, consolidated-primitive drift, Git/GitHub execution boundaries, no-direct-status-write, no-direct-workflow-write, autonomy SLO gate, bindings sync, hadolint). Run before committing. Excludes nilaway/security/playwright — CI owns those."
 
 [tasks."build:frontend:desktop"]
 run = "cd frontend && npm run build:desktop"

--- a/scripts/check-consolidated-primitives.sh
+++ b/scripts/check-consolidated-primitives.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Guard the four consolidation boundaries established by #3078/#3079/#3080/#3081.
+# The syntax-aware checker owns the exact exception ledger and rejects both new
+# copies and stale exceptions. Tests are included for truncation/JSON helpers;
+# *_test.go files are excluded only from status/provider literal checks because
+# wire-format fixtures must intentionally spell persisted values.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Prove the scanner still catches each forbidden shape before trusting its
+# repository-wide result.
+go test ./scripts/checkconsolidated
+
+files=()
+while IFS= read -r -d '' file; do
+  case "${file}" in
+    *.go) files+=("${file}") ;;
+  esac
+done < <(git ls-files -z --cached --others --exclude-standard)
+
+if ((${#files[@]} > 0)); then
+  go run ./scripts/checkconsolidated "${files[@]}"
+fi

--- a/scripts/check-consolidated-primitives.sh
+++ b/scripts/check-consolidated-primitives.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Guard the four consolidation boundaries established by #3078/#3079/#3080/#3081.
 # The syntax-aware checker owns the exact exception ledger and rejects both new
-# copies and stale exceptions. Tests are included for truncation/JSON helpers;
-# *_test.go files are excluded only from status/provider literal checks because
-# wire-format fixtures must intentionally spell persisted values.
+# copies and stale exceptions. Tests are included for every primitive; their
+# intentional wire-format fixtures must be listed in the exact exception ledger.
 
 set -euo pipefail
 

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -92,6 +92,11 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/sybra/config_sparse.go", "Sparse-config paths are slices at parser-derived YAML line/path boundaries.", map[string]int{"slice": 2})
 	add(kindStringTruncation, "internal/task/slug.go", "Task slugs are regex-normalized to lowercase ASCII before enforcing the identifier limit.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/worktree/attempt.go", "Git revisions are hexadecimal ASCII and this produces a branch suffix.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/manager_run.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short agent identifier.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/loopagent/store.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short loop-agent identifier.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/app.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width Kubernetes smoke-test identifier.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/task/comment.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short comment identifier.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/task/store.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short task identifier.", map[string]int{"slice": 1})
 
 	add(kindStringTruncation, "internal/agent/procsandbox_darwin_integration_test.go", "Integration fixtures split fixed-format sandbox profile text and byte buffers.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/project/repair_test.go", "Git-repair fixtures deliberately mutate fixed-format object/ref data.", map[string]int{"slice": 5})
@@ -104,6 +109,8 @@ func buildAllowances() map[allowanceKey]allowance {
 	// scanner can be confused by an unmatched quote in surrounding prose, so
 	// this span is tried second and accepted only if json.Unmarshal succeeds.
 	add(kindJSONExtraction, "internal/workflow/engine_steps_bestofn.go", "Fallback for unmatched quotes in judge prose; json.Unmarshal validates the candidate.", map[string]int{"outermostBraceSpan": 1})
+	add(kindJSONExtraction, "cmd/gen-api-shim/shim.go", "TypeScript signature parser balances every delimiter kind to split top-level parameters; it does not extract JSON.", map[string]int{"splitTopLevel": 1})
+	add(kindJSONExtraction, "internal/workflow/engine_steps_tamper.go", "Go-source tamper analysis counts lexical brace balance after excluding strings and comments; it does not extract JSON.", map[string]int{"codeBraceDelta": 1})
 
 	// Provider-name exceptions are external wire/vendor identifiers rather
 	// than Sybra dispatch comparisons.
@@ -603,7 +610,8 @@ func inspectFile(fset *token.FileSet, path string, file *ast.File, info *types.I
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch n := node.(type) {
 		case *ast.SliceExpr:
-			if !strings.HasPrefix(path, "internal/textutil/") && isStringExpr(n.X, info, stringNames, stringFields) && (n.Low != nil || n.High != nil) {
+			if !strings.HasPrefix(path, "internal/textutil/") && (n.Low != nil || n.High != nil) &&
+				(isStringExpr(n.X, info, stringNames, stringFields) || isUnresolvedCall(n.X, info)) {
 				out = append(out, finding{kind: kindStringTruncation, path: path, value: "slice", line: fset.Position(n.Pos()).Line})
 			}
 		case *ast.BasicLit:
@@ -634,6 +642,18 @@ func inspectFile(fset *token.FileSet, path string, file *ast.File, info *types.I
 		}
 	}
 	return out
+}
+
+func isUnresolvedCall(expr ast.Expr, info *types.Info) bool {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			break
+		}
+		expr = paren.X
+	}
+	_, ok := expr.(*ast.CallExpr)
+	return ok && (info == nil || info.TypeOf(expr) == nil)
 }
 
 func isStructTag(file *ast.File, lit *ast.BasicLit) bool {
@@ -810,10 +830,8 @@ func extractsJSONByBraces(fn *ast.FuncDecl) bool {
 	if hasFirst && hasLast {
 		return true
 	}
-	name := strings.ToLower(fn.Name.Name)
-	jsonishName := strings.Contains(name, "json") || strings.Contains(name, "object")
 	for _, directions := range braceDirections {
-		if directions == 3 && bodyHasBothBraces(body) && (jsonishName || returnsStringSlice(fn) || returnsIndexSpan(fn)) {
+		if directions == 3 && bodyHasBothBraces(body) {
 			return true
 		}
 	}
@@ -840,56 +858,6 @@ func assignmentDirection(name string, expr ast.Expr) uint8 {
 		return 2
 	}
 	return 0
-}
-
-func returnsIndexSpan(fn *ast.FuncDecl) bool {
-	if fn.Type.Results == nil {
-		return false
-	}
-	count := 0
-	for _, field := range fn.Type.Results.List {
-		id, ok := field.Type.(*ast.Ident)
-		if !ok || id.Name != "int" {
-			continue
-		}
-		if len(field.Names) == 0 {
-			count++
-		} else {
-			count += len(field.Names)
-		}
-	}
-	return count >= 2
-}
-
-func returnsStringSlice(fn *ast.FuncDecl) bool {
-	if fn.Type.Results == nil {
-		return false
-	}
-	stringResult := false
-	for _, field := range fn.Type.Results.List {
-		if id, ok := field.Type.(*ast.Ident); ok && id.Name == "string" {
-			stringResult = true
-			break
-		}
-	}
-	if !stringResult {
-		return false
-	}
-	found := false
-	ast.Inspect(fn.Body, func(node ast.Node) bool {
-		ret, ok := node.(*ast.ReturnStmt)
-		if !ok {
-			return !found
-		}
-		for _, result := range ret.Results {
-			if _, ok := result.(*ast.SliceExpr); ok {
-				found = true
-				return false
-			}
-		}
-		return !found
-	})
-	return found
 }
 
 func isBraceLiteral(expr ast.Expr) bool {

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -57,7 +57,7 @@ type gateError struct {
 // occurrence has the same semantics.
 var allowances = buildAllowances()
 
-func buildAllowances() map[allowanceKey]allowance {
+func buildAllowances() map[allowanceKey]allowance { //nolint:funlen // The explicit exception ledger is intentionally centralized for review.
 	out := make(map[allowanceKey]allowance)
 	add := func(kind findingKind, path, reason string, counts map[string]int) {
 		for value, count := range counts {
@@ -779,9 +779,9 @@ func isImportPath(file *ast.File, lit *ast.BasicLit) bool {
 	return false
 }
 
-func collectStringNames(file *ast.File, info *types.Info) (map[string]struct{}, map[string]struct{}) {
-	names := make(map[string]struct{})
-	fields := make(map[string]struct{})
+func collectStringNames(file *ast.File, info *types.Info) (names, fields map[string]struct{}) {
+	names = make(map[string]struct{})
+	fields = make(map[string]struct{})
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch n := node.(type) {
 		case *ast.Field:
@@ -922,10 +922,13 @@ func extractsJSONByBraces(fn *ast.FuncDecl) bool {
 			if !ok {
 				return true
 			}
-			if n.Tok == token.INC {
+			switch n.Tok {
+			case token.INC:
 				braceDirections[id.Name] |= 1
-			} else if n.Tok == token.DEC {
+			case token.DEC:
 				braceDirections[id.Name] |= 2
+			default:
+				// No other token is valid for ast.IncDecStmt.
 			}
 		case *ast.AssignStmt:
 			if len(n.Lhs) != 1 || len(n.Rhs) != 1 {
@@ -935,12 +938,15 @@ func extractsJSONByBraces(fn *ast.FuncDecl) bool {
 			if !ok {
 				return true
 			}
-			if n.Tok == token.ADD_ASSIGN {
+			switch n.Tok {
+			case token.ADD_ASSIGN:
 				braceDirections[id.Name] |= compoundDirection(false, n.Rhs[0])
-			} else if n.Tok == token.SUB_ASSIGN {
+			case token.SUB_ASSIGN:
 				braceDirections[id.Name] |= compoundDirection(true, n.Rhs[0])
-			} else if n.Tok == token.ASSIGN {
+			case token.ASSIGN:
 				braceDirections[id.Name] |= assignmentDirection(id.Name, n.Rhs[0])
+			default:
+				// Other assignment operators cannot encode a signed brace delta.
 			}
 		}
 		return true
@@ -1032,7 +1038,7 @@ func isBraceLiteral(expr ast.Expr) bool {
 }
 
 func bodyHasBothBraces(body *ast.BlockStmt) bool {
-	open, close := false, false
+	open, closeBrace := false, false
 	ast.Inspect(body, func(node ast.Node) bool {
 		lit, ok := node.(*ast.BasicLit)
 		if !ok || (lit.Kind != token.STRING && lit.Kind != token.CHAR) {
@@ -1041,9 +1047,9 @@ func bodyHasBothBraces(body *ast.BlockStmt) bool {
 		value, err := strconv.Unquote(lit.Value)
 		if err == nil {
 			open = open || value == "{"
-			close = close || value == "}"
+			closeBrace = closeBrace || value == "}"
 		}
 		return true
 	})
-	return open && close
+	return open && closeBrace
 }

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -7,12 +7,17 @@ package main
 import (
 	"fmt"
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 type findingKind string
@@ -57,7 +62,15 @@ func buildAllowances() map[allowanceKey]allowance {
 	out := make(map[allowanceKey]allowance)
 	add := func(kind findingKind, path, reason string, counts map[string]int) {
 		for value, count := range counts {
-			out[allowanceKey{kind: kind, path: path, value: value}] = allowance{count: count, reason: reason}
+			key := allowanceKey{kind: kind, path: path, value: value}
+			current := out[key]
+			current.count += count
+			if current.reason == "" {
+				current.reason = reason
+			} else if current.reason != reason {
+				current.reason += "; " + reason
+			}
+			out[key] = current
 		}
 	}
 
@@ -124,18 +137,352 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindTaskStatus, "internal/workflow/engine_steps_prfix.go", "PR-fix agent sentinel protocol has its own human/continue/done verdict vocabulary.", map[string]int{"human-required": 2, "done": 1})
 	add(kindTaskStatus, "internal/workflow/engine_steps_verify_checks.go", "StepOutput blocked is a workflow-step result, not the task status field.", map[string]int{"blocked": 1})
 
+	// The type-aware truncation rule intentionally treats every string slice as
+	// suspicious. These pre-existing parser/protocol/test slices are exact
+	// baselines; any added or removed occurrence requires a ledger review.
+	add(kindStringTruncation, "cmd/gen-api-shim/shim.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 7})
+	add(kindStringTruncation, "cmd/gen-config-docs/main.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/gen-events/main.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/sybra-cli/selfmonitor.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/sybra-perf/main.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 5})
+	add(kindStringTruncation, "internal/agent/discovery.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/k8s_job_runner.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/malformed_tool_call.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/orphan_sweep_other.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/procsandbox_darwin_integration_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/agent/procsandbox_linux_integration_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/reattach_linux.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/skill_invoke.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/tool_loop_semantic.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/cluster/tls_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/config/config_migration.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/experience/record_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/fsutil/fsutil.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/fsutil/projectkey.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/github/client.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/harnessevolution/cluster.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/harnessevolution/collector.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/harnessevolution/propose.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/health/docker.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/issueref/issueref.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/limits/live.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/llmjob/llmjob.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/monitor/issueoutbox.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/monitor/issuesink.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 8})
+	add(kindStringTruncation, "internal/notes/notes_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/project/git.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 4})
+	add(kindStringTruncation, "internal/project/repair_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 5})
+	add(kindStringTruncation, "internal/project/store_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/prompteval/store.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/promptlab/model.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/provider/probes.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sandbox/docker.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sandbox/envfile.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sandbox/k8s_integration_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/scrub/scrub.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 6})
+	add(kindStringTruncation, "internal/skillinvoke/skillinvoke.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 9})
+	add(kindStringTruncation, "internal/stats/pricing.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/sybra/app_automation_routing_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/sybra/app_umbrella_gate.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 4})
+	add(kindStringTruncation, "internal/sybra/config_sparse.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 4})
+	add(kindStringTruncation, "internal/sybra/config_subscribers.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/review/agent_manager_test_helpers_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/sybra/svc_tasks_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/svc_tasks.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/task/plan_draft.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/task/slug.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/umbrella/expand.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 9})
+	add(kindStringTruncation, "internal/umbrella/planner.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/builtin_plan_prompt_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/workflow/engine_events_agents.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/engine_parallel_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/workflow/engine_skill_receipt_summary.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/workflow/engine_steps_bestofn.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/workflow/engine_steps_clear_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/engine_steps_prfix.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/workflow/engine_steps_tamper.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 12})
+	add(kindStringTruncation, "internal/workflow/engine_steps_testroute.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 8})
+	add(kindStringTruncation, "internal/workflow/engine_steps_triage.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/workflow/engine_steps_verify_checks_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/engine_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/engine_validate_plan_contract.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/envtest_assets.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/template.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/worktree/branch.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/worktree/cleanup.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/worktree/manager_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+
+	// Test fixtures intentionally spell persisted wire values. They remain
+	// exact path/value/count entries so adding or removing a literal forces an
+	// explicit review of this ledger instead of receiving a blanket test exemption.
+	add(kindProvider, "cmd/fake-claude/main_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 5})
+	add(kindProvider, "cmd/sybra-cli/evaluation_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3})
+	add(kindProvider, "cmd/sybra-cli/main_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 11, "codex": 7, "copilot": 4})
+	add(kindProvider, "cmd/sybra-server/main_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 1, "copilot": 1})
+	add(kindProvider, "internal/abtest/selector_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 53, "codex": 12, "copilot": 2, "opencode": 1})
+	add(kindProvider, "internal/agent/abvariant_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 9, "codex": 11, "copilot": 2})
+	add(kindProvider, "internal/agent/allowed_tools_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 4, "copilot": 3, "opencode": 1})
+	add(kindProvider, "internal/agent/background_task_adversarial_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/copilot_stream_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"copilot": 6})
+	add(kindProvider, "internal/agent/discovery_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 4})
+	add(kindProvider, "internal/agent/effort_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/foreground_command_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/inspector_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/agent/k8s_job_runner_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 4, "opencode": 5})
+	add(kindProvider, "internal/agent/logfile_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 1})
+	add(kindProvider, "internal/agent/malformed_tool_call_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 6, "codex": 1})
+	add(kindProvider, "internal/agent/manager_gate_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 87, "codex": 58, "copilot": 8, "opencode": 5})
+	add(kindProvider, "internal/agent/manager_run_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 41, "codex": 18, "copilot": 3, "opencode": 1})
+	add(kindProvider, "internal/agent/manager_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 16, "codex": 25, "copilot": 5})
+	add(kindProvider, "internal/agent/model_json_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/opencode_stream_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"opencode": 5})
+	add(kindProvider, "internal/agent/orphan_sweep_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/procsandbox_linux_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 5, "codex": 4})
+	add(kindProvider, "internal/agent/procsandbox_read_darwin_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 1})
+	add(kindProvider, "internal/agent/procsandbox_read_linux_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/procsandbox_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 5})
+	add(kindProvider, "internal/agent/provider_lookup_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/reattach_effort_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/agent/reattach_escalation_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/reattach_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 13})
+	add(kindProvider, "internal/agent/registry_roundtrip_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1, "codex": 1})
+	add(kindProvider, "internal/agent/runner_headless_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 99, "codex": 35, "copilot": 9})
+	add(kindProvider, "internal/agent/session_filter_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 7, "codex": 8})
+	add(kindProvider, "internal/agent/skill_invoke_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1, "codex": 6, "copilot": 2, "opencode": 1})
+	add(kindProvider, "internal/agent/survive_restart_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 19, "codex": 2})
+	add(kindProvider, "internal/agent/tool_failure_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 7})
+	add(kindProvider, "internal/agent/tool_result_bound_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/agent/zz_adversarial_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 4, "copilot": 6})
+	add(kindProvider, "internal/config/config_providers_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 1, "copilot": 1, "opencode": 2})
+	add(kindProvider, "internal/config/config_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3, "codex": 4})
+	add(kindProvider, "internal/evaluation/scorecard_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 30, "codex": 24, "copilot": 4})
+	add(kindProvider, "internal/evaluation/service_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 6})
+	add(kindProvider, "internal/evaluation/weakness_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1, "codex": 3})
+	add(kindProvider, "internal/experience/record_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1, "codex": 2})
+	add(kindProvider, "internal/github/check_filter_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"copilot": 1})
+	add(kindProvider, "internal/learning/digest_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 4, "codex": 2, "copilot": 1})
+	add(kindProvider, "internal/learning/input_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3, "codex": 1})
+	add(kindProvider, "internal/learning/model_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/llmexec/llmexec_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 12, "codex": 20, "copilot": 9, "opencode": 6})
+	add(kindProvider, "internal/llmjob/llmjob_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 31, "codex": 8, "copilot": 4, "opencode": 4})
+	add(kindProvider, "internal/loopagent/scheduler_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/loopagent/store_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 1, "copilot": 1})
+	add(kindProvider, "internal/metrics/metrics_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 15, "codex": 7})
+	add(kindProvider, "internal/modeltier/tier_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 2, "opencode": 1})
+	add(kindProvider, "internal/monitor/capacity_dispatch_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 2})
+	add(kindProvider, "internal/monitor/no_capacity_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3, "codex": 2, "copilot": 2})
+	add(kindProvider, "internal/prompteval/promptfoo_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/provider/health_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 68, "codex": 36, "copilot": 6, "opencode": 4})
+	add(kindProvider, "internal/provider/reset_hint_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 1})
+	add(kindProvider, "internal/recovery/recovery_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/routing/service_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 6, "codex": 5})
+	add(kindProvider, "internal/selfmonitor/provider_feedback_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1, "codex": 2})
+	add(kindProvider, "internal/stats/pricing_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3, "codex": 5, "copilot": 1})
+	add(kindProvider, "internal/stats/store_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 3})
+	add(kindProvider, "internal/sybra/agentorch/agentorch_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 18, "codex": 4})
+	add(kindProvider, "internal/sybra/agentorch/prompt_render_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 1})
+	add(kindProvider, "internal/sybra/agentorch/scratch_manual_probe_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/sybra/app_agent_release_lifecycle_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3})
+	add(kindProvider, "internal/sybra/app_human_review_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3, "codex": 5})
+	add(kindProvider, "internal/sybra/app_provider_capacity_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 4, "codex": 2})
+	add(kindProvider, "internal/sybra/app_queue_order_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/sybra/app_startup_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/sybra/app_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 4})
+	add(kindProvider, "internal/sybra/app_tool_ledger_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/sybra/app_workflow_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 14})
+	add(kindProvider, "internal/sybra/completion/completion_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 4, "copilot": 2})
+	add(kindProvider, "internal/sybra/completion/malformed_tool_call_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/sybra/completion/parked_adoption_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/sybra/completion/permissions_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 3})
+	add(kindProvider, "internal/sybra/config_diff_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 1})
+	add(kindProvider, "internal/sybra/e2e_autonomy_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 11, "codex": 2})
+	add(kindProvider, "internal/sybra/e2e_bestofn_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/sybra/e2e_bootstrap_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/sybra/e2e_crossprovider_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 4, "codex": 1})
+	add(kindProvider, "internal/sybra/e2e_evaluation_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 1})
+	add(kindProvider, "internal/sybra/e2e_stats_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 5, "codex": 3})
+	add(kindProvider, "internal/sybra/e2e_workflow_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 76, "codex": 33, "copilot": 2})
+	add(kindProvider, "internal/sybra/lifecycle_metrics_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 9, "codex": 9})
+	add(kindProvider, "internal/sybra/monitor_cluster_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/sybra/orchestrator_resume_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/sybra/review/fix_dispatch_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/sybra/review/rebase_recover_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 3})
+	add(kindProvider, "internal/sybra/svc_config_reload_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 3, "codex": 5})
+	add(kindProvider, "internal/sybra/svc_info_runtimes_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 5, "codex": 5, "opencode": 2})
+	add(kindProvider, "internal/sybra/svc_orchestrator_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/sybra/svc_reviews_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/sybra/svc_tasks_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 2, "copilot": 3})
+	add(kindProvider, "internal/sybra/sybra_home_sentinel_e2e_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/task/model_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1, "codex": 1, "copilot": 1})
+	add(kindProvider, "internal/task/persistence_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 2})
+	add(kindProvider, "internal/task/store_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 2})
+	add(kindProvider, "internal/triage/classifier_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/umbrella/planner_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/watchdog/agent_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 10})
+	add(kindProvider, "internal/workflow/engine_agent_route_race_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/workflow/engine_bestofn_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2})
+	add(kindProvider, "internal/workflow/engine_parallel_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 9, "codex": 5})
+	add(kindProvider, "internal/workflow/engine_skill_receipt_zero_output_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/workflow/engine_steps_testroute_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"codex": 4})
+	add(kindProvider, "internal/workflow/engine_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 41, "codex": 23, "copilot": 3})
+	add(kindProvider, "internal/workflow/permutation_contract_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 2, "codex": 2})
+	add(kindProvider, "internal/workflow/provider_resolution_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 6, "codex": 15, "copilot": 4, "opencode": 2})
+	add(kindProvider, "internal/workflow/start_error_test.go", "Test fixture intentionally spells provider wire values to verify parsing, routing, or compatibility.", map[string]int{"claude": 1, "codex": 2})
+	add(kindTaskStatus, "cmd/sybra-cli/cli_home_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"todo": 1})
+	add(kindTaskStatus, "cmd/sybra-cli/doctor_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2})
+	add(kindTaskStatus, "cmd/sybra-cli/handoff_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "in-progress": 1, "in-review": 1, "ready-pr": 3, "ready-review": 1, "testing": 2})
+	add(kindTaskStatus, "cmd/sybra-cli/httpclient_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"todo": 5})
+	add(kindTaskStatus, "cmd/sybra-cli/main_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 4, "done": 5, "human-required": 2, "in-progress": 7, "in-review": 1, "ready-pr": 1, "todo": 3})
+	add(kindTaskStatus, "cmd/sybra-cli/progress_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 2, "todo": 1})
+	add(kindTaskStatus, "cmd/sybra-cli/unknown_key_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2})
+	add(kindTaskStatus, "internal/agent/convo_io_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 2})
+	add(kindTaskStatus, "internal/agent/logfile_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1})
+	add(kindTaskStatus, "internal/agent/manager_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"cancelled": 1})
+	add(kindTaskStatus, "internal/agent/model_json_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2})
+	add(kindTaskStatus, "internal/agent/opencode_stream_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1})
+	add(kindTaskStatus, "internal/agent/reattach_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1, "done": 3, "human-required": 4, "in-progress": 2, "todo": 3})
+	add(kindTaskStatus, "internal/agent/runner_headless_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 9})
+	add(kindTaskStatus, "internal/agent/stream_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2})
+	add(kindTaskStatus, "internal/agent/tool_calls_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1})
+	add(kindTaskStatus, "internal/agentqueue/queue_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"cancelled": 3, "done": 3, "in-progress": 3, "new": 4})
+	add(kindTaskStatus, "internal/audit/summary_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "in-progress": 2, "new": 1, "todo": 2})
+	add(kindTaskStatus, "internal/autoupdate/autoupdate_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 4, "new": 1})
+	add(kindTaskStatus, "internal/blocker/blocker_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 4, "cancelled": 1, "done": 1, "human-required": 10, "in-progress": 2, "new": 1, "todo": 1})
+	add(kindTaskStatus, "internal/evaluation/autonomy_trend_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 1, "in-review": 1})
+	add(kindTaskStatus, "internal/evaluation/phases_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1, "cancelled": 1, "done": 5, "human-required": 1, "in-progress": 10, "in-review": 9, "new": 1, "plan-review": 1, "planning": 5, "ready-pr": 1, "ready-review": 1, "testing": 3, "todo": 5})
+	add(kindTaskStatus, "internal/evaluation/scorecard_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 6, "in-progress": 6, "in-review": 14, "testing": 3})
+	add(kindTaskStatus, "internal/evaluation/slo_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 5, "in-progress": 6, "in-review": 2, "todo": 3})
+	add(kindTaskStatus, "internal/experience/store_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 4})
+	add(kindTaskStatus, "internal/fsutil/fsutil_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 9})
+	add(kindTaskStatus, "internal/github/issue_close_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2})
+	add(kindTaskStatus, "internal/github/rest_monitor_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 2})
+	add(kindTaskStatus, "internal/github/review_state_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 1})
+	add(kindTaskStatus, "internal/harnessevolution/cluster_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"testing": 1})
+	add(kindTaskStatus, "internal/health/checks_extra_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2, "human-required": 4, "in-progress": 7, "in-review": 1, "new": 1, "plan-review": 5, "planning": 2, "todo": 1})
+	add(kindTaskStatus, "internal/health/checks_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 2, "in-progress": 6, "in-review": 1, "todo": 7})
+	add(kindTaskStatus, "internal/health/e2e_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "human-required": 1, "in-progress": 3, "plan-review": 2, "planning": 1})
+	add(kindTaskStatus, "internal/health/fingerprint_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-review": 2, "todo": 1})
+	add(kindTaskStatus, "internal/intervention/fingerprint_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 3, "in-progress": 3, "ready-pr": 1})
+	add(kindTaskStatus, "internal/intervention/record_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 3, "todo": 2})
+	add(kindTaskStatus, "internal/intervention/store_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 5, "in-progress": 5})
+	add(kindTaskStatus, "internal/limits/collect_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 5})
+	add(kindTaskStatus, "internal/limits/store_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1, "new": 2})
+	add(kindTaskStatus, "internal/metrics/metrics_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "todo": 1})
+	add(kindTaskStatus, "internal/monitor/detector_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 1, "in-progress": 2, "new": 1, "plan-review": 3})
+	add(kindTaskStatus, "internal/monitor/prompts_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 12})
+	add(kindTaskStatus, "internal/monitor/remediator_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 9, "in-progress": 1, "plan-review": 2})
+	add(kindTaskStatus, "internal/project/git_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 1})
+	add(kindTaskStatus, "internal/routing/plan_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 5})
+	add(kindTaskStatus, "internal/selfmonitor/ledger_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 2})
+	add(kindTaskStatus, "internal/sybra/app_dispatch_gate_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"planning": 2})
+	add(kindTaskStatus, "internal/sybra/app_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 3})
+	add(kindTaskStatus, "internal/sybra/app_watcher_status_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"planning": 1})
+	add(kindTaskStatus, "internal/sybra/app_workflow_reason_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/sybra/completion/evidence_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 1})
+	add(kindTaskStatus, "internal/sybra/completion/parked_adoption_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "human-required": 2, "todo": 2})
+	add(kindTaskStatus, "internal/sybra/e2e_autonomy_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 2})
+	add(kindTaskStatus, "internal/sybra/e2e_bestofn_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 5})
+	add(kindTaskStatus, "internal/sybra/e2e_workflow_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 9, "in-review": 5, "plan-review": 8, "testing": 1, "todo": 1})
+	add(kindTaskStatus, "internal/sybra/review/automerge_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 2})
+	add(kindTaskStatus, "internal/sybra/review/autoresolve_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "in-progress": 1})
+	add(kindTaskStatus, "internal/sybra/review/pr_poll_sched_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "new": 2})
+	add(kindTaskStatus, "internal/sybra/review/rebase_recover_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2, "in-progress": 2, "in-review": 1})
+	add(kindTaskStatus, "internal/sybra/review/review_hold_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 1})
+	add(kindTaskStatus, "internal/sybra/review/unit_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1})
+	add(kindTaskStatus, "internal/sybra/svc_orchestrator_replaceable_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 4})
+	add(kindTaskStatus, "internal/sybra/svc_planning_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2, "plan-review": 1, "planning": 1})
+	add(kindTaskStatus, "internal/sybra/svc_stats_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 5, "in-review": 3, "todo": 2})
+	add(kindTaskStatus, "internal/sybra/svc_tasks_cluster_push_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1})
+	add(kindTaskStatus, "internal/sybra/svc_tasks_dispatch_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"cancelled": 1, "done": 1, "in-progress": 9, "in-review": 6, "ready-pr": 6, "ready-review": 2, "testing": 2})
+	add(kindTaskStatus, "internal/sybra/svc_tasks_listfornode_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 3})
+	add(kindTaskStatus, "internal/sybra/svc_tasks_lock_timeout_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/sybra/svc_tasks_restart_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 2})
+	add(kindTaskStatus, "internal/task/manager_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 1})
+	add(kindTaskStatus, "internal/task/parser_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2})
+	add(kindTaskStatus, "internal/task/persistence_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2, "testing": 2})
+	add(kindTaskStatus, "internal/task/store_lock_timeout_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/task/store_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 12})
+	add(kindTaskStatus, "internal/umbrella/tags_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/verdict/verdict_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"ready-pr": 1})
+	add(kindTaskStatus, "internal/watchdog/agent_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 3})
+	add(kindTaskStatus, "internal/workflow/atomic_status_workflow_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 3, "in-progress": 2})
+	add(kindTaskStatus, "internal/workflow/bounded_retry_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 2, "in-progress": 2})
+	add(kindTaskStatus, "internal/workflow/builtin_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1, "done": 2, "human-required": 7, "in-progress": 13, "in-review": 1, "planning": 3, "ready-pr": 3, "ready-review": 2, "todo": 1})
+	add(kindTaskStatus, "internal/workflow/condition_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 6, "in-progress": 3, "planning": 2, "todo": 4})
+	add(kindTaskStatus, "internal/workflow/effect_id_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-review": 1, "plan-review": 1, "todo": 1})
+	add(kindTaskStatus, "internal/workflow/effect_reclaim_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"planning": 1})
+	add(kindTaskStatus, "internal/workflow/engine_agent_route_race_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 1, "todo": 2})
+	add(kindTaskStatus, "internal/workflow/engine_autodispatch_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 1, "todo": 1})
+	add(kindTaskStatus, "internal/workflow/engine_bench_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"todo": 5})
+	add(kindTaskStatus, "internal/workflow/engine_bestofn_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2, "human-required": 10, "ready-review": 2, "todo": 3})
+	add(kindTaskStatus, "internal/workflow/engine_cascade_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 6, "in-progress": 7, "new": 4, "todo": 3})
+	add(kindTaskStatus, "internal/workflow/engine_dispatch_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 2, "ready-pr": 2})
+	add(kindTaskStatus, "internal/workflow/engine_drain_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 1})
+	add(kindTaskStatus, "internal/workflow/engine_events_watchdog_reask_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1, "human-required": 10, "in-progress": 20, "in-review": 2, "planning": 1, "ready-pr": 1, "testing": 5})
+	add(kindTaskStatus, "internal/workflow/engine_import_sidecar_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 8, "in-progress": 8, "planning": 4})
+	add(kindTaskStatus, "internal/workflow/engine_missing_step_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"cancelled": 3, "done": 3, "human-required": 2, "planning": 6})
+	add(kindTaskStatus, "internal/workflow/engine_parallel_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "human-required": 1, "todo": 11})
+	add(kindTaskStatus, "internal/workflow/engine_prompt_undelivered_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 2, "in-progress": 1})
+	add(kindTaskStatus, "internal/workflow/engine_resume_pr_steps_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 1, "in-progress": 1, "ready-pr": 2, "ready-review": 1})
+	add(kindTaskStatus, "internal/workflow/engine_skill_receipt_zero_output_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 2, "in-progress": 1})
+	add(kindTaskStatus, "internal/workflow/engine_stale_route_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 1, "in-progress": 2})
+	add(kindTaskStatus, "internal/workflow/engine_steps_admission_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1, "human-required": 9, "in-progress": 13})
+	add(kindTaskStatus, "internal/workflow/engine_steps_classify_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 5, "new": 5})
+	add(kindTaskStatus, "internal/workflow/engine_steps_clear_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 7})
+	add(kindTaskStatus, "internal/workflow/engine_steps_codegen_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 4, "in-progress": 12})
+	add(kindTaskStatus, "internal/workflow/engine_steps_evidence_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 1, "human-required": 9})
+	add(kindTaskStatus, "internal/workflow/engine_steps_focused_checks_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 2, "in-progress": 24})
+	add(kindTaskStatus, "internal/workflow/engine_steps_pr_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2, "human-required": 14, "in-progress": 3, "ready-pr": 47})
+	add(kindTaskStatus, "internal/workflow/engine_steps_prfix_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 14, "in-progress": 29, "in-review": 2})
+	add(kindTaskStatus, "internal/workflow/engine_steps_resume_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2, "human-required": 6, "in-progress": 10, "testing": 3})
+	add(kindTaskStatus, "internal/workflow/engine_steps_sync_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"ready-pr": 10})
+	add(kindTaskStatus, "internal/workflow/engine_steps_tamper_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 13, "in-progress": 41, "ready-review": 5})
+	add(kindTaskStatus, "internal/workflow/engine_steps_testroute_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 13, "in-progress": 14, "ready-pr": 6, "testing": 29})
+	add(kindTaskStatus, "internal/workflow/engine_steps_verify_checks_autofix_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 4, "in-progress": 25, "ready-review": 1, "todo": 1})
+	add(kindTaskStatus, "internal/workflow/engine_steps_verify_checks_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 5, "human-required": 5, "in-progress": 39})
+	add(kindTaskStatus, "internal/workflow/engine_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 10, "cancelled": 6, "done": 20, "human-required": 83, "in-progress": 168, "in-review": 26, "new": 2, "plan-review": 26, "planning": 37, "ready-pr": 16, "ready-review": 1, "testing": 4, "todo": 48})
+	add(kindTaskStatus, "internal/workflow/engine_validate_plan_contract_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 3, "planning": 8})
+	add(kindTaskStatus, "internal/workflow/engine_validate_plan_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 5, "planning": 5})
+	add(kindTaskStatus, "internal/workflow/evidence_attempts_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 4})
+	add(kindTaskStatus, "internal/workflow/execution_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"new": 2})
+	add(kindTaskStatus, "internal/workflow/handoff_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 1, "ready-pr": 2, "ready-review": 2, "testing": 2})
+	add(kindTaskStatus, "internal/workflow/model_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 2})
+	add(kindTaskStatus, "internal/workflow/permutation_contract_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"plan-review": 3, "todo": 1})
+	add(kindTaskStatus, "internal/workflow/rewind_retry_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-progress": 3})
+	add(kindTaskStatus, "internal/workflow/sidecar_seed_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"in-review": 1})
+	add(kindTaskStatus, "internal/workflow/start_error_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 5, "human-required": 8, "in-progress": 35, "todo": 9})
+	add(kindTaskStatus, "internal/workflow/state_reducer_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"done": 5, "human-required": 1, "in-review": 2, "plan-review": 5, "testing": 1, "todo": 2})
+	add(kindTaskStatus, "internal/workflow/status_reason_utf8_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 1, "planning": 1, "todo": 1})
+	add(kindTaskStatus, "internal/workflow/store_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"todo": 2})
+	add(kindTaskStatus, "internal/workflow/triage_review_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"blocked": 2, "human-required": 5, "testing": 10})
+	add(kindTaskStatus, "internal/workflow/zz_adversarial_verify_checks_test.go", "Test fixture intentionally spells persisted task-status wire values to verify workflow or compatibility.", map[string]int{"human-required": 1, "in-progress": 1})
+
 	return out
 }
 
-var taskStatuses = map[string]struct{}{
-	"new": {}, "todo": {}, "in-progress": {}, "ready-review": {},
-	"in-review": {}, "planning": {}, "plan-review": {}, "testing": {},
-	"ready-pr": {}, "human-required": {}, "blocked": {}, "done": {},
-	"cancelled": {},
+var taskStatuses = statusVocabulary()
+
+var providerNames = providerVocabulary()
+
+func statusVocabulary() map[string]struct{} {
+	out := make(map[string]struct{}, len(taskstatus.All()))
+	for _, status := range taskstatus.All() {
+		out[string(status)] = struct{}{}
+	}
+	return out
 }
 
-var providerNames = map[string]struct{}{
-	"claude": {}, "codex": {}, "copilot": {}, "opencode": {},
+func providerVocabulary() map[string]struct{} {
+	out := make(map[string]struct{}, len(providerid.All()))
+	for _, provider := range providerid.All() {
+		out[provider] = struct{}{}
+	}
+	return out
+}
+
+type parsedFile struct {
+	path string
+	file *ast.File
 }
 
 func main() {
@@ -144,7 +491,7 @@ func main() {
 		os.Exit(1)
 	}
 	fset := token.NewFileSet()
-	var findings []finding
+	groups := make(map[string][]parsedFile)
 	failed := false
 	for _, rawPath := range os.Args[1:] {
 		path := filepath.ToSlash(rawPath)
@@ -154,7 +501,20 @@ func main() {
 			failed = true
 			continue
 		}
-		findings = append(findings, inspectFile(fset, path, file)...)
+		key := filepath.Dir(path) + "\x00" + file.Name.Name
+		groups[key] = append(groups[key], parsedFile{path: path, file: file})
+	}
+
+	var findings []finding
+	for key, files := range groups {
+		asts := make([]*ast.File, 0, len(files))
+		for _, file := range files {
+			asts = append(asts, file.file)
+		}
+		info := collectTypeInfo(key, fset, asts)
+		for _, file := range files {
+			findings = append(findings, inspectFile(fset, file.path, file.file, info)...)
+		}
 	}
 
 	for _, issue := range auditFindings(findings, allowances) {
@@ -219,7 +579,19 @@ func canonicalPackage(kind findingKind) string {
 	}
 }
 
-func inspectFile(fset *token.FileSet, path string, file *ast.File) []finding {
+func collectTypeInfo(pkgPath string, fset *token.FileSet, files []*ast.File) *types.Info {
+	info := &types.Info{Types: make(map[ast.Expr]types.TypeAndValue)}
+	config := types.Config{
+		Importer: importer.Default(),
+		// Module-local and generated imports may be unavailable to the source
+		// importer. Retain partial local type facts instead of failing open.
+		Error: func(error) {},
+	}
+	_, _ = config.Check(pkgPath, fset, files, info)
+	return info
+}
+
+func inspectFile(fset *token.FileSet, path string, file *ast.File, info *types.Info) []finding {
 	// The checker necessarily contains the literal vocabulary and synthetic
 	// examples it searches for. It is its own bootstrap implementation, not a
 	// product caller of any consolidated primitive.
@@ -227,19 +599,15 @@ func inspectFile(fset *token.FileSet, path string, file *ast.File) []finding {
 		return nil
 	}
 	var out []finding
-	isTest := strings.HasSuffix(path, "_test.go")
 	stringNames, stringFields := collectStringNames(file)
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch n := node.(type) {
 		case *ast.SliceExpr:
-			if !strings.HasPrefix(path, "internal/textutil/") && isStringExpr(n.X, stringNames, stringFields) && isTruncatingSlice(n) {
+			if !strings.HasPrefix(path, "internal/textutil/") && isStringExpr(n.X, info, stringNames, stringFields) && (n.Low != nil || n.High != nil) {
 				out = append(out, finding{kind: kindStringTruncation, path: path, value: "slice", line: fset.Position(n.Pos()).Line})
 			}
 		case *ast.BasicLit:
-			// Tests intentionally spell persisted/wire values to prove parsing and
-			// compatibility. They are excluded only from the literal gates; their
-			// production helpers remain subject to truncation/extraction checks.
-			if isTest || n.Kind != token.STRING || isStructTag(file, n) {
+			if n.Kind != token.STRING || isStructTag(file, n) || isImportPath(file, n) {
 				return true
 			}
 			value, err := strconv.Unquote(n.Value)
@@ -281,6 +649,15 @@ func isStructTag(file *ast.File, lit *ast.BasicLit) bool {
 	return found
 }
 
+func isImportPath(file *ast.File, lit *ast.BasicLit) bool {
+	for _, spec := range file.Imports {
+		if spec.Path == lit {
+			return true
+		}
+	}
+	return false
+}
+
 func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{}) {
 	names := make(map[string]struct{})
 	fields := make(map[string]struct{})
@@ -310,7 +687,7 @@ func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{
 					return true
 				}
 				for i, rhs := range n.Rhs {
-					if !isStringExpr(rhs, names, fields) {
+					if !isStringExpr(rhs, nil, names, fields) {
 						continue
 					}
 					if id, ok := n.Lhs[i].(*ast.Ident); ok {
@@ -322,7 +699,7 @@ func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{
 					return true
 				}
 				for i, value := range n.Values {
-					if isStringExpr(value, names, fields) {
+					if isStringExpr(value, nil, names, fields) {
 						names[n.Names[i].Name] = struct{}{}
 					}
 				}
@@ -333,7 +710,14 @@ func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{
 	return names, fields
 }
 
-func isStringExpr(expr ast.Expr, names, fields map[string]struct{}) bool {
+func isStringExpr(expr ast.Expr, info *types.Info, names, fields map[string]struct{}) bool {
+	if info != nil {
+		if typ := info.TypeOf(expr); typ != nil {
+			if basic, ok := typ.Underlying().(*types.Basic); ok && basic.Kind() == types.String {
+				return true
+			}
+		}
+	}
 	switch e := expr.(type) {
 	case *ast.BasicLit:
 		return e.Kind == token.STRING
@@ -344,11 +728,11 @@ func isStringExpr(expr ast.Expr, names, fields map[string]struct{}) bool {
 		_, ok := fields[e.Sel.Name]
 		return ok
 	case *ast.ParenExpr:
-		return isStringExpr(e.X, names, fields)
+		return isStringExpr(e.X, info, names, fields)
 	case *ast.BinaryExpr:
-		return e.Op == token.ADD && (isStringExpr(e.X, names, fields) || isStringExpr(e.Y, names, fields))
+		return e.Op == token.ADD && (isStringExpr(e.X, info, names, fields) || isStringExpr(e.Y, info, names, fields))
 	case *ast.SliceExpr:
-		return isStringExpr(e.X, names, fields)
+		return isStringExpr(e.X, info, names, fields)
 	case *ast.CallExpr:
 		if id, ok := e.Fun.(*ast.Ident); ok {
 			return id.Name == "string"
@@ -376,63 +760,6 @@ func isStringExpr(expr ast.Expr, names, fields map[string]struct{}) bool {
 		}
 	}
 	return false
-}
-
-func isTruncatingSlice(slice *ast.SliceExpr) bool {
-	if slice.High != nil && looksLikeBound(slice.High) {
-		return true
-	}
-	return isTailBound(slice.Low)
-}
-
-func looksLikeBound(expr ast.Expr) bool {
-	switch e := expr.(type) {
-	case *ast.BasicLit:
-		return e.Kind == token.INT
-	case *ast.Ident:
-		name := strings.ToLower(e.Name)
-		return name == "n" || name == "size" || name == "count" || strings.Contains(name, "max") || strings.Contains(name, "limit") || strings.Contains(name, "cap") || strings.Contains(name, "bytes")
-	case *ast.ParenExpr:
-		return looksLikeBound(e.X)
-	case *ast.CallExpr:
-		if id, ok := e.Fun.(*ast.Ident); ok && (id.Name == "min" || id.Name == "max") {
-			return true
-		}
-	case *ast.BinaryExpr:
-		// A constant inside parser arithmetic (end+1, len(s)-1) is a
-		// delimiter adjustment, not a length budget. Binary bounds count only
-		// when one side carries an explicit max/limit/size signal.
-		return containsBoundSignal(e.X) || containsBoundSignal(e.Y)
-	}
-	return false
-}
-
-func containsBoundSignal(expr ast.Expr) bool {
-	switch e := expr.(type) {
-	case *ast.Ident:
-		return looksLikeBound(e)
-	case *ast.ParenExpr:
-		return containsBoundSignal(e.X)
-	case *ast.BinaryExpr:
-		return containsBoundSignal(e.X) || containsBoundSignal(e.Y)
-	case *ast.CallExpr:
-		id, ok := e.Fun.(*ast.Ident)
-		return ok && (id.Name == "min" || id.Name == "max")
-	}
-	return false
-}
-
-func isTailBound(expr ast.Expr) bool {
-	bin, ok := expr.(*ast.BinaryExpr)
-	if !ok || bin.Op != token.SUB || !looksLikeBound(bin.Y) {
-		return false
-	}
-	call, ok := bin.X.(*ast.CallExpr)
-	if !ok || len(call.Args) != 1 {
-		return false
-	}
-	id, ok := call.Fun.(*ast.Ident)
-	return ok && id.Name == "len"
 }
 
 func extractsJSONByBraces(fn *ast.FuncDecl) bool {
@@ -463,7 +790,7 @@ func extractsJSONByBraces(fn *ast.FuncDecl) bool {
 				braceDirections[id.Name] |= 2
 			}
 		case *ast.AssignStmt:
-			if len(n.Lhs) != 1 {
+			if len(n.Lhs) != 1 || len(n.Rhs) != 1 {
 				return true
 			}
 			id, ok := n.Lhs[0].(*ast.Ident)
@@ -474,6 +801,8 @@ func extractsJSONByBraces(fn *ast.FuncDecl) bool {
 				braceDirections[id.Name] |= 1
 			} else if n.Tok == token.SUB_ASSIGN {
 				braceDirections[id.Name] |= 2
+			} else if n.Tok == token.ASSIGN {
+				braceDirections[id.Name] |= assignmentDirection(id.Name, n.Rhs[0])
 			}
 		}
 		return true
@@ -484,11 +813,52 @@ func extractsJSONByBraces(fn *ast.FuncDecl) bool {
 	name := strings.ToLower(fn.Name.Name)
 	jsonishName := strings.Contains(name, "json") || strings.Contains(name, "object")
 	for _, directions := range braceDirections {
-		if directions == 3 && bodyHasBothBraces(body) && (jsonishName || returnsStringSlice(fn)) {
+		if directions == 3 && bodyHasBothBraces(body) && (jsonishName || returnsStringSlice(fn) || returnsIndexSpan(fn)) {
 			return true
 		}
 	}
 	return false
+}
+
+func assignmentDirection(name string, expr ast.Expr) uint8 {
+	bin, ok := expr.(*ast.BinaryExpr)
+	if !ok {
+		return 0
+	}
+	isName := func(expr ast.Expr) bool {
+		id, ok := expr.(*ast.Ident)
+		return ok && id.Name == name
+	}
+	isOne := func(expr ast.Expr) bool {
+		lit, ok := expr.(*ast.BasicLit)
+		return ok && lit.Kind == token.INT && lit.Value == "1"
+	}
+	if bin.Op == token.ADD && ((isName(bin.X) && isOne(bin.Y)) || (isOne(bin.X) && isName(bin.Y))) {
+		return 1
+	}
+	if bin.Op == token.SUB && isName(bin.X) && isOne(bin.Y) {
+		return 2
+	}
+	return 0
+}
+
+func returnsIndexSpan(fn *ast.FuncDecl) bool {
+	if fn.Type.Results == nil {
+		return false
+	}
+	count := 0
+	for _, field := range fn.Type.Results.List {
+		id, ok := field.Type.(*ast.Ident)
+		if !ok || id.Name != "int" {
+			continue
+		}
+		if len(field.Names) == 0 {
+			count++
+		} else {
+			count += len(field.Names)
+		}
+	}
+	return count >= 2
 }
 
 func returnsStringSlice(fn *ast.FuncDecl) bool {

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -7,13 +7,10 @@ package main
 import (
 	"fmt"
 	"go/ast"
-	"go/importer"
 	"go/parser"
 	"go/token"
 	"go/types"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -99,10 +96,6 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/sybra/app.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width Kubernetes smoke-test identifier.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/task/comment.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short comment identifier.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/task/store.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short task identifier.", map[string]int{"slice": 1})
-	add(kindStringTruncation, "cmd/sybra-cli/evaluation.go", "SHA-256 digests are hexadecimal ASCII; this slice produces a display-only short digest.", map[string]int{"slice": 1})
-	add(kindStringTruncation, "internal/monitor/detector.go", "Monitor body parsing slices at positions found by exact ASCII marker delimiters.", map[string]int{"slice": 2})
-	add(kindStringTruncation, "internal/project/git.go", "Git revisions are hexadecimal ASCII and these produce display-only short SHAs.", map[string]int{"slice": 3})
-	add(kindStringTruncation, "internal/sybra/e2e_bootstrap_test.go", "E2E fixture selects the fixed-width ASCII task-ID suffix used by the worktree naming contract.", map[string]int{"slice": 1})
 
 	add(kindStringTruncation, "internal/agent/procsandbox_darwin_integration_test.go", "Integration fixtures split fixed-format sandbox profile text and byte buffers.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/project/repair_test.go", "Git-repair fixtures deliberately mutate fixed-format object/ref data.", map[string]int{"slice": 5})
@@ -153,7 +146,7 @@ func buildAllowances() map[allowanceKey]allowance {
 	// The type-aware truncation rule intentionally treats every string slice as
 	// suspicious. These pre-existing parser/protocol/test slices are exact
 	// baselines; any added or removed occurrence requires a ledger review.
-	add(kindStringTruncation, "cmd/gen-api-shim/shim.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 7})
+	add(kindStringTruncation, "cmd/gen-api-shim/shim.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 6})
 	add(kindStringTruncation, "cmd/gen-config-docs/main.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "cmd/gen-events/main.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "cmd/sybra-cli/selfmonitor.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
@@ -169,7 +162,6 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/agent/tool_loop_semantic.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/cluster/tls_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/config/config_migration.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
-	add(kindStringTruncation, "internal/experience/record_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/fsutil/fsutil.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/fsutil/projectkey.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/github/client.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
@@ -183,12 +175,11 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/monitor/issueoutbox.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/monitor/issuesink.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 8})
 	add(kindStringTruncation, "internal/notes/notes_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
-	add(kindStringTruncation, "internal/project/git.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 4})
+	add(kindStringTruncation, "internal/project/git.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/project/repair_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 5})
 	add(kindStringTruncation, "internal/project/store_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/prompteval/store.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
 	add(kindStringTruncation, "internal/promptlab/model.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
-	add(kindStringTruncation, "internal/provider/probes.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/sandbox/docker.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/sandbox/envfile.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/sandbox/k8s_integration_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
@@ -200,7 +191,6 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/sybra/config_sparse.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 4})
 	add(kindStringTruncation, "internal/sybra/config_subscribers.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/sybra/review/agent_manager_test_helpers_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
-	add(kindStringTruncation, "internal/sybra/svc_tasks_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/sybra/svc_tasks.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/task/plan_draft.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/task/slug.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
@@ -208,7 +198,6 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/umbrella/planner.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/workflow/builtin_plan_prompt_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
 	add(kindStringTruncation, "internal/workflow/engine_events_agents.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
-	add(kindStringTruncation, "internal/workflow/engine_parallel_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 2})
 	add(kindStringTruncation, "internal/workflow/engine_skill_receipt_summary.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
 	add(kindStringTruncation, "internal/workflow/engine_steps_bestofn.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/workflow/engine_steps_clear_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
@@ -216,7 +205,6 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/workflow/engine_steps_tamper.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 12})
 	add(kindStringTruncation, "internal/workflow/engine_steps_testroute.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 8})
 	add(kindStringTruncation, "internal/workflow/engine_steps_triage.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
-	add(kindStringTruncation, "internal/workflow/engine_steps_verify_checks_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/workflow/engine_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/workflow/engine_validate_plan_contract.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/workflow/envtest_assets.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 1})
@@ -224,6 +212,57 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/worktree/branch.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 2})
 	add(kindStringTruncation, "internal/worktree/cleanup.go", "Pre-existing parser/protocol string slice retained as an exact audited baseline; count changes require migration review.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/worktree/manager_test.go", "Existing test fixture slices controlled parser/protocol text at a deliberate byte boundary.", map[string]int{"slice": 1})
+
+	// Calls whose imported result types are unavailable to the per-file type
+	// pass are tracked through assignments and treated as possible strings.
+	// These exact pre-existing non-string/parser slices are the fail-closed baseline.
+	add(kindStringTruncation, "cmd/fake-claude/main.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/fake-codex/main.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/fake-copilot/main.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/sybra-cli/main.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "cmd/sybra-perf/main.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/logfile.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/loop_detector.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/manager_control.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/model.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/reattach.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/runner_headless_test.go", "Conservative unresolved-call provenance reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/runner_headless.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/skill_invoke.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/tool_loop_semantic.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 4})
+	add(kindStringTruncation, "internal/agent/tool_result_bound.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 7})
+	add(kindStringTruncation, "internal/cleanup/protected.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/experience/store.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/gitexec/gitexec.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/github/client.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/github/runtime.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/httpapi/handler.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/intervention/store.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/monitor/issuesink.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/notification/emitter.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/procstat/sample_unix.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/project/repair.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/promptlab/collect.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/selfmonitor/loganalyzer.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 6})
+	add(kindStringTruncation, "internal/skillattr/skillattr.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/app_human_review.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/sybra/app_umbrella_gate.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/sybra/review/pr_poll_sched.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/sybra/svc_agents.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/svc_config.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/task/parser.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/task/status_effect.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/task/store_cache.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/task/store.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/task/transition.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/umbrella/expand.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/umbrella/ground.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/effect_claim.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/workflow/engine_skill_receipt_summary.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/engine_steps_tamper.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 4})
+	add(kindStringTruncation, "internal/workflow/engine_steps_testroute.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 9})
+	add(kindStringTruncation, "internal/workflow/envtest_assets.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/execution.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 4})
 
 	// Test fixtures intentionally spell persisted wire values. They remain
 	// exact path/value/count entries so adding or removing a literal forces an
@@ -519,18 +558,12 @@ func main() {
 	}
 
 	var findings []finding
-	imports, err := newModuleImporter(fset)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "check-consolidated-primitives:", err)
-		os.Exit(1)
-	}
-	for key, files := range groups {
-		asts := make([]*ast.File, 0, len(files))
+	for _, files := range groups {
 		for _, file := range files {
-			asts = append(asts, file.file)
-		}
-		info := collectTypeInfo(key, fset, asts, imports)
-		for _, file := range files {
+			var info *types.Info
+			if fileNeedsTypeInfo(file) {
+				info = collectTypeInfo(file.path, fset, []*ast.File{file.file}, nil)
+			}
 			findings = append(findings, inspectFile(fset, file.path, file.file, info)...)
 		}
 	}
@@ -549,6 +582,21 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println("check-consolidated-primitives: shared truncation, JSON extraction, task-status, and provider boundaries intact")
+}
+
+func fileNeedsTypeInfo(file parsedFile) bool {
+	if strings.HasPrefix(file.path, "internal/textutil/") {
+		return false
+	}
+	found := false
+	ast.Inspect(file.file, func(node ast.Node) bool {
+		if _, ok := node.(*ast.SliceExpr); ok {
+			found = true
+			return false
+		}
+		return !found
+	})
+	return found
 }
 
 func auditFindings(findings []finding, ledger map[allowanceKey]allowance) []gateError {
@@ -595,39 +643,6 @@ func canonicalPackage(kind findingKind) string {
 	default:
 		return "the shared package"
 	}
-}
-
-func newModuleImporter(fset *token.FileSet) (types.Importer, error) {
-	cmd := exec.Command("go", "list", "-deps", "-test", "-export", "-f={{if .Export}}{{.ImportPath}}|{{.Export}}{{end}}", "./...")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("load module export index: %w", err)
-	}
-	exports := make(map[string]string)
-	for line := range strings.SplitSeq(string(output), "\n") {
-		path, exportPath, ok := strings.Cut(line, "|")
-		if ok && path != "" && exportPath != "" && !strings.Contains(path, " [") {
-			exports[path] = exportPath
-		}
-	}
-	return importer.ForCompiler(fset, "gc", func(path string) (io.ReadCloser, error) {
-		if exportPath := exports[path]; exportPath != "" {
-			return os.Open(exportPath)
-		}
-		// A mutually exclusive build-tagged file may import a package absent
-		// from the host platform's batch index. Resolve that uncommon miss
-		// individually rather than leaving its call-result types unknown.
-		cmd := exec.Command("go", "list", "-export", "-f={{.Export}}", path)
-		output, err := cmd.Output()
-		if err != nil {
-			return nil, fmt.Errorf("resolve export data for %s: %w", path, err)
-		}
-		exportPath := strings.TrimSpace(string(output))
-		if exportPath == "" {
-			return nil, fmt.Errorf("resolve export data for %s: empty export path", path)
-		}
-		return os.Open(exportPath)
-	}), nil
 }
 
 func collectTypeInfo(pkgPath string, fset *token.FileSet, files []*ast.File, imports types.Importer) *types.Info {

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -1,0 +1,549 @@
+// Command checkconsolidated prevents production code from recreating primitives
+// that have a canonical shared package. It deliberately uses syntax-aware
+// inspection instead of line grep so formatting and raw/interpreted literals do
+// not change the result.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type findingKind string
+
+const (
+	kindStringTruncation findingKind = "string-byte-truncation"
+	kindJSONExtraction   findingKind = "json-brace-extraction"
+	kindTaskStatus       findingKind = "task-status-literal"
+	kindProvider         findingKind = "provider-name-literal"
+)
+
+type finding struct {
+	kind  findingKind
+	path  string
+	value string
+	line  int
+}
+
+type allowanceKey struct {
+	kind  findingKind
+	path  string
+	value string
+}
+
+type allowance struct {
+	count  int
+	reason string
+}
+
+type gateError struct {
+	finding *finding
+	message string
+}
+
+// allowances is the complete exception ledger. Counts are exact: removing an
+// old exception or adding another copy both fail until this list is changed in
+// review. Keep reasons specific enough that a reviewer can tell whether a new
+// occurrence has the same semantics.
+var allowances = buildAllowances()
+
+func buildAllowances() map[allowanceKey]allowance {
+	out := make(map[allowanceKey]allowance)
+	add := func(kind findingKind, path, reason string, counts map[string]int) {
+		for value, count := range counts {
+			out[allowanceKey{kind: kind, path: path, value: value}] = allowance{count: count, reason: reason}
+		}
+	}
+
+	// String slicing exceptions. These operate on an ASCII-only token, slice
+	// at parser-discovered boundaries, or are test fixtures for byte-oriented
+	// protocols; none truncates arbitrary human/provider text.
+	add(kindStringTruncation, "cmd/gen-config-docs/main.go", "Generated Go/YAML identifiers are normalized ASCII; the slice changes first-letter case.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/gen-events/main.go", "Generated event function identifiers are ASCII; the slice changes first-letter case.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/sybra-cli/main.go", "Git revisions are hexadecimal ASCII and this produces a display-only short SHA.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/discovery.go", "Provider session identifiers are ASCII protocol tokens and are shortened only for display.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/k8s_job_runner.go", "The value is an already-normalized ASCII Kubernetes DNS label.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/tool_result_bound.go", "The value is a hexadecimal digest used in an artifact filename.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/autoupdate/autoupdate.go", "Git revisions are hexadecimal ASCII and this produces a display-only short SHA.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/monitor/fingerprint.go", "The fingerprint slug is normalized to lowercase ASCII before its fixed-width cut.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/project/git.go", "Branch suffixes and Git revisions are validated ASCII protocol identifiers.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/provider/reset_hint.go", "Month names come from an ASCII provider protocol and the slice reads a three-byte abbreviation.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/stats/pricing.go", "Model IDs are ASCII protocol tokens; this slice parses a known pricing suffix.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/completion/evidence.go", "The evidence filename is regex-normalized to ASCII before enforcing the filesystem limit.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/config_sparse.go", "Sparse-config paths are slices at parser-derived YAML line/path boundaries.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/task/slug.go", "Task slugs are regex-normalized to lowercase ASCII before enforcing the identifier limit.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/worktree/attempt.go", "Git revisions are hexadecimal ASCII and this produces a branch suffix.", map[string]int{"slice": 1})
+
+	add(kindStringTruncation, "internal/agent/procsandbox_darwin_integration_test.go", "Integration fixtures split fixed-format sandbox profile text and byte buffers.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/project/repair_test.go", "Git-repair fixtures deliberately mutate fixed-format object/ref data.", map[string]int{"slice": 5})
+	add(kindStringTruncation, "internal/sybra/e2e_chaos_test.go", "Chaos fixture truncates a controlled ASCII test payload.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/e2e_workflow_test.go", "Workflow fixture slices a controlled ASCII command token.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/task/parser_test.go", "Parser fixture deliberately cuts serialized bytes to exercise malformed input.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/engine_test.go", "Engine fixture slices a controlled ASCII test token.", map[string]int{"slice": 1})
+
+	// One deliberately weaker JSON fallback survives: the balanced shared
+	// scanner can be confused by an unmatched quote in surrounding prose, so
+	// this span is tried second and accepted only if json.Unmarshal succeeds.
+	add(kindJSONExtraction, "internal/workflow/engine_steps_bestofn.go", "Fallback for unmatched quotes in judge prose; json.Unmarshal validates the candidate.", map[string]int{"outermostBraceSpan": 1})
+
+	// Provider-name exceptions are external wire/vendor identifiers rather
+	// than Sybra dispatch comparisons.
+	add(kindProvider, "internal/agent/discovery.go", "Names the codex executable in an OS process probe.", map[string]int{"codex": 1})
+	add(kindProvider, "internal/agent/manager_run.go", "Names OpenCode's vendor-owned state directories in sandbox policy.", map[string]int{"opencode": 2})
+	add(kindProvider, "internal/agent/provider_codex.go", "Rejects Claude-family model IDs passed to the Codex adapter.", map[string]int{"claude": 1})
+	add(kindProvider, "internal/config/file_config.go", "YAML migration paths must spell persisted provider keys on both alias and legacy sides.", map[string]int{"claude": 2, "codex": 2, "copilot": 2, "opencode": 2})
+	add(kindProvider, "internal/github/check_filter.go", "Matches the external Copilot check-run product name, not a dispatch provider.", map[string]int{"copilot": 1})
+	add(kindProvider, "internal/github/client.go", "Matches the external Copilot review actor/product name.", map[string]int{"copilot": 1})
+
+	// Task-status spellings below belong to other persisted protocols or
+	// deliberately simulate the CLI wire format. True task comparisons use
+	// internal/taskstatus constants and are not allowlisted.
+	add(kindTaskStatus, "cmd/fake-claude/main.go", "Fake-provider executable emits exact CLI/frontmatter wire values for E2E tests.", map[string]int{"todo": 1, "planning": 3, "done": 1, "in-review": 3, "human-required": 1, "plan-review": 1})
+	add(kindTaskStatus, "cmd/fake-codex/main.go", "Fake-provider executable emits exact CLI/frontmatter wire values for E2E tests.", map[string]int{"todo": 1, "planning": 3, "done": 1, "in-review": 2, "human-required": 1, "ready-pr": 1})
+	add(kindTaskStatus, "internal/autoupdate/autoupdate.go", "Auto-update Result has its own status vocabulary (blocked/new candidate), unrelated to tasks.", map[string]int{"blocked": 3, "new": 1})
+	add(kindTaskStatus, "internal/bgop/model.go", "Background-operation Status is a separate persisted enum.", map[string]int{"done": 1})
+	add(kindTaskStatus, "internal/config/config_migration.go", "Names the workflow.testing configuration key in alias/canonical YAML paths.", map[string]int{"testing": 4})
+	add(kindTaskStatus, "internal/evaluation/phases.go", "Evaluation phases are a separate reporting taxonomy.", map[string]int{"planning": 1, "testing": 1})
+	add(kindTaskStatus, "internal/github/automerge_backoff.go", "MergeErrorClass is a separate GitHub error taxonomy.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/monitor/detector.go", "Monitor evidence keys name board-count metrics in the serialized report.", map[string]int{"todo": 2})
+	add(kindTaskStatus, "internal/monitor/service.go", "Structured log key names the todo-count metric.", map[string]int{"todo": 1})
+	add(kindTaskStatus, "internal/sybra/app_init.go", "EvidenceDecision outcome is a separate verified/blocked result enum.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/sybra/config_registry.go", "Names the top-level testing configuration section.", map[string]int{"testing": 1})
+	add(kindTaskStatus, "internal/triage/model.go", "Normalizes the English tag alias testing to the test tag.", map[string]int{"testing": 1})
+	add(kindTaskStatus, "internal/umbrella/tags.go", "Umbrella expansion phases and control tags are separate vocabularies.", map[string]int{"planning": 1, "blocked": 1})
+	add(kindTaskStatus, "internal/verdict/verdict.go", "todo is a placeholder word rejected from model-authored prose, not a task status.", map[string]int{"todo": 1})
+	add(kindTaskStatus, "internal/workflow/engine_events_watchdog.go", "planning is prompt prose identifying the agent stage, not a status comparison.", map[string]int{"planning": 1})
+	add(kindTaskStatus, "internal/workflow/engine_steps_admission.go", "AdmissionDecision outcome is a separate admitted/blocked result enum.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/workflow/engine_steps_evidence.go", "EvidenceDecision outcome is a separate verified/blocked result enum.", map[string]int{"blocked": 1})
+	add(kindTaskStatus, "internal/workflow/engine_steps_prfix.go", "PR-fix agent sentinel protocol has its own human/continue/done verdict vocabulary.", map[string]int{"human-required": 2, "done": 1})
+	add(kindTaskStatus, "internal/workflow/engine_steps_verify_checks.go", "StepOutput blocked is a workflow-step result, not the task status field.", map[string]int{"blocked": 1})
+
+	return out
+}
+
+var taskStatuses = map[string]struct{}{
+	"new": {}, "todo": {}, "in-progress": {}, "ready-review": {},
+	"in-review": {}, "planning": {}, "plan-review": {}, "testing": {},
+	"ready-pr": {}, "human-required": {}, "blocked": {}, "done": {},
+	"cancelled": {},
+}
+
+var providerNames = map[string]struct{}{
+	"claude": {}, "codex": {}, "copilot": {}, "opencode": {},
+}
+
+func main() {
+	if err := validateAllowances(); err != nil {
+		fmt.Fprintln(os.Stderr, "check-consolidated-primitives:", err)
+		os.Exit(1)
+	}
+	fset := token.NewFileSet()
+	var findings []finding
+	failed := false
+	for _, rawPath := range os.Args[1:] {
+		path := filepath.ToSlash(rawPath)
+		file, err := parser.ParseFile(fset, rawPath, nil, 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "check-consolidated-primitives: parse %s: %v\n", path, err)
+			failed = true
+			continue
+		}
+		findings = append(findings, inspectFile(fset, path, file)...)
+	}
+
+	for _, issue := range auditFindings(findings, allowances) {
+		if issue.finding != nil {
+			f := issue.finding
+			fmt.Fprintf(os.Stderr, "::error file=%s,line=%d::%s %q is outside its canonical package; use %s or add a narrowly reasoned exception\n",
+				f.path, f.line, f.kind, f.value, canonicalPackage(f.kind))
+		} else {
+			fmt.Fprintln(os.Stderr, "check-consolidated-primitives:", issue.message)
+		}
+		failed = true
+	}
+	if failed {
+		os.Exit(1)
+	}
+	fmt.Println("check-consolidated-primitives: shared truncation, JSON extraction, task-status, and provider boundaries intact")
+}
+
+func auditFindings(findings []finding, ledger map[allowanceKey]allowance) []gateError {
+	counts := make(map[allowanceKey]int)
+	var issues []gateError
+	for i := range findings {
+		f := &findings[i]
+		key := allowanceKey{kind: f.kind, path: f.path, value: f.value}
+		counts[key]++
+		allowed, ok := ledger[key]
+		if !ok || counts[key] > allowed.count {
+			issues = append(issues, gateError{finding: f})
+		}
+	}
+	for key, allowed := range ledger {
+		if counts[key] >= allowed.count {
+			continue
+		}
+		issues = append(issues, gateError{message: fmt.Sprintf("stale exception %s %s %q: found %d, ledger requires %d (%s)",
+			key.kind, key.path, key.value, counts[key], allowed.count, allowed.reason)})
+	}
+	return issues
+}
+
+func validateAllowances() error {
+	for key, allowed := range allowances {
+		if key.kind == "" || key.path == "" || key.value == "" || allowed.count < 1 || strings.TrimSpace(allowed.reason) == "" {
+			return fmt.Errorf("invalid exception ledger entry: %#v => %#v", key, allowed)
+		}
+	}
+	return nil
+}
+
+func canonicalPackage(kind findingKind) string {
+	switch kind {
+	case kindStringTruncation:
+		return "internal/textutil"
+	case kindJSONExtraction:
+		return "internal/llmjob"
+	case kindTaskStatus:
+		return "internal/taskstatus"
+	case kindProvider:
+		return "internal/providerid"
+	default:
+		return "the shared package"
+	}
+}
+
+func inspectFile(fset *token.FileSet, path string, file *ast.File) []finding {
+	// The checker necessarily contains the literal vocabulary and synthetic
+	// examples it searches for. It is its own bootstrap implementation, not a
+	// product caller of any consolidated primitive.
+	if strings.HasPrefix(path, "scripts/checkconsolidated/") {
+		return nil
+	}
+	var out []finding
+	isTest := strings.HasSuffix(path, "_test.go")
+	stringNames, stringFields := collectStringNames(file)
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.SliceExpr:
+			if !strings.HasPrefix(path, "internal/textutil/") && isStringExpr(n.X, stringNames, stringFields) && isTruncatingSlice(n) {
+				out = append(out, finding{kind: kindStringTruncation, path: path, value: "slice", line: fset.Position(n.Pos()).Line})
+			}
+		case *ast.BasicLit:
+			// Tests intentionally spell persisted/wire values to prove parsing and
+			// compatibility. They are excluded only from the literal gates; their
+			// production helpers remain subject to truncation/extraction checks.
+			if isTest || n.Kind != token.STRING || isStructTag(file, n) {
+				return true
+			}
+			value, err := strconv.Unquote(n.Value)
+			if err != nil {
+				return true
+			}
+			if _, ok := taskStatuses[value]; ok && !strings.HasPrefix(path, "internal/taskstatus/") {
+				out = append(out, finding{kind: kindTaskStatus, path: path, value: value, line: fset.Position(n.Pos()).Line})
+			}
+			if _, ok := providerNames[value]; ok && !strings.HasPrefix(path, "internal/providerid/") {
+				out = append(out, finding{kind: kindProvider, path: path, value: value, line: fset.Position(n.Pos()).Line})
+			}
+		}
+		return true
+	})
+
+	if !strings.HasPrefix(path, "internal/llmjob/") {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !extractsJSONByBraces(fn) {
+				continue
+			}
+			out = append(out, finding{kind: kindJSONExtraction, path: path, value: fn.Name.Name, line: fset.Position(fn.Pos()).Line})
+		}
+	}
+	return out
+}
+
+func isStructTag(file *ast.File, lit *ast.BasicLit) bool {
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		field, ok := node.(*ast.Field)
+		if ok && field.Tag == lit {
+			found = true
+			return false
+		}
+		return !found
+	})
+	return found
+}
+
+func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{}) {
+	names := make(map[string]struct{})
+	fields := make(map[string]struct{})
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.Field:
+			if id, ok := n.Type.(*ast.Ident); ok && id.Name == "string" {
+				for _, name := range n.Names {
+					names[name.Name] = struct{}{}
+					fields[name.Name] = struct{}{}
+				}
+			}
+		case *ast.ValueSpec:
+			if id, ok := n.Type.(*ast.Ident); ok && id.Name == "string" {
+				for _, name := range n.Names {
+					names[name.Name] = struct{}{}
+				}
+			}
+		}
+		return true
+	})
+	for range 4 {
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case *ast.AssignStmt:
+				if len(n.Lhs) != len(n.Rhs) {
+					return true
+				}
+				for i, rhs := range n.Rhs {
+					if !isStringExpr(rhs, names, fields) {
+						continue
+					}
+					if id, ok := n.Lhs[i].(*ast.Ident); ok {
+						names[id.Name] = struct{}{}
+					}
+				}
+			case *ast.ValueSpec:
+				if len(n.Names) != len(n.Values) {
+					return true
+				}
+				for i, value := range n.Values {
+					if isStringExpr(value, names, fields) {
+						names[n.Names[i].Name] = struct{}{}
+					}
+				}
+			}
+			return true
+		})
+	}
+	return names, fields
+}
+
+func isStringExpr(expr ast.Expr, names, fields map[string]struct{}) bool {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		return e.Kind == token.STRING
+	case *ast.Ident:
+		_, ok := names[e.Name]
+		return ok
+	case *ast.SelectorExpr:
+		_, ok := fields[e.Sel.Name]
+		return ok
+	case *ast.ParenExpr:
+		return isStringExpr(e.X, names, fields)
+	case *ast.BinaryExpr:
+		return e.Op == token.ADD && (isStringExpr(e.X, names, fields) || isStringExpr(e.Y, names, fields))
+	case *ast.SliceExpr:
+		return isStringExpr(e.X, names, fields)
+	case *ast.CallExpr:
+		if id, ok := e.Fun.(*ast.Ident); ok {
+			return id.Name == "string"
+		}
+		sel, ok := e.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		if sel.Sel.Name == "String" || sel.Sel.Name == "Error" {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		if pkg.Name == "fmt" {
+			return strings.HasPrefix(sel.Sel.Name, "Sprint")
+		}
+		if pkg.Name != "strings" {
+			return false
+		}
+		switch sel.Sel.Name {
+		case "Clone", "Join", "Map", "Repeat", "Replace", "ReplaceAll", "ToLower", "ToUpper", "ToTitle", "Trim", "TrimFunc", "TrimLeft", "TrimLeftFunc", "TrimPrefix", "TrimRight", "TrimRightFunc", "TrimSpace", "TrimSuffix":
+			return true
+		}
+	}
+	return false
+}
+
+func isTruncatingSlice(slice *ast.SliceExpr) bool {
+	if slice.High != nil && looksLikeBound(slice.High) {
+		return true
+	}
+	return isTailBound(slice.Low)
+}
+
+func looksLikeBound(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		return e.Kind == token.INT
+	case *ast.Ident:
+		name := strings.ToLower(e.Name)
+		return name == "n" || name == "size" || name == "count" || strings.Contains(name, "max") || strings.Contains(name, "limit") || strings.Contains(name, "cap") || strings.Contains(name, "bytes")
+	case *ast.ParenExpr:
+		return looksLikeBound(e.X)
+	case *ast.CallExpr:
+		if id, ok := e.Fun.(*ast.Ident); ok && (id.Name == "min" || id.Name == "max") {
+			return true
+		}
+	case *ast.BinaryExpr:
+		// A constant inside parser arithmetic (end+1, len(s)-1) is a
+		// delimiter adjustment, not a length budget. Binary bounds count only
+		// when one side carries an explicit max/limit/size signal.
+		return containsBoundSignal(e.X) || containsBoundSignal(e.Y)
+	}
+	return false
+}
+
+func containsBoundSignal(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return looksLikeBound(e)
+	case *ast.ParenExpr:
+		return containsBoundSignal(e.X)
+	case *ast.BinaryExpr:
+		return containsBoundSignal(e.X) || containsBoundSignal(e.Y)
+	case *ast.CallExpr:
+		id, ok := e.Fun.(*ast.Ident)
+		return ok && (id.Name == "min" || id.Name == "max")
+	}
+	return false
+}
+
+func isTailBound(expr ast.Expr) bool {
+	bin, ok := expr.(*ast.BinaryExpr)
+	if !ok || bin.Op != token.SUB || !looksLikeBound(bin.Y) {
+		return false
+	}
+	call, ok := bin.X.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return false
+	}
+	id, ok := call.Fun.(*ast.Ident)
+	return ok && id.Name == "len"
+}
+
+func extractsJSONByBraces(fn *ast.FuncDecl) bool {
+	body := fn.Body
+	hasFirst, hasLast := false, false
+	braceDirections := make(map[string]uint8)
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.CallExpr:
+			sel, ok := n.Fun.(*ast.SelectorExpr)
+			if !ok || len(n.Args) < 2 || !isBraceLiteral(n.Args[1]) {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "Index", "IndexByte", "IndexRune":
+				hasFirst = true
+			case "LastIndex", "LastIndexByte":
+				hasLast = true
+			}
+		case *ast.IncDecStmt:
+			id, ok := n.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if n.Tok == token.INC {
+				braceDirections[id.Name] |= 1
+			} else if n.Tok == token.DEC {
+				braceDirections[id.Name] |= 2
+			}
+		case *ast.AssignStmt:
+			if len(n.Lhs) != 1 {
+				return true
+			}
+			id, ok := n.Lhs[0].(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if n.Tok == token.ADD_ASSIGN {
+				braceDirections[id.Name] |= 1
+			} else if n.Tok == token.SUB_ASSIGN {
+				braceDirections[id.Name] |= 2
+			}
+		}
+		return true
+	})
+	if hasFirst && hasLast {
+		return true
+	}
+	name := strings.ToLower(fn.Name.Name)
+	jsonishName := strings.Contains(name, "json") || strings.Contains(name, "object")
+	for _, directions := range braceDirections {
+		if directions == 3 && bodyHasBothBraces(body) && (jsonishName || returnsStringSlice(fn)) {
+			return true
+		}
+	}
+	return false
+}
+
+func returnsStringSlice(fn *ast.FuncDecl) bool {
+	if fn.Type.Results == nil {
+		return false
+	}
+	stringResult := false
+	for _, field := range fn.Type.Results.List {
+		if id, ok := field.Type.(*ast.Ident); ok && id.Name == "string" {
+			stringResult = true
+			break
+		}
+	}
+	if !stringResult {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok {
+			return !found
+		}
+		for _, result := range ret.Results {
+			if _, ok := result.(*ast.SliceExpr); ok {
+				found = true
+				return false
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+func isBraceLiteral(expr ast.Expr) bool {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || (lit.Kind != token.STRING && lit.Kind != token.CHAR) {
+		return false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	return err == nil && (value == "{" || value == "}")
+}
+
+func bodyHasBothBraces(body *ast.BlockStmt) bool {
+	open, close := false, false
+	ast.Inspect(body, func(node ast.Node) bool {
+		lit, ok := node.(*ast.BasicLit)
+		if !ok || (lit.Kind != token.STRING && lit.Kind != token.CHAR) {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err == nil {
+			open = open || value == "{"
+			close = close || value == "}"
+		}
+		return true
+	})
+	return open && close
+}

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -278,6 +278,30 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/sybra/svc_agents.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/sybra/svc_tasks.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 4})
 
+	// A slice whose base type remains unresolved is conservatively treated as a
+	// possible imported named string. These exact existing unknown-base slices
+	// keep that fail-closed policy reviewable without weakening production scans.
+	add(kindStringTruncation, "cmd/fake-claude/main.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/fake-codex/main.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/fake-copilot/main.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/sybra-cli/evaluation.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/sybra-cli/main.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/orphan_sweep_other.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/experience/record_test.go", "Unresolved imported/base type reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/learning/store.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/monitor/detector.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/project/conflict_recovery.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/provider/probes.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/app_human_review.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/e2e_bootstrap_test.go", "Unresolved imported/base type reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/svc_tasks_test.go", "Unresolved imported/base type reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/svc_tasks.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/workflow/engine_parallel_test.go", "Unresolved imported/base type reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/workflow/engine_steps_prfix.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/workflow/engine_steps_verify_checks_test.go", "Unresolved imported/base type reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "scripts/checkatomicwrite/main.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "scripts/checkgitexec/main.go", "Unresolved imported/base type reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+
 	// Test fixtures intentionally spell persisted wire values. They remain
 	// exact path/value/count entries so adding or removing a literal forces an
 	// explicit review of this ledger instead of receiving a blanket test exemption.
@@ -684,7 +708,7 @@ func inspectFile(fset *token.FileSet, path string, file *ast.File, info *types.I
 		switch n := node.(type) {
 		case *ast.SliceExpr:
 			if !strings.HasPrefix(path, "internal/textutil/") && (n.Low != nil || n.High != nil) &&
-				(isStringExpr(n.X, info, stringNames, stringFields) || isUnresolvedCall(n.X, info)) {
+				(isStringExpr(n.X, info, stringNames, stringFields) || isUnresolvedCall(n.X, info) || typeUnknown(n.X, info)) {
 				out = append(out, finding{kind: kindStringTruncation, path: path, value: "slice", line: fset.Position(n.Pos()).Line})
 			}
 		case *ast.BasicLit:
@@ -715,6 +739,10 @@ func inspectFile(fset *token.FileSet, path string, file *ast.File, info *types.I
 		}
 	}
 	return out
+}
+
+func typeUnknown(expr ast.Expr, info *types.Info) bool {
+	return info == nil || info.TypeOf(expr) == nil
 }
 
 func isUnresolvedCall(expr ast.Expr, info *types.Info) bool {

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -11,7 +11,9 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -97,6 +99,10 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/sybra/app.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width Kubernetes smoke-test identifier.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/task/comment.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short comment identifier.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/task/store.go", "UUID strings are canonical ASCII tokens; this slice selects the fixed-width short task identifier.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "cmd/sybra-cli/evaluation.go", "SHA-256 digests are hexadecimal ASCII; this slice produces a display-only short digest.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/monitor/detector.go", "Monitor body parsing slices at positions found by exact ASCII marker delimiters.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/project/git.go", "Git revisions are hexadecimal ASCII and these produce display-only short SHAs.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/sybra/e2e_bootstrap_test.go", "E2E fixture selects the fixed-width ASCII task-ID suffix used by the worktree naming contract.", map[string]int{"slice": 1})
 
 	add(kindStringTruncation, "internal/agent/procsandbox_darwin_integration_test.go", "Integration fixtures split fixed-format sandbox profile text and byte buffers.", map[string]int{"slice": 3})
 	add(kindStringTruncation, "internal/project/repair_test.go", "Git-repair fixtures deliberately mutate fixed-format object/ref data.", map[string]int{"slice": 5})
@@ -513,12 +519,17 @@ func main() {
 	}
 
 	var findings []finding
+	imports, err := newModuleImporter(fset)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "check-consolidated-primitives:", err)
+		os.Exit(1)
+	}
 	for key, files := range groups {
 		asts := make([]*ast.File, 0, len(files))
 		for _, file := range files {
 			asts = append(asts, file.file)
 		}
-		info := collectTypeInfo(key, fset, asts)
+		info := collectTypeInfo(key, fset, asts, imports)
 		for _, file := range files {
 			findings = append(findings, inspectFile(fset, file.path, file.file, info)...)
 		}
@@ -586,10 +597,43 @@ func canonicalPackage(kind findingKind) string {
 	}
 }
 
-func collectTypeInfo(pkgPath string, fset *token.FileSet, files []*ast.File) *types.Info {
+func newModuleImporter(fset *token.FileSet) (types.Importer, error) {
+	cmd := exec.Command("go", "list", "-deps", "-test", "-export", "-f={{if .Export}}{{.ImportPath}}|{{.Export}}{{end}}", "./...")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("load module export index: %w", err)
+	}
+	exports := make(map[string]string)
+	for line := range strings.SplitSeq(string(output), "\n") {
+		path, exportPath, ok := strings.Cut(line, "|")
+		if ok && path != "" && exportPath != "" && !strings.Contains(path, " [") {
+			exports[path] = exportPath
+		}
+	}
+	return importer.ForCompiler(fset, "gc", func(path string) (io.ReadCloser, error) {
+		if exportPath := exports[path]; exportPath != "" {
+			return os.Open(exportPath)
+		}
+		// A mutually exclusive build-tagged file may import a package absent
+		// from the host platform's batch index. Resolve that uncommon miss
+		// individually rather than leaving its call-result types unknown.
+		cmd := exec.Command("go", "list", "-export", "-f={{.Export}}", path)
+		output, err := cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("resolve export data for %s: %w", path, err)
+		}
+		exportPath := strings.TrimSpace(string(output))
+		if exportPath == "" {
+			return nil, fmt.Errorf("resolve export data for %s: empty export path", path)
+		}
+		return os.Open(exportPath)
+	}), nil
+}
+
+func collectTypeInfo(pkgPath string, fset *token.FileSet, files []*ast.File, imports types.Importer) *types.Info {
 	info := &types.Info{Types: make(map[ast.Expr]types.TypeAndValue)}
 	config := types.Config{
-		Importer: importer.Default(),
+		Importer: imports,
 		// Module-local and generated imports may be unavailable to the source
 		// importer. Retain partial local type facts instead of failing open.
 		Error: func(error) {},
@@ -606,7 +650,7 @@ func inspectFile(fset *token.FileSet, path string, file *ast.File, info *types.I
 		return nil
 	}
 	var out []finding
-	stringNames, stringFields := collectStringNames(file)
+	stringNames, stringFields := collectStringNames(file, info)
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch n := node.(type) {
 		case *ast.SliceExpr:
@@ -678,7 +722,7 @@ func isImportPath(file *ast.File, lit *ast.BasicLit) bool {
 	return false
 }
 
-func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{}) {
+func collectStringNames(file *ast.File, info *types.Info) (map[string]struct{}, map[string]struct{}) {
 	names := make(map[string]struct{})
 	fields := make(map[string]struct{})
 	ast.Inspect(file, func(node ast.Node) bool {
@@ -707,19 +751,17 @@ func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{
 					return true
 				}
 				for i, rhs := range n.Rhs {
-					if !isStringExpr(rhs, nil, names, fields) {
+					if !isStringExpr(rhs, info, names, fields) && !isUnresolvedCall(rhs, info) {
 						continue
 					}
-					if id, ok := n.Lhs[i].(*ast.Ident); ok {
-						names[id.Name] = struct{}{}
-					}
+					rememberStringTarget(n.Lhs[i], names, fields)
 				}
 			case *ast.ValueSpec:
 				if len(n.Names) != len(n.Values) {
 					return true
 				}
 				for i, value := range n.Values {
-					if isStringExpr(value, nil, names, fields) {
+					if isStringExpr(value, info, names, fields) || isUnresolvedCall(value, info) {
 						names[n.Names[i].Name] = struct{}{}
 					}
 				}
@@ -728,6 +770,15 @@ func collectStringNames(file *ast.File) (map[string]struct{}, map[string]struct{
 		})
 	}
 	return names, fields
+}
+
+func rememberStringTarget(expr ast.Expr, names, fields map[string]struct{}) {
+	switch target := expr.(type) {
+	case *ast.Ident:
+		names[target.Name] = struct{}{}
+	case *ast.SelectorExpr:
+		fields[target.Sel.Name] = struct{}{}
+	}
 }
 
 func isStringExpr(expr ast.Expr, info *types.Info, names, fields map[string]struct{}) bool {
@@ -818,9 +869,9 @@ func extractsJSONByBraces(fn *ast.FuncDecl) bool {
 				return true
 			}
 			if n.Tok == token.ADD_ASSIGN {
-				braceDirections[id.Name] |= 1
+				braceDirections[id.Name] |= compoundDirection(false, n.Rhs[0])
 			} else if n.Tok == token.SUB_ASSIGN {
-				braceDirections[id.Name] |= 2
+				braceDirections[id.Name] |= compoundDirection(true, n.Rhs[0])
 			} else if n.Tok == token.ASSIGN {
 				braceDirections[id.Name] |= assignmentDirection(id.Name, n.Rhs[0])
 			}
@@ -847,15 +898,59 @@ func assignmentDirection(name string, expr ast.Expr) uint8 {
 		id, ok := expr.(*ast.Ident)
 		return ok && id.Name == name
 	}
-	isOne := func(expr ast.Expr) bool {
-		lit, ok := expr.(*ast.BasicLit)
-		return ok && lit.Kind == token.INT && lit.Value == "1"
+	if bin.Op == token.ADD {
+		if isName(bin.X) {
+			return compoundDirection(false, bin.Y)
+		}
+		if isName(bin.Y) {
+			return compoundDirection(false, bin.X)
+		}
 	}
-	if bin.Op == token.ADD && ((isName(bin.X) && isOne(bin.Y)) || (isOne(bin.X) && isName(bin.Y))) {
+	if bin.Op == token.SUB && isName(bin.X) {
+		return compoundDirection(true, bin.Y)
+	}
+	return 0
+}
+
+func compoundDirection(subtract bool, delta ast.Expr) uint8 {
+	sign := integerSign(delta)
+	if sign == 0 {
+		// A dynamic delta can move in either direction. Treat it as both so a
+		// lookup-table or helper-computed brace delta cannot evade the gate.
+		return 3
+	}
+	if subtract {
+		sign = -sign
+	}
+	if sign > 0 {
 		return 1
 	}
-	if bin.Op == token.SUB && isName(bin.X) && isOne(bin.Y) {
-		return 2
+	return 2
+}
+
+func integerSign(expr ast.Expr) int {
+	switch value := expr.(type) {
+	case *ast.BasicLit:
+		if value.Kind != token.INT {
+			return 0
+		}
+		n, err := strconv.ParseInt(value.Value, 0, 64)
+		if err != nil || n == 0 {
+			return 0
+		}
+		if n > 0 {
+			return 1
+		}
+		return -1
+	case *ast.UnaryExpr:
+		if value.Op == token.SUB {
+			return -integerSign(value.X)
+		}
+		if value.Op == token.ADD {
+			return integerSign(value.X)
+		}
+	case *ast.ParenExpr:
+		return integerSign(value.X)
 	}
 	return 0
 }

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -264,6 +264,20 @@ func buildAllowances() map[allowanceKey]allowance {
 	add(kindStringTruncation, "internal/workflow/envtest_assets.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/workflow/execution.go", "Conservative unresolved-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 4})
 
+	// Multi-result unresolved calls conservatively taint every assignment target.
+	// These exact existing tuple-result slices keep that fail-closed rule reviewable.
+	add(kindStringTruncation, "cmd/gen-api-shim/shim.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/orphan_sweep_linux.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/agent/procsandbox_linux_test.go", "Conservative unresolved tuple-call provenance reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/agent/reattach.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/pressure/sample_darwin.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 2})
+	add(kindStringTruncation, "internal/procstat/procstat.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/project/git.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 5})
+	add(kindStringTruncation, "internal/stats/store.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 3})
+	add(kindStringTruncation, "internal/sybra/clusterlead/mirror_oob_integration_test.go", "Conservative unresolved tuple-call provenance reaches a controlled non-string test-fixture slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/svc_agents.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/sybra/svc_tasks.go", "Conservative unresolved tuple-call provenance reaches a pre-existing non-string or parser-boundary slice.", map[string]int{"slice": 4})
+
 	// Test fixtures intentionally spell persisted wire values. They remain
 	// exact path/value/count entries so adding or removing a literal forces an
 	// explicit review of this ledger instead of receiving a blanket test exemption.
@@ -763,6 +777,11 @@ func collectStringNames(file *ast.File, info *types.Info) (map[string]struct{}, 
 			switch n := node.(type) {
 			case *ast.AssignStmt:
 				if len(n.Lhs) != len(n.Rhs) {
+					if len(n.Rhs) == 1 && isUnresolvedCall(n.Rhs[0], info) {
+						for _, target := range n.Lhs {
+							rememberStringTarget(target, names, fields)
+						}
+					}
 					return true
 				}
 				for i, rhs := range n.Rhs {
@@ -773,6 +792,11 @@ func collectStringNames(file *ast.File, info *types.Info) (map[string]struct{}, 
 				}
 			case *ast.ValueSpec:
 				if len(n.Names) != len(n.Values) {
+					if len(n.Values) == 1 && isUnresolvedCall(n.Values[0], info) {
+						for _, name := range n.Names {
+							names[name.Name] = struct{}{}
+						}
+					}
 					return true
 				}
 				for i, value := range n.Values {

--- a/scripts/checkconsolidated/main_test.go
+++ b/scripts/checkconsolidated/main_test.go
@@ -88,6 +88,17 @@ func truncate(s message, boundary int) (message, string) {
 	}
 }
 
+func TestDetectsUnresolvedPackageCallSlice(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+import "github.com/google/uuid"
+func shortID() string { return uuid.NewString()[:8] }
+`)
+	if got := countKind(findings, kindStringTruncation); got != 1 {
+		t.Fatalf("truncation findings = %d, want 1: %#v", got, findings)
+	}
+}
+
 func TestDetectsAssignmentBraceCounterReturningSpan(t *testing.T) {
 	t.Parallel()
 	findings := findingsFor(t, "internal/example/drift.go", `package example
@@ -99,6 +110,23 @@ func scan(s string) (int, int) {
 		if depth == 0 { return start, i }
 	}
 	return -1, -1
+}
+`)
+	if got := countKind(findings, kindJSONExtraction); got != 1 {
+		t.Fatalf("JSON findings = %d, want 1: %#v", got, findings)
+	}
+}
+
+func TestDetectsBraceScannerRegardlessOfNameOrReturnShape(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+func payload(raw []byte) []byte {
+	depth, start := 0, 0
+	for end, char := range raw {
+		switch char { case '{': depth++; case '}': depth-- }
+		if depth == 0 { candidate := raw[start:end]; return candidate }
+	}
+	return nil
 }
 `)
 	if got := countKind(findings, kindJSONExtraction); got != 1 {
@@ -126,15 +154,10 @@ func TestCanonicalPackagesOwnThePrimitives(t *testing.T) {
 	}
 }
 
-func TestAvoidsDocumentedNonPrimitiveShapes(t *testing.T) {
+func TestAvoidsStructTagFalsePositive(t *testing.T) {
 	t.Parallel()
 	findings := findingsFor(t, "internal/example/parser.go", `package example
 type wire struct { Status string `+"`json:\"human-required\"`"+` }
-func codeBraceDelta(s string) int {
-	depth := 0
-	for _, c := range s { switch c { case '{': depth++; case '}': depth-- } }
-	return depth
-}
 `)
 	if len(findings) != 0 {
 		t.Fatalf("parser/struct-tag shapes produced findings: %#v", findings)

--- a/scripts/checkconsolidated/main_test.go
+++ b/scripts/checkconsolidated/main_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func findingsFor(t *testing.T, path, source string) []finding {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, 0)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return inspectFile(fset, path, file)
+}
+
+func countKind(findings []finding, kind findingKind) int {
+	n := 0
+	for _, f := range findings {
+		if f.kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+func TestDetectsEveryConsolidatedPrimitiveDrift(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+import "strings"
+func truncate(s string, maxBytes int) string { return s[:maxBytes] }
+func extractJSON(s string) string {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	return s[start:end]
+}
+var status = "human-required"
+var provider = "claude"
+`)
+	for _, kind := range []findingKind{kindStringTruncation, kindJSONExtraction, kindTaskStatus, kindProvider} {
+		if got := countKind(findings, kind); got != 1 {
+			t.Errorf("%s findings = %d, want 1; all findings: %#v", kind, got, findings)
+		}
+	}
+}
+
+func TestDetectsBalancedBraceScanner(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+func scan(s string) string {
+	depth := 0
+	start := 0
+	for _, c := range s {
+		switch c { case '{': depth++; case '}': depth-- }
+	}
+	return s[start:]
+}
+`)
+	if got := countKind(findings, kindJSONExtraction); got != 1 {
+		t.Fatalf("JSON findings = %d, want 1: %#v", got, findings)
+	}
+}
+
+func TestCanonicalPackagesOwnThePrimitives(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		src  string
+	}{
+		{"internal/textutil/new.go", `package textutil; func f(s string, n int) string { return s[:n] }`},
+		{"internal/llmjob/new.go", `package llmjob; import "strings"; func extractJSON(s string) string { return s[strings.IndexByte(s, '{'):strings.LastIndexByte(s, '}')] }`},
+		{"internal/taskstatus/new.go", `package taskstatus; const x = "human-required"`},
+		{"internal/providerid/new.go", `package providerid; const x = "claude"`},
+	}
+	for _, tc := range cases {
+		if got := findingsFor(t, tc.path, tc.src); len(got) != 0 {
+			t.Errorf("%s produced findings: %#v", tc.path, got)
+		}
+	}
+}
+
+func TestAvoidsDocumentedNonPrimitiveShapes(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/parser.go", `package example
+type wire struct { Status string `+"`json:\"human-required\"`"+` }
+func token(s string, idx int) string { return s[:idx] }
+func codeBraceDelta(s string) int {
+	depth := 0
+	for _, c := range s { switch c { case '{': depth++; case '}': depth-- } }
+	return depth
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("parser/struct-tag shapes produced findings: %#v", findings)
+	}
+}
+
+func TestTestFilesOnlyExemptWireLiterals(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift_test.go", `package example
+var status = "human-required"
+var provider = "claude"
+func truncate(s string, limit int) string { return s[:limit] }
+`)
+	if got := countKind(findings, kindStringTruncation); got != 1 {
+		t.Fatalf("truncation findings = %d, want 1: %#v", got, findings)
+	}
+	if got := countKind(findings, kindTaskStatus) + countKind(findings, kindProvider); got != 0 {
+		t.Fatalf("wire literal findings in test file = %d, want 0: %#v", got, findings)
+	}
+}
+
+func TestEveryExceptionHasAReasonAndExactPositiveCount(t *testing.T) {
+	t.Parallel()
+	if err := validateAllowances(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExceptionLedgerRejectsBothAddedAndStaleOccurrences(t *testing.T) {
+	t.Parallel()
+	key := allowanceKey{kind: kindProvider, path: "internal/example/vendor.go", value: "claude"}
+	ledger := map[allowanceKey]allowance{
+		key: {count: 1, reason: "external vendor executable name"},
+	}
+	base := finding{kind: key.kind, path: key.path, value: key.value, line: 3}
+	if issues := auditFindings([]finding{base}, ledger); len(issues) != 0 {
+		t.Fatalf("exact baseline produced issues: %#v", issues)
+	}
+	if issues := auditFindings([]finding{base, base}, ledger); len(issues) != 1 || issues[0].finding == nil {
+		t.Fatalf("added occurrence issues = %#v, want one source finding", issues)
+	}
+	if issues := auditFindings(nil, ledger); len(issues) != 1 || issues[0].finding != nil {
+		t.Fatalf("stale occurrence issues = %#v, want one stale-ledger error", issues)
+	}
+}

--- a/scripts/checkconsolidated/main_test.go
+++ b/scripts/checkconsolidated/main_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
 func findingsFor(t *testing.T, path, source string) []finding {
@@ -13,7 +17,8 @@ func findingsFor(t *testing.T, path, source string) []finding {
 	if err != nil {
 		t.Fatalf("parse fixture: %v", err)
 	}
-	return inspectFile(fset, path, file)
+	info := collectTypeInfo("fixture", fset, []*ast.File{file})
+	return inspectFile(fset, path, file, info)
 }
 
 func countKind(findings []finding, kind findingKind) int {
@@ -39,9 +44,15 @@ func extractJSON(s string) string {
 var status = "human-required"
 var provider = "claude"
 `)
-	for _, kind := range []findingKind{kindStringTruncation, kindJSONExtraction, kindTaskStatus, kindProvider} {
-		if got := countKind(findings, kind); got != 1 {
-			t.Errorf("%s findings = %d, want 1; all findings: %#v", kind, got, findings)
+	wants := map[findingKind]int{
+		kindStringTruncation: 2, // explicit truncation plus the JSON span slice
+		kindJSONExtraction:   1,
+		kindTaskStatus:       1,
+		kindProvider:         1,
+	}
+	for kind, want := range wants {
+		if got := countKind(findings, kind); got != want {
+			t.Errorf("%s findings = %d, want %d; all findings: %#v", kind, got, want, findings)
 		}
 	}
 }
@@ -63,20 +74,54 @@ func scan(s string) string {
 	}
 }
 
+func TestDetectsOrdinaryBoundAndNamedString(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+type message string
+func source() string { return "payload" }
+func truncate(s message, boundary int) (message, string) {
+	return s[:boundary], source()[:boundary]
+}
+`)
+	if got := countKind(findings, kindStringTruncation); got != 2 {
+		t.Fatalf("truncation findings = %d, want 2: %#v", got, findings)
+	}
+}
+
+func TestDetectsAssignmentBraceCounterReturningSpan(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+func scan(s string) (int, int) {
+	depth := 0
+	start := 0
+	for i, c := range s {
+		switch c { case '{': depth = depth + 1; case '}': depth = depth - 1 }
+		if depth == 0 { return start, i }
+	}
+	return -1, -1
+}
+`)
+	if got := countKind(findings, kindJSONExtraction); got != 1 {
+		t.Fatalf("JSON findings = %d, want 1: %#v", got, findings)
+	}
+}
+
 func TestCanonicalPackagesOwnThePrimitives(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		path string
 		src  string
+		kind findingKind
 	}{
-		{"internal/textutil/new.go", `package textutil; func f(s string, n int) string { return s[:n] }`},
-		{"internal/llmjob/new.go", `package llmjob; import "strings"; func extractJSON(s string) string { return s[strings.IndexByte(s, '{'):strings.LastIndexByte(s, '}')] }`},
-		{"internal/taskstatus/new.go", `package taskstatus; const x = "human-required"`},
-		{"internal/providerid/new.go", `package providerid; const x = "claude"`},
+		{"internal/textutil/new.go", `package textutil; func f(s string, n int) string { return s[:n] }`, kindStringTruncation},
+		{"internal/llmjob/new.go", `package llmjob; import "strings"; func extractJSON(s string) string { return s[strings.IndexByte(s, '{'):strings.LastIndexByte(s, '}')] }`, kindJSONExtraction},
+		{"internal/taskstatus/new.go", `package taskstatus; const x = "human-required"`, kindTaskStatus},
+		{"internal/providerid/new.go", `package providerid; const x = "claude"`, kindProvider},
 	}
 	for _, tc := range cases {
-		if got := findingsFor(t, tc.path, tc.src); len(got) != 0 {
-			t.Errorf("%s produced findings: %#v", tc.path, got)
+		findings := findingsFor(t, tc.path, tc.src)
+		if got := countKind(findings, tc.kind); got != 0 {
+			t.Errorf("%s produced %s findings: %#v", tc.path, tc.kind, findings)
 		}
 	}
 }
@@ -85,7 +130,6 @@ func TestAvoidsDocumentedNonPrimitiveShapes(t *testing.T) {
 	t.Parallel()
 	findings := findingsFor(t, "internal/example/parser.go", `package example
 type wire struct { Status string `+"`json:\"human-required\"`"+` }
-func token(s string, idx int) string { return s[:idx] }
 func codeBraceDelta(s string) int {
 	depth := 0
 	for _, c := range s { switch c { case '{': depth++; case '}': depth-- } }
@@ -97,7 +141,7 @@ func codeBraceDelta(s string) int {
 	}
 }
 
-func TestTestFilesOnlyExemptWireLiterals(t *testing.T) {
+func TestTestFilesRequireExplicitWireLiteralExceptions(t *testing.T) {
 	t.Parallel()
 	findings := findingsFor(t, "internal/example/drift_test.go", `package example
 var status = "human-required"
@@ -107,8 +151,28 @@ func truncate(s string, limit int) string { return s[:limit] }
 	if got := countKind(findings, kindStringTruncation); got != 1 {
 		t.Fatalf("truncation findings = %d, want 1: %#v", got, findings)
 	}
-	if got := countKind(findings, kindTaskStatus) + countKind(findings, kindProvider); got != 0 {
-		t.Fatalf("wire literal findings in test file = %d, want 0: %#v", got, findings)
+	if got := countKind(findings, kindTaskStatus) + countKind(findings, kindProvider); got != 2 {
+		t.Fatalf("wire literal findings in test file = %d, want 2: %#v", got, findings)
+	}
+}
+
+func TestVocabulariesComeFromCanonicalPackages(t *testing.T) {
+	t.Parallel()
+	if got, want := len(taskStatuses), len(taskstatus.All()); got != want {
+		t.Fatalf("task status vocabulary length = %d, want %d", got, want)
+	}
+	for _, status := range taskstatus.All() {
+		if _, ok := taskStatuses[string(status)]; !ok {
+			t.Errorf("task status vocabulary missing %q", status)
+		}
+	}
+	if got, want := len(providerNames), len(providerid.All()); got != want {
+		t.Fatalf("provider vocabulary length = %d, want %d", got, want)
+	}
+	for _, provider := range providerid.All() {
+		if _, ok := providerNames[provider]; !ok {
+			t.Errorf("provider vocabulary missing %q", provider)
+		}
 	}
 }
 

--- a/scripts/checkconsolidated/main_test.go
+++ b/scripts/checkconsolidated/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"go/ast"
-	"go/importer"
 	"go/parser"
 	"go/token"
 	"testing"
@@ -18,7 +17,7 @@ func findingsFor(t *testing.T, path, source string) []finding {
 	if err != nil {
 		t.Fatalf("parse fixture: %v", err)
 	}
-	info := collectTypeInfo("fixture", fset, []*ast.File{file}, importer.Default())
+	info := collectTypeInfo("fixture", fset, []*ast.File{file}, nil)
 	return inspectFile(fset, path, file, info)
 }
 
@@ -86,6 +85,17 @@ func truncate(s message, boundary int) (message, string) {
 `)
 	if got := countKind(findings, kindStringTruncation); got != 2 {
 		t.Fatalf("truncation findings = %d, want 2: %#v", got, findings)
+	}
+}
+
+func TestDetectsImportedNamedStringWhenTypeIsUnresolved(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+import "encoding/json"
+func truncate(s json.Number) string { return s[:8] }
+`)
+	if got := countKind(findings, kindStringTruncation); got != 1 {
+		t.Fatalf("truncation findings = %d, want 1: %#v", got, findings)
 	}
 }
 

--- a/scripts/checkconsolidated/main_test.go
+++ b/scripts/checkconsolidated/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"go/ast"
+	"go/importer"
 	"go/parser"
 	"go/token"
 	"testing"
@@ -17,7 +18,7 @@ func findingsFor(t *testing.T, path, source string) []finding {
 	if err != nil {
 		t.Fatalf("parse fixture: %v", err)
 	}
-	info := collectTypeInfo("fixture", fset, []*ast.File{file})
+	info := collectTypeInfo("fixture", fset, []*ast.File{file}, importer.Default())
 	return inspectFile(fset, path, file, info)
 }
 
@@ -99,6 +100,23 @@ func shortID() string { return uuid.NewString()[:8] }
 	}
 }
 
+func TestTracksUnresolvedCallThroughAssignments(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+import "github.com/google/uuid"
+type record struct { ID any }
+func shortID() (string, any) {
+	id := uuid.NewString()
+	var item record
+	item.ID = uuid.NewString()
+	return id[:8], item.ID[:8]
+}
+`)
+	if got := countKind(findings, kindStringTruncation); got != 2 {
+		t.Fatalf("truncation findings = %d, want 2: %#v", got, findings)
+	}
+}
+
 func TestDetectsAssignmentBraceCounterReturningSpan(t *testing.T) {
 	t.Parallel()
 	findings := findingsFor(t, "internal/example/drift.go", `package example
@@ -125,6 +143,24 @@ func payload(raw []byte) []byte {
 	for end, char := range raw {
 		switch char { case '{': depth++; case '}': depth-- }
 		if depth == 0 { candidate := raw[start:end]; return candidate }
+	}
+	return nil
+}
+`)
+	if got := countKind(findings, kindJSONExtraction); got != 1 {
+		t.Fatalf("JSON findings = %d, want 1: %#v", got, findings)
+	}
+}
+
+func TestDetectsLookupTableBraceDelta(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+func payload(raw []byte) []byte {
+	deltas := map[byte]int{'{': 1, '}': -1}
+	depth, start := 0, 0
+	for end, char := range raw {
+		depth += deltas[char]
+		if depth == 0 { return raw[start:end] }
 	}
 	return nil
 }

--- a/scripts/checkconsolidated/main_test.go
+++ b/scripts/checkconsolidated/main_test.go
@@ -117,6 +117,21 @@ func shortID() (string, any) {
 	}
 }
 
+func TestTracksUnresolvedTupleCallThroughAssignments(t *testing.T) {
+	t.Parallel()
+	findings := findingsFor(t, "internal/example/drift.go", `package example
+import "os"
+func shortHome() string {
+	home, err := os.UserHomeDir()
+	_ = err
+	return home[:8]
+}
+`)
+	if got := countKind(findings, kindStringTruncation); got != 1 {
+		t.Fatalf("truncation findings = %d, want 1: %#v", got, findings)
+	}
+}
+
 func TestDetectsAssignmentBraceCounterReturningSpan(t *testing.T) {
 	t.Parallel()
 	findings := findingsFor(t, "internal/example/drift.go", `package example


### PR DESCRIPTION
## Summary

- add a syntax-aware, fail-closed drift gate for string byte truncation and brace-based JSON extraction
- derive task-status and provider vocabularies from their canonical packages and enforce exact reasoned exception counts, including test fixtures
- run the identical gate from `mise run verify` and the dedicated CI job
- consolidate remaining status/provider comparisons and UTF-8-safe tail truncation onto shared primitives

## Verification

- `bash scripts/check-consolidated-primitives.sh`
- `go test -race ./scripts/checkconsolidated`
- independent adversarial review: APPROVE
- independent fresh-clone adversarial testing: PASS

Closes #3144