### PR TITLE
feat(storage): move queue and lease state to a db

### DIFF
--- a/internal/agent/background_task_adversarial_test.go
+++ b/internal/agent/background_task_adversarial_test.go
@@ -55,7 +55,12 @@ func TestAdversarial_LiveBackgroundTaskAtResultDoesNotCompleteCleanly(t *testing
 		t.Fatalf("Run: %v", err)
 	}
 
-	waitForAgentDone(t, ag, scaledDeadline(5*time.Second))
+	// Fifteen seconds, not five. scaledDeadline samples the host load once per
+	// process, and this package's tests start while the rest of a full run is
+	// still going — so the factor resolves before the load it exists to absorb
+	// arrives, and stays 1. The wait polls, so a larger ceiling costs nothing
+	// when the agent stops promptly and only tells a slow host from a stuck one.
+	waitForAgentDone(t, ag, scaledDeadline(15*time.Second))
 
 	if ag.GetState() == StateStopped && ag.GetExitErr() == nil && ag.HasBackgroundTasks() {
 		t.Fatalf("agent completed cleanly despite live background task: state=%s exitErr=%v hasBackgroundTasks=%v logs=%s",

--- a/internal/agentqueue/import.go
+++ b/internal/agentqueue/import.go
@@ -1,0 +1,45 @@
+package agentqueue
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "agentqueue"
+
+// Import copies the queued items into the database once.
+//
+// Bounded by the queue's own depth, so one transaction. The files are only
+// read; an interrupted import commits neither the rows nor the marker.
+func Import(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return dbimport.Once(ctx, database, ImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		fileStore, err := newStore(dir)
+		if err != nil {
+			return 0, err
+		}
+		items := fileStore.load(logger)
+		for i := range items {
+			it := items[i]
+			doc, err := yaml.Marshal(it)
+			if err != nil {
+				return 0, fmt.Errorf("marshal item: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(upsertQueueItem),
+				it.TaskID, it.Role, string(it.Priority), string(it.Status), string(doc)); err != nil {
+				return 0, fmt.Errorf("insert queue item: %w", err)
+			}
+		}
+		return len(items), nil
+	})
+}

--- a/internal/agentqueue/persistence.go
+++ b/internal/agentqueue/persistence.go
@@ -1,0 +1,20 @@
+package agentqueue
+
+import "log/slog"
+
+// Persistence is the queue's durability mirror. Two implementations exist: the
+// per-item YAML files and the database-backed SQLStore, selected by
+// config.Database.Backend.
+//
+// Every method is best-effort by contract: the in-memory queue is the
+// authority and a store failure is logged rather than failing the operation it
+// mirrors. Dispatch ordering does not depend on the order load returns — the
+// queue sorts by the persisted fields — so what has to survive a restart is
+// the item, not the sequence it was read in.
+type Persistence interface {
+	put(it Item) error
+	del(taskID string) error
+	load(log *slog.Logger) []Item
+}
+
+var _ Persistence = (*store)(nil)

--- a/internal/agentqueue/queue.go
+++ b/internal/agentqueue/queue.go
@@ -46,6 +46,9 @@ type Options struct {
 	// The boost is applied only inside PopReady's snapshot re-rank via an
 	// injected clock; it never mutates the heap's own clock-free ordering.
 	StarvationBoostAfter time.Duration
+	// Store mirrors the queue for durability. Nil keeps the per-item YAML files
+	// under dir, which is what an install with no database backend uses.
+	Store Persistence
 }
 
 // queueHeap implements container/heap.Interface ordered by Less, and keeps
@@ -88,7 +91,7 @@ func (h *queueHeap) Pop() any {
 type Queue struct {
 	mu    sync.Mutex
 	h     *queueHeap
-	store *store
+	store Persistence
 	log   *slog.Logger
 	now   func() time.Time
 	opts  Options
@@ -109,9 +112,13 @@ func New(dir string, opts Options, log *slog.Logger) (*Queue, error) {
 	if log == nil {
 		log = slog.Default()
 	}
-	st, err := newStore(dir)
-	if err != nil {
-		return nil, fmt.Errorf("agentqueue: init store: %w", err)
+	st := opts.Store
+	if st == nil {
+		fileStore, err := newStore(dir)
+		if err != nil {
+			return nil, fmt.Errorf("agentqueue: init store: %w", err)
+		}
+		st = fileStore
 	}
 
 	q := &Queue{

--- a/internal/agentqueue/queue_test.go
+++ b/internal/agentqueue/queue_test.go
@@ -440,8 +440,13 @@ func TestQueue_Reconcile(t *testing.T) {
 		t.Fatalf("Reconcile left %v, want only [keep]", snap)
 	}
 
-	// Store files for pruned items must be gone too.
-	dir := q.store.dir
+	// Store files for pruned items must be gone too. The queue holds its store
+	// behind an interface now, so this reaches the file one it was built with.
+	fileStore, ok := q.store.(*store)
+	if !ok {
+		t.Fatalf("queue store is %T, want the file store this test built", q.store)
+	}
+	dir := fileStore.dir
 	for _, id := range []string{"missing", "done", "cancelled", "in-progress"} {
 		if _, err := os.Stat(filepath.Join(dir, id+".yaml")); !os.IsNotExist(err) {
 			t.Errorf("expected store file for %q to be removed, stat err=%v", id, err)

--- a/internal/agentqueue/sqlstore.go
+++ b/internal/agentqueue/sqlstore.go
@@ -1,0 +1,124 @@
+package agentqueue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// queryTimeout bounds every statement. The queue mirrors from paths that carry
+// no context — an offer, a pop — so a stalled backend would otherwise hold one
+// open with nothing able to cancel it.
+const queryTimeout = 15 * time.Second
+
+// SQLStore mirrors the queue into the configured database backend.
+//
+// One row per task, written whole, so a crash leaves the row at its previous
+// value rather than a half-written file. Items are stored as the YAML the file
+// store already used, so both agree by construction.
+type SQLStore struct {
+	db     *db.DB
+	logger *slog.Logger
+}
+
+// NewSQLStore returns the database-backed queue mirror.
+func NewSQLStore(database *db.DB, logger *slog.Logger) (*SQLStore, error) {
+	if database == nil {
+		return nil, errors.New("agent queue store needs an open database")
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return &SQLStore{db: database, logger: logger}, nil
+}
+
+const (
+	upsertQueueItem = `INSERT INTO agent_queue_items (task_id, role, priority, status, doc)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (task_id) DO UPDATE SET
+			role = excluded.role, priority = excluded.priority,
+			status = excluded.status, doc = excluded.doc`
+
+	deleteQueueItem = `DELETE FROM agent_queue_items WHERE task_id = ?`
+
+	selectQueueItems = `SELECT doc FROM agent_queue_items ORDER BY `
+)
+
+func (s *SQLStore) put(it Item) error {
+	if it.TaskID == "" {
+		return errors.New("agentqueue: item has no task id")
+	}
+	doc, err := yaml.Marshal(it)
+	if err != nil {
+		return fmt.Errorf("marshal item: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, upsertQueueItem,
+		it.TaskID, it.Role, string(it.Priority), string(it.Status), string(doc)); err != nil {
+		return fmt.Errorf("write queue item: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) del(taskID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, deleteQueueItem, taskID); err != nil {
+		return fmt.Errorf("delete queue item: %w", err)
+	}
+	return nil
+}
+
+// load returns every mirrored item.
+//
+// Ordered by task id so a read is reproducible, which the file store's map
+// iteration never was. Dispatch order does not come from here either way — the
+// queue sorts by the persisted fields — so what matters is that every item
+// comes back, not the sequence.
+func (s *SQLStore) load(log *slog.Logger) []Item {
+	if log == nil {
+		log = s.logger
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx, selectQueueItems+s.db.OrderText("task_id"))
+	if err != nil {
+		log.Warn("agentqueue.store.load.query-failed", "err", err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Item
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			log.Warn("agentqueue.store.load.scan-failed", "err", err)
+			return out
+		}
+		var it Item
+		if err := yaml.Unmarshal([]byte(doc), &it); err != nil {
+			// Skipped and logged, as the file store does with an unparseable
+			// file: one bad row must not cost the queue every other item.
+			log.Warn("agentqueue.store.load.parse-failed", "err", err)
+			continue
+		}
+		if it.TaskID == "" {
+			log.Warn("agentqueue.store.load.empty-task-id")
+			continue
+		}
+		out = append(out, it)
+	}
+	if err := rows.Err(); err != nil {
+		log.Warn("agentqueue.store.load.iterate-failed", "err", err)
+	}
+	return out
+}
+
+var _ Persistence = (*SQLStore)(nil)

--- a/internal/agentqueue/sqlstore_test.go
+++ b/internal/agentqueue/sqlstore_test.go
@@ -1,0 +1,135 @@
+package agentqueue
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func queueFixture() []Item {
+	return []Item{
+		{TaskID: "pr-review", Role: "review", Priority: task.PriorityLow, Status: task.StatusTodo},
+		{TaskID: "prompt-lab", Role: "implementation", Priority: task.PriorityUrgent, Status: task.StatusTodo},
+		{TaskID: "pr-fix", Role: "implementation", Priority: task.PriorityHigh, Status: task.StatusTodo, Manual: true},
+	}
+}
+
+func discard() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// TestSQLStore_OrderingSurvivesARestart is the issue's "queue ordering after a
+// restart matches the ordering before it".
+//
+// The order does not come from the store — the queue sorts by the persisted
+// fields — so this compares what a restarted queue actually dispatches, not
+// what the store happened to return.
+func TestSQLStore_OrderingSurvivesARestart(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLStore(d, discard())
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		q, err := New(t.TempDir(), Options{Store: store}, discard())
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		for _, it := range queueFixture() {
+			if !q.Offer(it) {
+				t.Fatalf("Offer(%s) refused", it.TaskID)
+			}
+		}
+		before := ids(q.Snapshot())
+
+		// A restart is a fresh queue over the same mirror.
+		again, err := New(t.TempDir(), Options{Store: store}, discard())
+		if err != nil {
+			t.Fatalf("New(restart): %v", err)
+		}
+		after := ids(again.Snapshot())
+
+		if len(after) != len(before) {
+			t.Fatalf("restart holds %d items, want %d (%v vs %v)", len(after), len(before), after, before)
+		}
+		for i := range before {
+			if before[i] != after[i] {
+				t.Fatalf("position %d: before restart %q, after %q (%v vs %v)", i, before[i], after[i], before, after)
+			}
+		}
+	})
+}
+
+func ids(items []Item) []string {
+	out := make([]string, 0, len(items))
+	for i := range items {
+		out = append(out, items[i].TaskID)
+	}
+	return out
+}
+
+// TestSQLStore_RemoveIsDurable pins that a popped item does not come back on
+// the next start, which is what a queue mirror exists to get right.
+func TestSQLStore_RemoveIsDurable(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLStore(d, discard())
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		q, err := New(t.TempDir(), Options{Store: store}, discard())
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		for _, it := range queueFixture() {
+			q.Offer(it)
+		}
+		q.Remove("pr-fix")
+		again, err := New(t.TempDir(), Options{Store: store}, discard())
+		if err != nil {
+			t.Fatalf("New(restart): %v", err)
+		}
+		for _, id := range ids(again.Snapshot()) {
+			if id == "pr-fix" {
+				t.Fatal("a removed item came back after restart")
+			}
+		}
+	})
+}
+
+// TestImport_IsOnceOnlyAndLeavesTheFiles pins the upgrade guarantees.
+func TestImport_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		dir := t.TempDir()
+		fileStore, err := newStore(dir)
+		if err != nil {
+			t.Fatalf("newStore: %v", err)
+		}
+		for _, it := range queueFixture() {
+			if err := fileStore.put(it); err != nil {
+				t.Fatalf("put: %v", err)
+			}
+		}
+		for range 2 {
+			if err := Import(t.Context(), d, dir, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLStore(d, discard())
+		if err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+		if got := store.load(discard()); len(got) != 3 {
+			t.Fatalf("after two imports the mirror holds %d items, want 3", len(got))
+		}
+		for _, it := range queueFixture() {
+			if _, err := os.Stat(filepath.Join(dir, it.TaskID+".yaml")); err != nil {
+				t.Errorf("import removed %s: %v", it.TaskID, err)
+			}
+		}
+	})
+}

--- a/internal/cleanup/protected.go
+++ b/internal/cleanup/protected.go
@@ -108,13 +108,41 @@ type protectedFile struct {
 
 var protectedStoreLocker = fsutil.NewKeyedLocker()
 
+// protectedFiles keeps the ledger in one JSON document, serialized by a lock
+// keyed on that document's path.
+type protectedFiles struct {
+	path string
+}
+
 type ProtectedStore struct {
 	path           string
+	store          ProtectedPersistence
 	reminderWindow time.Duration
 
 	// clock drives the reminder window. Read without a lock; set once at
 	// construction or during test setup.
 	clock clock.Clock
+}
+
+func (s *ProtectedStore) lock() (func(), error) {
+	if s == nil || s.store == nil {
+		return func() {}, nil
+	}
+	return s.store.Lock()
+}
+
+func (s *ProtectedStore) read() (protectedFile, error) {
+	if s == nil || s.store == nil {
+		return protectedFile{}, nil
+	}
+	return s.store.Read()
+}
+
+func (s *ProtectedStore) write(rec protectedFile) error {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	return s.store.Write(rec)
 }
 
 func DefaultProtectedStorePath() string {
@@ -126,14 +154,22 @@ func DefaultProtectedStore() *ProtectedStore {
 }
 
 func NewProtectedStore(path string) *ProtectedStore {
+	return NewProtectedStoreWith(path, &protectedFiles{path: path})
+}
+
+// NewProtectedStoreWith returns a store persisting through p rather than to the
+// JSON document at path. path is kept for the messages that name where findings
+// live.
+func NewProtectedStoreWith(path string, p ProtectedPersistence) *ProtectedStore {
 	return &ProtectedStore{
 		path:           path,
+		store:          p,
 		reminderWindow: DefaultReminderWindow,
 		clock:          clock.System{},
 	}
 }
 
-func (s *ProtectedStore) lock() (func(), error) {
+func (s *protectedFiles) Lock() (func(), error) {
 	if s == nil {
 		return func() {}, nil
 	}
@@ -155,7 +191,7 @@ func (s *ProtectedStore) lock() (func(), error) {
 	return unlock, nil
 }
 
-func (s *ProtectedStore) read() (protectedFile, error) {
+func (s *protectedFiles) Read() (protectedFile, error) {
 	if s == nil || strings.TrimSpace(s.path) == "" {
 		return protectedFile{}, nil
 	}
@@ -173,7 +209,7 @@ func (s *ProtectedStore) read() (protectedFile, error) {
 	return rec, nil
 }
 
-func (s *ProtectedStore) write(rec protectedFile) error {
+func (s *protectedFiles) Write(rec protectedFile) error {
 	if s == nil || strings.TrimSpace(s.path) == "" {
 		return nil
 	}

--- a/internal/cleanup/protected_import.go
+++ b/internal/cleanup/protected_import.go
@@ -1,0 +1,43 @@
+package cleanup
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ProtectedImportDomain names this domain in the import marker table.
+const ProtectedImportDomain = "protectedfindings"
+
+// ImportProtected copies the protected-findings document into the database
+// once.
+//
+// Bounded — a finding resolves once its cause is cleared — so one transaction.
+// The document is only read; losing a finding here is what lets a later
+// cleanup pass delete the path it protects, so an interrupted import
+// committing nothing is the right failure.
+func ImportProtected(ctx context.Context, database *db.DB, path, scope string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ProtectedImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		rec, err := (&protectedFiles{path: path}).Read()
+		if err != nil {
+			return 0, err
+		}
+		for i := range rec.Findings {
+			f := &rec.Findings[i]
+			doc, err := json.Marshal(f)
+			if err != nil {
+				return 0, fmt.Errorf("protected findings: encode: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, upsertProtectedStmt(database),
+				f.ID, string(f.Kind), db.TimeValue(f.FirstSeenAt), string(doc)); err != nil {
+				return 0, fmt.Errorf("insert protected finding: %w", err)
+			}
+		}
+		return len(rec.Findings), nil
+	})
+}

--- a/internal/cleanup/protected_persistence.go
+++ b/internal/cleanup/protected_persistence.go
@@ -1,0 +1,17 @@
+package cleanup
+
+// ProtectedPersistence holds the protected-findings ledger. Two
+// implementations exist: the single JSON document and the database-backed
+// SQLProtectedStore, selected by config.Database.Backend.
+//
+// Lock acquires the exclusive hold a read-modify-write needs and returns its
+// release, which is the shape the store already had. Every mutating method is
+// one such cycle, and losing one loses the record that a path is protected —
+// after which a cleanup pass is free to delete it.
+type ProtectedPersistence interface {
+	Lock() (release func(), err error)
+	Read() (protectedFile, error)
+	Write(rec protectedFile) error
+}
+
+var _ ProtectedPersistence = (*protectedFiles)(nil)

--- a/internal/cleanup/protected_sqlstore.go
+++ b/internal/cleanup/protected_sqlstore.go
@@ -1,0 +1,182 @@
+package cleanup
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// LockProtected serializes protected-findings read-modify-writes across
+// processes.
+const LockProtected db.LockKey = 6_215_034_129_007
+
+// protectedQueryTimeout bounds a held lock. A cycle that cannot finish must
+// release rather than hold every other instance's cleanup pass behind it.
+const protectedQueryTimeout = 30 * time.Second
+
+// SQLProtectedStore keeps protected findings in the configured database
+// backend.
+//
+// Lock begins a transaction holding an advisory lock and its release commits,
+// so a whole observe-or-resolve cycle is atomic against every other instance. A
+// process killed inside one leaves the previous state: losing the record that a
+// path is protected is what lets a later cleanup pass delete it.
+type SQLProtectedStore struct {
+	db *db.DB
+
+	mu sync.Mutex
+	tx *sql.Tx
+}
+
+// NewSQLProtectedStore returns the database-backed findings ledger.
+func NewSQLProtectedStore(database *db.DB) (*SQLProtectedStore, error) {
+	if database == nil {
+		return nil, errors.New("protected findings store needs an open database")
+	}
+	return &SQLProtectedStore{db: database}, nil
+}
+
+const (
+	// One statement per dialect rather than a concatenation, so nothing in this
+	// file builds SQL from a value at runtime.
+	selectProtectedByKey  = `SELECT doc FROM cleanup_protected ORDER BY key`
+	selectProtectedByKeyC = `SELECT doc FROM cleanup_protected ORDER BY key COLLATE "C"`
+
+	// Both placeholder styles spelled out rather than rebound at the call, so
+	// every statement this file executes is a constant.
+	upsertProtected = `INSERT INTO cleanup_protected (key, kind, recorded_at, doc)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT (key) DO UPDATE SET
+			kind = excluded.kind, recorded_at = excluded.recorded_at, doc = excluded.doc`
+
+	upsertProtectedPG = `INSERT INTO cleanup_protected (key, kind, recorded_at, doc)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (key) DO UPDATE SET
+			kind = excluded.kind, recorded_at = excluded.recorded_at, doc = excluded.doc`
+
+	deleteAllProtected = `DELETE FROM cleanup_protected`
+)
+
+// Lock begins the transaction a read-modify-write runs in. The returned release
+// commits it.
+func (s *SQLProtectedStore) Lock() (func(), error) {
+	s.mu.Lock()
+	ctx, cancel := context.WithTimeout(context.Background(), protectedQueryTimeout)
+
+	tx, err := s.db.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		cancel()
+		s.mu.Unlock()
+		return nil, fmt.Errorf("protected findings: begin: %w", err)
+	}
+	if s.db.Dialect() == db.Postgres {
+		if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", int64(LockProtected)); err != nil {
+			_ = tx.Rollback()
+			cancel()
+			s.mu.Unlock()
+			return nil, fmt.Errorf("protected findings: lock: %w", err)
+		}
+	}
+	s.tx = tx
+
+	return func() {
+		defer func() {
+			s.tx = nil
+			cancel()
+			s.mu.Unlock()
+		}()
+		if err := tx.Commit(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			// The release carries no error by contract, so a commit that fails
+			// has nowhere to report. Rolling back keeps the ledger at its
+			// previous value rather than leaving a half-applied cycle.
+			_ = tx.Rollback()
+		}
+	}, nil
+}
+
+// Read returns the whole ledger, ordered by key so a pass sees findings in the
+// same order every time — which is what the document's own sorted slice gave.
+func (s *SQLProtectedStore) Read() (protectedFile, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), protectedQueryTimeout)
+	defer cancel()
+	var rows *sql.Rows
+	var err error
+	if s.db.Dialect() == db.Postgres {
+		if s.tx != nil {
+			rows, err = s.tx.QueryContext(ctx, selectProtectedByKeyC)
+		} else {
+			rows, err = s.db.QueryContext(ctx, selectProtectedByKeyC)
+		}
+	} else {
+		if s.tx != nil {
+			rows, err = s.tx.QueryContext(ctx, selectProtectedByKey)
+		} else {
+			rows, err = s.db.QueryContext(ctx, selectProtectedByKey)
+		}
+	}
+	if err != nil {
+		return protectedFile{}, fmt.Errorf("protected findings: read: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var rec protectedFile
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return protectedFile{}, fmt.Errorf("protected findings: scan: %w", err)
+		}
+		var f Finding
+		if err := json.Unmarshal([]byte(doc), &f); err != nil {
+			return protectedFile{}, fmt.Errorf("protected findings: decode: %w", err)
+		}
+		rec.Findings = append(rec.Findings, f)
+	}
+	if err := rows.Err(); err != nil {
+		return protectedFile{}, fmt.Errorf("protected findings: iterate: %w", err)
+	}
+	return rec, nil
+}
+
+// Write replaces the ledger.
+//
+// Called only inside a locked cycle, so the delete and the inserts are one
+// transaction: no other instance observes the gap, and a process killed here
+// commits neither half.
+func (s *SQLProtectedStore) Write(rec protectedFile) error {
+	if s.tx == nil {
+		return errors.New("protected findings: Write outside a locked cycle")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), protectedQueryTimeout)
+	defer cancel()
+	if _, err := s.tx.ExecContext(ctx, deleteAllProtected); err != nil {
+		return fmt.Errorf("protected findings: clear: %w", err)
+	}
+	for i := range rec.Findings {
+		f := &rec.Findings[i]
+		doc, err := json.Marshal(f)
+		if err != nil {
+			return fmt.Errorf("protected findings: encode: %w", err)
+		}
+		if _, err := s.tx.ExecContext(ctx, upsertProtectedStmt(s.db),
+			f.ID, string(f.Kind), db.TimeValue(f.FirstSeenAt), string(doc)); err != nil {
+			return fmt.Errorf("protected findings: write: %w", err)
+		}
+	}
+	return nil
+}
+
+var _ ProtectedPersistence = (*SQLProtectedStore)(nil)
+
+// upsertProtectedStmt returns the finding upsert for this dialect.
+func upsertProtectedStmt(d *db.DB) string {
+	if d.Dialect() == db.Postgres {
+		return upsertProtectedPG
+	}
+	return upsertProtected
+}

--- a/internal/cleanup/protected_sqlstore_test.go
+++ b/internal/cleanup/protected_sqlstore_test.go
@@ -1,0 +1,147 @@
+package cleanup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func findingsFixture() protectedFile {
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return protectedFile{Findings: []Finding{
+		{ID: "wt-b", Kind: ResourceWorktree, Path: "/tmp/b", Reason: "held", FirstSeenAt: base.Add(time.Hour)},
+		{ID: "wt-a", Kind: ResourceWorktree, Path: "/tmp/a", Reason: "held", FirstSeenAt: base},
+	}}
+}
+
+// TestSQLProtectedStore_RoundTripsInAStableOrder pins that a finding survives
+// and that a pass reads them in one order, which the JSON document's own sorted
+// slice gave.
+func TestSQLProtectedStore_RoundTripsInAStableOrder(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLProtectedStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLProtectedStore: %v", err)
+		}
+		release, err := store.Lock()
+		if err != nil {
+			t.Fatalf("Lock: %v", err)
+		}
+		if err := store.Write(findingsFixture()); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		release()
+
+		got, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		if len(got.Findings) != 2 {
+			t.Fatalf("read %d findings, want 2", len(got.Findings))
+		}
+		if got.Findings[0].ID != "wt-a" {
+			t.Errorf("order starts at %q, want wt-a", got.Findings[0].ID)
+		}
+	})
+}
+
+// TestSQLProtectedStore_WriteOutsideALockIsRefused keeps a later caller from
+// replacing the ledger without the serialization that makes the cycle safe.
+func TestSQLProtectedStore_WriteOutsideALockIsRefused(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLProtectedStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLProtectedStore: %v", err)
+		}
+		if err := store.Write(findingsFixture()); err == nil {
+			t.Fatal("Write succeeded outside a locked cycle; nothing serialized it")
+		}
+	})
+}
+
+// TestSQLProtectedStore_LockedCyclesDoNotOverlap is the issue's "two concurrent
+// updates to the same record cannot lose one of them". Losing a finding is what
+// lets a later cleanup pass delete the path it protects.
+func TestSQLProtectedStore_LockedCyclesDoNotOverlap(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		var (
+			mu      sync.Mutex
+			inside  int
+			overlap bool
+		)
+		var wg sync.WaitGroup
+		for range 4 {
+			store, err := NewSQLProtectedStore(d)
+			if err != nil {
+				t.Fatalf("NewSQLProtectedStore: %v", err)
+			}
+			wg.Go(func() {
+				for range 8 {
+					release, err := store.Lock()
+					if err != nil {
+						t.Errorf("Lock: %v", err)
+						return
+					}
+					mu.Lock()
+					inside++
+					if inside > 1 {
+						overlap = true
+					}
+					mu.Unlock()
+					time.Sleep(time.Millisecond)
+					mu.Lock()
+					inside--
+					mu.Unlock()
+					release()
+				}
+			})
+		}
+		wg.Wait()
+		if overlap {
+			t.Fatal("two instances held the findings ledger at once; a protected path can be forgotten")
+		}
+	})
+}
+
+// TestImportProtected_IsOnceOnlyAndLeavesTheFile pins the upgrade guarantees.
+func TestImportProtected_IsOnceOnlyAndLeavesTheFile(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "protected-findings.json")
+		data, err := json.MarshalIndent(findingsFixture(), "", "  ")
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		for range 2 {
+			if err := ImportProtected(t.Context(), d, path, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLProtectedStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLProtectedStore: %v", err)
+		}
+		got, err := store.Read()
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		if len(got.Findings) != 2 {
+			t.Fatalf("after two imports the ledger holds %d findings, want 2", len(got.Findings))
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("import removed the original document: %v", err)
+		}
+	})
+}

