### PR TITLE
fix(task): stop a task write voiding its cert

### DIFF
--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -239,7 +239,8 @@ func (m *Manager) MutationTransportIdentity(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	parts = append(parts, fmt.Sprintf("%s|%s|%d|%d", resolvedTask, taskInfo.Mode(), taskInfo.Size(), taskInfo.ModTime().UnixNano()))
+	// Omit the task file's mtime and size for the same reason as the directory above: a run patches its own task constantly, so an ordinary status or body write would otherwise read as the mutation route having been replaced underneath a healthy run.
+	parts = append(parts, fmt.Sprintf("%s|%s", resolvedTask, taskInfo.Mode()))
 	return strings.Join(parts, "\x00"), nil
 }
 

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -702,3 +702,35 @@ func TestManagerOnExternalUpdateWaitsForBusyWriterAndStillFires(t *testing.T) {
 		t.Fatalf("hook calls = %v, want [todo->in-progress]", fired)
 	}
 }
+
+// TestMutationTransportIdentityStableAcrossTaskUpdate pins that an ordinary
+// task write does not invalidate the certificate the identity guards.
+//
+// The identity deliberately omits the store directory's mtime and size because
+// the probe's own create-remove write changes them. The task file needed the
+// same treatment for the same reason: a run patches its task constantly, so
+// including the file's size and mtime made every status change look like the
+// mutation route had been replaced underneath a healthy run.
+func TestMutationTransportIdentityStableAcrossTaskUpdate(t *testing.T) {
+	m, _ := newTestManager(t)
+	created, err := m.Create("mutation identity", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := m.MutationTransportIdentity(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := StatusInProgress
+	body := created.Body + "\n\nmore body so the file size changes too"
+	if _, err := m.Update(created.ID, Update{Status: &status, Body: &body}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := m.MutationTransportIdentity(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("an ordinary task update changed the mutation identity\nbefore: %q\nafter:  %q", before, after)
+	}
+}


### PR DESCRIPTION
## Motivation

`MutationTransportIdentity` is read-only evidence that the task-mutation route has not changed underneath a run, and it feeds the run-environment certificate's cache key. It deliberately omits the store directory's mtime and size, because `ProbeMutationTransport`'s own create-remove write changes them — then included both for the task file, which a run patches constantly. Every status change and body edit therefore read as the mutation route having been replaced, voiding the certificate under a perfectly healthy run.

> Changelog: fix(task): stop an ordinary task write voiding its run certificate

## Implementation information

The task file contributes its resolved path and permission mode, and no longer its size or mtime. That still catches what certification exists to invalidate on — replacement through a symlink, and a writable to read-only transition — which is the same reasoning the directory above it already used.

The existing test pinned that the identity is stable across a probe and tracks permission changes; it never pinned stability across an ordinary task update, which is why this survived. The new test writes a real status and body change through `Manager.Update` and asserts the identity is unchanged. It fails without the fix, on the size and mtime fields only.

## Supporting documentation

Part of #3246 and independent of the rest of it: this is one of that issue's outcomes ("a task update no longer fails on a file identity check") and does not depend on the storage backend decision or on any lock removal, so it is separated out rather than held behind them.
