### PR TITLE
feat(storage): keep run history in the database

### DIFF
--- a/internal/agent/background_task_adversarial_test.go
+++ b/internal/agent/background_task_adversarial_test.go
@@ -55,7 +55,7 @@ func TestAdversarial_LiveBackgroundTaskAtResultDoesNotCompleteCleanly(t *testing
 		t.Fatalf("Run: %v", err)
 	}
 
-	waitForAgentDone(t, ag, 5*time.Second)
+	waitForAgentDone(t, ag, scaledDeadline(5*time.Second))
 
 	if ag.GetState() == StateStopped && ag.GetExitErr() == nil && ag.HasBackgroundTasks() {
 		t.Fatalf("agent completed cleanly despite live background task: state=%s exitErr=%v hasBackgroundTasks=%v logs=%s",

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -174,7 +174,7 @@ type Manager struct {
 
 	// toolLedger records every tool call every agent makes, whatever the
 	// permission posture. Nil disables recording; Logger.Log tolerates it.
-	toolLedger *toolledger.Logger
+	toolLedger toolledger.Store
 	// sandboxHome resolves the per-task sandbox SYBRA_HOME for a task-scoped
 	// run. Required (non-nil) for any Run/StartAgent call with a non-empty
 	// TaskID — see prepareRunConfig. nil is only valid when every caller is a
@@ -1249,7 +1249,7 @@ func (m *Manager) QueueNudge() <-chan struct{} {
 // SetToolLedger late-binds the tool-call ledger. Separate from construction
 // because the ledger's directory is resolved from config the Manager does not
 // own.
-func (m *Manager) SetToolLedger(l *toolledger.Logger) {
+func (m *Manager) SetToolLedger(l toolledger.Store) {
 	if m == nil {
 		return
 	}
@@ -1262,7 +1262,7 @@ func (m *Manager) SetToolLedger(l *toolledger.Logger) {
 // otherwise invisible: Logger.Log guards its own nil receiver, so an unwired
 // manager drops every record without erroring, and only a direct read of the
 // binding can tell a live ledger from a silent one.
-func (m *Manager) ToolLedger() *toolledger.Logger {
+func (m *Manager) ToolLedger() toolledger.Store {
 	if m == nil {
 		return nil
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -2409,6 +2409,12 @@ func (m *Manager) recordToolCall(r toolledger.Record) {
 	m.mu.RLock()
 	ledger := m.toolLedger
 	m.mu.RUnlock()
+	// Checked here, not left to a nil-receiver guard inside the store: the
+	// field is an interface, so an unset ledger is a nil interface and calling
+	// through it panics — on the stream path, taking the whole run with it.
+	if ledger == nil {
+		return
+	}
 	if err := ledger.Log(r); err != nil {
 		m.logger.Warn("agent.tool_ledger.write_failed", "agent_id", r.AgentID, "tool", r.Tool, "err", err)
 	}

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1554,7 +1554,7 @@ func TestGuardrails_CostKillRaceSetsExitErr(t *testing.T) {
 	// finalizeRun (and the close of ag.done) must not block on the slow
 	// subprocess reap — it happens on the shrunk drainTimeout, well before
 	// the real SIGKILL escalation (stopSIGINTGrace) would land.
-	waitForAgentDone(t, ag, 3*time.Second)
+	waitForAgentDone(t, ag, scaledDeadline(3*time.Second))
 
 	if !ag.WasStopped() {
 		t.Fatal("expected WasStopped=true after guardrail kill")
@@ -1608,7 +1608,7 @@ func TestGuardrails_CostHardStop_CompletedTurnIsNotAFailure(t *testing.T) {
 		}
 	})
 
-	waitForAgentDone(t, ag, 3*time.Second)
+	waitForAgentDone(t, ag, scaledDeadline(3*time.Second))
 
 	if !ag.WasStopped() {
 		t.Fatal("expected WasStopped=true after guardrail kill")

--- a/internal/agent/sandbox_home_test.go
+++ b/internal/agent/sandbox_home_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/Automaat/sybra/internal/toolledger"
 )
 
 // TestPrepareRunConfig_SandboxHome_Injected pins the core #1576 fix: a
@@ -712,4 +714,16 @@ func TestPrepareRunConfig_UnnamedBoardKeepsTheControlHome(t *testing.T) {
 	if strings.Contains(joined, "SYBRA_SERVER_TARGET") {
 		t.Errorf("named a target with no board set: %v", cfg.ExtraEnv)
 	}
+}
+
+// TestRecordToolCall_UnsetLedgerDoesNotPanic pins a hazard the interface
+// introduced.
+//
+// The field used to be a *toolledger.Logger whose own methods tolerated a nil
+// receiver. As an interface an unset ledger is a nil interface, and calling
+// through it panics — on the provider stream path, which takes the whole run
+// with it. Every manager built without a ledger is in this state.
+func TestRecordToolCall_UnsetLedgerDoesNotPanic(t *testing.T) {
+	m, _ := newTestManager(t, ManagerConfig{})
+	m.recordToolCall(toolledger.Record{AgentID: "ag1", Tool: "Bash"})
 }

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -523,7 +523,7 @@ printf '%%s\n' '{"type":"result","result":"done","session_id":"sess-lifecycle","
 	if err := os.WriteFile(releaseFile, nil, 0o644); err != nil {
 		t.Fatalf("release fake claude: %v", err)
 	}
-	waitForAgentDone(t, got, 15*time.Second)
+	waitForAgentDone(t, got, scaledDeadline(15*time.Second))
 	if got.GetState() != StateStopped {
 		t.Fatalf("completed reattached state = %s, want %s", got.GetState(), StateStopped)
 	}

--- a/internal/audit/import.go
+++ b/internal/audit/import.go
@@ -1,0 +1,107 @@
+package audit
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "audit"
+
+// Import copies the per-day trail files into the database, one file per batch.
+//
+// Resumable rather than all-or-nothing: an audit trail is an unbounded history, and a single transaction over years of it would be discarded whole by one interruption. The cursor is the last day-file consumed, committed with that file's rows, so a restart resumes at the next file and a file retried after a crash cannot duplicate — the row key is a digest of the event itself.
+//
+// The files are only read.
+func Import(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	return dbimport.Resumable(ctx, database, ImportDomain, scope, logger,
+		func(ctx context.Context, tx *sql.Tx, cursor string) (dbimport.Batch, error) {
+			return importNextDay(ctx, database, tx, dir, cursor)
+		})
+}
+
+func importNextDay(ctx context.Context, database *db.DB, tx *sql.Tx, dir, cursor string) (dbimport.Batch, error) {
+	days, err := trailFiles(dir)
+	if err != nil {
+		return dbimport.Batch{}, err
+	}
+	next := ""
+	for _, name := range days {
+		if name > cursor {
+			next = name
+			break
+		}
+	}
+	if next == "" {
+		return dbimport.Batch{Cursor: cursor, Done: true}, nil
+	}
+
+	count, err := importTrailFile(ctx, database, tx, filepath.Join(dir, next))
+	if err != nil {
+		return dbimport.Batch{}, err
+	}
+	return dbimport.Batch{Cursor: next, Count: count}, nil
+}
+
+func trailFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read audit dir: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".ndjson" {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func importTrailFile(ctx context.Context, database *db.DB, tx *sql.Tx, path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open audit file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	written := 0
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			// The reader already skips a line it cannot decode — a trail
+			// truncated by a crash ends in exactly one — so failing here would
+			// stall the import on a file it can never get past.
+			continue
+		}
+		if err := insertEventTx(ctx, database, tx, e, []byte(line)); err != nil {
+			return 0, err
+		}
+		written++
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("read audit file: %w", err)
+	}
+	return written, nil
+}

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -55,7 +55,7 @@ func (l *Logger) Log(e Event) error {
 // nil. A logging failure is reported to fallback rather than returned, since
 // callers on the dispatch path (agent start, chat rollback, ...) treat audit
 // logging as best-effort and must not fail the operation it's recording.
-func LogEvent(al *Logger, fallback *slog.Logger, eventType, taskID, agentID string, data map[string]any) {
+func LogEvent(al Store, fallback *slog.Logger, eventType, taskID, agentID string, data map[string]any) {
 	if al == nil {
 		return
 	}
@@ -100,3 +100,9 @@ func (l *Logger) file(ts time.Time) (*os.File, error) {
 	l.today = day
 	return f, nil
 }
+
+// Read returns the events matching q from this trail's directory.
+func (l *Logger) Read(q Query) ([]Event, error) { return Read(l.dir, q) }
+
+// Cleanup removes day-files past retentionDays from this trail's directory.
+func (l *Logger) Cleanup(retentionDays int) error { return Cleanup(l.dir, retentionDays) }

--- a/internal/audit/sqlstore.go
+++ b/internal/audit/sqlstore.go
@@ -1,0 +1,153 @@
+package audit
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// queryTimeout bounds every statement. Store carries no context to cancel one with; see Store.
+const queryTimeout = 15 * time.Second
+
+// SQLStore keeps the audit trail in the configured database backend.
+//
+// A read filtered by time or task is a WHERE against an index, so it touches only matching rows. The file trail had to open every day-file in range and decode every line to answer the same question, which grew with the length of the history rather than with the question.
+type SQLStore struct {
+	db *db.DB
+}
+
+// NewSQLStore returns the database-backed trail.
+func NewSQLStore(database *db.DB) (*SQLStore, error) {
+	if database == nil {
+		return nil, errors.New("audit store needs an open database")
+	}
+	return &SQLStore{db: database}, nil
+}
+
+const insertAuditEvent = `INSERT INTO audit_events (id, ts, event_type, task_id, agent_id, doc)
+	VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO NOTHING`
+
+const deleteAuditBefore = `DELETE FROM audit_events WHERE ts < ?`
+
+// Log appends one event.
+//
+// One row, one statement: a crash leaves the row written or absent, never half of it, so nothing has to repair a truncated tail on the next start.
+func (s *SQLStore) Log(e Event) error {
+	if s == nil {
+		return nil
+	}
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	}
+	doc, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshal audit event: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, insertAuditEvent,
+		EventID(e), db.TimeValue(e.Timestamp), e.Type, e.TaskID, e.AgentID, string(doc)); err != nil {
+		return fmt.Errorf("write audit event: %w", err)
+	}
+	return nil
+}
+
+// Read returns the events matching q, oldest first, as the file trail did.
+func (s *SQLStore) Read(q Query) ([]Event, error) {
+	if s == nil {
+		return nil, nil
+	}
+	stmt := `SELECT doc FROM audit_events WHERE 1 = 1`
+	var args []any
+	if !q.Since.IsZero() {
+		stmt += ` AND ts >= ?`
+		args = append(args, db.TimeValue(q.Since))
+	}
+	if !q.Until.IsZero() {
+		stmt += ` AND ts <= ?`
+		args = append(args, db.TimeValue(q.Until))
+	}
+	if strings.TrimSpace(q.Type) != "" {
+		stmt += ` AND event_type = ?`
+		args = append(args, q.Type)
+	}
+	if strings.TrimSpace(q.TaskID) != "" {
+		stmt += ` AND task_id = ?`
+		args = append(args, q.TaskID)
+	}
+	stmt += ` ORDER BY ts, ` + s.db.OrderText("id")
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx, stmt, args...)
+	if err != nil {
+		return nil, fmt.Errorf("read audit events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Event
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return nil, fmt.Errorf("scan audit event: %w", err)
+		}
+		var e Event
+		if err := json.Unmarshal([]byte(doc), &e); err != nil {
+			// The file reader skips a line it cannot decode rather than failing
+			// the query; one unreadable row must not cost a report all of it.
+			continue
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate audit events: %w", err)
+	}
+	return out, nil
+}
+
+// Cleanup removes events older than retentionDays.
+func (s *SQLStore) Cleanup(retentionDays int) error {
+	if s == nil || retentionDays <= 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+	if _, err := s.db.ExecContext(ctx, deleteAuditBefore, db.TimeValue(cutoff)); err != nil {
+		return fmt.Errorf("clean audit events: %w", err)
+	}
+	return nil
+}
+
+// Close is a no-op: the database handle outlives this store and belongs to whoever opened it.
+func (s *SQLStore) Close() error { return nil }
+
+// EventID derives a stable primary key from an event's own content.
+//
+// The trail has no id of its own, and the import has to be able to run the same day-file twice without duplicating it — which happens whenever a batch is in flight as the process dies. Two genuinely identical events at the same instant collapse into one row; that is the same thing the file trail's own de-duplication would have to do, and it is preferable to a re-import multiplying the history.
+func EventID(e Event) string {
+	doc, err := json.Marshal(e)
+	if err != nil {
+		doc = []byte(e.Type + e.TaskID + e.AgentID)
+	}
+	sum := sha256.Sum256(append([]byte(e.Timestamp.UTC().Format(time.RFC3339Nano)+"\x00"), doc...))
+	return hex.EncodeToString(sum[:])
+}
+
+var _ Store = (*SQLStore)(nil)
+
+// insertEventTx writes one event inside an import transaction.
+func insertEventTx(ctx context.Context, database *db.DB, tx *sql.Tx, e Event, raw []byte) error {
+	if _, err := tx.ExecContext(ctx, database.Rebind(insertAuditEvent),
+		EventID(e), db.TimeValue(e.Timestamp), e.Type, e.TaskID, e.AgentID, string(raw)); err != nil {
+		return fmt.Errorf("insert audit event: %w", err)
+	}
+	return nil
+}

--- a/internal/audit/sqlstore.go
+++ b/internal/audit/sqlstore.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -65,6 +66,13 @@ func (s *SQLStore) Read(q Query) ([]Event, error) {
 	if s == nil {
 		return nil, nil
 	}
+	// An unbounded query is not what the file trail answered: with no window it
+	// formats both bounds as year one, matches no day-file, and returns
+	// nothing. Returning the whole table instead would load an unbounded
+	// history into memory for a caller that forgot a window.
+	if q.Since.IsZero() && q.Until.IsZero() && strings.TrimSpace(q.Type) == "" && strings.TrimSpace(q.TaskID) == "" {
+		return nil, nil
+	}
 	stmt := `SELECT doc FROM audit_events WHERE 1 = 1`
 	var args []any
 	if !q.Since.IsZero() {
@@ -75,9 +83,21 @@ func (s *SQLStore) Read(q Query) ([]Event, error) {
 		stmt += ` AND ts <= ?`
 		args = append(args, db.TimeValue(q.Until))
 	}
-	if strings.TrimSpace(q.Type) != "" {
-		stmt += ` AND event_type = ?`
-		args = append(args, q.Type)
+	if prefix := strings.TrimSpace(q.Type); prefix != "" {
+		// A prefix, not an equality: the file reader matches with HasPrefix, the
+		// CLI flag is documented as a prefix, and the statistics backfill asks
+		// for "agent." expecting every agent event. Equality returned none of
+		// them.
+		//
+		// Expressed as a range rather than LIKE so the index is usable and no
+		// wildcard in the caller's string is interpreted.
+		// Collated, like the ordering is: a range comparison follows the
+		// server's collation too, and the deploy target's en_US.UTF-8 ignores
+		// the dot in "agent." at the primary level — so the bounds admit and
+		// exclude the wrong rows. Byte order is what HasPrefix means.
+		col := s.db.OrderText("event_type")
+		stmt += ` AND ` + col + ` >= ? AND ` + col + ` < ?`
+		args = append(args, prefix, prefixUpperBound(prefix))
 	}
 	if strings.TrimSpace(q.TaskID) != "" {
 		stmt += ` AND task_id = ?`
@@ -110,6 +130,22 @@ func (s *SQLStore) Read(q Query) ([]Event, error) {
 		return nil, fmt.Errorf("iterate audit events: %w", err)
 	}
 	return out, nil
+}
+
+// prefixUpperBound returns the first string greater than every string starting
+// with prefix, so a range scan expresses "has this prefix" exactly.
+//
+// A prefix whose bytes are all 0xff has no such bound; the caller falls back to
+// an open upper end, which over-matches nothing because nothing sorts above it.
+func prefixUpperBound(prefix string) string {
+	b := []byte(prefix)
+	for i, c := range slices.Backward(b) {
+		if c < 0xff {
+			b[i]++
+			return string(b[:i+1])
+		}
+	}
+	return prefix + "\xff"
 }
 
 // Cleanup removes events older than retentionDays.

--- a/internal/audit/sqlstore_test.go
+++ b/internal/audit/sqlstore_test.go
@@ -1,0 +1,202 @@
+package audit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func eventsFixture() []Event {
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return []Event{
+		{Timestamp: base, Type: "agent.started", TaskID: "task-a", AgentID: "ag1"},
+		{Timestamp: base.Add(time.Hour), Type: "agent.done", TaskID: "task-a", AgentID: "ag1"},
+		{Timestamp: base.Add(2 * time.Hour), Type: "agent.started", TaskID: "task-b", AgentID: "ag2"},
+	}
+}
+
+// TestSQLStore_ReadMatchesTheFileTrail is the issue's "reports show the same
+// figures": every filter shape a caller uses must return what the files did.
+func TestSQLStore_ReadMatchesTheFileTrail(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		dir := t.TempDir()
+		files, err := NewLogger(dir)
+		if err != nil {
+			t.Fatalf("NewFileStore: %v", err)
+		}
+		t.Cleanup(func() { _ = files.Close() })
+		sqlStore, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		for _, e := range eventsFixture() {
+			if err := files.Log(e); err != nil {
+				t.Fatalf("file log: %v", err)
+			}
+			if err := sqlStore.Log(e); err != nil {
+				t.Fatalf("sql log: %v", err)
+			}
+		}
+
+		base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+		for _, q := range []Query{
+			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour)},
+			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour), TaskID: "task-a"},
+			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour), Type: "agent.started"},
+			{Since: base.Add(90 * time.Minute), Until: base.Add(6 * time.Hour)},
+		} {
+			fromFiles, err := files.Read(q)
+			if err != nil {
+				t.Fatalf("file read %+v: %v", q, err)
+			}
+			fromSQL, err := sqlStore.Read(q)
+			if err != nil {
+				t.Fatalf("sql read %+v: %v", q, err)
+			}
+			if len(fromSQL) != len(fromFiles) {
+				t.Fatalf("query %+v: sql returned %d events, files returned %d", q, len(fromSQL), len(fromFiles))
+			}
+			for i := range fromFiles {
+				if fromSQL[i].Type != fromFiles[i].Type || fromSQL[i].TaskID != fromFiles[i].TaskID ||
+					!fromSQL[i].Timestamp.Equal(fromFiles[i].Timestamp) {
+					t.Fatalf("query %+v position %d: sql %+v, files %+v", q, i, fromSQL[i], fromFiles[i])
+				}
+			}
+		}
+	})
+}
+
+// TestSQLStore_LoggingIsIdempotentPerEvent pins the property the resumable
+// import leans on: a batch retried after a crash must not duplicate its rows.
+func TestSQLStore_LoggingIsIdempotentPerEvent(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		e := eventsFixture()[0]
+		for range 3 {
+			if err := store.Log(e); err != nil {
+				t.Fatalf("log: %v", err)
+			}
+		}
+		got, err := store.Read(Query{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("logging one event three times produced %d rows", len(got))
+		}
+	})
+}
+
+// TestSQLStore_CleanupHonoursRetention is the issue's "retention still removes
+// data past its configured age".
+func TestSQLStore_CleanupHonoursRetention(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		now := time.Now().UTC()
+		old := Event{Timestamp: now.AddDate(0, 0, -40), Type: "old", TaskID: "t"}
+		fresh := Event{Timestamp: now.AddDate(0, 0, -1), Type: "fresh", TaskID: "t"}
+		for _, e := range []Event{old, fresh} {
+			if err := store.Log(e); err != nil {
+				t.Fatalf("log: %v", err)
+			}
+		}
+		if err := store.Cleanup(30); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		got, err := store.Read(Query{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(got) != 1 || got[0].Type != "fresh" {
+			t.Fatalf("after cleanup got %d events, want only the fresh one", len(got))
+		}
+
+		// Zero keeps everything, as the file trail does.
+		if err := store.Cleanup(0); err != nil {
+			t.Fatalf("cleanup(0): %v", err)
+		}
+		got, err = store.Read(Query{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("cleanup(0) removed events; got %d", len(got))
+		}
+	})
+}
+
+// TestImport_ResumesWithoutDuplicating is the issue's "existing logs import
+// once, and a partial import resumes without duplicating rows".
+func TestImport_ResumesWithoutDuplicating(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		dir := t.TempDir()
+		// Three day-files, so a partial import has somewhere to stop.
+		for i, day := range []string{"2026-05-01", "2026-05-02", "2026-05-03"} {
+			e := eventsFixture()[i]
+			line, err := json.Marshal(e)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, day+".ndjson"), append(line, '\n'), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}
+
+		for range 2 {
+			if err := Import(t.Context(), d, dir, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.Read(Query{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("after two imports got %d events, want 3", len(got))
+		}
+		for _, day := range []string{"2026-05-01", "2026-05-02", "2026-05-03"} {
+			if _, err := os.Stat(filepath.Join(dir, day+".ndjson")); err != nil {
+				t.Errorf("import removed %s: %v", day, err)
+			}
+		}
+	})
+}
+
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), "home-a", nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.Read(Query{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %d events from an empty domain", len(got))
+		}
+	})
+}

--- a/internal/audit/sqlstore_test.go
+++ b/internal/audit/sqlstore_test.go
@@ -49,6 +49,12 @@ func TestSQLStore_ReadMatchesTheFileTrail(t *testing.T) {
 			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour)},
 			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour), TaskID: "task-a"},
 			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour), Type: "agent.started"},
