### PR TITLE
refactor(errclass): answer the error class once

### DIFF
--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1699,16 +1699,17 @@ func classifyAgentError(err error) string {
 		return ErrorKindPromptUndelivered
 	}
 	msg := strings.ToLower(err.Error())
+	class := errclass.Classify(msg, errclass.AgentRecoveryBiased)
 	switch {
 	case strings.Contains(msg, "worktree") || strings.Contains(msg, "already checked out"):
 		return "worktree_conflict"
-	case errclass.Classify(msg, errclass.AgentRecoveryBiased) == errclass.Transient:
+	case class == errclass.Transient:
 		return "git_clone"
 	case strings.Contains(msg, "permission denied") ||
 		strings.Contains(msg, "eacces") ||
 		strings.Contains(msg, "operation not permitted"):
 		return "permission_denied"
-	case errclass.Classify(msg, errclass.AgentRecoveryBiased) == errclass.RateLimited:
+	case class == errclass.RateLimited:
 		return "rate_limit"
 	default:
 		return "crash"

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1702,20 +1702,13 @@ func classifyAgentError(err error) string {
 	switch {
 	case strings.Contains(msg, "worktree") || strings.Contains(msg, "already checked out"):
 		return "worktree_conflict"
-	case strings.Contains(msg, "clone") ||
-		strings.Contains(msg, "fetch origin") ||
-		strings.Contains(msg, "git fetch") ||
-		strings.Contains(msg, "could not resolve host") ||
-		strings.Contains(msg, "dial tcp") ||
-		strings.Contains(msg, "i/o timeout") ||
-		strings.Contains(msg, "dns") ||
-		(strings.Contains(msg, "git") && strings.Contains(msg, "network")):
+	case errclass.Classify(msg, errclass.AgentRecoveryBiased) == errclass.Transient:
 		return "git_clone"
 	case strings.Contains(msg, "permission denied") ||
 		strings.Contains(msg, "eacces") ||
 		strings.Contains(msg, "operation not permitted"):
 		return "permission_denied"
-	case errclass.Matches(msg, errclass.AgentRateLimitPhrases):
+	case errclass.Classify(msg, errclass.AgentRecoveryBiased) == errclass.RateLimited:
 		return "rate_limit"
 	default:
 		return "crash"

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"log/slog"
 	"slices"
-	"strings"
 
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/provider"
 )
 
@@ -138,8 +138,7 @@ func resultSubtypeIsError(subtype string) bool {
 }
 
 func substringMatch529(s string) bool {
-	lower := strings.ToLower(s)
-	return strings.Contains(lower, "529") || strings.Contains(lower, "overloaded")
+	return errclass.Classify(s, errclass.AgentStreamRecoveryBiased) == errclass.RateLimited
 }
 
 func warnSubstringFallback(logger *slog.Logger) {

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -1,0 +1,83 @@
+package errclass
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifyPolicies(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		policy Policy
+		text   string
+		want   Class
+	}{
+		{"poller retries plain 500", GitHubPollerRetryBiased, "gh: HTTP 500", Transient},
+		{"poller shares workflow 401", GitHubPollerRetryBiased, "401 Unauthorized", Auth},
+		{"poller deadline", GitHubPollerRetryBiased, "context deadline exceeded", Transient},
+		{"command rejects plain 500", GHCommandEscalationBiased, "gh: HTTP 500", Permanent},
+		{"command retries gateway", GHCommandEscalationBiased, "gh: HTTP 502", Transient},
+		{"command exposes rate limit", GHCommandEscalationBiased, "API rate limit exceeded", RateLimited},
+		{"monitor knows generic rate limit", MonitorCooldownBiased, "rate limit exceeded", RateLimited},
+		{"monitor knows shared wall", MonitorCooldownBiased, "github rate-limit wall", RateLimited},
+		{"token mint bare rate limit", GitHubTokenMintCooldownBiased, "request forbidden: rate limit", RateLimited},
+		{"git deadline stays unknown", GitTransportEscalationBiased, "context deadline exceeded", Unknown},
+		{"git timeout is transient", GitTransportEscalationBiased, "connection timed out", Transient},
+		{"permanent tls is not retried", GitTransportEscalationBiased, "tls: first record does not look like a TLS handshake", Permanent},
+		{"workflow prose deadline", WorkflowProseRetryBiased, "context deadline exceeded", Transient},
+		{"workflow github rate limit", WorkflowProseRetryBiased, "GitHub API rate limit", RateLimited},
+		{"workflow generic rate prose stays unknown", WorkflowProseRetryBiased, "provider rate limit", Unknown},
+		{"blocked merge stays permanent to poller", GitHubPollerRetryBiased, "waiting for status timed out", Permanent},
+		{"agent clone outranks rate limit", AgentRecoveryBiased, "git fetch: 429 rate limit", Transient},
+		{"agent overload recovers", AgentRecoveryBiased, "provider overloaded", RateLimited},
+		{"stream fallback keeps permissive 529", AgentStreamRecoveryBiased, "token 1529", RateLimited},
+		{"llmexec rejects embedded 529", LLMExecRecoveryBiased, "token 1529", Unknown},
+		{"llmexec accepts standalone 529", LLMExecRecoveryBiased, "HTTP 529", RateLimited},
+		{"pr fix remote resumes", PRFixProseRetryBiased, "remote unreachable", Transient},
+		{"pr fix credentials stop", PRFixProseRetryBiased, "missing credential", Permanent},
+		{"unrecognized stays unknown", GitHubPollerRetryBiased, "something failed", Unknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Classify(tt.text, tt.policy); got != tt.want {
+				t.Fatalf("Classify(%q, %q) = %q, want %q", tt.text, tt.policy, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPolicyBiasIsExplicit(t *testing.T) {
+	t.Parallel()
+	tests := map[Policy]Bias{
+		GitHubPollerRetryBiased:       RetryBiased,
+		GHCommandEscalationBiased:     EscalationBiased,
+		MonitorCooldownBiased:         CooldownBiased,
+		GitHubTokenMintCooldownBiased: CooldownBiased,
+		GitTransportEscalationBiased:  EscalationBiased,
+		WorkflowProseRetryBiased:      RetryBiased,
+		AgentRecoveryBiased:           RecoveryBiased,
+		AgentStreamRecoveryBiased:     RecoveryBiased,
+		LLMExecRecoveryBiased:         RecoveryBiased,
+		PRFixProseRetryBiased:         RetryBiased,
+	}
+	for policy, want := range tests {
+		if got := policy.Bias(); got != want {
+			t.Errorf("%q.Bias() = %q, want %q", policy, got, want)
+		}
+	}
+	if got := Policy("future-policy").Bias(); got != "" {
+		t.Errorf("unknown policy bias = %q, want empty", got)
+	}
+}
+
+func TestClassifyErr(t *testing.T) {
+	t.Parallel()
+	if got := ClassifyErr(nil, GitHubPollerRetryBiased); got != Unknown {
+		t.Fatalf("nil = %q, want unknown", got)
+	}
+	if got := ClassifyErr(errors.New("HTTP 503"), GitHubPollerRetryBiased); got != Transient {
+		t.Fatalf("HTTP 503 = %q, want transient", got)
+	}
+}

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -14,8 +14,11 @@ func TestClassifyPolicies(t *testing.T) {
 		want   Class
 	}{
 		{"poller retries plain 500", GitHubPollerRetryBiased, "gh: HTTP 500", Transient},
+		{"retry-biased poller keeps 503 over auth", GitHubPollerRetryBiased, "bad credentials; HTTP 503", Transient},
+		{"retry-biased poller keeps rate over auth", GitHubPollerRetryBiased, "bad credentials; API rate limit exceeded", RateLimited},
 		{"poller shares workflow 401", GitHubPollerRetryBiased, "401 Unauthorized", Auth},
 		{"poller deadline", GitHubPollerRetryBiased, "context deadline exceeded", Transient},
+		{"circuit-biased poller keeps auth over 503", GitHubCircuitEscalationBiased, "bad credentials; HTTP 503", Auth},
 		{"command rejects plain 500", GHCommandEscalationBiased, "gh: HTTP 500", Permanent},
 		{"command retries gateway", GHCommandEscalationBiased, "gh: HTTP 502", Transient},
 		{"command exposes rate limit", GHCommandEscalationBiased, "API rate limit exceeded", RateLimited},
@@ -52,6 +55,7 @@ func TestPolicyBiasIsExplicit(t *testing.T) {
 	t.Parallel()
 	tests := map[Policy]Bias{
 		GitHubPollerRetryBiased:       RetryBiased,
+		GitHubCircuitEscalationBiased: EscalationBiased,
 		GHCommandEscalationBiased:     EscalationBiased,
 		MonitorCooldownBiased:         CooldownBiased,
 		GitHubTokenMintCooldownBiased: CooldownBiased,

--- a/internal/errclass/compatibility_test.go
+++ b/internal/errclass/compatibility_test.go
@@ -1,0 +1,235 @@
+package errclass
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const compatibilityCorpusSize = 18_242
+
+// TestDifferentialCompatibilityCorpus compares the pre-#3162 downstream
+// decision at every migrated site with the policy result. The corpus size is
+// fixed so adding a phrase cannot silently shrink the exercised surface.
+// Only the two decisions named by #3162 are allowed to differ: GitHub's shared
+// auth circuit learns "401 unauthorized", and monitor learns the complete
+// GitHub rate-limit vocabulary.
+func TestDifferentialCompatibilityCorpus(t *testing.T) {
+	t.Parallel()
+	corpus := recordedCompatibilityCorpus()
+	if len(corpus) != compatibilityCorpusSize {
+		t.Fatalf("corpus has %d inputs, want %d", len(corpus), compatibilityCorpusSize)
+	}
+
+	policies := []Policy{
+		GitHubPollerRetryBiased,
+		GHCommandEscalationBiased,
+		MonitorCooldownBiased,
+		GitHubTokenMintCooldownBiased,
+		GitTransportEscalationBiased,
+		WorkflowProseRetryBiased,
+		AgentRecoveryBiased,
+		AgentStreamRecoveryBiased,
+		LLMExecRecoveryBiased,
+		PRFixProseRetryBiased,
+	}
+	intended := map[string]int{"github-401-auth": 0, "monitor-rate-limit": 0}
+	for _, input := range corpus {
+		for _, policy := range policies {
+			before := legacyDownstreamClass(input, policy)
+			after := downstreamClass(Classify(input, policy), policy)
+			if before == after {
+				continue
+			}
+			kind, ok := intendedDifference(input, policy, before, after)
+			if !ok {
+				t.Errorf("unexpected differential for %q under %s: before=%s after=%s", input, policy, before, after)
+				continue
+			}
+			intended[kind]++
+		}
+	}
+	for kind, count := range intended {
+		if count == 0 {
+			t.Errorf("corpus did not exercise intended difference %s", kind)
+		}
+	}
+	t.Logf("checked %d inputs across %d policies; intended differences: %v", len(corpus), len(policies), intended)
+}
+
+func downstreamClass(class Class, policy Policy) Class {
+	switch policy {
+	case GHCommandEscalationBiased, GitTransportEscalationBiased:
+		if class == Transient {
+			return Transient
+		}
+		return Unknown
+	case MonitorCooldownBiased, GitHubTokenMintCooldownBiased:
+		if class == RateLimited {
+			return RateLimited
+		}
+		return Unknown
+	case PRFixProseRetryBiased:
+		if class == Transient {
+			return Transient
+		}
+		return Unknown
+	case AgentRecoveryBiased:
+		if class == Transient || class == RateLimited {
+			return class
+		}
+		return Unknown
+	case AgentStreamRecoveryBiased, LLMExecRecoveryBiased:
+		if class == RateLimited {
+			return RateLimited
+		}
+		return Unknown
+	default:
+		return class
+	}
+}
+
+func intendedDifference(input string, policy Policy, before, after Class) (string, bool) {
+	lower := strings.ToLower(input)
+	switch {
+	case policy == GitHubPollerRetryBiased && before != Auth && after == Auth &&
+		strings.Contains(lower, "401 unauthorized"):
+		return "github-401-auth", true
+	case policy == MonitorCooldownBiased && before == Unknown && after == RateLimited &&
+		(strings.Contains(lower, "rate limit exceeded") || strings.Contains(lower, "github rate-limit wall")):
+		return "monitor-rate-limit", true
+	default:
+		return "", false
+	}
+}
+
+func legacyDownstreamClass(text string, policy Policy) Class {
+	lower := strings.ToLower(text)
+	contains := func(phrases ...string) bool {
+		for _, phrase := range phrases {
+			if strings.Contains(lower, phrase) {
+				return true
+			}
+		}
+		return false
+	}
+	switch policy {
+	case GitHubPollerRetryBiased:
+		switch {
+		case contains("github auth circuit open", "http 401", "bad credentials", "gh auth login", "gh_token environment variable"):
+			return Auth
+		case contains("github rate-limit wall", "secondary rate limit", "api rate limit exceeded", "rate limit exceeded"):
+			return RateLimited
+		case strings.Contains(lower, "http 5"), contains("dial tcp", "i/o timeout", "context deadline exceeded", "connection reset", "connection refused", "tls handshake timeout", "no route to host"):
+			return Transient
+		case contains("not mergeable", "required status check", "review is required", "changes requested", "waiting for status", "blocked by", "base branch policy prohibits the merge"):
+			return Permanent
+		default:
+			return Unknown
+		}
+	case GHCommandEscalationBiased:
+		if contains("http 502", "http 503", "http 504", "operation timed out", "i/o timeout", "deadline exceeded", "connection reset", "connection refused", "stream error", "unexpected eof", "tls handshake") {
+			return Transient
+		}
+		return Unknown
+	case MonitorCooldownBiased:
+		if contains("api rate limit exceeded", "secondary rate limit") {
+			return RateLimited
+		}
+		return Unknown
+	case GitHubTokenMintCooldownBiased:
+		if contains("rate limit") {
+			return RateLimited
+		}
+		return Unknown
+	case GitTransportEscalationBiased:
+		if contains("connection refused", "connection reset", "connection timed out", "failed to connect", "couldn't connect to server", "could not resolve host", "couldn't resolve host", "network is unreachable", "operation timed out", "temporary failure in name resolution", "no route to host", "ssh: connect to host", "recv failure", "tls handshake timeout", "empty reply from server", "early eof", "unexpected disconnect while reading sideband packet") {
+			return Transient
+		}
+		return Unknown
+	case WorkflowProseRetryBiased:
+		switch {
+		case legacyWorkflowRateLimit(lower):
+			return RateLimited
+		case contains("connection refused", "connection reset", "could not resolve host", "no such host", "no route to host", "network is unreachable", "temporary failure in name resolution", "i/o timeout", "timed out", "context deadline exceeded", "tls handshake", "tls:"), hasWorkflowGatewayStatus(lower):
+			return Transient
+		case contains("bad credentials", "authentication failed", "failed to log in", "gh auth", "gh_token is invalid", "github_token is invalid", "token has expired", "could not read username for 'https://github.com'", "401 unauthorized"):
+			return Auth
+		default:
+			return Unknown
+		}
+	case AgentRecoveryBiased:
+		switch {
+		case contains("clone", "fetch origin", "git fetch", "could not resolve host", "dial tcp", "i/o timeout", "dns"),
+			strings.Contains(lower, "git") && strings.Contains(lower, "network"):
+			return Transient
+		case contains("rate limit", "429", "overloaded"):
+			return RateLimited
+		default:
+			return Unknown
+		}
+	case AgentStreamRecoveryBiased:
+		if contains("529", "overloaded") {
+			return RateLimited
+		}
+		return Unknown
+	case LLMExecRecoveryBiased:
+		if hasStandaloneCode(lower, "529") || contains("overloaded") {
+			return RateLimited
+		}
+		return Unknown
+	case PRFixProseRetryBiased:
+		switch {
+		case contains("missing credential", "authentication", "permission denied"):
+			return Unknown
+		case contains("connection refused", "connection reset", "connection timed out", "failed to connect", "couldn't connect to server", "could not resolve host", "couldn't resolve host", "network is unreachable", "operation timed out", "temporary failure in name resolution", "no route to host", "ssh: connect to host", "recv failure", "tls handshake timeout", "empty reply from server", "early eof", "unexpected disconnect while reading sideband packet"),
+			strings.Contains(lower, "remote unreachable"),
+			strings.Contains(lower, "transport") && strings.Contains(lower, "github"):
+			return Transient
+		default:
+			return Unknown
+		}
+	default:
+		return Unknown
+	}
+}
+
+func legacyWorkflowRateLimit(lower string) bool {
+	if !strings.Contains(lower, "rate limit") {
+		return false
+	}
+	return strings.Contains(lower, "github") || strings.Contains(lower, "graphql") ||
+		strings.Contains(lower, "gh ") || strings.Contains(lower, "api rate limit") ||
+		strings.Contains(lower, "secondary rate limit")
+}
+
+func recordedCompatibilityCorpus() []string {
+	vocabulary := []string{
+		"", "ordinary failure", "HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504",
+		"401 unauthorized", "HTTP 401", "bad credentials", "gh auth login",
+		"github auth circuit open", "secondary rate limit", "api rate limit exceeded",
+		"rate limit exceeded", "github rate-limit wall", "context deadline exceeded",
+		"connection timed out", "operation timed out", "i/o timeout", "dial tcp",
+		"connection reset", "connection refused", "could not resolve host", "no such host",
+		"network is unreachable", "tls handshake timeout", "tls: certificate signed by unknown authority",
+		"tls: first record does not look like a TLS handshake", "stream error", "unexpected EOF",
+		"git fetch", "clone failed", "DNS", "429", "529", "1529", "overloaded", "waiting for status timed out",
+		"required status check", "review is required", "base branch policy prohibits the merge",
+		"permission denied", "authentication failed", "token has expired", "GitHub API rate limit",
+		"missing credential", "remote unreachable", "GitHub transport failure",
+	}
+	templates := []string{
+		"%s %s", "ERROR: %s (%s)", "prefix[%s]suffix %s", "before %s after %s", "%s; then %s",
+		"(%s) unrelated=%s", "UPPER %s / lower %s", "%s\n%s",
+	}
+	out := make([]string, 0, compatibilityCorpusSize)
+	for _, value := range vocabulary {
+		out = append(out, value, strings.ToUpper(value), "wrapped: "+value)
+	}
+	for i := 0; len(out) < compatibilityCorpusSize; i++ {
+		a := vocabulary[i%len(vocabulary)]
+		b := vocabulary[(i*37+11)%len(vocabulary)]
+		out = append(out, fmt.Sprintf(templates[i%len(templates)], a, b))
+	}
+	return out[:compatibilityCorpusSize]
+}

--- a/internal/errclass/compatibility_test.go
+++ b/internal/errclass/compatibility_test.go
@@ -1,18 +1,49 @@
 package errclass
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 )
 
-const compatibilityCorpusSize = 18_242
+const (
+	compatibilityCorpusSize   = 18_242
+	compatibilityCorpusSHA256 = "ac80280282ec9c65731953d33ca7543e6d61f565192a6c96659b98bc2cce3042"
+)
 
-// TestDifferentialCompatibilityCorpus compares the pre-#3162 downstream
-// decision at every migrated site with the policy result. The corpus size is
-// fixed so adding a phrase cannot silently shrink the exercised surface.
-// Only the two decisions named by #3162 are allowed to differ: GitHub's shared
-// auth circuit learns "401 unauthorized", and monitor learns the complete
+type downstreamDecision string
+
+const (
+	decisionDefault  downstreamDecision = "default"
+	decisionRetry    downstreamDecision = "retry"
+	decisionCooldown downstreamDecision = "cooldown"
+	decisionAuth     downstreamDecision = "auth-circuit"
+	decisionBlocked  downstreamDecision = "blocked"
+	decisionGit      downstreamDecision = "git-recovery"
+	decisionCapacity downstreamDecision = "capacity-recovery"
+	decisionStop     downstreamDecision = "stop"
+)
+
+type compatibilitySite struct {
+	name   string
+	before func(string) downstreamDecision
+	after  func(string) downstreamDecision
+}
+
+// TestDifferentialCompatibilityCorpus replays the pre-#3162 downstream
+// decision order at every migrated operational surface, rather than comparing
+// independent predicates or an invented global precedence. The input sequence
+// reconstructs the corpus recorded for #3161: every pre-image literal in nine
+// casing/token-boundary variants, representative real tool/transport bodies,
+// Unicode case-fold probes, and fixed-seed mixed-phrase inputs. Its hash makes
+// the recording immutable: changing the generator or ordering requires an
+// explicit snapshot review.
+//
+// Only the two behavior changes named by #3162 are accepted: GitHub's auth
+// circuit learns bare "401 unauthorized", and monitor learns the complete
 // GitHub rate-limit vocabulary.
 func TestDifferentialCompatibilityCorpus(t *testing.T) {
 	t.Parallel()
@@ -20,30 +51,21 @@ func TestDifferentialCompatibilityCorpus(t *testing.T) {
 	if len(corpus) != compatibilityCorpusSize {
 		t.Fatalf("corpus has %d inputs, want %d", len(corpus), compatibilityCorpusSize)
 	}
-
-	policies := []Policy{
-		GitHubPollerRetryBiased,
-		GHCommandEscalationBiased,
-		MonitorCooldownBiased,
-		GitHubTokenMintCooldownBiased,
-		GitTransportEscalationBiased,
-		WorkflowProseRetryBiased,
-		AgentRecoveryBiased,
-		AgentStreamRecoveryBiased,
-		LLMExecRecoveryBiased,
-		PRFixProseRetryBiased,
+	hash := corpusHash(corpus)
+	if hash != compatibilityCorpusSHA256 {
+		t.Fatalf("corpus hash = %s, want recorded %s", hash, compatibilityCorpusSHA256)
 	}
+
 	intended := map[string]int{"github-401-auth": 0, "monitor-rate-limit": 0}
 	for _, input := range corpus {
-		for _, policy := range policies {
-			before := legacyDownstreamClass(input, policy)
-			after := downstreamClass(Classify(input, policy), policy)
+		for _, site := range compatibilitySites() {
+			before, after := site.before(input), site.after(input)
 			if before == after {
 				continue
 			}
-			kind, ok := intendedDifference(input, policy, before, after)
+			kind, ok := intendedDifference(input, site.name, before, after)
 			if !ok {
-				t.Errorf("unexpected differential for %q under %s: before=%s after=%s", input, policy, before, after)
+				t.Errorf("unexpected differential for %q at %s: before=%s after=%s", input, site.name, before, after)
 				continue
 			}
 			intended[kind]++
@@ -54,182 +76,448 @@ func TestDifferentialCompatibilityCorpus(t *testing.T) {
 			t.Errorf("corpus did not exercise intended difference %s", kind)
 		}
 	}
-	t.Logf("checked %d inputs across %d policies; intended differences: %v", len(corpus), len(policies), intended)
+	t.Logf("checked %d recorded inputs across %d downstream sites; intended differences: %v", len(corpus), len(compatibilitySites()), intended)
 }
 
-func downstreamClass(class Class, policy Policy) Class {
-	switch policy {
-	case GHCommandEscalationBiased, GitTransportEscalationBiased:
-		if class == Transient {
-			return Transient
-		}
-		return Unknown
-	case MonitorCooldownBiased, GitHubTokenMintCooldownBiased:
-		if class == RateLimited {
-			return RateLimited
-		}
-		return Unknown
-	case PRFixProseRetryBiased:
-		if class == Transient {
-			return Transient
-		}
-		return Unknown
-	case AgentRecoveryBiased:
-		if class == Transient || class == RateLimited {
-			return class
-		}
-		return Unknown
-	case AgentStreamRecoveryBiased, LLMExecRecoveryBiased:
-		if class == RateLimited {
-			return RateLimited
-		}
-		return Unknown
-	default:
-		return class
+func compatibilitySites() []compatibilitySite {
+	return []compatibilitySite{
+		{
+			name: "github-review-fetch-retry-first",
+			before: func(s string) downstreamDecision {
+				switch {
+				case legacyGitHubTransient(s):
+					return decisionRetry
+				case legacyGitHubAuth(s):
+					return decisionAuth
+				default:
+					return decisionDefault
+				}
+			},
+			after: func(s string) downstreamDecision {
+				return githubDecision(Classify(s, GitHubPollerRetryBiased))
+			},
+		},
+		{
+			name: "github-poller-auth-first",
+			before: func(s string) downstreamDecision {
+				switch {
+				case legacyGitHubAuth(s):
+					return decisionAuth
+				case legacyGitHubTransient(s):
+					return decisionRetry
+				default:
+					return decisionDefault
+				}
+			},
+			after: func(s string) downstreamDecision {
+				return githubDecision(Classify(s, GitHubCircuitEscalationBiased))
+			},
+		},
+		{
+			name:   "github-auth-only",
+			before: func(s string) downstreamDecision { return choose(legacyGitHubAuth(s), decisionAuth) },
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, GitHubCircuitEscalationBiased) == Auth, decisionAuth)
+			},
+		},
+		{
+			name:   "github-rate-cooldown",
+			before: func(s string) downstreamDecision { return choose(legacyGitHubRate(s), decisionCooldown) },
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, MonitorCooldownBiased) == RateLimited, decisionCooldown)
+			},
+		},
+		{
+			name:   "gh-command-immediate-retry",
+			before: func(s string) downstreamDecision { return choose(legacyGHCommandTransient(s), decisionRetry) },
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, GHCommandEscalationBiased) == Transient, decisionRetry)
+			},
+		},
+		{
+			name:   "monitor-rate-cooldown",
+			before: func(s string) downstreamDecision { return choose(legacyMonitorRate(s), decisionCooldown) },
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, MonitorCooldownBiased) == RateLimited, decisionCooldown)
+			},
+		},
+		{
+			name:   "github-token-mint-cooldown",
+			before: func(s string) downstreamDecision { return choose(containsLower(s, "rate limit"), decisionCooldown) },
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, GitHubTokenMintCooldownBiased) == RateLimited, decisionCooldown)
+			},
+		},
+		{
+			name:   "git-transport-escalation",
+			before: func(s string) downstreamDecision { return choose(legacyGitTransport(s), decisionRetry) },
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, GitTransportEscalationBiased) == Transient, decisionRetry)
+			},
+		},
+		{
+			name:   "workflow-prose-routing",
+			before: legacyWorkflowDecision,
+			after:  func(s string) downstreamDecision { return workflowDecision(Classify(s, WorkflowProseRetryBiased)) },
+		},
+		{
+			name:   "agent-fatal-recovery",
+			before: legacyAgentDecision,
+			after:  currentAgentDecision,
+		},
+		{
+			name: "agent-stream-overload",
+			before: func(s string) downstreamDecision {
+				return choose(containsAnyLower(s, "529", "overloaded"), decisionCapacity)
+			},
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, AgentStreamRecoveryBiased) == RateLimited, decisionCapacity)
+			},
+		},
+		{
+			name: "llmexec-overload",
+			before: func(s string) downstreamDecision {
+				return choose(hasStandaloneCode(strings.ToLower(s), "529") || containsLower(s, "overloaded"), decisionCapacity)
+			},
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, LLMExecRecoveryBiased) == RateLimited, decisionCapacity)
+			},
+		},
+		{
+			name:   "pr-fix-recovery",
+			before: legacyPRFixDecision,
+			after: func(s string) downstreamDecision {
+				return choose(Classify(s, PRFixProseRetryBiased) == Transient, decisionRetry)
+			},
+		},
+		{
+			name:   "merge-backoff",
+			before: legacyMergeDecision,
+			after:  currentMergeDecision,
+		},
 	}
 }
 
