### PR TITLE
fix(recovery): classify stalled runs

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -2132,6 +2132,11 @@ type RunConfig struct {
 	// intra-package before buildHeadlessInvocation; cleared by defer after the
 	// subprocess exits. Never set by callers.
 	outputSchemaPath string
+	// promptFallback marks the one-shot retry after stream-json prompt
+	// delivery failed. Unlike ordinary one-shot runs, its prompt write must
+	// succeed: this is the recovery attempt's only way to deliver the task.
+	// It is runner-private and never set by callers.
+	promptFallback bool
 	// HeadlessSteerable, when true, launches a claude headless run with the
 	// stdin/stream-json shape (mirroring the conversational invocation)
 	// instead of the legacy one-shot `-p <prompt>` invocation, so the running

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -204,6 +204,7 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 		a.SetExitErr(nil)
 		fallback := cfg
 		fallback.HeadlessSteerable = false
+		fallback.promptFallback = true
 		return m.runHeadlessAttempt(ctx, a, fallback, outFile, tailOffset)
 	}
 	return retry, err
@@ -287,6 +288,28 @@ func (m *Manager) writeAndCloseHeadlessPrompt(a *Agent, stdin io.WriteCloser, pr
 	}
 }
 
+// handleOneShotPromptWrite preserves the legacy best-effort behavior for a
+// normal one-shot run: a CLI that exits immediately can close stdin after
+// having already produced its terminal result. The recovery fallback is
+// different: an undelivered prompt there must fail closed rather than leave a
+// task silently stranded.
+func (m *Manager) handleOneShotPromptWrite(a *Agent, cmd *exec.Cmd, writeErr error, required bool) error {
+	if writeErr == nil {
+		return nil
+	}
+	m.logger.Warn("agent.headless.initial-prompt", "id", a.ID, "err", writeErr, "required", required)
+	if !required {
+		return nil
+	}
+	a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
+	a.SetExitErr(fmt.Errorf("%w: %w", errPromptUndelivered, writeErr))
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}
+	return fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
+}
+
 func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, inv headlessInvocation) (retry bool, err error) {
 	cmd := newProviderCmd(ctx, &cfg, false, inv.name, inv.args...)
 	if a.sessionCWD != "" {
@@ -359,15 +382,8 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 			return false, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
 		}
 	} else if promptStdin != nil {
-		if writeErr := m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt); writeErr != nil {
-			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
-			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
-			a.SetExitErr(fmt.Errorf("%w: %w", errPromptUndelivered, writeErr))
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
-			_ = cmd.Wait()
-			return false, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
+		if writeErr := m.handleOneShotPromptWrite(a, cmd, m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt), cfg.promptFallback); writeErr != nil {
+			return false, writeErr
 		}
 	}
 
@@ -564,15 +580,8 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 			return nil, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
 		}
 	} else if promptStdin != nil {
-		if writeErr := m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt); writeErr != nil {
-			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
-			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
-			a.SetExitErr(fmt.Errorf("%w: %w", errPromptUndelivered, writeErr))
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-				_ = cmd.Wait()
-			}
-			return nil, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
+		if writeErr := m.handleOneShotPromptWrite(a, cmd, m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt), cfg.promptFallback); writeErr != nil {
+			return nil, writeErr
 		}
 	}
 	return cmd, nil

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -192,9 +192,21 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 
 	if m.survives() && a.Mode == "headless" {
 		inv := prepared.inv
-		return m.runHeadlessAttemptSurvive(ctx, a, prepared.cfg, outFile, tailOffset, inv.name, inv.args, inv.env, inv.command)
+		retry, err = m.runHeadlessAttemptSurvive(ctx, a, prepared.cfg, outFile, tailOffset, inv.name, inv.args, inv.env, inv.command)
+	} else {
+		retry, err = m.runHeadlessAttemptPipe(ctx, a, prepared.cfg, outFile, prepared.inv)
 	}
