### PR TITLE
feat(storage): keep records in the database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     # skips and sqlite-only SQL reaches an operator's postgres box unreviewed.
     services:
       postgres:
-        image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+        image: postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317
         env:
           POSTGRES_USER: sybra
           POSTGRES_PASSWORD: sybra

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,18 @@ Rules for a store that moves to the backend:
   DSN's `_txlock=immediate`). A plain read inside a transaction does not
   serialize: postgres loses the other writer's edit silently, sqlite fails with
   `SQLITE_BUSY_SNAPSHOT`.
+- Give the domain an import, and run it before anything seeds. `dbimport.Once`
+  copies the existing files in the first time a database is used and never
+  again; the marker row commits in the *same* transaction as the rows it
+  covers, so an interrupted run leaves neither and the next start retries. A
+  store that swaps implementations without one starts empty and the operator
+  silently loses every existing record — which is exactly what
+  `initLoopAgents` did between #3235 and #3239.
+- Import reads the files and never moves or deletes them. The operator decides
+  when the originals go.
+- Order the read explicitly. A table has no natural order, so a store that
+  reproduces a directory listing needs an `ORDER BY` matching what the file
+  store sorted by, and a test that compares both listings over one fixture.
 - Never edit a migration that has shipped — the runner records a checksum and
   refuses to start on a changed file, because the edit reaches a fresh database
   and silently misses every existing one.

--- a/internal/bgop/import.go
+++ b/internal/bgop/import.go
@@ -15,14 +15,20 @@ const ImportDomain = "bgop"
 // Import copies the persisted background operations into the database once.
 //
 // This domain is one document rather than a directory, so the import reads that one file. It is only read; an interrupted import commits neither the rows nor the marker and the next start retries from it.
-func Import(ctx context.Context, database *db.DB, path string, logger *slog.Logger) error {
-	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
-		ops, err := NewFilePersistence(path).Load()
-		if err != nil {
-			// A document this build cannot parse is not worth failing every start over: these records are progress reporting for operations that have already finished or died with the process that ran them.
-			return 0, nil
+//
+// The imported rows belong to owner: the document was this instance's, and on a shared board another instance must not adopt or delete them.
+func Import(ctx context.Context, database *db.DB, path, owner string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return dbimport.Once(ctx, database, ImportDomain, owner, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		// A document this build cannot parse imports as nothing rather than failing every start: these records are progress reporting for operations that already finished, or died with the process that ran them.
+		ops, loadErr := NewFilePersistence(path).Load()
+		if loadErr != nil {
+			logger.Warn("bgop.import.unreadable", "path", path, "err", loadErr)
+			ops = nil
 		}
-		if err := insertOps(ctx, database, tx, ops); err != nil {
+		if err := insertOps(ctx, database, tx, owner, ops); err != nil {
 			return 0, err
 		}
 		return len(ops), nil

--- a/internal/bgop/import.go
+++ b/internal/bgop/import.go
@@ -1,0 +1,30 @@
+package bgop
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "bgop"
+
+// Import copies the persisted background operations into the database once.
+//
+// This domain is one document rather than a directory, so the import reads that one file. It is only read; an interrupted import commits neither the rows nor the marker and the next start retries from it.
+func Import(ctx context.Context, database *db.DB, path string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		ops, err := NewFilePersistence(path).Load()
+		if err != nil {
+			// A document this build cannot parse is not worth failing every start over: these records are progress reporting for operations that have already finished or died with the process that ran them.
+			return 0, nil
+		}
+		if err := insertOps(ctx, database, tx, ops); err != nil {
+			return 0, err
+		}
+		return len(ops), nil
+	})
+}

--- a/internal/bgop/persistence.go
+++ b/internal/bgop/persistence.go
@@ -1,0 +1,63 @@
+package bgop
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// Persistence is where a tracker's operations survive a restart.
+//
+// Save takes the whole set rather than one record, because that is what the tracker has always written: the set on disk is the set in memory, and an operation dropped for age disappears by not being in the next Save. A store that persisted individual records would need its own eviction path to match.
+//
+// Missing state is not an error. A first start has nothing to load, and reporting that as a failure would put a warning in the log of every fresh install.
+type Persistence interface {
+	Load() ([]Operation, error)
+	Save(ops []Operation) error
+}
+
+// FilePersistence keeps operations in one JSON document.
+type FilePersistence struct {
+	path string
+}
+
+// NewFilePersistence returns the file-backed store, writing to path.
+func NewFilePersistence(path string) *FilePersistence {
+	return &FilePersistence{path: path}
+}
+
+// Path is the document this store writes, for a caller that reports where state lives.
+func (p *FilePersistence) Path() string { return p.path }
+
+// Load reads the persisted set, or nothing when the file has never been written.
+func (p *FilePersistence) Load() ([]Operation, error) {
+	data, err := os.ReadFile(p.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read background operations: %w", err)
+	}
+	var ops []Operation
+	if err := json.Unmarshal(data, &ops); err != nil {
+		return nil, fmt.Errorf("unmarshal background operations: %w", err)
+	}
+	return ops, nil
+}
+
+// Save replaces the persisted set.
+func (p *FilePersistence) Save(ops []Operation) error {
+	data, err := json.MarshalIndent(ops, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal background operations: %w", err)
+	}
+	if err := fsutil.AtomicWrite(p.path, data); err != nil {
+		return fmt.Errorf("write background operations: %w", err)
+	}
+	return nil
+}
+
+var _ Persistence = (*FilePersistence)(nil)

--- a/internal/bgop/sqlstore.go
+++ b/internal/bgop/sqlstore.go
@@ -1,0 +1,100 @@
+package bgop
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// queryTimeout bounds every statement this store runs. The tracker saves from paths that carry no context — an operation finishing, a phase advancing — so a stalled backend would otherwise hold one open with nothing able to cancel it.
+const queryTimeout = 15 * time.Second
+
+// SQLPersistence keeps background operations in the configured database backend.
+//
+// One row per operation, with the fields a human scans in an operator query lifted into columns beside the document. Save replaces the whole set in one transaction, so a reader never sees a half-written board.
+type SQLPersistence struct {
+	db *db.DB
+}
+
+// NewSQLPersistence returns the database-backed store.
+func NewSQLPersistence(database *db.DB) (*SQLPersistence, error) {
+	if database == nil {
+		return nil, errors.New("background operation store needs an open database")
+	}
+	return &SQLPersistence{db: database}, nil
+}
+
+const (
+	selectBgops = `SELECT doc FROM background_operations ORDER BY started_at, id`
+
+	upsertBgop = `INSERT INTO background_operations (id, kind, status, started_at, doc)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (id) DO UPDATE SET
+			kind = excluded.kind, status = excluded.status,
+			started_at = excluded.started_at, doc = excluded.doc`
+
+	deleteAllBgops = `DELETE FROM background_operations`
+)
+
+// Load returns the persisted operations, oldest first.
+func (p *SQLPersistence) Load() ([]Operation, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	rows, err := p.db.QueryContext(ctx, selectBgops)
+	if err != nil {
+		return nil, fmt.Errorf("list background operations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ops []Operation
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return nil, fmt.Errorf("scan background operation: %w", err)
+		}
+		var op Operation
+		if err := json.Unmarshal([]byte(doc), &op); err != nil {
+			continue
+		}
+		ops = append(ops, op)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate background operations: %w", err)
+	}
+	return ops, nil
+}
+
+// Save replaces the persisted set with ops.
+//
+// The tracker hands over its whole set, and an operation it dropped for age is gone precisely by being absent here, so the old rows go first rather than being diffed against the new ones.
+func (p *SQLPersistence) Save(ops []Operation) error {
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	return p.db.InTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteAllBgops)); err != nil {
+			return fmt.Errorf("clear background operations: %w", err)
+		}
+		return insertOps(ctx, p.db, tx, ops)
+	})
+}
+
+func insertOps(ctx context.Context, database *db.DB, tx *sql.Tx, ops []Operation) error {
+	for i := range ops {
+		doc, err := json.Marshal(ops[i])
+		if err != nil {
+			return fmt.Errorf("marshal background operation: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, database.Rebind(upsertBgop),
+			ops[i].ID, string(ops[i].Type), string(ops[i].Status),
+			db.TimeValue(ops[i].StartedAt), string(doc)); err != nil {
+			return fmt.Errorf("write background operation: %w", err)
+		}
+	}
+	return nil
+}
+
+var _ Persistence = (*SQLPersistence)(nil)

--- a/internal/bgop/sqlstore.go
+++ b/internal/bgop/sqlstore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/db"
@@ -16,36 +17,43 @@ const queryTimeout = 15 * time.Second
 
 // SQLPersistence keeps background operations in the configured database backend.
 //
-// One row per operation, with the fields a human scans in an operator query lifted into columns beside the document. Save replaces the whole set in one transaction, so a reader never sees a half-written board.
+// One row per operation, with the fields a human scans in an operator query lifted into columns beside the document.
+//
+// Rows are scoped to an owner, and an instance reads and replaces only its own. A postgres board is shared by several machines by design, and each tracker hands over its whole set on every change — so without the scope, one machine starting an operation would delete every operation the others were running. It also matches what the file backend did, where each machine kept its own document.
 type SQLPersistence struct {
-	db *db.DB
+	db    *db.DB
+	owner string
 }
 
-// NewSQLPersistence returns the database-backed store.
-func NewSQLPersistence(database *db.DB) (*SQLPersistence, error) {
+// NewSQLPersistence returns the database-backed store for one instance.
+//
+// owner must be stable across restarts for a given instance, or that instance abandons its own rows on every start and never restores them. It must differ between instances sharing a board.
+func NewSQLPersistence(database *db.DB, owner string) (*SQLPersistence, error) {
 	if database == nil {
 		return nil, errors.New("background operation store needs an open database")
 	}
-	return &SQLPersistence{db: database}, nil
+	if strings.TrimSpace(owner) == "" {
+		return nil, errors.New("background operation store needs an owner")
+	}
+	return &SQLPersistence{db: database, owner: owner}, nil
 }
 
 const (
-	selectBgops = `SELECT doc FROM background_operations ORDER BY started_at, id`
-
-	upsertBgop = `INSERT INTO background_operations (id, kind, status, started_at, doc)
-		VALUES (?, ?, ?, ?, ?)
+	upsertBgop = `INSERT INTO background_operations (id, owner, kind, status, started_at, doc)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT (id) DO UPDATE SET
-			kind = excluded.kind, status = excluded.status,
+			owner = excluded.owner, kind = excluded.kind, status = excluded.status,
 			started_at = excluded.started_at, doc = excluded.doc`
 
-	deleteAllBgops = `DELETE FROM background_operations`
+	deleteOwnedBgops = `DELETE FROM background_operations WHERE owner = ?`
 )
 
 // Load returns the persisted operations, oldest first.
 func (p *SQLPersistence) Load() ([]Operation, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
-	rows, err := p.db.QueryContext(ctx, selectBgops)
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT doc FROM background_operations WHERE owner = ? ORDER BY started_at, `+p.db.OrderText("id"), p.owner)
 	if err != nil {
 		return nil, fmt.Errorf("list background operations: %w", err)
 	}
@@ -75,21 +83,21 @@ func (p *SQLPersistence) Save(ops []Operation) error {
 	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
 	return p.db.InTx(ctx, func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteAllBgops)); err != nil {
+		if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteOwnedBgops), p.owner); err != nil {
 			return fmt.Errorf("clear background operations: %w", err)
 		}
-		return insertOps(ctx, p.db, tx, ops)
+		return insertOps(ctx, p.db, tx, p.owner, ops)
 	})
 }
 
-func insertOps(ctx context.Context, database *db.DB, tx *sql.Tx, ops []Operation) error {
+func insertOps(ctx context.Context, database *db.DB, tx *sql.Tx, owner string, ops []Operation) error {
 	for i := range ops {
 		doc, err := json.Marshal(ops[i])
 		if err != nil {
 			return fmt.Errorf("marshal background operation: %w", err)
 		}
 		if _, err := tx.ExecContext(ctx, database.Rebind(upsertBgop),
-			ops[i].ID, string(ops[i].Type), string(ops[i].Status),
+			ops[i].ID, owner, string(ops[i].Type), string(ops[i].Status),
 			db.TimeValue(ops[i].StartedAt), string(doc)); err != nil {
 			return fmt.Errorf("write background operation: %w", err)
 		}

--- a/internal/bgop/sqlstore_test.go
+++ b/internal/bgop/sqlstore_test.go
@@ -24,7 +24,8 @@ func opsFixture() []Operation {
 // is gone by being absent rather than by an explicit delete.
 func TestSQLPersistence_SaveReplacesTheSet(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
-		store, err := NewSQLPersistence(d)
+		t.Helper()
+		store, err := NewSQLPersistence(d, "instance-a")
 		if err != nil {
 			t.Fatalf("NewSQLPersistence: %v", err)
 		}
@@ -54,8 +55,8 @@ func TestSQLPersistence_SaveReplacesTheSet(t *testing.T) {
 
 func ids(ops []Operation) []string {
 	out := make([]string, 0, len(ops))
-	for _, op := range ops {
-		out = append(out, op.ID)
+	for i := range ops {
+		out = append(out, ops[i].ID)
 	}
 	return out
 }
@@ -64,6 +65,7 @@ func ids(ops []Operation) []string {
 // document this domain keeps.
 func TestImport_IsOnceOnlyAndLeavesTheFile(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		path := filepath.Join(t.TempDir(), "bgops.json")
 		data, err := json.MarshalIndent(opsFixture(), "", "  ")
 		if err != nil {
@@ -74,11 +76,11 @@ func TestImport_IsOnceOnlyAndLeavesTheFile(t *testing.T) {
 		}
 
 		for range 2 {
-			if err := Import(t.Context(), d, path, nil); err != nil {
+			if err := Import(t.Context(), d, path, "instance-a", nil); err != nil {
 				t.Fatalf("import: %v", err)
 			}
 		}
-		store, err := NewSQLPersistence(d)
+		store, err := NewSQLPersistence(d, "instance-a")
 		if err != nil {
 			t.Fatalf("NewSQLPersistence: %v", err)
 		}
@@ -97,10 +99,11 @@ func TestImport_IsOnceOnlyAndLeavesTheFile(t *testing.T) {
 
 func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
-		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written.json"), nil); err != nil {
+		t.Helper()
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written.json"), "instance-a", nil); err != nil {
 			t.Fatalf("import: %v", err)
 		}
-		store, err := NewSQLPersistence(d)
+		store, err := NewSQLPersistence(d, "instance-a")
 		if err != nil {
 			t.Fatalf("NewSQLPersistence: %v", err)
 		}
@@ -110,6 +113,59 @@ func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
 		}
 		if len(got) != 0 {
 			t.Fatalf("got %d operations from an empty domain", len(got))
+		}
+	})
+}
+
+// TestSQLPersistence_InstancesDoNotClobberEachOther is the shared-board case a
+// postgres backend exists for.
+//
+// Each tracker hands over its whole set on every change, so a store that
+// replaced every row would make one machine's next Start delete every
+// operation the other machines were running — and the operator would watch
+// their progress panel empty itself for no visible reason.
+func TestSQLPersistence_InstancesDoNotClobberEachOther(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		storeA, err := NewSQLPersistence(d, "instance-a")
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		storeB, err := NewSQLPersistence(d, "instance-b")
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		trackerA := NewTracker(func(string, any) {}, storeA, nil)
+		trackerB := NewTracker(func(string, any) {}, storeB, nil)
+
+		trackerA.Start(TypeClone, "machine A clone", "o/r", "task-a")
+		trackerB.Start(TypeClone, "machine B clone", "o/r", "task-b")
+
+		ownedByA, err := storeA.Load()
+		if err != nil {
+			t.Fatalf("load A: %v", err)
+		}
+		if len(ownedByA) != 1 || ownedByA[0].Label != "machine A clone" {
+			t.Fatalf("instance A sees %v, want only its own operation", ids(ownedByA))
+		}
+		ownedByB, err := storeB.Load()
+		if err != nil {
+			t.Fatalf("load B: %v", err)
+		}
+		if len(ownedByB) != 1 || ownedByB[0].Label != "machine B clone" {
+			t.Fatalf("instance B lost its operation to the other instance: %v", ids(ownedByB))
+		}
+	})
+}
+
+// TestNewSQLPersistence_RefusesAnEmptyOwner keeps every instance from sharing
+// one blank scope, which is the clobbering case again with no symptom to
+// notice it by.
+func TestNewSQLPersistence_RefusesAnEmptyOwner(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		if _, err := NewSQLPersistence(d, "  "); err == nil {
+			t.Fatal("accepted a blank owner; every instance would share one scope")
 		}
 	})
 }

--- a/internal/bgop/sqlstore_test.go
+++ b/internal/bgop/sqlstore_test.go
@@ -1,0 +1,115 @@
+package bgop
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func opsFixture() []Operation {
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return []Operation{
+		{ID: "op-a", Type: TypeClone, Status: StatusDone, StartedAt: base, CompletedAt: base.Add(time.Minute), Label: "first"},
+		{ID: "op-b", Type: TypeWorktreePrep, Status: StatusDone, StartedAt: base.Add(time.Hour), CompletedAt: base.Add(time.Hour), Label: "second"},
+	}
+}
+
+// TestSQLPersistence_SaveReplacesTheSet pins the semantics the tracker has
+// always had: it hands over its whole set, and an operation it dropped for age
+// is gone by being absent rather than by an explicit delete.
+func TestSQLPersistence_SaveReplacesTheSet(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		if err := store.Save(opsFixture()); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		got, err := store.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(got) != 2 || got[0].ID != "op-a" || got[1].ID != "op-b" {
+			t.Fatalf("load returned %v, want op-a then op-b", ids(got))
+		}
+
+		if err := store.Save(opsFixture()[:1]); err != nil {
+			t.Fatalf("second save: %v", err)
+		}
+		got, err = store.Load()
+		if err != nil {
+			t.Fatalf("second load: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "op-a" {
+			t.Fatalf("dropped operation survived: %v", ids(got))
+		}
+	})
+}
+
+func ids(ops []Operation) []string {
+	out := make([]string, 0, len(ops))
+	for _, op := range ops {
+		out = append(out, op.ID)
+	}
+	return out
+}
+
+// TestImport_IsOnceOnlyAndLeavesTheFile pins the upgrade guarantees for the one
+// document this domain keeps.
+func TestImport_IsOnceOnlyAndLeavesTheFile(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		path := filepath.Join(t.TempDir(), "bgops.json")
+		data, err := json.MarshalIndent(opsFixture(), "", "  ")
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		for range 2 {
+			if err := Import(t.Context(), d, path, nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		got, err := store.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("after two imports got %d operations, want 2: %v", len(got), ids(got))
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("import removed the original document: %v", err)
+		}
+	})
+}
+
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written.json"), nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		got, err := store.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %d operations from an empty domain", len(got))
+		}
+	})
+}