--- a/internal/db/migrations/postgres/0004_coordination.sql
+++ b/internal/db/migrations/postgres/0004_coordination.sql
@@ -15,3 +15,11 @@ CREATE TABLE IF NOT EXISTS ledger_revisions (
 	ledger TEXT PRIMARY KEY,
 	revision BIGINT NOT NULL DEFAULT 0
 )
+--;;
+CREATE TABLE IF NOT EXISTS agent_queue_items (
+	task_id TEXT PRIMARY KEY,
+	role TEXT NOT NULL DEFAULT '',
+	priority TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT '',
+	doc TEXT NOT NULL
+)

--- a/internal/db/migrations/postgres/0004_coordination.sql
+++ b/internal/db/migrations/postgres/0004_coordination.sql
@@ -33,3 +33,18 @@ CREATE TABLE IF NOT EXISTS monitor_incidents (
 )
 --;;
 CREATE INDEX IF NOT EXISTS monitor_incidents_state_idx ON monitor_incidents (state, last_seen)
+--;;
+CREATE TABLE IF NOT EXISTS issue_outbox (
+	fingerprint TEXT PRIMARY KEY,
+	operation TEXT NOT NULL DEFAULT '',
+	attempts BIGINT NOT NULL DEFAULT 0,
+	first_failed_at BIGINT NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE TABLE IF NOT EXISTS cleanup_protected (
+	key TEXT PRIMARY KEY,
+	kind TEXT NOT NULL DEFAULT '',
+	recorded_at BIGINT NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)

--- a/internal/db/migrations/postgres/0004_coordination.sql
+++ b/internal/db/migrations/postgres/0004_coordination.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS attempt_leases (
+	id TEXT PRIMARY KEY,
+	task_id TEXT NOT NULL DEFAULT '',
+	provider TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT '',
+	expires_at BIGINT NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS attempt_leases_expiry_idx ON attempt_leases (expires_at)
+--;;
+CREATE INDEX IF NOT EXISTS attempt_leases_task_idx ON attempt_leases (task_id)
+--;;
+CREATE TABLE IF NOT EXISTS ledger_revisions (
+	ledger TEXT PRIMARY KEY,
+	revision BIGINT NOT NULL DEFAULT 0
+)

--- a/internal/db/migrations/postgres/0004_coordination.sql
+++ b/internal/db/migrations/postgres/0004_coordination.sql
@@ -23,3 +23,13 @@ CREATE TABLE IF NOT EXISTS agent_queue_items (
 	status TEXT NOT NULL DEFAULT '',
 	doc TEXT NOT NULL
 )
+--;;
+CREATE TABLE IF NOT EXISTS monitor_incidents (
+	fingerprint TEXT PRIMARY KEY,
+	state TEXT NOT NULL DEFAULT '',
+	failure_code TEXT NOT NULL DEFAULT '',
+	last_seen BIGINT NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS monitor_incidents_state_idx ON monitor_incidents (state, last_seen)

--- a/internal/db/migrations/sqlite/0004_coordination.sql
+++ b/internal/db/migrations/sqlite/0004_coordination.sql
@@ -15,3 +15,11 @@ CREATE TABLE IF NOT EXISTS ledger_revisions (
 	ledger TEXT PRIMARY KEY,
 	revision INTEGER NOT NULL DEFAULT 0
 )
+--;;
+CREATE TABLE IF NOT EXISTS agent_queue_items (
+	task_id TEXT PRIMARY KEY,
+	role TEXT NOT NULL DEFAULT '',
+	priority TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT '',
+	doc TEXT NOT NULL
+)

--- a/internal/db/migrations/sqlite/0004_coordination.sql
+++ b/internal/db/migrations/sqlite/0004_coordination.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS attempt_leases (
+	id TEXT PRIMARY KEY,
+	task_id TEXT NOT NULL DEFAULT '',
+	provider TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT '',
+	expires_at INTEGER NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS attempt_leases_expiry_idx ON attempt_leases (expires_at)
+--;;
+CREATE INDEX IF NOT EXISTS attempt_leases_task_idx ON attempt_leases (task_id)
+--;;
+CREATE TABLE IF NOT EXISTS ledger_revisions (
+	ledger TEXT PRIMARY KEY,
+	revision INTEGER NOT NULL DEFAULT 0
+)

--- a/internal/db/migrations/sqlite/0004_coordination.sql
+++ b/internal/db/migrations/sqlite/0004_coordination.sql
@@ -23,3 +23,13 @@ CREATE TABLE IF NOT EXISTS agent_queue_items (
 	status TEXT NOT NULL DEFAULT '',
 	doc TEXT NOT NULL
 )
+--;;
+CREATE TABLE IF NOT EXISTS monitor_incidents (
+	fingerprint TEXT PRIMARY KEY,
+	state TEXT NOT NULL DEFAULT '',
+	failure_code TEXT NOT NULL DEFAULT '',
+	last_seen INTEGER NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE INDEX IF NOT EXISTS monitor_incidents_state_idx ON monitor_incidents (state, last_seen)

--- a/internal/db/migrations/sqlite/0004_coordination.sql
+++ b/internal/db/migrations/sqlite/0004_coordination.sql
@@ -33,3 +33,18 @@ CREATE TABLE IF NOT EXISTS monitor_incidents (
 )
 --;;
 CREATE INDEX IF NOT EXISTS monitor_incidents_state_idx ON monitor_incidents (state, last_seen)
+--;;
+CREATE TABLE IF NOT EXISTS issue_outbox (
+	fingerprint TEXT PRIMARY KEY,
+	operation TEXT NOT NULL DEFAULT '',
+	attempts INTEGER NOT NULL DEFAULT 0,
+	first_failed_at INTEGER NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)
+--;;
+CREATE TABLE IF NOT EXISTS cleanup_protected (
+	key TEXT PRIMARY KEY,
+	kind TEXT NOT NULL DEFAULT '',
+	recorded_at INTEGER NOT NULL DEFAULT 0,
+	doc TEXT NOT NULL
+)

--- a/internal/monitor/incident_import.go
+++ b/internal/monitor/incident_import.go
@@ -1,0 +1,41 @@
+package monitor
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// IncidentImportDomain names this domain in the import marker table.
+const IncidentImportDomain = "incidents"
+
+// ImportIncidents copies the incident files into the database once.
+//
+// Bounded — an incident is closed once its cause is fixed — so one transaction.
+// The files are only read.
+func ImportIncidents(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, IncidentImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		incidents, err := newIncidentFiles(dir).List()
+		if err != nil {
+			return 0, err
+		}
+		for i := range incidents {
+			in := incidents[i]
+			doc, err := yaml.Marshal(in)
+			if err != nil {
+				return 0, fmt.Errorf("incident store: encode: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(upsertIncident),
+				in.Fingerprint, string(in.State), in.FailureCode, db.TimeValue(in.LastSeen), string(doc)); err != nil {
+				return 0, fmt.Errorf("insert incident: %w", err)
+			}
+		}
+		return len(incidents), nil
+	})
+}

--- a/internal/monitor/incident_persistence.go
+++ b/internal/monitor/incident_persistence.go
@@ -1,0 +1,97 @@
+package monitor
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// IncidentPersistence is where the incident ledger lives. Two implementations
+// exist: the per-fingerprint YAML files and the database-backed
+// SQLIncidentStore, selected by config.Database.Backend.
+//
+// Lock acquires the exclusive hold a read-modify-write needs and returns its
+// release. Every public method on IncidentStore is one such cycle — observe,
+// remediate, reconcile, link — and losing one loses an operator's record that
+// something failed, or re-files an issue that was already filed.
+//
+// A handle rather than a callback because that is the shape the store already
+// had: the database implementation begins a transaction on Lock and commits it
+// on release, which is the same contract an advisory file lock offers.
+type IncidentPersistence interface {
+	Lock() (release func() error, err error)
+	Load(fingerprint string) (Incident, bool, error)
+	Save(in Incident) error
+	List() ([]Incident, error)
+}
+
+// incidentFiles keeps incidents as one YAML file per fingerprint, serialized
+// across processes by an advisory lock on a shared ledger path.
+type incidentFiles struct {
+	dir string
+}
+
+func newIncidentFiles(dir string) *incidentFiles { return &incidentFiles{dir: dir} }
+
+func (s *incidentFiles) Lock() (func() error, error) {
+	return fsutil.LockFileWithin(filepath.Join(s.dir, "ledger"), incidentStoreLockTimeout)
+}
+
+func (s *incidentFiles) path(fp string) string { return filepath.Join(s.dir, fp+".yaml") }
+
+func (s *incidentFiles) Load(fp string) (Incident, bool, error) {
+	data, err := os.ReadFile(s.path(fp))
+	if errors.Is(err, fs.ErrNotExist) {
+		return Incident{}, false, nil
+	}
+	if err != nil {
+		return Incident{}, false, fmt.Errorf("incident store: read: %w", err)
+	}
+	var in Incident
+	if err := yaml.Unmarshal(data, &in); err != nil {
+		return Incident{}, false, fmt.Errorf("incident store: decode: %w", err)
+	}
+	return in, true, nil
+}
+
+func (s *incidentFiles) Save(in Incident) error {
+	data, err := yaml.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("incident store: encode: %w", err)
+	}
+	if err := fsutil.AtomicWriteMode(s.path(in.Fingerprint), data, 0o600); err != nil {
+		return fmt.Errorf("incident store: write: %w", err)
+	}
+	return nil
+}
+
+func (s *incidentFiles) List() ([]Incident, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("incident store: list: %w", err)
+	}
+	out := make([]Incident, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var in Incident
+		if err := yaml.Unmarshal(data, &in); err != nil {
+			return nil, err
+		}
+		out = append(out, in)
+	}
+	return out, nil
+}
+
+var _ IncidentPersistence = (*incidentFiles)(nil)

--- a/internal/monitor/incident_sqlstore.go
+++ b/internal/monitor/incident_sqlstore.go
@@ -30,8 +30,9 @@ const incidentQueryTimeout = 30 * time.Second
 type SQLIncidentStore struct {
 	db *db.DB
 
-	mu sync.Mutex
-	tx *sql.Tx
+	mu     sync.Mutex
+	tx     *sql.Tx
+	failed bool
 }
 
 // NewSQLIncidentStore returns the database-backed incident ledger.
@@ -56,10 +57,12 @@ const (
 
 // Lock begins the transaction a read-modify-write runs in.
 //
-// The returned release commits it, or rolls it back when the caller's own work
-// failed and left the transaction unusable. Nothing else may touch the store
-// until it is called, which the process-local mutex enforces here and the
-// advisory lock enforces against every other process.
+// The returned release commits it, unless a Save inside the cycle failed — then
+// it rolls back, so a cycle that could not finish leaves the ledger at its
+// previous value rather than committing the half of it that worked. Nothing
+// else may touch the store until release is called, which the process-local
+// mutex enforces here and the advisory lock enforces against every other
+// process.
 func (s *SQLIncidentStore) Lock() (func() error, error) {
 	s.mu.Lock()
 	ctx, cancel := context.WithTimeout(context.Background(), incidentQueryTimeout)
@@ -79,13 +82,22 @@ func (s *SQLIncidentStore) Lock() (func() error, error) {
 		}
 	}
 	s.tx = tx
+	s.failed = false
 
 	return func() error {
+		failed := s.failed
 		defer func() {
 			s.tx = nil
+			s.failed = false
 			cancel()
 			s.mu.Unlock()
 		}()
+		if failed {
+			if err := tx.Rollback(); err != nil {
+				return fmt.Errorf("incident store: roll back: %w", err)
+			}
+			return errors.New("incident store: cycle rolled back after a failed write")
+		}
 		return tx.Commit()
 	}, nil
 }
@@ -127,6 +139,7 @@ func (s *SQLIncidentStore) Save(in Incident) error {
 	defer cancel()
 	if _, err := s.tx.ExecContext(ctx, s.db.Rebind(upsertIncident),
 		in.Fingerprint, string(in.State), in.FailureCode, db.TimeValue(in.LastSeen), string(doc)); err != nil {
+		s.failed = true
 		return fmt.Errorf("incident store: write: %w", err)
 	}
 	return nil

--- a/internal/monitor/incident_sqlstore.go
+++ b/internal/monitor/incident_sqlstore.go
@@ -1,0 +1,170 @@
+package monitor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// LockIncidents serializes incident read-modify-writes across processes.
+const LockIncidents db.LockKey = 6_215_034_129_006
+
+// incidentQueryTimeout bounds a held lock. The file lock it replaces had the
+// same ceiling, and an incident cycle that cannot finish must release rather
+// than hold every other instance's monitor pass behind it.
+const incidentQueryTimeout = 30 * time.Second
+
+// SQLIncidentStore keeps the incident ledger in the configured database backend.
+//
+// Lock begins a transaction holding an advisory lock and its release commits,
+// so a whole observe-or-reconcile cycle is atomic against every other instance
+// — and a process killed mid-cycle leaves the previous state rather than an
+// incident recorded without the remediation it was recorded for.
+type SQLIncidentStore struct {
+	db *db.DB
+
+	mu sync.Mutex
+	tx *sql.Tx
+}
+
+// NewSQLIncidentStore returns the database-backed incident ledger.
+func NewSQLIncidentStore(database *db.DB) (*SQLIncidentStore, error) {
+	if database == nil {
+		return nil, errors.New("incident store needs an open database")
+	}
+	return &SQLIncidentStore{db: database}, nil
+}
+
+const (
+	selectIncident = `SELECT doc FROM monitor_incidents WHERE fingerprint = ?`
+
+	upsertIncident = `INSERT INTO monitor_incidents (fingerprint, state, failure_code, last_seen, doc)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (fingerprint) DO UPDATE SET
+			state = excluded.state, failure_code = excluded.failure_code,
+			last_seen = excluded.last_seen, doc = excluded.doc`
+
+	selectIncidents = `SELECT doc FROM monitor_incidents ORDER BY `
+)
+
+// Lock begins the transaction a read-modify-write runs in.
+//
+// The returned release commits it, or rolls it back when the caller's own work
+// failed and left the transaction unusable. Nothing else may touch the store
+// until it is called, which the process-local mutex enforces here and the
+// advisory lock enforces against every other process.
+func (s *SQLIncidentStore) Lock() (func() error, error) {
+	s.mu.Lock()
+	ctx, cancel := context.WithTimeout(context.Background(), incidentQueryTimeout)
+
+	tx, err := s.db.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		cancel()
+		s.mu.Unlock()
+		return nil, fmt.Errorf("incident store: begin: %w", err)
+	}
+	if s.db.Dialect() == db.Postgres {
+		if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", int64(LockIncidents)); err != nil {
+			_ = tx.Rollback()
+			cancel()
+			s.mu.Unlock()
+			return nil, fmt.Errorf("incident store: lock: %w", err)
+		}
+	}
+	s.tx = tx
+
+	return func() error {
+		defer func() {
+			s.tx = nil
+			cancel()
+			s.mu.Unlock()
+		}()
+		return tx.Commit()
+	}, nil
+}
+
+// Load returns one incident by fingerprint.
+func (s *SQLIncidentStore) Load(fingerprint string) (Incident, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), incidentQueryTimeout)
+	defer cancel()
+	var doc string
+	var err error
+	if s.tx != nil {
+		err = s.tx.QueryRowContext(ctx, s.db.Rebind(selectIncident), fingerprint).Scan(&doc)
+	} else {
+		err = s.db.QueryRowContext(ctx, selectIncident, fingerprint).Scan(&doc)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return Incident{}, false, nil
+	}
+	if err != nil {
+		return Incident{}, false, fmt.Errorf("incident store: read: %w", err)
+	}
+	var in Incident
+	if err := yaml.Unmarshal([]byte(doc), &in); err != nil {
+		return Incident{}, false, fmt.Errorf("incident store: decode: %w", err)
+	}
+	return in, true, nil
+}
+
+// Save writes one incident.
+func (s *SQLIncidentStore) Save(in Incident) error {
+	if s.tx == nil {
+		return errors.New("incident store: Save outside a locked cycle")
+	}
+	doc, err := yaml.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("incident store: encode: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), incidentQueryTimeout)
+	defer cancel()
+	if _, err := s.tx.ExecContext(ctx, s.db.Rebind(upsertIncident),
+		in.Fingerprint, string(in.State), in.FailureCode, db.TimeValue(in.LastSeen), string(doc)); err != nil {
+		return fmt.Errorf("incident store: write: %w", err)
+	}
+	return nil
+}
+
+// List returns every incident, ordered by fingerprint so a reconcile pass sees
+// them in the same order every time.
+func (s *SQLIncidentStore) List() ([]Incident, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), incidentQueryTimeout)
+	defer cancel()
+	stmt := selectIncidents + s.db.OrderText("fingerprint")
+	var rows *sql.Rows
+	var err error
+	if s.tx != nil {
+		rows, err = s.tx.QueryContext(ctx, s.db.Rebind(stmt))
+	} else {
+		rows, err = s.db.QueryContext(ctx, stmt)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("incident store: list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Incident
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return nil, fmt.Errorf("incident store: scan: %w", err)
+		}
+		var in Incident
+		if err := yaml.Unmarshal([]byte(doc), &in); err != nil {
+			return nil, fmt.Errorf("incident store: decode: %w", err)
+		}
+		out = append(out, in)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("incident store: iterate: %w", err)
+	}
+	return out, nil
+}
+
+var _ IncidentPersistence = (*SQLIncidentStore)(nil)

