### PR TITLE
refactor(workflow): reconcile run outcomes from observed state

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1273,6 +1273,30 @@ func IsWorktreeDirty(ctx context.Context, worktreePath string) (bool, error) {
 	return worktreeDirty(ctx, worktreePath)
 }
 
+// WorktreeOperation reports the in-progress Git operation whose state would be
+// destroyed by reset/sanitize/remove. Empty means no recognized operation.
+func WorktreeOperation(ctx context.Context, worktreePath string) string {
+	gitDir, err := gitexec.Output(ctx, gitexec.Options{Dir: worktreePath}, "rev-parse", "--git-dir")
+	if err != nil {
+		return "unknown"
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreePath, gitDir)
+	}
+	for _, candidate := range []struct{ name, marker string }{
+		{"merge", "MERGE_HEAD"},
+		{"rebase", "rebase-merge"},
+		{"rebase", "rebase-apply"},
+		{"cherry-pick", "CHERRY_PICK_HEAD"},
+		{"revert", "REVERT_HEAD"},
+	} {
+		if _, err := os.Stat(filepath.Join(gitDir, candidate.marker)); err == nil {
+			return candidate.name
+		}
+	}
+	return ""
+}
+
 // HasUnpushedCommits reports whether HEAD in worktreePath holds commits that
 // no remote-tracking ref locally knows about. Errs toward true: if the count
 // cannot be determined (not a git repo, missing dir, git failure), callers

--- a/internal/project/worktree_operation_test.go
+++ b/internal/project/worktree_operation_test.go
@@ -1,0 +1,28 @@
+package project
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/gitexec"
+)
+
+func TestWorktreeOperationDetectsMergeMarker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ctx := context.Background()
+	if err := gitexec.Run(ctx, gitexec.Options{Dir: dir}, "init"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if got := WorktreeOperation(ctx, dir); got != "" {
+		t.Fatalf("clean operation = %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git", "MERGE_HEAD"), []byte("deadbeef\n"), 0o600); err != nil {
+		t.Fatalf("write MERGE_HEAD: %v", err)
+	}
+	if got := WorktreeOperation(ctx, dir); got != "merge" {
+		t.Fatalf("operation = %q, want merge", got)
+	}
+}

