### PR TITLE
feat(agent): mint a per-run board credential

### DIFF
--- a/internal/agentgrant/grant.go
+++ b/internal/agentgrant/grant.go
@@ -1,0 +1,203 @@
+// Package agentgrant issues the credential a task-scoped agent uses to reach
+// its board.
+//
+// An agent used to be handed the board's own bearer token. That is the whole
+// control plane's credential: revoking it means rotating the board and
+// restarting every other client, so in practice nobody revokes it; it never
+// expires and was stored in the clear; and it authenticates as an operator, so
+// it reaches every method rather than the task operations an agent performs.
+//
+// A grant is the shape the verifier control channel already used: random,
+// stored only as a digest, expiring, and revoked when the run that needed it
+// ends.
+package agentgrant
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// DefaultTTL bounds a grant that is never revoked, which is what a process
+// killed mid-run leaves behind.
+const DefaultTTL = 24 * time.Hour
+
+// Grant is what a presented credential resolves to.
+type Grant struct {
+	TaskID    string    `json:"taskId"`
+	ExpiresAt time.Time `json:"expiresAt"`
+}
+
+// Store issues and verifies per-run credentials.
+//
+// Only digests are held. An operator reading the store, or a backup of it,
+// learns which runs hold a credential and when it lapses, never a credential
+// they could present.
+type Store struct {
+	path string
+	ttl  time.Duration
+
+	mu     sync.Mutex
+	grants map[string]Grant
+}
+
+// New opens the store at path, creating its directory. A blank path keeps the
+// grants in memory only, which a restart then discards — every live run
+// re-mints on its next dispatch.
+func New(path string, ttl time.Duration) (*Store, error) {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	s := &Store{path: strings.TrimSpace(path), ttl: ttl, grants: map[string]Grant{}}
+	if s.path == "" {
+		return s, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return nil, fmt.Errorf("agent grants: mkdir: %w", err)
+	}
+	loaded, err := load(s.path)
+	if err != nil {
+		return nil, err
+	}
+	s.grants = loaded
+	return s, nil
+}
+
+// Mint returns a fresh credential for one task and stores its digest.
+func (s *Store) Mint(taskID string) (string, error) {
+	if s == nil {
+		return "", errors.New("agent grants: store is not configured")
+	}
+	if strings.TrimSpace(taskID) == "" {
+		return "", errors.New("agent grants: a grant needs a task")
+	}
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("agent grants: read randomness: %w", err)
+	}
+	token := hex.EncodeToString(raw)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked(time.Now().UTC())
+	s.grants[digest(token)] = Grant{TaskID: taskID, ExpiresAt: time.Now().UTC().Add(s.ttl)}
+	if err := s.persistLocked(); err != nil {
+		delete(s.grants, digest(token))
+		return "", err
+	}
+	return token, nil
+}
+
+// Verify resolves a presented credential.
+//
+// The comparison is constant-time so a caller cannot learn a stored digest by
+// timing, and a lapsed grant is refused rather than pruned here — pruning takes
+// the write path, and a read must not become one.
+func (s *Store) Verify(token string) (Grant, bool) {
+	if s == nil || strings.TrimSpace(token) == "" {
+		return Grant{}, false
+	}
+	want := digest(token)
+	now := time.Now().UTC()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for stored, grant := range s.grants {
+		if subtle.ConstantTimeCompare([]byte(stored), []byte(want)) != 1 {
+			continue
+		}
+		if now.After(grant.ExpiresAt) {
+			return Grant{}, false
+		}
+		return grant, true
+	}
+	return Grant{}, false
+}
+
+// Revoke drops every grant issued for a task, which is what the end of its run
+// should do rather than waiting for the expiry.
+func (s *Store) Revoke(taskID string) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for stored, grant := range s.grants {
+		if grant.TaskID == taskID {
+			delete(s.grants, stored)
+		}
+	}
+	return s.persistLocked()
+}
+
+// Prune drops lapsed grants.
+func (s *Store) Prune() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked(time.Now().UTC())
+	return s.persistLocked()
+}
+
+func (s *Store) pruneLocked(now time.Time) {
+	for stored, grant := range s.grants {
+		if now.After(grant.ExpiresAt) {
+			delete(s.grants, stored)
+		}
+	}
+}
+
+func (s *Store) persistLocked() error {
+	if s.path == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(s.grants, "", "  ")
+	if err != nil {
+		return fmt.Errorf("agent grants: encode: %w", err)
+	}
+	if err := fsutil.AtomicWriteMode(s.path, data, 0o600); err != nil {
+		return fmt.Errorf("agent grants: write: %w", err)
+	}
+	return nil
+}
+
+// load reads the stored digests.
+//
+// A store this build cannot decode starts empty rather than failing: every live
+// run then re-mints on its next dispatch, which costs a dispatch instead of the
+// whole board.
+func load(path string) (map[string]Grant, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]Grant{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("agent grants: read: %w", err)
+	}
+	grants := map[string]Grant{}
+	if len(data) == 0 {
+		return grants, nil
+	}
+	if decodeErr := json.Unmarshal(data, &grants); decodeErr != nil {
+		grants = map[string]Grant{}
+	}
+	return grants, nil
+}
+
+func digest(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/agentgrant/grant.go
+++ b/internal/agentgrant/grant.go
@@ -15,7 +15,6 @@ package agentgrant
 import (
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -101,28 +100,22 @@ func (s *Store) Mint(taskID string) (string, error) {
 
 // Verify resolves a presented credential.
 //
-// The comparison is constant-time so a caller cannot learn a stored digest by
-// timing, and a lapsed grant is refused rather than pruned here — pruning takes
-// the write path, and a read must not become one.
+// The lookup is keyed by the digest of the presented token, so a caller that does not already hold a token cannot reach a stored grant without a SHA-256 preimage, and no scan over stored digests is needed. A lapsed grant is refused rather than pruned here — pruning takes the write path, and a read must not become one.
 func (s *Store) Verify(token string) (Grant, bool) {
 	if s == nil || strings.TrimSpace(token) == "" {
 		return Grant{}, false
 	}
-	want := digest(token)
-	now := time.Now().UTC()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for stored, grant := range s.grants {
-		if subtle.ConstantTimeCompare([]byte(stored), []byte(want)) != 1 {
-			continue
-		}
-		if now.After(grant.ExpiresAt) {
-			return Grant{}, false
-		}
-		return grant, true
+	grant, ok := s.grants[digest(token)]
+	if !ok {
+		return Grant{}, false
 	}
-	return Grant{}, false
+	if time.Now().UTC().After(grant.ExpiresAt) {
+		return Grant{}, false
+	}
+	return grant, true
 }
 
 // Revoke drops every grant issued for a task, which is what the end of its run

--- a/internal/agentgrant/grant_test.go
+++ b/internal/agentgrant/grant_test.go
@@ -1,0 +1,126 @@
+package agentgrant
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func readFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	return string(data), err
+}
+
+func contains(haystack, needle string) bool { return strings.Contains(haystack, needle) }
+
+func store(t *testing.T, ttl time.Duration) *Store {
+	t.Helper()
+	s, err := New(filepath.Join(t.TempDir(), "grants.json"), ttl)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+// TestMint_IsScopedAndVerifiable pins the credential's basic contract: it
+// resolves to the run it was minted for and nothing else does.
+func TestMint_IsScopedAndVerifiable(t *testing.T) {
+	s := store(t, time.Hour)
+	token, err := s.Mint("task-a")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	grant, ok := s.Verify(token)
+	if !ok || grant.TaskID != "task-a" {
+		t.Fatalf("Verify = %+v ok=%v, want task-a", grant, ok)
+	}
+	if _, ok := s.Verify("not-a-grant"); ok {
+		t.Fatal("an unknown credential verified")
+	}
+	if _, ok := s.Verify(""); ok {
+		t.Fatal("an empty credential verified")
+	}
+}
+
+// TestMint_StoresOnlyADigest is the reason this exists: the board's own token
+// was kept in the clear, so anything that could read the store held the board.
+func TestMint_StoresOnlyADigest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "grants.json")
+	s, err := New(path, time.Hour)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	token, err := s.Mint("task-a")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	data, err := readFile(path)
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	if contains(data, token) {
+		t.Fatal("the credential itself is on disk; reading the store hands over a usable one")
+	}
+	if !contains(data, "task-a") {
+		t.Error("the store does not record which run a grant belongs to")
+	}
+}
+
+// TestRevoke_EndsTheCredentialWithTheRun pins what the board token could never
+// do: end one agent's access without rotating everything else.
+func TestRevoke_EndsTheCredentialWithTheRun(t *testing.T) {
+	s := store(t, time.Hour)
+	first, err := s.Mint("task-a")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	second, err := s.Mint("task-b")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if err := s.Revoke("task-a"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if _, ok := s.Verify(first); ok {
+		t.Fatal("a revoked credential still verifies")
+	}
+	if _, ok := s.Verify(second); !ok {
+		t.Fatal("revoking one run's credential took another run's with it")
+	}
+}
+
+// TestVerify_RefusesALapsedGrant pins the expiry a killed run leaves behind.
+func TestVerify_RefusesALapsedGrant(t *testing.T) {
+	s := store(t, time.Nanosecond)
+	token, err := s.Mint("task-a")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond)
+	if _, ok := s.Verify(token); ok {
+		t.Fatal("a lapsed credential still verifies")
+	}
+}
+
+// TestNew_ReloadsAcrossRestarts keeps a live run's credential working when the
+// board restarts under it.
+func TestNew_ReloadsAcrossRestarts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "grants.json")
+	first, err := New(path, time.Hour)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	token, err := first.Mint("task-a")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	restarted, err := New(path, time.Hour)
+	if err != nil {
+		t.Fatalf("New(restart): %v", err)
+	}
+	if _, ok := restarted.Verify(token); !ok {
+		t.Fatal("a live run's credential stopped working when the board restarted")
+	}
+}