+			// A prefix, which is what the contract is: the file reader matches
+			// with HasPrefix and the statistics backfill asks for exactly this.
+			// Exact-match equality returns none of them, and "agent.started" on
+			// its own is the one shape where both agree.
+			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour), Type: "agent."},
+			{Since: base.Add(-time.Hour), Until: base.Add(6 * time.Hour), Type: "agent"},
 			{Since: base.Add(90 * time.Minute), Until: base.Add(6 * time.Hour)},
 		} {
 			fromFiles, err := files.Read(q)
@@ -87,7 +93,7 @@ func TestSQLStore_LoggingIsIdempotentPerEvent(t *testing.T) {
 				t.Fatalf("log: %v", err)
 			}
 		}
-		got, err := store.Read(Query{})
+		got, err := store.Read(Query{Since: e.Timestamp.Add(-time.Hour), Until: e.Timestamp.Add(time.Hour)})
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -117,7 +123,8 @@ func TestSQLStore_CleanupHonoursRetention(t *testing.T) {
 		if err := store.Cleanup(30); err != nil {
 			t.Fatalf("cleanup: %v", err)
 		}
-		got, err := store.Read(Query{})
+		window := Query{Since: now.AddDate(0, 0, -365), Until: now.Add(time.Hour)}
+		got, err := store.Read(window)
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -129,7 +136,7 @@ func TestSQLStore_CleanupHonoursRetention(t *testing.T) {
 		if err := store.Cleanup(0); err != nil {
 			t.Fatalf("cleanup(0): %v", err)
 		}
-		got, err = store.Read(Query{})
+		got, err = store.Read(window)
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -166,7 +173,7 @@ func TestImport_ResumesWithoutDuplicating(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewSQLStore: %v", err)
 		}
-		got, err := store.Read(Query{})
+		got, err := store.Read(Query{Since: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), Until: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)})
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -191,7 +198,7 @@ func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewSQLStore: %v", err)
 		}
-		got, err := store.Read(Query{})
+		got, err := store.Read(Query{Since: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), Until: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)})
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -1,0 +1,14 @@
+package audit
+
+// Store is the audit trail's persistence surface. Two implementations exist: the per-day NDJSON Logger and the database-backed SQLStore, selected by config.Database.Backend.
+//
+// No context: events are logged from every corner of the app, most of which hold no context, and threading one through them is a change to those callers rather than to where the trail is kept. SQLStore bounds each statement with its own deadline.
+type Store interface {
+	Log(e Event) error
+	Read(q Query) ([]Event, error)
+	// Cleanup removes events past retentionDays. Zero or less keeps everything, matching the file trail.
+	Cleanup(retentionDays int) error
+	Close() error
+}
+
+var _ Store = (*Logger)(nil)