--- a/internal/reconcile/decision.go
+++ b/internal/reconcile/decision.go
@@ -1,0 +1,148 @@
+package reconcile
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+)
+
+func Decide(s Snapshot) Plan {
+	plan := Plan{
+		Preconditions: Preconditions{
+			TaskGeneration:     s.TaskGeneration,
+			WorkflowGeneration: s.WorkflowGeneration,
+			LeaseID:            s.Lease.ID,
+			RunID:              s.Run.ID,
+			LocalSHA:           s.Git.HeadSHA,
+			RemoteSHA:          s.Git.RemoteSHA,
+			PRHeadSHA:          s.PR.HeadSHA,
+			SidecarsDigest:     digestSidecars(s.Sidecars),
+			EvidenceDigest:     digestEvidence(s.Evidence.Items),
+		},
+		Cleanup: PreservationProof{
+			TaskGeneration: s.TaskGeneration,
+			LeaseID:        s.Lease.ID,
+			ObservedSHA:    s.Git.HeadSHA,
+			NoDirtyWork:    s.Git.Available && s.Git.Healthy && !s.Git.Dirty && !s.Git.Staged && s.Git.Operation == "",
+			NoLocalOnlyWork: s.Git.Available && s.Git.Healthy &&
+				((s.Git.RemoteSHA != "" && s.Git.Ahead == 0 && (s.Git.RemoteSHA == s.Git.HeadSHA || s.Git.Behind > 0)) ||
+					(s.Git.RemoteSHA == "" && s.Git.BaseSHA != "" && s.Git.HeadSHA == s.Git.BaseSHA)),
+		},
+	}
+
+	return decide(s, plan)
+}
+
+func digestSidecars(items []SidecarState) string {
+	rows := make([]string, 0, len(items))
+	for _, item := range items {
+		rows = append(rows, item.Name+"\x00"+item.Digest)
+	}
+	sort.Strings(rows)
+	return digestRows(rows)
+}
+
+func digestEvidence(items []EvidenceItem) string {
+	rows := make([]string, 0, len(items))
+	for _, item := range items {
+		passed := "false"
+		if item.Passed {
+			passed = "true"
+		}
+		rows = append(rows, item.Criterion+"\x00"+item.SourceSHA+"\x00"+passed)
+	}
+	sort.Strings(rows)
+	return digestRows(rows)
+}
+
+func digestRows(rows []string) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.Join(rows, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+func decide(s Snapshot, plan Plan) Plan {
+	if s.Lease.Required && (!s.Lease.Current || s.Lease.ID == "") {
+		return withAction(plan, ActionWait, "stale or missing attempt lease")
+	}
+	if s.Evidence.Required && (!s.Evidence.Verified || s.Evidence.SourceSHA != s.Git.HeadSHA) {
+		return withAction(plan, ActionWait, "verification evidence does not match observed HEAD")
+	}
+	if !s.Git.Available {
+		if s.PR.Number > 0 && strings.EqualFold(s.PR.State, "OPEN") && strings.EqualFold(s.PR.Mergeable, "MERGEABLE") {
+			return withDelivery(plan, ActionResumeMergeablePR, "live PR is mergeable without a local checkout")
+		}
+		return withAction(plan, ActionWait, "authoritative worktree is unavailable")
+	}
+	if !s.Git.Healthy || !s.Git.HeadExists {
+		return withAction(plan, ActionQuarantine, "Git administration or HEAD object is unhealthy")
+	}
+	if s.Git.Operation != "" {
+		return withAction(plan, ActionRepair, "Git operation requires bounded recovery: "+s.Git.Operation)
+	}
+	if s.Git.Dirty || s.Git.Staged {
+		return withAction(plan, ActionCheckpoint, "uncommitted author work must be checkpointed")
+	}
+	// A watchdog/restart may observe a non-terminal provider run after the live
+	// PR already contains the authoritative work. Git/PR state, not missing
+	// provider prose, owns this no-op recovery decision.
+	if strings.EqualFold(s.PR.State, "OPEN") && strings.EqualFold(s.PR.Mergeable, "MERGEABLE") && noAdditiveLocalWork(s) {
+		return withDelivery(plan, ActionResumeMergeablePR, "live PR is mergeable and recovery produced no additive work")
+	}
+	if !s.Run.Terminal && s.Intent != IntentCleanup {
+		return withAction(plan, ActionWait, "provider run has no terminal outcome")
+	}
+
+	switch strings.ToUpper(s.PR.State) {
+	case "MERGED":
+		if s.Git.RemoteSHA != "" && s.Git.RemoteSHA != s.Git.HeadSHA {
+			return withAction(plan, ActionAdoptRemote, "PR branch contains newer reachable work")
+		}
+		return withDelivery(plan, ActionAdvance, "PR is already merged and local task work is preserved")
+	case "CLOSED":
+		return withAction(plan, ActionHumanDecision, "PR was closed without merge")
+	case "OPEN":
+		if strings.EqualFold(s.PR.Mergeable, "CONFLICTING") {
+			return withAction(plan, ActionRepair, "live PR has content conflicts")
+		}
+	}
+
+	if s.Git.RemoteSHA == "" && s.Git.TaskWorkReachable {
+		return withAction(plan, ActionPush, "reachable task work has no remote branch")
+	}
+	if s.Git.RemoteSHA != "" && s.Git.RemoteSHA != s.Git.HeadSHA {
+		if s.Git.Ahead > 0 {
+			return withAction(plan, ActionPush, "local task work is ahead of the remote branch")
+		}
+		if s.Git.Behind > 0 {
+			return withAction(plan, ActionAdoptRemote, "remote branch contains newer reachable work")
+		}
+		return withAction(plan, ActionRepair, "local and remote branch histories diverged")
+	}
+	if s.Git.TreeEquivalentToBase && !s.Git.TaskWorkReachable {
+		return withAction(plan, ActionRepair, "base-equivalent tree contains no reachable task work")
+	}
+	if !s.Run.Success {
+		return withDelivery(plan, ActionRepair, "terminal author run failed")
+	}
+	return withDelivery(plan, ActionAdvance, "observed state is safe to advance")
+}
+
+func noAdditiveLocalWork(s Snapshot) bool {
+	return s.Git.RemoteSHA != "" && s.Git.Ahead == 0
+}
+
+func withAction(plan Plan, action Action, reason string) Plan {
+	plan.Action = action
+	plan.Reason = reason
+	return plan
+}
+
+func withDelivery(plan Plan, action Action, reason string) Plan {
+	plan = withAction(plan, action, reason)
+	plan.DeliverRunOutcome = true
+	return plan
+}

--- a/internal/reconcile/decision_test.go
+++ b/internal/reconcile/decision_test.go
@@ -1,0 +1,177 @@
+package reconcile
+
+import (
+	"reflect"
+	"testing"
+)
+
+func baselineSnapshot() Snapshot {
+	return Snapshot{
+		Intent: IntentAuthorCompletion, TaskID: "task-1", TaskGeneration: 7, WorkflowGeneration: 7,
+		Lease: LeaseState{ID: "agent-1", Required: true, Current: true},
+		Run:   RunState{ID: "agent-1", Role: "implementation", Terminal: true, Success: true},
+		Git:   GitState{Available: true, Healthy: true, HeadSHA: "head", BaseSHA: "base", RemoteSHA: "head", HeadExists: true, TaskWorkReachable: true},
+	}
+}
+
+func TestDecideMatrix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*Snapshot)
+		want   Action
+	}{
+		{"clean equal advances", func(*Snapshot) {}, ActionAdvance},
+		{"stale lease waits", func(s *Snapshot) { s.Lease.Current = false }, ActionWait},
+		{"dirty checkpoints", func(s *Snapshot) { s.Git.Dirty = true }, ActionCheckpoint},
+		{"staged checkpoints", func(s *Snapshot) { s.Git.Staged = true }, ActionCheckpoint},
+		{"merge conflict repairs", func(s *Snapshot) { s.Git.Operation = "merge" }, ActionRepair},
+		{"bad git quarantines", func(s *Snapshot) { s.Git.Healthy = false }, ActionQuarantine},
+		{"missing remote pushes", func(s *Snapshot) { s.Git.RemoteSHA = "" }, ActionPush},
+		{"local ahead pushes", func(s *Snapshot) { s.Git.RemoteSHA = "old"; s.Git.Ahead = 1 }, ActionPush},
+		{"remote ahead adopts", func(s *Snapshot) { s.Git.RemoteSHA = "remote-new-sha"; s.Git.Behind = 1 }, ActionAdoptRemote},
+		{"diverged repairs", func(s *Snapshot) { s.Git.RemoteSHA = "other" }, ActionRepair},
+		{"empty equivalent repairs", func(s *Snapshot) { s.Git.TreeEquivalentToBase = true; s.Git.TaskWorkReachable = false }, ActionRepair},
+		{"reachable equivalent advances", func(s *Snapshot) { s.Git.TreeEquivalentToBase = true }, ActionAdvance},
+		{"mergeable no-op resumes", func(s *Snapshot) {
+			s.PR = PRState{Number: 1, State: "OPEN", Mergeable: "MERGEABLE", HeadSHA: "head"}
+			s.Git.Ahead = 0
+		}, ActionResumeMergeablePR},
+		{"mergeable PR without observed remote does not hide local state", func(s *Snapshot) {
+			s.PR = PRState{Number: 1, State: "OPEN", Mergeable: "MERGEABLE", HeadSHA: "remote-head"}
+			s.Git.RemoteSHA = ""
+			s.Git.Ahead = 0
+		}, ActionPush},
+		{"mergeable PR with base-equivalent local history still pushes", func(s *Snapshot) {
+			s.PR = PRState{Number: 1, State: "OPEN", Mergeable: "MERGEABLE", HeadSHA: "remote-head"}
+			s.Git.RemoteSHA = ""
+			s.Git.TreeEquivalentToBase = true
+		}, ActionPush},
+		{"conflicted PR repairs", func(s *Snapshot) { s.PR = PRState{Number: 1, State: "OPEN", Mergeable: "CONFLICTING"} }, ActionRepair},
+		{"closed PR asks human", func(s *Snapshot) { s.PR = PRState{Number: 1, State: "CLOSED"} }, ActionHumanDecision},
+		{"merged PR advances when branch is already preserved", func(s *Snapshot) { s.PR = PRState{Number: 1, State: "MERGED"} }, ActionAdvance},
+		{"evidence mismatch waits", func(s *Snapshot) { s.Evidence = EvidenceState{Required: true, SourceSHA: "old", Verified: true} }, ActionWait},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := baselineSnapshot()
+			tc.mutate(&s)
+			if got := Decide(s).Action; got != tc.want {
+				t.Fatalf("Decide().Action = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecideOnlyDeliversSafeOrFailedRunOutcomes(t *testing.T) {
+	t.Parallel()
+	s := baselineSnapshot()
+	if plan := Decide(s); !plan.DeliverRunOutcome {
+		t.Fatalf("advance plan did not deliver outcome: %#v", plan)
+	}
+	s.Git.Operation = "merge"
+	if plan := Decide(s); plan.DeliverRunOutcome || plan.Action != ActionRepair {
+		t.Fatalf("unresolved Git operation was delivered: %#v", plan)
+	}
+	s.Git.Operation = ""
+	s.Run.Success = false
+	if plan := Decide(s); !plan.DeliverRunOutcome || plan.Action != ActionRepair {
+		t.Fatalf("failed run was not delivered to bounded workflow retry: %#v", plan)
+	}
+}
+
+func TestDecideCarriesEveryMutationPrecondition(t *testing.T) {
+	t.Parallel()
+	s := baselineSnapshot()
+	s.PR.HeadSHA = "pr-head"
+	s.Sidecars = []SidecarState{{Name: "review", Digest: "sidecar-digest"}}
+	s.Evidence.Items = []EvidenceItem{{Criterion: "verify", SourceSHA: "head", Passed: true}}
+	p := Decide(s)
+	want := Preconditions{
+		TaskGeneration: 7, WorkflowGeneration: 7, LeaseID: "agent-1", RunID: "agent-1",
+		LocalSHA: "head", RemoteSHA: "head", PRHeadSHA: "pr-head",
+		SidecarsDigest: digestSidecars(s.Sidecars), EvidenceDigest: digestEvidence(s.Evidence.Items),
+	}
+	if !reflect.DeepEqual(p.Preconditions, want) {
+		t.Fatalf("preconditions = %#v, want %#v", p.Preconditions, want)
+	}
+}
+
+func TestObservationDigestsAreOrderIndependentAndContentSensitive(t *testing.T) {
+	t.Parallel()
+	a := baselineSnapshot()
+	a.Sidecars = []SidecarState{{Name: "plan", Digest: "a"}, {Name: "review", Digest: "b"}}
+	a.Evidence.Items = []EvidenceItem{{Criterion: "test", SourceSHA: "head", Passed: true}, {Criterion: "review", SourceSHA: "head", Passed: true}}
+	b := a
+	b.Sidecars = []SidecarState{a.Sidecars[1], a.Sidecars[0]}
+	b.Evidence.Items = []EvidenceItem{a.Evidence.Items[1], a.Evidence.Items[0]}
+	if Decide(a).Preconditions != Decide(b).Preconditions {
+		t.Fatal("equivalent observations produced order-dependent preconditions")
+	}
+	b.Evidence.Items[0].Passed = false
+	if Decide(a).Preconditions.EvidenceDigest == Decide(b).Preconditions.EvidenceDigest {
+		t.Fatal("changed verification evidence did not change its precondition digest")
+	}
+}
+
+func TestCleanupProofFailsClosed(t *testing.T) {
+	t.Parallel()
+	for _, mutate := range []func(*Snapshot){
+		func(s *Snapshot) { s.Git.Dirty = true },
+		func(s *Snapshot) { s.Git.Staged = true },
+		func(s *Snapshot) { s.Git.Operation = "rebase" },
+		func(s *Snapshot) { s.Git.Ahead = 1 },
+		func(s *Snapshot) { s.Git.RemoteSHA = "other" },
+		func(s *Snapshot) { s.Git.RemoteSHA = ""; s.Git.TaskWorkReachable = true },
+		func(s *Snapshot) { s.Git.Healthy = false },
+	} {
+		s := baselineSnapshot()
+		mutate(&s)
+		if Decide(s).AllowsCleanup() {
+			t.Fatalf("unsafe snapshot unexpectedly allowed cleanup: %#v", s.Git)
+		}
+	}
+}
+
+func TestCleanupProofAllowsProvenRemoteStateWithNoTaskWork(t *testing.T) {
+	t.Parallel()
+	s := baselineSnapshot()
+	s.Git.TaskWorkReachable = false
+	if !Decide(s).AllowsCleanup() {
+		t.Fatal("clean remote-equal snapshot without task work did not allow cleanup")
+	}
+}
+
+func TestCleanupProofFailsClosedWithoutAnAuthoritativeBaseOrRemote(t *testing.T) {
+	t.Parallel()
+	s := baselineSnapshot()
+	s.Git.RemoteSHA = ""
+	s.Git.BaseSHA = ""
+	s.Git.Ahead = 0
+	s.Git.TaskWorkReachable = false
+	if plan := Decide(s); plan.Cleanup.NoLocalOnlyWork || plan.AllowsCleanup() {
+		t.Fatalf("unknown base and remote approved cleanup: %#v", plan)
+	}
+
+	s.Git.BaseSHA = s.Git.HeadSHA
+	if plan := Decide(s); !plan.Cleanup.NoLocalOnlyWork || !plan.AllowsCleanup() {
+		t.Fatalf("known unchanged base rejected cleanup: %#v", plan)
+	}
+}
+
+func FuzzDecideDeterministic(f *testing.F) {
+	f.Add(true, true, false, false, 0, 0, "OPEN", "MERGEABLE")
+	f.Fuzz(func(t *testing.T, lease, healthy, dirty, staged bool, ahead, behind int, prState, mergeable string) {
+		s := baselineSnapshot()
+		s.Lease.Current = lease
+		s.Git.Healthy = healthy
+		s.Git.Dirty = dirty
+		s.Git.Staged = staged
+		s.Git.Ahead = ahead
+		s.Git.Behind = behind
+		s.PR = PRState{Number: 1, State: prState, Mergeable: mergeable}
+		if a, b := Decide(s), Decide(s); !reflect.DeepEqual(a, b) {
+			t.Fatalf("Decide is nondeterministic: %#v != %#v", a, b)
+		}
+	})
+}

--- a/internal/reconcile/model.go
+++ b/internal/reconcile/model.go
@@ -1,0 +1,166 @@
+// Package reconcile turns observed task, run, Git, PR, and verification state
+// into deterministic post-run action plans. It deliberately contains no I/O:
+// callers must observe a fresh Snapshot and apply the returned Preconditions
+// atomically before performing an effect.
+package reconcile
+
+import "context"
+
+type Intent string
+
+const (
+	IntentAuthorCompletion Intent = "author-completion"
+	IntentFixReview        Intent = "fix-review"
+	IntentPRFix            Intent = "pr-fix"
+	IntentHumanRecovery    Intent = "human-recovery"
+	IntentStaleRun         Intent = "stale-run"
+	IntentRestart          Intent = "restart"
+	IntentCleanup          Intent = "cleanup"
+)
+
+type Action string
+
+const (
+	ActionAdvance           Action = "advance"
+	ActionCheckpoint        Action = "checkpoint"
+	ActionPush              Action = "push"
+	ActionAdoptRemote       Action = "adopt-remote"
+	ActionResumeMergeablePR Action = "resume-mergeable-pr"
+	ActionRepair            Action = "repair"
+	ActionQuarantine        Action = "quarantine"
+	ActionWait              Action = "wait"
+	ActionHumanDecision     Action = "human-decision"
+)
+
+type Snapshot struct {
+	Intent Intent
+
+	TaskID             string
+	TaskGeneration     int64
+	WorkflowGeneration int64
+	WorkflowID         string
+	WorkflowStep       string
+
+	Lease    LeaseState
+	Run      RunState
+	Git      GitState
+	PR       PRState
+	Evidence EvidenceState
+	Sidecars []SidecarState
+
+	Replay bool
+}
+
+type LeaseState struct {
+	ID       string
+	Required bool
+	Current  bool
+}
+
+type RunState struct {
+	ID       string
+	Role     string
+	Terminal bool
+	Success  bool
+}
+
+type GitState struct {
+	Available bool
+	Healthy   bool
+
+	Branch    string
+	HeadSHA   string
+	BaseSHA   string
+	RemoteSHA string
+	PRHeadSHA string
+
+	HeadExists           bool
+	Dirty                bool
+	Staged               bool
+	Operation            string
+	Ahead                int
+	Behind               int
+	TaskWorkReachable    bool
+	TreeEquivalentToBase bool
+}
+
+type PRState struct {
+	Number          int
+	State           string
+	HeadSHA         string
+	BaseSHA         string
+	Mergeable       string
+	Checks          string
+	ReviewsResolved bool
+}
+
+type EvidenceState struct {
+	Required  bool
+	SourceSHA string
+	Verified  bool
+	Items     []EvidenceItem
+}
+
+// EvidenceItem is one durable verification result bound to the revision it
+// actually inspected. SourceSHA is deliberately explicit: an accepted result
+// for an older tree must never be confused with evidence for the current HEAD.
+type EvidenceItem struct {
+	Criterion string
+	SourceSHA string
+	Passed    bool
+}
+
+// SidecarState records the content identity of a task sidecar observed during
+// reconciliation. The pure decision does not interpret sidecar prose; it only
+// carries stable digests into effect preconditions so a concurrent import or
+// rewrite forces re-observation.
+type SidecarState struct {
+	Name   string
+	Digest string
+}
+
+type Preconditions struct {
+	TaskGeneration     int64
+	WorkflowGeneration int64
+	LeaseID            string
+	RunID              string
+	LocalSHA           string
+	RemoteSHA          string
+	PRHeadSHA          string
+	SidecarsDigest     string
+	EvidenceDigest     string
+}
+
+type PreservationProof struct {
+	TaskGeneration  int64
+	LeaseID         string
+	ObservedSHA     string
+	NoDirtyWork     bool
+	NoLocalOnlyWork bool
+}
+
+type Plan struct {
+	Action            Action
+	Reason            string
+	DeliverRunOutcome bool
+	Preconditions     Preconditions
+	Cleanup           PreservationProof
+}
+
+type Request struct {
+	TaskID string
+	RunID  string
+	Intent Intent
+}
+
+// Runner is the single post-run reconciliation seam used by live completion,
+// reattach, and stale-run recovery. Implementations must return a plan derived
+// from a fresh observed snapshot; nil means reconciliation is disabled only in
+// deliberately partial test/degraded wiring.
+type Runner interface {
+	Reconcile(context.Context, Request) (Plan, error)
+}
+
+func (p Plan) AllowsCleanup() bool {
+	return p.Cleanup.NoDirtyWork && p.Cleanup.NoLocalOnlyWork && p.Cleanup.ObservedSHA != ""
+}

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Automaat/sybra/internal/cleanup"
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/reconcile"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -78,6 +79,8 @@ type Recovery struct {
 	Orchestrator      Orchestrator
 	Projects          ProjectGetter
 	PRs               PRResolver
+	Reconciler        reconcile.Runner
+	ConflictRecovery  func(taskID string) bool
 	Logger            *slog.Logger
 	Throttle          *logging.ErrorThrottle
 	WG                *sync.WaitGroup
@@ -116,10 +119,10 @@ type Recovery struct {
 	CommitBeforePrune func(context.Context)
 }
 
-// RunStartupCleanup sequences boot-time maintenance in the order that lets
-// each step see the output of the previous one: worktree repair first so
-// orphans show up to the subsequent sweep; stale run state next so
-// restart-stale sees a clean slate.
+// RunStartupCleanup reconciles terminal/stale runs before any destructive
+// worktree sweep. A completed-but-unpushed commit is still task work even when
+// the task file already looks terminal; cleanup may only see it after the
+// reconciler has preserved/adopted it or proved there is none.
 func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 	// Reattach to surviving agent subprocesses FIRST so the sweeps below —
 	// which all key off HasRunningAgentForTask — see them as live and do
@@ -131,11 +134,7 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 		r.Logger.Info("recovery.orphan_reap", "count", reaped)
 	}
 	r.Worktrees.RepairAll(ctx)
-	r.pruneTrash(ctx)
-	r.Worktrees.CleanupOrphaned(ctx)
-	r.cleanupOrphanedSandboxes(ctx)
 	r.cleanStaleRuns()
-	r.pruneAgentLogs()
 	if r.WorkflowEngine != nil {
 		// Ordered ahead of the replay: reattach above has established which
 		// steps are genuinely still running, and both replay paths below claim
@@ -144,6 +143,10 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 		r.WorkflowEngine.ReplayPersistedEffects()
 	}
 	r.RestartStaleInProgress(ctx)
+	r.pruneTrash(ctx)
+	r.Worktrees.CleanupOrphaned(ctx)
+	r.cleanupOrphanedSandboxes(ctx)
+	r.pruneAgentLogs()
 }
 
 // pruneAgentLogs enforces retention (age/empty deletion, gzip compression,

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/blocker"
 	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/reconcile"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 )
