### PR TITLE
fix(stats): import the pre-ndjson history shape

### DIFF
--- a/internal/stats/import.go
+++ b/internal/stats/import.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/Automaat/sybra/internal/db"
 	"github.com/Automaat/sybra/internal/dbimport"
@@ -27,10 +30,37 @@ const importBatchSize = 2000
 //
 // The file is only read.
 func Import(ctx context.Context, database *db.DB, path, scope string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
 	return dbimport.Resumable(ctx, database, ImportDomain, scope, logger,
 		func(ctx context.Context, tx *sql.Tx, cursor string) (dbimport.Batch, error) {
-			return importBatch(ctx, database, tx, path, cursor)
+			batch, err := importBatch(ctx, database, tx, path, cursor)
+			if err == nil && batch.Done {
+				warnIfHistoryWasDropped(path, cursor, batch, logger)
+			}
+			return batch, err
 		})
+}
+
+// warnIfHistoryWasDropped reports a history file that exists and holds data but
+// contributed no rows.
+//
+// The legacy-array shape did exactly this, and the only line it produced was an
+// INFO saying the import had finished — so an operator's whole run history
+// disappeared with nothing to read afterwards that said so. Any future shape
+// this build cannot parse now says so at least once.
+func warnIfHistoryWasDropped(path, cursor string, batch dbimport.Batch, logger *slog.Logger) {
+	if batch.Count > 0 || cursor != "" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Size() == 0 {
+		return
+	}
+	logger.Warn("stats.import.no_records",
+		"path", path, "bytes", info.Size(),
+		"reason", "the history file holds data this build could not read; run statistics will start empty")
 }
 
 func importBatch(ctx context.Context, database *db.DB, tx *sql.Tx, path, cursor string) (dbimport.Batch, error) {
@@ -47,6 +77,30 @@ func importBatch(ctx context.Context, database *db.DB, tx *sql.Tx, path, cursor 
 	}
 	defer func() { _ = f.Close() }()
 
+	// The shape the writer emitted before run records became NDJSON: one JSON
+	// array. The file store still reads it, so a board that has not started a
+	// newer build since is holding exactly this — and reading it line by line
+	// finds one unparseable line and imports the operator's entire history as
+	// nothing. Under a database backend nothing else ever opens the file, so
+	// the rewrite that would have converted it never happens either.
+	if legacy, ok, err := readLegacyArray(f); err != nil {
+		return dbimport.Batch{}, err
+	} else if ok {
+		for i := range legacy {
+			doc, err := json.Marshal(legacy[i])
+			if err != nil {
+				return dbimport.Batch{}, fmt.Errorf("encode run record: %w", err)
+			}
+			if err := insertRunTx(ctx, database, tx, legacy[i], doc); err != nil {
+				return dbimport.Batch{}, err
+			}
+		}
+		return dbimport.Batch{Cursor: strconv.Itoa(len(legacy)), Count: len(legacy), Done: true}, nil
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return dbimport.Batch{}, fmt.Errorf("rewind run history: %w", err)
+	}
+
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 	read := 0
@@ -59,14 +113,19 @@ func importBatch(ctx context.Context, database *db.DB, tx *sql.Tx, path, cursor 
 		line := strings.TrimSpace(scanner.Text())
 		if line != "" {
 			var r RunRecord
-			if err := json.Unmarshal([]byte(line), &r); err != nil {
+			switch {
+			case json.Unmarshal([]byte(line), &r) != nil:
 				// The file store already tolerates a torn final line, which is
 				// what a crash mid-append leaves. Failing here would stall the
 				// import on a line it could never get past.
-				r = RunRecord{}
-			} else if err := insertRunTx(ctx, database, tx, r, []byte(line)); err != nil {
-				return dbimport.Batch{}, err
-			} else {
+			case r.ID == "":
+				// A line that decodes but carries no id is not a run. Inserting
+				// it would take the empty primary key, and the next such line
+				// would collide with it rather than be stored.
+			default:
+				if err := insertRunTx(ctx, database, tx, r, []byte(line)); err != nil {
+					return dbimport.Batch{}, err
+				}
 				written++
 			}
 		}
@@ -89,4 +148,41 @@ func parseCursor(cursor string) (int, error) {
 		return 0, fmt.Errorf("run history import cursor %q is not a line count", cursor)
 	}
 	return n, nil
+}
+
+// readLegacyArray decodes the pre-NDJSON whole-file JSON array, reporting
+// whether the file was in that shape at all.
+//
+// Bounded by one document rather than batched: this shape predates the change
+// that made the history append-only, so it is what a board accumulated up to
+// that point and not a log that keeps growing.
+func readLegacyArray(f *os.File) ([]RunRecord, bool, error) {
+	head := make([]byte, 1)
+	for {
+		n, err := f.Read(head)
+		if errors.Is(err, io.EOF) {
+			return nil, false, nil
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("read run history: %w", err)
+		}
+		if n == 0 {
+			continue
+		}
+		if unicode.IsSpace(rune(head[0])) {
+			continue
+		}
+		if head[0] != '[' {
+			return nil, false, nil
+		}
+		break
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, false, fmt.Errorf("rewind run history: %w", err)
+	}
+	var runs []RunRecord
+	if err := json.NewDecoder(f).Decode(&runs); err != nil {
+		return nil, false, fmt.Errorf("decode legacy run history: %w", err)
+	}
+	return runs, true, nil
 }

--- a/internal/stats/import.go
+++ b/internal/stats/import.go
@@ -86,7 +86,14 @@ func importBatch(ctx context.Context, database *db.DB, tx *sql.Tx, path, cursor 
 	if legacy, ok, err := readLegacyArray(f); err != nil {
 		return dbimport.Batch{}, err
 	} else if ok {
+		written := 0
 		for i := range legacy {
+			if legacy[i].ID == "" {
+				// The same rule the ndjson path applies: a record with no id
+				// would take the empty primary key, and the next such record
+				// would collide with it rather than be stored.
+				continue
+			}
 			doc, err := json.Marshal(legacy[i])
 			if err != nil {
 				return dbimport.Batch{}, fmt.Errorf("encode run record: %w", err)
@@ -94,8 +101,9 @@ func importBatch(ctx context.Context, database *db.DB, tx *sql.Tx, path, cursor 
 			if err := insertRunTx(ctx, database, tx, legacy[i], doc); err != nil {
 				return dbimport.Batch{}, err
 			}
+			written++
 		}
-		return dbimport.Batch{Cursor: strconv.Itoa(len(legacy)), Count: len(legacy), Done: true}, nil
+		return dbimport.Batch{Cursor: strconv.Itoa(len(legacy)), Count: written, Done: true}, nil
 	}
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		return dbimport.Batch{}, fmt.Errorf("rewind run history: %w", err)

--- a/internal/stats/legacy_import_test.go
+++ b/internal/stats/legacy_import_test.go
@@ -89,3 +89,36 @@ func TestImport_WarnsWhenAHistoryFileContributesNothing(t *testing.T) {
 		}
 	})
 }
+
+// TestImport_LegacySkipsRecordsWithNoID keeps the legacy path on the same rule
+// as the ndjson one. An id-less record takes the empty primary key, and the
+// next one collides with it rather than being stored.
+func TestImport_LegacySkipsRecordsWithNoID(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+		runs := []RunRecord{
+			{ID: "", TaskID: "t-0", CostUSD: 1, Timestamp: now},
+			{ID: "", TaskID: "t-1", CostUSD: 2, Timestamp: now},
+			{ID: "legacy-ok", TaskID: "t-2", CostUSD: 3, Timestamp: now},
+		}
+		data, err := json.Marshal(runs)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		path := filepath.Join(t.TempDir(), "stats.json")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := Import(t.Context(), d, path, "home-a", nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		store, err := NewSQLStore(d, nil)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		if n := store.Len(); n != 1 {
+			t.Fatalf("import stored %d records, want only the one carrying an id", n)
+		}
+	})
+}

--- a/internal/stats/legacy_import_test.go
+++ b/internal/stats/legacy_import_test.go
@@ -1,0 +1,91 @@
+package stats
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+// TestImport_LegacyJSONArrayHistory pins the shape the writer emitted before
+// run records became NDJSON. The file store still reads it, so a board that has
+// not started a newer build since still holds exactly this file — and importing
+// it as nothing loses the operator's whole run history, silently and for good.
+func TestImport_LegacyJSONArrayHistory(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+		runs := []RunRecord{
+			{ID: "legacy-0", TaskID: "t-0", Mode: "headless", Role: "implementation", CostUSD: 2, Timestamp: now},
+			{ID: "legacy-1", TaskID: "t-1", Mode: "headless", Role: "review", CostUSD: 4, Timestamp: now.Add(time.Hour)},
+		}
+		data, err := json.Marshal(runs)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		path := filepath.Join(t.TempDir(), "stats.json")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		// Import runs first, as it does in production: under a database backend
+		// the file store is never opened, so nothing rewrites the legacy shape
+		// into NDJSON before the import reads it. Opening the store here would
+		// convert the file and hide the defect entirely.
+		if err := Import(t.Context(), d, path, "home-a", nil); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		sqlStore, err := NewSQLStore(d, nil)
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		if n := sqlStore.Len(); n != 2 {
+			t.Fatalf("import moved %d records, want 2; the operator's history was dropped", n)
+		}
+
+		// A separate copy confirms the file store really does read this shape,
+		// which is why a board can still be holding it.
+		copyPath := filepath.Join(t.TempDir(), "stats.json")
+		if err := os.WriteFile(copyPath, data, 0o600); err != nil {
+			t.Fatalf("write copy: %v", err)
+		}
+		fileStore, err := NewStore(copyPath)
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		if n := fileStore.Len(); n != 2 {
+			t.Fatalf("the file store read %d records from the legacy shape, want 2", n)
+		}
+	})
+}
+
+// TestImport_WarnsWhenAHistoryFileContributesNothing pins the second half of
+// the defect: the loss was silent. The only line the legacy shape produced was
+// an INFO saying the import had finished, so nothing an operator could read
+// afterwards said their history had gone.
+func TestImport_WarnsWhenAHistoryFileContributesNothing(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "stats.json")
+		// A shape no build reads: not NDJSON records, not the legacy array.
+		if err := os.WriteFile(path, []byte("not json at all\n"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+		if err := Import(t.Context(), d, path, "home-a", logger); err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		if !strings.Contains(buf.String(), "stats.import.no_records") {
+			t.Fatalf("a history file that contributed nothing was imported silently; log was %q", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
## Motivation

An adversarial manual run against #3240 (merged) found that flipping `storage.database.backend` on a real board can drop the operator's entire run history — silently, permanently, on both engines.

Run records were written as one JSON array until `8f188c246 fix(stats): append run records as ndjson` landed on 2026-08-03. `internal/stats/store.go` still reads that shape on purpose, so any board that has not started a build newer than that date is holding exactly this file. The import read it line by line, hit one unparseable line, and moved nothing:

```
=== GetStats allTime (6 runs, $12.00 on disk) ===
file      totalRuns=6 totalCostUsd=12
sqlite    totalRuns=0 totalCostUsd=0
postgres  totalRuns=0 totalCostUsd=0
```

Two things made it worse than a one-off miss. The marker committed as complete with a zero tally (`record_count=0, done=1`), so a restart never retries. And under a database backend nothing opens `stats.NewStore`, so the rewrite that would otherwise have converted the file to ndjson never runs — the board keeps the shape that cannot be imported.

> Changelog: fix(stats): import the pre-ndjson history shape

## Implementation information

The import now recognises the whole-file array and decodes it as one document. That shape predates the change which made the history append-only, so it is bounded by what a board accumulated up to that date rather than a log that keeps growing — one transaction is right for it, and the ndjson path keeps its batching and cursor.

**The silence was the other half of the defect.** The only line the failure produced was an INFO saying the import had finished. A history file that exists, holds bytes, and contributes no rows now logs `stats.import.no_records` with the path and size, so any future shape this build cannot read says so at least once instead of looking like an empty board.

A line that decodes but carries no id is no longer inserted. It would take the empty primary key, and the next such line would collide with it rather than be stored — which is how a malformed trailing line could have masked a second one.

### Coverage

`TestImport_LegacyJSONArrayHistory` reproduces the reported loss in production order — import first, because opening the file store rewrites the legacy shape and hides the defect entirely. That ordering matters: my first attempt at this test passed against the broken code for exactly that reason. Mutation-checked on both engines: removing the legacy branch fails it with `import moved 0 records, want 2`.

`TestImport_WarnsWhenAHistoryFileContributesNothing` pins the warning against a shape no build reads.

## Supporting documentation

Found by the adversarial manual run on #3260, which reported it after that PR had already merged.