### PR TITLE
fix(reconcile): retain worktrees with missing HEAD objects

### DIFF
--- a/internal/reconcile/decision.go
+++ b/internal/reconcile/decision.go
@@ -25,7 +25,7 @@ func Decide(s Snapshot) Plan {
 			LeaseID:        s.Lease.ID,
 			ObservedSHA:    s.Git.HeadSHA,
 			NoDirtyWork:    s.Git.Available && s.Git.Healthy && !s.Git.Dirty && !s.Git.Staged && s.Git.Operation == "",
-			NoLocalOnlyWork: s.Git.Available && s.Git.Healthy &&
+			NoLocalOnlyWork: s.Git.Available && s.Git.Healthy && s.Git.HeadExists &&
 				((s.Git.RemoteSHA != "" && s.Git.Ahead == 0 && (s.Git.RemoteSHA == s.Git.HeadSHA || s.Git.Behind > 0)) ||
 					(s.Git.RemoteSHA == "" && s.Git.BaseSHA != "" && s.Git.HeadSHA == s.Git.BaseSHA)),
 		},

--- a/internal/reconcile/decision_test.go
+++ b/internal/reconcile/decision_test.go
@@ -124,6 +124,7 @@ func TestCleanupProofFailsClosed(t *testing.T) {
 		func(s *Snapshot) { s.Git.RemoteSHA = "other" },
 		func(s *Snapshot) { s.Git.RemoteSHA = ""; s.Git.TaskWorkReachable = true },
 		func(s *Snapshot) { s.Git.Healthy = false },
+		func(s *Snapshot) { s.Git.HeadExists = false },
 	} {
 		s := baselineSnapshot()
 		mutate(&s)


### PR DESCRIPTION
Follow-up to #3184 after the merged reconciler review identified one final fail-closed cleanup gap.

- require the observed HEAD object to exist before proving no local-only work
- cover corrupted/missing HEAD objects in the cleanup-proof matrix

Validation: focused reconciliation tests, Nilaway, golangci-lint.