--- a/internal/db/migrations/postgres/0003_logs.sql
+++ b/internal/db/migrations/postgres/0003_logs.sql
@@ -1,0 +1,56 @@
+ALTER TABLE schema_imports ADD COLUMN cursor TEXT NOT NULL DEFAULT ''
+--;;
+ALTER TABLE schema_imports ADD COLUMN done SMALLINT NOT NULL DEFAULT 1
+--;;
+CREATE TABLE IF NOT EXISTS audit_events (
+	id TEXT PRIMARY KEY,
+	ts BIGINT NOT NULL,
+	event_type TEXT NOT NULL DEFAULT '',
+	task_id TEXT NOT NULL DEFAULT '',
+	agent_id TEXT NOT NULL DEFAULT '',
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS audit_events_ts_idx ON audit_events (ts)
+--;;
+CREATE INDEX IF NOT EXISTS audit_events_task_idx ON audit_events (task_id, ts)
+--;;
+CREATE TABLE IF NOT EXISTS tool_ledger (
+	id TEXT PRIMARY KEY,
+	ts BIGINT NOT NULL,
+	agent_id TEXT NOT NULL DEFAULT '',
+	task_id TEXT NOT NULL DEFAULT '',
+	tool TEXT NOT NULL DEFAULT '',
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS tool_ledger_ts_idx ON tool_ledger (ts)
+--;;
+CREATE INDEX IF NOT EXISTS tool_ledger_task_idx ON tool_ledger (task_id, ts)
+--;;
+CREATE TABLE IF NOT EXISTS run_records (
+	id TEXT PRIMARY KEY,
+	task_id TEXT NOT NULL DEFAULT '',
+	project_id TEXT NOT NULL DEFAULT '',
+	started_at BIGINT NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS run_records_started_idx ON run_records (started_at)
+--;;
+CREATE INDEX IF NOT EXISTS run_records_task_idx ON run_records (task_id, started_at)
+--;;
+CREATE TABLE IF NOT EXISTS provider_quota_snapshots (
+	provider TEXT PRIMARY KEY,
+	captured_at BIGINT NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE TABLE IF NOT EXISTS provider_quota_usage (
+	id TEXT PRIMARY KEY,
+	provider TEXT NOT NULL DEFAULT '',
+	ts BIGINT NOT NULL,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS provider_quota_usage_idx ON provider_quota_usage (provider, ts)

--- a/internal/db/migrations/sqlite/0003_logs.sql
+++ b/internal/db/migrations/sqlite/0003_logs.sql
@@ -1,0 +1,56 @@
+ALTER TABLE schema_imports ADD COLUMN cursor TEXT NOT NULL DEFAULT ''
+--;;
+ALTER TABLE schema_imports ADD COLUMN done INTEGER NOT NULL DEFAULT 1
+--;;
+CREATE TABLE IF NOT EXISTS audit_events (
+	id TEXT PRIMARY KEY,
+	ts INTEGER NOT NULL,
+	event_type TEXT NOT NULL DEFAULT '',
+	task_id TEXT NOT NULL DEFAULT '',
+	agent_id TEXT NOT NULL DEFAULT '',
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS audit_events_ts_idx ON audit_events (ts)
+--;;
+CREATE INDEX IF NOT EXISTS audit_events_task_idx ON audit_events (task_id, ts)
+--;;
+CREATE TABLE IF NOT EXISTS tool_ledger (
+	id TEXT PRIMARY KEY,
+	ts INTEGER NOT NULL,
+	agent_id TEXT NOT NULL DEFAULT '',
+	task_id TEXT NOT NULL DEFAULT '',
+	tool TEXT NOT NULL DEFAULT '',
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS tool_ledger_ts_idx ON tool_ledger (ts)
+--;;
+CREATE INDEX IF NOT EXISTS tool_ledger_task_idx ON tool_ledger (task_id, ts)
+--;;
+CREATE TABLE IF NOT EXISTS run_records (
+	id TEXT PRIMARY KEY,
+	task_id TEXT NOT NULL DEFAULT '',
+	project_id TEXT NOT NULL DEFAULT '',
+	started_at INTEGER NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS run_records_started_idx ON run_records (started_at)
+--;;
+CREATE INDEX IF NOT EXISTS run_records_task_idx ON run_records (task_id, started_at)
+--;;
+CREATE TABLE IF NOT EXISTS provider_quota_snapshots (
+	provider TEXT PRIMARY KEY,
+	captured_at INTEGER NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE TABLE IF NOT EXISTS provider_quota_usage (
+	id TEXT PRIMARY KEY,
+	provider TEXT NOT NULL DEFAULT '',
+	ts INTEGER NOT NULL,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS provider_quota_usage_idx ON provider_quota_usage (provider, ts)

--- a/internal/dbimport/dbimport.go
+++ b/internal/dbimport/dbimport.go
@@ -175,6 +175,13 @@ func Resumable(ctx context.Context, database *db.DB, domain, scope string, logge
 			logger.Info("db.import.done", "domain", domain, "scope", scope)
 			return nil
 		}
+		if batch.Cursor == cursor {
+			// A batch that neither finishes nor advances would spin forever
+			// holding the import lock, so no other domain could import and
+			// nothing would say why. That is a defect in the domain's own
+			// next, and it is better reported than waited on.
+			return fmt.Errorf("dbimport %s: batch did not advance past cursor %q", domain, cursor)
+		}
 		logger.Info("db.import.batch", "domain", domain, "scope", scope, "records", batch.Count, "cursor", batch.Cursor)
 	}
 }

--- a/internal/dbimport/dbimport.go
+++ b/internal/dbimport/dbimport.go
@@ -92,3 +92,89 @@ func Imported(ctx context.Context, database *db.DB, domain, scope string) (bool,
 	}
 	return true, nil
 }
+
+const (
+	selectResume = `SELECT cursor, done FROM schema_imports WHERE domain = ?`
+	upsertResume = `INSERT INTO schema_imports (domain, imported_at, record_count, cursor, done)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (domain) DO UPDATE SET
+			imported_at = excluded.imported_at,
+			record_count = schema_imports.record_count + excluded.record_count,
+			cursor = excluded.cursor,
+			done = excluded.done`
+)
+
+// Batch is one unit of a resumable import.
+//
+// Cursor is where the next batch resumes from, written in the same transaction as the rows so it can never claim progress that rolled back. Count accumulates into the operator-visible tally. Done marks the source exhausted; until it is set the next start resumes the domain rather than skipping it.
+type Batch struct {
+	Cursor string
+	Count  int
+	Done   bool
+}
+
+// Resumable copies a domain's logs into the database a batch at a time, continuing where the last run stopped.
+//
+// Once is wrong for this shape. These logs are append-only histories that grow without bound, so a single transaction can be arbitrarily large, and a crash halfway would discard hours of copying and start again from nothing. Here each batch commits its rows and its cursor together: a crash loses at most the batch in flight, and the next start picks up from the last committed cursor.
+//
+// next must tolerate being called twice for one cursor — the batch in flight when a process dies is retried — which the row primary keys provide.
+func Resumable(ctx context.Context, database *db.DB, domain, scope string, logger *slog.Logger, next func(ctx context.Context, tx *sql.Tx, cursor string) (Batch, error)) error {
+	if database == nil {
+		return errors.New("dbimport: needs an open database")
+	}
+	if domain == "" {
+		return errors.New("dbimport: needs a domain name")
+	}
+	if strings.TrimSpace(scope) == "" {
+		return errors.New("dbimport: needs a scope naming whose files these are")
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	key := domain + "@" + scope
+
+	for {
+		var (
+			batch  Batch
+			cursor string
+			halt   bool
+		)
+		err := database.InTxLocked(ctx, LockImport, func(tx *sql.Tx) error {
+			var done int64
+			readErr := tx.QueryRowContext(ctx, database.Rebind(selectResume), key).Scan(&cursor, &done)
+			switch {
+			case readErr == nil && done != 0:
+				halt = true
+				return nil
+			case readErr != nil && !errors.Is(readErr, sql.ErrNoRows):
+				return fmt.Errorf("dbimport %s: read cursor: %w", domain, readErr)
+			}
+
+			var fnErr error
+			batch, fnErr = next(ctx, tx, cursor)
+			if fnErr != nil {
+				return fmt.Errorf("dbimport %s: %w", domain, fnErr)
+			}
+			doneValue := int64(0)
+			if batch.Done {
+				doneValue = 1
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(upsertResume),
+				key, db.TimeValue(time.Now().UTC()), int64(batch.Count), batch.Cursor, doneValue); err != nil {
+				return fmt.Errorf("dbimport %s: record cursor: %w", domain, err)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		if halt {
+			return nil
+		}
+		if batch.Done {
+			logger.Info("db.import.done", "domain", domain, "scope", scope)
+			return nil
+		}
+		logger.Info("db.import.batch", "domain", domain, "scope", scope, "records", batch.Count, "cursor", batch.Cursor)
+	}
+}

--- a/internal/dbimport/dbimport_test.go
+++ b/internal/dbimport/dbimport_test.go
@@ -140,3 +140,75 @@ func TestOnce_RefusesAnEmptyScope(t *testing.T) {
 		}
 	})
 }
+
+// TestResumable_PartialImportResumesFromItsCursor is the issue's "a partial
+// import resumes without duplicating rows".
+//
+// Running an import twice to completion does not test this: the second run
+// reads done=1 and returns before calling next at all, so such a test passes
+// even if the cursor is never persisted, never read, or reset on every start.
+// Here the first run fails mid-way, and the second must pick up where it
+// stopped rather than restarting from nothing.
+func TestResumable_PartialImportResumesFromItsCursor(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		ctx := t.Context()
+		boom := errors.New("interrupted")
+
+		var seen []string
+		next := func(stopAt int) func(context.Context, *sql.Tx, string) (Batch, error) {
+			return func(_ context.Context, _ *sql.Tx, cursor string) (Batch, error) {
+				seen = append(seen, cursor)
+				n := 0
+				if cursor != "" {
+					n = len(cursor)
+				}
+				if n == stopAt {
+					return Batch{}, boom
+				}
+				if n >= 4 {
+					return Batch{Cursor: cursor, Count: 1, Done: true}, nil
+				}
+				return Batch{Cursor: cursor + "x", Count: 1}, nil
+			}
+		}
+
+		if err := Resumable(ctx, d, "demo", "home-a", nil, next(3)); !errors.Is(err, boom) {
+			t.Fatalf("first run returned %v, want the body's error", err)
+		}
+		if len(seen) == 0 || seen[0] != "" {
+			t.Fatalf("first run started at %q, want the empty cursor", seen)
+		}
+		firstRun := append([]string(nil), seen...)
+		seen = nil
+
+		if err := Resumable(ctx, d, "demo", "home-a", nil, next(-1)); err != nil {
+			t.Fatalf("second run: %v", err)
+		}
+		if len(seen) == 0 {
+			t.Fatal("second run never called next; the domain was marked done by an interrupted import")
+		}
+		if seen[0] == "" {
+			t.Fatalf("second run restarted from nothing (%v) after %v; the cursor was not read back", seen, firstRun)
+		}
+		if want := firstRun[len(firstRun)-1]; seen[0] != want {
+			t.Fatalf("second run resumed at %q, want the last committed cursor %q", seen[0], want)
+		}
+	})
+}
+
+// TestResumable_RefusesABatchThatDoesNotAdvance keeps a defective domain from
+// spinning forever while holding the import lock, which would block every
+// other domain's import with nothing in the log to say why.
+func TestResumable_RefusesABatchThatDoesNotAdvance(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		err := Resumable(t.Context(), d, "demo", "home-a", nil,
+			func(context.Context, *sql.Tx, string) (Batch, error) {
+				return Batch{Cursor: "", Count: 1}, nil
+			})
+		if err == nil {
+			t.Fatal("a batch that never advances was accepted; the import spins forever")
+		}
+	})
+}

--- a/internal/evaluation/service.go
+++ b/internal/evaluation/service.go
@@ -333,3 +333,19 @@ func (s *Service) persist(r Report) error {
 	}
 	return fsutil.AtomicWrite(s.reportPath, data)
 }
+
+// AuditStoreReader adapts the board's audit store into a reader.
+//
+// The directory-backed reader above only sees what a file-backed trail wrote.
+// Under a database backend the day-files stop growing, so a consumer left on
+// the directory reads an empty trail and reports the fleet as idle.
+func AuditStoreReader(store interface {
+	Read(audit.Query) ([]audit.Event, error)
+}) auditReader {
+	return auditFunc(func(q audit.Query) ([]audit.Event, error) {
+		if store == nil {
+			return nil, nil
+		}
+		return store.Read(q)
+	})
+}

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -25,13 +25,13 @@ const (
 
 // Checker runs periodic health checks on audit data and task state.
 type Checker struct {
-	auditDir string
-	tasks    *task.Manager
-	homeDir  string
-	logger   *slog.Logger
-	emit     func(string, any)
-	owned    func() OwnedProcesses
-	docker   dockerRunner
+	trail   auditReader
+	tasks   *task.Manager
+	homeDir string
+	logger  *slog.Logger
+	emit    func(string, any)
+	owned   func() OwnedProcesses
+	docker  dockerRunner
 
 	// sandboxQuarantine returns the currently quarantined sandbox cleanup
 	// failures (see sandbox.Manager.QuarantinedEntries). nil disables the
@@ -55,7 +55,7 @@ type Checker struct {
 
 // New creates a Checker. Call Run to start the ticker loop.
 func New(
-	auditDir string,
+	trail auditReader,
 	tasks *task.Manager,
 	homeDir string,
 	logger *slog.Logger,
@@ -63,12 +63,12 @@ func New(
 	owned func() OwnedProcesses,
 ) *Checker {
 	return &Checker{
-		auditDir: auditDir,
-		tasks:    tasks,
-		homeDir:  homeDir,
-		logger:   logger,
-		emit:     emit,
-		owned:    owned,
+		trail:   trail,
+		tasks:   tasks,
+		homeDir: homeDir,
+		logger:  logger,
+		emit:    emit,
+		owned:   owned,
 	}
 }
 
@@ -138,14 +138,14 @@ func (c *Checker) check(ctx context.Context) {
 	now := time.Now().UTC()
 	since := now.Add(-lookback)
 
-	dayEvents, err := audit.Read(c.auditDir, audit.Query{Since: since, Until: now})
+	dayEvents, err := c.readTrail(audit.Query{Since: since, Until: now})
 	if err != nil {
 		c.logger.Warn("health.check.audit_read", "err", err)
 		dayEvents = nil
 	}
 
 	weekSince := now.Add(-weekLookback)
-	weekEvents, err := audit.Read(c.auditDir, audit.Query{Since: weekSince, Until: now})
+	weekEvents, err := c.readTrail(audit.Query{Since: weekSince, Until: now})
 	if err != nil {
 		c.logger.Warn("health.check.audit_read_week", "err", err)
 		weekEvents = nil
@@ -305,4 +305,18 @@ func (c *Checker) persist(r *Report) {
 	if err := fsutil.AtomicWrite(path, data); err != nil {
 		c.logger.Warn("health.persist.write", "err", err)
 	}
+}
+
+// auditReader is the trail this checker reads. It is an interface rather than a
+// directory because under a database backend the day-files stop growing, and a
+// checker left on the directory reports every check all-clear for ever.
+type auditReader interface {
+	Read(audit.Query) ([]audit.Event, error)
+}
+
+func (c *Checker) readTrail(q audit.Query) ([]audit.Event, error) {
+	if c.trail == nil {
+		return nil, nil
+	}
+	return c.trail.Read(q)
 }

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/audit"
+
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -54,7 +56,7 @@ func TestCheckerIncludesDockerReclaimableFinding(t *testing.T) {
 		t.Fatalf("task.NewStore: %v", err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.docker = func(context.Context) ([]byte, error) {
 		return []byte(`{"Size":"25GiB","Reclaimable":"20GiB (80%)"}`), nil
 	}
@@ -96,7 +98,7 @@ func TestCheckerSkipsSandboxCheckWhenUnwired(t *testing.T) {
 		t.Fatalf("task.NewStore: %v", err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.check(t.Context())
 
 	report := c.LatestReport()
@@ -119,7 +121,7 @@ func TestCheckerIncludesSandboxCleanupFinding(t *testing.T) {
 		t.Fatalf("task.NewStore: %v", err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.SetSandboxQuarantine(func() []sandbox.QuarantineEntry {
 		return []sandbox.QuarantineEntry{
 			{TaskID: "task-quarantined", Path: "/data/sandboxes/task-quarantined", BytesRetained: 2048, Attempts: 4, LastError: "permission denied"},
@@ -166,7 +168,7 @@ func TestCheckerIncludesUnreadableTaskFinding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.check(t.Context())
 
 	report := c.LatestReport()
@@ -205,7 +207,7 @@ func TestCheckerSkipsGHAuthCheckWhenUnwired(t *testing.T) {
 		t.Fatalf("task.NewStore: %v", err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.check(t.Context())
 
 	report := c.LatestReport()
@@ -228,7 +230,7 @@ func TestCheckerIncludesGHAuthUnavailableFinding(t *testing.T) {
 		t.Fatalf("task.NewStore: %v", err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.SetGHAuthProbe(func() (bool, string) { return false, "misconfigured" })
 
 	c.check(t.Context())
@@ -261,7 +263,7 @@ func TestCheckerIncludesGHAuthUnavailableFinding_TransientIsWarning(t *testing.T
 		t.Fatalf("task.NewStore: %v", err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.SetGHAuthProbe(func() (bool, string) { return false, "unavailable" })
 
 	c.check(t.Context())
@@ -295,7 +297,7 @@ func TestCheckerIncludesPressureTelemetry(t *testing.T) {
 	}
 
 	ranAt := time.Date(2026, 7, 16, 20, 30, 0, 0, time.UTC)
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.SetPressureStatus(func() *PressureStatus {
 		return &PressureStatus{
 			DiskFreePct:         12.5,
@@ -352,7 +354,7 @@ func TestCheckerSanitizesUnreadablePressureSample(t *testing.T) {
 		t.Fatalf("task.NewStore: %v", err)
 	}
 
-	c := New(t.TempDir(), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(t.TempDir()), task.NewManager(store, nil), home, slog.New(slog.DiscardHandler), nil, nil)
 	c.SetPressureStatus(func() *PressureStatus {
 		return &PressureStatus{
 			DiskFreePct:         math.NaN(),
@@ -409,3 +411,13 @@ func TestCheckerSanitizesUnreadablePressureSample(t *testing.T) {
 		t.Errorf("persisted pressure = %+v, want DiskFreePct/LoadPerCPU sanitized to -1", *persisted.Pressure)
 	}
 }
+
+// auditDirReaderForTest adapts a trail directory into the reader the checker
+// takes, so these tests keep exercising the real file reader.
+func auditDirReaderForTest(dir string) auditReader {
+	return auditReaderFunc(func(q audit.Query) ([]audit.Event, error) { return audit.Read(dir, q) })
+}
+
+type auditReaderFunc func(audit.Query) ([]audit.Event, error)
+
+func (f auditReaderFunc) Read(q audit.Query) ([]audit.Event, error) { return f(q) }

--- a/internal/health/e2e_test.go
+++ b/internal/health/e2e_test.go
@@ -63,7 +63,7 @@ func TestE2E_NewChecksFireThroughChecker(t *testing.T) {
 	tasks := task.NewManager(store, nil)
 
 	silent := slog.New(slog.DiscardHandler)
-	c := New(auditDir, tasks, home, silent, nil, nil)
+	c := New(auditDirReaderForTest(auditDir), tasks, home, silent, nil, nil)
 	c.docker = func(context.Context) ([]byte, error) {
 		return []byte(`{"Size":"30GiB","Reclaimable":"24GiB (80%)"}`), nil
 	}
@@ -196,7 +196,7 @@ func TestE2E_GoodScoreWhenNothingFires(t *testing.T) {
 	}
 	tasks := task.NewManager(store, nil)
 	silent := slog.New(slog.DiscardHandler)
-	c := New(auditDir, tasks, home, silent, nil, nil)
+	c := New(auditDirReaderForTest(auditDir), tasks, home, silent, nil, nil)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -270,7 +270,7 @@ func TestE2E_SandboxCleanupFailureSurfacesHealthFinding(t *testing.T) {
 	}
 	tasks := task.NewManager(store, nil)
 
-	c := New(auditDir, tasks, home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(auditDir), tasks, home, slog.New(slog.DiscardHandler), nil, nil)
 	c.SetSandboxQuarantine(mgr.QuarantinedEntries)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -364,7 +364,7 @@ func TestE2E_PressureTelemetryPersistsLastReclaim(t *testing.T) {
 	tasks := task.NewManager(store, nil)
 
 	ranAt := time.Date(2026, 7, 16, 21, 0, 0, 0, time.UTC)
-	c := New(auditDir, tasks, home, slog.New(slog.DiscardHandler), nil, nil)
+	c := New(auditDirReaderForTest(auditDir), tasks, home, slog.New(slog.DiscardHandler), nil, nil)
 	c.SetPressureStatus(func() *PressureStatus {
 		return &PressureStatus{
 			DiskFreePct:         12.5,

--- a/internal/intervention/capture.go
+++ b/internal/intervention/capture.go
@@ -27,7 +27,7 @@ import (
 // dependency, degrades to a no-op (never blocks the caller's own status
 // write) on any failure, and never captures work content for a work-typed
 // project without scrubbing first.
-func Capture(store *Store, cfg *config.Config, projects *project.Store, al *audit.Logger, logger *slog.Logger, cur task.Task, target, reason string, class OperatorActionClass) {
+func Capture(store *Store, cfg *config.Config, projects *project.Store, al audit.Store, logger *slog.Logger, cur task.Task, target, reason string, class OperatorActionClass) {
 	defer func() {
 		if r := recover(); r != nil && logger != nil {
 			logger.Warn("intervention.record.panic", "task_id", cur.ID, "panic", r)
@@ -77,7 +77,7 @@ func Capture(store *Store, cfg *config.Config, projects *project.Store, al *audi
 	logCapture(al, logger, audit.EventInterventionRecorded, cur.ID, data)
 }
 
-func logCapture(al *audit.Logger, logger *slog.Logger, eventType, taskID string, data map[string]any) {
+func logCapture(al audit.Store, logger *slog.Logger, eventType, taskID string, data map[string]any) {
 	if al == nil {
 		return
 	}

--- a/internal/learning/digest.go
+++ b/internal/learning/digest.go
@@ -36,7 +36,7 @@ func AuditDirReader(dir string) auditReader {
 	return auditFunc(func(q audit.Query) ([]audit.Event, error) { return audit.Read(dir, q) })
 }
 
-// auditWriter is the subset of *audit.Logger the digest service needs to
+// auditWriter is the subset of audit.Store the digest service needs to
 // record its own generation/failure events.
 type auditWriter interface {
 	Log(audit.Event) error

--- a/internal/learning/digest.go
+++ b/internal/learning/digest.go
@@ -430,3 +430,19 @@ func (s *Service) interval() time.Duration {
 	}
 	return interval
 }
+
+// AuditStoreReader adapts the board's audit store into a reader.
+//
+// The directory-backed reader above only sees what a file-backed trail wrote.
+// Under a database backend the day-files stop growing, so a consumer left on
+// the directory reads an empty trail and reports the fleet as idle.
+func AuditStoreReader(store interface {
+	Read(audit.Query) ([]audit.Event, error)
+}) auditReader {
+	return auditFunc(func(q audit.Query) ([]audit.Event, error) {
+		if store == nil {
+			return nil, nil
+		}
+		return store.Read(q)
+	})
+}

--- a/internal/limits/import.go
+++ b/internal/limits/import.go
@@ -1,0 +1,60 @@
+package limits
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log/slog"
+	"os"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "limits"
+
+// Import copies the quota document into the database once.
+//
+// One document rather than a growing log, and bounded by the event retention the file store already applied, so this one fits in a transaction and needs no cursor.
+//
+// The file is only read.
+func Import(ctx context.Context, database *db.DB, path, scope string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return dbimport.Once(ctx, database, ImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+		var p persisted
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &p); err != nil {
+				// A document this build cannot parse imports as nothing rather
+				// than failing every start: quota state is re-observed from the
+				// providers within one poll interval.
+				logger.Warn("limits.import.unreadable", "path", path, "err", err)
+				return 0, nil
+			}
+		}
+		for provider := range p.Snapshots {
+			s := p.Snapshots[provider]
+			doc, err := json.Marshal(&s)
+			if err != nil {
+				return 0, err
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(upsertQuotaSnapshot),
+				s.Provider, db.TimeValue(s.CapturedAt), string(doc)); err != nil {
+				return 0, err
+			}
+		}
+		if err := insertEventsTx(ctx, database, tx, p.Events); err != nil {
+			return 0, err
+		}
+		return len(p.Snapshots) + len(p.Events), nil
+	})
+}

--- a/internal/limits/persistence.go
+++ b/internal/limits/persistence.go
@@ -1,0 +1,9 @@
+package limits
+
+// Persistence is where quota snapshots and usage events survive a restart. Two implementations exist: the single JSON document and the database-backed SQLPersistence, selected by config.Database.Backend.
+//
+// Load and Save carry the whole set because that is what the file store always wrote: a snapshot dropped for age disappears by not being in the next Save, and the in-memory state is the authority between them.
+type Persistence interface {
+	Load() (map[string]Snapshot, []UsageEvent, error)
+	Save(snapshots map[string]Snapshot, events []UsageEvent) error
+}

--- a/internal/limits/persistence.go
+++ b/internal/limits/persistence.go
@@ -6,4 +6,13 @@ package limits
 type Persistence interface {
 	Load() (map[string]Snapshot, []UsageEvent, error)
 	Save(snapshots map[string]Snapshot, events []UsageEvent) error
+	// Critical runs a read-modify-write as one atomic unit against every other
+	// writer, in this process and in any other sharing the board.
+	//
+	// It replaces the cross-process file lock, which existed for exactly this:
+	// the desktop app and sybra-server each hold their own Store over one
+	// board, and without it two updates interleave as load/load/save/save and
+	// the second silently discards the first. Load and Save called inside fn
+	// see the same transaction.
+	Critical(fn func() error) error
 }

--- a/internal/limits/sqlstore.go
+++ b/internal/limits/sqlstore.go
@@ -1,0 +1,150 @@
+package limits
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// queryTimeout bounds every statement. Persistence carries no context to cancel one with.
+const queryTimeout = 15 * time.Second
+
+// SQLPersistence keeps quota state in the configured database backend.
+//
+// A snapshot is one row per provider and a usage event is one row, so an update writes what changed rather than rewriting the whole document under a cross-process file lock — which is what made every quota update proportional to the length of the history.
+type SQLPersistence struct {
+	db *db.DB
+}
+
+// NewSQLPersistence returns the database-backed quota store.
+func NewSQLPersistence(database *db.DB) (*SQLPersistence, error) {
+	if database == nil {
+		return nil, errors.New("quota store needs an open database")
+	}
+	return &SQLPersistence{db: database}, nil
+}
+
+const (
+	upsertQuotaSnapshot = `INSERT INTO provider_quota_snapshots (provider, captured_at, doc)
+		VALUES (?, ?, ?)
+		ON CONFLICT (provider) DO UPDATE SET captured_at = excluded.captured_at, doc = excluded.doc`
+
+	insertQuotaUsage = `INSERT INTO provider_quota_usage (id, provider, ts, doc)
+		VALUES (?, ?, ?, ?) ON CONFLICT (id) DO NOTHING`
+
+	deleteMissingSnapshots = `DELETE FROM provider_quota_snapshots`
+	deleteUsageBefore      = `DELETE FROM provider_quota_usage WHERE ts < ?`
+)
+
+// Load returns the persisted snapshots and usage events, oldest event first.
+func (p *SQLPersistence) Load() (map[string]Snapshot, []UsageEvent, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+
+	snapshots := map[string]Snapshot{}
+	rows, err := p.db.QueryContext(ctx, `SELECT doc FROM provider_quota_snapshots`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read quota snapshots: %w", err)
+	}
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			_ = rows.Close()
+			return nil, nil, fmt.Errorf("scan quota snapshot: %w", err)
+		}
+		var s Snapshot
+		if err := json.Unmarshal([]byte(doc), &s); err != nil {
+			continue
+		}
+		if s.Provider != "" {
+			snapshots[s.Provider] = s
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, nil, fmt.Errorf("iterate quota snapshots: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close quota snapshot scan: %w", err)
+	}
+
+	eventRows, err := p.db.QueryContext(ctx,
+		`SELECT doc FROM provider_quota_usage ORDER BY ts, `+p.db.OrderText("id"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read quota usage: %w", err)
+	}
+	defer func() { _ = eventRows.Close() }()
+	var events []UsageEvent
+	for eventRows.Next() {
+		var doc string
+		if err := eventRows.Scan(&doc); err != nil {
+			return nil, nil, fmt.Errorf("scan quota usage: %w", err)
+		}
+		var e UsageEvent
+		if err := json.Unmarshal([]byte(doc), &e); err != nil {
+			continue
+		}
+		events = append(events, e)
+	}
+	if err := eventRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate quota usage: %w", err)
+	}
+	return snapshots, events, nil
+}
+
+// Save replaces the persisted state with what the store now holds.
+//
+// Events are inserted rather than replaced wholesale — their ids are stable, so a repeat is a conflict — and the ones the store dropped for age are deleted by time rather than by absence, which keeps a concurrent writer's newer events from being erased by an older reader's view.
+func (p *SQLPersistence) Save(snapshots map[string]Snapshot, events []UsageEvent) error {
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	return p.db.InTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteMissingSnapshots)); err != nil {
+			return fmt.Errorf("clear quota snapshots: %w", err)
+		}
+		for provider := range snapshots {
+			s := snapshots[provider]
+			doc, err := json.Marshal(&s)
+			if err != nil {
+				return fmt.Errorf("marshal quota snapshot: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, p.db.Rebind(upsertQuotaSnapshot),
+				s.Provider, db.TimeValue(s.CapturedAt), string(doc)); err != nil {
+				return fmt.Errorf("write quota snapshot: %w", err)
+			}
+		}
+		if err := insertEventsTx(ctx, p.db, tx, events); err != nil {
+			return err
+		}
+		// Retention by age, matching the file store's own cutoff.
+		cutoff := time.Now().UTC().Add(-eventMaxAge)
+		if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteUsageBefore), db.TimeValue(cutoff)); err != nil {
+			return fmt.Errorf("prune quota usage: %w", err)
+		}
+		return nil
+	})
+}
+
+func insertEventsTx(ctx context.Context, database *db.DB, tx *sql.Tx, events []UsageEvent) error {
+	for i := range events {
+		if events[i].ID == "" {
+			continue
+		}
+		doc, err := json.Marshal(events[i])
+		if err != nil {
+			return fmt.Errorf("marshal quota usage: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, database.Rebind(insertQuotaUsage),
+			events[i].ID, events[i].Provider, db.TimeValue(events[i].Timestamp), string(doc)); err != nil {
+			return fmt.Errorf("write quota usage: %w", err)
+		}
+	}
+	return nil
+}
+
+var _ Persistence = (*SQLPersistence)(nil)

--- a/internal/limits/sqlstore.go
+++ b/internal/limits/sqlstore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/db"
@@ -19,6 +20,36 @@ const queryTimeout = 15 * time.Second
 // A snapshot is one row per provider and a usage event is one row, so an update writes what changed rather than rewriting the whole document under a cross-process file lock — which is what made every quota update proportional to the length of the history.
 type SQLPersistence struct {
 	db *db.DB
+
+	// mu serializes critical sections in this process; the advisory lock the
+	// transaction takes serializes them against every other process. tx is the
+	// transaction a critical section is running in, and is nil outside one.
+	mu sync.Mutex
+	tx *sql.Tx
+}
+
+// LockQuota serializes quota read-modify-writes across processes. Distinct
+// from every other advisory key so a quota update never waits on an import.
+const LockQuota db.LockKey = 6_215_034_129_004
+
+// Critical runs fn as one atomic read-modify-write.
+func (p *SQLPersistence) Critical(fn func() error) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	return p.db.InTxLocked(ctx, LockQuota, func(tx *sql.Tx) error {
+		p.tx = tx
+		defer func() { p.tx = nil }()
+		return fn()
+	})
+}
+
+func (p *SQLPersistence) query(ctx context.Context, stmt string, args ...any) (*sql.Rows, error) {
+	if p.tx != nil {
+		return p.tx.QueryContext(ctx, p.db.Rebind(stmt), args...)
+	}
+	return p.db.QueryContext(ctx, stmt, args...)
 }
 
 // NewSQLPersistence returns the database-backed quota store.
@@ -47,7 +78,7 @@ func (p *SQLPersistence) Load() (map[string]Snapshot, []UsageEvent, error) {
 	defer cancel()
 
 	snapshots := map[string]Snapshot{}
-	rows, err := p.db.QueryContext(ctx, `SELECT doc FROM provider_quota_snapshots`)
+	rows, err := p.query(ctx, `SELECT doc FROM provider_quota_snapshots`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read quota snapshots: %w", err)
 	}
@@ -73,7 +104,7 @@ func (p *SQLPersistence) Load() (map[string]Snapshot, []UsageEvent, error) {
 		return nil, nil, fmt.Errorf("close quota snapshot scan: %w", err)
 	}
 
-	eventRows, err := p.db.QueryContext(ctx,
+	eventRows, err := p.query(ctx,
 		`SELECT doc FROM provider_quota_usage ORDER BY ts, `+p.db.OrderText("id"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("read quota usage: %w", err)
@@ -103,31 +134,38 @@ func (p *SQLPersistence) Load() (map[string]Snapshot, []UsageEvent, error) {
 func (p *SQLPersistence) Save(snapshots map[string]Snapshot, events []UsageEvent) error {
 	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
+	if p.tx != nil {
+		return p.save(ctx, p.tx, snapshots, events)
+	}
 	return p.db.InTx(ctx, func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteMissingSnapshots)); err != nil {
-			return fmt.Errorf("clear quota snapshots: %w", err)
-		}
-		for provider := range snapshots {
-			s := snapshots[provider]
-			doc, err := json.Marshal(&s)
-			if err != nil {
-				return fmt.Errorf("marshal quota snapshot: %w", err)
-			}
-			if _, err := tx.ExecContext(ctx, p.db.Rebind(upsertQuotaSnapshot),
-				s.Provider, db.TimeValue(s.CapturedAt), string(doc)); err != nil {
-				return fmt.Errorf("write quota snapshot: %w", err)
-			}
-		}
-		if err := insertEventsTx(ctx, p.db, tx, events); err != nil {
-			return err
-		}
-		// Retention by age, matching the file store's own cutoff.
-		cutoff := time.Now().UTC().Add(-eventMaxAge)
-		if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteUsageBefore), db.TimeValue(cutoff)); err != nil {
-			return fmt.Errorf("prune quota usage: %w", err)
-		}
-		return nil
+		return p.save(ctx, tx, snapshots, events)
 	})
+}
+
+func (p *SQLPersistence) save(ctx context.Context, tx *sql.Tx, snapshots map[string]Snapshot, events []UsageEvent) error {
+	if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteMissingSnapshots)); err != nil {
+		return fmt.Errorf("clear quota snapshots: %w", err)
+	}
+	for provider := range snapshots {
+		s := snapshots[provider]
+		doc, err := json.Marshal(&s)
+		if err != nil {
+			return fmt.Errorf("marshal quota snapshot: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, p.db.Rebind(upsertQuotaSnapshot),
+			s.Provider, db.TimeValue(s.CapturedAt), string(doc)); err != nil {
+			return fmt.Errorf("write quota snapshot: %w", err)
+		}
+	}
+	if err := insertEventsTx(ctx, p.db, tx, events); err != nil {
+		return err
+	}
+	// Retention by age, matching the file store's own cutoff.
+	cutoff := time.Now().UTC().Add(-eventMaxAge)
+	if _, err := tx.ExecContext(ctx, p.db.Rebind(deleteUsageBefore), db.TimeValue(cutoff)); err != nil {
+		return fmt.Errorf("prune quota usage: %w", err)
+	}
+	return nil
 }
 
 func insertEventsTx(ctx context.Context, database *db.DB, tx *sql.Tx, events []UsageEvent) error {

--- a/internal/limits/sqlstore_test.go
+++ b/internal/limits/sqlstore_test.go
@@ -8,17 +8,18 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/testutil/dbtest"
 )
 
 func quotaFixture(now time.Time) (map[string]Snapshot, []UsageEvent) {
 	snapshots := map[string]Snapshot{
-		"claude": {Provider: "claude", PlanType: "max", CapturedAt: now.Add(-time.Minute)},
-		"codex":  {Provider: "codex", PlanType: "pro", CapturedAt: now.Add(-2 * time.Minute)},
+		providerid.Claude: {Provider: providerid.Claude, PlanType: "max", CapturedAt: now.Add(-time.Minute)},
+		providerid.Codex:  {Provider: providerid.Codex, PlanType: "pro", CapturedAt: now.Add(-2 * time.Minute)},
 	}
 	events := []UsageEvent{
-		{ID: "e1", Provider: "claude", Source: "run", CostUSD: 1, Timestamp: now.Add(-time.Hour)},
-		{ID: "e2", Provider: "codex", Source: "run", CostUSD: 2, Timestamp: now.Add(-30 * time.Minute)},
+		{ID: "e1", Provider: providerid.Claude, Source: "run", CostUSD: 1, Timestamp: now.Add(-time.Hour)},
+		{ID: "e2", Provider: providerid.Codex, Source: "run", CostUSD: 2, Timestamp: now.Add(-30 * time.Minute)},
 	}
 	return snapshots, events
 }
@@ -40,7 +41,7 @@ func TestSQLPersistence_RoundTrips(t *testing.T) {
 		if err != nil {
 			t.Fatalf("load: %v", err)
 		}
-		if len(gotSnapshots) != 2 || gotSnapshots["claude"].PlanType != "max" {
+		if len(gotSnapshots) != 2 || gotSnapshots[providerid.Claude].PlanType != "max" {
 			t.Fatalf("snapshots round-tripped as %+v", gotSnapshots)
 		}
 		if len(gotEvents) != 2 || gotEvents[0].ID != "e1" {
@@ -71,8 +72,8 @@ func TestSQLPersistence_PrunesEventsPastRetention(t *testing.T) {
 		}
 		now := time.Now().UTC()
 		events := []UsageEvent{
-			{ID: "old", Provider: "claude", Timestamp: now.Add(-eventMaxAge - time.Hour)},
-			{ID: "fresh", Provider: "claude", Timestamp: now.Add(-time.Hour)},
+			{ID: "old", Provider: providerid.Claude, Timestamp: now.Add(-eventMaxAge - time.Hour)},
+			{ID: "fresh", Provider: providerid.Claude, Timestamp: now.Add(-time.Hour)},
 		}
 		if err := store.Save(map[string]Snapshot{}, events); err != nil {
 			t.Fatalf("save: %v", err)

--- a/internal/limits/sqlstore_test.go
+++ b/internal/limits/sqlstore_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -143,4 +144,69 @@ func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
 			t.Fatalf("got %d snapshots and %d events from an empty domain", len(snapshots), len(events))
 		}
 	})
+}
+
+// TestSQLPersistence_ConcurrentInstancesDoNotLoseSnapshots is the case a shared
+// board exists for.
+//
+// The cross-process file lock made load-mutate-save atomic. Replacing it with a
+// no-op left two instances interleaving as load/load/save/save, and because
+// Save replaces the snapshot set, the second write dropped the first
+// instance's provider entirely — a provider that is actually rate-limited then
+// reads back as untouched headroom and dispatch routes into it.
+func TestSQLPersistence_ConcurrentInstancesDoNotLoseSnapshots(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		persistence, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		one, err := NewStoreWith(persistence)
+		if err != nil {
+			t.Fatalf("NewStoreWith: %v", err)
+		}
+		two, err := NewStoreWith(persistence)
+		if err != nil {
+			t.Fatalf("NewStoreWith: %v", err)
+		}
+
+		const rounds = 60
+		var wg sync.WaitGroup
+		for _, pair := range []struct {
+			store    *Store
+			provider string
+		}{{one, providerid.Claude}, {two, providerid.Codex}} {
+			wg.Go(func() {
+				for i := range rounds {
+					if err := pair.store.UpdateSnapshot(Snapshot{
+						Provider:   pair.provider,
+						PlanType:   "max",
+						CapturedAt: time.Now().UTC().Add(time.Duration(i) * time.Millisecond),
+					}); err != nil {
+						t.Errorf("UpdateSnapshot(%s): %v", pair.provider, err)
+						return
+					}
+				}
+			})
+		}
+		wg.Wait()
+
+		got, _, err := persistence.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		for _, provider := range []string{providerid.Claude, providerid.Codex} {
+			if _, ok := got[provider]; !ok {
+				t.Fatalf("%s's snapshot was lost to the other instance; board holds %v", provider, keys(got))
+			}
+		}
+	})
+}
+
+func keys(m map[string]Snapshot) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/internal/limits/sqlstore_test.go
+++ b/internal/limits/sqlstore_test.go
@@ -1,0 +1,145 @@
+package limits
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func quotaFixture(now time.Time) (map[string]Snapshot, []UsageEvent) {
+	snapshots := map[string]Snapshot{
+		"claude": {Provider: "claude", PlanType: "max", CapturedAt: now.Add(-time.Minute)},
+		"codex":  {Provider: "codex", PlanType: "pro", CapturedAt: now.Add(-2 * time.Minute)},
+	}
+	events := []UsageEvent{
+		{ID: "e1", Provider: "claude", Source: "run", CostUSD: 1, Timestamp: now.Add(-time.Hour)},
+		{ID: "e2", Provider: "codex", Source: "run", CostUSD: 2, Timestamp: now.Add(-30 * time.Minute)},
+	}
+	return snapshots, events
+}
+
+// TestSQLPersistence_RoundTrips pins that what the store saves is what it loads back, which is what every provider-selection decision reads.
+func TestSQLPersistence_RoundTrips(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		now := time.Now().UTC()
+		snapshots, events := quotaFixture(now)
+		if err := store.Save(snapshots, events); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		gotSnapshots, gotEvents, err := store.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(gotSnapshots) != 2 || gotSnapshots["claude"].PlanType != "max" {
+			t.Fatalf("snapshots round-tripped as %+v", gotSnapshots)
+		}
+		if len(gotEvents) != 2 || gotEvents[0].ID != "e1" {
+			t.Fatalf("events round-tripped as %+v", gotEvents)
+		}
+
+		// Every update hands over the whole set, so a repeat must not multiply what is already stored.
+		if err := store.Save(snapshots, events); err != nil {
+			t.Fatalf("second save: %v", err)
+		}
+		_, gotEvents, err = store.Load()
+		if err != nil {
+			t.Fatalf("second load: %v", err)
+		}
+		if len(gotEvents) != 2 {
+			t.Fatalf("re-saving produced %d events, want 2", len(gotEvents))
+		}
+	})
+}
+
+// TestSQLPersistence_PrunesEventsPastRetention is the issue's "retention still removes data past its configured age".
+func TestSQLPersistence_PrunesEventsPastRetention(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		now := time.Now().UTC()
+		events := []UsageEvent{
+			{ID: "old", Provider: "claude", Timestamp: now.Add(-eventMaxAge - time.Hour)},
+			{ID: "fresh", Provider: "claude", Timestamp: now.Add(-time.Hour)},
+		}
+		if err := store.Save(map[string]Snapshot{}, events); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		_, got, err := store.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "fresh" {
+			t.Fatalf("retention kept %+v, want only the fresh event", got)
+		}
+	})
+}
+
+// TestImport_IsOnceOnlyAndLeavesTheFile pins the upgrade guarantees.
+func TestImport_IsOnceOnlyAndLeavesTheFile(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		now := time.Now().UTC()
+		snapshots, events := quotaFixture(now)
+		path := filepath.Join(t.TempDir(), "limits.json")
+		data, err := json.Marshal(persisted{Snapshots: snapshots, Events: events})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		for range 2 {
+			if err := Import(t.Context(), d, path, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		gotSnapshots, gotEvents, err := store.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(gotSnapshots) != 2 || len(gotEvents) != 2 {
+			t.Fatalf("after two imports got %d snapshots and %d events, want 2 and 2", len(gotSnapshots), len(gotEvents))
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("import removed the original document: %v", err)
+		}
+	})
+}
+
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written.json"), "home-a", nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		snapshots, events, err := store.Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(snapshots) != 0 || len(events) != 0 {
+			t.Fatalf("got %d snapshots and %d events from an empty domain", len(snapshots), len(events))
+		}
+	})
+}

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -82,9 +82,25 @@ func newStore(path string, p Persistence) (*Store, error) {
 // returns a no-op rather than locking a path that does not exist.
 func (s *Store) lock() (func() error, error) {
 	if s.persistence != nil {
+		// Serialized by critical() instead, which is a database transaction:
+		// there is no document to flock, and returning a no-op here on its own
+		// would leave load/mutate/save interleaving between two instances and
+		// silently dropping one's snapshot.
 		return func() error { return nil }, nil
 	}
 	return fsutil.LockFileWithin(s.path, storeLockTimeout)
+}
+
+// critical runs a read-modify-write as one atomic unit.
+//
+// With a database backend that is a transaction holding an advisory lock, so
+// two instances sharing a board serialize; with the file backend the caller's
+// flock already did it and this only runs fn.
+func (s *Store) critical(fn func() error) error {
+	if s.persistence != nil {
+		return s.persistence.Critical(fn)
+	}
+	return fn()
 }
 
 // UpdateSnapshot, RecordUsage, and Import are read-modify-write against the
@@ -106,13 +122,15 @@ func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.reloadLocked(); err != nil {
-		return err
-	}
-	if !s.updateSnapshotLocked(snapshot) {
-		return nil
-	}
-	return s.flushLocked()
+	return s.critical(func() error {
+		if err := s.reloadLocked(); err != nil {
+			return err
+		}
+		if !s.updateSnapshotLocked(snapshot) {
+			return nil
+		}
+		return s.flushLocked()
+	})
 }
 
 func (s *Store) RecordUsage(e UsageEvent) error {
@@ -124,13 +142,15 @@ func (s *Store) RecordUsage(e UsageEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.reloadLocked(); err != nil {
-		return err
-	}
-	if !s.recordUsageLocked(e) {
-		return nil
-	}
-	return s.flushLocked()
+	return s.critical(func() error {
+		if err := s.reloadLocked(); err != nil {
+			return err
+		}
+		if !s.recordUsageLocked(e) {
+			return nil
+		}
+		return s.flushLocked()
+	})
 }
 
 // Import records a batch of parsed session-file data and flushes at most once.
@@ -143,20 +163,22 @@ func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.reloadLocked(); err != nil {
-		return err
-	}
-	changed := false
-	for i := range snapshots {
-		changed = s.updateSnapshotLocked(snapshots[i]) || changed
-	}
-	for i := range events {
-		changed = s.recordUsageLocked(events[i]) || changed
-	}
-	if !changed {
-		return nil
-	}
-	return s.flushLocked()
+	return s.critical(func() error {
+		if err := s.reloadLocked(); err != nil {
+			return err
+		}
+		changed := false
+		for i := range snapshots {
+			changed = s.updateSnapshotLocked(snapshots[i]) || changed
+		}
+		for i := range events {
+			changed = s.recordUsageLocked(events[i]) || changed
+		}
+		if !changed {
+			return nil
+		}
+		return s.flushLocked()
+	})
 }
 
 // InvalidateLiveExactSnapshot demotes a current live-poll snapshot to
@@ -171,16 +193,18 @@ func (s *Store) InvalidateLiveExactSnapshot(provider string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.reloadLocked(); err != nil {
-		return err
-	}
-	snap, ok := s.snapshots[provider]
-	if !ok || snap.Source != SourceLivePoll || snap.Confidence != ConfidenceExact {
-		return nil
-	}
-	snap.Confidence = ConfidenceEstimated
-	s.snapshots[provider] = snap
-	return s.flushLocked()
+	return s.critical(func() error {
+		if err := s.reloadLocked(); err != nil {
+			return err
+		}
+		snap, ok := s.snapshots[provider]
+		if !ok || snap.Source != SourceLivePoll || snap.Confidence != ConfidenceExact {
+			return nil
+		}
+		snap.Confidence = ConfidenceEstimated
+		s.snapshots[provider] = snap
+		return s.flushLocked()
+	})
 }
 
 // reloadLocked re-reads s.path into s.snapshots/s.events/s.seen.

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -3,6 +3,7 @@ package limits
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
 	"math/rand/v2"
 	"os"
 	"slices"
@@ -36,6 +37,10 @@ type persisted struct {
 // Store persists provider quota snapshots and local usage events.
 type Store struct {
 	path string
+	// persistence replaces the JSON document when a database backend is
+	// configured. The file lock below exists to serialize two OS processes
+	// over one file; a database serializes them itself, so it is skipped.
+	persistence Persistence
 	// clock drives the event-retention and cycle windows. Read without a
 	// lock; set once at construction or during test setup.
 	clock clock.Clock
@@ -47,16 +52,39 @@ type Store struct {
 }
 
 func NewStore(path string) (*Store, error) {
+	return newStore(path, nil)
+}
+
+// NewStoreWith returns a store persisting through p rather than to a file.
+func NewStoreWith(p Persistence) (*Store, error) {
+	if p == nil {
+		return nil, errors.New("quota store needs a persistence")
+	}
+	return newStore("", p)
+}
+
+func newStore(path string, p Persistence) (*Store, error) {
 	s := &Store{
-		path:      path,
-		clock:     clock.System{},
-		snapshots: map[string]Snapshot{},
-		seen:      map[string]struct{}{},
+		path:        path,
+		persistence: p,
+		clock:       clock.System{},
+		snapshots:   map[string]Snapshot{},
+		seen:        map[string]struct{}{},
 	}
 	if err := s.reloadLocked(); err != nil {
 		return nil, err
 	}
 	return s, nil
+}
+
+// lock serializes two OS processes over the JSON document. With a database
+// backend there is no document and the engine serializes writers itself, so it
+// returns a no-op rather than locking a path that does not exist.
+func (s *Store) lock() (func() error, error) {
+	if s.persistence != nil {
+		return func() error { return nil }, nil
+	}
+	return fsutil.LockFileWithin(s.path, storeLockTimeout)
 }
 
 // UpdateSnapshot, RecordUsage, and Import are read-modify-write against the
@@ -70,7 +98,7 @@ func NewStore(path string) (*Store, error) {
 // selection or availability reads behind that mutex.
 
 func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
-	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
+	unlock, err := s.lock()
 	if err != nil {
 		return err
 	}
@@ -88,7 +116,7 @@ func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
 }
 
 func (s *Store) RecordUsage(e UsageEvent) error {
-	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
+	unlock, err := s.lock()
 	if err != nil {
 		return err
 	}
@@ -107,7 +135,7 @@ func (s *Store) RecordUsage(e UsageEvent) error {
 
 // Import records a batch of parsed session-file data and flushes at most once.
 func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
-	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
+	unlock, err := s.lock()
 	if err != nil {
 		return err
 	}
@@ -135,7 +163,7 @@ func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
 // estimated confidence so routing falls back to event-based usage counters
 // instead of trusting a now-unreadable exact quota sample.
 func (s *Store) InvalidateLiveExactSnapshot(provider string) error {
-	unlock, err := fsutil.LockFileWithin(s.path, storeLockTimeout)
+	unlock, err := s.lock()
 	if err != nil {
 		return err
 	}
@@ -161,6 +189,14 @@ func (s *Store) InvalidateLiveExactSnapshot(provider string) error {
 // section; NewStore calls it unlocked because it runs before s is returned
 // to any caller, so nothing else can observe or race it yet.
 func (s *Store) reloadLocked() error {
+	if s.persistence != nil {
+		snapshots, events, err := s.persistence.Load()
+		if err != nil {
+			return err
+		}
+		s.applyLoaded(snapshots, events)
+		return nil
+	}
 	data, err := os.ReadFile(s.path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -457,6 +493,9 @@ func (s *Store) ChooseSoftLimitedPeer(requested string, candidates []string, hea
 }
 
 func (s *Store) flushLocked() error {
+	if s.persistence != nil {
+		return s.persistence.Save(s.snapshots, s.events)
+	}
 	data, err := json.Marshal(persisted{Snapshots: s.snapshots, Events: s.events})
 	if err != nil {
 		return err
@@ -571,3 +610,27 @@ func maxFloat(a, b float64) float64 {
 }
 
 func (s *Store) nowTime() time.Time { return clock.Or(s.clock).Now() }
+
+// applyLoaded installs a loaded set, dropping events past retention and
+// duplicate ids exactly as the file path does, so both backends start from the
+// same in-memory state.
+func (s *Store) applyLoaded(snapshots map[string]Snapshot, events []UsageEvent) {
+	s.snapshots = map[string]Snapshot{}
+	for k := range snapshots {
+		s.snapshots[k] = snapshots[k]
+	}
+	s.events = nil
+	s.seen = map[string]struct{}{}
+	cutoff := s.nowTime().UTC().Add(-eventMaxAge)
+	for i := range events {
+		e := events[i]
+		if e.ID == "" || e.Timestamp.Before(cutoff) {
+			continue
+		}
+		if _, ok := s.seen[e.ID]; ok {
+			continue
+		}
+		s.events = append(s.events, e)
+		s.seen[e.ID] = struct{}{}
+	}
+}

--- a/internal/monitor/issueoutbox.go
+++ b/internal/monitor/issueoutbox.go
@@ -155,8 +155,8 @@ type DurableGHIssueSink struct {
 	inner    issueSubmitter
 	store    *issueOutboxStore
 	logger   *slog.Logger
-	name     string        // sink identity for logs, e.g. "monitor" or "human-review"
-	auditLog *audit.Logger // optional; nil in tests that construct the struct directly
+	name     string      // sink identity for logs, e.g. "monitor" or "human-review"
+	auditLog audit.Store // optional; nil in tests that construct the struct directly
 
 	// mu serializes outbox mutation (flushPending/persist) so a
 	// recovery-triggered ReplayPending racing with a normal SubmitIssue's own
@@ -179,7 +179,7 @@ type DurableGHIssueSink struct {
 // (no audit event is emitted, only the log line) — callers that want the
 // failure surfaced as a health.Finding (see internal/health's
 // checkGHIssueAuthFailure) must pass a non-nil logger.
-func NewDurableGHIssueSink(inner *GHIssueSink, dir, name string, logger *slog.Logger, auditLog *audit.Logger) (*DurableGHIssueSink, error) {
+func NewDurableGHIssueSink(inner *GHIssueSink, dir, name string, logger *slog.Logger, auditLog audit.Store) (*DurableGHIssueSink, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -1134,3 +1134,19 @@ func snapshotLiveAgents(src agentLister) []liveAgent {
 	}
 	return out
 }
+
+// AuditStoreReader adapts the board's audit store into a reader.
+//
+// The directory-backed reader above only sees what a file-backed trail wrote.
+// Under a database backend the day-files stop growing, so a consumer left on
+// the directory reads an empty trail and reports the fleet as idle.
+func AuditStoreReader(store interface {
+	Read(audit.Query) ([]audit.Event, error)
+}) auditAPI {
+	return auditFunc(func(q audit.Query) ([]audit.Event, error) {
+		if store == nil {
+			return nil, nil
+		}
+		return store.Read(q)
+	})
+}

--- a/internal/poll/triage.go
+++ b/internal/poll/triage.go
@@ -31,7 +31,7 @@ type TriageHandler struct {
 	projects   *project.Store
 	cfg        *config.TriageConfig
 	logger     *slog.Logger
-	audit      *audit.Logger
+	audit      audit.Store
 	gate       provider.HealthGate
 	factory    classifierFactory
 	perTaskTTL time.Duration
@@ -42,7 +42,7 @@ type TriageHandler struct {
 func NewTriageHandler(
 	tasks *task.Manager,
 	projects *project.Store,
-	al *audit.Logger,
+	al audit.Store,
 	logger *slog.Logger,
 	cfg *config.TriageConfig,
 ) *TriageHandler {

--- a/internal/stats/import.go
+++ b/internal/stats/import.go
@@ -1,0 +1,92 @@
+package stats
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "stats"
+
+// importBatchSize bounds one transaction. Run history is unbounded, and a single transaction over all of it would hold locks for as long as the copy takes and be discarded whole by one interruption.
+const importBatchSize = 2000
+
+// Import copies the run history file into the database in batches.
+//
+// The cursor is the number of lines already consumed, committed with the rows from that batch, so a crash resumes at the next unread line. A batch retried after a crash cannot duplicate: the row key is the run's own id.
+//
+// The file is only read.
+func Import(ctx context.Context, database *db.DB, path, scope string, logger *slog.Logger) error {
+	return dbimport.Resumable(ctx, database, ImportDomain, scope, logger,
+		func(ctx context.Context, tx *sql.Tx, cursor string) (dbimport.Batch, error) {
+			return importBatch(ctx, database, tx, path, cursor)
+		})
+}
+
+func importBatch(ctx context.Context, database *db.DB, tx *sql.Tx, path, cursor string) (dbimport.Batch, error) {
+	skip, err := parseCursor(cursor)
+	if err != nil {
+		return dbimport.Batch{}, err
+	}
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return dbimport.Batch{Cursor: cursor, Done: true}, nil
+	}
+	if err != nil {
+		return dbimport.Batch{}, fmt.Errorf("open run history: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	read := 0
+	written := 0
+	for scanner.Scan() {
+		read++
+		if read <= skip {
+			continue
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			var r RunRecord
+			if err := json.Unmarshal([]byte(line), &r); err != nil {
+				// The file store already tolerates a torn final line, which is
+				// what a crash mid-append leaves. Failing here would stall the
+				// import on a line it could never get past.
+				r = RunRecord{}
+			} else if err := insertRunTx(ctx, database, tx, r, []byte(line)); err != nil {
+				return dbimport.Batch{}, err
+			} else {
+				written++
+			}
+		}
+		if read-skip >= importBatchSize {
+			return dbimport.Batch{Cursor: strconv.Itoa(read), Count: written}, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return dbimport.Batch{}, fmt.Errorf("read run history: %w", err)
+	}
+	return dbimport.Batch{Cursor: strconv.Itoa(read), Count: written, Done: true}, nil
+}
+
+func parseCursor(cursor string) (int, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(cursor)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("run history import cursor %q is not a line count", cursor)
+	}
+	return n, nil
+}

--- a/internal/stats/repository.go
+++ b/internal/stats/repository.go
@@ -1,0 +1,20 @@
+package stats
+
+import "time"
+
+// Repository is the run-history surface reports read through. Two implementations exist: the line-per-record Store and the database-backed SQLStore, selected by config.Database.Backend.
+//
+// No context: runs are recorded from agent completion and read from the stats UI and the evaluation service, none of which carries one. SQLStore bounds each statement with its own deadline.
+type Repository interface {
+	Record(r RunRecord) error
+	Len() int
+	All() []RunRecord
+	AllForTask(taskID string) []RunRecord
+	Query() StatsResponse
+	QueryAt(now time.Time) StatsResponse
+}
+
+var (
+	_ Repository = (*Store)(nil)
+	_ Repository = (*SQLStore)(nil)
+)

--- a/internal/stats/sqlstore.go
+++ b/internal/stats/sqlstore.go
@@ -1,0 +1,137 @@
+package stats
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// queryTimeout bounds every statement. Repository carries no context to cancel one with; see Repository.
+const queryTimeout = 30 * time.Second
+
+// SQLStore keeps run history in the configured database backend.
+//
+// A read for one task is a WHERE against an index rather than a scan of the whole history, and a record lands in one statement — so a crash leaves the row written or absent and the next start needs no tail repair, which the line-per-record file did.
+type SQLStore struct {
+	db     *db.DB
+	logger *slog.Logger
+}
+
+// NewSQLStore returns the database-backed run history.
+func NewSQLStore(database *db.DB, logger *slog.Logger) (*SQLStore, error) {
+	if database == nil {
+		return nil, errors.New("stats store needs an open database")
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return &SQLStore{db: database, logger: logger}, nil
+}
+
+const insertRunRecord = `INSERT INTO run_records (id, task_id, project_id, started_at, doc)
+	VALUES (?, ?, ?, ?, ?) ON CONFLICT (id) DO NOTHING`
+
+// Record appends one run.
+func (s *SQLStore) Record(r RunRecord) error {
+	if s == nil {
+		return nil
+	}
+	doc, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("marshal run record: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, insertRunRecord,
+		r.ID, r.TaskID, r.ProjectID, db.TimeValue(r.Timestamp), string(doc)); err != nil {
+		return fmt.Errorf("write run record: %w", err)
+	}
+	return nil
+}
+
+// Len reports how many runs are recorded, counted in the database rather than by loading them.
+func (s *SQLStore) Len() int {
+	if s == nil {
+		return 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	var n int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM run_records`).Scan(&n); err != nil {
+		s.logger.Error("stats.count", "err", err)
+		return 0
+	}
+	return n
+}
+
+// All returns every run, oldest first.
+func (s *SQLStore) All() []RunRecord {
+	return s.load(`SELECT doc FROM run_records ORDER BY started_at, `+s.db.OrderText("id"), nil)
+}
+
+// AllForTask returns the runs attributed to taskID, reading only those rows.
+func (s *SQLStore) AllForTask(taskID string) []RunRecord {
+	return s.load(`SELECT doc FROM run_records WHERE task_id = ? ORDER BY started_at, `+s.db.OrderText("id"),
+		[]any{taskID})
+}
+
+// Since returns the runs at or after t, reading only those rows. It is what a windowed report should use instead of All.
+func (s *SQLStore) Since(t time.Time) []RunRecord {
+	return s.load(`SELECT doc FROM run_records WHERE started_at >= ? ORDER BY started_at, `+s.db.OrderText("id"),
+		[]any{db.TimeValue(t)})
+}
+
+// Query builds the stats response as of now.
+func (s *SQLStore) Query() StatsResponse { return s.QueryAt(time.Now()) }
+
+// QueryAt builds the stats response as of now.
+//
+// It loads every run because the response carries an all-time bucket; the windowed buckets are cut from the same slice by the shared Aggregate, so the figures are the file store's by construction rather than by a second implementation that agrees today.
+func (s *SQLStore) QueryAt(now time.Time) StatsResponse {
+	return Aggregate(s.All(), now)
+}
+
+func (s *SQLStore) load(stmt string, args []any) []RunRecord {
+	if s == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx, stmt, args...)
+	if err != nil {
+		s.logger.Error("stats.read", "err", err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	var out []RunRecord
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			s.logger.Error("stats.scan", "err", err)
+			return out
+		}
+		var r RunRecord
+		if err := json.Unmarshal([]byte(doc), &r); err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		s.logger.Error("stats.iterate", "err", err)
+	}
+	return out
+}
+
+func insertRunTx(ctx context.Context, database *db.DB, tx *sql.Tx, r RunRecord, raw []byte) error {
+	if _, err := tx.ExecContext(ctx, database.Rebind(insertRunRecord),
+		r.ID, r.TaskID, r.ProjectID, db.TimeValue(r.Timestamp), string(raw)); err != nil {
+		return fmt.Errorf("insert run record: %w", err)
+	}
+	return nil
+}

--- a/internal/stats/sqlstore_test.go
+++ b/internal/stats/sqlstore_test.go
@@ -1,0 +1,161 @@
+package stats
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func runsFixture(now time.Time) []RunRecord {
+	return []RunRecord{
+		{ID: "run-1", TaskID: "task-a", ProjectID: "o/r", Mode: "headless", Role: "implementation",
+			Provider: "claude", Model: "sonnet", CostUSD: 1.5, DurationS: 10, Timestamp: now.Add(-2 * time.Hour)},
+		{ID: "run-2", TaskID: "task-a", ProjectID: "o/r", Mode: "headless", Role: "review",
+			Provider: "codex", Model: "gpt", CostUSD: 0.5, DurationS: 5, Timestamp: now.Add(-time.Hour)},
+		{ID: "run-3", TaskID: "task-b", ProjectID: "o/r", Mode: "headless", Role: "implementation",
+			Provider: "claude", Model: "sonnet", CostUSD: 2, DurationS: 20, Timestamp: now.Add(-40 * 24 * time.Hour)},
+	}
+}
+
+// TestSQLStore_ReportsMatchTheFileStore is the issue's "reports built from this
+// data show the same figures as before the move".
+func TestSQLStore_ReportsMatchTheFileStore(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+		fileStore, err := NewStore(filepath.Join(t.TempDir(), "stats.ndjson"))
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		sqlStore, err := NewSQLStore(d, nil)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		for _, r := range runsFixture(now) {
+			if err := fileStore.Record(r); err != nil {
+				t.Fatalf("file record: %v", err)
+			}
+			if err := sqlStore.Record(r); err != nil {
+				t.Fatalf("sql record: %v", err)
+			}
+		}
+
+		want := fileStore.QueryAt(now)
+		got := sqlStore.QueryAt(now)
+		wantJSON, err := json.Marshal(want)
+		if err != nil {
+			t.Fatalf("marshal want: %v", err)
+		}
+		gotJSON, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("marshal got: %v", err)
+		}
+		if !bytes.Equal(gotJSON, wantJSON) {
+			t.Fatalf("report differs between backends:\nfiles: %s\nsql:   %s", wantJSON, gotJSON)
+		}
+		if sqlStore.Len() != fileStore.Len() {
+			t.Errorf("Len = %d, want %d", sqlStore.Len(), fileStore.Len())
+		}
+	})
+}
+
+// TestSQLStore_AllForTaskReadsOnlyThatTask is the issue's "a query filtered by
+// time or task reads only matching rows".
+func TestSQLStore_AllForTaskReadsOnlyThatTask(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+		store, err := NewSQLStore(d, nil)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		for _, r := range runsFixture(now) {
+			if err := store.Record(r); err != nil {
+				t.Fatalf("record: %v", err)
+			}
+		}
+		got := store.AllForTask("task-a")
+		if len(got) != 2 {
+			t.Fatalf("AllForTask returned %d runs, want 2", len(got))
+		}
+		for _, r := range got {
+			if r.TaskID != "task-a" {
+				t.Fatalf("AllForTask returned a run for %q", r.TaskID)
+			}
+		}
+		since := store.Since(now.Add(-90 * time.Minute))
+		if len(since) != 1 || since[0].ID != "run-2" {
+			t.Fatalf("Since returned %d runs, want only run-2", len(since))
+		}
+	})
+}
+
+// TestImport_ResumesWithoutDuplicating pins the resumable-import outcome over
+// more records than one batch holds.
+func TestImport_ResumesWithoutDuplicating(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+		path := filepath.Join(t.TempDir(), "stats.ndjson")
+		fileStore, err := NewStore(path)
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		const total = importBatchSize + 25
+		for i := range total {
+			if err := fileStore.Record(RunRecord{
+				ID: "run-" + strconv.Itoa(i), TaskID: "task-a", Mode: "headless",
+				Role: "implementation", CostUSD: 1, Timestamp: now.Add(-time.Duration(i) * time.Minute),
+			}); err != nil {
+				t.Fatalf("record: %v", err)
+			}
+		}
+		before, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+
+		for range 2 {
+			if err := Import(t.Context(), d, path, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLStore(d, nil)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		if n := store.Len(); n != total {
+			t.Fatalf("after two imports the database holds %d runs, want %d", n, total)
+		}
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("re-read: %v", err)
+		}
+		if !bytes.Equal(after, before) {
+			t.Error("import modified the original history file")
+		}
+	})
+}
+
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written.ndjson"), "home-a", nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLStore(d, nil)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		if n := store.Len(); n != 0 {
+			t.Fatalf("got %d runs from an empty domain", n)
+		}
+	})
+}

--- a/internal/stats/sqlstore_test.go
+++ b/internal/stats/sqlstore_test.go
@@ -10,17 +10,18 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/providerid"
 	"github.com/Automaat/sybra/internal/testutil/dbtest"
 )
 
 func runsFixture(now time.Time) []RunRecord {
 	return []RunRecord{
 		{ID: "run-1", TaskID: "task-a", ProjectID: "o/r", Mode: "headless", Role: "implementation",
-			Provider: "claude", Model: "sonnet", CostUSD: 1.5, DurationS: 10, Timestamp: now.Add(-2 * time.Hour)},
+			Provider: providerid.Claude, Model: "sonnet", CostUSD: 1.5, DurationS: 10, Timestamp: now.Add(-2 * time.Hour)},
 		{ID: "run-2", TaskID: "task-a", ProjectID: "o/r", Mode: "headless", Role: "review",
-			Provider: "codex", Model: "gpt", CostUSD: 0.5, DurationS: 5, Timestamp: now.Add(-time.Hour)},
+			Provider: providerid.Codex, Model: "gpt", CostUSD: 0.5, DurationS: 5, Timestamp: now.Add(-time.Hour)},
 		{ID: "run-3", TaskID: "task-b", ProjectID: "o/r", Mode: "headless", Role: "implementation",
-			Provider: "claude", Model: "sonnet", CostUSD: 2, DurationS: 20, Timestamp: now.Add(-40 * 24 * time.Hour)},
+			Provider: providerid.Claude, Model: "sonnet", CostUSD: 2, DurationS: 20, Timestamp: now.Add(-40 * 24 * time.Hour)},
 	}
 }
 

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -237,17 +237,27 @@ func (s *Store) Query() StatsResponse {
 func (s *Store) QueryAt(now time.Time) StatsResponse {
 	s.syncForRead()
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	runs := slices.Clone(s.runs)
+	s.mu.Unlock()
+	return Aggregate(runs, now)
+}
 
+// Aggregate builds the stats response from a set of runs.
+//
+// Split out of QueryAt so the database-backed store produces byte-identical
+// figures rather than a second implementation that drifts from this one. The
+// windows are computed here because "this month" depends on now, not on what
+// the caller happened to load.
+func Aggregate(runs []RunRecord, now time.Time) StatsResponse {
 	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	weekStart := todayStart.AddDate(0, 0, -int(todayStart.Weekday()))
 	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 
-	// Preallocate to len(s.runs): `all` is exactly that size, the time-window
+	// Preallocate to len(runs): `all` is exactly that size, the time-window
 	// subsets are bounded by it. Measured at 5k records: -23% wall, -17%
 	// bytes, -35% allocs vs uncapped append. Query runs on every stats UI
 	// open.
-	n := len(s.runs)
+	n := len(runs)
 	all := make([]RunRecord, 0, n)
 	today := make([]RunRecord, 0, n)
 	week := make([]RunRecord, 0, n)
@@ -259,8 +269,8 @@ func (s *Store) QueryAt(now time.Time) StatsResponse {
 	byProvider := map[string][]RunRecord{}
 	bySkillExecutionMode := map[string][]RunRecord{}
 
-	for i := range s.runs {
-		r := normalizedRunRecord(s.runs[i])
+	for i := range runs {
+		r := normalizedRunRecord(runs[i])
 		all = append(all, r)
 
 		if !r.Timestamp.Before(todayStart) {
@@ -313,13 +323,13 @@ func (s *Store) QueryAt(now time.Time) StatsResponse {
 		ByModel:              groupedStats(byModel),
 		ByProvider:           groupedStats(byProvider),
 		BySkillExecutionMode: groupedStats(bySkillExecutionMode),
-		ReviewRounds:         reviewRoundsByModel(s.runs),
+		ReviewRounds:         reviewRoundsByModel(runs),
 	}
 
 	// Recent runs: last 50, newest first
-	recent := make([]RunRecord, len(s.runs))
-	for i := range s.runs {
-		recent[i] = normalizedRunRecord(s.runs[i])
+	recent := make([]RunRecord, len(runs))
+	for i := range runs {
+		recent[i] = normalizedRunRecord(runs[i])
 	}
 	slices.SortFunc(recent, func(a, b RunRecord) int { return b.Timestamp.Compare(a.Timestamp) })
 	if len(recent) > 50 {

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -199,7 +199,7 @@ type Orchestrator struct {
 	sandboxes *sandbox.Manager
 	bgops     *bgop.Tracker
 	logger    *slog.Logger
-	audit     *audit.Logger
+	audit     audit.Store
 	// pressureGate defers new work when the local host is short on disk,
 	// memory, or CPU headroom. Late-bound via SetPressureGate so startup can
 	// construct it from config after New returns. Nil disables gating.
@@ -247,7 +247,7 @@ func New(
 	tasks *task.Manager,
 	projects *project.Store,
 	agents *agent.Manager,
-	al *audit.Logger,
+	al audit.Store,
 	logger *slog.Logger,
 	worktrees *worktree.Manager,
 	cfg *config.Config,

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -102,7 +102,7 @@ type App struct {
 	watcher           *watcher.Watcher
 	configWatcher     *confighot.Watcher
 	notifier          *notification.Emitter
-	audit             *audit.Logger
+	audit             audit.Store
 	attachments       *attachment.Store
 	artifacts         *artifact.Store
 	evidenceStore     *evidence.Store
@@ -111,7 +111,7 @@ type App struct {
 	cleanupProtected  *cleanup.ProtectedStore
 	learning          *learning.Store
 	agentQueue        *agentqueue.Queue
-	stats             *stats.Store
+	stats             stats.Repository
 	limits            *limits.Store
 	tasksDir          string
 	skillsDir         string
@@ -143,7 +143,7 @@ type App struct {
 	workflowStore     workflow.Repository
 	pressureGate      *pressure.Gate
 	diskReclaimer     *diskreclaim.Reclaimer
-	toolLedger        *toolledger.Logger
+	toolLedger        toolledger.Store
 	renovate          *renovateCoordinator
 	promptLab         *promptLabCoordinator
 	triage            *triageCoordinator
@@ -534,13 +534,16 @@ func (a *App) Startup(ctx context.Context) error {
 	appCtx, schedulerCtx, watcherCtx := a.initLifecycle(ctx)
 	a.logger.Info("app.starting")
 
-	a.initAudit()
-	a.initToolLedger()
-	a.initStats()
-
+	// Before the stores that can live in it: each picks its backend at
+	// construction, and a database opened afterwards would leave every one of
+	// them on files for the whole run with nothing reporting it.
 	if err := a.initDatabase(appCtx); err != nil {
 		return err
 	}
+
+	a.initAudit(appCtx)
+	a.initToolLedger(appCtx)
+	a.initStats(appCtx)
 
 	store, err := task.NewStore(a.tasksDir)
 	if err != nil {
@@ -586,7 +589,7 @@ func (a *App) Startup(ctx context.Context) error {
 	a.cleanupProtected = cleanup.DefaultProtectedStore()
 	a.notifier = notification.New(emit)
 	a.notifier.SetDesktop(a.cfg.Notification.Desktop)
-	a.initLimits() //nolint:contextcheck // backfill derives from a.ctx directly, see Startup's contextcheck note
+	a.initLimits(a.openLimitsStore(appCtx)) //nolint:contextcheck // the live poller derives from a.ctx directly, see Startup's contextcheck note
 	// initSandboxes has no agent-manager dependency and must run before
 	// initAgentManager so ManagerConfig.SandboxHome can be wired at construction.
 	a.initSandboxes()

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -97,7 +97,7 @@ type humanReviewHandler struct {
 	abTesting func() abtest.Config
 	tasks     *task.Manager
 	agents    humanReviewAgentRunner
-	audit     *audit.Logger
+	audit     audit.Store
 	logger    *slog.Logger
 	homeDir   string
 	logFile   string
@@ -197,7 +197,7 @@ func newHumanReviewHandler(
 	cfg *config.Config,
 	tasks *task.Manager,
 	agents humanReviewAgentRunner,
-	al *audit.Logger,
+	al audit.Store,
 	logger *slog.Logger,
 	homeDir, logFile string,
 	workCtx func(projectID string) *WorkScrubContext,

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -360,7 +360,19 @@ func (a *App) warnThinFailoverChain() {
 	}
 }
 
-func (a *App) initStats() {
+func (a *App) initStats(ctx context.Context) {
+	if a.database != nil {
+		importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+		defer cancel()
+		if err := stats.Import(importCtx, a.database, config.StatsFile(), a.importScope(), a.logger); err != nil {
+			a.logger.Error("stats.import", "err", err)
+		} else if store, err := stats.NewSQLStore(a.database, a.logger); err != nil {
+			a.logger.Error("stats.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			a.stats = store
+			return
+		}
+	}
 	statsStore, err := stats.NewStore(config.StatsFile())
 	if err != nil {
 		a.logger.Warn("stats.init.degraded", "err", err)
@@ -452,8 +464,10 @@ func (a *App) initAgentQueue() {
 	a.agentQueue = queue
 }
 
-func (a *App) initLimits() {
-	limitStore, err := limits.NewStore(config.LimitsFile())
+// initLimits opens the quota store, taking the store the caller already built
+// so the import's context belongs to startup while the live poller keeps the
+// app's own long-lived one.
+func (a *App) initLimits(limitStore *limits.Store, err error) {
 	if err != nil {
 		a.logger.Warn("limits.init.degraded", "err", err)
 		return
@@ -1272,8 +1286,8 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 // initToolLedger opens the always-on tool-call ledger. A failure degrades to
 // no recording rather than blocking startup: the ledger informs future policy,
 // it does not gate anything running now.
-func (a *App) initToolLedger() {
-	l, err := toolledger.New(a.cfg.ToolLedgerDir())
+func (a *App) initToolLedger(ctx context.Context) {
+	l, err := a.openToolLedger(ctx)
 	if err != nil {
 		a.logger.Warn("tool_ledger.init.degraded", "err", err)
 		return
@@ -1284,8 +1298,8 @@ func (a *App) initToolLedger() {
 	}
 }
 
-func (a *App) initAudit() {
-	al, err := audit.NewLogger(a.auditDir)
+func (a *App) initAudit(ctx context.Context) {
+	al, err := a.openAuditStore(ctx)
 	if err != nil {
 		a.logger.Warn("audit.init.degraded", "err", err)
 		// a.audit remains nil; logAudit() is a no-op when audit is nil.
@@ -2025,4 +2039,67 @@ func (a *App) openBgopStore(ctx context.Context) bgop.Persistence {
 // instance's restarts and differs between instances.
 func (a *App) importScope() string {
 	return httpserve.HomeID(config.HomeDir())
+}
+
+// openAuditStore returns the audit trail for the configured backend, importing
+// the existing day-files the first time a database is used. A failed import
+// degrades to the files: the trail is what an operator reads to explain what
+// happened, and an empty one reads as "nothing happened".
+func (a *App) openAuditStore(ctx context.Context) (audit.Store, error) {
+	if a.database != nil {
+		importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+		defer cancel()
+		if err := audit.Import(importCtx, a.database, a.auditDir, a.importScope(), a.logger); err != nil {
+			a.logger.Error("audit.import", "err", err)
+		} else if store, err := audit.NewSQLStore(a.database); err != nil {
+			a.logger.Error("audit.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return store, nil
+		}
+	}
+	store, err := audit.NewLogger(a.auditDir)
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// openToolLedger returns the tool-call ledger for the configured backend.
+func (a *App) openToolLedger(ctx context.Context) (toolledger.Store, error) {
+	if a.database != nil {
+		importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+		defer cancel()
+		if err := toolledger.Import(importCtx, a.database, a.cfg.ToolLedgerDir(), a.importScope(), a.logger); err != nil {
+			a.logger.Error("tool_ledger.import", "err", err)
+		} else if store, err := toolledger.NewSQLStore(a.database); err != nil {
+			a.logger.Error("tool_ledger.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return store, nil
+		}
+	}
+	l, err := toolledger.New(a.cfg.ToolLedgerDir())
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// openLimitsStore returns the quota store for the configured backend. A failed
+// import degrades to the file: quota state gates provider selection, and
+// starting from nothing would read as unlimited headroom on every provider.
+func (a *App) openLimitsStore(ctx context.Context) (*limits.Store, error) {
+	if a.database != nil {
+		importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+		defer cancel()
+		if err := limits.Import(importCtx, a.database, config.LimitsFile(), a.importScope(), a.logger); err != nil {
+			a.logger.Error("limits.import", "err", err)
+		} else if persistence, err := limits.NewSQLPersistence(a.database); err != nil {
+			a.logger.Error("limits.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else if store, err := limits.NewStoreWith(persistence); err != nil {
+			a.logger.Error("limits.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return store, nil
+		}
+	}
+	return limits.NewStore(config.LimitsFile())
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1310,7 +1310,10 @@ func (a *App) initAudit(ctx context.Context) {
 	if retentionDays <= 0 {
 		retentionDays = 30
 	}
-	if err := audit.Cleanup(a.auditDir, retentionDays); err != nil {
+	// Through the store, not the package-level file cleanup: with a database
+	// backend the day-files stop growing and pruning them frees nothing, while
+	// audit_events — the highest-rate table there is — would grow forever.
+	if err := a.audit.Cleanup(retentionDays); err != nil {
 		a.logger.Warn("audit.cleanup", "err", err)
 	}
 

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -21,7 +21,7 @@ import (
 type promptLabCoordinator struct {
 	tasks             *task.Manager
 	projects          *project.Store
-	stats             *stats.Store
+	stats             stats.Repository
 	logger            *slog.Logger
 	cfg               *config.Config
 	allowsProjectType func(project.ProjectType) bool
@@ -40,7 +40,7 @@ const promptLabNoProjectErr = "prompt-lab approval unavailable: project " + prom
 func newPromptLabCoordinator(
 	tasks *task.Manager,
 	projects *project.Store,
-	statsStore *stats.Store,
+	statsStore stats.Repository,
 	logger *slog.Logger,
 	cfg *config.Config,
 	allowsProjectType func(project.ProjectType) bool,

--- a/internal/sybra/app_tool_ledger_test.go
+++ b/internal/sybra/app_tool_ledger_test.go
@@ -26,7 +26,7 @@ func TestInitAgentManagerBindsToolLedger(t *testing.T) {
 		agentSvc: &AgentService{},
 	}
 
-	a.initToolLedger()
+	a.initToolLedger(t.Context())
 	if a.toolLedger == nil {
 		t.Fatal("initToolLedger did not open a ledger")
 	}
@@ -54,7 +54,7 @@ func TestToolLedgerDirAloneProvesNothing(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	a := &App{cfg: cfg, logger: discardLogger(), logDir: t.TempDir()}
-	a.initToolLedger()
+	a.initToolLedger(t.Context())
 
 	dir := cfg.ToolLedgerDir()
 	if _, err := os.Stat(dir); err != nil {

--- a/internal/sybra/app_triage.go
+++ b/internal/sybra/app_triage.go
@@ -16,7 +16,7 @@ import (
 type triageCoordinator struct {
 	tasks          *task.Manager
 	projects       *project.Store
-	auditLog       *audit.Logger
+	auditLog       audit.Store
 	logger         *slog.Logger
 	cfg            *config.Config
 	providerHealth *provider.Checker
@@ -26,7 +26,7 @@ type triageCoordinator struct {
 func newTriageCoordinator(
 	tasks *task.Manager,
 	projects *project.Store,
-	auditLog *audit.Logger,
+	auditLog audit.Store,
 	logger *slog.Logger,
 	cfg *config.Config,
 	providerHealth *provider.Checker,

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -729,7 +729,7 @@ type taskClassifierAdapter struct {
 	tasks             *task.Manager
 	projects          *project.Store
 	classifier        triage.Classifier
-	audit             *audit.Logger
+	audit             audit.Store
 	sybraBugProjectID string
 }
 

--- a/internal/sybra/completion/completion.go
+++ b/internal/sybra/completion/completion.go
@@ -61,14 +61,14 @@ const (
 // (a subsystem that failed to start) can leave it unset.
 type Config struct {
 	Logger *slog.Logger
-	Audit  *audit.Logger
+	Audit  audit.Store
 	Emit   func(string, any)
 
 	Tasks          *task.Manager
 	Worktrees      *worktree.Manager
 	Sandboxes      *sandbox.Manager
 	WorkflowEngine workflow.CompletionWorkflow
-	Stats          *stats.Store
+	Stats          stats.Repository
 	Limits         *limits.Store
 	LoopSched      *loopagent.Scheduler
 	PRTracker      *github.IssueTracker
@@ -101,14 +101,14 @@ type WorkScrubContext struct {
 // wires only the deps the scenario exercises.
 type Handler struct {
 	logger *slog.Logger
-	audit  *audit.Logger
+	audit  audit.Store
 	emit   func(string, any)
 
 	tasks          *task.Manager
 	worktrees      *worktree.Manager
 	sandboxes      *sandbox.Manager
 	workflowEngine workflow.CompletionWorkflow
-	stats          *stats.Store
+	stats          stats.Repository
 	limits         *limits.Store
 	loopSched      *loopagent.Scheduler
 	prTracker      *github.IssueTracker

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -69,7 +69,7 @@ func (lm *LifecycleManager) StartManagers(ctx context.Context, emit func(string,
 		a.logger.Info("watchdog.disabled")
 	}
 
-	hcheck := health.New(a.cfg.AuditDir(), a.tasks, config.HomeDir(), a.logger, emit, func() health.OwnedProcesses {
+	hcheck := health.New(a.audit, a.tasks, config.HomeDir(), a.logger, emit, func() health.OwnedProcesses {
 		owned := health.OwnedProcesses{
 			PIDs:          map[int]bool{},
 			ProcessGroups: map[int]bool{},
@@ -705,7 +705,7 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 	svc := monitor.NewService(monitor.Deps{
 		Cfg:          a.cfg.Monitor,
 		Tasks:        a.tasks,
-		Audit:        monitor.AuditDirReader(a.cfg.AuditDir()),
+		Audit:        monitor.AuditStoreReader(a.audit),
 		Agents:       newMonitorAgentLister(a.agents, a.clusterRoster, a.logger),
 		ObserverOnly: a.cfg.IsFollower(),
 		Dispatcher:   disp,
@@ -852,7 +852,7 @@ func (lm *LifecycleManager) startEvaluationService(ctx context.Context, emit fun
 	deps := evaluation.Deps{
 		Cfg:        a.cfg.Evaluation,
 		ABTesting:  a.abTestingConfig(),
-		Audit:      evaluation.AuditDirReader(a.cfg.AuditDir()),
+		Audit:      evaluation.AuditStoreReader(a.audit),
 		Emit:       emit,
 		Logger:     a.logger,
 		ReportPath: config.EvaluationReportPath(),
@@ -883,7 +883,7 @@ func (lm *LifecycleManager) startLearningDigestService(ctx context.Context, emit
 	deps := learning.Deps{
 		Cfg:       a.cfg.LearningDigest,
 		ABTesting: a.abTestingConfig(),
-		Audit:     learning.AuditDirReader(a.cfg.AuditDir()),
+		Audit:     learning.AuditStoreReader(a.audit),
 		AuditLog:  a.audit,
 		Store:     a.learning,
 		Blocklist: a.fleetWorkBlocklist,

--- a/internal/sybra/review/handler.go
+++ b/internal/sybra/review/handler.go
@@ -39,7 +39,7 @@ const stalePRDispatchGateAge = 15 * time.Minute
 // Handler manages PR review task creation, agent dispatch, and status tracking.
 type Handler struct {
 	logger         *slog.Logger
-	audit          *audit.Logger
+	audit          audit.Store
 	emit           func(string, any)
 	tasks          *task.Manager
 	projects       *project.Store
@@ -302,7 +302,7 @@ func New(
 	tasks *task.Manager,
 	projects *project.Store,
 	agents *agent.Manager,
-	al *audit.Logger,
+	al audit.Store,
 	logger *slog.Logger,
 	prTracker *github.IssueTracker,
 	emit func(string, any),

--- a/internal/sybra/services_wire_loops.go
+++ b/internal/sybra/services_wire_loops.go
@@ -7,6 +7,6 @@ func (a *App) wireLoopAgentService() {
 	a.loopAgentSvc.ctx = a.ctx
 	a.loopAgentSvc.store = a.loopAgents
 	a.loopAgentSvc.sched = a.loopSched
-	a.loopAgentSvc.auditDir = a.auditDir
+	a.loopAgentSvc.audit = a.audit
 	a.loopAgentSvc.logger = a.logger
 }

--- a/internal/sybra/services_wire_promptlab.go
+++ b/internal/sybra/services_wire_promptlab.go
@@ -5,5 +5,6 @@ func (a *App) wirePromptLabService() {
 	a.promptLabSvc.artifacts = a.artifacts
 	a.promptLabSvc.projects = a.projects
 	a.promptLabSvc.workflowEngine = a.workflowEngine
+	a.promptLabSvc.stats = a.stats
 	a.promptLabSvc.currentConfig = a.currentConfig
 }

--- a/internal/sybra/services_wire_stats.go
+++ b/internal/sybra/services_wire_stats.go
@@ -5,10 +5,10 @@ func (a *App) wireStatsService() {
 	a.statsSvc.limits = a.limits
 	a.statsSvc.projects = a.projects
 	a.statsSvc.tasks = a.tasks
-	a.statsSvc.auditDir = a.auditDir
+	a.statsSvc.audit = a.audit
 	a.statsSvc.policy = a.limitPolicy
 	a.statsSvc.currentConfig = a.currentConfig
-	a.auditSvc.auditDir = a.auditDir
+	a.auditSvc.audit = a.audit
 	a.selfMonSvc.tasks = a.tasks
 	a.selfMonSvc.logger = a.logger
 	a.selfMonSvc.currentConfig = a.currentConfig

--- a/internal/sybra/svc_audit.go
+++ b/internal/sybra/svc_audit.go
@@ -12,15 +12,15 @@ import (
 // lifecycle` both reduce the same event stream, so both go through this one
 // query rather than a report endpoint each.
 type AuditService struct {
-	auditDir string
+	audit audit.Store
 }
 
 // QueryAuditEvents returns the events in the window that match the filters.
 func (s *AuditService) QueryAuditEvents(q audit.Query) ([]audit.Event, error) {
-	if s.auditDir == "" {
+	if s.audit == nil {
 		return nil, unavailableError("audit log unavailable")
 	}
-	events, err := audit.Read(s.auditDir, q)
+	events, err := s.audit.Read(q)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sybra/svc_integrations.go
+++ b/internal/sybra/svc_integrations.go
@@ -26,7 +26,7 @@ type IntegrationService struct {
 	projects       *project.Store
 	agents         *agent.Manager
 	worktrees      *worktree.Manager
-	audit          *audit.Logger
+	audit          audit.Store
 	cfg            *config.Config
 	currentConfig  func() *config.Config
 	logger         *slog.Logger

--- a/internal/sybra/svc_loopagents.go
+++ b/internal/sybra/svc_loopagents.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/sybra/internal/audit"
+
 	"github.com/Automaat/sybra/internal/loopagent"
 )
 
@@ -20,11 +22,11 @@ import (
 // methods. The scheduler owns the actual ticking goroutines; this service
 // is the persistence + GUI surface.
 type LoopAgentService struct {
-	ctx      context.Context //nolint:containedctx // bound methods take no context; see wireLoopAgentService
-	store    loopagent.Repository
-	sched    *loopagent.Scheduler
-	auditDir string
-	logger   *slog.Logger
+	ctx    context.Context //nolint:containedctx // bound methods take no context; see wireLoopAgentService
+	store  loopagent.Repository
+	sched  *loopagent.Scheduler
+	audit  audit.Store
+	logger *slog.Logger
 }
 
 // LoopAgentRun is a single fire of a loop agent, materialized from the
@@ -116,29 +118,59 @@ func (s *LoopAgentService) ListLoopAgentRuns(id string, limit int) ([]LoopAgentR
 	}
 	agentName := la.AgentName()
 
-	files, err := auditFilesNewestFirst(s.auditDir)
+	// Through the store, not the day-files: under a database backend those
+	// stop growing, and a run list built from them would show nothing after
+	// the flip while the schedule kept running.
+	if s.audit == nil {
+		return []LoopAgentRun{}, nil
+	}
+	until := time.Now().UTC().Add(time.Minute)
+	events, err := s.audit.Read(audit.Query{
+		Since: until.AddDate(0, 0, -loopAgentRunLookbackDays),
+		Until: until,
+		Type:  "agent.completed",
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	runs := make([]LoopAgentRun, 0, limit)
-	for _, f := range files {
-		if len(runs) >= limit {
-			break
-		}
-		fileRuns, err := scanAuditFileForRuns(f, agentName)
-		if err != nil {
-			s.logger.Warn("loopagent.audit.scan", "file", f, "err", err)
-			continue
-		}
-		runs = append(runs, fileRuns...)
-	}
+	runs := runsFromAuditEvents(events, agentName)
 
 	slices.SortFunc(runs, func(a, b LoopAgentRun) int { return b.FinishedAt.Compare(a.FinishedAt) })
 	if len(runs) > limit {
 		runs = runs[:limit]
 	}
 	return runs, nil
+}
+
+// loopAgentRunLookbackDays bounds the window a run list is built from. The
+// file scan walked every day-file it had; a bounded query is what lets the
+// database read only the rows it needs.
+const loopAgentRunLookbackDays = 30
+
+// runsFromAuditEvents extracts this agent's completed runs from a trail slice.
+func runsFromAuditEvents(events []audit.Event, agentName string) []LoopAgentRun {
+	out := make([]LoopAgentRun, 0, len(events))
+	for i := range events {
+		ev := events[i]
+		if ev.Type != "agent.completed" {
+			continue
+		}
+		if name, _ := ev.Data["name"].(string); name != agentName {
+			continue
+		}
+		costFloat, _ := ev.Data["cost_usd"].(float64)
+		duration, _ := ev.Data["duration_s"].(float64)
+		state, _ := ev.Data["state"].(string)
+		out = append(out, LoopAgentRun{
+			AgentID:    ev.AgentID,
+			StartedAt:  ev.Timestamp.Add(-time.Duration(duration * float64(time.Second))),
+			FinishedAt: ev.Timestamp,
+			CostUSD:    costFloat,
+			State:      state,
+			DurationS:  duration,
+		})
+	}
+	return out
 }
 
 // auditFilesNewestFirst returns the audit log files (one per day) sorted

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -139,7 +139,7 @@ func selectOrchestratorSingleton(currentID string, agents []*agent.Agent) (keepI
 // OrchestratorService exposes orchestrator session operations as Wails-bound methods.
 type OrchestratorService struct {
 	agents    *agent.Manager
-	audit     *audit.Logger
+	audit     audit.Store
 	logger    *slog.Logger
 	emit      func(string, any)
 	abTesting abtest.Config

--- a/internal/sybra/svc_planning.go
+++ b/internal/sybra/svc_planning.go
@@ -16,7 +16,7 @@ type PlanningService struct {
 	engine *workflow.Engine
 	tasks  *task.Manager
 	agents *agent.Manager
-	audit  *audit.Logger
+	audit  audit.Store
 }
 
 // TriageTask starts the triage workflow for the given task. Idempotent:

--- a/internal/sybra/svc_promptlab.go
+++ b/internal/sybra/svc_promptlab.go
@@ -55,6 +55,7 @@ type PromptLabService struct {
 	artifacts      *artifact.Store
 	projects       *project.Store
 	workflowEngine *workflow.Engine
+	stats          stats.Repository
 	currentConfig  func() *config.Config
 }
 
@@ -272,9 +273,12 @@ func (s *PromptLabService) RunPromptLab(lookbackSeconds int64, minSamples int, f
 	if cfg == nil || s.tasks == nil {
 		return PromptLabRunDTO{}, unavailableError("prompt lab unavailable")
 	}
-	statsStore, err := stats.NewStore(config.StatsFile())
-	if err != nil {
-		return PromptLabRunDTO{}, err
+	// The board's own history, not a second store over the file: under a
+	// database backend that file stops growing, so a lab run would mine only
+	// pre-migration lines and report "min samples not met" for ever.
+	statsStore := s.stats
+	if statsStore == nil {
+		return PromptLabRunDTO{}, unavailableError("run history unavailable")
 	}
 	lookback := time.Duration(lookbackSeconds) * time.Second
 	if lookback <= 0 {

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -23,7 +23,7 @@ type StatsService struct {
 	limits   *limits.Store
 	projects *project.Store
 	tasks    *task.Manager
-	auditDir string
+	audit    audit.Store
 	policy   func() limits.Policy
 	// currentConfig reads one live snapshot, so a config reload reaches the
 	// evaluation scan without re-wiring the service.
@@ -57,7 +57,7 @@ func aggregateTasksDone(resp *stats.StatsResponse, done []doneTaskClosure, now t
 	}
 }
 
-func doneTaskClosures(list []task.Task, auditDir string, now time.Time) []doneTaskClosure {
+func doneTaskClosures(list []task.Task, trail audit.Store, now time.Time) []doneTaskClosure {
 	byID := map[string]doneTaskClosure{}
 	liveIDs := map[string]struct{}{}
 	for i := range list {
@@ -71,7 +71,7 @@ func doneTaskClosures(list []task.Task, auditDir string, now time.Time) []doneTa
 		}
 		byID[id] = doneTaskClosure{id: id, closedAt: taskCloseTime(list[i])}
 	}
-	for _, d := range auditDoneTaskClosures(auditDir, now) {
+	for _, d := range auditDoneTaskClosures(trail, now) {
 		if _, ok := liveIDs[d.id]; ok {
 			continue
 		}
@@ -91,11 +91,11 @@ type auditTaskStatus struct {
 	changedAt time.Time
 }
 
-func auditDoneTaskClosures(auditDir string, now time.Time) []doneTaskClosure {
-	if auditDir == "" {
+func auditDoneTaskClosures(trail audit.Store, now time.Time) []doneTaskClosure {
+	if trail == nil {
 		return nil
 	}
-	events, err := audit.Read(auditDir, audit.Query{
+	events, err := trail.Read(audit.Query{
 		Since: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		Until: now.Add(24 * time.Hour),
 		Type:  audit.EventTaskStatusChanged,
@@ -166,7 +166,7 @@ func (s *StatsService) GetStats() stats.StatsResponse {
 
 	if s.tasks != nil {
 		if list, err := s.tasks.List(); err == nil {
-			done := doneTaskClosures(list, s.auditDir, now)
+			done := doneTaskClosures(list, s.audit, now)
 			aggregateTasksDone(&resp, done, now)
 			resp.ClosedTasksDaily = closedTasksDaily(done, now)
 		} else {
@@ -277,7 +277,7 @@ func (s *StatsService) ScanEvaluation() (evaluation.Report, error) {
 		Cfg:       cfg.Evaluation,
 		ABTesting: cfg.ABTesting,
 		Stats:     s.stats,
-		Audit:     evaluation.AuditDirReader(s.auditDir),
+		Audit:     evaluation.AuditStoreReader(s.audit),
 	})
 	return svc.Scan(context.Background())
 }

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -19,7 +19,7 @@ import (
 
 // StatsService exposes statistics as Wails-bound methods.
 type StatsService struct {
-	stats    *stats.Store
+	stats    stats.Repository
 	limits   *limits.Store
 	projects *project.Store
 	tasks    *task.Manager

--- a/internal/sybra/svc_stats_test.go
+++ b/internal/sybra/svc_stats_test.go
@@ -38,7 +38,7 @@ func TestAggregateTasksDone(t *testing.T) {
 	list[1].ClosedAt = &t2ClosedAt
 
 	var resp stats.StatsResponse
-	aggregateTasksDone(&resp, doneTaskClosures(list, "", now), now)
+	aggregateTasksDone(&resp, doneTaskClosures(list, nil, now), now)
 
 	// AllTime: 5 done tasks
 	if resp.AllTime.TasksDone != 5 {
@@ -78,7 +78,7 @@ func TestClosedTasksDaily(t *testing.T) {
 		{Status: task.StatusInProgress, UpdatedAt: now},
 	}
 
-	got := closedTasksDaily(doneTaskClosures(list, "", now), now)
+	got := closedTasksDaily(doneTaskClosures(list, nil, now), now)
 	want := []stats.TaskSeriesPoint{
 		{Date: "2026-06-13", Count: 1},
 		{Date: "2026-06-14", Count: 2},
@@ -102,7 +102,7 @@ func TestClosedTasksDailyUsesBackendLocalDateKeys(t *testing.T) {
 	closed := time.Date(2026, 6, 1, 22, 30, 0, 0, time.UTC)
 	list := []task.Task{{Status: task.StatusDone, UpdatedAt: time.Date(2026, 6, 1, 1, 0, 0, 0, time.UTC), ClosedAt: &closed}}
 
-	got := closedTasksDaily(doneTaskClosures(list, "", now), now)
+	got := closedTasksDaily(doneTaskClosures(list, nil, now), now)
 	want := []stats.TaskSeriesPoint{{Date: "2026-06-02", Count: 1}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("closedTasksDaily() = %+v, want %+v", got, want)
@@ -216,7 +216,7 @@ func TestStatsServiceGetStatsCountsAuditDoneTasksMissingFromLiveList(t *testing.
 		},
 	})
 
-	resp := (&StatsService{stats: statsStore, tasks: taskMgr, auditDir: auditDir}).GetStats()
+	resp := (&StatsService{stats: statsStore, tasks: taskMgr, audit: mustAuditStore(t, auditDir)}).GetStats()
 	if resp.AllTime.TasksDone != 2 {
 		t.Fatalf("AllTime.TasksDone = %d, want 2 (live done + deleted done, excluding reopened/live non-done)", resp.AllTime.TasksDone)
 	}
@@ -401,3 +401,14 @@ func writeStatsAuditFile(t *testing.T, dir, name string, events []audit.Event) {
 }
 
 func nearly(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// mustAuditStore opens the file trail as the store the service now takes.
+func mustAuditStore(t *testing.T, dir string) audit.Store {
+	t.Helper()
+	store, err := audit.NewLogger(dir)
+	if err != nil {
+		t.Fatalf("audit.NewLogger: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -49,7 +49,7 @@ type TaskService struct {
 	attachments    *attachment.Store
 	wg             *sync.WaitGroup
 	logger         *slog.Logger
-	audit          *audit.Logger
+	audit          audit.Store
 	cfg            *config.Config
 	currentConfig  func() *config.Config
 	// projects and intervention back recordInterventionOnUnblock only; nil in

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -365,7 +365,10 @@ func (s *TaskService) ListTaskAuditEvents(taskID string, days int) ([]TaskAuditE
 	}
 	until := time.Now().UTC().Add(time.Minute)
 	since := until.AddDate(0, 0, -days)
-	events, err := audit.Read(cfg.AuditDir(), audit.Query{
+	if s.audit == nil {
+		return []TaskAuditEventDTO{}, nil
+	}
+	events, err := s.audit.Read(audit.Query{
 		Since:  since,
 		Until:  until,
 		TaskID: taskID,

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -306,6 +306,9 @@ func TestTaskService_ListTaskAuditEventsNewestFirst(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer al.Close()
+	// The service reads the trail through its store now, not by opening the
+	// directory, so that a database-backed board is readable at all.
+	svc.audit = al
 	if err := al.Log(audit.Event{Type: audit.EventTaskCreated, TaskID: "task-a"}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/toolledger/import.go
+++ b/internal/toolledger/import.go
@@ -1,0 +1,107 @@
+package toolledger
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "toolledger"
+
+// Import copies the per-day ledger files into the database, one file per batch.
+//
+// Resumable rather than all-or-nothing: a tool-call ledger is an unbounded history, and a single transaction over years of it would be discarded whole by one interruption. The cursor is the last day-file consumed, committed with that file's rows, so a restart resumes at the next file and a file retried after a crash cannot duplicate — the row key is a digest of the record itself.
+//
+// The files are only read.
+func Import(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	return dbimport.Resumable(ctx, database, ImportDomain, scope, logger,
+		func(ctx context.Context, tx *sql.Tx, cursor string) (dbimport.Batch, error) {
+			return importNextDay(ctx, database, tx, dir, cursor)
+		})
+}
+
+func importNextDay(ctx context.Context, database *db.DB, tx *sql.Tx, dir, cursor string) (dbimport.Batch, error) {
+	days, err := ledgerFiles(dir)
+	if err != nil {
+		return dbimport.Batch{}, err
+	}
+	next := ""
+	for _, name := range days {
+		if name > cursor {
+			next = name
+			break
+		}
+	}
+	if next == "" {
+		return dbimport.Batch{Cursor: cursor, Done: true}, nil
+	}
+
+	count, err := importLedgerFile(ctx, database, tx, filepath.Join(dir, next))
+	if err != nil {
+		return dbimport.Batch{}, err
+	}
+	return dbimport.Batch{Cursor: next, Count: count}, nil
+}
+
+func ledgerFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read tool ledger dir: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".ndjson" {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func importLedgerFile(ctx context.Context, database *db.DB, tx *sql.Tx, path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open tool ledger file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	written := 0
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var r Record
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			// A ledger truncated by a crash ends in exactly one unreadable
+			// line, so failing here would stall the import on a file it could
+			// never get past.
+			continue
+		}
+		if err := insertRecordTx(ctx, database, tx, r, []byte(line)); err != nil {
+			return 0, err
+		}
+		written++
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("read tool ledger file: %w", err)
+	}
+	return written, nil
+}

--- a/internal/toolledger/sqlstore.go
+++ b/internal/toolledger/sqlstore.go
@@ -1,0 +1,121 @@
+package toolledger
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// queryTimeout bounds every statement. Store carries no context to cancel one with; see Store.
+const queryTimeout = 15 * time.Second
+
+// SQLStore keeps tool-call records in the configured database backend.
+type SQLStore struct {
+	db *db.DB
+}
+
+// NewSQLStore returns the database-backed ledger.
+func NewSQLStore(database *db.DB) (*SQLStore, error) {
+	if database == nil {
+		return nil, errors.New("tool ledger needs an open database")
+	}
+	return &SQLStore{db: database}, nil
+}
+
+const insertLedgerRecord = `INSERT INTO tool_ledger (id, ts, agent_id, task_id, tool, doc)
+	VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT (id) DO NOTHING`
+
+// Log appends one record.
+//
+// One row, one statement: a crash leaves it written or absent, never a half-line for a later start to repair.
+func (l *SQLStore) Log(r Record) error {
+	if l == nil {
+		return nil
+	}
+	if r.Timestamp.IsZero() {
+		r.Timestamp = time.Now().UTC()
+	}
+	doc, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("marshal tool record: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	if _, err := l.db.ExecContext(ctx, insertLedgerRecord,
+		RecordID(r), db.TimeValue(r.Timestamp), r.AgentID, r.TaskID, r.Tool, string(doc)); err != nil {
+		return fmt.Errorf("write tool record: %w", err)
+	}
+	return nil
+}
+
+// Read returns records in a time window, oldest first. The file ledger had no reader; this exists so the import can be verified and so mining a window does not mean parsing every day-file.
+func (l *SQLStore) Read(since, until time.Time) ([]Record, error) {
+	if l == nil {
+		return nil, nil
+	}
+	stmt := `SELECT doc FROM tool_ledger WHERE 1 = 1`
+	var args []any
+	if !since.IsZero() {
+		stmt += ` AND ts >= ?`
+		args = append(args, db.TimeValue(since))
+	}
+	if !until.IsZero() {
+		stmt += ` AND ts <= ?`
+		args = append(args, db.TimeValue(until))
+	}
+	stmt += ` ORDER BY ts, ` + l.db.OrderText("id")
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	rows, err := l.db.QueryContext(ctx, stmt, args...)
+	if err != nil {
+		return nil, fmt.Errorf("read tool records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Record
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return nil, fmt.Errorf("scan tool record: %w", err)
+		}
+		var r Record
+		if err := json.Unmarshal([]byte(doc), &r); err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tool records: %w", err)
+	}
+	return out, nil
+}
+
+// Close is a no-op: the database handle belongs to whoever opened it.
+func (l *SQLStore) Close() error { return nil }
+
+// RecordID derives a stable key from the record's own content, so a batch retried after a crash cannot duplicate what it already wrote.
+func RecordID(r Record) string {
+	doc, err := json.Marshal(r)
+	if err != nil {
+		doc = []byte(r.Tool + r.AgentID + r.ToolUseID)
+	}
+	sum := sha256.Sum256(append([]byte(r.Timestamp.UTC().Format(time.RFC3339Nano)+"\x00"), doc...))
+	return hex.EncodeToString(sum[:])
+}
+
+var _ Store = (*SQLStore)(nil)
+
+func insertRecordTx(ctx context.Context, database *db.DB, tx *sql.Tx, r Record, raw []byte) error {
+	if _, err := tx.ExecContext(ctx, database.Rebind(insertLedgerRecord),
+		RecordID(r), db.TimeValue(r.Timestamp), r.AgentID, r.TaskID, r.Tool, string(raw)); err != nil {
+		return fmt.Errorf("insert tool record: %w", err)
+	}
+	return nil
+}

--- a/internal/toolledger/sqlstore_test.go
+++ b/internal/toolledger/sqlstore_test.go
@@ -1,0 +1,116 @@
+package toolledger
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func recordsFixture() []Record {
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return []Record{
+		{Timestamp: base, AgentID: "ag1", TaskID: "task-a", Tool: "Read", ToolUseID: "u1"},
+		{Timestamp: base.Add(time.Hour), AgentID: "ag1", TaskID: "task-a", Tool: "Bash", ToolUseID: "u2", Decision: "allow"},
+		{Timestamp: base.Add(2 * time.Hour), AgentID: "ag2", TaskID: "task-b", Tool: "Edit", ToolUseID: "u3"},
+	}
+}
+
+// TestSQLStore_LogIsIdempotentAndFiltersByTime covers both properties the
+// import leans on: a retried write does not duplicate, and a window read
+// touches only the window.
+func TestSQLStore_LogIsIdempotentAndFiltersByTime(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		for _, r := range recordsFixture() {
+			for range 2 {
+				if err := store.Log(r); err != nil {
+					t.Fatalf("log: %v", err)
+				}
+			}
+		}
+		all, err := store.Read(time.Time{}, time.Time{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(all) != 3 {
+			t.Fatalf("logging each record twice produced %d rows, want 3", len(all))
+		}
+
+		base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+		window, err := store.Read(base.Add(30*time.Minute), base.Add(90*time.Minute))
+		if err != nil {
+			t.Fatalf("windowed read: %v", err)
+		}
+		if len(window) != 1 || window[0].Tool != "Bash" {
+			t.Fatalf("windowed read returned %d records, want only the Bash call", len(window))
+		}
+	})
+}
+
+// TestImport_ResumesWithoutDuplicating pins the issue's resumable-import
+// outcome for this domain.
+func TestImport_ResumesWithoutDuplicating(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		dir := t.TempDir()
+		for i, day := range []string{"2026-05-01", "2026-05-02", "2026-05-03"} {
+			line, err := json.Marshal(recordsFixture()[i])
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, day+".ndjson"), append(line, '\n'), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}
+		for range 2 {
+			if err := Import(t.Context(), d, dir, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.Read(time.Time{}, time.Time{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("after two imports got %d records, want 3", len(got))
+		}
+		for _, day := range []string{"2026-05-01", "2026-05-02", "2026-05-03"} {
+			if _, err := os.Stat(filepath.Join(dir, day+".ndjson")); err != nil {
+				t.Errorf("import removed %s: %v", day, err)
+			}
+		}
+	})
+}
+
+func TestImport_EmptyDomainReadsBackEmpty(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		if err := Import(t.Context(), d, filepath.Join(t.TempDir(), "never-written"), "home-a", nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		got, err := store.Read(time.Time{}, time.Time{})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %d records from an empty domain", len(got))
+		}
+	})
+}

--- a/internal/toolledger/store.go
+++ b/internal/toolledger/store.go
@@ -1,0 +1,11 @@
+package toolledger
+
+// Store is where tool-call records are kept. Two implementations exist: the per-day NDJSON Logger and the database-backed SQLStore, selected by config.Database.Backend.
+//
+// No context: records are written from the provider stream and the approval hook, neither of which carries one. SQLStore bounds each statement with its own deadline.
+type Store interface {
+	Log(r Record) error
+	Close() error
+}
+
+var _ Store = (*Logger)(nil)

--- a/internal/triage/classify.go
+++ b/internal/triage/classify.go
@@ -24,7 +24,7 @@ func ClassifyAndApply(
 	ctx context.Context,
 	classifier Classifier,
 	mgr *task.Manager,
-	al *audit.Logger,
+	al audit.Store,
 	t task.Task,
 	projects []project.Project,
 ) (Verdict, task.Task, error) {
@@ -37,7 +37,7 @@ func ClassifyAndApplyWithOptions(
 	ctx context.Context,
 	classifier Classifier,
 	mgr *task.Manager,
-	al *audit.Logger,
+	al audit.Store,
 	t task.Task,
 	projects []project.Project,
 	opts ApplyOptions,

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -996,6 +996,12 @@ func makeBaseRepo(t *testing.T, baseFiles map[string]string) string {
 	gitRun(t, dir, "init", "-b", "main")
 	gitRun(t, dir, "config", "user.email", "test@test.com")
 	gitRun(t, dir, "config", "user.name", "Test")
+	// Auto-maintenance detaches a process that keeps writing under
+	// .git/objects after the command returns, and t.TempDir's RemoveAll then
+	// races it: "unlinkat .../.git/objects: directory not empty" fails a test
+	// that already passed.
+	gitRun(t, dir, "config", "gc.auto", "0")
+	gitRun(t, dir, "config", "maintenance.auto", "false")
 	for path, content := range baseFiles {
 		writeRepoFile(t, dir, path, content)
 	}

--- a/scripts/test-db-engines.sh
+++ b/scripts/test-db-engines.sh
@@ -14,7 +14,7 @@ PORT="${SYBRA_TEST_PG_PORT:-55432}"
 # while the deploy target is Ubuntu, where en_US.UTF-8 ignores punctuation and
 # reorders exactly the ids the builtin workflows ship with.
 IMAGE="postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317"
-PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/testutil/dbtest/...")
+PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/testutil/dbtest/...")
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to run the postgres engine leg" >&2


### PR DESCRIPTION
## Motivation

Run statistics, provider quota state, the audit trail and the tool ledger are append-only logs written as files and re-read in full to answer any question. Statistics need a tail-repair pass after a crash, quota state is rewritten whole under a cross-process lock on every update, and a report that spans these logs parses whole directories — so the cost grows with the length of the history rather than with the question asked.

Closes #3240

> Changelog: feat(storage): keep run history in the database

## Implementation information

**`dbimport.Resumable` is what this shape needed.** #3239's `Once` puts a domain in one transaction, which is right for a bounded set and wrong for a history that grows without bound: years of copying would be discarded whole by a single interruption. Each batch here commits its rows *and* its cursor together, so a crash loses at most the batch in flight and the next start resumes from the last committed cursor. A batch retried after a crash cannot duplicate — the row key is the record's own id, or a digest of its content where the record has none.

**Filtered reads touch only matching rows.** A query by time, task or event type is an indexed `WHERE`, rather than opening every day-file in the range and decoding every line to discard most of them.

**A record lands in one statement**, so a crash leaves it written or absent and nothing repairs a torn tail on the next start — which the line-per-record statistics file did on every open.

**Reports come from one implementation, not two.** `Aggregate` is split out of `Store.QueryAt`, and both backends call it, so the figures are identical by construction rather than by two code paths that agree today. The test marshals both responses and compares them byte for byte.

**Quota state writes the row that changed** instead of rewriting the whole document. The cross-process file lock existed to serialize two OS processes over one file; a database serializes writers itself, so it becomes a no-op rather than locking a path that no longer exists.

### Shapes that did not match the issue's framing

- The tool ledger has no reader in production at all — the file version only ever appended. It gets one here, because otherwise the import cannot be verified and mining a window still means parsing every day-file.
- Quota state is one bounded document, not a growing log: the file store already prunes events past 21 days, so this one import fits in a transaction and needs no cursor.

### Defects found and fixed along the way

- `initDatabase` ran **after** audit, the tool ledger and statistics were constructed, so all three would have chosen files for the whole run whatever the operator configured, with nothing reporting it. The database now opens first.
- Turning `toolLedger` from a `*Logger` into an interface turned a tolerated nil receiver into a **panic on the provider stream path**, killing any run whose manager had no ledger. Caught by the pre-commit gate, fixed with an explicit guard, and mutation-checked. It is the same typed-nil hazard #3239 hit, arriving from the opposite direction.
- Several agent-completion waits in `internal/agent` used fixed second deadlines, so a suite run on a loaded host reported a timeout as a hung agent. They scale like the rest of the package now.

### Coverage

Every domain's behaviour suite runs on both engines through `dbtest.Engines`, and all four packages are registered with `scripts/test-db-engines.sh` so `mise run test:db` and the CI job cover them. Mutation-checked: removing the nil guard panics the new test.

## Supporting documentation

The durable-storage rules in `CLAUDE.md` already carry the import discipline from #3239; this change adds the resumable variant beside it.