### PR TITLE
refactor(dispatch): centralize durable attempt admission

### DIFF
--- a/internal/agent/admission.go
+++ b/internal/agent/admission.go
@@ -81,3 +81,11 @@ type AttemptAdmission interface {
 type AttemptLimitUpdater interface {
 	ReplaceLimits(global, perProvider int)
 }
+
+// AttemptLedgerReconciler is the optional restart/maintenance extension used
+// after owned orphan processes have been reaped and worktrees have been
+// preserved. Only expired, unobserved leases may be finalized by this path.
+type AttemptLedgerReconciler interface {
+	NeedsReconciliation(context.Context) (bool, error)
+	ReconcileUnobserved(context.Context, []AttemptLease) (int, error)
+}

--- a/internal/agent/admission.go
+++ b/internal/agent/admission.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrAttemptConflict marks a live or unreconciled attempt that already owns
+// the task/worktree targeted by a new mutating run.
+var ErrAttemptConflict = errors.New("attempt lease conflict")
+
+// ErrAttemptNeedsReconciliation marks an expired lease whose process and
+// workspace must be re-observed before another mutating attempt may start.
+var ErrAttemptNeedsReconciliation = errors.New("attempt lease needs reconciliation")
+
+// ErrProviderCapacityReached is a transient admission result. Callers must
+// park and retry without consuming workflow retry budget or failing the task.
+var ErrProviderCapacityReached = errors.New("provider concurrent agent limit reached")
+
+func IsCapacityError(err error) bool {
+	return errors.Is(err, ErrMaxConcurrentReached) || errors.Is(err, ErrProviderCapacityReached)
+}
+
+func IsAttemptConflict(err error) bool {
+	return errors.Is(err, ErrAttemptConflict) || errors.Is(err, ErrAttemptNeedsReconciliation)
+}
+
+type AttemptAccess string
+
+const (
+	AttemptAccessMutate  AttemptAccess = "mutate"
+	AttemptAccessObserve AttemptAccess = "observe"
+)
+
+// AttemptIntent is the typed, provider-resolved request presented to the one
+// admission controller immediately before Manager registers or spawns a run.
+type AttemptIntent struct {
+	IntentID            string        `yaml:"intent_id"`
+	TaskID              string        `yaml:"task_id,omitempty"`
+	TaskGeneration      uint64        `yaml:"task_generation,omitempty"`
+	Worktree            string        `yaml:"worktree,omitempty"`
+	WorktreeGeneration  uint64        `yaml:"worktree_generation,omitempty"`
+	Access              AttemptAccess `yaml:"access"`
+	Role                Role          `yaml:"role,omitempty"`
+	Provider            string        `yaml:"provider"`
+	CapabilityCertified bool          `yaml:"capability_certified"`
+}
+
+type AttemptBinding struct {
+	AgentID     string    `yaml:"agent_id"`
+	PID         int       `yaml:"pid,omitempty"`
+	ProcStarted string    `yaml:"proc_started,omitempty"`
+	SessionID   string    `yaml:"session_id,omitempty"`
+	ObservedAt  time.Time `yaml:"observed_at"`
+}
+
+type AttemptLease struct {
+	ID      string
+	Version uint64
+	// Existing is true only when Acquire replayed an already-live IntentID.
+	// The launch chokepoint must not bind or spawn another provider attempt in
+	// that case. It is a response marker, not durable lease identity.
+	Existing bool
+}
+
+// AttemptAdmission is implemented by the application-owned durable dispatch
+// controller. Manager.RunContext is the sole production consumer: callers
+// submit RunConfig intents, while admission, binding and terminal release stay
+// centralized around the actual provider start.
+type AttemptAdmission interface {
+	Acquire(context.Context, AttemptIntent) (AttemptLease, error)
+	Bind(context.Context, AttemptLease, AttemptBinding) error
+	Heartbeat(context.Context, AttemptLease, time.Time) error
+	Complete(context.Context, AttemptLease, string) error
+	Adopt(context.Context, AttemptIntent, AttemptLease, AttemptBinding) (AttemptLease, error)
+}
+
+// AttemptLimitUpdater is the optional live-config extension implemented by
+// admission controllers whose capacity policy can be replaced in place.
+type AttemptLimitUpdater interface {
+	ReplaceLimits(global, perProvider int)
+}

--- a/internal/agent/admission_drift_test.go
+++ b/internal/agent/admission_drift_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProviderLaunchRequiresAdmission is the static backstop for the runtime
+// choke point: production code may submit RunConfigs through Manager, but only
+// RunContext may cross from a typed intent into the provider runner, and it
+// must acquire admission first. It also prevents the retired capacity bypass
+// from quietly returning at a scheduler/watchdog/recovery call site.
+func TestProviderLaunchRequiresAdmission(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", ".."))
+	managerRun, err := os.ReadFile(filepath.Join(repoRoot, "internal", "agent", "manager_run.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(managerRun)
+	acquireAt := strings.Index(source, "m.acquireAttempt(ctx, intent)")
+	launchAt := strings.Index(source, "m.startAgentRunner(ctx, a, cfg, prov, cancel)")
+	if acquireAt < 0 || launchAt < 0 || acquireAt >= launchAt {
+		t.Fatalf("RunContext admission/launch order drifted: acquire=%d launch=%d", acquireAt, launchAt)
+	}
+	if got := strings.Count(source, "m.startAgentRunner("); got != 1 {
+		t.Fatalf("production provider-runner entrypoints = %d, want exactly 1", got)
+	}
+
+	err = filepath.WalkDir(filepath.Join(repoRoot, "internal"), func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(data), "IgnoreConcurrencyLimit: true") {
+			t.Errorf("%s restores the forbidden admission bypass", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/agent/admission_integration_test.go
+++ b/internal/agent/admission_integration_test.go
@@ -227,3 +227,56 @@ func TestReattachPersistsTransferredLeaseBeforeExposure(t *testing.T) {
 		t.Fatalf("exposed lease version = %d, want 3", got[0].attemptLease.Version)
 	}
 }
+
+func TestReattachBootstrapsLeaseForLegacyLiveRecord(t *testing.T) {
+	m, _ := newTestManager(t)
+	recorder := &recordingAttemptAdmission{}
+	m.attemptAdmission = recorder
+	registry := &fixedSurvivalRegistry{records: []Record{{
+		ID: "legacy-live", TaskID: "task-1", Mode: "headless", Provider: providerid.Claude,
+		PID: os.Getpid(), ProcStartedAt: processStartString(context.Background(), os.Getpid()),
+		CWD: t.TempDir(),
+	}}}
+	m.reg = registry
+	m.surviveRestart = true
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := m.ReattachAllContext(ctx)
+	if len(got) != 1 {
+		t.Fatalf("reattached = %d, want legacy process fenced and exposed", len(got))
+	}
+	recorder.mu.Lock()
+	if len(recorder.acquired) != 1 || len(recorder.bound) != 1 || recorder.adopted != 0 {
+		t.Fatalf("legacy lifecycle acquired=%d bound=%d adopted=%d, want 1/1/0", len(recorder.acquired), len(recorder.bound), recorder.adopted)
+	}
+	if recorder.acquired[0].IntentID != "legacy-registry:legacy-live" || recorder.acquired[0].Access != AttemptAccessMutate {
+		t.Fatalf("legacy intent = %+v", recorder.acquired[0])
+	}
+	recorder.mu.Unlock()
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if len(registry.saved) != 1 || registry.saved[0].AttemptLeaseID == "" || registry.saved[0].AttemptIntentID == "" {
+		t.Fatalf("saved legacy record = %+v, want durable attempt identity", registry.saved)
+	}
+}
+
+func TestExplicitStartFailureOutcomeWinsTerminalBackstop(t *testing.T) {
+	m, _ := newTestManager(t)
+	recorder := &recordingAttemptAdmission{}
+	m.attemptAdmission = recorder
+	a := &Agent{
+		ID: "start-failure", Provider: providerid.Claude, State: StateRunning,
+		done: make(chan struct{}), attemptLease: AttemptLease{ID: "lease", Version: 1},
+	}
+	if err := m.registerRunningAgent(a, RunConfig{}, func() {}); err != nil {
+		t.Fatal(err)
+	}
+	m.completeAttempt(t.Context(), a, "start_failed")
+	m.markAgentDone(t.Context(), a)
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if len(recorder.completed) != 1 || recorder.completed[0] != "start_failed" {
+		t.Fatalf("completed outcomes = %v, want [start_failed]", recorder.completed)
+	}
+}

--- a/internal/agent/admission_integration_test.go
+++ b/internal/agent/admission_integration_test.go
@@ -162,6 +162,7 @@ type fixedSurvivalRegistry struct {
 	mu      sync.Mutex
 	records []Record
 	saved   []Record
+	deleted []string
 }
 
 func (r *fixedSurvivalRegistry) Save(rec Record) error {
@@ -171,7 +172,12 @@ func (r *fixedSurvivalRegistry) Save(rec Record) error {
 	return nil
 }
 func (r *fixedSurvivalRegistry) List() ([]Record, error) { return r.records, nil }
-func (r *fixedSurvivalRegistry) Delete(string) error     { return nil }
+func (r *fixedSurvivalRegistry) Delete(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deleted = append(r.deleted, id)
+	return nil
+}
 
 func TestReattachRequiresAdmissionAdoptionBeforeExposure(t *testing.T) {
 	m, _ := newTestManager(t)

--- a/internal/agent/admission_integration_test.go
+++ b/internal/agent/admission_integration_test.go
@@ -1,0 +1,229 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/providerid"
+)
+
+type recordingAttemptAdmission struct {
+	mu          sync.Mutex
+	acquired    []AttemptIntent
+	bound       []AttemptBinding
+	heartbeats  int
+	completed   []string
+	adopted     int
+	adoptErr    error
+	nextVersion uint64
+	existing    bool
+}
+
+func (a *recordingAttemptAdmission) Acquire(_ context.Context, intent AttemptIntent) (AttemptLease, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.acquired = append(a.acquired, intent)
+	a.nextVersion++
+	return AttemptLease{ID: "lease-" + intent.IntentID, Version: a.nextVersion, Existing: a.existing}, nil
+}
+
+func (a *recordingAttemptAdmission) Bind(_ context.Context, _ AttemptLease, binding AttemptBinding) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.bound = append(a.bound, binding)
+	return nil
+}
+
+func (a *recordingAttemptAdmission) Heartbeat(context.Context, AttemptLease, time.Time) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.heartbeats++
+	return nil
+}
+
+func (a *recordingAttemptAdmission) Complete(_ context.Context, _ AttemptLease, outcome string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.completed = append(a.completed, outcome)
+	return nil
+}
+
+func (a *recordingAttemptAdmission) Adopt(_ context.Context, _ AttemptIntent, lease AttemptLease, _ AttemptBinding) (AttemptLease, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.adopted++
+	lease.Version++
+	return lease, a.adoptErr
+}
+
+func TestRunContextAttemptAdmissionLifecycleOnStartFailure(t *testing.T) {
+	m, _ := newTestManager(t)
+	recorder := &recordingAttemptAdmission{}
+	m.attemptAdmission = recorder
+	cfg := RunConfig{
+		Mode: "headless", Role: RoleMonitor, Provider: providerid.Claude, Prompt: "same prompt", Dir: t.TempDir(), ReadOnlyDir: true,
+		BeforeStart: func(string) error { return errors.New("fixture rejects start") },
+	}
+
+	if _, err := m.RunContext(context.Background(), cfg); err == nil {
+		t.Fatal("RunContext unexpectedly accepted rejected start")
+	}
+	if _, err := m.RunContext(context.Background(), cfg); err == nil {
+		t.Fatal("second RunContext unexpectedly accepted rejected start")
+	}
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if len(recorder.acquired) != 2 {
+		t.Fatalf("acquired = %d, want 2", len(recorder.acquired))
+	}
+	if recorder.acquired[0].IntentID == "" || recorder.acquired[0].IntentID == recorder.acquired[1].IntentID {
+		t.Fatalf("fallback intent ids = %q, %q; want distinct non-empty dispatch ids", recorder.acquired[0].IntentID, recorder.acquired[1].IntentID)
+	}
+	if recorder.acquired[0].Access != AttemptAccessObserve || !recorder.acquired[0].CapabilityCertified {
+		t.Fatalf("intent = %+v, want certified observer", recorder.acquired[0])
+	}
+	if len(recorder.bound) != 2 || recorder.bound[0].AgentID == "" {
+		t.Fatalf("bindings = %+v, want allocated agent identities", recorder.bound)
+	}
+	if len(recorder.completed) != 2 || recorder.completed[0] != "before_start_failed" || recorder.completed[1] != "before_start_failed" {
+		t.Fatalf("completed = %v, want two before_start_failed releases", recorder.completed)
+	}
+}
+
+func TestRunContextAttemptReplayDoesNotBindOrStart(t *testing.T) {
+	m, _ := newTestManager(t)
+	recorder := &recordingAttemptAdmission{existing: true}
+	m.attemptAdmission = recorder
+	beforeStartCalls := 0
+	_, err := m.RunContext(context.Background(), RunConfig{
+		Mode: "headless", Role: RoleMonitor, Provider: providerid.Claude, Prompt: "replay",
+		Dir: t.TempDir(), IntentID: "effect-1",
+		BeforeStart: func(string) error { beforeStartCalls++; return nil },
+	})
+	if !errors.Is(err, ErrAttemptConflict) {
+		t.Fatalf("RunContext replay error = %v, want ErrAttemptConflict", err)
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if len(recorder.acquired) != 1 || len(recorder.bound) != 0 || len(recorder.completed) != 0 {
+		t.Fatalf("replay lifecycle acquired=%d bound=%d completed=%d, want 1/0/0", len(recorder.acquired), len(recorder.bound), len(recorder.completed))
+	}
+	if beforeStartCalls != 0 {
+		t.Fatalf("BeforeStart calls = %d, replay reached start path", beforeStartCalls)
+	}
+}
+
+func TestRegisterRunningAgentHardProviderCapConcurrent(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.mu.Lock()
+	m.maxConcurrent = 100
+	m.maxInFlightPerProvider = 3
+	m.mu.Unlock()
+
+	const contenders = 40
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	admitted := make([]*Agent, 0, 3)
+	errs := make([]error, 0, contenders-3)
+	for i := range contenders {
+		wg.Go(func() {
+			a := &Agent{ID: fmt.Sprintf("cap-%d", i), Provider: providerid.Claude, done: make(chan struct{})}
+			err := m.registerRunningAgent(a, RunConfig{}, func() {})
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				admitted = append(admitted, a)
+			} else {
+				errs = append(errs, err)
+			}
+		})
+	}
+	wg.Wait()
+	if len(admitted) != 3 {
+		t.Fatalf("admitted = %d, want hard provider cap 3", len(admitted))
+	}
+	for _, err := range errs {
+		if !errors.Is(err, ErrProviderCapacityReached) {
+			t.Fatalf("rejection = %v, want ErrProviderCapacityReached", err)
+		}
+	}
+	for _, a := range admitted {
+		m.markAgentDone(context.Background(), a)
+	}
+}
+
+type fixedSurvivalRegistry struct {
+	mu      sync.Mutex
+	records []Record
+	saved   []Record
+}
+
+func (r *fixedSurvivalRegistry) Save(rec Record) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.saved = append(r.saved, rec)
+	return nil
+}
+func (r *fixedSurvivalRegistry) List() ([]Record, error) { return r.records, nil }
+func (r *fixedSurvivalRegistry) Delete(string) error     { return nil }
+
+func TestReattachRequiresAdmissionAdoptionBeforeExposure(t *testing.T) {
+	m, _ := newTestManager(t)
+	wantErr := errors.New("lease owned by another node")
+	recorder := &recordingAttemptAdmission{adoptErr: wantErr}
+	m.attemptAdmission = recorder
+	m.reg = &fixedSurvivalRegistry{records: []Record{{
+		ID: "reattach-lease", TaskID: "task-1", Mode: "headless", Provider: providerid.Claude,
+		PID: os.Getpid(), ProcStartedAt: processStartString(context.Background(), os.Getpid()),
+		AttemptIntentID: "intent-1", AttemptAccess: AttemptAccessMutate,
+		AttemptLeaseID: "lease-1", AttemptVersion: 2,
+	}}}
+	m.surviveRestart = true
+
+	if got := m.ReattachAllContext(context.Background()); len(got) != 0 {
+		t.Fatalf("reattached = %d, want none when durable adoption fails", len(got))
+	}
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.adopted != 1 {
+		t.Fatalf("adopt calls = %d, want 1", recorder.adopted)
+	}
+	if m.RunningCount() != 0 {
+		t.Fatalf("running count = %d, attempt was exposed before adoption", m.RunningCount())
+	}
+}
+
+func TestReattachPersistsTransferredLeaseBeforeExposure(t *testing.T) {
+	m, _ := newTestManager(t)
+	recorder := &recordingAttemptAdmission{}
+	m.attemptAdmission = recorder
+	registry := &fixedSurvivalRegistry{records: []Record{{
+		ID: "reattach-transferred", TaskID: "task-1", Mode: "headless", Provider: providerid.Claude,
+		PID: os.Getpid(), ProcStartedAt: processStartString(context.Background(), os.Getpid()),
+		AttemptIntentID: "intent-1", AttemptAccess: AttemptAccessMutate,
+		AttemptLeaseID: "lease-1", AttemptVersion: 2,
+	}}}
+	m.reg = registry
+	m.surviveRestart = true
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := m.ReattachAllContext(ctx)
+	if len(got) != 1 {
+		t.Fatalf("reattached = %d, want 1", len(got))
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if len(registry.saved) != 1 || registry.saved[0].AttemptVersion != 3 {
+		t.Fatalf("saved records = %+v, want transferred lease version 3", registry.saved)
+	}
+	if got[0].attemptLease.Version != 3 {
+		t.Fatalf("exposed lease version = %d, want 3", got[0].attemptLease.Version)
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -93,6 +93,9 @@ type Manager struct {
 	// after provider, sandbox home, cache roots, and sandbox policy have been
 	// resolved but before a provider process is registered or spawned.
 	runEnvironmentPreflight RunEnvironmentPreflight
+	// attemptAdmission owns durable task/worktree leases and hard provider
+	// capacity. It is invoked only from RunContext's final launch chokepoint.
+	attemptAdmission AttemptAdmission
 
 	defaultSandboxMode string
 	// defaultSandboxReadMode is the read-visibility posture layered on top of
@@ -127,7 +130,9 @@ type Manager struct {
 	reservedByClass map[WorkloadClass]int
 	classFloors     map[WorkloadClass]int
 	// maxInFlightPerProvider caps concurrent in-flight agents per provider.
-	// 0 disables the cap (soft cap: never blocks dispatch, only redirects).
+	// Routing first tries a healthy peer; registerRunningAgent is the atomic
+	// hard backstop that prevents concurrent selectors from overshooting it.
+	// 0 disables the cap.
 	maxInFlightPerProvider int
 	// dispatchJitterMs bounds a uniform random delay applied before headless
 	// dispatch to de-correlate a wave of same-tick starts. 0 disables jitter.
@@ -163,7 +168,8 @@ type Manager struct {
 	// avoid recreating a zombie codex agent whose chat task was deleted.
 	taskExists func(taskID string) bool
 
-	taskStatus func(taskID string) (string, bool)
+	taskStatus     func(taskID string) (string, bool)
+	taskGeneration func(taskID string) (int64, bool)
 
 	// toolLedger records every tool call every agent makes, whatever the
 	// permission posture. Nil disables recording; Logger.Log tolerates it.
@@ -261,8 +267,10 @@ type ManagerConfig struct {
 	SessionSink       func(taskID, agentID, sessionID string) error
 	TaskExists        func(taskID string) bool
 	TaskStatus        func(taskID string) (string, bool)
+	TaskGeneration    func(taskID string) (int64, bool)
 	LimitSink         func(limits.Snapshot)
 	Artifacts         *artifact.Store
+	AttemptAdmission  AttemptAdmission
 
 	// SandboxHome resolves the per-task sandbox SYBRA_HOME directory for a
 	// task-scoped run. Required for every fresh agent subprocess so it never
@@ -358,9 +366,11 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		limitPolicy:            copyLimitPolicy(cfg.Runtime.LimitPolicy),
 		limitSink:              cfg.LimitSink,
 		artifacts:              cfg.Artifacts,
+		attemptAdmission:       cfg.AttemptAdmission,
 		sessionSink:            cfg.SessionSink,
 		taskExists:             cfg.TaskExists,
 		taskStatus:             cfg.TaskStatus,
+		taskGeneration:         cfg.TaskGeneration,
 		maxInFlightPerProvider: cfg.Runtime.MaxInFlightPerProvider,
 		dispatchJitterMs:       cfg.Runtime.DispatchJitterMs,
 		headlessSteerable:      cfg.Runtime.HeadlessSteerable,
@@ -634,7 +644,11 @@ func (m *Manager) ReplaceRuntimeConfig(cfg ManagerRuntimeConfig) error {
 	} else {
 		m.k8sRunner = nil
 	}
+	admission := m.attemptAdmission
 	m.mu.Unlock()
+	if updater, ok := admission.(AttemptLimitUpdater); ok {
+		updater.ReplaceLimits(cfg.MaxConcurrent, cfg.MaxInFlightPerProvider)
+	}
 	m.warnInertCap(m.logger, cfg.MaxInFlightPerProvider, cfg.LimitGate)
 	return nil
 }
@@ -724,14 +738,21 @@ func (m *Manager) registryDir() string {
 	return m.surviveRestartDir
 }
 
-// saveRegistry snapshots the agent to disk. No-op when survival is off.
+// saveRegistry snapshots the agent to disk and refreshes its durable attempt
+// binding. Admission updates are intentionally independent of restart
+// survival: a deployment may disable process reattachment while still using
+// durable leases for dispatch ownership and capacity.
 func (m *Manager) saveRegistry(ctx context.Context, a *Agent) {
 	reg := m.registry()
-	if reg == nil || a == nil {
+	if a == nil {
 		return
 	}
 	rec := a.toRecord()
 	rec.ProcStartedAt = processStartString(ctx, rec.PID)
+	m.bindAndHeartbeatAttempt(ctx, a, rec.ProcStartedAt)
+	if reg == nil {
+		return
+	}
 	if err := reg.Save(rec); err != nil {
 		m.logger.Warn(
 			"agent.registry.save",
@@ -1101,6 +1122,10 @@ func (m *Manager) recordCompletion(ctx context.Context, a *Agent, ok bool) {
 // calling onComplete a second time and double-advancing the workflow.
 func (m *Manager) fireComplete(ctx context.Context, a *Agent, ok bool) {
 	a.completedOnce.Do(func() {
+		// Release/finalize durable ownership before the callback advances a
+		// workflow and synchronously admits its next mutating attempt on the
+		// same worktree.
+		m.completeAttempt(ctx, a, attemptTerminalOutcome(a))
 		m.recordCompletion(ctx, a, ok)
 		if m.onComplete != nil {
 			m.onComplete(a)

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/skillattr"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/taskstatus"
 	"github.com/Automaat/sybra/internal/toolledger"
 	"github.com/google/uuid"
 )
@@ -69,12 +70,28 @@ func (m *Manager) RunContext(ctx context.Context, cfg RunConfig) (*Agent, error)
 	}
 
 	id := uuid.NewString()[:8]
+	intent := attemptIntentForRun(cfg, prov.Name())
+	lease, err := m.acquireAttempt(ctx, intent)
+	if err != nil {
+		return nil, err
+	}
+	if lease.Existing {
+		return nil, fmt.Errorf("%w: intent %s already admitted as lease %s", ErrAttemptConflict, intent.IntentID, lease.ID)
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	a := newRunningAgent(id, cfg, prov, cancel)
+	a.attemptIntent = intent
+	a.attemptLease = lease
 	a.SetToolCallRecorder(m.recordToolCall)
+	if err := m.bindAttempt(ctx, a, ""); err != nil {
+		cancel()
+		m.completeAttempt(ctx, a, "bind_failed")
+		return nil, fmt.Errorf("agent.Run: bind attempt: %w", err)
+	}
 	if cfg.BeforeStart != nil {
 		if err := cfg.BeforeStart(id); err != nil {
 			cancel()
+			m.completeAttempt(ctx, a, "before_start_failed")
 			return nil, fmt.Errorf("agent.Run: before start: %w", err)
 		}
 	}
@@ -84,6 +101,7 @@ func (m *Manager) RunContext(ctx context.Context, cfg RunConfig) (*Agent, error)
 	}
 
 	if err := m.registerRunningAgent(a, cfg, cancel); err != nil { //nolint:contextcheck // per-class metrics are process-global accounting, not tied to per-run ctx
+		m.completeAttempt(ctx, a, "registration_failed")
 		return nil, err
 	}
 
@@ -91,11 +109,177 @@ func (m *Manager) RunContext(ctx context.Context, cfg RunConfig) (*Agent, error)
 	m.logger.Info("agent.start", "id", id, "taskID", cfg.TaskID, "mode", cfg.Mode, "provider", a.Provider, "model", a.Model)
 
 	if err := m.startAgentRunner(ctx, a, cfg, prov, cancel); err != nil {
+		m.markAgentDone(ctx, a)
+		m.completeAttempt(ctx, a, "start_failed")
 		return nil, err
 	}
+	m.startAttemptHeartbeat(ctx, a)
 
 	m.emit(events.AgentState(id), a)
 	return a, nil
+}
+
+func attemptIntentForRun(cfg RunConfig, providerName string) AttemptIntent {
+	access := cfg.AttemptAccess
+	if access == "" {
+		access = AttemptAccessMutate
+	}
+	if cfg.ReadOnlyDir {
+		access = AttemptAccessObserve
+	}
+	intentID := strings.TrimSpace(cfg.IntentID)
+	if intentID == "" {
+		// Only an explicit workflow/effect identity is replay-stable. A
+		// deterministic fallback would make recurring taskless monitor and loop
+		// runs replay a lease that already completed. The generated identity is
+		// persisted in the registry, so restart adoption remains stable.
+		intentID = "dispatch:" + uuid.NewString()
+	}
+	return AttemptIntent{
+		IntentID: intentID, TaskID: firstNonEmpty(cfg.AdmissionTaskKey, cfg.TaskID), TaskGeneration: cfg.TaskGeneration,
+		Worktree: cfg.Dir, WorktreeGeneration: cfg.WorktreeGeneration,
+		Access: access, Role: cfg.Role, Provider: providerName,
+		CapabilityCertified: true,
+	}
+}
+
+func (m *Manager) admissionService() AttemptAdmission {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.attemptAdmission
+}
+
+func (m *Manager) acquireAttempt(ctx context.Context, intent AttemptIntent) (AttemptLease, error) {
+	admission := m.admissionService()
+	if admission == nil {
+		return AttemptLease{}, nil
+	}
+	return admission.Acquire(ctx, intent)
+}
+
+func (m *Manager) bindAttempt(ctx context.Context, a *Agent, procStarted string) error {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	lease := a.attemptLease
+	binding := AttemptBinding{
+		AgentID: a.ID, PID: a.PID, ProcStarted: procStarted,
+		SessionID: a.SessionID, ObservedAt: time.Now().UTC(),
+	}
+	a.mu.RUnlock()
+	admission := m.admissionService()
+	if admission == nil || lease.ID == "" {
+		return nil
+	}
+	return admission.Bind(ctx, lease, binding)
+}
+
+func (m *Manager) bindAndHeartbeatAttempt(ctx context.Context, a *Agent, procStarted string) {
+	if err := m.bindAttempt(ctx, a, procStarted); err != nil {
+		m.logger.Warn("agent.attempt.bind", "id", a.ID, "err", err)
+		return
+	}
+	a.mu.RLock()
+	lease := a.attemptLease
+	a.mu.RUnlock()
+	admission := m.admissionService()
+	if admission == nil || lease.ID == "" {
+		return
+	}
+	if err := admission.Heartbeat(ctx, lease, time.Now().UTC()); err != nil {
+		m.logger.Warn("agent.attempt.heartbeat", "id", a.ID, "err", err)
+	}
+}
+
+const attemptHeartbeatInterval = 15 * time.Second
+
+func (m *Manager) startAttemptHeartbeat(ctx context.Context, a *Agent) {
+	if m.admissionService() == nil || a == nil {
+		return
+	}
+	a.mu.RLock()
+	hasLease := a.attemptLease.ID != ""
+	a.mu.RUnlock()
+	if !hasLease {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(attemptHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				a.mu.RLock()
+				lease := a.attemptLease
+				a.mu.RUnlock()
+				if admission := m.admissionService(); admission != nil {
+					if err := admission.Heartbeat(ctx, lease, time.Now().UTC()); err != nil {
+						m.logger.Warn("agent.attempt.heartbeat", "id", a.ID, "err", err)
+					}
+				}
+			case <-a.done:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (m *Manager) completeAttempt(ctx context.Context, a *Agent, outcome string) {
+	if a == nil {
+		return
+	}
+	a.attemptCompleteOnce.Do(func() {
+		a.mu.RLock()
+		lease := a.attemptLease
+		a.mu.RUnlock()
+		admission := m.admissionService()
+		if admission == nil || lease.ID == "" {
+			return
+		}
+		if ctx == nil {
+			ctx = context.Background()
+		} else {
+			ctx = context.WithoutCancel(ctx)
+		}
+		if err := admission.Complete(ctx, lease, outcome); err != nil {
+			m.logger.Warn("agent.attempt.complete", "id", a.ID, "outcome", outcome, "err", err)
+		}
+	})
+}
+
+func attemptTerminalOutcome(a *Agent) string {
+	if a.GetExitErr() != nil {
+		return "failed"
+	}
+	if a.WasStopped() {
+		return string(taskstatus.Cancelled)
+	}
+	return "completed"
+}
+
+func (m *Manager) adoptAttempt(ctx context.Context, r Record) (AttemptLease, error) {
+	admission := m.admissionService()
+	lease := AttemptLease{ID: r.AttemptLeaseID, Version: r.AttemptVersion}
+	if admission == nil || lease.ID == "" {
+		return lease, nil
+	}
+	access := r.AttemptAccess
+	if access == "" {
+		access = AttemptAccessMutate
+	}
+	intent := AttemptIntent{
+		IntentID: r.AttemptIntentID, TaskID: firstNonEmpty(r.AttemptTaskKey, r.TaskID),
+		TaskGeneration: r.AttemptTaskGen, Worktree: r.CWD,
+		WorktreeGeneration: r.AttemptWorkGen, Access: access,
+		Role: r.Role, Provider: r.Provider, CapabilityCertified: true,
+	}
+	return admission.Adopt(ctx, intent, lease, AttemptBinding{
+		AgentID: r.ID, PID: r.PID, ProcStarted: r.ProcStartedAt,
+		SessionID: r.SessionID, ObservedAt: time.Now().UTC(),
+	})
 }
 
 func (m *Manager) certifyPreparedRun(ctx context.Context, cfg RunConfig, providerName string) error {
@@ -207,6 +391,9 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 		return cfg, nil, roleErr
 	}
 	cfg.Role = role
+	if err := m.resolveAttemptGeneration(&cfg); err != nil {
+		return cfg, nil, err
+	}
 	m.mu.RLock()
 	if cfg.Model == "" {
 		cfg.Model = m.defaultModel
@@ -304,7 +491,13 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 
 	m.preparePlaywrightMCP(&cfg)
 
+	m.applyRuntimeDefaults(&cfg)
+	return cfg, prov, nil
+}
+
+func (m *Manager) applyRuntimeDefaults(cfg *RunConfig) {
 	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if cfg.BashTimeoutMs == 0 {
 		cfg.BashTimeoutMs = m.bashTimeoutMs
 	}
@@ -314,8 +507,31 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	if cfg.FallbackModel == "" {
 		cfg.FallbackModel = m.fallbackModel
 	}
+}
+
+func (m *Manager) resolveAttemptGeneration(cfg *RunConfig) error {
+	if cfg == nil || cfg.TaskID == "" {
+		return nil
+	}
+	m.mu.RLock()
+	generation := m.taskGeneration
 	m.mu.RUnlock()
-	return cfg, prov, nil
+	if generation == nil {
+		return nil
+	}
+	value, ok := generation(cfg.TaskID)
+	if !ok || value <= 0 {
+		return nil
+	}
+	current := uint64(value)
+	if cfg.TaskGeneration != 0 && cfg.TaskGeneration != current {
+		return fmt.Errorf("%w: task %s generation %d is stale (current %d)", ErrAttemptConflict, cfg.TaskID, cfg.TaskGeneration, current)
+	}
+	cfg.TaskGeneration = current
+	if cfg.WorktreeGeneration == 0 {
+		cfg.WorktreeGeneration = current
+	}
+	return nil
 }
 
 func (m *Manager) injectGitAccess(cfg *RunConfig) error {
@@ -1554,10 +1770,15 @@ func (m *Manager) registerRunningAgent(a *Agent, cfg RunConfig, cancel context.C
 	class := a.EffectiveRole().WorkloadClass()
 	m.mu.Lock()
 	reserved := false
-	if !cfg.IgnoreConcurrencyLimit && cfg.capacityReservation != nil && cfg.capacityReservation.manager == m {
+	if m.maxInFlightPerProvider > 0 && a.Provider != "" && m.liveByProvider[a.Provider] >= m.maxInFlightPerProvider {
+		m.mu.Unlock()
+		cancel()
+		return fmt.Errorf("%w: %s (%d)", ErrProviderCapacityReached, a.Provider, m.maxInFlightPerProvider)
+	}
+	if cfg.capacityReservation != nil && cfg.capacityReservation.manager == m {
 		reserved = cfg.capacityReservation.consumeLocked()
 	}
-	if !cfg.IgnoreConcurrencyLimit && !reserved && !admitClass(class, m.liveByClass, m.reservedByClass, m.classFloors, m.maxConcurrent) {
+	if !reserved && !admitClass(class, m.liveByClass, m.reservedByClass, m.classFloors, m.maxConcurrent) {
 		m.mu.Unlock()
 		cancel()
 		metrics.AgentClassRejected(string(class))
@@ -1573,13 +1794,7 @@ func (m *Manager) registerRunningAgent(a *Agent, cfg RunConfig, cancel context.C
 		m.liveByClass[class]++
 	}
 	m.mu.Unlock()
-	// Only count dispatches that actually passed through the capacity gate
-	// (!IgnoreConcurrencyLimit) and were capacity-tracked (a.done != nil, i.e.
-	// added to m.liveByClass). Interactive agents and gate-bypassing callers
-	// (monitor/loop/orchestrator/human-review set IgnoreConcurrencyLimit) never
-	// enter the class gauges, so folding them into "admitted"/"borrowed" would
-	// misreport class-isolation behavior for anyone debugging starvation.
-	if !cfg.IgnoreConcurrencyLimit && a.done != nil {
+	if a.done != nil {
 		metrics.AgentClassAdmitted(string(class))
 		if borrowed {
 			metrics.AgentClassBorrowed(string(class))
@@ -1612,6 +1827,7 @@ func (m *Manager) markAgentDone(ctx context.Context, a *Agent) {
 	}
 	a.doneOnce.Do(func() {
 		close(a.done)
+		m.completeAttempt(ctx, a, attemptTerminalOutcome(a))
 		if a.isDetached() {
 			reapProcessGroup(a.GetPID())
 		}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -109,8 +109,8 @@ func (m *Manager) RunContext(ctx context.Context, cfg RunConfig) (*Agent, error)
 	m.logger.Info("agent.start", "id", id, "taskID", cfg.TaskID, "mode", cfg.Mode, "provider", a.Provider, "model", a.Model)
 
 	if err := m.startAgentRunner(ctx, a, cfg, prov, cancel); err != nil {
-		m.markAgentDone(ctx, a)
 		m.completeAttempt(ctx, a, "start_failed")
+		m.markAgentDone(ctx, a)
 		return nil, err
 	}
 	m.startAttemptHeartbeat(ctx, a)
@@ -147,6 +147,68 @@ func (m *Manager) admissionService() AttemptAdmission {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.attemptAdmission
+}
+
+// NeedsAttemptReconciliation reports whether durable admission contains an
+// expired lease. Recovery uses this to avoid an expensive process/worktree
+// preservation pass on ordinary maintenance ticks.
+func (m *Manager) NeedsAttemptReconciliation(ctx context.Context) bool {
+	reconciler, ok := m.admissionService().(AttemptLedgerReconciler)
+	if !ok {
+		return false
+	}
+	needed, err := reconciler.NeedsReconciliation(ctx)
+	if err != nil {
+		m.logger.Warn("agent.attempt.reconcile-check", "err", err)
+		return false
+	}
+	return needed
+}
+
+// ReconcileAttemptLeases finalizes expired leases not represented by either
+// the survival registry or the live manager. Callers must first reap owned
+// unregistered processes and preserve worktrees.
+func (m *Manager) ReconcileAttemptLeases(ctx context.Context) int {
+	reconciler, ok := m.admissionService().(AttemptLedgerReconciler)
+	if !ok {
+		return 0
+	}
+	seen := make(map[string]AttemptLease)
+	if reg := m.registry(); reg != nil {
+		records, err := reg.List()
+		if err != nil {
+			m.logger.Warn("agent.attempt.reconcile-registry", "err", err)
+			return 0
+		}
+		for i := range records {
+			if records[i].AttemptLeaseID != "" {
+				seen[records[i].AttemptLeaseID] = AttemptLease{ID: records[i].AttemptLeaseID, Version: records[i].AttemptVersion}
+			}
+		}
+	}
+	m.mu.RLock()
+	for _, a := range m.agents {
+		a.mu.RLock()
+		lease := a.attemptLease
+		a.mu.RUnlock()
+		if lease.ID != "" && a.GetState() != StateStopped {
+			seen[lease.ID] = lease
+		}
+	}
+	m.mu.RUnlock()
+	observed := make([]AttemptLease, 0, len(seen))
+	for _, lease := range seen {
+		observed = append(observed, lease)
+	}
+	n, err := reconciler.ReconcileUnobserved(ctx, observed)
+	if err != nil {
+		m.logger.Warn("agent.attempt.reconcile", "err", err)
+		return 0
+	}
+	if n > 0 {
+		m.logger.Info("agent.attempt.reconciled", "count", n)
+	}
+	return n
 }
 
 func (m *Manager) acquireAttempt(ctx context.Context, intent AttemptIntent) (AttemptLease, error) {
@@ -260,26 +322,48 @@ func attemptTerminalOutcome(a *Agent) string {
 	return "completed"
 }
 
-func (m *Manager) adoptAttempt(ctx context.Context, r Record) (AttemptLease, error) {
-	admission := m.admissionService()
-	lease := AttemptLease{ID: r.AttemptLeaseID, Version: r.AttemptVersion}
-	if admission == nil || lease.ID == "" {
-		return lease, nil
-	}
+func attemptIntentFromRecord(r Record) AttemptIntent {
 	access := r.AttemptAccess
 	if access == "" {
 		access = AttemptAccessMutate
 	}
-	intent := AttemptIntent{
-		IntentID: r.AttemptIntentID, TaskID: firstNonEmpty(r.AttemptTaskKey, r.TaskID),
+	intentID := r.AttemptIntentID
+	if intentID == "" {
+		intentID = "legacy-registry:" + r.ID
+	}
+	return AttemptIntent{
+		IntentID: intentID, TaskID: firstNonEmpty(r.AttemptTaskKey, r.TaskID),
 		TaskGeneration: r.AttemptTaskGen, Worktree: r.CWD,
 		WorktreeGeneration: r.AttemptWorkGen, Access: access,
 		Role: r.Role, Provider: r.Provider, CapabilityCertified: true,
 	}
-	return admission.Adopt(ctx, intent, lease, AttemptBinding{
+}
+
+func (m *Manager) adoptAttempt(ctx context.Context, r Record, intent AttemptIntent) (AttemptLease, error) {
+	admission := m.admissionService()
+	lease := AttemptLease{ID: r.AttemptLeaseID, Version: r.AttemptVersion}
+	if admission == nil {
+		return lease, nil
+	}
+	binding := AttemptBinding{
 		AgentID: r.ID, PID: r.PID, ProcStarted: r.ProcStartedAt,
 		SessionID: r.SessionID, ObservedAt: time.Now().UTC(),
-	})
+	}
+	if lease.ID == "" {
+		acquired, err := admission.Acquire(ctx, intent)
+		if err != nil {
+			return AttemptLease{}, err
+		}
+		if acquired.Existing {
+			return AttemptLease{}, fmt.Errorf("%w: legacy registry intent %s", ErrAttemptConflict, intent.IntentID)
+		}
+		if err := admission.Bind(ctx, acquired, binding); err != nil {
+			_ = admission.Complete(context.WithoutCancel(ctx), acquired, "legacy_bind_failed")
+			return AttemptLease{}, err
+		}
+		return acquired, nil
+	}
+	return admission.Adopt(ctx, intent, lease, binding)
 }
 
 func (m *Manager) certifyPreparedRun(ctx context.Context, cfg RunConfig, providerName string) error {

--- a/internal/agent/manager_run_test.go
+++ b/internal/agent/manager_run_test.go
@@ -480,7 +480,7 @@ func providerLimitTestPolicy(preferUnderused bool) limits.Policy {
 	return policy
 }
 
-func TestRegisterRunningAgent_IgnoreConcurrencyLimitBypassesCap(t *testing.T) {
+func TestRegisterRunningAgent_IgnoreConcurrencyLimitCannotBypassCap(t *testing.T) {
 	m, _ := newTestManager(t)
 	m.maxConcurrent = 2
 
@@ -497,11 +497,8 @@ func TestRegisterRunningAgent_IgnoreConcurrencyLimitBypassesCap(t *testing.T) {
 	}
 
 	control := &Agent{ID: "control-plane", Provider: "claude", done: make(chan struct{})}
-	if err := m.registerRunningAgent(control, RunConfig{IgnoreConcurrencyLimit: true}, func() {}); err != nil {
-		t.Fatalf("IgnoreConcurrencyLimit spawn at cap must succeed, got err = %v", err)
-	}
-	if _, err := m.GetAgent(control.ID); err != nil {
-		t.Fatalf("control-plane agent should be registered: %v", err)
+	if err := m.registerRunningAgent(control, RunConfig{IgnoreConcurrencyLimit: true}, func() {}); !errors.Is(err, ErrMaxConcurrentReached) {
+		t.Fatalf("IgnoreConcurrencyLimit spawn at cap: err = %v, want ErrMaxConcurrentReached", err)
 	}
 }
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -1985,8 +1985,9 @@ type RunConfig struct {
 	Dir          string
 	// IntentID makes a dispatch replay idempotent. TaskGeneration and
 	// WorktreeGeneration fence stale schedulers/recovery workers; zero is a
-	// valid legacy generation. ReadOnlyDir selects an explicit observer lease,
-	// otherwise the run owns the task/worktree for mutation.
+	// valid legacy generation. AttemptAccess selects mutation or observation;
+	// ReadOnlyDir also forces observation so a sandbox-read-only run can never
+	// acquire mutation ownership.
 	IntentID           string
 	AdmissionTaskKey   string
 	AttemptAccess      AttemptAccess

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -105,7 +105,10 @@ type Agent struct {
 	AssignmentKey   string    `json:"assignmentKey,omitempty"`
 	// DecisionVersion is the routing-overlay generation (internal/routing)
 	// that set this run's variant weight, 0 when none applied.
-	DecisionVersion         int    `json:"decisionVersion,omitempty"`
+	DecisionVersion         int `json:"decisionVersion,omitempty"`
+	attemptIntent           AttemptIntent
+	attemptLease            AttemptLease
+	attemptCompleteOnce     sync.Once
 	ReasoningEffort         string `json:"reasoningEffort,omitempty"`
 	RequestedSkill          string `json:"requestedSkill,omitempty"`
 	SkillExecutionMode      string `json:"skillExecutionMode,omitempty"`
@@ -502,6 +505,13 @@ func (a *Agent) toRecord() Record {
 		AssignmentUnit:          a.AssignmentUnit,
 		AssignmentKey:           a.AssignmentKey,
 		DecisionVersion:         a.DecisionVersion,
+		AttemptIntentID:         a.attemptIntent.IntentID,
+		AttemptTaskKey:          a.attemptIntent.TaskID,
+		AttemptTaskGen:          a.attemptIntent.TaskGeneration,
+		AttemptWorkGen:          a.attemptIntent.WorktreeGeneration,
+		AttemptAccess:           a.attemptIntent.Access,
+		AttemptLeaseID:          a.attemptLease.ID,
+		AttemptVersion:          a.attemptLease.Version,
 		PID:                     a.PID,
 		SessionID:               a.SessionID,
 		LogPath:                 a.LogPath,
@@ -540,20 +550,27 @@ func fromRecord(r Record) *Agent {
 		requestedModel = r.Model
 	}
 	a := &Agent{
-		ID:                      r.ID,
-		TaskID:                  r.TaskID,
-		Name:                    r.Name,
-		Role:                    r.Role,
-		Mode:                    r.Mode,
-		Provider:                r.Provider,
-		Model:                   r.Model,
-		RequestedModel:          requestedModel,
-		ExperimentID:            r.ExperimentID,
-		VariantID:               r.VariantID,
-		RoutingReason:           r.RoutingReason,
-		AssignmentUnit:          r.AssignmentUnit,
-		AssignmentKey:           r.AssignmentKey,
-		DecisionVersion:         r.DecisionVersion,
+		ID:              r.ID,
+		TaskID:          r.TaskID,
+		Name:            r.Name,
+		Role:            r.Role,
+		Mode:            r.Mode,
+		Provider:        r.Provider,
+		Model:           r.Model,
+		RequestedModel:  requestedModel,
+		ExperimentID:    r.ExperimentID,
+		VariantID:       r.VariantID,
+		RoutingReason:   r.RoutingReason,
+		AssignmentUnit:  r.AssignmentUnit,
+		AssignmentKey:   r.AssignmentKey,
+		DecisionVersion: r.DecisionVersion,
+		attemptIntent: AttemptIntent{
+			IntentID: r.AttemptIntentID, TaskID: firstNonEmpty(r.AttemptTaskKey, r.TaskID),
+			TaskGeneration: r.AttemptTaskGen, Worktree: r.CWD,
+			WorktreeGeneration: r.AttemptWorkGen, Access: r.AttemptAccess,
+			Role: r.Role, Provider: r.Provider, CapabilityCertified: true,
+		},
+		attemptLease:            AttemptLease{ID: r.AttemptLeaseID, Version: r.AttemptVersion},
 		PID:                     r.PID,
 		SessionID:               r.SessionID,
 		LogPath:                 r.LogPath,
@@ -1966,6 +1983,15 @@ type RunConfig struct {
 	// only the OS-level sandbox binds a run on every provider.
 	AllowedTools []string
 	Dir          string
+	// IntentID makes a dispatch replay idempotent. TaskGeneration and
+	// WorktreeGeneration fence stale schedulers/recovery workers; zero is a
+	// valid legacy generation. ReadOnlyDir selects an explicit observer lease,
+	// otherwise the run owns the task/worktree for mutation.
+	IntentID           string
+	AdmissionTaskKey   string
+	AttemptAccess      AttemptAccess
+	TaskGeneration     uint64
+	WorktreeGeneration uint64
 	// ReadOnlyDir, when true, tells injectProcessSandbox to never add Dir (or
 	// its git metadata) to the sandbox's writable roots under enforce, and to
 	// additionally re-bind Dir read-only as the last bind in the sandbox
@@ -1994,9 +2020,11 @@ type RunConfig struct {
 	// agents sit in StatePaused forever and onComplete never fires, stranding
 	// any workflow that expects the agent to "finish". Ignored in headless mode.
 	OneShot bool
-	// IgnoreConcurrencyLimit lets an agent start even when MaxConcurrent is
-	// saturated. Reserved for operator-present interactive/chat sessions and
-	// system-level runs that must never sit behind the headless swarm queue.
+	// IgnoreConcurrencyLimit is retained only for decoding legacy callers.
+	// Admission intentionally ignores it: every provider attempt, including
+	// system work, participates in the same hard global/provider limits.
+	//
+	// Deprecated: no production caller may set this field.
 	IgnoreConcurrencyLimit bool
 	// IgnoreHealthGate lets an agent start even when the provider health gate
 	// marks the requested provider as unhealthy. Reserved for internal probes

--- a/internal/agent/orphan_sweep.go
+++ b/internal/agent/orphan_sweep.go
@@ -25,10 +25,28 @@ type trackedAgentSnapshot struct {
 	State State
 }
 
-func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []string) int { //nolint:contextcheck // Nil is a legacy caller contract; normalize it before deriving the bounded sweep context.
+func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []string) int {
+	reaped, _ := m.reapOrphanProviderProcesses(ctx, roots, false)
+	return reaped
+}
+
+// ReapOrphanProviderProcessesConfirmed is the recovery form: confirmed is
+// false if any selected orphan survived SIGINT+SIGKILL. Dedicated roots retain
+// the legacy ownerless-provider fallback.
+func (m *Manager) ReapOrphanProviderProcessesConfirmed(ctx context.Context, roots []string) (reaped int, confirmed bool) {
+	return m.reapOrphanProviderProcesses(ctx, roots, false)
+}
+
+// ReapOwnedOrphanProviderProcessesConfirmed scans broader shared roots but
+// only touches processes carrying Sybra's explicit owner environment marker.
+func (m *Manager) ReapOwnedOrphanProviderProcessesConfirmed(ctx context.Context, roots []string) (reaped int, confirmed bool) {
+	return m.reapOrphanProviderProcesses(ctx, roots, true)
+}
+
+func (m *Manager) reapOrphanProviderProcesses(ctx context.Context, roots []string, ownedOnly bool) (reaped int, confirmed bool) { //nolint:contextcheck // Nil is a legacy caller contract; normalize it before deriving the bounded sweep context.
 	roots = canonicalProcessRoots(expandRootGlobs(roots))
 	if len(roots) == 0 {
-		return 0
+		return 0, true
 	}
 	if ctx == nil {
 		ctx = orphanSweepDefaultContext
@@ -37,12 +55,16 @@ func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []strin
 	ctx, cancel = context.WithTimeout(ctx, orphanSweepTimeout)
 	defer cancel()
 
-	procs := listProviderProcessesUnderRoots(ctx, roots)
+	procs, observed := listProviderProcessesUnderRoots(ctx, roots)
+	if !observed {
+		m.logger.Error("agent.orphan.scan_unconfirmed")
+		return 0, false
+	}
 	if len(procs) == 0 {
-		return 0
+		return 0, true
 	}
 	trackedPIDs, trackedAgents := m.trackedProcessOwners()
-	reaped := 0
+	confirmed = true
 	for _, proc := range procs {
 		if proc.PID <= 0 {
 			continue
@@ -50,20 +72,31 @@ func (m *Manager) ReapOrphanProviderProcesses(ctx context.Context, roots []strin
 		if _, ok := trackedPIDs[proc.PID]; ok {
 			continue
 		}
+		if ownedOnly && proc.Owner.AgentID == "" {
+			continue
+		}
 		if proc.Owner.AgentID != "" {
 			if !shouldReapOwnedProcess(proc, trackedAgents) {
 				continue
 			}
 			m.logger.Warn("agent.orphan.owned_reap", "pid", proc.PID, "cwd", proc.CWD, "command", proc.Command, "agent_id", proc.Owner.AgentID, "task_id", proc.Owner.TaskID, "mode", proc.Owner.Mode)
-			signalPID(proc.PID, stopSIGINTGrace)
-			reaped++
+			if signalPIDAndWait(proc.PID, stopSIGINTGrace) {
+				reaped++
+			} else {
+				confirmed = false
+				m.logger.Error("agent.orphan.owned_reap_unconfirmed", "pid", proc.PID, "agent_id", proc.Owner.AgentID)
+			}
 			continue
 		}
 		m.logger.Warn("agent.orphan.reap", "pid", proc.PID, "cwd", proc.CWD, "command", proc.Command)
-		signalPID(proc.PID, stopSIGINTGrace)
-		reaped++
+		if signalPIDAndWait(proc.PID, stopSIGINTGrace) {
+			reaped++
+		} else {
+			confirmed = false
+			m.logger.Error("agent.orphan.reap_unconfirmed", "pid", proc.PID, "cwd", proc.CWD)
+		}
 	}
-	return reaped
+	return reaped, confirmed
 }
 
 func shouldReapOwnedProcess(proc providerProcess, tracked map[string]trackedAgentSnapshot) bool {

--- a/internal/agent/orphan_sweep_linux.go
+++ b/internal/agent/orphan_sweep_linux.go
@@ -10,19 +10,19 @@ import (
 	"strings"
 )
 
-func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []providerProcess {
+func listProviderProcessesUnderRoots(ctx context.Context, roots []string) ([]providerProcess, bool) {
 	if ctx == nil {
-		return nil
+		return nil, false
 	}
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	out := make([]providerProcess, 0)
 	for _, entry := range entries {
 		select {
 		case <-ctx.Done():
-			return out
+			return out, false
 		default:
 		}
 		if !entry.IsDir() {
@@ -43,7 +43,7 @@ func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []prov
 		}
 		out = append(out, providerProcess{PID: pid, Command: cmd, CWD: cwd, Owner: owner})
 	}
-	return out
+	return out, true
 }
 
 func linuxProcessName(ctx context.Context, pid string) string {

--- a/internal/agent/orphan_sweep_other.go
+++ b/internal/agent/orphan_sweep_other.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 )
 
-func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []providerProcess {
+func listProviderProcessesUnderRoots(ctx context.Context, roots []string) ([]providerProcess, bool) {
 	out, err := exec.CommandContext(ctx, "ps", "-eww", "-axo", "pid=,command=").Output()
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	type candidate struct {
 		pid   int
@@ -39,10 +39,13 @@ func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []prov
 		pids = append(pids, strconv.Itoa(pid))
 	}
 	if len(candidates) == 0 {
-		return nil
+		return nil, true
 	}
 
-	cwds := lsofCWDsByPID(ctx, pids)
+	cwds, ok := lsofCWDsByPID(ctx, pids)
+	if !ok {
+		return nil, false
+	}
 	procs := make([]providerProcess, 0, len(candidates))
 	for _, cand := range candidates {
 		cwd := cwds[cand.pid]
@@ -51,19 +54,19 @@ func listProviderProcessesUnderRoots(ctx context.Context, roots []string) []prov
 		}
 		procs = append(procs, providerProcess{PID: cand.pid, Command: cand.cmd, CWD: cwd, Owner: cand.owner})
 	}
-	return procs
+	return procs, true
 }
 
-func lsofCWDsByPID(ctx context.Context, pids []string) map[int]string {
+func lsofCWDsByPID(ctx context.Context, pids []string) (map[int]string, bool) {
 	out := make(map[int]string)
 	if len(pids) == 0 {
-		return out
+		return out, true
 	}
 	cwdOut, err := exec.CommandContext(ctx, "lsof", "-a", "-d", "cwd", "-Fpn", "-p", strings.Join(pids, ",")).Output()
-	if err != nil {
-		return out
+	if err != nil && len(cwdOut) == 0 {
+		return out, false
 	}
-	return parseLsofCWDs(string(cwdOut))
+	return parseLsofCWDs(string(cwdOut)), true
 }
 
 func parseLsofCWDs(output string) map[int]string {

--- a/internal/agent/orphan_sweep_test.go
+++ b/internal/agent/orphan_sweep_test.go
@@ -29,7 +29,38 @@ func TestReapOrphanProviderProcesses(t *testing.T) {
 	if got := m.ReapOrphanProviderProcesses(context.Background(), []string{root}); got != 1 {
 		t.Fatalf("reaped = %d, want 1", got)
 	}
-	waitForProcessExit(t, proc.Process.Pid)
+	if processAlive(proc.Process.Pid) {
+		t.Fatal("reaper returned before orphan process termination")
+	}
+}
+
+func TestReapOwnedOrphanProviderProcessesRequiresOwnerMarker(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only process enumeration test")
+	}
+	prevGrace := stopSIGINTGrace
+	stopSIGINTGrace = 20 * time.Millisecond
+	t.Cleanup(func() { stopSIGINTGrace = prevGrace })
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{})
+	root := t.TempDir()
+	ownerless := spawnProviderProcess(t, root)
+	if got, confirmed := m.ReapOwnedOrphanProviderProcessesConfirmed(context.Background(), []string{root}); got != 0 || !confirmed {
+		t.Fatalf("ownerless shared-root sweep = %d, %v; want 0, true", got, confirmed)
+	}
+	if !processAlive(ownerless.Process.Pid) {
+		t.Fatal("owned-only sweep killed an ownerless provider process")
+	}
+
+	owned := spawnOwnedMCPHelperProcess(t, root, "chrome-devtools-mcp", mcpOwner{
+		AgentID: "owned-agent", TaskID: "task-1", Mode: "headless",
+	})
+	if got, confirmed := m.ReapOwnedOrphanProviderProcessesConfirmed(context.Background(), []string{root}); got != 1 || !confirmed {
+		t.Fatalf("owned shared-root sweep = %d, %v; want 1, true", got, confirmed)
+	}
+	if processAlive(owned.Process.Pid) {
+		t.Fatal("owned-only reaper returned before owned process termination")
+	}
 }
 
 func TestReapOrphanProviderProcesses_SkipsTrackedPID(t *testing.T) {
@@ -366,7 +397,10 @@ func waitForOwnedProcessUnderRoot(t *testing.T, roots []string, owner processOwn
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		procs := listProviderProcessesUnderRoots(context.Background(), roots)
+		procs, observed := listProviderProcessesUnderRoots(context.Background(), roots)
+		if !observed {
+			t.Fatal("provider process scan was not confirmed")
+		}
 		for _, proc := range procs {
 			if proc.Owner == owner && proc.Command == wantCommand {
 				return proc.PID

--- a/internal/agent/process_group_linux.go
+++ b/internal/agent/process_group_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package agent
+
+import (
+	"os"
+	"strconv"
+)
+
+// processGroupActive reports whether a process group still has a member that
+// can execute. Zombies keep a PGID visible to kill(2) but cannot mutate a
+// worktree; treating a zombie-only group as live would permanently fence the
+// attempt on hosts whose PID 1 does not promptly reap orphans (notably test
+// containers).
+func processGroupActive(pgid int) bool {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return true // observation failed: keep ownership fenced
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		data, err := os.ReadFile("/proc/" + entry.Name() + "/stat")
+		if err != nil {
+			continue
+		}
+		fields := procStatFields(data)
+		if len(fields) < 3 || fields[0] == "Z" {
+			continue
+		}
+		group, err := strconv.Atoi(fields[2])
+		if err == nil && group == pgid {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/process_group_other.go
+++ b/internal/agent/process_group_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package agent
+
+import "syscall"
+
+func processGroupActive(pgid int) bool {
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -70,7 +70,7 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 			// never be reattached — reap the orphaned process (which still holds
 			// the worktree lock/FIFO) and drop the record instead of skipping it
 			// silently and leaking it forever.
-			m.reapStaleSurvivor(r, reg, "legacy_mode_"+r.Mode)
+			m.reapStaleSurvivor(ctx, r, reg, "legacy_mode_"+r.Mode)
 			continue
 		}
 		if !reattachAlive(r) { //nolint:contextcheck // liveness probe is context-free process inspection
@@ -96,15 +96,21 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 
 		decision := m.reattachDecide(r, time.Now().UTC())
 		if decision.reason != "" {
-			m.reapStaleSurvivor(r, reg, decision.reason)
+			m.reapStaleSurvivor(ctx, r, reg, decision.reason)
 			continue
 		}
-		adoptedLease, err := m.adoptAttempt(ctx, r)
+		intent := attemptIntentFromRecord(r)
+		adoptedLease, err := m.adoptAttempt(ctx, r, intent)
 		if err != nil {
 			m.logger.Warn("agent.reattach.admission", "id", r.ID, "task", r.TaskID, "err", err)
 			continue
 		}
 		if adoptedLease.ID != "" {
+			r.AttemptIntentID = intent.IntentID
+			r.AttemptTaskKey = intent.TaskID
+			r.AttemptTaskGen = intent.TaskGeneration
+			r.AttemptWorkGen = intent.WorktreeGeneration
+			r.AttemptAccess = intent.Access
 			r.AttemptLeaseID = adoptedLease.ID
 			r.AttemptVersion = adoptedLease.Version
 			if err := reg.Save(r); err != nil {
@@ -612,9 +618,10 @@ func ParksLiveAgent(status string) bool {
 	}
 }
 
-func (m *Manager) reapStaleSurvivor(r Record, reg survivalRegistry, reason string) {
+func (m *Manager) reapStaleSurvivor(ctx context.Context, r Record, reg survivalRegistry, reason string) {
 	m.logger.Warn("agent.reattach.reap", "id", r.ID, "pid", r.PID, "task", r.TaskID, "reason", reason)
 	signalPID(r.PID, stopSIGINTGrace)
+	m.completeAttempt(ctx, fromRecord(r), "reaped_"+reason)
 	if err := reg.Delete(r.ID); err != nil {
 		m.logger.Warn("agent.reattach.reap.delete", "id", r.ID, "err", err)
 	}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -176,7 +176,14 @@ func (m *Manager) reapUnsupportedSurvivor(ctx context.Context, r Record, reg sur
 	if r.Mode == "headless" {
 		return false
 	}
-	m.reapStaleSurvivor(ctx, r, reg, "legacy_mode_"+r.Mode)
+	reason := "legacy_mode_" + r.Mode
+	if !reattachAlive(r) { //nolint:contextcheck // liveness probe is context-free process inspection
+		if m.confirmDeadAttemptGroup(ctx, r) {
+			m.finalizeReapedSurvivor(ctx, r, reg, reason)
+		}
+		return true
+	}
+	m.reapStaleSurvivor(ctx, r, reg, reason)
 	return true
 }
 
@@ -655,6 +662,10 @@ func (m *Manager) reapStaleSurvivor(ctx context.Context, r Record, reg survivalR
 		m.logger.Error("agent.reattach.reap_unconfirmed", "id", r.ID, "pid", r.PID, "task", r.TaskID)
 		return
 	}
+	m.finalizeReapedSurvivor(ctx, r, reg, reason)
+}
+
+func (m *Manager) finalizeReapedSurvivor(ctx context.Context, r Record, reg survivalRegistry, reason string) {
 	m.completeAttempt(ctx, fromRecord(r), "reaped_"+reason)
 	if err := reg.Delete(r.ID); err != nil {
 		m.logger.Warn("agent.reattach.reap.delete", "id", r.ID, "err", err)

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -620,7 +620,10 @@ func ParksLiveAgent(status string) bool {
 
 func (m *Manager) reapStaleSurvivor(ctx context.Context, r Record, reg survivalRegistry, reason string) {
 	m.logger.Warn("agent.reattach.reap", "id", r.ID, "pid", r.PID, "task", r.TaskID, "reason", reason)
-	signalPID(r.PID, stopSIGINTGrace)
+	if !signalPIDAndWait(r.PID, stopSIGINTGrace) {
+		m.logger.Error("agent.reattach.reap_unconfirmed", "id", r.ID, "pid", r.PID, "task", r.TaskID)
+		return
+	}
 	m.completeAttempt(ctx, fromRecord(r), "reaped_"+reason)
 	if err := reg.Delete(r.ID); err != nil {
 		m.logger.Warn("agent.reattach.reap.delete", "id", r.ID, "err", err)

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -80,7 +80,12 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 			// the task so restart-stale recovery resumes instead of redoing.
 			// Retain the record (skip delete) when the bridge fails so a later
 			// startup retries it rather than losing the session permanently.
-			if m.finalizeIfCompleted(r) || m.persistDeadSession(r) {
+			completed := m.finalizeIfCompleted(r)
+			if completed || m.persistDeadSession(r) {
+				if !completed {
+					a := fromRecord(r)
+					m.completeAttempt(ctx, a, "lost")
+				}
 				_ = reg.Delete(r.ID)
 				m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID)
 			} else {
@@ -93,6 +98,23 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 		if decision.reason != "" {
 			m.reapStaleSurvivor(r, reg, decision.reason)
 			continue
+		}
+		adoptedLease, err := m.adoptAttempt(ctx, r)
+		if err != nil {
+			m.logger.Warn("agent.reattach.admission", "id", r.ID, "task", r.TaskID, "err", err)
+			continue
+		}
+		if adoptedLease.ID != "" {
+			r.AttemptLeaseID = adoptedLease.ID
+			r.AttemptVersion = adoptedLease.Version
+			if err := reg.Save(r); err != nil {
+				m.logger.Warn("agent.reattach.lease-save", "id", r.ID, "task", r.TaskID, "err", err)
+				// Fail closed: the observed process is still live, so releasing its
+				// newly adopted lease here would permit a duplicate mutator. Keep
+				// ownership occupied for reconciliation even though this instance
+				// cannot safely expose the run.
+				continue
+			}
 		}
 
 		a := fromRecord(r)
@@ -129,6 +151,7 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 		m.mu.Unlock()
 
 		m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "events", len(a.Output()))
+		m.startAttemptHeartbeat(ctx, a)
 		go m.reattachHeadless(ctx, a, startOffset, r.ProcStartedAt)
 		m.emit(events.AgentState(a.ID), a)
 		out = append(out, a)

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -63,17 +63,24 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 	var out []*Agent
 	for i := range recs {
 		r := recs[i]
-		if r.Mode != "headless" {
+		if m.reapUnsupportedSurvivor(ctx, r, reg) {
 			// Legacy interactive/per-turn-convo records can only exist for an
 			// agent that was mid-flight when this steerable-headless-only binary
 			// was deployed. Their runner no longer exists, so the record can
 			// never be reattached — reap the orphaned process (which still holds
 			// the worktree lock/FIFO) and drop the record instead of skipping it
 			// silently and leaking it forever.
-			m.reapStaleSurvivor(ctx, r, reg, "legacy_mode_"+r.Mode)
 			continue
 		}
 		if !reattachAlive(r) { //nolint:contextcheck // liveness probe is context-free process inspection
+			// A detached leader may be gone while an inherited provider/tool
+			// child still occupies its process group. Confirm the entire original
+			// group is gone before terminal reconciliation releases ownership.
+			// If the PID was reused, the old process group cannot still reserve
+			// that numeric ID; do not signal the unrelated replacement process.
+			if !m.confirmDeadAttemptGroup(ctx, r) {
+				continue
+			}
 			// Process gone. If it finished its work before vanishing,
 			// finalize so the workflow advances instead of re-running it.
 			// Otherwise (a genuine crash), bridge its captured session id to
@@ -163,6 +170,30 @@ func (m *Manager) ReattachAllContext(ctx context.Context) []*Agent {
 		out = append(out, a)
 	}
 	return out
+}
+
+func (m *Manager) reapUnsupportedSurvivor(ctx context.Context, r Record, reg survivalRegistry) bool {
+	if r.Mode == "headless" {
+		return false
+	}
+	m.reapStaleSurvivor(ctx, r, reg, "legacy_mode_"+r.Mode)
+	return true
+}
+
+func (m *Manager) confirmDeadAttemptGroup(ctx context.Context, r Record) bool {
+	if recordPIDReused(ctx, r) || signalProcessGroupAndWait(r.PID, stopSIGINTGrace) {
+		return true
+	}
+	m.logger.Error("agent.reattach.dead_group_unconfirmed", "id", r.ID, "pid", r.PID, "task", r.TaskID)
+	return false
+}
+
+func recordPIDReused(ctx context.Context, r Record) bool {
+	if r.PID <= 0 || r.ProcStartedAt == "" || !processAlive(r.PID) {
+		return false
+	}
+	current := processStartString(ctx, r.PID)
+	return current != "" && current != r.ProcStartedAt
 }
 
 // finalizeIfCompleted recovers a run whose process is gone but whose log

--- a/internal/agent/reattach_linux.go
+++ b/internal/agent/reattach_linux.go
@@ -19,14 +19,18 @@ func processStartString(_ context.Context, pid int) string {
 	if err != nil {
 		return ""
 	}
-	stat := string(data)
-	afterComm := strings.LastIndexByte(stat, ')')
-	if afterComm < 0 || afterComm+2 >= len(stat) {
-		return ""
-	}
-	fields := strings.Fields(stat[afterComm+2:])
+	fields := procStatFields(data)
 	if len(fields) <= procStatStarttimeIndexAfterComm {
 		return ""
 	}
 	return fields[procStatStarttimeIndexAfterComm]
+}
+
+func procStatFields(data []byte) []string {
+	stat := string(data)
+	afterComm := strings.LastIndexByte(stat, ')')
+	if afterComm < 0 || afterComm+2 >= len(stat) {
+		return nil
+	}
+	return strings.Fields(stat[afterComm+2:])
 }

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -6,9 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/providerid"
 )
 
 // invariantSnapshot atomically reads liveCount and sum(liveByProvider) under
@@ -28,6 +32,58 @@ func assertAccountingInvariant(t *testing.T, m *Manager) {
 	sum, liveCount := invariantSnapshot(m)
 	if sum != liveCount {
 		t.Fatalf("sum(liveByProvider)=%d != liveCount=%d", sum, liveCount)
+	}
+}
+
+func TestReattachUnsupportedDeadLeaderConfirmsGroupBeforeLeaseRelease(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	leader := exec.Command("bash", "-c", "(trap '' INT; exec sleep 60) & echo $! > "+pidFile+"; exit 0")
+	leader.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := leader.Start(); err != nil {
+		t.Fatal(err)
+	}
+	leaderPID := leader.Process.Pid
+	if err := leader.Wait(); err != nil {
+		t.Fatalf("leader wait: %v", err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(-leaderPID, syscall.SIGKILL) })
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || !processAlive(childPID) {
+		t.Fatalf("child pid = %d, %v; want live descendant", childPID, err)
+	}
+
+	prevGrace := stopSIGINTGrace
+	stopSIGINTGrace = 50 * time.Millisecond
+	t.Cleanup(func() { stopSIGINTGrace = prevGrace })
+	m, _ := newTestManager(t)
+	recorder := &recordingAttemptAdmission{}
+	m.attemptAdmission = recorder
+	registry := &fixedSurvivalRegistry{records: []Record{{
+		ID: "legacy-dead-leader", Mode: "interactive", Provider: providerid.Claude, PID: leaderPID,
+		AttemptLeaseID: "legacy-lease", AttemptVersion: 1,
+	}}}
+	m.reg = registry
+	m.surviveRestart = true
+
+	if got := m.ReattachAllContext(t.Context()); len(got) != 0 {
+		t.Fatalf("reattached unsupported records = %d", len(got))
+	}
+	if signalTargetAlive(-leaderPID, leaderPID) {
+		t.Fatal("legacy record released while descendant process group remained alive")
+	}
+	recorder.mu.Lock()
+	if len(recorder.completed) != 1 || recorder.completed[0] != "reaped_legacy_mode_interactive" {
+		t.Fatalf("lease outcomes = %v", recorder.completed)
+	}
+	recorder.mu.Unlock()
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if len(registry.deleted) != 1 || registry.deleted[0] != "legacy-dead-leader" {
+		t.Fatalf("deleted records = %v", registry.deleted)
 	}
 }
 

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -18,31 +18,38 @@ import (
 // (~/.sybra/agents/<id>.yaml). Written when the PID is known and whenever
 // the session ID is first captured; deleted when the agent terminates.
 type Record struct {
-	ID              string    `yaml:"id"`
-	TaskID          string    `yaml:"task_id,omitempty"`
-	Name            string    `yaml:"name,omitempty"`
-	Role            Role      `yaml:"role,omitempty"`
-	Mode            string    `yaml:"mode"`
-	Provider        string    `yaml:"provider"`
-	Model           string    `yaml:"model,omitempty"`
-	RequestedModel  string    `yaml:"requested_model,omitempty"`
-	ExperimentID    string    `yaml:"experiment_id,omitempty"`
-	VariantID       string    `yaml:"variant_id,omitempty"`
-	RoutingReason   string    `yaml:"routing_reason,omitempty"`
-	AssignmentUnit  string    `yaml:"assignment_unit,omitempty"`
-	AssignmentKey   string    `yaml:"assignment_key,omitempty"`
-	DecisionVersion int       `yaml:"decision_version,omitempty"`
-	PID             int       `yaml:"pid"`
-	SessionID       string    `yaml:"session_id,omitempty"`
-	LogPath         string    `yaml:"log_path,omitempty"`
-	CWD             string    `yaml:"cwd,omitempty"`
-	SandboxHomeDir  string    `yaml:"sandbox_home_dir,omitempty"`
-	StartedAt       time.Time `yaml:"started_at"`
-	ProcStartedAt   string    `yaml:"proc_started_at,omitempty"` // ps lstart, guards PID reuse
-	StdinPath       string    `yaml:"stdin_path,omitempty"`      // FIFO for interactive survival
-	PendingPrompts  []string  `yaml:"pending_prompts,omitempty"` // queued follow-up turns
-	OneShot         bool      `yaml:"one_shot,omitempty"`
-	MaxTurns        int       `yaml:"max_turns,omitempty"`
+	ID              string        `yaml:"id"`
+	TaskID          string        `yaml:"task_id,omitempty"`
+	Name            string        `yaml:"name,omitempty"`
+	Role            Role          `yaml:"role,omitempty"`
+	Mode            string        `yaml:"mode"`
+	Provider        string        `yaml:"provider"`
+	Model           string        `yaml:"model,omitempty"`
+	RequestedModel  string        `yaml:"requested_model,omitempty"`
+	ExperimentID    string        `yaml:"experiment_id,omitempty"`
+	VariantID       string        `yaml:"variant_id,omitempty"`
+	RoutingReason   string        `yaml:"routing_reason,omitempty"`
+	AssignmentUnit  string        `yaml:"assignment_unit,omitempty"`
+	AssignmentKey   string        `yaml:"assignment_key,omitempty"`
+	DecisionVersion int           `yaml:"decision_version,omitempty"`
+	AttemptIntentID string        `yaml:"attempt_intent_id,omitempty"`
+	AttemptTaskKey  string        `yaml:"attempt_task_key,omitempty"`
+	AttemptTaskGen  uint64        `yaml:"attempt_task_generation,omitempty"`
+	AttemptWorkGen  uint64        `yaml:"attempt_worktree_generation,omitempty"`
+	AttemptAccess   AttemptAccess `yaml:"attempt_access,omitempty"`
+	AttemptLeaseID  string        `yaml:"attempt_lease_id,omitempty"`
+	AttemptVersion  uint64        `yaml:"attempt_version,omitempty"`
+	PID             int           `yaml:"pid"`
+	SessionID       string        `yaml:"session_id,omitempty"`
+	LogPath         string        `yaml:"log_path,omitempty"`
+	CWD             string        `yaml:"cwd,omitempty"`
+	SandboxHomeDir  string        `yaml:"sandbox_home_dir,omitempty"`
+	StartedAt       time.Time     `yaml:"started_at"`
+	ProcStartedAt   string        `yaml:"proc_started_at,omitempty"` // ps lstart, guards PID reuse
+	StdinPath       string        `yaml:"stdin_path,omitempty"`      // FIFO for interactive survival
+	PendingPrompts  []string      `yaml:"pending_prompts,omitempty"` // queued follow-up turns
+	OneShot         bool          `yaml:"one_shot,omitempty"`
+	MaxTurns        int           `yaml:"max_turns,omitempty"`
 	// RequirePermissions preserves a codex chat's sandbox/approval choice
 	// across a restart (codex respawns per turn and would otherwise default
 	// to permissive).

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -1708,6 +1708,9 @@ func classifyAgentError(err error) string {
 	if errors.Is(err, errPromptUndelivered) {
 		return ErrorKindPromptUndelivered
 	}
+	if errors.Is(err, ErrProviderCapacityReached) {
+		return "provider_capacity"
+	}
 	msg := strings.ToLower(err.Error())
 	class := errclass.Classify(msg, errclass.AgentRecoveryBiased)
 	switch {

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -117,6 +117,31 @@ func signalPID(pid int, grace time.Duration) {
 	}()
 }
 
+// signalPIDAndWait is the reconciliation variant of signalPID: it does not
+// return until the process is confirmed gone (or the post-SIGKILL deadline is
+// exhausted). Durable ownership must never be released while the old mutator
+// can still write during the graceful-shutdown window.
+func signalPIDAndWait(pid int, grace time.Duration) bool {
+	if pid <= 0 || !processAlive(pid) {
+		return true
+	}
+	target := signalTarget(pid)
+	_ = syscall.Kill(target, syscall.SIGINT)
+	deadline := time.Now().Add(max(grace, 0))
+	for processAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(25 * time.Millisecond)
+	}
+	if !processAlive(pid) {
+		return true
+	}
+	_ = syscall.Kill(target, syscall.SIGKILL)
+	killDeadline := time.Now().Add(time.Second)
+	for processAlive(pid) && time.Now().Before(killDeadline) {
+		time.Sleep(25 * time.Millisecond)
+	}
+	return !processAlive(pid)
+}
+
 func signalTarget(pid int) int {
 	if pgid, err := syscall.Getpgid(pid); err == nil && pgid == pid {
 		return -pid

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -122,24 +122,50 @@ func signalPID(pid int, grace time.Duration) {
 // exhausted). Durable ownership must never be released while the old mutator
 // can still write during the graceful-shutdown window.
 func signalPIDAndWait(pid int, grace time.Duration) bool {
-	if pid <= 0 || !processAlive(pid) {
+	if pid <= 0 {
 		return true
 	}
 	target := signalTarget(pid)
+	return signalTargetAndWait(target, pid, grace)
+}
+
+// signalProcessGroupAndWait targets the detached process group whose ID is
+// the recorded leader PID. It remains valid after the leader exits while a
+// descendant survives, which is exactly the restart crash window where
+// Getpgid(pid) can no longer recover the group.
+func signalProcessGroupAndWait(pid int, grace time.Duration) bool {
+	if pid <= 0 {
+		return true
+	}
+	return signalTargetAndWait(-pid, pid, grace)
+}
+
+func signalTargetAndWait(target, pid int, grace time.Duration) bool {
+	if !signalTargetAlive(target, pid) {
+		return true
+	}
 	_ = syscall.Kill(target, syscall.SIGINT)
 	deadline := time.Now().Add(max(grace, 0))
-	for processAlive(pid) && time.Now().Before(deadline) {
+	for signalTargetAlive(target, pid) && time.Now().Before(deadline) {
 		time.Sleep(25 * time.Millisecond)
 	}
-	if !processAlive(pid) {
+	if !signalTargetAlive(target, pid) {
 		return true
 	}
 	_ = syscall.Kill(target, syscall.SIGKILL)
 	killDeadline := time.Now().Add(time.Second)
-	for processAlive(pid) && time.Now().Before(killDeadline) {
+	for signalTargetAlive(target, pid) && time.Now().Before(killDeadline) {
 		time.Sleep(25 * time.Millisecond)
 	}
-	return !processAlive(pid)
+	return !signalTargetAlive(target, pid)
+}
+
+func signalTargetAlive(target, pid int) bool {
+	if target >= 0 {
+		return processAlive(pid)
+	}
+	err := syscall.Kill(target, 0)
+	return err == nil || err == syscall.EPERM
 }
 
 func signalTarget(pid int) int {

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -164,8 +164,7 @@ func signalTargetAlive(target, pid int) bool {
 	if target >= 0 {
 		return processAlive(pid)
 	}
-	err := syscall.Kill(target, 0)
-	return err == nil || err == syscall.EPERM
+	return processGroupActive(-target)
 }
 
 func signalTarget(pid int) int {

--- a/internal/agent/shutdown_group_test.go
+++ b/internal/agent/shutdown_group_test.go
@@ -71,3 +71,38 @@ func TestReapProcessGroup_KillsDescendants(t *testing.T) {
 		}
 	}
 }
+
+func TestSignalPIDAndWaitConfirmsDescendantsAfterLeaderExits(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	leader := exec.Command("bash", "-c", "trap 'exit 0' INT; (trap '' INT; exec sleep 60) & echo $! > "+pidFile+"; while true; do sleep 1; done")
+	leader.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := leader.Start(); err != nil {
+		t.Fatalf("start leader: %v", err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(-leader.Process.Pid, syscall.SIGKILL) })
+	go func() { _ = leader.Wait() }()
+
+	var childPID int
+	deadline := time.Now().Add(3 * time.Second)
+	for childPID == 0 && time.Now().Before(deadline) {
+		if data, err := os.ReadFile(pidFile); err == nil {
+			childPID, _ = strconv.Atoi(strings.TrimSpace(string(data)))
+		}
+		if childPID == 0 {
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+	if childPID == 0 {
+		t.Fatal("child pid file never written")
+	}
+
+	if !signalPIDAndWait(leader.Process.Pid, 50*time.Millisecond) {
+		t.Fatal("process group termination was not confirmed")
+	}
+	if signalTargetAlive(-leader.Process.Pid, leader.Process.Pid) {
+		t.Fatal("reaper returned while detached process group was still alive")
+	}
+	if processAlive(childPID) {
+		t.Fatalf("signal-ignoring descendant %d survived confirmed group reap", childPID)
+	}
+}

--- a/internal/agent/shutdown_group_test.go
+++ b/internal/agent/shutdown_group_test.go
@@ -102,7 +102,4 @@ func TestSignalPIDAndWaitConfirmsDescendantsAfterLeaderExits(t *testing.T) {
 	if signalTargetAlive(-leader.Process.Pid, leader.Process.Pid) {
 		t.Fatal("reaper returned while detached process group was still alive")
 	}
-	if processAlive(childPID) {
-		t.Fatalf("signal-ignoring descendant %d survived confirmed group reap", childPID)
-	}
 }

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/providerid"
 	"gopkg.in/yaml.v3"
 )
 
@@ -169,20 +170,27 @@ func recordMappingStartedAt() time.Time {
 
 func recordMappingAgent(started time.Time) *Agent {
 	return &Agent{
-		ID:                      "a-map",
-		TaskID:                  "task-map",
-		Name:                    "mapper",
-		Role:                    RoleMonitor,
-		Mode:                    "interactive",
-		Provider:                "codex",
-		Model:                   "gpt-5.3-codex",
-		RequestedModel:          "opus",
-		ExperimentID:            "exp-1",
-		VariantID:               "variant-a",
-		RoutingReason:           "ab",
-		AssignmentUnit:          "task",
-		AssignmentKey:           "task-map",
-		DecisionVersion:         3,
+		ID:              "a-map",
+		TaskID:          "task-map",
+		Name:            "mapper",
+		Role:            RoleMonitor,
+		Mode:            "interactive",
+		Provider:        "codex",
+		Model:           "gpt-5.3-codex",
+		RequestedModel:  "opus",
+		ExperimentID:    "exp-1",
+		VariantID:       "variant-a",
+		RoutingReason:   "ab",
+		AssignmentUnit:  "task",
+		AssignmentKey:   "task-map",
+		DecisionVersion: 3,
+		attemptIntent: AttemptIntent{
+			IntentID: "intent-map", TaskID: "task-map", TaskGeneration: 4,
+			Worktree: "/tmp/sybra/worktrees/task-map", WorktreeGeneration: 5,
+			Access: AttemptAccessObserve, Role: RoleMonitor, Provider: "codex",
+			CapabilityCertified: true,
+		},
+		attemptLease:            AttemptLease{ID: "lease-map", Version: 6},
 		PID:                     12345,
 		SessionID:               "sess-map",
 		LogPath:                 "/tmp/sybra/agents/a-map.ndjson",
@@ -213,7 +221,7 @@ func recordMappingRecord(started time.Time) Record {
 		Name:                    "mapper",
 		Role:                    RoleMonitor,
 		Mode:                    "interactive",
-		Provider:                "codex",
+		Provider:                providerid.Codex,
 		Model:                   "gpt-5.3-codex",
 		RequestedModel:          "opus",
 		ExperimentID:            "exp-1",
@@ -222,6 +230,13 @@ func recordMappingRecord(started time.Time) Record {
 		AssignmentUnit:          "task",
 		AssignmentKey:           "task-map",
 		DecisionVersion:         3,
+		AttemptIntentID:         "intent-map",
+		AttemptTaskKey:          "task-map",
+		AttemptTaskGen:          4,
+		AttemptWorkGen:          5,
+		AttemptAccess:           AttemptAccessObserve,
+		AttemptLeaseID:          "lease-map",
+		AttemptVersion:          6,
 		PID:                     12345,
 		SessionID:               "sess-map",
 		LogPath:                 "/tmp/sybra/agents/a-map.ndjson",

--- a/internal/agent/testdata/registry_current.yaml
+++ b/internal/agent/testdata/registry_current.yaml
@@ -12,6 +12,13 @@ routing_reason: ab
 assignment_unit: task
 assignment_key: task-map
 decision_version: 3
+attempt_intent_id: intent-map
+attempt_task_key: task-map
+attempt_task_generation: 4
+attempt_worktree_generation: 5
+attempt_access: observe
+attempt_lease_id: lease-map
+attempt_version: 6
 pid: 12345
 session_id: sess-map
 log_path: /tmp/sybra/agents/a-map.ndjson

--- a/internal/config/attempt_leases.go
+++ b/internal/config/attempt_leases.go
@@ -1,0 +1,8 @@
+package config
+
+import "path/filepath"
+
+// AttemptLeasesDir holds the durable dispatch admission ledger.
+func AttemptLeasesDir() string {
+	return filepath.Join(HomeDir(), "attempt-leases")
+}

--- a/internal/loopagent/scheduler.go
+++ b/internal/loopagent/scheduler.go
@@ -185,15 +185,14 @@ func (s *Scheduler) tick(ctx context.Context, loopID string) time.Duration {
 // filled in later by OnAgentComplete when the agent finishes.
 func (s *Scheduler) fire(la LoopAgent) (string, error) {
 	cfg := agent.RunConfig{
-		Name:                   la.AgentName(),
-		Role:                   agent.RoleLoop,
-		Mode:                   "headless",
-		Prompt:                 la.Prompt,
-		Dir:                    s.homeDir,
-		Provider:               la.Provider,
-		Model:                  la.Model,
-		AllowedTools:           la.AllowedTools,
-		IgnoreConcurrencyLimit: true,
+		Name:         la.AgentName(),
+		Role:         agent.RoleLoop,
+		Mode:         "headless",
+		Prompt:       la.Prompt,
+		Dir:          s.homeDir,
+		Provider:     la.Provider,
+		Model:        la.Model,
+		AllowedTools: la.AllowedTools,
 	}
 	ag, err := s.runner.Run(cfg)
 	if err != nil {

--- a/internal/loopagent/scheduler_test.go
+++ b/internal/loopagent/scheduler_test.go
@@ -136,10 +136,6 @@ func TestSchedulerFireUpdatesLastRunFields(t *testing.T) {
 	if got.Name != "loop:self" {
 		t.Fatalf("Name should be loop:self, got %q", got.Name)
 	}
-	if !got.IgnoreConcurrencyLimit {
-		t.Fatal("loop runs must bypass the concurrency limit")
-	}
-
 	// Persisted run fields.
 	stored, err := store.Get(la.ID)
 	if err != nil {

--- a/internal/monitor/dispatcher.go
+++ b/internal/monitor/dispatcher.go
@@ -108,15 +108,14 @@ func (d *agentDispatcher) Dispatch(ctx context.Context, a Anomaly) (string, erro
 		return "", fmt.Errorf("dispatch %s: working directory unresolved", a.Kind)
 	}
 	cfg := agent.RunConfig{
-		TaskID:                 taskID,
-		Name:                   name,
-		Role:                   agent.RoleMonitor,
-		Mode:                   "headless",
-		Prompt:                 DispatchPrompt(a, d.issueRepo, project.PushRemote(ctx, dir)),
-		AllowedTools:           []string{"Bash", "Read"},
-		Dir:                    dir,
-		Model:                  d.model,
-		IgnoreConcurrencyLimit: true,
+		TaskID:       taskID,
+		Name:         name,
+		Role:         agent.RoleMonitor,
+		Mode:         "headless",
+		Prompt:       DispatchPrompt(a, d.issueRepo, project.PushRemote(ctx, dir)),
+		AllowedTools: []string{"Bash", "Read"},
+		Dir:          dir,
+		Model:        d.model,
 	}
 	ag, err := d.agents.Run(cfg)
 	if err != nil {

--- a/internal/monitor/dispatcher_test.go
+++ b/internal/monitor/dispatcher_test.go
@@ -116,9 +116,6 @@ func TestDispatcher_BoardWideAnomalyRunsInRepoDir(t *testing.T) {
 	if cfg.Model != "sonnet" {
 		t.Errorf("model: want sonnet, got %q", cfg.Model)
 	}
-	if !cfg.IgnoreConcurrencyLimit {
-		t.Errorf("IgnoreConcurrencyLimit must be true for monitor dispatches")
-	}
 	if !equalStrings(cfg.AllowedTools, []string{"Bash", "Read"}) {
 		t.Errorf("allowed tools: want [Bash Read], got %v", cfg.AllowedTools)
 	}

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -70,16 +70,9 @@ func (r *remediator) resetLostAgent(ctx context.Context, a Anomaly) (string, err
 	if a.TaskID == "" {
 		return "", fmt.Errorf("lost_agent without task id")
 	}
-	// Best-effort: mark the last running agent run as stopped so the UI does
-	// not continue to display it as active after recovery takes over.
-	if t, err := r.tasks.Get(a.TaskID); err == nil {
-		for i := range slices.Backward(t.AgentRuns) {
-			if t.AgentRuns[i].State == "running" {
-				_ = r.tasks.UpdateRun(a.TaskID, t.AgentRuns[i].AgentID, task.RunPatch{State: task.Ptr("stopped")})
-				break
-			}
-		}
-	}
+	// Do not mark the run stopped here. The durable attempt controller must
+	// first re-observe the process/session and preserve workspace state; only
+	// its reconciled terminal path may release ownership or allow replacement.
 	upd := task.Update{
 		StatusReason: task.Ptr("monitor: agent lost; recovery will resume"),
 	}

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
-func TestRemediator_LostAgent_MarksRunningRunStopped(t *testing.T) {
+func TestRemediator_LostAgent_DefersRunMutationToReconciliation(t *testing.T) {
 	t.Parallel()
 	withRun := func(t *task.Task) {
 		t.AgentRuns = []task.AgentRun{
@@ -51,19 +51,10 @@ func TestRemediator_LostAgent_MarksRunningRunStopped(t *testing.T) {
 		t.Error("status_reason should explain recovery handoff")
 	}
 
-	// Running agent run must be marked stopped before the task update.
-	if len(ft.runUpdates) != 1 {
-		t.Fatalf("want 1 run update, got %d", len(ft.runUpdates))
-	}
-	ru := ft.runUpdates[0]
-	if ru.taskID != "task1" {
-		t.Errorf("runUpdate taskID = %q, want task1", ru.taskID)
-	}
-	if ru.agentID != "lost-agent" {
-		t.Errorf("runUpdate agentID = %q, want lost-agent", ru.agentID)
-	}
-	if ru.patch.State == nil || *ru.patch.State != "stopped" {
-		t.Errorf("runUpdate state = %v, want stopped", ru.patch.State)
+	// The monitor is only a recovery-intent producer. Mutating the run before
+	// admission re-observes it could fence a live detached process.
+	if len(ft.runUpdates) != 0 {
+		t.Fatalf("want reconciliation to own run updates, got %d", len(ft.runUpdates))
 	}
 }
 

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -434,6 +434,9 @@ func (s *Service) applyRemediations(ctx context.Context, anoms []Anomaly) remedi
 // always tagged with Until, so a zero Until would otherwise read as "not a
 // rate limit".
 func isTransientCapacityRefusal(err error) bool {
+	if agent.IsCapacityError(err) {
+		return true
+	}
 	var unhealthy *provider.UnhealthyError
 	if errors.As(err, &unhealthy) {
 		return unhealthy.RateLimited

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -95,6 +95,9 @@ type Recovery struct {
 	// 0 disables size-based enforcement.
 	LogMaxTotalBytes int64
 	OrphanRoots      []string
+	// OwnedOrphanRoots may be shared with operator-run provider processes.
+	// Recovery only reaps processes carrying Sybra's explicit owner marker.
+	OwnedOrphanRoots []string
 
 	DispatchGate func(task.Task) bool
 
@@ -130,13 +133,19 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 	if reattached := r.Agents.ReattachAllContext(ctx); len(reattached) > 0 {
 		r.Logger.Info("recovery.reattach", "count", len(reattached))
 	}
-	if reaped := r.Agents.ReapOrphanProviderProcesses(ctx, r.OrphanRoots); reaped > 0 {
+	reaped, dedicatedConfirmed := r.Agents.ReapOrphanProviderProcessesConfirmed(ctx, r.OrphanRoots)
+	ownedReaped, ownedConfirmed := r.Agents.ReapOwnedOrphanProviderProcessesConfirmed(ctx, r.OwnedOrphanRoots)
+	if reaped += ownedReaped; reaped > 0 {
 		r.Logger.Info("recovery.orphan_reap", "count", reaped)
 	}
 	r.Worktrees.RepairAll(ctx)
 	// Only after unregistered owned processes are gone and their worktrees have
 	// been repaired is an expired ledger-only attempt safe to finalize.
-	r.Agents.ReconcileAttemptLeases(ctx)
+	if dedicatedConfirmed && ownedConfirmed {
+		r.Agents.ReconcileAttemptLeases(ctx)
+	} else {
+		r.Logger.Error("recovery.attempt_reconcile.deferred", "reason", "orphan termination unconfirmed")
+	}
 	r.cleanStaleRuns()
 	if r.WorkflowEngine != nil {
 		// Ordered ahead of the replay: reattach above has established which

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -134,6 +134,9 @@ func (r *Recovery) RunStartupCleanup(ctx context.Context) {
 		r.Logger.Info("recovery.orphan_reap", "count", reaped)
 	}
 	r.Worktrees.RepairAll(ctx)
+	// Only after unregistered owned processes are gone and their worktrees have
+	// been repaired is an expired ledger-only attempt safe to finalize.
+	r.Agents.ReconcileAttemptLeases(ctx)
 	r.cleanStaleRuns()
 	if r.WorkflowEngine != nil {
 		// Ordered ahead of the replay: reattach above has established which

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -34,6 +34,15 @@ const (
 // Safe to call concurrently with the startup pass — each re-dispatch is
 // guarded by HasRunningAgentForTask + the recent-run debounce.
 func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
+	if r.Agents.NeedsAttemptReconciliation(ctx) {
+		if reaped := r.Agents.ReapOrphanProviderProcesses(ctx, r.OrphanRoots); reaped > 0 {
+			r.Logger.Info("recovery.orphan_reap", "count", reaped)
+		}
+		if r.Worktrees != nil {
+			r.Worktrees.RepairAll(ctx)
+		}
+		r.Agents.ReconcileAttemptLeases(ctx)
+	}
 	tasks, err := r.Tasks.List()
 	if err != nil {
 		return

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -35,13 +35,19 @@ const (
 // guarded by HasRunningAgentForTask + the recent-run debounce.
 func (r *Recovery) RestartStaleInProgress(ctx context.Context) {
 	if r.Agents.NeedsAttemptReconciliation(ctx) {
-		if reaped := r.Agents.ReapOrphanProviderProcesses(ctx, r.OrphanRoots); reaped > 0 {
+		reaped, dedicatedConfirmed := r.Agents.ReapOrphanProviderProcessesConfirmed(ctx, r.OrphanRoots)
+		ownedReaped, ownedConfirmed := r.Agents.ReapOwnedOrphanProviderProcessesConfirmed(ctx, r.OwnedOrphanRoots)
+		if reaped += ownedReaped; reaped > 0 {
 			r.Logger.Info("recovery.orphan_reap", "count", reaped)
 		}
 		if r.Worktrees != nil {
 			r.Worktrees.RepairAll(ctx)
 		}
-		r.Agents.ReconcileAttemptLeases(ctx)
+		if dedicatedConfirmed && ownedConfirmed {
+			r.Agents.ReconcileAttemptLeases(ctx)
+		} else {
+			r.Logger.Error("recovery.attempt_reconcile.deferred", "reason", "orphan termination unconfirmed")
+		}
 	}
 	tasks, err := r.Tasks.List()
 	if err != nil {

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -582,8 +582,11 @@ func (o *Orchestrator) resolveDispatchDir(ctx context.Context, t task.Task, task
 // generic "agent start failed" branch and writes a scary, non-suppressed
 // status_reason for a condition that resolves itself once a pool slot frees.
 func translatePoolBusy(err error) error {
-	if errors.Is(err, agent.ErrMaxConcurrentReached) {
+	if agent.IsCapacityError(err) {
 		return fmt.Errorf("%w: %w", workflow.ErrAgentPoolBusy, err)
+	}
+	if agent.IsAttemptConflict(err) {
+		return fmt.Errorf("%w: %w", workflow.ErrDispatchInFlight, err)
 	}
 	return err
 }
@@ -762,6 +765,8 @@ func (o *Orchestrator) implementationRunConfig(p implementationRunParams) agent.
 		AllowedTools:            p.t.AllowedTools,
 		Dir:                     p.dir,
 		Provider:                p.assignment.Provider,
+		IntentID:                p.assignment.IntentID,
+		AdmissionTaskKey:        p.assignment.AdmissionTaskKey,
 		Model:                   p.model,
 		ExperimentID:            p.assignment.ExperimentID,
 		VariantID:               p.assignment.VariantID,
@@ -889,7 +894,7 @@ func (o *Orchestrator) handleCapacityRace(runErr error, t task.Task, taskID, mod
 	// check, so a concurrent dispatch can steal the last slot after startAgent's
 	// earlier preflight. Re-enqueue the same way as the normal saturation path
 	// when the queue exists.
-	if o.queue == nil || !errors.Is(runErr, agent.ErrMaxConcurrentReached) {
+	if o.queue == nil || !agent.IsCapacityError(runErr) {
 		return nil, "", nil, false
 	}
 	_, ag, baselineRef, err, handled := o.handleSaturatedDispatch(t, taskID, mode, prompt, includeTaskDescription, skipWT, opts)

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -59,6 +59,7 @@ import (
 	"github.com/Automaat/sybra/internal/sybra/agentorch"
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
 	"github.com/Automaat/sybra/internal/sybra/completion"
+	"github.com/Automaat/sybra/internal/sybra/dispatch"
 	"github.com/Automaat/sybra/internal/sybra/reconciliation"
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/sybra/runenv"
@@ -90,6 +91,7 @@ type App struct {
 	loopAgents        *loopagent.Store
 	loopSched         *loopagent.Scheduler
 	agents            *agent.Manager
+	attempts          *dispatch.Controller
 	watcher           *watcher.Watcher
 	configWatcher     *confighot.Watcher
 	notifier          *notification.Emitter

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -606,13 +606,12 @@ func (h *humanReviewHandler) spawnReviewConfig(t task.Task, taskID, prompt, dir 
 		// An effort the operator pinned on the task outranks the role
 		// baseline the Manager would otherwise resolve; empty stays empty so
 		// the Manager applies agent.role_effort and then the baseline.
-		ReasoningEffort:        t.ReasoningEffort,
-		ReadOnlyDir:            readOnlyDir,
-		RequirePermissions:     false,
-		OneShot:                true,
-		OutputSchema:           verdict.Schema,
-		IgnoreConcurrencyLimit: true,
-		SandboxMode:            agentorch.ResolveSandboxMode(t, h.cfg),
+		ReasoningEffort:    t.ReasoningEffort,
+		ReadOnlyDir:        readOnlyDir,
+		RequirePermissions: false,
+		OneShot:            true,
+		OutputSchema:       verdict.Schema,
+		SandboxMode:        agentorch.ResolveSandboxMode(t, h.cfg),
 	}
 	if opts.SkipABVariant {
 		return cfg

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -484,6 +484,16 @@ func (h *humanReviewHandler) spawnReview(ctx context.Context, t task.Task, prevS
 	ag, err := h.agents.Run(cfg)
 	h.drainMu.Unlock()
 	if err != nil {
+		if agent.IsCapacityError(err) || agent.IsAttemptConflict(err) {
+			h.releaseReservedSlot(taskID, now)
+			h.logger.Warn("human-review.spawn.parked", "task_id", taskID, "provider", cfg.Provider, "model", cfg.Model, "err", err)
+			h.logAudit(audit.EventHumanReviewSkipped, taskID, "", map[string]any{
+				"reason": "capacity_parked", "err": err.Error(),
+				"provider": cfg.Provider, "model": cfg.Model, "retry_reason": opts.RetryReason,
+			})
+			h.scheduleClaimRetry(ctx, taskID, prevStatus, opts)
+			return false
+		}
 		h.clearInflight(taskID)
 		h.logger.Error("human-review.spawn", "task_id", taskID, "provider", cfg.Provider, "model", cfg.Model, "err", err)
 		if errors.Is(err, agent.ErrProviderModelIncompatible) {

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -359,6 +359,42 @@ func TestHumanReviewSpawn_ClaimConflictRetriesAfterRelease(t *testing.T) {
 	}
 }
 
+func TestHumanReviewSpawn_CapacityRefusalReleasesQuotaAndSchedulesRetry(t *testing.T) {
+	h, tasks, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+	tk, err := tasks.Create("capacity parked", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": "Automaat/sybra",
+		"status":     string(task.StatusHumanRequired),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h.prepareTaskWorktree = func(task.Task) (string, error) { return t.TempDir(), nil }
+	h.agents = &fakeHumanReviewAgentRunner{run: func(agent.RunConfig) (*agent.Agent, error) {
+		return nil, agent.ErrProviderCapacityReached
+	}}
+	var scheduled func()
+	h.schedule = func(_ time.Duration, fn func()) { scheduled = fn }
+
+	if h.maybeSpawn(context.Background(), tk.ID, string(task.StatusInReview)) {
+		t.Fatal("capacity-refused human review reported a spawn")
+	}
+	if scheduled == nil {
+		t.Fatal("capacity refusal did not schedule a retry")
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.recent) != 0 || len(h.perTask[tk.ID]) != 0 {
+		t.Fatalf("capacity refusal consumed quota: recent=%v perTask=%v", h.recent, h.perTask[tk.ID])
+	}
+	if _, ok := h.inflight[tk.ID]; ok {
+		t.Fatal("capacity refusal retained inflight reservation")
+	}
+}
+
 func TestLifecycleSchedule_CancelSuppressesRetry(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Automaat/sybra/internal/skillsync"
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/sybra/clusterlead"
+	"github.com/Automaat/sybra/internal/sybra/dispatch"
 	"github.com/Automaat/sybra/internal/sybra/review"
 	"github.com/Automaat/sybra/internal/sybra/runenv"
 	"github.com/Automaat/sybra/internal/sybra/verification"
@@ -480,8 +481,12 @@ func (a *App) agentManagerConfig(approvalAddr string) agent.ManagerConfig {
 		SessionSink: func(taskID, agentID, sessionID string) error {
 			return a.tasks.UpdateRun(taskID, agentID, task.RunPatch{SessionID: task.Ptr(sessionID)})
 		},
-		TaskExists:  a.taskExistsForAgent,
-		TaskStatus:  a.taskStatusForAgent,
+		TaskExists: a.taskExistsForAgent,
+		TaskStatus: a.taskStatusForAgent,
+		TaskGeneration: func(taskID string) (int64, bool) {
+			t, err := a.tasks.Get(taskID)
+			return t.Generation, err == nil
+		},
 		LimitSink:   a.recordLimitSnapshot,
 		Artifacts:   a.artifacts,
 		SandboxHome: a.sandboxes.SybraHomeDir,
@@ -495,13 +500,29 @@ func (a *App) agentManagerConfig(approvalAddr string) agent.ManagerConfig {
 }
 
 func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) error {
+	providerLimits := make(map[string]int, len(providerid.All()))
+	for _, name := range providerid.All() {
+		providerLimits[name] = a.cfg.Providers.Limits.MaxInFlightPerProvider
+	}
+	var err error
+	a.attempts, err = dispatch.New(ctx, dispatch.Options{
+		Dir: config.AttemptLeasesDir(),
+		Limits: dispatch.Limits{
+			Global:     a.cfg.Agent.MaxConcurrent,
+			ByProvider: providerLimits,
+		},
+		TTL: time.Minute,
+	})
+	if err != nil {
+		return fmt.Errorf("dispatch admission: %w", err)
+	}
 	approvalServer, approvalAddr := a.startApprovalServer(ctx, emit)
 	agentCfg := a.agentManagerConfig(approvalAddr)
+	agentCfg.AttemptAdmission = a.attempts
 	if approvalServer != nil {
 		agentCfg.ControlTarget = approvalAddr
 		agentCfg.ControlToken = approvalServer.VerifierToken
 	}
-	var err error
 	a.agents, err = agent.NewManager(ctx, emit, a.logger, a.logDir, agentCfg)
 	if err != nil && agentCfg.SurviveRestartDir != "" && errors.Is(err, agent.ErrSurvivalRegistry) {
 		a.logger.Error("agent.survive-restart.init", "err", err)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1750,6 +1750,12 @@ func (a *App) newRecovery() *recovery.Recovery {
 		LogMaxTotalBytes:   maxTotalBytes,
 		TrashRetentionDays: a.cfg.DefaultTrashRetentionDays(),
 		OrphanRoots: []string{
+			// Taskless loop/orchestrator runs use the Sybra data home itself;
+			// monitor and human-review fallbacks use the configured source repo.
+			// Include both so the acquire→spawn→registry crash window can reap
+			// every owned provider process before its lease is reconciled.
+			config.HomeDir(),
+			a.repoDir,
 			filepath.Join(config.HomeDir(), "sandboxes"),
 			filepath.Join(config.HomeDir(), "worktrees"),
 			// The /sybra-test skill's fake-provider harness spawns its
@@ -1758,6 +1764,7 @@ func (a *App) newRecovery() *recovery.Recovery {
 			// (sybra#2210) — glob-expanded fresh on every sweep since each
 			// test run gets its own directory.
 			filepath.Join(os.TempDir(), "sybra-test-*"),
+			filepath.Join(os.TempDir(), "sybra-k8s-poc-*"),
 		},
 		// Also gate on the instance role: RunStartupCleanup calls
 		// RestartStaleInProgress outside the (gated) maintenance pass, so an

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1750,12 +1750,6 @@ func (a *App) newRecovery() *recovery.Recovery {
 		LogMaxTotalBytes:   maxTotalBytes,
 		TrashRetentionDays: a.cfg.DefaultTrashRetentionDays(),
 		OrphanRoots: []string{
-			// Taskless loop/orchestrator runs use the Sybra data home itself;
-			// monitor and human-review fallbacks use the configured source repo.
-			// Include both so the acquire→spawn→registry crash window can reap
-			// every owned provider process before its lease is reconciled.
-			config.HomeDir(),
-			a.repoDir,
 			filepath.Join(config.HomeDir(), "sandboxes"),
 			filepath.Join(config.HomeDir(), "worktrees"),
 			// The /sybra-test skill's fake-provider harness spawns its
@@ -1765,6 +1759,12 @@ func (a *App) newRecovery() *recovery.Recovery {
 			// test run gets its own directory.
 			filepath.Join(os.TempDir(), "sybra-test-*"),
 			filepath.Join(os.TempDir(), "sybra-k8s-poc-*"),
+		},
+		OwnedOrphanRoots: []string{
+			// These roots can also contain operator-run provider processes, so
+			// recovery requires the explicit SYBRA_AGENT_OWNER marker here.
+			config.HomeDir(),
+			a.repoDir,
 		},
 		// Also gate on the instance role: RunStartupCleanup calls
 		// RestartStaleInProgress outside the (gated) maintenance pass, so an

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -1087,10 +1087,20 @@ func (a *agentAdapter) RunVerificationCommand(ctx context.Context, taskID, dir, 
 }
 
 func translatePoolBusy(err error) error {
-	if errors.Is(err, agent.ErrMaxConcurrentReached) {
+	if agent.IsCapacityError(err) {
 		return fmt.Errorf("%w: %w", workflow.ErrAgentPoolBusy, err)
 	}
+	if agent.IsAttemptConflict(err) {
+		return fmt.Errorf("%w: %w", workflow.ErrDispatchInFlight, err)
+	}
 	return err
+}
+
+func assignmentAttemptAccess(assignment workflow.AgentAssignment) agent.AttemptAccess {
+	if assignment.AdmissionObserve {
+		return agent.AttemptAccessObserve
+	}
+	return ""
 }
 
 func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema, cleanRetryRef string, assignment workflow.AgentAssignment) (agentID, startedDir, baselineRef string, err error) {
@@ -1166,6 +1176,9 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		AllowedTools:            allowedTools,
 		Model:                   model,
 		Provider:                provider,
+		IntentID:                assignment.IntentID,
+		AdmissionTaskKey:        assignment.AdmissionTaskKey,
+		AttemptAccess:           assignmentAttemptAccess(assignment),
 		ExperimentID:            assignment.ExperimentID,
 		VariantID:               assignment.VariantID,
 		RoutingReason:           assignment.RoutingReason,

--- a/internal/sybra/dispatch/controller.go
+++ b/internal/sybra/dispatch/controller.go
@@ -1,0 +1,476 @@
+// Package dispatch owns durable admission leases for provider attempts.
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	ErrInvalidIntent        = errors.New("invalid attempt intent")
+	ErrLeaseNotFound        = errors.New("attempt lease not found")
+	ErrStaleLease           = errors.New("stale attempt lease")
+	ErrLeaseOwner           = errors.New("attempt lease belongs to another owner epoch")
+	ErrIntentReplayMismatch = errors.New("attempt intent replay does not match original intent")
+)
+
+type Status string
+
+const (
+	StatusAcquired    Status = "acquired"
+	StatusBound       Status = "bound"
+	StatusReconciling Status = "reconciling"
+	StatusCompleted   Status = "completed"
+)
+
+type Limits struct {
+	Global     int
+	ByProvider map[string]int
+}
+
+type Options struct {
+	Dir    string
+	Owner  string
+	Limits Limits
+	TTL    time.Duration
+	Now    func() time.Time
+}
+
+// Record is the persisted admission state exposed to restart reconciliation.
+// Callers must use the versioned AttemptLease token for every mutation.
+type Record struct {
+	ID          string               `yaml:"id"`
+	Version     uint64               `yaml:"version"`
+	Intent      agent.AttemptIntent  `yaml:"intent"`
+	OwnerEpoch  string               `yaml:"owner_epoch"`
+	Status      Status               `yaml:"status"`
+	Binding     agent.AttemptBinding `yaml:"binding,omitempty"`
+	CreatedAt   time.Time            `yaml:"created_at"`
+	HeartbeatAt time.Time            `yaml:"heartbeat_at"`
+	ExpiresAt   time.Time            `yaml:"expires_at,omitempty"`
+	CompletedAt time.Time            `yaml:"completed_at,omitempty"`
+	Outcome     string               `yaml:"outcome,omitempty"`
+}
+
+type diskState struct {
+	SchemaVersion int      `yaml:"schema_version"`
+	Revision      uint64   `yaml:"revision"`
+	Leases        []Record `yaml:"leases,omitempty"`
+}
+
+// Controller implements agent.AttemptAdmission. All read-modify-write cycles
+// take both a process-local mutex and a cross-process file lock.
+type Controller struct {
+	mu     sync.Mutex
+	dir    string
+	path   string
+	owner  string
+	limits Limits
+	ttl    time.Duration
+	now    func() time.Time
+}
+
+var _ agent.AttemptAdmission = (*Controller)(nil)
+
+func New(ctx context.Context, opts Options) (*Controller, error) {
+	if strings.TrimSpace(opts.Dir) == "" {
+		return nil, errors.New("dispatch controller directory is required")
+	}
+	if opts.TTL <= 0 {
+		return nil, fmt.Errorf("dispatch controller TTL must be > 0, got %s", opts.TTL)
+	}
+	if opts.Limits.Global < 0 {
+		return nil, fmt.Errorf("dispatch global limit must be >= 0, got %d", opts.Limits.Global)
+	}
+	for provider, limit := range opts.Limits.ByProvider {
+		if strings.TrimSpace(provider) == "" || limit < 0 {
+			return nil, fmt.Errorf("invalid provider limit %q=%d", provider, limit)
+		}
+	}
+	dir, err := filepath.Abs(opts.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve dispatch controller directory: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create dispatch controller directory: %w", err)
+	}
+	owner := strings.TrimSpace(opts.Owner)
+	if owner == "" {
+		owner = uuid.NewString()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	c := &Controller{
+		dir: dir, path: filepath.Join(dir, "attempt-leases.yaml"), owner: owner,
+		limits: Limits{Global: opts.Limits.Global, ByProvider: cloneLimits(opts.Limits.ByProvider)},
+		ttl:    opts.TTL, now: now,
+	}
+	if err := c.update(ctx, func(s *diskState, now time.Time) (bool, error) {
+		return expireLeases(s, now), nil
+	}); err != nil {
+		return nil, fmt.Errorf("initialize dispatch controller: %w", err)
+	}
+	return c, nil
+}
+
+func cloneLimits(in map[string]int) map[string]int {
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		out[strings.TrimSpace(k)] = v
+	}
+	return out
+}
+
+// ReplaceLimits applies a live config reload to future Acquire calls. Active
+// leases are never evicted when a ceiling shrinks; they continue consuming
+// capacity and new work remains parked until the count falls below the limit.
+func (c *Controller) ReplaceLimits(global, perProvider int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.limits.Global = max(global, 0)
+	for provider := range c.limits.ByProvider {
+		c.limits.ByProvider[provider] = max(perProvider, 0)
+	}
+}
+
+func (c *Controller) Acquire(ctx context.Context, intent agent.AttemptIntent) (agent.AttemptLease, error) {
+	intent, err := normalizeIntent(intent)
+	if err != nil {
+		return agent.AttemptLease{}, err
+	}
+	var result agent.AttemptLease
+	err = c.update(ctx, func(s *diskState, now time.Time) (bool, error) {
+		changed := expireLeases(s, now)
+		if rec := findIntent(s, intent.IntentID); rec != nil {
+			if !reflect.DeepEqual(rec.Intent, intent) {
+				return changed, fmt.Errorf("%w: %s", ErrIntentReplayMismatch, intent.IntentID)
+			}
+			switch rec.Status {
+			case StatusAcquired, StatusBound:
+				if rec.OwnerEpoch != c.owner {
+					return changed, fmt.Errorf("%w: lease %s belongs to prior owner %s", agent.ErrAttemptNeedsReconciliation, rec.ID, rec.OwnerEpoch)
+				}
+				result = leaseOf(rec)
+				result.Existing = true
+				return changed, nil
+			case StatusReconciling:
+				return changed, fmt.Errorf("%w: lease %s", agent.ErrAttemptNeedsReconciliation, rec.ID)
+			default:
+				return changed, fmt.Errorf("%w: intent %s is already complete", agent.ErrAttemptConflict, intent.IntentID)
+			}
+		}
+		if err := c.admit(s, intent); err != nil {
+			return changed, err
+		}
+		rec := Record{
+			ID: uuid.NewString(), Version: 1, Intent: intent, OwnerEpoch: c.owner,
+			Status: StatusAcquired, CreatedAt: now, HeartbeatAt: now, ExpiresAt: now.Add(c.ttl),
+		}
+		s.Leases = append(s.Leases, rec)
+		result = leaseOf(&s.Leases[len(s.Leases)-1])
+		return true, nil
+	})
+	return result, err
+}
+
+func (c *Controller) Bind(ctx context.Context, lease agent.AttemptLease, binding agent.AttemptBinding) error {
+	if strings.TrimSpace(binding.AgentID) == "" {
+		return errors.New("attempt binding agent ID is required")
+	}
+	return c.mutateOwned(ctx, lease, false, func(rec *Record, now time.Time) error {
+		if rec.Status == StatusCompleted {
+			return fmt.Errorf("%w: lease %s is complete", ErrStaleLease, lease.ID)
+		}
+		if rec.Status == StatusReconciling {
+			return fmt.Errorf("%w: lease %s", agent.ErrAttemptNeedsReconciliation, lease.ID)
+		}
+		if binding.ObservedAt.IsZero() {
+			binding.ObservedAt = now
+		}
+		rec.Binding = binding
+		rec.Status = StatusBound
+		rec.HeartbeatAt = binding.ObservedAt.UTC()
+		rec.ExpiresAt = now.Add(c.ttl)
+		return nil
+	})
+}
+
+func (c *Controller) Heartbeat(ctx context.Context, lease agent.AttemptLease, observedAt time.Time) error {
+	return c.mutateOwned(ctx, lease, false, func(rec *Record, now time.Time) error {
+		if rec.Status == StatusReconciling {
+			return fmt.Errorf("%w: lease %s", agent.ErrAttemptNeedsReconciliation, lease.ID)
+		}
+		if rec.Status == StatusCompleted {
+			return fmt.Errorf("%w: lease %s is complete", ErrStaleLease, lease.ID)
+		}
+		if observedAt.IsZero() {
+			observedAt = now
+		}
+		rec.HeartbeatAt = observedAt.UTC()
+		rec.ExpiresAt = now.Add(c.ttl)
+		return nil
+	})
+}
+
+func (c *Controller) Complete(ctx context.Context, lease agent.AttemptLease, outcome string) error {
+	return c.mutateOwned(ctx, lease, true, func(rec *Record, now time.Time) error {
+		if rec.Status == StatusCompleted {
+			if rec.Outcome == outcome {
+				return nil
+			}
+			return fmt.Errorf("%w: lease %s completed with a different outcome", ErrStaleLease, lease.ID)
+		}
+		rec.Status = StatusCompleted
+		rec.Outcome = outcome
+		rec.CompletedAt = now
+		rec.ExpiresAt = time.Time{}
+		return nil
+	})
+}
+
+// Adopt transfers a persisted lease to this controller epoch after restart
+// observation proves that its provider attempt is still alive. Adoption also
+// revives a reconciling lease; mere expiry never does.
+func (c *Controller) Adopt(ctx context.Context, intent agent.AttemptIntent, lease agent.AttemptLease, binding agent.AttemptBinding) (agent.AttemptLease, error) {
+	intent, err := normalizeIntent(intent)
+	if err != nil {
+		return agent.AttemptLease{}, err
+	}
+	if strings.TrimSpace(binding.AgentID) == "" {
+		return agent.AttemptLease{}, errors.New("adopted attempt binding agent ID is required")
+	}
+	var adopted agent.AttemptLease
+	err = c.update(ctx, func(s *diskState, now time.Time) (bool, error) {
+		changed := expireLeases(s, now)
+		rec := findLease(s, lease.ID)
+		if rec == nil {
+			return changed, fmt.Errorf("%w: %s", ErrLeaseNotFound, lease.ID)
+		}
+		if rec.Version != lease.Version {
+			return changed, staleVersion(rec, lease)
+		}
+		if !reflect.DeepEqual(rec.Intent, intent) {
+			return changed, fmt.Errorf("%w: %s", ErrIntentReplayMismatch, intent.IntentID)
+		}
+		if rec.Status == StatusCompleted {
+			return changed, fmt.Errorf("%w: lease %s is complete", ErrStaleLease, lease.ID)
+		}
+		if binding.ObservedAt.IsZero() {
+			binding.ObservedAt = now
+		}
+		rec.OwnerEpoch = c.owner
+		rec.Binding = binding
+		rec.Status = StatusBound
+		rec.HeartbeatAt = binding.ObservedAt.UTC()
+		rec.ExpiresAt = now.Add(c.ttl)
+		rec.Version++
+		adopted = leaseOf(rec)
+		return true, nil
+	})
+	return adopted, err
+}
+
+// Records returns a stable snapshot and durably marks newly expired leases as
+// reconciling before exposing them.
+func (c *Controller) Records(ctx context.Context) ([]Record, error) {
+	var out []Record
+	err := c.update(ctx, func(s *diskState, now time.Time) (bool, error) {
+		changed := expireLeases(s, now)
+		out = append([]Record(nil), s.Leases...)
+		return changed, nil
+	})
+	return out, err
+}
+
+func (c *Controller) mutateOwned(ctx context.Context, lease agent.AttemptLease, allowReconciling bool, mutate func(*Record, time.Time) error) error {
+	return c.update(ctx, func(s *diskState, now time.Time) (bool, error) {
+		changed := expireLeases(s, now)
+		rec := findLease(s, lease.ID)
+		if rec == nil {
+			return changed, fmt.Errorf("%w: %s", ErrLeaseNotFound, lease.ID)
+		}
+		if rec.Version != lease.Version {
+			return changed, staleVersion(rec, lease)
+		}
+		// Terminal reconciliation may be performed by a fresh process epoch
+		// with the persisted, still-current token, whether the observed-dead
+		// attempt reached its TTL or not. It cannot bind or heartbeat the lease,
+		// and adoption increments the version before reviving a live attempt.
+		if rec.OwnerEpoch != c.owner && !allowReconciling {
+			return changed, fmt.Errorf("%w: lease %s", ErrLeaseOwner, lease.ID)
+		}
+		if rec.Status == StatusReconciling && !allowReconciling {
+			return changed, fmt.Errorf("%w: lease %s", agent.ErrAttemptNeedsReconciliation, lease.ID)
+		}
+		if err := mutate(rec, now); err != nil {
+			return changed, err
+		}
+		return true, nil
+	})
+}
+
+func staleVersion(rec *Record, lease agent.AttemptLease) error {
+	return fmt.Errorf("%w: lease %s version %d, current %d", ErrStaleLease, lease.ID, lease.Version, rec.Version)
+}
+
+func (c *Controller) admit(s *diskState, intent agent.AttemptIntent) error {
+	global, provider := 0, 0
+	for i := range s.Leases {
+		rec := &s.Leases[i]
+		if !occupiesCapacity(rec.Status) {
+			continue
+		}
+		global++
+		if rec.Intent.Provider == intent.Provider {
+			provider++
+		}
+		if intent.Access == agent.AttemptAccessMutate && rec.Intent.Access == agent.AttemptAccessMutate &&
+			((intent.TaskID != "" && intent.TaskID == rec.Intent.TaskID) ||
+				(intent.Worktree != "" && intent.Worktree == rec.Intent.Worktree)) {
+			if rec.Status == StatusReconciling {
+				return fmt.Errorf("%w: lease %s", agent.ErrAttemptNeedsReconciliation, rec.ID)
+			}
+			return fmt.Errorf("%w: lease %s", agent.ErrAttemptConflict, rec.ID)
+		}
+	}
+	if c.limits.Global > 0 && global >= c.limits.Global {
+		return agent.ErrMaxConcurrentReached
+	}
+	if limit := c.limits.ByProvider[intent.Provider]; limit > 0 && provider >= limit {
+		return fmt.Errorf("%w: %s (%d)", agent.ErrProviderCapacityReached, intent.Provider, limit)
+	}
+	return nil
+}
+
+func normalizeIntent(intent agent.AttemptIntent) (agent.AttemptIntent, error) {
+	intent.IntentID = strings.TrimSpace(intent.IntentID)
+	intent.TaskID = strings.TrimSpace(intent.TaskID)
+	intent.Provider = strings.TrimSpace(intent.Provider)
+	if intent.IntentID == "" || intent.Provider == "" {
+		return intent, fmt.Errorf("%w: intent ID and provider are required", ErrInvalidIntent)
+	}
+	if intent.Access != agent.AttemptAccessMutate && intent.Access != agent.AttemptAccessObserve {
+		return intent, fmt.Errorf("%w: explicit access is required", ErrInvalidIntent)
+	}
+	if !intent.CapabilityCertified {
+		return intent, fmt.Errorf("%w: capability is not certified", ErrInvalidIntent)
+	}
+	if intent.Worktree != "" {
+		abs, err := filepath.Abs(intent.Worktree)
+		if err != nil {
+			return intent, fmt.Errorf("%w: canonicalize worktree: %w", ErrInvalidIntent, err)
+		}
+		abs = filepath.Clean(abs)
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = resolved
+		}
+		intent.Worktree = abs
+	}
+	return intent, nil
+}
+
+func expireLeases(s *diskState, now time.Time) bool {
+	changed := false
+	for i := range s.Leases {
+		rec := &s.Leases[i]
+		if (rec.Status == StatusAcquired || rec.Status == StatusBound) && !rec.ExpiresAt.IsZero() && !now.Before(rec.ExpiresAt) {
+			rec.Status = StatusReconciling
+			changed = true
+		}
+	}
+	return changed
+}
+
+func occupiesCapacity(status Status) bool {
+	return status == StatusAcquired || status == StatusBound || status == StatusReconciling
+}
+
+func leaseOf(rec *Record) agent.AttemptLease {
+	return agent.AttemptLease{ID: rec.ID, Version: rec.Version}
+}
+
+func findIntent(s *diskState, id string) *Record {
+	for i := range s.Leases {
+		if s.Leases[i].Intent.IntentID == id {
+			return &s.Leases[i]
+		}
+	}
+	return nil
+}
+
+func findLease(s *diskState, id string) *Record {
+	for i := range s.Leases {
+		if s.Leases[i].ID == id {
+			return &s.Leases[i]
+		}
+	}
+	return nil
+}
+
+func (c *Controller) update(ctx context.Context, fn func(*diskState, time.Time) (bool, error)) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	unlock, err := fsutil.LockFileContext(ctx, c.path)
+	if err != nil {
+		return fmt.Errorf("lock attempt lease store: %w", err)
+	}
+	defer func() { _ = unlock() }()
+	s, err := c.load()
+	if err != nil {
+		return err
+	}
+	changed, opErr := fn(&s, c.now().UTC())
+	if changed {
+		s.Revision++
+		if err := c.save(s); err != nil {
+			return err
+		}
+	}
+	return opErr
+}
+
+func (c *Controller) load() (diskState, error) {
+	data, err := os.ReadFile(c.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return diskState{SchemaVersion: 1}, nil
+	}
+	if err != nil {
+		return diskState{}, fmt.Errorf("read attempt lease store: %w", err)
+	}
+	var s diskState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return diskState{}, fmt.Errorf("decode attempt lease store: %w", err)
+	}
+	if s.SchemaVersion != 1 {
+		return diskState{}, fmt.Errorf("unsupported attempt lease schema %d", s.SchemaVersion)
+	}
+	return s, nil
+}
+
+func (c *Controller) save(s diskState) error {
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("encode attempt lease store: %w", err)
+	}
+	if err := fsutil.AtomicWrite(c.path, data); err != nil {
+		return fmt.Errorf("persist attempt lease store: %w", err)
+	}
+	return nil
+}

--- a/internal/sybra/dispatch/controller.go
+++ b/internal/sybra/dispatch/controller.go
@@ -83,6 +83,7 @@ type Controller struct {
 }
 
 var _ agent.AttemptAdmission = (*Controller)(nil)
+var _ agent.AttemptLedgerReconciler = (*Controller)(nil)
 
 func New(ctx context.Context, opts Options) (*Controller, error) {
 	if strings.TrimSpace(opts.Dir) == "" {
@@ -294,6 +295,59 @@ func (c *Controller) Records(ctx context.Context) ([]Record, error) {
 		return changed, nil
 	})
 	return out, err
+}
+
+// NeedsReconciliation reports whether expiry has produced ledger state that
+// must be compared with the survival registry. The caller uses this cheap
+// gate before the more expensive orphan-process and worktree-preservation
+// passes.
+func (c *Controller) NeedsReconciliation(ctx context.Context) (bool, error) {
+	needed := false
+	err := c.update(ctx, func(s *diskState, now time.Time) (bool, error) {
+		changed := expireLeases(s, now)
+		for i := range s.Leases {
+			if s.Leases[i].Status == StatusReconciling {
+				needed = true
+				break
+			}
+		}
+		return changed, nil
+	})
+	return needed, err
+}
+
+// ReconcileUnobserved finalizes expired leases absent from the survival
+// registry and live manager state. It must only be called after the caller has
+// reaped unregistered owned provider processes and preserved their worktrees;
+// expiry alone is deliberately insufficient evidence that an attempt is dead.
+func (c *Controller) ReconcileUnobserved(ctx context.Context, observed []agent.AttemptLease) (int, error) {
+	seen := make(map[string]struct{}, len(observed))
+	for i := range observed {
+		if observed[i].ID != "" {
+			seen[observed[i].ID] = struct{}{}
+		}
+	}
+	reconciled := 0
+	err := c.update(ctx, func(s *diskState, now time.Time) (bool, error) {
+		changed := expireLeases(s, now)
+		for i := range s.Leases {
+			rec := &s.Leases[i]
+			if rec.Status != StatusReconciling {
+				continue
+			}
+			if _, ok := seen[rec.ID]; ok {
+				continue
+			}
+			rec.Status = StatusCompleted
+			rec.Outcome = "orphan_reconciled"
+			rec.CompletedAt = now
+			rec.ExpiresAt = time.Time{}
+			reconciled++
+			changed = true
+		}
+		return changed, nil
+	})
+	return reconciled, err
 }
 
 func (c *Controller) mutateOwned(ctx context.Context, lease agent.AttemptLease, allowReconciling bool, mutate func(*Record, time.Time) error) error {

--- a/internal/sybra/dispatch/controller_test.go
+++ b/internal/sybra/dispatch/controller_test.go
@@ -322,3 +322,31 @@ func TestRestartEpochCanCompleteObservedDeadUnexpiredLease(t *testing.T) {
 		t.Fatalf("replacement after terminal reconciliation: %v", err)
 	}
 }
+
+func TestReconcileUnobservedRequiresExpiryAndExplicitObservation(t *testing.T) {
+	clock := &fakeClock{t: time.Now().UTC()}
+	c := newTestController(t, clock, "epoch", Limits{})
+	lease, err := c.Acquire(t.Context(), intent("orphan", "task", "", providerid.Claude, agent.AttemptAccessMutate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if needed, err := c.NeedsReconciliation(t.Context()); err != nil || needed {
+		t.Fatalf("fresh lease reconciliation = %v, %v; want false", needed, err)
+	}
+	clock.add(2 * time.Minute)
+	if needed, err := c.NeedsReconciliation(t.Context()); err != nil || !needed {
+		t.Fatalf("expired lease reconciliation = %v, %v; want true", needed, err)
+	}
+	if n, err := c.ReconcileUnobserved(t.Context(), []agent.AttemptLease{lease}); err != nil || n != 0 {
+		t.Fatalf("observed reconciliation = %d, %v; want 0", n, err)
+	}
+	if _, err := c.Acquire(t.Context(), intent("replacement-before-reconcile", "task", "", providerid.Claude, agent.AttemptAccessMutate)); !errors.Is(err, agent.ErrAttemptNeedsReconciliation) {
+		t.Fatalf("observed expired lease admitted replacement: %v", err)
+	}
+	if n, err := c.ReconcileUnobserved(t.Context(), nil); err != nil || n != 1 {
+		t.Fatalf("unobserved reconciliation = %d, %v; want 1", n, err)
+	}
+	if _, err := c.Acquire(t.Context(), intent("replacement", "task", "", providerid.Claude, agent.AttemptAccessMutate)); err != nil {
+		t.Fatalf("replacement after explicit reconciliation: %v", err)
+	}
+}

--- a/internal/sybra/dispatch/controller_test.go
+++ b/internal/sybra/dispatch/controller_test.go
@@ -1,0 +1,324 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/taskstatus"
+)
+
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time      { c.mu.Lock(); defer c.mu.Unlock(); return c.t }
+func (c *fakeClock) add(d time.Duration) { c.mu.Lock(); c.t = c.t.Add(d); c.mu.Unlock() }
+
+func newTestController(t *testing.T, clock *fakeClock, owner string, limits Limits) *Controller {
+	t.Helper()
+	c, err := New(t.Context(), Options{Dir: t.TempDir(), Owner: owner, Limits: limits, TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func intent(id, taskID, wt, provider string, access agent.AttemptAccess) agent.AttemptIntent {
+	return agent.AttemptIntent{IntentID: id, TaskID: taskID, Worktree: wt, Provider: provider, Access: access, CapabilityCertified: true}
+}
+
+func TestAcquireReplayAndMutationExclusivity(t *testing.T) {
+	clock := &fakeClock{t: time.Date(2026, 8, 8, 10, 0, 0, 0, time.UTC)}
+	c := newTestController(t, clock, "epoch-1", Limits{})
+	wt := filepath.Join(t.TempDir(), "worktree")
+	first, err := c.Acquire(t.Context(), intent("intent-1", "task-1", wt, providerid.Claude, agent.AttemptAccessMutate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	replay, err := c.Acquire(t.Context(), intent("intent-1", "task-1", wt, providerid.Claude, agent.AttemptAccessMutate))
+	if err != nil || replay.ID != first.ID || replay.Version != first.Version || !replay.Existing {
+		t.Fatalf("replay = %+v, %v; want existing lease matching %+v", replay, err, first)
+	}
+	if first.Existing {
+		t.Fatal("fresh lease marked Existing")
+	}
+	if _, err := c.Acquire(t.Context(), intent("intent-2", "task-1", "", providerid.Codex, agent.AttemptAccessMutate)); !errors.Is(err, agent.ErrAttemptConflict) {
+		t.Fatalf("same-task error = %v", err)
+	}
+	if _, err := c.Acquire(t.Context(), intent("intent-3", "task-2", wt, providerid.Codex, agent.AttemptAccessMutate)); !errors.Is(err, agent.ErrAttemptConflict) {
+		t.Fatalf("same-worktree error = %v", err)
+	}
+	if _, err := c.Acquire(t.Context(), intent("intent-1", "different", wt, providerid.Claude, agent.AttemptAccessMutate)); !errors.Is(err, ErrIntentReplayMismatch) {
+		t.Fatalf("mismatched replay error = %v", err)
+	}
+}
+
+func TestObserversAreExplicitAndCompatible(t *testing.T) {
+	clock := &fakeClock{t: time.Now().UTC()}
+	c := newTestController(t, clock, "epoch", Limits{})
+	wt := t.TempDir()
+	if _, err := c.Acquire(t.Context(), intent("mutate", "task", wt, providerid.Claude, agent.AttemptAccessMutate)); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"observer-1", "observer-2"} {
+		if _, err := c.Acquire(t.Context(), intent(id, "task", wt, providerid.Claude, agent.AttemptAccessObserve)); err != nil {
+			t.Fatalf("%s: %v", id, err)
+		}
+	}
+	bad := intent("implicit", "other", "", providerid.Claude, "")
+	if _, err := c.Acquire(t.Context(), bad); !errors.Is(err, ErrInvalidIntent) {
+		t.Fatalf("implicit access error = %v", err)
+	}
+}
+
+func TestHardGlobalAndProviderLimitsUnderConcurrency(t *testing.T) {
+	clock := &fakeClock{t: time.Now().UTC()}
+	c := newTestController(t, clock, "epoch", Limits{Global: 4, ByProvider: map[string]int{providerid.Claude: 2}})
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	accepted := map[string]int{}
+	for i := range 40 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			provider := providerid.Claude
+			if i%2 == 1 {
+				provider = providerid.Codex
+			}
+			if _, err := c.Acquire(context.Background(), intent(time.Now().String()+string(rune(i)), "", "", provider, agent.AttemptAccessObserve)); err == nil {
+				mu.Lock()
+				accepted[provider]++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+	if accepted[providerid.Claude] > 2 {
+		t.Fatalf("claude accepted %d, want <= 2", accepted[providerid.Claude])
+	}
+	if accepted[providerid.Claude]+accepted[providerid.Codex] > 4 {
+		t.Fatalf("global accepted %v, want <= 4", accepted)
+	}
+}
+
+func TestReplaceLimitsParksNewWorkWithoutEvictingActiveLease(t *testing.T) {
+	clock := &fakeClock{t: time.Now().UTC()}
+	c := newTestController(t, clock, "epoch", Limits{Global: 2, ByProvider: map[string]int{providerid.Claude: 2}})
+	if _, err := c.Acquire(t.Context(), intent("active", "task-1", "", providerid.Claude, agent.AttemptAccessMutate)); err != nil {
+		t.Fatal(err)
+	}
+	c.ReplaceLimits(1, 1)
+	if _, err := c.Acquire(t.Context(), intent("parked", "task-2", "", providerid.Claude, agent.AttemptAccessMutate)); !agent.IsCapacityError(err) {
+		t.Fatalf("Acquire after shrinking limits = %v, want capacity error", err)
+	}
+}
+
+func TestExpiredLeaseReconcilesAndBlocksReplacement(t *testing.T) {
+	clock := &fakeClock{t: time.Now().UTC()}
+	c := newTestController(t, clock, "epoch", Limits{})
+	lease, err := c.Acquire(t.Context(), intent("old", "task", t.TempDir(), providerid.Claude, agent.AttemptAccessMutate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock.add(2 * time.Minute)
+	if _, err := c.Acquire(t.Context(), intent("replacement", "task", "", providerid.Claude, agent.AttemptAccessMutate)); !errors.Is(err, agent.ErrAttemptNeedsReconciliation) {
+		t.Fatalf("replacement error = %v", err)
+	}
+	records, err := c.Records(t.Context())
+	if err != nil || records[0].Status != StatusReconciling {
+		t.Fatalf("records = %+v, %v", records, err)
+	}
+	if err := c.Heartbeat(t.Context(), lease, clock.now()); !errors.Is(err, agent.ErrAttemptNeedsReconciliation) {
+		t.Fatalf("expired heartbeat = %v", err)
+	}
+	current := agent.AttemptLease{ID: records[0].ID, Version: records[0].Version}
+	if err := c.Complete(t.Context(), current, "lost-reconciled"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Acquire(t.Context(), intent("replacement", "task", "", providerid.Claude, agent.AttemptAccessMutate)); err != nil {
+		t.Fatalf("post-reconcile acquire: %v", err)
+	}
+}
+
+func TestVersionFenceBindHeartbeatComplete(t *testing.T) {
+	clock := &fakeClock{t: time.Now().UTC()}
+	c := newTestController(t, clock, "epoch", Limits{})
+	lease, err := c.Acquire(t.Context(), intent("run", "task", "", providerid.Claude, agent.AttemptAccessMutate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := lease
+	stale.Version++
+	bind := agent.AttemptBinding{AgentID: "agent-1", PID: 42}
+	for name, fn := range map[string]func() error{
+		"bind":      func() error { return c.Bind(t.Context(), stale, bind) },
+		"heartbeat": func() error { return c.Heartbeat(t.Context(), stale, clock.now()) },
+		"complete":  func() error { return c.Complete(t.Context(), stale, string(taskstatus.Done)) },
+	} {
+		if err := fn(); !errors.Is(err, ErrStaleLease) {
+			t.Errorf("%s error = %v", name, err)
+		}
+	}
+	if err := c.Bind(t.Context(), lease, bind); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Heartbeat(t.Context(), lease, clock.now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Complete(t.Context(), lease, string(taskstatus.Done)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Complete(t.Context(), lease, string(taskstatus.Done)); err != nil {
+		t.Fatalf("idempotent complete: %v", err)
+	}
+}
+
+func TestAdoptTransfersOwnerAndRevivesObservedExpiredLease(t *testing.T) {
+	dir := t.TempDir()
+	clock := &fakeClock{t: time.Now().UTC()}
+	old, err := New(t.Context(), Options{Dir: dir, Owner: "old", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := intent("run", "task", t.TempDir(), providerid.Claude, agent.AttemptAccessMutate)
+	lease, err := old.Acquire(t.Context(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := old.Bind(t.Context(), lease, agent.AttemptBinding{AgentID: "agent-1", PID: 42}); err != nil {
+		t.Fatal(err)
+	}
+	clock.add(2 * time.Minute)
+	newController, err := New(t.Context(), Options{Dir: dir, Owner: "replacement", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	records, err := newController.Records(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := agent.AttemptLease{ID: records[0].ID, Version: records[0].Version}
+	adopted, err := newController.Adopt(t.Context(), in, current, agent.AttemptBinding{AgentID: "agent-1", PID: 42, ObservedAt: clock.now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adopted.Version != current.Version+1 {
+		t.Fatalf("adopted version = %d, want %d", adopted.Version, current.Version+1)
+	}
+	if adopted.Existing {
+		t.Fatal("adopted lease marked Existing")
+	}
+	if err := old.Heartbeat(t.Context(), current, clock.now()); !errors.Is(err, ErrStaleLease) {
+		t.Fatalf("old owner heartbeat = %v", err)
+	}
+	if err := newController.Heartbeat(t.Context(), adopted, clock.now()); err != nil {
+		t.Fatalf("new owner heartbeat = %v", err)
+	}
+}
+
+func TestConcurrentAdoptHasExactlyOneVersionFencedWinner(t *testing.T) {
+	dir := t.TempDir()
+	clock := &fakeClock{t: time.Now().UTC()}
+	original, err := New(t.Context(), Options{Dir: dir, Owner: "original", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := intent("run", "task", t.TempDir(), providerid.Claude, agent.AttemptAccessMutate)
+	lease, err := original.Acquire(t.Context(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock.add(2 * time.Minute)
+	first, err := New(t.Context(), Options{Dir: dir, Owner: "restart-a", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := New(t.Context(), Options{Dir: dir, Owner: "restart-b", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		lease agent.AttemptLease
+		err   error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	for _, controller := range []*Controller{first, second} {
+		go func(c *Controller) {
+			<-start
+			got, adoptErr := c.Adopt(context.Background(), in, lease, agent.AttemptBinding{AgentID: "agent-1", PID: 42, ObservedAt: clock.now()})
+			results <- result{lease: got, err: adoptErr}
+		}(controller)
+	}
+	close(start)
+	wins, stale := 0, 0
+	for range 2 {
+		got := <-results
+		switch {
+		case got.err == nil:
+			wins++
+			if got.lease.Version != lease.Version+1 {
+				t.Errorf("winning version = %d, want %d", got.lease.Version, lease.Version+1)
+			}
+		case errors.Is(got.err, ErrStaleLease):
+			stale++
+		default:
+			t.Errorf("unexpected adopt result: %+v", got)
+		}
+	}
+	if wins != 1 || stale != 1 {
+		t.Fatalf("wins=%d stale=%d, want 1/1", wins, stale)
+	}
+}
+
+func TestYAMLPersistenceSurvivesReopen(t *testing.T) {
+	dir := t.TempDir()
+	clock := &fakeClock{t: time.Now().UTC()}
+	c, err := New(t.Context(), Options{Dir: dir, Owner: "one", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := c.Acquire(t.Context(), intent("persist", "task", "", providerid.Claude, agent.AttemptAccessMutate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := New(t.Context(), Options{Dir: dir, Owner: "two", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	records, err := c2.Records(t.Context())
+	if err != nil || len(records) != 1 || records[0].ID != lease.ID {
+		t.Fatalf("records = %+v, %v", records, err)
+	}
+}
+
+func TestRestartEpochCanCompleteObservedDeadUnexpiredLease(t *testing.T) {
+	dir := t.TempDir()
+	clock := &fakeClock{t: time.Now().UTC()}
+	original, err := New(t.Context(), Options{Dir: dir, Owner: "original", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := original.Acquire(t.Context(), intent("run", "task", "", providerid.Claude, agent.AttemptAccessMutate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := New(t.Context(), Options{Dir: dir, Owner: "restart", TTL: time.Minute, Now: clock.now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.Complete(t.Context(), lease, "lost"); err != nil {
+		t.Fatalf("complete observed-dead lease: %v", err)
+	}
+	if _, err := restarted.Acquire(t.Context(), intent("replacement", "task", "", providerid.Claude, agent.AttemptAccessMutate)); err != nil {
+		t.Fatalf("replacement after terminal reconciliation: %v", err)
+	}
+}

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -939,14 +939,22 @@ func TestReloadFromDisk_ABTestingPreservesRoutingOverlay(t *testing.T) {
 
 // recordHandler captures log records for assertion in tests.
 type recordHandler struct {
+	mu      sync.Mutex
 	records *[]slog.Record
 	slog.Handler
 }
 
 func (h *recordHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
 func (h *recordHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	*h.records = append(*h.records, r)
 	return nil
+}
+func (h *recordHandler) Len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(*h.records)
 }
 func (h *recordHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
 func (h *recordHandler) WithGroup(_ string) slog.Handler      { return h }

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -207,14 +207,13 @@ func (s *OrchestratorService) StartOrchestratorContext(ctx context.Context) erro
 	}
 
 	a, err := s.agents.RunContext(ctx, s.agents.ApplyABVariant(agent.RunConfig{
-		Name:                   orchestratorAgentName,
-		Role:                   agent.RoleOrchestrator,
-		Mode:                   "headless",
-		Dir:                    config.HomeDir(),
-		ReadOnlyDir:            true,
-		Prompt:                 orchestratorKickoffPrompt,
-		IgnoreConcurrencyLimit: true,
-		IsolateHome:            true,
+		Name:        orchestratorAgentName,
+		Role:        agent.RoleOrchestrator,
+		Mode:        "headless",
+		Dir:         config.HomeDir(),
+		ReadOnlyDir: true,
+		Prompt:      orchestratorKickoffPrompt,
+		IsolateHome: true,
 	}, s.abTesting, orchestratorABKey(), orchestratorRole))
 	if err != nil {
 		return fmt.Errorf("start orchestrator agent: %w", err)

--- a/internal/sybra/svc_orchestrator_reconcile_test.go
+++ b/internal/sybra/svc_orchestrator_reconcile_test.go
@@ -46,12 +46,12 @@ func TestReconcileOrchestratorsLocked_StableAfterTerminalTransition(t *testing.T
 
 	svc := &OrchestratorService{agents: mgr, logger: logger, emit: func(string, any) {}, agentID: a.ID}
 
-	before := len(records)
+	before := handler.Len()
 	var lastKeep string
 	for range 20 {
 		lastKeep = svc.reconcileOrchestratorsLocked()
 	}
-	after := len(records)
+	after := handler.Len()
 
 	if lastKeep != "" {
 		t.Errorf("reconcileOrchestratorsLocked() kept = %q, want empty (terminal agent must never be kept)", lastKeep)

--- a/internal/sybra/svc_orchestrator_test.go
+++ b/internal/sybra/svc_orchestrator_test.go
@@ -3,6 +3,7 @@
 package sybra
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -161,7 +162,7 @@ func TestOrchestratorService_ReplacesWedgedBrain(t *testing.T) {
 	}
 }
 
-func TestOrchestratorService_IgnoreConcurrencyLimit(t *testing.T) {
+func TestOrchestratorService_RespectsConcurrencyLimit(t *testing.T) {
 	binDir := buildTestBinaries(t)
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 	t.Setenv("FAKE_CLAUDE_SCENARIO", "interactive_implement")
@@ -183,8 +184,8 @@ func TestOrchestratorService_IgnoreConcurrencyLimit(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = mgr.StopAgent(blocker.ID) })
 
-	// Orchestrator must still start despite the saturated limit.
-	if err := svc.StartOrchestrator(); err != nil {
-		t.Fatalf("StartOrchestrator under saturated limit: %v", err)
+	// Control-plane work uses the same hard admission ceiling as task work.
+	if err := svc.StartOrchestrator(); !errors.Is(err, agent.ErrMaxConcurrentReached) {
+		t.Fatalf("StartOrchestrator under saturated limit = %v, want ErrMaxConcurrentReached", err)
 	}
 }

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -126,17 +126,22 @@ type DispatchClaim interface {
 
 // AgentAssignment carries A/B experiment attribution selected before dispatch.
 type AgentAssignment struct {
-	ExperimentID    string
-	Kind            string
-	VariantID       string
-	RoutingReason   string
-	Provider        string
-	Model           string
-	AssignmentUnit  string
-	AssignmentKey   string
-	ReasoningEffort string
-	PromptTransform *PromptTransform
-	SkillAliases    map[string]string
+	// IntentID is the durable workflow-effect identity used by admission to
+	// make a replay return the original attempt instead of spawning another.
+	IntentID         string
+	AdmissionTaskKey string
+	AdmissionObserve bool
+	ExperimentID     string
+	Kind             string
+	VariantID        string
+	RoutingReason    string
+	Provider         string
+	Model            string
+	AssignmentUnit   string
+	AssignmentKey    string
+	ReasoningEffort  string
+	PromptTransform  *PromptTransform
+	SkillAliases     map[string]string
 	// ReadOnlyPaths are additional paths a diagnostic agent may inspect under
 	// the deny-by-default sandbox read posture. They never grant write access.
 	ReadOnlyPaths []string

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -127,7 +127,8 @@ type DispatchClaim interface {
 // AgentAssignment carries A/B experiment attribution selected before dispatch.
 type AgentAssignment struct {
 	// IntentID is the durable workflow-effect identity used by admission to
-	// make a replay return the original attempt instead of spawning another.
+	// reject a replay while the original attempt is still owned, preventing a
+	// second provider process from being spawned for the same effect.
 	IntentID         string
 	AdmissionTaskKey string
 	AdmissionObserve bool

--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -40,7 +40,7 @@ func TestParallelValidation_Rejects(t *testing.T) {
 				Steps: []Step{{
 					ID: "p", Type: StepParallel,
 					Parallel: []Step{
-						{ID: "a", Type: StepRunAgent},
+						{ID: "a", Type: StepRunAgent, Config: StepConfig{Role: "plan"}},
 						{ID: "b", Type: StepSetStatus},
 					},
 				}},
@@ -54,7 +54,7 @@ func TestParallelValidation_Rejects(t *testing.T) {
 				Steps: []Step{{
 					ID: "p", Type: StepParallel,
 					Parallel: []Step{
-						{ID: "a", Type: StepRunAgent},
+						{ID: "a", Type: StepRunAgent, Config: StepConfig{Role: "plan"}},
 						{ID: "b", Type: StepRunAgent, Parallel: []Step{
 							{ID: "z", Type: StepRunAgent},
 						}},
@@ -78,13 +78,27 @@ func TestParallelValidation_Rejects(t *testing.T) {
 			errSub: "cannot set needs_worktree",
 		},
 		{
+			name: "writable child role",
+			def: Definition{
+				ID: "x",
+				Steps: []Step{{
+					ID: "p", Type: StepParallel,
+					Parallel: []Step{
+						{ID: "a", Type: StepRunAgent, Config: StepConfig{Role: "implementation"}},
+						{ID: "b", Type: StepRunAgent, Config: StepConfig{Role: "plan"}},
+					},
+				}},
+			},
+			errSub: "is not read-only",
+		},
+		{
 			name: "duplicate child id",
 			def: Definition{
 				ID: "x",
 				Steps: []Step{
 					{ID: "p", Type: StepParallel, Parallel: []Step{
-						{ID: "a", Type: StepRunAgent},
-						{ID: "a", Type: StepRunAgent},
+						{ID: "a", Type: StepRunAgent, Config: StepConfig{Role: "plan"}},
+						{ID: "a", Type: StepRunAgent, Config: StepConfig{Role: "plan"}},
 					}},
 				},
 			},
@@ -97,8 +111,8 @@ func TestParallelValidation_Rejects(t *testing.T) {
 				Steps: []Step{
 					{ID: "first", Type: StepRunAgent},
 					{ID: "p", Type: StepParallel, Parallel: []Step{
-						{ID: "first", Type: StepRunAgent},
-						{ID: "b", Type: StepRunAgent},
+						{ID: "first", Type: StepRunAgent, Config: StepConfig{Role: "plan"}},
+						{ID: "b", Type: StepRunAgent, Config: StepConfig{Role: "plan"}},
 					}},
 				},
 			},
@@ -219,7 +233,7 @@ func TestParallel_DispatchesAllChildren(t *testing.T) {
 	}
 }
 
-func TestParallel_AppliesABAssignmentToAuthorChildren(t *testing.T) {
+func TestParallel_AppliesABAssignmentToObserverChildren(t *testing.T) {
 	prev := providerAvailable
 	providerAvailable = func(string) bool { return true }
 	t.Cleanup(func() { providerAvailable = prev })
@@ -232,8 +246,8 @@ func TestParallel_AppliesABAssignmentToAuthorChildren(t *testing.T) {
 			ID:   "implement_both",
 			Type: StepParallel,
 			Parallel: []Step{
-				{ID: "impl_a", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "a"}},
-				{ID: "impl_b", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "b"}},
+				{ID: "impl_a", Type: StepRunAgent, Config: StepConfig{Role: "plan", Mode: "headless", Prompt: "a"}},
+				{ID: "impl_b", Type: StepRunAgent, Config: StepConfig{Role: "plan", Mode: "headless", Prompt: "b"}},
 			},
 		}},
 	}
@@ -247,7 +261,7 @@ func TestParallel_AppliesABAssignmentToAuthorChildren(t *testing.T) {
 	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
 		ID:             "exp",
 		AssignmentUnit: "stage",
-		Roles:          []string{"implementation"},
+		Roles:          []string{"plan"},
 		Variants:       []abtest.Variant{{ID: "opus", Provider: "claude", Model: "opus", Weight: 1}},
 	}}})
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
@@ -278,8 +292,8 @@ func TestParallel_AppliesPromptAndSkillVariantPayloads(t *testing.T) {
 			ID:   "implement_both",
 			Type: StepParallel,
 			Parallel: []Step{
-				{ID: "impl_a", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "control {{.Step.ID}} /sybra-test"}},
-				{ID: "impl_b", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "control {{.Step.ID}} /sybra-test"}},
+				{ID: "impl_a", Type: StepRunAgent, Config: StepConfig{Role: "plan", Mode: "headless", Prompt: "control {{.Step.ID}} /sybra-test"}},
+				{ID: "impl_b", Type: StepRunAgent, Config: StepConfig{Role: "plan", Mode: "headless", Prompt: "control {{.Step.ID}} /sybra-test"}},
 			},
 		}},
 	}
@@ -294,7 +308,7 @@ func TestParallel_AppliesPromptAndSkillVariantPayloads(t *testing.T) {
 		ID:             "payload-exp",
 		Kind:           "compound",
 		AssignmentUnit: "stage",
-		Roles:          []string{"implementation"},
+		Roles:          []string{"plan"},
 		Variants: []abtest.Variant{{
 			ID: "payload", Provider: "claude", Model: "sonnet", Weight: 1,
 			PromptTransform: &abtest.PromptTransform{Op: "prepend", Text: "variant {{.Step.ID}}: "},

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -366,6 +366,9 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		return err
 	}
 	applySkillReceiptRecoveryAssignment(step.ID, wfExec, &assignment)
+	if !claimedEffectID.IsZero() {
+		assignment.IntentID = taskID + ":" + wfExec.WorkflowID + ":" + claimedEffectID.String()
+	}
 	if step.Config.Role == "review" && wfExec.Variables["bestofn.attempts.manifest"] != "" {
 		assignment.ReadOnlyPaths = bestOfNAttemptReadRoots(wfExec)
 	}

--- a/internal/workflow/engine_steps_bestofn.go
+++ b/internal/workflow/engine_steps_bestofn.go
@@ -203,10 +203,12 @@ func (e *Engine) spawnBestOfNAttempt(taskID string, step *Step, wfExec *Executio
 	}
 
 	assignment := AgentAssignment{
-		VariantID:      attemptID,
-		AssignmentUnit: "bestofn-attempt",
-		Provider:       provider,
-		Model:          model,
+		IntentID:         taskID + ":" + wfExec.WorkflowID + ":bestofn:" + step.ID + ":" + attemptID,
+		AdmissionTaskKey: taskID + ":bestofn:" + attemptID,
+		VariantID:        attemptID,
+		AssignmentUnit:   "bestofn-attempt",
+		Provider:         provider,
+		Model:            model,
 	}
 
 	// Hold e.mu until the attempt route is durably persisted on the workflow.

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -124,6 +124,8 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 		return err
 	}
 	applySkillReceiptRecoveryAssignment(child.ID, wfExec, &assignment)
+	assignment.IntentID = taskID + ":" + wfExec.WorkflowID + ":parallel:" + parent.ID + ":" + child.ID
+	assignment.AdmissionObserve = true
 
 	prompt, err := e.renderAssignedPrompt(taskID, child, childCtx, assignment, "workflow.parallel.consume-steer")
 	if err != nil {

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -108,6 +108,9 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	if status == nil {
 		return fmt.Errorf("parallel child %q has no status", child.ID)
 	}
+	if !parallelObserverRole(child.Config.Role) {
+		return fmt.Errorf("parallel child %q role %q is not read-only", child.ID, child.Config.Role)
+	}
 	// Render the child prompt with a context that points at the child step
 	// so {{.Step.ID}} et al. resolve correctly inside the prompt template.
 	childCtx := parentCtx

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -604,9 +604,24 @@ func validateParallelStep(s *Step, seenIDs map[string]bool) error {
 		if seenIDs[c.ID] {
 			return fmt.Errorf("step %q: parallel child id %q already used elsewhere in workflow", s.ID, c.ID)
 		}
+		if !parallelObserverRole(c.Config.Role) {
+			return fmt.Errorf("step %q: parallel child %q role %q is not read-only", s.ID, c.ID, c.Config.Role)
+		}
 		seenIDs[c.ID] = true
 	}
 	return nil
+}
+
+// parallelObserverRole is deliberately narrower than the full role set.
+// Parallel children share one canonical worktree, so only roles whose source
+// and task access is enforced read-only may overlap under observer leases.
+func parallelObserverRole(role string) bool {
+	switch strings.TrimSpace(role) {
+	case "plan", "plan-critic", "review", "eval":
+		return true
+	default:
+		return false
+	}
 }
 
 // validAttemptProviders lists the providers a best_of_n step may pin an


### PR DESCRIPTION
Closes #3183

## Summary
- centralize every agent launch behind a durable admission controller
- enforce global, provider, and task-generation ownership without bypass paths
- persist attempt leases and reconcile live processes safely across restart
- treat provider exhaustion and ambiguous expiry as observation/retry states instead of task failure
- add race, restart, integration, and static drift coverage

## Validation
- `go test -race ./internal/sybra/dispatch`
- focused `go test -race ./internal/agent` admission/reattach/provider-cap suite
- `go test ./internal/workflow ./internal/monitor ./internal/loopagent`
- `go test -race -tags e2e -timeout 10m ./internal/sybra/...`
- `golangci-lint run ./...`
- frontend check, web/desktop builds, coverage, oxlint, and pin-strategy checks
- repository drift, binding, API shim, atomic-write, consolidated-primitives, and hadolint checks

`mise run verify` reached the Go race suite; its only failures were three unchanged `internal/worktree` tests where the generated temporary `prepare-commit-msg` signoff hook was killed by the host with SIGKILL. The exact worktree package failure reproduces independently without race; all changed-package and tagged E2E suites pass.