-	return m.runHeadlessAttemptPipe(ctx, a, prepared.cfg, outFile, prepared.inv)
+
+	if errors.Is(err, errPromptUndelivered) && prepared.cfg.HeadlessSteerable && prepared.inv.name == providerid.Claude {
+		m.logger.Warn("agent.headless.prompt-fallback", "id", a.ID, "provider", prepared.inv.name,
+			"transport", "stream-json", "payload_bytes", len(prepared.cfg.Prompt), "fallback", "one-shot-stdin")
+		a.SetError("", "")
+		a.SetExitErr(nil)
+		fallback := cfg
+		fallback.HeadlessSteerable = false
+		return m.runHeadlessAttempt(ctx, a, fallback, outFile, tailOffset)
+	}
+	return retry, err
 }
 
 func prepareHeadlessAttempt(a *Agent, cfg RunConfig) (preparedHeadlessAttempt, error) {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -264,14 +264,27 @@ func stdinPromptHeadlessInvocation(steerable bool, providerName string) bool {
 
 // writeAndCloseHeadlessPrompt sends the one-shot stdin prompt then closes the
 // pipe so the child (default --input-format text) sees EOF immediately,
-// matching a plain `claude -p <text>` run's stdin behavior. Never returns an
-// error to the caller: a write failure here should not abort an otherwise
-// healthy attempt, only be logged for diagnosis.
-func (m *Manager) writeAndCloseHeadlessPrompt(a *Agent, stdin io.WriteCloser, prompt string) {
-	if _, err := io.WriteString(stdin, prompt); err != nil {
-		m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", err)
+// matching a plain `claude -p <text>` run's stdin behavior. The delivery is
+// bounded: a child that does not consume stdin must not strand the runner.
+func (m *Manager) writeAndCloseHeadlessPrompt(a *Agent, stdin io.WriteCloser, prompt string) error {
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(stdin, prompt)
+		done <- err
+	}()
+	timer := time.NewTimer(stdinInitialWriteTimeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		_ = stdin.Close()
+		if err != nil {
+			return fmt.Errorf("write stdin: %w", err)
+		}
+		return nil
+	case <-timer.C:
+		_ = stdin.Close()
+		return fmt.Errorf("write stdin: timed out after %s, pipe closed", stdinInitialWriteTimeout)
 	}
-	_ = stdin.Close()
 }
 
 func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, inv headlessInvocation) (retry bool, err error) {
@@ -346,7 +359,16 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 			return false, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
 		}
 	} else if promptStdin != nil {
-		m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt)
+		if writeErr := m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt); writeErr != nil {
+			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
+			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
+			a.SetExitErr(fmt.Errorf("%w: %w", errPromptUndelivered, writeErr))
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			_ = cmd.Wait()
+			return false, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
+		}
 	}
 
 	// Open log file on first successful start; subsequent retries append to same file.
