### PR TITLE
docs(docs): fix the storage backend key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,11 +144,12 @@ The content-security policy comes from the response header `internal/httpserve` 
 
 ### Durable Storage Backend
 
-`storage.database.backend` selects where durable state lives: `file` (the
-default — the per-domain filesystem stores Sybra has always used), `sqlite`
-(embedded single file, one machine alone), or `postgres` (shared server,
-several machines on one board). Omitting the block changes nothing, so no
-existing install needs migrating.
+`database.backend` selects where durable state lives: `sqlite` (embedded
+single file, the default when unset, one machine alone), `postgres` (shared
+server, several machines on one board), or `file` (the per-domain filesystem
+stores Sybra has always used, retained for rollback and being retired). An
+install that never named this key migrates itself to sqlite on first start;
+the original files are left in place.
 
 `internal/db` opens the handle, applies the embedded per-dialect migrations in
 `internal/db/migrations/<dialect>/`, and is the only place that knows a dialect.

--- a/internal/dbimport/dbimport.go
+++ b/internal/dbimport/dbimport.go
@@ -1,5 +1,5 @@
 // Package dbimport moves a domain's existing files into the database exactly
-// once, so flipping storage.database.backend does not silently start from an
+// once, so flipping database.backend does not silently start from an
 // empty board.
 package dbimport
 


### PR DESCRIPTION
## Motivation

CLAUDE.md's Durable Storage Backend section documented the setting as
`storage.database.backend`. The config is flat — the real key is
`database.backend` — so following the doc as written produces a
config the server rejects on startup as an unknown key. The section
also still said `file` was the default, which changed to `sqlite`.

## Implementation information

- Fixed the key path and default claim in CLAUDE.md.
- Fixed the same wrong key in a `dbimport` package doc comment.
- Left `docs/CONFIG.md` untouched — it's generated, and its
  `storage.database.backend` there documents the real v2 canonical
  namespace path with `database.backend` as a working legacy alias,
  which is accurate (verified: `storage.database.backend` only
  parses under `schema_version: 2`; `database.backend` always works).
- Verified with a real `sybra-server` build: the fixed key starts the
  server against sqlite; the old documented key fails with `unknown
  config key "storage"`.

Closes #3273

> Changelog: docs(docs): fix the storage backend key