@@ -110,7 +111,7 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 			"task_id", t.ID, "reason", "provider_rate_limited", "provider", lr.Provider)
 		return
 	}
-	if r.recoverCompletedHeadlessRun(&t) {
+	if r.recoverCompletedHeadlessRun(ctx, &t) {
 		// recoverCompletedHeadlessRun handled this task (last headless run
 		// completed but workflow step was never recorded). Skip the generic
 		// stale-restart path only when it actually fired HandleAgentComplete;
@@ -168,7 +169,7 @@ func (r *Recovery) restartTaskIfStale(ctx context.Context, t task.Task) {
 	oneShot := false
 	if t.AgentMode != "headless" {
 		var handled bool
-		oneShot, handled = r.resolveInteractiveStaleRestart(&t)
+		oneShot, handled = r.resolveInteractiveStaleRestart(ctx, &t)
 		if handled {
 			return
 		}
@@ -532,7 +533,7 @@ func (r *Recovery) surfaceStartFailure(ctx context.Context, taskID string, curre
 // recoverStaleInteractive (handled=true, caller should skip re-dispatch), or
 // fallen through to the normal restart/escalation path below with the
 // resolved oneShot flag.
-func (r *Recovery) resolveInteractiveStaleRestart(t *task.Task) (oneShot, handled bool) {
+func (r *Recovery) resolveInteractiveStaleRestart(ctx context.Context, t *task.Task) (oneShot, handled bool) {
 	lr := lastAgentRun(t)
 	switch {
 	case lr == nil:
@@ -560,7 +561,7 @@ func (r *Recovery) resolveInteractiveStaleRestart(t *task.Task) (oneShot, handle
 			r.Logger.Info("restart-stale.no-workflow-fallthrough", "task_id", t.ID)
 			return false, false
 		}
-		r.recoverStaleInteractive(t)
+		r.recoverStaleInteractive(ctx, t)
 		return false, true
 	default:
 		r.Logger.Info("restart-stale.interactive-oneshot", "task_id", t.ID)
@@ -573,7 +574,7 @@ func (r *Recovery) resolveInteractiveStaleRestart(t *task.Task) (oneShot, handle
 // stopped (if still claiming running) and drives the workflow engine to
 // advance the current step using the stored result — mirroring the
 // normal onAgentComplete callback so evaluate/next steps fire.
-func (r *Recovery) recoverStaleInteractive(t *task.Task) {
+func (r *Recovery) recoverStaleInteractive(ctx context.Context, t *task.Task) {
 	lr := lastAgentRun(t)
 	if lr == nil {
 		r.Logger.Info("recover-stale.skip", "task_id", t.ID, "reason", "no_agent_runs")
@@ -596,6 +597,9 @@ func (r *Recovery) recoverStaleInteractive(t *task.Task) {
 	}
 	if r.WorkflowEngine == nil || t.Workflow == nil {
 		r.Logger.Info("recover-stale.no-workflow", "task_id", t.ID)
+		return
+	}
+	if !r.reconcileBeforeAdvance(ctx, t.ID, lr.AgentID, reconcile.IntentRestart) {
 		return
 	}
 	if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
@@ -647,7 +651,7 @@ func (r *Recovery) recoverStaleInteractive(t *task.Task) {
 // recoverCompletedHeadlessRun returns true when it fires HandleAgentComplete,
 // false when the task does not match the "completed but callback lost" shape.
 // Callers should only skip generic stale-restart logic on a true return.
-func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) bool {
+func (r *Recovery) recoverCompletedHeadlessRun(ctx context.Context, t *task.Task) bool {
 	lr := latestTrackedCurrentStepRun(t)
 	if lr == nil {
 		return false
@@ -681,6 +685,9 @@ func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) bool {
 	if r.Agents.HasRunningAgentForTask(t.ID) {
 		return false
 	}
+	if !r.reconcileBeforeAdvance(ctx, t.ID, lr.AgentID, reconcile.IntentStaleRun) {
+		return true
+	}
 	success := lr.Outcome == task.RunOutcomeSuccess
 	r.Logger.Info("recover-completed-headless-run",
 		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep,
@@ -706,6 +713,37 @@ func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) bool {
 		Result:   lr.Result,
 	})
 	return true
+}
+
+func (r *Recovery) reconcileBeforeAdvance(ctx context.Context, taskID, runID string, intent reconcile.Intent) bool {
+	if r.Reconciler == nil {
+		return true
+	}
+	plan, err := r.Reconciler.Reconcile(ctx, reconcile.Request{TaskID: taskID, RunID: runID, Intent: intent})
+	if err != nil {
+		r.Logger.Error("post-run.reconcile.recovery", "task_id", taskID, "run_id", runID, "err", err)
+		return false
+	}
+	switch plan.Action {
+	case reconcile.ActionAdvance, reconcile.ActionResumeMergeablePR:
+		return plan.DeliverRunOutcome
+	case reconcile.ActionRepair:
+		if plan.DeliverRunOutcome {
+			return true
+		}
+		if r.ConflictRecovery != nil && r.ConflictRecovery(taskID) {
+			r.Logger.Info("post-run.reconcile.recovery.repair-started", "task_id", taskID, "run_id", runID, "reason", plan.Reason)
+		} else {
+			r.Logger.Warn("post-run.reconcile.recovery.repair-held", "task_id", taskID, "run_id", runID, "reason", plan.Reason)
+		}
+		return false
+	case reconcile.ActionWait, reconcile.ActionQuarantine, reconcile.ActionHumanDecision:
+		r.Logger.Warn("post-run.reconcile.recovery.held", "task_id", taskID, "run_id", runID, "action", plan.Action, "reason", plan.Reason)
+		return false
+	default:
+		r.Logger.Warn("post-run.reconcile.recovery.effect-incomplete", "task_id", taskID, "run_id", runID, "action", plan.Action, "reason", plan.Reason)
+		return false
+	}
 }
 
 func lastAgentRun(t *task.Task) *task.AgentRun {

--- a/internal/recovery/stale_reconciliation_internal_test.go
+++ b/internal/recovery/stale_reconciliation_internal_test.go
@@ -1,0 +1,36 @@
+package recovery
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/reconcile"
+)
+
+type fixedReconciler struct {
+	plan reconcile.Plan
+	req  reconcile.Request
+}
+
+func (r *fixedReconciler) Reconcile(_ context.Context, req reconcile.Request) (reconcile.Plan, error) {
+	r.req = req
+	return r.plan, nil
+}
+
+func TestReconcileBeforeAdvanceFencesStaleRecovery(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.DiscardHandler)
+	runner := &fixedReconciler{plan: reconcile.Plan{Action: reconcile.ActionWait, Reason: "stale lease"}}
+	r := &Recovery{Logger: logger, Reconciler: runner}
+	if r.reconcileBeforeAdvance(context.Background(), "task-1", "run-1", reconcile.IntentStaleRun) {
+		t.Fatal("stale recovery advanced through a wait plan")
+	}
+	if runner.req.TaskID != "task-1" || runner.req.RunID != "run-1" || runner.req.Intent != reconcile.IntentStaleRun {
+		t.Fatalf("request = %#v", runner.req)
+	}
+	runner.plan = reconcile.Plan{Action: reconcile.ActionAdvance, DeliverRunOutcome: true}
+	if !r.reconcileBeforeAdvance(context.Background(), "task-1", "run-1", reconcile.IntentRestart) {
+		t.Fatal("safe restart plan did not advance")
+	}
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -59,6 +59,7 @@ import (
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/completion"
+	"github.com/Automaat/sybra/internal/sybra/reconciliation"
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/sybra/verification"
@@ -123,6 +124,7 @@ type App struct {
 	agentOrch         *agentorch.Orchestrator
 	runenv            *runenv.Service
 	verification      *verification.Manager
+	postRunReconciler *reconciliation.Reconciler
 	reviewer          *review.Handler
 	assigner          *clusterlead.Assigner
 	mirror            *clusterlead.Mirror

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1495,6 +1495,7 @@ func (a *App) workflowDependencies(agentLauncher *agentAdapter) workflow.Depende
 			AttemptWorktrees:     &attemptWorktreeAdapter{tasks: a.tasks, mgr: a.worktrees},
 			Verification:         &verificationWorkspaceAdapter{mgr: a.verification},
 			VerificationCommands: agentLauncher,
+			PostRun:              a.postRunReconciliation(),
 		},
 	}
 }
@@ -1717,6 +1718,7 @@ func (a *App) newRecovery() *recovery.Recovery {
 		Orchestrator:       a.agentOrch,
 		Projects:           a.projects,
 		PRs:                newRecoveryPRResolver(),
+		Reconciler:         a.postRunReconciliation(),
 		Logger:             a.logger,
 		Throttle:           a.restartStaleErr,
 		WG:                 &a.wg,
@@ -1742,6 +1744,9 @@ func (a *App) newRecovery() *recovery.Recovery {
 		// on boot with no operator action. Evaluated per call, so it sees the
 		// role applyInstanceRole resolves at the top of startLifecycle.
 		DispatchGate: func(t task.Task) bool { return a.runsScheduler() && a.runsTaskLocally(t) },
+	}
+	if a.workflowEngine != nil {
+		r.ConflictRecovery = a.workflowEngine.TryConflictRecovery
 	}
 	// Gate on the config, not just a non-nil snapshotter: the snapshotter is
 	// always constructed, but when the feature is disabled its repo is never

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -528,14 +528,44 @@ func typedBlockerEscalation(status task.Status, state blocker.State, reason stri
 var errWorkflowWriteFenceMismatch = errors.New("workflow write fence mismatch")
 
 func (a *taskAdapter) SetWorkflowIf(id string, fence workflow.WorkflowWriteFence, wf *workflow.Execution) (bool, error) {
-	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+	_, err := a.tasks.ApplyFn(id, func(cur task.Task) (task.TransitionIntent, error) {
 		if cur.Generation != fence.Generation || cur.Status != fence.Status ||
 			cur.StatusReason != fence.StatusReason || cur.Workflow == nil ||
 			cur.Workflow.WorkflowID != fence.WorkflowID || cur.Workflow.CurrentStep != fence.CurrentStep ||
 			cur.Workflow.State != fence.State {
-			return task.Update{}, errWorkflowWriteFenceMismatch
+			return task.TransitionIntent{}, errWorkflowWriteFenceMismatch
 		}
-		return task.Update{Workflow: &wf}, nil
+		expectedStatus := cur.Status
+		return task.TransitionIntent{
+			TaskID: id, ToStatus: cur.Status, Actor: "workflow.engine.set_workflow_if",
+			ExpectedGeneration: &fence.Generation, ExpectedStatus: &expectedStatus,
+			Extra: task.Update{Workflow: &wf},
+		}, nil
+	})
+	if errors.Is(err, errWorkflowWriteFenceMismatch) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func (a *taskAdapter) SetStatusAndWorkflowIf(id string, fence workflow.WorkflowWriteFence, status taskstatus.Status, reason string, wf *workflow.Execution) (bool, error) {
+	st, err := task.ValidateStatus(string(status))
+	if err != nil {
+		return false, err
+	}
+	_, err = a.tasks.ApplyFn(id, func(cur task.Task) (task.TransitionIntent, error) {
+		if cur.Generation != fence.Generation || cur.Status != fence.Status ||
+			cur.StatusReason != fence.StatusReason || cur.Workflow == nil ||
+			cur.Workflow.WorkflowID != fence.WorkflowID || cur.Workflow.CurrentStep != fence.CurrentStep ||
+			cur.Workflow.State != fence.State {
+			return task.TransitionIntent{}, errWorkflowWriteFenceMismatch
+		}
+		expectedStatus := cur.Status
+		return task.TransitionIntent{
+			TaskID: id, ToStatus: st, Actor: "workflow.engine.set_status_and_workflow_if",
+			ExpectedGeneration: &fence.Generation, ExpectedStatus: &expectedStatus,
+			Extra: task.Update{StatusReason: task.Ptr(reason), Workflow: &wf},
+		}, nil
 	})
 	if errors.Is(err, errWorkflowWriteFenceMismatch) {
 		return false, nil

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/loopagent"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/reconcile"
 	"github.com/Automaat/sybra/internal/runoutcome"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/skillattr"
@@ -73,6 +74,7 @@ type Config struct {
 	PRTracker      *github.IssueTracker
 	Cfg            *config.Config
 	Artifacts      *artifact.Store
+	Reconciler     reconcile.Runner
 	WorkScrub      func(projectID string) *WorkScrubContext
 
 	// HumanReviewComplete routes a completed human-review agent's verdict
@@ -115,7 +117,8 @@ type Handler struct {
 	// completed test-runner's Playwright MCP evidence (screenshots/console
 	// logs) before terminal worktree cleanup. Nil-safe: importTestRunnerEvidence
 	// no-ops when unset (degraded init / tests).
-	artifacts *artifact.Store
+	artifacts  *artifact.Store
+	reconciler reconcile.Runner
 	// workScrub resolves a project ID to a WorkScrubContext (App.workScrubContextForTask).
 	// Used by importTestRunnerEvidence to redact work-repo identifiers from
 	// captured evidence before it lands in the local artifact store. Nil-safe:
@@ -142,6 +145,7 @@ func New(cfg Config) *Handler {
 		prTracker:           cfg.PRTracker,
 		cfg:                 cfg.Cfg,
 		artifacts:           cfg.Artifacts,
+		reconciler:          cfg.Reconciler,
 		workScrub:           cfg.WorkScrub,
 		humanReviewComplete: cfg.HumanReviewComplete,
 		conflictRecovery:    cfg.ConflictRecovery,
@@ -304,6 +308,10 @@ func (h *Handler) afterRunPersisted(ag *agent.Agent, resultContent string, exitE
 	// status), which must not happen behind a human's or the monitor's
 	// deliberate parking.
 	parked, parkedAdoption := h.parkedAdoption(ag)
+	stall := classifyStall(ag, exitErr)
+	if !h.reconcileAuthorCompletion(ag, stall.Stalled) {
+		return
+	}
 
 	if !parkedAdoption {
 		h.salvageInterruptedReview(ag)
@@ -320,8 +328,6 @@ func (h *Handler) afterRunPersisted(ag *agent.Agent, resultContent string, exitE
 		}
 		return
 	}
-
-	stall := classifyStall(ag, exitErr)
 
 	if !parkedAdoption && ag.EffectiveRole() == agent.RoleFixReview && exitErr == nil && !stall.Stalled {
 		h.handleFixReviewCompletion(ag)
@@ -359,6 +365,83 @@ func (h *Handler) afterRunPersisted(ag *agent.Agent, resultContent string, exitE
 			go h.sandboxes.Remove(ag.TaskID)
 		}
 	}
+}
+
+func (h *Handler) reconcileAuthorCompletion(ag *agent.Agent, stalled bool) bool {
+	role := ag.EffectiveRole()
+	if h.reconciler == nil || !role.AuthorsCode() {
+		return true
+	}
+	intent := reconcile.IntentAuthorCompletion
+	switch role {
+	case agent.RoleFixReview:
+		intent = reconcile.IntentFixReview
+	case agent.RolePRFix, agent.RoleTestFix:
+		intent = reconcile.IntentPRFix
+	case agent.RoleHumanReview:
+		intent = reconcile.IntentHumanRecovery
+	default:
+		// The AuthorsCode guard above excludes every verifier/coordinator role;
+		// implementation and any future code-author role use the base intent.
+	}
+	plan, err := h.reconciler.Reconcile(context.Background(), reconcile.Request{TaskID: ag.TaskID, RunID: ag.ID, Intent: intent})
+	if err != nil {
+		h.logger.Error("post-run.reconcile", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
+		// A stalled attempt still has to reach the workflow's retry/reschedule
+		// handling. That path is non-destructive; cleanup remains independently
+		// fail-closed behind CanCleanup's fresh observation.
+		return stalled || role == agent.RoleHumanReview
+	}
+	// Human-review remains an out-of-band diagnosis. Reconciliation still
+	// checkpoints any authored work first, but its verdict handler owns the
+	// resulting task transition.
+	if role == agent.RoleHumanReview {
+		return true
+	}
+	switch plan.Action {
+	case reconcile.ActionAdvance, reconcile.ActionResumeMergeablePR:
+		return plan.DeliverRunOutcome
+	case reconcile.ActionWait:
+		h.logger.Info("post-run.reconcile.wait", "task_id", ag.TaskID, "agent_id", ag.ID, "reason", plan.Reason)
+		return stalled
+	case reconcile.ActionRepair:
+		if plan.DeliverRunOutcome {
+			return true
+		}
+		if h.conflictRecovery != nil && h.conflictRecovery(ag.TaskID) {
+			h.logger.Info("post-run.reconcile.repair-started", "task_id", ag.TaskID, "agent_id", ag.ID, "reason", plan.Reason)
+		} else {
+			h.logger.Warn("post-run.reconcile.repair-held", "task_id", ag.TaskID, "agent_id", ag.ID, "reason", plan.Reason)
+		}
+		return false
+	case reconcile.ActionQuarantine:
+		return h.parkReconciliation(ag.TaskID, plan, task.StatusBlocked)
+	case reconcile.ActionHumanDecision:
+		return h.parkReconciliation(ag.TaskID, plan, task.StatusHumanRequired)
+	default:
+		h.logger.Warn("post-run.reconcile.effect-incomplete", "task_id", ag.TaskID, "agent_id", ag.ID, "action", plan.Action, "reason", plan.Reason)
+		return false
+	}
+}
+
+func (h *Handler) parkReconciliation(taskID string, plan reconcile.Plan, status task.Status) bool {
+	extra := task.Update{StatusReason: task.Ptr("post-run reconciliation: " + plan.Reason)}
+	if status == task.StatusHumanRequired {
+		extra.Escalation = task.OperatorDecisionRequired("post_run.pr_closed", plan.Reason)
+		extra.AutonomyOutcome = task.HumanRequiredOutcome()
+	} else {
+		extra.Escalation = task.MachineFailure("post_run.git_unhealthy", plan.Reason)
+		extra.AutonomyOutcome = task.QuarantinedOutcome()
+	}
+	_, err := h.tasks.Apply(task.TransitionIntent{
+		TaskID: taskID, ToStatus: status, Actor: "post-run.reconciler", Extra: extra,
+		ExpectedGeneration: &plan.Preconditions.TaskGeneration,
+		IdempotencyKey:     "post-run:" + plan.Preconditions.RunID + ":" + string(plan.Action),
+	})
+	if err != nil {
+		h.logger.Error("post-run.reconcile.park", "task_id", taskID, "action", plan.Action, "err", err)
+	}
+	return false
 }
 
 // parkedAdoption reports whether ag is a survivor that reattach adopted over a

--- a/internal/sybra/completion/reconciliation_test.go
+++ b/internal/sybra/completion/reconciliation_test.go
@@ -1,0 +1,81 @@
+package completion
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/reconcile"
+)
+
+type recordingReconciler struct {
+	plan reconcile.Plan
+	req  reconcile.Request
+}
+
+func (r *recordingReconciler) Reconcile(_ context.Context, req reconcile.Request) (reconcile.Plan, error) {
+	r.req = req
+	return r.plan, nil
+}
+
+func TestAuthorCompletionPassesThroughReconciler(t *testing.T) {
+	t.Parallel()
+	r := &recordingReconciler{plan: reconcile.Plan{Action: reconcile.ActionAdvance, DeliverRunOutcome: true}}
+	h := New(Config{Logger: discardLogger(), Reconciler: r})
+	ag := &agent.Agent{ID: "run-1", TaskID: "task-1", Role: agent.RoleImplementation}
+	if !h.reconcileAuthorCompletion(ag, false) {
+		t.Fatal("safe reconciliation did not allow workflow advancement")
+	}
+	if r.req.TaskID != ag.TaskID || r.req.RunID != ag.ID || r.req.Intent != reconcile.IntentAuthorCompletion {
+		t.Fatalf("request = %#v", r.req)
+	}
+}
+
+func TestAuthorCompletionStartsRepairInsteadOfAdvancing(t *testing.T) {
+	t.Parallel()
+	r := &recordingReconciler{plan: reconcile.Plan{Action: reconcile.ActionRepair, Reason: "merge in progress"}}
+	started := false
+	h := New(Config{Logger: discardLogger(), Reconciler: r, ConflictRecovery: func(string) bool {
+		started = true
+		return true
+	}})
+	if h.reconcileAuthorCompletion(&agent.Agent{ID: "run-1", TaskID: "task-1", Role: agent.RoleImplementation}, false) {
+		t.Fatal("repair plan advanced the unresolved author run")
+	}
+	if !started {
+		t.Fatal("repair plan did not start bounded conflict recovery")
+	}
+}
+
+func TestAuthorCompletionWaitsInsteadOfAdvancing(t *testing.T) {
+	t.Parallel()
+	r := &recordingReconciler{plan: reconcile.Plan{Action: reconcile.ActionWait, Reason: "stale lease"}}
+	h := New(Config{Logger: discardLogger(), Reconciler: r})
+	if h.reconcileAuthorCompletion(&agent.Agent{ID: "run-1", TaskID: "task-1", Role: agent.RolePRFix}, false) {
+		t.Fatal("wait plan allowed workflow advancement")
+	}
+	if r.req.Intent != reconcile.IntentPRFix {
+		t.Fatalf("intent = %q, want %q", r.req.Intent, reconcile.IntentPRFix)
+	}
+}
+
+func TestStalledAuthorWaitStillReachesRetryRouting(t *testing.T) {
+	t.Parallel()
+	r := &recordingReconciler{plan: reconcile.Plan{Action: reconcile.ActionWait, Reason: "run is non-terminal"}}
+	h := New(Config{Logger: discardLogger(), Reconciler: r})
+	if !h.reconcileAuthorCompletion(&agent.Agent{ID: "run-1", TaskID: "task-1", Role: agent.RoleImplementation}, true) {
+		t.Fatal("stalled run did not continue to retry routing after reconciliation")
+	}
+}
+
+func TestHumanRecoveryObservesButKeepsVerdictAuthority(t *testing.T) {
+	t.Parallel()
+	r := &recordingReconciler{plan: reconcile.Plan{Action: reconcile.ActionWait}}
+	h := New(Config{Logger: discardLogger(), Reconciler: r})
+	if !h.reconcileAuthorCompletion(&agent.Agent{ID: "run-1", TaskID: "task-1", Role: agent.RoleHumanReview}, false) {
+		t.Fatal("reconciler replaced human-review verdict routing")
+	}
+	if r.req.Intent != reconcile.IntentHumanRecovery {
+		t.Fatalf("intent = %q, want %q", r.req.Intent, reconcile.IntentHumanRecovery)
+	}
+}

--- a/internal/sybra/reconciliation/reconciler.go
+++ b/internal/sybra/reconciliation/reconciler.go
@@ -1,0 +1,332 @@
+// Package reconciliation observes application state and drives the pure
+// internal/reconcile decision table. It is nested under internal/sybra because
+// observation still touches App-adjacent task, project, worktree, and GitHub
+// dependencies.
+package reconciliation
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/evidence"
+	"github.com/Automaat/sybra/internal/gitexec"
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/reconcile"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+const maxReobserveAttempts = 5
+
+type Config struct {
+	Tasks     *task.Manager
+	Projects  *project.Store
+	Worktrees *worktree.Manager
+	Logger    *slog.Logger
+	Evidence  *evidence.Store
+
+	FetchPRState   func(string, int) (github.PRState, error)
+	FetchPRHeadSHA func(string, int) (string, error)
+}
+
+type Reconciler struct {
+	tasks     *task.Manager
+	projects  *project.Store
+	worktrees *worktree.Manager
+	logger    *slog.Logger
+	evidence  *evidence.Store
+	prState   func(string, int) (github.PRState, error)
+	prHead    func(string, int) (string, error)
+}
+
+func New(cfg Config) *Reconciler {
+	state := cfg.FetchPRState
+	if state == nil {
+		state = github.FetchPRState
+	}
+	head := cfg.FetchPRHeadSHA
+	if head == nil {
+		head = github.FetchPRHeadSHA
+	}
+	return &Reconciler{tasks: cfg.Tasks, projects: cfg.Projects, worktrees: cfg.Worktrees, logger: cfg.Logger, evidence: cfg.Evidence, prState: state, prHead: head}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Plan, error) {
+	for range maxReobserveAttempts {
+		snapshot, err := r.observe(ctx, req, "")
+		if err != nil {
+			return reconcile.Plan{}, err
+		}
+		plan := reconcile.Decide(snapshot.Snapshot)
+		if plan.Action != reconcile.ActionCheckpoint && plan.Action != reconcile.ActionPush && plan.Action != reconcile.ActionAdoptRemote {
+			r.log(req, plan)
+			return plan, nil
+		}
+
+		fresh, err := r.observe(ctx, req, "")
+		if err != nil {
+			return reconcile.Plan{}, err
+		}
+		freshPlan := reconcile.Decide(fresh.Snapshot)
+		if freshPlan.Action != plan.Action || !samePreconditions(plan.Preconditions, freshPlan.Preconditions) {
+			continue
+		}
+		switch plan.Action {
+		case reconcile.ActionCheckpoint:
+			_, err = project.CheckpointCommit(ctx, fresh.GitPath(), "wip: reconcile completed agent work\n\nSybra preserved observed author changes before post-run routing.")
+			if err != nil {
+				return reconcile.Plan{}, fmt.Errorf("reconcile checkpoint: %w", err)
+			}
+		case reconcile.ActionPush:
+			if err = project.PushSync(ctx, fresh.GitPath(), fresh.Git.Branch); err != nil {
+				return reconcile.Plan{}, fmt.Errorf("reconcile push: %w", err)
+			}
+		case reconcile.ActionAdoptRemote:
+			if err = project.ReconcileWithRemote(ctx, fresh.GitPath(), fresh.Git.Branch); err != nil {
+				return reconcile.Plan{}, fmt.Errorf("reconcile adopt remote: %w", err)
+			}
+		default:
+			return reconcile.Plan{}, fmt.Errorf("reconcile: unsupported effect action %q", plan.Action)
+		}
+	}
+	return reconcile.Plan{}, fmt.Errorf("reconcile: state changed during %d attempts", maxReobserveAttempts)
+}
+
+// CanCleanup is the destructive worktree gate. It re-observes instead of
+// trusting a completion-time plan, so task generation, lease ownership, HEAD,
+// remote reachability, dirty state, and operation markers are current at the
+// exact cleanup attempt.
+func (r *Reconciler) CanCleanup(ctx context.Context, t task.Task, path string) bool {
+	snapshot, err := r.observe(ctx, reconcile.Request{TaskID: t.ID, Intent: reconcile.IntentCleanup}, path)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("post-run.cleanup.reconcile", "task_id", t.ID, "err", err)
+		}
+		return false
+	}
+	return reconcile.Decide(snapshot.Snapshot).AllowsCleanup()
+}
+
+// observedSnapshot embeds only while applying a strict checkpoint. Keeping the
+// path out of reconcile.Snapshot prevents an ambient filesystem location from
+// becoming part of the pure decision contract or an idempotency key.
+type observedSnapshot struct {
+	reconcile.Snapshot
+	gitPath string
+}
+
+func (s observedSnapshot) GitPath() string { return s.gitPath }
+
+func (r *Reconciler) observe(ctx context.Context, req reconcile.Request, pathOverride string) (observedSnapshot, error) {
+	if r == nil || r.tasks == nil {
+		return observedSnapshot{}, fmt.Errorf("reconcile: task store is unavailable")
+	}
+	t, err := r.tasks.Get(req.TaskID)
+	if err != nil {
+		return observedSnapshot{}, fmt.Errorf("reconcile task: %w", err)
+	}
+	s := reconcile.Snapshot{Intent: req.Intent, TaskID: t.ID, TaskGeneration: t.Generation, WorkflowGeneration: t.Generation}
+	s.Sidecars = observedSidecars(t)
+	if r.evidence != nil {
+		completionEvidence, evidenceErr := r.evidence.Load(t.ID)
+		if evidenceErr != nil {
+			return observedSnapshot{}, fmt.Errorf("reconcile verification evidence: %w", evidenceErr)
+		}
+		s.Evidence = observedEvidence(completionEvidence)
+	}
+	if t.Workflow != nil {
+		s.WorkflowID = t.Workflow.WorkflowID
+		s.WorkflowStep = t.Workflow.CurrentStep
+		if req.RunID != "" {
+			s.Lease = reconcile.LeaseState{ID: req.RunID, Required: true}
+		}
+		if step, ok := t.Workflow.AgentRoute(req.RunID); ok {
+			s.Lease.Current = step == t.Workflow.CurrentStep
+		}
+	}
+	for i := range t.AgentRuns {
+		run := &t.AgentRuns[i]
+		if run.AgentID != req.RunID {
+			continue
+		}
+		s.Run = reconcile.RunState{ID: run.AgentID, Role: run.Role, Terminal: run.Outcome != "", Success: run.Outcome == task.RunOutcomeSuccess}
+		break
+	}
+	if req.Intent == reconcile.IntentCleanup && s.Run.ID == "" {
+		s.Run.Terminal = true
+		s.Run.Success = true
+	}
+
+	path := pathOverride
+	if path == "" {
+		path = t.WorktreeDir
+	}
+	if path == "" && r.worktrees != nil {
+		path = r.worktrees.PathFor(t)
+	}
+	if path != "" {
+		if _, statErr := os.Stat(path); statErr == nil {
+			git, gitErr := r.observeGit(ctx, &t, path)
+			if gitErr != nil {
+				return observedSnapshot{}, gitErr
+			}
+			s.Git = git
+		}
+	}
+	if t.PRNumber > 0 {
+		pr, prErr := r.prState(t.ProjectID, t.PRNumber)
+		if prErr != nil {
+			return observedSnapshot{}, fmt.Errorf("reconcile PR state: %w", prErr)
+		}
+		head, headErr := r.prHead(t.ProjectID, t.PRNumber)
+		if headErr != nil {
+			return observedSnapshot{}, fmt.Errorf("reconcile PR head: %w", headErr)
+		}
+		s.PR = reconcile.PRState{Number: t.PRNumber, State: pr.State, HeadSHA: head, Mergeable: pr.Mergeable, Checks: pr.CIStatus()}
+		s.Git.PRHeadSHA = head
+	}
+	return observedSnapshot{Snapshot: s, gitPath: path}, nil
+}
+
+func observedSidecars(t task.Task) []reconcile.SidecarState {
+	contents := []struct {
+		name    string
+		content string
+	}{
+		{"plan", t.Plan},
+		{"plan-contract", t.PlanContract},
+		{"plan-critique", t.PlanCritique},
+		{"plan-research", t.PlanResearch},
+		{"plan-decisions", t.PlanDecisions},
+		{"plan-brief", t.PlanBrief},
+		{"code-review", t.CodeReview},
+		{"current-test-failures", t.CurrentTestFailures},
+		{"acceptance-ledger", t.AcceptanceLedger},
+		{"spec-decision", t.SpecDecision},
+	}
+	items := make([]reconcile.SidecarState, 0, len(contents)+len(t.PlanDrafts))
+	for _, sidecar := range contents {
+		if sidecar.content != "" {
+			items = append(items, reconcile.SidecarState{Name: sidecar.name, Digest: contentDigest(sidecar.content)})
+		}
+	}
+	for name, content := range t.PlanDrafts {
+		if content != "" {
+			items = append(items, reconcile.SidecarState{Name: "plan-draft:" + name, Digest: contentDigest(content)})
+		}
+	}
+	return items
+}
+
+func observedEvidence(completionEvidence evidence.CompletionEvidence) reconcile.EvidenceState {
+	state := reconcile.EvidenceState{Verified: len(completionEvidence.Criteria) > 0}
+	for i := range completionEvidence.Criteria {
+		criterion := &completionEvidence.Criteria[i]
+		item := reconcile.EvidenceItem{Criterion: criterion.Criterion, SourceSHA: criterion.FinalRev, Passed: criterion.Passed()}
+		state.Items = append(state.Items, item)
+		if !item.Passed || item.SourceSHA == "" {
+			state.Verified = false
+		}
+		if state.SourceSHA == "" {
+			state.SourceSHA = item.SourceSHA
+		} else if state.SourceSHA != item.SourceSHA {
+			state.SourceSHA = ""
+			state.Verified = false
+		}
+	}
+	return state
+}
+
+func contentDigest(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+func (r *Reconciler) observeGit(ctx context.Context, t *task.Task, path string) (reconcile.GitState, error) {
+	g := reconcile.GitState{Available: true, Branch: t.Branch, Healthy: project.WorktreeHealthy(ctx, path)}
+	if !g.Healthy {
+		return g, nil
+	}
+	head, err := project.CurrentCommit(ctx, path)
+	if err != nil {
+		return g, fmt.Errorf("reconcile HEAD: %w", err)
+	}
+	g.HeadSHA = head
+	g.HeadExists = gitexec.RunQuiet(ctx, gitexec.Options{Dir: path}, "cat-file", "-e", head+"^{commit}") == nil
+	dirty, err := project.IsWorktreeDirty(ctx, path)
+	if err != nil {
+		return g, fmt.Errorf("reconcile dirty state: %w", err)
+	}
+	g.Dirty = dirty
+	g.Staged = gitexec.RunQuiet(ctx, gitexec.Options{Dir: path}, "diff", "--cached", "--quiet") != nil
+	g.Operation = project.WorktreeOperation(ctx, path)
+
+	if t.Branch != "" {
+		remote, exists, err := project.RefreshedRemoteTrackingSHA(ctx, path, project.PushRemote(ctx, path), t.Branch)
+		if err != nil {
+			return g, fmt.Errorf("reconcile remote branch: %w", err)
+		}
+		if exists {
+			g.RemoteSHA = remote
+			g.Behind, g.Ahead, err = aheadBehind(ctx, path, remote, head)
+			if err != nil {
+				return g, fmt.Errorf("reconcile remote reachability: %w", err)
+			}
+		}
+	}
+	if r.projects != nil && t.ProjectID != "" {
+		proj, err := r.projects.Get(t.ProjectID)
+		if err != nil {
+			return g, fmt.Errorf("reconcile project: %w", err)
+		}
+		baseBranch, err := project.DefaultBranch(ctx, proj.ClonePath)
+		if err != nil {
+			return g, fmt.Errorf("reconcile base branch: %w", err)
+		}
+		if base, ok := project.ResolveBareRef(ctx, proj.ClonePath, "refs/remotes/origin/"+baseBranch); ok {
+			g.BaseSHA = base
+			_, baseAhead, reachabilityErr := aheadBehind(ctx, path, base, head)
+			if reachabilityErr != nil {
+				return g, fmt.Errorf("reconcile base reachability: %w", reachabilityErr)
+			}
+			g.TaskWorkReachable = head != base && (baseAhead > 0 || g.RemoteSHA == head || g.PRHeadSHA == head)
+			g.TreeEquivalentToBase = gitexec.RunQuiet(ctx, gitexec.Options{Dir: path}, "diff", "--quiet", base, head) == nil
+		}
+	}
+	return g, nil
+}
+
+func aheadBehind(ctx context.Context, path, left, right string) (behind, ahead int, err error) {
+	out, err := gitexec.Output(ctx, gitexec.Options{Dir: path}, "rev-list", "--left-right", "--count", left+"..."+right)
+	if err != nil {
+		return 0, 0, err
+	}
+	parts := strings.Fields(out)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("unexpected rev-list output %q", out)
+	}
+	behind, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse behind count %q: %w", parts[0], err)
+	}
+	ahead, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse ahead count %q: %w", parts[1], err)
+	}
+	return behind, ahead, nil
+}
+
+func samePreconditions(a, b reconcile.Preconditions) bool { return a == b }
+
+func (r *Reconciler) log(req reconcile.Request, plan reconcile.Plan) {
+	if r.logger != nil {
+		r.logger.Info("post-run.reconciled", "task_id", req.TaskID, "run_id", req.RunID, "intent", req.Intent, "action", plan.Action, "reason", plan.Reason)
+	}
+}

--- a/internal/sybra/reconciliation/reconciler_test.go
+++ b/internal/sybra/reconciliation/reconciler_test.go
@@ -1,0 +1,167 @@
+package reconciliation
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/evidence"
+	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/reconcile"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+func TestCanCleanupObservesTheExactRequestedPath(t *testing.T) {
+	t.Parallel()
+	canonical := t.TempDir()
+	attempt := t.TempDir()
+	for _, repo := range []string{canonical, attempt} {
+		runGit(t, repo, "init", "-b", "main")
+		runGit(t, repo, "config", "user.name", "Sybra Test")
+		runGit(t, repo, "config", "user.email", "test@example.com")
+		if err := os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, repo, "add", "base.txt")
+		runGit(t, repo, "commit", "-m", "base")
+	}
+	if err := os.WriteFile(filepath.Join(attempt, "uncommitted.txt"), []byte("preserve\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	created, err := tasks.CreateFull("cleanup", "", task.AgentModeHeadless, task.Update{WorktreeDir: task.Ptr(canonical)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := New(Config{Tasks: tasks})
+	if runner.CanCleanup(context.Background(), created, attempt) {
+		t.Fatal("cleanup gate approved a dirty requested attempt path by observing the clean canonical path")
+	}
+}
+
+func TestReconcileTreatsPrunedWorkflowRouteAsStaleLease(t *testing.T) {
+	t.Parallel()
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	wf := &workflow.Execution{WorkflowID: "wf", CurrentStep: "current", AgentRoutes: map[string]string{"new-run": "current"}}
+	created, err := tasks.Create("lease", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = tasks.Update(created.ID, task.Update{Workflow: task.Ptr(wf)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.AddRun(created.ID, task.AgentRun{AgentID: "old-run", Role: "implementation", Mode: "headless", State: "stopped", Outcome: task.RunOutcomeSuccess}); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := New(Config{Tasks: tasks}).Reconcile(context.Background(), reconcile.Request{TaskID: created.ID, RunID: "old-run", Intent: reconcile.IntentAuthorCompletion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Action != reconcile.ActionWait || plan.Reason != "stale or missing attempt lease" {
+		t.Fatalf("pruned route plan = %#v", plan)
+	}
+}
+
+func TestReconcileCheckpointsDirtyAuthorWorkBeforeAdvancing(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.name", "Sybra Test")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "base")
+
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	created, err := tasks.CreateFull("checkpoint", "", task.AgentModeHeadless, task.Update{WorktreeDir: task.Ptr(repo)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const runID = "author-1"
+	if err := tasks.AddRun(created.ID, task.AgentRun{AgentID: runID, Role: "implementation", Mode: "headless", State: "stopped", Outcome: task.RunOutcomeSuccess}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "work.txt"), []byte("preserve me\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := New(Config{Tasks: tasks})
+	plan, err := runner.Reconcile(ctx, reconcile.Request{TaskID: created.ID, RunID: runID, Intent: reconcile.IntentAuthorCompletion})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if plan.Action != reconcile.ActionAdvance {
+		t.Fatalf("action = %q, want advance", plan.Action)
+	}
+	if got := runGit(t, repo, "status", "--porcelain"); got != "" {
+		t.Fatalf("worktree remained dirty after checkpoint: %q", got)
+	}
+	if got := runGit(t, repo, "show", "--format=", "--name-only", "HEAD"); got != "work.txt\n" {
+		t.Fatalf("checkpoint files = %q, want work.txt", got)
+	}
+}
+
+func TestObservedSidecarsRecordsOnlyContentDigests(t *testing.T) {
+	t.Parallel()
+	taskState := task.Task{
+		Plan:       "private plan content",
+		CodeReview: "private review content",
+		PlanDrafts: map[string]string{providerid.Codex: "private draft", "empty": ""},
+	}
+	got := observedSidecars(taskState)
+	if len(got) != 3 {
+		t.Fatalf("observed sidecars = %#v, want three non-empty entries", got)
+	}
+	for _, item := range got {
+		if item.Digest == "" || item.Digest == taskState.Plan || item.Digest == taskState.CodeReview {
+			t.Fatalf("sidecar %q did not retain a content-only digest: %#v", item.Name, item)
+		}
+	}
+}
+
+func TestObservedEvidenceKeepsRevisionBinding(t *testing.T) {
+	t.Parallel()
+	got := observedEvidence(evidence.CompletionEvidence{Criteria: []evidence.CriterionEvidence{
+		{Criterion: "verify_checks", ExitStatus: 0, FinalRev: "head", Timestamp: time.Now()},
+		{Criterion: "review", ExitStatus: 0, FinalRev: "head", Timestamp: time.Now()},
+	}})
+	if !got.Verified || got.SourceSHA != "head" || len(got.Items) != 2 {
+		t.Fatalf("observed evidence = %#v", got)
+	}
+	got = observedEvidence(evidence.CompletionEvidence{Criteria: []evidence.CriterionEvidence{
+		{Criterion: "verify_checks", ExitStatus: 0, FinalRev: "old"},
+		{Criterion: "review", ExitStatus: 0, FinalRev: "head"},
+	}})
+	if got.Verified || got.SourceSHA != "" {
+		t.Fatalf("mixed-source evidence was accepted: %#v", got)
+	}
+}

--- a/internal/sybra/review/workflow_test_adapters_test.go
+++ b/internal/sybra/review/workflow_test_adapters_test.go
@@ -272,14 +272,44 @@ func testTypedBlockerEscalation(status task.Status, state blocker.State, reason 
 	return task.ControlPlaneFailure(code, owner, reason), task.QuarantinedOutcome()
 }
 func (a *taskAdapter) SetWorkflowIf(id string, fence workflow.WorkflowWriteFence, wf *workflow.Execution) (bool, error) {
-	_, err := a.tasks.UpdateFn(id, func(cur task.Task) (task.Update, error) {
+	_, err := a.tasks.ApplyFn(id, func(cur task.Task) (task.TransitionIntent, error) {
 		if cur.Generation != fence.Generation || cur.Status != fence.Status ||
 			cur.StatusReason != fence.StatusReason || cur.Workflow == nil ||
 			cur.Workflow.WorkflowID != fence.WorkflowID || cur.Workflow.CurrentStep != fence.CurrentStep ||
 			cur.Workflow.State != fence.State {
-			return task.Update{}, errWorkflowWriteFenceMismatch
+			return task.TransitionIntent{}, errWorkflowWriteFenceMismatch
 		}
-		return task.Update{Workflow: &wf}, nil
+		expectedStatus := cur.Status
+		return task.TransitionIntent{
+			TaskID: id, ToStatus: cur.Status, Actor: "workflow.engine.set_workflow_if",
+			ExpectedGeneration: &fence.Generation, ExpectedStatus: &expectedStatus,
+			Extra: task.Update{Workflow: &wf},
+		}, nil
+	})
+	if errors.Is(err, errWorkflowWriteFenceMismatch) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func (a *taskAdapter) SetStatusAndWorkflowIf(id string, fence workflow.WorkflowWriteFence, status taskstatus.Status, reason string, wf *workflow.Execution) (bool, error) {
+	st, err := task.ValidateStatus(string(status))
+	if err != nil {
+		return false, err
+	}
+	_, err = a.tasks.ApplyFn(id, func(cur task.Task) (task.TransitionIntent, error) {
+		if cur.Generation != fence.Generation || cur.Status != fence.Status ||
+			cur.StatusReason != fence.StatusReason || cur.Workflow == nil ||
+			cur.Workflow.WorkflowID != fence.WorkflowID || cur.Workflow.CurrentStep != fence.CurrentStep ||
+			cur.Workflow.State != fence.State {
+			return task.TransitionIntent{}, errWorkflowWriteFenceMismatch
+		}
+		expectedStatus := cur.Status
+		return task.TransitionIntent{
+			TaskID: id, ToStatus: st, Actor: "workflow.engine.set_status_and_workflow_if",
+			ExpectedGeneration: &fence.Generation, ExpectedStatus: &expectedStatus,
+			Extra: task.Update{StatusReason: task.Ptr(reason), Workflow: &wf},
+		}, nil
 	})
 	if errors.Is(err, errWorkflowWriteFenceMismatch) {
 		return false, nil

--- a/internal/sybra/services_wire_completion.go
+++ b/internal/sybra/services_wire_completion.go
@@ -1,6 +1,24 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/sybra/completion"
+import (
+	"github.com/Automaat/sybra/internal/sybra/completion"
+	"github.com/Automaat/sybra/internal/sybra/reconciliation"
+)
+
+func (a *App) postRunReconciliation() *reconciliation.Reconciler {
+	if a == nil || a.tasks == nil {
+		return nil
+	}
+	if a.postRunReconciler == nil {
+		a.postRunReconciler = reconciliation.New(reconciliation.Config{
+			Tasks: a.tasks, Projects: a.projects, Worktrees: a.worktrees, Logger: a.logger, Evidence: a.evidenceStore,
+		})
+		if a.worktrees != nil {
+			a.worktrees.SetCleanupGate(a.postRunReconciler.CanCleanup)
+		}
+	}
+	return a.postRunReconciler
+}
 
 // newAgentCompletionHandler constructs the handler with every dependency
 // the App holds. Called from wireServices once all subsystems are
@@ -9,18 +27,19 @@ import "github.com/Automaat/sybra/internal/sybra/completion"
 // handler's nil-checks at call time handle the latter.
 func (a *App) newAgentCompletionHandler(emit func(string, any)) *completion.Handler {
 	cfg := completion.Config{
-		Logger:    a.logger,
-		Audit:     a.audit,
-		Emit:      emit,
-		Tasks:     a.tasks,
-		Worktrees: a.worktrees,
-		Sandboxes: a.sandboxes,
-		Stats:     a.stats,
-		Limits:    a.limits,
-		LoopSched: a.loopSched,
-		PRTracker: a.prTracker,
-		Cfg:       a.cfg,
-		Artifacts: a.artifacts,
+		Logger:     a.logger,
+		Audit:      a.audit,
+		Emit:       emit,
+		Tasks:      a.tasks,
+		Worktrees:  a.worktrees,
+		Sandboxes:  a.sandboxes,
+		Stats:      a.stats,
+		Limits:     a.limits,
+		LoopSched:  a.loopSched,
+		PRTracker:  a.prTracker,
+		Cfg:        a.cfg,
+		Artifacts:  a.artifacts,
+		Reconciler: a.postRunReconciliation(),
 		WorkScrub: func(projectID string) *completion.WorkScrubContext {
 			ctx := a.workScrubContextForTask(projectID)
 			if ctx == nil {

--- a/internal/sybra/services_wire_completion_test.go
+++ b/internal/sybra/services_wire_completion_test.go
@@ -1,0 +1,13 @@
+package sybra
+
+import "testing"
+
+func TestPostRunReconciliationSkipsDegradedApp(t *testing.T) {
+	t.Parallel()
+	if got := (*App)(nil).postRunReconciliation(); got != nil {
+		t.Fatalf("nil app reconciler = %v, want nil", got)
+	}
+	if got := (&App{}).postRunReconciliation(); got != nil {
+		t.Fatalf("app without task manager reconciler = %v, want nil", got)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/prompteval"
+	"github.com/Automaat/sybra/internal/reconcile"
 
 	"github.com/Automaat/sybra/internal/taskstatus"
 )
@@ -183,6 +184,9 @@ type TaskProvider interface {
 	// task still matches fence. It prevents a maintenance scan from overwriting
 	// a newer operator/automation workflow with a stale snapshot.
 	SetWorkflowIf(id string, fence WorkflowWriteFence, wf *Execution) (bool, error)
+	// SetStatusAndWorkflowIf atomically applies a reconciled workflow routing
+	// effect while the same workflow write fence still holds.
+	SetStatusAndWorkflowIf(id string, fence WorkflowWriteFence, status taskstatus.Status, reason string, wf *Execution) (bool, error)
 	ClaimWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error)
 	CompleteWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error)
 	ReleaseWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error)
@@ -783,6 +787,7 @@ type ExecutionSurface struct {
 	AttemptWorktrees     AttemptWorktreeManager
 	Verification         VerificationWorkspaceManager
 	VerificationCommands VerificationCommandRunner
+	PostRun              reconcile.Runner
 }
 
 func (d Dependencies) missing() []string {
@@ -799,6 +804,7 @@ func (d Dependencies) missing() []string {
 		namedDependency{"Execution.AttemptWorktrees", d.Execution.AttemptWorktrees},
 		namedDependency{"Execution.Verification", d.Execution.Verification},
 		namedDependency{"Execution.VerificationCommands", d.Execution.VerificationCommands},
+		namedDependency{"Execution.PostRun", d.Execution.PostRun},
 	)...)
 	return missing
 }

--- a/internal/workflow/engine_dependencies_test.go
+++ b/internal/workflow/engine_dependencies_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/reconcile"
 )
 
 func TestNewEngineRejectsIncompleteDependencies(t *testing.T) {
@@ -23,6 +24,7 @@ func TestNewEngineRejectsIncompleteDependencies(t *testing.T) {
 		"Store", "Tasks", "Agents", "Logger", "PR.Linker",
 		"Execution.Worktrees", "Execution.Classifier", "Execution.AttemptWorktrees",
 		"Execution.Verification", "Execution.VerificationCommands",
+		"Execution.PostRun",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q does not name missing %s", err, want)
@@ -113,6 +115,9 @@ func (stubExecutionSurface) ReleaseVerification(VerificationWorkspace) {}
 func (stubExecutionSurface) RunVerificationCommand(context.Context, string, string, string, []string, io.Writer) error {
 	return nil
 }
+func (stubExecutionSurface) Reconcile(context.Context, reconcile.Request) (reconcile.Plan, error) {
+	return reconcile.Plan{Action: reconcile.ActionAdvance, DeliverRunOutcome: true}, nil
+}
 
 func completeDependencies() Dependencies {
 	execution := stubExecutionSurface{}
@@ -130,6 +135,7 @@ func completeDependencies() Dependencies {
 			AttemptWorktrees:     execution,
 			Verification:         execution,
 			VerificationCommands: execution,
+			PostRun:              execution,
 		},
 	}
 }

--- a/internal/workflow/engine_events_watchdog.go
+++ b/internal/workflow/engine_events_watchdog.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/blocker"
+	"github.com/Automaat/sybra/internal/reconcile"
 	"github.com/Automaat/sybra/internal/taskstatus"
 	"github.com/Automaat/sybra/internal/watchdogreason"
 )
@@ -76,19 +77,55 @@ func (e *Engine) handleWatchdogHangReadyPR(t *TaskInfo, step *Step) bool {
 	if !state.ReadyToMerge() {
 		return false
 	}
+	runID := ""
+	if n := len(t.AgentRuns); n > 0 {
+		runID = t.AgentRuns[n-1].AgentID
+	}
+	if e.execution.PostRun != nil {
+		plan, reconcileErr := e.execution.PostRun.Reconcile(e.ctx, reconcile.Request{TaskID: t.ID, RunID: runID, Intent: reconcile.IntentRestart})
+		if reconcileErr != nil {
+			e.logger.Warn("workflow.watchdog-hang.ready-pr.reconcile", "task_id", t.ID, "pr", t.PRNumber, "err", reconcileErr)
+			return true
+		}
+		if plan.Action != reconcile.ActionResumeMergeablePR || !plan.DeliverRunOutcome {
+			e.logger.Info("workflow.watchdog-hang.ready-pr.held", "task_id", t.ID, "pr", t.PRNumber, "action", plan.Action, "reason", plan.Reason)
+			return true
+		}
+		freshPlan, freshErr := e.execution.PostRun.Reconcile(e.ctx, reconcile.Request{TaskID: t.ID, RunID: runID, Intent: reconcile.IntentRestart})
+		if freshErr != nil || freshPlan.Action != plan.Action || freshPlan.Preconditions != plan.Preconditions ||
+			plan.Preconditions.TaskGeneration != t.Generation || plan.Preconditions.WorkflowGeneration != t.Generation ||
+			plan.Preconditions.LeaseID != runID {
+			e.logger.Info("workflow.watchdog-hang.ready-pr.stale", "task_id", t.ID, "pr", t.PRNumber, "err", freshErr)
+			return true
+		}
+	}
 
-	delete(t.Workflow.Variables, watchdogReaskNoteVar)
+	fence := WorkflowWriteFence{
+		Generation:   t.Generation,
+		Status:       t.Status,
+		StatusReason: t.StatusReason,
+		WorkflowID:   t.Workflow.WorkflowID,
+		CurrentStep:  t.Workflow.CurrentStep,
+		State:        t.Workflow.State,
+	}
+	nextWorkflow := t.Workflow.Clone()
+	if nextWorkflow == nil {
+		e.logger.Warn("workflow.watchdog-hang.ready-pr.clone", "task_id", t.ID, "pr", t.PRNumber)
+		return true
+	}
+	delete(nextWorkflow.Variables, watchdogReaskNoteVar)
 	now := time.Now().UTC()
-	t.Workflow.State = ExecCompleted
-	t.Workflow.CompletedAt = &now
-	t.Workflow.CurrentStep = ""
-	t.Workflow.SetVar("cancel_reason", "watchdog hang: implementation superseded by linked PR already open and green")
-	if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
+	nextWorkflow.State = ExecCompleted
+	nextWorkflow.CompletedAt = &now
+	nextWorkflow.CurrentStep = ""
+	nextWorkflow.SetVar("cancel_reason", "watchdog hang: implementation superseded by linked PR already open and green")
+	applied, err := e.tasks.SetStatusAndWorkflowIf(t.ID, fence, taskstatus.InReview, "", nextWorkflow)
+	if err != nil {
 		e.logger.Error("workflow.watchdog-hang.ready-pr.persist", "task_id", t.ID, "step", step.ID, "pr", t.PRNumber, "err", err)
 		return true
 	}
-	if err := e.tasks.UpdateTaskStatus(t.ID, taskstatus.InReview, ""); err != nil {
-		e.logger.Error("workflow.watchdog-hang.ready-pr.status", "task_id", t.ID, "step", step.ID, "pr", t.PRNumber, "err", err)
+	if !applied {
+		e.logger.Info("workflow.watchdog-hang.ready-pr.stale", "task_id", t.ID, "step", step.ID, "pr", t.PRNumber)
 		return true
 	}
 	e.logger.Info("workflow.watchdog-hang.ready-pr", "task_id", t.ID, "step", step.ID, "pr", t.PRNumber, "ci_status", state.CIStatus())

--- a/internal/workflow/engine_events_watchdog_reask_test.go
+++ b/internal/workflow/engine_events_watchdog_reask_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"testing"
@@ -8,7 +9,20 @@ import (
 
 	"github.com/Automaat/sybra/internal/blocker"
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/reconcile"
+	"github.com/Automaat/sybra/internal/taskstatus"
 )
+
+type scriptedPostRun struct {
+	plans []reconcile.Plan
+	calls int
+}
+
+func (s *scriptedPostRun) Reconcile(context.Context, reconcile.Request) (reconcile.Plan, error) {
+	plan := s.plans[min(s.calls, len(s.plans)-1)]
+	s.calls++
+	return plan, nil
+}
 
 type watchdogRecoveryAssertion func(*testing.T, *memTasks, *Execution)
 
@@ -447,6 +461,46 @@ func TestResumeStalled_WatchdogHangReadyPRSkipsRedispatch(t *testing.T) {
 	}
 	if got.Workflow.Variables["cancel_reason"] != "watchdog hang: implementation superseded by linked PR already open and green" {
 		t.Fatalf("cancel_reason = %q", got.Workflow.Variables["cancel_reason"])
+	}
+}
+
+func TestResumeStalled_WatchdogReadyPRRejectsChangedReconciliationPreconditions(t *testing.T) {
+	t.Parallel()
+	tasks := newMemTasks()
+	engine := NewTestEngine(newStoreWithBuiltin(t, "simple-task-implement"), tasks, newMockAgents(), discardLogger())
+	engine.setPRStateFetcherForTest(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
+	first := reconcile.Plan{
+		Action:            reconcile.ActionResumeMergeablePR,
+		DeliverRunOutcome: true,
+		Preconditions: reconcile.Preconditions{
+			TaskGeneration:     7,
+			WorkflowGeneration: 7,
+			LeaseID:            "run-1",
+			PRHeadSHA:          "old-head",
+		},
+	}
+	second := first
+	second.Preconditions.PRHeadSHA = "new-head"
+	postRun := &scriptedPostRun{plans: []reconcile.Plan{first, second}}
+	engine.execution.PostRun = postRun
+	wf := &Execution{WorkflowID: "simple-task-implement", CurrentStep: "implement", State: ExecWaiting, Variables: map[string]string{}, StartedAt: time.Now().UTC()}
+	tasks.Put(TaskInfo{
+		ID: "t1", Generation: 7, Status: taskstatus.InProgress, StatusReason: "watchdog hang: no stream activity",
+		ProjectID: "owner/repo", PRNumber: 42, Workflow: wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "run-1", Role: "implementation"}},
+	})
+
+	engine.ResumeStalled()
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != taskstatus.InProgress || got.Workflow.State != ExecWaiting || got.Workflow.CurrentStep != "implement" {
+		t.Fatalf("stale reconciliation plan mutated task: status=%q workflow=%#v", got.Status, got.Workflow)
+	}
+	if postRun.calls != 2 {
+		t.Fatalf("reconcile calls = %d, want immediate re-observation", postRun.calls)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -989,6 +989,26 @@ func (m *memTasks) SetWorkflowIf(id string, fence WorkflowWriteFence, wf *Execut
 	return true, nil
 }
 
+func (m *memTasks) SetStatusAndWorkflowIf(id string, fence WorkflowWriteFence, status taskstatus.Status, reason string, wf *Execution) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return false, fmt.Errorf("task %s not found", id)
+	}
+	if t.Generation != fence.Generation || t.Status != fence.Status ||
+		t.StatusReason != fence.StatusReason || t.Workflow == nil ||
+		t.Workflow.WorkflowID != fence.WorkflowID || t.Workflow.CurrentStep != fence.CurrentStep ||
+		t.Workflow.State != fence.State {
+		return false, nil
+	}
+	t.Status = status
+	t.StatusReason = reason
+	m.reasons[id] = reason
+	t.Workflow = wf.Clone()
+	return true, nil
+}
+
 func (m *memTasks) ClaimWorkflowEffect(id string, claim EffectClaim) (EffectClaimResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -89,7 +89,8 @@ func (m *Manager) RemoveTask(ctx context.Context, t task.Task) {
 	// per-task chokepoint fired on task completion (completion.OnComplete),
 	// manual terminal transitions (UpdateTask), and explicit deletes
 	// (DeleteTask); consistent with doctor cleanup, even those never bypass it.
-	if project.HasUnpushedCommits(ctx, wtPath) {
+	if (m.cleanupGate != nil && !m.cleanupGate(ctx, t, wtPath)) ||
+		(m.cleanupGate == nil && worktreeNeedsPreservation(ctx, wtPath)) {
 		m.logger.Warn("worktree.cleanup.unpushed-commits", "path", wtPath)
 		return
 	}
@@ -218,7 +219,8 @@ func (m *Manager) CleanupOrphaned(ctx context.Context) {
 // reapOrphanedWorktree removes one swept worktree directory. Caller holds the
 // path lock. A nil t is a directory whose task no longer exists.
 func (m *Manager) reapOrphanedWorktree(ctx context.Context, wtPath, name string, t *task.Task, observedProtected map[string]bool) {
-	if project.HasUnpushedCommits(ctx, wtPath) {
+	if (t != nil && m.cleanupGate != nil && !m.cleanupGate(ctx, *t, wtPath)) ||
+		((t == nil || m.cleanupGate == nil) && worktreeNeedsPreservation(ctx, wtPath)) {
 		m.observeProtectedWorktree(ctx, wtPath, taskIDFromWorktreeDir(name), observedProtected)
 		return
 	}
@@ -241,6 +243,14 @@ func (m *Manager) reapOrphanedWorktree(ctx context.Context, wtPath, name string,
 		}
 	}
 	m.logger.Info("worktree.orphan-cleaned", "path", wtPath)
+}
+
+func worktreeNeedsPreservation(ctx context.Context, path string) bool {
+	if project.HasUnpushedCommits(ctx, path) {
+		return true
+	}
+	dirty, err := project.IsWorktreeDirty(ctx, path)
+	return err != nil || dirty || project.WorktreeOperation(ctx, path) != ""
 }
 
 func (m *Manager) observeProtectedWorktree(ctx context.Context, path, taskID string, observed map[string]bool) {

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -24,6 +24,10 @@ type PRBranchResolver func(repo string, prNumber int) (string, error)
 // Injected to avoid importing internal/agent.
 type AgentChecker func(taskID string) bool
 
+// CleanupGate proves that a fresh observed task/worktree snapshot contains no
+// local-only work before a destructive removal. false fails closed.
+type CleanupGate func(context.Context, task.Task, string) bool
+
 // defaultSetupTimeout caps the entire SetupCommands batch per worktree.
 // Accommodates cold `mise install` / `npm ci` runs on first use of a project
 // but prevents stuck commands from blocking worktree creation forever.
@@ -68,12 +72,17 @@ type Manager struct {
 	hasLiveAgentOnly AgentChecker
 	misePath         string
 	protected        *cleanup.ProtectedStore
+	cleanupGate      CleanupGate
 	// paths serializes mutating operations per worktree directory. Not a
 	// Config field: it is process-internal state, and every Manager must have
 	// its own (a shared one would let two Managers over different worktree
 	// roots contend on identical relative paths).
 	paths pathLocks
 }
+
+// SetCleanupGate late-binds the post-run reconciler after both the worktree
+// manager and task/project stores exist.
+func (m *Manager) SetCleanupGate(gate CleanupGate) { m.cleanupGate = gate }
 
 func New(cfg Config) *Manager {
 	timeout := cfg.SetupTimeout


### PR DESCRIPTION
## Summary
- add a pure post-run decision model over task, lease, Git, PR, sidecar, and SHA-bound evidence state
- route live completion, stale/restart recovery, and watchdog no-op recovery through one reconciler
- require a fresh preservation proof before managed worktree cleanup and checkpoint dirty author work behind generation/SHA preconditions

## Verification
- `golangci-lint run ./...`
- focused Go tests for reconcile, reconciliation, completion, recovery, workflow, project
- `mise run verify` progressed through build/module gates and all race-test packages except two existing worktree integration tests whose temporary prepare-commit-msg hook was killed by the local host with signal 9; the focused hook test passes

Closes #3184