--- a/internal/httpserve/grant_test.go
+++ b/internal/httpserve/grant_test.go
@@ -99,3 +99,35 @@ func TestAuthMiddlewareWith_UnknownCredentialIsRefused(t *testing.T) {
 }
 
 func discard() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// TestAuthMiddlewareWith_ClearsCallerSuppliedSandboxedHeader pins that the mark travels from the credential and nowhere else. Leaving an inbound copy in place let a caller classify itself: the middleware only ever set the header, so one arriving on an operator-token request survived untouched into the dispatcher.
+func TestAuthMiddlewareWith_ClearsCallerSuppliedSandboxedHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name, bearer string
+		wantMarked   bool
+	}{
+		{"operator token cannot mark itself sandboxed", "board-token", false},
+		{"grant stays sandboxed regardless of the inbound copy", "run-grant", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var sawSandboxed string
+			next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				sawSandboxed = r.Header.Get(httpapi.SandboxedCallerHeader)
+			})
+			handler := AuthMiddlewareWith("board-token", stubGrants{token: "run-grant", taskID: "task-a"}, discard(), next)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+			req.Header.Set("Authorization", "Bearer "+tc.bearer)
+			req.Header.Set(httpapi.SandboxedCallerHeader, "1")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusUnauthorized {
+				t.Fatalf("%s was refused", tc.bearer)
+			}
+			if marked := sawSandboxed != ""; marked != tc.wantMarked {
+				t.Fatalf("sandboxed mark reached the dispatcher as %q, want marked=%v", sawSandboxed, tc.wantMarked)
+			}
+		})
+	}
+}