-func intendedDifference(input string, policy Policy, before, after Class) (string, bool) {
+func githubDecision(class Class) downstreamDecision {
+	switch class {
+	case Transient, RateLimited:
+		return decisionRetry
+	case Auth:
+		return decisionAuth
+	default:
+		return decisionDefault
+	}
+}
+
+func workflowDecision(class Class) downstreamDecision {
+	switch class {
+	case RateLimited:
+		return decisionCooldown
+	case Transient:
+		return decisionRetry
+	case Auth:
+		return decisionAuth
+	default:
+		return decisionDefault
+	}
+}
+
+func currentAgentDecision(s string) downstreamDecision {
+	class := Classify(s, AgentRecoveryBiased)
+	switch {
+	case class == Transient:
+		return decisionGit
+	case containsAnyLower(s, "permission denied", "eacces", "operation not permitted"):
+		return decisionStop
+	case class == RateLimited:
+		return decisionCapacity
+	default:
+		return decisionDefault
+	}
+}
+
+func legacyWorkflowDecision(s string) downstreamDecision {
+	lower := strings.ToLower(s)
+	switch {
+	case legacyWorkflowRateLimit(lower):
+		return decisionCooldown
+	case containsAny(lower, legacyWorkflowTransientPhrases()...) || hasWorkflowGatewayStatus(lower):
+		return decisionRetry
+	case containsAny(lower, legacyWorkflowAuthPhrases()...):
+		return decisionAuth
+	default:
+		return decisionDefault
+	}
+}
+
+func legacyAgentDecision(s string) downstreamDecision {
+	lower := strings.ToLower(s)
+	switch {
+	case containsAny(lower, legacyAgentGitPhrases()...) || strings.Contains(lower, "git") && strings.Contains(lower, "network"):
+		return decisionGit
+	case containsAny(lower, "permission denied", "eacces", "operation not permitted"):
+		return decisionStop
+	case containsAny(lower, "rate limit", "429", "overloaded"):
+		return decisionCapacity
+	default:
+		return decisionDefault
+	}
+}
+
+func legacyPRFixDecision(s string) downstreamDecision {
+	lower := strings.ToLower(s)
+	if containsAny(lower, "missing credential", "authentication", "permission denied") {
+		return decisionDefault
+	}
+	return choose(containsAny(lower, legacyGitTransportPhrases()...) ||
+		strings.Contains(lower, "remote unreachable") ||
+		strings.Contains(lower, "transport") && strings.Contains(lower, "github"), decisionRetry)
+}
+
+func legacyMergeDecision(s string) downstreamDecision {
+	switch {
+	case legacyGitHubAuth(s):
+		return decisionAuth
+	case legacyGitHubRate(s):
+		return decisionCooldown
+	case legacyGitHubNetworkTransient(s):
+		return decisionRetry
+	case containsAnyLower(s, legacyMergeBlockedPhrases()...):
+		return decisionBlocked
+	default:
+		return decisionDefault
+	}
+}
+
+func currentMergeDecision(s string) downstreamDecision {
+	switch Classify(s, GitHubCircuitEscalationBiased) {
+	case Auth:
+		return decisionAuth
+	case RateLimited:
+		return decisionCooldown
+	case Transient:
+		return decisionRetry
+	case Permanent:
+		return decisionBlocked
+	default:
+		return decisionDefault
+	}
+}
+
+func intendedDifference(input, site string, before, after downstreamDecision) (string, bool) {
 	lower := strings.ToLower(input)
 	switch {
-	case policy == GitHubPollerRetryBiased && before != Auth && after == Auth &&
-		strings.Contains(lower, "401 unauthorized"):
+	case strings.Contains(lower, "401 unauthorized") && before != decisionAuth && after == decisionAuth:
 		return "github-401-auth", true
-	case policy == MonitorCooldownBiased && before == Unknown && after == RateLimited &&
-		(strings.Contains(lower, "rate limit exceeded") || strings.Contains(lower, "github rate-limit wall")):
+	case site == "monitor-rate-cooldown" && before == decisionDefault && after == decisionCooldown &&
+		(strings.Contains(lower, "rate limit exceeded") || strings.Contains(lower, GitHubRateLimitWallMarker)):
 		return "monitor-rate-limit", true
 	default:
 		return "", false
 	}
 }
 
-func legacyDownstreamClass(text string, policy Policy) Class {
-	lower := strings.ToLower(text)
-	contains := func(phrases ...string) bool {
-		for _, phrase := range phrases {
-			if strings.Contains(lower, phrase) {
-				return true
-			}
-		}
-		return false
+func choose(ok bool, yes downstreamDecision) downstreamDecision {
+	if ok {
+		return yes
 	}
-	switch policy {
-	case GitHubPollerRetryBiased:
-		switch {
-		case contains("github auth circuit open", "http 401", "bad credentials", "gh auth login", "gh_token environment variable"):
-			return Auth
-		case contains("github rate-limit wall", "secondary rate limit", "api rate limit exceeded", "rate limit exceeded"):
-			return RateLimited
-		case strings.Contains(lower, "http 5"), contains("dial tcp", "i/o timeout", "context deadline exceeded", "connection reset", "connection refused", "tls handshake timeout", "no route to host"):
-			return Transient
-		case contains("not mergeable", "required status check", "review is required", "changes requested", "waiting for status", "blocked by", "base branch policy prohibits the merge"):
-			return Permanent
-		default:
-			return Unknown
-		}
-	case GHCommandEscalationBiased:
-		if contains("http 502", "http 503", "http 504", "operation timed out", "i/o timeout", "deadline exceeded", "connection reset", "connection refused", "stream error", "unexpected eof", "tls handshake") {
-			return Transient
-		}
-		return Unknown
-	case MonitorCooldownBiased:
-		if contains("api rate limit exceeded", "secondary rate limit") {
-			return RateLimited
-		}
-		return Unknown
-	case GitHubTokenMintCooldownBiased:
-		if contains("rate limit") {
-			return RateLimited
-		}
-		return Unknown
-	case GitTransportEscalationBiased:
-		if contains("connection refused", "connection reset", "connection timed out", "failed to connect", "couldn't connect to server", "could not resolve host", "couldn't resolve host", "network is unreachable", "operation timed out", "temporary failure in name resolution", "no route to host", "ssh: connect to host", "recv failure", "tls handshake timeout", "empty reply from server", "early eof", "unexpected disconnect while reading sideband packet") {
-			return Transient
-		}
-		return Unknown
-	case WorkflowProseRetryBiased:
-		switch {
-		case legacyWorkflowRateLimit(lower):
-			return RateLimited
-		case contains("connection refused", "connection reset", "could not resolve host", "no such host", "no route to host", "network is unreachable", "temporary failure in name resolution", "i/o timeout", "timed out", "context deadline exceeded", "tls handshake", "tls:"), hasWorkflowGatewayStatus(lower):
-			return Transient
-		case contains("bad credentials", "authentication failed", "failed to log in", "gh auth", "gh_token is invalid", "github_token is invalid", "token has expired", "could not read username for 'https://github.com'", "401 unauthorized"):
-			return Auth
-		default:
-			return Unknown
-		}
-	case AgentRecoveryBiased:
-		switch {
-		case contains("clone", "fetch origin", "git fetch", "could not resolve host", "dial tcp", "i/o timeout", "dns"),
-			strings.Contains(lower, "git") && strings.Contains(lower, "network"):
-			return Transient
-		case contains("rate limit", "429", "overloaded"):
-			return RateLimited
-		default:
-			return Unknown
-		}
-	case AgentStreamRecoveryBiased:
-		if contains("529", "overloaded") {
-			return RateLimited
-		}
-		return Unknown
-	case LLMExecRecoveryBiased:
-		if hasStandaloneCode(lower, "529") || contains("overloaded") {
-			return RateLimited
-		}
-		return Unknown
-	case PRFixProseRetryBiased:
-		switch {
-		case contains("missing credential", "authentication", "permission denied"):
-			return Unknown
-		case contains("connection refused", "connection reset", "connection timed out", "failed to connect", "couldn't connect to server", "could not resolve host", "couldn't resolve host", "network is unreachable", "operation timed out", "temporary failure in name resolution", "no route to host", "ssh: connect to host", "recv failure", "tls handshake timeout", "empty reply from server", "early eof", "unexpected disconnect while reading sideband packet"),
-			strings.Contains(lower, "remote unreachable"),
-			strings.Contains(lower, "transport") && strings.Contains(lower, "github"):
-			return Transient
-		default:
-			return Unknown
-		}
-	default:
-		return Unknown
-	}
+	return decisionDefault
+}
+
+func legacyGitHubTransient(s string) bool {
+	return legacyGitHubNetworkTransient(s) || legacyGitHubRate(s)
+}
+
+func legacyGitHubNetworkTransient(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, "http 5") || containsAny(lower, legacyGitHubTransientPhrases()...)
+}
+
+func legacyGitHubAuth(s string) bool {
+	return containsAnyLower(s, GitHubAuthCircuitMarker, "http 401", "bad credentials", "gh auth login", "gh_token environment variable")
+}
+
+func legacyGitHubRate(s string) bool {
+	return containsAnyLower(s, GitHubRateLimitWallMarker, "secondary rate limit", "api rate limit exceeded", "rate limit exceeded")
+}
+
+func legacyMonitorRate(s string) bool {
+	return containsAnyLower(s, "api rate limit exceeded", "secondary rate limit")
+}
+
+func legacyGHCommandTransient(s string) bool {
+	return containsAnyLower(s, legacyGHCommandTransientPhrases()...)
+}
+
+func legacyGitTransport(s string) bool {
+	return containsAnyLower(s, legacyGitTransportPhrases()...)
 }
 
 func legacyWorkflowRateLimit(lower string) bool {
-	if !strings.Contains(lower, "rate limit") {
-		return false
+	return strings.Contains(lower, "rate limit") &&
+		(strings.Contains(lower, "github") || strings.Contains(lower, "graphql") ||
+			strings.Contains(lower, "gh ") || strings.Contains(lower, "api rate limit") ||
+			strings.Contains(lower, "secondary rate limit"))
+}
+
+func containsLower(s, phrase string) bool { return strings.Contains(strings.ToLower(s), phrase) }
+
+func containsAnyLower(s string, phrases ...string) bool {
+	return containsAny(strings.ToLower(s), phrases...)
+}
+
+func containsAny(lower string, phrases ...string) bool {
+	for _, phrase := range phrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
 	}
-	return strings.Contains(lower, "github") || strings.Contains(lower, "graphql") ||
-		strings.Contains(lower, "gh ") || strings.Contains(lower, "api rate limit") ||
-		strings.Contains(lower, "secondary rate limit")
+	return false
+}
+
+func legacyGitHubTransientPhrases() []string {
+	return []string{"dial tcp", "i/o timeout", "context deadline exceeded", "connection reset", "connection refused", "tls handshake timeout", "no route to host"}
+}
+
+func legacyGHCommandTransientPhrases() []string {
+	return []string{"http 502", "http 503", "http 504", "operation timed out", "i/o timeout", "deadline exceeded", "connection reset", "connection refused", "stream error", "unexpected eof", "tls handshake"}
+}
+
+func legacyGitTransportPhrases() []string {
+	return []string{"connection refused", "connection reset", "connection timed out", "failed to connect", "couldn't connect to server", "could not resolve host", "couldn't resolve host", "network is unreachable", "operation timed out", "temporary failure in name resolution", "no route to host", "ssh: connect to host", "recv failure", "tls handshake timeout", "empty reply from server", "early eof", "unexpected disconnect while reading sideband packet"}
+}
+
+func legacyWorkflowTransientPhrases() []string {
+	return []string{"connection refused", "connection reset", "could not resolve host", "no such host", "no route to host", "network is unreachable", "temporary failure in name resolution", "i/o timeout", "timed out", "context deadline exceeded", "tls handshake", "tls:"}
+}
+
+func legacyWorkflowAuthPhrases() []string {
+	return []string{"bad credentials", "authentication failed", "failed to log in", "gh auth", "gh_token is invalid", "github_token is invalid", "token has expired", "could not read username for 'https://github.com'", "401 unauthorized"}
+}
+
+func legacyAgentGitPhrases() []string {
+	return []string{"clone", "fetch origin", "git fetch", "could not resolve host", "dial tcp", "i/o timeout", "dns"}
+}
+
+func legacyMergeBlockedPhrases() []string {
+	return []string{"not mergeable", "required status check", "review is required", "changes requested", "waiting for status", "blocked by", "base branch policy prohibits the merge"}
 }
 
 func recordedCompatibilityCorpus() []string {
-	vocabulary := []string{
-		"", "ordinary failure", "HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504",
-		"401 unauthorized", "HTTP 401", "bad credentials", "gh auth login",
-		"github auth circuit open", "secondary rate limit", "api rate limit exceeded",
-		"rate limit exceeded", "github rate-limit wall", "context deadline exceeded",
-		"connection timed out", "operation timed out", "i/o timeout", "dial tcp",
-		"connection reset", "connection refused", "could not resolve host", "no such host",
-		"network is unreachable", "tls handshake timeout", "tls: certificate signed by unknown authority",
-		"tls: first record does not look like a TLS handshake", "stream error", "unexpected EOF",
-		"git fetch", "clone failed", "DNS", "429", "529", "1529", "overloaded", "waiting for status timed out",
-		"required status check", "review is required", "base branch policy prohibits the merge",
-		"permission denied", "authentication failed", "token has expired", "GitHub API rate limit",
-		"missing credential", "remote unreachable", "GitHub transport failure",
-	}
-	templates := []string{
-		"%s %s", "ERROR: %s (%s)", "prefix[%s]suffix %s", "before %s after %s", "%s; then %s",
-		"(%s) unrelated=%s", "UPPER %s / lower %s", "%s\n%s",
-	}
+	phrases := compatibilityVocabulary()
 	out := make([]string, 0, compatibilityCorpusSize)
-	for _, value := range vocabulary {
-		out = append(out, value, strings.ToUpper(value), "wrapped: "+value)
+	seen := make(map[string]struct{}, compatibilityCorpusSize)
+	add := func(s string) {
+		if len(out) == compatibilityCorpusSize {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
 	}
-	for i := 0; len(out) < compatibilityCorpusSize; i++ {
-		a := vocabulary[i%len(vocabulary)]
-		b := vocabulary[(i*37+11)%len(vocabulary)]
-		out = append(out, fmt.Sprintf(templates[i%len(templates)], a, b))
+
+	for _, phrase := range phrases {
+		for _, variant := range phraseVariants(phrase) {
+			add(variant)
+		}
 	}
-	return out[:compatibilityCorpusSize]
+	for _, sample := range recordedRealErrors() {
+		add(sample)
+	}
+
+	rng := rand.New(rand.NewSource(0x3162))
+	separators := []string{"; ", "\n", " | ", ": ", " ... ", " [cause] ", " / "}
+	for len(out) < compatibilityCorpusSize {
+		a := phrases[rng.Intn(len(phrases))]
+		b := phrases[rng.Intn(len(phrases))]
+		c := phrases[rng.Intn(len(phrases))]
+		sep1 := separators[rng.Intn(len(separators))]
+		sep2 := separators[rng.Intn(len(separators))]
+		add(fmt.Sprintf("recorded-%05d: %s%s%s%s%s", len(out), a, sep1, b, sep2, c))
+	}
+	return out
+}
+
+func compatibilityVocabulary() []string {
+	groups := [][]string{
+		badRefPhrases,
+		legacyGitHubTransientPhrases(),
+		legacyGHCommandTransientPhrases(),
+		{GitHubRateLimitWallMarker, "secondary rate limit", "api rate limit exceeded", "rate limit exceeded"},
+		{GitHubAuthCircuitMarker, "http 401", "401 unauthorized", "bad credentials", "gh auth login", "gh_token environment variable"},
+		legacyGitTransportPhrases(),
+		legacyWorkflowTransientPhrases(),
+		legacyWorkflowAuthPhrases(),
+		legacyAgentGitPhrases(),
+		{"rate limit", "429", "529", "1529", "overloaded"},
+		legacyMergeBlockedPhrases(),
+		{"x509:", "tls: first record does not look like a tls handshake", "missing credential", "authentication", "permission denied", "eacces", "operation not permitted", "remote unreachable", "github transport failure", "http 500", "http 502", "http 503", "http 504", "ordinary failure", ""},
+	}
+	var out []string
+	seen := map[string]struct{}{}
+	for _, group := range groups {
+		for _, phrase := range group {
+			if _, ok := seen[phrase]; ok {
+				continue
+			}
+			seen[phrase] = struct{}{}
+			out = append(out, phrase)
+		}
+	}
+	return out
+}
+
+func phraseVariants(phrase string) []string {
+	return []string{
+		phrase,
+		strings.ToUpper(phrase),
+		"error: " + phrase,
+		"prefix[" + phrase + "]suffix",
+		"before " + phrase + " after",
+		phrase + "\ncaused by: ordinary failure",
+		"ordinary failure; " + phrase,
+		"token=" + phrase,
+		"İnput «" + phrase + "» Ω",
+	}
+}
+
+func recordedRealErrors() []string {
+	return []string{
+		"gh: Bad credentials (HTTP 401)",
+		"gh: Bad credentials; HTTP 503",
+		"gh: Bad credentials; API rate limit exceeded",
+		"GraphQL: API rate limit exceeded for user ID 1",
+		"You have exceeded a secondary rate limit",
+		"HTTP 403: rate limit exceeded",
+		"Post https://api.github.com/graphql: dial tcp: i/o timeout",
+		"Get https://api.github.com: context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+		"read tcp 127.0.0.1:443: connection reset by peer",
+		"ssh: connect to host github.com port 22: Operation timed out",
+		"fatal: unable to access 'https://github.com/o/r/': Could not resolve host: github.com",
+		"fatal: unable to access 'https://github.com/o/r/': TLS connect error",
+		"tls: first record does not look like a TLS handshake",
+		"x509: certificate signed by unknown authority",
+		"error: RPC failed; curl 56 Recv failure: Connection reset by peer",
+		"fetch-pack: unexpected disconnect while reading sideband packet",
+		"fatal: early EOF",
+		"waiting for status timed out",
+		"merge blocked by required status check",
+		"git fetch origin failed: API rate limit exceeded",
+		"provider overloaded (529)",
+		"processed 1529 tokens successfully",
+		"could not read Username for 'https://github.com': terminal prompts disabled",
+		"GH_TOKEN environment variable is invalid",
+		"remote unreachable: GitHub transport failure",
+	}
+}
+
+func corpusHash(corpus []string) string {
+	h := sha256.New()
+	for _, input := range corpus {
+		_, _ = h.Write([]byte(input))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/errclass/compatibility_test.go
+++ b/internal/errclass/compatibility_test.go
@@ -17,14 +17,14 @@ const (
 type downstreamDecision string
 
 const (
-	decisionDefault  downstreamDecision = "default"
-	decisionRetry    downstreamDecision = "retry"
-	decisionCooldown downstreamDecision = "cooldown"
-	decisionAuth     downstreamDecision = "auth-circuit"
-	decisionBlocked  downstreamDecision = "blocked"
-	decisionGit      downstreamDecision = "git-recovery"
-	decisionCapacity downstreamDecision = "capacity-recovery"
-	decisionStop     downstreamDecision = "stop"
+	decisionDefault   downstreamDecision = "default"
+	decisionRetry     downstreamDecision = "retry"
+	decisionCooldown  downstreamDecision = "cooldown"
+	decisionAuth      downstreamDecision = "auth-circuit"
+	decisionMergeHeld downstreamDecision = "merge-held"
+	decisionGit       downstreamDecision = "git-recovery"
+	decisionCapacity  downstreamDecision = "capacity-recovery"
+	decisionStop      downstreamDecision = "stop"
 )
 
 type compatibilitySite struct {
@@ -283,7 +283,7 @@ func legacyMergeDecision(s string) downstreamDecision {
 	case legacyGitHubNetworkTransient(s):
 		return decisionRetry
 	case containsAnyLower(s, legacyMergeBlockedPhrases()...):
-		return decisionBlocked
+		return decisionMergeHeld
 	default:
 		return decisionDefault
 	}
@@ -298,7 +298,7 @@ func currentMergeDecision(s string) downstreamDecision {
 	case Transient:
 		return decisionRetry
 	case Permanent:
-		return decisionBlocked
+		return decisionMergeHeld
 	default:
 		return decisionDefault
 	}

--- a/internal/errclass/compatibility_test.go
+++ b/internal/errclass/compatibility_test.go
@@ -405,6 +405,9 @@ func legacyMergeBlockedPhrases() []string {
 
 func recordedCompatibilityCorpus() []string {
 	phrases := compatibilityVocabulary()
+	if len(phrases) == 0 {
+		panic("compatibility vocabulary is empty")
+	}
 	out := make([]string, 0, compatibilityCorpusSize)
 	seen := make(map[string]struct{}, compatibilityCorpusSize)
 	add := func(s string) {

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -59,8 +59,13 @@ type Policy string
 
 const (
 	// GitHubPollerRetryBiased reads wrapped GitHub errors. A missed transient
-	// answer escalates every affected poller, so this policy includes every 5xx.
+	// answer escalates every affected poller, so this policy includes every 5xx
+	// and gives transient evidence precedence over auth/rate-limit overlays.
 	GitHubPollerRetryBiased Policy = "github-poller-retry-biased"
+	// GitHubCircuitEscalationBiased reads the same wrapped GitHub errors at
+	// callers that check authentication first. A mixed error must trip the
+	// shared auth circuit instead of entering the ordinary transient retry path.
+	GitHubCircuitEscalationBiased Policy = "github-circuit-escalation-biased"
 	// GHCommandEscalationBiased reads raw gh output inside the immediate retry
 	// loop. It excludes plain 500 and rate limits so retries do not amplify them.
 	GHCommandEscalationBiased Policy = "gh-command-escalation-biased"
@@ -97,7 +102,7 @@ func (p Policy) Bias() Bias {
 	switch p {
 	case GitHubPollerRetryBiased, WorkflowProseRetryBiased, PRFixProseRetryBiased:
 		return RetryBiased
-	case GHCommandEscalationBiased, GitTransportEscalationBiased:
+	case GitHubCircuitEscalationBiased, GHCommandEscalationBiased, GitTransportEscalationBiased:
 		return EscalationBiased
 	case MonitorCooldownBiased, GitHubTokenMintCooldownBiased:
 		return CooldownBiased
@@ -182,7 +187,9 @@ func Classify(text string, policy Policy) Class {
 	lower := strings.ToLower(text)
 	switch policy {
 	case GitHubPollerRetryBiased:
-		return classifyGitHubPoller(lower)
+		return classifyGitHubPollerRetryFirst(lower)
+	case GitHubCircuitEscalationBiased:
+		return classifyGitHubPollerAuthFirst(lower)
 	case GHCommandEscalationBiased:
 		return classifyGHCommand(lower)
 	case MonitorCooldownBiased:
@@ -206,7 +213,22 @@ func Classify(text string, policy Policy) Class {
 	}
 }
 
-func classifyGitHubPoller(lower string) Class {
+func classifyGitHubPollerRetryFirst(lower string) Class {
+	switch {
+	case strings.Contains(lower, "http 5"), matchesLower(lower, githubTransientPhrases):
+		return Transient
+	case matchesLower(lower, githubRateLimitPhrases):
+		return RateLimited
+	case matchesLower(lower, githubAuthPhrases):
+		return Auth
+	case matchesLower(lower, mergeBlockedPhrases):
+		return Permanent
+	default:
+		return Unknown
+	}
+}
+
+func classifyGitHubPollerAuthFirst(lower string) Class {
 	switch {
 	case matchesLower(lower, githubAuthPhrases):
 		return Auth

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -1,165 +1,401 @@
-// Package errclass holds every phrase table used to decide whether an error
-// is transient, rate limited, or an auth failure.
+// Package errclass is the single operational error classifier.
 //
-// The tables used to live in a dozen packages, where they drifted apart
-// unseen. The twelve bad-ref needles existed byte-identically in
-// internal/project and internal/workflow. internal/monitor knew two of the
-// four rate-limit phrases internal/github knew. Nothing made a reader of one
-// table aware of the others.
+// Callers choose a policy whose name states which classification mistake is
+// safer at that site. The policies intentionally do not share one indiscriminate
+// phrase union: pollers may retry broadly to avoid a board-wide escalation,
+// while git transport must classify narrowly because a false transient answer
+// can retry forever without reaching a human.
 //
-// This package co-locates them and does not merge them. Each caller keeps the
-// exact set it had, because the sets differ for good reasons: IsTransientError
-// gates poller escalation, where under-reporting transience escalates the
-// whole board; IsTransientNetworkError becomes worktree.ErrTransientFetch,
-// which callers must never escalate, so over-reporting there retries forever
-// with no human told; and the workflow tables read agent prose rather than a
-// transport error. Merging the answers changes retry and escalation behaviour
-// at every one of those sites and needs per-site judgement. See the follow-up
-// issue #3162.
+// Provider CLI signal parsing in internal/provider and telemetry aggregation in
+// internal/selfmonitor are deliberately outside this classifier. The former
+// consumes structured, provider-specific status fields and quota reset hints;
+// the latter labels observations and does not make retry/cooldown/park decisions.
 //
-// It is a leaf on purpose. internal/github depends on internal/clock alone, so
-// anything heavier here would cycle.
+// This package remains a leaf because internal/github can otherwise create an
+// import cycle.
 package errclass
 
 import "strings"
 
-// The one genuinely shared table, reached through IsBadRef.
-var (
-	// The twelve needles internal/project and internal/workflow each carried byte-identically.
-	badRefPhrases = []string{
-		"bad object head",
-		"fatal: bad object",
-		"not a valid object name",
-		"invalid object",
-		"invalid revision range",
-		"missing object",
-		"unable to read sha1 file",
-		"object file",
-		"loose object",
-		"unknown revision",
-		"ambiguous argument",
-		"reference broken",
-	}
+// Class is the four-way operational answer. Unknown is retained separately so
+// an unrecognized phrase is never silently promoted to a permanent failure.
+type Class string
+
+const (
+	Unknown     Class = "unknown"
+	Transient   Class = "transient"
+	RateLimited Class = "rate_limited"
+	Auth        Class = "auth"
+	Permanent   Class = "permanent"
 )
 
-// Tables owned by a single caller. They live here so a reader sees all of
-// them at once and can tell which phrase one table knows and another misses.
+// Synthetic GitHub errors use these canonical markers so their producers and
+// the classifier cannot drift independently.
+const (
+	GitHubAuthCircuitMarker   = "github auth circuit open"
+	GitHubRateLimitWallMarker = "github rate-limit wall"
+)
+
+// Bias documents which side of an ambiguous phrase is safer for a policy.
+type Bias string
+
+const (
+	// RetryBiased accepts an occasional extra bounded retry to avoid escalating
+	// a self-healing failure.
+	RetryBiased Bias = "retry"
+	// EscalationBiased accepts an occasional escalation to avoid an unbounded
+	// retry or a retry against unchanged state.
+	EscalationBiased Bias = "escalate"
+	// CooldownBiased accepts an occasional cooldown to avoid spending more of a
+	// shared rate-limit budget.
+	CooldownBiased Bias = "cooldown"
+	// RecoveryBiased accepts an occasional recovery dispatch to avoid burning a
+	// task's terminal workflow retry budget.
+	RecoveryBiased Bias = "recover"
+)
+
+// Policy identifies the input surface and its accepted error direction.
+type Policy string
+
+const (
+	// GitHubPollerRetryBiased reads wrapped GitHub errors. A missed transient
+	// answer escalates every affected poller, so this policy includes every 5xx.
+	GitHubPollerRetryBiased Policy = "github-poller-retry-biased"
+	// GHCommandEscalationBiased reads raw gh output inside the immediate retry
+	// loop. It excludes plain 500 and rate limits so retries do not amplify them.
+	GHCommandEscalationBiased Policy = "gh-command-escalation-biased"
+	// MonitorCooldownBiased reads direct gh issue-sink failures. A missed rate
+	// limit spends the shared token, so it follows the complete GitHub set.
+	MonitorCooldownBiased Policy = "monitor-cooldown-biased"
+	// GitHubTokenMintCooldownBiased reads a 403 installation-token response.
+	// The HTTP status supplies the GitHub context, so a bare rate-limit phrase
+	// is sufficient and must cooldown rather than report bad credentials.
+	GitHubTokenMintCooldownBiased Policy = "github-token-mint-cooldown-biased" //nolint:gosec // This names a policy; it is not a credential.
+	// GitTransportEscalationBiased reads git fetch/ls-remote failures. Its
+	// transient answer becomes a condition callers must never escalate.
+	GitTransportEscalationBiased Policy = "git-transport-escalation-biased"
+	// WorkflowProseRetryBiased reads agent prose, where bare timeout/TLS wording
+	// is useful reachability evidence and every retry is bounded by workflow state.
+	WorkflowProseRetryBiased Policy = "workflow-prose-retry-biased"
+	// AgentRecoveryBiased reads fatal provider-run errors. Recovery labels avoid
+	// consuming terminal workflow retry budget for capacity and clone failures.
+	AgentRecoveryBiased Policy = "agent-recovery-biased"
+	// AgentStreamRecoveryBiased preserves the provider stream's permissive
+	// substring fallback when structured overload fields are absent.
+	AgentStreamRecoveryBiased Policy = "agent-stream-recovery-biased"
+	// LLMExecRecoveryBiased requires 529 to be a standalone status code so an
+	// unrelated token count such as 1529 cannot fail over a provider.
+	LLMExecRecoveryBiased Policy = "llmexec-recovery-biased"
+	// PRFixProseRetryBiased reads a persisted worktree-preparation reason. A
+	// false transient answer repeats recovery, but that retry is bounded; a
+	// missed transient strands an otherwise recoverable PR-fix task.
+	PRFixProseRetryBiased Policy = "pr-fix-prose-retry-biased"
+)
+
+// Bias reports the documented error direction for policy.
+func (p Policy) Bias() Bias {
+	switch p {
+	case GitHubPollerRetryBiased, WorkflowProseRetryBiased, PRFixProseRetryBiased:
+		return RetryBiased
+	case GHCommandEscalationBiased, GitTransportEscalationBiased:
+		return EscalationBiased
+	case MonitorCooldownBiased, GitHubTokenMintCooldownBiased:
+		return CooldownBiased
+	case AgentRecoveryBiased, AgentStreamRecoveryBiased, LLMExecRecoveryBiased:
+		return RecoveryBiased
+	default:
+		return ""
+	}
+}
+
 var (
-	// github.IsTransientError, whose false answer escalates a poller.
-	GitHubTransientPhrases = []string{
-		"dial tcp",
-		"i/o timeout",
-		"context deadline exceeded",
-		"connection reset",
-		"connection refused",
-		"tls handshake timeout",
+	badRefPhrases = []string{
+		"bad object head", "fatal: bad object", "not a valid object name",
+		"invalid object", "invalid revision range", "missing object",
+		"unable to read sha1 file", "object file", "loose object",
+		"unknown revision", "ambiguous argument", "reference broken",
+	}
+
+	githubTransientPhrases = []string{
+		"dial tcp", "i/o timeout", "context deadline exceeded",
+		"connection reset", "connection refused", "tls handshake timeout",
 		"no route to host",
 	}
-
-	// github.isTransientGHError, which reads raw gh output rather than a wrapped error.
-	GHOutputTransientPhrases = []string{
-		"http 502",
-		"http 503",
-		"http 504",
-		"operation timed out",
-		"i/o timeout",
-		"deadline exceeded",
-		"connection reset",
-		"connection refused",
-		"stream error",
-		"unexpected eof",
-		"tls handshake",
+	ghOutputTransientPhrases = []string{
+		"http 502", "http 503", "http 504", "operation timed out",
+		"i/o timeout", "deadline exceeded", "connection reset",
+		"connection refused", "stream error", "unexpected eof", "tls handshake",
 	}
-
-	// github.isRateLimitedMessage.
-	GitHubRateLimitPhrases = []string{
-		"secondary rate limit",
-		"api rate limit exceeded",
-		"rate limit exceeded",
+	githubRateLimitPhrases = []string{
+		GitHubRateLimitWallMarker, "secondary rate limit",
+		"api rate limit exceeded", "rate limit exceeded",
 	}
-
-	// github.isAuthErrorMsg. "gh auth login" stays narrow: the bare prefix also
-	// matches gh's missing-scope hint, which would hold the shared circuit open.
-	GitHubAuthPhrases = []string{
-		"http 401",
-		"bad credentials",
-		"gh auth login",
-		"gh_token environment variable",
+	githubAuthPhrases = []string{
+		GitHubAuthCircuitMarker, "http 401", "401 unauthorized",
+		"bad credentials", "gh auth login", "gh_token environment variable",
 	}
-
-	// monitor.classifyGHError, which knows fewer phrases than github does.
-	MonitorRateLimitPhrases = []string{
-		"api rate limit exceeded",
-		"secondary rate limit",
-	}
-
-	// project.IsTransientNetworkError, whose true answer must never escalate.
-	GitTransportPhrases = []string{
-		"connection refused",
-		"connection reset",
-		"connection timed out",
-		"failed to connect",
-		"couldn't connect to server",
-		"could not resolve host",
-		"couldn't resolve host",
-		"network is unreachable",
-		"operation timed out",
-		"temporary failure in name resolution",
-		"no route to host",
-		"ssh: connect to host",
-		"recv failure",
-		"tls handshake timeout",
-		"empty reply from server",
-		"early eof",
+	gitTransportPhrases = []string{
+		"connection refused", "connection reset", "connection timed out",
+		"failed to connect", "couldn't connect to server", "could not resolve host",
+		"couldn't resolve host", "network is unreachable", "operation timed out",
+		"temporary failure in name resolution", "no route to host",
+		"ssh: connect to host", "recv failure", "tls handshake timeout",
+		"empty reply from server", "early eof",
 		"unexpected disconnect while reading sideband packet",
 	}
-
-	// workflow.looksLikeTransientGitHub, which reads agent prose, so a bare
-	// "timed out" and "tls:" are reachability signals rather than merge state.
-	WorkflowTransientPhrases = []string{
-		"connection refused",
-		"connection reset",
-		"could not resolve host",
-		"no such host",
-		"no route to host",
-		"network is unreachable",
-		"temporary failure in name resolution",
-		"i/o timeout",
-		"timed out",
-		"context deadline exceeded",
-		"tls handshake",
-		"tls:",
+	workflowTransientPhrases = []string{
+		"connection refused", "connection reset", "could not resolve host",
+		"no such host", "no route to host", "network is unreachable",
+		"temporary failure in name resolution", "i/o timeout", "timed out",
+		"context deadline exceeded", "tls handshake", "tls:",
 	}
-
-	// workflow.looksLikeAuthFailure, whose "gh auth" is broader than github's
-	// because an echoed command is this site's usual credential signal.
-	WorkflowAuthPhrases = []string{
-		"bad credentials",
-		"authentication failed",
-		"failed to log in",
-		"gh auth",
-		"gh_token is invalid",
-		"github_token is invalid",
-		"token has expired",
-		"could not read username for 'https://github.com'",
-		"401 unauthorized",
+	workflowAuthPhrases = []string{
+		"bad credentials", "authentication failed", "failed to log in", "gh auth",
+		"gh_token is invalid", "github_token is invalid", "token has expired",
+		"could not read username for 'https://github.com'", "401 unauthorized",
 	}
-
-	// agent.classifyAgentError's rate_limit bucket.
-	AgentRateLimitPhrases = []string{
-		"rate limit",
-		"429",
-		"overloaded",
+	agentRateLimitPhrases = []string{"rate limit", "429", "overloaded"}
+	agentGitPhrases       = []string{
+		"clone", "fetch origin", "git fetch", "could not resolve host",
+		"dial tcp", "i/o timeout", "dns",
+	}
+	mergeBlockedPhrases = []string{
+		"not mergeable", "required status check", "review is required",
+		"changes requested", "waiting for status", "blocked by",
+		"base branch policy prohibits the merge",
+	}
+	explicitPermanentTransportPhrases = []string{
+		"x509:", "tls: first record does not look like a tls handshake",
+	}
+	prFixPermanentPhrases = []string{
+		"missing credential", "authentication", "permission denied",
 	}
 )
 
-// Matches reports whether text contains any phrase in families, comparing
-// case-insensitively. Every table entry is lowercase for that reason.
-func Matches(text string, families ...[]string) bool {
+// Classify answers the operational error question once under policy. Auth
+// outranks rate limiting, and rate limiting outranks an ordinary transient
+// failure unless a policy documents legacy precedence (the agent clone bucket).
+func Classify(text string, policy Policy) Class {
+	if text == "" {
+		return Unknown
+	}
+	lower := strings.ToLower(text)
+	switch policy {
+	case GitHubPollerRetryBiased:
+		return classifyGitHubPoller(lower)
+	case GHCommandEscalationBiased:
+		return classifyGHCommand(lower)
+	case MonitorCooldownBiased:
+		return classifyMonitor(lower)
+	case GitHubTokenMintCooldownBiased:
+		return classifyTokenMint(lower)
+	case GitTransportEscalationBiased:
+		return classifyGitTransport(lower)
+	case WorkflowProseRetryBiased:
+		return classifyWorkflowProse(lower)
+	case AgentRecoveryBiased:
+		return classifyAgent(lower)
+	case AgentStreamRecoveryBiased:
+		return classifyAgentStream(lower)
+	case LLMExecRecoveryBiased:
+		return classifyLLMExec(lower)
+	case PRFixProseRetryBiased:
+		return classifyPRFixProse(lower)
+	default:
+		return Unknown
+	}
+}
+
+func classifyGitHubPoller(lower string) Class {
+	switch {
+	case matchesLower(lower, githubAuthPhrases):
+		return Auth
+	case matchesLower(lower, githubRateLimitPhrases):
+		return RateLimited
+	case strings.Contains(lower, "http 5"), matchesLower(lower, githubTransientPhrases):
+		return Transient
+	case matchesLower(lower, mergeBlockedPhrases):
+		return Permanent
+	default:
+		return Unknown
+	}
+}
+
+func classifyGHCommand(lower string) Class {
+	switch {
+	case matchesLower(lower, ghOutputTransientPhrases):
+		return Transient
+	case matchesLower(lower, githubRateLimitPhrases):
+		return RateLimited
+	case matchesLower(lower, githubAuthPhrases):
+		return Auth
+	case strings.Contains(lower, "http 500"):
+		return Permanent
+	default:
+		return Unknown
+	}
+}
+
+func classifyMonitor(lower string) Class {
+	switch {
+	case matchesLower(lower, githubRateLimitPhrases):
+		return RateLimited
+	case matchesLower(lower, githubAuthPhrases):
+		return Auth
+	default:
+		return Unknown
+	}
+}
+
+func classifyTokenMint(lower string) Class {
+	if strings.Contains(lower, "rate limit") {
+		return RateLimited
+	}
+	return Unknown
+}
+
+func classifyGitTransport(lower string) Class {
+	switch {
+	case matchesLower(lower, gitTransportPhrases):
+		return Transient
+	case matchesLower(lower, githubAuthPhrases, workflowAuthPhrases):
+		return Auth
+	case matchesLower(lower, githubRateLimitPhrases):
+		return RateLimited
+	case matchesLower(lower, explicitPermanentTransportPhrases):
+		return Permanent
+	default:
+		return Unknown
+	}
+}
+
+func classifyWorkflowProse(lower string) Class {
+	// Preserve workflow's decision order: cooldown, then bounded transient
+	// retry, then bounded auth retry. Agent prose can mention more than one.
+	switch {
+	case isWorkflowRateLimit(lower):
+		return RateLimited
+	case matchesLower(lower, workflowTransientPhrases), hasWorkflowGatewayStatus(lower):
+		return Transient
+	case matchesLower(lower, workflowAuthPhrases):
+		return Auth
+	default:
+		return Unknown
+	}
+}
+
+func classifyAgent(lower string) Class {
+	// Preserve the agent's legacy precedence: a git-fetch error that also
+	// contains rate-limit prose belongs to the clone recovery bucket.
+	switch {
+	case matchesLower(lower, agentGitPhrases),
+		strings.Contains(lower, "git") && strings.Contains(lower, "network"):
+		return Transient
+	case matchesLower(lower, agentRateLimitPhrases):
+		return RateLimited
+	default:
+		return Unknown
+	}
+}
+
+func classifyAgentStream(lower string) Class {
+	if strings.Contains(lower, "529") || strings.Contains(lower, "overloaded") {
+		return RateLimited
+	}
+	return Unknown
+}
+
+func classifyLLMExec(lower string) Class {
+	if hasStandaloneCode(lower, "529") || strings.Contains(lower, "overloaded") {
+		return RateLimited
+	}
+	return Unknown
+}
+
+func classifyPRFixProse(lower string) Class {
+	switch {
+	case matchesLower(lower, prFixPermanentPhrases):
+		return Permanent
+	case matchesLower(lower, gitTransportPhrases),
+		strings.Contains(lower, "remote unreachable"),
+		strings.Contains(lower, "transport") && strings.Contains(lower, "github"):
+		return Transient
+	default:
+		return Unknown
+	}
+}
+
+// ClassifyErr is Classify over err. Nil has no evidence and is Unknown.
+func ClassifyErr(err error, policy Policy) Class {
+	if err == nil {
+		return Unknown
+	}
+	return Classify(err.Error(), policy)
+}
+
+// IsBadRef reports a corrupt or unresolvable git object or ref.
+func IsBadRef(text string) bool {
+	return matches(text, badRefPhrases)
+}
+
+func isWorkflowRateLimit(lower string) bool {
+	if !strings.Contains(lower, "rate limit") {
+		return false
+	}
+	return strings.Contains(lower, "github") ||
+		strings.Contains(lower, "graphql") ||
+		strings.Contains(lower, "gh ") ||
+		strings.Contains(lower, "api rate limit") ||
+		strings.Contains(lower, "secondary rate limit")
+}
+
+func hasWorkflowGatewayStatus(lower string) bool {
+	for _, code := range []string{"502", "503"} {
+		idx := strings.Index(lower, code)
+		if idx < 0 {
+			continue
+		}
+		if idx > 0 && isAlphaNumeric(lower[idx-1]) {
+			continue
+		}
+		end := idx + len(code)
+		if end < len(lower) && isAlphaNumeric(lower[end]) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isAlphaNumeric(b byte) bool {
+	return b >= '0' && b <= '9' || b >= 'a' && b <= 'z'
+}
+
+func hasStandaloneCode(lower, code string) bool {
+	for start := 0; start < len(lower); {
+		idx := strings.Index(lower[start:], code)
+		if idx < 0 {
+			return false
+		}
+		idx += start
+		end := idx + len(code)
+		if (idx == 0 || !isAlphaNumeric(lower[idx-1])) &&
+			(end == len(lower) || !isAlphaNumeric(lower[end])) {
+			return true
+		}
+		start = idx + 1
+	}
+	return false
+}
+
+func matches(text string, families ...[]string) bool {
 	if text == "" {
 		return false
 	}
-	lower := strings.ToLower(text)
+	return matchesLower(strings.ToLower(text), families...)
+}
+
+func matchesLower(lower string, families ...[]string) bool {
 	for _, family := range families {
 		for _, phrase := range family {
 			if strings.Contains(lower, phrase) {
@@ -168,9 +404,4 @@ func Matches(text string, families ...[]string) bool {
 		}
 	}
 	return false
-}
-
-// IsBadRef reports a corrupt or unresolvable git object or ref.
-func IsBadRef(text string) bool {
-	return Matches(text, badRefPhrases)
 }

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -177,9 +177,10 @@ var (
 	}
 )
 
-// Classify answers the operational error question once under policy. Auth
-// outranks rate limiting, and rate limiting outranks an ordinary transient
-// failure unless a policy documents legacy precedence (the agent clone bucket).
+// Classify answers the operational error question once under policy. Each
+// policy owns its precedence: retry-biased GitHub callers prefer transient and
+// rate-limit evidence, auth-circuit callers prefer auth, workflow prose prefers
+// rate limits, and agent recovery preserves the legacy git-clone bucket first.
 func Classify(text string, policy Policy) Class {
 	if text == "" {
 		return Unknown

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -395,7 +395,7 @@ func isAlphaNumeric(b byte) bool {
 
 func hasStandaloneCode(lower, code string) bool {
 	for token := range strings.FieldsFuncSeq(lower, func(r rune) bool {
-		return !(r >= '0' && r <= '9' || r >= 'a' && r <= 'z')
+		return (r < '0' || r > '9') && (r < 'a' || r > 'z')
 	}) {
 		if token == code {
 			return true

--- a/internal/errclass/errclass.go
+++ b/internal/errclass/errclass.go
@@ -394,18 +394,12 @@ func isAlphaNumeric(b byte) bool {
 }
 
 func hasStandaloneCode(lower, code string) bool {
-	for start := 0; start < len(lower); {
-		idx := strings.Index(lower[start:], code)
-		if idx < 0 {
-			return false
-		}
-		idx += start
-		end := idx + len(code)
-		if (idx == 0 || !isAlphaNumeric(lower[idx-1])) &&
-			(end == len(lower) || !isAlphaNumeric(lower[end])) {
+	for token := range strings.FieldsFuncSeq(lower, func(r rune) bool {
+		return !(r >= '0' && r <= '9' || r >= 'a' && r <= 'z')
+	}) {
+		if token == code {
 			return true
 		}
-		start = idx + 1
 	}
 	return false
 }

--- a/internal/errclass/errclass_test.go
+++ b/internal/errclass/errclass_test.go
@@ -24,10 +24,10 @@ func TestIsBadRef(t *testing.T) {
 }
 
 func TestMatchesIsCaseInsensitive(t *testing.T) {
-	if !Matches("FATAL: BAD OBJECT HEAD", badRefPhrases) {
-		t.Fatal("Matches should lowercase the input")
+	if !matches("FATAL: BAD OBJECT HEAD", badRefPhrases) {
+		t.Fatal("matches should lowercase the input")
 	}
-	if Matches("anything", nil) {
-		t.Fatal("Matches with no families should be false")
+	if matches("anything", nil) {
+		t.Fatal("matches with no families should be false")
 	}
 }

--- a/internal/errclass/families_test.go
+++ b/internal/errclass/families_test.go
@@ -8,15 +8,17 @@ import (
 func allFamilies() map[string][]string {
 	return map[string][]string{
 		"badRefPhrases":            badRefPhrases,
-		"GitHubTransientPhrases":   GitHubTransientPhrases,
-		"GHOutputTransientPhrases": GHOutputTransientPhrases,
-		"GitHubRateLimitPhrases":   GitHubRateLimitPhrases,
-		"GitHubAuthPhrases":        GitHubAuthPhrases,
-		"MonitorRateLimitPhrases":  MonitorRateLimitPhrases,
-		"GitTransportPhrases":      GitTransportPhrases,
-		"WorkflowTransientPhrases": WorkflowTransientPhrases,
-		"WorkflowAuthPhrases":      WorkflowAuthPhrases,
-		"AgentRateLimitPhrases":    AgentRateLimitPhrases,
+		"githubTransientPhrases":   githubTransientPhrases,
+		"ghOutputTransientPhrases": ghOutputTransientPhrases,
+		"githubRateLimitPhrases":   githubRateLimitPhrases,
+		"githubAuthPhrases":        githubAuthPhrases,
+		"gitTransportPhrases":      gitTransportPhrases,
+		"workflowTransientPhrases": workflowTransientPhrases,
+		"workflowAuthPhrases":      workflowAuthPhrases,
+		"agentRateLimitPhrases":    agentRateLimitPhrases,
+		"agentGitPhrases":          agentGitPhrases,
+		"mergeBlockedPhrases":      mergeBlockedPhrases,
+		"prFixPermanentPhrases":    prFixPermanentPhrases,
 	}
 }
 

--- a/internal/github/appauth.go
+++ b/internal/github/appauth.go
@@ -15,9 +15,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/sybra/internal/errclass"
 )
 
 // AppCredentials identifies a GitHub App installation. The private key stays on
@@ -403,7 +404,7 @@ func classifyMintError(err error) AuthState {
 	case http.StatusUnauthorized, http.StatusNotFound, http.StatusUnprocessableEntity:
 		return AuthMisconfigured
 	case http.StatusForbidden:
-		if strings.Contains(strings.ToLower(me.message), "rate limit") {
+		if errclass.Classify(me.message, errclass.GitHubTokenMintCooldownBiased) == errclass.RateLimited {
 			return AuthRateLimited
 		}
 		return AuthMisconfigured

--- a/internal/github/authhealth.go
+++ b/internal/github/authhealth.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -269,8 +268,7 @@ func (t *authHealthTracker) applyFailureBackoffLocked() {
 // ObserveCallResult can classify a combined stdout+stderr blob the same way
 // IsAuthError classifies a wrapped error.
 func isAuthErrorMsg(msg string) bool {
-	return strings.Contains(strings.ToLower(msg), authCircuitOpenMarker) ||
-		errclass.Matches(msg, errclass.GitHubAuthPhrases)
+	return errclass.Classify(msg, errclass.GitHubPollerRetryBiased) == errclass.Auth
 }
 
 // authCircuitOpenMarker tags the synthetic error returned while the circuit
@@ -278,7 +276,7 @@ func isAuthErrorMsg(msg string) bool {
 // outbox, push-preflight retry, poller circuits) treats a suppressed call the
 // same way it treats a real one instead of mistaking it for an unrelated
 // failure.
-const authCircuitOpenMarker = "github auth circuit open"
+const authCircuitOpenMarker = errclass.GitHubAuthCircuitMarker
 
 // NewAuthCircuitOpenError builds the synthetic error a gh invocation
 // chokepoint returns when it suppresses a call instead of shelling out.

--- a/internal/github/authhealth.go
+++ b/internal/github/authhealth.go
@@ -268,7 +268,7 @@ func (t *authHealthTracker) applyFailureBackoffLocked() {
 // ObserveCallResult can classify a combined stdout+stderr blob the same way
 // IsAuthError classifies a wrapped error.
 func isAuthErrorMsg(msg string) bool {
-	return errclass.Classify(msg, errclass.GitHubPollerRetryBiased) == errclass.Auth
+	return errclass.Classify(msg, errclass.GitHubCircuitEscalationBiased) == errclass.Auth
 }
 
 // authCircuitOpenMarker tags the synthetic error returned while the circuit

--- a/internal/github/automerge_backoff.go
+++ b/internal/github/automerge_backoff.go
@@ -2,11 +2,11 @@ package github
 
 import (
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/backoff"
+	"github.com/Automaat/sybra/internal/errclass"
 )
 
 // MergeErrorClass classifies a failed auto-merge attempt so AutoMergeBackoff
@@ -48,36 +48,18 @@ func ClassifyMergeError(err error) MergeErrorClass {
 	if err == nil {
 		return ""
 	}
-	switch {
-	case IsAuthError(err):
+	switch errclass.ClassifyErr(err, errclass.GitHubPollerRetryBiased) {
+	case errclass.Auth:
 		return MergeErrorAuth
-	case isRateLimitedMessage(strings.ToLower(err.Error())):
+	case errclass.RateLimited:
 		return MergeErrorRateLimit
-	case IsTransientError(err):
+	case errclass.Transient:
 		return MergeErrorTransient
-	case isMergeBlockedMessage(err.Error()):
+	case errclass.Permanent:
 		return MergeErrorBlocked
 	default:
 		return MergeErrorUnknown
 	}
-}
-
-func isMergeBlockedMessage(msg string) bool {
-	lower := strings.ToLower(msg)
-	for _, sig := range []string{
-		"not mergeable",
-		"required status check",
-		"review is required",
-		"changes requested",
-		"waiting for status",
-		"blocked by",
-		"base branch policy prohibits the merge",
-	} {
-		if strings.Contains(lower, sig) {
-			return true
-		}
-	}
-	return false
 }
 
 // autoMergeBackoffWindow maps a MergeErrorClass to its base retry delay and

--- a/internal/github/automerge_backoff.go
+++ b/internal/github/automerge_backoff.go
@@ -41,14 +41,13 @@ const (
 
 // ClassifyMergeError buckets a failed MergePR/MergePRViaREST/EnableAutoMerge
 // error so AutoMergeBackoff can size its retry window per failure mode.
-// Reuses the same message-matching helpers the rest of the package already
-// uses for retry decisions (IsAuthError, isRateLimitedMessage,
-// IsTransientError) instead of re-deriving the classification.
+// Uses the auth-first policy because the legacy caller checked auth, then rate
+// limit, then transient evidence before its merge-state bucket.
 func ClassifyMergeError(err error) MergeErrorClass {
 	if err == nil {
 		return ""
 	}
-	switch errclass.ClassifyErr(err, errclass.GitHubPollerRetryBiased) {
+	switch errclass.ClassifyErr(err, errclass.GitHubCircuitEscalationBiased) {
 	case errclass.Auth:
 		return MergeErrorAuth
 	case errclass.RateLimited:

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -697,16 +697,21 @@ func ViewerLoginCtx(ctx context.Context) string {
 // in-flight request at once, so a gap here turns a ten-second network wobble
 // into a board-wide escalation storm.
 func IsTransientError(err error) bool {
-	if err == nil {
-		return false
-	}
-	// A skipped optional poll (low GraphQL budget) is transient by design: back
-	// off and retry next cycle rather than treating it as a hard fetch failure.
-	if errors.Is(err, ErrBudgetExhausted) {
-		return true
-	}
-	class := errclass.ClassifyErr(err, errclass.GitHubPollerRetryBiased)
+	class := ClassifyError(err, errclass.GitHubPollerRetryBiased)
 	return class == errclass.Transient || class == errclass.RateLimited
+}
+
+// ClassifyError answers once under the caller's explicit GitHub policy. The
+// budget sentinel is transient independently of message text: it means an
+// optional poll was intentionally skipped until the shared budget recovers.
+func ClassifyError(err error, policy errclass.Policy) errclass.Class {
+	if err == nil {
+		return errclass.Unknown
+	}
+	if errors.Is(err, ErrBudgetExhausted) {
+		return errclass.Transient
+	}
+	return errclass.ClassifyErr(err, policy)
 }
 
 // IsAuthError reports whether err is a GitHub authentication failure — an

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -705,18 +705,8 @@ func IsTransientError(err error) bool {
 	if errors.Is(err, ErrBudgetExhausted) {
 		return true
 	}
-	msg := strings.ToLower(err.Error())
-	// HTTP 5xx: sanitized gh output produces "gh: http 5xx". Broader than the
-	// gateway-only list gh output uses, because this predicate gates poller
-	// escalation: a 500 read as permanent costs a board-wide escalation storm.
-	if strings.Contains(msg, "http 5") {
-		return true
-	}
-	// Rate limiting is backpressure, not a defect — GitHub is telling us to wait.
-	if isRateLimitedMessage(msg) {
-		return true
-	}
-	return errclass.Matches(msg, errclass.GitHubTransientPhrases)
+	class := errclass.ClassifyErr(err, errclass.GitHubPollerRetryBiased)
+	return class == errclass.Transient || class == errclass.RateLimited
 }
 
 // IsAuthError reports whether err is a GitHub authentication failure — an

--- a/internal/github/errclass_sites_test.go
+++ b/internal/github/errclass_sites_test.go
@@ -3,7 +3,25 @@ package github
 import (
 	"errors"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/errclass"
 )
+
+func TestClassifyError_MixedEvidenceRespectsCallerBias(t *testing.T) {
+	t.Parallel()
+	for _, msg := range []string{
+		"gh: Bad credentials; HTTP 503",
+		"gh: Bad credentials; API rate limit exceeded",
+	} {
+		err := errors.New(msg)
+		if !IsTransientError(err) {
+			t.Errorf("IsTransientError(%q) = false, want legacy retry-biased true", msg)
+		}
+		if got := ClassifyError(err, errclass.GitHubCircuitEscalationBiased); got != errclass.Auth {
+			t.Errorf("circuit classification for %q = %q, want auth", msg, got)
+		}
+	}
+}
 
 // TestIsTransientGHError_PinsLiterals pins the literal set isTransientGHError
 // matched before it moved onto errclass. StreamPhrases in particular had no

--- a/internal/github/errclass_sites_test.go
+++ b/internal/github/errclass_sites_test.go
@@ -67,9 +67,9 @@ func TestIsRateLimitedMessage_PinsLiterals(t *testing.T) {
 	}
 }
 
-// TestIsAuthErrorMsg_PinsLiterals pins the credential phrases, including the
-// two that stay local to this package: the narrow "gh auth login" and the
-// GH_TOKEN hint.
+// TestIsAuthErrorMsg_PinsLiterals pins the credential phrases. The shared
+// classifier deliberately adds the workflow site's "401 Unauthorized" so a
+// REST-shaped auth failure trips the same circuit instead of being invisible.
 func TestIsAuthErrorMsg_PinsLiterals(t *testing.T) {
 	for _, tc := range []struct {
 		msg  string
@@ -85,7 +85,7 @@ func TestIsAuthErrorMsg_PinsLiterals(t *testing.T) {
 		// would hold the shared circuit open across every gh call.
 		{msg: "gh: Your token has not been granted the required scopes. To request it, run: gh auth refresh -s read:org", want: false},
 		{msg: "fatal: Authentication failed for 'https://github.com/o/r.git/'", want: false},
-		{msg: "remote: 401 Unauthorized", want: false},
+		{msg: "remote: 401 Unauthorized", want: true},
 		{msg: "connection refused", want: false},
 		{msg: "", want: false},
 	} {

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -55,8 +55,7 @@ func isTransientGHError(out []byte, err error) bool {
 	if err == nil || isRateLimitedResponse(resp) {
 		return false
 	}
-	msg := string(out)
-	return errclass.Matches(msg, errclass.GHOutputTransientPhrases)
+	return errclass.Classify(string(out), errclass.GHCommandEscalationBiased) == errclass.Transient
 }
 
 type ttlCache[T any] struct {
@@ -298,7 +297,7 @@ func (g *ghRequestGate) lockContext(ctx context.Context) error {
 	return nil
 }
 
-const rateLimitWallMarker = "github rate-limit wall"
+const rateLimitWallMarker = errclass.GitHubRateLimitWallMarker
 
 type rateLimitWallError struct{ retryAfter time.Time }
 
@@ -423,8 +422,7 @@ func (g *ghRequestGate) pressure() (fraction float64, known bool) {
 }
 
 func isRateLimitedMessage(msg string) bool {
-	return strings.Contains(strings.ToLower(msg), rateLimitWallMarker) ||
-		errclass.Matches(msg, errclass.GitHubRateLimitPhrases)
+	return errclass.Classify(msg, errclass.GitHubPollerRetryBiased) == errclass.RateLimited
 }
 
 func isGraphQLRateLimitBody(body []byte) bool {
@@ -464,8 +462,7 @@ func isRateLimitedResponse(resp ghHTTPResponse) bool {
 	if json.Unmarshal(resp.body, &envelope) != nil {
 		return false
 	}
-	return strings.Contains(strings.ToLower(envelope.Message), "secondary rate limit") ||
-		strings.Contains(strings.ToLower(envelope.Message), "api rate limit exceeded")
+	return errclass.Classify(envelope.Message, errclass.GitHubPollerRetryBiased) == errclass.RateLimited
 }
 
 func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, error) {

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -422,7 +422,7 @@ func (g *ghRequestGate) pressure() (fraction float64, known bool) {
 }
 
 func isRateLimitedMessage(msg string) bool {
-	return errclass.Classify(msg, errclass.GitHubPollerRetryBiased) == errclass.RateLimited
+	return errclass.Classify(msg, errclass.MonitorCooldownBiased) == errclass.RateLimited
 }
 
 func isGraphQLRateLimitBody(body []byte) bool {
@@ -462,7 +462,7 @@ func isRateLimitedResponse(resp ghHTTPResponse) bool {
 	if json.Unmarshal(resp.body, &envelope) != nil {
 		return false
 	}
-	return errclass.Classify(envelope.Message, errclass.GitHubPollerRetryBiased) == errclass.RateLimited
+	return errclass.Classify(envelope.Message, errclass.MonitorCooldownBiased) == errclass.RateLimited
 }
 
 func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, error) {

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -13,11 +13,11 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"regexp"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/providerid"
 )
@@ -451,15 +451,12 @@ func classifyError(p, stderrOut, content string) provider.Classification {
 
 func overloaded(parts ...string) bool {
 	for _, p := range parts {
-		lower := strings.ToLower(p)
-		if overloadedStatusCode.MatchString(lower) || strings.Contains(lower, "overloaded") {
+		if errclass.Classify(p, errclass.LLMExecRecoveryBiased) == errclass.RateLimited {
 			return true
 		}
 	}
 	return false
 }
-
-var overloadedStatusCode = regexp.MustCompile(`\b529\b`)
 
 func schemaFlagRejected(providerName, schema string, parts ...string) bool {
 	if providerName != providerid.Codex || strings.TrimSpace(schema) == "" {

--- a/internal/monitor/issueoutbox.go
+++ b/internal/monitor/issueoutbox.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/github"
 	"gopkg.in/yaml.v3"
@@ -199,7 +200,7 @@ func (d *DurableGHIssueSink) SubmitIssue(ctx context.Context, title, body string
 	if err == nil {
 		return created, url, nil
 	}
-	if !github.IsAuthError(err) {
+	if github.ClassifyError(err, errclass.GitHubCircuitEscalationBiased) != errclass.Auth {
 		return created, url, err
 	}
 	d.persist(title, body, extraLabels, err)

--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -314,7 +314,7 @@ func classifyGHError(op string, out []byte, err error) error {
 	}
 	out = redactSecrets(out)
 	msg := err.Error() + "\n" + string(out)
-	if errclass.Matches(msg, errclass.MonitorRateLimitPhrases) {
+	if errclass.Classify(msg, errclass.MonitorCooldownBiased) == errclass.RateLimited {
 		return ErrGHRateLimit
 	}
 	if detail := sanitizeGHOutput(out); detail != "" {

--- a/internal/monitor/issuesink_test.go
+++ b/internal/monitor/issuesink_test.go
@@ -305,6 +305,22 @@ func TestGHIssueSink_ClassifiesRateLimitFromOutput(t *testing.T) {
 	}
 }
 
+func TestClassifyGHError_UsesCompleteGitHubRateLimitVocabulary(t *testing.T) {
+	t.Parallel()
+	for _, msg := range []string{
+		"rate limit exceeded",
+		"github rate-limit wall: suppressing calls",
+	} {
+		t.Run(msg, func(t *testing.T) {
+			t.Parallel()
+			err := classifyGHError("gh issue create", []byte(msg), errors.New("exit status 1"))
+			if !errors.Is(err, ErrGHRateLimit) {
+				t.Fatalf("classifyGHError(%q) = %v, want ErrGHRateLimit", msg, err)
+			}
+		})
+	}
+}
+
 func TestGHIssueSink_CreateErrorIncludesSanitizedOutput(t *testing.T) {
 	fe := &fakeExecer{
 		listResp:   []byte(`[]`),

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/metrics"
@@ -150,8 +151,9 @@ func (f *IssuesFetcher) Poll(ctx context.Context) time.Duration {
 	issues, err := f.fetchAssigned()
 	metrics.GitHubFetch(ctx, err == nil)
 	if err != nil {
-		switch {
-		case github.IsAuthError(err):
+		class := github.ClassifyError(err, errclass.GitHubCircuitEscalationBiased)
+		switch class {
+		case errclass.Auth:
 			f.transientFetchFails = 0
 			f.authCircuit.RecordFailure(err)
 			if f.authCircuit.Open() {
@@ -160,7 +162,7 @@ func (f *IssuesFetcher) Poll(ctx context.Context) time.Duration {
 			// Pre-trip: Info, not Warn, so up-to-threshold auth failures don't
 			// flood before the circuit's single trip line.
 			f.logger.Info("issues.fetch", "err", err)
-		case github.IsTransientError(err):
+		case errclass.Transient, errclass.RateLimited:
 			f.transientFetchFails++
 			if f.transientFetchFails < issuesTransientWarnThreshold {
 				f.logger.Info("issues.fetch", "err", err)
@@ -189,15 +191,16 @@ func (f *IssuesFetcher) pollSnapshot(ctx context.Context) {
 	snapshot, err := f.fetchSnapshot(repos, synapseIssueLabel)
 	metrics.GitHubFetch(ctx, err == nil)
 	if err != nil {
-		switch {
-		case github.IsAuthError(err):
+		class := github.ClassifyError(err, errclass.GitHubCircuitEscalationBiased)
+		switch class {
+		case errclass.Auth:
 			f.transientFetchFails = 0
 			f.authCircuit.RecordFailure(err)
 			if !f.authCircuit.Open() {
 				// Pre-trip: Info, not Warn (see Poll's auth branch).
 				f.logger.Info("issues.fetch", "err", err)
 			}
-		case github.IsTransientError(err):
+		case errclass.Transient, errclass.RateLimited:
 			f.transientFetchFails++
 			if f.transientFetchFails < issuesTransientWarnThreshold {
 				f.logger.Info("issues.fetch", "err", err)
@@ -246,7 +249,8 @@ func (f *IssuesFetcher) syncMentionedIssuesToTasks() {
 
 	mentioned, err := f.fetchMentioned(repos, f.mentionTrigger)
 	if err != nil {
-		if github.IsTransientError(err) {
+		class := github.ClassifyError(err, errclass.GitHubPollerRetryBiased)
+		if class == errclass.Transient || class == errclass.RateLimited {
 			f.transientMentionedFails++
 			if f.transientMentionedFails < issuesTransientWarnThreshold {
 				f.logger.Info("mentioned-issues.fetch", "err", err)
@@ -280,7 +284,8 @@ func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
 
 	labeled, err := f.fetchLabeled(repos, synapseIssueLabel)
 	if err != nil {
-		if github.IsTransientError(err) {
+		class := github.ClassifyError(err, errclass.GitHubPollerRetryBiased)
+		if class == errclass.Transient || class == errclass.RateLimited {
 			f.transientLabeledFails++
 			if f.transientLabeledFails < issuesTransientWarnThreshold {
 				f.logger.Info("labeled-issues.fetch", "err", err)

--- a/internal/poll/renovate.go
+++ b/internal/poll/renovate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/metrics"
@@ -143,8 +144,9 @@ func (h *RenovateHandler) pollRenovatePRs(ctx context.Context) time.Duration {
 	prs, err := fetchFn(ctx, cfg.Author, repos)
 	metrics.RenovatePoll(ctx, err == nil)
 	if err != nil {
-		switch {
-		case github.IsAuthError(err):
+		class := github.ClassifyError(err, errclass.GitHubCircuitEscalationBiased)
+		switch class {
+		case errclass.Auth:
 			h.transientFetchFails = 0
 			h.authCircuit.RecordFailure(err)
 			if h.authCircuit.Open() {
@@ -153,7 +155,7 @@ func (h *RenovateHandler) pollRenovatePRs(ctx context.Context) time.Duration {
 			// Pre-trip: Info, not Warn, so up-to-threshold auth failures don't
 			// flood before the circuit's single trip line.
 			h.logger.Info("renovate.fetch", "err", err)
-		case github.IsTransientError(err):
+		case errclass.Transient, errclass.RateLimited:
 			h.transientFetchFails++
 			if h.transientFetchFails < renovateTransientWarnThreshold {
 				h.logger.Info("renovate.fetch", "err", err)

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/github"
 	"gopkg.in/yaml.v3"
@@ -1151,7 +1152,7 @@ func pushLocked(ctx context.Context, worktreePath string, args ...string) error 
 			if err == nil {
 				return nil
 			}
-			if idx == 0 && len(attempts) > 1 && github.IsAuthError(err) {
+			if idx == 0 && len(attempts) > 1 && github.ClassifyError(err, errclass.GitHubCircuitEscalationBiased) == errclass.Auth {
 				injectedErr = err
 				continue
 			}
@@ -1766,7 +1767,7 @@ func checkGitPushAuth(ctx context.Context, worktreePath, remote string) error {
 			return nil
 		}
 		failures = append(failures, attempt.label+": "+msg)
-		if idx == 0 && len(attempts) > 1 && github.IsAuthError(attemptErr) {
+		if idx == 0 && len(attempts) > 1 && github.ClassifyError(attemptErr, errclass.GitHubCircuitEscalationBiased) == errclass.Auth {
 			continue
 		}
 		break

--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -13,10 +13,7 @@ var gitOpRetrySleepContext = sleepWithContext
 // network/transport failure from a git remote operation (fetch, ls-remote)
 // rather than a genuine content conflict, auth failure, or misconfiguration.
 func IsTransientNetworkError(err error) bool {
-	if err == nil {
-		return false
-	}
-	return errclass.Matches(err.Error(), errclass.GitTransportPhrases)
+	return errclass.ClassifyErr(err, errclass.GitTransportEscalationBiased) == errclass.Transient
 }
 
 // withNetworkRetry runs fn, retrying on gitOpRetryBackoffs when the failure

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -1,5 +1,12 @@
 package provider
 
+// Provider signal classification intentionally stays outside internal/errclass.
+// It consumes structured provider-specific status/type fields, distinguishes a
+// clean agent answer from provider stderr, and extracts quota reset hints that
+// determine cooldown duration. It already gives every provider runner one
+// centralized answer; reducing that evidence to an operational text policy
+// would reintroduce the false quota parks guarded below.
+
 import (
 	"strings"
 	"time"

--- a/internal/selfmonitor/loganalyzer.go
+++ b/internal/selfmonitor/loganalyzer.go
@@ -98,7 +98,10 @@ type ToolCallTrace struct {
 }
 
 // ErrorClass aggregates tool_result / result-event errors by a coarse
-// category (rate_limit, permission_denied, ...).
+// category (rate_limit, permission_denied, ...). These classifiers deliberately
+// stay local instead of using internal/errclass: they label structured telemetry
+// for reports and correlation, including classes such as not_found and
+// permission_denied, but never choose a runtime retry, cooldown, or park action.
 type ErrorClass struct {
 	Class  string `json:"class"`
 	Count  int    `json:"count"`

--- a/internal/sybra/app_renovate.go
+++ b/internal/sybra/app_renovate.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
@@ -110,7 +111,8 @@ func (c *renovateCoordinator) prsForMonitor() []github.PullRequest {
 func (c *renovateCoordinator) recordMonitorFetchError(err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if github.IsAuthError(err) {
+	class := github.ClassifyError(err, errclass.GitHubCircuitEscalationBiased)
+	if class == errclass.Auth {
 		// A dead token is not transient: the poller's circuit (skipped on in
 		// prsForMonitor) governs backoff, so keep this path quiet at Info
 		// rather than warn-flooding every monitor cycle (#1516).
@@ -118,7 +120,7 @@ func (c *renovateCoordinator) recordMonitorFetchError(err error) {
 		c.logger.Info("pr-monitor.renovate-fetch", "err", err)
 		return
 	}
-	if github.IsTransientError(err) {
+	if class == errclass.Transient || class == errclass.RateLimited {
 		c.monitorTransientFails++
 		if c.monitorTransientFails < review.TransientFetchWarnThreshold {
 			c.logger.Info("pr-monitor.renovate-fetch", "err", err)

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/experience"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/intervention"
@@ -568,10 +569,11 @@ func (r *Handler) fetchSplitReviewSummary(runSybraSearch, runAssignedSearch bool
 }
 
 func (r *Handler) handleReviewSummaryFetchError(ctx context.Context, tasks []task.Task, fetchErr error) time.Duration {
-	switch {
-	case github.IsTransientError(fetchErr):
+	class := github.ClassifyError(fetchErr, errclass.GitHubPollerRetryBiased)
+	switch class {
+	case errclass.Transient, errclass.RateLimited:
 		r.handleTransientReviewFetchError(ctx, tasks, fetchErr)
-	case github.IsAuthError(fetchErr):
+	case errclass.Auth:
 		r.transientFetchFails = 0
 		r.authCircuit.RecordFailure(fetchErr)
 		if r.authCircuit.Open() {
@@ -1013,7 +1015,7 @@ func (r *Handler) fetchKnownTaskPRs(matchers []github.TaskMatcher, retain []stri
 	for i := range results {
 		res := &results[i]
 		if res.Err != nil {
-			if github.IsAuthError(res.Err) {
+			if github.ClassifyError(res.Err, errclass.GitHubCircuitEscalationBiased) == errclass.Auth {
 				if authErr == nil {
 					authErr = res.Err
 				}

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/task"
@@ -417,7 +418,8 @@ const reconcileEscalationReason = "review reconcile failed"
 // task a fresh free budget, silently doubling how long #2164-style breakage
 // can run undetected across a redeploy.
 func (r *Handler) recordReconcileFailure(t *task.Task, err error) {
-	if github.IsTransientError(err) {
+	class := github.ClassifyError(err, errclass.GitHubPollerRetryBiased)
+	if class == errclass.Transient || class == errclass.RateLimited {
 		r.logger.Warn("review.my-state", "task_id", t.ID, "err", err, "transient", true)
 		return
 	}

--- a/internal/workflow/engine_steps_admission.go
+++ b/internal/workflow/engine_steps_admission.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/taskstatus"
 )
 
@@ -89,14 +90,15 @@ func (e *Engine) execAdmissionPreflight(taskID string, step *Step, wfExec *Execu
 // identical error moments later in the same workflow), while a genuine auth
 // failure or otherwise unclassifiable credential problem escalates to a
 // terminal blocker.KindCredentialRequired — the same distinction
-// looksLikeAuthFailure draws (a broken token does not self-heal, a network
-// blip does).
+// the workflow prose policy draws (a broken token does not self-heal, a
+// network blip does).
 func (e *Engine) classifyAdmissionCredentialError(taskID string, step *Step, wfExec *Execution, t TaskInfo, err error) (StepOutput, error) {
 	msg := err.Error()
-	switch {
-	case looksLikeGitHubRateLimit(msg):
+	class := errclass.Classify(msg, errclass.WorkflowProseRetryBiased)
+	switch class {
+	case errclass.RateLimited:
 		return e.parkStepForRetry(taskID, wfExec, t, step.ID, prCreateRetryStatusReason, "workflow.admission-preflight.rate-limit")
-	case looksLikeTransientGitHub(msg):
+	case errclass.Transient:
 		return e.parkStepForRetry(taskID, wfExec, t, step.ID, prCreateTransientStatusReason, "workflow.admission-preflight.transient")
 	default:
 		return e.blockAdmission(taskID, step, t, blocker.KindCredentialRequired,

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -306,15 +306,7 @@ func isPRCreationStep(stepID string) bool {
 }
 
 func looksLikeGitHubRateLimit(output string) bool {
-	lower := strings.ToLower(output)
-	if !strings.Contains(lower, "rate limit") {
-		return false
-	}
-	return strings.Contains(lower, "github") ||
-		strings.Contains(lower, "graphql") ||
-		strings.Contains(lower, "gh ") ||
-		strings.Contains(lower, "api rate limit") ||
-		strings.Contains(lower, "secondary rate limit")
+	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.RateLimited
 }
 
 // looksLikeTransientGitHub matches network-level failures that keep a PR
@@ -324,49 +316,12 @@ func looksLikeGitHubRateLimit(output string) bool {
 // looksLikeGitHubRateLimit (requires "rate limit") and looksLikeAuthFailure
 // (credential problems, which are not naturally time-bounded).
 func looksLikeTransientGitHub(output string) bool {
-	return errclass.Matches(output, errclass.WorkflowTransientPhrases) ||
-		looksLikeGatewayStatus(strings.ToLower(output))
-}
-
-// looksLikeGatewayStatus matches HTTP 502/503 responses regardless of how the
-// status is phrased ("HTTP 502", "502 bad gateway", "503 Service Unavailable",
-// ...) — GitHub/gh can surface either the bare code or a reason phrase.
-func looksLikeGatewayStatus(lower string) bool {
-	for _, code := range []string{"502", "503"} {
-		idx := strings.Index(lower, code)
-		if idx < 0 {
-			continue
-		}
-		// Guard against matching a status embedded in a larger token
-		// (e.g. "15029" or "abc502def") by requiring non-alphanumeric
-		// boundaries around the code.
-		if idx > 0 && !isStatusBoundary(lower[idx-1]) {
-			continue
-		}
-		end := idx + len(code)
-		if end < len(lower) && !isStatusBoundary(lower[end]) {
-			continue
-		}
-		return true
-	}
-	return false
-}
-
-func isDigit(b byte) bool {
-	return b >= '0' && b <= '9'
-}
-
-func isLowerAlpha(b byte) bool {
-	return b >= 'a' && b <= 'z'
-}
-
-func isStatusBoundary(b byte) bool {
-	return !isDigit(b) && !isLowerAlpha(b)
+	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.Transient
 }
 
 // looksLikeAuthFailure matches bad/expired GitHub credentials. Unlike rate
 // limits or network blips, a broken token does not self-heal, so callers must
 // bound how many times they retry before escalating to a human.
 func looksLikeAuthFailure(output string) bool {
-	return errclass.Matches(output, errclass.WorkflowAuthPhrases)
+	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.Auth
 }

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -187,12 +187,13 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 	reason := "no agent result to evaluate"
 	if last != nil {
 		if isPRCreationStep(last.StepID) {
-			switch {
-			case looksLikeGitHubRateLimit(last.Output):
+			class := errclass.Classify(last.Output, errclass.WorkflowProseRetryBiased)
+			switch class {
+			case errclass.RateLimited:
 				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateRetryStatusReason, "workflow.evaluate.pr-create-rate-limit")
-			case looksLikeTransientGitHub(last.Output):
+			case errclass.Transient:
 				return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateTransientStatusReason, "workflow.evaluate.pr-create-transient-outage")
-			case looksLikeAuthFailure(last.Output):
+			case errclass.Auth:
 				// Bad/expired credentials are not naturally time-bounded like a
 				// rate limit or a network blip, so they only get a bounded
 				// number of retries before escalating to a human.
@@ -202,6 +203,8 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 					return e.parkStepForRetry(taskID, wfExec, t, last.StepID, prCreateAuthRetryReason, "workflow.evaluate.pr-create-auth-retry", "attempt", attempts+1, "max", maxPRCreateAuthRetries)
 				}
 				reason = fmt.Sprintf("PR creation failing due to invalid or expired GitHub credentials after %d retries", attempts)
+			case errclass.Unknown, errclass.Permanent:
+				// Continue to the ordinary failed/no-PR evaluation below.
 			}
 		}
 		if reason == "no agent result to evaluate" {
@@ -296,32 +299,10 @@ func looksLikeImplementGitHubRetry(output string) bool {
 	if !githubish {
 		return false
 	}
-	return looksLikeGitHubRateLimit(output) ||
-		looksLikeTransientGitHub(output) ||
-		looksLikeAuthFailure(output)
+	class := errclass.Classify(output, errclass.WorkflowProseRetryBiased)
+	return class == errclass.RateLimited || class == errclass.Transient || class == errclass.Auth
 }
 
 func isPRCreationStep(stepID string) bool {
 	return stepID == "create_pr" || stepID == "push_existing_pr"
-}
-
-func looksLikeGitHubRateLimit(output string) bool {
-	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.RateLimited
-}
-
-// looksLikeTransientGitHub matches network-level failures that keep a PR
-// creation agent from reaching GitHub at all — DNS/connection errors, TLS
-// failures, timeouts, and 502/503 responses. These are naturally time-bounded
-// (retrying once connectivity is restored is safe) and are distinct from
-// looksLikeGitHubRateLimit (requires "rate limit") and looksLikeAuthFailure
-// (credential problems, which are not naturally time-bounded).
-func looksLikeTransientGitHub(output string) bool {
-	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.Transient
-}
-
-// looksLikeAuthFailure matches bad/expired GitHub credentials. Unlike rate
-// limits or network blips, a broken token does not self-heal, so callers must
-// bound how many times they retry before escalating to a human.
-func looksLikeAuthFailure(output string) bool {
-	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.Auth
 }

--- a/internal/workflow/engine_steps_pr.go
+++ b/internal/workflow/engine_steps_pr.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/gitexec"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/taskstatus"
@@ -454,12 +455,13 @@ func (e *Engine) escalatePendingConflictRecovery(taskID string) {
 // escalates exactly as before.
 func (e *Engine) classifyPRGitError(taskID string, step *Step, wfExec *Execution, t TaskInfo, err error, phase string) (StepOutput, error) {
 	msg := err.Error()
-	switch {
-	case looksLikeGitHubRateLimit(msg):
+	class := errclass.Classify(msg, errclass.WorkflowProseRetryBiased)
+	switch class {
+	case errclass.RateLimited:
 		return e.parkStepForRetry(taskID, wfExec, t, step.ID, prCreateRetryStatusReason, "workflow.pr-tail.rate-limit", "phase", phase)
-	case looksLikeTransientGitHub(msg):
+	case errclass.Transient:
 		return e.parkStepForRetry(taskID, wfExec, t, step.ID, prCreateTransientStatusReason, "workflow.pr-tail.transient", "phase", phase)
-	case looksLikeAuthFailure(msg):
+	case errclass.Auth:
 		attempts := parseWorkflowInt(wfExec.Variables[prCreateAuthAttemptsVar])
 		if attempts < maxPRCreateAuthRetries {
 			wfExec.SetVar(prCreateAuthAttemptsVar, strconv.Itoa(attempts+1))

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/errclass"
 	"github.com/Automaat/sybra/internal/prepstate"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/taskstatus"
@@ -175,15 +176,7 @@ func prFixShouldResumeNoPRRecovery(t TaskInfo, reason string) bool {
 	if reason == "" {
 		return false
 	}
-	lower := strings.ToLower(reason)
-	if strings.Contains(lower, "missing credential") || strings.Contains(lower, "authentication") || strings.Contains(lower, "permission denied") {
-		return false
-	}
-	if project.IsTransientNetworkError(errors.New(reason)) {
-		return true
-	}
-	return strings.Contains(lower, "remote unreachable") ||
-		(strings.Contains(lower, "transport") && strings.Contains(lower, "github"))
+	return errclass.Classify(reason, errclass.PRFixProseRetryBiased) == errclass.Transient
 }
 
 func (e *Engine) recordPreparedWorktreeState(taskID string, wfExec *Execution, t TaskInfo) {

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -1517,3 +1517,28 @@ func TestIsCodeAuthorRun_IncludesTestFix(t *testing.T) {
 		t.Error("isCodeAuthorRun({Role: \"test-fix\"}) = false, want true")
 	}
 }
+
+func TestPRFixShouldResumeNoPRRecovery_UsesSharedClassification(t *testing.T) {
+	t.Parallel()
+	withoutPR := TaskInfo{}
+	for _, tc := range []struct {
+		reason string
+		want   bool
+	}{
+		{"connection refused", true},
+		{"remote unreachable", true},
+		{"GitHub transport unavailable", true},
+		{"missing credential", false},
+		{"authentication failed", false},
+		{"permission denied", false},
+		{"unknown preparation failure", false},
+	} {
+		if got := prFixShouldResumeNoPRRecovery(withoutPR, tc.reason); got != tc.want {
+			t.Errorf("prFixShouldResumeNoPRRecovery(%q) = %v, want %v", tc.reason, got, tc.want)
+		}
+	}
+	withPR := TaskInfo{PRNumber: 42}
+	if prFixShouldResumeNoPRRecovery(withPR, "connection refused") {
+		t.Fatal("task with PR must not resume no-PR recovery")
+	}
+}

--- a/internal/workflow/errclass_sites_test.go
+++ b/internal/workflow/errclass_sites_test.go
@@ -3,7 +3,24 @@ package workflow
 import (
 	"errors"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/errclass"
 )
+
+// These predicate-shaped helpers exist only to keep the pre-#3162 literal
+// pinning tests readable. Production callers classify once and switch on the
+// four-way result; none use these adapters.
+func looksLikeGitHubRateLimit(output string) bool {
+	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.RateLimited
+}
+
+func looksLikeTransientGitHub(output string) bool {
+	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.Transient
+}
+
+func looksLikeAuthFailure(output string) bool {
+	return errclass.Classify(output, errclass.WorkflowProseRetryBiased) == errclass.Auth
+}
 
 // TestShouldRetryVerifyCommitsGitError_PinsLiterals pins the twelve bad-ref
 // needles this predicate carried before it moved onto errclass. It had no test


### PR DESCRIPTION
## Summary

- introduce one four-way operational classifier with named retry, escalation, cooldown, and recovery policies
- migrate GitHub, monitor, git transport, workflow prose, agent recovery, and LLM execution callers to classify each error once under an explicit bias
- preserve caller-specific precedence and downstream retry, cooldown, park, and backoff behavior
- add a hash-locked 18,242-input differential corpus across 14 downstream decision sites
- document why provider CLI signal parsing and self-monitor telemetry stay outside the operational classifier

## Deliberate behavior changes

- bare `401 Unauthorized` now reaches the shared GitHub authentication circuit
- monitor cooldown recognizes the complete GitHub rate-limit vocabulary

All other recorded decisions remain unchanged, including retry-first versus auth-first mixed evidence, plain HTTP 500 disagreement, narrow git transport handling, permanent TLS failures, blocked-merge backoff, and agent git-fetch precedence.

## Validation

- affected-package Go suites pass, including full workflow, review-handler, and Sybra suites
- affected-package golangci-lint passes
- independent adversarial review: PASS on `1609775a`
- independent adversarial testing: PASS, including corpus mutation and mixed-evidence probes

Closes #3162