--- a/internal/bgop/tracker.go
+++ b/internal/bgop/tracker.go
@@ -1,16 +1,12 @@
 package bgop
 
 import (
-	"encoding/json"
-	"errors"
 	"log/slog"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/clock"
 	"github.com/Automaat/sybra/internal/events"
-	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/google/uuid"
 )
 
@@ -20,11 +16,11 @@ const completionTTL = 5 * time.Minute
 // Tracker manages in-memory background operations and persists them to disk so
 // the frontend can restore state after an app restart.
 type Tracker struct {
-	mu       sync.RWMutex
-	ops      map[string]*Operation
-	emit     func(string, any)
-	diskPath string
-	logger   *slog.Logger
+	mu     sync.RWMutex
+	ops    map[string]*Operation
+	emit   func(string, any)
+	store  Persistence
+	logger *slog.Logger
 
 	// clock is read without the mutex, including from methods that already
 	// hold it. Set it once at construction time, before the tracker is
@@ -34,16 +30,16 @@ type Tracker struct {
 
 // NewTracker creates a Tracker that broadcasts events via emit and persists to diskPath.
 // A nil logger falls back to slog.Default().
-func NewTracker(emit func(string, any), diskPath string, logger *slog.Logger) *Tracker {
+func NewTracker(emit func(string, any), store Persistence, logger *slog.Logger) *Tracker {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &Tracker{
-		ops:      make(map[string]*Operation),
-		emit:     emit,
-		diskPath: diskPath,
-		logger:   logger,
-		clock:    clock.System{},
+		ops:    make(map[string]*Operation),
+		emit:   emit,
+		store:  store,
+		logger: logger,
+		clock:  clock.System{},
 	}
 }
 
@@ -156,16 +152,12 @@ func (t *Tracker) List() []Operation {
 // survived a restart are marked failed (they cannot be resumed). Ops older
 // than completionTTL are discarded.
 func (t *Tracker) LoadFromDisk() {
-	data, err := os.ReadFile(t.diskPath)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			t.logger.Error("bgop.load.read", "path", t.diskPath, "err", err)
-		}
+	if t.store == nil {
 		return
 	}
-	var ops []Operation
-	if err := json.Unmarshal(data, &ops); err != nil {
-		t.logger.Error("bgop.load.unmarshal", "path", t.diskPath, "err", err)
+	ops, err := t.store.Load()
+	if err != nil {
+		t.logger.Error("bgop.load", "err", err)
 		return
 	}
 	cutoff := t.now().Add(-completionTTL)
@@ -210,12 +202,10 @@ func (t *Tracker) saveToDisk() {
 	}
 	t.mu.Unlock()
 
-	data, err := json.MarshalIndent(ops, "", "  ")
-	if err != nil {
-		t.logger.Error("bgop.save.marshal", "path", t.diskPath, "err", err)
+	if t.store == nil {
 		return
 	}
-	if err := fsutil.AtomicWrite(t.diskPath, data); err != nil {
-		t.logger.Error("bgop.save.write", "path", t.diskPath, "err", err)
+	if err := t.store.Save(ops); err != nil {
+		t.logger.Error("bgop.save", "err", err)
 	}
 }

--- a/internal/bgop/tracker_clock_test.go
+++ b/internal/bgop/tracker_clock_test.go
@@ -13,7 +13,7 @@ import (
 // only be exercised by sleeping past it, so it was not exercised at all.
 func TestListDropsCompletedOpsPastTheTTLWithoutSleeping(t *testing.T) {
 	fake := clock.NewFake(time.Time{})
-	tracker := NewTracker(func(string, any) {}, filepath.Join(t.TempDir(), "ops.json"), nil)
+	tracker := NewTracker(func(string, any) {}, NewFilePersistence(filepath.Join(t.TempDir(), "ops.json")), nil)
 	tracker.SetClock(fake)
 
 	done := tracker.Start(TypeClone, "finished", "owner/repo", "task-1")
@@ -42,7 +42,7 @@ func TestListDropsCompletedOpsPastTheTTLWithoutSleeping(t *testing.T) {
 // A failed op is subject to the same window as a completed one.
 func TestListDropsFailedOpsPastTheTTL(t *testing.T) {
 	fake := clock.NewFake(time.Time{})
-	tracker := NewTracker(func(string, any) {}, filepath.Join(t.TempDir(), "ops.json"), nil)
+	tracker := NewTracker(func(string, any) {}, NewFilePersistence(filepath.Join(t.TempDir(), "ops.json")), nil)
 	tracker.SetClock(fake)
 
 	id := tracker.Start(TypeClone, "doomed", "owner/repo", "task-1")
@@ -58,7 +58,7 @@ func TestListDropsFailedOpsPastTheTTL(t *testing.T) {
 }
 
 func TestTrackerDefaultsToTheSystemClock(t *testing.T) {
-	tracker := NewTracker(func(string, any) {}, filepath.Join(t.TempDir(), "ops.json"), nil)
+	tracker := NewTracker(func(string, any) {}, NewFilePersistence(filepath.Join(t.TempDir(), "ops.json")), nil)
 	before := time.Now().UTC()
 	id := tracker.Start(TypeClone, "now", "owner/repo", "task-1")
 	after := time.Now().UTC()

--- a/internal/bgop/tracker_test.go
+++ b/internal/bgop/tracker_test.go
@@ -13,8 +13,16 @@ import (
 
 func newTestTracker(t *testing.T) *Tracker {
 	t.Helper()
+	tr, _ := newTestTrackerAt(t)
+	return tr
+}
+
+// newTestTrackerAt returns a tracker and the document it persists to, for the
+// tests that assert on the file itself.
+func newTestTrackerAt(t *testing.T) (*Tracker, string) {
+	t.Helper()
 	diskPath := filepath.Join(t.TempDir(), "bgops.json")
-	return NewTracker(func(string, any) {}, diskPath, nil)
+	return NewTracker(func(string, any) {}, NewFilePersistence(diskPath), nil), diskPath
 }
 
 func TestTracker_StartCompleteFail(t *testing.T) {
@@ -132,17 +140,17 @@ func TestTracker_List_KeepsRunningRegardlessOfAge(t *testing.T) {
 }
 
 func TestTracker_SaveAndLoadFromDisk_RoundTrip(t *testing.T) {
-	tr := newTestTracker(t)
+	tr, trPath := newTestTrackerAt(t)
 
 	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
 	tr.Complete(id)
 
-	if _, err := os.Stat(tr.diskPath); err != nil {
-		t.Fatalf("expected persisted file at %s: %v", tr.diskPath, err)
+	if _, err := os.Stat(trPath); err != nil {
+		t.Fatalf("expected persisted file at %s: %v", trPath, err)
 	}
 
 	// Fresh tracker sharing the same disk path should restore the op.
-	tr2 := NewTracker(func(string, any) {}, tr.diskPath, nil)
+	tr2 := NewTracker(func(string, any) {}, NewFilePersistence(trPath), nil)
 	tr2.LoadFromDisk()
 
 	ops := tr2.List()
@@ -179,7 +187,7 @@ func TestTracker_LoadFromDisk_MarksRunningOpsFailed(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	tr := NewTracker(func(string, any) {}, diskPath, nil)
+	tr := NewTracker(func(string, any) {}, NewFilePersistence(diskPath), nil)
 	tr.LoadFromDisk()
 
 	loaded := tr.List()
@@ -241,7 +249,7 @@ func TestTracker_LoadFromDisk_DiscardsExpiredCompletions(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	tr := NewTracker(func(string, any) {}, diskPath, nil)
+	tr := NewTracker(func(string, any) {}, NewFilePersistence(diskPath), nil)
 	tr.LoadFromDisk()
 
 	loaded := tr.List()
@@ -266,7 +274,7 @@ func TestTracker_LoadFromDisk_DiscardsExpiredCompletions(t *testing.T) {
 }
 
 func TestTracker_SaveToDisk_DropsTransientState(t *testing.T) {
-	tr := newTestTracker(t)
+	tr, trPath := newTestTrackerAt(t)
 
 	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
 	tr.UpdatePhase(id, "fetching")
@@ -286,7 +294,7 @@ func TestTracker_SaveToDisk_DropsTransientState(t *testing.T) {
 	tr.UpdatePhase(doneID, "phase should not persist")
 	tr.Complete(doneID)
 
-	data, err := os.ReadFile(tr.diskPath)
+	data, err := os.ReadFile(trPath)
 	if err != nil {
 		t.Fatalf("read persisted file: %v", err)
 	}
@@ -313,7 +321,7 @@ func TestTracker_LoadFromDisk_MissingFile_NoErrorLogged(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
-	tr := NewTracker(func(string, any) {}, diskPath, logger)
+	tr := NewTracker(func(string, any) {}, NewFilePersistence(diskPath), logger)
 	tr.LoadFromDisk()
 
 	if ops := tr.List(); len(ops) != 0 {
@@ -332,7 +340,7 @@ func TestTracker_LoadFromDisk_CorruptedJSON_LogsAndKeepsRunning(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
-	tr := NewTracker(func(string, any) {}, diskPath, logger)
+	tr := NewTracker(func(string, any) {}, NewFilePersistence(diskPath), logger)
 
 	// Should not panic on corrupted data.
 	tr.LoadFromDisk()
@@ -358,7 +366,7 @@ func TestTracker_SaveToDisk_WriteFailureIsLogged(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
-	tr := NewTracker(func(string, any) {}, diskPath, logger)
+	tr := NewTracker(func(string, any) {}, NewFilePersistence(diskPath), logger)
 	tr.Start(TypeClone, "cloning", "proj1", "task1")
 
 	if logBuf.Len() == 0 {

--- a/internal/bgop/tracker_test.go
+++ b/internal/bgop/tracker_test.go
@@ -19,10 +19,10 @@ func newTestTracker(t *testing.T) *Tracker {
 
 // newTestTrackerAt returns a tracker and the document it persists to, for the
 // tests that assert on the file itself.
-func newTestTrackerAt(t *testing.T) (*Tracker, string) {
+func newTestTrackerAt(t *testing.T) (tracker *Tracker, diskPath string) {
 	t.Helper()
-	diskPath := filepath.Join(t.TempDir(), "bgops.json")
-	return NewTracker(func(string, any) {}, NewFilePersistence(diskPath), nil), diskPath
+	path := filepath.Join(t.TempDir(), "bgops.json")
+	return NewTracker(func(string, any) {}, NewFilePersistence(path), nil), path
 }
 
 func TestTracker_StartCompleteFail(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -446,3 +446,18 @@ func scanKeywordValue(dsn string, i int) (value string, next int) {
 	}
 	return dsn[start:i], i
 }
+
+// OrderText renders an ORDER BY term that sorts by byte value on every engine.
+//
+// Postgres orders text by the server's collation, and the deploy target's
+// en_US.UTF-8 ignores punctuation at the primary level: "pr-review" sorts after
+// "prompt-lab-author" there and before it on sqlite. The file stores these
+// tables replace listed a directory, which is byte order, and the workflow
+// engine breaks priority ties on exactly that order — so without this, which
+// workflow a task dispatches depends on the engine and the server's locale.
+func (d *DB) OrderText(column string) string {
+	if d.dialect == Postgres {
+		return column + ` COLLATE "C"`
+	}
+	return column
+}

--- a/internal/db/migrations/postgres/0002_records.sql
+++ b/internal/db/migrations/postgres/0002_records.sql
@@ -34,8 +34,12 @@ CREATE TABLE IF NOT EXISTS workflow_snapshots (
 --;;
 CREATE TABLE IF NOT EXISTS background_operations (
 	id TEXT PRIMARY KEY,
+	owner TEXT NOT NULL DEFAULT '',
 	kind TEXT NOT NULL DEFAULT '',
 	status TEXT NOT NULL DEFAULT '',
 	started_at BIGINT NOT NULL DEFAULT 0,
 	doc TEXT NOT NULL
 )
+--;;
+CREATE INDEX IF NOT EXISTS background_operations_owner_idx
+	ON background_operations (owner, started_at, id)

--- a/internal/db/migrations/postgres/0002_records.sql
+++ b/internal/db/migrations/postgres/0002_records.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS schema_imports (
+	domain TEXT PRIMARY KEY,
+	imported_at BIGINT NOT NULL,
+	record_count BIGINT NOT NULL DEFAULT 0
+)
+--;;
+CREATE TABLE IF NOT EXISTS experience_records (
+	project_key TEXT NOT NULL,
+	record_id TEXT NOT NULL,
+	created_at BIGINT NOT NULL,
+	doc TEXT NOT NULL,
+	PRIMARY KEY (project_key, record_id)
+)
+--;;
+CREATE INDEX IF NOT EXISTS experience_records_query_idx
+	ON experience_records (project_key, created_at DESC, record_id)
+--;;
+CREATE TABLE IF NOT EXISTS workflow_definitions (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL DEFAULT '',
+	builtin SMALLINT NOT NULL DEFAULT 0,
+	created_at BIGINT NOT NULL,
+	updated_at BIGINT NOT NULL,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE TABLE IF NOT EXISTS workflow_snapshots (
+	workflow_id TEXT NOT NULL,
+	hash TEXT NOT NULL,
+	created_at BIGINT NOT NULL,
+	doc TEXT NOT NULL,
+	PRIMARY KEY (workflow_id, hash)
+)
+--;;
+CREATE TABLE IF NOT EXISTS background_operations (
+	id TEXT PRIMARY KEY,
+	kind TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT '',
+	started_at BIGINT NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)

--- a/internal/db/migrations/sqlite/0002_records.sql
+++ b/internal/db/migrations/sqlite/0002_records.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS schema_imports (
+	domain TEXT PRIMARY KEY,
+	imported_at INTEGER NOT NULL,
+	record_count INTEGER NOT NULL DEFAULT 0
+)
+--;;
+CREATE TABLE IF NOT EXISTS experience_records (
+	project_key TEXT NOT NULL,
+	record_id TEXT NOT NULL,
+	created_at INTEGER NOT NULL,
+	doc TEXT NOT NULL,
+	PRIMARY KEY (project_key, record_id)
+)
+--;;
+CREATE INDEX IF NOT EXISTS experience_records_query_idx
+	ON experience_records (project_key, created_at DESC, record_id)
+--;;
+CREATE TABLE IF NOT EXISTS workflow_definitions (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL DEFAULT '',
+	builtin INTEGER NOT NULL DEFAULT 0,
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE TABLE IF NOT EXISTS workflow_snapshots (
+	workflow_id TEXT NOT NULL,
+	hash TEXT NOT NULL,
+	created_at INTEGER NOT NULL,
+	doc TEXT NOT NULL,
+	PRIMARY KEY (workflow_id, hash)
+)
+--;;
+CREATE TABLE IF NOT EXISTS background_operations (
+	id TEXT PRIMARY KEY,
+	kind TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT '',
+	started_at INTEGER NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)

--- a/internal/db/migrations/sqlite/0002_records.sql
+++ b/internal/db/migrations/sqlite/0002_records.sql
@@ -34,8 +34,12 @@ CREATE TABLE IF NOT EXISTS workflow_snapshots (
 --;;
 CREATE TABLE IF NOT EXISTS background_operations (
 	id TEXT PRIMARY KEY,
+	owner TEXT NOT NULL DEFAULT '',
 	kind TEXT NOT NULL DEFAULT '',
 	status TEXT NOT NULL DEFAULT '',
 	started_at INTEGER NOT NULL DEFAULT 0,
 	doc TEXT NOT NULL
 )
+--;;
+CREATE INDEX IF NOT EXISTS background_operations_owner_idx
+	ON background_operations (owner, started_at, id)

--- a/internal/dbimport/dbimport.go
+++ b/internal/dbimport/dbimport.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/db"
@@ -24,26 +25,36 @@ const (
 	insertImport = `INSERT INTO schema_imports (domain, imported_at, record_count) VALUES (?, ?, ?)`
 )
 
-// Once copies a domain's files into the database the first time it is called
-// against a given database, and does nothing on every start after that.
+// Once copies one instance's files for a domain into the database the first
+// time it is called, and does nothing on every start after that.
+//
+// The marker is keyed by domain AND scope, where scope identifies the home the
+// files came from. A postgres board is shared by several machines, each with
+// its own home and its own files: a marker keyed by domain alone would let
+// whichever instance started first claim the domain, and every other machine's
+// records would sit unimported forever with nothing reporting it.
 //
 // fn reports how many records it wrote. The marker row is inserted in the same
 // transaction as those writes, so an interrupted run commits neither and the
 // next start retries from files that were never touched — fn must only read
 // them. A domain whose files are already gone is a legitimate zero.
-func Once(ctx context.Context, database *db.DB, domain string, logger *slog.Logger, fn func(context.Context, *sql.Tx) (int, error)) error {
+func Once(ctx context.Context, database *db.DB, domain, scope string, logger *slog.Logger, fn func(context.Context, *sql.Tx) (int, error)) error {
 	if database == nil {
 		return errors.New("dbimport: needs an open database")
 	}
 	if domain == "" {
 		return errors.New("dbimport: needs a domain name")
 	}
+	if strings.TrimSpace(scope) == "" {
+		return errors.New("dbimport: needs a scope naming whose files these are")
+	}
+	key := domain + "@" + scope
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
 	}
 	return database.InTxLocked(ctx, LockImport, func(tx *sql.Tx) error {
 		var count int64
-		err := tx.QueryRowContext(ctx, database.Rebind(selectImport), domain).Scan(&count)
+		err := tx.QueryRowContext(ctx, database.Rebind(selectImport), key).Scan(&count)
 		switch {
 		case err == nil:
 			return nil
@@ -56,10 +67,10 @@ func Once(ctx context.Context, database *db.DB, domain string, logger *slog.Logg
 			return fmt.Errorf("dbimport %s: %w", domain, err)
 		}
 		if _, err := tx.ExecContext(ctx, database.Rebind(insertImport),
-			domain, db.TimeValue(time.Now().UTC()), int64(written)); err != nil {
+			key, db.TimeValue(time.Now().UTC()), int64(written)); err != nil {
 			return fmt.Errorf("dbimport %s: record marker: %w", domain, err)
 		}
-		logger.Info("db.import.done", "domain", domain, "records", written)
+		logger.Info("db.import.done", "domain", domain, "scope", scope, "records", written)
 		return nil
 	})
 }
@@ -67,12 +78,12 @@ func Once(ctx context.Context, database *db.DB, domain string, logger *slog.Logg
 // Imported reports whether a domain has already been imported. It exists for
 // tests and for callers that need to order work around the import, not as a
 // substitute for the marker Once writes.
-func Imported(ctx context.Context, database *db.DB, domain string) (bool, error) {
+func Imported(ctx context.Context, database *db.DB, domain, scope string) (bool, error) {
 	if database == nil {
 		return false, errors.New("dbimport: needs an open database")
 	}
 	var count int64
-	err := database.QueryRowContext(ctx, selectImport, domain).Scan(&count)
+	err := database.QueryRowContext(ctx, selectImport, domain+"@"+scope).Scan(&count)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}

--- a/internal/dbimport/dbimport.go
+++ b/internal/dbimport/dbimport.go
@@ -1,0 +1,83 @@
+// Package dbimport moves a domain's existing files into the database exactly
+// once, so flipping storage.database.backend does not silently start from an
+// empty board.
+package dbimport
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// LockImport serializes the whole import across processes. Two instances
+// sharing one postgres board both start, both find no marker, and both copy
+// every file in without it.
+const LockImport db.LockKey = 6_215_034_129_003
+
+const (
+	selectImport = `SELECT record_count FROM schema_imports WHERE domain = ?`
+	insertImport = `INSERT INTO schema_imports (domain, imported_at, record_count) VALUES (?, ?, ?)`
+)
+
+// Once copies a domain's files into the database the first time it is called
+// against a given database, and does nothing on every start after that.
+//
+// fn reports how many records it wrote. The marker row is inserted in the same
+// transaction as those writes, so an interrupted run commits neither and the
+// next start retries from files that were never touched — fn must only read
+// them. A domain whose files are already gone is a legitimate zero.
+func Once(ctx context.Context, database *db.DB, domain string, logger *slog.Logger, fn func(context.Context, *sql.Tx) (int, error)) error {
+	if database == nil {
+		return errors.New("dbimport: needs an open database")
+	}
+	if domain == "" {
+		return errors.New("dbimport: needs a domain name")
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return database.InTxLocked(ctx, LockImport, func(tx *sql.Tx) error {
+		var count int64
+		err := tx.QueryRowContext(ctx, database.Rebind(selectImport), domain).Scan(&count)
+		switch {
+		case err == nil:
+			return nil
+		case !errors.Is(err, sql.ErrNoRows):
+			return fmt.Errorf("dbimport %s: read marker: %w", domain, err)
+		}
+
+		written, err := fn(ctx, tx)
+		if err != nil {
+			return fmt.Errorf("dbimport %s: %w", domain, err)
+		}
+		if _, err := tx.ExecContext(ctx, database.Rebind(insertImport),
+			domain, db.TimeValue(time.Now().UTC()), int64(written)); err != nil {
+			return fmt.Errorf("dbimport %s: record marker: %w", domain, err)
+		}
+		logger.Info("db.import.done", "domain", domain, "records", written)
+		return nil
+	})
+}
+
+// Imported reports whether a domain has already been imported. It exists for
+// tests and for callers that need to order work around the import, not as a
+// substitute for the marker Once writes.
+func Imported(ctx context.Context, database *db.DB, domain string) (bool, error) {
+	if database == nil {
+		return false, errors.New("dbimport: needs an open database")
+	}
+	var count int64
+	err := database.QueryRowContext(ctx, selectImport, domain).Scan(&count)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("dbimport %s: read marker: %w", domain, err)
+	}
+	return true, nil
+}

--- a/internal/dbimport/dbimport_test.go
+++ b/internal/dbimport/dbimport_test.go
@@ -14,9 +14,10 @@ import (
 // guarantee every domain's import relies on.
 func TestOnce_RunsExactlyOnce(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		calls := 0
 		for range 3 {
-			if err := Once(t.Context(), d, "demo", nil, func(context.Context, *sql.Tx) (int, error) {
+			if err := Once(t.Context(), d, "demo", "home-a", nil, func(context.Context, *sql.Tx) (int, error) {
 				calls++
 				return 7, nil
 			}); err != nil {
@@ -36,9 +37,10 @@ func TestOnce_RunsExactlyOnce(t *testing.T) {
 // no rows (or the retry duplicates everything it already wrote).
 func TestOnce_InterruptedImportRetriesCleanly(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		ctx := t.Context()
 		boom := errors.New("interrupted")
-		err := Once(ctx, d, "demo", nil, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		err := Once(ctx, d, "demo", "home-a", nil, func(ctx context.Context, tx *sql.Tx) (int, error) {
 			if _, err := tx.ExecContext(ctx, d.Rebind(
 				`INSERT INTO experience_records (project_key, record_id, created_at, doc) VALUES (?, ?, ?, ?)`),
 				"proj", "half-written", int64(0), "{}"); err != nil {
@@ -50,7 +52,7 @@ func TestOnce_InterruptedImportRetriesCleanly(t *testing.T) {
 			t.Fatalf("interrupted import returned %v, want the body's error", err)
 		}
 
-		done, err := Imported(ctx, d, "demo")
+		done, err := Imported(ctx, d, "demo", "home-a")
 		if err != nil {
 			t.Fatalf("imported: %v", err)
 		}
@@ -68,7 +70,7 @@ func TestOnce_InterruptedImportRetriesCleanly(t *testing.T) {
 		}
 
 		calls := 0
-		if err := Once(ctx, d, "demo", nil, func(context.Context, *sql.Tx) (int, error) {
+		if err := Once(ctx, d, "demo", "home-a", nil, func(context.Context, *sql.Tx) (int, error) {
 			calls++
 			return 1, nil
 		}); err != nil {
@@ -84,10 +86,11 @@ func TestOnce_InterruptedImportRetriesCleanly(t *testing.T) {
 // another's — every domain imports on its own schedule.
 func TestOnce_DomainsAreIndependent(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		ran := map[string]int{}
 		for _, domain := range []string{"alpha", "beta"} {
 			for range 2 {
-				if err := Once(t.Context(), d, domain, nil, func(context.Context, *sql.Tx) (int, error) {
+				if err := Once(t.Context(), d, domain, "home-a", nil, func(context.Context, *sql.Tx) (int, error) {
 					ran[domain]++
 					return 0, nil
 				}); err != nil {
@@ -97,6 +100,43 @@ func TestOnce_DomainsAreIndependent(t *testing.T) {
 		}
 		if ran["alpha"] != 1 || ran["beta"] != 1 {
 			t.Fatalf("ran %v, want each domain exactly once", ran)
+		}
+	})
+}
+
+// TestOnce_ScopesAreIndependent is the shared-board case.
+//
+// A postgres board is shared by several machines, each with its own home and
+// its own files. Keyed by domain alone, whichever instance started first would
+// claim the domain and every other machine's records would sit unimported
+// forever, with nothing reporting it.
+func TestOnce_ScopesAreIndependent(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		ran := map[string]int{}
+		for _, scope := range []string{"home-a", "home-b"} {
+			for range 2 {
+				if err := Once(t.Context(), d, "demo", scope, nil, func(context.Context, *sql.Tx) (int, error) {
+					ran[scope]++
+					return 0, nil
+				}); err != nil {
+					t.Fatalf("once %s: %v", scope, err)
+				}
+			}
+		}
+		if ran["home-a"] != 1 || ran["home-b"] != 1 {
+			t.Fatalf("ran %v, want each home imported exactly once", ran)
+		}
+	})
+}
+
+func TestOnce_RefusesAnEmptyScope(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		if err := Once(t.Context(), d, "demo", "  ", nil, func(context.Context, *sql.Tx) (int, error) {
+			return 0, nil
+		}); err == nil {
+			t.Fatal("accepted a blank scope; every home would share one marker")
 		}
 	})
 }

--- a/internal/dbimport/dbimport_test.go
+++ b/internal/dbimport/dbimport_test.go
@@ -1,0 +1,102 @@
+package dbimport
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+// TestOnce_RunsExactlyOnce is the "second start does not duplicate them"
+// guarantee every domain's import relies on.
+func TestOnce_RunsExactlyOnce(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		calls := 0
+		for range 3 {
+			if err := Once(t.Context(), d, "demo", nil, func(context.Context, *sql.Tx) (int, error) {
+				calls++
+				return 7, nil
+			}); err != nil {
+				t.Fatalf("once: %v", err)
+			}
+		}
+		if calls != 1 {
+			t.Fatalf("import body ran %d times, want 1", calls)
+		}
+	})
+}
+
+// TestOnce_InterruptedImportRetriesCleanly is the issue's hardest guarantee.
+//
+// The marker is written in the same transaction as the rows, so a body that
+// fails halfway must leave neither: no marker (or the domain never retries) and
+// no rows (or the retry duplicates everything it already wrote).
+func TestOnce_InterruptedImportRetriesCleanly(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		ctx := t.Context()
+		boom := errors.New("interrupted")
+		err := Once(ctx, d, "demo", nil, func(ctx context.Context, tx *sql.Tx) (int, error) {
+			if _, err := tx.ExecContext(ctx, d.Rebind(
+				`INSERT INTO experience_records (project_key, record_id, created_at, doc) VALUES (?, ?, ?, ?)`),
+				"proj", "half-written", int64(0), "{}"); err != nil {
+				return 0, err
+			}
+			return 0, boom
+		})
+		if !errors.Is(err, boom) {
+			t.Fatalf("interrupted import returned %v, want the body's error", err)
+		}
+
+		done, err := Imported(ctx, d, "demo")
+		if err != nil {
+			t.Fatalf("imported: %v", err)
+		}
+		if done {
+			t.Fatal("an interrupted import left a marker; the domain would never retry")
+		}
+
+		var rows int
+		if err := d.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM experience_records WHERE record_id = ?`, "half-written").Scan(&rows); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if rows != 0 {
+			t.Fatalf("an interrupted import committed %d rows; the retry would duplicate them", rows)
+		}
+
+		calls := 0
+		if err := Once(ctx, d, "demo", nil, func(context.Context, *sql.Tx) (int, error) {
+			calls++
+			return 1, nil
+		}); err != nil {
+			t.Fatalf("retry: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("retry ran the body %d times, want 1", calls)
+		}
+	})
+}
+
+// TestOnce_DomainsAreIndependent keeps one domain's marker from standing in for
+// another's — every domain imports on its own schedule.
+func TestOnce_DomainsAreIndependent(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		ran := map[string]int{}
+		for _, domain := range []string{"alpha", "beta"} {
+			for range 2 {
+				if err := Once(t.Context(), d, domain, nil, func(context.Context, *sql.Tx) (int, error) {
+					ran[domain]++
+					return 0, nil
+				}); err != nil {
+					t.Fatalf("once %s: %v", domain, err)
+				}
+			}
+		}
+		if ran["alpha"] != 1 || ran["beta"] != 1 {
+			t.Fatalf("ran %v, want each domain exactly once", ran)
+		}
+	})
+}

--- a/internal/experience/import.go
+++ b/internal/experience/import.go
@@ -21,8 +21,8 @@ const ImportDomain = "experience"
 // The files are only read. An operator who flips the backend and dislikes the
 // result still has them, and an import interrupted halfway commits nothing, so
 // the next start retries against an untouched directory.
-func Import(ctx context.Context, database *db.DB, dir string, logger *slog.Logger) error {
-	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+func Import(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
 		return importRecords(ctx, database, tx, dir)
 	})
 }

--- a/internal/experience/import.go
+++ b/internal/experience/import.go
@@ -1,0 +1,77 @@
+package experience
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "experience"
+
+// Import copies the per-project record files into the database once.
+//
+// The files are only read. An operator who flips the backend and dislikes the
+// result still has them, and an import interrupted halfway commits nothing, so
+// the next start retries against an untouched directory.
+func Import(ctx context.Context, database *db.DB, dir string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		return importRecords(ctx, database, tx, dir)
+	})
+}
+
+func importRecords(ctx context.Context, database *db.DB, tx *sql.Tx, dir string) (int, error) {
+	projects, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		// Nothing has ever written a record. A fresh install is a legitimate
+		// zero, not a failure to import.
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read experience dir: %w", err)
+	}
+	written := 0
+	for _, entry := range projects {
+		if !entry.IsDir() {
+			continue
+		}
+		projectKey := entry.Name()
+		files, err := os.ReadDir(filepath.Join(dir, projectKey))
+		if err != nil {
+			return 0, fmt.Errorf("read project experience dir: %w", err)
+		}
+		for _, file := range files {
+			if file.IsDir() || filepath.Ext(file.Name()) != ".json" {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, projectKey, file.Name()))
+			if err != nil {
+				return 0, fmt.Errorf("read experience record: %w", err)
+			}
+			var rec Record
+			if err := json.Unmarshal(data, &rec); err != nil {
+				// The file store already skips what it cannot parse, so an
+				// unreadable record is not new breakage and must not stop the
+				// whole import — which would retry and fail again forever.
+				continue
+			}
+			recordID, err := sanitizeRecordID(rec.TaskID)
+			if err != nil {
+				continue
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(upsertExperienceSQLite),
+				projectKey, recordID, db.TimeValue(rec.CreatedAt), string(data)); err != nil {
+				return 0, fmt.Errorf("insert experience record: %w", err)
+			}
+			written++
+		}
+	}
+	return written, nil
+}

--- a/internal/experience/repository.go
+++ b/internal/experience/repository.go
@@ -1,0 +1,15 @@
+package experience
+
+// Repository is the advisory-memory surface triage and planning read through. Two implementations exist: the per-project-directory Store and the database-backed SQLStore, selected by config.Database.Backend.
+//
+// These methods take no context. Records are read while assembling an agent's prompt and written from the review handler's landing path, neither of which carries one, and threading a context through those callers is a change to them rather than to where records are stored. SQLStore bounds each statement with its own deadline instead, so a stalled backend cannot hold a dispatch open indefinitely.
+type Repository interface {
+	Put(projectID string, rec Record) error
+	Query(projectID string, limit int) ([]Record, error)
+	Delete(projectID string) error
+}
+
+var (
+	_ Repository = (*Store)(nil)
+	_ Repository = (*SQLStore)(nil)
+)

--- a/internal/experience/sqlstore.go
+++ b/internal/experience/sqlstore.go
@@ -37,19 +37,7 @@ const (
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT (project_key, record_id) DO UPDATE SET created_at = excluded.created_at, doc = excluded.doc`
 
-	// Ordering matches the file store's: newest first, ties broken by record id
-	// so a re-read returns the same slice rather than whatever the engine
-	// happened to scan.
-	selectExperience = `SELECT doc FROM experience_records
-		WHERE project_key = ? ORDER BY created_at DESC, record_id ASC LIMIT ?`
-
 	deleteExperienceProject = `DELETE FROM experience_records WHERE project_key = ?`
-
-	// selectExperienceOverCap finds the records beyond the per-project cap. The
-	// file store enforces the same ceiling by deleting the oldest files, and a
-	// project that never stops producing records would otherwise grow forever.
-	selectExperienceOverCap = `SELECT record_id FROM experience_records
-		WHERE project_key = ? ORDER BY created_at DESC, record_id ASC LIMIT -1 OFFSET ?`
 
 	deleteExperienceRecord = `DELETE FROM experience_records WHERE project_key = ? AND record_id = ?`
 )
@@ -94,7 +82,7 @@ func (s *SQLStore) Query(projectID string, limit int) ([]Record, error) {
 	}
 	ctx, cancel := s.context()
 	defer cancel()
-	rows, err := s.db.QueryContext(ctx, selectExperience, key, limit)
+	rows, err := s.db.QueryContext(ctx, s.selectSQL(), key, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query experience records: %w", err)
 	}
@@ -176,15 +164,25 @@ func (s *SQLStore) enforceCapTx(ctx context.Context, tx *sql.Tx, projectKey stri
 	return nil
 }
 
-// overCapSQL returns the over-cap query for this dialect. SQLite spells an
-// offset without a limit as "LIMIT -1 OFFSET n"; postgres rejects that and
-// takes a bare OFFSET.
+// selectSQL is the ordered read. Newest first, ties broken by record id in byte
+// order so both engines return what the file store's own sort returned.
+func (s *SQLStore) selectSQL() string {
+	return `SELECT doc FROM experience_records WHERE project_key = ? ORDER BY ` + s.order() + ` LIMIT ?`
+}
+
+// overCapSQL finds the records beyond the per-project cap, which the file store
+// enforces by deleting the oldest files. SQLite spells an offset without a
+// limit as "LIMIT -1 OFFSET n"; postgres rejects that and takes a bare OFFSET.
 func (s *SQLStore) overCapSQL() string {
+	stmt := `SELECT record_id FROM experience_records WHERE project_key = ? ORDER BY ` + s.order()
 	if s.db.Dialect() == db.Postgres {
-		return `SELECT record_id FROM experience_records
-		WHERE project_key = ? ORDER BY created_at DESC, record_id ASC OFFSET ?`
+		return stmt + ` OFFSET ?`
 	}
-	return selectExperienceOverCap
+	return stmt + ` LIMIT -1 OFFSET ?`
+}
+
+func (s *SQLStore) order() string {
+	return `created_at DESC, ` + s.db.OrderText("record_id") + ` ASC`
 }
 
 // queryTimeout bounds every statement this store runs, because Repository carries no context to cancel one with. See Repository.

--- a/internal/experience/sqlstore.go
+++ b/internal/experience/sqlstore.go
@@ -1,0 +1,195 @@
+package experience
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// SQLStore persists advisory records in the configured database backend.
+//
+// The record is stored as the JSON document the file store already wrote, with
+// only the three fields a query needs lifted into columns. These records are
+// advisory context for triage and planning, never a decision gate, so nothing
+// reads an individual field in SQL and a schema per field would buy a
+// migration for every addition to Record.
+type SQLStore struct {
+	db            *db.DB
+	maxPerProject int
+}
+
+// NewSQLStore returns a database-backed advisory memory.
+func NewSQLStore(database *db.DB) (*SQLStore, error) {
+	if database == nil {
+		return nil, errors.New("experience sql store needs an open database")
+	}
+	return &SQLStore{db: database, maxPerProject: defaultMaxPerProject}, nil
+}
+
+const (
+	upsertExperienceSQLite = `INSERT INTO experience_records (project_key, record_id, created_at, doc)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT (project_key, record_id) DO UPDATE SET created_at = excluded.created_at, doc = excluded.doc`
+
+	// Ordering matches the file store's: newest first, ties broken by record id
+	// so a re-read returns the same slice rather than whatever the engine
+	// happened to scan.
+	selectExperience = `SELECT doc FROM experience_records
+		WHERE project_key = ? ORDER BY created_at DESC, record_id ASC LIMIT ?`
+
+	deleteExperienceProject = `DELETE FROM experience_records WHERE project_key = ?`
+
+	// selectExperienceOverCap finds the records beyond the per-project cap. The
+	// file store enforces the same ceiling by deleting the oldest files, and a
+	// project that never stops producing records would otherwise grow forever.
+	selectExperienceOverCap = `SELECT record_id FROM experience_records
+		WHERE project_key = ? ORDER BY created_at DESC, record_id ASC LIMIT -1 OFFSET ?`
+
+	deleteExperienceRecord = `DELETE FROM experience_records WHERE project_key = ? AND record_id = ?`
+)
+
+// Put writes one record and enforces the per-project cap, both in one
+// transaction so a reader never sees the write without the eviction.
+func (s *SQLStore) Put(projectID string, rec Record) error {
+	if s == nil {
+		return nil
+	}
+	key, err := fsutil.ProjectKeyDir(projectID)
+	if err != nil {
+		return err
+	}
+	recordID, err := sanitizeRecordID(rec.TaskID)
+	if err != nil {
+		return err
+	}
+	doc, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal experience record: %w", err)
+	}
+	ctx, cancel := s.context()
+	defer cancel()
+	return s.db.InTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, s.db.Rebind(s.upsertSQL()),
+			key, recordID, db.TimeValue(rec.CreatedAt), string(doc)); err != nil {
+			return fmt.Errorf("write experience record: %w", err)
+		}
+		return s.enforceCapTx(ctx, tx, key)
+	})
+}
+
+// Query returns up to limit records for a project, newest first.
+func (s *SQLStore) Query(projectID string, limit int) ([]Record, error) {
+	if s == nil || limit <= 0 {
+		return nil, nil
+	}
+	key, err := fsutil.ProjectKeyDir(projectID)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := s.context()
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx, selectExperience, key, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query experience records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Record
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return nil, fmt.Errorf("scan experience record: %w", err)
+		}
+		var rec Record
+		if err := json.Unmarshal([]byte(doc), &rec); err != nil {
+			// Matches the file store, which skips a record it cannot parse
+			// rather than failing the query: this is advisory context, and one
+			// unreadable row must not cost an agent all of it.
+			continue
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate experience records: %w", err)
+	}
+	return out, nil
+}
+
+// Delete drops every record for a project.
+func (s *SQLStore) Delete(projectID string) error {
+	if s == nil {
+		return nil
+	}
+	key, err := fsutil.ProjectKeyDir(projectID)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := s.context()
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, deleteExperienceProject, key); err != nil {
+		return fmt.Errorf("delete project experience records: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) upsertSQL() string {
+	// Postgres spells the conflict target the same way; the statement is
+	// shared because both engines accept this form.
+	return upsertExperienceSQLite
+}
+
+func (s *SQLStore) enforceCapTx(ctx context.Context, tx *sql.Tx, projectKey string) error {
+	maxRecords := s.maxPerProject
+	if maxRecords <= 0 {
+		maxRecords = defaultMaxPerProject
+	}
+	rows, err := tx.QueryContext(ctx, s.db.Rebind(s.overCapSQL()), projectKey, maxRecords)
+	if err != nil {
+		return fmt.Errorf("find experience records over cap: %w", err)
+	}
+	var doomed []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan experience record id: %w", err)
+		}
+		doomed = append(doomed, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate experience records over cap: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close experience record scan: %w", err)
+	}
+	for _, id := range doomed {
+		if _, err := tx.ExecContext(ctx, s.db.Rebind(deleteExperienceRecord), projectKey, id); err != nil {
+			return fmt.Errorf("evict experience record: %w", err)
+		}
+	}
+	return nil
+}
+
+// overCapSQL returns the over-cap query for this dialect. SQLite spells an
+// offset without a limit as "LIMIT -1 OFFSET n"; postgres rejects that and
+// takes a bare OFFSET.
+func (s *SQLStore) overCapSQL() string {
+	if s.db.Dialect() == db.Postgres {
+		return `SELECT record_id FROM experience_records
+		WHERE project_key = ? ORDER BY created_at DESC, record_id ASC OFFSET ?`
+	}
+	return selectExperienceOverCap
+}
+
+// queryTimeout bounds every statement this store runs, because Repository carries no context to cancel one with. See Repository.
+const queryTimeout = 15 * time.Second
+
+func (s *SQLStore) context() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), queryTimeout)
+}

--- a/internal/experience/sqlstore_test.go
+++ b/internal/experience/sqlstore_test.go
@@ -18,7 +18,8 @@ func seedRecordFiles(t *testing.T, dir, projectKey string, recs []Record) {
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	for _, rec := range recs {
+	for i := range recs {
+		rec := &recs[i]
 		data, err := json.MarshalIndent(rec, "", "  ")
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
@@ -31,10 +32,16 @@ func seedRecordFiles(t *testing.T, dir, projectKey string, recs []Record) {
 
 func recordsFixture() []Record {
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	// The two tied records are chosen so the tiebreak actually discriminates.
+	// Byte order puts "pr-review" before "prompt-lab" (0x2d < 0x6f); glibc's
+	// en_US.UTF-8 ignores the hyphen and puts "promptlab" first. A pair that
+	// happens to agree under both — "pr-fix" and "prompt-lab" do — makes this
+	// assertion unfalsifiable.
 	return []Record{
-		{TaskID: "task-a", CreatedAt: base, ProjectID: "o/r", Title: "oldest"},
-		{TaskID: "task-c", CreatedAt: base.Add(2 * time.Hour), ProjectID: "o/r", Title: "newest"},
-		{TaskID: "task-b", CreatedAt: base.Add(time.Hour), ProjectID: "o/r", Title: "middle"},
+		{TaskID: "prompt-lab", CreatedAt: base, ProjectID: "o/r", Title: "tied-second"},
+		{TaskID: "pr-review", CreatedAt: base, ProjectID: "o/r", Title: "tied-first"},
+		{TaskID: "branch-conflict", CreatedAt: base.Add(2 * time.Hour), ProjectID: "o/r", Title: "newest"},
+		{TaskID: "pr-fix", CreatedAt: base.Add(time.Hour), ProjectID: "o/r", Title: "middle"},
 	}
 }
 
@@ -44,6 +51,7 @@ func recordsFixture() []Record {
 // production.
 func TestSQLStore_QueryMatchesTheFileStoreOrder(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		dir := t.TempDir()
 		fileStore, err := New(dir)
 		if err != nil {
@@ -83,8 +91,8 @@ func TestSQLStore_QueryMatchesTheFileStoreOrder(t *testing.T) {
 
 func ids(recs []Record) []string {
 	out := make([]string, 0, len(recs))
-	for _, r := range recs {
-		out = append(out, r.TaskID)
+	for i := range recs {
+		out = append(out, recs[i].TaskID)
 	}
 	return out
 }
@@ -94,6 +102,7 @@ func ids(recs []Record) []string {
 // and the originals stay on disk.
 func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		dir := t.TempDir()
 		// The directory name the file store would have written, so the import
 		// reads exactly what an upgrading install has on disk.
@@ -104,7 +113,7 @@ func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
 		seedRecordFiles(t, dir, projectKey, recordsFixture())
 
 		for i := range 2 {
-			if err := Import(t.Context(), d, dir, nil); err != nil {
+			if err := Import(t.Context(), d, dir, "home-a", nil); err != nil {
 				t.Fatalf("import %d: %v", i, err)
 			}
 		}
@@ -117,11 +126,11 @@ func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("query: %v", err)
 		}
-		if len(got) != 3 {
-			t.Fatalf("after two imports got %d records, want 3: %v", len(got), ids(got))
+		if len(got) != len(recordsFixture()) {
+			t.Fatalf("after two imports got %d records, want %d: %v", len(got), len(recordsFixture()), ids(got))
 		}
-		if got[0].TaskID != "task-c" {
-			t.Errorf("newest record is %q, want task-c: %v", got[0].TaskID, ids(got))
+		if got[0].TaskID != "branch-conflict" {
+			t.Errorf("newest record is %q, want branch-conflict: %v", got[0].TaskID, ids(got))
 		}
 		for _, rec := range recordsFixture() {
 			path := filepath.Join(dir, projectKey, rec.TaskID+".json")
@@ -136,7 +145,8 @@ func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
 // records yet returns empty rather than failing".
 func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
-		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), nil); err != nil {
+		t.Helper()
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), "home-a", nil); err != nil {
 			t.Fatalf("import: %v", err)
 		}
 		store, err := NewSQLStore(d)

--- a/internal/experience/sqlstore_test.go
+++ b/internal/experience/sqlstore_test.go
@@ -1,0 +1,154 @@
+package experience
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func seedRecordFiles(t *testing.T, dir, projectKey string, recs []Record) {
+	t.Helper()
+	projectDir := filepath.Join(dir, projectKey)
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, rec := range recs {
+		data, err := json.MarshalIndent(rec, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(projectDir, rec.TaskID+".json"), append(data, '\n'), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+}
+
+func recordsFixture() []Record {
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return []Record{
+		{TaskID: "task-a", CreatedAt: base, ProjectID: "o/r", Title: "oldest"},
+		{TaskID: "task-c", CreatedAt: base.Add(2 * time.Hour), ProjectID: "o/r", Title: "newest"},
+		{TaskID: "task-b", CreatedAt: base.Add(time.Hour), ProjectID: "o/r", Title: "middle"},
+	}
+}
+
+// TestSQLStore_QueryMatchesTheFileStoreOrder is the issue's "same records in
+// the same order" outcome. A table has no natural order, so an omitted ORDER BY
+// reads correct in a unit test and reorders an agent's advisory context in
+// production.
+func TestSQLStore_QueryMatchesTheFileStoreOrder(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		dir := t.TempDir()
+		fileStore, err := New(dir)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		sqlStore, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		for _, rec := range recordsFixture() {
+			if err := fileStore.Put("o/r", rec); err != nil {
+				t.Fatalf("file put: %v", err)
+			}
+			if err := sqlStore.Put("o/r", rec); err != nil {
+				t.Fatalf("sql put: %v", err)
+			}
+		}
+		fromFiles, err := fileStore.Query("o/r", 10)
+		if err != nil {
+			t.Fatalf("file query: %v", err)
+		}
+		fromSQL, err := sqlStore.Query("o/r", 10)
+		if err != nil {
+			t.Fatalf("sql query: %v", err)
+		}
+		if len(fromSQL) != len(fromFiles) {
+			t.Fatalf("sql returned %d records, files returned %d", len(fromSQL), len(fromFiles))
+		}
+		for i := range fromFiles {
+			if fromSQL[i].TaskID != fromFiles[i].TaskID {
+				t.Fatalf("position %d: sql %q, files %q (sql=%v files=%v)",
+					i, fromSQL[i].TaskID, fromFiles[i].TaskID, ids(fromSQL), ids(fromFiles))
+			}
+		}
+	})
+}
+
+func ids(recs []Record) []string {
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.TaskID)
+	}
+	return out
+}
+
+// TestImport_IsOnceOnlyAndLeavesTheFiles pins the three upgrade guarantees the
+// issue asks for: files import once, a second start does not duplicate them,
+// and the originals stay on disk.
+func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		dir := t.TempDir()
+		// The directory name the file store would have written, so the import
+		// reads exactly what an upgrading install has on disk.
+		projectKey, err := fsutil.ProjectKeyDir("o/r")
+		if err != nil {
+			t.Fatalf("ProjectKeyDir: %v", err)
+		}
+		seedRecordFiles(t, dir, projectKey, recordsFixture())
+
+		for i := range 2 {
+			if err := Import(t.Context(), d, dir, nil); err != nil {
+				t.Fatalf("import %d: %v", i, err)
+			}
+		}
+
+		store, storeErr := NewSQLStore(d)
+		if storeErr != nil {
+			t.Fatalf("NewSQLStore: %v", storeErr)
+		}
+		got, err := store.Query("o/r", 100)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("after two imports got %d records, want 3: %v", len(got), ids(got))
+		}
+		if got[0].TaskID != "task-c" {
+			t.Errorf("newest record is %q, want task-c: %v", got[0].TaskID, ids(got))
+		}
+		for _, rec := range recordsFixture() {
+			path := filepath.Join(dir, projectKey, rec.TaskID+".json")
+			if _, err := os.Stat(path); err != nil {
+				t.Errorf("import removed the original %s: %v", path, err)
+			}
+		}
+	})
+}
+
+// TestImport_EmptyDomainReadsBackEmpty is the issue's "reading a domain with no
+// records yet returns empty rather than failing".
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.Query("o/r", 10)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %d records from an empty domain", len(got))
+		}
+	})
+}

--- a/internal/loopagent/import.go
+++ b/internal/loopagent/import.go
@@ -1,0 +1,50 @@
+package loopagent
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "loopagent"
+
+// Import copies the per-file loop agent definitions into the database once.
+//
+// This domain moved to the database before the shared import existed, so an operator who switched backends silently started with no loop agents at all and their schedules simply stopped running. Existing installs pick them up on the first start after this lands.
+func Import(ctx context.Context, database *db.DB, dir string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		store, err := NewStore(dir)
+		if err != nil {
+			return 0, err
+		}
+		agents, err := store.List(ctx)
+		if err != nil {
+			return 0, err
+		}
+		for i := range agents {
+			if err := insertTx(ctx, database, tx, agents[i]); err != nil {
+				return 0, err
+			}
+		}
+		return len(agents), nil
+	})
+}
+
+// insertTx writes one record exactly as it stands.
+//
+// Not Create: that mints a fresh id and fresh timestamps, which is right for a new agent and wrong for an import — the scheduler's run history and the GUI's links both key on the id the file already carried.
+func insertTx(ctx context.Context, database *db.DB, tx *sql.Tx, la LoopAgent) error {
+	tools, err := marshalTools(la.AllowedTools)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, database.Rebind(insertLoopAgent), insertArgs(la, tools)...); err != nil {
+		return fmt.Errorf("insert loop agent: %w", err)
+	}
+	return nil
+}

--- a/internal/loopagent/import.go
+++ b/internal/loopagent/import.go
@@ -16,8 +16,8 @@ const ImportDomain = "loopagent"
 // Import copies the per-file loop agent definitions into the database once.
 //
 // This domain moved to the database before the shared import existed, so an operator who switched backends silently started with no loop agents at all and their schedules simply stopped running. Existing installs pick them up on the first start after this lands.
-func Import(ctx context.Context, database *db.DB, dir string, logger *slog.Logger) error {
-	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+func Import(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
 		store, err := NewStore(dir)
 		if err != nil {
 			return 0, err
@@ -26,13 +26,49 @@ func Import(ctx context.Context, database *db.DB, dir string, logger *slog.Logge
 		if err != nil {
 			return 0, err
 		}
+		taken, err := namesInUse(ctx, database, tx)
+		if err != nil {
+			return 0, err
+		}
+		written := 0
 		for i := range agents {
+			// Reconciled by name, not inserted blind. #3235 swapped the store
+			// while the table was empty, so the first-boot seed re-created
+			// sybra-self-monitor under a fresh id while the operator's file
+			// stayed on disk. A blind import gives that schedule a second row
+			// and the scheduler then runs it twice, at double cost.
+			if _, exists := taken[agents[i].Name]; exists {
+				continue
+			}
 			if err := insertTx(ctx, database, tx, agents[i]); err != nil {
 				return 0, err
 			}
+			taken[agents[i].Name] = struct{}{}
+			written++
 		}
-		return len(agents), nil
+		return written, nil
 	})
+}
+
+// namesInUse reads the names already in the table, inside the import's own transaction so a concurrent create cannot slip between the read and the inserts.
+func namesInUse(ctx context.Context, database *db.DB, tx *sql.Tx) (map[string]struct{}, error) {
+	rows, err := tx.QueryContext(ctx, database.Rebind(`SELECT name FROM loop_agents`))
+	if err != nil {
+		return nil, fmt.Errorf("read loop agent names: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	taken := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan loop agent name: %w", err)
+		}
+		taken[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate loop agent names: %w", err)
+	}
+	return taken, nil
 }
 
 // insertTx writes one record exactly as it stands.
@@ -43,7 +79,11 @@ func insertTx(ctx context.Context, database *db.DB, tx *sql.Tx, la LoopAgent) er
 	if err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, database.Rebind(insertLoopAgent), insertArgs(la, tools)...); err != nil {
+	// DO NOTHING on a duplicate id: two files can carry one id (the store lists
+	// by directory, not by filename), and a failed insert would abort the whole
+	// import — which, because the marker commits with the rows, then fails
+	// identically on every start and never imports anything at all.
+	if _, err := tx.ExecContext(ctx, database.Rebind(insertLoopAgent+` ON CONFLICT (id) DO NOTHING`), insertArgs(la, tools)...); err != nil {
 		return fmt.Errorf("insert loop agent: %w", err)
 	}
 	return nil

--- a/internal/loopagent/import_test.go
+++ b/internal/loopagent/import_test.go
@@ -13,6 +13,7 @@ import (
 // run history and the GUI both key on them.
 func TestImport_KeepsIdsAndRunsOnce(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		ctx := t.Context()
 		dir := t.TempDir()
 		fileStore, err := NewStore(dir)
@@ -25,7 +26,7 @@ func TestImport_KeepsIdsAndRunsOnce(t *testing.T) {
 		}
 
 		for range 2 {
-			if err := Import(ctx, d, dir, nil); err != nil {
+			if err := Import(ctx, d, dir, "home-a", nil); err != nil {
 				t.Fatalf("import: %v", err)
 			}
 		}
@@ -54,7 +55,8 @@ func TestImport_KeepsIdsAndRunsOnce(t *testing.T) {
 
 func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
-		if err := Import(t.Context(), d, t.TempDir(), nil); err != nil {
+		t.Helper()
+		if err := Import(t.Context(), d, t.TempDir(), "home-a", nil); err != nil {
 			t.Fatalf("import: %v", err)
 		}
 		store, err := NewSQLStore(d)

--- a/internal/loopagent/import_test.go
+++ b/internal/loopagent/import_test.go
@@ -1,0 +1,72 @@
+package loopagent
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+// TestImport_KeepsIdsAndRunsOnce is what #3235 left undone: switching backends
+// swapped the store and started from an empty table, so an operator's loop
+// agents silently stopped running. The ids must survive too — the scheduler's
+// run history and the GUI both key on them.
+func TestImport_KeepsIdsAndRunsOnce(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		ctx := t.Context()
+		dir := t.TempDir()
+		fileStore, err := NewStore(dir)
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		created, err := fileStore.Create(ctx, LoopAgent{Name: "nightly", Prompt: "run", IntervalSec: 3600})
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+
+		for range 2 {
+			if err := Import(ctx, d, dir, nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		sqlStore, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := sqlStore.List(ctx)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("after two imports got %d agents, want 1", len(got))
+		}
+		if got[0].ID != created.ID {
+			t.Errorf("import minted a new id %q, want %q", got[0].ID, created.ID)
+		}
+		if got[0].Name != "nightly" {
+			t.Errorf("name = %q, want nightly", got[0].Name)
+		}
+		if _, err := fileStore.Get(ctx, created.ID); err != nil {
+			t.Errorf("import removed the original file: %v", err)
+		}
+	})
+}
+
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		if err := Import(t.Context(), d, t.TempDir(), nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.List(t.Context())
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %d agents from an empty domain", len(got))
+		}
+	})
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -106,7 +106,7 @@ type App struct {
 	attachments       *attachment.Store
 	artifacts         *artifact.Store
 	evidenceStore     *evidence.Store
-	experience        *experience.Store
+	experience        experience.Repository
 	intervention      *intervention.Store
 	cleanupProtected  *cleanup.ProtectedStore
 	learning          *learning.Store
@@ -140,7 +140,7 @@ type App struct {
 	clusterRoster     *cluster.Roster
 	clusterSvc        *ClusterService
 	workflowEngine    *workflow.Engine
-	workflowStore     *workflow.Store
+	workflowStore     workflow.Repository
 	pressureGate      *pressure.Gate
 	diskReclaimer     *diskreclaim.Reclaimer
 	toolLedger        *toolledger.Logger
@@ -582,7 +582,7 @@ func (a *App) Startup(ctx context.Context) error {
 	// startLifecycle and startupRecoveryPending's doc comment).
 	a.startupRecoveryPending.Store(true)
 	a.initStatusHook() //nolint:contextcheck // workflow engine uses its own e.ctx field, see Startup's contextcheck note
-	a.initLocalStores()
+	a.initLocalStores(appCtx)
 	a.cleanupProtected = cleanup.DefaultProtectedStore()
 	a.notifier = notification.New(emit)
 	a.notifier.SetDesktop(a.cfg.Notification.Desktop)

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -559,7 +559,7 @@ func (a *App) Startup(ctx context.Context) error {
 		return err
 	}
 
-	if err := a.initLoopAgents(); err != nil {
+	if err := a.initLoopAgents(appCtx); err != nil {
 		return fmt.Errorf("loop agents: %w", err)
 	}
 	if a.emitFactory != nil {
@@ -568,7 +568,7 @@ func (a *App) Startup(ctx context.Context) error {
 		a.emit = func(string, any) {}
 	}
 	emit := a.taskEventEmitter(store)
-	a.initBgops(emit)
+	a.initBgops(appCtx, emit)
 
 	a.emitDegradedWarnings(emit)
 	a.tasks = task.NewManager(store, task.EmitterFunc(emit))
@@ -615,7 +615,11 @@ func (a *App) Startup(ctx context.Context) error {
 	a.initRunEnvironment()
 	a.initReviewer(emit)
 
-	a.initWorkflowEngine()
+	wfStore, wfErr := a.openWorkflowStore(appCtx)
+	if wfErr != nil {
+		a.logger.Error("workflow.store.init", "err", wfErr)
+	}
+	a.initWorkflowEngine(wfStore)
 
 	a.initCluster()
 

--- a/internal/sybra/app_database_backend_test.go
+++ b/internal/sybra/app_database_backend_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/experience"
+	"github.com/Automaat/sybra/internal/loopagent"
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
@@ -124,5 +125,43 @@ func TestDatabaseBackend_ExperienceUsesTheBackend(t *testing.T) {
 	a.initExperience(t.Context())
 	if _, ok := a.experience.(*experience.SQLStore); !ok {
 		t.Fatalf("advisory memory is %T, want the database-backed store", a.experience)
+	}
+}
+
+// TestDatabaseBackend_FailedLoopAgentImportKeepsTheFiles pins the degrade path.
+//
+// Continuing to an empty table when the import failed drops every schedule the
+// operator has, for the whole uptime, while the definitions sit intact on disk
+// — and the first-boot seed then re-creates the built-in one under a new id.
+// One ERROR line is the only sign.
+func TestDatabaseBackend_FailedLoopAgentImportKeepsTheFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	cfg := testConfig(t)
+	cfg.Database = config.DatabaseConfig{Backend: config.DBBackendSQLite, DSN: filepath.Join(home, "sybra.db")}
+	// A path the import cannot read, which is what a permissions slip or a
+	// stray file in the home produces.
+	cfg.LoopAgentsDir = filepath.Join(home, "loop-agents")
+	if err := os.WriteFile(cfg.LoopAgentsDir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	a := NewApp(discardLogger(), &slog.LevelVar{}, cfg)
+	if err := a.initDatabase(t.Context()); err != nil {
+		t.Fatalf("initDatabase: %v", err)
+	}
+	t.Cleanup(func() {
+		if a.database != nil {
+			_ = a.database.Close()
+		}
+	})
+
+	err := a.initLoopAgents(t.Context())
+	if _, ok := a.loopAgents.(*loopagent.SQLStore); ok {
+		t.Fatal("a failed import still switched to the database; every existing schedule silently stops running")
+	}
+	if err == nil && a.loopAgents == nil {
+		t.Fatal("no store at all after a failed import")
 	}
 }

--- a/internal/sybra/app_database_backend_test.go
+++ b/internal/sybra/app_database_backend_test.go
@@ -1,0 +1,128 @@
+package sybra
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/experience"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+// TestOpenWorkflowStore_UnusableDirYieldsANilRepository pins the typed-nil trap.
+//
+// openWorkflowStore returns an interface. Handing back a nil *Store on the
+// error path makes a NON-nil interface, so every `if store == nil` guard
+// downstream passes it through and the first call — SyncBuiltins' List — panics
+// on the nil receiver, taking startup with it.
+func TestOpenWorkflowStore_UnusableDirYieldsANilRepository(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+	// A regular file where the workflows directory belongs, which is what an
+	// operator's stray file or a read-only home produces.
+	if err := os.WriteFile(filepath.Join(home, "workflows"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	a := NewApp(discardLogger(), &slog.LevelVar{}, testConfig(t))
+	store, err := a.openWorkflowStore(t.Context())
+	if err == nil {
+		t.Fatal("opening a store over a regular file succeeded")
+	}
+	if store != nil {
+		t.Fatalf("returned a non-nil repository (%T) alongside an error; a nil guard cannot see it", store)
+	}
+
+	// The engine must survive being handed that nil rather than panicking.
+	a.initWorkflowEngine(nil)
+}
+
+// TestDatabaseBackend_ImportsThenSeeds runs startup's store wiring against a
+// real sqlite backend, which nothing in this package did before.
+//
+// It covers the ordering the change depends on: the workflow import runs first,
+// so an operator's edited definition survives, and the builtins seed on top
+// rather than being overwritten by an import that arrived late.
+func TestDatabaseBackend_ImportsThenSeeds(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	workflowsDir := filepath.Join(home, "workflows")
+	if err := os.MkdirAll(workflowsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// An operator's own workflow, which no builtin will ever seed over.
+	const custom = "id: operator-only\nname: operator's own\nsteps:\n  - id: s\n    type: set_status\n    config:\n      status: todo\n"
+	if err := os.WriteFile(filepath.Join(workflowsDir, "operator-only.yaml"), []byte(custom), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	cfg := testConfig(t)
+	cfg.Database = config.DatabaseConfig{Backend: config.DBBackendSQLite, DSN: filepath.Join(home, "sybra.db")}
+
+	a := NewApp(discardLogger(), &slog.LevelVar{}, cfg)
+	if err := a.initDatabase(t.Context()); err != nil {
+		t.Fatalf("initDatabase: %v", err)
+	}
+	t.Cleanup(func() {
+		if a.database != nil {
+			_ = a.database.Close()
+		}
+	})
+	if a.database == nil {
+		t.Fatal("sqlite backend configured but no database opened")
+	}
+
+	store, err := a.openWorkflowStore(t.Context())
+	if err != nil {
+		t.Fatalf("openWorkflowStore: %v", err)
+	}
+	if _, ok := store.(*workflow.SQLStore); !ok {
+		t.Fatalf("configured backend gave %T, want the database-backed store", store)
+	}
+	if err := workflow.SyncBuiltins(store); err != nil {
+		t.Fatalf("sync builtins: %v", err)
+	}
+
+	got, err := store.Get("operator-only")
+	if err != nil {
+		t.Fatalf("the operator's own workflow did not survive import + seed: %v", err)
+	}
+	if got.Name != "operator's own" {
+		t.Errorf("workflow name = %q, want the operator's", got.Name)
+	}
+
+	defs, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(defs) < 2 {
+		t.Fatalf("listed %d definitions; the builtins did not seed alongside the imported one", len(defs))
+	}
+}
+
+// TestDatabaseBackend_ExperienceUsesTheBackend pins that the advisory store
+// actually follows the configured backend rather than quietly staying on files.
+func TestDatabaseBackend_ExperienceUsesTheBackend(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	cfg := testConfig(t)
+	cfg.Database = config.DatabaseConfig{Backend: config.DBBackendSQLite, DSN: filepath.Join(home, "sybra.db")}
+
+	a := NewApp(discardLogger(), &slog.LevelVar{}, cfg)
+	if err := a.initDatabase(t.Context()); err != nil {
+		t.Fatalf("initDatabase: %v", err)
+	}
+	t.Cleanup(func() {
+		if a.database != nil {
+			_ = a.database.Close()
+		}
+	})
+	a.initExperience(t.Context())
+	if _, ok := a.experience.(*experience.SQLStore); !ok {
+		t.Fatalf("advisory memory is %T, want the database-backed store", a.experience)
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Automaat/sybra/internal/evidence"
 	"github.com/Automaat/sybra/internal/experience"
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/httpserve"
 	"github.com/Automaat/sybra/internal/intervention"
 	"github.com/Automaat/sybra/internal/learning"
 	"github.com/Automaat/sybra/internal/limits"
@@ -172,8 +173,8 @@ type startupDegradedEvent struct {
 	Reason    string `json:"reason"`
 }
 
-func (a *App) initBgops(emit func(string, any)) {
-	a.bgops = bgop.NewTracker(emit, a.openBgopStore(), a.logger)
+func (a *App) initBgops(ctx context.Context, emit func(string, any)) {
+	a.bgops = bgop.NewTracker(emit, a.openBgopStore(ctx), a.logger)
 	a.bgops.LoadFromDisk()
 }
 
@@ -401,7 +402,7 @@ func (a *App) initAttachments() {
 func (a *App) initExperience(ctx context.Context) {
 	dir := a.cfg.ExperiencesDir()
 	if a.database != nil {
-		if err := experience.Import(ctx, a.database, dir, a.logger); err != nil {
+		if err := experience.Import(ctx, a.database, dir, a.importScope(), a.logger); err != nil {
 			// Degrade to files rather than start on a half-populated table: an
 			// empty advisory memory reads as "this project has no history",
 			// which is a worse answer than the one the files still hold.
@@ -1396,7 +1397,9 @@ func (a *App) initAutomations(ctx context.Context, emit func(string, any)) *poll
 	return a.initIssuesFetcher(emit)
 }
 
-func (a *App) initWorkflowEngine() {
+// initWorkflowEngine wires the engine onto wfStore, which the caller opens: the
+// engine's own contexts outlive startup, so the import's belongs to the caller.
+func (a *App) initWorkflowEngine(wfStore workflow.Repository) {
 	if os.Getenv("SYBRA_DISABLE_WORKFLOWS") == "1" {
 		a.logger.Info("workflow.disabled")
 		return
@@ -1405,10 +1408,7 @@ func (a *App) initWorkflowEngine() {
 	if q != nil && a.agentOrch != nil {
 		a.agentOrch.SetQueue(q)
 	}
-
-	wfStore, err := a.openWorkflowStore()
-	if err != nil {
-		a.logger.Error("workflow.store.init", "err", err)
+	if wfStore == nil {
 		return
 	}
 	a.workflowStore = wfStore
@@ -1422,7 +1422,7 @@ func (a *App) initWorkflowEngine() {
 	if a.sandboxes == nil {
 		panic("wire workflow engine: sandbox manager is nil")
 	}
-	a.workflowEngine, err = workflow.NewEngine(
+	engine, err := workflow.NewEngine(
 		wfStore,
 		&taskAdapter{tasks: a.tasks, projects: a.projects},
 		agentLauncher,
@@ -1432,6 +1432,7 @@ func (a *App) initWorkflowEngine() {
 	if err != nil {
 		panic("wire workflow engine: " + err.Error())
 	}
+	a.workflowEngine = engine
 	a.configureWorkflowPolicies()
 	if a.cfg.Evaluation.Offline.Enabled {
 		gate := prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline)
@@ -1752,11 +1753,11 @@ func (a *App) logAudit(eventType, taskID, agentID string, data map[string]any) {
 // first boot only. It is disabled by default so the user can review the
 // configuration in the GUI before enabling. Idempotent: if a record with
 // the same Name already exists this is a no-op.
-func (a *App) initLoopAgents() error {
+func (a *App) initLoopAgents(ctx context.Context) error {
 	if a.database != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), workflowImportTimeout)
+		ctx, cancel := context.WithTimeout(ctx, importTimeout)
 		defer cancel()
-		if err := loopagent.Import(ctx, a.database, a.cfg.LoopAgentsDir, a.logger); err != nil {
+		if err := loopagent.Import(ctx, a.database, a.cfg.LoopAgentsDir, a.importScope(), a.logger); err != nil {
 			// Not fatal: the schedules already in the database still run, and
 			// the files stay for the next start to retry from.
 			a.logger.Error("loopagent.import", "err", err)
@@ -1965,12 +1966,12 @@ func (a *App) syncSkillsBundle(signing project.SigningPolicy) {
 // openWorkflowStore returns the definition store for the configured backend, importing the existing files the first time a database is used.
 //
 // A failed import falls back to files rather than starting on a half-populated table: an empty workflow set means no task can dispatch at all.
-func (a *App) openWorkflowStore() (workflow.Repository, error) {
+func (a *App) openWorkflowStore(ctx context.Context) (workflow.Repository, error) {
 	dir := config.WorkflowsDir()
 	if a.database != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), workflowImportTimeout)
+		ctx, cancel := context.WithTimeout(ctx, importTimeout)
 		defer cancel()
-		if err := workflow.Import(ctx, a.database, dir, a.logger); err != nil {
+		if err := workflow.Import(ctx, a.database, dir, a.importScope(), a.logger); err != nil {
 			a.logger.Error("workflow.import", "err", err)
 		} else if store, err := workflow.NewSQLStore(a.database); err != nil {
 			a.logger.Error("workflow.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
@@ -1978,27 +1979,49 @@ func (a *App) openWorkflowStore() (workflow.Repository, error) {
 			return store, nil
 		}
 	}
-	return workflow.NewStore(dir)
+	store, err := workflow.NewStore(dir)
+	if err != nil {
+		// Returned as a nil interface, not a nil *Store: a typed nil is a
+		// non-nil interface, so every caller's nil check passes it through and
+		// the first method call panics on the nil receiver.
+		return nil, err
+	}
+	return store, nil
 }
 
-// workflowImportTimeout bounds the one-off copy of workflow files into the database. initWorkflowEngine has no context to pass and a stalled backend must not hold startup open forever.
-const workflowImportTimeout = 2 * time.Minute
+// importTimeout bounds a one-off copy of a domain's files into the database, on top of the startup context it derives from, so a stalled backend cannot hold startup open forever even while nothing has cancelled it.
+const importTimeout = 2 * time.Minute
 
 // openBgopStore returns where background operations survive a restart, importing the existing document the first time a database is used.
 //
 // A failed import degrades to the file: these records drive a progress panel, and losing them costs an operator visibility rather than work.
-func (a *App) openBgopStore() bgop.Persistence {
+func (a *App) openBgopStore(ctx context.Context) bgop.Persistence {
 	path := filepath.Join(config.HomeDir(), "bgops.json")
 	if a.database != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), workflowImportTimeout)
+		ctx, cancel := context.WithTimeout(ctx, importTimeout)
 		defer cancel()
-		if err := bgop.Import(ctx, a.database, path, a.logger); err != nil {
+		// The home this instance serves, digested: stable across its restarts so
+		// it reclaims its own rows, and different from any other instance
+		// sharing the board so it never deletes theirs.
+		owner := a.importScope()
+		if err := bgop.Import(ctx, a.database, path, owner, a.logger); err != nil {
 			a.logger.Error("bgop.import", "err", err)
-		} else if store, err := bgop.NewSQLPersistence(a.database); err != nil {
+		} else if store, err := bgop.NewSQLPersistence(a.database, owner); err != nil {
 			a.logger.Error("bgop.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
 		} else {
 			return store
 		}
 	}
 	return bgop.NewFilePersistence(path)
+}
+
+// importScope identifies whose files an import is copying in.
+//
+// A postgres board is shared by several machines, each with its own home and
+// its own files. Keyed by domain alone, whichever instance started first would
+// claim the domain and every other machine's records would sit unimported
+// forever with nothing reporting it. The digest is stable across this
+// instance's restarts and differs between instances.
+func (a *App) importScope() string {
+	return httpserve.HomeID(config.HomeDir())
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -173,7 +173,7 @@ type startupDegradedEvent struct {
 }
 
 func (a *App) initBgops(emit func(string, any)) {
-	a.bgops = bgop.NewTracker(emit, filepath.Join(config.HomeDir(), "bgops.json"), a.logger)
+	a.bgops = bgop.NewTracker(emit, a.openBgopStore(), a.logger)
 	a.bgops.LoadFromDisk()
 }
 
@@ -374,11 +374,11 @@ func (a *App) initStats() {
 
 // initLocalStores wires the small local-only data stores that degrade to nil
 // on failure rather than blocking startup.
-func (a *App) initLocalStores() {
+func (a *App) initLocalStores(ctx context.Context) {
 	a.initAttachments()
 	a.initArtifacts()
 	a.verification = verification.New(filepath.Join(config.HomeDir(), "verification"), a.artifacts, a.logger)
-	a.initExperience()
+	a.initExperience(ctx)
 	a.initIntervention()
 	a.initLearning()
 	a.initAgentQueue()
@@ -398,8 +398,22 @@ func (a *App) initAttachments() {
 	})
 }
 
-func (a *App) initExperience() {
-	store, err := experience.New(a.cfg.ExperiencesDir())
+func (a *App) initExperience(ctx context.Context) {
+	dir := a.cfg.ExperiencesDir()
+	if a.database != nil {
+		if err := experience.Import(ctx, a.database, dir, a.logger); err != nil {
+			// Degrade to files rather than start on a half-populated table: an
+			// empty advisory memory reads as "this project has no history",
+			// which is a worse answer than the one the files still hold.
+			a.logger.Error("experience.import", "err", err)
+		} else if store, err := experience.NewSQLStore(a.database); err != nil {
+			a.logger.Error("experience.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			a.experience = store
+			return
+		}
+	}
+	store, err := experience.New(dir)
 	if err != nil {
 		a.logger.Warn("experience.init.degraded", "err", err)
 		return
@@ -1392,12 +1406,15 @@ func (a *App) initWorkflowEngine() {
 		a.agentOrch.SetQueue(q)
 	}
 
-	wfStore, err := workflow.NewStore(config.WorkflowsDir())
+	wfStore, err := a.openWorkflowStore()
 	if err != nil {
 		a.logger.Error("workflow.store.init", "err", err)
 		return
 	}
 	a.workflowStore = wfStore
+	// After the import, never before: seeding writes each builtin under its own
+	// id, so an import that followed it would overwrite an operator's edited
+	// copy with the shipped one.
 	if syncErr := workflow.SyncBuiltins(wfStore); syncErr != nil {
 		a.logger.Error("workflow.sync-builtins", "err", syncErr)
 	}
@@ -1737,6 +1754,13 @@ func (a *App) logAudit(eventType, taskID, agentID string, data map[string]any) {
 // the same Name already exists this is a no-op.
 func (a *App) initLoopAgents() error {
 	if a.database != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), workflowImportTimeout)
+		defer cancel()
+		if err := loopagent.Import(ctx, a.database, a.cfg.LoopAgentsDir, a.logger); err != nil {
+			// Not fatal: the schedules already in the database still run, and
+			// the files stay for the next start to retry from.
+			a.logger.Error("loopagent.import", "err", err)
+		}
 		store, err := loopagent.NewSQLStore(a.database)
 		if err != nil {
 			a.logger.Error("loopagent.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
@@ -1936,4 +1960,45 @@ func (a *App) syncSkillsBundle(signing project.SigningPolicy) {
 		UserHomeDir:          userHome,
 		DowngradeCommitFlags: !signing.SignsCommits(context.Background()),
 	})
+}
+
+// openWorkflowStore returns the definition store for the configured backend, importing the existing files the first time a database is used.
+//
+// A failed import falls back to files rather than starting on a half-populated table: an empty workflow set means no task can dispatch at all.
+func (a *App) openWorkflowStore() (workflow.Repository, error) {
+	dir := config.WorkflowsDir()
+	if a.database != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), workflowImportTimeout)
+		defer cancel()
+		if err := workflow.Import(ctx, a.database, dir, a.logger); err != nil {
+			a.logger.Error("workflow.import", "err", err)
+		} else if store, err := workflow.NewSQLStore(a.database); err != nil {
+			a.logger.Error("workflow.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return store, nil
+		}
+	}
+	return workflow.NewStore(dir)
+}
+
+// workflowImportTimeout bounds the one-off copy of workflow files into the database. initWorkflowEngine has no context to pass and a stalled backend must not hold startup open forever.
+const workflowImportTimeout = 2 * time.Minute
+
+// openBgopStore returns where background operations survive a restart, importing the existing document the first time a database is used.
+//
+// A failed import degrades to the file: these records drive a progress panel, and losing them costs an operator visibility rather than work.
+func (a *App) openBgopStore() bgop.Persistence {
+	path := filepath.Join(config.HomeDir(), "bgops.json")
+	if a.database != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), workflowImportTimeout)
+		defer cancel()
+		if err := bgop.Import(ctx, a.database, path, a.logger); err != nil {
+			a.logger.Error("bgop.import", "err", err)
+		} else if store, err := bgop.NewSQLPersistence(a.database); err != nil {
+			a.logger.Error("bgop.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return store
+		}
+	}
+	return bgop.NewFilePersistence(path)
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1755,20 +1755,21 @@ func (a *App) logAudit(eventType, taskID, agentID string, data map[string]any) {
 // the same Name already exists this is a no-op.
 func (a *App) initLoopAgents(ctx context.Context) error {
 	if a.database != nil {
-		ctx, cancel := context.WithTimeout(ctx, importTimeout)
+		importCtx, cancel := context.WithTimeout(ctx, importTimeout)
 		defer cancel()
-		if err := loopagent.Import(ctx, a.database, a.cfg.LoopAgentsDir, a.importScope(), a.logger); err != nil {
-			// Not fatal: the schedules already in the database still run, and
-			// the files stay for the next start to retry from.
+		// Degrade to the files on a failed import, as every other domain does.
+		// Continuing to an empty table drops the operator's schedules for the
+		// whole uptime while their definitions sit intact on disk, and the
+		// first-boot seed then re-creates the built-in one under a new id — all
+		// behind a single log line.
+		if err := loopagent.Import(importCtx, a.database, a.cfg.LoopAgentsDir, a.importScope(), a.logger); err != nil {
 			a.logger.Error("loopagent.import", "err", err)
-		}
-		store, err := loopagent.NewSQLStore(a.database)
-		if err != nil {
+		} else if store, err := loopagent.NewSQLStore(a.database); err != nil {
 			a.logger.Error("loopagent.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
-			return err
+		} else {
+			a.loopAgents = store
+			return nil
 		}
-		a.loopAgents = store
-		return nil
 	}
 	store, err := loopagent.NewStore(a.cfg.LoopAgentsDir)
 	if err != nil {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -1075,7 +1075,7 @@ type agentAdapter struct {
 	tasks        *task.Manager
 	projects     *project.Store
 	sandboxes    *sandbox.Manager
-	experience   *experience.Store
+	experience   experience.Repository
 	pressure     *pressure.Gate
 	runenv       *runenv.Service
 	verification *verification.Manager

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -52,7 +52,7 @@ type Handler struct {
 	// SetSigningPolicy. Empty means "not late-bound", not "auto".
 	signing    atomic.Value
 	abTesting  func() abtest.Config
-	experience *experience.Store
+	experience experience.Repository
 	// intervention captures a genuine human-required unblock through the two
 	// automated exit paths this package owns (reconcileHumanRequiredBlockers,
 	// advanceClosedTaskPR). Late-bound via SetInterventionStore since it is
@@ -309,7 +309,7 @@ func New(
 	worktrees *worktree.Manager,
 	renovatePRsFn func() []github.PullRequest,
 	cfg *config.Config,
-	experienceStore *experience.Store,
+	experienceStore experience.Repository,
 ) *Handler {
 	return &Handler{
 		audit:               al,

--- a/internal/sybra/svc_workflow.go
+++ b/internal/sybra/svc_workflow.go
@@ -9,7 +9,7 @@ import (
 // WorkflowService exposes workflow operations as Wails-bound methods.
 type WorkflowService struct {
 	engine *workflow.Engine
-	store  *workflow.Store
+	store  workflow.Repository
 }
 
 // ListWorkflows returns all workflow definitions.

--- a/internal/workflow/builtin.go
+++ b/internal/workflow/builtin.go
@@ -165,7 +165,7 @@ func validateHandoffBuiltinVariant(variant handoffBuiltinVariant) error {
 //     match triggers with stale prompts or sidecar contracts.
 //   - If a stored version exists with Builtin=false (user cleared the flag
 //     to opt out of sync), it is preserved.
-func SyncBuiltins(store *Store) error {
+func SyncBuiltins(store Repository) error {
 	defs, err := BuiltinDefinitions()
 	if err != nil {
 		return err

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -451,7 +451,7 @@ type pendingRecovery struct {
 
 // Engine executes workflow definitions against tasks.
 type Engine struct {
-	store            *Store
+	store            Repository
 	tasks            TaskProvider
 	agents           AgentLauncher
 	pr               PRSurface
@@ -604,7 +604,7 @@ type Dependencies struct {
 // NewEngine creates a production workflow engine. Every collaborator whose
 // absence would skip or disable workflow behavior is validated before the
 // engine is returned.
-func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger, deps Dependencies) (*Engine, error) {
+func NewEngine(store Repository, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger, deps Dependencies) (*Engine, error) {
 	missing := missingDependencyNames(
 		namedDependency{"Store", store},
 		namedDependency{"Tasks", tasks},
@@ -621,7 +621,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 // NewTestEngine creates a deliberately partial engine for focused tests. Tests
 // can bind only the collaborators they exercise through the documented test
 // seams; production must use NewEngine so missing dependencies fail at startup.
-func NewTestEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {
+func NewTestEngine(store Repository, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {
 	return newEngine(store, tasks, agents, logger, Dependencies{
 		Execution: ExecutionSurface{
 			BranchSyncer: skippedBranchSyncer{},
@@ -632,7 +632,7 @@ func NewTestEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logge
 	})
 }
 
-func newEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger, deps Dependencies) *Engine {
+func newEngine(store Repository, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger, deps Dependencies) *Engine {
 	e := &Engine{
 		store:            store,
 		tasks:            tasks,
@@ -767,7 +767,7 @@ func (e *Engine) SetAdmissionDecisionHook(hook func(TaskInfo, AdmissionDecision)
 }
 
 // Defs returns the workflow definition store.
-func (e *Engine) Defs() *Store { return e.store }
+func (e *Engine) Defs() Repository { return e.store }
 
 // PRSurface is the pull-request dependency group: every collaborator the
 // engine needs to open, find, link, close and re-review a PR. NewEngine

--- a/internal/workflow/import.go
+++ b/internal/workflow/import.go
@@ -24,8 +24,8 @@ const ImportDomain = "workflow"
 // It must run before builtins are seeded. Seeding writes each builtin under its own id, so an import that ran afterwards would find those rows already present and overwrite a definition the operator had edited with the shipped one.
 //
 // The files are only read; an interrupted import commits neither the rows nor the marker, so the next start retries against an untouched directory.
-func Import(ctx context.Context, database *db.DB, dir string, logger *slog.Logger) error {
-	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+func Import(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
 		written, err := importDefinitions(ctx, database, tx, dir)
 		if err != nil {
 			return 0, err

--- a/internal/workflow/import.go
+++ b/internal/workflow/import.go
@@ -1,0 +1,125 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "workflow"
+
+// Import copies workflow definitions and their snapshots into the database once.
+//
+// It must run before builtins are seeded. Seeding writes each builtin under its own id, so an import that ran afterwards would find those rows already present and overwrite a definition the operator had edited with the shipped one.
+//
+// The files are only read; an interrupted import commits neither the rows nor the marker, so the next start retries against an untouched directory.
+func Import(ctx context.Context, database *db.DB, dir string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		written, err := importDefinitions(ctx, database, tx, dir)
+		if err != nil {
+			return 0, err
+		}
+		snapshots, err := importSnapshots(ctx, database, tx, filepath.Join(dir, "snapshots"))
+		if err != nil {
+			return 0, err
+		}
+		return written + snapshots, nil
+	})
+}
+
+func importDefinitions(ctx context.Context, database *db.DB, tx *sql.Tx, dir string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read workflows dir: %w", err)
+	}
+	written := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return 0, fmt.Errorf("read workflow: %w", err)
+		}
+		def, err := parseDefinition(data)
+		if err != nil {
+			// The file store already skips what it cannot parse. Failing here would leave the import to retry and fail again on every start.
+			continue
+		}
+		stamp := def.UpdatedAt
+		if stamp.IsZero() {
+			stamp = time.Now().UTC()
+		}
+		created := def.CreatedAt
+		if created.IsZero() {
+			created = stamp
+		}
+		if _, err := tx.ExecContext(ctx, database.Rebind(upsertWorkflow),
+			def.ID, def.Name, db.BoolValue(def.Builtin),
+			db.TimeValue(created), db.TimeValue(stamp), string(data)); err != nil {
+			return 0, fmt.Errorf("insert workflow: %w", err)
+		}
+		written++
+	}
+	return written, nil
+}
+
+func importSnapshots(ctx context.Context, database *db.DB, tx *sql.Tx, dir string) (int, error) {
+	workflows, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read workflow snapshots dir: %w", err)
+	}
+	written := 0
+	for _, wf := range workflows {
+		if !wf.IsDir() {
+			continue
+		}
+		files, err := os.ReadDir(filepath.Join(dir, wf.Name()))
+		if err != nil {
+			return 0, fmt.Errorf("read workflow snapshot dir: %w", err)
+		}
+		for _, file := range files {
+			hash := strings.TrimSuffix(file.Name(), ".yaml")
+			if file.IsDir() || filepath.Ext(file.Name()) != ".yaml" || !snapshotHashPattern.MatchString(hash) {
+				continue
+			}
+			path := filepath.Join(dir, wf.Name(), file.Name())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return 0, fmt.Errorf("read workflow snapshot: %w", err)
+			}
+			stamp := time.Now().UTC()
+			if info, statErr := os.Stat(path); statErr == nil {
+				// The file's own mtime, so a snapshot keeps roughly the age it had rather than every one of them dating from the upgrade.
+				stamp = info.ModTime().UTC()
+			}
+			var def Definition
+			if err := yaml.Unmarshal(data, &def); err != nil {
+				continue
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(insertSnapshot),
+				wf.Name(), hash, db.TimeValue(stamp), string(data)); err != nil {
+				return 0, fmt.Errorf("insert workflow snapshot: %w", err)
+			}
+			written++
+		}
+	}
+	return written, nil
+}

--- a/internal/workflow/repository.go
+++ b/internal/workflow/repository.go
@@ -1,0 +1,30 @@
+package workflow
+
+// Repository is the definition and snapshot surface the engine reads through.
+// Two implementations exist: the per-file Store and the database-backed
+// SQLStore, selected by config.Database.Backend.
+//
+// Unlike the other repositories moved to the database, these methods take no
+// context. The engine calls them from step evaluation and dispatch, neither of
+// which carries one, and threading a context through the engine is a change to
+// the engine rather than to where definitions are stored. SQLStore therefore
+// bounds each query with its own deadline — see NewSQLStore — so a stalled
+// backend cannot hold shutdown open indefinitely. Give this interface a
+// context the day the engine has one to give.
+type Repository interface {
+	List() ([]Definition, error)
+	Get(id string) (Definition, error)
+	Save(def Definition) error
+	Delete(id string) error
+	SaveSnapshot(def Definition) (string, error)
+	GetSnapshot(workflowID, hash string) (Definition, error)
+	// Dir is the directory definitions live in, or "" for a backend that has
+	// none. Callers that show an operator where to edit a workflow by hand use
+	// it, and must handle the empty case rather than printing a bare path.
+	Dir() string
+}
+
+var (
+	_ Repository = (*Store)(nil)
+	_ Repository = (*SQLStore)(nil)
+)

--- a/internal/workflow/sqlstore.go
+++ b/internal/workflow/sqlstore.go
@@ -55,11 +55,13 @@ const (
 // Dir reports that definitions have no directory under this backend.
 func (s *SQLStore) Dir() string { return "" }
 
-// List returns every definition in byte order of its id, which is what the file store's directory listing gave and what the engine breaks priority ties on.
+// List returns every definition in the order the file store's directory listing gave, which is what the engine breaks priority ties on.
+//
+// Ordered by the file NAME, not the id: the file store sorts "<id>.yaml", so "wfx-a" precedes "wfx" there ('-' < '.') while ordering by id alone puts the prefix first. Two same-priority workflows would otherwise dispatch differently depending on the backend.
 func (s *SQLStore) List() ([]Definition, error) {
 	ctx, cancel := s.context()
 	defer cancel()
-	rows, err := s.db.QueryContext(ctx, `SELECT doc FROM workflow_definitions ORDER BY `+s.db.OrderText("id"))
+	rows, err := s.db.QueryContext(ctx, `SELECT doc FROM workflow_definitions ORDER BY `+s.db.OrderText(`id || '.yaml'`))
 	if err != nil {
 		return nil, fmt.Errorf("list workflows: %w", err)
 	}

--- a/internal/workflow/sqlstore.go
+++ b/internal/workflow/sqlstore.go
@@ -33,8 +33,6 @@ func NewSQLStore(database *db.DB) (*SQLStore, error) {
 }
 
 const (
-	selectWorkflows = `SELECT doc FROM workflow_definitions ORDER BY id`
-
 	selectWorkflow = `SELECT doc FROM workflow_definitions WHERE id = ?`
 
 	upsertWorkflow = `INSERT INTO workflow_definitions (id, name, builtin, created_at, updated_at, doc)
@@ -57,11 +55,11 @@ const (
 // Dir reports that definitions have no directory under this backend.
 func (s *SQLStore) Dir() string { return "" }
 
-// List returns every definition, ordered by id so a re-read returns the same slice. A table has no natural order.
+// List returns every definition in byte order of its id, which is what the file store's directory listing gave and what the engine breaks priority ties on.
 func (s *SQLStore) List() ([]Definition, error) {
 	ctx, cancel := s.context()
 	defer cancel()
-	rows, err := s.db.QueryContext(ctx, selectWorkflows)
+	rows, err := s.db.QueryContext(ctx, `SELECT doc FROM workflow_definitions ORDER BY `+s.db.OrderText("id"))
 	if err != nil {
 		return nil, fmt.Errorf("list workflows: %w", err)
 	}
@@ -142,11 +140,21 @@ func (s *SQLStore) Save(def Definition) error {
 }
 
 // Delete removes a definition. Its snapshots stay: a running task references one by hash, and dropping them would strand it mid-workflow.
+//
+// A missing id is an error, as it is for the file store: the GUI shows what Delete returns, and reporting success on one backend and failure on the other for the same click is worse than either answer.
 func (s *SQLStore) Delete(id string) error {
 	ctx, cancel := s.context()
 	defer cancel()
-	if _, err := s.db.ExecContext(ctx, deleteWorkflow, id); err != nil {
+	res, err := s.db.ExecContext(ctx, deleteWorkflow, id)
+	if err != nil {
 		return fmt.Errorf("delete workflow %q: %w", id, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete workflow %q: %w", id, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("workflow %s not found", id)
 	}
 	return nil
 }

--- a/internal/workflow/sqlstore.go
+++ b/internal/workflow/sqlstore.go
@@ -1,0 +1,208 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// queryTimeout bounds every statement this store runs.
+//
+// The Repository methods take no context (see there), so without a deadline a stalled postgres connection would hold a dispatch — and shutdown — open with no way to cancel it. Generous enough that a loaded shared board still answers, short enough that a dead one is reported rather than waited on.
+const queryTimeout = 15 * time.Second
+
+// SQLStore persists workflow definitions and their snapshots in the configured database backend.
+//
+// The YAML document is stored verbatim rather than decomposed into columns. Definitions are read back through the same parser the files went through, so an unmodelled field survives a round trip and a step-shape change needs no migration; the few fields a query filters on are lifted into columns beside the document.
+type SQLStore struct {
+	db *db.DB
+}
+
+// NewSQLStore returns a database-backed workflow repository.
+func NewSQLStore(database *db.DB) (*SQLStore, error) {
+	if database == nil {
+		return nil, errors.New("workflow sql store needs an open database")
+	}
+	return &SQLStore{db: database}, nil
+}
+
+const (
+	selectWorkflows = `SELECT doc FROM workflow_definitions ORDER BY id`
+
+	selectWorkflow = `SELECT doc FROM workflow_definitions WHERE id = ?`
+
+	upsertWorkflow = `INSERT INTO workflow_definitions (id, name, builtin, created_at, updated_at, doc)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT (id) DO UPDATE SET
+			name = excluded.name, builtin = excluded.builtin,
+			created_at = excluded.created_at, updated_at = excluded.updated_at, doc = excluded.doc`
+
+	deleteWorkflow = `DELETE FROM workflow_definitions WHERE id = ?`
+
+	selectWorkflowCreatedAt = `SELECT created_at FROM workflow_definitions WHERE id = ?`
+
+	// A snapshot is keyed by a hash of its own content, so a repeat write carries identical bytes and there is nothing to update.
+	insertSnapshot = `INSERT INTO workflow_snapshots (workflow_id, hash, created_at, doc)
+		VALUES (?, ?, ?, ?) ON CONFLICT (workflow_id, hash) DO NOTHING`
+
+	selectSnapshot = `SELECT doc FROM workflow_snapshots WHERE workflow_id = ? AND hash = ?`
+)
+
+// Dir reports that definitions have no directory under this backend.
+func (s *SQLStore) Dir() string { return "" }
+
+// List returns every definition, ordered by id so a re-read returns the same slice. A table has no natural order.
+func (s *SQLStore) List() ([]Definition, error) {
+	ctx, cancel := s.context()
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx, selectWorkflows)
+	if err != nil {
+		return nil, fmt.Errorf("list workflows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var defs []Definition
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return nil, fmt.Errorf("scan workflow: %w", err)
+		}
+		def, err := parseDefinition([]byte(doc))
+		if err != nil {
+			// The file store logs and skips a definition it cannot parse; failing the whole listing here would take every other workflow down with it.
+			continue
+		}
+		defs = append(defs, def)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workflows: %w", err)
+	}
+	return defs, nil
+}
+
+// Get returns one definition by id.
+func (s *SQLStore) Get(id string) (Definition, error) {
+	ctx, cancel := s.context()
+	defer cancel()
+	var doc string
+	err := s.db.QueryRowContext(ctx, selectWorkflow, id).Scan(&doc)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Definition{}, fmt.Errorf("workflow %q not found: %w", id, err)
+	}
+	if err != nil {
+		return Definition{}, fmt.Errorf("read workflow %q: %w", id, err)
+	}
+	return parseDefinition([]byte(doc))
+}
+
+// Save writes a definition, stamping timestamps the way the file store does: CreatedAt survives the first write, UpdatedAt is always now.
+func (s *SQLStore) Save(def Definition) error {
+	if def.ID == "" {
+		return fmt.Errorf("workflow ID is required")
+	}
+	ctx, cancel := s.context()
+	defer cancel()
+
+	now := db.StoredTime(time.Now().UTC())
+	return s.db.InTx(ctx, func(tx *sql.Tx) error {
+		// Read inside the transaction: two writers would otherwise both find no row, and the later one would reset the definition's age.
+		var existing int64
+		err := tx.QueryRowContext(ctx, s.db.Rebind(selectWorkflowCreatedAt), def.ID).Scan(&existing)
+		switch {
+		case err == nil:
+			def.CreatedAt = db.TimeFrom(existing)
+		case errors.Is(err, sql.ErrNoRows):
+			if def.CreatedAt.IsZero() {
+				def.CreatedAt = now
+			}
+		default:
+			return fmt.Errorf("read workflow age: %w", err)
+		}
+		def.UpdatedAt = now
+
+		if vErr := def.Validate(); vErr != nil {
+			return fmt.Errorf("validate workflow: %w", vErr)
+		}
+		doc, mErr := yaml.Marshal(def)
+		if mErr != nil {
+			return fmt.Errorf("marshal workflow: %w", mErr)
+		}
+		if _, err := tx.ExecContext(ctx, s.db.Rebind(upsertWorkflow),
+			def.ID, def.Name, db.BoolValue(def.Builtin),
+			db.TimeValue(def.CreatedAt), db.TimeValue(def.UpdatedAt), string(doc)); err != nil {
+			return fmt.Errorf("write workflow: %w", err)
+		}
+		return nil
+	})
+}
+
+// Delete removes a definition. Its snapshots stay: a running task references one by hash, and dropping them would strand it mid-workflow.
+func (s *SQLStore) Delete(id string) error {
+	ctx, cancel := s.context()
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, deleteWorkflow, id); err != nil {
+		return fmt.Errorf("delete workflow %q: %w", id, err)
+	}
+	return nil
+}
+
+// SaveSnapshot stores an immutable copy keyed by the definition's semantic hash and returns that hash. An existing snapshot is left exactly as it is.
+func (s *SQLStore) SaveSnapshot(def Definition) (string, error) {
+	if def.ID == "" {
+		return "", fmt.Errorf("workflow ID is required")
+	}
+	hash, err := def.SemanticHash()
+	if err != nil {
+		return "", err
+	}
+	doc, err := yaml.Marshal(def)
+	if err != nil {
+		return "", fmt.Errorf("marshal workflow snapshot: %w", err)
+	}
+	ctx, cancel := s.context()
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, insertSnapshot,
+		def.ID, hash, db.TimeValue(db.StoredTime(time.Now().UTC())), string(doc)); err != nil {
+		return "", fmt.Errorf("write workflow snapshot: %w", err)
+	}
+	return hash, nil
+}
+
+// GetSnapshot returns the definition a task was dispatched against.
+func (s *SQLStore) GetSnapshot(workflowID, hash string) (Definition, error) {
+	if !snapshotHashPattern.MatchString(hash) {
+		return Definition{}, fmt.Errorf("invalid workflow snapshot hash %q", hash)
+	}
+	ctx, cancel := s.context()
+	defer cancel()
+	var doc string
+	err := s.db.QueryRowContext(ctx, selectSnapshot, workflowID, hash).Scan(&doc)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Definition{}, fmt.Errorf("workflow snapshot %q/%q not found: %w", workflowID, hash, err)
+	}
+	if err != nil {
+		return Definition{}, fmt.Errorf("read workflow snapshot: %w", err)
+	}
+	return parseDefinition([]byte(doc))
+}
+
+func (s *SQLStore) context() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), queryTimeout)
+}
+
+// parseDefinition decodes and validates a stored workflow document. It is the same decode the file store performs, so a definition read from either backend has passed the same checks.
+func parseDefinition(data []byte) (Definition, error) {
+	var def Definition
+	if err := yaml.Unmarshal(data, &def); err != nil {
+		return Definition{}, fmt.Errorf("unmarshal workflow: %w", err)
+	}
+	if vErr := def.Validate(); vErr != nil {
+		return Definition{}, fmt.Errorf("validate workflow %s: %w", def.ID, vErr)
+	}
+	return def, nil
+}

--- a/internal/workflow/sqlstore_test.go
+++ b/internal/workflow/sqlstore_test.go
@@ -1,0 +1,176 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func importFixture(t *testing.T, dir string, defs []Definition) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, def := range defs {
+		data, err := yaml.Marshal(def)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, def.ID+".yaml"), data, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+}
+
+func definitionsFixture() []Definition {
+	step := Step{ID: "s", Type: StepSetStatus, Config: StepConfig{Status: "todo"}}
+	return []Definition{
+		{ID: "wf-b", Name: "beta", Steps: []Step{step}},
+		{ID: "wf-a", Name: "alpha", Steps: []Step{step}},
+	}
+}
+
+// TestSQLStore_ListMatchesTheFileStoreOrder is the issue's "same records in the
+// same order". A table has no natural order, so a missing ORDER BY reads fine
+// in one engine and reshuffles the workflow list in the other.
+func TestSQLStore_ListMatchesTheFileStoreOrder(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		dir := t.TempDir()
+		fileStore, err := NewStore(dir)
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		sqlStore, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		for _, def := range definitionsFixture() {
+			if err := fileStore.Save(def); err != nil {
+				t.Fatalf("file save: %v", err)
+			}
+			if err := sqlStore.Save(def); err != nil {
+				t.Fatalf("sql save: %v", err)
+			}
+		}
+		fromFiles, err := fileStore.List()
+		if err != nil {
+			t.Fatalf("file list: %v", err)
+		}
+		fromSQL, err := sqlStore.List()
+		if err != nil {
+			t.Fatalf("sql list: %v", err)
+		}
+		if len(fromSQL) != len(fromFiles) {
+			t.Fatalf("sql listed %d, files listed %d", len(fromSQL), len(fromFiles))
+		}
+		for i := range fromFiles {
+			if fromSQL[i].ID != fromFiles[i].ID {
+				t.Fatalf("position %d: sql %q, files %q", i, fromSQL[i].ID, fromFiles[i].ID)
+			}
+		}
+	})
+}
+
+// TestSQLStore_SnapshotIsImmutableAndKeyedByContent pins the snapshot contract
+// the engine depends on: a task holds a hash and must get back exactly the
+// definition it was dispatched against, however often the workflow has since
+// been edited.
+func TestSQLStore_SnapshotIsImmutableAndKeyedByContent(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		def := definitionsFixture()[0]
+		hash, err := store.SaveSnapshot(def)
+		if err != nil {
+			t.Fatalf("save snapshot: %v", err)
+		}
+		again, err := store.SaveSnapshot(def)
+		if err != nil {
+			t.Fatalf("re-save snapshot: %v", err)
+		}
+		if again != hash {
+			t.Fatalf("same definition hashed to %q then %q", hash, again)
+		}
+		got, err := store.GetSnapshot(def.ID, hash)
+		if err != nil {
+			t.Fatalf("get snapshot: %v", err)
+		}
+		if got.Name != def.Name {
+			t.Errorf("snapshot name = %q, want %q", got.Name, def.Name)
+		}
+
+		// Editing the definition must leave the snapshot alone: a task mid-run
+		// still resolves the steps it started with.
+		edited := def
+		edited.Name = "renamed"
+		if err := store.Save(edited); err != nil {
+			t.Fatalf("save edited: %v", err)
+		}
+		got, err = store.GetSnapshot(def.ID, hash)
+		if err != nil {
+			t.Fatalf("get snapshot after edit: %v", err)
+		}
+		if got.Name != def.Name {
+			t.Errorf("snapshot followed the edit: name = %q, want %q", got.Name, def.Name)
+		}
+	})
+}
+
+// TestImport_IsOnceOnlyAndLeavesTheFiles pins the upgrade guarantees: import
+// once, no duplicates on a second start, originals untouched, and an empty
+// domain reads back empty rather than failing.
+func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		dir := t.TempDir()
+		defs := definitionsFixture()
+		importFixture(t, dir, defs)
+
+		for range 2 {
+			if err := Import(t.Context(), d, dir, nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(got) != len(defs) {
+			t.Fatalf("after two imports got %d definitions, want %d", len(got), len(defs))
+		}
+		for _, def := range defs {
+			if _, err := os.Stat(filepath.Join(dir, def.ID+".yaml")); err != nil {
+				t.Errorf("import removed the original %s: %v", def.ID, err)
+			}
+		}
+	})
+}
+
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.List()
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %d definitions from an empty domain", len(got))
+		}
+	})
+}

--- a/internal/workflow/sqlstore_test.go
+++ b/internal/workflow/sqlstore_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/taskstatus"
 	"github.com/Automaat/sybra/internal/testutil/dbtest"
 )
 
@@ -16,7 +17,8 @@ func importFixture(t *testing.T, dir string, defs []Definition) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	for _, def := range defs {
+	for i := range defs {
+		def := &defs[i]
 		data, err := yaml.Marshal(def)
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
@@ -28,10 +30,17 @@ func importFixture(t *testing.T, dir string, defs []Definition) {
 }
 
 func definitionsFixture() []Definition {
-	step := Step{ID: "s", Type: StepSetStatus, Config: StepConfig{Status: "todo"}}
+	step := Step{ID: "s", Type: StepSetStatus, Config: StepConfig{Status: string(taskstatus.Todo)}}
+	// Ids that carry punctuation, and the shipped builtins' own shapes. Under
+	// glibc's en_US.UTF-8 the hyphen is ignored at the primary level, so
+	// "pr-review" sorts after "prompt-lab-author" — the opposite of byte order
+	// and of what the file store's directory listing gave. Ids like "wf-a"/
+	// "wf-b" sort identically under every collation and can never fail here.
 	return []Definition{
-		{ID: "wf-b", Name: "beta", Steps: []Step{step}},
-		{ID: "wf-a", Name: "alpha", Steps: []Step{step}},
+		{ID: "prompt-lab-author", Name: "author", Steps: []Step{step}},
+		{ID: "pr-review", Name: "review", Steps: []Step{step}},
+		{ID: "pr-fix", Name: "fix", Steps: []Step{step}},
+		{ID: "branch-conflict-fix", Name: "conflict", Steps: []Step{step}},
 	}
 }
 
@@ -40,6 +49,7 @@ func definitionsFixture() []Definition {
 // in one engine and reshuffles the workflow list in the other.
 func TestSQLStore_ListMatchesTheFileStoreOrder(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		dir := t.TempDir()
 		fileStore, err := NewStore(dir)
 		if err != nil {
@@ -82,6 +92,7 @@ func TestSQLStore_ListMatchesTheFileStoreOrder(t *testing.T) {
 // been edited.
 func TestSQLStore_SnapshotIsImmutableAndKeyedByContent(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		store, err := NewSQLStore(d)
 		if err != nil {
 			t.Fatalf("NewSQLStore: %v", err)
@@ -128,12 +139,13 @@ func TestSQLStore_SnapshotIsImmutableAndKeyedByContent(t *testing.T) {
 // domain reads back empty rather than failing.
 func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
 		dir := t.TempDir()
 		defs := definitionsFixture()
 		importFixture(t, dir, defs)
 
 		for range 2 {
-			if err := Import(t.Context(), d, dir, nil); err != nil {
+			if err := Import(t.Context(), d, dir, "home-a", nil); err != nil {
 				t.Fatalf("import: %v", err)
 			}
 		}
@@ -158,7 +170,8 @@ func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
 
 func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
 	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
-		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), nil); err != nil {
+		t.Helper()
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), "home-a", nil); err != nil {
 			t.Fatalf("import: %v", err)
 		}
 		store, err := NewSQLStore(d)

--- a/internal/workflow/sqlstore_test.go
+++ b/internal/workflow/sqlstore_test.go
@@ -41,6 +41,12 @@ func definitionsFixture() []Definition {
 		{ID: "pr-review", Name: "review", Steps: []Step{step}},
 		{ID: "pr-fix", Name: "fix", Steps: []Step{step}},
 		{ID: "branch-conflict-fix", Name: "conflict", Steps: []Step{step}},
+		// A prefix pair. The file store sorts "<id>.yaml", so "wfx-a" comes
+		// first ('-' < '.'); ordering by the bare id puts "wfx" first because a
+		// prefix is shorter. Without this pair the parity assertion cannot see
+		// the difference.
+		{ID: "wfx", Name: "prefix", Steps: []Step{step}},
+		{ID: "wfx-a", Name: "prefixed", Steps: []Step{step}},
 	}
 }
 

--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -118,8 +118,11 @@ k3d kubeconfig get "$CLUSTER" > "$KUBECONFIG"
 # intermittent red on a job that has nothing to do with the change under test.
 log "Waiting for the node to be ready"
 kubectl wait --for=condition=Ready node --all --timeout=180s
+# A deadline from the clock, not $SECONDS: that counts from shell start and the
+# image build already ran, so the guard would fire before the first attempt.
+openapi_deadline=$(( $(date +%s) + 180 ))
 until kubectl get --raw /openapi/v2 >/dev/null 2>&1; do
-  [ "$SECONDS" -lt 300 ] || fail "the API server never served its openapi document"
+  [ "$(date +%s)" -lt "$openapi_deadline" ] || fail "the API server never served its openapi document"
   sleep 2
 done
 

--- a/scripts/smoke-k3d.sh
+++ b/scripts/smoke-k3d.sh
@@ -110,8 +110,30 @@ k3d cluster create "$CLUSTER" --agents 0 --wait \
   --kubeconfig-update-default=false --kubeconfig-switch-context=false
 k3d kubeconfig get "$CLUSTER" > "$KUBECONFIG"
 
+# `k3d cluster create --wait` returns once the server container reports ready,
+# which is earlier than k3s having containerd listening and the API server
+# serving its openapi document. Importing then fails with "cannot access socket
+# /run/k3s/containerd/containerd.sock", and the next kubectl fails validation
+# against an API server that is "currently unable to handle the request" — an
+# intermittent red on a job that has nothing to do with the change under test.
+log "Waiting for the node to be ready"
+kubectl wait --for=condition=Ready node --all --timeout=180s
+until kubectl get --raw /openapi/v2 >/dev/null 2>&1; do
+  [ "$SECONDS" -lt 300 ] || fail "the API server never served its openapi document"
+  sleep 2
+done
+
 log "Importing $IMAGE"
-k3d image import "$IMAGE" -c "$CLUSTER"
+# Retried: the socket can still be a moment behind a Ready node, and re-importing
+# an image already present is a no-op.
+for attempt in 1 2 3; do
+  if k3d image import "$IMAGE" -c "$CLUSTER"; then
+    break
+  fi
+  [ "$attempt" -lt 3 ] || fail "could not import $IMAGE into $CLUSTER"
+  log "import attempt $attempt failed; retrying"
+  sleep 10
+done
 
 # Resolve the config BEFORE anything is applied. The old order applied the
 # kustomization (starting a pod on the default config), swapped the ConfigMap,

--- a/scripts/test-db-engines.sh
+++ b/scripts/test-db-engines.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 CONTAINER="${SYBRA_TEST_PG_CONTAINER:-sybra-test-postgres}"
 PORT="${SYBRA_TEST_PG_PORT:-55432}"
 IMAGE="postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193"
-PACKAGES=("./internal/db/..." "./internal/loopagent/..." "./internal/testutil/dbtest/...")
+PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/testutil/dbtest/...")
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to run the postgres engine leg" >&2

--- a/scripts/test-db-engines.sh
+++ b/scripts/test-db-engines.sh
@@ -9,7 +9,11 @@ cd "$(dirname "$0")/.."
 
 CONTAINER="${SYBRA_TEST_PG_CONTAINER:-sybra-test-postgres}"
 PORT="${SYBRA_TEST_PG_PORT:-55432}"
-IMAGE="postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193"
+# The glibc image, not alpine. musl collates text byte-wise, so an alpine
+# server agrees with sqlite for free and an ordering test cannot fail on it —
+# while the deploy target is Ubuntu, where en_US.UTF-8 ignores punctuation and
+# reorders exactly the ids the builtin workflows ship with.
+IMAGE="postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317"
 PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/testutil/dbtest/...")
 
 if ! command -v docker >/dev/null 2>&1; then


### PR DESCRIPTION
## Motivation

Four small record sets each hand-rolled their own listing, reading and writing, and each rescanned a directory to answer a query. None has a reader outside the app, which makes them the safest place to prove the migration pattern every larger store will follow.

The pattern was missing its most important half. `initLoopAgents` already swapped stores on `storage.database.backend`, but nothing moved the existing records, so an operator who flipped the backend started with an empty table and their loop agents silently stopped running. This adds the import and applies it to loop agents too, so those installs pick their schedules back up on the next start.

Closes #3239

> Changelog: feat(storage): keep records in the database

## Implementation information

`dbimport.Once(ctx, db, domain, fn)` copies a domain's files in the first time a database is used and never again. The marker row is inserted in the **same transaction** as the rows it covers, so an interrupted run commits neither and the next start retries against files it never touched — which is the issue's "retries cleanly" outcome, and the one guarantee that is easy to get subtly wrong. The whole thing runs under `InTxLocked` with its own lock key, so two instances sharing one postgres board cannot both import.

Files are only ever read. Nothing moves or deletes them; the operator decides when the originals go.

**Ordering matters in two places.** The workflow import runs *before* builtins are seeded — seeding writes each builtin under its own id, so an import that followed would replace an operator's edited copy with the shipped one. And every SQL read is ordered explicitly, then tested against the file store's own listing over one fixture: a table has no natural order, so an omitted `ORDER BY` reads correct on one engine and reshuffles an agent's advisory context on the other.

**Shapes that did not match the issue's framing**, worth naming rather than papering over:

- Background operations are not a directory. They are one `bgops.json` written whole, so the import reads one document and `Save` replaces the whole set in one transaction — the tracker has always handed over its entire set, and an operation it dropped for age is gone by being absent rather than by an explicit delete. One operation kind is deliberately event-only and still never persisted.
- Workflow snapshots are keyed by `(workflow id, content hash)`, not by hash alone — the layout is `snapshots/<id>/<hash>.yaml`. That composite makes the snapshot import idempotent for free: re-importing identical content is a primary-key conflict, not a duplicate.

Records are stored as the document each store already wrote — JSON for advisory records, the definition's YAML verbatim for workflows — with only the fields a query filters on lifted into columns. An unmodelled field survives a round trip, and a change to `Record` or to a step's shape needs no migration.

### One deliberate inconsistency

`experience.Repository` and `workflow.Repository` take **no** `context.Context`, unlike `loopagent.Repository`. Advisory records are read while assembling an agent's prompt and workflow definitions are read during step evaluation and dispatch; none of those callers has a context to pass, and threading one through the workflow engine is a change to the engine rather than to where records are stored. Both SQL stores bound every statement with their own deadline instead, so a stalled backend still cannot hold shutdown open indefinitely. Give these interfaces a context the day their callers have one to give.

### Defects found and fixed along the way

Found by an adversarial pass that reproduced each one on both engines:

- `openWorkflowStore` returned a nil `*Store` inside a **non-nil interface**, so every `== nil` guard downstream passed it through and `SyncBuiltins` panicked on the nil receiver. A stray regular file where `$SYBRA_HOME/workflows` belongs was enough to crash startup.
- The loop agent import inserted every file blind, and the upgrade path that actually exists produces a collision: #3235 swapped the store while the table was empty, the first-boot seed re-created `sybra-self-monitor` under a fresh id, and this import would have added the operator's file back as a second **enabled** row — the scheduler then runs that schedule twice, at double cost. It reconciles by name now.
- A duplicate id aborted the import transaction, and because the marker commits with the rows, no marker was ever written: the import then failed identically on every restart and nothing ever reached the database.
- The import marker was keyed by domain alone. On a board shared by several machines — the reason postgres is a backend at all — the first instance to start claimed a domain and every other machine's files stayed unimported forever, silently. Markers now carry the home they came from.
- `ORDER BY id` follows the server's collation, so the SQL store did **not** reproduce the file store's order on a real postgres and the two engines disagreed with each other. Under the deploy target's `en_US.UTF-8` a hyphen is ignored at the primary level, so `pr-review` sorts after `prompt-lab-author` — and `matchWorkflow` breaks priority ties on exactly that order, so which workflow a task dispatches would depend on the engine and the server's locale. Both engines sort by byte value now.
- Deleting an absent workflow reported success on the database backend and an error on the file one, for the same click.

Two of those tests could not have failed as first written: the fixtures used ids that sort identically under every collation, and CI pinned `postgres:17-alpine`, whose musl locale collates byte-wise and so agrees with sqlite for free. Both the fixtures and the image changed; removing the collation fix now fails the order tests on postgres.

### Coverage

Every domain's behaviour suite runs on both engines through `dbtest.Engines`, and all five packages are registered with `scripts/test-db-engines.sh` so `mise run test:db` and the CI job cover them.

`internal/sybra` had no test that configured a database backend at all, so every App-level path here was unexecuted — the import-before-seed ordering, the four degrade-to-files fallbacks, and the typed-nil crash above. It has one now.

Mutation-checked: moving the import marker into its own transaction fails the retry test; removing the owner scope fails the shared-board test; removing the collation fix fails both order tests on postgres; returning the typed nil fails the startup test.

### Found by running it

A manual pass started the server against each backend and watched which workflow a task actually dispatched, which caught two things the review and both engines' suites had missed:

- The SQL store's list order did **not** match the file store's, and a comment in the diff asserted that it did. The file store sorts `<id>.yaml`, so `wfx-a` precedes `wfx` (`'-' < '.'`), while ordering by the bare id puts the prefix first — the shipped builtins reorder the same way, and two same-priority workflows dispatched differently depending on the backend. The fixture had no prefix pair, so the parity test could not see it.
- A failed loop-agent import continued to an empty table, so every schedule an operator had stopped running for the whole uptime while its definition sat intact on disk, and the seed re-created the built-in under a new id — behind a single log line. The other three domains already degraded to files; this one does now.

Both are re-verified: identical 25-id list and identical `picked=wfx-a` dispatch across file, sqlite and postgres, and a failed import that keeps serving the operator's schedules and then imports them cleanly once the cause is removed.

## Open questions

One observation could not be grounded. In a single long-lived home a deleted loop agent reappeared after restart with its original id and timestamps; four subsequent trials (two fresh homes, one repeat in the same home, one with the same probe) all showed the delete persisting. The original reading coincided with inspecting the app's live WAL-mode sqlite file through a bind mount, which would explain it as a measurement artifact rather than a product defect. Recorded here rather than dropped.

## Unrelated fix carried along

`k3d Job Runner Smoke` went red on this branch for a reason that has nothing to do with it: `k3d cluster create --wait` returns before k3s has containerd listening or the API server serving openapi, so the image import hit a missing socket. Rather than re-run it green, the script now waits for the node and for openapi and retries the import.

## Supporting documentation

`CLAUDE.md`'s durable-storage rules gain the three that were missing: give the domain an import and run it before anything seeds, read the files without moving them, and order the read explicitly against the file store's listing.