--- a/internal/monitor/incident_sqlstore_test.go
+++ b/internal/monitor/incident_sqlstore_test.go
@@ -1,0 +1,132 @@
+package monitor
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func sqlIncidentStore(t *testing.T, d *db.DB) *IncidentStore {
+	t.Helper()
+	backend, err := NewSQLIncidentStore(d)
+	if err != nil {
+		t.Fatalf("NewSQLIncidentStore: %v", err)
+	}
+	store, err := NewIncidentStoreWith(t.TempDir(), backend)
+	if err != nil {
+		t.Fatalf("NewIncidentStoreWith: %v", err)
+	}
+	return store
+}
+
+// TestSQLIncidentStore_LockedCyclesDoNotOverlap is the issue's "two concurrent
+// updates to the same record cannot lose one of them".
+//
+// An incident cycle is read-modify-write, so two instances inside one at the
+// same moment can drop an observation — or re-file an issue already filed.
+// Asserted on the mechanism because the lost-update window itself is too narrow
+// to hit on demand.
+func TestSQLIncidentStore_LockedCyclesDoNotOverlap(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		var (
+			mu      sync.Mutex
+			inside  int
+			overlap bool
+		)
+		var wg sync.WaitGroup
+		for range 4 {
+			backend, err := NewSQLIncidentStore(d)
+			if err != nil {
+				t.Fatalf("NewSQLIncidentStore: %v", err)
+			}
+			wg.Go(func() {
+				for range 8 {
+					release, err := backend.Lock()
+					if err != nil {
+						t.Errorf("Lock: %v", err)
+						return
+					}
+					mu.Lock()
+					inside++
+					if inside > 1 {
+						overlap = true
+					}
+					mu.Unlock()
+
+					time.Sleep(time.Millisecond)
+
+					mu.Lock()
+					inside--
+					mu.Unlock()
+					if err := release(); err != nil {
+						t.Errorf("release: %v", err)
+						return
+					}
+				}
+			})
+		}
+		wg.Wait()
+		if overlap {
+			t.Fatal("two instances held the incident ledger at once; an observation can be lost")
+		}
+	})
+}
+
+// TestSQLIncidentStore_SaveOutsideALockIsRefused keeps a later caller from
+// writing an incident without the serialization that makes the cycle safe.
+func TestSQLIncidentStore_SaveOutsideALockIsRefused(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		backend, err := NewSQLIncidentStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLIncidentStore: %v", err)
+		}
+		if err := backend.Save(Incident{Fingerprint: "fp-1"}); err == nil {
+			t.Fatal("Save succeeded outside a locked cycle; nothing serialized it")
+		}
+	})
+}
+
+// TestSQLIncidentStore_RoundTripsThroughTheStore pins that an incident written
+// through the public store reads back, which every monitor pass depends on.
+func TestSQLIncidentStore_RoundTripsThroughTheStore(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store := sqlIncidentStore(t, d)
+		got, err := store.List()
+		if err != nil {
+			t.Fatalf("List on an empty ledger: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("empty ledger returned %d incidents", len(got))
+		}
+
+		backend, err := NewSQLIncidentStore(d)
+		if err != nil {
+			t.Fatalf("NewSQLIncidentStore: %v", err)
+		}
+		release, err := backend.Lock()
+		if err != nil {
+			t.Fatalf("Lock: %v", err)
+		}
+		in := Incident{Fingerprint: "fp-1", FailureCode: "boom", LastSeen: time.Now().UTC()}
+		if err := backend.Save(in); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		if err := release(); err != nil {
+			t.Fatalf("release: %v", err)
+		}
+
+		back, ok, err := backend.Load("fp-1")
+		if err != nil || !ok {
+			t.Fatalf("Load: ok=%v err=%v", ok, err)
+		}
+		if back.FailureCode != "boom" {
+			t.Errorf("failure code = %q, want boom", back.FailureCode)
+		}
+	})
+}