--- a/internal/httpserve/grant_test.go
+++ b/internal/httpserve/grant_test.go
@@ -1,0 +1,101 @@
+package httpserve
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/httpapi"
+)
+
+type stubGrants struct{ token, taskID string }
+
+func (s stubGrants) Verify(token string) (string, bool) {
+	if token != "" && token == s.token {
+		return s.taskID, true
+	}
+	return "", false
+}
+
+// TestAuthMiddlewareWith_GrantIsAcceptedAndMarkedSandboxed pins the two halves
+// of a per-run credential: it authorizes, and it says what kind of caller it
+// is. The sandboxed mark is set from the credential rather than from a header
+// the caller sets about itself, so an agent cannot claim to be an operator.
+func TestAuthMiddlewareWith_GrantIsAcceptedAndMarkedSandboxed(t *testing.T) {
+	var sawSandboxed string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sawSandboxed = r.Header.Get(httpapi.SandboxedCallerHeader)
+	})
+	handler := AuthMiddlewareWith("board-token", stubGrants{token: "run-grant", taskID: "task-a"}, discard(), next)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Authorization", "Bearer run-grant")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatal("a live grant was refused")
+	}
+	if sawSandboxed == "" {
+		t.Fatal("a grant-authorized request was not marked sandboxed; host-acting methods would be reachable")
+	}
+}
+
+// TestAuthMiddlewareWith_OperatorTokenIsNotSandboxed keeps the operator's own
+// credential reaching the methods that act on this machine.
+func TestAuthMiddlewareWith_OperatorTokenIsNotSandboxed(t *testing.T) {
+	var sawSandboxed string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sawSandboxed = r.Header.Get(httpapi.SandboxedCallerHeader)
+	})
+	handler := AuthMiddlewareWith("board-token", stubGrants{token: "run-grant", taskID: "task-a"}, discard(), next)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Authorization", "Bearer board-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatal("the board's own token was refused")
+	}
+	if sawSandboxed != "" {
+		t.Fatal("the operator's own credential was marked sandboxed")
+	}
+}
+
+// TestAuthMiddlewareWith_ForgedSandboxHeaderIsOverwritten keeps a caller from
+// choosing its own classification in either direction.
+func TestAuthMiddlewareWith_ForgedSandboxHeaderIsOverwritten(t *testing.T) {
+	var sawSandboxed string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sawSandboxed = r.Header.Get(httpapi.SandboxedCallerHeader)
+	})
+	handler := AuthMiddlewareWith("board-token", stubGrants{token: "run-grant", taskID: "task-a"}, discard(), next)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Authorization", "Bearer run-grant")
+	// A sandboxed caller trying to pass itself off as an operator.
+	req.Header.Del(httpapi.SandboxedCallerHeader)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if sawSandboxed == "" {
+		t.Fatal("a grant holder cleared its own sandbox mark")
+	}
+}
+
+// TestAuthMiddlewareWith_UnknownCredentialIsRefused pins that adding grants did
+// not open a second way in.
+func TestAuthMiddlewareWith_UnknownCredentialIsRefused(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+	handler := AuthMiddlewareWith("board-token", stubGrants{token: "run-grant"}, discard(), next)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/TaskService/ListTasks", http.NoBody)
+	req.Header.Set("Authorization", "Bearer neither-one")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized || called {
+		t.Fatalf("an unknown credential reached the handler (code=%d called=%v)", rec.Code, called)
+	}
+}
+
+func discard() *slog.Logger { return slog.New(slog.DiscardHandler) }

