### PR TITLE
feat: certify run environments before dispatch

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/blocker/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/blocker/models.ts
@@ -34,6 +34,7 @@ export enum Kind {
     KindReviewFixExhausted = "review_fix_exhausted",
     KindTriageRetryExhausted = "triage_retry_exhausted",
     KindWatchdogRateLimitExhausted = "watchdog_rate_limit_exhausted",
+    KindRunEnvironment = "run_environment",
 
     /**
      * KindDependencyScopeUnmet marks a task blocked on a depends_on issue

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3026,9 +3026,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -89,6 +89,10 @@ type Manager struct {
 	// built-in per-role reasoning-effort baseline, keyed by role name. Read by
 	// resolveReasoningEffort under mu.
 	roleEffort map[string]string
+	// runEnvironmentPreflight is the final application-owned admission gate
+	// after provider, sandbox home, cache roots, and sandbox policy have been
+	// resolved but before a provider process is registered or spawned.
+	runEnvironmentPreflight RunEnvironmentPreflight
 
 	defaultSandboxMode string
 	// defaultSandboxReadMode is the read-visibility posture layered on top of
@@ -198,6 +202,30 @@ type Manager struct {
 	// each free a slot collapses into a single pending wake-up for whatever
 	// dispatch loop reads QueueNudge.
 	queueNudge chan struct{}
+}
+
+// RunEnvironment is the exact provider-facing identity available immediately
+// before a process starts. ScratchRoots are the mutable non-source roots that
+// prepareRunConfig selected for this run.
+type RunEnvironment struct {
+	TaskID        string
+	Role          Role
+	Dir           string
+	ReadOnlyPaths []string
+	Provider      string
+	SandboxMode   string
+	ScratchRoots  []string
+}
+
+// RunEnvironmentPreflight certifies a prepared provider run before spawn.
+type RunEnvironmentPreflight func(context.Context, RunEnvironment) error
+
+// SetRunEnvironmentPreflight late-binds the application certification gate.
+// Nil disables it for focused Manager tests and standalone consumers.
+func (m *Manager) SetRunEnvironmentPreflight(preflight RunEnvironmentPreflight) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runEnvironmentPreflight = preflight
 }
 
 type LimitGate interface {

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -101,8 +101,40 @@ func (m *Manager) certifyPreparedRun(ctx context.Context, cfg RunConfig, provide
 	return preflight(ctx, RunEnvironment{
 		TaskID: cfg.TaskID, Role: cfg.Role, Dir: cfg.Dir, ReadOnlyPaths: slices.Clone(cfg.ReadOnlyPaths), Provider: providerName,
 		SandboxMode:  cfg.SandboxMode,
-		ScratchRoots: []string{cfg.resolvedSandboxHome, os.TempDir(), sharedBuildCacheDir()},
+		ScratchRoots: preparedScratchRoots(cfg),
 	})
+}
+
+func preparedScratchRoots(cfg RunConfig) []string {
+	roots := []string{
+		cfg.resolvedSandboxHome,
+		os.TempDir(),
+		sharedBuildCacheDir(),
+		buildcache.TaskGoBuildDir(cfg.TaskID),
+		buildcache.SharedGoModDir(),
+		buildcache.SharedNPMDir(),
+	}
+	if cfg.resolvedSandboxHome != "" {
+		roots = append(roots, filepath.Join(cfg.resolvedSandboxHome, "golangci-lint-cache"))
+	}
+	return compactPaths(roots)
+}
+
+func compactPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	result := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		result = append(result, path)
+	}
+	return result
 }
 
 // jitterDispatch sleeps a uniform random [0, dispatchJitterMs] duration so a
@@ -426,10 +458,21 @@ func (m *Manager) CertificationScratchRoots(taskID string) ([]string, error) {
 		return nil, errors.New("sandbox home resolver returned an empty path")
 	}
 	sharedCache := sharedBuildCacheDir()
-	if err := os.MkdirAll(sharedCache, 0o755); err != nil {
-		return nil, fmt.Errorf("create shared build cache root: %w", err)
+	roots := compactPaths([]string{
+		sandboxHome,
+		os.TempDir(),
+		sharedCache,
+		buildcache.TaskGoBuildDir(taskID),
+		buildcache.SharedGoModDir(),
+		buildcache.SharedNPMDir(),
+		filepath.Join(sandboxHome, "golangci-lint-cache"),
+	})
+	for _, root := range roots {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			return nil, fmt.Errorf("create certification scratch root %q: %w", root, err)
+		}
 	}
-	return []string{sandboxHome, os.TempDir(), sharedCache}, nil
+	return roots, nil
 }
 
 func (m *Manager) injectSharedBuildCache(cfg *RunConfig) error {

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"math/rand/v2"
@@ -62,6 +63,9 @@ func (m *Manager) RunContext(ctx context.Context, cfg RunConfig) (*Agent, error)
 	if err != nil {
 		return nil, err
 	}
+	if err := m.certifyPreparedRun(ctx, cfg, prov.Name()); err != nil {
+		return nil, err
+	}
 
 	id := uuid.NewString()[:8]
 	ctx, cancel := context.WithCancel(ctx)
@@ -85,6 +89,20 @@ func (m *Manager) RunContext(ctx context.Context, cfg RunConfig) (*Agent, error)
 
 	m.emit(events.AgentState(id), a)
 	return a, nil
+}
+
+func (m *Manager) certifyPreparedRun(ctx context.Context, cfg RunConfig, providerName string) error {
+	m.mu.RLock()
+	preflight := m.runEnvironmentPreflight
+	m.mu.RUnlock()
+	if preflight == nil {
+		return nil
+	}
+	return preflight(ctx, RunEnvironment{
+		TaskID: cfg.TaskID, Role: cfg.Role, Dir: cfg.Dir, ReadOnlyPaths: slices.Clone(cfg.ReadOnlyPaths), Provider: providerName,
+		SandboxMode:  cfg.SandboxMode,
+		ScratchRoots: []string{cfg.resolvedSandboxHome, os.TempDir(), sharedBuildCacheDir()},
+	})
 }
 
 // jitterDispatch sleeps a uniform random [0, dispatchJitterMs] duration so a
@@ -383,6 +401,35 @@ func (m *Manager) injectGolangciCache(cfg *RunConfig) error {
 
 func sharedBuildCacheDir() string {
 	return buildcache.SharedRoot()
+}
+
+// CertificationScratchRoots resolves and materializes the mutable roots that
+// prepareRunConfig will expose to a task-scoped provider process. Keeping this
+// projection on Manager prevents the run-environment gate from guessing at
+// private sandbox-home and build-cache policy.
+func (m *Manager) CertificationScratchRoots(taskID string) ([]string, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return nil, errors.New("certification scratch roots require a task id")
+	}
+	m.mu.RLock()
+	resolve := m.sandboxHome
+	m.mu.RUnlock()
+	if resolve == nil {
+		return nil, errors.New("certification scratch roots require a sandbox home resolver")
+	}
+	sandboxHome, err := resolve(taskID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox home: %w", err)
+	}
+	if strings.TrimSpace(sandboxHome) == "" {
+		return nil, errors.New("sandbox home resolver returned an empty path")
+	}
+	sharedCache := sharedBuildCacheDir()
+	if err := os.MkdirAll(sharedCache, 0o755); err != nil {
+		return nil, fmt.Errorf("create shared build cache root: %w", err)
+	}
+	return []string{sandboxHome, os.TempDir(), sharedCache}, nil
 }
 
 func (m *Manager) injectSharedBuildCache(cfg *RunConfig) error {

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -123,6 +123,7 @@ func (r Role) CapabilityRequirements(action string) []autonomy.CapabilityRequire
 	}
 	requirements := []autonomy.CapabilityRequirement{
 		{Capability: autonomy.CapabilitySourceRead, Action: action, Scope: "task", Repairable: true},
+		{Capability: autonomy.CapabilityScratchWrite, Action: action, Scope: "task", Repairable: true},
 		{Capability: autonomy.CapabilityObjectStore, Action: action, Scope: "project", Repairable: true},
 		{Capability: autonomy.CapabilityCheckoutHealth, Action: action, Scope: "task", Repairable: true},
 		{Capability: autonomy.CapabilitySandboxMechanism, Action: action, Scope: "host"},

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -124,10 +124,14 @@ func (r Role) CapabilityRequirements(action string) []autonomy.CapabilityRequire
 	requirements := []autonomy.CapabilityRequirement{
 		{Capability: autonomy.CapabilitySourceRead, Action: action, Scope: "task", Repairable: true},
 		{Capability: autonomy.CapabilityScratchWrite, Action: action, Scope: "task", Repairable: true},
-		{Capability: autonomy.CapabilityObjectStore, Action: action, Scope: "project", Repairable: true},
-		{Capability: autonomy.CapabilityCheckoutHealth, Action: action, Scope: "task", Repairable: true},
 		{Capability: autonomy.CapabilitySandboxMechanism, Action: action, Scope: "host"},
 		{Capability: autonomy.CapabilityProviderCapacity, Action: action, Scope: "provider"},
+	}
+	if r.AuthorsCode() || r.JudgesWithoutWriting() || r == RoleTestRunner {
+		requirements = append(requirements,
+			autonomy.CapabilityRequirement{Capability: autonomy.CapabilityObjectStore, Action: action, Scope: "project", Repairable: true},
+			autonomy.CapabilityRequirement{Capability: autonomy.CapabilityCheckoutHealth, Action: action, Scope: "task", Repairable: true},
+		)
 	}
 	if r.AuthorsCode() {
 		requirements = append(requirements,

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -124,6 +124,7 @@ func (r Role) CapabilityRequirements(action string) []autonomy.CapabilityRequire
 	requirements := []autonomy.CapabilityRequirement{
 		{Capability: autonomy.CapabilitySourceRead, Action: action, Scope: "task", Repairable: true},
 		{Capability: autonomy.CapabilityObjectStore, Action: action, Scope: "project", Repairable: true},
+		{Capability: autonomy.CapabilityCheckoutHealth, Action: action, Scope: "task", Repairable: true},
 		{Capability: autonomy.CapabilitySandboxMechanism, Action: action, Scope: "host"},
 		{Capability: autonomy.CapabilityProviderCapacity, Action: action, Scope: "provider"},
 	}

--- a/internal/agent/role_capability_test.go
+++ b/internal/agent/role_capability_test.go
@@ -26,10 +26,17 @@ func TestEveryRoleDeclaresValidCapabilities(t *testing.T) {
 func TestVerifierCapabilityContractDoesNotGrantAuthoritativeSourceWrite(t *testing.T) {
 	t.Parallel()
 	for _, role := range []Role{RoleReview, RolePlan, RolePlanCritic, RoleEval, RoleTestRunner} {
+		hasScratchWrite := false
 		for _, requirement := range role.CapabilityRequirements("verify") {
 			if requirement.Capability == "source_write" {
 				t.Errorf("verifier role %q received source_write", role)
 			}
+			if requirement.Capability == "scratch_write" {
+				hasScratchWrite = true
+			}
+		}
+		if !hasScratchWrite {
+			t.Errorf("verifier role %q did not receive scratch_write", role)
 		}
 	}
 }

--- a/internal/agent/role_capability_test.go
+++ b/internal/agent/role_capability_test.go
@@ -1,6 +1,10 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/autonomy"
+)
 
 func TestEveryRoleDeclaresValidCapabilities(t *testing.T) {
 	t.Parallel()
@@ -37,6 +41,26 @@ func TestVerifierCapabilityContractDoesNotGrantAuthoritativeSourceWrite(t *testi
 		}
 		if !hasScratchWrite {
 			t.Errorf("verifier role %q did not receive scratch_write", role)
+		}
+	}
+}
+
+func TestCheckoutCapabilitiesOnlyForCheckoutRoles(t *testing.T) {
+	t.Parallel()
+	for _, role := range AllRoles() {
+		want := role.AuthorsCode() || role.JudgesWithoutWriting() || role == RoleTestRunner
+		gotObjectStore := false
+		gotCheckoutHealth := false
+		for _, requirement := range role.CapabilityRequirements("dispatch") {
+			if requirement.Capability == autonomy.CapabilityObjectStore {
+				gotObjectStore = true
+			}
+			if requirement.Capability == autonomy.CapabilityCheckoutHealth {
+				gotCheckoutHealth = true
+			}
+		}
+		if gotObjectStore != want || gotCheckoutHealth != want {
+			t.Errorf("role %q checkout capabilities = object_store:%v checkout_health:%v, want both %v", role, gotObjectStore, gotCheckoutHealth, want)
 		}
 	}
 }

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -43,6 +43,26 @@ func TestPrepareRunConfig_SandboxHome_Injected(t *testing.T) {
 	}
 }
 
+func TestPreparedScratchRootsIncludeConcreteCacheDirectories(t *testing.T) {
+	t.Setenv("SYBRA_HOME", t.TempDir())
+	sandboxDir := t.TempDir()
+	cfg := RunConfig{TaskID: "task-cache", resolvedSandboxHome: sandboxDir}
+
+	got := preparedScratchRoots(cfg)
+	base := sharedBuildCacheDir()
+	for _, want := range []string{
+		sandboxDir,
+		filepath.Join(sandboxDir, "golangci-lint-cache"),
+		filepath.Join(base, "go-build", "task-cache"),
+		filepath.Join(base, "go-mod"),
+		filepath.Join(base, "npm"),
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("scratch roots %v do not contain %q", got, want)
+		}
+	}
+}
+
 // TestPrepareRunConfig_SandboxHome_SystemRunSkipsInjection pins that only
 // runs with an empty TaskID (system/probe runs) are allowed to skip sandbox
 // injection — every task-scoped run must go through it.

--- a/internal/agent/sandbox_probe.go
+++ b/internal/agent/sandbox_probe.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// SandboxPostureObservation separates mechanism availability from actual
+// containment. In particular report mode may validate a mechanism but is
+// never evidence that the provider process will be contained.
+type SandboxPostureObservation struct {
+	Mode      string
+	Mechanism string
+	Available bool
+	Contained bool
+	Evidence  string
+}
+
+// ProbeSandboxPosture validates the host mechanism and embedded profile
+// before dispatch, without spawning a provider process.
+func ProbeSandboxPosture(rawMode string) (SandboxPostureObservation, error) {
+	mode, err := config.NormalizeSandboxMode(rawMode)
+	if err != nil {
+		return SandboxPostureObservation{}, err
+	}
+	observation := SandboxPostureObservation{Mode: mode, Mechanism: sandboxWrapperName()}
+	if mode == "off" {
+		observation.Available = true
+		observation.Evidence = "sandbox posture is explicitly off"
+		return observation, nil
+	}
+	if !sandboxExecAvailable() {
+		observation.Evidence = sandboxWrapperName() + " unavailable"
+		if mode == "report" {
+			// Report is observational only and must never block a run or claim
+			// containment, even when the host wrapper is absent.
+			observation.Available = true
+			return observation, nil
+		}
+		return observation, fmt.Errorf("enforce sandbox mode requires %s", sandboxWrapperName())
+	}
+	observation.Available = true
+	if mode == "report" {
+		observation.Evidence = sandboxWrapperName() + " available; report mode does not wrap the process"
+		return observation, nil
+	}
+	profile, profileErr := materializeSandboxProfile()
+	if profileErr != nil {
+		observation.Available = false
+		observation.Evidence = "sandbox profile unavailable"
+		return observation, profileErr
+	}
+	observation.Contained = true
+	observation.Evidence = sandboxWrapperName() + " profile ready at " + profile
+	return observation, nil
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -27,7 +27,11 @@ const (
 	// on a block, the blocker.Kind and reason. Recorded on every dispatch,
 	// not just blocks, so evaluation can correlate predicted risk/clarity
 	// against actual task outcome.
-	EventAdmissionDecided = "admission.decided"
+	EventAdmissionDecided               = "admission.decided"
+	EventRunEnvironmentCertified        = "runenv.certified"
+	EventRunEnvironmentRepair           = "runenv.repair"
+	EventRunEnvironmentQuarantined      = "runenv.quarantined"
+	EventRunEnvironmentScopeQuarantined = "runenv.scope_quarantined"
 	// EventCompletionEvidenceVerified records the workflow engine's
 	// require_evidence step (internal/workflow/engine_steps_evidence.go)
 	// finding every applicable criterion present, passing, and fresh for the

--- a/internal/autonomy/model.go
+++ b/internal/autonomy/model.go
@@ -16,6 +16,7 @@ const (
 	CapabilitySourceRead       Capability = "source_read"
 	CapabilitySourceWrite      Capability = "source_write"
 	CapabilityGitAdminWrite    Capability = "git_admin_write"
+	CapabilityCheckoutHealth   Capability = "checkout_health"
 	CapabilityObjectStore      Capability = "object_store_health"
 	CapabilitySigning          Capability = "signing"
 	CapabilityTaskMutation     Capability = "task_mutation"
@@ -26,7 +27,7 @@ const (
 
 var allCapabilities = []Capability{
 	CapabilitySourceRead, CapabilitySourceWrite, CapabilityGitAdminWrite,
-	CapabilityObjectStore, CapabilitySigning, CapabilityTaskMutation,
+	CapabilityCheckoutHealth, CapabilityObjectStore, CapabilitySigning, CapabilityTaskMutation,
 	CapabilitySandboxMechanism, CapabilityProviderCapacity, CapabilityNetworkGitHub,
 }
 

--- a/internal/autonomy/model.go
+++ b/internal/autonomy/model.go
@@ -15,6 +15,7 @@ type Capability string
 const (
 	CapabilitySourceRead       Capability = "source_read"
 	CapabilitySourceWrite      Capability = "source_write"
+	CapabilityScratchWrite     Capability = "scratch_write"
 	CapabilityGitAdminWrite    Capability = "git_admin_write"
 	CapabilityCheckoutHealth   Capability = "checkout_health"
 	CapabilityObjectStore      Capability = "object_store_health"
@@ -26,7 +27,7 @@ const (
 )
 
 var allCapabilities = []Capability{
-	CapabilitySourceRead, CapabilitySourceWrite, CapabilityGitAdminWrite,
+	CapabilitySourceRead, CapabilitySourceWrite, CapabilityScratchWrite, CapabilityGitAdminWrite,
 	CapabilityCheckoutHealth, CapabilityObjectStore, CapabilitySigning, CapabilityTaskMutation,
 	CapabilitySandboxMechanism, CapabilityProviderCapacity, CapabilityNetworkGitHub,
 }

--- a/internal/blocker/blocker.go
+++ b/internal/blocker/blocker.go
@@ -19,6 +19,7 @@ const (
 	KindReviewFixExhausted         Kind = "review_fix_exhausted"
 	KindTriageRetryExhausted       Kind = "triage_retry_exhausted"
 	KindWatchdogRateLimitExhausted Kind = "watchdog_rate_limit_exhausted"
+	KindRunEnvironment             Kind = "run_environment"
 	// KindDependencyScopeUnmet marks a task blocked on a depends_on issue
 	// whose closure a prior agent/human run explicitly verified did NOT
 	// satisfy the scope this task actually needs (e.g. the closing PR only

--- a/internal/project/signing.go
+++ b/internal/project/signing.go
@@ -91,6 +91,9 @@ func GPGSigningAvailable(ctx context.Context) bool {
 func ProbeGPGSigning(ctx context.Context) error {
 	key, err := gitexec.Output(ctx, gitexec.Options{}, "config", "--global", "--get", "user.signingkey")
 	if err != nil {
+		if code, ok := gitexec.ExitCode(err); ok && code == 1 {
+			return errors.New("resolve signing key: key is not configured")
+		}
 		return fmt.Errorf("resolve signing key: %w", err)
 	}
 	if strings.TrimSpace(key) == "" {

--- a/internal/project/signing.go
+++ b/internal/project/signing.go
@@ -2,6 +2,11 @@ package project
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/gitexec"
 )
@@ -78,6 +83,37 @@ func GPGSigningAvailable(ctx context.Context) bool {
 		return false
 	}
 	return out != ""
+}
+
+// ProbeGPGSigning performs a bounded, non-persisting signature with the exact
+// configured OpenPGP key. A configured key name alone is not proof that its
+// secret key or signing agent is usable by an unattended provider process.
+func ProbeGPGSigning(ctx context.Context) error {
+	key, err := gitexec.Output(ctx, gitexec.Options{}, "config", "--global", "--get", "user.signingkey")
+	if err != nil {
+		return fmt.Errorf("resolve signing key: %w", err)
+	}
+	if strings.TrimSpace(key) == "" {
+		return errors.New("resolve signing key: key is not configured")
+	}
+	format, _ := gitexec.Output(ctx, gitexec.Options{}, "config", "--global", "--get", "gpg.format")
+	if format != "" && format != "openpgp" {
+		return fmt.Errorf("unsupported signing format %q for non-persisting probe", format)
+	}
+	program, _ := gitexec.Output(ctx, gitexec.Options{}, "config", "--global", "--get", "gpg.program")
+	if strings.TrimSpace(program) == "" {
+		program = "gpg"
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(probeCtx, program,
+		"--batch", "--no-tty", "--pinentry-mode", "error",
+		"--local-user", key, "--detach-sign", "--armor", "--output", "-")
+	cmd.Stdin = strings.NewReader("sybra run environment signing probe\n")
+	if output, runErr := cmd.CombinedOutput(); runErr != nil {
+		return fmt.Errorf("signing probe: %w: %s", runErr, strings.TrimSpace(string(output)))
+	}
+	return nil
 }
 
 // CommitSignFlags returns the git commit flags an agent should use on this

--- a/internal/project/signing_policy_test.go
+++ b/internal/project/signing_policy_test.go
@@ -2,11 +2,41 @@ package project
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/gitexec"
 )
+
+func TestProbeGPGSigningExecutesConfiguredSigner(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		exitCode int
+		wantErr  bool
+	}{{name: "usable", exitCode: 0}, {name: "unusable", exitCode: 7, wantErr: true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			signer := filepath.Join(root, "fake-gpg")
+			if err := os.WriteFile(signer, fmt.Appendf(nil, "#!/bin/sh\ncat >/dev/null\nexit %d\n", tc.exitCode), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(root, "gitconfig")
+			configBody := fmt.Sprintf("[user]\n\tsigningkey = test-key\n[gpg]\n\tprogram = %s\n", signer)
+			if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+			t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+			err := ProbeGPGSigning(context.Background())
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ProbeGPGSigning() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
 
 func TestNormalizeSigningPolicy(t *testing.T) {
 	tests := []struct {

--- a/internal/project/signing_policy_test.go
+++ b/internal/project/signing_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -35,6 +36,19 @@ func TestProbeGPGSigningExecutesConfiguredSigner(t *testing.T) {
 				t.Fatalf("ProbeGPGSigning() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestProbeGPGSigningReportsMissingKey(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(configPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", configPath)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	err := ProbeGPGSigning(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "key is not configured") {
+		t.Fatalf("ProbeGPGSigning() error = %v", err)
 	}
 }
 

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/skillattr"
 	"github.com/Automaat/sybra/internal/skillinvoke"
+	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
@@ -210,6 +211,10 @@ type Orchestrator struct {
 	// exactly as it did before this feature landed) — every read site
 	// nil-guards for this reason.
 	queue *agentqueue.Queue
+	// runenv certifies the concrete worktree, Git admin area, provider, and
+	// host posture immediately before Run. Nil is retained for construction
+	// tests and degraded startup; App always late-binds it before dispatch.
+	runenv *runenv.Service
 	// conflictRecovery turns a worktree-prep rebase conflict into an autonomous
 	// conflict pr-fix instead of a human escalation. Wired via SetConflictRecovery
 	// in wireServices after the review.Handler exists; nil keeps the
@@ -277,6 +282,11 @@ func (o *Orchestrator) SetPressureGate(gate *pressure.Gate) {
 // once the review.Handler that implements it exists.
 func (o *Orchestrator) SetConflictRecovery(fn func(taskID string) bool) {
 	o.conflictRecovery = fn
+}
+
+// SetRunEnvironment late-binds pre-dispatch certification.
+func (o *Orchestrator) SetRunEnvironment(service *runenv.Service) {
+	o.runenv = service
 }
 
 // SetQueue late-binds the admission queue once agentqueue.New succeeds at
@@ -677,14 +687,14 @@ func (o *Orchestrator) startAgent(ctx context.Context, taskID, mode, prompt stri
 	if postureErr != nil {
 		return nil, "", postureErr
 	}
-	return o.runImplementationAgent(taskID, prompt, includeTaskDescription, oneShot, skipWT, dir, effMode, requirePerm, posture, baselineRef, resumeSessionID, model, t, assignment, opts, reservation)
+	return o.runImplementationAgent(ctx, taskID, prompt, includeTaskDescription, oneShot, skipWT, dir, effMode, requirePerm, posture, baselineRef, resumeSessionID, model, t, assignment, opts, reservation)
 }
 
 // runImplementationAgent builds the RunConfig for an implementation dispatch,
 // launches it, and translates a launch failure through the same
 // capacity-race / provider-gate handling startAgent used inline before this
 // was split out to satisfy funlen.
-func (o *Orchestrator) runImplementationAgent(taskID, prompt string, includeTaskDescription, oneShot, skipWT bool, dir, effMode string, requirePerm bool, posture, baselineRef, resumeSessionID, model string, t task.Task, assignment workflow.AgentAssignment, opts startOptions, reservation *agent.CapacityReservation) (*agent.Agent, string, error) {
+func (o *Orchestrator) runImplementationAgent(ctx context.Context, taskID, prompt string, includeTaskDescription, oneShot, skipWT bool, dir, effMode string, requirePerm bool, posture, baselineRef, resumeSessionID, model string, t task.Task, assignment workflow.AgentAssignment, opts startOptions, reservation *agent.CapacityReservation) (*agent.Agent, string, error) {
 	extraEnv := o.SandboxEnvIfRunning(taskID)
 	fullPrompt := BuildTaskStartPrompt(t, prompt, includeTaskDescription)
 	o.logSandboxEscapeHatch(taskID, t)
@@ -694,6 +704,9 @@ func (o *Orchestrator) runImplementationAgent(taskID, prompt string, includeTask
 		oneShot:         oneShot,
 		resumeSessionID: resumeSessionID, extraEnv: extraEnv, opts: opts,
 	})
+	if err := o.certifyRunEnvironment(ctx, taskID, t, agent.RoleImplementation, &runCfg); err != nil {
+		return nil, "", err
+	}
 	var (
 		ag  *agent.Agent
 		err error
@@ -704,6 +717,9 @@ func (o *Orchestrator) runImplementationAgent(taskID, prompt string, includeTask
 		ag, err = o.agents.Run(runCfg)
 	}
 	if err != nil {
+		if o.runenv != nil && runenv.IsEnvironmentFailure(err) {
+			o.runenv.InvalidateTask(taskID)
+		}
 		o.handleProviderGateStartError(taskID, err)
 		if ag, baselineRef, capErr, handled := o.handleCapacityRace(err, t, taskID, effMode, prompt, includeTaskDescription, skipWT, opts); handled {
 			if ag != nil {
@@ -718,6 +734,43 @@ func (o *Orchestrator) runImplementationAgent(taskID, prompt string, includeTask
 	}
 	o.recordImplAgentStart(ag, t, taskID, effMode, posture, requirePerm, oneShot, fullPrompt)
 	return ag, baselineRef, nil
+}
+
+func (o *Orchestrator) certifyRunEnvironment(ctx context.Context, taskID string, t task.Task, role agent.Role, cfg *agent.RunConfig) error {
+	if o.runenv == nil {
+		return nil
+	}
+	resolvedProvider, err := o.agents.ResolveProvider(*cfg)
+	if err != nil {
+		return err
+	}
+	cloneDir := ""
+	cloneGeneration := ""
+	if t.ProjectID != "" && o.projects != nil {
+		p, projectErr := o.projects.Get(t.ProjectID)
+		if projectErr != nil {
+			return projectErr
+		}
+		cloneDir = p.ClonePath
+		cloneGeneration = p.CloneGeneration
+	}
+	scratchRoots, err := o.agents.CertificationScratchRoots(taskID)
+	if err != nil {
+		return err
+	}
+	action := string(role) + ".dispatch"
+	if role == "" {
+		action = "implementation.dispatch"
+	}
+	_, err = o.runenv.Certify(ctx, runenv.Request{
+		TaskID: taskID, ProjectID: t.ProjectID, Action: action,
+		WorkDir: cfg.Dir, ScratchRoots: scratchRoots, CloneDir: cloneDir, CloneGeneration: cloneGeneration, TaskBranch: t.Branch,
+		Provider: resolvedProvider, SandboxMode: cfg.SandboxMode,
+		SigningPolicy: project.NormalizeSigningPolicy(o.cfg.CommitSigning()),
+		Requirements:  role.CapabilityRequirements(action),
+		ConfigVersion: fmt.Sprintf("%s|%s", cfg.SandboxMode, o.cfg.CommitSigning()),
+	})
+	return err
 }
 
 // implementationRunParams collects startAgent's locals for
@@ -1397,7 +1450,7 @@ func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 		prompt = steered
 	}
 	o.logSandboxEscapeHatch(taskID, t)
-	ag, err := o.agents.Run(agent.RunConfig{
+	runCfg := agent.RunConfig{
 		TaskID:                 taskID,
 		Name:                   agent.RolePRFix.AgentName(t.Title),
 		Role:                   agent.RolePRFix,
@@ -1412,7 +1465,11 @@ func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 		// pr-fix is a code-author role — keep the NOTES.md contract airtight so
 		// an adopted (handoff) worktree's scratchpad carries through.
 		SeedWorkingMemory: agent.RolePRFix.AuthorsCode(),
-	})
+	}
+	if err := o.certifyRunEnvironment(o.baseCtx(), taskID, t, agent.RolePRFix, &runCfg); err != nil {
+		return err
+	}
+	ag, err := o.agents.Run(runCfg)
 	if err != nil {
 		return translatePoolBusy(err)
 	}

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -704,9 +704,6 @@ func (o *Orchestrator) runImplementationAgent(ctx context.Context, taskID, promp
 		oneShot:         oneShot,
 		resumeSessionID: resumeSessionID, extraEnv: extraEnv, opts: opts,
 	})
-	if err := o.certifyRunEnvironment(ctx, taskID, t, agent.RoleImplementation, &runCfg); err != nil {
-		return nil, "", err
-	}
 	var (
 		ag  *agent.Agent
 		err error
@@ -734,43 +731,6 @@ func (o *Orchestrator) runImplementationAgent(ctx context.Context, taskID, promp
 	}
 	o.recordImplAgentStart(ag, t, taskID, effMode, posture, requirePerm, oneShot, fullPrompt)
 	return ag, baselineRef, nil
-}
-
-func (o *Orchestrator) certifyRunEnvironment(ctx context.Context, taskID string, t task.Task, role agent.Role, cfg *agent.RunConfig) error {
-	if o.runenv == nil {
-		return nil
-	}
-	resolvedProvider, err := o.agents.ResolveProvider(*cfg)
-	if err != nil {
-		return err
-	}
-	cloneDir := ""
-	cloneGeneration := ""
-	if t.ProjectID != "" && o.projects != nil {
-		p, projectErr := o.projects.Get(t.ProjectID)
-		if projectErr != nil {
-			return projectErr
-		}
-		cloneDir = p.ClonePath
-		cloneGeneration = p.CloneGeneration
-	}
-	scratchRoots, err := o.agents.CertificationScratchRoots(taskID)
-	if err != nil {
-		return err
-	}
-	action := string(role) + ".dispatch"
-	if role == "" {
-		action = "implementation.dispatch"
-	}
-	_, err = o.runenv.Certify(ctx, runenv.Request{
-		TaskID: taskID, ProjectID: t.ProjectID, Action: action,
-		WorkDir: cfg.Dir, ScratchRoots: scratchRoots, CloneDir: cloneDir, CloneGeneration: cloneGeneration, TaskBranch: t.Branch,
-		Provider: resolvedProvider, SandboxMode: cfg.SandboxMode,
-		SigningPolicy: project.NormalizeSigningPolicy(o.cfg.CommitSigning()),
-		Requirements:  role.CapabilityRequirements(action),
-		ConfigVersion: fmt.Sprintf("%s|%s", cfg.SandboxMode, o.cfg.CommitSigning()),
-	})
-	return err
 }
 
 // implementationRunParams collects startAgent's locals for
@@ -1465,9 +1425,6 @@ func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 		// pr-fix is a code-author role — keep the NOTES.md contract airtight so
 		// an adopted (handoff) worktree's scratchpad carries through.
 		SeedWorkingMemory: agent.RolePRFix.AuthorsCode(),
-	}
-	if err := o.certifyRunEnvironment(o.baseCtx(), taskID, t, agent.RolePRFix, &runCfg); err != nil {
-		return err
 	}
 	ag, err := o.agents.Run(runCfg)
 	if err != nil {

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -714,9 +714,7 @@ func (o *Orchestrator) runImplementationAgent(ctx context.Context, taskID, promp
 		ag, err = o.agents.Run(runCfg)
 	}
 	if err != nil {
-		if o.runenv != nil && runenv.IsEnvironmentFailure(err) {
-			o.runenv.InvalidateTask(taskID)
-		}
+		o.invalidateRunEnvironmentOnStartError(taskID, err)
 		o.handleProviderGateStartError(taskID, err)
 		if ag, baselineRef, capErr, handled := o.handleCapacityRace(err, t, taskID, effMode, prompt, includeTaskDescription, skipWT, opts); handled {
 			if ag != nil {
@@ -1428,6 +1426,7 @@ func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 	}
 	ag, err := o.agents.Run(runCfg)
 	if err != nil {
+		o.invalidateRunEnvironmentOnStartError(taskID, err)
 		return translatePoolBusy(err)
 	}
 
@@ -1446,6 +1445,12 @@ func (o *Orchestrator) StartPRFixAgent(taskID string) error {
 		o.logger.Error("task.add-run", "task_id", taskID, "err", err)
 	}
 	return nil
+}
+
+func (o *Orchestrator) invalidateRunEnvironmentOnStartError(taskID string, err error) {
+	if o.runenv != nil && runenv.IsEnvironmentFailure(err) {
+		o.runenv.InvalidateTask(taskID)
+	}
 }
 
 func fallbackDispatchDir(dir string) string {

--- a/internal/sybra/agentorch/agentorch_test.go
+++ b/internal/sybra/agentorch/agentorch_test.go
@@ -1,6 +1,7 @@
 package agentorch
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -13,8 +14,11 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/agentqueue"
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/autonomy"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
@@ -204,6 +208,36 @@ func TestStartPRFixAgent_TaskCostExceededBlocksDispatch(t *testing.T) {
 	}
 	if !errors.Is(err, workflow.ErrTaskCostExceeded) {
 		t.Fatalf("err = %v, want wrapping workflow.ErrTaskCostExceeded", err)
+	}
+}
+
+func TestStartErrorInvalidatesRunEnvironmentCertificate(t *testing.T) {
+	t.Parallel()
+	probes := 0
+	service := runenv.New(runenv.Deps{
+		ProbeProvider: func(context.Context, string) (runenv.ProbeResult, error) {
+			probes++
+			return runenv.ProbeResult{Available: true}, nil
+		},
+	})
+	req := runenv.Request{
+		TaskID: "task", Action: "pr-fix.dispatch", WorkDir: t.TempDir(), Provider: providerid.Codex,
+		Requirements: []autonomy.CapabilityRequirement{{
+			Capability: autonomy.CapabilityProviderCapacity,
+			Action:     "pr-fix.dispatch",
+			Scope:      "provider",
+		}},
+	}
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{runenv: service}
+	o.invalidateRunEnvironmentOnStartError(req.TaskID, errors.New("provider start: read-only file system"))
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if probes != 2 {
+		t.Fatalf("provider probes = %d, want recertification after environment-shaped start error", probes)
 	}
 }
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -60,6 +60,7 @@ import (
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/completion"
 	"github.com/Automaat/sybra/internal/sybra/review"
+	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/tasksnapshot"
 	"github.com/Automaat/sybra/internal/toolledger"
@@ -119,6 +120,7 @@ type App struct {
 	learningDigestSvc *learning.Service
 	routingSvc        *routing.Service
 	agentOrch         *agentorch.Orchestrator
+	runenv            *runenv.Service
 	reviewer          *review.Handler
 	assigner          *clusterlead.Assigner
 	mirror            *clusterlead.Mirror
@@ -442,6 +444,7 @@ func (a *App) startLifecycle(schedulerCtx, watcherCtx context.Context, emit func
 		if a.humanReview != nil {
 			a.humanReview.recoverStrandedUnblockedTasks() //nolint:contextcheck // handler bounds its git/PR checks with dedicated timeouts, matching live completion.
 		}
+		a.certifyStartupRunEnvironment(schedulerCtx)
 		// Arm dispatch now that reattach/replay/restart-stale have run, then
 		// nudge so any task that changed status during the window (buffered,
 		// not dispatched — see startupRecoveryPending) is picked up by the
@@ -595,6 +598,7 @@ func (a *App) Startup(ctx context.Context) error {
 	})
 	a.agentOrch = agentorch.New(a.tasks, a.projects, a.agents, a.audit, a.logger, a.worktrees, a.cfg)
 	a.agentOrch.SetContext(appCtx)
+	a.initRunEnvironment()
 	a.reviewer = review.New(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees, a.renovatePRsForMonitor, a.cfg, a.experience)
 	a.reviewer.SetABTestingSource(a.abTestingConfig)
 	a.reviewer.SetInterventionStore(a.intervention)

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/scrub"
+	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/textutil"
 	"github.com/Automaat/sybra/internal/verdict"
@@ -610,6 +611,7 @@ func (h *humanReviewHandler) spawnReviewConfig(t task.Task, taskID, prompt, dir 
 		OneShot:                true,
 		OutputSchema:           verdict.Schema,
 		IgnoreConcurrencyLimit: true,
+		SandboxMode:            agentorch.ResolveSandboxMode(t, h.cfg),
 	}
 	if opts.SkipABVariant {
 		return cfg

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/review"
+	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/toolledger"
 	"github.com/Automaat/sybra/internal/umbrella"
@@ -593,11 +594,29 @@ func k8sJobRunnerConfigFromConfig(cfg config.K8sJobsConfig) agent.K8sJobRunnerCo
 }
 
 func (a *App) onAgentComplete(ag *agent.Agent) {
+	if a.runenv != nil && agentRunEnvironmentFailed(ag) {
+		a.runenv.InvalidateTask(ag.TaskID)
+	}
 	if a.agentCompletion == nil {
 		a.logger.Warn("agent.complete.unwired", "id", ag.ID, "task_id", ag.TaskID)
 		return
 	}
 	a.agentCompletion.OnComplete(ag)
+}
+
+func agentRunEnvironmentFailed(ag *agent.Agent) bool {
+	if runenv.IsEnvironmentFailure(ag.GetExitErr()) {
+		return true
+	}
+	outputs := ag.Output()
+	for i := range outputs {
+		event := &outputs[i]
+		diagnostic := strings.Join([]string{event.Content, event.ErrorType, event.TerminalReason}, " ")
+		if runenv.IsEnvironmentFailure(errors.New(diagnostic)) {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *App) recordLimitSnapshot(snapshot limits.Snapshot) {
@@ -1497,6 +1516,7 @@ func (a *App) newWorkflowAgentLauncher() *agentAdapter {
 		sandboxes:  a.sandboxes,
 		experience: a.experience,
 		pressure:   pressureGate,
+		runenv:     a.runenv,
 	}
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -611,6 +611,9 @@ func agentRunEnvironmentFailed(ag *agent.Agent) bool {
 	outputs := ag.Output()
 	for i := range outputs {
 		event := &outputs[i]
+		if event.Type != "result" && event.ErrorType == "" && event.TerminalReason == "" {
+			continue
+		}
 		diagnostic := strings.Join([]string{event.Content, event.ErrorType, event.TerminalReason}, " ")
 		if runenv.IsEnvironmentFailure(errors.New(diagnostic)) {
 			return true

--- a/internal/sybra/app_runenv.go
+++ b/internal/sybra/app_runenv.go
@@ -1,0 +1,206 @@
+package sybra
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/autonomy"
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/sybra/runenv"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func (a *App) initRunEnvironment() {
+	a.runenv = runenv.New(runenv.Deps{
+		ProbeSandbox: func(_ context.Context, mode string) (runenv.ProbeResult, error) {
+			observation, err := agent.ProbeSandboxPosture(mode)
+			return runenv.ProbeResult{Available: observation.Available, Contained: observation.Contained, Evidence: observation.Evidence}, err
+		},
+		ProbeProvider: func(_ context.Context, providerName string) (runenv.ProbeResult, error) {
+			if a.providerHealth == nil || a.providerHealth.IsHealthy(providerName) {
+				return runenv.ProbeResult{Available: true, Evidence: "provider health gate admits dispatch"}, nil
+			}
+			return runenv.ProbeResult{Code: "provider_unavailable", Evidence: a.providerHealth.Reason(providerName)}, errors.New("provider health gate denied dispatch")
+		},
+		ProbeNetwork: func(_ context.Context, _ string) (runenv.ProbeResult, error) {
+			if open, _ := github.AuthCircuitOpen(); open {
+				snapshot := github.AuthHealthSnapshot()
+				return runenv.ProbeResult{Code: "github_auth_unavailable", Evidence: string(snapshot.State)}, errors.New("GitHub auth circuit is open")
+			}
+			return runenv.ProbeResult{Available: true, Evidence: "GitHub auth circuit admits requests"}, nil
+		},
+		ProbeTaskMutation: func(_ context.Context, taskID string) (runenv.ProbeResult, error) {
+			// Deliberately validate the Manager transport without exposing its
+			// store to runenv or performing a timestamp-changing no-op write.
+			if a.tasks == nil {
+				return runenv.ProbeResult{Code: "task_mutation_unavailable"}, errors.New("task manager unavailable")
+			}
+			if err := a.tasks.ProbeMutationTransport(taskID); err != nil {
+				return runenv.ProbeResult{Code: "task_mutation_unavailable"}, err
+			}
+			return runenv.ProbeResult{Available: true, Evidence: "task manager mutation lock available"}, nil
+		},
+		Repair: func(ctx context.Context, req runenv.Request, failed []runenv.Observation) error {
+			if strings.TrimSpace(req.CloneDir) == "" {
+				return errors.New("no safe clone repair is available")
+			}
+			if !slices.ContainsFunc(failed, func(observation runenv.Observation) bool {
+				return observation.Capability == autonomy.CapabilityObjectStore || observation.Capability == autonomy.CapabilityCheckoutHealth
+			}) {
+				return errors.New("no safe repair is available for this capability")
+			}
+			_, err := project.EnsureBareCloneHealthy(ctx, req.CloneDir, req.TaskBranch)
+			return err
+		},
+		Quarantine: a.quarantineRunEnvironment,
+		Audit: func(event string, certificate runenv.Certificate, failure *runenv.CertificationError) {
+			eventType := map[string]string{
+				"runenv.certified":   audit.EventRunEnvironmentCertified,
+				"runenv.repair":      audit.EventRunEnvironmentRepair,
+				"runenv.quarantined": audit.EventRunEnvironmentQuarantined,
+			}[event]
+			if eventType == "" {
+				eventType = event
+			}
+			data := map[string]any{"certificate_id": certificate.ID, "fingerprint": certificate.Fingerprint, "action": certificate.Action, "expires_at": certificate.ExpiresAt, "repaired": certificate.Repaired}
+			if failure != nil {
+				data["reason_code"] = failure.Code
+				data["scope"] = failure.Scope
+				data["capability"] = failure.Capability
+			}
+			a.logAudit(eventType, certificate.TaskID, "", data)
+		},
+	})
+	a.agentOrch.SetRunEnvironment(a.runenv)
+	a.agents.SetRunEnvironmentPreflight(a.certifyPreparedRunEnvironment)
+}
+
+func (a *App) certifyPreparedRunEnvironment(ctx context.Context, environment agent.RunEnvironment) error {
+	if strings.TrimSpace(environment.TaskID) == "" {
+		return nil
+	}
+	t, err := a.tasks.Get(environment.TaskID)
+	if err != nil {
+		// StartK8sPocAgent is an explicit project-less smoke run. It has no
+		// authoritative task or Git checkout, but its actual writable roots,
+		// provider, and sandbox posture must still be certified before spawn.
+		if !strings.HasPrefix(environment.TaskID, "k8s-poc-") {
+			return err
+		}
+		_, err = a.runenv.Certify(ctx, runenv.Request{
+			TaskID: environment.TaskID, Action: "implementation.dispatch", WorkDir: environment.Dir,
+			ScratchRoots: environment.ScratchRoots, Provider: environment.Provider, SandboxMode: environment.SandboxMode,
+			Requirements: []autonomy.CapabilityRequirement{
+				{Capability: autonomy.CapabilitySourceRead, Action: "implementation.dispatch", Scope: "task"},
+				{Capability: autonomy.CapabilitySourceWrite, Action: "implementation.dispatch", Scope: "task"},
+				{Capability: autonomy.CapabilitySandboxMechanism, Action: "implementation.dispatch", Scope: "host"},
+				{Capability: autonomy.CapabilityProviderCapacity, Action: "implementation.dispatch", Scope: "provider"},
+			},
+			ConfigVersion: environment.SandboxMode,
+		})
+		return err
+	}
+	cloneDir, cloneGeneration := "", ""
+	if t.ProjectID != "" {
+		p, projectErr := a.projects.Get(t.ProjectID)
+		if projectErr != nil {
+			return projectErr
+		}
+		cloneDir, cloneGeneration = p.ClonePath, p.CloneGeneration
+	}
+	action := string(environment.Role) + ".dispatch"
+	if environment.Role == "" {
+		action = "implementation.dispatch"
+	}
+	requirements := environment.Role.CapabilityRequirements(action)
+	mutationIdentity := ""
+	if slices.ContainsFunc(requirements, func(requirement autonomy.CapabilityRequirement) bool {
+		return requirement.Capability == autonomy.CapabilityTaskMutation
+	}) {
+		mutationIdentity, err = a.tasks.MutationTransportIdentity(t.ID)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = a.runenv.Certify(ctx, runenv.Request{
+		TaskID: t.ID, ProjectID: t.ProjectID, Action: action, WorkDir: environment.Dir,
+		ReadRoots: environment.ReadOnlyPaths, GitRoots: environment.ReadOnlyPaths,
+		ScratchRoots: environment.ScratchRoots, CloneDir: cloneDir, CloneGeneration: cloneGeneration, TaskBranch: t.Branch,
+		Provider: environment.Provider, SandboxMode: environment.SandboxMode,
+		SigningPolicy:        project.NormalizeSigningPolicy(a.cfg.CommitSigning()),
+		TaskMutationIdentity: mutationIdentity,
+		Requirements:         requirements,
+		ConfigVersion:        fmt.Sprintf("%s|%s", environment.SandboxMode, a.cfg.CommitSigning()),
+	})
+	return err
+}
+
+// certifyStartupRunEnvironment records host posture after survivor reattach
+// and stranded-verdict replay, but before the startup dispatch gate opens.
+// This ordering prevents a transient host/provider observation from mutating
+// recovery inputs while still guaranteeing certification before scheduling.
+func (a *App) certifyStartupRunEnvironment(ctx context.Context) {
+	_, err := a.runenv.Certify(ctx, runenv.Request{
+		TaskID: "host", Action: "startup.host", WorkDir: a.tasksDir,
+		Provider: a.cfg.Agent.Provider, SandboxMode: a.cfg.DefaultSandboxMode(),
+		SigningPolicy: project.NormalizeSigningPolicy(a.cfg.CommitSigning()),
+		Requirements: []autonomy.CapabilityRequirement{
+			{Capability: autonomy.CapabilitySandboxMechanism, Action: "startup.host", Scope: "host"},
+			{Capability: autonomy.CapabilityProviderCapacity, Action: "startup.host", Scope: "provider"},
+		},
+		ConfigVersion: a.cfg.DefaultSandboxMode() + "|" + a.cfg.CommitSigning(),
+	})
+	if err != nil {
+		a.logger.Warn("runenv.startup.failed", "err", err)
+	}
+}
+
+// quarantineRunEnvironment applies one generic machine-owned reason to every
+// non-terminal task in the failed project scope. The runenv service coalesces
+// this callback per environment fingerprint, so a broken shared clone cannot
+// generate a task-update storm.
+func (a *App) quarantineRunEnvironment(_ context.Context, failure runenv.CertificationError) {
+	if a.tasks == nil {
+		return
+	}
+	tasks, err := a.tasks.List()
+	if err != nil {
+		a.logger.Error("runenv.quarantine.list", "err", err)
+		return
+	}
+	reasonText := fmt.Sprintf("execution environment quarantined: %s", failure.Code)
+	affected := 0
+	for i := range tasks {
+		current := &tasks[i]
+		if current.Status == task.StatusDone || current.Status == task.StatusCancelled {
+			continue
+		}
+		if failure.Scope == "task" && current.ID != failure.TaskID {
+			continue
+		}
+		if failure.Scope == "project" && current.ProjectID != failure.ProjectID {
+			continue
+		}
+		if failure.Scope != "host" && failure.Scope != "provider" && failure.Scope != "project" && current.ID != failure.TaskID {
+			continue
+		}
+		update := task.Update{StatusReason: task.Ptr(reasonText)}
+		if current.Status != task.StatusHumanRequired {
+			update.Status = task.Ptr(task.StatusBlocked)
+			update.Escalation = task.MachineFailure("runenv."+failure.Code, reasonText)
+			update.AutonomyOutcome = task.QuarantinedOutcome()
+		}
+		if _, updateErr := a.tasks.Update(current.ID, update); updateErr != nil {
+			a.logger.Error("runenv.quarantine.update", "task_id", current.ID, "err", updateErr)
+			continue
+		}
+		affected++
+	}
+	a.logAudit(audit.EventRunEnvironmentScopeQuarantined, failure.TaskID, "", map[string]any{"scope": failure.Scope, "reason_code": failure.Code, "affected_tasks": affected})
+}

--- a/internal/sybra/app_runenv.go
+++ b/internal/sybra/app_runenv.go
@@ -99,6 +99,7 @@ func (a *App) certifyPreparedRunEnvironment(ctx context.Context, environment age
 			Requirements: []autonomy.CapabilityRequirement{
 				{Capability: autonomy.CapabilitySourceRead, Action: "implementation.dispatch", Scope: "task"},
 				{Capability: autonomy.CapabilitySourceWrite, Action: "implementation.dispatch", Scope: "task"},
+				{Capability: autonomy.CapabilityScratchWrite, Action: "implementation.dispatch", Scope: "task"},
 				{Capability: autonomy.CapabilitySandboxMechanism, Action: "implementation.dispatch", Scope: "host"},
 				{Capability: autonomy.CapabilityProviderCapacity, Action: "implementation.dispatch", Scope: "provider"},
 			},

--- a/internal/sybra/app_runenv.go
+++ b/internal/sybra/app_runenv.go
@@ -26,12 +26,12 @@ func (a *App) initRunEnvironment() {
 			if a.providerHealth == nil || a.providerHealth.IsHealthy(providerName) {
 				return runenv.ProbeResult{Available: true, Evidence: "provider health gate admits dispatch"}, nil
 			}
-			return runenv.ProbeResult{Code: "provider_unavailable", Evidence: a.providerHealth.Reason(providerName)}, errors.New("provider health gate denied dispatch")
+			return runenv.ProbeResult{Code: "provider_unavailable", Evidence: a.providerHealth.Reason(providerName), Owner: autonomy.FailureOwnerExternalTransient}, errors.New("provider health gate denied dispatch")
 		},
 		ProbeNetwork: func(_ context.Context, _ string) (runenv.ProbeResult, error) {
 			if open, _ := github.AuthCircuitOpen(); open {
 				snapshot := github.AuthHealthSnapshot()
-				return runenv.ProbeResult{Code: "github_auth_unavailable", Evidence: string(snapshot.State)}, errors.New("GitHub auth circuit is open")
+				return githubAuthProbeFailure(snapshot), errors.New("GitHub auth circuit is open")
 			}
 			return runenv.ProbeResult{Available: true, Evidence: "GitHub auth circuit admits requests"}, nil
 		},
@@ -79,6 +79,16 @@ func (a *App) initRunEnvironment() {
 	})
 	a.agentOrch.SetRunEnvironment(a.runenv)
 	a.agents.SetRunEnvironmentPreflight(a.certifyPreparedRunEnvironment)
+}
+
+func githubAuthProbeFailure(snapshot github.AuthSnapshot) runenv.ProbeResult {
+	owner := autonomy.FailureOwnerExternalTransient
+	code := "github_auth_unavailable"
+	if snapshot.State == github.AuthMisconfigured {
+		owner = autonomy.FailureOwnerOperatorAuthority
+		code = "github_auth_misconfigured"
+	}
+	return runenv.ProbeResult{Code: code, Evidence: string(snapshot.State), Owner: owner}
 }
 
 func (a *App) certifyPreparedRunEnvironment(ctx context.Context, environment agent.RunEnvironment) error {

--- a/internal/sybra/app_runenv.go
+++ b/internal/sybra/app_runenv.go
@@ -173,9 +173,9 @@ func (a *App) certifyStartupRunEnvironment(ctx context.Context) {
 }
 
 // quarantineRunEnvironment applies one generic machine-owned reason to every
-// non-terminal task in the failed project scope. The runenv service coalesces
-// this callback per environment fingerprint, so a broken shared clone cannot
-// generate a task-update storm.
+// non-terminal task selected by the failure's task/project/host/provider
+// scope. The runenv service coalesces callbacks per scope and fingerprint so
+// one shared defect cannot generate a task-update storm.
 func (a *App) quarantineRunEnvironment(_ context.Context, failure runenv.CertificationError) {
 	if a.tasks == nil {
 		return

--- a/internal/sybra/app_runenv_test.go
+++ b/internal/sybra/app_runenv_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/autonomy"
+	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 func TestAgentRunEnvironmentFailedReadsExitAndStreamDiagnostics(t *testing.T) {
@@ -35,6 +38,43 @@ func TestAgentRunEnvironmentFailedReadsExitAndStreamDiagnostics(t *testing.T) {
 				t.Fatalf("agentRunEnvironmentFailed() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGitHubAuthProbeFailurePreservesTransientAndAuthorityOwnership(t *testing.T) {
+	tests := []struct {
+		state github.AuthState
+		owner autonomy.FailureOwner
+		code  string
+	}{
+		{state: github.AuthUnavailable, owner: autonomy.FailureOwnerExternalTransient, code: "github_auth_unavailable"},
+		{state: github.AuthRateLimited, owner: autonomy.FailureOwnerExternalTransient, code: "github_auth_unavailable"},
+		{state: github.AuthMisconfigured, owner: autonomy.FailureOwnerOperatorAuthority, code: "github_auth_misconfigured"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			got := githubAuthProbeFailure(github.AuthSnapshot{State: tt.state})
+			if got.Owner != tt.owner || got.Code != tt.code {
+				t.Fatalf("probe failure = %+v, want owner=%q code=%q", got, tt.owner, tt.code)
+			}
+		})
+	}
+}
+
+func TestMisconfiguredGitHubAuthCertificationRequiresCredentialAuthority(t *testing.T) {
+	service := runenv.New(runenv.Deps{ProbeNetwork: func(context.Context, string) (runenv.ProbeResult, error) {
+		return githubAuthProbeFailure(github.AuthSnapshot{State: github.AuthMisconfigured}), errors.New("GitHub auth circuit is open")
+	}})
+	_, err := service.Certify(context.Background(), runenv.Request{
+		TaskID: "review-task", ProjectID: "owner/repo", Action: "review.dispatch", WorkDir: t.TempDir(),
+		Requirements: []autonomy.CapabilityRequirement{{Capability: autonomy.CapabilityNetworkGitHub, Action: "review.dispatch", Scope: "project"}},
+	})
+	if err == nil {
+		t.Fatal("Certify succeeded with misconfigured GitHub auth")
+	}
+	failure := workflow.ClassifyAgentStartFailure(err)
+	if !failure.Permanent || failure.Blocker.Kind != blocker.KindCredentialRequired || !blocker.AllowsHumanRequired(failure.Blocker.Kind) {
+		t.Fatalf("classification = %#v", failure)
 	}
 }
 

--- a/internal/sybra/app_runenv_test.go
+++ b/internal/sybra/app_runenv_test.go
@@ -31,6 +31,16 @@ func TestAgentRunEnvironmentFailedReadsExitAndStreamDiagnostics(t *testing.T) {
 			ag.AppendOutput(agent.StreamEvent{Type: "result", Content: "commit failed: gpg failed to sign the data"})
 			return ag
 		}, want: true},
+		{name: "assistant prose is not a diagnostic", agent: func() *agent.Agent {
+			ag := &agent.Agent{}
+			ag.AppendOutput(agent.StreamEvent{Type: "assistant", Content: "I fixed the read-only file system handling"})
+			return ag
+		}, want: false},
+		{name: "structured error is a diagnostic", agent: func() *agent.Agent {
+			ag := &agent.Agent{}
+			ag.AppendOutput(agent.StreamEvent{Type: "system", ErrorType: "read-only file system"})
+			return ag
+		}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sybra/app_runenv_test.go
+++ b/internal/sybra/app_runenv_test.go
@@ -1,0 +1,60 @@
+package sybra
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/autonomy"
+	"github.com/Automaat/sybra/internal/sybra/runenv"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestAgentRunEnvironmentFailedReadsExitAndStreamDiagnostics(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent func() *agent.Agent
+		want  bool
+	}{
+		{name: "clean", agent: func() *agent.Agent { return &agent.Agent{} }, want: false},
+		{name: "exit error", agent: func() *agent.Agent {
+			ag := &agent.Agent{}
+			ag.SetExitErr(errors.New("fatal: read-only file system"))
+			return ag
+		}, want: true},
+		{name: "terminal content", agent: func() *agent.Agent {
+			ag := &agent.Agent{}
+			ag.AppendOutput(agent.StreamEvent{Type: "result", Content: "commit failed: gpg failed to sign the data"})
+			return ag
+		}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentRunEnvironmentFailed(tt.agent()); got != tt.want {
+				t.Fatalf("agentRunEnvironmentFailed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuarantineRunEnvironmentParksMachineOwnedTask(t *testing.T) {
+	a := setupApp(t)
+	created, err := a.tasks.Create("quarantine me", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.tasks.Update(created.ID, task.Update{Status: task.Ptr(task.StatusInProgress)}); err != nil {
+		t.Fatal(err)
+	}
+	a.quarantineRunEnvironment(context.Background(), runenv.CertificationError{
+		TaskID: created.ID, Action: "implementation.dispatch", Scope: "task", Code: "checkout_unhealthy", Capability: autonomy.CapabilityCheckoutHealth,
+	})
+	got, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusBlocked || got.AutonomyOutcome != autonomy.OutcomeQuarantined {
+		t.Fatalf("quarantined task status/outcome = %q/%q", got.Status, got.AutonomyOutcome)
+	}
+}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/skillinvoke"
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
+	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/taskstatus"
 	"github.com/Automaat/sybra/internal/triage"
@@ -1001,6 +1002,7 @@ type agentAdapter struct {
 	sandboxes  *sandbox.Manager
 	experience *experience.Store
 	pressure   *pressure.Gate
+	runenv     *runenv.Service
 }
 
 func translatePoolBusy(err error) error {
@@ -1100,6 +1102,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		MaxTurns:               t.MaxTurns,
 		RequirePermissions:     agentorch.ResolvePermission(t, a.agentOrch.Cfg()),
 		HeadlessPermissionMode: posture,
+		SandboxMode:            agentorch.ResolveSandboxMode(t, a.agentOrch.Cfg()),
 		ReasoningEffort:        agentorch.FirstNonEmpty(assignment.ReasoningEffort, t.ReasoningEffort, agentorch.ResolveRoleEffort(r, a.agentOrch.Cfg())),
 		// Code-author roles (implementation/fix-review/pr-fix) are primed with
 		// NOTES.md; verifier roles (review/test-runner/eval) share the same
@@ -1144,12 +1147,9 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		}
 	}
 
-	baselineRef = agentorch.CurrentWorktreeHead(context.Background(), cfg.Dir)
-	a.configureTestRunnerRun(&cfg, taskID, r, t)
-
-	ag, err := a.agents.Run(cfg)
+	ag, baselineRef, err := a.launchCertifiedDirect(t, r, &cfg)
 	if err != nil {
-		return "", "", "", translatePoolBusy(err)
+		return "", "", "", err
 	}
 
 	if recErr := a.recordSystemAgentStart(taskID, role, mode, cfg, ag); recErr != nil {
@@ -1157,6 +1157,71 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	}
 
 	return ag.ID, cfg.Dir, baselineRef, nil
+}
+
+func (a *agentAdapter) launchCertifiedDirect(t task.Task, role agent.Role, cfg *agent.RunConfig) (*agent.Agent, string, error) {
+	baselineRef := agentorch.CurrentWorktreeHead(context.Background(), cfg.Dir)
+	a.configureTestRunnerRun(cfg, t.ID, role, t)
+	if err := a.certifyRunEnvironment(t, role, cfg); err != nil {
+		return nil, "", err
+	}
+	ag, err := a.agents.Run(*cfg)
+	if err != nil {
+		if a.runenv != nil && runenv.IsEnvironmentFailure(err) {
+			a.runenv.InvalidateTask(t.ID)
+		}
+		return nil, "", translatePoolBusy(err)
+	}
+	return ag, baselineRef, nil
+}
+
+func (a *agentAdapter) certifyRunEnvironment(t task.Task, role agent.Role, cfg *agent.RunConfig) error {
+	if a.runenv == nil {
+		return nil
+	}
+	resolvedProvider, err := a.agents.ResolveProvider(*cfg)
+	if err != nil {
+		return err
+	}
+	cloneDir := ""
+	cloneGeneration := ""
+	if t.ProjectID != "" && a.projects != nil {
+		p, projectErr := a.projects.Get(t.ProjectID)
+		if projectErr != nil {
+			return projectErr
+		}
+		cloneDir = p.ClonePath
+		cloneGeneration = p.CloneGeneration
+	}
+	scratchRoots, err := a.agents.CertificationScratchRoots(t.ID)
+	if err != nil {
+		return err
+	}
+	action := string(role) + ".dispatch"
+	if role == "" {
+		action = "implementation.dispatch"
+	}
+	requirements := role.CapabilityRequirements(action)
+	mutationIdentity := ""
+	if slices.ContainsFunc(requirements, func(requirement autonomy.CapabilityRequirement) bool {
+		return requirement.Capability == autonomy.CapabilityTaskMutation
+	}) {
+		mutationIdentity, err = a.tasks.MutationTransportIdentity(t.ID)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = a.runenv.Certify(context.Background(), runenv.Request{
+		TaskID: t.ID, ProjectID: t.ProjectID, Action: action,
+		WorkDir: cfg.Dir, ReadRoots: cfg.ReadOnlyPaths, GitRoots: cfg.ReadOnlyPaths,
+		ScratchRoots: scratchRoots, CloneDir: cloneDir, CloneGeneration: cloneGeneration, TaskBranch: t.Branch,
+		Provider: resolvedProvider, SandboxMode: cfg.SandboxMode,
+		SigningPolicy:        project.NormalizeSigningPolicy(a.agentOrch.Cfg().CommitSigning()),
+		TaskMutationIdentity: mutationIdentity,
+		Requirements:         requirements,
+		ConfigVersion:        fmt.Sprintf("%s|%s", cfg.SandboxMode, a.agentOrch.Cfg().CommitSigning()),
+	})
+	return err
 }
 
 // fallbackAgentWorkingDir creates an otherwise empty, per-run cwd for a

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -1162,9 +1162,6 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 func (a *agentAdapter) launchCertifiedDirect(t task.Task, role agent.Role, cfg *agent.RunConfig) (*agent.Agent, string, error) {
 	baselineRef := agentorch.CurrentWorktreeHead(context.Background(), cfg.Dir)
 	a.configureTestRunnerRun(cfg, t.ID, role, t)
-	if err := a.certifyRunEnvironment(t, role, cfg); err != nil {
-		return nil, "", err
-	}
 	ag, err := a.agents.Run(*cfg)
 	if err != nil {
 		if a.runenv != nil && runenv.IsEnvironmentFailure(err) {
@@ -1173,55 +1170,6 @@ func (a *agentAdapter) launchCertifiedDirect(t task.Task, role agent.Role, cfg *
 		return nil, "", translatePoolBusy(err)
 	}
 	return ag, baselineRef, nil
-}
-
-func (a *agentAdapter) certifyRunEnvironment(t task.Task, role agent.Role, cfg *agent.RunConfig) error {
-	if a.runenv == nil {
-		return nil
-	}
-	resolvedProvider, err := a.agents.ResolveProvider(*cfg)
-	if err != nil {
-		return err
-	}
-	cloneDir := ""
-	cloneGeneration := ""
-	if t.ProjectID != "" && a.projects != nil {
-		p, projectErr := a.projects.Get(t.ProjectID)
-		if projectErr != nil {
-			return projectErr
-		}
-		cloneDir = p.ClonePath
-		cloneGeneration = p.CloneGeneration
-	}
-	scratchRoots, err := a.agents.CertificationScratchRoots(t.ID)
-	if err != nil {
-		return err
-	}
-	action := string(role) + ".dispatch"
-	if role == "" {
-		action = "implementation.dispatch"
-	}
-	requirements := role.CapabilityRequirements(action)
-	mutationIdentity := ""
-	if slices.ContainsFunc(requirements, func(requirement autonomy.CapabilityRequirement) bool {
-		return requirement.Capability == autonomy.CapabilityTaskMutation
-	}) {
-		mutationIdentity, err = a.tasks.MutationTransportIdentity(t.ID)
-		if err != nil {
-			return err
-		}
-	}
-	_, err = a.runenv.Certify(context.Background(), runenv.Request{
-		TaskID: t.ID, ProjectID: t.ProjectID, Action: action,
-		WorkDir: cfg.Dir, ReadRoots: cfg.ReadOnlyPaths, GitRoots: cfg.ReadOnlyPaths,
-		ScratchRoots: scratchRoots, CloneDir: cloneDir, CloneGeneration: cloneGeneration, TaskBranch: t.Branch,
-		Provider: resolvedProvider, SandboxMode: cfg.SandboxMode,
-		SigningPolicy:        project.NormalizeSigningPolicy(a.agentOrch.Cfg().CommitSigning()),
-		TaskMutationIdentity: mutationIdentity,
-		Requirements:         requirements,
-		ConfigVersion:        fmt.Sprintf("%s|%s", cfg.SandboxMode, a.agentOrch.Cfg().CommitSigning()),
-	})
-	return err
 }
 
 // fallbackAgentWorkingDir creates an otherwise empty, per-run cwd for a

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -148,6 +148,7 @@ func (r *Handler) StartFixReviewAgent(t task.Task) error {
 		// the Manager applies agent.role_effort and then the baseline.
 		ReasoningEffort:        t.ReasoningEffort,
 		HeadlessPermissionMode: posture,
+		SandboxMode:            agentorch.ResolveSandboxMode(t, r.cfg),
 		// MaxTurns intentionally not inherited: fix-review agents need
 		// enough turns to fetch the PR, apply fixes, and commit.
 	})
@@ -220,7 +221,7 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 
 	prompt := StaffCodeReviewPrompt(current.ProjectID, current.PRNumber)
 
-	cfg := r.agents.ApplyABVariant(StaffCodeReviewRunConfig(current, prompt, dir, posture), r.abTestingConfig(), current.ID, string(agent.RoleReview))
+	cfg := r.agents.ApplyABVariant(StaffCodeReviewRunConfig(current, prompt, dir, posture, agentorch.ResolveSandboxMode(current, r.cfg)), r.abTestingConfig(), current.ID, string(agent.RoleReview))
 	ag, err := r.agents.Run(cfg)
 	if err != nil {
 		return err
@@ -259,7 +260,11 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 // A/B-disabled fallback keep their high-scrutiny model; an A/B pick overrides it.
 // MaxTurns is intentionally not inherited: review agents need enough turns to
 // fetch the PR, run the skill, and write findings.
-func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture string) agent.RunConfig {
+func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture string, sandboxMode ...string) agent.RunConfig {
+	resolvedSandboxMode := ""
+	if len(sandboxMode) > 0 {
+		resolvedSandboxMode = sandboxMode[0]
+	}
 	return agent.RunConfig{
 		TaskID: t.ID,
 		Name:   agent.RoleReview.AgentName(t.Title),
@@ -273,6 +278,8 @@ func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture string) agent.Ru
 		// the Manager applies agent.role_effort and then the baseline.
 		ReasoningEffort:        t.ReasoningEffort,
 		HeadlessPermissionMode: posture,
+		SandboxMode:            resolvedSandboxMode,
+		ReadOnlyDir:            true,
 	}
 }
 

--- a/internal/sybra/review/inbound.go
+++ b/internal/sybra/review/inbound.go
@@ -260,11 +260,7 @@ func (r *Handler) StartReviewAgent(t task.Task, force bool) error {
 // A/B-disabled fallback keep their high-scrutiny model; an A/B pick overrides it.
 // MaxTurns is intentionally not inherited: review agents need enough turns to
 // fetch the PR, run the skill, and write findings.
-func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture string, sandboxMode ...string) agent.RunConfig {
-	resolvedSandboxMode := ""
-	if len(sandboxMode) > 0 {
-		resolvedSandboxMode = sandboxMode[0]
-	}
+func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture, sandboxMode string) agent.RunConfig {
 	return agent.RunConfig{
 		TaskID: t.ID,
 		Name:   agent.RoleReview.AgentName(t.Title),
@@ -278,7 +274,7 @@ func StaffCodeReviewRunConfig(t task.Task, prompt, dir, posture string, sandboxM
 		// the Manager applies agent.role_effort and then the baseline.
 		ReasoningEffort:        t.ReasoningEffort,
 		HeadlessPermissionMode: posture,
-		SandboxMode:            resolvedSandboxMode,
+		SandboxMode:            sandboxMode,
 		ReadOnlyDir:            true,
 	}
 }

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -456,7 +456,7 @@ func TestStaffCodeReviewRunConfigCarriesTaskReasoningEffort(t *testing.T) {
 			t.Parallel()
 			cfg := StaffCodeReviewRunConfig(
 				task.Task{ID: "review-task", Title: "Needs review", ReasoningEffort: tt.pinned},
-				"Run /staff-code-review", t.TempDir(), "default",
+				"Run /staff-code-review", t.TempDir(), "default", "enforce",
 			)
 			if cfg.ReasoningEffort != tt.want {
 				t.Fatalf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, tt.want)

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -408,7 +408,7 @@ func TestPushPreflightFailureReasonKeepsValidUTF8(t *testing.T) {
 }
 
 func TestStaffCodeReviewRunConfigLeavesProviderUnpinned(t *testing.T) {
-	cfg := StaffCodeReviewRunConfig(task.Task{ID: "review-task", Title: "Needs review"}, "Run /staff-code-review", t.TempDir(), "default")
+	cfg := StaffCodeReviewRunConfig(task.Task{ID: "review-task", Title: "Needs review"}, "Run /staff-code-review", t.TempDir(), "default", "enforce")
 
 	if cfg.Name != agent.RoleReview.AgentName("Needs review") {
 		t.Fatalf("Name = %q, want %q", cfg.Name, agent.RoleReview.AgentName("Needs review"))
@@ -424,6 +424,12 @@ func TestStaffCodeReviewRunConfigLeavesProviderUnpinned(t *testing.T) {
 	}
 	if cfg.HeadlessPermissionMode != "default" {
 		t.Fatalf("HeadlessPermissionMode = %q, want default", cfg.HeadlessPermissionMode)
+	}
+	if !cfg.ReadOnlyDir {
+		t.Fatal("ReadOnlyDir = false, want verifier worktree protected")
+	}
+	if cfg.SandboxMode != "enforce" {
+		t.Fatalf("SandboxMode = %q, want enforce", cfg.SandboxMode)
 	}
 	if cfg.DisableProviderFailover {
 		t.Fatal("DisableProviderFailover = true, want false (availability preferred)")

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -33,15 +33,16 @@ const (
 
 // Observation is immutable evidence for one required capability.
 type Observation struct {
-	Capability autonomy.Capability `json:"capability"`
-	Scope      string              `json:"scope"`
-	Satisfied  bool                `json:"satisfied"`
-	Available  bool                `json:"available"`
-	Contained  bool                `json:"contained"`
-	Code       string              `json:"code,omitempty"`
-	Evidence   string              `json:"evidence,omitempty"`
-	Repairable bool                `json:"repairable"`
-	ObservedAt time.Time           `json:"observedAt"`
+	Capability autonomy.Capability   `json:"capability"`
+	Scope      string                `json:"scope"`
+	Satisfied  bool                  `json:"satisfied"`
+	Available  bool                  `json:"available"`
+	Contained  bool                  `json:"contained"`
+	Code       string                `json:"code,omitempty"`
+	Evidence   string                `json:"evidence,omitempty"`
+	Repairable bool                  `json:"repairable"`
+	Owner      autonomy.FailureOwner `json:"owner,omitempty"`
+	ObservedAt time.Time             `json:"observedAt"`
 }
 
 // Certificate is the time-bounded admission proof for one action and exact
@@ -88,6 +89,7 @@ type ProbeResult struct {
 	Contained bool
 	Code      string
 	Evidence  string
+	Owner     autonomy.FailureOwner
 }
 
 // CertificationError is the stable machine-owned reason passed to quarantine policy.
@@ -98,6 +100,7 @@ type CertificationError struct {
 	Scope      string
 	Code       string
 	Capability autonomy.Capability
+	Owner      autonomy.FailureOwner
 	Cause      error
 }
 
@@ -114,6 +117,17 @@ func (f CertificationError) Unwrap() error { return f.Cause }
 // as machine-owned without importing this App-scoped package and creating an
 // import cycle.
 func (f CertificationError) MachineFailureCode() string { return f.Code }
+
+// MachineFailureTransient distinguishes external admission signals that are
+// expected to self-heal from machine-owned environment defects that require a
+// deterministic repair before dispatch can resume.
+func (f CertificationError) MachineFailureTransient() bool {
+	return f.Owner == autonomy.FailureOwnerExternalTransient
+}
+
+func (f CertificationError) MachineFailureRequiresCredentials() bool {
+	return f.Owner == autonomy.FailureOwnerOperatorAuthority
+}
 
 // Deps keeps state-changing authority outside this package.
 type Deps struct {
@@ -218,15 +232,15 @@ func (s *Service) Certify(ctx context.Context, req Request) (Certificate, error)
 	failed := failedObservations(cert)
 	if len(failed) > 0 && slices.ContainsFunc(failed, func(o Observation) bool { return o.Repairable }) && s.deps.Repair != nil {
 		if repairErr := s.deps.Repair(ctx, req, failed); repairErr == nil {
-			if s.deps.Audit != nil {
-				s.deps.Audit("runenv.repair", cert, nil)
-			}
 			freshKey, fpErr := fingerprint(ctx, req)
 			if fpErr == nil {
 				key = freshKey
 			}
 			cert = s.observe(ctx, req, key, true)
 			failed = failedObservations(cert)
+			if s.deps.Audit != nil {
+				s.deps.Audit("runenv.repair", cert, nil)
+			}
 		}
 	}
 	if len(failed) > 0 {
@@ -275,7 +289,7 @@ func (s *Service) observe(ctx context.Context, req Request, key string, repaired
 	for _, requirement := range req.Requirements {
 		obs := Observation{Capability: requirement.Capability, Scope: requirement.Scope, Repairable: requirement.Repairable, ObservedAt: now}
 		result, err := s.probe(ctx, req, requirement.Capability)
-		obs.Available, obs.Contained, obs.Code, obs.Evidence = result.Available, result.Contained, result.Code, result.Evidence
+		obs.Available, obs.Contained, obs.Code, obs.Evidence, obs.Owner = result.Available, result.Contained, result.Code, result.Evidence, result.Owner
 		obs.Satisfied = err == nil && result.Available
 		if err != nil && obs.Code == "" {
 			obs.Code = capabilityCode(requirement.Capability)
@@ -663,7 +677,11 @@ func failureFrom(req Request, o Observation) CertificationError {
 	if strings.TrimSpace(o.Evidence) != "" {
 		cause = errors.New(o.Evidence)
 	}
-	return CertificationError{TaskID: req.TaskID, ProjectID: req.ProjectID, Action: req.Action, Scope: o.Scope, Code: firstNonEmpty(o.Code, capabilityCode(o.Capability)), Capability: o.Capability, Cause: cause}
+	owner := o.Owner
+	if owner == autonomy.FailureOwnerUnknown {
+		owner = autonomy.FailureOwnerMachine
+	}
+	return CertificationError{TaskID: req.TaskID, ProjectID: req.ProjectID, Action: req.Action, Scope: o.Scope, Code: firstNonEmpty(o.Code, capabilityCode(o.Capability)), Capability: o.Capability, Owner: owner, Cause: cause}
 }
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -193,7 +193,7 @@ func (s *Service) Certify(ctx context.Context, req Request) (Certificate, error)
 	if err != nil {
 		return Certificate{}, err
 	}
-	lock := s.keyLock(firstNonEmpty(req.CloneDir, req.ProjectID, req.WorkDir, req.TaskID))
+	lock := s.keyLock(firstNonEmpty(req.CloneDir, req.ProjectID, "global"))
 	lock.Lock()
 	defer lock.Unlock()
 	now := s.deps.Now()
@@ -435,7 +435,12 @@ func requestGitRoots(req Request) []string {
 	if len(req.GitRoots) > 0 {
 		return req.GitRoots
 	}
-	return []string{req.WorkDir}
+	if slices.ContainsFunc(req.Requirements, func(requirement autonomy.CapabilityRequirement) bool {
+		return requirement.Capability == autonomy.CapabilityGitAdminWrite || requirement.Capability == autonomy.CapabilityCheckoutHealth
+	}) {
+		return []string{req.WorkDir}
+	}
+	return nil
 }
 
 func probeIndexObjects(ctx context.Context, workDir string) error {
@@ -550,16 +555,20 @@ func fileIdentity(path string) string {
 	if err != nil {
 		return path + "|missing"
 	}
-	contents, err := os.ReadFile(resolved)
+	file, err := os.Open(resolved)
 	if err != nil {
 		return resolved + "|unavailable|" + err.Error()
 	}
+	defer file.Close()
 	info, err := os.Stat(resolved)
 	if err != nil {
 		return resolved + "|unavailable|" + err.Error()
 	}
-	sum := sha256.Sum256(contents)
-	return resolved + "|" + info.Mode().String() + "|" + strconv.FormatInt(info.Size(), 10) + "|" + hex.EncodeToString(sum[:])
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return resolved + "|unavailable|" + err.Error()
+	}
+	return resolved + "|" + info.Mode().String() + "|" + strconv.FormatInt(info.Size(), 10) + "|" + hex.EncodeToString(hash.Sum(nil))
 }
 
 func directoryIdentity(path string) string {

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -346,6 +346,9 @@ func (s *Service) probe(ctx context.Context, req Request, capability autonomy.Ca
 		if err := probeObjectStore(ctx, req); err != nil {
 			return ProbeResult{Code: "object_store_unhealthy"}, err
 		}
+		if req.CloneDir == "" {
+			return ProbeResult{Available: true, Evidence: "no shared object store declared"}, nil
+		}
 		return ProbeResult{Available: true, Evidence: "shared object store and refs readable"}, nil
 	case autonomy.CapabilitySigning:
 		if req.SigningPolicy.SignsCommits(ctx) {

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -189,13 +189,13 @@ func (s *Service) Certify(ctx context.Context, req Request) (Certificate, error)
 	if err := validate(req); err != nil {
 		return Certificate{}, err
 	}
+	lock := s.keyLock(firstNonEmpty(req.CloneDir, req.ProjectID, "global"))
+	lock.Lock()
+	defer lock.Unlock()
 	key, err := fingerprint(ctx, req)
 	if err != nil {
 		return Certificate{}, err
 	}
-	lock := s.keyLock(firstNonEmpty(req.CloneDir, req.ProjectID, "global"))
-	lock.Lock()
-	defer lock.Unlock()
 	now := s.deps.Now()
 	s.mu.Lock()
 	s.pruneExpiredLocked(now)

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -298,12 +298,17 @@ func (s *Service) probe(ctx context.Context, req Request, capability autonomy.Ca
 		}
 		return ProbeResult{Available: true, Evidence: "source roots readable"}, nil
 	case autonomy.CapabilitySourceWrite:
-		for _, root := range append([]string{req.WorkDir}, req.ScratchRoots...) {
+		if err := probeWrite(req.WorkDir); err != nil {
+			return ProbeResult{Code: "source_write_unavailable"}, err
+		}
+		return ProbeResult{Available: true, Evidence: "source root writable"}, nil
+	case autonomy.CapabilityScratchWrite:
+		for _, root := range req.ScratchRoots {
 			if err := probeWrite(root); err != nil {
-				return ProbeResult{Code: "source_write_unavailable"}, err
+				return ProbeResult{Code: "scratch_write_unavailable"}, err
 			}
 		}
-		return ProbeResult{Available: true, Evidence: "required source and scratch roots writable"}, nil
+		return ProbeResult{Available: true, Evidence: "required scratch roots writable"}, nil
 	case autonomy.CapabilityGitAdminWrite:
 		gitDir, common, err := gitDirs(ctx, req.WorkDir)
 		if err != nil {
@@ -555,41 +560,50 @@ func fileIdentity(path string) string {
 	if err != nil {
 		return path + "|missing"
 	}
-	file, err := os.Open(resolved)
-	if err != nil {
-		return resolved + "|unavailable|" + err.Error()
-	}
-	defer file.Close()
 	info, err := os.Stat(resolved)
 	if err != nil {
 		return resolved + "|unavailable|" + err.Error()
 	}
-	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return resolved + "|unavailable|" + err.Error()
-	}
-	return resolved + "|" + info.Mode().String() + "|" + strconv.FormatInt(info.Size(), 10) + "|" + hex.EncodeToString(hash.Sum(nil))
+	return resolved + "|" + info.Mode().String() + "|" + strconv.FormatInt(info.Size(), 10) + "|" + strconv.FormatInt(info.ModTime().UnixNano(), 10)
 }
 
+// directoryIdentity deliberately caps traversal so fingerprint lookup remains
+// cheap on repositories with very large ref namespaces. The current HEAD is
+// fingerprinted separately, and clone generation covers shared-clone refresh.
 func directoryIdentity(path string) string {
+	const maxEntries = 256
 	hash := sha256.New()
-	err := filepath.WalkDir(path, func(candidate string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		relative, err := filepath.Rel(path, candidate)
-		if err != nil {
-			return err
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return err
-		}
-		_, _ = io.WriteString(hash, relative+"|"+entry.Type().String()+"|"+strconv.FormatInt(info.Size(), 10)+"|"+strconv.FormatInt(info.ModTime().UnixNano(), 10)+"\n")
-		return nil
-	})
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return path + "|unavailable|" + err.Error()
+	}
+	written := 0
+	for _, entry := range entries {
+		if written == maxEntries {
+			_, _ = io.WriteString(hash, "truncated\n")
+			break
+		}
+		if err := writeEntryIdentity(hash, entry.Name(), entry); err != nil {
+			return path + "|unavailable|" + err.Error()
+		}
+		written++
+		if !entry.IsDir() {
+			continue
+		}
+		children, readErr := os.ReadDir(filepath.Join(path, entry.Name()))
+		if readErr != nil {
+			return path + "|unavailable|" + readErr.Error()
+		}
+		for _, child := range children {
+			if written == maxEntries {
+				_, _ = io.WriteString(hash, "truncated\n")
+				break
+			}
+			if err := writeEntryIdentity(hash, entry.Name()+"/"+child.Name(), child); err != nil {
+				return path + "|unavailable|" + err.Error()
+			}
+			written++
+		}
 	}
 	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -1,0 +1,659 @@
+// Package runenv certifies the concrete environment an agent will use before
+// provider tokens are spent. It deliberately owns no task or project stores;
+// mutation, repair, quarantine, and audit are narrow callbacks supplied by the
+// application control plane.
+package runenv
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/autonomy"
+	"github.com/Automaat/sybra/internal/gitexec"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/textutil"
+)
+
+const (
+	defaultTTL = 2 * time.Minute
+	failureTTL = 30 * time.Second
+)
+
+// Observation is immutable evidence for one required capability.
+type Observation struct {
+	Capability autonomy.Capability `json:"capability"`
+	Scope      string              `json:"scope"`
+	Satisfied  bool                `json:"satisfied"`
+	Available  bool                `json:"available"`
+	Contained  bool                `json:"contained"`
+	Code       string              `json:"code,omitempty"`
+	Evidence   string              `json:"evidence,omitempty"`
+	Repairable bool                `json:"repairable"`
+	ObservedAt time.Time           `json:"observedAt"`
+}
+
+// Certificate is the time-bounded admission proof for one action and exact
+// run environment fingerprint.
+type Certificate struct {
+	ID           string        `json:"id"`
+	Fingerprint  string        `json:"fingerprint"`
+	TaskID       string        `json:"taskId"`
+	ProjectID    string        `json:"projectId,omitempty"`
+	Action       string        `json:"action"`
+	Observations []Observation `json:"observations"`
+	ObservedAt   time.Time     `json:"observedAt"`
+	ExpiresAt    time.Time     `json:"expiresAt"`
+	Repaired     bool          `json:"repaired"`
+}
+
+func (c Certificate) Current(now time.Time) bool {
+	return c.ID != "" && now.Before(c.ExpiresAt) && !slices.ContainsFunc(c.Observations, func(o Observation) bool { return !o.Satisfied })
+}
+
+// Request describes the actual paths and policy selected for a pending run.
+type Request struct {
+	TaskID               string
+	ProjectID            string
+	Action               string
+	WorkDir              string
+	ReadRoots            []string
+	GitRoots             []string
+	ScratchRoots         []string
+	CloneDir             string
+	TaskBranch           string
+	Provider             string
+	SandboxMode          string
+	SigningPolicy        project.SigningPolicy
+	TaskMutationIdentity string
+	Requirements         []autonomy.CapabilityRequirement
+	ConfigVersion        string
+	CloneGeneration      string
+}
+
+// ProbeResult is returned by application-owned probes.
+type ProbeResult struct {
+	Available bool
+	Contained bool
+	Code      string
+	Evidence  string
+}
+
+// CertificationError is the stable machine-owned reason passed to quarantine policy.
+type CertificationError struct {
+	TaskID     string
+	ProjectID  string
+	Action     string
+	Scope      string
+	Code       string
+	Capability autonomy.Capability
+	Cause      error
+}
+
+func (f CertificationError) Error() string {
+	if f.Cause != nil {
+		return fmt.Sprintf("run environment certification failed: %s (%s): %v", f.Code, f.Capability, f.Cause)
+	}
+	return fmt.Sprintf("run environment certification failed: %s (%s)", f.Code, f.Capability)
+}
+
+func (f CertificationError) Unwrap() error { return f.Cause }
+
+// MachineFailureCode lets workflow admission classify certification failures
+// as machine-owned without importing this App-scoped package and creating an
+// import cycle.
+func (f CertificationError) MachineFailureCode() string { return f.Code }
+
+// Deps keeps state-changing authority outside this package.
+type Deps struct {
+	ProbeSandbox      func(context.Context, string) (ProbeResult, error)
+	ProbeProvider     func(context.Context, string) (ProbeResult, error)
+	ProbeNetwork      func(context.Context, string) (ProbeResult, error)
+	ProbeTaskMutation func(context.Context, string) (ProbeResult, error)
+	Repair            func(context.Context, Request, []Observation) error
+	Quarantine        func(context.Context, CertificationError)
+	Audit             func(string, Certificate, *CertificationError)
+	Now               func() time.Time
+	TTL               time.Duration
+}
+
+type cacheEntry struct{ cert Certificate }
+type quarantineEntry struct {
+	failure   CertificationError
+	expiresAt time.Time
+}
+
+// Service serializes certification and repair per shared project clone.
+type Service struct {
+	deps        Deps
+	mu          sync.Mutex
+	cache       map[string]cacheEntry
+	locks       map[string]*sync.Mutex
+	quarantined map[string]quarantineEntry
+}
+
+func New(deps Deps) *Service {
+	if deps.Now == nil {
+		deps.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if deps.TTL <= 0 {
+		deps.TTL = defaultTTL
+	}
+	return &Service{deps: deps, cache: map[string]cacheEntry{}, locks: map[string]*sync.Mutex{}, quarantined: map[string]quarantineEntry{}}
+}
+
+// InvalidateTask drops otherwise-current evidence after a provider reports a
+// filesystem, object, or signing failure. The next retry must re-observe and
+// may repair before another provider process starts.
+func (s *Service) InvalidateTask(taskID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key := range s.cache {
+		if s.cache[key].cert.TaskID == taskID {
+			delete(s.cache, key)
+		}
+	}
+}
+
+// IsEnvironmentFailure recognizes provider/start errors that invalidate a
+// certificate. It is diagnostic only; admission policy still branches on the
+// typed observation produced by the following certification pass.
+func IsEnvironmentFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{"read-only file system", "operation not permitted", "bad object", "invalid object", "missing blob", "missing commit", "unable to read tree", "gpg failed to sign", "signer unavailable"} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// Certify returns a current certificate or a typed failure. At most one safe
+// repair is attempted, under the same clone-scoped lock, then every required
+// capability is observed again from scratch.
+func (s *Service) Certify(ctx context.Context, req Request) (Certificate, error) {
+	if err := validate(req); err != nil {
+		return Certificate{}, err
+	}
+	key, err := fingerprint(ctx, req)
+	if err != nil {
+		return Certificate{}, err
+	}
+	lock := s.keyLock(firstNonEmpty(req.CloneDir, req.ProjectID, req.WorkDir, req.TaskID))
+	lock.Lock()
+	defer lock.Unlock()
+	now := s.deps.Now()
+	s.mu.Lock()
+	entry, ok := s.cache[key]
+	s.mu.Unlock()
+	if ok && entry.cert.Current(now) {
+		return entry.cert, nil
+	}
+	if ok && now.Before(entry.cert.ExpiresAt) {
+		if failed := failedObservations(entry.cert); len(failed) > 0 {
+			return Certificate{}, failureFrom(req, failed[0])
+		}
+	}
+	if failure, blocked := s.activeQuarantine(req, now); blocked {
+		failure.TaskID, failure.Action = req.TaskID, req.Action
+		return Certificate{}, failure
+	}
+
+	cert := s.observe(ctx, req, key, false)
+	failed := failedObservations(cert)
+	if len(failed) > 0 && slices.ContainsFunc(failed, func(o Observation) bool { return o.Repairable }) && s.deps.Repair != nil {
+		if repairErr := s.deps.Repair(ctx, req, failed); repairErr == nil {
+			if s.deps.Audit != nil {
+				s.deps.Audit("runenv.repair", cert, nil)
+			}
+			freshKey, fpErr := fingerprint(ctx, req)
+			if fpErr == nil {
+				key = freshKey
+			}
+			cert = s.observe(ctx, req, key, true)
+			failed = failedObservations(cert)
+		}
+	}
+	if len(failed) > 0 {
+		failure := failureFrom(req, failed[0])
+		cert.ExpiresAt = s.deps.Now().Add(failureTTL)
+		s.mu.Lock()
+		s.cache[key] = cacheEntry{cert: cert}
+		s.mu.Unlock()
+		// Provider and GitHub availability are external/transient admission
+		// signals, not evidence that a host, project, or task filesystem is
+		// unsafe. Cache them to suppress duplicate starts, but never apply the
+		// machine-owned environment quarantine to tasks.
+		if failure.Capability != autonomy.CapabilityProviderCapacity && failure.Capability != autonomy.CapabilityNetworkGitHub {
+			s.quarantineOnce(ctx, key, failure, cert)
+		}
+		return Certificate{}, failure
+	}
+	s.mu.Lock()
+	s.cache[key] = cacheEntry{cert: cert}
+	for _, observation := range cert.Observations {
+		delete(s.quarantined, quarantineScopeKey(req, observation.Scope, observation.Capability))
+	}
+	s.mu.Unlock()
+	if s.deps.Audit != nil {
+		s.deps.Audit("runenv.certified", cert, nil)
+	}
+	return cert, nil
+}
+
+func (s *Service) observe(ctx context.Context, req Request, key string, repaired bool) Certificate {
+	now := s.deps.Now()
+	cert := Certificate{ID: certificateID(key, now), Fingerprint: key, TaskID: req.TaskID, ProjectID: req.ProjectID, Action: req.Action, ObservedAt: now, ExpiresAt: now.Add(s.deps.TTL), Repaired: repaired}
+	for _, requirement := range req.Requirements {
+		obs := Observation{Capability: requirement.Capability, Scope: requirement.Scope, Repairable: requirement.Repairable, ObservedAt: now}
+		result, err := s.probe(ctx, req, requirement.Capability)
+		obs.Available, obs.Contained, obs.Code, obs.Evidence = result.Available, result.Contained, result.Code, result.Evidence
+		obs.Satisfied = err == nil && result.Available
+		if err != nil && obs.Code == "" {
+			obs.Code = capabilityCode(requirement.Capability)
+		}
+		if err != nil && obs.Evidence == "" {
+			obs.Evidence = err.Error()
+		}
+		cert.Observations = append(cert.Observations, obs)
+	}
+	return cert
+}
+
+func (s *Service) probe(ctx context.Context, req Request, capability autonomy.Capability) (ProbeResult, error) {
+	switch capability {
+	case autonomy.CapabilitySourceRead:
+		for _, root := range append([]string{req.WorkDir}, req.ReadRoots...) {
+			if err := probeRead(root); err != nil {
+				return ProbeResult{Code: "source_read_unavailable"}, err
+			}
+		}
+		return ProbeResult{Available: true, Evidence: "source roots readable"}, nil
+	case autonomy.CapabilitySourceWrite:
+		for _, root := range append([]string{req.WorkDir}, req.ScratchRoots...) {
+			if err := probeWrite(root); err != nil {
+				return ProbeResult{Code: "source_write_unavailable"}, err
+			}
+		}
+		return ProbeResult{Available: true, Evidence: "required source and scratch roots writable"}, nil
+	case autonomy.CapabilityGitAdminWrite:
+		gitDir, common, err := gitDirs(ctx, req.WorkDir)
+		if err != nil {
+			return ProbeResult{Code: "git_admin_invalid"}, err
+		}
+		if err := probeWrite(gitDir); err != nil {
+			return ProbeResult{Code: "git_admin_readonly"}, err
+		}
+		if common != gitDir {
+			if err := probeWrite(common); err != nil {
+				return ProbeResult{Code: "git_admin_readonly"}, err
+			}
+		}
+		return ProbeResult{Available: true, Evidence: "git admin writable; common dir=" + common}, nil
+	case autonomy.CapabilityCheckoutHealth:
+		if err := probeCheckouts(ctx, req); err != nil {
+			return ProbeResult{Code: "checkout_unhealthy"}, err
+		}
+		return ProbeResult{Available: true, Evidence: "checkout Git metadata and referenced objects readable"}, nil
+	case autonomy.CapabilityObjectStore:
+		if err := probeObjectStore(ctx, req); err != nil {
+			return ProbeResult{Code: "object_store_unhealthy"}, err
+		}
+		return ProbeResult{Available: true, Evidence: "shared object store and refs readable"}, nil
+	case autonomy.CapabilitySigning:
+		if req.SigningPolicy.SignsCommits(ctx) {
+			if err := project.ProbeGPGSigning(ctx); err != nil {
+				return ProbeResult{Code: "signer_unavailable"}, err
+			}
+		}
+		return ProbeResult{Available: true, Evidence: "signing policy " + string(req.SigningPolicy)}, nil
+	case autonomy.CapabilityTaskMutation:
+		return callProbe(ctx, s.deps.ProbeTaskMutation, req.TaskID, "task_mutation_unavailable")
+	case autonomy.CapabilitySandboxMechanism:
+		return callProbe(ctx, s.deps.ProbeSandbox, req.SandboxMode, "sandbox_unavailable")
+	case autonomy.CapabilityProviderCapacity:
+		return callProbe(ctx, s.deps.ProbeProvider, req.Provider, "provider_unavailable")
+	case autonomy.CapabilityNetworkGitHub:
+		return callProbe(ctx, s.deps.ProbeNetwork, req.ProjectID, "github_network_unavailable")
+	default:
+		return ProbeResult{Code: "unknown_capability"}, fmt.Errorf("unknown capability %q", capability)
+	}
+}
+
+func callProbe(ctx context.Context, fn func(context.Context, string) (ProbeResult, error), value, code string) (ProbeResult, error) {
+	if fn == nil {
+		return ProbeResult{Code: code}, errors.New("probe is not configured")
+	}
+	r, err := fn(ctx, value)
+	if err != nil && r.Code == "" {
+		r.Code = code
+	}
+	return r, err
+}
+
+func probeRead(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Readdirnames(1)
+	if err == nil || errors.Is(err, io.EOF) {
+		return nil
+	}
+	return err
+}
+
+func probeWrite(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("write root is empty")
+	}
+	f, err := os.CreateTemp(dir, ".sybra-runenv-probe-")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	if closeErr := f.Close(); closeErr != nil {
+		_ = os.Remove(name)
+		return closeErr
+	}
+	return os.Remove(name)
+}
+
+func gitDirs(ctx context.Context, workDir string) (gitDir, common string, err error) {
+	gitDir, err = gitexec.Output(ctx, gitexec.Options{Dir: workDir}, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err != nil {
+		return "", "", err
+	}
+	common, err = project.CommonDir(ctx, workDir)
+	if err != nil {
+		return "", "", err
+	}
+	if info, statErr := os.Stat(gitDir); statErr != nil || !info.IsDir() {
+		return "", "", fmt.Errorf("invalid git dir %q", gitDir)
+	}
+	if info, statErr := os.Stat(common); statErr != nil || !info.IsDir() {
+		return "", "", fmt.Errorf("invalid git common dir %q", common)
+	}
+	return gitDir, common, nil
+}
+
+func probeCheckouts(ctx context.Context, req Request) error {
+	for _, root := range requestGitRoots(req) {
+		if _, _, err := gitDirs(ctx, root); err != nil {
+			return err
+		}
+		if _, err := gitexec.Output(ctx, gitexec.Options{Dir: root}, "rev-parse", "--verify", "HEAD^{commit}"); err != nil {
+			return err
+		}
+		if _, err := gitexec.Output(ctx, gitexec.Options{Dir: root}, "cat-file", "-e", "HEAD^{tree}"); err != nil {
+			return err
+		}
+		if err := probeIndexObjects(ctx, root); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func probeObjectStore(ctx context.Context, req Request) error {
+	if req.CloneDir != "" {
+		return project.CheckBareCloneHealth(ctx, req.CloneDir)
+	}
+	return nil
+}
+
+func requestGitRoots(req Request) []string {
+	if len(req.GitRoots) > 0 {
+		return req.GitRoots
+	}
+	return []string{req.WorkDir}
+}
+
+func probeIndexObjects(ctx context.Context, workDir string) error {
+	staged, err := gitexec.RawOutput(ctx, gitexec.Options{Dir: workDir}, "ls-files", "--stage", "-z")
+	if err != nil {
+		return err
+	}
+	var objectIDs strings.Builder
+	for record := range bytes.SplitSeq(staged, []byte{0}) {
+		if len(record) == 0 {
+			continue
+		}
+		header, _, ok := bytes.Cut(record, []byte{'\t'})
+		if !ok {
+			return errors.New("malformed staged index entry")
+		}
+		fields := bytes.Fields(header)
+		if len(fields) < 2 || string(fields[0]) == "160000" {
+			continue
+		}
+		objectIDs.Write(fields[1])
+		objectIDs.WriteByte('\n')
+	}
+	if objectIDs.Len() == 0 {
+		return nil
+	}
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: workDir, Stdin: strings.NewReader(objectIDs.String())}, "cat-file", "--batch-check=%(objectname) %(objecttype)")
+	if err != nil {
+		return err
+	}
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.HasSuffix(strings.TrimSpace(line), " missing") {
+			return fmt.Errorf("index references unavailable object: %s", line)
+		}
+	}
+	return nil
+}
+
+func validate(req Request) error {
+	if strings.TrimSpace(req.TaskID) == "" || strings.TrimSpace(req.Action) == "" || strings.TrimSpace(req.WorkDir) == "" {
+		return errors.New("runenv request requires task, action, and work directory")
+	}
+	if len(req.Requirements) == 0 {
+		return errors.New("runenv request requires capabilities")
+	}
+	for _, r := range req.Requirements {
+		if err := r.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fingerprint(ctx context.Context, req Request) (string, error) {
+	parts := []string{req.TaskID, req.ProjectID, req.Action, req.WorkDir, req.CloneDir, req.CloneGeneration, req.TaskBranch, req.Provider, req.SandboxMode, string(req.SigningPolicy), req.TaskMutationIdentity, req.ConfigVersion}
+	if abs, err := filepath.EvalSymlinks(req.WorkDir); err == nil {
+		parts = append(parts, abs)
+	}
+	for _, root := range append(append([]string{req.WorkDir}, req.ReadRoots...), req.ScratchRoots...) {
+		parts = append(parts, pathIdentity(root))
+	}
+	for _, root := range requestGitRoots(req) {
+		parts = append(parts, "git-root", root)
+		gitDir, common, err := gitDirs(ctx, root)
+		if err != nil {
+			parts = append(parts, "unavailable", err.Error())
+			continue
+		}
+		parts = append(parts,
+			pathIdentity(gitDir),
+			pathIdentity(common),
+			fileIdentity(filepath.Join(gitDir, "index")),
+			fileIdentity(filepath.Join(gitDir, "HEAD")),
+			directoryIdentity(filepath.Join(common, "refs")),
+			fileIdentity(filepath.Join(common, "packed-refs")),
+			directoryIdentity(filepath.Join(common, "objects")),
+		)
+		if head, err := gitexec.Output(ctx, gitexec.Options{Dir: root}, "rev-parse", "HEAD"); err == nil {
+			parts = append(parts, head)
+		}
+	}
+	if req.CloneDir != "" {
+		parts = append(parts,
+			pathIdentity(req.CloneDir),
+			directoryIdentity(filepath.Join(req.CloneDir, "objects")),
+			directoryIdentity(filepath.Join(req.CloneDir, "refs")),
+			fileIdentity(filepath.Join(req.CloneDir, "packed-refs")),
+			fileIdentity(filepath.Join(req.CloneDir, "HEAD")),
+		)
+	}
+	for _, r := range req.Requirements {
+		parts = append(parts, string(r.Capability), r.Scope, strconv.FormatBool(r.Repairable))
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func pathIdentity(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path + "|missing"
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return resolved + "|missing"
+	}
+	return resolved + "|" + info.Mode().String()
+}
+
+func fileIdentity(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path + "|missing"
+	}
+	contents, err := os.ReadFile(resolved)
+	if err != nil {
+		return resolved + "|unavailable|" + err.Error()
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return resolved + "|unavailable|" + err.Error()
+	}
+	sum := sha256.Sum256(contents)
+	return resolved + "|" + info.Mode().String() + "|" + strconv.FormatInt(info.Size(), 10) + "|" + hex.EncodeToString(sum[:])
+}
+
+func directoryIdentity(path string) string {
+	hash := sha256.New()
+	err := filepath.WalkDir(path, func(candidate string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(path, candidate)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		_, _ = io.WriteString(hash, relative+"|"+entry.Type().String()+"|"+strconv.FormatInt(info.Size(), 10)+"|"+strconv.FormatInt(info.ModTime().UnixNano(), 10)+"\n")
+		return nil
+	})
+	if err != nil {
+		return path + "|unavailable|" + err.Error()
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func certificateID(key string, now time.Time) string {
+	sum := sha256.Sum256([]byte(key + now.String()))
+	return "runenv-" + textutil.TruncateBytes(hex.EncodeToString(sum[:]), 16, "")
+}
+func failedObservations(c Certificate) []Observation {
+	return slices.DeleteFunc(slices.Clone(c.Observations), func(o Observation) bool { return o.Satisfied })
+}
+func capabilityCode(c autonomy.Capability) string {
+	return strings.ReplaceAll(string(c), "_health", "") + "_unavailable"
+}
+func failureFrom(req Request, o Observation) CertificationError {
+	var cause error
+	if strings.TrimSpace(o.Evidence) != "" {
+		cause = errors.New(o.Evidence)
+	}
+	return CertificationError{TaskID: req.TaskID, ProjectID: req.ProjectID, Action: req.Action, Scope: o.Scope, Code: firstNonEmpty(o.Code, capabilityCode(o.Capability)), Capability: o.Capability, Cause: cause}
+}
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func (s *Service) keyLock(key string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if lock := s.locks[key]; lock != nil {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	s.locks[key] = lock
+	return lock
+}
+
+func (s *Service) quarantineOnce(ctx context.Context, _ string, failure CertificationError, cert Certificate) {
+	key := quarantineScopeKey(Request{TaskID: failure.TaskID, ProjectID: failure.ProjectID}, failure.Scope, failure.Capability)
+	s.mu.Lock()
+	_, exists := s.quarantined[key]
+	if !exists {
+		s.quarantined[key] = quarantineEntry{failure: failure, expiresAt: cert.ExpiresAt}
+	}
+	s.mu.Unlock()
+	if exists {
+		return
+	}
+	if s.deps.Quarantine != nil {
+		s.deps.Quarantine(ctx, failure)
+	}
+	if s.deps.Audit != nil {
+		s.deps.Audit("runenv.quarantined", cert, &failure)
+	}
+}
+
+func (s *Service) activeQuarantine(req Request, now time.Time) (CertificationError, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, requirement := range req.Requirements {
+		key := quarantineScopeKey(req, requirement.Scope, requirement.Capability)
+		entry, ok := s.quarantined[key]
+		if !ok {
+			continue
+		}
+		if !now.Before(entry.expiresAt) {
+			delete(s.quarantined, key)
+			continue
+		}
+		return entry.failure, true
+	}
+	return CertificationError{}, false
+}
+
+func quarantineScopeKey(req Request, scope string, capability autonomy.Capability) string {
+	identity := req.TaskID
+	switch scope {
+	case "host":
+		identity = "host"
+	case "project":
+		identity = req.ProjectID
+	case "provider":
+		identity = "provider"
+	}
+	return scope + "|" + identity + "|" + string(capability)
+}

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -198,6 +198,7 @@ func (s *Service) Certify(ctx context.Context, req Request) (Certificate, error)
 	defer lock.Unlock()
 	now := s.deps.Now()
 	s.mu.Lock()
+	s.pruneExpiredLocked(now)
 	entry, ok := s.cache[key]
 	s.mu.Unlock()
 	if ok && entry.cert.Current(now) {
@@ -253,6 +254,19 @@ func (s *Service) Certify(ctx context.Context, req Request) (Certificate, error)
 		s.deps.Audit("runenv.certified", cert, nil)
 	}
 	return cert, nil
+}
+
+func (s *Service) pruneExpiredLocked(now time.Time) {
+	for key := range s.cache {
+		if !now.Before(s.cache[key].cert.ExpiresAt) {
+			delete(s.cache, key)
+		}
+	}
+	for key := range s.quarantined {
+		if !now.Before(s.quarantined[key].expiresAt) {
+			delete(s.quarantined, key)
+		}
+	}
 }
 
 func (s *Service) observe(ctx context.Context, req Request, key string, repaired bool) Certificate {
@@ -497,7 +511,7 @@ func fingerprint(ctx context.Context, req Request) (string, error) {
 			fileIdentity(filepath.Join(gitDir, "HEAD")),
 			directoryIdentity(filepath.Join(common, "refs")),
 			fileIdentity(filepath.Join(common, "packed-refs")),
-			directoryIdentity(filepath.Join(common, "objects")),
+			objectStoreIdentity(filepath.Join(common, "objects")),
 		)
 		if head, err := gitexec.Output(ctx, gitexec.Options{Dir: root}, "rev-parse", "HEAD"); err == nil {
 			parts = append(parts, head)
@@ -506,7 +520,7 @@ func fingerprint(ctx context.Context, req Request) (string, error) {
 	if req.CloneDir != "" {
 		parts = append(parts,
 			pathIdentity(req.CloneDir),
-			directoryIdentity(filepath.Join(req.CloneDir, "objects")),
+			objectStoreIdentity(filepath.Join(req.CloneDir, "objects")),
 			directoryIdentity(filepath.Join(req.CloneDir, "refs")),
 			fileIdentity(filepath.Join(req.CloneDir, "packed-refs")),
 			fileIdentity(filepath.Join(req.CloneDir, "HEAD")),
@@ -569,6 +583,46 @@ func directoryIdentity(path string) string {
 		return path + "|unavailable|" + err.Error()
 	}
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// objectStoreIdentity is deliberately bounded by Git's object-store layout:
+// loose objects live one level below a two-hex fanout directory, so the
+// fanout directory's metadata changes when a loose object is added/removed.
+// Pack/info contain a small number of generation files whose metadata is also
+// included. This detects structural mutations without walking every object.
+func objectStoreIdentity(path string) string {
+	hash := sha256.New()
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return path + "|unavailable|" + err.Error()
+	}
+	for _, entry := range entries {
+		if err := writeEntryIdentity(hash, entry.Name(), entry); err != nil {
+			return path + "|unavailable|" + err.Error()
+		}
+		if !entry.IsDir() || (entry.Name() != "pack" && entry.Name() != "info") {
+			continue
+		}
+		children, readErr := os.ReadDir(filepath.Join(path, entry.Name()))
+		if readErr != nil {
+			return path + "|unavailable|" + readErr.Error()
+		}
+		for _, child := range children {
+			if err := writeEntryIdentity(hash, entry.Name()+"/"+child.Name(), child); err != nil {
+				return path + "|unavailable|" + err.Error()
+			}
+		}
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func writeEntryIdentity(w io.Writer, name string, entry os.DirEntry) error {
+	info, err := entry.Info()
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, name+"|"+entry.Type().String()+"|"+strconv.FormatInt(info.Size(), 10)+"|"+strconv.FormatInt(info.ModTime().UnixNano(), 10)+"\n")
+	return err
 }
 
 func certificateID(key string, now time.Time) string {

--- a/internal/sybra/runenv/runenv.go
+++ b/internal/sybra/runenv/runenv.go
@@ -317,6 +317,9 @@ func (s *Service) probe(ctx context.Context, req Request, capability autonomy.Ca
 		}
 		return ProbeResult{Available: true, Evidence: "source root writable"}, nil
 	case autonomy.CapabilityScratchWrite:
+		if len(req.ScratchRoots) == 0 {
+			return ProbeResult{Code: "scratch_write_unavailable"}, errors.New("scratch roots are not declared")
+		}
 		for _, root := range req.ScratchRoots {
 			if err := probeWrite(root); err != nil {
 				return ProbeResult{Code: "scratch_write_unavailable"}, err

--- a/internal/sybra/runenv/runenv_test.go
+++ b/internal/sybra/runenv/runenv_test.go
@@ -421,6 +421,50 @@ func TestProjectFailureCoalescesQuarantineAcrossTasks(t *testing.T) {
 	}
 }
 
+func TestRequestGitRootsSkipsGitForNonGitCapabilities(t *testing.T) {
+	req := Request{
+		WorkDir: t.TempDir(),
+		Requirements: []autonomy.CapabilityRequirement{{
+			Capability: autonomy.CapabilitySandboxMechanism,
+			Action:     "startup.host",
+			Scope:      "host",
+		}},
+	}
+	if got := requestGitRoots(req); got != nil {
+		t.Fatalf("requestGitRoots() = %v, want nil for non-Git requirements", got)
+	}
+	req.Requirements = append(req.Requirements, autonomy.CapabilityRequirement{
+		Capability: autonomy.CapabilityCheckoutHealth,
+		Action:     "startup.host",
+		Scope:      "task",
+	})
+	if got := requestGitRoots(req); len(got) != 1 || got[0] != req.WorkDir {
+		t.Fatalf("requestGitRoots() = %v, want [%q]", got, req.WorkDir)
+	}
+}
+
+func TestProjectlessCertificationsUseBoundedRepairLock(t *testing.T) {
+	service := New(Deps{ProbeSandbox: healthyProbe(false)})
+	for i := range 25 {
+		req := Request{
+			TaskID:  fmt.Sprintf("task-%d", i),
+			Action:  "startup.host",
+			WorkDir: filepath.Join(t.TempDir(), "work"),
+			Requirements: []autonomy.CapabilityRequirement{{
+				Capability: autonomy.CapabilitySandboxMechanism,
+				Action:     "startup.host",
+				Scope:      "host",
+			}},
+		}
+		if _, err := service.Certify(context.Background(), req); err != nil {
+			t.Fatalf("Certify(%d): %v", i, err)
+		}
+	}
+	if got := len(service.locks); got != 1 {
+		t.Fatalf("repair locks = %d, want one shared projectless lock", got)
+	}
+}
+
 func healthyProbe(contained bool) func(context.Context, string) (ProbeResult, error) {
 	return func(context.Context, string) (ProbeResult, error) {
 		return ProbeResult{Available: true, Contained: contained}, nil

--- a/internal/sybra/runenv/runenv_test.go
+++ b/internal/sybra/runenv/runenv_test.go
@@ -1,0 +1,454 @@
+package runenv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/autonomy"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/providerid"
+)
+
+func TestCertifyLinkedWorktreeAndCachesStableEnvironment(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	var providerProbes atomic.Int32
+	service := New(Deps{
+		ProbeSandbox: healthyProbe(false),
+		ProbeProvider: func(context.Context, string) (ProbeResult, error) {
+			providerProbes.Add(1)
+			return ProbeResult{Available: true}, nil
+		},
+		ProbeTaskMutation: healthyProbe(false),
+	})
+	req := authorRequest(bare, worktree)
+	first, err := service.Certify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Certify: %v", err)
+	}
+	second, err := service.Certify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Certify cached: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("certificate IDs differ: %q != %q", first.ID, second.ID)
+	}
+	if providerProbes.Load() != 1 {
+		t.Fatalf("provider probes = %d, want 1", providerProbes.Load())
+	}
+	if !first.Current(time.Now()) {
+		t.Fatal("new certificate is not current")
+	}
+}
+
+func TestCachedCertificateInvalidatesWhenScratchRootBecomesReadOnly(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	scratch := t.TempDir()
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false)})
+	req := authorRequest(bare, worktree)
+	req.ScratchRoots = []string{scratch}
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatalf("Certify: %v", err)
+	}
+	if err := os.Chmod(scratch, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(scratch, 0o755) })
+	_, err := service.Certify(context.Background(), req)
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Code != "source_write_unavailable" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+}
+
+func TestVerifierNeverReceivesSourceWriteProbe(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeNetwork: healthyProbe(false)})
+	req := Request{TaskID: "judge", ProjectID: "owner/repo", Action: "review.dispatch", WorkDir: worktree, CloneDir: bare, Provider: providerid.Codex, SandboxMode: "report", SigningPolicy: project.SigningNever, Requirements: agent.RoleReview.CapabilityRequirements("review.dispatch")}
+	cert, err := service.Certify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Certify: %v", err)
+	}
+	for _, observation := range cert.Observations {
+		if observation.Capability == autonomy.CapabilitySourceWrite || observation.Capability == autonomy.CapabilityGitAdminWrite {
+			t.Fatalf("verifier certificate includes mutation capability: %+v", observation)
+		}
+	}
+}
+
+func TestRepairIsSerializedAndProducesFreshCertificate(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	var unhealthy atomic.Bool
+	unhealthy.Store(true)
+	var repairs atomic.Int32
+	service := New(Deps{
+		ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false),
+		Repair: func(context.Context, Request, []Observation) error {
+			repairs.Add(1)
+			unhealthy.Store(false)
+			return nil
+		},
+	})
+	// Replace the object-store requirement with a repairable callback-driven
+	// failure by temporarily making the worktree unreadable through a missing
+	// source path, then restoring it in Repair.
+	missing := filepath.Join(filepath.Dir(worktree), "missing")
+	req := authorRequest(bare, worktree)
+	req.WorkDir = missing
+	service.deps.Repair = func(context.Context, Request, []Observation) error {
+		repairs.Add(1)
+		if !unhealthy.Swap(false) {
+			return errors.New("duplicate repair")
+		}
+		return os.Rename(worktree, missing)
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for range 2 {
+		wg.Go(func() {
+			_, certifyErr := service.Certify(context.Background(), req)
+			errs <- certifyErr
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for certifyErr := range errs {
+		if certifyErr != nil {
+			t.Fatalf("Certify: %v", certifyErr)
+		}
+	}
+	if repairs.Load() != 1 {
+		t.Fatalf("repairs = %d, want 1", repairs.Load())
+	}
+}
+
+func TestDetectsReadOnlySourceAndGitAdminSeparately(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false)})
+	req := authorRequest(bare, worktree)
+	if err := os.Chmod(worktree, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(worktree, 0o755) })
+	_, err := service.Certify(context.Background(), req)
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Code != "source_write_unavailable" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+
+	if err := os.Chmod(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitDir := gitOutput(t, worktree, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err := os.Chmod(gitDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(gitDir, 0o755) })
+	service = New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false)})
+	_, err = service.Certify(context.Background(), req)
+	if !errors.As(err, &failure) || failure.Code != "git_admin_readonly" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+}
+
+func TestSandboxReportIsAvailableButNeverContained(t *testing.T) {
+	observation, err := agent.ProbeSandboxPosture("report")
+	if err != nil {
+		t.Fatalf("ProbeSandboxPosture(report): %v", err)
+	}
+	if !observation.Available || observation.Contained {
+		t.Fatalf("report observation = %+v", observation)
+	}
+}
+
+func TestMissingReferencedObjectFailsBeforeDispatch(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false)})
+	req := authorRequest(bare, worktree)
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatalf("initial Certify: %v", err)
+	}
+	tree := gitOutput(t, worktree, "rev-parse", "HEAD^{tree}")
+	fanout := fmt.Sprintf("%.2s", tree)
+	objectPath := filepath.Join(bare, "objects", fanout, strings.TrimPrefix(tree, fanout))
+	if err := os.Remove(objectPath); err != nil {
+		t.Fatalf("remove referenced tree: %v", err)
+	}
+	_, err := service.Certify(context.Background(), req)
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Code != "object_store_unhealthy" || failure.Scope != "project" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+}
+
+func TestIndexReferencedObjectFailsBeforeDispatch(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	path := filepath.Join(worktree, "staged.txt")
+	if err := os.WriteFile(path, []byte("staged only\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, worktree, "add", "staged.txt")
+	blob := gitOutput(t, worktree, "rev-parse", ":staged.txt")
+	fanout := fmt.Sprintf("%.2s", blob)
+	objectPath := filepath.Join(bare, "objects", fanout, strings.TrimPrefix(blob, fanout))
+	if err := os.Remove(objectPath); err != nil {
+		t.Fatalf("remove staged blob: %v", err)
+	}
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false)})
+	_, err := service.Certify(context.Background(), authorRequest(bare, worktree))
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Code != "checkout_unhealthy" || failure.Scope != "task" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+}
+
+func TestIndexReferencedObjectRepairsThenFreshlyCertifies(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	path := filepath.Join(worktree, "staged.txt")
+	if err := os.WriteFile(path, []byte("preserve me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, worktree, "add", "staged.txt")
+	blob := gitOutput(t, worktree, "rev-parse", ":staged.txt")
+	fanout := fmt.Sprintf("%.2s", blob)
+	if err := os.Remove(filepath.Join(bare, "objects", fanout, strings.TrimPrefix(blob, fanout))); err != nil {
+		t.Fatal(err)
+	}
+	service := New(Deps{
+		ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false),
+		Repair: func(ctx context.Context, req Request, _ []Observation) error {
+			_, err := project.EnsureBareCloneHealthy(ctx, req.CloneDir, req.TaskBranch)
+			return err
+		},
+	})
+	cert, err := service.Certify(context.Background(), authorRequest(bare, worktree))
+	if err != nil {
+		t.Fatalf("Certify after repair: %v", err)
+	}
+	if !cert.Repaired {
+		t.Fatal("certificate did not record repair")
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil || string(contents) != "preserve me\n" {
+		t.Fatalf("worktree file was not preserved: %q / %v", contents, err)
+	}
+	if staged := gitOutput(t, worktree, "ls-files", "--stage", "staged.txt"); staged != "" {
+		t.Fatalf("rebuilt index retained invalid staged entry: %s", staged)
+	}
+}
+
+func TestCachedCertificateInvalidatesWhenIndexChanges(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false)})
+	req := authorRequest(bare, worktree)
+	first, err := service.Certify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("initial Certify: %v", err)
+	}
+	missing := strings.Repeat("1", 40)
+	runGit(t, worktree, "update-index", "--add", "--info-only", "--cacheinfo", "100644,"+missing+",missing.txt")
+
+	second, err := service.Certify(context.Background(), req)
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Code != "checkout_unhealthy" || failure.Scope != "task" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+	if second.ID == first.ID {
+		t.Fatalf("reused stale certificate %q after index mutation", first.ID)
+	}
+}
+
+func TestCachedCertificateInvalidatesWhenCloneRefChanges(t *testing.T) {
+	bare, worktree := linkedWorktree(t)
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false)})
+	req := authorRequest(bare, worktree)
+	first, err := service.Certify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("initial Certify: %v", err)
+	}
+	poison := filepath.Join(bare, "refs", "heads", "poison")
+	if err := os.WriteFile(poison, []byte(strings.Repeat("2", 40)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := service.Certify(context.Background(), req)
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Code != "object_store_unhealthy" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+	if second.ID == first.ID {
+		t.Fatalf("reused stale certificate %q after clone ref mutation", first.ID)
+	}
+}
+
+func TestWorktreeLessJudgeCertifiesCandidateGitRoots(t *testing.T) {
+	bare, first := linkedWorktree(t)
+	second := filepath.Join(t.TempDir(), "second")
+	runGit(t, "", "--git-dir", bare, "worktree", "add", "-b", "second", second, "HEAD")
+	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false)})
+	req := Request{
+		TaskID: "judge", ProjectID: "project", Action: "review.dispatch", WorkDir: t.TempDir(),
+		ReadRoots: []string{first, second}, GitRoots: []string{first, second}, CloneDir: bare,
+		Requirements: []autonomy.CapabilityRequirement{
+			{Capability: autonomy.CapabilitySourceRead, Action: "review.dispatch", Scope: "task"},
+			{Capability: autonomy.CapabilityObjectStore, Action: "review.dispatch", Scope: "project"},
+			{Capability: autonomy.CapabilityCheckoutHealth, Action: "review.dispatch", Scope: "task"},
+		},
+	}
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatalf("Certify worktree-less judge: %v", err)
+	}
+}
+
+func TestIsEnvironmentFailureRecognizesInvalidObject(t *testing.T) {
+	if !IsEnvironmentFailure(errors.New("recovery commit: invalid object 111111 for 'ghost.txt'")) {
+		t.Fatal("invalid object did not invalidate certificate")
+	}
+}
+
+func TestTaskMutationIdentityInvalidatesCachedCertificate(t *testing.T) {
+	var probes atomic.Int32
+	service := New(Deps{ProbeTaskMutation: func(context.Context, string) (ProbeResult, error) {
+		probes.Add(1)
+		return ProbeResult{Available: true}, nil
+	}})
+	req := Request{
+		TaskID: "task", Action: "triage.dispatch", WorkDir: t.TempDir(), TaskMutationIdentity: "writable",
+		Requirements: []autonomy.CapabilityRequirement{{Capability: autonomy.CapabilityTaskMutation, Action: "triage.dispatch", Scope: "task"}},
+	}
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	req.TaskMutationIdentity = "read-only"
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if probes.Load() != 2 {
+		t.Fatalf("mutation probes = %d, want 2 after identity change", probes.Load())
+	}
+}
+
+func TestFailedProviderCertificateSuppressesDuplicateProbeWithoutQuarantine(t *testing.T) {
+	var probes, quarantines atomic.Int32
+	service := New(Deps{
+		ProbeProvider: func(context.Context, string) (ProbeResult, error) {
+			probes.Add(1)
+			return ProbeResult{Code: "provider_unavailable"}, errors.New("at capacity")
+		},
+		Quarantine: func(context.Context, CertificationError) { quarantines.Add(1) },
+	})
+	req := Request{TaskID: "task", Action: "dispatch", WorkDir: t.TempDir(), Provider: providerid.Codex, Requirements: []autonomy.CapabilityRequirement{{Capability: autonomy.CapabilityProviderCapacity, Action: "dispatch", Scope: "provider"}}}
+	for range 2 {
+		if _, err := service.Certify(context.Background(), req); err == nil {
+			t.Fatal("Certify succeeded")
+		}
+	}
+	if probes.Load() != 1 {
+		t.Fatalf("probes = %d, want 1", probes.Load())
+	}
+	if quarantines.Load() != 0 {
+		t.Fatalf("quarantines = %d, want 0 for external provider capacity", quarantines.Load())
+	}
+}
+
+func TestFailedMachineCertificateCoalescesQuarantine(t *testing.T) {
+	var quarantines atomic.Int32
+	service := New(Deps{Quarantine: func(context.Context, CertificationError) { quarantines.Add(1) }})
+	req := Request{TaskID: "task", Action: "dispatch", WorkDir: filepath.Join(t.TempDir(), "missing"), Requirements: []autonomy.CapabilityRequirement{{Capability: autonomy.CapabilitySourceRead, Action: "dispatch", Scope: "task"}}}
+	for range 2 {
+		if _, err := service.Certify(context.Background(), req); err == nil {
+			t.Fatal("Certify succeeded")
+		}
+	}
+	if quarantines.Load() != 1 {
+		t.Fatalf("quarantines = %d, want 1", quarantines.Load())
+	}
+}
+
+func TestProjectFailureCoalescesQuarantineAcrossTasks(t *testing.T) {
+	var quarantines atomic.Int32
+	var probes atomic.Int32
+	service := New(Deps{
+		ProbeSandbox: func(context.Context, string) (ProbeResult, error) {
+			probes.Add(1)
+			return ProbeResult{Code: "machine_project_failure"}, errors.New("project unavailable")
+		},
+		Quarantine: func(context.Context, CertificationError) { quarantines.Add(1) },
+	})
+	root := filepath.Join(t.TempDir(), "missing")
+	for _, taskID := range []string{"task-one", "task-two"} {
+		req := Request{TaskID: taskID, ProjectID: "owner/repo", Action: "dispatch", WorkDir: root, Requirements: []autonomy.CapabilityRequirement{{Capability: autonomy.CapabilitySandboxMechanism, Action: "dispatch", Scope: "project"}}}
+		if _, err := service.Certify(context.Background(), req); err == nil {
+			t.Fatalf("Certify(%s) succeeded", taskID)
+		}
+	}
+	if quarantines.Load() != 1 {
+		t.Fatalf("quarantines = %d, want 1 for one shared project failure", quarantines.Load())
+	}
+	if probes.Load() != 1 {
+		t.Fatalf("probes = %d, want 1 while shared project quarantine is current", probes.Load())
+	}
+}
+
+func healthyProbe(contained bool) func(context.Context, string) (ProbeResult, error) {
+	return func(context.Context, string) (ProbeResult, error) {
+		return ProbeResult{Available: true, Contained: contained}, nil
+	}
+}
+
+func authorRequest(bare, worktree string) Request {
+	return Request{TaskID: "task", ProjectID: "owner/repo", Action: "implementation.dispatch", WorkDir: worktree, CloneDir: bare, Provider: providerid.Codex, SandboxMode: "report", SigningPolicy: project.SigningNever, Requirements: agent.RoleImplementation.CapabilityRequirements("implementation.dispatch")}
+}
+
+func linkedWorktree(t *testing.T) (bare, worktree string) {
+	t.Helper()
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	bare, worktree = filepath.Join(root, "repo.git"), filepath.Join(root, "worktree")
+	runGit(t, root, "init", source)
+	runGit(t, source, "config", "user.email", "test@example.com")
+	runGit(t, source, "config", "user.name", "Test")
+	runGit(t, source, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(source, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "add", "seed.txt")
+	runGit(t, source, "commit", "-m", "seed")
+	runGit(t, root, "clone", "--bare", source, bare)
+	runGit(t, bare, "worktree", "add", worktree, "HEAD")
+	return bare, worktree
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return string(bytesTrimSpace(out))
+}
+func bytesTrimSpace(value []byte) []byte {
+	for len(value) > 0 && (value[len(value)-1] == '\n' || value[len(value)-1] == '\r') {
+		value = value[:len(value)-1]
+	}
+	return value
+}

--- a/internal/sybra/runenv/runenv_test.go
+++ b/internal/sybra/runenv/runenv_test.go
@@ -139,12 +139,20 @@ func TestRepairIsSerializedAndProducesFreshCertificate(t *testing.T) {
 	var unhealthy atomic.Bool
 	unhealthy.Store(true)
 	var repairs atomic.Int32
+	var repairAudits atomic.Int32
+	var repairedAudit Certificate
 	service := New(Deps{
 		ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeTaskMutation: healthyProbe(false),
 		Repair: func(context.Context, Request, []Observation) error {
 			repairs.Add(1)
 			unhealthy.Store(false)
 			return nil
+		},
+		Audit: func(event string, cert Certificate, _ *CertificationError) {
+			if event == "runenv.repair" {
+				repairAudits.Add(1)
+				repairedAudit = cert
+			}
 		},
 	})
 	// Replace the object-store requirement with a repairable callback-driven
@@ -177,6 +185,9 @@ func TestRepairIsSerializedAndProducesFreshCertificate(t *testing.T) {
 	}
 	if repairs.Load() != 1 {
 		t.Fatalf("repairs = %d, want 1", repairs.Load())
+	}
+	if repairAudits.Load() != 1 || !repairedAudit.Repaired {
+		t.Fatalf("repair audit = %+v (count %d), want repaired certificate", repairedAudit, repairAudits.Load())
 	}
 }
 

--- a/internal/sybra/runenv/runenv_test.go
+++ b/internal/sybra/runenv/runenv_test.go
@@ -87,7 +87,7 @@ func TestCachedCertificateInvalidatesWhenScratchRootBecomesReadOnly(t *testing.T
 	t.Cleanup(func() { _ = os.Chmod(scratch, 0o755) })
 	_, err := service.Certify(context.Background(), req)
 	var failure CertificationError
-	if !errors.As(err, &failure) || failure.Code != "source_write_unavailable" {
+	if !errors.As(err, &failure) || failure.Code != "scratch_write_unavailable" || failure.Capability != autonomy.CapabilityScratchWrite {
 		t.Fatalf("failure = %#v / %v", failure, err)
 	}
 }
@@ -100,10 +100,37 @@ func TestVerifierNeverReceivesSourceWriteProbe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Certify: %v", err)
 	}
+	hasScratchWrite := false
 	for _, observation := range cert.Observations {
 		if observation.Capability == autonomy.CapabilitySourceWrite || observation.Capability == autonomy.CapabilityGitAdminWrite {
 			t.Fatalf("verifier certificate includes mutation capability: %+v", observation)
 		}
+		if observation.Capability == autonomy.CapabilityScratchWrite {
+			hasScratchWrite = true
+		}
+	}
+	if !hasScratchWrite {
+		t.Fatal("verifier certificate omitted scratch-write capability")
+	}
+}
+
+func TestScratchWriteIsCertifiedWithoutSourceWrite(t *testing.T) {
+	workDir := t.TempDir()
+	req := Request{
+		TaskID:       "judge",
+		Action:       "review.dispatch",
+		WorkDir:      workDir,
+		ScratchRoots: []string{filepath.Join(t.TempDir(), "missing")},
+		Requirements: []autonomy.CapabilityRequirement{{
+			Capability: autonomy.CapabilityScratchWrite,
+			Action:     "review.dispatch",
+			Scope:      "task",
+		}},
+	}
+	_, err := New(Deps{}).Certify(context.Background(), req)
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Capability != autonomy.CapabilityScratchWrite || failure.Code != "scratch_write_unavailable" {
+		t.Fatalf("failure = %#v / %v", failure, err)
 	}
 }
 

--- a/internal/sybra/runenv/runenv_test.go
+++ b/internal/sybra/runenv/runenv_test.go
@@ -481,6 +481,23 @@ func TestRequestGitRootsSkipsGitForNonGitCapabilities(t *testing.T) {
 	}
 }
 
+func TestObjectStoreEvidenceDoesNotClaimUndeclaredClone(t *testing.T) {
+	cert, err := New(Deps{}).Certify(context.Background(), Request{
+		TaskID: "projectless", Action: "dispatch", WorkDir: t.TempDir(),
+		Requirements: []autonomy.CapabilityRequirement{{
+			Capability: autonomy.CapabilityObjectStore,
+			Action:     "dispatch",
+			Scope:      "project",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cert.Observations[0].Evidence; got != "no shared object store declared" {
+		t.Fatalf("evidence = %q", got)
+	}
+}
+
 func TestProjectlessCertificationsUseBoundedRepairLock(t *testing.T) {
 	service := New(Deps{ProbeSandbox: healthyProbe(false)})
 	for i := range 25 {

--- a/internal/sybra/runenv/runenv_test.go
+++ b/internal/sybra/runenv/runenv_test.go
@@ -95,7 +95,7 @@ func TestCachedCertificateInvalidatesWhenScratchRootBecomesReadOnly(t *testing.T
 func TestVerifierNeverReceivesSourceWriteProbe(t *testing.T) {
 	bare, worktree := linkedWorktree(t)
 	service := New(Deps{ProbeSandbox: healthyProbe(false), ProbeProvider: healthyProbe(false), ProbeNetwork: healthyProbe(false)})
-	req := Request{TaskID: "judge", ProjectID: "owner/repo", Action: "review.dispatch", WorkDir: worktree, CloneDir: bare, Provider: providerid.Codex, SandboxMode: "report", SigningPolicy: project.SigningNever, Requirements: agent.RoleReview.CapabilityRequirements("review.dispatch")}
+	req := Request{TaskID: "judge", ProjectID: "owner/repo", Action: "review.dispatch", WorkDir: worktree, ScratchRoots: []string{t.TempDir()}, CloneDir: bare, Provider: providerid.Codex, SandboxMode: "report", SigningPolicy: project.SigningNever, Requirements: agent.RoleReview.CapabilityRequirements("review.dispatch")}
 	cert, err := service.Certify(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Certify: %v", err)
@@ -121,6 +121,22 @@ func TestScratchWriteIsCertifiedWithoutSourceWrite(t *testing.T) {
 		Action:       "review.dispatch",
 		WorkDir:      workDir,
 		ScratchRoots: []string{filepath.Join(t.TempDir(), "missing")},
+		Requirements: []autonomy.CapabilityRequirement{{
+			Capability: autonomy.CapabilityScratchWrite,
+			Action:     "review.dispatch",
+			Scope:      "task",
+		}},
+	}
+	_, err := New(Deps{}).Certify(context.Background(), req)
+	var failure CertificationError
+	if !errors.As(err, &failure) || failure.Capability != autonomy.CapabilityScratchWrite || failure.Code != "scratch_write_unavailable" {
+		t.Fatalf("failure = %#v / %v", failure, err)
+	}
+}
+
+func TestScratchWriteRejectsMissingRoots(t *testing.T) {
+	req := Request{
+		TaskID: "judge", Action: "review.dispatch", WorkDir: t.TempDir(),
 		Requirements: []autonomy.CapabilityRequirement{{
 			Capability: autonomy.CapabilityScratchWrite,
 			Action:     "review.dispatch",
@@ -527,7 +543,7 @@ func healthyProbe(contained bool) func(context.Context, string) (ProbeResult, er
 }
 
 func authorRequest(bare, worktree string) Request {
-	return Request{TaskID: "task", ProjectID: "owner/repo", Action: "implementation.dispatch", WorkDir: worktree, CloneDir: bare, Provider: providerid.Codex, SandboxMode: "report", SigningPolicy: project.SigningNever, Requirements: agent.RoleImplementation.CapabilityRequirements("implementation.dispatch")}
+	return Request{TaskID: "task", ProjectID: "owner/repo", Action: "implementation.dispatch", WorkDir: worktree, ScratchRoots: []string{filepath.Dir(worktree)}, CloneDir: bare, Provider: providerid.Codex, SandboxMode: "report", SigningPolicy: project.SigningNever, Requirements: agent.RoleImplementation.CapabilityRequirements("implementation.dispatch")}
 }
 
 func linkedWorktree(t *testing.T) (bare, worktree string) {

--- a/internal/sybra/runenv/runenv_test.go
+++ b/internal/sybra/runenv/runenv_test.go
@@ -50,6 +50,28 @@ func TestCertifyLinkedWorktreeAndCachesStableEnvironment(t *testing.T) {
 	}
 }
 
+func TestCertifyEvictsExpiredFingerprintEntries(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	service := New(Deps{Now: func() time.Time { return now }, TTL: time.Second})
+	req := Request{
+		TaskID: "task", Action: "read.dispatch", WorkDir: t.TempDir(), ConfigVersion: "one",
+		Requirements: []autonomy.CapabilityRequirement{{Capability: autonomy.CapabilitySourceRead, Action: "read.dispatch", Scope: "task"}},
+	}
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(2 * time.Second)
+	req.ConfigVersion = "two"
+	if _, err := service.Certify(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	service.mu.Lock()
+	defer service.mu.Unlock()
+	if len(service.cache) != 1 {
+		t.Fatalf("cache entries = %d, want only current fingerprint", len(service.cache))
+	}
+}
+
 func TestCachedCertificateInvalidatesWhenScratchRootBecomesReadOnly(t *testing.T) {
 	bare, worktree := linkedWorktree(t)
 	scratch := t.TempDir()

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -182,6 +183,55 @@ func (m *Manager) List() ([]Task, error) { return m.store.List() }
 
 // Get returns a single task by ID (lock-free).
 func (m *Manager) Get(id string) (Task, error) { return m.store.Get(id) }
+
+// ProbeMutationTransport verifies that the task exists and that the same
+// process-local plus cross-process lock used by every Manager mutation can be
+// acquired. It intentionally performs no write, so certification does not
+// change task timestamps or emit lifecycle events.
+func (m *Manager) ProbeMutationTransport(id string) error {
+	if _, err := m.store.Get(id); err != nil {
+		return err
+	}
+	unlock, err := m.store.lockTask(id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	probe, err := os.CreateTemp(m.store.Dir(), ".sybra-task-mutation-probe-")
+	if err != nil {
+		return err
+	}
+	name := probe.Name()
+	if closeErr := probe.Close(); closeErr != nil {
+		_ = os.Remove(name)
+		return closeErr
+	}
+	return os.Remove(name)
+}
+
+// MutationTransportIdentity returns read-only cache evidence for the task
+// store path used by ProbeMutationTransport. Permission or replacement
+// changes therefore invalidate a run-environment certificate without exposing
+// Store mutation authority to the certifier.
+func (m *Manager) MutationTransportIdentity(id string) (string, error) {
+	t, err := m.store.Get(id)
+	if err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, 2)
+	for _, path := range []string{m.store.Dir(), t.FilePath} {
+		resolved, resolveErr := filepath.EvalSymlinks(path)
+		if resolveErr != nil {
+			return "", resolveErr
+		}
+		info, statErr := os.Stat(resolved)
+		if statErr != nil {
+			return "", statErr
+		}
+		parts = append(parts, fmt.Sprintf("%s|%s|%d|%d", resolved, info.Mode(), info.Size(), info.ModTime().UnixNano()))
+	}
+	return strings.Join(parts, "\x00"), nil
+}
 
 // Create persists a new task and emits task:created.
 func (m *Manager) Create(title, body, mode string) (Task, error) {

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -186,8 +186,8 @@ func (m *Manager) Get(id string) (Task, error) { return m.store.Get(id) }
 
 // ProbeMutationTransport verifies that the task exists and that the same
 // process-local plus cross-process lock used by every Manager mutation can be
-// acquired. It intentionally performs no write, so certification does not
-// change task timestamps or emit lifecycle events.
+// acquired. Its temporary write verifies real directory mutability without
+// changing task contents/timestamps or emitting lifecycle events.
 func (m *Manager) ProbeMutationTransport(id string) error {
 	if _, err := m.store.Get(id); err != nil {
 		return err
@@ -218,18 +218,28 @@ func (m *Manager) MutationTransportIdentity(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	parts := make([]string, 0, 2)
-	for _, path := range []string{m.store.Dir(), t.FilePath} {
-		resolved, resolveErr := filepath.EvalSymlinks(path)
-		if resolveErr != nil {
-			return "", resolveErr
-		}
-		info, statErr := os.Stat(resolved)
-		if statErr != nil {
-			return "", statErr
-		}
-		parts = append(parts, fmt.Sprintf("%s|%s|%d|%d", resolved, info.Mode(), info.Size(), info.ModTime().UnixNano()))
+	resolvedDir, err := filepath.EvalSymlinks(m.store.Dir())
+	if err != nil {
+		return "", err
 	}
+	dirInfo, err := os.Stat(resolvedDir)
+	if err != nil {
+		return "", err
+	}
+	// Do not include directory mtime/size: ProbeMutationTransport's own
+	// create-remove write changes them. Path + permission mode still detects
+	// the route changes certification needs to invalidate (replacement through
+	// a symlink and writable/read-only transitions).
+	parts := []string{fmt.Sprintf("%s|%s", resolvedDir, dirInfo.Mode())}
+	resolvedTask, err := filepath.EvalSymlinks(t.FilePath)
+	if err != nil {
+		return "", err
+	}
+	taskInfo, err := os.Stat(resolvedTask)
+	if err != nil {
+		return "", err
+	}
+	parts = append(parts, fmt.Sprintf("%s|%s|%d|%d", resolvedTask, taskInfo.Mode(), taskInfo.Size(), taskInfo.ModTime().UnixNano()))
 	return strings.Join(parts, "\x00"), nil
 }
 

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -48,6 +48,40 @@ func newTestManager(t *testing.T) (*Manager, *recordingEmitter) {
 	return NewManager(store, emitter), emitter
 }
 
+func TestMutationTransportIdentityStableAcrossProbeAndTracksPermissions(t *testing.T) {
+	m, _ := newTestManager(t)
+	created, err := m.Create("mutation identity", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := m.MutationTransportIdentity(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ProbeMutationTransport(created.ID); err != nil {
+		t.Fatal(err)
+	}
+	after, err := m.MutationTransportIdentity(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("probe changed mutation identity\nbefore: %q\nafter:  %q", before, after)
+	}
+	dir := m.store.Dir()
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	readOnly, err := m.MutationTransportIdentity(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readOnly == before {
+		t.Fatal("permission change did not invalidate mutation identity")
+	}
+}
+
 func TestManagerCreateEmitsEvent(t *testing.T) {
 	t.Parallel()
 	m, emitter := newTestManager(t)

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -97,7 +97,18 @@ func ClassifyAgentStartFailure(err error) AgentStartFailure {
 	if err == nil {
 		return out
 	}
+	var machineFailure interface{ MachineFailureCode() string }
 	switch {
+	case errors.As(err, &machineFailure):
+		out.Permanent = true
+		out.Reason = textutil.TruncateBytesTotal("agent start blocked: machine run environment unavailable ("+machineFailure.MachineFailureCode()+")", startReasonMaxLen, "...")
+		out.Blocker = blocker.State{
+			Kind:       blocker.KindRunEnvironment,
+			Actor:      blocker.ActorWorkflow,
+			Code:       machineFailure.MachineFailureCode(),
+			NextAction: "repair_run_environment",
+		}
+		return out
 	case errors.Is(err, ErrDispatchInFlight):
 		// Transient and self-healing: another dispatcher holds the claim and
 		// will start the agent. Suppress the reason entirely.

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -97,6 +97,9 @@ func ClassifyAgentStartFailure(err error) AgentStartFailure {
 	if err == nil {
 		return out
 	}
+	if typed, ok := classifyOwnedMachineFailure(err); ok {
+		return typed
+	}
 	var machineFailure interface{ MachineFailureCode() string }
 	switch {
 	case errors.As(err, &machineFailure):
@@ -225,6 +228,42 @@ func ClassifyAgentStartFailure(err error) AgentStartFailure {
 	return out
 }
 
+func classifyOwnedMachineFailure(err error) (AgentStartFailure, bool) {
+	if isCredentialMachineFailure(err) {
+		return classifyCredentialMachineFailure(err), true
+	}
+	if isTransientMachineFailure(err) {
+		return classifyTransientMachineFailure(err), true
+	}
+	return AgentStartFailure{}, false
+}
+
+func classifyTransientMachineFailure(err error) AgentStartFailure {
+	var failure interface{ MachineFailureCode() string }
+	if !errors.As(err, &failure) {
+		return AgentStartFailure{}
+	}
+	return AgentStartFailure{Reason: textutil.TruncateBytesTotal("agent start delayed: transient run environment unavailable ("+failure.MachineFailureCode()+")", startReasonMaxLen, "...")}
+}
+
+func classifyCredentialMachineFailure(err error) AgentStartFailure {
+	var failure interface{ MachineFailureCode() string }
+	if !errors.As(err, &failure) {
+		return AgentStartFailure{}
+	}
+	return AgentStartFailure{
+		Reason:    textutil.TruncateBytesTotal("agent start blocked: credentials unavailable ("+failure.MachineFailureCode()+")", startReasonMaxLen, "..."),
+		Permanent: true,
+		Blocker: blocker.State{
+			Kind:       blocker.KindCredentialRequired,
+			Actor:      blocker.ActorWorkflow,
+			Code:       failure.MachineFailureCode(),
+			NextAction: "refresh_credentials",
+			Exhausted:  true,
+		},
+	}
+}
+
 // isTransientCapacityError reports whether err is a provider-capacity throttle
 // (rate limit) that self-heals once the provider's cooldown window expires.
 // Such errors must not be counted toward the circuit breaker or escalated to
@@ -251,7 +290,18 @@ func transientAgentStartError(err error) bool {
 		errors.Is(err, worktreeerr.ErrTransientFetch) ||
 		errors.Is(err, worktreeerr.ErrAgentRunning) ||
 		errors.Is(err, worktreeerr.ErrPreparationInFlight) ||
-		errors.Is(err, provider.ErrProviderUnhealthy)
+		errors.Is(err, provider.ErrProviderUnhealthy) ||
+		isTransientMachineFailure(err)
+}
+
+func isTransientMachineFailure(err error) bool {
+	var transient interface{ MachineFailureTransient() bool }
+	return errors.As(err, &transient) && transient.MachineFailureTransient()
+}
+
+func isCredentialMachineFailure(err error) bool {
+	var credential interface{ MachineFailureRequiresCredentials() bool }
+	return errors.As(err, &credential) && credential.MachineFailureRequiresCredentials()
 }
 
 // isDeferredNotFailed reports whether err represents a benign defer that must
@@ -262,7 +312,7 @@ func transientAgentStartError(err error) bool {
 // dispatch attempt and wrongly escalate to human-required for a condition
 // that self-heals once load drops.
 func isDeferredNotFailed(err error) bool {
-	return errors.Is(err, ErrResourcePressure)
+	return errors.Is(err, ErrResourcePressure) || isTransientMachineFailure(err)
 }
 
 func isTransientFetchReason(reason string) bool {

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -21,12 +21,45 @@ type machineStartError struct{ code string }
 func (f machineStartError) Error() string              { return "certification failed: " + f.code }
 func (f machineStartError) MachineFailureCode() string { return f.code }
 
+type transientMachineStartError struct{ machineStartError }
+
+func (transientMachineStartError) MachineFailureTransient() bool { return true }
+
+type credentialMachineStartError struct{ machineStartError }
+
+func (credentialMachineStartError) MachineFailureRequiresCredentials() bool { return true }
+
 func TestClassifyAgentStartFailureKeepsRunEnvironmentMachineOwned(t *testing.T) {
 	failure := ClassifyAgentStartFailure(machineStartError{code: "checkout_unhealthy"})
 	if !failure.Permanent || failure.Blocker.Kind != blocker.KindRunEnvironment || blocker.AllowsHumanRequired(failure.Blocker.Kind) {
 		t.Fatalf("classification = %#v", failure)
 	}
 	if failure.Blocker.Code != "checkout_unhealthy" {
+		t.Fatalf("blocker code = %q", failure.Blocker.Code)
+	}
+}
+
+func TestClassifyAgentStartFailureKeepsTransientEnvironmentRetryable(t *testing.T) {
+	err := transientMachineStartError{machineStartError{code: "provider_unavailable"}}
+	failure := ClassifyAgentStartFailure(err)
+	if failure.Permanent || !failure.Blocker.IsZero() {
+		t.Fatalf("classification = %#v", failure)
+	}
+	if !strings.Contains(failure.Reason, "transient run environment unavailable") {
+		t.Fatalf("reason = %q", failure.Reason)
+	}
+	if !transientAgentStartError(err) || !isDeferredNotFailed(err) {
+		t.Fatal("transient machine failure must be deferred without feeding the breaker")
+	}
+}
+
+func TestClassifyAgentStartFailureRoutesCredentialEnvironmentFailureToAuthority(t *testing.T) {
+	err := credentialMachineStartError{machineStartError{code: "github_auth_misconfigured"}}
+	failure := ClassifyAgentStartFailure(err)
+	if !failure.Permanent || failure.Blocker.Kind != blocker.KindCredentialRequired || !blocker.AllowsHumanRequired(failure.Blocker.Kind) {
+		t.Fatalf("classification = %#v", failure)
+	}
+	if failure.Blocker.Code != "github_auth_misconfigured" {
 		t.Fatalf("blocker code = %q", failure.Blocker.Code)
 	}
 }

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -16,6 +16,21 @@ import (
 	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
+type machineStartError struct{ code string }
+
+func (f machineStartError) Error() string              { return "certification failed: " + f.code }
+func (f machineStartError) MachineFailureCode() string { return f.code }
+
+func TestClassifyAgentStartFailureKeepsRunEnvironmentMachineOwned(t *testing.T) {
+	failure := ClassifyAgentStartFailure(machineStartError{code: "checkout_unhealthy"})
+	if !failure.Permanent || failure.Blocker.Kind != blocker.KindRunEnvironment || blocker.AllowsHumanRequired(failure.Blocker.Kind) {
+		t.Fatalf("classification = %#v", failure)
+	}
+	if failure.Blocker.Code != "checkout_unhealthy" {
+		t.Fatalf("blocker code = %q", failure.Blocker.Code)
+	}
+}
+
 func TestClassifyAgentStartError(t *testing.T) {
 	cases := []struct {
 		name          string


### PR DESCRIPTION
Closes #3179

## Summary
- add typed, expiring run-environment certificates at the final provider dispatch choke point
- certify source/scratch paths, linked Git metadata, checkout and shared object health, signing, sandbox posture, task mutation, provider, and GitHub availability
- serialize safe repair, invalidate stable evidence on filesystem/Git/signing changes, and apply scope-correct machine-owned quarantine
- preserve worktree-less best-of-N judge certification through explicit candidate read/Git roots

## Validation
- independent adversarial review: CLEAN
- independent execution-backed manual testing: PASS
- `golangci-lint run ./...`
- focused Go suites for agent, runenv, workflow, task, project, review, and Sybra
- `go test -race -tags e2e -timeout 10m -parallel 8 ./internal/sybra/...` (known pre-existing stranded-verdict base failure excluded)
- full race suite passed except a host SIGKILL flake in `TestPromoteAttempt_OnlyWinnerCommitsLandOnCanonical`; the exact race test passed immediately in isolation
- frontend checks/build/coverage and repository policy gates passed earlier in the branch validation