### PR TITLE
test(e2e): seed screenshot fixtures over the API

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -27,9 +27,8 @@ jobs:
 
       - name: Seed fixtures
         run: |
-          mkdir -p "$SYBRA_HOME/tasks" "$SYBRA_HOME/workflows"
+          mkdir -p "$SYBRA_HOME/tasks"
           cp frontend/e2e/fixtures/*.md "$SYBRA_HOME/tasks/"
-          cp frontend/e2e/fixtures/wf-editor-e2e.yaml "$SYBRA_HOME/workflows/"
           # Marker proving this is a disposable e2e home; the suite refuses
           # destructive task cleanup without it (#1576).
           touch "$SYBRA_HOME/.sybra-e2e-home"

--- a/frontend/e2e/lib/api.ts
+++ b/frontend/e2e/lib/api.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { load as parseYAML } from 'js-yaml'
+
+const API_BASE = 'http://localhost:8080'
+
+/**
+ * The bearer token the server running out of `sybraHome` uses.
+ *
+ * CI writes an explicit `server.auth_token` into the home's config, while a
+ * local run leaves it empty and the server generates one into
+ * `server_auth_token`. Both are checked so callers work either way.
+ */
+export async function authToken(sybraHome: string): Promise<string> {
+  try {
+    const cfg = parseYAML(
+      await readFile(join(sybraHome, 'config.yaml'), 'utf8'),
+    ) as { server?: { auth_token?: string } } | undefined
+    const fromConfig = cfg?.server?.auth_token?.trim()
+    if (fromConfig) {
+      return fromConfig
+    }
+  } catch {
+    /* no config file, fall through to the generated token */
+  }
+  return (await readFile(join(sybraHome, 'server_auth_token'), 'utf8')).trim()
+}
+
+/** POST one JSON-RPC-style call against a bound service method. */
+export async function apiCall(
+  sybraHome: string,
+  service: string,
+  method: string,
+  args: unknown[],
+): Promise<Response> {
+  const res = await fetch(`${API_BASE}/api/${service}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${await authToken(sybraHome)}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  })
+  if (!res.ok) {
+    throw new Error(`${service}/${method} failed: ${res.status} ${await res.text()}`)
+  }
+  return res
+}

--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -11,17 +11,33 @@ import { mockGitHub } from './lib/github-mocks.js'
 import { mockProjects } from './lib/project-mocks.js'
 import { mockProviderHealth } from './lib/provider-mocks.js'
 import { mockReviewComments } from './lib/review-mocks.js'
-import { copyFile, mkdir } from 'node:fs/promises'
-import { existsSync } from 'node:fs'
+import { copyFile, mkdir, readFile } from 'node:fs/promises'
+import { load as parseYAML } from 'js-yaml'
 import { join } from 'node:path'
 
 import { isolatedSybraHome } from './lib/sybra-home'
+import { apiCall } from './lib/api'
 
 const SYBRA_HOME = isolatedSybraHome()
 const TASKS_DIR = join(SYBRA_HOME, 'tasks')
-const WORKFLOWS_DIR = join(SYBRA_HOME, 'workflows')
 
 const OUT_DIR = join(import.meta.dirname, '..', '..', 'docs', 'screenshots')
+
+/**
+ * Seed the workflow fixture through the API rather than the workflows
+ * directory.
+ *
+ * The directory is only the store under the `file` backend. Writing a YAML
+ * there after the server booted is invisible to every other backend, because
+ * those read rows and the one-time file import has already run by then —
+ * see frontend/e2e/workflow-editor.spec.ts for the suite that first hit this.
+ */
+async function seedWorkflowFixture() {
+  const src = join(import.meta.dirname, 'fixtures', 'wf-editor-e2e.yaml')
+  await apiCall(SYBRA_HOME, 'WorkflowService', 'SaveWorkflow', [
+    parseYAML(await readFile(src, 'utf8')),
+  ])
+}
 
 async function shot(page: Page, theme: 'light' | 'dark', name: string) {
   await page.screenshot({
@@ -49,21 +65,13 @@ test.beforeAll(async () => {
   await mkdir(join(OUT_DIR, 'light'), { recursive: true })
   await mkdir(join(OUT_DIR, 'dark'), { recursive: true })
 
-  // Ensure task fixtures are present
   for (const f of ['auth0001.md', 'test0001.md', 'db0001.md', 'plan0001.md']) {
     const src = join(import.meta.dirname, 'fixtures', f)
     const dst = join(TASKS_DIR, f)
     await copyFile(src, dst)
   }
 
-  // Ensure workflow fixture is present
-  if (!existsSync(WORKFLOWS_DIR)) {
-    await mkdir(WORKFLOWS_DIR, { recursive: true })
-  }
-  await copyFile(
-    join(import.meta.dirname, 'fixtures', 'wf-editor-e2e.yaml'),
-    join(WORKFLOWS_DIR, 'wf-editor-e2e.yaml'),
-  )
+  await seedWorkflowFixture()
 })
 
 // Run every screenshot block in both themes

--- a/frontend/e2e/workflow-editor.spec.ts
+++ b/frontend/e2e/workflow-editor.spec.ts
@@ -4,10 +4,10 @@ import { join } from "node:path";
 import { load as parseYAML } from "js-yaml";
 
 import { isolatedSybraHome } from "./lib/sybra-home";
+import { apiCall } from "./lib/api";
 
 const SYBRA_HOME = isolatedSybraHome();
 const FIXTURE_ID = "wf-editor-e2e";
-const API_BASE = "http://localhost:8080";
 
 /**
  * Seed and read the fixture through the API rather than the workflows
@@ -20,41 +20,8 @@ const API_BASE = "http://localhost:8080";
  * suite stayed green. Going through the API exercises whichever backend is
  * configured.
  */
-/**
- * The bearer token this home's server runs with.
- *
- * CI writes an explicit `server.auth_token` into the home's config, while a
- * local run leaves it empty and the server generates one into
- * `server_auth_token`. Both are checked so the suite works either way.
- */
-async function authToken(): Promise<string> {
-  try {
-    const cfg = parseYAML(
-      await readFile(join(SYBRA_HOME, "config.yaml"), "utf8"),
-    ) as { server?: { auth_token?: string } } | undefined;
-    const fromConfig = cfg?.server?.auth_token?.trim();
-    if (fromConfig) {
-      return fromConfig;
-    }
-  } catch {
-    /* no config file, fall through to the generated token */
-  }
-  return (await readFile(join(SYBRA_HOME, "server_auth_token"), "utf8")).trim();
-}
-
 async function api(method: string, args: unknown[]): Promise<Response> {
-  const res = await fetch(`${API_BASE}/api/WorkflowService/${method}`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${await authToken()}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(args),
-  });
-  if (!res.ok) {
-    throw new Error(`${method} failed: ${res.status} ${await res.text()}`);
-  }
-  return res;
+  return apiCall(SYBRA_HOME, "WorkflowService", method, args);
 }
 
 async function ensureFixture() {


### PR DESCRIPTION
## Motivation

The screenshot suite copied a workflow YAML into the workflows
directory after the server had already started. That directory is
only the store under the file backend; a database-backed board reads
rows and the one-time file import has already run by then, so the
fixture was silently invisible under the sqlite default — the same
defect already fixed in the workflow editor suite.

## Implementation information

- Ported the workflow editor suite's API-seeding pattern
  (`WorkflowService/SaveWorkflow`) into the screenshot suite.
- Extracted the duplicated token/API-call helper both specs now share
  into `frontend/e2e/lib/api.ts`.
- Dropped the screenshots CI job's own pre-boot copy of the fixture
  into the workflows directory — it duplicated the new API seed and
  was a landmine for any run against a non-fresh home.
- Verified with a real Playwright run against a real `sybra-server`
  on the sqlite default: the workflow screenshot tests pass and show
  the seeded fixture; reverting the fix reproduces the original
  timeout failure against the same running server.

## Open questions

Task fixtures in this suite (and in `history.spec.ts`, `tasks.spec.ts`,
`workflow.spec.ts`) are still seeded by writing `.md` files into the
tasks directory after boot. Verified this is not currently broken —
unlike workflows, a task file dropped in post-boot is picked up live
by the file watcher regardless of backend. That watcher is what
#3246 (open) plans to remove, which would silently break these same
fixtures the same way this issue describes. Left untouched here since
today they work and the issue is scoped to the workflow directory;
flagging so converting them lands together with #3246.

Closes #3275

> Changelog: test(e2e): seed screenshot fixtures over the API