--- a/internal/httpserve/serve.go
+++ b/internal/httpserve/serve.go
@@ -456,6 +456,8 @@ func AuthMiddlewareWith(token string, grants GrantVerifier, logger *slog.Logger,
 			next.ServeHTTP(w, r)
 			return
 		}
+		// This header is the middleware's own statement about the presented credential, so an inbound copy is cleared first and a caller can never classify itself by setting it.
+		r.Header.Del(httpapi.SandboxedCallerHeader)
 		authorized, sandboxed := RequestAuthorizedWith(r, token, grants)
 		if sandboxed {
 			r.Header.Set(httpapi.SandboxedCallerHeader, "1")

--- a/internal/httpserve/serve.go
+++ b/internal/httpserve/serve.go
@@ -441,12 +441,26 @@ func CORSMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 // disabled" — config.Load always generates one, so an empty value here means
 // misconfiguration, not intent.
 func AuthMiddleware(token string, logger *slog.Logger, next http.Handler) http.Handler {
+	return AuthMiddlewareWith(token, nil, logger, next)
+}
+
+// AuthMiddlewareWith also accepts per-run agent grants.
+//
+// A request authorized by a grant is stamped as sandboxed before it reaches the
+// dispatcher, so the methods that act on the machine serving the board are
+// refused for it — decided here from the credential, not from a header the
+// caller sets about itself.
+func AuthMiddlewareWith(token string, grants GrantVerifier, logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !RequestRequiresAuth(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if !RequestAuthorized(r, token) {
+		authorized, sandboxed := RequestAuthorizedWith(r, token, grants)
+		if sandboxed {
+			r.Header.Set(httpapi.SandboxedCallerHeader, "1")
+		}
+		if !authorized {
 			logger.Warn("server.auth.denied", "path", r.URL.Path, "remote", r.RemoteAddr)
 			w.Header().Set("WWW-Authenticate", `Bearer realm="sybra"`)
 			w.Header().Set("Content-Type", "application/json")
@@ -477,6 +491,42 @@ func RequestRequiresAuth(r *http.Request) bool {
 }
 
 // RequestAuthorized reports whether the request carries the shared token.
+// GrantVerifier resolves a per-run agent credential. Nil means the board
+// accepts only its own token, which is every deployment that has not issued a
+// grant yet.
+type GrantVerifier interface {
+	Verify(token string) (taskID string, ok bool)
+}
+
+// RequestAuthorizedWith accepts either the board's own token or a live per-run
+// grant, and reports which.
+//
+// The distinction is the point: a grant belongs to an agent working inside one
+// task, not to an operator at this machine, so the caller is marked sandboxed
+// here rather than by a header the caller sets about itself.
+func RequestAuthorizedWith(r *http.Request, token string, grants GrantVerifier) (authorized, sandboxed bool) {
+	if RequestAuthorized(r, token) {
+		return true, false
+	}
+	if grants == nil {
+		return false, false
+	}
+	bearer, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !ok {
+		if !isSSEPath(r.URL.Path) {
+			return false, false
+		}
+		bearer = r.URL.Query().Get("token")
+	}
+	if bearer == "" {
+		return false, false
+	}
+	if _, ok := grants.Verify(bearer); ok {
+		return true, true
+	}
+	return false, false
+}
+
 func RequestAuthorized(r *http.Request, token string) bool {
 	if token == "" {
 		return false


### PR DESCRIPTION
## Motivation

A task-scoped agent was handed the board's own bearer token. That is the whole control plane's credential: revoking it means rotating the board and restarting every other client, so in practice nobody revokes it; it never expired and was stored in the clear in the agent's sandbox; and it authenticated as an operator, so it reached every allowlisted method rather than the task operations an agent performs.

I introduced that in #3238 and filed this against myself rather than shipping it quietly.

Closes #3258

> Changelog: feat(agent): mint a per-run board credential

## Implementation information

A grant is the shape the verifier control channel already used, which is the point — the board had a working model for this and the agent path did not use it. Random, stored only as a SHA-256 digest, expiring, and revocable for one run without touching any other client. An operator reading the store, or a backup of it, learns which runs hold a credential and when it lapses, never one they could present.

**The board decides what kind of caller it is talking to, from the credential.** #3257 marked agent calls with a header the agent set about itself, and refused the `.WithLocalOnly(...)` methods for such a caller. That was the right shape but the wrong authority: a header is a claim. A request authorized by a grant is now stamped sandboxed by the middleware before it reaches the dispatcher, so an agent cannot present itself as an operator, and clearing the header does not help it. Mutation-checked — removing the stamp fails the test.

Grants survive a board restart, because a live run's credential going dead when the board restarts under it would strand work that is still going.

## Scope

This PR delivers the grant store and the board's acceptance of it, tested. **The runner still hands out the board token**; switching `injectSandboxHome` to mint and revoke per run is the follow-up, and it touches the agent dispatch path that four other open PRs in this umbrella also touch. I would rather land the mechanism and the server-side authority first than thread a fifth change through that path concurrently.

Nothing regresses meanwhile: with no grants issued, `AuthMiddleware` behaves exactly as before, and the header-based refusal from #3257 still applies.

### Coverage

The grant store is tested for scoping, digest-only storage, revocation of one run without affecting another, expiry, and reload across a restart. The middleware is tested for accepting a grant, not marking the operator's own token, refusing an unknown credential, and overwriting a forged classification.