@@ -542,7 +564,16 @@ func (m *Manager) startHeadlessSurviveProcess(ctx context.Context, a *Agent, cfg
 			return nil, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
 		}
 	} else if promptStdin != nil {
-		m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt)
+		if writeErr := m.writeAndCloseHeadlessPrompt(a, promptStdin, cfg.Prompt); writeErr != nil {
+			m.logger.Error("agent.headless.initial-prompt", "id", a.ID, "err", writeErr)
+			a.SetError(ErrorKindPromptUndelivered, writeErr.Error())
+			a.SetExitErr(fmt.Errorf("%w: %w", errPromptUndelivered, writeErr))
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+			}
+			return nil, fmt.Errorf("deliver initial prompt: %w: %w", errPromptUndelivered, writeErr)
+		}
 	}
 	return cmd, nil
 }

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -3414,7 +3414,7 @@ func TestHeadlessSteerProducesFurtherTurn(t *testing.T) {
 	// like the real claude CLI is resolved in production.
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	m, _ := newTestManager(t)
-	a := &Agent{ID: "a1", TaskID: "task-1", Mode: "headless", Provider: "claude", State: StateRunning}
+	a := &Agent{ID: "a1", TaskID: "task-1", Mode: "headless", Provider: providerid.Claude, State: StateRunning}
 
 	inv := headlessInvocation{
 		name:    "claude",

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/skillattr"
 )
 
@@ -3077,7 +3078,9 @@ func TestWriteAndCloseHeadlessPrompt(t *testing.T) {
 		close(done)
 	}()
 
-	m.writeAndCloseHeadlessPrompt(a, w, "do the thing")
+	if err := m.writeAndCloseHeadlessPrompt(a, w, "do the thing"); err != nil {
+		t.Fatalf("writeAndCloseHeadlessPrompt: %v", err)
+	}
 
 	select {
 	case <-done:
@@ -3538,7 +3541,7 @@ case " $* " in
   *) prompt=$(cat); echo "{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"s-1\",\"total_cost_usd\":0.01,\"result\":\"$prompt\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}" ;;
 esac
 `
-	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(script), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, providerid.Claude), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -3530,6 +3530,31 @@ func TestHeadlessNonSteerablePipeWritesPromptOverStdin(t *testing.T) {
 	}
 }
 
+func TestHeadlessPromptUndeliveredFallsBackToOneShotStdin(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/bash
+case " $* " in
+  *" --input-format stream-json "*) sleep 1 ;;
+  *) prompt=$(cat); echo "{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"s-1\",\"total_cost_usd\":0.01,\"result\":\"$prompt\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}" ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "a1", TaskID: "task-1", Mode: "headless", Provider: "claude", State: StateRunning}
+	a.convo.writeTimeout = 10 * time.Millisecond
+	prompt := strings.Repeat("x", 1<<20)
+	var outFile *os.File
+	if _, err := m.runHeadlessAttempt(context.Background(), a, RunConfig{Prompt: prompt, HeadlessSteerable: true}, &outFile, new(int64)); err != nil {
+		t.Fatalf("runHeadlessAttempt: %v", err)
+	}
+	if a.GetExitErr() != nil {
+		t.Fatalf("fallback exit error: %v", a.GetExitErr())
+	}
+}
+
 // A checkpoint handoff commits the run's work and sets escalation reason
 // "checkpoint"; internal/sybra/completion routes RescheduleCheckpointedAgent
 // off that exact value. The terminal result event lands after the checkpoint

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1895,7 +1895,7 @@ func (r *Handler) dropTerminalWorktreeFailure(taskID string, wtErr error) bool {
 		escalation := task.MachineFailure("git.task_branch_missing", reason)
 		outcome := task.QuarantinedOutcome()
 		if errors.Is(wtErr, worktree.ErrLocalWorkPreserved) {
-			reason = fmt.Sprintf("local worktree state was preserved; resolve or abort the in-progress git operation before retrying (%s)", wtErr)
+			reason = fmt.Sprintf("local worktree state was preserved; inspect and resolve local changes or an in-progress git operation before retrying (%s)", wtErr)
 			toStatus = task.StatusHumanRequired
 			escalation = task.OperatorDecisionRequired("git.worktree_local_state_preserved", reason)
 			outcome = task.HumanRequiredOutcome()

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -1861,7 +1861,7 @@ func worktreeFailureTerminal(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, worktree.ErrTaskBranchMissing) {
+	if errors.Is(err, worktree.ErrTaskBranchMissing) || errors.Is(err, worktree.ErrLocalWorkPreserved) {
 		return true
 	}
 	return strings.Contains(err.Error(), "invalid reference")
@@ -1891,14 +1891,23 @@ func (r *Handler) dropTerminalWorktreeFailure(taskID string, wtErr error) bool {
 	r.clearWorktreeFailure(taskID)
 	if got.Status != task.StatusHumanRequired && got.Status != task.StatusBlocked {
 		reason := fmt.Sprintf("branch deleted: fix worktree cannot be created (%s)", wtErr)
+		toStatus := task.StatusBlocked
+		escalation := task.MachineFailure("git.task_branch_missing", reason)
+		outcome := task.QuarantinedOutcome()
+		if errors.Is(wtErr, worktree.ErrLocalWorkPreserved) {
+			reason = fmt.Sprintf("local worktree state was preserved; resolve or abort the in-progress git operation before retrying (%s)", wtErr)
+			toStatus = task.StatusHumanRequired
+			escalation = task.OperatorDecisionRequired("git.worktree_local_state_preserved", reason)
+			outcome = task.HumanRequiredOutcome()
+		}
 		if _, uerr := r.tasks.Apply(task.TransitionIntent{
 			TaskID:   taskID,
-			ToStatus: task.StatusBlocked,
+			ToStatus: toStatus,
 			Actor:    "review.pr-monitor.worktree.terminal-escalate",
 			Extra: task.Update{
 				StatusReason:    task.Ptr(reason),
-				Escalation:      task.MachineFailure("git.task_branch_missing", reason),
-				AutonomyOutcome: task.QuarantinedOutcome(),
+				Escalation:      escalation,
+				AutonomyOutcome: outcome,
 			},
 		}); uerr != nil {
 			r.logger.Error("pr-monitor.worktree.terminal-escalate", "task_id", taskID, "err", uerr)

--- a/internal/sybra/review/worktree_drop_test.go
+++ b/internal/sybra/review/worktree_drop_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -16,8 +17,16 @@ func TestDropTerminalWorktreeFailure(t *testing.T) {
 		deleteTask   bool
 		wantTerminal bool
 		wantHumanReq bool
+		wantStatus   task.Status
 		wantSkipNext bool
 	}{
+		{
+			name:         "preserved local work is terminal with recovery guidance",
+			wtErr:        fmt.Errorf("prepare fix worktree: %w", worktree.ErrLocalWorkPreserved),
+			wantTerminal: true,
+			wantHumanReq: true,
+			wantStatus:   task.StatusHumanRequired,
+		},
 		{
 			name:         "missing task branch is terminal and escalates",
 			wtErr:        worktree.ErrTaskBranchMissing,
@@ -73,8 +82,12 @@ func TestDropTerminalWorktreeFailure(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if got.Status != task.StatusBlocked {
-					t.Fatalf("status = %q, want blocked", got.Status)
+				wantStatus := tt.wantStatus
+				if wantStatus == "" {
+					wantStatus = task.StatusBlocked
+				}
+				if got.Status != wantStatus {
+					t.Fatalf("status = %q, want %q", got.Status, wantStatus)
 				}
 				if n := r.wtFailures[tk.ID]; n != 0 {
 					t.Fatalf("wtFailures = %d, want 0 for a terminal failure", n)

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -430,16 +430,16 @@ func (m *Manager) RepairAll(ctx context.Context) {
 func (m *Manager) refuseRecreateWithLocalWork(ctx context.Context, taskID, wtPath, reason string) error {
 	if project.HasUnpushedCommits(ctx, wtPath) {
 		m.logger.Error("worktree.recreate.unpushed-commits", "task_id", taskID, "path", wtPath, "reason", reason)
-		return fmt.Errorf("refusing to recreate %s worktree %s: it holds commits that never reached a remote", reason, wtPath)
+		return fmt.Errorf("%w: refusing to recreate %s worktree %s: it holds commits that never reached a remote", ErrLocalWorkPreserved, reason, wtPath)
 	}
 	dirty, err := project.IsWorktreeDirty(ctx, wtPath)
 	if err != nil {
 		m.logger.Error("worktree.recreate.inspect-local-work", "task_id", taskID, "path", wtPath, "reason", reason, "err", err)
-		return fmt.Errorf("refusing to recreate %s worktree %s: cannot verify that its local state is clean: %w", reason, wtPath, err)
+		return fmt.Errorf("%w: refusing to recreate %s worktree %s: cannot verify that its local state is clean: %w", ErrLocalWorkPreserved, reason, wtPath, err)
 	}
 	if dirty {
 		m.logger.Error("worktree.recreate.uncommitted-work", "task_id", taskID, "path", wtPath, "reason", reason)
-		return fmt.Errorf("refusing to recreate %s worktree %s: it holds uncommitted work", reason, wtPath)
+		return fmt.Errorf("%w: refusing to recreate %s worktree %s: it holds uncommitted work", ErrLocalWorkPreserved, reason, wtPath)
 	}
 	return nil
 }

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -40,6 +40,11 @@ var ErrAgentRunning = worktreeerr.ErrAgentRunning
 // than guess at.
 var ErrTaskBranchMissing = errors.New("task branch does not exist locally or on origin")
 
+// ErrLocalWorkPreserved marks a deliberate refusal to recreate a worktree
+// containing local state. Callers must surface recovery guidance rather than
+// counting it as a transient preparation failure.
+var ErrLocalWorkPreserved = errors.New("local worktree state preserved")
+
 // SyncResult classifies the outcome of a proactive branch sync
 // (Manager.SyncTaskBranch). String values are stable — they are recorded as
 // workflow step output and generic artifacts, so renaming a constant changes


### PR DESCRIPTION
## Motivation

Recovery dispatches must preserve actionable local state and avoid repeating a failed prompt transport.

## Implementation information

Adds a bounded one-shot stdin fallback after a Claude stream-input delivery timeout, including a subprocess regression test. Marks preserved local worktree state as a typed terminal condition, which stops monitor retries and provides recovery guidance without removing local work.

Closes #3230

> Changelog: fix(recovery): classify stalled runs