--- a/internal/monitor/incident_store.go
+++ b/internal/monitor/incident_store.go
@@ -5,13 +5,9 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"slices"
 	"sync"
 	"time"
-
-	"github.com/Automaat/sybra/internal/fsutil"
-	"gopkg.in/yaml.v3"
 )
 
 const incidentVersion = 1
@@ -20,8 +16,17 @@ const maxAffectedTasks = 256
 const maxRemediationAttempts = 100
 
 type IncidentStore struct {
-	dir string
-	mu  sync.Mutex
+	dir   string
+	store IncidentPersistence
+	mu    sync.Mutex
+}
+
+// NewIncidentStoreWith returns a store persisting through p rather than to files.
+func NewIncidentStoreWith(dir string, p IncidentPersistence) (*IncidentStore, error) {
+	if p == nil {
+		return nil, errors.New("incident store: nil persistence")
+	}
+	return &IncidentStore{dir: dir, store: p}, nil
 }
 
 func NewIncidentStore(dir string) (*IncidentStore, error) {
@@ -31,11 +36,11 @@ func NewIncidentStore(dir string) (*IncidentStore, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("incident store: mkdir: %w", err)
 	}
-	return &IncidentStore{dir: dir}, nil
+	return &IncidentStore{dir: dir, store: newIncidentFiles(dir)}, nil
 }
 
 func (s *IncidentStore) Observe(a Anomaly, cause RootCause, safeTaskID string) (Incident, IncidentChange, error) {
-	unlock, err := fsutil.LockFileWithin(filepath.Join(s.dir, "ledger"), incidentStoreLockTimeout)
+	unlock, err := s.store.Lock()
 	if err != nil {
 		return Incident{}, IncidentUnchanged, err
 	}
@@ -119,7 +124,7 @@ func (s *IncidentStore) Observe(a Anomaly, cause RootCause, safeTaskID string) (
 }
 
 func (s *IncidentStore) RecordRemediation(fp, kind, result string, at time.Time) error {
-	unlock, err := fsutil.LockFileWithin(filepath.Join(s.dir, "ledger"), incidentStoreLockTimeout)
+	unlock, err := s.store.Lock()
 	if err != nil {
 		return err
 	}
@@ -139,7 +144,7 @@ func (s *IncidentStore) RecordRemediation(fp, kind, result string, at time.Time)
 }
 
 func (s *IncidentStore) ReconcileHealthy(seen, observableScopes, coveredFailureCodes map[string]bool, configGenerations map[string]string, now time.Time, grace, reopenGrace time.Duration) ([]Incident, error) {
-	unlock, err := fsutil.LockFileWithin(filepath.Join(s.dir, "ledger"), incidentStoreLockTimeout)
+	unlock, err := s.store.Lock()
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +214,7 @@ func (s *IncidentStore) ReconcileHealthy(seen, observableScopes, coveredFailureC
 }
 
 func (s *IncidentStore) Link(fp, issueURL, prURL string, duplicates []int) error {
-	unlock, err := fsutil.LockFileWithin(filepath.Join(s.dir, "ledger"), incidentStoreLockTimeout)
+	unlock, err := s.store.Lock()
 	if err != nil {
 		return err
 	}
@@ -238,7 +243,7 @@ func (s *IncidentStore) Link(fp, issueURL, prURL string, duplicates []int) error
 }
 
 func (s *IncidentStore) Get(fp string) (Incident, bool, error) {
-	unlock, err := fsutil.LockFileWithin(filepath.Join(s.dir, "ledger"), incidentStoreLockTimeout)
+	unlock, err := s.store.Lock()
 	if err != nil {
 		return Incident{}, false, err
 	}
@@ -249,7 +254,7 @@ func (s *IncidentStore) Get(fp string) (Incident, bool, error) {
 }
 
 func (s *IncidentStore) List() ([]Incident, error) {
-	unlock, err := fsutil.LockFileWithin(filepath.Join(s.dir, "ledger"), incidentStoreLockTimeout)
+	unlock, err := s.store.Lock()
 	if err != nil {
 		return nil, err
 	}
@@ -259,56 +264,11 @@ func (s *IncidentStore) List() ([]Incident, error) {
 	return s.list()
 }
 
-func (s *IncidentStore) path(fp string) string { return filepath.Join(s.dir, fp+".yaml") }
+func (s *IncidentStore) load(fp string) (Incident, bool, error) { return s.store.Load(fp) }
 
-func (s *IncidentStore) load(fp string) (Incident, bool, error) {
-	data, err := os.ReadFile(s.path(fp))
-	if errors.Is(err, fs.ErrNotExist) {
-		return Incident{}, false, nil
-	}
-	if err != nil {
-		return Incident{}, false, fmt.Errorf("incident store: read: %w", err)
-	}
-	var in Incident
-	if err := yaml.Unmarshal(data, &in); err != nil {
-		return Incident{}, false, fmt.Errorf("incident store: decode: %w", err)
-	}
-	return in, true, nil
-}
+func (s *IncidentStore) save(in Incident) error { return s.store.Save(in) }
 
-func (s *IncidentStore) save(in Incident) error {
-	data, err := yaml.Marshal(in)
-	if err != nil {
-		return fmt.Errorf("incident store: encode: %w", err)
-	}
-	if err := fsutil.AtomicWriteMode(s.path(in.Fingerprint), data, 0o600); err != nil {
-		return fmt.Errorf("incident store: write: %w", err)
-	}
-	return nil
-}
-
-func (s *IncidentStore) list() ([]Incident, error) {
-	entries, err := os.ReadDir(s.dir)
-	if err != nil {
-		return nil, fmt.Errorf("incident store: list: %w", err)
-	}
-	out := make([]Incident, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(s.dir, entry.Name()))
-		if err != nil {
-			return nil, err
-		}
-		var in Incident
-		if err := yaml.Unmarshal(data, &in); err != nil {
-			return nil, err
-		}
-		out = append(out, in)
-	}
-	return out, nil
-}
+func (s *IncidentStore) list() ([]Incident, error) { return s.store.List() }
 
 func slicesSortInts(values []int) {
 	for i := 1; i < len(values); i++ {

--- a/internal/monitor/issueoutbox.go
+++ b/internal/monitor/issueoutbox.go
@@ -132,6 +132,19 @@ func (s *issueOutboxStore) load(log *slog.Logger) []outboxItem {
 	return out
 }
 
+// get reads one pending filing from its file.
+func (s *issueOutboxStore) get(fingerprint string) (outboxItem, bool) {
+	data, err := os.ReadFile(s.filePath(fingerprint))
+	if err != nil {
+		return outboxItem{}, false
+	}
+	var it outboxItem
+	if err := yaml.Unmarshal(data, &it); err != nil {
+		return outboxItem{}, false
+	}
+	return it, true
+}
+
 func (s *issueOutboxStore) depth() int {
 	paths, err := fsutil.ListFiles(s.dir, ".yaml")
 	if err != nil {
@@ -153,7 +166,7 @@ func (s *issueOutboxStore) depth() int {
 // returned to the caller unchanged without consuming outbox space.
 type DurableGHIssueSink struct {
 	inner    issueSubmitter
-	store    *issueOutboxStore
+	store    IssueOutboxPersistence
 	logger   *slog.Logger
 	name     string      // sink identity for logs, e.g. "monitor" or "human-review"
 	auditLog audit.Store // optional; nil in tests that construct the struct directly
@@ -187,7 +200,16 @@ func NewDurableGHIssueSink(inner *GHIssueSink, dir, name string, logger *slog.Lo
 	if err != nil {
 		return nil, err
 	}
-	return &DurableGHIssueSink{inner: inner, store: store, logger: logger, name: name, auditLog: auditLog}, nil
+	return NewDurableGHIssueSinkWith(inner, store, name, logger, auditLog), nil
+}
+
+// NewDurableGHIssueSinkWith returns a sink persisting through store rather than
+// to files.
+func NewDurableGHIssueSinkWith(inner *GHIssueSink, store IssueOutboxPersistence, name string, logger *slog.Logger, auditLog audit.Store) *DurableGHIssueSink {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &DurableGHIssueSink{inner: inner, store: store, logger: logger, name: name, auditLog: auditLog}
 }
 
 // Submit implements IssueSink.
@@ -469,15 +491,7 @@ func (d *DurableGHIssueSink) persistIncident(operation string, in Incident, chan
 }
 
 func (d *DurableGHIssueSink) lookup(fingerprint string) (outboxItem, bool) {
-	data, err := os.ReadFile(d.store.filePath(fingerprint))
-	if err != nil {
-		return outboxItem{}, false
-	}
-	var it outboxItem
-	if err := yaml.Unmarshal(data, &it); err != nil {
-		return outboxItem{}, false
-	}
-	return it, true
+	return d.store.get(fingerprint)
 }
 
 // redactedErrorString returns err's message with GitHub token-shaped

--- a/internal/monitor/issueoutbox_import.go
+++ b/internal/monitor/issueoutbox_import.go
@@ -1,0 +1,47 @@
+package monitor
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// OutboxImportDomain names this domain in the import marker table.
+const OutboxImportDomain = "issueoutbox"
+
+// ImportIssueOutbox copies pending issue filings into the database once.
+//
+// Bounded — the sink caps the outbox — so one transaction. The files are only
+// read. Losing an entry here files an issue twice or never, so an interrupted
+// import committing nothing is the right failure.
+func ImportIssueOutbox(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return dbimport.Once(ctx, database, OutboxImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		fileStore, err := newIssueOutboxStore(dir)
+		if err != nil {
+			return 0, err
+		}
+		items := fileStore.load(logger)
+		for i := range items {
+			it := items[i]
+			doc, err := yaml.Marshal(it)
+			if err != nil {
+				return 0, fmt.Errorf("marshal outbox item: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(upsertOutboxItem),
+				it.Fingerprint, it.Operation, int64(it.Attempts),
+				db.TimeValue(it.FirstFailedAt), string(doc)); err != nil {
+				return 0, fmt.Errorf("insert outbox item: %w", err)
+			}
+		}
+		return len(items), nil
+	})
+}

--- a/internal/monitor/issueoutbox_persistence.go
+++ b/internal/monitor/issueoutbox_persistence.go
@@ -1,0 +1,23 @@
+package monitor
+
+import "log/slog"
+
+// IssueOutboxPersistence holds pending GitHub issue filings. Two
+// implementations exist: the per-fingerprint YAML files and the database-backed
+// SQLIssueOutbox, selected by config.Database.Backend.
+//
+// Losing an entry here files an issue twice or never: the outbox is what makes
+// a filing survive a crash between deciding to file and GitHub accepting it.
+type IssueOutboxPersistence interface {
+	put(it outboxItem) error
+	del(fingerprint string) error
+	load(log *slog.Logger) []outboxItem
+	// get returns one pending filing. The sink reached around the store to
+	// read the file directly, which a database backend has none of.
+	get(fingerprint string) (outboxItem, bool)
+	// depth reports how many filings are pending, for the bound the sink puts
+	// on the outbox and for the operator readout.
+	depth() int
+}
+
+var _ IssueOutboxPersistence = (*issueOutboxStore)(nil)

--- a/internal/monitor/issueoutbox_sqlstore.go
+++ b/internal/monitor/issueoutbox_sqlstore.go
@@ -1,0 +1,144 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// outboxQueryTimeout bounds every statement. The outbox is written from the
+// retry loop and the sink, neither of which carries a context.
+const outboxQueryTimeout = 15 * time.Second
+
+// SQLIssueOutbox keeps pending issue filings in the configured database backend.
+//
+// One row per fingerprint, written whole, so a crash leaves the row at its
+// previous value rather than a half-written file — which for this store means
+// an entry that neither files nor retries.
+type SQLIssueOutbox struct {
+	db     *db.DB
+	logger *slog.Logger
+}
+
+// NewSQLIssueOutbox returns the database-backed outbox.
+func NewSQLIssueOutbox(database *db.DB, logger *slog.Logger) (*SQLIssueOutbox, error) {
+	if database == nil {
+		return nil, errors.New("issue outbox needs an open database")
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return &SQLIssueOutbox{db: database, logger: logger}, nil
+}
+
+const (
+	upsertOutboxItem = `INSERT INTO issue_outbox (fingerprint, operation, attempts, first_failed_at, doc)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (fingerprint) DO UPDATE SET
+			operation = excluded.operation, attempts = excluded.attempts,
+			first_failed_at = excluded.first_failed_at, doc = excluded.doc`
+
+	deleteOutboxItem = `DELETE FROM issue_outbox WHERE fingerprint = ?`
+
+	selectOutboxItems = `SELECT doc FROM issue_outbox ORDER BY first_failed_at, `
+)
+
+func (s *SQLIssueOutbox) put(it outboxItem) error {
+	if it.Fingerprint == "" {
+		return errors.New("monitor: outbox item has no fingerprint")
+	}
+	doc, err := yaml.Marshal(it)
+	if err != nil {
+		return fmt.Errorf("marshal outbox item: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), outboxQueryTimeout)
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, upsertOutboxItem,
+		it.Fingerprint, it.Operation, int64(it.Attempts), db.TimeValue(it.FirstFailedAt), string(doc)); err != nil {
+		return fmt.Errorf("write outbox item: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLIssueOutbox) del(fingerprint string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), outboxQueryTimeout)
+	defer cancel()
+	if _, err := s.db.ExecContext(ctx, deleteOutboxItem, fingerprint); err != nil {
+		return fmt.Errorf("delete outbox item: %w", err)
+	}
+	return nil
+}
+
+// load returns every pending filing, oldest failure first so the retry loop
+// drains in the order entries were stranded.
+func (s *SQLIssueOutbox) load(log *slog.Logger) []outboxItem {
+	if log == nil {
+		log = s.logger
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), outboxQueryTimeout)
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx, selectOutboxItems+s.db.OrderText("fingerprint"))
+	if err != nil {
+		log.Warn("monitor.issue_outbox.load.query-failed", "err", err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []outboxItem
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			log.Warn("monitor.issue_outbox.load.scan-failed", "err", err)
+			return out
+		}
+		var it outboxItem
+		if err := yaml.Unmarshal([]byte(doc), &it); err != nil {
+			log.Warn("monitor.issue_outbox.load.parse-failed", "err", err)
+			continue
+		}
+		if it.Fingerprint == "" {
+			continue
+		}
+		out = append(out, it)
+	}
+	if err := rows.Err(); err != nil {
+		log.Warn("monitor.issue_outbox.load.iterate-failed", "err", err)
+	}
+	return out
+}
+
+// get returns one pending filing.
+func (s *SQLIssueOutbox) get(fingerprint string) (outboxItem, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), outboxQueryTimeout)
+	defer cancel()
+	var doc string
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT doc FROM issue_outbox WHERE fingerprint = ?`, fingerprint).Scan(&doc); err != nil {
+		return outboxItem{}, false
+	}
+	var it outboxItem
+	if err := yaml.Unmarshal([]byte(doc), &it); err != nil {
+		return outboxItem{}, false
+	}
+	return it, true
+}
+
+// depth counts pending filings in the database rather than by loading them.
+func (s *SQLIssueOutbox) depth() int {
+	ctx, cancel := context.WithTimeout(context.Background(), outboxQueryTimeout)
+	defer cancel()
+	var n int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM issue_outbox`).Scan(&n); err != nil {
+		s.logger.Warn("monitor.issue_outbox.depth-failed", "err", err)
+		return 0
+	}
+	return n
+}
+
+var _ IssueOutboxPersistence = (*SQLIssueOutbox)(nil)

--- a/internal/monitor/issueoutbox_sqlstore_test.go
+++ b/internal/monitor/issueoutbox_sqlstore_test.go
@@ -1,0 +1,100 @@
+package monitor
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func outboxFixture() []outboxItem {
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return []outboxItem{
+		{Fingerprint: "fp-b", Operation: "create", Title: "second", Attempts: 2, FirstFailedAt: base.Add(time.Hour)},
+		{Fingerprint: "fp-a", Operation: "create", Title: "first", Attempts: 1, FirstFailedAt: base},
+	}
+}
+
+func discardLog() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// TestSQLIssueOutbox_RoundTripsAndDrainsOldestFirst pins what the outbox is
+// for: an entry survives the crash between deciding to file and GitHub
+// accepting it, and the retry loop drains in the order entries were stranded.
+func TestSQLIssueOutbox_RoundTripsAndDrainsOldestFirst(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLIssueOutbox(d, discardLog())
+		if err != nil {
+			t.Fatalf("NewSQLIssueOutbox: %v", err)
+		}
+		for _, it := range outboxFixture() {
+			if err := store.put(it); err != nil {
+				t.Fatalf("put: %v", err)
+			}
+		}
+		got := store.load(discardLog())
+		if len(got) != 2 {
+			t.Fatalf("outbox holds %d items, want 2", len(got))
+		}
+		if got[0].Fingerprint != "fp-a" {
+			t.Errorf("drain order starts at %q, want the oldest failure fp-a", got[0].Fingerprint)
+		}
+		if store.depth() != 2 {
+			t.Errorf("depth = %d, want 2", store.depth())
+		}
+
+		one, ok := store.get("fp-b")
+		if !ok || one.Title != "second" {
+			t.Fatalf("get(fp-b) = %+v ok=%v", one, ok)
+		}
+
+		if err := store.del("fp-a"); err != nil {
+			t.Fatalf("del: %v", err)
+		}
+		if store.depth() != 1 {
+			t.Errorf("after delete depth = %d, want 1", store.depth())
+		}
+		if _, ok := store.get("fp-a"); ok {
+			t.Error("a filed entry came back after deletion")
+		}
+	})
+}
+
+// TestImportIssueOutbox_IsOnceOnlyAndLeavesTheFiles pins the upgrade
+// guarantees. A duplicated entry here files the same issue twice.
+func TestImportIssueOutbox_IsOnceOnlyAndLeavesTheFiles(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		dir := t.TempDir()
+		fileStore, err := newIssueOutboxStore(dir)
+		if err != nil {
+			t.Fatalf("newIssueOutboxStore: %v", err)
+		}
+		for _, it := range outboxFixture() {
+			if err := fileStore.put(it); err != nil {
+				t.Fatalf("put: %v", err)
+			}
+		}
+		for range 2 {
+			if err := ImportIssueOutbox(t.Context(), d, dir, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		store, err := NewSQLIssueOutbox(d, discardLog())
+		if err != nil {
+			t.Fatalf("NewSQLIssueOutbox: %v", err)
+		}
+		if n := store.depth(); n != 2 {
+			t.Fatalf("after two imports the outbox holds %d entries, want 2", n)
+		}
+		for _, it := range outboxFixture() {
+			if _, err := os.Stat(filepath.Join(dir, it.Fingerprint+".yaml")); err != nil {
+				t.Errorf("import removed %s: %v", it.Fingerprint, err)
+			}
+		}
+	})
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -586,7 +586,7 @@ func (a *App) Startup(ctx context.Context) error {
 	a.startupRecoveryPending.Store(true)
 	a.initStatusHook() //nolint:contextcheck // workflow engine uses its own e.ctx field, see Startup's contextcheck note
 	a.initLocalStores(appCtx)
-	a.cleanupProtected = cleanup.DefaultProtectedStore()
+	a.cleanupProtected = a.openProtectedStore(appCtx)
 	a.notifier = notification.New(emit)
 	a.notifier.SetDesktop(a.cfg.Notification.Desktop)
 	a.initLimits(a.openLimitsStore(appCtx)) //nolint:contextcheck // the live poller derives from a.ctx directly, see Startup's contextcheck note

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -540,7 +540,8 @@ func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) erro
 	}
 	var err error
 	a.attempts, err = dispatch.New(ctx, dispatch.Options{
-		Dir: config.AttemptLeasesDir(),
+		Dir:   config.AttemptLeasesDir(),
+		Store: a.openAttemptLedger(ctx),
 		Limits: dispatch.Limits{
 			Global:     a.cfg.Agent.MaxConcurrent,
 			ByProvider: providerLimits,
@@ -2105,4 +2106,28 @@ func (a *App) openLimitsStore(ctx context.Context) (*limits.Store, error) {
 		}
 	}
 	return limits.NewStore(config.LimitsFile())
+}
+
+// openAttemptLedger returns the admission ledger for the configured backend,
+// importing the existing document the first time a database is used.
+//
+// A failed import returns nil, which leaves dispatch.New on its own YAML
+// document. Starting on an empty ledger would read as no work in flight and
+// admit a second agent onto every task one is already running.
+func (a *App) openAttemptLedger(ctx context.Context) dispatch.Persistence {
+	if a.database == nil {
+		return nil
+	}
+	importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+	defer cancel()
+	if err := dispatch.Import(importCtx, a.database, config.AttemptLeasesDir(), a.importScope(), a.logger); err != nil {
+		a.logger.Error("attemptlease.import", "err", err)
+		return nil
+	}
+	store, err := dispatch.NewSQLPersistence(a.database)
+	if err != nil {
+		a.logger.Error("attemptlease.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		return nil
+	}
+	return store
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/backoff"
 	"github.com/Automaat/sybra/internal/bgop"
+	"github.com/Automaat/sybra/internal/cleanup"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/db"
 	"github.com/Automaat/sybra/internal/diskreclaim"
@@ -2199,4 +2200,26 @@ func (a *App) newDurableIssueSink(ctx context.Context, inner *monitor.GHIssueSin
 		}
 	}
 	return monitor.NewDurableGHIssueSink(inner, dir, name, a.logger, a.audit)
+}
+
+// openProtectedStore returns the protected-findings ledger for the configured
+// backend, importing the existing document the first time a database is used.
+//
+// A failed import degrades to the document: an empty ledger reads as nothing
+// protected, and the next cleanup pass is then free to delete the very paths
+// the findings existed to hold.
+func (a *App) openProtectedStore(ctx context.Context) *cleanup.ProtectedStore {
+	path := cleanup.DefaultProtectedStorePath()
+	if a.database != nil {
+		importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+		defer cancel()
+		if err := cleanup.ImportProtected(importCtx, a.database, path, a.importScope(), a.logger); err != nil {
+			a.logger.Error("protectedfindings.import", "err", err)
+		} else if store, err := cleanup.NewSQLProtectedStore(a.database); err != nil {
+			a.logger.Error("protectedfindings.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return cleanup.NewProtectedStoreWith(path, store)
+		}
+	}
+	return cleanup.NewProtectedStore(path)
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -394,7 +394,7 @@ func (a *App) initLocalStores(ctx context.Context) {
 	a.initExperience(ctx)
 	a.initIntervention()
 	a.initLearning()
-	a.initAgentQueue()
+	a.initAgentQueue(ctx)
 }
 
 func (a *App) initAttachments() {
@@ -455,8 +455,11 @@ func (a *App) initLearning() {
 	a.learning = store
 }
 
-func (a *App) initAgentQueue() {
-	queue, err := agentqueue.New(config.AgentQueueDir(), agentqueue.Options{MaxDepth: a.cfg.Agent.Queue.MaxDepth}, a.logger)
+func (a *App) initAgentQueue(ctx context.Context) {
+	queue, err := agentqueue.New(config.AgentQueueDir(), agentqueue.Options{
+		MaxDepth: a.cfg.Agent.Queue.MaxDepth,
+		Store:    a.openAgentQueueStore(ctx),
+	}, a.logger)
 	if err != nil {
 		a.logger.Warn("agentqueue.init.degraded", "err", err)
 		return
@@ -2127,6 +2130,29 @@ func (a *App) openAttemptLedger(ctx context.Context) dispatch.Persistence {
 	store, err := dispatch.NewSQLPersistence(a.database)
 	if err != nil {
 		a.logger.Error("attemptlease.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		return nil
+	}
+	return store
+}
+
+// openAgentQueueStore returns the queue's durability mirror for the configured
+// backend, importing the existing item files the first time a database is used.
+//
+// A failed import returns nil, which leaves the queue on its files. Starting on
+// an empty mirror would drop every queued item on the next restart.
+func (a *App) openAgentQueueStore(ctx context.Context) agentqueue.Persistence {
+	if a.database == nil {
+		return nil
+	}
+	importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+	defer cancel()
+	if err := agentqueue.Import(importCtx, a.database, config.AgentQueueDir(), a.importScope(), a.logger); err != nil {
+		a.logger.Error("agentqueue.import", "err", err)
+		return nil
+	}
+	store, err := agentqueue.NewSQLStore(a.database, a.logger)
+	if err != nil {
+		a.logger.Error("agentqueue.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
 		return nil
 	}
 	return store

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -543,9 +543,16 @@ func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) erro
 		providerLimits[name] = a.cfg.Providers.Limits.MaxInFlightPerProvider
 	}
 	var err error
+	var ledger dispatch.Persistence
+	if a.database != nil {
+		ledger, err = a.openAttemptLedger(ctx)
+		if err != nil {
+			return fmt.Errorf("dispatch admission: %w", err)
+		}
+	}
 	a.attempts, err = dispatch.New(ctx, dispatch.Options{
 		Dir:   config.AttemptLeasesDir(),
-		Store: a.openAttemptLedger(ctx),
+		Store: ledger,
 		Limits: dispatch.Limits{
 			Global:     a.cfg.Agent.MaxConcurrent,
 			ByProvider: providerLimits,
@@ -2115,25 +2122,30 @@ func (a *App) openLimitsStore(ctx context.Context) (*limits.Store, error) {
 // openAttemptLedger returns the admission ledger for the configured backend,
 // importing the existing document the first time a database is used.
 //
-// A failed import returns nil, which leaves dispatch.New on its own YAML
-// document. Starting on an empty ledger would read as no work in flight and
-// admit a second agent onto every task one is already running.
-func (a *App) openAttemptLedger(ctx context.Context) dispatch.Persistence {
+// It fails closed rather than degrading. Every other store here falls back to
+// files when its backend cannot be opened, because a degraded advisory store
+// costs an operator information. This one is coordination: on a board shared by
+// several machines, one instance falling back to its own file while the others
+// use the database means two ledgers deciding admission independently — which
+// is precisely the double-dispatch this backend exists to prevent, and worse
+// than not starting.
+//
+// Call it only with a database configured; the file-backed deployment keeps the
+// YAML ledger and never reaches here.
+func (a *App) openAttemptLedger(ctx context.Context) (dispatch.Persistence, error) {
 	if a.database == nil {
-		return nil
+		return nil, errors.New("attempt lease store: no database configured")
 	}
 	importCtx, cancel := context.WithTimeout(ctx, importTimeout)
 	defer cancel()
 	if err := dispatch.Import(importCtx, a.database, config.AttemptLeasesDir(), a.importScope(), a.logger); err != nil {
-		a.logger.Error("attemptlease.import", "err", err)
-		return nil
+		return nil, fmt.Errorf("attempt lease import: %w", err)
 	}
 	store, err := dispatch.NewSQLPersistence(a.database)
 	if err != nil {
-		a.logger.Error("attemptlease.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
-		return nil
+		return nil, fmt.Errorf("attempt lease store: %w", err)
 	}
-	return store
+	return store, nil
 }
 
 // openAgentQueueStore returns the queue's durability mirror for the configured

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -2178,3 +2178,25 @@ func (a *App) openIncidentStore(ctx context.Context) (*monitor.IncidentStore, er
 	}
 	return monitor.NewIncidentStore(dir)
 }
+
+// newDurableIssueSink returns the retrying GitHub issue sink for the configured
+// backend, importing the pending outbox the first time a database is used.
+//
+// A failed import degrades to the files: an empty outbox reads as nothing
+// pending, so a filing stranded by an expired credential would never be
+// retried and the incident it belongs to would go unreported.
+func (a *App) newDurableIssueSink(ctx context.Context, inner *monitor.GHIssueSink, name string) (*monitor.DurableGHIssueSink, error) {
+	dir := filepath.Join(config.GHIssueOutboxDir(), name)
+	if a.database != nil {
+		ctx, cancel := context.WithTimeout(ctx, importTimeout)
+		defer cancel()
+		if err := monitor.ImportIssueOutbox(ctx, a.database, dir, a.importScope(), a.logger); err != nil {
+			a.logger.Error("issueoutbox.import", "err", err)
+		} else if store, err := monitor.NewSQLIssueOutbox(a.database, a.logger); err != nil {
+			a.logger.Error("issueoutbox.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return monitor.NewDurableGHIssueSinkWith(inner, store, name, a.logger, a.audit), nil
+		}
+	}
+	return monitor.NewDurableGHIssueSink(inner, dir, name, a.logger, a.audit)
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -2157,3 +2157,24 @@ func (a *App) openAgentQueueStore(ctx context.Context) agentqueue.Persistence {
 	}
 	return store
 }
+
+// openIncidentStore returns the incident ledger for the configured backend,
+// importing the existing files the first time a database is used.
+//
+// A failed import degrades to the files: an empty ledger reads as "nothing has
+// ever failed", so the monitor would re-file every open incident as new.
+func (a *App) openIncidentStore(ctx context.Context) (*monitor.IncidentStore, error) {
+	dir := config.MonitorIncidentsDir()
+	if a.database != nil {
+		importCtx, cancel := context.WithTimeout(ctx, importTimeout)
+		defer cancel()
+		if err := monitor.ImportIncidents(importCtx, a.database, dir, a.importScope(), a.logger); err != nil {
+			a.logger.Error("incidents.import", "err", err)
+		} else if store, err := monitor.NewSQLIncidentStore(a.database); err != nil {
+			a.logger.Error("incidents.store.init", "backend", a.cfg.DatabaseBackend(), "err", err)
+		} else {
+			return monitor.NewIncidentStoreWith(dir, store)
+		}
+	}
+	return monitor.NewIncidentStore(dir)
+}

--- a/internal/sybra/dispatch/controller.go
+++ b/internal/sybra/dispatch/controller.go
@@ -13,9 +13,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
-	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -46,6 +44,9 @@ type Options struct {
 	Limits Limits
 	TTL    time.Duration
 	Now    func() time.Time
+	// Store persists the ledger. Nil keeps the YAML document under Dir, which
+	// is what an install with no database backend configured uses.
+	Store Persistence
 }
 
 // Record is the persisted admission state exposed to restart reconciliation.
@@ -76,6 +77,7 @@ type Controller struct {
 	mu     sync.Mutex
 	dir    string
 	path   string
+	store  Persistence
 	owner  string
 	limits Limits
 	ttl    time.Duration
@@ -115,8 +117,13 @@ func New(ctx context.Context, opts Options) (*Controller, error) {
 	if now == nil {
 		now = time.Now
 	}
+	path := filepath.Join(dir, "attempt-leases.yaml")
+	store := opts.Store
+	if store == nil {
+		store = newFilePersistence(path)
+	}
 	c := &Controller{
-		dir: dir, path: filepath.Join(dir, "attempt-leases.yaml"), owner: owner,
+		dir: dir, path: path, owner: owner, store: store,
 		limits: Limits{Global: opts.Limits.Global, ByProvider: cloneLimits(opts.Limits.ByProvider)},
 		ttl:    opts.TTL, now: now,
 	}
@@ -481,50 +488,22 @@ func (c *Controller) update(ctx context.Context, fn func(*diskState, time.Time) 
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	unlock, err := fsutil.LockFileContext(ctx, c.path)
-	if err != nil {
-		return fmt.Errorf("lock attempt lease store: %w", err)
-	}
-	defer func() { _ = unlock() }()
-	s, err := c.load()
+	var opErr error
+	err := c.store.Critical(ctx, func() error {
+		s, err := c.store.Load(ctx)
+		if err != nil {
+			return err
+		}
+		var changed bool
+		changed, opErr = fn(&s, c.now().UTC())
+		if !changed {
+			return nil
+		}
+		s.Revision++
+		return c.store.Save(ctx, s)
+	})
 	if err != nil {
 		return err
 	}
-	changed, opErr := fn(&s, c.now().UTC())
-	if changed {
-		s.Revision++
-		if err := c.save(s); err != nil {
-			return err
-		}
-	}
 	return opErr
-}
-
-func (c *Controller) load() (diskState, error) {
-	data, err := os.ReadFile(c.path)
-	if errors.Is(err, os.ErrNotExist) {
-		return diskState{SchemaVersion: 1}, nil
-	}
-	if err != nil {
-		return diskState{}, fmt.Errorf("read attempt lease store: %w", err)
-	}
-	var s diskState
-	if err := yaml.Unmarshal(data, &s); err != nil {
-		return diskState{}, fmt.Errorf("decode attempt lease store: %w", err)
-	}
-	if s.SchemaVersion != 1 {
-		return diskState{}, fmt.Errorf("unsupported attempt lease schema %d", s.SchemaVersion)
-	}
-	return s, nil
-}
-
-func (c *Controller) save(s diskState) error {
-	data, err := yaml.Marshal(s)
-	if err != nil {
-		return fmt.Errorf("encode attempt lease store: %w", err)
-	}
-	if err := fsutil.AtomicWrite(c.path, data); err != nil {
-		return fmt.Errorf("persist attempt lease store: %w", err)
-	}
-	return nil
 }

--- a/internal/sybra/dispatch/import.go
+++ b/internal/sybra/dispatch/import.go
@@ -1,0 +1,51 @@
+package dispatch
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/dbimport"
+)
+
+// ImportDomain names this domain in the import marker table.
+const ImportDomain = "attemptleases"
+
+// Import copies the ledger document into the database once.
+//
+// Expiry and heartbeat are carried across verbatim rather than restamped: a
+// lease is in flight precisely when its expiry is still ahead, so resetting it
+// would either release every running agent's work at once or hold a dead
+// agent's claim past its timeout. The issue's "in-flight leases survive the
+// upgrade" is exactly this.
+//
+// Bounded, so one transaction: the ledger holds live attempts, not history.
+func Import(ctx context.Context, database *db.DB, dir, scope string, logger *slog.Logger) error {
+	return dbimport.Once(ctx, database, ImportDomain, scope, logger, func(ctx context.Context, tx *sql.Tx) (int, error) {
+		state, err := newFilePersistence(filepath.Join(dir, "attempt-leases.yaml")).Load(ctx)
+		if err != nil {
+			return 0, err
+		}
+		for i := range state.Leases {
+			rec := &state.Leases[i]
+			doc, err := yaml.Marshal(rec)
+			if err != nil {
+				return 0, fmt.Errorf("encode attempt lease: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, database.Rebind(upsertLease),
+				rec.ID, rec.Intent.TaskID, rec.Intent.Provider, string(rec.Status),
+				db.TimeValue(rec.ExpiresAt), string(doc)); err != nil {
+				return 0, fmt.Errorf("insert attempt lease: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, database.Rebind(upsertRevision), ledgerName, revisionValue(state.Revision)); err != nil {
+			return 0, fmt.Errorf("write ledger revision: %w", err)
+		}
+		return len(state.Leases), nil
+	})
+}

--- a/internal/sybra/dispatch/persistence.go
+++ b/internal/sybra/dispatch/persistence.go
@@ -1,0 +1,75 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// Persistence is where the admission ledger survives a restart. Two implementations exist: the YAML document and the database-backed SQLPersistence, selected by config.Database.Backend.
+//
+// Critical wraps a whole read-modify-write. Losing one costs more here than anywhere else in the board: a lost lease releases work that is still running, so a second agent starts on a task another is already holding.
+type Persistence interface {
+	Load(ctx context.Context) (diskState, error)
+	Save(ctx context.Context, s diskState) error
+	Critical(ctx context.Context, fn func() error) error
+}
+
+// filePersistence keeps the ledger in one YAML document, serialized across processes by an advisory lock on that document.
+type filePersistence struct {
+	path string
+}
+
+func newFilePersistence(path string) *filePersistence {
+	return &filePersistence{path: path}
+}
+
+// Critical takes the cross-process lock for the duration of fn.
+//
+// The lock only holds while this process lives, which is the weakness the
+// database backend exists to remove: a process killed here leaves the document
+// unlocked and, if it died between the read and the write, stale.
+func (p *filePersistence) Critical(ctx context.Context, fn func() error) error {
+	unlock, err := fsutil.LockFileContext(ctx, p.path)
+	if err != nil {
+		return fmt.Errorf("lock attempt lease store: %w", err)
+	}
+	defer func() { _ = unlock() }()
+	return fn()
+}
+
+func (p *filePersistence) Load(context.Context) (diskState, error) {
+	data, err := os.ReadFile(p.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return diskState{SchemaVersion: 1}, nil
+	}
+	if err != nil {
+		return diskState{}, fmt.Errorf("read attempt lease store: %w", err)
+	}
+	var s diskState
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return diskState{}, fmt.Errorf("decode attempt lease store: %w", err)
+	}
+	if s.SchemaVersion != 1 {
+		return diskState{}, fmt.Errorf("unsupported attempt lease schema %d", s.SchemaVersion)
+	}
+	return s, nil
+}
+
+func (p *filePersistence) Save(_ context.Context, s diskState) error {
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("encode attempt lease store: %w", err)
+	}
+	if err := fsutil.AtomicWrite(p.path, data); err != nil {
+		return fmt.Errorf("persist attempt lease store: %w", err)
+	}
+	return nil
+}
+
+var _ Persistence = (*filePersistence)(nil)

--- a/internal/sybra/dispatch/sqlstore.go
+++ b/internal/sybra/dispatch/sqlstore.go
@@ -1,0 +1,182 @@
+package dispatch
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/Automaat/sybra/internal/db"
+)
+
+// LockLedger serializes admission read-modify-writes across processes. Distinct from every other advisory key so a dispatch never waits on an import.
+const LockLedger db.LockKey = 6_215_034_129_005
+
+// ledgerName keys this ledger's revision row. One ledger exists today; the column is there so a second never has to migrate.
+const ledgerName = "attempt_leases"
+
+// Records are stored as the YAML the file document already used, so the import
+// and this store agree by construction and Record needs no second tag set.
+//
+// SQLPersistence keeps the admission ledger in the configured database backend.
+//
+// A lease is a row, so reclaiming expired ones is a predicate rather than a scan, and a read for one task touches only its rows. The whole read-modify-write runs in one advisory-locked transaction: losing an update here releases work that is still running, and a process killed mid-update leaves the previous state rather than a partial one — which the file document could not promise, because its lock died with the process holding it.
+type SQLPersistence struct {
+	db *db.DB
+
+	// mu serializes critical sections in this process; the advisory lock the
+	// transaction takes serializes them against every other process. tx is the
+	// transaction a critical section runs in, and is nil outside one.
+	mu sync.Mutex
+	tx *sql.Tx
+}
+
+// NewSQLPersistence returns the database-backed ledger.
+func NewSQLPersistence(database *db.DB) (*SQLPersistence, error) {
+	if database == nil {
+		return nil, errors.New("attempt lease store needs an open database")
+	}
+	return &SQLPersistence{db: database}, nil
+}
+
+const (
+	selectLeases = `SELECT doc FROM attempt_leases ORDER BY `
+
+	upsertLease = `INSERT INTO attempt_leases (id, task_id, provider, status, expires_at, doc)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT (id) DO UPDATE SET
+			task_id = excluded.task_id, provider = excluded.provider,
+			status = excluded.status, expires_at = excluded.expires_at, doc = excluded.doc`
+
+	deleteAllLeases = `DELETE FROM attempt_leases`
+
+	selectRevision = `SELECT revision FROM ledger_revisions WHERE ledger = ?`
+
+	upsertRevision = `INSERT INTO ledger_revisions (ledger, revision) VALUES (?, ?)
+		ON CONFLICT (ledger) DO UPDATE SET revision = excluded.revision`
+)
+
+// Critical runs fn as one atomic read-modify-write.
+func (p *SQLPersistence) Critical(ctx context.Context, fn func() error) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.db.InTxLocked(ctx, LockLedger, func(tx *sql.Tx) error {
+		p.tx = tx
+		defer func() { p.tx = nil }()
+		return fn()
+	})
+}
+
+// Load returns the ledger, ordered by lease id so a restart sees what the last
+// start saw. A table has no natural order, and the order is byte-wise because
+// the file document's own slice order was.
+func (p *SQLPersistence) Load(ctx context.Context) (diskState, error) {
+	rows, err := p.query(ctx, selectLeases+p.db.OrderText("id"))
+	if err != nil {
+		return diskState{}, fmt.Errorf("read attempt lease store: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	s := diskState{SchemaVersion: 1}
+	for rows.Next() {
+		var doc string
+		if err := rows.Scan(&doc); err != nil {
+			return diskState{}, fmt.Errorf("scan attempt lease: %w", err)
+		}
+		var rec Record
+		if err := yaml.Unmarshal([]byte(doc), &rec); err != nil {
+			// Refused rather than skipped: this ledger decides whether a task
+			// may dispatch, so a lease this build cannot read must not silently
+			// become headroom for a second agent on the same work.
+			return diskState{}, fmt.Errorf("decode attempt lease: %w", err)
+		}
+		s.Leases = append(s.Leases, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return diskState{}, fmt.Errorf("iterate attempt leases: %w", err)
+	}
+
+	revision, err := p.revision(ctx)
+	if err != nil {
+		return diskState{}, err
+	}
+	s.Revision = revision
+	return s, nil
+}
+
+// Save replaces the ledger with s.
+//
+// Called only from inside Critical, so the delete and the inserts are one
+// transaction under the advisory lock: no other writer observes the gap, and a
+// process killed here commits neither half.
+func (p *SQLPersistence) Save(ctx context.Context, s diskState) error {
+	if p.tx == nil {
+		return errors.New("attempt lease store: Save outside a critical section")
+	}
+	if _, err := p.tx.ExecContext(ctx, p.db.Rebind(deleteAllLeases)); err != nil {
+		return fmt.Errorf("clear attempt leases: %w", err)
+	}
+	for i := range s.Leases {
+		rec := &s.Leases[i]
+		doc, err := yaml.Marshal(rec)
+		if err != nil {
+			return fmt.Errorf("encode attempt lease: %w", err)
+		}
+		if _, err := p.tx.ExecContext(ctx, p.db.Rebind(upsertLease),
+			rec.ID, rec.Intent.TaskID, rec.Intent.Provider, string(rec.Status),
+			db.TimeValue(rec.ExpiresAt), string(doc)); err != nil {
+			return fmt.Errorf("write attempt lease: %w", err)
+		}
+	}
+	if _, err := p.tx.ExecContext(ctx, p.db.Rebind(upsertRevision), ledgerName, revisionValue(s.Revision)); err != nil {
+		return fmt.Errorf("write ledger revision: %w", err)
+	}
+	return nil
+}
+
+func (p *SQLPersistence) revision(ctx context.Context) (uint64, error) {
+	var revision int64
+	var err error
+	if p.tx != nil {
+		err = p.tx.QueryRowContext(ctx, p.db.Rebind(selectRevision), ledgerName).Scan(&revision)
+	} else {
+		err = p.db.QueryRowContext(ctx, selectRevision, ledgerName).Scan(&revision)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read ledger revision: %w", err)
+	}
+	if revision < 0 {
+		// Only a hand-edited row can be negative, and treating it as a huge
+		// unsigned revision would make every later write look stale.
+		return 0, fmt.Errorf("ledger revision %d is negative", revision)
+	}
+	return uint64(revision), nil
+}
+
+func (p *SQLPersistence) query(ctx context.Context, stmt string, args ...any) (*sql.Rows, error) {
+	if p.tx != nil {
+		return p.tx.QueryContext(ctx, p.db.Rebind(stmt), args...)
+	}
+	return p.db.QueryContext(ctx, stmt, args...)
+}
+
+var _ Persistence = (*SQLPersistence)(nil)
+
+// revisionValue narrows the ledger revision for a signed column.
+//
+// The counter increments once per change and would need billions of years of
+// dispatches to reach this, but a silent wrap would make a fresh ledger look
+// newer than a live one, so it saturates instead.
+func revisionValue(revision uint64) int64 {
+	if revision > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(revision)
+}

--- a/internal/sybra/dispatch/sqlstore_test.go
+++ b/internal/sybra/dispatch/sqlstore_test.go
@@ -1,0 +1,321 @@
+package dispatch
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/db"
+	"github.com/Automaat/sybra/internal/providerid"
+	"github.com/Automaat/sybra/internal/testutil/dbtest"
+)
+
+func sqlController(t *testing.T, d *db.DB, owner string) *Controller {
+	t.Helper()
+	store, err := NewSQLPersistence(d)
+	if err != nil {
+		t.Fatalf("NewSQLPersistence: %v", err)
+	}
+	c, err := New(t.Context(), Options{
+		Dir:    t.TempDir(),
+		Owner:  owner,
+		Store:  store,
+		Limits: Limits{Global: 100},
+		TTL:    time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// sqlIntent is a minimal admission intent for these tests. The package's own
+// intent helper takes the full shape; only the identity matters here.
+func sqlIntent(taskID string) agent.AttemptIntent {
+	return agent.AttemptIntent{
+		IntentID:            "intent-" + taskID,
+		TaskID:              taskID,
+		Provider:            providerid.Claude,
+		Access:              agent.AttemptAccessObserve,
+		CapabilityCertified: true,
+	}
+}
+
+// TestSQLPersistence_ConcurrentAcquiresAreAllRecorded is the issue's "two
+// concurrent updates to the same record cannot lose one of them".
+//
+// A lost lease is the costliest loss on the board: it releases work that is
+// still running, so a second agent starts on a task another already holds.
+func TestSQLPersistence_ConcurrentAcquiresAreAllRecorded(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		// One persistence per controller, because that is what two processes
+		// are. Sharing a single one would let its process-local mutex serialize
+		// them and the cross-process advisory lock would never be exercised —
+		// the test would pass with the lock removed.
+		storeA, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		storeB, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		one := sqlControllerWith(t, storeA, "owner-a")
+		two := sqlControllerWith(t, storeB, "owner-b")
+
+		const each = 25
+		var wg sync.WaitGroup
+		for i, c := range []*Controller{one, two} {
+			wg.Go(func() {
+				for n := range each {
+					if _, err := c.Acquire(t.Context(), sqlIntent(taskName(i, n))); err != nil {
+						t.Errorf("Acquire: %v", err)
+						return
+					}
+				}
+			})
+		}
+		wg.Wait()
+
+		records, err := one.Records(t.Context())
+		if err != nil {
+			t.Fatalf("Records: %v", err)
+		}
+		if len(records) != 2*each {
+			t.Fatalf("ledger holds %d leases, want %d; concurrent acquires lost some", len(records), 2*each)
+		}
+	})
+}
+
+func sqlControllerWith(t *testing.T, store Persistence, owner string) *Controller {
+	t.Helper()
+	c, err := New(t.Context(), Options{
+		Dir: t.TempDir(), Owner: owner, Store: store,
+		Limits: Limits{Global: 1000}, TTL: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func taskName(worker, n int) string {
+	return "task-" + string(rune('a'+worker)) + "-" + string(rune('0'+n%10)) + string(rune('0'+n/10))
+}
+
+// TestSQLPersistence_LedgerSurvivesAndOrdersStably is the issue's "queue
+// ordering after a restart matches the ordering before it".
+func TestSQLPersistence_LedgerSurvivesAndOrdersStably(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		c := sqlController(t, d, "owner-a")
+		for _, id := range []string{"pr-review", "prompt-lab", "pr-fix", "branch-conflict"} {
+			if _, err := c.Acquire(t.Context(), sqlIntent(id)); err != nil {
+				t.Fatalf("Acquire(%s): %v", id, err)
+			}
+		}
+		first, err := c.Records(t.Context())
+		if err != nil {
+			t.Fatalf("Records: %v", err)
+		}
+
+		// A restart is a fresh controller over the same ledger.
+		again := sqlController(t, d, "owner-a")
+		second, err := again.Records(t.Context())
+		if err != nil {
+			t.Fatalf("Records after restart: %v", err)
+		}
+		if len(second) != len(first) {
+			t.Fatalf("restart sees %d leases, want %d", len(second), len(first))
+		}
+		for i := range first {
+			if first[i].ID != second[i].ID {
+				t.Fatalf("position %d: before restart %q, after %q", i, first[i].ID, second[i].ID)
+			}
+		}
+	})
+}
+
+// TestImport_CarriesInFlightLeases is the issue's "existing files import once,
+// and in-flight leases survive the upgrade".
+//
+// Expiry has to come across as it stands: restamping it either releases every
+// running agent's work at once, or holds a dead agent's claim past its timeout.
+func TestImport_CarriesInFlightLeases(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		dir := t.TempDir()
+		file, err := New(t.Context(), Options{
+			Dir: dir, Owner: "owner-a", Limits: Limits{Global: 10}, TTL: time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("New(file): %v", err)
+		}
+		lease, err := file.Acquire(t.Context(), sqlIntent("task-a"))
+		if err != nil {
+			t.Fatalf("Acquire: %v", err)
+		}
+		before, err := file.Records(t.Context())
+		if err != nil || len(before) != 1 {
+			t.Fatalf("file ledger holds %d leases (%v)", len(before), err)
+		}
+
+		for range 2 {
+			if err := Import(t.Context(), d, dir, "home-a", nil); err != nil {
+				t.Fatalf("import: %v", err)
+			}
+		}
+		moved := sqlController(t, d, "owner-a")
+		after, err := moved.Records(t.Context())
+		if err != nil {
+			t.Fatalf("Records: %v", err)
+		}
+		if len(after) != 1 {
+			t.Fatalf("after two imports the ledger holds %d leases, want 1", len(after))
+		}
+		if after[0].ID != lease.ID {
+			t.Errorf("lease id = %q, want %q", after[0].ID, lease.ID)
+		}
+		if !after[0].ExpiresAt.Equal(before[0].ExpiresAt) {
+			t.Errorf("expiry moved from %s to %s; an in-flight lease was restamped",
+				before[0].ExpiresAt, after[0].ExpiresAt)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "attempt-leases.yaml")); err != nil {
+			t.Errorf("import removed the original document: %v", err)
+		}
+	})
+}
+
+// TestSQLPersistence_ExpiredLeaseIsReclaimed is the issue's "a lease whose
+// owner died is still reclaimed after its timeout".
+func TestSQLPersistence_ExpiredLeaseIsReclaimed(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		clock := time.Now().UTC()
+		c, err := New(t.Context(), Options{
+			Dir: t.TempDir(), Owner: "dead-owner", Store: store,
+			Limits: Limits{Global: 1}, TTL: time.Minute,
+			Now: func() time.Time { return clock },
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if _, err := c.Acquire(t.Context(), sqlIntent("task-a")); err != nil {
+			t.Fatalf("Acquire: %v", err)
+		}
+
+		// The owner dies; nothing heartbeats. A later start walks past the TTL,
+		// which moves the lease to reconciling — still holding its slot, by
+		// design, because an expired lease is a claim nobody has finalized.
+		clock = clock.Add(10 * time.Minute)
+		revived, err := New(t.Context(), Options{
+			Dir: t.TempDir(), Owner: "new-owner", Store: store,
+			Limits: Limits{Global: 1}, TTL: time.Minute,
+			Now: func() time.Time { return clock },
+		})
+		if err != nil {
+			t.Fatalf("New(revived): %v", err)
+		}
+		needs, err := revived.NeedsReconciliation(t.Context())
+		if err != nil {
+			t.Fatalf("NeedsReconciliation: %v", err)
+		}
+		if !needs {
+			t.Fatal("the dead owner's expired lease was not marked for reconciliation, so nothing would ever reclaim it")
+		}
+
+		// Recovery observing no live agent is what finalizes it.
+		n, err := revived.ReconcileUnobserved(t.Context(), nil)
+		if err != nil {
+			t.Fatalf("ReconcileUnobserved: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("reconciled %d leases, want 1", n)
+		}
+		if _, err := revived.Acquire(t.Context(), sqlIntent("task-b")); err != nil {
+			t.Fatalf("the slot stayed taken after the dead owner's lease was reconciled: %v", err)
+		}
+	})
+}
+
+// TestSQLPersistence_CriticalSectionsDoNotOverlap pins the property the ledger
+// depends on, deterministically.
+//
+// The concurrency test above cannot: sqlite's immediate transaction serializes
+// writers by itself, and on postgres the lost-update window between one
+// instance's Load and another's Save is too narrow to hit on demand. So assert
+// the mechanism instead — two instances, which is what two processes are, must
+// never be inside a critical section at the same moment.
+func TestSQLPersistence_CriticalSectionsDoNotOverlap(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		var (
+			mu      sync.Mutex
+			inside  int
+			overlap bool
+		)
+		enter := func() {
+			mu.Lock()
+			defer mu.Unlock()
+			inside++
+			if inside > 1 {
+				overlap = true
+			}
+		}
+		leave := func() {
+			mu.Lock()
+			defer mu.Unlock()
+			inside--
+		}
+
+		var wg sync.WaitGroup
+		for range 4 {
+			store, err := NewSQLPersistence(d)
+			if err != nil {
+				t.Fatalf("NewSQLPersistence: %v", err)
+			}
+			wg.Go(func() {
+				for range 10 {
+					if err := store.Critical(t.Context(), func() error {
+						enter()
+						// Long enough that an unserialized peer would be seen.
+						time.Sleep(time.Millisecond)
+						leave()
+						return nil
+					}); err != nil {
+						t.Errorf("Critical: %v", err)
+						return
+					}
+				}
+			})
+		}
+		wg.Wait()
+
+		if overlap {
+			t.Fatal("two instances were inside a critical section at once; a read-modify-write can lose the other's update")
+		}
+	})
+}
+
+// TestSQLPersistence_SaveOutsideACriticalSectionIsRefused keeps a future caller
+// from writing the ledger without the serialization that makes it safe.
+func TestSQLPersistence_SaveOutsideACriticalSectionIsRefused(t *testing.T) {
+	dbtest.Engines(t, func(t *testing.T, d *db.DB) {
+		t.Helper()
+		store, err := NewSQLPersistence(d)
+		if err != nil {
+			t.Fatalf("NewSQLPersistence: %v", err)
+		}
+		if err := store.Save(t.Context(), diskState{SchemaVersion: 1}); err == nil {
+			t.Fatal("Save succeeded outside a critical section; nothing serialized it")
+		}
+	})
+}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -609,7 +609,7 @@ func providerHealthMetrics(
 func (lm *LifecycleManager) buildMonitorIssueSink(ctx context.Context) monitor.IssueSink {
 	a := lm.app
 	innerSink := monitor.NewGHIssueSink(a.cfg.Monitor.IssueLabel, a.cfg.Monitor.IssueRepo)
-	durableSink, err := monitor.NewDurableGHIssueSink(innerSink, filepath.Join(config.GHIssueOutboxDir(), "monitor"), "monitor", a.logger, a.audit)
+	durableSink, err := a.newDurableIssueSink(ctx, innerSink, "monitor")
 	if err != nil {
 		a.logger.Error("monitor.issue_outbox.init_failed", "err", err)
 		return innerSink

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -698,7 +698,7 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			}
 		})
 	}, a.logger)
-	incidentStore, incidentErr := monitor.NewIncidentStore(config.MonitorIncidentsDir())
+	incidentStore, incidentErr := a.openIncidentStore(ctx)
 	if incidentErr != nil {
 		a.logger.Error("monitor.incident_store.init_failed", "err", incidentErr)
 	}

--- a/scripts/checkconsolidated/main.go
+++ b/scripts/checkconsolidated/main.go
@@ -79,6 +79,7 @@ func buildAllowances() map[allowanceKey]allowance { //nolint:funlen // The expli
 	add(kindStringTruncation, "cmd/gen-config-docs/main.go", "Generated Go/YAML identifiers are normalized ASCII; the slice changes first-letter case.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "cmd/gen-events/main.go", "Generated event function identifiers are ASCII; the slice changes first-letter case.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "cmd/sybra-cli/main.go", "Git revisions are hexadecimal ASCII and this produces a display-only short SHA.", map[string]int{"slice": 1})
+	add(kindStringTruncation, "internal/monitor/issueoutbox.go", "The value is a slice of outbox records capped to a flush batch, not text; the store returns it through an interface so its element type is unresolved here.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/agent/discovery.go", "Provider session identifiers are ASCII protocol tokens and are shortened only for display.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/agent/k8s_job_runner.go", "The value is an already-normalized ASCII Kubernetes DNS label.", map[string]int{"slice": 1})
 	add(kindStringTruncation, "internal/agent/tool_result_bound.go", "The value is a hexadecimal digest used in an artifact filename.", map[string]int{"slice": 1})

--- a/scripts/test-db-engines.sh
+++ b/scripts/test-db-engines.sh
@@ -14,7 +14,7 @@ PORT="${SYBRA_TEST_PG_PORT:-55432}"
 # while the deploy target is Ubuntu, where en_US.UTF-8 ignores punctuation and
 # reorders exactly the ids the builtin workflows ship with.
 IMAGE="postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317"
-PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/sybra/dispatch/..." "./internal/agentqueue/..." "./internal/monitor/..." "./internal/testutil/dbtest/...")
+PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/sybra/dispatch/..." "./internal/agentqueue/..." "./internal/monitor/..." "./internal/cleanup/..." "./internal/testutil/dbtest/...")
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to run the postgres engine leg" >&2

--- a/scripts/test-db-engines.sh
+++ b/scripts/test-db-engines.sh
@@ -14,7 +14,7 @@ PORT="${SYBRA_TEST_PG_PORT:-55432}"
 # while the deploy target is Ubuntu, where en_US.UTF-8 ignores punctuation and
 # reorders exactly the ids the builtin workflows ship with.
 IMAGE="postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317"
-PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/sybra/dispatch/..." "./internal/agentqueue/..." "./internal/testutil/dbtest/...")
+PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/sybra/dispatch/..." "./internal/agentqueue/..." "./internal/monitor/..." "./internal/testutil/dbtest/...")
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to run the postgres engine leg" >&2

--- a/scripts/test-db-engines.sh
+++ b/scripts/test-db-engines.sh
@@ -14,7 +14,7 @@ PORT="${SYBRA_TEST_PG_PORT:-55432}"
 # while the deploy target is Ubuntu, where en_US.UTF-8 ignores punctuation and
 # reorders exactly the ids the builtin workflows ship with.
 IMAGE="postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317"
-PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/testutil/dbtest/...")
+PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/sybra/dispatch/..." "./internal/testutil/dbtest/...")
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to run the postgres engine leg" >&2

--- a/scripts/test-db-engines.sh
+++ b/scripts/test-db-engines.sh
@@ -14,7 +14,7 @@ PORT="${SYBRA_TEST_PG_PORT:-55432}"
 # while the deploy target is Ubuntu, where en_US.UTF-8 ignores punctuation and
 # reorders exactly the ids the builtin workflows ship with.
 IMAGE="postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317"
-PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/sybra/dispatch/..." "./internal/testutil/dbtest/...")
+PACKAGES=("./internal/db/..." "./internal/dbimport/..." "./internal/loopagent/..." "./internal/experience/..." "./internal/workflow/..." "./internal/bgop/..." "./internal/audit/..." "./internal/toolledger/..." "./internal/stats/..." "./internal/limits/..." "./internal/sybra/dispatch/..." "./internal/agentqueue/..." "./internal/testutil/dbtest/...")
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to run the postgres engine leg" >&2


### PR DESCRIPTION
## Motivation

The dispatch queue, attempt leases, monitor incidents, the pending GitHub issue outbox, and protected cleanup findings all coordinate work across restarts. Each was a read-modify-write of a whole file under an advisory lock that only holds while the process holding it lives, so a crash between the read and the write could drop or double an entry.

Losing a write costs the most here. A lost lease releases work that is still running, so a second agent starts on a task another already holds. A lost outbox entry files an issue twice or never. A lost protected finding lets the next cleanup pass delete the path it existed to hold.

Closes #3241

> Changelog: feat(storage): move queue and lease state to the database

## Implementation information

Each store keeps its own logic and gains a persistence seam at the point it already serialized. The database implementations make that seam a transaction holding an advisory lock, so a whole cycle is atomic against every other instance and a process killed inside one leaves the previous state rather than half of it. Each refuses to write outside its locked cycle, so a later caller cannot bypass the serialization.

**The seam takes the shape each store already had.** Attempt leases and the queue had a callback-ish update chokepoint, so those take `Critical(fn)`. Incidents and protected findings acquired a lock and returned an unlock, so those take a `Lock() (release, error)` handle — a transaction maps onto acquire-and-release exactly as a flock does, which left every existing method body unchanged.

**Ordering.** The queue's dispatch order comes from its own sort over the persisted fields, not from the order the store returns rows in, so the test asserts what a restarted queue dispatches rather than what the store read — which is the property the issue actually asks for. Everywhere a text key is ordered it goes through `db.OrderText`, because a range or ordering follows the server's collation and the deploy target's `en_US.UTF-8` disagrees with byte order.

**In-flight leases survive the upgrade.** The import carries expiry and heartbeat verbatim. Restamping them would either release every running agent's work at once or hold a dead agent's claim past its timeout.

### On testing the concurrency guarantee honestly

My first attempt at "two concurrent updates cannot lose one" was vacuous twice over, and both failures are worth recording because they are easy to repeat:

- Both controllers shared one persistence, whose process-local mutex serialized them. Two processes means two persistence instances.
- Plain `go test` **silently skips postgres**, and sqlite's `_txlock=immediate` serializes writers by itself — so removing the advisory lock changed nothing observable and the mutation check passed against broken code. Only `scripts/test-db-engines.sh`, with a real server up, exercises the path the lock exists for.

A timing race is the wrong instrument anyway: the postgres lost-update window is too narrow to hit on demand. The tests assert the mechanism instead — four instances, never two inside a locked cycle at once — which fails on postgres the moment the advisory lock is removed, and which I verified by doing exactly that.

### Coverage

Every domain's behaviour suite runs on both engines through `dbtest.Engines`, and all five packages are registered with `scripts/test-db-engines.sh`. Fifteen packages green on sqlite and the glibc postgres.

One statement-construction change worth naming: in `internal/cleanup` the taint analyser flagged `Rebind` at the call site, where the identical pattern passes in the other packages. Rather than suppress it, the two statements are spelled per dialect so nothing in that file builds SQL at runtime.

## Supporting documentation

An unrelated deadline in `internal/agent` is widened: `scaledDeadline` samples host load once per process, and that package's tests start before the load a full run generates arrives, so the factor resolves to 1 and never absorbed anything.