### PR TITLE
fix(workflow): recreate worktrees during PR recovery

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -846,7 +846,11 @@ func (a *checkConfigGetterAdapter) SetupCommands(ctx context.Context, taskID str
 	return project.MergeSetup(repoSetup, p.SetupCommands)
 }
 
-func ensureReadyPRWorktree(ctx context.Context, tasks *task.Manager, mgr *worktree.Manager, taskID string) (path string, ok bool, err error) {
+// ensurePRTailWorktree restores a missing worktree for deterministic PR-tail
+// operations. Branch-conflict recovery runs while a task is in-progress, not
+// ready-pr, so limiting this to ready-pr strands an otherwise recoverable
+// branch just before push_branch can publish it.
+func ensurePRTailWorktree(ctx context.Context, tasks *task.Manager, mgr *worktree.Manager, taskID string) (path string, ok bool, err error) {
 	if tasks == nil || mgr == nil {
 		return "", false, nil
 	}
@@ -858,7 +862,7 @@ func ensureReadyPRWorktree(ctx context.Context, tasks *task.Manager, mgr *worktr
 	if _, err := os.Stat(path); err == nil {
 		return path, true, nil
 	}
-	if t.Status != task.StatusReadyPR || strings.TrimSpace(t.ProjectID) == "" {
+	if !statusCanRunPRTail(t.Status) || strings.TrimSpace(t.ProjectID) == "" {
 		return "", false, nil
 	}
 
@@ -875,8 +879,17 @@ func ensureReadyPRWorktree(ctx context.Context, tasks *task.Manager, mgr *worktr
 	return prepared, true, nil
 }
 
+func statusCanRunPRTail(status task.Status) bool {
+	switch status {
+	case task.StatusInProgress, task.StatusReadyReview, task.StatusInReview, task.StatusTesting, task.StatusReadyPR:
+		return true
+	default:
+		return false
+	}
+}
+
 func (a *worktreeGetterAdapter) GetWorktreePath(taskID string) (string, bool) {
-	path, ok, err := ensureReadyPRWorktree(context.Background(), a.tasks, a.mgr, taskID)
+	path, ok, err := ensurePRTailWorktree(context.Background(), a.tasks, a.mgr, taskID)
 	if err != nil {
 		return "", false
 	}
@@ -884,7 +897,7 @@ func (a *worktreeGetterAdapter) GetWorktreePath(taskID string) (string, bool) {
 }
 
 func (a *worktreeGetterAdapter) ResolvePRWorktree(ctx context.Context, taskID string) (path string, found bool, err error) {
-	return ensureReadyPRWorktree(ctx, a.tasks, a.mgr, taskID)
+	return ensurePRTailWorktree(ctx, a.tasks, a.mgr, taskID)
 }
 
 func (*attemptNoteAppenderAdapter) AppendReimplementNote(ctx context.Context, _, wtPath, marker, note string) error {
@@ -898,7 +911,7 @@ type branchSyncerAdapter struct {
 }
 
 func (a *branchSyncerAdapter) SyncTaskBranch(ctx context.Context, taskID string) (string, error) {
-	if _, ok, err := ensureReadyPRWorktree(ctx, a.tasks, a.mgr, taskID); err != nil {
+	if _, ok, err := ensurePRTailWorktree(ctx, a.tasks, a.mgr, taskID); err != nil {
 		return worktree.SyncFailed.String(), fmt.Errorf("sync branch: ensure worktree: %w", err)
 	} else if !ok {
 		return worktree.SyncSkipped.String(), nil

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -193,14 +193,14 @@ func TestBranchSyncerAdapter_TaskLookupFailureReturnsFailedResult(t *testing.T) 
 	}
 }
 
-type readyPRRecoveryHarness struct {
+type prTailRecoveryHarness struct {
 	branch string
 	task   task.Task
 	tasks  *task.Manager
 	mgr    *worktree.Manager
 }
 
-func newReadyPRRecoveryHarness(t *testing.T) readyPRRecoveryHarness {
+func newPRTailRecoveryHarness(t *testing.T, status task.Status) prTailRecoveryHarness {
 	t.Helper()
 
 	run := func(args ...string) {
@@ -283,7 +283,7 @@ func newReadyPRRecoveryHarness(t *testing.T) readyPRRecoveryHarness {
 		t.Fatal(err)
 	}
 	created, err = taskMgr.Update(created.ID, task.Update{
-		Status:    task.Ptr(task.StatusReadyPR),
+		Status:    task.Ptr(status),
 		ProjectID: task.Ptr("owner/repo"),
 		Branch:    task.Ptr(branch),
 	})
@@ -301,7 +301,7 @@ func newReadyPRRecoveryHarness(t *testing.T) readyPRRecoveryHarness {
 		t.Fatalf("expected no worktree before recovery, got err=%v", err)
 	}
 
-	return readyPRRecoveryHarness{
+	return prTailRecoveryHarness{
 		branch: branch,
 		task:   created,
 		tasks:  taskMgr,
@@ -312,7 +312,7 @@ func newReadyPRRecoveryHarness(t *testing.T) readyPRRecoveryHarness {
 func TestWorktreeGetterAdapter_GetWorktreePath_RecoversReadyPRWorktree(t *testing.T) {
 	t.Parallel()
 
-	h := newReadyPRRecoveryHarness(t)
+	h := newPRTailRecoveryHarness(t, task.StatusReadyPR)
 	adapter := &worktreeGetterAdapter{tasks: h.tasks, mgr: h.mgr}
 
 	path, ok := adapter.GetWorktreePath(h.task.ID)
@@ -337,7 +337,7 @@ func TestWorktreeGetterAdapter_GetWorktreePath_RecoversReadyPRWorktree(t *testin
 func TestWorktreeGetterAdapter_ResolvePRWorktree_RecoversRemoteBranch(t *testing.T) {
 	t.Parallel()
 
-	h := newReadyPRRecoveryHarness(t)
+	h := newPRTailRecoveryHarness(t, task.StatusReadyPR)
 	adapter := &worktreeGetterAdapter{tasks: h.tasks, mgr: h.mgr}
 
 	path, ok, err := adapter.ResolvePRWorktree(context.Background(), h.task.ID)
@@ -355,10 +355,12 @@ func TestWorktreeGetterAdapter_ResolvePRWorktree_RecoversRemoteBranch(t *testing
 	}
 }
 
-func TestBranchSyncerAdapter_SyncTaskBranch_RecoversMissingReadyPRWorktree(t *testing.T) {
+func TestBranchSyncerAdapter_SyncTaskBranch_RecoversMissingInProgressWorktree(t *testing.T) {
 	t.Parallel()
 
-	h := newReadyPRRecoveryHarness(t)
+	// branch-conflict-fix sets the task to in-progress before its deterministic
+	// push/sync tail needs the worktree again.
+	h := newPRTailRecoveryHarness(t, task.StatusInProgress)
 	adapter := &branchSyncerAdapter{tasks: h.tasks, mgr: h.mgr}
 
 	result, err := adapter.SyncTaskBranch(context.Background(), h.task.ID)


### PR DESCRIPTION
Restores missing task worktrees for deterministic PR-tail operations while a conflict-recovery workflow is in progress, rather than parking the task at `push_branch`.

Includes regression coverage for the `in-progress` branch-conflict recovery path.

Tests:
- `go test ./internal/sybra -run 'Test(WorktreeGetterAdapter|BranchSyncerAdapter_SyncTaskBranch_RecoversMissingInProgressWorktree)' -count=1`